### PR TITLE
Font Resize at Runtime

### DIFF
--- a/src/Window.zig
+++ b/src/Window.zig
@@ -79,8 +79,10 @@ io: termio.Impl,
 io_thread: termio.Thread,
 io_thr: std.Thread,
 
-/// The dimensions of the grid in rows and columns.
+/// All the cached sizes since we need them at various times.
+screen_size: renderer.ScreenSize,
 grid_size: renderer.GridSize,
+cell_size: renderer.CellSize,
 
 /// Explicit padding due to configuration
 padding: renderer.Padding,
@@ -262,6 +264,9 @@ pub fn create(alloc: Allocator, app: *App, config: *const Config) !*Window {
     });
     errdefer font_group.deinit(alloc);
 
+    // Pre-calculate our initial cell size ourselves.
+    const cell_size = try renderer.CellSize.init(alloc, font_group);
+
     // Convert our padding from points to pixels
     const padding_x = (@intToFloat(f32, config.@"window-padding-x") * x_dpi) / 72;
     const padding_y = (@intToFloat(f32, config.@"window-padding-y") * y_dpi) / 72;
@@ -279,6 +284,7 @@ pub fn create(alloc: Allocator, app: *App, config: *const Config) !*Window {
             .explicit = padding,
             .balance = config.@"window-padding-balance",
         },
