### PR TITLE
Reflow on Resize

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,6 @@ Performance:
 Correctness:
 
 * `exit` in the shell should close the window
-* scrollback: reflow on resize
 * test wrap against wraptest: https://github.com/mattiase/wraptest
   - automate this in some way
 

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -705,7 +705,7 @@ pub fn resize(self: *Screen, alloc: Allocator, rows: usize, cols: usize) !void {
                 // If our y is more than our rows, we need to scroll
                 if (y >= self.rows) {
                     self.scroll(.{ .delta = 1 });
-                    y -= 1;
+                    y = self.rows - 1;
                     x = 0;
                 }
 
@@ -718,6 +718,7 @@ pub fn resize(self: *Screen, alloc: Allocator, rows: usize, cols: usize) !void {
                 }
 
                 // Copy the old cell, unset the old wrap state
+                // log.warn("y={} x={} rows={}", .{ y, x, self.rows });
                 var new_cell = self.getCell(y, x);
                 new_cell.* = cell;
                 new_cell.attrs.wrap = 0;

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -745,7 +745,7 @@ pub fn resize(self: *Screen, alloc: Allocator, rows: usize, cols: usize) !void {
                     cursor_pos.x == i)
                 {
                     assert(new_cursor == null);
-                    new_cursor = .{ .x = x, .y = y };
+                    new_cursor = .{ .x = x, .y = self.visible_offset + y };
                 }
 
                 // Copy the old cell, unset the old wrap state
@@ -766,7 +766,7 @@ pub fn resize(self: *Screen, alloc: Allocator, rows: usize, cols: usize) !void {
                 assert(new_cursor == null);
                 new_cursor = .{
                     .x = @minimum(cursor_pos.x, self.cols - 1),
-                    .y = y,
+                    .y = self.visible_offset + y,
                 };
             }
 

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -689,14 +689,6 @@ pub fn resize(self: *Screen, alloc: Allocator, rows: usize, cols: usize) !void {
                     i -= 1;
                 }
 
-                // If our cursor was past the end of this line, move it
-                // to the end of the contentful area.
-                if (cursor_pos.y == iter.value - 1 and
-                    cursor_pos.x >= i)
-                {
-                    cursor_pos.x = i - 1;
-                }
-
                 break :trim row[0..i];
             };
 
@@ -732,6 +724,18 @@ pub fn resize(self: *Screen, alloc: Allocator, rows: usize, cols: usize) !void {
 
                 // Next
                 x += 1;
+            }
+
+            // If our cursor is on this line but not in a content area,
+            // then we just set it to be at the end.
+            if (cursor_pos.y == iter.value - 1 and
+                cursor_pos.x >= trimmed_row.len)
+            {
+                assert(new_cursor == null);
+                new_cursor = .{
+                    .x = @minimum(cursor_pos.x, self.cols - 1),
+                    .y = y,
+                };
             }
 
             // If we aren't wrapping, then move to the next row

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -265,20 +265,20 @@ pub fn getCell(self: Screen, row: usize, col: usize) *Cell {
 
 /// Returns the index for the given row (0-indexed) into the underlying
 /// storage array. The row is 0-indexed from the top of the screen.
-fn rowIndex(self: Screen, idx: RowIndex) usize {
+fn rowIndex(self: *const Screen, idx: RowIndex) usize {
     const y = switch (idx) {
         .screen => |y| y: {
-            assert(y < self.bottom);
+            assert(y <= RowIndexTag.screen.max(self));
             break :y y;
         },
 
         .viewport => |y| y: {
-            assert(y < self.rows);
+            assert(y <= RowIndexTag.viewport.max(self));
             break :y y + self.visible_offset;
         },
 
         .active => |y| y: {
-            assert(y < self.rows);
+            assert(y <= RowIndexTag.active.max(self));
             break :y self.bottomOffset() + y;
         },
     };

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -444,6 +444,13 @@ pub fn copyRow(self: *Screen, dst: usize, src: usize) void {
 /// This will trim data if the size is getting smaller. This will reflow the
 /// soft wrapped text.
 pub fn resize(self: *Screen, alloc: Allocator, rows: usize, cols: usize) !void {
+    defer {
+        assert(self.cursor.x < self.cols);
+        assert(self.cursor.y < self.rows);
+        assert(self.rows == rows);
+        assert(self.cols == cols);
+    }
+
     // If the rows increased, we alloc space for the new rows (w/ existing cols)
     // and move the viewport such that the bottom is in view.
     if (rows > self.rows) {

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -252,7 +252,7 @@ pub fn resize(self: *Terminal, alloc: Allocator, cols_req: usize, rows: usize) !
 ///
 /// The caller must free the string.
 pub fn plainString(self: Terminal, alloc: Allocator) ![]const u8 {
-    return try self.screen.testString(alloc);
+    return try self.screen.testString(alloc, .viewport);
 }
 
 /// Save cursor position and further state.

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -214,8 +214,6 @@ pub fn resize(self: *Terminal, alloc: Allocator, cols_req: usize, rows: usize) !
     const tracy = trace(@src());
     defer tracy.end();
 
-    // TODO: test, wrapping, etc.
-
     // If we have deccolm supported then we are fixed at either 80 or 132
     // columns depending on if mode 3 is set or not.
     // TODO: test
@@ -232,9 +230,13 @@ pub fn resize(self: *Terminal, alloc: Allocator, cols_req: usize, rows: usize) !
     }
 
     // If we're making the screen smaller, dealloc the unused items.
-    // TODO: reflow
-    try self.screen.resize(alloc, rows, cols);
-    try self.secondary_screen.resize(alloc, rows, cols);
+    if (self.active_screen == .primary) {
+        try self.screen.resize(alloc, rows, cols);
+        try self.secondary_screen.resizeWithoutReflow(alloc, rows, cols);
+    } else {
+        try self.screen.resizeWithoutReflow(alloc, rows, cols);
+        try self.secondary_screen.resize(alloc, rows, cols);
+    }
 
     // Set our size
     self.cols = cols;

--- a/src/terminal/point.zig
+++ b/src/terminal/point.zig
@@ -76,6 +76,24 @@ pub const ScreenPoint = struct {
             (self.y == other.y and self.x < other.x);
     }
 
+    /// Converts this to a viewport point. If the point is above the
+    /// viewport this will move the point to (0, 0) and if it is below
+    /// the viewport it'll move it to (cols - 1, rows - 1).
+    pub fn toViewport(self: ScreenPoint, screen: *const Screen) Viewport {
+        // TODO: test
+
+        // Before viewport
+        if (self.y < screen.visible_offset) return .{ .x = 0, .y = 0 };
+
+        // After viewport
+        if (self.y > screen.visible_offset + screen.rows) return .{
+            .x = screen.cols - 1,
+            .y = screen.rows - 1,
+        };
+
+        return .{ .x = self.x, .y = self.y - screen.visible_offset };
+    }
+
     test "before" {
         const testing = std.testing;
 


### PR DESCRIPTION
This introduces text and cursor reflow on resize. 

Admittedly, this is not the most efficient implementation. Specifically, _shrinking columns_ is awful. I think I have to rethink parts of the Screen data structure to make this more efficient (and I have ideas). In the mean time, this makes reflow mostly work and starts to add a fairly significant test suite for reflow. 

This 100% needs another pass, but the test suite should be solid for refactoring and it gives us a place to keep adding more reflow tests as we find bugs.

https://user-images.githubusercontent.com/1299/183562865-462e7449-b2d7-4e37-9e56-a51cf8dcaa94.mp4