### PR TITLE
OSC 52: Clipboard Control

### DIFF
--- a/src/Window.zig
+++ b/src/Window.zig
@@ -607,6 +607,11 @@ pub fn handleMessage(self: *Window, msg: Message) !void {
 }
 
 fn clipboardRead(self: *const Window, kind: u8) !void {
+    if (!self.config.@"clipboard-read") {
+        log.info("application attempted to read clipboard, but 'clipboard-read' setting is off", .{});
+        return;
+    }
+
     const data = glfw.getClipboardString() catch |err| {
         log.warn("error reading clipboard: {}", .{err});
         return;
@@ -638,6 +643,11 @@ fn clipboardRead(self: *const Window, kind: u8) !void {
 }
 
 fn clipboardWrite(self: *const Window, data: []const u8) !void {
+    if (!self.config.@"clipboard-write") {
+        log.info("application attempted to write clipboard, but 'clipboard-write' setting is off", .{});
+        return;
+    }
+
     const dec = std.base64.standard.Decoder;
 
     // Build buffer

--- a/src/config.zig
+++ b/src/config.zig
@@ -141,6 +141,12 @@ pub const Config = struct {
     /// specified in the configuration "font-size" will be used.
     @"window-inherit-font-size": bool = true,
 
+    /// Whether to allow programs running in the terminal to read/write to
+    /// the system clipboard (OSC 52, for googling). The default is to
+    /// disallow clipboard reading but allow writing.
+    @"clipboard-read": bool = false,
+    @"clipboard-write": bool = true,
+
     /// Additional configuration files to read.
     @"config-file": RepeatableString = .{},
 

--- a/src/terminal/Parser.zig
+++ b/src/terminal/Parser.zig
@@ -567,6 +567,31 @@ test "osc: change window title" {
 
         const cmd = a[0].?.osc_dispatch;
         try testing.expect(cmd == .change_window_title);
+        try testing.expectEqualStrings("abc", cmd.change_window_title);
+    }
+}
+
+test "osc: change window title (end in esc)" {
+    var p = init();
+    _ = p.next(0x1B);
+    _ = p.next(']');
+    _ = p.next('0');
+    _ = p.next(';');
+    _ = p.next('a');
+    _ = p.next('b');
+    _ = p.next('c');
+
+    {
+        const a = p.next(0x1B);
+        _ = p.next('\\');
+        try testing.expect(p.state == .ground);
+        try testing.expect(a[0].? == .osc_dispatch);
+        try testing.expect(a[1] == null);
+        try testing.expect(a[2] == null);
+
+        const cmd = a[0].?.osc_dispatch;
+        try testing.expect(cmd == .change_window_title);
+        try testing.expectEqualStrings("abc", cmd.change_window_title);
     }
 }
 

--- a/src/terminal/osc.zig
+++ b/src/terminal/osc.zig
@@ -326,11 +326,7 @@ pub const Parser = struct {
                 else => self.state = .invalid,
             },
 
-            .string => {
-                // Complete once we receive one character since we have
-                // at least SOME value for the expected string value.
-                self.complete = true;
-            },
+            .string => self.complete = true,
         }
     }
 
@@ -352,6 +348,10 @@ pub const Parser = struct {
         }
     }
 
+    fn endString(self: *Parser) void {
+        self.temp_state.str.* = self.buf[self.buf_start..self.buf_idx];
+    }
+
     /// End the sequence and return the command, if any. If the return value
     /// is null, then no valid command was found.
     pub fn end(self: *Parser) ?Command {
@@ -364,7 +364,7 @@ pub const Parser = struct {
         switch (self.state) {
             .semantic_exit_code => self.endSemanticExitCode(),
             .semantic_option_value => self.endSemanticOptionValue(),
-            .string => self.temp_state.str.* = self.buf[self.buf_start..self.buf_idx],
+            .string => self.endString(),
             else => {},
         }
 

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -464,6 +464,12 @@ pub fn Stream(comptime Handler: type) type {
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
 
+                .clipboard_contents => |clip| {
+                    if (@hasDecl(T, "clipboardContents")) {
+                        try self.handler.clipboardContents(clip.kind, clip.data);
+                    } else log.warn("unimplemented OSC callback: {}", .{cmd});
+                },
+
                 else => if (@hasDecl(T, "oscUnimplemented"))
                     try self.handler.oscUnimplemented(cmd)
                 else

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -829,6 +829,12 @@ const StreamHandler = struct {
             return;
         }
 
-        unreachable;
+        // Write clipboard contents
+        _ = self.window_mailbox.push(.{
+            .clipboard_write = try Window.Message.WriteReq.init(
+                self.alloc,
+                data,
+            ),
+        }, .{ .forever = {} });
     }
 };

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -815,4 +815,20 @@ const StreamHandler = struct {
             .set_title = buf,
         }, .{ .forever = {} });
     }
+
+    pub fn clipboardContents(self: *StreamHandler, kind: u8, data: []const u8) !void {
+        // Note: we ignore the "kind" field and always use the primary clipboard.
+        // iTerm also appears to do this but other terminals seem to only allow
+        // certain. Let's investigate more.
+
+        // Get clipboard contents
+        if (data.len == 1 and data[0] == '?') {
+            _ = self.window_mailbox.push(.{
+                .clipboard_read = kind,
+            }, .{ .forever = {} });
+            return;
+        }
+
+        unreachable;
+    }
 };

--- a/src/window/message.zig
+++ b/src/window/message.zig
@@ -1,9 +1,14 @@
 const App = @import("../App.zig");
 const Window = @import("../Window.zig");
 const renderer = @import("../renderer.zig");
+const termio = @import("../termio.zig");
 
 /// The message types that can be sent to a single window.
 pub const Message = union(enum) {
+    /// Represents a write request. Magic number comes from the max size
+    /// we want this union to be.
+    pub const WriteReq = termio.MessageData(u8, 256);
+
     /// Set the title of the window.
     /// TODO: we should change this to a "WriteReq" style structure in
     /// the termio message so that we can more efficiently send strings
@@ -15,6 +20,9 @@ pub const Message = union(enum) {
 
     /// Read the clipboard and write to the pty.
     clipboard_read: u8,
+
+    /// Write the clipboard contents.
+    clipboard_write: WriteReq,
 };
 
 /// A window mailbox.

--- a/src/window/message.zig
+++ b/src/window/message.zig
@@ -12,6 +12,9 @@ pub const Message = union(enum) {
 
     /// Change the cell size.
     cell_size: renderer.CellSize,
+
+    /// Read the clipboard and write to the pty.
+    clipboard_read: u8,
 };
 
 /// A window mailbox.


### PR DESCRIPTION
Fixes #31 

This adds support for OSC 52 -- applications can read/write the clipboard. Due to the security risk of this, the default configuration allows for writing but _not reading_. This is configurable using two new settings: `clipboard-read` and `clipboard-write` (both booleans).