### PR TITLE
Font discovery on Linux via fontconfig

### DIFF
--- a/pkg/freetype/Library.zig
+++ b/pkg/freetype/Library.zig
@@ -32,6 +32,18 @@ pub fn version(self: Library) Version {
     return v;
 }
 
+/// Call FT_New_Face to open a font from a file.
+pub fn initFace(self: Library, path: [:0]const u8, index: i32) Error!Face {
+    var face: Face = undefined;
+    try intToError(c.FT_New_Face(
+        self.handle,
+        path.ptr,
+        index,
+        &face.handle,
+    ));
+    return face;
+}
+
 /// Call FT_Open_Face to open a font that has been loaded into memory.
 pub fn initMemoryFace(self: Library, data: []const u8, index: i32) Error!Face {
     var face: Face = undefined;

--- a/pkg/freetype/build.zig
+++ b/pkg/freetype/build.zig
@@ -89,7 +89,7 @@ pub fn buildFreetype(
         "-DHAVE_UNISTD_H",
         "-DHAVE_FCNTL_H",
 
-        //"-fno-sanitize=undefined",
+        "-fno-sanitize=undefined",
     });
     if (opt.libpng.enabled) try flags.append("-DFT_CONFIG_OPTION_USE_PNG=1");
     if (opt.zlib.enabled) try flags.append("-DFT_CONFIG_OPTION_SYSTEM_ZLIB=1");

