### PR TITLE
macos: Metal Renderer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,9 +58,6 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
 
     - name: test
-      run: nix develop -c zig build test -fstage1
-
-    - name: test stage2
       run: nix develop -c zig build test
 
     - name: Test Dynamic Build

--- a/build.zig
+++ b/build.zig
@@ -230,9 +230,12 @@ fn addDeps(
     try glfw.link(b, step, glfw_opts);
 
     // Imgui, we have to do this later since we need some information
-    const imgui_backends = [_][]const u8{ "glfw", "opengl3" };
+    const imgui_backends = if (step.target.isDarwin())
+        &[_][]const u8{ "glfw", "opengl3", "metal" }
+    else
+        &[_][]const u8{ "glfw", "opengl3" };
     var imgui_opts: imgui.Options = .{
-        .backends = &imgui_backends,
+        .backends = imgui_backends,
         .freetype = .{ .enabled = true },
     };
 

--- a/build.zig
+++ b/build.zig
@@ -223,7 +223,10 @@ fn addDeps(
     _ = try utf8proc.link(b, step);
 
     // Glfw
-    const glfw_opts: glfw.Options = .{ .metal = false, .opengl = false };
+    const glfw_opts: glfw.Options = .{
+        .metal = step.target.isDarwin(),
+        .opengl = false,
+    };
     try glfw.link(b, step, glfw_opts);
 
     // Imgui, we have to do this later since we need some information

--- a/pkg/imgui/build.zig
+++ b/pkg/imgui/build.zig
@@ -101,11 +101,17 @@ pub fn buildImgui(
     lib.addCSourceFiles(srcs, flags.items);
     if (opt.backends) |backends| {
         for (backends) |backend| {
+            const ext = if (std.mem.eql(u8, "metal", backend)) ext: {
+                // Metal requires some extra frameworks
+                step.linkFramework("QuartzCore");
+                break :ext "mm";
+            } else "cpp";
+
             var buf: [4096]u8 = undefined;
             const path = try std.fmt.bufPrint(
                 &buf,
-                "{s}imgui/backends/imgui_impl_{s}.cpp",
-                .{ root, backend },
+                "{s}imgui/backends/imgui_impl_{s}.{s}",
+                .{ root, backend, ext },
             );
 
             lib.addCSourceFile(path, flags.items);

--- a/pkg/imgui/impl_glfw.zig
+++ b/pkg/imgui/impl_glfw.zig
@@ -13,6 +13,10 @@ pub const ImplGlfw = struct {
         return ImGui_ImplGlfw_InitForOpenGL(win, install_callbacks);
     }
 
+    pub fn initForOther(win: *GLFWWindow, install_callbacks: bool) bool {
+        return ImGui_ImplGlfw_InitForOther(win, install_callbacks);
+    }
+
     pub fn shutdown() void {
         return ImGui_ImplGlfw_Shutdown();
     }
@@ -23,6 +27,7 @@ pub const ImplGlfw = struct {
 
     extern "c" fn glfwGetError(?*const anyopaque) c_int;
     extern "c" fn ImGui_ImplGlfw_InitForOpenGL(*GLFWWindow, bool) bool;
+    extern "c" fn ImGui_ImplGlfw_InitForOther(*GLFWWindow, bool) bool;
     extern "c" fn ImGui_ImplGlfw_Shutdown() void;
     extern "c" fn ImGui_ImplGlfw_NewFrame() void;
 };

--- a/pkg/imgui/impl_metal.zig
+++ b/pkg/imgui/impl_metal.zig
@@ -1,0 +1,31 @@
+const std = @import("std");
+const c = @import("c.zig");
+const imgui = @import("main.zig");
+const Allocator = std.mem.Allocator;
+
+pub const ImplMetal = struct {
+    pub fn init(device: ?*anyopaque) bool {
+        return ImGui_ImplMetal_Init(device);
+    }
+
+    pub fn shutdown() void {
+        return ImGui_ImplMetal_Shutdown();
+    }
+
+    pub fn newFrame(render_pass_desc: ?*anyopaque) void {
+        return ImGui_ImplMetal_NewFrame(render_pass_desc);
+    }
+
+    pub fn renderDrawData(
+        data: *imgui.DrawData,
+        command_buffer: ?*anyopaque,
+        command_encoder: ?*anyopaque,
+    ) void {
+        ImGui_ImplMetal_RenderDrawData(data, command_buffer, command_encoder);
+    }
+
+    extern "c" fn ImGui_ImplMetal_Init(?*anyopaque) bool;
+    extern "c" fn ImGui_ImplMetal_Shutdown() void;
+    extern "c" fn ImGui_ImplMetal_NewFrame(?*anyopaque) void;
+    extern "c" fn ImGui_ImplMetal_RenderDrawData(*imgui.DrawData, ?*anyopaque, ?*anyopaque) void;
+};

--- a/pkg/imgui/main.zig
+++ b/pkg/imgui/main.zig
@@ -7,6 +7,7 @@ pub usingnamespace @import("io.zig");
 pub usingnamespace @import("style.zig");
 
 pub usingnamespace @import("impl_glfw.zig");
+pub usingnamespace @import("impl_metal.zig");
 pub usingnamespace @import("impl_opengl3.zig");
 
 test {

--- a/pkg/objc/object.zig
+++ b/pkg/objc/object.zig
@@ -54,7 +54,7 @@ pub const Object = struct {
             break :getter objc.sel(val);
         } else objc.sel(n);
 
-        self.msgSend(T, getter, .{});
+        return self.msgSend(T, getter, .{});
     }
 };
 

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -36,7 +36,7 @@ const log = std.log.scoped(.window);
 const WRITE_REQ_PREALLOC = std.math.pow(usize, 2, 5);
 
 // The renderer implementation to use.
-const Renderer = renderer.OpenGL;
+const Renderer = renderer.Renderer;
 
 /// Allocator
 alloc: Allocator,

--- a/src/main.zig
+++ b/src/main.zig
@@ -6,6 +6,7 @@ const fontconfig = @import("fontconfig");
 const freetype = @import("freetype");
 const harfbuzz = @import("harfbuzz");
 const tracy = @import("tracy");
+const renderer = @import("renderer.zig");
 
 const App = @import("App.zig");
 const cli_args = @import("cli_args.zig");
@@ -19,6 +20,7 @@ pub fn main() !void {
     if (options.fontconfig) {
         log.info("dependency fontconfig={d}", .{fontconfig.version()});
     }
+    log.info("renderer={}", .{renderer.Renderer});
 
     const GPA = std.heap.GeneralPurposeAllocator(.{});
     var gpa: ?GPA = gpa: {

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -7,10 +7,20 @@
 //! APIs. The renderers in this package assume that the renderer is already
 //! setup (OpenGL has a context, Vulkan has a surface, etc.)
 
+const builtin = @import("builtin");
+
 pub usingnamespace @import("renderer/size.zig");
+pub const Metal = @import("renderer/Metal.zig");
 pub const OpenGL = @import("renderer/OpenGL.zig");
 pub const Thread = @import("renderer/Thread.zig");
 pub const State = @import("renderer/State.zig");
+
+/// The implementation to use for the renderer. This is comptime chosen
+/// so that every build has exactly one renderer implementation.
+pub const Renderer = switch (builtin.os.tag) {
+    .macos => Metal,
+    else => OpenGL,
+};
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -9,6 +9,7 @@
 
 const builtin = @import("builtin");
 
+pub usingnamespace @import("renderer/cursor.zig");
 pub usingnamespace @import("renderer/size.zig");
 pub const Metal = @import("renderer/Metal.zig");
 pub const OpenGL = @import("renderer/OpenGL.zig");

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -810,7 +810,16 @@ fn initPipelineState(device: objc.Object, library: objc.Object) !objc.Object {
 
         // Value is MTLPixelFormatBGRA8Unorm
         attachment.setProperty("pixelFormat", @as(c_ulong, 80));
+
+        // Blending. This is required so that our text we render on top
+        // of our drawable properly blends into the bg.
         attachment.setProperty("blendingEnabled", true);
+        attachment.setProperty("rgbBlendOperation", @enumToInt(MTLBlendOperation.add));
+        attachment.setProperty("alphaBlendOperation", @enumToInt(MTLBlendOperation.add));
+        attachment.setProperty("sourceRGBBlendFactor", @enumToInt(MTLBlendFactor.source_alpha));
+        attachment.setProperty("sourceAlphaBlendFactor", @enumToInt(MTLBlendFactor.source_alpha));
+        attachment.setProperty("destinationRGBBlendFactor", @enumToInt(MTLBlendFactor.one_minus_source_alpha));
+        attachment.setProperty("destinationAlphaBlendFactor", @enumToInt(MTLBlendFactor.one_minus_source_alpha));
     }
 
     // Make our state
@@ -937,6 +946,38 @@ const MTLPixelFormat = enum(c_ulong) {
 /// https://developer.apple.com/documentation/metal/mtlpurgeablestate?language=objc
 const MTLPurgeableState = enum(c_ulong) {
     empty = 4,
+};
+
+/// https://developer.apple.com/documentation/metal/mtlblendfactor?language=objc
+const MTLBlendFactor = enum(c_ulong) {
+    zero = 0,
+    one = 1,
+    source_color = 2,
+    one_minus_source_color = 3,
+    source_alpha = 4,
+    one_minus_source_alpha = 5,
+    dest_color = 6,
+    one_minus_dest_color = 7,
+    dest_alpha = 8,
+    one_minus_dest_alpha = 9,
+    source_alpha_saturated = 10,
+    blend_color = 11,
+    one_minus_blend_color = 12,
+    blend_alpha = 13,
+    one_minus_blend_alpha = 14,
+    source_1_color = 15,
+    one_minus_source_1_color = 16,
+    source_1_alpha = 17,
+    one_minus_source_1_alpha = 18,
+};
+
+/// https://developer.apple.com/documentation/metal/mtlblendoperation?language=objc
+const MTLBlendOperation = enum(c_ulong) {
+    add = 0,
+    subtract = 1,
+    reverse_subtract = 2,
+    min = 3,
+    max = 4,
 };
 
 /// https://developer.apple.com/documentation/metal/mtlresourceoptions?language=objc

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -810,6 +810,7 @@ fn initPipelineState(device: objc.Object, library: objc.Object) !objc.Object {
 
         // Value is MTLPixelFormatBGRA8Unorm
         attachment.setProperty("pixelFormat", @as(c_ulong, 80));
+        attachment.setProperty("blendingEnabled", true);
     }
 
     // Make our state
@@ -930,6 +931,7 @@ const MTLVertexStepFunction = enum(c_ulong) {
 /// https://developer.apple.com/documentation/metal/mtlpixelformat?language=objc
 const MTLPixelFormat = enum(c_ulong) {
     r8unorm = 10,
+    bgra8unorm = 80,
 };
 
 /// https://developer.apple.com/documentation/metal/mtlpurgeablestate?language=objc

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -361,7 +361,8 @@ pub fn render(
 
         // Set the size of the drawable surface to the scaled bounds
         self.swapchain.setProperty("drawableSize", scaled);
-        log.warn("bounds={} screen={} scaled={}", .{ bounds, screen_size, scaled });
+        _ = screen_size;
+        //log.warn("bounds={} screen={} scaled={}", .{ bounds, screen_size, scaled });
 
         // Setup our uniforms
         const old = self.uniforms;

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1,0 +1,86 @@
+//! Renderer implementation for Metal.
+pub const Metal = @This();
+
+const std = @import("std");
+const glfw = @import("glfw");
+const font = @import("../font/main.zig");
+const terminal = @import("../terminal/main.zig");
+const renderer = @import("../renderer.zig");
+const Allocator = std.mem.Allocator;
+
+const log = std.log.scoped(.metal);
+
+/// Current cell dimensions for this grid.
+cell_size: renderer.CellSize,
+
+/// Default foreground color
+foreground: terminal.color.RGB,
+
+/// Default background color
+background: terminal.color.RGB,
+
+/// Returns the hints that we want for this
+pub fn windowHints() glfw.Window.Hints {
+    return .{
+        .client_api = .no_api,
+        // .cocoa_graphics_switching = builtin.os.tag == .macos,
+        // .cocoa_retina_framebuffer = true,
+    };
+}
+
+/// This is called early right after window creation to setup our
+/// window surface as necessary.
+pub fn windowInit(window: glfw.Window) !void {
+    _ = window;
+}
+
+pub fn init(alloc: Allocator, font_group: *font.GroupCache) !Metal {
+    // Get our cell metrics based on a regular font ascii 'M'. Why 'M'?
+    // Doesn't matter, any normal ASCII will do we're just trying to make
+    // sure we use the regular font.
+    const metrics = metrics: {
+        const index = (try font_group.indexForCodepoint(alloc, 'M', .regular, .text)).?;
+        const face = try font_group.group.faceFromIndex(index);
+        break :metrics face.metrics;
+    };
+    log.debug("cell dimensions={}", .{metrics});
+
+    return Metal{
+        .cell_size = .{ .width = metrics.cell_width, .height = metrics.cell_height },
+        .background = .{ .r = 0, .g = 0, .b = 0 },
+        .foreground = .{ .r = 255, .g = 255, .b = 255 },
+    };
+}
+
+pub fn deinit(self: *Metal) void {
+    self.* = undefined;
+}
+
+/// This is called just prior to spinning up the renderer thread for
+/// final main thread setup requirements.
+pub fn finalizeInit(self: *const Metal, window: glfw.Window) !void {
+    _ = self;
+    _ = window;
+}
+
+/// Callback called by renderer.Thread when it begins.
+pub fn threadEnter(self: *const Metal, window: glfw.Window) !void {
+    _ = self;
+    _ = window;
+}
+
+/// Callback called by renderer.Thread when it exits.
+pub fn threadExit(self: *const Metal) void {
+    _ = self;
+}
+
+/// The primary render callback that is completely thread-safe.
+pub fn render(
+    self: *Metal,
+    window: glfw.Window,
+    state: *renderer.State,
+) !void {
+    _ = self;
+    _ = window;
+    _ = state;
+}

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -136,6 +136,10 @@ pub fn init(alloc: Allocator, font_group: *font.GroupCache) !Metal {
         const swapchain = CAMetalLayer.msgSend(objc.Object, objc.sel("layer"), .{});
         swapchain.setProperty("device", device.value);
         swapchain.setProperty("opaque", true);
+
+        // disable v-sync
+        swapchain.setProperty("displaySyncEnabled", false);
+
         break :swapchain swapchain;
     };
 

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -2,11 +2,18 @@
 pub const Metal = @This();
 
 const std = @import("std");
+const builtin = @import("builtin");
 const glfw = @import("glfw");
+const objc = @import("objc");
 const font = @import("../font/main.zig");
 const terminal = @import("../terminal/main.zig");
 const renderer = @import("../renderer.zig");
 const Allocator = std.mem.Allocator;
+
+// Get native API access on certain platforms so we can do more customization.
+const glfwNative = glfw.Native(.{
+    .cocoa = builtin.os.tag == .macos,
+});
 
 const log = std.log.scoped(.metal);
 
@@ -18,6 +25,11 @@ foreground: terminal.color.RGB,
 
 /// Default background color
 background: terminal.color.RGB,
+
+/// Metal objects
+device: objc.Object, // MTLDevice
+queue: objc.Object, // MTLCommandQueue
+swapchain: objc.Object, // CAMetalLayer
 
 /// Returns the hints that we want for this
 pub fn windowHints() glfw.Window.Hints {
@@ -32,9 +44,23 @@ pub fn windowHints() glfw.Window.Hints {
 /// window surface as necessary.
 pub fn windowInit(window: glfw.Window) !void {
     _ = window;
+
+    // We don't do anything else here because we want to set everything
+    // else up during actual initialization.
 }
 
 pub fn init(alloc: Allocator, font_group: *font.GroupCache) !Metal {
+    // Initialize our metal stuff
+    const device = objc.Object.fromId(MTLCreateSystemDefaultDevice());
+    const queue = device.msgSend(objc.Object, objc.sel("newCommandQueue"), .{});
+    const swapchain = swapchain: {
+        const CAMetalLayer = objc.Class.getClass("CAMetalLayer").?;
+        const swapchain = CAMetalLayer.msgSend(objc.Object, objc.sel("layer"), .{});
+        swapchain.setProperty("device", device.value);
+        swapchain.setProperty("opaque", true);
+        break :swapchain swapchain;
+    };
+
     // Get our cell metrics based on a regular font ascii 'M'. Why 'M'?
     // Doesn't matter, any normal ASCII will do we're just trying to make
     // sure we use the regular font.
@@ -49,6 +75,9 @@ pub fn init(alloc: Allocator, font_group: *font.GroupCache) !Metal {
         .cell_size = .{ .width = metrics.cell_width, .height = metrics.cell_height },
         .background = .{ .r = 0, .g = 0, .b = 0 },
         .foreground = .{ .r = 255, .g = 255, .b = 255 },
+        .device = device,
+        .queue = queue,
+        .swapchain = swapchain,
     };
 }
 
@@ -59,19 +88,26 @@ pub fn deinit(self: *Metal) void {
 /// This is called just prior to spinning up the renderer thread for
 /// final main thread setup requirements.
 pub fn finalizeInit(self: *const Metal, window: glfw.Window) !void {
-    _ = self;
-    _ = window;
+    // Set our window backing layer to be our swapchain
+    const nswindow = objc.Object.fromId(glfwNative.getCocoaWindow(window).?);
+    const contentView = objc.Object.fromId(nswindow.getProperty(?*anyopaque, "contentView").?);
+    contentView.setProperty("layer", self.swapchain.value);
+    contentView.setProperty("wantsLayer", true);
 }
 
 /// Callback called by renderer.Thread when it begins.
 pub fn threadEnter(self: *const Metal, window: glfw.Window) !void {
     _ = self;
     _ = window;
+
+    // Metal requires no per-thread state.
 }
 
 /// Callback called by renderer.Thread when it exits.
 pub fn threadExit(self: *const Metal) void {
     _ = self;
+
+    // Metal requires no per-thread state.
 }
 
 /// The primary render callback that is completely thread-safe.
@@ -80,7 +116,109 @@ pub fn render(
     window: glfw.Window,
     state: *renderer.State,
 ) !void {
-    _ = self;
     _ = window;
-    _ = state;
+
+    // Data we extract out of the critical area.
+    const Critical = struct {
+        bg: terminal.color.RGB,
+    };
+
+    // Update all our data as tightly as possible within the mutex.
+    const critical: Critical = critical: {
+        state.mutex.lock();
+        defer state.mutex.unlock();
+
+        // Swap bg/fg if the terminal is reversed
+        const bg = self.background;
+        const fg = self.foreground;
+        defer {
+            self.background = bg;
+            self.foreground = fg;
+        }
+        if (state.terminal.modes.reverse_colors) {
+            self.background = fg;
+            self.foreground = bg;
+        }
+
+        break :critical .{
+            .bg = self.background,
+        };
+    };
+
+    // @autoreleasepool {}
+    const pool = objc_autoreleasePoolPush();
+    defer objc_autoreleasePoolPop(pool);
+
+    // Get our surface (CAMetalDrawable)
+    const surface = self.swapchain.msgSend(objc.Object, objc.sel("nextDrawable"), .{});
+
+    // MTLRenderPassDescriptor
+    const MTLRenderPassDescriptor = objc.Class.getClass("MTLRenderPassDescriptor").?;
+    const desc = desc: {
+        const desc = MTLRenderPassDescriptor.msgSend(
+            objc.Object,
+            objc.sel("renderPassDescriptor"),
+            .{},
+        );
+
+        // Set our color attachment to be our drawable surface.
+        const attachments = objc.Object.fromId(desc.getProperty(?*anyopaque, "colorAttachments"));
+        {
+            const attachment = attachments.msgSend(
+                objc.Object,
+                objc.sel("objectAtIndexedSubscript:"),
+                .{@as(c_ulong, 0)},
+            );
+
+            attachment.setProperty("loadAction", @enumToInt(MTLLoadAction.clear));
+            attachment.setProperty("storeAction", @enumToInt(MTLStoreAction.store));
+            attachment.setProperty("texture", surface.getProperty(objc.c.id, "texture").?);
+            attachment.setProperty("clearColor", MTLClearColor{
+                .red = @intToFloat(f32, critical.bg.r) / 255,
+                .green = @intToFloat(f32, critical.bg.g) / 255,
+                .blue = @intToFloat(f32, critical.bg.b) / 255,
+                .alpha = 1.0,
+            });
+        }
+
+        break :desc desc;
+    };
+
+    // Command buffer (MTLCommandBuffer)
+    const buffer = self.queue.msgSend(objc.Object, objc.sel("commandBuffer"), .{});
+
+    // MTLRenderCommandEncoder
+    const encoder = buffer.msgSend(
+        objc.Object,
+        objc.sel("renderCommandEncoderWithDescriptor:"),
+        .{desc.value},
+    );
+    encoder.msgSend(void, objc.sel("endEncoding"), .{});
+
+    buffer.msgSend(void, objc.sel("presentDrawable:"), .{surface.value});
+    buffer.msgSend(void, objc.sel("commit"), .{});
 }
+
+/// https://developer.apple.com/documentation/metal/mtlloadaction?language=objc
+const MTLLoadAction = enum(c_ulong) {
+    dont_care = 0,
+    load = 1,
+    clear = 2,
+};
+
+/// https://developer.apple.com/documentation/metal/mtlstoreaction?language=objc
+const MTLStoreAction = enum(c_ulong) {
+    dont_care = 0,
+    store = 1,
+};
+
+const MTLClearColor = extern struct {
+    red: f64,
+    green: f64,
+    blue: f64,
+    alpha: f64,
+};
+
+extern "c" fn MTLCreateSystemDefaultDevice() ?*anyopaque;
+extern "c" fn objc_autoreleasePoolPush() ?*anyopaque;
+extern "c" fn objc_autoreleasePoolPop(?*anyopaque) void;

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -483,6 +483,8 @@ pub fn render(
         const devmode_data = devmode_data: {
             if (state.devmode) |dm| {
                 if (dm.visible) {
+                    imgui.ImplOpenGL3.newFrame();
+                    imgui.ImplGlfw.newFrame();
                     try dm.update();
                     break :devmode_data try dm.render();
                 }

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -66,32 +66,13 @@ font_shaper: font.Shaper,
 /// Whether the cursor is visible or not. This is used to control cursor
 /// blinking.
 cursor_visible: bool,
-cursor_style: CursorStyle,
+cursor_style: renderer.CursorStyle,
 
 /// Default foreground color
 foreground: terminal.color.RGB,
 
 /// Default background color
 background: terminal.color.RGB,
-
-/// Available cursor styles for drawing. The values represents the mode value
-/// in the shader.
-pub const CursorStyle = enum(u8) {
-    box = 3,
-    box_hollow = 4,
-    bar = 5,
-
-    /// Create a cursor style from the terminal style request.
-    pub fn fromTerminal(style: terminal.CursorStyle) ?CursorStyle {
-        return switch (style) {
-            .blinking_block, .steady_block => .box,
-            .blinking_bar, .steady_bar => .bar,
-            .blinking_underline, .steady_underline => null, // TODO
-            .default => .box,
-            else => null,
-        };
-    }
-};
 
 /// The raw structure that maps directly to the buffer sent to the vertex shader.
 /// This must be "extern" so that the field order is not reordered by the
@@ -144,6 +125,14 @@ const GPUCellMode = enum(u8) {
 
     // Non-exhaustive because masks change it
     _,
+
+    pub fn fromCursor(cursor: renderer.CursorStyle) GPUCellMode {
+        return switch (cursor) {
+            .box => .cursor_rect,
+            .box_hollow => .cursor_rect_hollow,
+            .bar => .cursor_bar,
+        };
+    }
 
     /// Apply a mask to the mode.
     pub fn mask(self: GPUCellMode, m: GPUCellMode) GPUCellMode {
@@ -468,7 +457,7 @@ pub fn render(
         // Setup our cursor state
         if (state.focused) {
             self.cursor_visible = state.cursor.visible and !state.cursor.blink;
-            self.cursor_style = CursorStyle.fromTerminal(state.cursor.style) orelse .box;
+            self.cursor_style = renderer.CursorStyle.fromTerminal(state.cursor.style) orelse .box;
         } else {
             self.cursor_visible = true;
             self.cursor_style = .box_hollow;
@@ -701,13 +690,8 @@ fn addCursor(self: *OpenGL, term: *Terminal) void {
             term.screen.cursor.x,
         );
 
-        var mode: GPUCellMode = @intToEnum(
-            GPUCellMode,
-            @enumToInt(self.cursor_style),
-        );
-
         self.cells.appendAssumeCapacity(.{
-            .mode = mode,
+            .mode = GPUCellMode.fromCursor(self.cursor_style),
             .grid_col = @intCast(u16, term.screen.cursor.x),
             .grid_row = @intCast(u16, term.screen.cursor.y),
             .grid_width = if (cell.attrs.wide) 2 else 1,

--- a/src/renderer/cursor.zig
+++ b/src/renderer/cursor.zig
@@ -1,0 +1,19 @@
+const terminal = @import("../terminal/main.zig");
+
+/// Available cursor styles for drawing that renderers must support.
+pub const CursorStyle = enum {
+    box,
+    box_hollow,
+    bar,
+
+    /// Create a cursor style from the terminal style request.
+    pub fn fromTerminal(style: terminal.CursorStyle) ?CursorStyle {
+        return switch (style) {
+            .blinking_block, .steady_block => .box,
+            .blinking_bar, .steady_bar => .bar,
+            .blinking_underline, .steady_underline => null, // TODO
+            .default => .box,
+            else => null,
+        };
+    }
+};

--- a/src/shaders/cell.metal
+++ b/src/shaders/cell.metal
@@ -14,7 +14,6 @@ enum Mode : uint8_t {
 
 struct Uniforms {
   float4x4 projection_matrix;
-  float2 px_scale;
   float2 cell_size;
   float underline_position;
   float underline_thickness;
@@ -60,7 +59,7 @@ vertex VertexOut uber_vertex(
   VertexIn input [[ stage_in ]],
   constant Uniforms &uniforms [[ buffer(1) ]]
 ) {
-  float2 cell_size = uniforms.cell_size * uniforms.px_scale;
+  float2 cell_size = uniforms.cell_size;
   cell_size.x = cell_size.x * input.cell_width;
 
   // Convert the grid x,y into world space x, y by accounting for cell size
@@ -95,8 +94,8 @@ vertex VertexOut uber_vertex(
 
   case MODE_FG:
   case MODE_FG_COLOR: {
-    float2 glyph_size = float2(input.glyph_size) * uniforms.px_scale;
-    float2 glyph_offset = float2(input.glyph_offset) * uniforms.px_scale;
+    float2 glyph_size = float2(input.glyph_size);
+    float2 glyph_offset = float2(input.glyph_offset);
 
     // If the glyph is larger than our cell, we need to downsample it.
     // The "+ 3" here is to give some wiggle room for fonts that are
@@ -121,7 +120,6 @@ vertex VertexOut uber_vertex(
 
     // Calculate the texture coordinate in pixels. This is NOT normalized
     // (between 0.0 and 1.0) and must be done in the fragment shader.
-    // TODO: do I need to px_scale?
     out.tex_coord = float2(input.glyph_pos) + float2(input.glyph_size) * position;
     break;
   }
@@ -158,7 +156,7 @@ vertex VertexOut uber_vertex(
     float2 underline_size = float2(cell_size.x, uniforms.underline_thickness);
 
     // Position the underline where we are told to
-    float2 underline_offset = float2(cell_size.x, uniforms.underline_position * uniforms.px_scale.y);
+    float2 underline_offset = float2(cell_size.x, uniforms.underline_position);
 
     // Go to the bottom of the cell, take away the size of the
     // underline, and that is our position. We also float it slightly
@@ -174,7 +172,7 @@ vertex VertexOut uber_vertex(
     float2 strikethrough_size = float2(cell_size.x, uniforms.strikethrough_thickness);
 
     // Position the strikethrough where we are told to
-    float2 strikethrough_offset = float2(cell_size.x, uniforms.strikethrough_position * uniforms.px_scale.y);
+    float2 strikethrough_offset = float2(cell_size.x, uniforms.strikethrough_position);
 
     // Go to the bottom of the cell, take away the size of the
     // strikethrough, and that is our position. We also float it slightly

--- a/src/shaders/cell.metal
+++ b/src/shaders/cell.metal
@@ -1,0 +1,35 @@
+vertex float4 basic_vertex(unsigned int vid [[ vertex_id ]]) {
+  // Where we are in the grid (x, y) where top-left is origin
+  float2 grid_coord = float2(0.0f, 0.0f);
+
+  // The size of a single cell in pixels
+  float2 cell_size = float2(75.0f, 100.0f);
+
+  // Convert the grid x,y into world space x, y by accounting for cell size
+  float2 cell_pos = cell_size * grid_coord;
+
+  // Turn the cell position into a vertex point depending on the
+  // vertex ID. Since we use instanced drawing, we have 4 vertices
+  // for each corner of the cell. We can use vertex ID to determine
+  // which one we're looking at. Using this, we can use 1 or 0 to keep
+  // or discard the value for the vertex.
+  //
+  // 0 = top-right
+  // 1 = bot-right
+  // 2 = bot-left
+  // 3 = top-left
+  float2 position;
+  position.x = (vid == 0 || vid == 1) ? 1.0f : 0.0f;
+  position.y = (vid == 0 || vid == 3) ? 0.0f : 1.0f;
+
+  // Calculate the final position of our cell in world space.
+  // We have to add our cell size since our vertices are offset
+  // one cell up and to the left. (Do the math to verify yourself)
+  cell_pos = cell_pos + cell_size * position;
+
+  return float4(cell_pos.x, cell_pos.y, 0.5f, 1.0f);
+}
+
+fragment half4 basic_fragment() {
+  return half4(1.0);
+}

--- a/src/shaders/cell.metal
+++ b/src/shaders/cell.metal
@@ -3,7 +3,8 @@ vertex float4 basic_vertex(unsigned int vid [[ vertex_id ]]) {
   float2 grid_coord = float2(0.0f, 0.0f);
 
   // The size of a single cell in pixels
-  float2 cell_size = float2(75.0f, 100.0f);
+  //float2 cell_size = float2(75.0f, 100.0f);
+  float2 cell_size = float2(1.0f, 1.0f);
 
   // Convert the grid x,y into world space x, y by accounting for cell size
   float2 cell_pos = cell_size * grid_coord;
@@ -25,11 +26,17 @@ vertex float4 basic_vertex(unsigned int vid [[ vertex_id ]]) {
   // Calculate the final position of our cell in world space.
   // We have to add our cell size since our vertices are offset
   // one cell up and to the left. (Do the math to verify yourself)
-  cell_pos = cell_pos + cell_size * position;
+  cell_pos = cell_size * position;
 
-  return float4(cell_pos.x, cell_pos.y, 0.5f, 1.0f);
+  return float4(cell_pos.x, cell_pos.y, 0.0f, 1.0f);
+}
+
+vertex float4 demo_vertex(
+  const device packed_float3* vertex_array [[ buffer(0) ]],
+  unsigned int vid [[ vertex_id ]]) {
+  return float4(vertex_array[vid], 1.0);
 }
 
 fragment half4 basic_fragment() {
-  return half4(1.0);
+  return half4(1.0, 0.0, 0.0, 1.0);
 }

--- a/src/shaders/cell.metal
+++ b/src/shaders/cell.metal
@@ -1,26 +1,46 @@
 using namespace metal;
 
+// The possible modes that a shader can take.
+enum Mode : uint8_t {
+    MODE_BG = 1u,
+    MODE_FG = 2u,
+};
+
 struct Uniforms {
   float4x4 projection_matrix;
   float2 cell_size;
 };
 
 struct VertexIn {
+  // The mode for this cell.
+  uint8_t mode [[ attribute(0) ]];
+
   // The grid coordinates (x, y) where x < columns and y < rows
-  float2 grid_pos [[ attribute(0) ]];
+  float2 grid_pos [[ attribute(1) ]];
+
+  // The fields below are present only when rendering text.
+
+  // The position of the glyph in the texture (x,y)
+  uint2 glyph_pos [[ attribute(2) ]];
+
+  // The size of the glyph in the texture (w,h)
+  uint2 glyph_size [[ attribute(3) ]];
+
+  // The left and top bearings for the glyph (x,y)
+  int2 glyph_offset [[ attribute(4) ]];
 };
 
-vertex float4 basic_vertex(
+struct VertexOut {
+  float4 position [[ position ]];
+};
+
+vertex VertexOut uber_vertex(
   unsigned int vid [[ vertex_id ]],
   VertexIn input [[ stage_in ]],
   constant Uniforms &uniforms [[ buffer(1) ]]
 ) {
-  // Where we are in the grid (x, y) where top-left is origin
-  // float2 grid_coord = float2(5.0f, 0.0f);
-  float2 grid_coord = input.grid_pos;
-
   // Convert the grid x,y into world space x, y by accounting for cell size
-  float2 cell_pos = uniforms.cell_size * grid_coord;
+  float2 cell_pos = uniforms.cell_size * input.grid_pos;
 
   // Turn the cell position into a vertex point depending on the
   // vertex ID. Since we use instanced drawing, we have 4 vertices
@@ -36,14 +56,43 @@ vertex float4 basic_vertex(
   position.x = (vid == 0 || vid == 1) ? 1.0f : 0.0f;
   position.y = (vid == 0 || vid == 3) ? 0.0f : 1.0f;
 
-  // Calculate the final position of our cell in world space.
-  // We have to add our cell size since our vertices are offset
-  // one cell up and to the left. (Do the math to verify yourself)
-  cell_pos = cell_pos + uniforms.cell_size * position;
+  // TODO: scale
+  float2 cell_size = uniforms.cell_size;
 
-  return uniforms.projection_matrix * float4(cell_pos.x, cell_pos.y, 0.0f, 1.0f);
+  VertexOut out;
+  switch (input.mode) {
+  case MODE_BG:
+    // Calculate the final position of our cell in world space.
+    // We have to add our cell size since our vertices are offset
+    // one cell up and to the left. (Do the math to verify yourself)
+    cell_pos = cell_pos + uniforms.cell_size * position;
+
+    out.position = uniforms.projection_matrix * float4(cell_pos.x, cell_pos.y, 0.0f, 1.0f);
+    break;
+
+  case MODE_FG:
+    float2 glyph_size = float2(input.glyph_size);
+    float2 glyph_offset = float2(input.glyph_offset);
+
+    // TODO: downsampling
+
+    // The glyph_offset.y is the y bearing, a y value that when added
+    // to the baseline is the offset (+y is up). Our grid goes down.
+    // So we flip it with `cell_size.y - glyph_offset.y`.
+    glyph_offset.y = cell_size.y - glyph_offset.y;
+
+    // Calculate the final position of the cell.
+    cell_pos = cell_pos + glyph_size * position + glyph_offset;
+
+    out.position = uniforms.projection_matrix * float4(cell_pos.x, cell_pos.y, 0.0f, 1.0f);
+    break;
+  }
+
+  return out;
 }
 
-fragment half4 basic_fragment() {
+fragment half4 uber_fragment(
+  VertexOut in [[ stage_in ]]
+) {
   return half4(1.0, 0.0, 0.0, 1.0);
 }

--- a/src/shaders/cell.metal
+++ b/src/shaders/cell.metal
@@ -1,13 +1,19 @@
-vertex float4 basic_vertex(unsigned int vid [[ vertex_id ]]) {
+using namespace metal;
+
+struct Uniforms {
+    float4x4 projection_matrix;
+    float2 cell_size;
+};
+
+vertex float4 basic_vertex(
+  unsigned int vid [[ vertex_id ]],
+  constant Uniforms &uniforms [[ buffer(1) ]]
+) {
   // Where we are in the grid (x, y) where top-left is origin
   float2 grid_coord = float2(0.0f, 0.0f);
 
-  // The size of a single cell in pixels
-  //float2 cell_size = float2(75.0f, 100.0f);
-  float2 cell_size = float2(1.0f, 1.0f);
-
   // Convert the grid x,y into world space x, y by accounting for cell size
-  float2 cell_pos = cell_size * grid_coord;
+  float2 cell_pos = uniforms.cell_size * grid_coord;
 
   // Turn the cell position into a vertex point depending on the
   // vertex ID. Since we use instanced drawing, we have 4 vertices
@@ -26,9 +32,9 @@ vertex float4 basic_vertex(unsigned int vid [[ vertex_id ]]) {
   // Calculate the final position of our cell in world space.
   // We have to add our cell size since our vertices are offset
   // one cell up and to the left. (Do the math to verify yourself)
-  cell_pos = cell_pos + cell_size * position;
+  cell_pos = cell_pos + uniforms.cell_size * position;
 
-  return float4(cell_pos.x, cell_pos.y, 0.0f, 1.0f);
+  return uniforms.projection_matrix * float4(cell_pos.x, cell_pos.y, 0.0f, 1.0f);
 }
 
 fragment half4 basic_fragment() {

--- a/src/shaders/cell.metal
+++ b/src/shaders/cell.metal
@@ -1,16 +1,23 @@
 using namespace metal;
 
 struct Uniforms {
-    float4x4 projection_matrix;
-    float2 cell_size;
+  float4x4 projection_matrix;
+  float2 cell_size;
+};
+
+struct VertexIn {
+  // The grid coordinates (x, y) where x < columns and y < rows
+  float2 grid_pos [[ attribute(0) ]];
 };
 
 vertex float4 basic_vertex(
   unsigned int vid [[ vertex_id ]],
+  VertexIn input [[ stage_in ]],
   constant Uniforms &uniforms [[ buffer(1) ]]
 ) {
   // Where we are in the grid (x, y) where top-left is origin
-  float2 grid_coord = float2(0.0f, 0.0f);
+  // float2 grid_coord = float2(5.0f, 0.0f);
+  float2 grid_coord = input.grid_pos;
 
   // Convert the grid x,y into world space x, y by accounting for cell size
   float2 cell_pos = uniforms.cell_size * grid_coord;

--- a/src/shaders/cell.metal
+++ b/src/shaders/cell.metal
@@ -18,6 +18,10 @@ struct VertexIn {
   // The grid coordinates (x, y) where x < columns and y < rows
   float2 grid_pos [[ attribute(1) ]];
 
+  // The color. For BG modes, this is the bg color, for FG modes this is
+  // the text color. For styles, this is the color of the style.
+  uchar4 color [[ attribute(5) ]];
+
   // The fields below are present only when rendering text.
 
   // The position of the glyph in the texture (x,y)
@@ -32,6 +36,8 @@ struct VertexIn {
 
 struct VertexOut {
   float4 position [[ position ]];
+  uint8_t mode;
+  float4 color;
 };
 
 vertex VertexOut uber_vertex(
@@ -60,6 +66,8 @@ vertex VertexOut uber_vertex(
   float2 cell_size = uniforms.cell_size;
 
   VertexOut out;
+  out.mode = input.mode;
+  out.color = float4(input.color) / 255.0f;
   switch (input.mode) {
   case MODE_BG:
     // Calculate the final position of our cell in world space.
@@ -91,8 +99,17 @@ vertex VertexOut uber_vertex(
   return out;
 }
 
-fragment half4 uber_fragment(
-  VertexOut in [[ stage_in ]]
+fragment float4 uber_fragment(
+  VertexOut in [[ stage_in ]],
+  texture2d<float> textureGreyscale [[ texture(0) ]]
 ) {
-  return half4(1.0, 0.0, 0.0, 1.0);
+  constexpr sampler textureSampler;
+
+  switch (in.mode) {
+  case MODE_BG:
+    return in.color;
+
+  case MODE_FG:
+    return in.color;
+  }
 }

--- a/src/shaders/cell.metal
+++ b/src/shaders/cell.metal
@@ -26,15 +26,9 @@ vertex float4 basic_vertex(unsigned int vid [[ vertex_id ]]) {
   // Calculate the final position of our cell in world space.
   // We have to add our cell size since our vertices are offset
   // one cell up and to the left. (Do the math to verify yourself)
-  cell_pos = cell_size * position;
+  cell_pos = cell_pos + cell_size * position;
 
   return float4(cell_pos.x, cell_pos.y, 0.0f, 1.0f);
-}
-
-vertex float4 demo_vertex(
-  const device packed_float3* vertex_array [[ buffer(0) ]],
-  unsigned int vid [[ vertex_id ]]) {
-  return float4(vertex_array[vid], 1.0);
 }
 
 fragment half4 basic_fragment() {

--- a/src/shaders/cell.v.glsl
+++ b/src/shaders/cell.v.glsl
@@ -147,7 +147,7 @@ void main() {
         glyph_offset_calc.y = cell_size_scaled.y - glyph_offset_calc.y;
 
         // Calculate the final position of the cell.
-        cell_pos = cell_pos + glyph_size_downsampled * position + glyph_offset_calc;
+        cell_pos = cell_pos + (glyph_size_downsampled * position) + glyph_offset_calc;
         gl_Position = projection * vec4(cell_pos, cell_z, 1.0);
 
         // We need to convert our texture position and size to normalized


### PR DESCRIPTION
This implements a pure Metal renderer for macOS targets. 

Performance:
  - Average frame time: 0.7ms (Metal) vs. 1.5ms (OpenGL)
  - Average fps while `cat`-ing a 1GB file (vsync disabled): 100 (Metal) vs. 70 (OpenGL)
    * Note: while the frame time is 2x faster in Metal, the FPS is not 2x for what I assume to be lock contention on terminal state.

Why?
  - OpenGL has been deprecated on macOS since 2018. 
  - All OpenGL has to go through a Metal translation layer anyways, which has a non-zero cost. 
  - There is a bug on Mac where rendering OpenGL on a separate thread from the windowing thread can cause crashes, so most OpenGL software just don't multi-thread render on Mac. 
  - Metal is more explicit about resource management compared to OpenGL, so we gain performance.
  - Metal is much more multi-thread friendly, so our multi-threaded renderer works great! (with resizes!)
  

