### PR TITLE
Multi-Window

### DIFF
--- a/pkg/imgui/context.zig
+++ b/pkg/imgui/context.zig
@@ -14,6 +14,10 @@ pub const Context = opaque {
         c.igDestroyContext(self.cval());
     }
 
+    pub fn setCurrent(self: *Context) void {
+        c.igSetCurrentContext(self.cval());
+    }
+
     pub inline fn cval(self: *Context) *c.ImGuiContext {
         return @ptrCast(
             *c.ImGuiContext,
@@ -25,4 +29,6 @@ pub const Context = opaque {
 test {
     var ctx = try Context.create();
     defer ctx.destroy();
+
+    ctx.setCurrent();
 }

--- a/src/App.zig
+++ b/src/App.zig
@@ -10,6 +10,7 @@ const Window = @import("Window.zig");
 const tracy = @import("tracy");
 const Config = @import("config.zig").Config;
 const BlockingQueue = @import("./blocking_queue.zig").BlockingQueue;
+const renderer = @import("renderer.zig");
 
 const log = std.log.scoped(.app);
 
@@ -34,34 +35,33 @@ mailbox: *Mailbox,
 /// Initialize the main app instance. This creates the main window, sets
 /// up the renderer state, compiles the shaders, etc. This is the primary
 /// "startup" logic.
-pub fn init(alloc: Allocator, config: *const Config) !App {
+pub fn create(alloc: Allocator, config: *const Config) !*App {
     // The mailbox for messaging this thread
     var mailbox = try Mailbox.create(alloc);
     errdefer mailbox.destroy(alloc);
 
-    // Create the first window
-    var window = try Window.create(alloc, config);
-    errdefer window.destroy();
-
-    // Create our windows list and add our initial window.
-    var windows: WindowList = .{};
-    errdefer windows.deinit(alloc);
-    try windows.append(alloc, window);
-
-    return App{
+    var app = try alloc.create(App);
+    errdefer alloc.destroy(app);
+    app.* = .{
         .alloc = alloc,
-        .windows = windows,
+        .windows = .{},
         .config = config,
         .mailbox = mailbox,
     };
+    errdefer app.windows.deinit(alloc);
+
+    // Create the first window
+    try app.newWindow();
+
+    return app;
 }
 
-pub fn deinit(self: *App) void {
+pub fn destroy(self: *App) void {
     // Clean up all our windows
     for (self.windows.items) |window| window.destroy();
     self.windows.deinit(self.alloc);
     self.mailbox.destroy(self.alloc);
-    self.* = undefined;
+    self.alloc.destroy(self);
 }
 
 /// Wake up the app event loop. This should be called after any messages
@@ -86,6 +86,11 @@ pub fn run(self: *App) !void {
         while (i < self.windows.items.len) {
             const window = self.windows.items[i];
             if (window.shouldClose()) {
+                // If this was our final window, deinitialize the renderer
+                if (self.windows.items.len == 1) {
+                    renderer.Renderer.lastWindowDeinit();
+                }
+
                 window.destroy();
                 _ = self.windows.swapRemove(i);
                 continue;
@@ -107,8 +112,21 @@ fn drainMailbox(self: *App) !void {
     while (drain.next()) |message| {
         log.debug("mailbox message={}", .{message});
         switch (message) {
-            .new_window => unreachable,
+            .new_window => try self.newWindow(),
         }
+    }
+}
+
+/// Create a new window
+fn newWindow(self: *App) !void {
+    var window = try Window.create(self.alloc, self, self.config);
+    errdefer window.destroy();
+    try self.windows.append(self.alloc, window);
+    errdefer _ = self.windows.pop();
+
+    // This was the first window, so we need to initialize our renderer.
+    if (self.windows.items.len == 1) {
+        try window.renderer.firstWindowInit(window.window);
     }
 }
 

--- a/src/App.zig
+++ b/src/App.zig
@@ -74,7 +74,8 @@ pub fn wakeup(self: App) void {
 /// Run the main event loop for the application. This blocks until the
 /// application quits or every window is closed.
 pub fn run(self: *App) !void {
-    while (self.windows.items.len > 0) {
+    var quit: bool = false;
+    while (!quit and self.windows.items.len > 0) {
         // Block for any glfw events.
         try glfw.waitEvents();
 
@@ -100,12 +101,12 @@ pub fn run(self: *App) !void {
         }
 
         // Drain our mailbox
-        try self.drainMailbox();
+        try self.drainMailbox(&quit);
     }
 }
 
 /// Drain the mailbox.
-fn drainMailbox(self: *App) !void {
+fn drainMailbox(self: *App, quit: *bool) !void {
     var drain = self.mailbox.drain();
     defer drain.deinit();
 
@@ -113,6 +114,7 @@ fn drainMailbox(self: *App) !void {
         log.debug("mailbox message={}", .{message});
         switch (message) {
             .new_window => try self.newWindow(),
+            .quit => quit.* = true,
         }
     }
 }
@@ -134,4 +136,7 @@ fn newWindow(self: *App) !void {
 pub const Message = union(enum) {
     /// Create a new terminal window.
     new_window: void,
+
+    /// Quit
+    quit: void,
 };

--- a/src/App.zig
+++ b/src/App.zig
@@ -9,46 +9,111 @@ const glfw = @import("glfw");
 const Window = @import("Window.zig");
 const tracy = @import("tracy");
 const Config = @import("config.zig").Config;
+const BlockingQueue = @import("./blocking_queue.zig").BlockingQueue;
 
 const log = std.log.scoped(.app);
+
+const WindowList = std.ArrayListUnmanaged(*Window);
+
+/// The type used for sending messages to the app thread.
+pub const Mailbox = BlockingQueue(Message, 64);
 
 /// General purpose allocator
 alloc: Allocator,
 
-/// The primary window for the application. We currently support only
-/// single window operations.
-window: *Window,
+/// The list of windows that are currently open
+windows: WindowList,
 
 // The configuration for the app.
 config: *const Config,
+
+/// The mailbox that can be used to send this thread messages. Note
+/// this is a blocking queue so if it is full you will get errors (or block).
+mailbox: *Mailbox,
 
 /// Initialize the main app instance. This creates the main window, sets
 /// up the renderer state, compiles the shaders, etc. This is the primary
 /// "startup" logic.
 pub fn init(alloc: Allocator, config: *const Config) !App {
-    // Create the window
+    // The mailbox for messaging this thread
+    var mailbox = try Mailbox.create(alloc);
+    errdefer mailbox.destroy(alloc);
+
+    // Create the first window
     var window = try Window.create(alloc, config);
     errdefer window.destroy();
 
+    // Create our windows list and add our initial window.
+    var windows: WindowList = .{};
+    errdefer windows.deinit(alloc);
+    try windows.append(alloc, window);
+
     return App{
         .alloc = alloc,
-        .window = window,
+        .windows = windows,
         .config = config,
+        .mailbox = mailbox,
     };
 }
 
 pub fn deinit(self: *App) void {
-    self.window.destroy();
+    // Clean up all our windows
+    for (self.windows.items) |window| window.destroy();
+    self.windows.deinit(self.alloc);
+    self.mailbox.destroy(self.alloc);
     self.* = undefined;
 }
 
-pub fn run(self: App) !void {
-    while (!self.window.shouldClose()) {
-        // Block for any glfw events. This may also be an "empty" event
-        // posted by the libuv watcher so that we trigger a libuv loop tick.
+/// Wake up the app event loop. This should be called after any messages
+/// are sent to the mailbox.
+pub fn wakeup(self: App) void {
+    _ = self;
+    glfw.postEmptyEvent() catch {};
+}
+
+/// Run the main event loop for the application. This blocks until the
+/// application quits or every window is closed.
+pub fn run(self: *App) !void {
+    while (self.windows.items.len > 0) {
+        // Block for any glfw events.
         try glfw.waitEvents();
 
         // Mark this so we're in a totally different "frame"
         tracy.frameMark();
+
+        // If any windows are closing, destroy them
+        var i: usize = 0;
+        while (i < self.windows.items.len) {
+            const window = self.windows.items[i];
+            if (window.shouldClose()) {
+                window.destroy();
+                _ = self.windows.swapRemove(i);
+                continue;
+            }
+
+            i += 1;
+        }
+
+        // Drain our mailbox
+        try self.drainMailbox();
     }
 }
+
+/// Drain the mailbox.
+fn drainMailbox(self: *App) !void {
+    var drain = self.mailbox.drain();
+    defer drain.deinit();
+
+    while (drain.next()) |message| {
+        log.debug("mailbox message={}", .{message});
+        switch (message) {
+            .new_window => unreachable,
+        }
+    }
+}
+
+/// The message types that can be sent to the app thread.
+pub const Message = union(enum) {
+    /// Create a new terminal window.
+    new_window: void,
+};

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -761,7 +761,7 @@ fn keyCallback(
                 .new_window => {
                     _ = win.app.mailbox.push(.{
                         .new_window = {},
-                    }, .{ .forever = {} });
+                    }, .{ .instant = {} });
                     win.app.wakeup();
                 },
             }

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -136,6 +136,10 @@ pub fn create(alloc: Allocator, config: *const Config) !*Window {
     };
 
     // Find all the fonts for this window
+    //
+    // Future: we can share the font group amongst all windows to save
+    // some new window init time and some memory. This will require making
+    // thread-safe changes to font structs.
     var font_lib = try font.Library.init();
     errdefer font_lib.deinit();
     var font_group = try alloc.create(font.GroupCache);

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -764,6 +764,8 @@ fn keyCallback(
                     }, .{ .instant = {} });
                     win.app.wakeup();
                 },
+
+                .close_window => win.window.setShouldClose(true),
             }
 
             // Bindings always result in us ignoring the char if printable

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -342,7 +342,7 @@ pub fn create(alloc: Allocator, app: *App, config: *const Config) !*Window {
         .grid_size = grid_size,
         .config = config,
 
-        .imgui_ctx = if (!DevMode.enabled) void else try imgui.Context.create(),
+        .imgui_ctx = if (!DevMode.enabled) {} else try imgui.Context.create(),
     };
     errdefer if (DevMode.enabled) self.imgui_ctx.destroy();
 
@@ -766,6 +766,13 @@ fn keyCallback(
                 },
 
                 .close_window => win.window.setShouldClose(true),
+
+                .quit => {
+                    _ = win.app.mailbox.push(.{
+                        .quit = {},
+                    }, .{ .instant = {} });
+                    win.app.wakeup();
+                },
             }
 
             // Bindings always result in us ignoring the char if printable

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -255,6 +255,7 @@ pub fn create(alloc: Allocator, app: *App, config: *const Config) !*Window {
 
     // Create our terminal grid with the initial window size
     var renderer_impl = try Renderer.init(alloc, font_group);
+    errdefer renderer_impl.deinit();
     renderer_impl.background = .{
         .r = config.background.r,
         .g = config.background.g,

--- a/src/config.zig
+++ b/src/config.zig
@@ -157,6 +157,12 @@ pub const Config = struct {
             .{ .toggle_dev_mode = {} },
         );
 
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .up, .mods = .{ .super = true } },
+            .{ .new_window = {} },
+        );
+
         return result;
     }
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -159,8 +159,13 @@ pub const Config = struct {
 
         try result.keybind.set.put(
             alloc,
-            .{ .key = .up, .mods = .{ .super = true } },
+            .{ .key = .n, .mods = .{ .super = true } },
             .{ .new_window = {} },
+        );
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .w, .mods = .{ .super = true } },
+            .{ .close_window = {} },
         );
 
         return result;

--- a/src/config.zig
+++ b/src/config.zig
@@ -157,6 +157,7 @@ pub const Config = struct {
             .{ .toggle_dev_mode = {} },
         );
 
+        // Windowing
         try result.keybind.set.put(
             alloc,
             .{ .key = .n, .mods = .{ .super = true } },
@@ -167,12 +168,11 @@ pub const Config = struct {
             .{ .key = .w, .mods = .{ .super = true } },
             .{ .close_window = {} },
         );
-
         if (builtin.os.tag == .macos) {
             try result.keybind.set.put(
                 alloc,
                 .{ .key = .q, .mods = .{ .super = true } },
-                .{ .close_window = {} },
+                .{ .quit = {} },
             );
         }
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -168,6 +168,14 @@ pub const Config = struct {
             .{ .close_window = {} },
         );
 
+        if (builtin.os.tag == .macos) {
+            try result.keybind.set.put(
+                alloc,
+                .{ .key = .q, .mods = .{ .super = true } },
+                .{ .close_window = {} },
+            );
+        }
+
         return result;
     }
 

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -139,6 +139,9 @@ pub const Action = union(enum) {
 
     /// Close the current window
     close_window: void,
+
+    /// Quit ghostty
+    quit: void,
 };
 
 /// Trigger is the associated key state that can trigger an action.

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -134,8 +134,11 @@ pub const Action = union(enum) {
     /// Dev mode
     toggle_dev_mode: void,
 
-    /// Open a new terminal window.
+    /// Open a new window
     new_window: void,
+
+    /// Close the current window
+    close_window: void,
 };
 
 /// Trigger is the associated key state that can trigger an action.

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -133,6 +133,9 @@ pub const Action = union(enum) {
 
     /// Dev mode
     toggle_dev_mode: void,
+
+    /// Open a new terminal window.
+    new_window: void,
 };
 
 /// Trigger is the associated key state that can trigger an action.

--- a/src/main.zig
+++ b/src/main.zig
@@ -128,8 +128,8 @@ pub fn main() !void {
     defer glfw.terminate();
 
     // Run our app
-    var app = try App.init(alloc, &config);
-    defer app.deinit();
+    var app = try App.create(alloc, &config);
+    defer app.destroy();
     try app.run();
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -22,6 +22,9 @@ pub fn main() !void {
     }
     std.log.info("renderer={}", .{renderer.Renderer});
 
+    // First things first, we fix our file descriptors
+    fixMaxFiles();
+
     const GPA = std.heap.GeneralPurposeAllocator(.{});
     var gpa: ?GPA = gpa: {
         // Use the libc allocator if it is available beacuse it is WAY
@@ -186,6 +189,54 @@ pub fn log(
 
 fn glfwErrorCallback(code: glfw.Error, desc: [:0]const u8) void {
     std.log.warn("glfw error={} message={s}", .{ code, desc });
+}
+
+/// This maximizes the number of file descriptors we can have open. We
+/// need to do this because each window consumes at least a handful of fds.
+/// This is extracted from the Zig compiler source code.
+fn fixMaxFiles() void {
+    if (!@hasDecl(std.os.system, "rlimit")) return;
+    const posix = std.os;
+
+    var lim = posix.getrlimit(.NOFILE) catch {
+        std.log.warn("failed to query file handle limit, may limit max windows", .{});
+        return; // Oh well; we tried.
+    };
+    if (comptime builtin.target.isDarwin()) {
+        // On Darwin, `NOFILE` is bounded by a hardcoded value `OPEN_MAX`.
+        // According to the man pages for setrlimit():
+        //   setrlimit() now returns with errno set to EINVAL in places that historically succeeded.
+        //   It no longer accepts "rlim_cur = RLIM.INFINITY" for RLIM.NOFILE.
+        //   Use "rlim_cur = min(OPEN_MAX, rlim_max)".
+        lim.max = std.math.min(std.os.darwin.OPEN_MAX, lim.max);
+    }
+
+    // If we're already at the max, we're done.
+    if (lim.cur >= lim.max) {
+        std.log.debug("file handle limit already maximized value={}", .{lim.cur});
+        return;
+    }
+
+    // Do a binary search for the limit.
+    var min: posix.rlim_t = lim.cur;
+    var max: posix.rlim_t = 1 << 20;
+    // But if there's a defined upper bound, don't search, just set it.
+    if (lim.max != posix.RLIM.INFINITY) {
+        min = lim.max;
+        max = lim.max;
+    }
+
+    while (true) {
+        lim.cur = min + @divTrunc(max - min, 2); // on freebsd rlim_t is signed
+        if (posix.setrlimit(.NOFILE, lim)) |_| {
+            min = lim.cur;
+        } else |_| {
+            max = lim.cur;
+        }
+        if (min + 1 >= max) break;
+    }
+
+    std.log.debug("file handle limit raised value={}", .{lim.cur});
 }
 
 test {

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -265,10 +265,8 @@ pub fn finalizeWindowInit(self: *const Metal, window: glfw.Window) !void {
     layer.setProperty("contentsScale", scaleFactor);
 }
 
-/// This is called only after the first window is opened. This may be
-/// called multiple times if all windows are closed and a new one is
-/// reopened.
-pub fn firstWindowInit(self: *const Metal, window: glfw.Window) !void {
+/// This is called if this renderer runs DevMode.
+pub fn initDevMode(self: *const Metal, window: glfw.Window) !void {
     if (DevMode.enabled) {
         // Initialize for our window
         assert(imgui.ImplGlfw.initForOther(
@@ -279,8 +277,10 @@ pub fn firstWindowInit(self: *const Metal, window: glfw.Window) !void {
     }
 }
 
-/// This is called only when the last window is destroyed.
-pub fn lastWindowDeinit() void {
+/// This is called if this renderer runs DevMode.
+pub fn deinitDevMode(self: *const Metal) void {
+    _ = self;
+
     if (DevMode.enabled) {
         imgui.ImplMetal.shutdown();
         imgui.ImplGlfw.shutdown();

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -300,11 +300,6 @@ pub fn init(alloc: Allocator, font_group: *font.GroupCache) !OpenGL {
 }
 
 pub fn deinit(self: *OpenGL) void {
-    if (DevMode.enabled) {
-        imgui.ImplOpenGL3.shutdown();
-        imgui.ImplGlfw.shutdown();
-    }
-
     self.font_shaper.deinit();
     self.alloc.free(self.font_shaper.cell_buf);
 
@@ -387,7 +382,17 @@ pub fn windowInit(window: glfw.Window) !void {
 
 /// This is called just prior to spinning up the renderer thread for
 /// final main thread setup requirements.
-pub fn finalizeInit(self: *const OpenGL, window: glfw.Window) !void {
+pub fn finalizeWindowInit(self: *const OpenGL, window: glfw.Window) !void {
+    _ = self;
+    _ = window;
+}
+
+/// This is called only after the first window is opened. This may be
+/// called multiple times if all windows are closed and a new one is
+/// reopened.
+pub fn firstWindowInit(self: *const OpenGL, window: glfw.Window) !void {
+    _ = self;
+
     if (DevMode.enabled) {
         // Initialize for our window
         assert(imgui.ImplGlfw.initForOpenGL(
@@ -396,9 +401,14 @@ pub fn finalizeInit(self: *const OpenGL, window: glfw.Window) !void {
         ));
         assert(imgui.ImplOpenGL3.init("#version 330 core"));
     }
+}
 
-    // Call thread exit to clean up our context
-    self.threadExit();
+/// This is called only when the last window is destroyed.
+pub fn lastWindowDeinit() void {
+    if (DevMode.enabled) {
+        imgui.ImplOpenGL3.shutdown();
+        imgui.ImplGlfw.shutdown();
+    }
 }
 
 /// Callback called by renderer.Thread when it begins.

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -387,10 +387,8 @@ pub fn finalizeWindowInit(self: *const OpenGL, window: glfw.Window) !void {
     _ = window;
 }
 
-/// This is called only after the first window is opened. This may be
-/// called multiple times if all windows are closed and a new one is
-/// reopened.
-pub fn firstWindowInit(self: *const OpenGL, window: glfw.Window) !void {
+/// This is called if this renderer runs DevMode.
+pub fn initDevMode(self: *const OpenGL, window: glfw.Window) !void {
     _ = self;
 
     if (DevMode.enabled) {
@@ -403,8 +401,10 @@ pub fn firstWindowInit(self: *const OpenGL, window: glfw.Window) !void {
     }
 }
 
-/// This is called only when the last window is destroyed.
-pub fn lastWindowDeinit() void {
+/// This is called if this renderer runs DevMode.
+pub fn deinitDevMode(self: *const OpenGL) void {
+    _ = self;
+
     if (DevMode.enabled) {
         imgui.ImplOpenGL3.shutdown();
         imgui.ImplGlfw.shutdown();

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -65,7 +65,11 @@ pub fn init(
 
     // Create our event loop.
     var loop = try libuv.Loop.init(alloc);
-    errdefer loop.deinit(alloc);
+    errdefer {
+        // Run the loop once to close any of our handles
+        _ = loop.run(.nowait) catch 0;
+        loop.deinit(alloc);
+    }
     loop.setData(allocPtr);
 
     // This async handle is used to "wake up" the renderer and force a render.

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -49,7 +49,11 @@ pub fn init(
 
     // Create our event loop.
     var loop = try libuv.Loop.init(alloc);
-    errdefer loop.deinit(alloc);
+    errdefer {
+        // Run the loop once to close any of our handles
+        _ = loop.run(.nowait) catch 0;
+        loop.deinit(alloc);
+    }
     loop.setData(allocPtr);
 
     // This async handle is used to "wake up" the renderer and force a render.


### PR DESCRIPTION
This adds the ability to have multiple windows by introducing new keybind actions `new_window`, `close_window`, and `quit`. These are bound on macOS by default to the standard `cmd+n`, `cmd+w`, and `cmd+q`, respectively.

The multi-window logic is absolutely minimal: we don't do any GPU data sharing between windows, so each window recreates a full font texture for example. We can continue to further optimize this in the future.

DevMode is also pretty limited (arguably broken) with multi-window: DevMode only works on the _first_ window opened. If you close the first window, DevMode is no longer available. This is due to complexities around multi-threading and imgui. It is possible to fix this but I deferred it since it was a bit of a mess!