--- a/src/Grid.zig
+++ b/src/Grid.zig
@@ -160,10 +160,36 @@ pub fn init(
     var font_lib = try font.Library.init();
     errdefer font_lib.deinit();
     var font_group = try font.GroupCache.init(alloc, group: {
-        var group = try font.Group.init(alloc, font_lib);
+        var group = try font.Group.init(alloc, font_lib, font_size);
         errdefer group.deinit(alloc);
 
-        // Our regular font
+        // Search for fonts
+        {
+            var disco = font.Discover.init();
+            defer disco.deinit();
+
+            {
+                var disco_it = try disco.discover(.{
+                    .family = "Fira Code",
+                    .size = font_size.points,
+                });
+                defer disco_it.deinit();
+                if (try disco_it.next()) |face|
+                    try group.addFace(alloc, .regular, face);
+            }
+            {
+                var disco_it = try disco.discover(.{
+                    .family = "Fira Code",
+                    .size = font_size.points,
+                    .bold = true,
+                });
+                defer disco_it.deinit();
+                if (try disco_it.next()) |face|
+                    try group.addFace(alloc, .bold, face);
+            }
+        }
+
+        // Our built-in font will be used as a backup
         try group.addFace(
             alloc,
             .regular,

--- a/src/Grid.zig
+++ b/src/Grid.zig
@@ -164,7 +164,7 @@ pub fn init(
         errdefer group.deinit(alloc);
 
         // Search for fonts
-        {
+        if (font.Discover != void) {
             var disco = font.Discover.init();
             defer disco.deinit();
 

--- a/src/Grid.zig
+++ b/src/Grid.zig
@@ -167,24 +167,24 @@ pub fn init(
         try group.addFace(
             alloc,
             .regular,
-            try font.Face.init(font_lib, face_ttf, font_size),
+            font.DeferredFace.initLoaded(try font.Face.init(font_lib, face_ttf, font_size)),
         );
         try group.addFace(
             alloc,
             .bold,
-            try font.Face.init(font_lib, face_bold_ttf, font_size),
+            font.DeferredFace.initLoaded(try font.Face.init(font_lib, face_bold_ttf, font_size)),
         );
 
         // Emoji
         try group.addFace(
             alloc,
             .regular,
-            try font.Face.init(font_lib, face_emoji_ttf, font_size),
+            font.DeferredFace.initLoaded(try font.Face.init(font_lib, face_emoji_ttf, font_size)),
         );
         try group.addFace(
             alloc,
             .regular,
-            try font.Face.init(font_lib, face_emoji_text_ttf, font_size),
+            font.DeferredFace.initLoaded(try font.Face.init(font_lib, face_emoji_text_ttf, font_size)),
         );
 
         break :group group;

--- a/src/Grid.zig
+++ b/src/Grid.zig
@@ -174,8 +174,10 @@ pub fn init(
                     .size = font_size.points,
                 });
                 defer disco_it.deinit();
-                if (try disco_it.next()) |face|
+                if (try disco_it.next()) |face| {
+                    log.debug("font regular: {s}", .{try face.name()});
                     try group.addFace(alloc, .regular, face);
+                }
             }
             {
                 var disco_it = try disco.discover(.{
@@ -184,8 +186,35 @@ pub fn init(
                     .bold = true,
                 });
                 defer disco_it.deinit();
-                if (try disco_it.next()) |face|
+                if (try disco_it.next()) |face| {
+                    log.debug("font bold: {s}", .{try face.name()});
                     try group.addFace(alloc, .bold, face);
+                }
+            }
+            {
+                var disco_it = try disco.discover(.{
+                    .family = "Fira Code",
+                    .size = font_size.points,
+                    .italic = true,
+                });
+                defer disco_it.deinit();
+                if (try disco_it.next()) |face| {
+                    log.debug("font italic: {s}", .{try face.name()});
+                    try group.addFace(alloc, .italic, face);
+                }
+            }
+            {
+                var disco_it = try disco.discover(.{
+                    .family = "Fira Code",
+                    .size = font_size.points,
+                    .bold = true,
+                    .italic = true,
+                });
+                defer disco_it.deinit();
+                if (try disco_it.next()) |face| {
+                    log.debug("font bold+italic: {s}", .{try face.name()});
+                    try group.addFace(alloc, .bold_italic, face);
+                }
             }
         }
 

--- a/src/Grid.zig
+++ b/src/Grid.zig
@@ -160,7 +160,7 @@ pub fn init(
     var font_lib = try font.Library.init();
     errdefer font_lib.deinit();
     var font_group = try font.GroupCache.init(alloc, group: {
-        var group = try font.Group.init(alloc);
+        var group = try font.Group.init(alloc, font_lib);
         errdefer group.deinit(alloc);
 
         // Our regular font
@@ -610,7 +610,7 @@ pub fn updateCell(
     // If the cell has a character, draw it
     if (cell.char > 0) {
         // Render
-        const face = self.font_group.group.faceFromIndex(shaper_run.font_index);
+        const face = try self.font_group.group.faceFromIndex(shaper_run.font_index);
         const glyph = try self.font_group.renderGlyph(
             self.alloc,
             shaper_run.font_index,

--- a/src/cli_args.zig
+++ b/src/cli_args.zig
@@ -110,15 +110,20 @@ fn parseIntoField(
 
             // No parseCLI, magic the value based on the type
             @field(dst, field.name) = switch (Field) {
-                []const u8 => if (value) |slice| value: {
+                []const u8 => value: {
+                    const slice = value orelse return error.ValueRequired;
                     const buf = try alloc.alloc(u8, slice.len);
                     mem.copy(u8, buf, slice);
                     break :value buf;
-                } else return error.ValueRequired,
+                },
 
                 bool => try parseBool(value orelse "t"),
 
-                u8 => try std.fmt.parseInt(u8, value orelse return error.ValueRequired, 0),
+                u8 => try std.fmt.parseInt(
+                    u8,
+                    value orelse return error.ValueRequired,
+                    0,
+                ),
 
                 else => unreachable,
             };

--- a/src/config.zig
+++ b/src/config.zig
@@ -6,6 +6,12 @@ const inputpkg = @import("input.zig");
 /// Config is the main config struct. These fields map directly to the
 /// CLI flag names hence we use a lot of `@""` syntax to support hyphens.
 pub const Config = struct {
+    /// The font families to use.
+    @"font-family": ?[]const u8 = null,
+    @"font-family-bold": ?[]const u8 = null,
+    @"font-family-italic": ?[]const u8 = null,
+    @"font-family-bold-italic": ?[]const u8 = null,
+
     /// Font size in points
     @"font-size": u8 = 12,
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -7,10 +7,10 @@ const inputpkg = @import("input.zig");
 /// CLI flag names hence we use a lot of `@""` syntax to support hyphens.
 pub const Config = struct {
     /// The font families to use.
-    @"font-family": ?[]const u8 = null,
-    @"font-family-bold": ?[]const u8 = null,
-    @"font-family-italic": ?[]const u8 = null,
-    @"font-family-bold-italic": ?[]const u8 = null,
+    @"font-family": ?[:0]const u8 = null,
+    @"font-family-bold": ?[:0]const u8 = null,
+    @"font-family-italic": ?[:0]const u8 = null,
+    @"font-family-bold-italic": ?[:0]const u8 = null,
 
     /// Font size in points
     @"font-size": u8 = 12,
@@ -121,6 +121,25 @@ pub const Config = struct {
         try result.keybind.set.put(alloc, .{ .key = .f12 }, .{ .csi = "24~" });
 
         return result;
+    }
+
+    pub fn finalize(self: *Config) !void {
+        // If we have a font-family set and don't set the others, default
+        // the others to the font family. This way, if someone does
+        // --font-family=foo, then we try to get the stylized versions of
+        // "foo" as well.
+        if (self.@"font-family") |family| {
+            const fields = &[_][]const u8{
+                "font-family-bold",
+                "font-family-italic",
+                "font-family-bold-italic",
+            };
+            inline for (fields) |field| {
+                if (@field(self, field) == null) {
+                    @field(self, field) = family;
+                }
+            }
+        }
     }
 };
 

--- a/src/font/DeferredFace.zig
+++ b/src/font/DeferredFace.zig
@@ -61,6 +61,31 @@ pub inline fn loaded(self: DeferredFace) bool {
     return self.face != null;
 }
 
+pub fn load(self: *DeferredFace) !void {
+    // No-op if we already loaded
+    if (self.face != null) return;
+
+    if (options.fontconfig) {
+        try self.loadFontconfig();
+        return;
+    }
+
+    unreachable;
+}
+
+fn loadFontconfig(self: *DeferredFace) !void {
+    assert(self.face == null);
+    const fc = self.fc.?;
+
+    // Filename and index for our face so we can load it
+    const filename = (try fc.pattern.get(.file, 0)).string;
+    const face_index = (try fc.pattern.get(.index, 0)).integer;
+
+    self.face = try Face.initFile(filename, face_index, .{
+        .points = fc.req_size,
+    });
+}
+
 /// Returns true if this face can satisfy the given codepoint and
 /// presentation. If presentation is null, then it just checks if the
 /// codepoint is present at all.

--- a/src/font/DeferredFace.zig
+++ b/src/font/DeferredFace.zig
@@ -1,0 +1,37 @@
+//! A deferred face represents a single font face with all the information
+//! necessary to load it, but defers loading the full face until it is
+//! needed.
+//!
+//! This allows us to have many fallback fonts to look for glyphs, but
+//! only load them if they're really needed.
+const DeferredFace = @This();
+
+const std = @import("std");
+const assert = std.debug.assert;
+const fontconfig = @import("fontconfig");
+const options = @import("main.zig").options;
+const Face = @import("main.zig").Face;
+
+/// The loaded face (once loaded).
+face: ?Face = null,
+
+/// Fontconfig
+fc: if (options.fontconfig) Fontconfig else void = undefined,
+
+/// Fontconfig specific data. This is only present if building with fontconfig.
+pub const Fontconfig = struct {
+    pattern: *fontconfig.Pattern,
+    charset: *fontconfig.CharSet,
+    langset: *fontconfig.LangSet,
+};
+
+pub fn deinit(self: *DeferredFace) void {
+    if (self.face) |*face| face.deinit();
+
+    self.* = undefined;
+}
+
+/// Returns true if the face has been loaded.
+pub inline fn loaded(self: DeferredFace) bool {
+    return self.face != null;
+}

--- a/src/font/DeferredFace.zig
+++ b/src/font/DeferredFace.zig
@@ -23,9 +23,20 @@ fc: if (options.fontconfig) ?Fontconfig else void = if (options.fontconfig) null
 
 /// Fontconfig specific data. This is only present if building with fontconfig.
 pub const Fontconfig = struct {
+    /// The pattern for this font. This must be the "render prepared" pattern.
+    /// (i.e. call FcFontRenderPrepare).
     pattern: *fontconfig.Pattern,
+
+    /// Charset and Langset are used for quick lookup if a codepoint and
+    /// presentation style are supported. They can be derived from pattern
+    /// but are cached since they're frequently used.
     charset: *const fontconfig.CharSet,
     langset: *const fontconfig.LangSet,
+
+    /// The requested size in points for this font. This is used for loading.
+    /// This can't be derived from pattern because the requested size may
+    /// differ from the size the font advertises supported.
+    req_size: u16,
 
     pub fn deinit(self: *Fontconfig) void {
         self.pattern.destroy();

--- a/src/font/DeferredFace.zig
+++ b/src/font/DeferredFace.zig
@@ -11,6 +11,7 @@ const assert = std.debug.assert;
 const fontconfig = @import("fontconfig");
 const options = @import("main.zig").options;
 const Face = @import("main.zig").Face;
+const Presentation = @import("main.zig").Presentation;
 
 /// The loaded face (once loaded).
 face: ?Face = null,
@@ -34,4 +35,43 @@ pub fn deinit(self: *DeferredFace) void {
 /// Returns true if the face has been loaded.
 pub inline fn loaded(self: DeferredFace) bool {
     return self.face != null;
+}
+
+/// Returns true if this face can satisfy the given codepoint and
+/// presentation. If presentation is null, then it just checks if the
+/// codepoint is present at all.
+///
+/// This should not require the face to be loaded IF we're using a
+/// discovery mechanism (i.e. fontconfig). If no discovery is used,
+/// the face is always expected to be loaded.
+pub fn hasCodepoint(self: DeferredFace, cp: u32, p: ?Presentation) bool {
+    // If we have the face, use the face.
+    if (self.face) |face| {
+        if (p) |desired| if (face.presentation != desired) return false;
+        return face.glyphIndex(cp) != null;
+    }
+
+    // If we are using fontconfig, use the fontconfig metadata to
+    // avoid loading the face.
+    if (options.fontconfig) {
+        // Check if char exists
+        if (!self.fc.charset.hasChar(cp)) return false;
+
+        // If we have a presentation, check it matches
+        if (p) |desired| {
+            const emoji_lang = "und-zsye";
+            const actual: Presentation = if (self.fc.langset.hasLang(emoji_lang))
+                .emoji
+            else
+                .text;
+
+            return desired == actual;
+        }
+
+        return true;
+    }
+
+    // This is unreachable because discovery mechanisms terminate, and
+    // if we're not using a discovery mechanism, the face MUST be loaded.
+    unreachable;
 }

--- a/src/font/Face.zig
+++ b/src/font/Face.zig
@@ -51,6 +51,23 @@ pub const DesiredSize = struct {
 };
 
 /// Initialize a new font face with the given source in-memory.
+pub fn initFile(lib: Library, path: [:0]const u8, index: i32, size: DesiredSize) !Face {
+    const face = try lib.lib.initFace(path, index);
+    errdefer face.deinit();
+    try face.selectCharmap(.unicode);
+    try setSize_(face, size);
+
+    const hb_font = try harfbuzz.freetype.createFont(face.handle);
+    errdefer hb_font.destroy();
+
+    return Face{
+        .face = face,
+        .hb_font = hb_font,
+        .presentation = if (face.hasColor()) .emoji else .text,
+    };
+}
+
+/// Initialize a new font face with the given source in-memory.
 pub fn init(lib: Library, source: [:0]const u8, size: DesiredSize) !Face {
     const face = try lib.lib.initMemoryFace(source, 0);
     errdefer face.deinit();

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -58,8 +58,8 @@ pub fn deinit(self: *Group, alloc: Allocator) void {
 ///
 /// The group takes ownership of the face. The face will be deallocated when
 /// the group is deallocated.
-pub fn addFace(self: *Group, alloc: Allocator, style: Style, face: Face) !void {
-    try self.faces.getPtr(style).append(alloc, .{ .face = face });
+pub fn addFace(self: *Group, alloc: Allocator, style: Style, face: DeferredFace) !void {
+    try self.faces.getPtr(style).append(alloc, face);
 }
 
 /// This represents a specific font in the group.
@@ -169,9 +169,9 @@ test {
     var group = try init(alloc);
     defer group.deinit(alloc);
 
-    try group.addFace(alloc, .regular, try Face.init(lib, testFont, .{ .points = 12 }));
-    try group.addFace(alloc, .regular, try Face.init(lib, testEmoji, .{ .points = 12 }));
-    try group.addFace(alloc, .regular, try Face.init(lib, testEmojiText, .{ .points = 12 }));
+    try group.addFace(alloc, .regular, DeferredFace.initLoaded(try Face.init(lib, testFont, .{ .points = 12 })));
+    try group.addFace(alloc, .regular, DeferredFace.initLoaded(try Face.init(lib, testEmoji, .{ .points = 12 })));
+    try group.addFace(alloc, .regular, DeferredFace.initLoaded(try Face.init(lib, testEmojiText, .{ .points = 12 })));
 
     // Should find all visible ASCII
     var i: u32 = 32;

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -112,13 +112,7 @@ pub fn indexForCodepoint(
 
 fn indexForCodepointExact(self: Group, cp: u32, style: Style, p: ?Presentation) ?FontIndex {
     for (self.faces.get(style).items) |deferred, i| {
-        const face = deferred.face.?;
-
-        // If the presentation is null, we allow the first presentation we
-        // can find. Otherwise, we check for the specific one requested.
-        if (p != null and face.presentation != p.?) continue;
-
-        if (face.glyphIndex(cp) != null) {
+        if (deferred.hasCodepoint(cp, p)) {
             return FontIndex{
                 .style = style,
                 .idx = @intCast(FontIndex.IndexInt, i),

--- a/src/font/GroupCache.zig
+++ b/src/font/GroupCache.zig
@@ -7,6 +7,7 @@ const Allocator = std.mem.Allocator;
 
 const Atlas = @import("../Atlas.zig");
 const Face = @import("main.zig").Face;
+const DeferredFace = @import("main.zig").DeferredFace;
 const Library = @import("main.zig").Library;
 const Glyph = @import("main.zig").Glyph;
 const Style = @import("main.zig").Style;
@@ -221,7 +222,11 @@ test {
     defer cache.deinit(alloc);
 
     // Setup group
-    try cache.group.addFace(alloc, .regular, try Face.init(lib, testFont, .{ .points = 12 }));
+    try cache.group.addFace(
+        alloc,
+        .regular,
+        DeferredFace.initLoaded(try Face.init(lib, testFont, .{ .points = 12 })),
+    );
     const group = cache.group;
 
     // Visible ASCII. Do it twice to verify cache.

--- a/src/font/GroupCache.zig
+++ b/src/font/GroupCache.zig
@@ -218,7 +218,11 @@ test {
     var lib = try Library.init();
     defer lib.deinit();
 
-    var cache = try init(alloc, try Group.init(alloc, lib));
+    var cache = try init(alloc, try Group.init(
+        alloc,
+        lib,
+        .{ .points = 12 },
+    ));
     defer cache.deinit(alloc);
 
     // Setup group

--- a/src/font/GroupCache.zig
+++ b/src/font/GroupCache.zig
@@ -129,7 +129,7 @@ pub fn metrics(self: *GroupCache, alloc: Allocator) !Metrics {
     };
 
     const cell_baseline = cell_baseline: {
-        const face = self.group.faces.get(.regular).items[0];
+        const face = self.group.faces.get(.regular).items[0].face.?;
         break :cell_baseline cell_height - @intToFloat(
             f32,
             face.unitsToPxY(face.face.handle.*.ascender),

--- a/src/font/GroupCache.zig
+++ b/src/font/GroupCache.zig
@@ -94,7 +94,7 @@ pub fn metrics(self: *GroupCache, alloc: Allocator) !Metrics {
         var i: u32 = 32;
         while (i <= 126) : (i += 1) {
             const index = (try self.indexForCodepoint(alloc, i, .regular, .text)).?;
-            const face = self.group.faceFromIndex(index);
+            const face = try self.group.faceFromIndex(index);
             const glyph_index = face.glyphIndex(i).?;
             const glyph = try self.renderGlyph(alloc, index, glyph_index);
             if (glyph.advance_x > cell_width) {
@@ -110,7 +110,7 @@ pub fn metrics(self: *GroupCache, alloc: Allocator) !Metrics {
     const cell_height: f32 = cell_height: {
         // Get the '_' char for height
         const index = (try self.indexForCodepoint(alloc, '_', .regular, .text)).?;
-        const face = self.group.faceFromIndex(index);
+        const face = try self.group.faceFromIndex(index);
         const glyph_index = face.glyphIndex('_').?;
         const glyph = try self.renderGlyph(alloc, index, glyph_index);
 
@@ -179,7 +179,7 @@ pub fn renderGlyph(
     if (gop.found_existing) return gop.value_ptr.*;
 
     // Uncached, render it
-    const face = self.group.faceFromIndex(index);
+    const face = try self.group.faceFromIndex(index);
     const atlas: *Atlas = if (face.hasColor()) &self.atlas_color else &self.atlas_greyscale;
     const glyph = self.group.renderGlyph(
         alloc,
@@ -218,7 +218,7 @@ test {
     var lib = try Library.init();
     defer lib.deinit();
 
-    var cache = try init(alloc, try Group.init(alloc));
+    var cache = try init(alloc, try Group.init(alloc, lib));
     defer cache.deinit(alloc);
 
     // Setup group
@@ -237,7 +237,7 @@ test {
         try testing.expectEqual(@as(Group.FontIndex.IndexInt, 0), idx.idx);
 
         // Render
-        const face = cache.group.faceFromIndex(idx);
+        const face = try cache.group.faceFromIndex(idx);
         const glyph_index = face.glyphIndex(i).?;
         _ = try cache.renderGlyph(
             alloc,
@@ -258,7 +258,7 @@ test {
             try testing.expectEqual(@as(Group.FontIndex.IndexInt, 0), idx.idx);
 
             // Render
-            const face = group.faceFromIndex(idx);
+            const face = try group.faceFromIndex(idx);
             const glyph_index = face.glyphIndex(i).?;
             _ = try cache.renderGlyph(
                 alloc,

--- a/src/font/Shaper.zig
+++ b/src/font/Shaper.zig
@@ -8,6 +8,7 @@ const harfbuzz = @import("harfbuzz");
 const trace = @import("tracy").trace;
 const Atlas = @import("../Atlas.zig");
 const Face = @import("main.zig").Face;
+const DeferredFace = @import("main.zig").DeferredFace;
 const Group = @import("main.zig").Group;
 const GroupCache = @import("main.zig").GroupCache;
 const Library = @import("main.zig").Library;
@@ -599,9 +600,9 @@ fn testShaper(alloc: Allocator) !TestShaper {
     errdefer cache_ptr.*.deinit(alloc);
 
     // Setup group
-    try cache_ptr.group.addFace(alloc, .regular, try Face.init(lib, testFont, .{ .points = 12 }));
-    try cache_ptr.group.addFace(alloc, .regular, try Face.init(lib, testEmoji, .{ .points = 12 }));
-    try cache_ptr.group.addFace(alloc, .regular, try Face.init(lib, testEmojiText, .{ .points = 12 }));
+    try cache_ptr.group.addFace(alloc, .regular, DeferredFace.initLoaded(try Face.init(lib, testFont, .{ .points = 12 })));
+    try cache_ptr.group.addFace(alloc, .regular, DeferredFace.initLoaded(try Face.init(lib, testEmoji, .{ .points = 12 })));
+    try cache_ptr.group.addFace(alloc, .regular, DeferredFace.initLoaded(try Face.init(lib, testEmojiText, .{ .points = 12 })));
 
     var cell_buf = try alloc.alloc(Cell, 80);
     errdefer alloc.free(cell_buf);

--- a/src/font/Shaper.zig
+++ b/src/font/Shaper.zig
@@ -596,7 +596,11 @@ fn testShaper(alloc: Allocator) !TestShaper {
 
     var cache_ptr = try alloc.create(GroupCache);
     errdefer alloc.destroy(cache_ptr);
-    cache_ptr.* = try GroupCache.init(alloc, try Group.init(alloc, lib));
+    cache_ptr.* = try GroupCache.init(alloc, try Group.init(
+        alloc,
+        lib,
+        .{ .points = 12 },
+    ));
     errdefer cache_ptr.*.deinit(alloc);
 
     // Setup group

--- a/src/font/Shaper.zig
+++ b/src/font/Shaper.zig
@@ -62,7 +62,7 @@ pub fn shape(self: *Shaper, run: TextRun) ![]Cell {
         harfbuzz.Feature.fromString("liga").?,
     };
 
-    const face = run.group.group.faceFromIndex(run.font_index);
+    const face = try run.group.group.faceFromIndex(run.font_index);
     harfbuzz.shape(face.hb_font, self.hb_buf, hb_feats);
 
     // If our buffer is empty, we short-circuit the rest of the work
@@ -596,7 +596,7 @@ fn testShaper(alloc: Allocator) !TestShaper {
 
     var cache_ptr = try alloc.create(GroupCache);
     errdefer alloc.destroy(cache_ptr);
-    cache_ptr.* = try GroupCache.init(alloc, try Group.init(alloc));
+    cache_ptr.* = try GroupCache.init(alloc, try Group.init(alloc, lib));
     errdefer cache_ptr.*.deinit(alloc);
 
     // Setup group

--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -39,7 +39,11 @@ pub const Descriptor = struct {
     pub fn toFcPattern(self: Descriptor) *fontconfig.Pattern {
         const pat = fontconfig.Pattern.create();
         assert(pat.add(.family, .{ .string = self.family }, false));
-        if (self.size > 0) assert(pat.add(.size, .{ .integer = self.size }, false));
+        if (self.size > 0) assert(pat.add(
+            .size,
+            .{ .integer = self.size },
+            false,
+        ));
         if (self.bold) assert(pat.add(
             .weight,
             .{ .integer = @enumToInt(fontconfig.Weight.bold) },
@@ -64,6 +68,10 @@ pub const Fontconfig = struct {
         return .{ .fc_config = fontconfig.initLoadConfigAndFonts() };
     }
 
+    pub fn deinit(self: *Fontconfig) void {
+        _ = self;
+    }
+
     /// Discover fonts from a descriptor. This returns an iterator that can
     /// be used to build up the deferred fonts.
     pub fn discover(self: *Fontconfig, desc: Descriptor) !DiscoverIterator {
@@ -84,7 +92,6 @@ pub const Fontconfig = struct {
             .set = res.fs,
             .fonts = res.fs.fonts(),
             .i = 0,
-            .req_size = @floatToInt(u16, (try pat.get(.size, 0)).double),
         };
     }
 
@@ -94,7 +101,6 @@ pub const Fontconfig = struct {
         set: *fontconfig.FontSet,
         fonts: []*fontconfig.Pattern,
         i: usize,
-        req_size: u16,
 
         pub fn deinit(self: *DiscoverIterator) void {
             self.set.destroy();
@@ -122,7 +128,6 @@ pub const Fontconfig = struct {
                     .pattern = font_pattern,
                     .charset = (try font_pattern.get(.charset, 0)).char_set,
                     .langset = (try font_pattern.get(.lang, 0)).lang_set,
-                    .req_size = self.req_size,
                 },
             };
         }

--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -1,16 +1,17 @@
 const std = @import("std");
 const assert = std.debug.assert;
 const fontconfig = @import("fontconfig");
+const options = @import("main.zig").options;
 const DeferredFace = @import("main.zig").DeferredFace;
 
 const log = std.log.named(.discovery);
 
-pub const Error = error{
-    FontConfigFailed,
-};
+/// Discover implementation for the compile options.
+pub const Discover = if (options.fontconfig) Fontconfig else void;
 
 /// Descriptor is used to search for fonts. The only required field
-/// is "family". The rest are ignored unless they're set to a non-zero value.
+/// is "family". The rest are ignored unless they're set to a non-zero
+/// value.
 pub const Descriptor = struct {
     /// Font family to search for. This can be a fully qualified font
     /// name such as "Fira Code", "monospace", "serif", etc. Memory is
@@ -74,7 +75,7 @@ pub const Fontconfig = struct {
 
         // Search
         const res = self.fc_config.fontSort(pat, true, null);
-        if (res.result != .match) return Error.FontConfigFailed;
+        if (res.result != .match) return error.FontConfigFailed;
         errdefer res.fs.destroy();
 
         return DiscoverIterator{
@@ -129,6 +130,8 @@ pub const Fontconfig = struct {
 };
 
 test {
+    if (!options.fontconfig) return error.SkipZigTest;
+
     const testing = std.testing;
 
     var fc = Fontconfig.init();

--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -1,0 +1,77 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const fontconfig = @import("fontconfig");
+
+const log = std.log.named(.discovery);
+
+/// Descriptor is used to search for fonts. The only required field
+/// is "family". The rest are ignored unless they're set to a non-zero value.
+pub const Descriptor = struct {
+    /// Font family to search for. This can be a fully qualified font
+    /// name such as "Fira Code", "monospace", "serif", etc. Memory is
+    /// owned by the caller and should be freed when this descriptor
+    /// is no longer in use. The discovery structs will never store the
+    /// descriptor.
+    ///
+    /// On systems that use fontconfig (Linux), this can be a full
+    /// fontconfig pattern, such as "Fira Code-14:bold".
+    family: [:0]const u8,
+
+    /// Font size in points that the font should support.
+    size: u16 = 0,
+
+    /// True if we want to search specifically for a font that supports
+    /// bold, italic, or both.
+    bold: bool = false,
+    italic: bool = false,
+
+    /// Convert to Fontconfig pattern to use for lookup. The pattern does
+    /// not have defaults filled/substituted (Fontconfig thing) so callers
+    /// must still do this.
+    pub fn toFcPattern(self: Descriptor) *fontconfig.Pattern {
+        const pat = fontconfig.Pattern.create();
+        assert(pat.add(.family, .{ .string = self.family }, false));
+        if (self.size > 0) assert(pat.add(.size, .{ .integer = self.size }, false));
+        if (self.bold) assert(pat.add(
+            .weight,
+            .{ .integer = @enumToInt(fontconfig.Weight.bold) },
+            false,
+        ));
+        if (self.italic) assert(pat.add(
+            .slant,
+            .{ .integer = @enumToInt(fontconfig.Slant.italic) },
+            false,
+        ));
+
+        return pat;
+    }
+};
+
+pub const Fontconfig = struct {
+    fc_config: *fontconfig.Config,
+
+    pub fn init() Fontconfig {
+        // safe to call multiple times and concurrently
+        _ = fontconfig.init();
+        return .{ .fc_config = fontconfig.initLoadConfig() };
+    }
+
+    pub fn discover(self: *Fontconfig, desc: Descriptor) void {
+        // Build our pattern that we'll search for
+        const pat = desc.toFcPattern();
+        defer pat.destroy();
+        assert(self.fc_config.substituteWithPat(pat, .pattern));
+        pat.defaultSubstitute();
+
+        // Search
+        const res = self.fc_config.fontSort(pat, true, null);
+        defer res.fs.destroy();
+    }
+};
+
+test {
+    defer fontconfig.fini();
+    var fc = Fontconfig.init();
+
+    fc.discover(.{ .family = "monospace" });
+}

--- a/src/font/main.zig
+++ b/src/font/main.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const build_options = @import("build_options");
 
+pub const discovery = @import("discovery.zig");
 pub const DeferredFace = @import("DeferredFace.zig");
 pub const Face = @import("Face.zig");
 pub const Group = @import("Group.zig");
@@ -8,6 +9,8 @@ pub const GroupCache = @import("GroupCache.zig");
 pub const Glyph = @import("Glyph.zig");
 pub const Library = @import("Library.zig");
 pub const Shaper = @import("Shaper.zig");
+pub const Descriptor = discovery.Descriptor;
+pub const Discover = discovery.Discover;
 
 /// Build options
 pub const options: struct {
@@ -42,7 +45,4 @@ pub const Metrics = struct {
 
 test {
     @import("std").testing.refAllDecls(@This());
-
-    // TODO
-    if (options.fontconfig) _ = @import("discovery.zig");
 }

--- a/src/font/main.zig
+++ b/src/font/main.zig
@@ -1,11 +1,20 @@
 const std = @import("std");
+const build_options = @import("build_options");
 
+pub const DeferredFace = @import("DeferredFace.zig");
 pub const Face = @import("Face.zig");
 pub const Group = @import("Group.zig");
 pub const GroupCache = @import("GroupCache.zig");
 pub const Glyph = @import("Glyph.zig");
 pub const Library = @import("Library.zig");
 pub const Shaper = @import("Shaper.zig");
+
+/// Build options
+pub const options: struct {
+    fontconfig: bool = false,
+} = .{
+    .fontconfig = build_options.fontconfig,
+};
 
 /// The styles that a family can take.
 pub const Style = enum(u3) {
@@ -33,4 +42,7 @@ pub const Metrics = struct {
 
 test {
     @import("std").testing.refAllDecls(@This());
+
+    // TODO
+    if (options.fontconfig) _ = @import("discovery.zig");
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -16,7 +16,7 @@ const log = std.log.scoped(.main);
 pub fn main() !void {
     // Output some debug information right away
     log.info("dependency harfbuzz={s}", .{harfbuzz.versionString()});
-    if (builtin.os.tag == .linux) {
+    if (options.fontconfig) {
         log.info("dependency fontconfig={d}", .{fontconfig.version()});
     }
 


### PR DESCRIPTION
This adds the `--font-family` set of configuration flags to choose a font that is installed on the system rather than the embedded font in the binary. This uses fontconfig on Linux and only supports Linux at the moment.

Fontconfig is an optional dependency, building with `-Dfontconfig=false` will disable fontconfig and font discovery on all platforms. Fontconfig is only enabled by default on Linux. 