+        .window_mailbox = .{ .window = self, .app = app.mailbox },
     });
     errdefer renderer_impl.deinit();
     renderer_impl.background = .{
@@ -298,13 +304,16 @@ pub fn create(alloc: Allocator, app: *App, config: *const Config) !*Window {
         .width = window_size.width,
         .height = window_size.height,
     };
-    const grid_size = renderer_impl.gridSize(screen_size);
+    const grid_size = renderer.GridSize.init(
+        screen_size.subPadding(padding),
+        cell_size,
+    );
 
     // Set a minimum size that is cols=10 h=4. This matches Mac's Terminal.app
     // but is otherwise somewhat arbitrary.
     try window.setSizeLimits(.{
-        .width = @floatToInt(u32, renderer_impl.cell_size.width * 10),
-        .height = @floatToInt(u32, renderer_impl.cell_size.height * 4),
+        .width = @floatToInt(u32, cell_size.width * 10),
+        .height = @floatToInt(u32, cell_size.height * 4),
     }, .{ .width = null, .height = null });
 
     // Create the cursor
@@ -371,7 +380,9 @@ pub fn create(alloc: Allocator, app: *App, config: *const Config) !*Window {
         .io = io,
         .io_thread = io_thread,
         .io_thr = undefined,
+        .screen_size = screen_size,
         .grid_size = grid_size,
+        .cell_size = cell_size,
         .padding = padding,
         .config = config,
 
@@ -569,18 +580,22 @@ fn sizeCallback(window: glfw.Window, width: i32, height: i32) void {
         };
     };
 
-    const screen_size: renderer.ScreenSize = .{
-        .width = px_size.width,
-        .height = px_size.height,
-    };
-
     const win = window.getUserPointer(Window) orelse return;
 
     // TODO: if our screen size didn't change, then we should avoid the
     // overhead of inter-thread communication
 
+    // Save our screen size
+    win.screen_size = .{
+        .width = px_size.width,
+        .height = px_size.height,
+    };
+
     // Recalculate our grid size
-    win.grid_size = win.renderer.gridSize(screen_size);
+    win.grid_size = renderer.GridSize.init(
+        win.screen_size.subPadding(win.padding),
+        win.cell_size,
+    );
     if (win.grid_size.columns < 5 and (win.padding.left > 0 or win.padding.right > 0)) {
         log.warn("WARNING: very small terminal grid detected with padding " ++
             "set. Is your padding reasonable?", .{});
@@ -594,7 +609,7 @@ fn sizeCallback(window: glfw.Window, width: i32, height: i32) void {
     _ = win.io_thread.mailbox.push(.{
         .resize = .{
             .grid_size = win.grid_size,
-            .screen_size = screen_size,
+            .screen_size = win.screen_size,
             .padding = win.padding,
         },
     }, .{ .forever = {} });
@@ -1386,10 +1401,10 @@ fn cursorPosCallback(
     //
 
     // the boundary point at which we consider selection or non-selection
-    const cell_xboundary = win.renderer.cell_size.width * 0.6;
+    const cell_xboundary = win.cell_size.width * 0.6;
 
     // first xpos of the clicked cell
-    const cell_xstart = @intToFloat(f32, win.mouse.left_click_point.x) * win.renderer.cell_size.width;
+    const cell_xstart = @intToFloat(f32, win.mouse.left_click_point.x) * win.cell_size.width;
     const cell_start_xpos = win.mouse.left_click_xpos - cell_xstart;
 
     // If this is the same cell, then we only start the selection if weve
@@ -1464,7 +1479,7 @@ fn posToViewport(self: Window, xpos: f64, ypos: f64) terminal.point.Viewport {
     return .{
         .x = if (xpos < 0) 0 else x: {
             // Our cell is the mouse divided by cell width
-            const cell_width = @floatCast(f64, self.renderer.cell_size.width);
+            const cell_width = @floatCast(f64, self.cell_size.width);
             const x = @floatToInt(usize, xpos / cell_width);
 
             // Can be off the screen if the user drags it out, so max
@@ -1473,7 +1488,7 @@ fn posToViewport(self: Window, xpos: f64, ypos: f64) terminal.point.Viewport {
         },
 
         .y = if (ypos < 0) 0 else y: {
-            const cell_height = @floatCast(f64, self.renderer.cell_size.height);
+            const cell_height = @floatCast(f64, self.cell_size.height);
             const y = @floatToInt(usize, ypos / cell_height);
             break :y @min(y, self.io.terminal.rows - 1);
         },

--- a/src/config.zig
+++ b/src/config.zig
@@ -176,6 +176,23 @@ pub const Config = struct {
         try result.keybind.set.put(alloc, .{ .key = .f11 }, .{ .csi = "23~" });
         try result.keybind.set.put(alloc, .{ .key = .f12 }, .{ .csi = "24~" });
 
+        // Fonts
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .equal, .mods = .{ .super = true } },
+            .{ .increase_font_size = 1 },
+        );
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .minus, .mods = .{ .super = true } },
+            .{ .decrease_font_size = 1 },
+        );
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .zero, .mods = .{ .super = true } },
+            .{ .reset_font_size = {} },
+        );
+
         // Dev Mode
         try result.keybind.set.put(
             alloc,

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -65,6 +65,15 @@ pub const Face = struct {
         self.* = undefined;
     }
 
+    /// Resize the font in-place. If this succeeds, the caller is responsible
+    /// for clearing any glyph caches, font atlas data, etc.
+    pub fn setSize(self: *Face, size: font.face.DesiredSize) !void {
+        // We just create a copy and replace ourself
+        const face = try initFontCopy(self.font, size);
+        self.deinit();
+        self.* = face;
+    }
+
     /// Returns the glyph index for the given Unicode code point. If this
     /// face doesn't support this glyph, null is returned.
     pub fn glyphIndex(self: Face, cp: u32) ?u32 {

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -131,6 +131,13 @@ pub const Action = union(enum) {
     copy_to_clipboard: void,
     paste_from_clipboard: void,
 
+    /// Increase/decrease the font size by a certain amount
+    increase_font_size: u16,
+    decrease_font_size: u16,
+
+    /// Reset the font size to the original configured size
+    reset_font_size: void,
+
     /// Dev mode
     toggle_dev_mode: void,
 

--- a/src/input/key.zig
+++ b/src/input/key.zig
@@ -49,8 +49,22 @@ pub const Key = enum {
     y,
     z,
 
+    // numbers
+    zero,
+    one,
+    two,
+    three,
+    four,
+    five,
+    six,
+    seven,
+    eight,
+    nine,
+
     // other
     grave_accent, // `
+    minus,
+    equal,
 
     // control
     up,

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -320,6 +320,9 @@ pub fn deinit(self: *OpenGL) void {
 }
 
 fn resetCellsLRU(self: *OpenGL) void {
+    // Preserve the old capacity so that we have space in our LRU
+    const cap = self.cells_lru.capacity;
+
     // Our LRU values are array lists so we need to deallocate those first
     var it = self.cells_lru.queue.first;
     while (it) |node| {
@@ -329,7 +332,7 @@ fn resetCellsLRU(self: *OpenGL) void {
     self.cells_lru.deinit(self.alloc);
 
     // Initialize our new LRU
-    self.cells_lru = CellsLRU.init(0);
+    self.cells_lru = CellsLRU.init(cap);
 }
 
 /// Returns the hints that we want for this
@@ -468,6 +471,8 @@ pub fn blinkCursor(self: *OpenGL, reset: bool) void {
 ///
 /// Must be called on the render thread.
 pub fn setFontSize(self: *OpenGL, size: font.face.DesiredSize) !void {
+    log.info("set font size={}", .{size});
+
     // Set our new size, this will also reset our font atlas.
     try self.font_group.setSize(size);
 

--- a/src/renderer/Options.zig
+++ b/src/renderer/Options.zig
@@ -2,12 +2,17 @@
 
 const font = @import("../font/main.zig");
 const renderer = @import("../renderer.zig");
+const Window = @import("../Window.zig");
 
 /// The font group that should be used.
 font_group: *font.GroupCache,
 
 /// Padding options for the viewport.
 padding: Padding,
+
+/// The mailbox for sending the window messages. This is only valid
+/// once the thread has started and should not be used outside of the thread.
+window_mailbox: Window.Mailbox,
 
 pub const Padding = struct {
     // Explicit padding options, in pixels. The windowing thread is

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -275,6 +275,10 @@ fn drainMailbox(self: *Thread) !void {
                     _ = try self.cursor_h.again();
                 }
             },
+
+            .font_size => |size| {
+                try self.renderer.setFontSize(size);
+            },
         }
     }
 }

--- a/src/renderer/message.zig
+++ b/src/renderer/message.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
+const font = @import("../font/main.zig");
 
 /// The messages that can be sent to a renderer thread.
 pub const Message = union(enum) {
@@ -12,4 +13,9 @@ pub const Message = union(enum) {
     /// Reset the cursor blink by immediately showing the cursor then
     /// restarting the timer.
     reset_cursor_blink: void,
+
+    /// Change the font size. This should recalculate the grid size and
+    /// send a grid size change message back to the window thread if
+    /// the size changes.
+    font_size: font.face.DesiredSize,
 };

--- a/src/window/message.zig
+++ b/src/window/message.zig
@@ -1,5 +1,6 @@
 const App = @import("../App.zig");
 const Window = @import("../Window.zig");
+const renderer = @import("../renderer.zig");
 
 /// The message types that can be sent to a single window.
 pub const Message = union(enum) {

--- a/src/window/message.zig
+++ b/src/window/message.zig
@@ -9,6 +9,9 @@ pub const Message = union(enum) {
     /// the termio message so that we can more efficiently send strings
     /// of any length
     set_title: [256]u8,
+
+    /// Change the cell size.
+    cell_size: renderer.CellSize,
 };
 
 /// A window mailbox.


### PR DESCRIPTION
Fixes #24 

https://user-images.githubusercontent.com/1299/202083190-6654e3f5-4d8b-408f-91b3-8e1ede13739d.mp4

This introduces three new bindable keyboard actions:

* `increase_font_size=<n>` (default: `cmd +`) - Increase the font size by `n` points.
* `decrease_font_size=<n>` (default: `cmd -`) - Decrease the font size by `n` points.
* `reset_font_size` (default: `cmd 0`) - Reset to the originally configured font size.

This was more complicated than I expected! There were a couple complexities:

First, changing font size => changes cell size => can change grid size => needs to be sent to pty => needs to resize terminal (with reflow). Second, changing font size has to clear our font atlas and also send down a lot of updated GPU uniforms for font metrics (cell size, underline position, etc.). 

This is implemented in the following flow:

  1. Window thread gets font size change request via keyboard bindings.
  2. Window thread sends font size message to renderer thread.
  3. Renderer thread changes font size in the glyph rasterizer, resets the texture atlas, recalculates font metrics, updates GPU uniforms, recalculates the cell size.
  4. Renderer thread sends cell size change (if it changed) message to Window.
  5. Window updates cached sizing, sends resize message to Termio thread.
  6. Termio thread updates PTY size (ioctl), then resizes the terminal state and performs text reflow.
  7. Termio thread marks the full screen as dirty for the renderer.
  8. Renderer redraws the new size on the next frame.

As another note, the font size is changed in-place; we don't have to reload the full font face (i.e. parse the TTF and so on). Both Freetype and CoreText provide APIs for changing font size in-place.