### PR TITLE
Multi-Pass Rendering for Backgrounds

### DIFF
--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -667,7 +667,7 @@ pub fn rebuildCells(
 
         // * 3 for background modes and cursor and underlines
         // + 1 for cursor
-        (screen.rows * screen.cols * 3) + 1,
+        (screen.rows * screen.cols * 2) + 1,
     );
 
     // We've written no data to the GPU, refresh it all


### PR DESCRIPTION
Fixes #45 

Previously, we would render all "cells" (bg, fg, decorations, cursor) in a single GPU pass. This created issues because depending on the ordering of the cells, proper depth was not maintained. A real issue caused by this can be seen in #45. One approach to solve this is to use a real GPU depth buffer. I tried this and ran into various [fixable] issues, and I didn't want to deal with it. 

Instead, the approach taken in this PR is to execute the shader in multiple passes: first for the bg, then everything else. This resolves the issue.

This approach is also beneficial because we plan to split our uber shader into smaller shaders which will require we start splitting data and doing multi-pass anyways. So this helps lay some of the groundwork for that.

See #45 for more details on the fix.