### PR TITLE
Balanced Viewport Margins/Padding

### DIFF
--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -952,31 +952,8 @@ fn setScreenSize(self: *OpenGL, dim: renderer.ScreenSize) !void {
     // Determine if we need to pad the window. For "auto" padding, we take
     // the leftover amounts on the right/bottom that don't fit a full grid cell
     // and we split them equal across all boundaries.
-
-    // The size of our full grid
-    const grid_width = @intToFloat(f32, grid_size.columns) * self.cell_size.width;
-    const grid_height = @intToFloat(f32, grid_size.rows) * self.cell_size.height;
-
-    // The empty space to the right of a line and bottom of the last row
-    const space_right = @intToFloat(f32, dim.width) - grid_width;
-    const space_bot = @intToFloat(f32, dim.height) - grid_height;
-
-    // The left/right padding is just an equal split.
-    const padding_right = @floatToInt(i32, @floor(space_right / 2));
-    const padding_left = padding_right;
-
-    // The top/bottom padding is interesting. Subjectively, lots of padding
-    // at the top looks bad. So instead of always being equal (like left/right),
-    // we force the top padding to be at most equal to the left, and the bottom
-    // padding is the difference thereafter.
-    const padding_top = @min(padding_left, @floatToInt(i32, @floor(space_bot / 2)));
-    const padding_bot = @floatToInt(i32, space_bot - @intToFloat(f32, padding_top));
-
-    // The full padded dimensions of the renderable area.
-    const padded_dim: renderer.ScreenSize = .{
-        .width = dim.width - @intCast(u32, padding_left + padding_right),
-        .height = dim.height - @intCast(u32, padding_bot + padding_top),
-    };
+    const padding = renderer.Padding.balanced(dim, grid_size, self.cell_size);
+    const padded_dim = dim.subPadding(padding);
 
     log.debug("screen size padded={} screen={} grid={} cell={}", .{ padded_dim, dim, grid_size, self.cell_size });
 
@@ -998,8 +975,8 @@ fn setScreenSize(self: *OpenGL, dim: renderer.ScreenSize) !void {
     // Update our viewport for this context to be the entire window.
     // OpenGL works in pixels, so we have to use the pixel size.
     try gl.viewport(
-        padding_left,
-        padding_bot,
+        @floatToInt(i32, padding.left),
+        @floatToInt(i32, padding.bottom),
         @intCast(i32, padded_dim.width),
         @intCast(i32, padded_dim.height),
     );

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -975,10 +975,10 @@ fn setScreenSize(self: *OpenGL, dim: renderer.ScreenSize) !void {
     // Update our viewport for this context to be the entire window.
     // OpenGL works in pixels, so we have to use the pixel size.
     try gl.viewport(
-        @floatToInt(i32, padding.left),
-        @floatToInt(i32, padding.bottom),
-        @intCast(i32, padded_dim.width),
-        @intCast(i32, padded_dim.height),
+        0,
+        0,
+        @intCast(i32, dim.width),
+        @intCast(i32, dim.height),
     );
 
     // Update the projection uniform within our shader
@@ -990,10 +990,10 @@ fn setScreenSize(self: *OpenGL, dim: renderer.ScreenSize) !void {
 
             // 2D orthographic projection with the full w/h
             math.ortho2d(
-                0,
+                -1 * padding.left,
                 @intToFloat(f32, padded_dim.width),
                 @intToFloat(f32, padded_dim.height),
-                0,
+                -1 * padding.top,
             ),
         );
     }


### PR DESCRIPTION
Related to #28 (but doesn't resolve it fully).

Previously, ghostty always rendered the given exactly in the top-left. However, window dimensions are rarely perfectly divisible by the cell size. The cell size is fixed given a font and font size. Therefore, there was usually extra padding on the right and bottom. If the window was _not quite_ the cell size but close, this padding can be quite large.

This PR changes the behavior so that this extra padding is automatically balanced to the top and left, too. This makes the worst possible padding look a lot better, and the viewport is always balanced. If the window dimensions happen to be perfectly divisible, the grid will still hug the top/left.

I first noticed this behavior with Kitty, and I haven't noticed it in any other terminal emulator.

**This will be configurable in a future PR.**

Before/after is shown below with the same font and font size.

## Before

<img width="460" alt="CleanShot 2022-11-14 at 13 15 35@2x" src="https://user-images.githubusercontent.com/1299/201767486-1b8cad98-f49c-4973-8f12-04957203766b.png">

## After

<img width="487" alt="CleanShot 2022-11-14 at 13 16 28@2x" src="https://user-images.githubusercontent.com/1299/201767496-fcd52698-2b1a-4873-916f-2b6a029ec344.png">
