### PR TITLE
Mouse Reporting

### DIFF
--- a/src/Window.zig
+++ b/src/Window.zig
@@ -907,6 +907,9 @@ fn mouseReport(
         },
 
         .sgr => {
+            // Final character to send in the CSI
+            const final: u8 = if (action == .release) 'm' else 'M';
+
             // Response always is at least 4 chars, so this leaves the
             // remainder for numbers which are very large...
             var buf: [32]u8 = undefined;
@@ -914,7 +917,7 @@ fn mouseReport(
                 button_code,
                 viewport_point.x + 1,
                 viewport_point.y + 1,
-                @as(u8, if (action == .release) 'm' else 'M'),
+                final,
             });
 
             try self.queueWrite(resp);
@@ -934,6 +937,9 @@ fn mouseReport(
         },
 
         .sgr_pixels => {
+            // Final character to send in the CSI
+            const final: u8 = if (action == .release) 'm' else 'M';
+
             // Response always is at least 4 chars, so this leaves the
             // remainder for numbers which are very large...
             var buf: [32]u8 = undefined;
@@ -941,7 +947,7 @@ fn mouseReport(
                 button_code,
                 pos.xpos,
                 pos.ypos,
-                @as(u8, if (action == .release) 'm' else 'M'),
+                final,
             });
 
             try self.queueWrite(resp);
