### PR TITLE
Graphemes and ZWJs

### DIFF
--- a/src/Window.zig
+++ b/src/Window.zig
@@ -1499,7 +1499,7 @@ pub fn eraseChars(self: *Window, count: usize) !void {
 }
 
 pub fn insertLines(self: *Window, count: usize) !void {
-    self.terminal.insertLines(count);
+    try self.terminal.insertLines(count);
 }
 
 pub fn insertBlanks(self: *Window, count: usize) !void {
@@ -1507,7 +1507,7 @@ pub fn insertBlanks(self: *Window, count: usize) !void {
 }
 
 pub fn deleteLines(self: *Window, count: usize) !void {
-    self.terminal.deleteLines(count);
+    try self.terminal.deleteLines(count);
 }
 
 pub fn reverseIndex(self: *Window) !void {
@@ -1663,7 +1663,7 @@ pub fn setCursorStyle(
 }
 
 pub fn decaln(self: *Window) !void {
-    self.terminal.decaln();
+    try self.terminal.decaln();
 }
 
 pub fn tabClear(self: *Window, cmd: terminal.TabClear) !void {
@@ -1687,11 +1687,11 @@ pub fn enquiry(self: *Window) !void {
 }
 
 pub fn scrollDown(self: *Window, count: usize) !void {
-    self.terminal.scrollDown(count);
+    try self.terminal.scrollDown(count);
 }
 
 pub fn scrollUp(self: *Window, count: usize) !void {
-    self.terminal.scrollUp(count);
+    try self.terminal.scrollUp(count);
 }
 
 pub fn setActiveStatusDisplay(

--- a/src/font/Shaper.zig
+++ b/src/font/Shaper.zig
@@ -107,6 +107,15 @@ pub const RunIterator = struct {
 
             // Continue with our run
             self.shaper.hb_buf.add(cell.char, @intCast(u32, j));
+
+            // If this cell is part of a grapheme cluster, add all the grapheme
+            // data points.
+            if (cell.attrs.grapheme) {
+                var it = self.row.codepointIterator(j);
+                while (it.next()) |cp| {
+                    self.shaper.hb_buf.add(cp, @intCast(u32, j));
+                }
+            }
         }
 
         // Finalize our buffer

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1497,6 +1497,7 @@ pub fn testWriteString(self: *Screen, text: []const u8) !void {
         // Get our row
         var row = self.getRow(.{ .active = y });
 
+        // If we have a previous cell, we check if we're part of a grapheme.
         if (grapheme.cell) |prev_cell| {
             const grapheme_break = brk: {
                 var state: i32 = 0;

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -455,7 +455,12 @@ pub fn print(self: *Terminal, c: u21) !void {
     // extremely fast and we take this much slower path for graphemes. No hate
     // on graphemes, I'd love to make them much faster, but I wanted to focus
     // on correctness first.
-    if (c > 255 and self.screen.cursor.x > 0) {
+    //
+    // NOTE: This is disabled because no shells handle this correctly. We'll
+    // need to work with shells and other emulators to probably figure out
+    // a way to support this. In the mean time, I'm going to keep all the
+    // grapheme detection and keep it up to date so we're ready to go.
+    if (false and c > 255 and self.screen.cursor.x > 0) {
         // TODO: test this!
 
         const row = self.screen.getRow(.{ .active = self.screen.cursor.y });

--- a/src/terminal/color.zig
+++ b/src/terminal/color.zig
@@ -95,9 +95,9 @@ pub const Name = enum(u8) {
 
 /// RGB
 pub const RGB = packed struct {
-    r: u8,
-    g: u8,
-    b: u8,
+    r: u8 = 0,
+    g: u8 = 0,
+    b: u8 = 0,
 
     test {
         try std.testing.expectEqual(@as(usize, 3), @sizeOf(RGB));

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -51,9 +51,7 @@ pub fn Stream(comptime Handler: type) type {
             const actions = self.parser.next(c);
             for (actions) |action_opt| {
                 // if (action_opt) |action| {
-                //     if (action != .print) {
-                //         log.info("action: {}", .{action});
-                //     }
+                //     log.info("action: {}", .{action});
                 // }
                 switch (action_opt orelse continue) {
                     .print => |p| if (@hasDecl(T, "print")) try self.handler.print(p),


### PR DESCRIPTION
This makes our terminal completely grapheme-aware. Unfortunately, ZERO client applications (shells) handle this correctly. Rather than throw away the work, I plan to continue to maintain it in the hope that one day we can fix the protocol to make it all work correctly.

Meanwhile, grapheme cluster segmentation is disabled and there is no performance cost to it existing.

The one useful bit is that regardless of the above, I now collect ZWJs (zero-width joiners) properly which should result in correct text shaping once we merge that in.