### PR TITLE
Improve font metrics calculation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 Bugs:
 
-* Underline should use freetype underline thickness hint
 * Glyph baseline is using the main font, but it can vary font to font
 
 Performance:

--- a/pkg/freetype/face.zig
+++ b/pkg/freetype/face.zig
@@ -24,6 +24,13 @@ pub const Face = struct {
         return c.FT_HAS_COLOR(self.handle);
     }
 
+    /// A macro that returns true whenever a face object contains a scalable
+    /// font face (true for TrueType, Type 1, Type 42, CID, OpenType/CFF,
+    /// and PFR font formats).
+    pub fn isScalable(self: Face) bool {
+        return c.FT_IS_SCALABLE(self.handle);
+    }
+
     /// Select a given charmap by its encoding tag (as listed in freetype.h).
     pub fn selectCharmap(self: Face, encoding: Encoding) Error!void {
         return intToError(c.FT_Select_Charmap(self.handle, @enumToInt(encoding)));

--- a/shaders/cell.v.glsl
+++ b/shaders/cell.v.glsl
@@ -57,7 +57,8 @@ uniform sampler2D text;
 uniform sampler2D text_color;
 uniform vec2 cell_size;
 uniform mat4 projection;
-uniform float glyph_baseline;
+uniform float underline_position;
+uniform float underline_thickness;
 
 /********************************************************************
  * Modes
@@ -196,18 +197,16 @@ void main() {
         break;
 
     case MODE_UNDERLINE:
-        // Make the underline a smaller version of our cell
-        // TODO: use real font underline thickness
-        vec2 underline_size = vec2(cell_size_scaled.x, cell_size_scaled.y*0.05);
+        // Underline Y value is just our thickness
+        vec2 underline_size = vec2(cell_size_scaled.x, underline_thickness);
 
-        // Position our underline so that it is midway between the glyph
-        // baseline and the bottom of the cell.
-        vec2 underline_offset = vec2(cell_size_scaled.x, cell_size_scaled.y - (glyph_baseline / 2));
+        // Position the underline where we are told to
+        vec2 underline_offset = vec2(cell_size_scaled.x, underline_position) ;
 
         // Go to the bottom of the cell, take away the size of the
         // underline, and that is our position. We also float it slightly
         // above the bottom.
-        cell_pos = cell_pos + underline_offset - underline_size * position;
+        cell_pos = cell_pos + underline_offset - (underline_size * position);
 
         gl_Position = projection * vec4(cell_pos, cell_z, 1.0);
         color = fg_color_in / 255.0;

--- a/shaders/cell.v.glsl
+++ b/shaders/cell.v.glsl
@@ -138,9 +138,8 @@ void main() {
 
         // The glyph_offset.y is the y bearing, a y value that when added
         // to the baseline is the offset (+y is up). Our grid goes down.
-        // So we flip it with `cell_size.y - glyph_offset.y`. The glyph_baseline
-        // uniform sets our line baseline where characters "sit".
-        glyph_offset_calc.y = cell_size_scaled.y - glyph_offset_calc.y - glyph_baseline;
+        // So we flip it with `cell_size.y - glyph_offset.y`.
+        glyph_offset_calc.y = cell_size_scaled.y - glyph_offset_calc.y;
 
         // Calculate the final position of the cell.
         cell_pos = cell_pos + glyph_size_downsampled * position + glyph_offset_calc;

--- a/src/Grid.zig
+++ b/src/Grid.zig
@@ -158,9 +158,14 @@ pub fn init(alloc: Allocator, font_group: *font.GroupCache) !Grid {
     var shaper = try font.Shaper.init(shape_buf);
     errdefer shaper.deinit();
 
-    // Load all visible ASCII characters and build our cell width based on
-    // the widest character that we see.
-    const metrics = try font_group.metrics(alloc);
+    // Get our cell metrics based on a regular font ascii 'M'. Why 'M'?
+    // Doesn't matter, any normal ASCII will do we're just trying to make
+    // sure we use the regular font.
+    const metrics = metrics: {
+        const index = (try font_group.indexForCodepoint(alloc, 'M', .regular, .text)).?;
+        const face = try font_group.group.faceFromIndex(index);
+        break :metrics face.metrics;
+    };
     log.debug("cell dimensions={}", .{metrics});
 
     // Create our shader

--- a/src/Grid.zig
+++ b/src/Grid.zig
@@ -178,7 +178,8 @@ pub fn init(alloc: Allocator, font_group: *font.GroupCache) !Grid {
     const pbind = try program.use();
     defer pbind.unbind();
     try program.setUniform("cell_size", @Vector(2, f32){ metrics.cell_width, metrics.cell_height });
-    try program.setUniform("glyph_baseline", metrics.cell_baseline);
+    try program.setUniform("underline_position", metrics.underline_position);
+    try program.setUniform("underline_thickness", metrics.underline_thickness);
 
     // Set all of our texture indexes
     try program.setUniform("text", 0);

--- a/src/font/GroupCache.zig
+++ b/src/font/GroupCache.zig
@@ -12,7 +12,6 @@ const Library = @import("main.zig").Library;
 const Glyph = @import("main.zig").Glyph;
 const Style = @import("main.zig").Style;
 const Group = @import("main.zig").Group;
-const Metrics = @import("main.zig").Metrics;
 const Presentation = @import("main.zig").Presentation;
 
 const log = std.log.scoped(.font_groupcache);
@@ -82,66 +81,6 @@ pub fn deinit(self: *GroupCache, alloc: Allocator) void {
 pub fn reset(self: *GroupCache) void {
     self.codepoints.clearRetainingCapacity();
     self.glyphs.clearRetainingCapacity();
-}
-
-/// Calculate the metrics for this group. This also warms the cache
-/// since this preloads all the ASCII characters.
-pub fn metrics(self: *GroupCache, alloc: Allocator) !Metrics {
-    // Load all visible ASCII characters and build our cell width based on
-    // the widest character that we see.
-    const cell_width: f32 = cell_width: {
-        var cell_width: f32 = 0;
-        var i: u32 = 32;
-        while (i <= 126) : (i += 1) {
-            const index = (try self.indexForCodepoint(alloc, i, .regular, .text)).?;
-            const face = try self.group.faceFromIndex(index);
-            const glyph_index = face.glyphIndex(i).?;
-            const glyph = try self.renderGlyph(alloc, index, glyph_index);
-            if (glyph.advance_x > cell_width) {
-                cell_width = @ceil(glyph.advance_x);
-            }
-        }
-
-        break :cell_width cell_width;
-    };
-
-    // The cell height is the vertical height required to render underscore
-    // '_' which should live at the bottom of a cell.
-    const cell_height: f32 = cell_height: {
-        // Get the '_' char for height
-        const index = (try self.indexForCodepoint(alloc, '_', .regular, .text)).?;
-        const face = try self.group.faceFromIndex(index);
-        const glyph_index = face.glyphIndex('_').?;
-        const glyph = try self.renderGlyph(alloc, index, glyph_index);
-
-        // This is the height reported by the font face
-        const face_height: i32 = face.unitsToPxY(face.face.handle.*.height);
-
-        // Determine the height of the underscore char
-        var res: i32 = face.unitsToPxY(face.face.handle.*.ascender);
-        res -= glyph.offset_y;
-        res += @intCast(i32, glyph.height);
-
-        // We take whatever is larger to account for some fonts that
-        // put the underscore outside f the rectangle.
-        if (res < face_height) res = face_height;
-
-        break :cell_height @intToFloat(f32, res);
-    };
-
-    const cell_baseline = cell_baseline: {
-        const face = self.group.faces.get(.regular).items[0].face.?;
-        break :cell_baseline cell_height - @intToFloat(
-            f32,
-            face.unitsToPxY(face.face.handle.*.ascender),
-        );
-    };
-
-    return Metrics{
-        .cell_width = cell_width,
-        .cell_height = cell_height,
-        .cell_baseline = cell_baseline,
-    };
 }
 
 /// Get the font index for a given codepoint. This is cached.

--- a/src/font/main.zig
+++ b/src/font/main.zig
@@ -49,16 +49,6 @@ pub const Presentation = enum(u1) {
     emoji = 1, // U+FEOF
 };
 
-/// Font metrics useful for things such as grid calculation.
-pub const Metrics = struct {
-    /// The width and height of a monospace cell.
-    cell_width: f32,
-    cell_height: f32,
-
-    /// The baseline offset that can be used to place underlines.
-    cell_baseline: f32,
-};
-
 test {
     @import("std").testing.refAllDecls(@This());
 }


### PR DESCRIPTION
This improves the way we calculate metrics based on fonts to be more accurate. Two practical impacts:

* We now position the underline and underline thickness based on the font metrics
* We now correctly position Apple Emoji font

And I'm going to follow this up with strikethrough since that should be possible now.