### PR TITLE
Emoji and Wide Unicode Char Support (i.e. Asian characters)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,10 +35,10 @@ jobs:
       with:
         nix_path: nixpkgs=channel:nixos-unstable
 
-    # Run our go tests within the context of the dev shell from the flake. This
-    # will ensure we have all our dependencies.
+    # Cross-compile the binary. We always use static building for this
+    # because its the only way to access the headers.
     - name: Test Build
-      run: nix develop -c zig build -Dtarget=${{ matrix.target }}
+      run: nix develop -c zig build -Dstatic=true -Dtarget=${{ matrix.target }}
 
   test:
     strategy:
@@ -57,7 +57,9 @@ jobs:
       with:
         nix_path: nixpkgs=channel:nixos-unstable
 
-    # Run our go tests within the context of the dev shell from the flake. This
-    # will ensure we have all our dependencies.
     - name: test
       run: nix develop -c zig build test
+
+    - name: Test Dynamic Build
+      run: nix develop -c zig build -Dstatic=false
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "vendor/libpng"]
 	path = vendor/libpng
 	url = https://github.com/glennrp/libpng.git
+[submodule "vendor/utf8proc"]
+	path = vendor/utf8proc
+	url = https://github.com/JuliaStrings/utf8proc.git

--- a/build.zig
+++ b/build.zig
@@ -71,7 +71,11 @@ pub fn build(b: *std.build.Builder) !void {
         wasm.setTarget(.{ .cpu_arch = .wasm32, .os_tag = .freestanding });
         wasm.setBuildMode(mode);
         wasm.setOutputDir("zig-out");
+
+        // Wasm-specific deps
         wasm.addPackage(tracylib.pkg);
+        wasm.addPackage(utf8proc.pkg);
+        _ = try utf8proc.link(b, wasm);
 
         const step = b.step("term-wasm", "Build the terminal.wasm library");
         step.dependOn(&wasm.step);

--- a/build.zig
+++ b/build.zig
@@ -6,6 +6,7 @@ const glfw = @import("vendor/mach/glfw/build.zig");
 const freetype = @import("pkg/freetype/build.zig");
 const libuv = @import("pkg/libuv/build.zig");
 const libpng = @import("pkg/libpng/build.zig");
+const utf8proc = @import("pkg/utf8proc/build.zig");
 const zlib = @import("pkg/zlib/build.zig");
 const tracylib = @import("pkg/tracy/build.zig");
 const system_sdk = @import("vendor/mach/glfw/system_sdk.zig");
@@ -181,6 +182,10 @@ fn addDeps(
     step.addPackage(libuv.pkg);
     var libuv_step = try libuv.link(b, step);
     system_sdk.include(b, libuv_step, .{});
+
+    // utf8proc
+    step.addPackage(utf8proc.pkg);
+    _ = try utf8proc.link(b, step);
 
     // Tracy
     step.addPackage(tracylib.pkg);

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -19,18 +19,26 @@
 , freetype
 , libpng
 , libGL
+, libuv
 , libX11
 , libXcursor
 , libXext
 , libXi
 , libXinerama
 , libXrandr
+, zlib
 }:
 let
   # See package.nix. Keep in sync.
   rpathLibs = [
     libGL
   ] ++ lib.optionals stdenv.isLinux [
+    bzip2
+    freetype
+    libpng
+    libuv
+    zlib
+
     libX11
     libXcursor
     libXi
@@ -61,6 +69,12 @@ in mkShell rec {
   buildInputs = [
     # TODO: non-linux
   ] ++ lib.optionals stdenv.isLinux [
+    bzip2
+    freetype
+    libpng
+    libuv
+    zlib
+
     libX11
     libXcursor
     libXext

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -29,7 +29,6 @@
 let
   # See package.nix. Keep in sync.
   rpathLibs = [
-    libpng
     libGL
   ] ++ lib.optionals stdenv.isLinux [
     libX11
@@ -62,7 +61,6 @@ in mkShell rec {
   buildInputs = [
     # TODO: non-linux
   ] ++ lib.optionals stdenv.isLinux [
-    libpng
     libX11
     libXcursor
     libXext

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -29,6 +29,7 @@
 let
   # See package.nix. Keep in sync.
   rpathLibs = [
+    libpng
     libGL
   ] ++ lib.optionals stdenv.isLinux [
     libX11
@@ -61,6 +62,7 @@ in mkShell rec {
   buildInputs = [
     # TODO: non-linux
   ] ++ lib.optionals stdenv.isLinux [
+    libpng
     libX11
     libXcursor
     libXext

--- a/pkg/freetype/build.zig
+++ b/pkg/freetype/build.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 /// Directories with our includes.
 const root = thisDir() ++ "../../../vendor/freetype/";
 const include_path = root ++ "include";
-const include_path_self = thisDir();
+pub const include_path_self = thisDir();
 
 pub const pkg = std.build.Pkg{
     .name = "freetype",

--- a/pkg/utf8proc/build.zig
+++ b/pkg/utf8proc/build.zig
@@ -1,0 +1,51 @@
+const std = @import("std");
+
+/// Directories with our includes.
+const root = thisDir() ++ "../../../vendor/utf8proc/";
+const include_path = root;
+
+pub const include_paths = .{include_path};
+
+pub const pkg = std.build.Pkg{
+    .name = "utf8proc",
+    .source = .{ .path = thisDir() ++ "/main.zig" },
+};
+
+fn thisDir() []const u8 {
+    return std.fs.path.dirname(@src().file) orelse ".";
+}
+
+pub fn link(b: *std.build.Builder, step: *std.build.LibExeObjStep) !*std.build.LibExeObjStep {
+    const lib = try buildLib(b, step);
+    step.linkLibrary(lib);
+    step.addIncludePath(include_path);
+    return lib;
+}
+
+pub fn buildLib(
+    b: *std.build.Builder,
+    step: *std.build.LibExeObjStep,
+) !*std.build.LibExeObjStep {
+    const lib = b.addStaticLibrary("utf8proc", null);
+    lib.setTarget(step.target);
+    lib.setBuildMode(step.build_mode);
+
+    // Include
+    lib.addIncludePath(include_path);
+
+    // Link
+    lib.linkLibC();
+
+    // Compile
+    var flags = std.ArrayList([]const u8).init(b.allocator);
+    defer flags.deinit();
+
+    // C files
+    lib.addCSourceFiles(srcs, flags.items);
+
+    return lib;
+}
+
+const srcs = &.{
+    root ++ "utf8proc.c",
+};

--- a/pkg/utf8proc/c.zig
+++ b/pkg/utf8proc/c.zig
@@ -1,0 +1,3 @@
+pub usingnamespace @cImport({
+    @cInclude("utf8proc.h");
+});

--- a/pkg/utf8proc/main.zig
+++ b/pkg/utf8proc/main.zig
@@ -1,0 +1,8 @@
+pub const c = @import("c.zig");
+
+/// Given a codepoint, return a character width analogous to `wcwidth(codepoint)`,
+/// except that a width of 0 is returned for non-printable codepoints
+/// instead of -1 as in `wcwidth`.
+pub fn charwidth(codepoint: u21) u8 {
+    return @intCast(u8, c.utf8proc_charwidth(@intCast(i32, codepoint)));
+}

--- a/shaders/cell.f.glsl
+++ b/shaders/cell.f.glsl
@@ -31,6 +31,7 @@ const uint MODE_CURSOR_RECT = 3u;
 const uint MODE_CURSOR_RECT_HOLLOW = 4u;
 const uint MODE_CURSOR_BAR = 5u;
 const uint MODE_UNDERLINE = 6u;
+const uint MODE_WIDE_MASK = 128u; // 0b1000_0000
 
 void main() {
     float a;

--- a/shaders/cell.f.glsl
+++ b/shaders/cell.f.glsl
@@ -18,6 +18,7 @@ layout(location = 0) out vec4 out_FragColor;
 
 // Font texture
 uniform sampler2D text;
+uniform sampler2D text_color;
 
 // Dimensions of the cell
 uniform vec2 cell_size;
@@ -25,20 +26,27 @@ uniform vec2 cell_size;
 // See vertex shader
 const uint MODE_BG = 1u;
 const uint MODE_FG = 2u;
+const uint MODE_FG_COLOR = 7u;
 const uint MODE_CURSOR_RECT = 3u;
 const uint MODE_CURSOR_RECT_HOLLOW = 4u;
 const uint MODE_CURSOR_BAR = 5u;
 const uint MODE_UNDERLINE = 6u;
 
 void main() {
+    float a;
+
     switch (mode) {
     case MODE_BG:
         out_FragColor = color;
         break;
 
     case MODE_FG:
-        float a = texture(text, glyph_tex_coords).r;
+        a = texture(text, glyph_tex_coords).r;
         out_FragColor = vec4(color.rgb, color.a*a);
+        break;
+
+    case MODE_FG_COLOR:
+        out_FragColor = texture(text_color, glyph_tex_coords);
         break;
 
     case MODE_CURSOR_RECT:

--- a/shaders/cell.v.glsl
+++ b/shaders/cell.v.glsl
@@ -11,6 +11,7 @@ const uint MODE_CURSOR_RECT = 3u;
 const uint MODE_CURSOR_RECT_HOLLOW = 4u;
 const uint MODE_CURSOR_BAR = 5u;
 const uint MODE_UNDERLINE = 6u;
+const uint MODE_WIDE_MASK = 128u; // 0b1000_0000
 
 // The grid coordinates (x, y) where x < columns and y < rows
 layout (location = 0) in vec2 grid_coord;
@@ -77,8 +78,12 @@ uniform float glyph_baseline;
  */
 
 void main() {
-    // We always forward our mode
-    mode = mode_in;
+    // Remove any masks from our mode
+    uint mode_unmasked = mode_in & ~MODE_WIDE_MASK;
+
+    // We always forward our mode unmasked because the fragment
+    // shader doesn't use any of the masks.
+    mode = mode_unmasked;
 
     // Top-left cell coordinates converted to world space
     // Example: (1,0) with a 30 wide cell is converted to (30,0)
@@ -103,12 +108,18 @@ void main() {
     position.x = (gl_VertexID == 0 || gl_VertexID == 1) ? 1. : 0.;
     position.y = (gl_VertexID == 0 || gl_VertexID == 3) ? 0. : 1.;
 
-    switch (mode_in) {
+    // Scaled for wide chars
+    vec2 cell_size_scaled = cell_size;
+    if ((mode_in & MODE_WIDE_MASK) == MODE_WIDE_MASK) {
+        cell_size_scaled.x = cell_size_scaled.x * 2;
+    }
+
+    switch (mode) {
     case MODE_BG:
         // Calculate the final position of our cell in world space.
         // We have to add our cell size since our vertices are offset
         // one cell up and to the left. (Do the math to verify yourself)
-        cell_pos = cell_pos + cell_size * position;
+        cell_pos = cell_pos + cell_size_scaled * position;
 
         gl_Position = projection * vec4(cell_pos, cell_z, 1.0);
         color = bg_color_in / 255.0;
@@ -122,8 +133,8 @@ void main() {
         // TODO: for now, we assume this means it is a full width character
         // TODO: in the future, use unicode libs to verify this.
         vec2 glyph_size_downsampled = glyph_size;
-        if (mode_in == MODE_FG_COLOR && glyph_size.x > cell_size.x) {
-            glyph_size_downsampled.x = cell_size.x * 2;
+        if (glyph_size.x > cell_size.x) {
+            glyph_size_downsampled.x = cell_size_scaled.x;
             glyph_size_downsampled.y = glyph_size.y * (glyph_size_downsampled.x / glyph_size.x);
             glyph_offset_calc.y = glyph_offset.y * (glyph_size_downsampled.x / glyph_size.x);
         }
@@ -132,7 +143,7 @@ void main() {
         // to the baseline is the offset (+y is up). Our grid goes down.
         // So we flip it with `cell_size.y - glyph_offset.y`. The glyph_baseline
         // uniform sets our line baseline where characters "sit".
-        glyph_offset_calc.y = cell_size.y - glyph_offset_calc.y - glyph_baseline;
+        glyph_offset_calc.y = cell_size_scaled.y - glyph_offset_calc.y - glyph_baseline;
 
         // Calculate the final position of the cell.
         cell_pos = cell_pos + glyph_size_downsampled * position + glyph_offset_calc;
@@ -141,7 +152,7 @@ void main() {
         // We need to convert our texture position and size to normalized
         // device coordinates (0 to 1.0) by dividing by the size of the texture.
         ivec2 text_size;
-        switch(mode_in) {
+        switch(mode) {
         case MODE_FG:
             text_size = textureSize(text, 0);
             break;
@@ -160,7 +171,7 @@ void main() {
 
     case MODE_CURSOR_RECT:
         // Same as background since we're taking up the whole cell.
-        cell_pos = cell_pos + cell_size * position;
+        cell_pos = cell_pos + cell_size_scaled * position;
 
         gl_Position = projection * vec4(cell_pos, cell_z, 1.0);
         color = bg_color_in / 255.0;
@@ -171,7 +182,7 @@ void main() {
         screen_cell_pos = cell_pos;
 
         // Same as background since we're taking up the whole cell.
-        cell_pos = cell_pos + cell_size * position;
+        cell_pos = cell_pos + cell_size_scaled * position;
 
         gl_Position = projection * vec4(cell_pos, cell_z, 1.0);
         color = bg_color_in / 255.0;
@@ -191,11 +202,11 @@ void main() {
     case MODE_UNDERLINE:
         // Make the underline a smaller version of our cell
         // TODO: use real font underline thickness
-        vec2 underline_size = vec2(cell_size.x, cell_size.y*0.05);
+        vec2 underline_size = vec2(cell_size_scaled.x, cell_size_scaled.y*0.05);
 
         // Position our underline so that it is midway between the glyph
         // baseline and the bottom of the cell.
-        vec2 underline_offset = vec2(cell_size.x, cell_size.y - (glyph_baseline / 2));
+        vec2 underline_offset = vec2(cell_size_scaled.x, cell_size_scaled.y - (glyph_baseline / 2));
 
         // Go to the bottom of the cell, take away the size of the
         // underline, and that is our position. We also float it slightly

--- a/shaders/cell.v.glsl
+++ b/shaders/cell.v.glsl
@@ -122,7 +122,7 @@ void main() {
         // TODO: for now, we assume this means it is a full width character
         // TODO: in the future, use unicode libs to verify this.
         vec2 glyph_size_downsampled = glyph_size;
-        if (glyph_size.x > cell_size.x) {
+        if (mode_in == MODE_FG_COLOR && glyph_size.x > cell_size.x) {
             glyph_size_downsampled.x = cell_size.x * 2;
             glyph_size_downsampled.y = glyph_size.y * (glyph_size_downsampled.x / glyph_size.x);
             glyph_offset_calc.y = glyph_offset.y * (glyph_size_downsampled.x / glyph_size.x);

--- a/src/Grid.zig
+++ b/src/Grid.zig
@@ -510,6 +510,9 @@ pub fn updateCell(
         break :colors res;
     };
 
+    // If we are a trailing spacer, we never render anything.
+    if (cell.attrs.wide_spacer_tail == 1) return true;
+
     // Calculate the amount of space we need in the cells list.
     const needed = needed: {
         var i: usize = 0;

--- a/src/font/Face.zig
+++ b/src/font/Face.zig
@@ -97,7 +97,7 @@ pub fn loadGlyph(self: Face, alloc: Allocator, atlas: *Atlas, cp: u32) !Glyph {
         if (idx > 0) break :glyph_index idx;
 
         // Unknown glyph.
-        log.warn("glyph not found: {x}", .{cp});
+        //log.warn("glyph not found: {x}", .{cp});
         return error.GlyphNotFound;
     };
     //log.warn("glyph index: {}", .{glyph_index});

--- a/src/font/Face.zig
+++ b/src/font/Face.zig
@@ -98,9 +98,7 @@ pub fn loadGlyph(self: Face, alloc: Allocator, atlas: *Atlas, cp: u32) !Glyph {
 
         // Unknown glyph.
         log.warn("glyph not found: {x}", .{cp});
-
-        // TODO: render something more identifiable than a space
-        break :glyph_index ftc.FT_Get_Char_Index(self.ft_face, ' ');
+        return error.GlyphNotFound;
     };
     //log.warn("glyph index: {}", .{glyph_index});
 

--- a/src/font/FallbackSet.zig
+++ b/src/font/FallbackSet.zig
@@ -1,0 +1,150 @@
+//! FallbackSet represents a set of families in priority order to load a glyph.
+//! This can be used to merge multiple font families together to find a glyph
+//! for a codepoint.
+const FallbackSet = @This();
+
+const std = @import("std");
+const assert = std.debug.assert;
+const Allocator = std.mem.Allocator;
+
+const ftc = @import("freetype").c;
+const Atlas = @import("../Atlas.zig");
+const Family = @import("main.zig").Family;
+const Glyph = @import("main.zig").Glyph;
+const Style = @import("main.zig").Style;
+
+const ftok = ftc.FT_Err_Ok;
+const log = std.log.scoped(.font_fallback);
+
+/// The families to look for in order. This should be managed directly
+/// by the caller of the set. Deinit will deallocate this.
+families: std.ArrayListUnmanaged(Family) = .{},
+
+/// A quick lookup that points directly to the family that loaded a glyph.
+glyphs: std.AutoHashMapUnmanaged(GlyphKey, usize) = .{},
+
+const GlyphKey = struct {
+    style: Style,
+    codepoint: u32,
+};
+
+pub fn deinit(self: *FallbackSet, alloc: Allocator) void {
+    self.families.deinit(alloc);
+    self.glyphs.deinit(alloc);
+    self.* = undefined;
+}
+
+pub const GetOrAdd = struct {
+    /// Index of the family where the glyph was loaded from
+    family: usize,
+
+    /// True if the glyph was found or whether it was newly loaded
+    found_existing: bool,
+
+    /// The glyph
+    glyph: *Glyph,
+};
+
+pub fn getOrAddGlyph(
+    self: *FallbackSet,
+    alloc: Allocator,
+    v: anytype,
+    style: Style,
+) !GetOrAdd {
+    assert(self.families.items.len > 0);
+
+    // We need a UTF32 codepoint
+    const utf32 = Family.codepoint(v);
+
+    // If we have this already, load it directly
+    const glyphKey: GlyphKey = .{ .style = style, .codepoint = utf32 };
+    const gop = try self.glyphs.getOrPut(alloc, glyphKey);
+    if (gop.found_existing) {
+        const i = gop.value_ptr.*;
+        assert(i < self.families.items.len);
+        return GetOrAdd{
+            .family = i,
+            .found_existing = true,
+            .glyph = self.families.items[i].getGlyph(v, style) orelse unreachable,
+        };
+    }
+    errdefer _ = self.glyphs.remove(glyphKey);
+
+    // Go through each familiy and look for a matching glyph
+    var fam_i: usize = 0;
+    const glyph = glyph: {
+        var style_current = style;
+        while (true) {
+            for (self.families.items) |*family, i| {
+                fam_i = i;
+
+                // If this family already has it loaded, return it.
+                if (family.getGlyph(v, style_current)) |glyph| break :glyph glyph;
+
+                // Try to load it.
+                if (family.addGlyph(alloc, v, style_current)) |glyph|
+                    break :glyph glyph
+                else |err| switch (err) {
+                    error.GlyphNotFound => {},
+                    else => return err,
+                }
+            }
+
+            // We never found any glyph! For our first fallback, we'll simply
+            // try to the non-styled variant.
+            if (style_current == .regular) break;
+            style_current = .regular;
+        }
+
+        // If we are regular, we use a fallback character
+        log.warn("glyph not found, using fallback. codepoint={x}", .{utf32});
+        break :glyph try self.families.items[0].addGlyph(alloc, ' ', style);
+    };
+
+    gop.value_ptr.* = fam_i;
+    return GetOrAdd{
+        .family = fam_i,
+        .glyph = glyph,
+
+        // Technically possible that we found this in a cache...
+        .found_existing = false,
+    };
+}
+
+test {
+    const fontRegular = @import("test.zig").fontRegular;
+    const fontEmoji = @import("test.zig").fontEmoji;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var set: FallbackSet = .{};
+    try set.families.append(alloc, fam: {
+        var fam = try Family.init(try Atlas.init(alloc, 512, .greyscale));
+        try fam.loadFaceFromMemory(.regular, fontRegular, 48);
+        break :fam fam;
+    });
+    try set.families.append(alloc, fam: {
+        var fam = try Family.init(try Atlas.init(alloc, 512, .rgba));
+        try fam.loadFaceFromMemory(.regular, fontEmoji, 48);
+        break :fam fam;
+    });
+
+    defer {
+        for (set.families.items) |*family| {
+            family.atlas.deinit(alloc);
+            family.deinit(alloc);
+        }
+        set.deinit(alloc);
+    }
+
+    // Generate all visible ASCII
+    var i: u8 = 32;
+    while (i < 127) : (i += 1) {
+        _ = try set.getOrAddGlyph(alloc, i, .regular);
+    }
+
+    // Emoji should work
+    _ = try set.getOrAddGlyph(alloc, '🥸', .regular);
+    _ = try set.getOrAddGlyph(alloc, '🥸', .bold);
+}

--- a/src/font/FallbackSet.zig
+++ b/src/font/FallbackSet.zig
@@ -12,6 +12,7 @@ const Atlas = @import("../Atlas.zig");
 const Family = @import("main.zig").Family;
 const Glyph = @import("main.zig").Glyph;
 const Style = @import("main.zig").Style;
+const codepoint = @import("main.zig").codepoint;
 
 const ftok = ftc.FT_Err_Ok;
 const log = std.log.scoped(.font_fallback);
@@ -54,7 +55,7 @@ pub fn getOrAddGlyph(
     assert(self.families.items.len > 0);
 
     // We need a UTF32 codepoint
-    const utf32 = Family.codepoint(v);
+    const utf32 = codepoint(v);
 
     // If we have this already, load it directly
     const glyphKey: GlyphKey = .{ .style = style, .codepoint = utf32 };

--- a/src/font/Family.zig
+++ b/src/font/Family.zig
@@ -137,13 +137,12 @@ pub fn addGlyph(self: *Family, alloc: Allocator, v: anytype, style: Style) !*Gly
     errdefer _ = self.glyphs.remove(glyphKey);
 
     // Get the glyph and add it to the atlas.
-    // TODO: handle glyph not found
     gop.value_ptr.* = try face.loadGlyph(alloc, &self.atlas, utf32);
     return gop.value_ptr;
 }
 
 /// Returns the UTF-32 codepoint for the given value.
-fn codepoint(v: anytype) u32 {
+pub fn codepoint(v: anytype) u32 {
     // We need a UTF32 codepoint for freetype
     return switch (@TypeOf(v)) {
         u32 => v,

--- a/src/font/Family.zig
+++ b/src/font/Family.zig
@@ -11,6 +11,7 @@ const Face = @import("main.zig").Face;
 const Glyph = @import("main.zig").Glyph;
 const Style = @import("main.zig").Style;
 const testFont = @import("test.zig").fontRegular;
+const codepoint = @import("main.zig").codepoint;
 
 const log = std.log.scoped(.font_family);
 
@@ -139,17 +140,6 @@ pub fn addGlyph(self: *Family, alloc: Allocator, v: anytype, style: Style) !*Gly
     // Get the glyph and add it to the atlas.
     gop.value_ptr.* = try face.loadGlyph(alloc, &self.atlas, utf32);
     return gop.value_ptr;
-}
-
-/// Returns the UTF-32 codepoint for the given value.
-pub fn codepoint(v: anytype) u32 {
-    // We need a UTF32 codepoint for freetype
-    return switch (@TypeOf(v)) {
-        u32 => v,
-        comptime_int, u8 => @intCast(u32, v),
-        []const u8 => @intCast(u32, try std.unicode.utfDecode(v)),
-        else => @compileError("invalid codepoint type"),
-    };
 }
 
 test {

--- a/src/font/main.zig
+++ b/src/font/main.zig
@@ -1,6 +1,7 @@
 pub const Face = @import("Face.zig");
 pub const Family = @import("Family.zig");
 pub const Glyph = @import("Glyph.zig");
+pub const FallbackSet = @import("FallbackSet.zig");
 
 /// Embedded fonts (for now)
 pub const fontRegular = @import("test.zig").fontRegular;
@@ -18,4 +19,5 @@ test {
     _ = Face;
     _ = Family;
     _ = Glyph;
+    _ = FallbackSet;
 }

--- a/src/font/main.zig
+++ b/src/font/main.zig
@@ -1,3 +1,5 @@
+const std = @import("std");
+
 pub const Face = @import("Face.zig");
 pub const Family = @import("Family.zig");
 pub const Glyph = @import("Glyph.zig");
@@ -14,6 +16,17 @@ pub const Style = enum {
     italic,
     bold_italic,
 };
+
+/// Returns the UTF-32 codepoint for the given value.
+pub fn codepoint(v: anytype) u32 {
+    // We need a UTF32 codepoint for freetype
+    return switch (@TypeOf(v)) {
+        u32 => v,
+        comptime_int, u8 => @intCast(u32, v),
+        []const u8 => @intCast(u32, try std.unicode.utfDecode(v)),
+        else => @compileError("invalid codepoint type"),
+    };
+}
 
 test {
     _ = Face;

--- a/src/font/test.zig
+++ b/src/font/test.zig
@@ -1,2 +1,3 @@
 pub const fontRegular = @embedFile("res/Inconsolata-Regular.ttf");
 pub const fontBold = @embedFile("res/Inconsolata-Bold.ttf");
+pub const fontEmoji = @embedFile("res/NotoColorEmoji.ttf");

--- a/src/opengl/Texture.zig
+++ b/src/opengl/Texture.zig
@@ -47,6 +47,7 @@ pub const Parameter = enum(c_uint) {
 /// Internal format enum for texture images.
 pub const InternalFormat = enum(c_int) {
     Red = c.GL_RED,
+    RGBA = c.GL_RGBA,
 
     // There are so many more that I haven't filled in.
     _,
@@ -55,6 +56,7 @@ pub const InternalFormat = enum(c_int) {
 /// Format for texture images
 pub const Format = enum(c_uint) {
     Red = c.GL_RED,
+    BGRA = c.GL_BGRA,
 
     // There are so many more that I haven't filled in.
     _,

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -71,6 +71,15 @@ pub const Cell = struct {
         /// should have this set. The first cell of the next row is actually
         /// part of this row in raw input.
         wrap: u1 = 0,
+
+        /// True if this is a wide character. This char takes up
+        /// two cells. The following cell ALWAYS is a space.
+        wide: u1 = 0,
+
+        /// Notes that this only exists to be blank for a preceeding
+        /// wide character (tail) or following (head).
+        wide_spacer_tail: u1 = 0,
+        wide_spacer_head: u1 = 0,
     } = .{},
 
     /// True if the cell should be skipped for drawing

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -25,8 +25,10 @@ const Screen = @This();
 // one day.
 
 const std = @import("std");
+const utf8proc = @import("utf8proc");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
+
 const color = @import("color.zig");
 const point = @import("point.zig");
 const Selection = @import("Selection.zig");
@@ -941,6 +943,10 @@ pub fn selectionString(self: Screen, alloc: Allocator, sel: Selection) ![:0]cons
             i += 1;
         }
 
+        // Skip spacers
+        if (cell.attrs.wide_spacer_head == 1 or
+            cell.attrs.wide_spacer_tail == 1) continue;
+
         const char = if (cell.char > 0) cell.char else ' ';
         i += try std.unicode.utf8Encode(@intCast(u21, char), buf[i..]);
     }
@@ -964,6 +970,10 @@ pub fn selectionString(self: Screen, alloc: Allocator, sel: Selection) ![:0]cons
             }
         }
 
+        // Skip spacers
+        if (cell.attrs.wide_spacer_head == 1 or
+            cell.attrs.wide_spacer_tail == 1) continue;
+
         const char = if (cell.char > 0) cell.char else ' ';
         i += try std.unicode.utf8Encode(@intCast(u21, char), buf[i..]);
     }
@@ -979,7 +989,7 @@ pub fn selectionString(self: Screen, alloc: Allocator, sel: Selection) ![:0]cons
 /// Returns the slices that make up the selection, in order. There are at most
 /// two parts to handle the ring buffer. If the selection fits in one contiguous
 /// slice, then the second slice will have a length of zero.
-fn selectionSlices(self: Screen, sel: Selection) struct {
+fn selectionSlices(self: Screen, sel_raw: Selection) struct {
     // Top offset can be used to determine if a newline is required by
     // seeing if the cell index plus the offset cleanly divides by screen cols.
     top_offset: usize,
@@ -988,10 +998,35 @@ fn selectionSlices(self: Screen, sel: Selection) struct {
 } {
     // Note: this function is tested via selectionString
 
-    assert(sel.start.y < self.totalRows());
-    assert(sel.end.y < self.totalRows());
-    assert(sel.start.x < self.cols);
-    assert(sel.end.x < self.cols);
+    assert(sel_raw.start.y < self.totalRows());
+    assert(sel_raw.end.y < self.totalRows());
+    assert(sel_raw.start.x < self.cols);
+    assert(sel_raw.end.x < self.cols);
+
+    const sel = sel: {
+        var sel = sel_raw;
+
+        // If the end of our selection is a wide char leader, include the
+        // first part of the next line.
+        if (sel.end.x == self.cols - 1) {
+            const row = self.getRow(.{ .screen = sel.end.y });
+            if (row[sel.end.x].attrs.wide_spacer_head == 1) {
+                sel.end.y += 1;
+                sel.end.x = 0;
+            }
+        }
+
+        // If the start of our selection is a wide char spacer, include the
+        // wide char.
+        if (sel.start.x > 0) {
+            const row = self.getRow(.{ .screen = sel.start.y });
+            if (row[sel.start.x].attrs.wide_spacer_tail == 1) {
+                sel.end.x -= 1;
+            }
+        }
+
+        break :sel sel;
+    };
 
     // Get the true "top" and "bottom"
     const sel_top = sel.topLeft();
@@ -1053,7 +1088,10 @@ pub fn testString(self: Screen, alloc: Allocator, tag: RowIndexTag) ![]const u8 
 fn testWriteString(self: *Screen, text: []const u8) void {
     var y: usize = 0;
     var x: usize = 0;
-    for (text) |c| {
+
+    const view = std.unicode.Utf8View.init(text) catch unreachable;
+    var iter = view.iterator();
+    while (iter.nextCodepoint()) |c| {
         // Explicit newline forces a new row
         if (c == '\n') {
             y += 1;
@@ -1082,7 +1120,39 @@ fn testWriteString(self: *Screen, text: []const u8) void {
             row = self.getRow(.{ .active = y });
         }
 
-        row[x].char = @intCast(u32, c);
+        // If our character is double-width, handle it.
+        const width = utf8proc.charwidth(c);
+        assert(width == 1 or width == 2);
+        switch (width) {
+            1 => row[x].char = @intCast(u32, c),
+
+            2 => {
+                if (x == self.cols - 1) {
+                    row[x].char = ' ';
+                    row[x].attrs.wide_spacer_head = 1;
+
+                    // wrap
+                    row[x].attrs.wrap = 1;
+                    y += 1;
+                    x = 0;
+                    if (y >= self.rows) {
+                        y -= 1;
+                        self.scroll(.{ .delta = 1 });
+                    }
+                    row = self.getRow(.{ .active = y });
+                }
+
+                row[x].char = @intCast(u32, c);
+                row[x].attrs.wide = 1;
+
+                x += 1;
+                row[x].char = ' ';
+                row[x].attrs.wide_spacer_tail = 1;
+            },
+
+            else => unreachable,
+        }
+
         x += 1;
     }
 }
@@ -1464,6 +1534,66 @@ test "Screen: selectionString wrap around" {
         });
         defer alloc.free(contents);
         const expected = "2EFGH\n3IJ";
+        try testing.expectEqualStrings(expected, contents);
+    }
+}
+
+test "Screen: selectionString wide char" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, 3, 5, 0);
+    defer s.deinit(alloc);
+    const str = "1A⚡";
+    s.testWriteString(str);
+
+    {
+        var contents = try s.selectionString(alloc, .{
+            .start = .{ .x = 0, .y = 0 },
+            .end = .{ .x = 3, .y = 0 },
+        });
+        defer alloc.free(contents);
+        const expected = str;
+        try testing.expectEqualStrings(expected, contents);
+    }
+
+    {
+        var contents = try s.selectionString(alloc, .{
+            .start = .{ .x = 0, .y = 0 },
+            .end = .{ .x = 2, .y = 0 },
+        });
+        defer alloc.free(contents);
+        const expected = str;
+        try testing.expectEqualStrings(expected, contents);
+    }
+
+    {
+        var contents = try s.selectionString(alloc, .{
+            .start = .{ .x = 3, .y = 0 },
+            .end = .{ .x = 3, .y = 0 },
+        });
+        defer alloc.free(contents);
+        const expected = "⚡";
+        try testing.expectEqualStrings(expected, contents);
+    }
+}
+
+test "Screen: selectionString wide char with header" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, 3, 5, 0);
+    defer s.deinit(alloc);
+    const str = "1ABC⚡";
+    s.testWriteString(str);
+
+    {
+        var contents = try s.selectionString(alloc, .{
+            .start = .{ .x = 0, .y = 0 },
+            .end = .{ .x = 4, .y = 0 },
+        });
+        defer alloc.free(contents);
+        const expected = str;
         try testing.expectEqualStrings(expected, contents);
     }
 }

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -6,9 +6,11 @@ const Terminal = @This();
 
 const std = @import("std");
 const builtin = @import("builtin");
+const utf8proc = @import("utf8proc");
 const testing = std.testing;
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
+
 const ansi = @import("ansi.zig");
 const csi = @import("csi.zig");
 const sgr = @import("sgr.zig");
@@ -341,22 +343,44 @@ pub fn print(self: *Terminal, c: u21) !void {
     // If we're not on the main display, do nothing for now
     if (self.status_display != .main) return;
 
+    // Determine the width of this character so we can handle
+    // non-single-width characters properly.
+    const width = utf8proc.charwidth(c);
+    assert(width == 1 or width == 2);
+
     // If we're soft-wrapping, then handle that first.
-    if (self.screen.cursor.pending_wrap and self.modes.autowrap == 1) {
-        // Mark that the cell is wrapped, which guarantees that there is
-        // at least one cell after it in the next row.
-        const cell = self.screen.getCell(self.screen.cursor.y, self.screen.cursor.x);
-        cell.attrs.wrap = 1;
+    if (self.screen.cursor.pending_wrap and self.modes.autowrap == 1)
+        _ = self.printWrap();
 
-        // Move to the next line
-        self.index();
-        self.screen.cursor.x = 0;
+    switch (width) {
+        // Single cell is very easy: just write in the cell
+        1 => _ = self.printCell(c),
+
+        // Wide character requires a spacer. We print this by
+        // using two cells: the first is flagged "wide" and has the
+        // wide char. The second is guaranteed to be a spacer if
+        // we're not at the end of the line.
+        2 => {
+            // If we don't have space for the wide char, we need
+            // to insert spacers and wrap. Then we just print the wide
+            // char as normal.
+            if (self.screen.cursor.x == self.cols - 1) {
+                const spacer_head = self.printCell(' ');
+                spacer_head.attrs.wide_spacer_head = 1;
+                _ = self.printWrap();
+            }
+
+            const wide_cell = self.printCell(c);
+            wide_cell.attrs.wide = 1;
+
+            // Write our spacer
+            self.screen.cursor.x += 1;
+            const spacer = self.printCell(' ');
+            spacer.attrs.wide_spacer_tail = 1;
+        },
+
+        else => unreachable,
     }
-
-    // Build our cell
-    const cell = self.screen.getCell(self.screen.cursor.y, self.screen.cursor.x);
-    cell.* = self.screen.cursor.pen;
-    cell.char = @intCast(u32, c);
 
     // Move the cursor
     self.screen.cursor.x += 1;
@@ -368,6 +392,71 @@ pub fn print(self: *Terminal, c: u21) !void {
         self.screen.cursor.x -= 1;
         self.screen.cursor.pending_wrap = true;
     }
+}
+
+fn printCell(self: *Terminal, c: u21) *Screen.Cell {
+    const cell = self.screen.getCell(
+        self.screen.cursor.y,
+        self.screen.cursor.x,
+    );
+
+    // If this cell is wide char then we need to clear it.
+    // We ignore wide spacer HEADS because we can just write
+    // single-width characters into that.
+    if (cell.attrs.wide == 1) {
+        const x = self.screen.cursor.x + 1;
+        assert(x < self.cols);
+
+        const spacer_cell = self.screen.getCell(self.screen.cursor.y, x);
+        assert(spacer_cell.attrs.wide_spacer_tail == 1);
+        spacer_cell.attrs.wide_spacer_tail = 0;
+
+        if (self.screen.cursor.x <= 1) {
+            self.clearWideSpacerHead();
+        }
+    } else if (cell.attrs.wide_spacer_tail == 1) {
+        assert(self.screen.cursor.x > 0);
+        const x = self.screen.cursor.x - 1;
+
+        const wide_cell = self.screen.getCell(self.screen.cursor.y, x);
+        assert(wide_cell.attrs.wide == 1);
+        wide_cell.attrs.wide = 0;
+
+        if (self.screen.cursor.x <= 1) {
+            self.clearWideSpacerHead();
+        }
+    }
+
+    // Write
+    cell.* = self.screen.cursor.pen;
+    cell.char = @intCast(u32, c);
+    return cell;
+}
+
+fn printWrap(self: *Terminal) *Screen.Cell {
+    // Mark that the cell is wrapped, which guarantees that there is
+    // at least one cell after it in the next row.
+    const cell = self.screen.getCell(
+        self.screen.cursor.y,
+        self.screen.cursor.x,
+    );
+    cell.attrs.wrap = 1;
+
+    // Move to the next line
+    self.index();
+    self.screen.cursor.x = 0;
+
+    return cell;
+}
+
+fn clearWideSpacerHead(self: *Terminal) void {
+    // TODO: handle deleting wide char on row 0 of active
+    assert(self.screen.cursor.y >= 1);
+    const cell = self.screen.getCell(
+        self.screen.cursor.y - 1,
+        self.cols - 1,
+    );
+    cell.attrs.wide_spacer_head = 0;
 }
 
 /// Resets all margins and fills the whole screen with the character 'E'

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -408,7 +408,6 @@ fn printCell(self: *Terminal, c: u21) *Screen.Cell {
         assert(x < self.cols);
 
         const spacer_cell = self.screen.getCell(self.screen.cursor.y, x);
-        assert(spacer_cell.attrs.wide_spacer_tail == 1);
         spacer_cell.attrs.wide_spacer_tail = 0;
 
         if (self.screen.cursor.x <= 1) {
@@ -419,7 +418,6 @@ fn printCell(self: *Terminal, c: u21) *Screen.Cell {
         const x = self.screen.cursor.x - 1;
 
         const wide_cell = self.screen.getCell(self.screen.cursor.y, x);
-        assert(wide_cell.attrs.wide == 1);
         wide_cell.attrs.wide = 0;
 
         if (self.screen.cursor.x <= 1) {

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -49,11 +49,11 @@ pub fn Stream(comptime Handler: type) type {
             //log.debug("char: {x}", .{c});
             const actions = self.parser.next(c);
             for (actions) |action_opt| {
-                if (action_opt) |action| {
-                    if (action != .print) {
-                        log.info("action: {}", .{action});
-                    }
-                }
+                // if (action_opt) |action| {
+                //     if (action != .print) {
+                //         log.info("action: {}", .{action});
+                //     }
+                // }
                 switch (action_opt orelse continue) {
                     .print => |p| if (@hasDecl(T, "print")) try self.handler.print(p),
                     .execute => |code| try self.execute(code),


### PR DESCRIPTION
Many changes to support emoji and wide chars:

- Freetype built with libpng support (some emoji font use pngs)
- Introduced `font.FallbackSet` structure for looking for glyphs in multiple fonts so we can find emojis
- Texture atlas supports 3 and 4 channel colors (RGB/RGBA, although emojis are in BGRA)
- `font.Face` supports loading colored fonts and glyphs
- `font.Face` supports fonts that do not support variable pixel sizes
- Shader supports two textures (greyscale and colored)
- Shader will downsample glyphs that don't fit into the cell size because some fixed size emoji fonts are large
- Shader supports wide (2x) cells across all types: cursor, fg, bg, underline
- Terminal state supports detecting and managing wide (2x) chars by looking them up in the Unicode EastAsianWidth database and populating "spacer" cells.
- Selection (and clipboard ops) support wide chars

https://user-images.githubusercontent.com/1299/185770527-ab05b235-1c76-460a-8333-f657db474a93.mp4


