### PR TITLE
Configurable 256 Color Palette

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -36,6 +36,16 @@ pub const Config = struct {
     /// Foreground color for the window.
     foreground: Color = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF },
 
+    /// Color palette for the 256 color form that many terminal applications
+    /// use. The syntax of this configuration is "N=HEXCODE" where "n"
+    /// is 0 to 255 (for the 256 colors) and HEXCODE is a typical RGB
+    /// color code such as "#AABBCC". The 0 to 255 correspond to the
+    /// terminal color table.
+    ///
+    /// For definitions on all the codes:
+    /// https://www.ditig.com/256-colors-cheat-sheet
+    palette: Palette = .{},
+
     /// The command to run, usually a shell. If this is not an absolute path,
     /// it'll be looked up in the PATH. If this is not set, a default will
     /// be looked up from your system. The rules for the default lookup are:

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -60,6 +60,9 @@ scrolling_region: ScrollingRegion,
 /// The charset state
 charset: CharsetState = .{},
 
+/// The color palette to use
+color_palette: color.Palette = color.default,
+
 /// The previous printed character. This is used for the repeat previous
 /// char CSI (ESC [ <n> b).
 previous_char: ?u21 = null,
@@ -429,12 +432,12 @@ pub fn setAttribute(self: *Terminal, attr: sgr.Attribute) !void {
 
         .@"8_fg" => |n| {
             self.screen.cursor.pen.attrs.has_fg = true;
-            self.screen.cursor.pen.fg = color.default[@enumToInt(n)];
+            self.screen.cursor.pen.fg = self.color_palette[@enumToInt(n)];
         },
 
         .@"8_bg" => |n| {
             self.screen.cursor.pen.attrs.has_bg = true;
-            self.screen.cursor.pen.bg = color.default[@enumToInt(n)];
+            self.screen.cursor.pen.bg = self.color_palette[@enumToInt(n)];
         },
 
         .reset_fg => self.screen.cursor.pen.attrs.has_fg = false,
@@ -443,22 +446,22 @@ pub fn setAttribute(self: *Terminal, attr: sgr.Attribute) !void {
 
         .@"8_bright_fg" => |n| {
             self.screen.cursor.pen.attrs.has_fg = true;
-            self.screen.cursor.pen.fg = color.default[@enumToInt(n)];
+            self.screen.cursor.pen.fg = self.color_palette[@enumToInt(n)];
         },
 
         .@"8_bright_bg" => |n| {
             self.screen.cursor.pen.attrs.has_bg = true;
-            self.screen.cursor.pen.bg = color.default[@enumToInt(n)];
+            self.screen.cursor.pen.bg = self.color_palette[@enumToInt(n)];
         },
 
         .@"256_fg" => |idx| {
             self.screen.cursor.pen.attrs.has_fg = true;
-            self.screen.cursor.pen.fg = color.default[idx];
+            self.screen.cursor.pen.fg = self.color_palette[idx];
         },
 
         .@"256_bg" => |idx| {
             self.screen.cursor.pen.attrs.has_bg = true;
-            self.screen.cursor.pen.bg = color.default[idx];
+            self.screen.cursor.pen.bg = self.color_palette[idx];
         },
 
         .unknown => return error.InvalidAttribute,

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -107,8 +107,13 @@ pub fn init(alloc: Allocator, opts: termio.Options) !Exec {
     log.info("started subcommand path={s} pid={?}", .{ path, cmd.pid });
 
     // Create our terminal
-    var term = try terminal.Terminal.init(alloc, opts.grid_size.columns, opts.grid_size.rows);
+    var term = try terminal.Terminal.init(
+        alloc,
+        opts.grid_size.columns,
+        opts.grid_size.rows,
+    );
     errdefer term.deinit(alloc);
+    term.color_palette = opts.config.palette.value;
 
     return Exec{
         .alloc = alloc,


### PR DESCRIPTION
The 256 color palette can now be configured with the `palette=N=HEX` format in the config. Example, Dracula:

```
foreground=#f8f8f2
background=#282a36
palette=0=#21222c
palette=8=#6272a4
palette=1=#ff5555
palette=9=#ff6e6e
palette=2=#50fa7b
palette=10=#69ff94
palette=3=#f1fa8c
palette=11=#ffffa5
palette=4=#bd93f9
palette=12=#d6acff
palette=5=#ff79c6
palette=13=#ff92df
palette=6=#8be9fd
palette=14=#a4ffff
palette=7=#f8f8f2
palette=15=#ffffff
```