@@ -1040,9 +1046,7 @@ fn cursorPosCallback(
     const win = window.getUserPointer(Window) orelse return;
 
     // Do a mouse report
-    if (win.terminal.modes.mouse_event == .button or
-        win.terminal.modes.mouse_event == .any)
-    {
+    if (win.terminal.modes.mouse_event != .none) {
         // We use the first mouse button we find pressed in order to report
         // since the spec (afaict) does not say...
         const button: ?input.MouseButton = button: for (win.mouse.click_state) |state, i| {

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -920,6 +920,19 @@ fn mouseReport(
             try self.queueWrite(resp);
         },
 
+        .urxvt => {
+            // Response always is at least 4 chars, so this leaves the
+            // remainder for numbers which are very large...
+            var buf: [32]u8 = undefined;
+            const resp = try std.fmt.bufPrint(&buf, "\x1B[{d};{d};{d}M", .{
+                32 + button_code,
+                viewport_point.x + 1,
+                viewport_point.y + 1,
+            });
+
+            try self.queueWrite(resp);
+        },
+
         else => @panic("TODO"),
     }
 }
@@ -1499,6 +1512,7 @@ pub fn setMode(self: *Window, mode: terminal.Mode, enabled: bool) !void {
 
         .mouse_format_utf8 => self.terminal.modes.mouse_format = if (enabled) .utf8 else .x10,
         .mouse_format_sgr => self.terminal.modes.mouse_format = if (enabled) .sgr else .x10,
+        .mouse_format_urxvt => self.terminal.modes.mouse_format = if (enabled) .urxvt else .x10,
 
         else => if (enabled) log.warn("unimplemented mode: {}", .{mode}),
     }

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -1069,7 +1069,7 @@ fn renderTimerCallback(t: *libuv.Timer) void {
         win.grid.background = bg;
         win.grid.foreground = fg;
     }
-    if (win.terminal.modes.reverse_colors == 1) {
+    if (win.terminal.modes.reverse_colors) {
         win.grid.background = fg;
         win.grid.foreground = bg;
     }
@@ -1080,7 +1080,7 @@ fn renderTimerCallback(t: *libuv.Timer) void {
         g: f32,
         b: f32,
         a: f32,
-    } = if (win.terminal.modes.reverse_colors == 1) .{
+    } = if (win.terminal.modes.reverse_colors) .{
         .r = @intToFloat(f32, fg.r) / 255,
         .g = @intToFloat(f32, fg.g) / 255,
         .b = @intToFloat(f32, fg.b) / 255,
@@ -1167,7 +1167,7 @@ pub fn setCursorCol(self: *Window, col: u16) !void {
 }
 
 pub fn setCursorRow(self: *Window, row: u16) !void {
-    if (self.terminal.modes.origin == 1) {
+    if (self.terminal.modes.origin) {
         // TODO
         log.err("setCursorRow: implement origin mode", .{});
         unreachable;
@@ -1234,19 +1234,19 @@ pub fn setTopAndBottomMargin(self: *Window, top: u16, bot: u16) !void {
 pub fn setMode(self: *Window, mode: terminal.Mode, enabled: bool) !void {
     switch (mode) {
         .reverse_colors => {
-            self.terminal.modes.reverse_colors = @boolToInt(enabled);
+            self.terminal.modes.reverse_colors = enabled;
 
             // Schedule a render since we changed colors
             try self.render_timer.schedule();
         },
 
         .origin => {
-            self.terminal.modes.origin = @boolToInt(enabled);
+            self.terminal.modes.origin = enabled;
             self.terminal.setCursorPos(1, 1);
         },
 
         .autowrap => {
-            self.terminal.modes.autowrap = @boolToInt(enabled);
+            self.terminal.modes.autowrap = enabled;
         },
 
         .cursor_visible => {
@@ -1323,7 +1323,7 @@ pub fn deviceStatusReport(
             const pos: struct {
                 x: usize,
                 y: usize,
-            } = if (self.terminal.modes.origin == 1) .{
+            } = if (self.terminal.modes.origin) .{
                 // TODO: what do we do if cursor is outside scrolling region?
                 .x = self.terminal.screen.cursor.x,
                 .y = self.terminal.screen.cursor.y -| self.terminal.scrolling_region.top,

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -933,7 +933,19 @@ fn mouseReport(
             try self.queueWrite(resp);
         },
 
-        else => @panic("TODO"),
+        .sgr_pixels => {
+            // Response always is at least 4 chars, so this leaves the
+            // remainder for numbers which are very large...
+            var buf: [32]u8 = undefined;
+            const resp = try std.fmt.bufPrint(&buf, "\x1B[<{d};{d};{d}{c}", .{
+                button_code,
+                pos.xpos,
+                pos.ypos,
+                @as(u8, if (action == .release) 'm' else 'M'),
+            });
+
+            try self.queueWrite(resp);
+        },
     }
 }
 
@@ -1513,6 +1525,7 @@ pub fn setMode(self: *Window, mode: terminal.Mode, enabled: bool) !void {
         .mouse_format_utf8 => self.terminal.modes.mouse_format = if (enabled) .utf8 else .x10,
         .mouse_format_sgr => self.terminal.modes.mouse_format = if (enabled) .sgr else .x10,
         .mouse_format_urxvt => self.terminal.modes.mouse_format = if (enabled) .urxvt else .x10,
+        .mouse_format_sgr_pixels => self.terminal.modes.mouse_format = if (enabled) .sgr_pixels else .x10,
 
         else => if (enabled) log.warn("unimplemented mode: {}", .{mode}),
     }

--- a/src/input.zig
+++ b/src/input.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 
+pub usingnamespace @import("input/mouse.zig");
 pub usingnamespace @import("input/key.zig");
 pub const Binding = @import("input/Binding.zig");
 

--- a/src/input/mouse.zig
+++ b/src/input/mouse.zig
@@ -1,0 +1,38 @@
+/// The state of a mouse button.
+pub const MouseButtonState = enum(u1) {
+    release = 0,
+    press = 1,
+};
+
+/// Possible mouse buttons. We only track up to 11 because thats the maximum
+/// button input that terminal mouse tracking handles without becoming
+/// ambiguous.
+///
+/// Its a bit silly to name numbers like this but given its a restricted
+/// set, it feels better than passing around raw numeric literals.
+pub const MouseButton = enum(u4) {
+    const Self = @This();
+
+    /// The maximum value in this enum. This can be used to create a densely
+    /// packed array, for example.
+    pub const max = max: {
+        var cur = 0;
+        for (@typeInfo(Self).Enum.fields) |field| {
+            if (field.value > cur) cur = field.value;
+        }
+
+        break :max cur;
+    };
+
+    left = 1,
+    right = 2,
+    middle = 3,
+    four = 4,
+    five = 5,
+    six = 6,
+    seven = 7,
+    eight = 8,
+    nine = 9,
+    ten = 10,
+    eleven = 11,
+};

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -68,13 +68,39 @@ modes: packed struct {
     deccolm: u1 = 0, // 3,
     deccolm_supported: u1 = 0, // 40
 
+    mouse_event: MouseEvents = .none,
+    mouse_format: MouseFormat = .x10,
+
     test {
         // We have this here so that we explicitly fail when we change the
         // size of modes. The size of modes is NOT particularly important,
         // we just want to be mentally aware when it happens.
-        try std.testing.expectEqual(1, @sizeOf(Self));
+        try std.testing.expectEqual(2, @sizeOf(Self));
     }
 } = .{},
+
+/// The event types that can be reported for mouse-related activities.
+/// These are all mutually exclusive (hence in a single enum).
+pub const MouseEvents = enum(u3) {
+    none = 0,
+
+    // TODO:
+    x10 = 1, // 9
+    normal = 2, // 1000
+    button = 3, // 1002
+    any = 4, // 1003
+};
+
+/// The format of mouse events when enabled.
+/// These are all mutually exclusive (hence in a single enum).
+pub const MouseFormat = enum(u3) {
+    // TODO:
+    x10 = 0,
+    utf8 = 1, // 1005
+    sgr = 2, // 1006
+    urxvt = 3, // 1015
+    sgr_pixels = 4, // 1016
+};
 
 /// Scrolling region is the area of the screen designated where scrolling
 /// occurs. Wen scrolling the screen, only this viewport is scrolled.

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -96,8 +96,6 @@ pub const MouseFormat = enum(u3) {
     utf8 = 1, // 1005
     sgr = 2, // 1006
     urxvt = 3, // 1015
-
-    // TODO:
     sgr_pixels = 4, // 1016
 };
 

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -85,9 +85,9 @@ pub const MouseEvents = enum(u3) {
     none = 0,
     x10 = 1, // 9
     normal = 2, // 1000
+    button = 3, // 1002
 
     // TODO:
-    button = 3, // 1002
     any = 4, // 1003
 };
 

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -93,9 +93,9 @@ pub const MouseEvents = enum(u3) {
 /// These are all mutually exclusive (hence in a single enum).
 pub const MouseFormat = enum(u3) {
     x10 = 0,
+    utf8 = 1, // 1005
 
     // TODO:
-    utf8 = 1, // 1005
     sgr = 2, // 1006
     urxvt = 3, // 1015
     sgr_pixels = 4, // 1016

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -95,9 +95,9 @@ pub const MouseFormat = enum(u3) {
     x10 = 0,
     utf8 = 1, // 1005
     sgr = 2, // 1006
+    urxvt = 3, // 1015
 
     // TODO:
-    urxvt = 3, // 1015
     sgr_pixels = 4, // 1016
 };
 

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -83,10 +83,10 @@ modes: packed struct {
 /// These are all mutually exclusive (hence in a single enum).
 pub const MouseEvents = enum(u3) {
     none = 0,
-
-    // TODO:
     x10 = 1, // 9
     normal = 2, // 1000
+
+    // TODO:
     button = 3, // 1002
     any = 4, // 1003
 };
@@ -94,8 +94,9 @@ pub const MouseEvents = enum(u3) {
 /// The format of mouse events when enabled.
 /// These are all mutually exclusive (hence in a single enum).
 pub const MouseFormat = enum(u3) {
-    // TODO:
     x10 = 0,
+
+    // TODO:
     utf8 = 1, // 1005
     sgr = 2, // 1006
     urxvt = 3, // 1015

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -94,9 +94,9 @@ pub const MouseEvents = enum(u3) {
 pub const MouseFormat = enum(u3) {
     x10 = 0,
     utf8 = 1, // 1005
+    sgr = 2, // 1006
 
     // TODO:
-    sgr = 2, // 1006
     urxvt = 3, // 1015
     sgr_pixels = 4, // 1016
 };

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -86,8 +86,6 @@ pub const MouseEvents = enum(u3) {
     x10 = 1, // 9
     normal = 2, // 1000
     button = 3, // 1002
-
-    // TODO:
     any = 4, // 1003
 };
 

--- a/src/terminal/ansi.zig
+++ b/src/terminal/ansi.zig
@@ -76,6 +76,10 @@ pub const Mode = enum(u16) {
     /// while the button is pressed when the cell in the grid changes.
     mouse_event_button = 1002,
 
+    /// Same as button mode but doesn't require a button to be pressed
+    /// to track mouse movement.
+    mouse_event_any = 1003,
+
     /// Alternate screen mode with save cursor and clear on enter.
     alt_screen_save_cursor_clear_enter = 1049,
 

--- a/src/terminal/ansi.zig
+++ b/src/terminal/ansi.zig
@@ -83,6 +83,9 @@ pub const Mode = enum(u16) {
     /// Report mouse position in the utf8 format to support larger screens.
     mouse_format_utf8 = 1005,
 
+    /// Report mouse position in the SGR format.
+    mouse_format_sgr = 1006,
+
     /// Alternate screen mode with save cursor and clear on enter.
     alt_screen_save_cursor_clear_enter = 1049,
 

--- a/src/terminal/ansi.zig
+++ b/src/terminal/ansi.zig
@@ -89,6 +89,9 @@ pub const Mode = enum(u16) {
     /// Report mouse position in the urxvt format.
     mouse_format_urxvt = 1015,
 
+    /// Report mouse position in the SGR format as pixels, instead of cells.
+    mouse_format_sgr_pixels = 1016,
+
     /// Alternate screen mode with save cursor and clear on enter.
     alt_screen_save_cursor_clear_enter = 1049,
 

--- a/src/terminal/ansi.zig
+++ b/src/terminal/ansi.zig
@@ -80,6 +80,9 @@ pub const Mode = enum(u16) {
     /// to track mouse movement.
     mouse_event_any = 1003,
 
+    /// Report mouse position in the utf8 format to support larger screens.
+    mouse_format_utf8 = 1005,
+
     /// Alternate screen mode with save cursor and clear on enter.
     alt_screen_save_cursor_clear_enter = 1049,
 

--- a/src/terminal/ansi.zig
+++ b/src/terminal/ansi.zig
@@ -58,6 +58,9 @@ pub const Mode = enum(u16) {
     /// Enable or disable automatic line wrapping.
     autowrap = 7,
 
+    /// Click-only (press) mouse reporting.
+    mouse_event_x10 = 9,
+
     /// Set whether the cursor is visible or not.
     cursor_visible = 25,
 

--- a/src/terminal/ansi.zig
+++ b/src/terminal/ansi.zig
@@ -86,6 +86,9 @@ pub const Mode = enum(u16) {
     /// Report mouse position in the SGR format.
     mouse_format_sgr = 1006,
 
+    /// Report mouse position in the urxvt format.
+    mouse_format_urxvt = 1015,
+
     /// Alternate screen mode with save cursor and clear on enter.
     alt_screen_save_cursor_clear_enter = 1049,
 

--- a/src/terminal/ansi.zig
+++ b/src/terminal/ansi.zig
@@ -72,6 +72,10 @@ pub const Mode = enum(u16) {
     /// "Normal" mouse events: click/release, scroll
     mouse_event_normal = 1000,
 
+    /// Same as normal mode but also send events for mouse motion
+    /// while the button is pressed when the cell in the grid changes.
+    mouse_event_button = 1002,
+
     /// Alternate screen mode with save cursor and clear on enter.
     alt_screen_save_cursor_clear_enter = 1049,
 

--- a/src/terminal/ansi.zig
+++ b/src/terminal/ansi.zig
@@ -69,6 +69,9 @@ pub const Mode = enum(u16) {
     /// mode ?3 is set or unset.
     enable_mode_3 = 40,
 
+    /// "Normal" mouse events: click/release, scroll
+    mouse_event_normal = 1000,
+
     /// Alternate screen mode with save cursor and clear on enter.
     alt_screen_save_cursor_clear_enter = 1049,
 


### PR DESCRIPTION
Implements all known formats and event types for mouse reporting. This makes vim, htop, etc. handle mouse events!

Mouse formats:

  * X10
  * UTF-8
  * SGR
  * urxvt
  * SGR Pixels

Event types:

  * X10
  * "Normal" - mouse button press/release, including scroll wheel
  * "Button" - "Normal" + mouse motion events while a button is pressed
  * "Any" - "Normal" + mouse motion events at anytime (even if a button is not pressed)

See: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-Mouse-Tracking