### PR TITLE
Procedurally generate and support box-drawing glyphs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "vendor/cimgui"]
 	path = vendor/cimgui
 	url = https://github.com/cimgui/cimgui.git
+[submodule "vendor/pixman"]
+	path = vendor/pixman
+	url = https://github.com/freedesktop/pixman.git

--- a/build.zig
+++ b/build.zig
@@ -264,6 +264,7 @@ fn addDeps(
         step.linkSystemLibrary("harfbuzz");
         step.linkSystemLibrary("libpng");
         step.linkSystemLibrary("libuv");
+        step.linkSystemLibrary("pixman-1");
         step.linkSystemLibrary("zlib");
 
         if (enable_fontconfig) step.linkSystemLibrary("fontconfig");

--- a/build.zig
+++ b/build.zig
@@ -12,6 +12,7 @@ const libuv = @import("pkg/libuv/build.zig");
 const libpng = @import("pkg/libpng/build.zig");
 const macos = @import("pkg/macos/build.zig");
 const objc = @import("pkg/objc/build.zig");
+const pixman = @import("pkg/pixman/build.zig");
 const stb_image_resize = @import("pkg/stb_image_resize/build.zig");
 const utf8proc = @import("pkg/utf8proc/build.zig");
 const zlib = @import("pkg/zlib/build.zig");
@@ -306,6 +307,10 @@ fn addDeps(
             },
         });
         system_sdk.include(b, harfbuzz_step, .{});
+
+        // Pixman
+        const pixman_step = try pixman.link(b, step, .{});
+        _ = pixman_step;
 
         // Libuv
         const libuv_step = try libuv.link(b, step);

--- a/build.zig
+++ b/build.zig
@@ -212,6 +212,7 @@ fn addDeps(
     step.addPackage(imgui.pkg);
     step.addPackage(glfw.pkg);
     step.addPackage(libuv.pkg);
+    step.addPackage(pixman.pkg);
     step.addPackage(stb_image_resize.pkg);
     step.addPackage(utf8proc.pkg);
 

--- a/conformance/blocks.zig
+++ b/conformance/blocks.zig
@@ -80,4 +80,20 @@ pub fn main() !void {
             try stdout.print("\n\n", .{});
         }
     }
+
+    {
+        try stdout.print("\x1b[4mOther\x1b[0m\n", .{});
+        var i: usize = 0x1FB70;
+        var step: usize = 32;
+        const end = 0x1FB8B;
+        while (i <= end) : (i += step) {
+            var j: usize = 0;
+            while (j < step) : (j += 1) {
+                const v = i + j;
+                if (v <= end) try stdout.print("{u} ", .{@intCast(u21, v)});
+            }
+
+            try stdout.print("\n\n", .{});
+        }
+    }
 }

--- a/conformance/blocks.zig
+++ b/conformance/blocks.zig
@@ -64,4 +64,43 @@ pub fn main() !void {
             try stdout.print("\n\n", .{});
         }
     }
+
+    {
+        try stdout.print("\x1b[4mWedge Triangles\x1b[0m\n", .{});
+        {
+            var i: usize = 0x1FB3C;
+            const end = 0x1FB40;
+            while (i <= end) : (i += 1) {
+                try stdout.print("{u} ", .{@intCast(u21, i)});
+            }
+        }
+        {
+            var i: usize = 0x1FB47;
+            const end = 0x1FB4B;
+            while (i <= end) : (i += 1) {
+                try stdout.print("{u} ", .{@intCast(u21, i)});
+            }
+        }
+        {
+            var i: usize = 0x1FB57;
+            const end = 0x1FB5B;
+            while (i <= end) : (i += 1) {
+                try stdout.print("{u} ", .{@intCast(u21, i)});
+            }
+        }
+        {
+            var i: usize = 0x1FB62;
+            const end = 0x1FB66;
+            while (i <= end) : (i += 1) {
+                try stdout.print("{u} ", .{@intCast(u21, i)});
+            }
+        }
+        {
+            var i: usize = 0x1FB6C;
+            const end = 0x1FB6F;
+            while (i <= end) : (i += 1) {
+                try stdout.print("{u} ", .{@intCast(u21, i)});
+            }
+        }
+    }
 }

--- a/conformance/blocks.zig
+++ b/conformance/blocks.zig
@@ -1,0 +1,67 @@
+//! Delete Line (DL) - Esc [ M
+const std = @import("std");
+
+pub fn main() !void {
+    const stdout = std.io.getStdOut().writer();
+
+    // Box Drawing
+    {
+        try stdout.print("\x1b[4mBox Drawing\x1b[0m\n", .{});
+        var i: usize = 0x2500;
+        var step: usize = 32;
+        while (i <= 0x257F) : (i += step) {
+            var j: usize = 0;
+            while (j < step) : (j += 1) {
+                try stdout.print("{u} ", .{@intCast(u21, i + j)});
+            }
+
+            try stdout.print("\n\n", .{});
+        }
+    }
+
+    // Block Elements
+    {
+        try stdout.print("\x1b[4mBlock Elements\x1b[0m\n", .{});
+        var i: usize = 0x2580;
+        var step: usize = 32;
+        while (i <= 0x259f) : (i += step) {
+            var j: usize = 0;
+            while (j < step) : (j += 1) {
+                try stdout.print("{u} ", .{@intCast(u21, i + j)});
+            }
+
+            try stdout.print("\n\n", .{});
+        }
+    }
+
+    // Braille Elements
+    {
+        try stdout.print("\x1b[4mBraille\x1b[0m\n", .{});
+        var i: usize = 0x2800;
+        var step: usize = 32;
+        while (i <= 0x28FF) : (i += step) {
+            var j: usize = 0;
+            while (j < step) : (j += 1) {
+                try stdout.print("{u} ", .{@intCast(u21, i + j)});
+            }
+
+            try stdout.print("\n\n", .{});
+        }
+    }
+
+    {
+        try stdout.print("\x1b[4mSextants\x1b[0m\n", .{});
+        var i: usize = 0x1FB00;
+        var step: usize = 32;
+        const end = 0x1FB3B;
+        while (i <= end) : (i += step) {
+            var j: usize = 0;
+            while (j < step) : (j += 1) {
+                const v = i + j;
+                if (v <= end) try stdout.print("{u} ", .{@intCast(u21, v)});
+            }
+
+            try stdout.print("\n\n", .{});
+        }
+    }
+}

--- a/conformance/blocks.zig
+++ b/conformance/blocks.zig
@@ -1,4 +1,4 @@
-//! Delete Line (DL) - Esc [ M
+//! Outputs various box glyphs for testing.
 const std = @import("std");
 
 pub fn main() !void {

--- a/conformance/blocks.zig
+++ b/conformance/blocks.zig
@@ -67,40 +67,17 @@ pub fn main() !void {
 
     {
         try stdout.print("\x1b[4mWedge Triangles\x1b[0m\n", .{});
-        {
-            var i: usize = 0x1FB3C;
-            const end = 0x1FB40;
-            while (i <= end) : (i += 1) {
-                try stdout.print("{u} ", .{@intCast(u21, i)});
+        var i: usize = 0x1FB3C;
+        var step: usize = 32;
+        const end = 0x1FB6B;
+        while (i <= end) : (i += step) {
+            var j: usize = 0;
+            while (j < step) : (j += 1) {
+                const v = i + j;
+                if (v <= end) try stdout.print("{u} ", .{@intCast(u21, v)});
             }
-        }
-        {
-            var i: usize = 0x1FB47;
-            const end = 0x1FB4B;
-            while (i <= end) : (i += 1) {
-                try stdout.print("{u} ", .{@intCast(u21, i)});
-            }
-        }
-        {
-            var i: usize = 0x1FB57;
-            const end = 0x1FB5B;
-            while (i <= end) : (i += 1) {
-                try stdout.print("{u} ", .{@intCast(u21, i)});
-            }
-        }
-        {
-            var i: usize = 0x1FB62;
-            const end = 0x1FB66;
-            while (i <= end) : (i += 1) {
-                try stdout.print("{u} ", .{@intCast(u21, i)});
-            }
-        }
-        {
-            var i: usize = 0x1FB6C;
-            const end = 0x1FB6F;
-            while (i <= end) : (i += 1) {
-                try stdout.print("{u} ", .{@intCast(u21, i)});
-            }
+
+            try stdout.print("\n\n", .{});
         }
     }
 }

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -31,6 +31,7 @@
 , libXi
 , libXinerama
 , libXrandr
+, pixman
 , zlib
 }:
 let
@@ -87,6 +88,7 @@ in mkShell rec {
     harfbuzz
     libpng
     libuv
+    pixman
     zlib
 
     libX11

--- a/pkg/pixman/build.zig
+++ b/pkg/pixman/build.zig
@@ -87,6 +87,10 @@ pub fn buildPixman(
 
         "-DSIZEOF_LONG=8",
         "-DPACKAGE=foo",
+
+        // There is ubsan
+        "-fno-sanitize=undefined",
+        "-fno-sanitize-trap=undefined",
     });
 
     if (!target.isWindows()) {

--- a/pkg/pixman/build.zig
+++ b/pkg/pixman/build.zig
@@ -1,0 +1,137 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+/// Directories with our includes.
+const root = thisDir() ++ "../../../vendor/pixman/";
+const include_path = root ++ "pixman/";
+const include_path_self = thisDir();
+
+pub const include_paths = .{ include_path, include_path_self };
+
+pub const pkg = std.build.Pkg{
+    .name = "pixman",
+    .source = .{ .path = thisDir() ++ "/main.zig" },
+};
+
+fn thisDir() []const u8 {
+    return std.fs.path.dirname(@src().file) orelse ".";
+}
+
+pub const Options = struct {};
+
+pub fn build(b: *std.build.Builder) !void {
+    const target = b.standardTargetOptions(.{});
+    const mode = b.standardReleaseOptions();
+    _ = target;
+    _ = mode;
+
+    const tests = b.addTestExe("pixman-test", "main.zig");
+    _ = try link(b, tests, .{});
+    tests.install();
+
+    const test_step = b.step("test", "Run tests");
+    const tests_run = tests.run();
+    test_step.dependOn(&tests_run.step);
+}
+
+pub fn link(
+    b: *std.build.Builder,
+    step: *std.build.LibExeObjStep,
+    opt: Options,
+) !*std.build.LibExeObjStep {
+    const lib = try buildPixman(b, step, opt);
+    step.linkLibrary(lib);
+    step.addIncludePath(include_path);
+    step.addIncludePath(include_path_self);
+    return lib;
+}
+
+pub fn buildPixman(
+    b: *std.build.Builder,
+    step: *std.build.LibExeObjStep,
+    opt: Options,
+) !*std.build.LibExeObjStep {
+    _ = opt;
+
+    const target = step.target;
+    const lib = b.addStaticLibrary("pixman", null);
+    lib.setTarget(step.target);
+    lib.setBuildMode(step.build_mode);
+
+    // Include
+    lib.addIncludePath(include_path);
+    lib.addIncludePath(include_path_self);
+
+    // Link
+    lib.linkLibC();
+    if (!target.isWindows()) {
+        lib.linkSystemLibrary("pthread");
+    }
+
+    // Compile
+    var flags = std.ArrayList([]const u8).init(b.allocator);
+    defer flags.deinit();
+
+    try flags.appendSlice(&.{
+        "-DHAVE_SIGACTION=1",
+        "-DHAVE_ALARM=1",
+        "-DHAVE_MPROTECT=1",
+        "-DHAVE_GETPAGESIZE=1",
+        "-DHAVE_MMAP=1",
+        "-DHAVE_GETISAX=1",
+        "-DHAVE_GETTIMEOFDAY=1",
+
+        "-DHAVE_FENV_H=1",
+        "-DHAVE_SYS_MMAN_H=1",
+        "-DHAVE_UNISTD_H=1",
+
+        "-DSIZEOF_LONG=8",
+        "-DPACKAGE=foo",
+    });
+
+    if (!target.isWindows()) {
+        try flags.appendSlice(&.{
+            "-DHAVE_PTHREADS=1",
+
+            "-DHAVE_POSIX_MEMALIGN=1",
+        });
+    }
+
+    // C files
+    lib.addCSourceFiles(srcs, flags.items);
+
+    return lib;
+}
+
+const srcs = &.{
+    root ++ "pixman/pixman.c",
+    root ++ "pixman/pixman-access.c",
+    root ++ "pixman/pixman-access-accessors.c",
+    root ++ "pixman/pixman-bits-image.c",
+    root ++ "pixman/pixman-combine32.c",
+    root ++ "pixman/pixman-combine-float.c",
+    root ++ "pixman/pixman-conical-gradient.c",
+    root ++ "pixman/pixman-filter.c",
+    root ++ "pixman/pixman-x86.c",
+    root ++ "pixman/pixman-mips.c",
+    root ++ "pixman/pixman-arm.c",
+    root ++ "pixman/pixman-ppc.c",
+    root ++ "pixman/pixman-edge.c",
+    root ++ "pixman/pixman-edge-accessors.c",
+    root ++ "pixman/pixman-fast-path.c",
+    root ++ "pixman/pixman-glyph.c",
+    root ++ "pixman/pixman-general.c",
+    root ++ "pixman/pixman-gradient-walker.c",
+    root ++ "pixman/pixman-image.c",
+    root ++ "pixman/pixman-implementation.c",
+    root ++ "pixman/pixman-linear-gradient.c",
+    root ++ "pixman/pixman-matrix.c",
+    root ++ "pixman/pixman-noop.c",
+    root ++ "pixman/pixman-radial-gradient.c",
+    root ++ "pixman/pixman-region16.c",
+    root ++ "pixman/pixman-region32.c",
+    root ++ "pixman/pixman-solid-fill.c",
+    root ++ "pixman/pixman-timer.c",
+    root ++ "pixman/pixman-trap.c",
+    root ++ "pixman/pixman-utils.c",
+};

--- a/pkg/pixman/build.zig
+++ b/pkg/pixman/build.zig
@@ -22,10 +22,10 @@ pub const Options = struct {};
 pub fn build(b: *std.build.Builder) !void {
     const target = b.standardTargetOptions(.{});
     const mode = b.standardReleaseOptions();
-    _ = target;
-    _ = mode;
 
     const tests = b.addTestExe("pixman-test", "main.zig");
+    tests.setBuildMode(mode);
+    tests.setTarget(target);
     _ = try link(b, tests, .{});
     tests.install();
 

--- a/pkg/pixman/c.zig
+++ b/pkg/pixman/c.zig
@@ -1,0 +1,3 @@
+pub usingnamespace @cImport({
+    @cInclude("pixman.h");
+});

--- a/pkg/pixman/error.zig
+++ b/pkg/pixman/error.zig
@@ -1,0 +1,4 @@
+pub const Error = error{
+    // Pixman doesn't really have errors so we just have a single error.
+    PixmanFailure,
+};

--- a/pkg/pixman/format.zig
+++ b/pkg/pixman/format.zig
@@ -108,3 +108,11 @@ test "bpp" {
     try testing.expectEqual(@as(u32, 4), FormatCode.g4.bpp());
     try testing.expectEqual(@as(u32, 8), FormatCode.g8.bpp());
 }
+
+test "stride" {
+    const testing = std.testing;
+
+    try testing.expectEqual(@as(c_int, 4), FormatCode.g1.strideForWidth(10));
+    try testing.expectEqual(@as(c_int, 8), FormatCode.g4.strideForWidth(10));
+    try testing.expectEqual(@as(c_int, 12), FormatCode.g8.strideForWidth(10));
+}

--- a/pkg/pixman/format.zig
+++ b/pkg/pixman/format.zig
@@ -96,8 +96,8 @@ pub const FormatCode = enum(c_uint) {
         const val = @enumToInt(self);
         const v1 = val >> ofs;
         const v2 = @as(c_uint, 1) << num;
-        const v3 = @intCast(u5, val >> 22);
-        return ((v1 & (v2 - 1)) << (v3 & 3));
+        const v3 = @intCast(u5, (val >> 22) & 3);
+        return ((v1 & (v2 - 1)) << v3);
     }
 };
 
@@ -106,4 +106,5 @@ test "bpp" {
 
     try testing.expectEqual(@as(u32, 1), FormatCode.g1.bpp());
     try testing.expectEqual(@as(u32, 4), FormatCode.g4.bpp());
+    try testing.expectEqual(@as(u32, 8), FormatCode.g8.bpp());
 }

--- a/pkg/pixman/format.zig
+++ b/pkg/pixman/format.zig
@@ -1,0 +1,109 @@
+const std = @import("std");
+const c = @import("c.zig");
+const pixman = @import("main.zig");
+
+pub const FormatCode = enum(c_uint) {
+    // 128bpp formats
+    rgba_float = c.PIXMAN_FORMAT_BYTE(128, c.PIXMAN_TYPE_RGBA_FLOAT, 32, 32, 32, 32),
+
+    // 96bpp formats
+    rgb_float = c.PIXMAN_FORMAT_BYTE(96, c.PIXMAN_TYPE_RGBA_FLOAT, 0, 32, 32, 32),
+
+    // 32bpp formats
+    a8r8g8b8 = c.PIXMAN_FORMAT(32, c.PIXMAN_TYPE_ARGB, 8, 8, 8, 8),
+    x8r8g8b8 = c.PIXMAN_FORMAT(32, c.PIXMAN_TYPE_ARGB, 0, 8, 8, 8),
+    a8b8g8r8 = c.PIXMAN_FORMAT(32, c.PIXMAN_TYPE_ABGR, 8, 8, 8, 8),
+    x8b8g8r8 = c.PIXMAN_FORMAT(32, c.PIXMAN_TYPE_ABGR, 0, 8, 8, 8),
+    b8g8r8a8 = c.PIXMAN_FORMAT(32, c.PIXMAN_TYPE_BGRA, 8, 8, 8, 8),
+    b8g8r8x8 = c.PIXMAN_FORMAT(32, c.PIXMAN_TYPE_BGRA, 0, 8, 8, 8),
+    r8g8b8a8 = c.PIXMAN_FORMAT(32, c.PIXMAN_TYPE_RGBA, 8, 8, 8, 8),
+    r8g8b8x8 = c.PIXMAN_FORMAT(32, c.PIXMAN_TYPE_RGBA, 0, 8, 8, 8),
+    x14r6g6b6 = c.PIXMAN_FORMAT(32, c.PIXMAN_TYPE_ARGB, 0, 6, 6, 6),
+    x2r10g10b10 = c.PIXMAN_FORMAT(32, c.PIXMAN_TYPE_ARGB, 0, 10, 10, 10),
+    a2r10g10b10 = c.PIXMAN_FORMAT(32, c.PIXMAN_TYPE_ARGB, 2, 10, 10, 10),
+    x2b10g10r10 = c.PIXMAN_FORMAT(32, c.PIXMAN_TYPE_ABGR, 0, 10, 10, 10),
+    a2b10g10r10 = c.PIXMAN_FORMAT(32, c.PIXMAN_TYPE_ABGR, 2, 10, 10, 10),
+
+    // sRGB formats
+    a8r8g8b8_sRGB = c.PIXMAN_FORMAT(32, c.PIXMAN_TYPE_ARGB_SRGB, 8, 8, 8, 8),
+    r8g8b8_sRGB = c.PIXMAN_FORMAT(24, c.PIXMAN_TYPE_ARGB_SRGB, 0, 8, 8, 8),
+
+    // 24bpp formats
+    r8g8b8 = c.PIXMAN_FORMAT(24, c.PIXMAN_TYPE_ARGB, 0, 8, 8, 8),
+    b8g8r8 = c.PIXMAN_FORMAT(24, c.PIXMAN_TYPE_ABGR, 0, 8, 8, 8),
+
+    // 16bpp formats
+    r5g6b5 = c.PIXMAN_FORMAT(16, c.PIXMAN_TYPE_ARGB, 0, 5, 6, 5),
+    b5g6r5 = c.PIXMAN_FORMAT(16, c.PIXMAN_TYPE_ABGR, 0, 5, 6, 5),
+
+    a1r5g5b5 = c.PIXMAN_FORMAT(16, c.PIXMAN_TYPE_ARGB, 1, 5, 5, 5),
+    x1r5g5b5 = c.PIXMAN_FORMAT(16, c.PIXMAN_TYPE_ARGB, 0, 5, 5, 5),
+    a1b5g5r5 = c.PIXMAN_FORMAT(16, c.PIXMAN_TYPE_ABGR, 1, 5, 5, 5),
+    x1b5g5r5 = c.PIXMAN_FORMAT(16, c.PIXMAN_TYPE_ABGR, 0, 5, 5, 5),
+    a4r4g4b4 = c.PIXMAN_FORMAT(16, c.PIXMAN_TYPE_ARGB, 4, 4, 4, 4),
+    x4r4g4b4 = c.PIXMAN_FORMAT(16, c.PIXMAN_TYPE_ARGB, 0, 4, 4, 4),
+    a4b4g4r4 = c.PIXMAN_FORMAT(16, c.PIXMAN_TYPE_ABGR, 4, 4, 4, 4),
+    x4b4g4r4 = c.PIXMAN_FORMAT(16, c.PIXMAN_TYPE_ABGR, 0, 4, 4, 4),
+
+    // 8bpp formats
+    a8 = c.PIXMAN_FORMAT(8, c.PIXMAN_TYPE_A, 8, 0, 0, 0),
+    r3g3b2 = c.PIXMAN_FORMAT(8, c.PIXMAN_TYPE_ARGB, 0, 3, 3, 2),
+    b2g3r3 = c.PIXMAN_FORMAT(8, c.PIXMAN_TYPE_ABGR, 0, 3, 3, 2),
+    a2r2g2b2 = c.PIXMAN_FORMAT(8, c.PIXMAN_TYPE_ARGB, 2, 2, 2, 2),
+    a2b2g2r2 = c.PIXMAN_FORMAT(8, c.PIXMAN_TYPE_ABGR, 2, 2, 2, 2),
+
+    c8 = c.PIXMAN_FORMAT(8, c.PIXMAN_TYPE_COLOR, 0, 0, 0, 0),
+    g8 = c.PIXMAN_FORMAT(8, c.PIXMAN_TYPE_GRAY, 0, 0, 0, 0),
+
+    x4a4 = c.PIXMAN_FORMAT(8, c.PIXMAN_TYPE_A, 4, 0, 0, 0),
+
+    // c8/g8 equivalent
+    // x4c4 = c.PIXMAN_FORMAT(8, c.PIXMAN_TYPE_COLOR, 0, 0, 0, 0),
+    // x4g4 = c.PIXMAN_FORMAT(8, c.PIXMAN_TYPE_GRAY, 0, 0, 0, 0),
+
+    // 4bpp formats
+    a4 = c.PIXMAN_FORMAT(4, c.PIXMAN_TYPE_A, 4, 0, 0, 0),
+    r1g2b1 = c.PIXMAN_FORMAT(4, c.PIXMAN_TYPE_ARGB, 0, 1, 2, 1),
+    b1g2r1 = c.PIXMAN_FORMAT(4, c.PIXMAN_TYPE_ABGR, 0, 1, 2, 1),
+    a1r1g1b1 = c.PIXMAN_FORMAT(4, c.PIXMAN_TYPE_ARGB, 1, 1, 1, 1),
+    a1b1g1r1 = c.PIXMAN_FORMAT(4, c.PIXMAN_TYPE_ABGR, 1, 1, 1, 1),
+
+    c4 = c.PIXMAN_FORMAT(4, c.PIXMAN_TYPE_COLOR, 0, 0, 0, 0),
+    g4 = c.PIXMAN_FORMAT(4, c.PIXMAN_TYPE_GRAY, 0, 0, 0, 0),
+
+    // 1bpp formats
+    a1 = c.PIXMAN_FORMAT(1, c.PIXMAN_TYPE_A, 1, 0, 0, 0),
+
+    g1 = c.PIXMAN_FORMAT(1, c.PIXMAN_TYPE_GRAY, 0, 0, 0, 0),
+
+    // YUV formats
+    yuy2 = c.PIXMAN_FORMAT(16, c.PIXMAN_TYPE_YUY2, 0, 0, 0, 0),
+    yv12 = c.PIXMAN_FORMAT(12, c.PIXMAN_TYPE_YV12, 0, 0, 0, 0),
+
+    pub inline fn bpp(self: FormatCode) u32 {
+        return self.reshift(24, 8);
+    }
+
+    /// Calculates a valid stride for the bpp and width. Based on Cairo.
+    pub fn strideForWidth(self: FormatCode, width: u32) c_int {
+        const alignment = @sizeOf(u32);
+        const val = @intCast(c_int, (self.bpp() * width + 7) / 8);
+        return val + (alignment - 1) & -alignment;
+    }
+
+    // Converted from pixman.h
+    fn reshift(self: FormatCode, ofs: u5, num: u5) u32 {
+        const val = @enumToInt(self);
+        const v1 = val >> ofs;
+        const v2 = @as(c_uint, 1) << num;
+        const v3 = @intCast(u5, val >> 22);
+        return ((v1 & (v2 - 1)) << (v3 & 3));
+    }
+};
+
+test "bpp" {
+    const testing = std.testing;
+
+    try testing.expectEqual(@as(u32, 1), FormatCode.g1.bpp());
+    try testing.expectEqual(@as(u32, 4), FormatCode.g4.bpp());
+}

--- a/pkg/pixman/image.zig
+++ b/pkg/pixman/image.zig
@@ -3,36 +3,86 @@ const c = @import("c.zig");
 const pixman = @import("main.zig");
 
 pub const Image = opaque {
-    pub inline fn createBitsNoClear(
+    pub fn createBitsNoClear(
         format: pixman.FormatCode,
         width: c_int,
         height: c_int,
         bits: [*]u32,
         stride: c_int,
-    ) ?*Image {
+    ) pixman.Error!*Image {
         return @ptrCast(?*Image, c.pixman_image_create_bits_no_clear(
             @enumToInt(format),
             width,
             height,
             bits,
             stride,
-        ));
+        )) orelse return pixman.Error.PixmanFailure;
     }
 
-    pub inline fn unref(self: *Image) bool {
+    pub fn unref(self: *Image) bool {
         return c.pixman_image_unref(@ptrCast(*c.pixman_image_t, self)) == 1;
+    }
+
+    pub fn fillBoxes(
+        self: *Image,
+        op: pixman.Op,
+        color: pixman.Color,
+        boxes: []const pixman.Box32,
+    ) pixman.Error!void {
+        if (c.pixman_image_fill_boxes(
+            @enumToInt(op),
+            @ptrCast(*c.pixman_image_t, self),
+            @ptrCast(*const c.pixman_color_t, &color),
+            @intCast(c_int, boxes.len),
+            @ptrCast([*c]const c.pixman_box32_t, boxes.ptr),
+        ) == 0) return pixman.Error.PixmanFailure;
     }
 };
 
 test "create and destroy" {
     const testing = std.testing;
+    const alloc = testing.allocator;
 
     const width = 10;
     const height = 10;
     const format: pixman.FormatCode = .g1;
     const stride = format.strideForWidth(width);
-    var bits: [width * height]u32 = undefined;
-    const img = Image.createBitsNoClear(.g1, width, height, &bits, stride);
-    try testing.expect(img != null);
-    try testing.expect(img.?.unref());
+
+    const len = height * @intCast(usize, stride);
+    var data = try alloc.alloc(u32, len);
+    defer alloc.free(data);
+    std.mem.set(u32, data, 0);
+    const img = try Image.createBitsNoClear(.g1, width, height, data.ptr, stride);
+    try testing.expect(img.unref());
+}
+
+test "fill boxes" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // Dimensions
+    const width = 100;
+    const height = 100;
+    const format: pixman.FormatCode = .a1;
+    const stride = format.strideForWidth(width);
+
+    // Image
+    const len = height * @intCast(usize, stride);
+    var data = try alloc.alloc(u32, len);
+    defer alloc.free(data);
+    std.mem.set(u32, data, 0);
+    const img = try Image.createBitsNoClear(format, width, height, data.ptr, stride);
+    defer _ = img.unref();
+
+    // Fill
+    const color: pixman.Color = .{ .red = 0xFFFF, .green = 0xFFFF, .blue = 0xFFFF, .alpha = 0xFFFF };
+    const boxes = &[_]pixman.Box32{
+        .{
+            .x1 = 0,
+            .y1 = 0,
+            .x2 = width,
+            .y2 = height,
+        },
+    };
+    try img.fillBoxes(.src, color, boxes);
 }

--- a/pkg/pixman/image.zig
+++ b/pkg/pixman/image.zig
@@ -56,7 +56,7 @@ test "create and destroy" {
     try testing.expect(img.unref());
 }
 
-test "fill boxes" {
+test "fill boxes a1" {
     const testing = std.testing;
     const alloc = testing.allocator;
 

--- a/pkg/pixman/image.zig
+++ b/pkg/pixman/image.zig
@@ -62,6 +62,21 @@ pub const Image = opaque {
         ) == 0) return pixman.Error.PixmanFailure;
     }
 
+    pub fn fillRectangles(
+        self: *Image,
+        op: pixman.Op,
+        color: pixman.Color,
+        rects: []const pixman.Rectangle16,
+    ) pixman.Error!void {
+        if (c.pixman_image_fill_rectangles(
+            @enumToInt(op),
+            @ptrCast(*c.pixman_image_t, self),
+            @ptrCast(*const c.pixman_color_t, &color),
+            @intCast(c_int, rects.len),
+            @ptrCast([*c]const c.pixman_rectangle16_t, rects.ptr),
+        ) == 0) return pixman.Error.PixmanFailure;
+    }
+
     pub fn rasterizeTrapezoid(
         self: *Image,
         trap: pixman.Trapezoid,

--- a/pkg/pixman/image.zig
+++ b/pkg/pixman/image.zig
@@ -19,6 +19,14 @@ pub const Image = opaque {
         )) orelse return pixman.Error.PixmanFailure;
     }
 
+    pub fn createSolidFill(
+        color: pixman.Color,
+    ) pixman.Error!*Image {
+        return @ptrCast(?*Image, c.pixman_image_create_solid_fill(
+            @ptrCast(*const c.pixman_color_t, &color),
+        )) orelse return pixman.Error.PixmanFailure;
+    }
+
     pub fn unref(self: *Image) bool {
         return c.pixman_image_unref(@ptrCast(*c.pixman_image_t, self)) == 1;
     }
@@ -88,6 +96,31 @@ pub const Image = opaque {
             @ptrCast(*const c.pixman_trapezoid_t, &trap),
             x_off,
             y_off,
+        );
+    }
+
+    pub fn compositeTriangles(
+        self: *Image,
+        op: pixman.Op,
+        src: *Image,
+        mask_format: pixman.FormatCode,
+        x_src: c_int,
+        y_src: c_int,
+        x_dst: c_int,
+        y_dst: c_int,
+        tris: []const pixman.Triangle,
+    ) void {
+        c.pixman_composite_triangles(
+            @enumToInt(op),
+            @ptrCast(*c.pixman_image_t, src),
+            @ptrCast(*c.pixman_image_t, self),
+            @enumToInt(mask_format),
+            x_src,
+            y_src,
+            x_dst,
+            y_dst,
+            @intCast(c_int, tris.len),
+            @ptrCast([*c]const c.pixman_triangle_t, tris.ptr),
         );
     }
 };

--- a/pkg/pixman/image.zig
+++ b/pkg/pixman/image.zig
@@ -1,0 +1,38 @@
+const std = @import("std");
+const c = @import("c.zig");
+const pixman = @import("main.zig");
+
+pub const Image = opaque {
+    pub inline fn createBitsNoClear(
+        format: pixman.FormatCode,
+        width: c_int,
+        height: c_int,
+        bits: [*]u32,
+        stride: c_int,
+    ) ?*Image {
+        return @ptrCast(?*Image, c.pixman_image_create_bits_no_clear(
+            @enumToInt(format),
+            width,
+            height,
+            bits,
+            stride,
+        ));
+    }
+
+    pub inline fn unref(self: *Image) bool {
+        return c.pixman_image_unref(@ptrCast(*c.pixman_image_t, self)) == 1;
+    }
+};
+
+test "create and destroy" {
+    const testing = std.testing;
+
+    const width = 10;
+    const height = 10;
+    const format: pixman.FormatCode = .g1;
+    const stride = format.strideForWidth(width);
+    var bits: [width * height]u32 = undefined;
+    const img = Image.createBitsNoClear(.g1, width, height, &bits, stride);
+    try testing.expect(img != null);
+    try testing.expect(img.?.unref());
+}

--- a/pkg/pixman/image.zig
+++ b/pkg/pixman/image.zig
@@ -61,6 +61,20 @@ pub const Image = opaque {
             @ptrCast([*c]const c.pixman_box32_t, boxes.ptr),
         ) == 0) return pixman.Error.PixmanFailure;
     }
+
+    pub fn rasterizeTrapezoid(
+        self: *Image,
+        trap: pixman.Trapezoid,
+        x_off: c_int,
+        y_off: c_int,
+    ) void {
+        c.pixman_rasterize_trapezoid(
+            @ptrCast(*c.pixman_image_t, self),
+            @ptrCast(*const c.pixman_trapezoid_t, &trap),
+            x_off,
+            y_off,
+        );
+    }
 };
 
 test "create and destroy" {

--- a/pkg/pixman/image.zig
+++ b/pkg/pixman/image.zig
@@ -99,6 +99,36 @@ pub const Image = opaque {
         );
     }
 
+    pub fn composite(
+        self: *Image,
+        op: pixman.Op,
+        src: *Image,
+        mask: ?*Image,
+        src_x: i16,
+        src_y: i16,
+        mask_x: i16,
+        mask_y: i16,
+        dest_x: i16,
+        dest_y: i16,
+        width: u16,
+        height: u16,
+    ) void {
+        c.pixman_image_composite(
+            @enumToInt(op),
+            @ptrCast(*c.pixman_image_t, src),
+            @ptrCast(?*c.pixman_image_t, mask),
+            @ptrCast(*c.pixman_image_t, self),
+            src_x,
+            src_y,
+            mask_x,
+            mask_y,
+            dest_x,
+            dest_y,
+            width,
+            height,
+        );
+    }
+
     pub fn compositeTriangles(
         self: *Image,
         op: pixman.Op,

--- a/pkg/pixman/main.zig
+++ b/pkg/pixman/main.zig
@@ -1,7 +1,9 @@
 const std = @import("std");
 pub const c = @import("c.zig");
+pub usingnamespace @import("error.zig");
 pub usingnamespace @import("format.zig");
 pub usingnamespace @import("image.zig");
+pub usingnamespace @import("types.zig");
 
 test {
     std.testing.refAllDecls(@This());

--- a/pkg/pixman/main.zig
+++ b/pkg/pixman/main.zig
@@ -1,0 +1,5 @@
+const std = @import("std");
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/pkg/pixman/main.zig
+++ b/pkg/pixman/main.zig
@@ -1,4 +1,7 @@
 const std = @import("std");
+pub const c = @import("c.zig");
+pub usingnamespace @import("format.zig");
+pub usingnamespace @import("image.zig");
 
 test {
     std.testing.refAllDecls(@This());

--- a/pkg/pixman/pixman-version.h
+++ b/pkg/pixman/pixman-version.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2008 Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Author: Carl D. Worth <cworth@cworth.org>
+ */
+
+#ifndef PIXMAN_VERSION_H__
+#define PIXMAN_VERSION_H__
+
+#ifndef PIXMAN_H__
+#  error pixman-version.h should only be included by pixman.h
+#endif
+
+#define PIXMAN_VERSION_MAJOR 999
+#define PIXMAN_VERSION_MINOR 999
+#define PIXMAN_VERSION_MICRO 999
+
+#define PIXMAN_VERSION_STRING "999.999.999"
+
+#define PIXMAN_VERSION_ENCODE(major, minor, micro) (	\
+	  ((major) * 10000)				\
+	+ ((minor) *   100)				\
+	+ ((micro) *     1))
+
+#define PIXMAN_VERSION PIXMAN_VERSION_ENCODE(	\
+	PIXMAN_VERSION_MAJOR,			\
+	PIXMAN_VERSION_MINOR,			\
+	PIXMAN_VERSION_MICRO)
+
+#ifndef PIXMAN_API
+# define PIXMAN_API
+#endif
+
+#endif /* PIXMAN_VERSION_H__ */

--- a/pkg/pixman/types.zig
+++ b/pkg/pixman/types.zig
@@ -1,0 +1,76 @@
+const std = @import("std");
+const c = @import("c.zig");
+const pixman = @import("main.zig");
+
+pub const Op = enum(c_uint) {
+    clear = 0x00,
+    src = 0x01,
+    dst = 0x02,
+    over = 0x03,
+    over_reverse = 0x04,
+    in = 0x05,
+    in_reverse = 0x06,
+    out = 0x07,
+    out_reverse = 0x08,
+    atop = 0x09,
+    atop_reverse = 0x0a,
+    xor = 0x0b,
+    add = 0x0c,
+    saturate = 0x0d,
+
+    disjoint_clear = 0x10,
+    disjoint_src = 0x11,
+    disjoint_dst = 0x12,
+    disjoint_over = 0x13,
+    disjoint_over_reverse = 0x14,
+    disjoint_in = 0x15,
+    disjoint_in_reverse = 0x16,
+    disjoint_out = 0x17,
+    disjoint_out_reverse = 0x18,
+    disjoint_atop = 0x19,
+    disjoint_atop_reverse = 0x1a,
+    disjoint_xor = 0x1b,
+
+    conjoint_clear = 0x20,
+    conjoint_src = 0x21,
+    conjoint_dst = 0x22,
+    conjoint_over = 0x23,
+    conjoint_over_reverse = 0x24,
+    conjoint_in = 0x25,
+    conjoint_in_reverse = 0x26,
+    conjoint_out = 0x27,
+    conjoint_out_reverse = 0x28,
+    conjoint_atop = 0x29,
+    conjoint_atop_reverse = 0x2a,
+    conjoint_xor = 0x2b,
+
+    multiply = 0x30,
+    screen = 0x31,
+    overlay = 0x32,
+    darken = 0x33,
+    lighten = 0x34,
+    color_dodge = 0x35,
+    color_burn = 0x36,
+    hard_light = 0x37,
+    soft_light = 0x38,
+    difference = 0x39,
+    exclusion = 0x3a,
+    hsl_hue = 0x3b,
+    hsl_saturation = 0x3c,
+    hsl_color = 0x3d,
+    hsl_luminosity = 0x3e,
+};
+
+pub const Color = extern struct {
+    red: u16,
+    green: u16,
+    blue: u16,
+    alpha: u16,
+};
+
+pub const Box32 = extern struct {
+    x1: i32,
+    y1: i32,
+    x2: i32,
+    y2: i32,
+};

--- a/pkg/pixman/types.zig
+++ b/pkg/pixman/types.zig
@@ -93,6 +93,12 @@ pub const LineFixed = extern struct {
     p2: PointFixed,
 };
 
+pub const Triangle = extern struct {
+    p1: PointFixed,
+    p2: PointFixed,
+    p3: PointFixed,
+};
+
 pub const Trapezoid = extern struct {
     top: Fixed,
     bottom: Fixed,

--- a/pkg/pixman/types.zig
+++ b/pkg/pixman/types.zig
@@ -74,3 +74,13 @@ pub const Box32 = extern struct {
     x2: i32,
     y2: i32,
 };
+
+pub const Indexed = extern struct {
+    color: bool,
+    rgba: [256]u32,
+    ent: [32768]u8,
+};
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/pkg/pixman/types.zig
+++ b/pkg/pixman/types.zig
@@ -100,6 +100,13 @@ pub const Trapezoid = extern struct {
     right: LineFixed,
 };
 
+pub const Rectangle16 = extern struct {
+    x: i16,
+    y: i16,
+    width: u16,
+    height: u16,
+};
+
 pub const Box32 = extern struct {
     x1: i32,
     y1: i32,

--- a/pkg/pixman/types.zig
+++ b/pkg/pixman/types.zig
@@ -68,6 +68,38 @@ pub const Color = extern struct {
     alpha: u16,
 };
 
+pub const Fixed = enum(i32) {
+    _,
+
+    pub fn init(v: anytype) Fixed {
+        return switch (@TypeOf(v)) {
+            comptime_int, u32 => @intToEnum(Fixed, v << 16),
+            f64 => @intToEnum(Fixed, @floatToInt(i32, v * 65536)),
+            else => {
+                @compileLog(@TypeOf(v));
+                @compileError("unsupported type");
+            },
+        };
+    }
+};
+
+pub const PointFixed = extern struct {
+    x: Fixed,
+    y: Fixed,
+};
+
+pub const LineFixed = extern struct {
+    p1: PointFixed,
+    p2: PointFixed,
+};
+
+pub const Trapezoid = extern struct {
+    top: Fixed,
+    bottom: Fixed,
+    left: LineFixed,
+    right: LineFixed,
+};
+
 pub const Box32 = extern struct {
     x1: i32,
     y1: i32,

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -296,10 +296,6 @@ pub fn create(alloc: Allocator, app: *App, config: *const Config) !*Window {
         .thickness = 2,
     };
 
-    // TEST
-    const idx = (try font_group.indexForCodepoint(alloc, 0x2500, .regular, null)).?;
-    _ = try font_group.renderGlyph(alloc, idx, 0x2500, null);
-
     // Convert our padding from points to pixels
     const padding_x = (@intToFloat(f32, config.@"window-padding-x") * x_dpi) / 72;
     const padding_y = (@intToFloat(f32, config.@"window-padding-y") * y_dpi) / 72;

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -289,6 +289,17 @@ pub fn create(alloc: Allocator, app: *App, config: *const Config) !*Window {
     // Pre-calculate our initial cell size ourselves.
     const cell_size = try renderer.CellSize.init(alloc, font_group);
 
+    // Setup our box font
+    font_group.group.box_font = font.BoxFont{
+        .width = @floatToInt(u32, cell_size.width),
+        .height = @floatToInt(u32, cell_size.height),
+        .thickness = 2,
+    };
+
+    // TEST
+    const idx = (try font_group.indexForCodepoint(alloc, 0x2500, .regular, null)).?;
+    _ = try font_group.renderGlyph(alloc, idx, 0x2500, null);
+
     // Convert our padding from points to pixels
     const padding_x = (@intToFloat(f32, config.@"window-padding-x") * x_dpi) / 72;
     const padding_y = (@intToFloat(f32, config.@"window-padding-y") * y_dpi) / 72;

--- a/src/font/BoxFont.zig
+++ b/src/font/BoxFont.zig
@@ -18,7 +18,8 @@ const log = std.log.scoped(.box_font);
 width: u32,
 height: u32,
 
-/// Base thickness value for lines of the box. This is in points.
+/// Base thickness value for lines of the box. This is in pixels. If you
+/// want to do any DPI scaling, it is expected to be done earlier.
 thickness: u32,
 
 /// We use alpha-channel-only images for the box font so white causes
@@ -51,13 +52,11 @@ pub fn renderGlyph(
     alloc: Allocator,
     atlas: *Atlas,
     cp: u32,
-    font_size: font.face.DesiredSize,
 ) !font.Glyph {
     assert(atlas.format == .greyscale);
 
     // TODO: render depending on cp
     _ = cp;
-    _ = font_size;
 
     // Determine the config for our image buffer. The images we draw
     // for boxes are always 8bpp
@@ -175,7 +174,6 @@ test "all" {
         alloc,
         &atlas_greyscale,
         0x2500,
-        .{ .points = 12 },
     );
     try testing.expectEqual(@as(u32, face.width), glyph.width);
     try testing.expectEqual(@as(u32, face.height), glyph.height);

--- a/src/font/BoxFont.zig
+++ b/src/font/BoxFont.zig
@@ -140,79 +140,96 @@ pub fn renderGlyph(
 
 fn draw(self: BoxFont, img: *pixman.Image, cp: u32) !void {
     switch (cp) {
-        0x2500 => self.draw_box_drawings_light_horizontal(img),
-        0x2501 => self.draw_box_drawings_heavy_horizontal(img),
-        0x2502 => self.draw_box_drawings_light_vertical(img),
-        0x2503 => self.draw_box_drawings_heavy_vertical(img),
-        0x2504 => self.draw_box_drawings_light_triple_dash_horizontal(img),
-        0x2505 => self.draw_box_drawings_heavy_triple_dash_horizontal(img),
-        0x2506 => self.draw_box_drawings_light_triple_dash_vertical(img),
-        0x2507 => self.draw_box_drawings_heavy_triple_dash_vertical(img),
-        0x2508 => self.draw_box_drawings_light_quadruple_dash_horizontal(img),
-        0x2509 => self.draw_box_drawings_heavy_quadruple_dash_horizontal(img),
-        0x250a => self.draw_box_drawings_light_quadruple_dash_vertical(img),
-        0x250b => self.draw_box_drawings_heavy_quadruple_dash_vertical(img),
-        0x250c => self.draw_box_drawings_light_down_and_right(img),
-        0x250d => self.draw_box_drawings_down_light_and_right_heavy(img),
-        0x250e => self.draw_box_drawings_down_heavy_and_right_light(img),
-        0x250f => self.draw_box_drawings_heavy_down_and_right(img),
+        0x2500 => self.draw_light_horizontal(img),
+        0x2501 => self.draw_heavy_horizontal(img),
+        0x2502 => self.draw_light_vertical(img),
+        0x2503 => self.draw_heavy_vertical(img),
+        0x2504 => self.draw_light_triple_dash_horizontal(img),
+        0x2505 => self.draw_heavy_triple_dash_horizontal(img),
+        0x2506 => self.draw_light_triple_dash_vertical(img),
+        0x2507 => self.draw_heavy_triple_dash_vertical(img),
+        0x2508 => self.draw_light_quadruple_dash_horizontal(img),
+        0x2509 => self.draw_heavy_quadruple_dash_horizontal(img),
+        0x250a => self.draw_light_quadruple_dash_vertical(img),
+        0x250b => self.draw_heavy_quadruple_dash_vertical(img),
+        0x250c => self.draw_light_down_and_right(img),
+        0x250d => self.draw_down_light_and_right_heavy(img),
+        0x250e => self.draw_down_heavy_and_right_light(img),
+        0x250f => self.draw_heavy_down_and_right(img),
 
-        0x2510 => self.draw_box_drawings_light_down_and_left(img),
-        0x2511 => self.draw_box_drawings_down_light_and_left_heavy(img),
-        0x2512 => self.draw_box_drawings_down_heavy_and_left_light(img),
-        0x2513 => self.draw_box_drawings_heavy_down_and_left(img),
-        0x2514 => self.draw_box_drawings_light_up_and_right(img),
-        0x2515 => self.draw_box_drawings_up_light_and_right_heavy(img),
-        0x2516 => self.draw_box_drawings_up_heavy_and_right_light(img),
-        0x2517 => self.draw_box_drawings_heavy_up_and_right(img),
-        0x2518 => self.draw_box_drawings_light_up_and_left(img),
-        0x2519 => self.draw_box_drawings_up_light_and_left_heavy(img),
-        0x251a => self.draw_box_drawings_up_heavy_and_left_light(img),
-        0x251b => self.draw_box_drawings_heavy_up_and_left(img),
-        0x251c => self.draw_box_drawings_light_vertical_and_right(img),
-        0x251d => self.draw_box_drawings_vertical_light_and_right_heavy(img),
-        0x251e => self.draw_box_drawings_up_heavy_and_right_down_light(img),
-        0x251f => self.draw_box_drawings_down_heavy_and_right_up_light(img),
+        0x2510 => self.draw_light_down_and_left(img),
+        0x2511 => self.draw_down_light_and_left_heavy(img),
+        0x2512 => self.draw_down_heavy_and_left_light(img),
+        0x2513 => self.draw_heavy_down_and_left(img),
+        0x2514 => self.draw_light_up_and_right(img),
+        0x2515 => self.draw_up_light_and_right_heavy(img),
+        0x2516 => self.draw_up_heavy_and_right_light(img),
+        0x2517 => self.draw_heavy_up_and_right(img),
+        0x2518 => self.draw_light_up_and_left(img),
+        0x2519 => self.draw_up_light_and_left_heavy(img),
+        0x251a => self.draw_up_heavy_and_left_light(img),
+        0x251b => self.draw_heavy_up_and_left(img),
+        0x251c => self.draw_light_vertical_and_right(img),
+        0x251d => self.draw_vertical_light_and_right_heavy(img),
+        0x251e => self.draw_up_heavy_and_right_down_light(img),
+        0x251f => self.draw_down_heavy_and_right_up_light(img),
 
-        0x2520 => self.draw_box_drawings_vertical_heavy_and_right_light(img),
-        0x2521 => self.draw_box_drawings_down_light_and_right_up_heavy(img),
-        0x2522 => self.draw_box_drawings_up_light_and_right_down_heavy(img),
-        0x2523 => self.draw_box_drawings_heavy_vertical_and_right(img),
-        0x2524 => self.draw_box_drawings_light_vertical_and_left(img),
-        0x2525 => self.draw_box_drawings_vertical_light_and_left_heavy(img),
-        0x2526 => self.draw_box_drawings_up_heavy_and_left_down_light(img),
-        0x2527 => self.draw_box_drawings_down_heavy_and_left_up_light(img),
-        0x2528 => self.draw_box_drawings_vertical_heavy_and_left_light(img),
-        0x2529 => self.draw_box_drawings_down_light_and_left_up_heavy(img),
-        0x252a => self.draw_box_drawings_up_light_and_left_down_heavy(img),
-        0x252b => self.draw_box_drawings_heavy_vertical_and_left(img),
-        0x252c => self.draw_box_drawings_light_down_and_horizontal(img),
-        0x252d => self.draw_box_drawings_left_heavy_and_right_down_light(img),
-        0x252e => self.draw_box_drawings_right_heavy_and_left_down_light(img),
-        0x252f => self.draw_box_drawings_down_light_and_horizontal_heavy(img),
+        0x2520 => self.draw_vertical_heavy_and_right_light(img),
+        0x2521 => self.draw_down_light_and_right_up_heavy(img),
+        0x2522 => self.draw_up_light_and_right_down_heavy(img),
+        0x2523 => self.draw_heavy_vertical_and_right(img),
+        0x2524 => self.draw_light_vertical_and_left(img),
+        0x2525 => self.draw_vertical_light_and_left_heavy(img),
+        0x2526 => self.draw_up_heavy_and_left_down_light(img),
+        0x2527 => self.draw_down_heavy_and_left_up_light(img),
+        0x2528 => self.draw_vertical_heavy_and_left_light(img),
+        0x2529 => self.draw_down_light_and_left_up_heavy(img),
+        0x252a => self.draw_up_light_and_left_down_heavy(img),
+        0x252b => self.draw_heavy_vertical_and_left(img),
+        0x252c => self.draw_light_down_and_horizontal(img),
+        0x252d => self.draw_left_heavy_and_right_down_light(img),
+        0x252e => self.draw_right_heavy_and_left_down_light(img),
+        0x252f => self.draw_down_light_and_horizontal_heavy(img),
+
+        0x2530 => self.draw_down_heavy_and_horizontal_light(img),
+        0x2531 => self.draw_right_light_and_left_down_heavy(img),
+        0x2532 => self.draw_left_light_and_right_down_heavy(img),
+        0x2533 => self.draw_heavy_down_and_horizontal(img),
+        0x2534 => self.draw_light_up_and_horizontal(img),
+        0x2535 => self.draw_left_heavy_and_right_up_light(img),
+        0x2536 => self.draw_right_heavy_and_left_up_light(img),
+        0x2537 => self.draw_up_light_and_horizontal_heavy(img),
+        0x2538 => self.draw_up_heavy_and_horizontal_light(img),
+        0x2539 => self.draw_right_light_and_left_up_heavy(img),
+        0x253a => self.draw_left_light_and_right_up_heavy(img),
+        0x253b => self.draw_heavy_up_and_horizontal(img),
+        0x253c => self.draw_light_vertical_and_horizontal(img),
+        0x253d => self.draw_left_heavy_and_right_vertical_light(img),
+        0x253e => self.draw_right_heavy_and_left_vertical_light(img),
+        0x253f => self.draw_vertical_light_and_horizontal_heavy(img),
 
         else => return error.InvalidCodepoint,
     }
 }
 
-fn draw_box_drawings_light_horizontal(self: BoxFont, img: *pixman.Image) void {
+fn draw_light_horizontal(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle(img, .light);
 }
 
-fn draw_box_drawings_heavy_horizontal(self: BoxFont, img: *pixman.Image) void {
+fn draw_heavy_horizontal(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle(img, .heavy);
 }
 
-fn draw_box_drawings_light_vertical(self: BoxFont, img: *pixman.Image) void {
+fn draw_light_vertical(self: BoxFont, img: *pixman.Image) void {
     self.vline_middle(img, .light);
 }
 
-fn draw_box_drawings_heavy_vertical(self: BoxFont, img: *pixman.Image) void {
+fn draw_heavy_vertical(self: BoxFont, img: *pixman.Image) void {
     self.vline_middle(img, .heavy);
 }
 
-fn draw_box_drawings_light_triple_dash_horizontal(self: BoxFont, img: *pixman.Image) void {
-    self.draw_box_drawings_dash_horizontal(
+fn draw_light_triple_dash_horizontal(self: BoxFont, img: *pixman.Image) void {
+    self.draw_dash_horizontal(
         img,
         3,
         Thickness.light.height(self.thickness),
@@ -220,8 +237,8 @@ fn draw_box_drawings_light_triple_dash_horizontal(self: BoxFont, img: *pixman.Im
     );
 }
 
-fn draw_box_drawings_heavy_triple_dash_horizontal(self: BoxFont, img: *pixman.Image) void {
-    self.draw_box_drawings_dash_horizontal(
+fn draw_heavy_triple_dash_horizontal(self: BoxFont, img: *pixman.Image) void {
+    self.draw_dash_horizontal(
         img,
         3,
         Thickness.heavy.height(self.thickness),
@@ -229,8 +246,8 @@ fn draw_box_drawings_heavy_triple_dash_horizontal(self: BoxFont, img: *pixman.Im
     );
 }
 
-fn draw_box_drawings_light_triple_dash_vertical(self: BoxFont, img: *pixman.Image) void {
-    self.draw_box_drawings_dash_vertical(
+fn draw_light_triple_dash_vertical(self: BoxFont, img: *pixman.Image) void {
+    self.draw_dash_vertical(
         img,
         3,
         Thickness.light.height(self.thickness),
@@ -238,8 +255,8 @@ fn draw_box_drawings_light_triple_dash_vertical(self: BoxFont, img: *pixman.Imag
     );
 }
 
-fn draw_box_drawings_heavy_triple_dash_vertical(self: BoxFont, img: *pixman.Image) void {
-    self.draw_box_drawings_dash_vertical(
+fn draw_heavy_triple_dash_vertical(self: BoxFont, img: *pixman.Image) void {
+    self.draw_dash_vertical(
         img,
         3,
         Thickness.heavy.height(self.thickness),
@@ -247,8 +264,8 @@ fn draw_box_drawings_heavy_triple_dash_vertical(self: BoxFont, img: *pixman.Imag
     );
 }
 
-fn draw_box_drawings_light_quadruple_dash_horizontal(self: BoxFont, img: *pixman.Image) void {
-    self.draw_box_drawings_dash_horizontal(
+fn draw_light_quadruple_dash_horizontal(self: BoxFont, img: *pixman.Image) void {
+    self.draw_dash_horizontal(
         img,
         4,
         Thickness.light.height(self.thickness),
@@ -256,8 +273,8 @@ fn draw_box_drawings_light_quadruple_dash_horizontal(self: BoxFont, img: *pixman
     );
 }
 
-fn draw_box_drawings_heavy_quadruple_dash_horizontal(self: BoxFont, img: *pixman.Image) void {
-    self.draw_box_drawings_dash_horizontal(
+fn draw_heavy_quadruple_dash_horizontal(self: BoxFont, img: *pixman.Image) void {
+    self.draw_dash_horizontal(
         img,
         4,
         Thickness.heavy.height(self.thickness),
@@ -265,8 +282,8 @@ fn draw_box_drawings_heavy_quadruple_dash_horizontal(self: BoxFont, img: *pixman
     );
 }
 
-fn draw_box_drawings_light_quadruple_dash_vertical(self: BoxFont, img: *pixman.Image) void {
-    self.draw_box_drawings_dash_vertical(
+fn draw_light_quadruple_dash_vertical(self: BoxFont, img: *pixman.Image) void {
+    self.draw_dash_vertical(
         img,
         4,
         Thickness.light.height(self.thickness),
@@ -274,8 +291,8 @@ fn draw_box_drawings_light_quadruple_dash_vertical(self: BoxFont, img: *pixman.I
     );
 }
 
-fn draw_box_drawings_heavy_quadruple_dash_vertical(self: BoxFont, img: *pixman.Image) void {
-    self.draw_box_drawings_dash_vertical(
+fn draw_heavy_quadruple_dash_vertical(self: BoxFont, img: *pixman.Image) void {
+    self.draw_dash_vertical(
         img,
         4,
         Thickness.heavy.height(self.thickness),
@@ -283,197 +300,285 @@ fn draw_box_drawings_heavy_quadruple_dash_vertical(self: BoxFont, img: *pixman.I
     );
 }
 
-fn draw_box_drawings_light_down_and_right(self: BoxFont, img: *pixman.Image) void {
+fn draw_light_down_and_right(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_right(img, .light, .light);
     self.vline_middle_down(img, .light, .light);
 }
 
-fn draw_box_drawings_down_light_and_right_heavy(self: BoxFont, img: *pixman.Image) void {
+fn draw_down_light_and_right_heavy(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_right(img, .light, .heavy);
     self.vline_middle_down(img, .light, .light);
 }
 
-fn draw_box_drawings_down_heavy_and_right_light(self: BoxFont, img: *pixman.Image) void {
+fn draw_down_heavy_and_right_light(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_right(img, .light, .light);
     self.vline_middle_down(img, .heavy, .light);
 }
 
-fn draw_box_drawings_heavy_down_and_right(self: BoxFont, img: *pixman.Image) void {
+fn draw_heavy_down_and_right(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_right(img, .heavy, .heavy);
     self.vline_middle_down(img, .heavy, .heavy);
 }
 
-fn draw_box_drawings_light_down_and_left(self: BoxFont, img: *pixman.Image) void {
+fn draw_light_down_and_left(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_left(img, .light, .light);
     self.vline_middle_down(img, .light, .light);
 }
 
-fn draw_box_drawings_down_light_and_left_heavy(self: BoxFont, img: *pixman.Image) void {
+fn draw_down_light_and_left_heavy(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_left(img, .light, .heavy);
     self.vline_middle_down(img, .light, .light);
 }
 
-fn draw_box_drawings_down_heavy_and_left_light(self: BoxFont, img: *pixman.Image) void {
+fn draw_down_heavy_and_left_light(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_left(img, .light, .light);
     self.vline_middle_down(img, .heavy, .light);
 }
 
-fn draw_box_drawings_heavy_down_and_left(self: BoxFont, img: *pixman.Image) void {
+fn draw_heavy_down_and_left(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_left(img, .heavy, .heavy);
     self.vline_middle_down(img, .heavy, .heavy);
 }
 
-fn draw_box_drawings_light_up_and_right(self: BoxFont, img: *pixman.Image) void {
+fn draw_light_up_and_right(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_right(img, .light, .light);
     self.vline_middle_up(img, .light, .light);
 }
 
-fn draw_box_drawings_up_light_and_right_heavy(self: BoxFont, img: *pixman.Image) void {
+fn draw_up_light_and_right_heavy(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_right(img, .light, .heavy);
     self.vline_middle_up(img, .light, .light);
 }
 
-fn draw_box_drawings_up_heavy_and_right_light(self: BoxFont, img: *pixman.Image) void {
+fn draw_up_heavy_and_right_light(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_right(img, .light, .light);
     self.vline_middle_up(img, .heavy, .light);
 }
 
-fn draw_box_drawings_heavy_up_and_right(self: BoxFont, img: *pixman.Image) void {
+fn draw_heavy_up_and_right(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_right(img, .heavy, .heavy);
     self.vline_middle_up(img, .heavy, .heavy);
 }
 
-fn draw_box_drawings_light_up_and_left(self: BoxFont, img: *pixman.Image) void {
+fn draw_light_up_and_left(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_left(img, .light, .light);
     self.vline_middle_up(img, .light, .light);
 }
 
-fn draw_box_drawings_up_light_and_left_heavy(self: BoxFont, img: *pixman.Image) void {
+fn draw_up_light_and_left_heavy(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_left(img, .light, .heavy);
     self.vline_middle_up(img, .light, .light);
 }
 
-fn draw_box_drawings_up_heavy_and_left_light(self: BoxFont, img: *pixman.Image) void {
+fn draw_up_heavy_and_left_light(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_left(img, .light, .light);
     self.vline_middle_up(img, .heavy, .light);
 }
 
-fn draw_box_drawings_heavy_up_and_left(self: BoxFont, img: *pixman.Image) void {
+fn draw_heavy_up_and_left(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_left(img, .heavy, .heavy);
     self.vline_middle_up(img, .heavy, .heavy);
 }
 
-fn draw_box_drawings_light_vertical_and_right(self: BoxFont, img: *pixman.Image) void {
+fn draw_light_vertical_and_right(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_right(img, .light, .light);
     self.vline_middle(img, .light);
 }
 
-fn draw_box_drawings_vertical_light_and_right_heavy(self: BoxFont, img: *pixman.Image) void {
+fn draw_vertical_light_and_right_heavy(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_right(img, .light, .heavy);
     self.vline_middle(img, .light);
 }
 
-fn draw_box_drawings_up_heavy_and_right_down_light(self: BoxFont, img: *pixman.Image) void {
+fn draw_up_heavy_and_right_down_light(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_right(img, .light, .light);
     self.vline_middle_up(img, .heavy, .light);
     self.vline_middle_down(img, .light, .light);
 }
 
-fn draw_box_drawings_down_heavy_and_right_up_light(self: BoxFont, img: *pixman.Image) void {
+fn draw_down_heavy_and_right_up_light(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_right(img, .light, .light);
     self.vline_middle_up(img, .light, .light);
     self.vline_middle_down(img, .heavy, .light);
 }
 
-fn draw_box_drawings_vertical_heavy_and_right_light(self: BoxFont, img: *pixman.Image) void {
+fn draw_vertical_heavy_and_right_light(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_right(img, .light, .light);
     self.vline_middle(img, .heavy);
 }
 
-fn draw_box_drawings_down_light_and_right_up_heavy(self: BoxFont, img: *pixman.Image) void {
+fn draw_down_light_and_right_up_heavy(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_right(img, .heavy, .heavy);
     self.vline_middle_up(img, .heavy, .heavy);
     self.vline_middle_down(img, .light, .light);
 }
 
-fn draw_box_drawings_up_light_and_right_down_heavy(self: BoxFont, img: *pixman.Image) void {
+fn draw_up_light_and_right_down_heavy(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_right(img, .heavy, .heavy);
     self.vline_middle_up(img, .light, .light);
     self.vline_middle_down(img, .heavy, .heavy);
 }
 
-fn draw_box_drawings_heavy_vertical_and_right(self: BoxFont, img: *pixman.Image) void {
+fn draw_heavy_vertical_and_right(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_right(img, .heavy, .heavy);
     self.vline_middle(img, .heavy);
 }
 
-fn draw_box_drawings_light_vertical_and_left(self: BoxFont, img: *pixman.Image) void {
+fn draw_light_vertical_and_left(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_left(img, .light, .light);
     self.vline_middle(img, .light);
 }
 
-fn draw_box_drawings_vertical_light_and_left_heavy(self: BoxFont, img: *pixman.Image) void {
+fn draw_vertical_light_and_left_heavy(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_left(img, .light, .heavy);
     self.vline_middle(img, .light);
 }
 
-fn draw_box_drawings_up_heavy_and_left_down_light(self: BoxFont, img: *pixman.Image) void {
+fn draw_up_heavy_and_left_down_light(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_left(img, .light, .light);
     self.vline_middle_up(img, .heavy, .light);
     self.vline_middle_down(img, .light, .light);
 }
 
-fn draw_box_drawings_down_heavy_and_left_up_light(self: BoxFont, img: *pixman.Image) void {
+fn draw_down_heavy_and_left_up_light(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_left(img, .light, .light);
     self.vline_middle_up(img, .light, .light);
     self.vline_middle_down(img, .heavy, .light);
 }
 
-fn draw_box_drawings_vertical_heavy_and_left_light(self: BoxFont, img: *pixman.Image) void {
+fn draw_vertical_heavy_and_left_light(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_left(img, .light, .light);
     self.vline_middle(img, .heavy);
 }
 
-fn draw_box_drawings_down_light_and_left_up_heavy(self: BoxFont, img: *pixman.Image) void {
+fn draw_down_light_and_left_up_heavy(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_left(img, .heavy, .heavy);
     self.vline_middle_up(img, .heavy, .heavy);
     self.vline_middle_down(img, .light, .light);
 }
 
-fn draw_box_drawings_up_light_and_left_down_heavy(self: BoxFont, img: *pixman.Image) void {
+fn draw_up_light_and_left_down_heavy(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_left(img, .heavy, .heavy);
     self.vline_middle_up(img, .light, .light);
     self.vline_middle_down(img, .heavy, .heavy);
 }
 
-fn draw_box_drawings_heavy_vertical_and_left(self: BoxFont, img: *pixman.Image) void {
+fn draw_heavy_vertical_and_left(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_left(img, .heavy, .heavy);
     self.vline_middle(img, .heavy);
 }
 
-fn draw_box_drawings_light_down_and_horizontal(self: BoxFont, img: *pixman.Image) void {
+fn draw_light_down_and_horizontal(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle(img, .light);
     self.vline_middle_down(img, .light, .light);
 }
 
-fn draw_box_drawings_left_heavy_and_right_down_light(self: BoxFont, img: *pixman.Image) void {
+fn draw_left_heavy_and_right_down_light(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_left(img, .light, .heavy);
     self.hline_middle_right(img, .light, .light);
     self.vline_middle_down(img, .light, .light);
 }
 
-fn draw_box_drawings_right_heavy_and_left_down_light(self: BoxFont, img: *pixman.Image) void {
+fn draw_right_heavy_and_left_down_light(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_left(img, .light, .light);
     self.hline_middle_right(img, .light, .heavy);
     self.vline_middle_down(img, .light, .light);
 }
 
-fn draw_box_drawings_down_light_and_horizontal_heavy(self: BoxFont, img: *pixman.Image) void {
+fn draw_down_light_and_horizontal_heavy(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle(img, .heavy);
     self.vline_middle_down(img, .light, .light);
 }
 
-fn draw_box_drawings_dash_horizontal(
+fn draw_down_heavy_and_horizontal_light(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle(img, .light);
+    self.vline_middle_down(img, .heavy, .light);
+}
+
+fn draw_right_light_and_left_down_heavy(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .heavy, .heavy);
+    self.hline_middle_right(img, .light, .light);
+    self.vline_middle_down(img, .heavy, .heavy);
+}
+
+fn draw_left_light_and_right_down_heavy(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .light, .light);
+    self.hline_middle_right(img, .heavy, .heavy);
+    self.vline_middle_down(img, .heavy, .heavy);
+}
+
+fn draw_heavy_down_and_horizontal(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle(img, .heavy);
+    self.vline_middle_down(img, .heavy, .heavy);
+}
+
+fn draw_light_up_and_horizontal(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle(img, .light);
+    self.vline_middle_up(img, .light, .light);
+}
+
+fn draw_left_heavy_and_right_up_light(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .light, .heavy);
+    self.hline_middle_right(img, .light, .light);
+    self.vline_middle_up(img, .light, .light);
+}
+
+fn draw_right_heavy_and_left_up_light(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .light, .light);
+    self.hline_middle_right(img, .light, .heavy);
+    self.vline_middle_up(img, .light, .light);
+}
+
+fn draw_up_light_and_horizontal_heavy(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle(img, .light);
+    self.vline_middle_up(img, .light, .light);
+}
+
+fn draw_up_heavy_and_horizontal_light(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle(img, .light);
+    self.vline_middle_up(img, .heavy, .light);
+}
+
+fn draw_right_light_and_left_up_heavy(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .heavy, .heavy);
+    self.hline_middle_right(img, .light, .light);
+    self.vline_middle_up(img, .heavy, .heavy);
+}
+
+fn draw_left_light_and_right_up_heavy(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .light, .light);
+    self.hline_middle_right(img, .heavy, .heavy);
+    self.vline_middle_up(img, .heavy, .heavy);
+}
+
+fn draw_heavy_up_and_horizontal(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle(img, .heavy);
+    self.vline_middle_up(img, .heavy, .heavy);
+}
+
+fn draw_light_vertical_and_horizontal(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle(img, .light);
+    self.vline_middle(img, .light);
+}
+
+fn draw_left_heavy_and_right_vertical_light(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .light, .heavy);
+    self.hline_middle_right(img, .light, .light);
+    self.vline_middle(img, .light);
+}
+
+fn draw_right_heavy_and_left_vertical_light(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .light, .light);
+    self.hline_middle_right(img, .light, .heavy);
+    self.vline_middle(img, .light);
+}
+
+fn draw_vertical_light_and_horizontal_heavy(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle(img, .heavy);
+    self.vline_middle(img, .light);
+}
+
+fn draw_dash_horizontal(
     self: BoxFont,
     img: *pixman.Image,
     count: u8,
@@ -539,7 +644,7 @@ fn draw_box_drawings_dash_horizontal(
         self.hline(img, x[3], x[3] + w[3], (self.height - thick_px) / 2, thick_px);
 }
 
-fn draw_box_drawings_dash_vertical(
+fn draw_dash_vertical(
     self: BoxFont,
     img: *pixman.Image,
     count: u8,

--- a/src/font/BoxFont.zig
+++ b/src/font/BoxFont.zig
@@ -352,6 +352,19 @@ fn draw(self: BoxFont, alloc: Allocator, img: *pixman.Image, cp: u32) !void {
         0x1fb85 => self.draw_upper_three_quarters_block(img),
         0x1fb86 => self.draw_upper_seven_eighths_block(img),
 
+        0x1fb7c => self.draw_left_and_lower_one_eighth_block(img),
+        0x1fb7d => self.draw_left_and_upper_one_eighth_block(img),
+        0x1fb7e => self.draw_right_and_upper_one_eighth_block(img),
+        0x1fb7f => self.draw_right_and_lower_one_eighth_block(img),
+        0x1fb80 => self.draw_upper_and_lower_one_eighth_block(img),
+        0x1fb81 => self.draw_horizontal_one_eighth_1358_block(img),
+
+        0x1fb87 => self.draw_right_one_quarter_block(img),
+        0x1fb88 => self.draw_right_three_eighths_block(img),
+        0x1fb89 => self.draw_right_five_eighths_block(img),
+        0x1fb8a => self.draw_right_three_quarters_block(img),
+        0x1fb8b => self.draw_right_seven_eighths_block(img),
+
         else => return error.InvalidCodepoint,
     }
 }
@@ -1457,6 +1470,88 @@ fn draw_right_one_eighth_block(self: BoxFont, img: *pixman.Image) void {
     self.rect(
         img,
         self.width - @floatToInt(u32, @round(@intToFloat(f64, self.width) / 8)),
+        0,
+        self.width,
+        self.height,
+    );
+}
+
+fn draw_left_and_lower_one_eighth_block(self: BoxFont, img: *pixman.Image) void {
+    self.draw_left_one_eighth_block(img);
+    self.draw_lower_one_eighth_block(img);
+}
+
+fn draw_left_and_upper_one_eighth_block(self: BoxFont, img: *pixman.Image) void {
+    self.draw_left_one_eighth_block(img);
+    self.draw_upper_one_eighth_block(img);
+}
+
+fn draw_right_and_upper_one_eighth_block(self: BoxFont, img: *pixman.Image) void {
+    self.draw_right_one_eighth_block(img);
+    self.draw_upper_one_eighth_block(img);
+}
+
+fn draw_right_and_lower_one_eighth_block(self: BoxFont, img: *pixman.Image) void {
+    self.draw_right_one_eighth_block(img);
+    self.draw_lower_one_eighth_block(img);
+}
+
+fn draw_upper_and_lower_one_eighth_block(self: BoxFont, img: *pixman.Image) void {
+    self.draw_upper_one_eighth_block(img);
+    self.draw_lower_one_eighth_block(img);
+}
+
+fn draw_horizontal_one_eighth_1358_block(self: BoxFont, img: *pixman.Image) void {
+    self.draw_upper_one_eighth_block(img);
+    self.draw_horizontal_one_eighth_block_n(img, 2);
+    self.draw_horizontal_one_eighth_block_n(img, 4);
+    self.draw_lower_one_eighth_block(img);
+}
+
+fn draw_right_one_quarter_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(
+        img,
+        self.width - @floatToInt(u32, @round(@intToFloat(f64, self.width) / 4)),
+        0,
+        self.width,
+        self.height,
+    );
+}
+
+fn draw_right_three_quarters_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(
+        img,
+        self.width - @floatToInt(u32, @round(3 * @intToFloat(f64, self.width) / 4)),
+        0,
+        self.width,
+        self.height,
+    );
+}
+
+fn draw_right_three_eighths_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(
+        img,
+        self.width - @floatToInt(u32, @round(3 * @intToFloat(f64, self.width) / 8)),
+        0,
+        self.width,
+        self.height,
+    );
+}
+
+fn draw_right_five_eighths_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(
+        img,
+        self.width - @floatToInt(u32, @round(5 * @intToFloat(f64, self.width) / 8)),
+        0,
+        self.width,
+        self.height,
+    );
+}
+
+fn draw_right_seven_eighths_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(
+        img,
+        self.width - @floatToInt(u32, @round(7 * @intToFloat(f64, self.width) / 8)),
         0,
         self.width,
         self.height,

--- a/src/font/BoxFont.zig
+++ b/src/font/BoxFont.zig
@@ -302,6 +302,13 @@ fn draw(self: BoxFont, alloc: Allocator, img: *pixman.Image, cp: u32) !void {
 
         0x1FB00...0x1FB3B => self.draw_sextant(img, cp),
 
+        0x1fb3c...0x1fb40,
+        0x1fb47...0x1fb4b,
+        0x1fb57...0x1fb5b,
+        0x1fb62...0x1fb66,
+        0x1fb6c...0x1fb6f,
+        => try self.draw_wedge_triangle(img, cp),
+
         else => return error.InvalidCodepoint,
     }
 }
@@ -1658,17 +1665,8 @@ fn draw_sextant(self: BoxFont, img: *pixman.Image, cp: u32) void {
     const idx = cp - 0x1fb00;
     const encoded = matrix[idx];
 
-    const x_halfs: [2]u32 = .{
-        @floatToInt(u32, @round(@intToFloat(f64, self.width) / 2)),
-        @floatToInt(u32, @intToFloat(f64, self.width) / 2),
-    };
-
-    const y_thirds: [2]u32 = switch (@mod(self.height, 3)) {
-        0 => .{ self.height / 3, 2 * self.height / 3 },
-        1 => .{ self.height / 3, 2 * self.height / 3 + 1 },
-        2 => .{ self.height / 3 + 1, 2 * self.height / 3 },
-        else => unreachable,
-    };
+    const x_halfs = self.xHalfs();
+    const y_thirds = self.yThirds();
 
     if (encoded & UPPER_LEFT > 0) self.rect(img, 0, 0, x_halfs[0], y_thirds[0]);
     if (encoded & MIDDLE_LEFT > 0) self.rect(img, 0, y_thirds[0], x_halfs[0], y_thirds[1]);
@@ -1676,6 +1674,381 @@ fn draw_sextant(self: BoxFont, img: *pixman.Image, cp: u32) void {
     if (encoded & UPPER_RIGHT > 0) self.rect(img, x_halfs[1], 0, self.width, y_thirds[0]);
     if (encoded & MIDDLE_RIGHT > 0) self.rect(img, x_halfs[1], y_thirds[0], self.width, y_thirds[1]);
     if (encoded & LOWER_RIGHT > 0) self.rect(img, x_halfs[1], y_thirds[1], self.width, self.height);
+}
+
+fn xHalfs(self: BoxFont) [2]u32 {
+    return .{
+        @floatToInt(u32, @round(@intToFloat(f64, self.width) / 2)),
+        @floatToInt(u32, @intToFloat(f64, self.width) / 2),
+    };
+}
+
+fn yThirds(self: BoxFont) [2]u32 {
+    return switch (@mod(self.height, 3)) {
+        0 => .{ self.height / 3, 2 * self.height / 3 },
+        1 => .{ self.height / 3, 2 * self.height / 3 + 1 },
+        2 => .{ self.height / 3 + 1, 2 * self.height / 3 },
+        else => unreachable,
+    };
+}
+
+fn draw_wedge_triangle(self: BoxFont, img: *pixman.Image, cp: u32) !void {
+    const width = self.width;
+    const height = self.height;
+
+    const x_halfs = self.xHalfs();
+    const y_thirds = self.yThirds();
+    const halfs0 = x_halfs[0];
+    const halfs1 = x_halfs[1];
+    const thirds0 = y_thirds[0];
+    const thirds1 = y_thirds[1];
+
+    var p1_x: u32 = 0;
+    var p2_x: u32 = 0;
+    var p3_x: u32 = 0;
+    var p1_y: u32 = 0;
+    var p2_y: u32 = 0;
+    var p3_y: u32 = 0;
+
+    switch (cp) {
+        0x1fb3c => {
+            p3_x = halfs0;
+            p1_y = thirds1;
+            p2_y = height;
+            p3_y = height;
+        },
+
+        0x1fb52 => {
+            p3_x = halfs0;
+            p1_y = thirds1;
+            p2_y = height;
+            p3_y = height;
+        },
+
+        0x1fb3d => {
+            p3_x = width;
+            p1_y = thirds1;
+            p2_y = height;
+            p3_y = height;
+        },
+
+        0x1fb53 => {
+            p3_x = width;
+            p1_y = thirds1;
+            p2_y = height;
+            p3_y = height;
+        },
+
+        0x1fb3e => {
+            p3_x = halfs0;
+            p1_y = thirds0;
+            p2_y = height;
+            p3_y = height;
+        },
+
+        0x1fb54 => {
+            p3_x = halfs0;
+            p1_y = thirds0;
+            p2_y = height;
+            p3_y = height;
+        },
+
+        0x1fb3f => {
+            p3_x = width;
+            p1_y = thirds0;
+            p2_y = height;
+            p3_y = height;
+        },
+
+        0x1fb55 => {
+            p3_x = width;
+            p1_y = thirds0;
+            p2_y = height;
+            p3_y = height;
+        },
+
+        0x1fb40, 0x1fb56 => {
+            p3_x = halfs0;
+            p1_y = 0;
+            p2_y = height;
+            p3_y = height;
+        },
+
+        0x1fb47 => {
+            p1_x = width;
+            p2_x = width;
+            p3_x = halfs1;
+            p1_y = thirds1;
+            p2_y = height;
+            p3_y = height;
+        },
+
+        0x1fb5d => {
+            p1_x = width;
+            p2_x = width;
+            p3_x = halfs1;
+            p1_y = thirds1;
+            p2_y = height;
+            p3_y = height;
+        },
+
+        0x1fb48 => {
+            p1_x = width;
+            p2_x = width;
+            p3_x = 0;
+            p1_y = thirds1;
+            p2_y = height;
+            p3_y = height;
+        },
+
+        0x1fb5e => {
+            p1_x = width;
+            p2_x = width;
+            p3_x = 0;
+            p1_y = thirds1;
+            p2_y = height;
+            p3_y = height;
+        },
+
+        0x1fb49 => {
+            p1_x = width;
+            p2_x = width;
+            p3_x = halfs1;
+            p1_y = thirds0;
+            p2_y = height;
+            p3_y = height;
+        },
+
+        0x1fb5f => {
+            p1_x = width;
+            p2_x = width;
+            p3_x = halfs1;
+            p1_y = thirds0;
+            p2_y = height;
+            p3_y = height;
+        },
+
+        0x1fb4a => {
+            p1_x = width;
+            p2_x = width;
+            p3_x = 0;
+            p1_y = thirds0;
+            p2_y = height;
+            p3_y = height;
+        },
+
+        0x1fb60 => {
+            p1_x = width;
+            p2_x = width;
+            p3_x = 0;
+            p1_y = thirds0;
+            p2_y = height;
+            p3_y = height;
+        },
+
+        0x1fb4b, 0x1fb61 => {
+            p1_x = width;
+            p2_x = width;
+            p3_x = halfs1;
+            p1_y = 0;
+            p2_y = height;
+            p3_y = height;
+        },
+
+        0x1fb57 => {
+            p3_x = halfs0;
+            p2_y = thirds0;
+        },
+
+        0x1fb41 => {
+            p3_x = halfs0;
+            p2_y = thirds0;
+        },
+
+        0x1fb58 => {
+            p3_x = width;
+            p2_y = thirds0;
+        },
+
+        0x1fb42 => {
+            p3_x = width;
+            p2_y = thirds0;
+        },
+
+        0x1fb59 => {
+            p3_x = halfs0;
+            p2_y = thirds1;
+        },
+
+        0x1fb43 => {
+            p3_x = halfs0;
+            p2_y = thirds1;
+        },
+
+        0x1fb5a => {
+            p3_x = width;
+            p2_y = thirds1;
+        },
+
+        0x1fb44 => {
+            p3_x = width;
+            p2_y = thirds1;
+        },
+
+        0x1fb5b, 0x1fb45 => {
+            p3_x = halfs0;
+            p2_y = height;
+        },
+
+        0x1fb62 => {
+            p1_x = width;
+            p2_x = width;
+            p3_x = halfs1;
+            p2_y = thirds0;
+        },
+
+        0x1fb4c => {
+            p1_x = width;
+            p2_x = width;
+            p3_x = halfs1;
+            p2_y = thirds0;
+        },
+
+        0x1fb63 => {
+            p1_x = width;
+            p2_x = width;
+            p3_x = 0;
+            p2_y = thirds0;
+        },
+
+        0x1fb4d => {
+            p1_x = width;
+            p2_x = width;
+            p3_x = 0;
+            p2_y = thirds0;
+        },
+
+        0x1fb64 => {
+            p1_x = width;
+            p2_x = width;
+            p3_x = halfs1;
+            p2_y = thirds1;
+        },
+
+        0x1fb4e => {
+            p1_x = width;
+            p2_x = width;
+            p3_x = halfs1;
+            p2_y = thirds1;
+        },
+
+        0x1fb65 => {
+            p1_x = width;
+            p2_x = width;
+            p3_x = 0;
+            p2_y = thirds1;
+        },
+
+        0x1fb4f => {
+            p1_x = width;
+            p2_x = width;
+            p3_x = 0;
+            p2_y = thirds1;
+        },
+
+        0x1fb66, 0x1fb50 => {
+            p1_x = width;
+            p2_x = width;
+            p3_x = halfs1;
+            p2_y = height;
+        },
+
+        0x1fb46 => {
+            p1_x = 0;
+            p1_y = thirds1;
+            p2_x = width;
+            p2_y = thirds0;
+            p3_x = width;
+            p3_y = p1_y;
+        },
+
+        0x1fb51 => {
+            p1_x = 0;
+            p1_y = thirds0;
+            p2_x = 0;
+            p2_y = thirds1;
+            p3_x = width;
+            p3_y = p2_y;
+        },
+
+        0x1fb5c => {
+            p1_x = 0;
+            p1_y = thirds0;
+            p2_x = 0;
+            p2_y = thirds1;
+            p3_x = width;
+            p3_y = p1_y;
+        },
+
+        0x1fb67 => {
+            p1_x = 0;
+            p1_y = thirds0;
+            p2_x = width;
+            p2_y = p1_y;
+            p3_x = width;
+            p3_y = thirds1;
+        },
+
+        0x1fb6c, 0x1fb68 => {
+            p1_x = 0;
+            p1_y = 0;
+            p2_x = halfs0;
+            p2_y = height / 2;
+            p3_x = 0;
+            p3_y = height;
+        },
+
+        0x1fb6d, 0x1fb69 => {
+            p1_x = 0;
+            p1_y = 0;
+            p2_x = halfs1;
+            p2_y = height / 2;
+            p3_x = width;
+            p3_y = 0;
+        },
+
+        0x1fb6e, 0x1fb6a => {
+            p1_x = width;
+            p1_y = 0;
+            p2_x = halfs1;
+            p2_y = height / 2;
+            p3_x = width;
+            p3_y = height;
+        },
+
+        0x1fb6f, 0x1fb6b => {
+            p1_x = 0;
+            p1_y = height;
+            p2_x = halfs1;
+            p2_y = height / 2;
+            p3_x = width;
+            p3_y = height;
+        },
+
+        else => unreachable,
+    }
+
+    const tris = &[_]pixman.Triangle{
+        .{
+            .p1 = .{ .x = pixman.Fixed.init(p1_x), .y = pixman.Fixed.init(p1_y) },
+            .p2 = .{ .x = pixman.Fixed.init(p2_x), .y = pixman.Fixed.init(p2_y) },
+            .p3 = .{ .x = pixman.Fixed.init(p3_x), .y = pixman.Fixed.init(p3_y) },
+        },
+    };
+
+    const src = try pixman.Image.createSolidFill(white);
+    defer _ = src.unref();
+    img.compositeTriangles(.over, src, .a8, 0, 0, 0, 0, tris);
 }
 
 fn draw_light_arc(

--- a/src/font/BoxFont.zig
+++ b/src/font/BoxFont.zig
@@ -332,6 +332,26 @@ fn draw(self: BoxFont, alloc: Allocator, img: *pixman.Image, cp: u32) !void {
             try self.draw_wedge_triangle(img, 0x1fb6e);
         },
 
+        0x1FB70 => self.draw_vertical_one_eighth_block_n(img, 1),
+        0x1FB71 => self.draw_vertical_one_eighth_block_n(img, 2),
+        0x1FB72 => self.draw_vertical_one_eighth_block_n(img, 3),
+        0x1FB73 => self.draw_vertical_one_eighth_block_n(img, 4),
+        0x1FB74 => self.draw_vertical_one_eighth_block_n(img, 5),
+        0x1FB75 => self.draw_vertical_one_eighth_block_n(img, 6),
+
+        0x1FB76 => self.draw_horizontal_one_eighth_block_n(img, 1),
+        0x1FB77 => self.draw_horizontal_one_eighth_block_n(img, 2),
+        0x1FB78 => self.draw_horizontal_one_eighth_block_n(img, 3),
+        0x1FB79 => self.draw_horizontal_one_eighth_block_n(img, 4),
+        0x1FB7A => self.draw_horizontal_one_eighth_block_n(img, 5),
+        0x1FB7B => self.draw_horizontal_one_eighth_block_n(img, 6),
+
+        0x1fb82 => self.draw_upper_one_quarter_block(img),
+        0x1fb83 => self.draw_upper_three_eighths_block(img),
+        0x1fb84 => self.draw_upper_five_eighths_block(img),
+        0x1fb85 => self.draw_upper_three_quarters_block(img),
+        0x1fb86 => self.draw_upper_seven_eighths_block(img),
+
         else => return error.InvalidCodepoint,
     }
 }

--- a/src/font/BoxFont.zig
+++ b/src/font/BoxFont.zig
@@ -174,6 +174,23 @@ fn draw(self: BoxFont, img: *pixman.Image, cp: u32) !void {
         0x251e => self.draw_box_drawings_up_heavy_and_right_down_light(img),
         0x251f => self.draw_box_drawings_down_heavy_and_right_up_light(img),
 
+        0x2520 => self.draw_box_drawings_vertical_heavy_and_right_light(img),
+        0x2521 => self.draw_box_drawings_down_light_and_right_up_heavy(img),
+        0x2522 => self.draw_box_drawings_up_light_and_right_down_heavy(img),
+        0x2523 => self.draw_box_drawings_heavy_vertical_and_right(img),
+        0x2524 => self.draw_box_drawings_light_vertical_and_left(img),
+        0x2525 => self.draw_box_drawings_vertical_light_and_left_heavy(img),
+        0x2526 => self.draw_box_drawings_up_heavy_and_left_down_light(img),
+        0x2527 => self.draw_box_drawings_down_heavy_and_left_up_light(img),
+        0x2528 => self.draw_box_drawings_vertical_heavy_and_left_light(img),
+        0x2529 => self.draw_box_drawings_down_light_and_left_up_heavy(img),
+        0x252a => self.draw_box_drawings_up_light_and_left_down_heavy(img),
+        0x252b => self.draw_box_drawings_heavy_vertical_and_left(img),
+        0x252c => self.draw_box_drawings_light_down_and_horizontal(img),
+        0x252d => self.draw_box_drawings_left_heavy_and_right_down_light(img),
+        0x252e => self.draw_box_drawings_right_heavy_and_left_down_light(img),
+        0x252f => self.draw_box_drawings_down_light_and_horizontal_heavy(img),
+
         else => return error.InvalidCodepoint,
     }
 }
@@ -366,6 +383,94 @@ fn draw_box_drawings_down_heavy_and_right_up_light(self: BoxFont, img: *pixman.I
     self.hline_middle_right(img, .light, .light);
     self.vline_middle_up(img, .light, .light);
     self.vline_middle_down(img, .heavy, .light);
+}
+
+fn draw_box_drawings_vertical_heavy_and_right_light(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_right(img, .light, .light);
+    self.vline_middle(img, .heavy);
+}
+
+fn draw_box_drawings_down_light_and_right_up_heavy(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_right(img, .heavy, .heavy);
+    self.vline_middle_up(img, .heavy, .heavy);
+    self.vline_middle_down(img, .light, .light);
+}
+
+fn draw_box_drawings_up_light_and_right_down_heavy(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_right(img, .heavy, .heavy);
+    self.vline_middle_up(img, .light, .light);
+    self.vline_middle_down(img, .heavy, .heavy);
+}
+
+fn draw_box_drawings_heavy_vertical_and_right(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_right(img, .heavy, .heavy);
+    self.vline_middle(img, .heavy);
+}
+
+fn draw_box_drawings_light_vertical_and_left(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .light, .light);
+    self.vline_middle(img, .light);
+}
+
+fn draw_box_drawings_vertical_light_and_left_heavy(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .light, .heavy);
+    self.vline_middle(img, .light);
+}
+
+fn draw_box_drawings_up_heavy_and_left_down_light(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .light, .light);
+    self.vline_middle_up(img, .heavy, .light);
+    self.vline_middle_down(img, .light, .light);
+}
+
+fn draw_box_drawings_down_heavy_and_left_up_light(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .light, .light);
+    self.vline_middle_up(img, .light, .light);
+    self.vline_middle_down(img, .heavy, .light);
+}
+
+fn draw_box_drawings_vertical_heavy_and_left_light(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .light, .light);
+    self.vline_middle(img, .heavy);
+}
+
+fn draw_box_drawings_down_light_and_left_up_heavy(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .heavy, .heavy);
+    self.vline_middle_up(img, .heavy, .heavy);
+    self.vline_middle_down(img, .light, .light);
+}
+
+fn draw_box_drawings_up_light_and_left_down_heavy(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .heavy, .heavy);
+    self.vline_middle_up(img, .light, .light);
+    self.vline_middle_down(img, .heavy, .heavy);
+}
+
+fn draw_box_drawings_heavy_vertical_and_left(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .heavy, .heavy);
+    self.vline_middle(img, .heavy);
+}
+
+fn draw_box_drawings_light_down_and_horizontal(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle(img, .light);
+    self.vline_middle_down(img, .light, .light);
+}
+
+fn draw_box_drawings_left_heavy_and_right_down_light(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .light, .heavy);
+    self.hline_middle_right(img, .light, .light);
+    self.vline_middle_down(img, .light, .light);
+}
+
+fn draw_box_drawings_right_heavy_and_left_down_light(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .light, .light);
+    self.hline_middle_right(img, .light, .heavy);
+    self.vline_middle_down(img, .light, .light);
+}
+
+fn draw_box_drawings_down_light_and_horizontal_heavy(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle(img, .heavy);
+    self.vline_middle_down(img, .light, .light);
 }
 
 fn draw_box_drawings_dash_horizontal(

--- a/src/font/BoxFont.zig
+++ b/src/font/BoxFont.zig
@@ -225,6 +225,23 @@ fn draw(self: BoxFont, img: *pixman.Image, cp: u32) !void {
         0x254e => self.draw_light_double_dash_vertical(img),
         0x254f => self.draw_heavy_double_dash_vertical(img),
 
+        0x2550 => self.draw_double_horizontal(img),
+        0x2551 => self.draw_double_vertical(img),
+        0x2552 => self.draw_down_single_and_right_double(img),
+        0x2553 => self.draw_down_double_and_right_single(img),
+        0x2554 => self.draw_double_down_and_right(img),
+        0x2555 => self.draw_down_single_and_left_double(img),
+        0x2556 => self.draw_down_double_and_left_single(img),
+        0x2557 => self.draw_double_down_and_left(img),
+        0x2558 => self.draw_up_single_and_right_double(img),
+        0x2559 => self.draw_up_double_and_right_single(img),
+        0x255a => self.draw_double_up_and_right(img),
+        0x255b => self.draw_up_single_and_left_double(img),
+        0x255c => self.draw_up_double_and_left_single(img),
+        0x255d => self.draw_double_up_and_left(img),
+        0x255e => self.draw_vertical_single_and_right_double(img),
+        0x255f => self.draw_vertical_double_and_right_single(img),
+
         else => return error.InvalidCodepoint,
     }
 }
@@ -703,6 +720,149 @@ fn draw_heavy_double_dash_vertical(self: BoxFont, img: *pixman.Image) void {
         Thickness.heavy.height(self.thickness),
         Thickness.heavy.height(self.thickness),
     );
+}
+
+fn draw_double_horizontal(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const mid = (self.height - thick_px * 3) / 2;
+    self.hline(img, 0, self.width, mid, thick_px);
+    self.hline(img, 0, self.width, mid + 2 * thick_px, thick_px);
+}
+
+fn draw_double_vertical(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const mid = (self.width - thick_px * 3) / 2;
+    self.vline(img, 0, self.height, mid, thick_px);
+    self.vline(img, 0, self.height, mid + 2 * thick_px, thick_px);
+}
+
+fn draw_down_single_and_right_double(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const hmid = (self.height - thick_px * 3) / 2;
+    const vmid = (self.width - thick_px) / 2;
+    self.vline_middle_down(img, .light, .light);
+    self.hline(img, vmid, self.width, hmid, thick_px);
+    self.hline(img, vmid, self.width, hmid + 2 * thick_px, thick_px);
+}
+
+fn draw_down_double_and_right_single(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const hmid = (self.height - thick_px) / 2;
+    const vmid = (self.width - thick_px * 3) / 2;
+    self.hline_middle_right(img, .light, .light);
+    self.vline(img, hmid, self.height, vmid, thick_px);
+    self.vline(img, hmid, self.height, vmid + 2 * thick_px, thick_px);
+}
+
+fn draw_double_down_and_right(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const hmid = (self.height - thick_px * 3) / 2;
+    const vmid = (self.width - thick_px * 3) / 2;
+    self.vline(img, hmid, self.height, vmid, thick_px);
+    self.vline(img, hmid + 2 * thick_px, self.height, vmid + 2 * thick_px, thick_px);
+    self.hline(img, vmid, self.width, hmid, thick_px);
+    self.hline(img, vmid + 2 * thick_px, self.width, hmid + 2 * thick_px, thick_px);
+}
+
+fn draw_down_single_and_left_double(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const hmid = (self.height - thick_px * 3) / 2;
+    const vmid = (self.width + thick_px) / 2;
+    self.vline_middle_down(img, .light, .light);
+    self.hline(img, 0, vmid, hmid, thick_px);
+    self.hline(img, 0, vmid, hmid + 2 * thick_px, thick_px);
+}
+
+fn draw_down_double_and_left_single(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const hmid = (self.height - thick_px) / 2;
+    const vmid = (self.width - thick_px * 3) / 2;
+    self.hline_middle_left(img, .light, .light);
+    self.vline(img, hmid, self.height, vmid, thick_px);
+    self.vline(img, hmid, self.height, vmid + 2 * thick_px, thick_px);
+}
+
+fn draw_double_down_and_left(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const hmid = (self.height - thick_px * 3) / 2;
+    const vmid = (self.width - thick_px * 3) / 2;
+    self.vline(img, hmid + 2 * thick_px, self.height, vmid, thick_px);
+    self.vline(img, hmid, self.height, vmid + 2 * thick_px, thick_px);
+    self.hline(img, 0, vmid + 2 * thick_px, hmid, thick_px);
+    self.hline(img, 0, vmid, hmid + 2 * thick_px, thick_px);
+}
+
+fn draw_up_single_and_right_double(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const hmid = (self.height - thick_px * 3) / 2;
+    const vmid = (self.width - thick_px) / 2;
+    self.vline_middle_up(img, .light, .light);
+    self.hline(img, vmid, self.width, hmid, thick_px);
+    self.hline(img, vmid, self.width, hmid + 2 * thick_px, thick_px);
+}
+
+fn draw_up_double_and_right_single(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const hmid = (self.height + thick_px) / 2;
+    const vmid = (self.width - thick_px * 3) / 2;
+    self.hline_middle_right(img, .light, .light);
+    self.vline(img, 0, hmid, vmid, thick_px);
+    self.vline(img, 0, hmid, vmid + 2 * thick_px, thick_px);
+}
+
+fn draw_double_up_and_right(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const hmid = (self.height - thick_px * 3) / 2;
+    const vmid = (self.width - thick_px * 3) / 2;
+    self.vline(img, 0, hmid + 2 * thick_px, vmid, thick_px);
+    self.vline(img, 0, hmid, vmid + 2 * thick_px, thick_px);
+    self.hline(img, vmid + 2 * thick_px, self.width, hmid, thick_px);
+    self.hline(img, vmid, self.width, hmid + 2 * thick_px, thick_px);
+}
+
+fn draw_up_single_and_left_double(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const hmid = (self.height - thick_px * 3) / 2;
+    const vmid = (self.width + thick_px) / 2;
+    self.vline_middle_up(img, .light, .light);
+    self.hline(img, 0, vmid, hmid, thick_px);
+    self.hline(img, 0, vmid, hmid + 2 * thick_px, thick_px);
+}
+
+fn draw_up_double_and_left_single(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const hmid = (self.height + thick_px) / 2;
+    const vmid = (self.width - thick_px * 3) / 2;
+    self.hline_middle_left(img, .light, .light);
+    self.vline(img, 0, hmid, vmid, thick_px);
+    self.vline(img, 0, hmid, vmid + 2 * thick_px, thick_px);
+}
+
+fn draw_double_up_and_left(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const hmid = (self.height - thick_px * 3) / 2;
+    const vmid = (self.width - thick_px * 3) / 2;
+    self.vline(img, 0, hmid + 0 * thick_px + thick_px, vmid, thick_px);
+    self.vline(img, 0, hmid + 2 * thick_px + thick_px, vmid + 2 * thick_px, thick_px);
+    self.hline(img, 0, vmid, hmid, thick_px);
+    self.hline(img, 0, vmid, hmid + 2 * thick_px, thick_px);
+}
+
+fn draw_vertical_single_and_right_double(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const hmid = (self.height - thick_px * 3) / 2;
+    const vmid = (self.width - thick_px) / 2;
+    self.vline_middle(img, .light);
+    self.hline(img, vmid, self.width, hmid, thick_px);
+    self.hline(img, vmid, self.width, hmid + 2 * thick_px, thick_px);
+}
+
+fn draw_vertical_double_and_right_single(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const vmid = (self.width - thick_px * 3) / 2;
+    self.hline(img, vmid + 2 * thick_px, self.width, (self.height - thick_px) / 2, thick_px);
+    self.vline(img, 0, self.height, vmid, thick_px);
+    self.vline(img, 0, self.height, vmid + 2 * thick_px, thick_px);
 }
 
 fn draw_dash_horizontal(

--- a/src/font/BoxFont.zig
+++ b/src/font/BoxFont.zig
@@ -257,6 +257,22 @@ fn draw(self: BoxFont, alloc: Allocator, img: *pixman.Image, cp: u32) !void {
         0x256c => self.draw_double_vertical_and_horizontal(img),
         0x256d...0x2570 => try self.draw_light_arc(alloc, img, cp),
 
+        0x2571 => self.draw_light_diagonal_upper_right_to_lower_left(img),
+        0x2572 => self.draw_light_diagonal_upper_left_to_lower_right(img),
+        0x2573 => self.draw_light_diagonal_cross(img),
+        0x2574 => self.draw_light_left(img),
+        0x2575 => self.draw_light_up(img),
+        0x2576 => self.draw_light_right(img),
+        0x2577 => self.draw_light_down(img),
+        0x2578 => self.draw_heavy_left(img),
+        0x2579 => self.draw_heavy_up(img),
+        0x257a => self.draw_heavy_right(img),
+        0x257b => self.draw_heavy_down(img),
+        0x257c => self.draw_light_left_and_heavy_right(img),
+        0x257d => self.draw_light_up_and_heavy_down(img),
+        0x257e => self.draw_heavy_left_and_light_right(img),
+        0x257f => self.draw_heavy_up_and_light_down(img),
+
         else => return error.InvalidCodepoint,
     }
 }
@@ -1004,6 +1020,123 @@ fn draw_double_vertical_and_horizontal(self: BoxFont, img: *pixman.Image) void {
     self.vline(img, 0, hmid, vmid + 2 * thick_px, thick_px);
     self.vline(img, hmid + 2 * thick_px, self.height, vmid, thick_px);
     self.vline(img, hmid + 2 * thick_px, self.height, vmid + 2 * thick_px, thick_px);
+}
+
+fn draw_light_diagonal_upper_right_to_lower_left(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    img.rasterizeTrapezoid(.{
+        .top = pixman.Fixed.init(0),
+        .bottom = pixman.Fixed.init(self.height),
+        .left = .{
+            .p1 = .{
+                .x = pixman.Fixed.init(@intToFloat(f64, self.width) - @intToFloat(f64, thick_px) / 2),
+                .y = pixman.Fixed.init(0),
+            },
+
+            .p2 = .{
+                .x = pixman.Fixed.init(0 - @intToFloat(f64, thick_px) / 2),
+                .y = pixman.Fixed.init(self.height),
+            },
+        },
+        .right = .{
+            .p1 = .{
+                .x = pixman.Fixed.init(@intToFloat(f64, self.width) + @intToFloat(f64, thick_px) / 2),
+                .y = pixman.Fixed.init(0),
+            },
+
+            .p2 = .{
+                .x = pixman.Fixed.init(0 + @intToFloat(f64, thick_px) / 2),
+                .y = pixman.Fixed.init(self.height),
+            },
+        },
+    }, 0, 0);
+}
+
+fn draw_light_diagonal_upper_left_to_lower_right(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    img.rasterizeTrapezoid(.{
+        .top = pixman.Fixed.init(0),
+        .bottom = pixman.Fixed.init(self.height),
+        .left = .{
+            .p1 = .{
+                .x = pixman.Fixed.init(0 - @intToFloat(f64, thick_px) / 2),
+                .y = pixman.Fixed.init(0),
+            },
+
+            .p2 = .{
+                .x = pixman.Fixed.init(@intToFloat(f64, self.width) - @intToFloat(f64, thick_px) / 2),
+                .y = pixman.Fixed.init(self.height),
+            },
+        },
+        .right = .{
+            .p1 = .{
+                .x = pixman.Fixed.init(0 + @intToFloat(f64, thick_px) / 2),
+                .y = pixman.Fixed.init(0),
+            },
+
+            .p2 = .{
+                .x = pixman.Fixed.init(@intToFloat(f64, self.width) + @intToFloat(f64, thick_px) / 2),
+                .y = pixman.Fixed.init(self.height),
+            },
+        },
+    }, 0, 0);
+}
+
+fn draw_light_diagonal_cross(self: BoxFont, img: *pixman.Image) void {
+    self.draw_light_diagonal_upper_right_to_lower_left(img);
+    self.draw_light_diagonal_upper_left_to_lower_right(img);
+}
+
+fn draw_light_left(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .light, .light);
+}
+
+fn draw_light_up(self: BoxFont, img: *pixman.Image) void {
+    self.vline_middle_up(img, .light, .light);
+}
+
+fn draw_light_right(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_right(img, .light, .light);
+}
+
+fn draw_light_down(self: BoxFont, img: *pixman.Image) void {
+    self.vline_middle_down(img, .light, .light);
+}
+
+fn draw_heavy_left(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .heavy, .heavy);
+}
+
+fn draw_heavy_up(self: BoxFont, img: *pixman.Image) void {
+    self.vline_middle_up(img, .heavy, .heavy);
+}
+
+fn draw_heavy_right(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_right(img, .heavy, .heavy);
+}
+
+fn draw_heavy_down(self: BoxFont, img: *pixman.Image) void {
+    self.vline_middle_down(img, .heavy, .heavy);
+}
+
+fn draw_light_left_and_heavy_right(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .light, .light);
+    self.hline_middle_right(img, .heavy, .heavy);
+}
+
+fn draw_light_up_and_heavy_down(self: BoxFont, img: *pixman.Image) void {
+    self.vline_middle_up(img, .light, .light);
+    self.vline_middle_down(img, .heavy, .heavy);
+}
+
+fn draw_heavy_left_and_light_right(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .heavy, .heavy);
+    self.hline_middle_right(img, .light, .light);
+}
+
+fn draw_heavy_up_and_light_down(self: BoxFont, img: *pixman.Image) void {
+    self.vline_middle_up(img, .heavy, .heavy);
+    self.vline_middle_down(img, .light, .light);
 }
 
 fn draw_light_arc(

--- a/src/font/BoxFont.zig
+++ b/src/font/BoxFont.zig
@@ -1,0 +1,168 @@
+//! This file contains functions for drawing the box drawing characters
+//! (https://en.wikipedia.org/wiki/Box-drawing_character) and related
+//! characters that are provided by the terminal.
+const BoxFont = @This();
+
+const std = @import("std");
+const assert = std.debug.assert;
+const Allocator = std.mem.Allocator;
+
+const pixman = @import("pixman");
+const font = @import("main.zig");
+const Atlas = @import("../Atlas.zig");
+
+/// The cell width and height because the boxes are fit perfectly
+/// into a cell so that they all properly connect with zero spacing.
+width: u32,
+height: u32,
+
+/// Base thickness value for lines of the box. This is in points.
+thickness: u32,
+
+/// We use alpha-channel-only images for the box font so white causes
+/// a pixel to be shown.
+const white: pixman.Color = .{
+    .red = 0xFFFF,
+    .green = 0xFFFF,
+    .blue = 0xFFFF,
+    .alpha = 0xFFFF,
+};
+
+/// The thickness of a line.
+const Thickness = enum {
+    light,
+    heavy,
+
+    /// Calculate the real height of a line based on its thickness
+    /// and a base thickness value. The base thickness value is expected
+    /// to be in pixels.
+    fn height(self: Thickness, base: u32) u32 {
+        return switch (self) {
+            .light => base,
+            .heavy => base * 3,
+        };
+    }
+};
+
+pub fn renderGlyph(
+    self: BoxFont,
+    alloc: Allocator,
+    atlas: *Atlas,
+    cp: u32,
+) !font.Glyph {
+    assert(atlas.format == .greyscale);
+
+    // TODO: render depending on cp
+    _ = cp;
+
+    // Determine the config for our image buffer. The images we draw
+    // for boxes are always 8bpp
+    const format: pixman.FormatCode = .a8;
+    const stride = format.strideForWidth(self.width);
+    const len = @intCast(usize, stride * @intCast(c_int, self.height));
+
+    // Allocate our buffer
+    var data = try alloc.alloc(u32, len);
+    defer alloc.free(data);
+    std.mem.set(u32, data, 0);
+
+    // Create the image we'll draw to
+    const img = try pixman.Image.createBitsNoClear(
+        format,
+        @intCast(c_int, self.width),
+        @intCast(c_int, self.height),
+        data.ptr,
+        stride,
+    );
+    defer _ = img.unref();
+
+    self.draw_box_drawings_light_horizontal(img);
+
+    // Reserve our region in the atlas and render the glyph to it.
+    const region = try atlas.reserve(alloc, self.width, self.height);
+    if (region.width > 0 and region.height > 0) {
+        // Convert our []u32 to []u8 since we use 8bpp formats
+        assert(format.bpp() == 8);
+        const len_u8 = len * 4;
+        const data_u8 = @alignCast(@alignOf(u8), @ptrCast([*]u8, data.ptr)[0..len_u8]);
+
+        const depth = atlas.format.depth();
+
+        // We can avoid a buffer copy if our atlas width and bitmap
+        // width match and the bitmap pitch is just the width (meaning
+        // the data is tightly packed).
+        const needs_copy = !(self.width * depth == stride);
+
+        // If we need to copy the data, we copy it into a temporary buffer.
+        const buffer = if (needs_copy) buffer: {
+            var temp = try alloc.alloc(u8, self.width * self.height * depth);
+            var dst_ptr = temp;
+            var src_ptr = data_u8.ptr;
+            var i: usize = 0;
+            while (i < self.height) : (i += 1) {
+                std.mem.copy(u8, dst_ptr, src_ptr[0 .. self.width * depth]);
+                dst_ptr = dst_ptr[self.width * depth ..];
+                src_ptr += @intCast(usize, stride);
+            }
+            break :buffer temp;
+        } else data_u8[0..(self.width * self.height * depth)];
+        defer if (buffer.ptr != data_u8.ptr) alloc.free(buffer);
+
+        // Write the glyph information into the atlas
+        assert(region.width == self.width);
+        assert(region.height == self.height);
+        atlas.set(region, buffer);
+    }
+
+    return font.Glyph{
+        .width = self.width,
+        .height = self.height,
+        .offset_x = 0,
+        .offset_y = 0,
+        .atlas_x = region.x,
+        .atlas_y = region.y,
+        .advance_x = @intToFloat(f32, self.width),
+    };
+}
+
+fn draw_box_drawings_light_horizontal(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle(img, .light);
+}
+
+fn hline_middle(self: BoxFont, img: *pixman.Image, thickness: Thickness) void {
+    const height = thickness.height(self.thickness);
+    self.hline(img, 0, self.width, (self.height - height) / 2, height);
+}
+
+fn hline(
+    self: BoxFont,
+    img: *pixman.Image,
+    x1: u32,
+    x2: u32,
+    y: u32,
+    thickness_px: u32,
+) void {
+    const boxes = &[_]pixman.Box32{
+        .{
+            .x1 = @intCast(i32, @min(@max(x1, 0), self.width)),
+            .x2 = @intCast(i32, @min(@max(x2, 0), self.width)),
+            .y1 = @intCast(i32, @min(@max(y, 0), self.height)),
+            .y2 = @intCast(i32, @min(@max(y + thickness_px, 0), self.height)),
+        },
+    };
+
+    img.fillBoxes(.src, white, boxes) catch {};
+}
+
+test "all" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var atlas_greyscale = try Atlas.init(alloc, 512, .greyscale);
+    defer atlas_greyscale.deinit(alloc);
+
+    const face: BoxFont = .{ .width = 18, .height = 36, .thickness = 2 };
+    const glyph = try face.renderGlyph(alloc, &atlas_greyscale, 0x2500);
+    try testing.expectEqual(@as(u32, face.width), glyph.width);
+    try testing.expectEqual(@as(u32, face.height), glyph.height);
+}

--- a/src/font/BoxFont.zig
+++ b/src/font/BoxFont.zig
@@ -242,6 +242,20 @@ fn draw(self: BoxFont, img: *pixman.Image, cp: u32) !void {
         0x255e => self.draw_vertical_single_and_right_double(img),
         0x255f => self.draw_vertical_double_and_right_single(img),
 
+        0x2560 => self.draw_double_vertical_and_right(img),
+        0x2561 => self.draw_vertical_single_and_left_double(img),
+        0x2562 => self.draw_vertical_double_and_left_single(img),
+        0x2563 => self.draw_double_vertical_and_left(img),
+        0x2564 => self.draw_down_single_and_horizontal_double(img),
+        0x2565 => self.draw_down_double_and_horizontal_single(img),
+        0x2566 => self.draw_double_down_and_horizontal(img),
+        0x2567 => self.draw_up_single_and_horizontal_double(img),
+        0x2568 => self.draw_up_double_and_horizontal_single(img),
+        0x2569 => self.draw_double_up_and_horizontal(img),
+        0x256a => self.draw_vertical_single_and_horizontal_double(img),
+        0x256b => self.draw_vertical_double_and_horizontal_single(img),
+        0x256c => self.draw_double_vertical_and_horizontal(img),
+
         else => return error.InvalidCodepoint,
     }
 }
@@ -863,6 +877,132 @@ fn draw_vertical_double_and_right_single(self: BoxFont, img: *pixman.Image) void
     self.hline(img, vmid + 2 * thick_px, self.width, (self.height - thick_px) / 2, thick_px);
     self.vline(img, 0, self.height, vmid, thick_px);
     self.vline(img, 0, self.height, vmid + 2 * thick_px, thick_px);
+}
+
+fn draw_double_vertical_and_right(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const hmid = (self.height - thick_px * 3) / 2;
+    const vmid = (self.width - thick_px * 3) / 2;
+    self.vline(img, 0, self.height, vmid, thick_px);
+    self.vline(img, 0, hmid, vmid + 2 * thick_px, thick_px);
+    self.vline(img, hmid + 2 * thick_px, self.height, vmid + 2 * thick_px, thick_px);
+    self.hline(img, vmid + 2 * thick_px, self.width, hmid, thick_px);
+    self.hline(img, vmid + 2 * thick_px, self.width, hmid + 2 * thick_px, thick_px);
+}
+
+fn draw_vertical_single_and_left_double(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const hmid = (self.height - thick_px * 3) / 2;
+    const vmid = (self.width + thick_px) / 2;
+    self.vline_middle(img, .light);
+    self.hline(img, 0, vmid, hmid, thick_px);
+    self.hline(img, 0, vmid, hmid + 2 * thick_px, thick_px);
+}
+
+fn draw_vertical_double_and_left_single(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const vmid = (self.width - thick_px * 3) / 2;
+    self.hline(img, 0, vmid, (self.height - thick_px) / 2, thick_px);
+    self.vline(img, 0, self.height, vmid, thick_px);
+    self.vline(img, 0, self.height, vmid + 2 * thick_px, thick_px);
+}
+
+fn draw_double_vertical_and_left(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const hmid = (self.height - thick_px * 3) / 2;
+    const vmid = (self.width - thick_px * 3) / 2;
+    self.vline(img, 0, self.height, vmid + 2 * thick_px, thick_px);
+    self.vline(img, 0, hmid, vmid, thick_px);
+    self.vline(img, hmid + 2 * thick_px, self.height, vmid, thick_px);
+    self.hline(img, 0, vmid + thick_px, hmid, thick_px);
+    self.hline(img, 0, vmid, hmid + 2 * thick_px, thick_px);
+}
+
+fn draw_down_single_and_horizontal_double(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const hmid = (self.height - thick_px * 3) / 2;
+    self.vline(img, hmid + 2 * thick_px, self.height, (self.width - thick_px) / 2, thick_px);
+    self.hline(img, 0, self.width, hmid, thick_px);
+    self.hline(img, 0, self.width, hmid + 2 * thick_px, thick_px);
+}
+
+fn draw_down_double_and_horizontal_single(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const hmid = (self.height - thick_px) / 2;
+    const vmid = (self.width - thick_px * 3) / 2;
+    self.hline_middle(img, .light);
+    self.vline(img, hmid, self.height, vmid, thick_px);
+    self.vline(img, hmid, self.height, vmid + 2 * thick_px, thick_px);
+}
+
+fn draw_double_down_and_horizontal(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const hmid = (self.height - thick_px * 3) / 2;
+    const vmid = (self.width - thick_px * 3) / 2;
+    self.hline(img, 0, self.width, hmid, thick_px);
+    self.hline(img, 0, vmid, hmid + 2 * thick_px, thick_px);
+    self.hline(img, vmid + 2 * thick_px, self.width, hmid + 2 * thick_px, thick_px);
+    self.vline(img, hmid + 2 * thick_px, self.height, vmid, thick_px);
+    self.vline(img, hmid + 2 * thick_px, self.height, vmid + 2 * thick_px, thick_px);
+}
+
+fn draw_up_single_and_horizontal_double(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const hmid = (self.height - thick_px * 3) / 2;
+    const vmid = (self.width - thick_px) / 2;
+    self.vline(img, 0, hmid, vmid, thick_px);
+    self.hline(img, 0, self.width, hmid, thick_px);
+    self.hline(img, 0, self.width, hmid + 2 * thick_px, thick_px);
+}
+
+fn draw_up_double_and_horizontal_single(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const hmid = (self.height - thick_px) / 2;
+    const vmid = (self.width - thick_px * 3) / 2;
+    self.hline_middle(img, .light);
+    self.vline(img, 0, hmid, vmid, thick_px);
+    self.vline(img, 0, hmid, vmid + 2 * thick_px, thick_px);
+}
+
+fn draw_double_up_and_horizontal(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const hmid = (self.height - thick_px * 3) / 2;
+    const vmid = (self.width - thick_px * 3) / 2;
+    self.vline(img, 0, hmid, vmid, thick_px);
+    self.vline(img, 0, hmid, vmid + 2 * thick_px, thick_px);
+    self.hline(img, 0, vmid + thick_px, hmid, thick_px);
+    self.hline(img, vmid + 2 * thick_px, self.width, hmid, thick_px);
+    self.hline(img, 0, self.width, hmid + 2 * thick_px, thick_px);
+}
+
+fn draw_vertical_single_and_horizontal_double(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const hmid = (self.height - thick_px * 3) / 2;
+    self.vline_middle(img, .light);
+    self.hline(img, 0, self.width, hmid, thick_px);
+    self.hline(img, 0, self.width, hmid + 2 * thick_px, thick_px);
+}
+
+fn draw_vertical_double_and_horizontal_single(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const vmid = (self.width - thick_px * 3) / 2;
+    self.hline_middle(img, .light);
+    self.vline(img, 0, self.height, vmid, thick_px);
+    self.vline(img, 0, self.height, vmid + 2 * thick_px, thick_px);
+}
+
+fn draw_double_vertical_and_horizontal(self: BoxFont, img: *pixman.Image) void {
+    const thick_px = Thickness.light.height(self.thickness);
+    const hmid = (self.height - thick_px * 3) / 2;
+    const vmid = (self.width - thick_px * 3) / 2;
+    self.hline(img, 0, vmid, hmid, thick_px);
+    self.hline(img, vmid + 2 * thick_px, self.width, hmid, thick_px);
+    self.hline(img, 0, vmid, hmid + 2 * thick_px, thick_px);
+    self.hline(img, vmid + 2 * thick_px, self.width, hmid + 2 * thick_px, thick_px);
+    self.vline(img, 0, hmid + thick_px, vmid, thick_px);
+    self.vline(img, 0, hmid, vmid + 2 * thick_px, thick_px);
+    self.vline(img, hmid + 2 * thick_px, self.height, vmid, thick_px);
+    self.vline(img, hmid + 2 * thick_px, self.height, vmid + 2 * thick_px, thick_px);
 }
 
 fn draw_dash_horizontal(

--- a/src/font/BoxFont.zig
+++ b/src/font/BoxFont.zig
@@ -156,6 +156,24 @@ fn draw(self: BoxFont, img: *pixman.Image, cp: u32) !void {
         0x250d => self.draw_box_drawings_down_light_and_right_heavy(img),
         0x250e => self.draw_box_drawings_down_heavy_and_right_light(img),
         0x250f => self.draw_box_drawings_heavy_down_and_right(img),
+
+        0x2510 => self.draw_box_drawings_light_down_and_left(img),
+        0x2511 => self.draw_box_drawings_down_light_and_left_heavy(img),
+        0x2512 => self.draw_box_drawings_down_heavy_and_left_light(img),
+        0x2513 => self.draw_box_drawings_heavy_down_and_left(img),
+        0x2514 => self.draw_box_drawings_light_up_and_right(img),
+        0x2515 => self.draw_box_drawings_up_light_and_right_heavy(img),
+        0x2516 => self.draw_box_drawings_up_heavy_and_right_light(img),
+        0x2517 => self.draw_box_drawings_heavy_up_and_right(img),
+        0x2518 => self.draw_box_drawings_light_up_and_left(img),
+        0x2519 => self.draw_box_drawings_up_light_and_left_heavy(img),
+        0x251a => self.draw_box_drawings_up_heavy_and_left_light(img),
+        0x251b => self.draw_box_drawings_heavy_up_and_left(img),
+        0x251c => self.draw_box_drawings_light_vertical_and_right(img),
+        0x251d => self.draw_box_drawings_vertical_light_and_right_heavy(img),
+        0x251e => self.draw_box_drawings_up_heavy_and_right_down_light(img),
+        0x251f => self.draw_box_drawings_down_heavy_and_right_up_light(img),
+
         else => return error.InvalidCodepoint,
     }
 }
@@ -266,6 +284,88 @@ fn draw_box_drawings_down_heavy_and_right_light(self: BoxFont, img: *pixman.Imag
 fn draw_box_drawings_heavy_down_and_right(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle_right(img, .heavy, .heavy);
     self.vline_middle_down(img, .heavy, .heavy);
+}
+
+fn draw_box_drawings_light_down_and_left(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .light, .light);
+    self.vline_middle_down(img, .light, .light);
+}
+
+fn draw_box_drawings_down_light_and_left_heavy(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .light, .heavy);
+    self.vline_middle_down(img, .light, .light);
+}
+
+fn draw_box_drawings_down_heavy_and_left_light(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .light, .light);
+    self.vline_middle_down(img, .heavy, .light);
+}
+
+fn draw_box_drawings_heavy_down_and_left(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .heavy, .heavy);
+    self.vline_middle_down(img, .heavy, .heavy);
+}
+
+fn draw_box_drawings_light_up_and_right(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_right(img, .light, .light);
+    self.vline_middle_up(img, .light, .light);
+}
+
+fn draw_box_drawings_up_light_and_right_heavy(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_right(img, .light, .heavy);
+    self.vline_middle_up(img, .light, .light);
+}
+
+fn draw_box_drawings_up_heavy_and_right_light(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_right(img, .light, .light);
+    self.vline_middle_up(img, .heavy, .light);
+}
+
+fn draw_box_drawings_heavy_up_and_right(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_right(img, .heavy, .heavy);
+    self.vline_middle_up(img, .heavy, .heavy);
+}
+
+fn draw_box_drawings_light_up_and_left(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .light, .light);
+    self.vline_middle_up(img, .light, .light);
+}
+
+fn draw_box_drawings_up_light_and_left_heavy(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .light, .heavy);
+    self.vline_middle_up(img, .light, .light);
+}
+
+fn draw_box_drawings_up_heavy_and_left_light(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .light, .light);
+    self.vline_middle_up(img, .heavy, .light);
+}
+
+fn draw_box_drawings_heavy_up_and_left(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .heavy, .heavy);
+    self.vline_middle_up(img, .heavy, .heavy);
+}
+
+fn draw_box_drawings_light_vertical_and_right(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_right(img, .light, .light);
+    self.vline_middle(img, .light);
+}
+
+fn draw_box_drawings_vertical_light_and_right_heavy(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_right(img, .light, .heavy);
+    self.vline_middle(img, .light);
+}
+
+fn draw_box_drawings_up_heavy_and_right_down_light(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_right(img, .light, .light);
+    self.vline_middle_up(img, .heavy, .light);
+    self.vline_middle_down(img, .light, .light);
+}
+
+fn draw_box_drawings_down_heavy_and_right_up_light(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_right(img, .light, .light);
+    self.vline_middle_up(img, .light, .light);
+    self.vline_middle_down(img, .heavy, .light);
 }
 
 fn draw_box_drawings_dash_horizontal(

--- a/src/font/BoxFont.zig
+++ b/src/font/BoxFont.zig
@@ -273,6 +273,23 @@ fn draw(self: BoxFont, alloc: Allocator, img: *pixman.Image, cp: u32) !void {
         0x257e => self.draw_heavy_left_and_light_right(img),
         0x257f => self.draw_heavy_up_and_light_down(img),
 
+        0x2580 => self.draw_upper_half_block(img),
+        0x2581 => self.draw_lower_one_eighth_block(img),
+        0x2582 => self.draw_lower_one_quarter_block(img),
+        0x2583 => self.draw_lower_three_eighths_block(img),
+        0x2584 => self.draw_lower_half_block(img),
+        0x2585 => self.draw_lower_five_eighths_block(img),
+        0x2586 => self.draw_lower_three_quarters_block(img),
+        0x2587 => self.draw_lower_seven_eighths_block(img),
+        0x2588 => self.draw_full_block(img),
+        0x2589 => self.draw_left_seven_eighths_block(img),
+        0x258a => self.draw_left_three_quarters_block(img),
+        0x258b => self.draw_left_five_eighths_block(img),
+        0x258c => self.draw_left_half_block(img),
+        0x258d => self.draw_left_three_eighths_block(img),
+        0x258e => self.draw_left_one_quarter_block(img),
+        0x258f => self.draw_left_one_eighth_block(img),
+
         else => return error.InvalidCodepoint,
     }
 }
@@ -1139,6 +1156,192 @@ fn draw_heavy_up_and_light_down(self: BoxFont, img: *pixman.Image) void {
     self.vline_middle_down(img, .light, .light);
 }
 
+fn draw_upper_half_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(img, 0, 0, self.width, self.height / 2);
+}
+
+fn draw_lower_one_eighth_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(img, 0, self.height - (self.height / 8), self.width, self.height);
+}
+
+fn draw_lower_one_quarter_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(img, 0, self.height - (self.height / 4), self.width, self.height);
+}
+
+fn draw_lower_three_eighths_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(
+        img,
+        0,
+        self.height - @floatToInt(u32, @round(3 * @intToFloat(f64, self.height) / 8)),
+        self.width,
+        self.height,
+    );
+}
+
+fn draw_lower_half_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(
+        img,
+        0,
+        self.height - @floatToInt(u32, @round(@intToFloat(f64, self.height) / 2)),
+        self.width,
+        self.height,
+    );
+}
+
+fn draw_lower_five_eighths_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(
+        img,
+        0,
+        self.height - @floatToInt(u32, @round(5 * @intToFloat(f64, self.height) / 8)),
+        self.width,
+        self.height,
+    );
+}
+
+fn draw_lower_three_quarters_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(
+        img,
+        0,
+        self.height - @floatToInt(u32, @round(3 * @intToFloat(f64, self.height) / 4)),
+        self.width,
+        self.height,
+    );
+}
+
+fn draw_lower_seven_eighths_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(
+        img,
+        0,
+        self.height - @floatToInt(u32, @round(7 * @intToFloat(f64, self.height) / 8)),
+        self.width,
+        self.height,
+    );
+}
+
+fn draw_upper_one_quarter_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(
+        img,
+        0,
+        0,
+        self.width,
+        @floatToInt(u32, @round(@intToFloat(f64, self.height) / 4)),
+    );
+}
+
+fn draw_upper_three_eighths_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(
+        img,
+        0,
+        0,
+        self.width,
+        @floatToInt(u32, @round(3 * @intToFloat(f64, self.height) / 8)),
+    );
+}
+
+fn draw_upper_five_eighths_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(
+        img,
+        0,
+        0,
+        self.width,
+        @floatToInt(u32, @round(5 * @intToFloat(f64, self.height) / 8)),
+    );
+}
+
+fn draw_upper_three_quarters_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(
+        img,
+        0,
+        0,
+        self.width,
+        @floatToInt(u32, @round(3 * @intToFloat(f64, self.height) / 4)),
+    );
+}
+
+fn draw_upper_seven_eighths_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(
+        img,
+        0,
+        0,
+        self.width,
+        @floatToInt(u32, @round(7 * @intToFloat(f64, self.height) / 8)),
+    );
+}
+
+fn draw_full_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(img, 0, 0, self.width, self.height);
+}
+
+fn draw_left_seven_eighths_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(
+        img,
+        0,
+        0,
+        @floatToInt(u32, @round(7 * @intToFloat(f64, self.width) / 8)),
+        self.height,
+    );
+}
+
+fn draw_left_three_quarters_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(
+        img,
+        0,
+        0,
+        @floatToInt(u32, @round(3 * @intToFloat(f64, self.width) / 4)),
+        self.height,
+    );
+}
+
+fn draw_left_five_eighths_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(
+        img,
+        0,
+        0,
+        @floatToInt(u32, @round(5 * @intToFloat(f64, self.width) / 8)),
+        self.height,
+    );
+}
+
+fn draw_left_half_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(
+        img,
+        0,
+        0,
+        @floatToInt(u32, @round(@intToFloat(f64, self.width) / 2)),
+        self.height,
+    );
+}
+
+fn draw_left_three_eighths_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(
+        img,
+        0,
+        0,
+        @floatToInt(u32, @round(3 * @intToFloat(f64, self.width) / 8)),
+        self.height,
+    );
+}
+
+fn draw_left_one_quarter_block(self: BoxFont, img: *pixman.Image) void {
+    self.rect(
+        img,
+        0,
+        0,
+        @floatToInt(u32, @round(@intToFloat(f64, self.width) / 4)),
+        self.height,
+    );
+}
+
+fn draw_vertical_one_eighth_block_n(self: BoxFont, img: *pixman.Image, n: u32) void {
+    const x = @floatToInt(u32, @round(@intToFloat(f64, n) * @intToFloat(f64, self.width) / 8));
+    const w = @floatToInt(u32, @round(@intToFloat(f64, self.width) / 8));
+    self.rect(img, x, 0, x + w, self.height);
+}
+
+fn draw_left_one_eighth_block(self: BoxFont, img: *pixman.Image) void {
+    self.draw_vertical_one_eighth_block_n(img, 0);
+}
+
 fn draw_light_arc(
     self: BoxFont,
     alloc: Allocator,
@@ -1626,6 +1829,26 @@ fn hline(
             .x2 = @intCast(i32, @min(@max(x2, 0), self.width)),
             .y1 = @intCast(i32, @min(@max(y, 0), self.height)),
             .y2 = @intCast(i32, @min(@max(y + thickness_px, 0), self.height)),
+        },
+    };
+
+    img.fillBoxes(.src, white, boxes) catch {};
+}
+
+fn rect(
+    self: BoxFont,
+    img: *pixman.Image,
+    x1: u32,
+    y1: u32,
+    x2: u32,
+    y2: u32,
+) void {
+    const boxes = &[_]pixman.Box32{
+        .{
+            .x1 = @intCast(i32, @min(@max(x1, 0), self.width)),
+            .y1 = @intCast(i32, @min(@max(y1, 0), self.height)),
+            .x2 = @intCast(i32, @min(@max(x2, 0), self.width)),
+            .y2 = @intCast(i32, @min(@max(y2, 0), self.height)),
         },
     };
 

--- a/src/font/BoxFont.zig
+++ b/src/font/BoxFont.zig
@@ -316,6 +316,22 @@ fn draw(self: BoxFont, alloc: Allocator, img: *pixman.Image, cp: u32) !void {
         0x1FB68...0x1FB6B,
         => try self.draw_wedge_triangle_inverted(img, cp),
 
+        0x1FB46,
+        0x1FB51,
+        0x1FB5C,
+        0x1FB67,
+        => try self.draw_wedge_triangle_and_box(img, cp),
+
+        0x1FB9A => {
+            try self.draw_wedge_triangle(img, 0x1fb6d);
+            try self.draw_wedge_triangle(img, 0x1fb6f);
+        },
+
+        0x1FB9B => {
+            try self.draw_wedge_triangle(img, 0x1fb6c);
+            try self.draw_wedge_triangle(img, 0x1fb6e);
+        },
+
         else => return error.InvalidCodepoint,
     }
 }
@@ -2076,6 +2092,32 @@ fn draw_wedge_triangle_inverted(self: BoxFont, img: *pixman.Image, cp: u32) !voi
         @intCast(u16, self.width),
         @intCast(u16, self.height),
     );
+}
+
+fn draw_wedge_triangle_and_box(self: BoxFont, img: *pixman.Image, cp: u32) !void {
+    try self.draw_wedge_triangle(img, cp);
+
+    const y_thirds = self.yThirds();
+    const box: pixman.Box32 = switch (cp) {
+        0x1fb46, 0x1fb51 => .{
+            .x1 = 0,
+            .y1 = @intCast(i32, y_thirds[1]),
+            .x2 = @intCast(i32, self.width),
+            .y2 = @intCast(i32, self.height),
+        },
+
+        0x1fb5c, 0x1fb67 => .{
+            .x1 = 0,
+            .y1 = 0,
+            .x2 = @intCast(i32, self.width),
+            .y2 = @intCast(i32, y_thirds[0]),
+        },
+
+        else => unreachable,
+    };
+
+    const boxes = &[_]pixman.Box32{box};
+    img.fillBoxes(.src, white, boxes) catch {};
 }
 
 fn draw_light_arc(

--- a/src/font/BoxFont.zig
+++ b/src/font/BoxFont.zig
@@ -302,12 +302,19 @@ fn draw(self: BoxFont, alloc: Allocator, img: *pixman.Image, cp: u32) !void {
 
         0x1FB00...0x1FB3B => self.draw_sextant(img, cp),
 
-        0x1fb3c...0x1fb40,
-        0x1fb47...0x1fb4b,
-        0x1fb57...0x1fb5b,
-        0x1fb62...0x1fb66,
-        0x1fb6c...0x1fb6f,
+        0x1FB3C...0x1FB40,
+        0x1FB47...0x1FB4B,
+        0x1FB57...0x1FB5B,
+        0x1FB62...0x1FB66,
+        0x1FB6C...0x1FB6F,
         => try self.draw_wedge_triangle(img, cp),
+
+        0x1FB41...0x1FB45,
+        0x1FB4C...0x1FB50,
+        0x1FB52...0x1FB56,
+        0x1FB5D...0x1FB61,
+        0x1FB68...0x1FB6B,
+        => try self.draw_wedge_triangle_inverted(img, cp),
 
         else => return error.InvalidCodepoint,
     }
@@ -2049,6 +2056,26 @@ fn draw_wedge_triangle(self: BoxFont, img: *pixman.Image, cp: u32) !void {
     const src = try pixman.Image.createSolidFill(white);
     defer _ = src.unref();
     img.compositeTriangles(.over, src, .a8, 0, 0, 0, 0, tris);
+}
+
+fn draw_wedge_triangle_inverted(self: BoxFont, img: *pixman.Image, cp: u32) !void {
+    try self.draw_wedge_triangle(img, cp);
+
+    const src = try pixman.Image.createSolidFill(white);
+    defer _ = src.unref();
+    img.composite(
+        .out,
+        src,
+        null,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        @intCast(u16, self.width),
+        @intCast(u16, self.height),
+    );
 }
 
 fn draw_light_arc(

--- a/src/font/BoxFont.zig
+++ b/src/font/BoxFont.zig
@@ -208,6 +208,23 @@ fn draw(self: BoxFont, img: *pixman.Image, cp: u32) !void {
         0x253e => self.draw_right_heavy_and_left_vertical_light(img),
         0x253f => self.draw_vertical_light_and_horizontal_heavy(img),
 
+        0x2540 => self.draw_up_heavy_and_down_horizontal_light(img),
+        0x2541 => self.draw_down_heavy_and_up_horizontal_light(img),
+        0x2542 => self.draw_vertical_heavy_and_horizontal_light(img),
+        0x2543 => self.draw_left_up_heavy_and_right_down_light(img),
+        0x2544 => self.draw_right_up_heavy_and_left_down_light(img),
+        0x2545 => self.draw_left_down_heavy_and_right_up_light(img),
+        0x2546 => self.draw_right_down_heavy_and_left_up_light(img),
+        0x2547 => self.draw_down_light_and_up_horizontal_heavy(img),
+        0x2548 => self.draw_up_light_and_down_horizontal_heavy(img),
+        0x2549 => self.draw_right_light_and_left_vertical_heavy(img),
+        0x254a => self.draw_left_light_and_right_vertical_heavy(img),
+        0x254b => self.draw_heavy_vertical_and_horizontal(img),
+        0x254c => self.draw_light_double_dash_horizontal(img),
+        0x254d => self.draw_heavy_double_dash_horizontal(img),
+        0x254e => self.draw_light_double_dash_vertical(img),
+        0x254f => self.draw_heavy_double_dash_vertical(img),
+
         else => return error.InvalidCodepoint,
     }
 }
@@ -576,6 +593,116 @@ fn draw_right_heavy_and_left_vertical_light(self: BoxFont, img: *pixman.Image) v
 fn draw_vertical_light_and_horizontal_heavy(self: BoxFont, img: *pixman.Image) void {
     self.hline_middle(img, .heavy);
     self.vline_middle(img, .light);
+}
+
+fn draw_up_heavy_and_down_horizontal_light(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle(img, .light);
+    self.vline_middle_up(img, .heavy, .heavy);
+    self.vline_middle_down(img, .light, .light);
+}
+
+fn draw_down_heavy_and_up_horizontal_light(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle(img, .light);
+    self.vline_middle_up(img, .light, .light);
+    self.vline_middle_down(img, .heavy, .light);
+}
+
+fn draw_vertical_heavy_and_horizontal_light(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle(img, .light);
+    self.vline_middle(img, .heavy);
+}
+
+fn draw_left_up_heavy_and_right_down_light(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .heavy, .heavy);
+    self.hline_middle_right(img, .light, .light);
+    self.vline_middle_up(img, .heavy, .heavy);
+    self.vline_middle_down(img, .light, .light);
+}
+
+fn draw_right_up_heavy_and_left_down_light(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .light, .light);
+    self.hline_middle_right(img, .heavy, .heavy);
+    self.vline_middle_up(img, .heavy, .heavy);
+    self.vline_middle_down(img, .light, .light);
+}
+
+fn draw_left_down_heavy_and_right_up_light(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .heavy, .heavy);
+    self.hline_middle_right(img, .light, .light);
+    self.vline_middle_up(img, .light, .light);
+    self.vline_middle_down(img, .heavy, .heavy);
+}
+
+fn draw_right_down_heavy_and_left_up_light(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .light, .light);
+    self.hline_middle_right(img, .heavy, .heavy);
+    self.vline_middle_up(img, .light, .light);
+    self.vline_middle_down(img, .heavy, .heavy);
+}
+
+fn draw_down_light_and_up_horizontal_heavy(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle(img, .heavy);
+    self.vline_middle_up(img, .heavy, .heavy);
+    self.vline_middle_down(img, .light, .light);
+}
+
+fn draw_up_light_and_down_horizontal_heavy(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle(img, .heavy);
+    self.vline_middle_up(img, .light, .light);
+    self.vline_middle_down(img, .heavy, .heavy);
+}
+
+fn draw_right_light_and_left_vertical_heavy(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .heavy, .heavy);
+    self.hline_middle_right(img, .light, .light);
+    self.vline_middle(img, .heavy);
+}
+
+fn draw_left_light_and_right_vertical_heavy(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle_left(img, .light, .light);
+    self.hline_middle_right(img, .heavy, .heavy);
+    self.vline_middle(img, .heavy);
+}
+
+fn draw_heavy_vertical_and_horizontal(self: BoxFont, img: *pixman.Image) void {
+    self.hline_middle(img, .heavy);
+    self.vline_middle(img, .heavy);
+}
+
+fn draw_light_double_dash_horizontal(self: BoxFont, img: *pixman.Image) void {
+    self.draw_dash_horizontal(
+        img,
+        2,
+        Thickness.light.height(self.thickness),
+        Thickness.light.height(self.thickness),
+    );
+}
+
+fn draw_heavy_double_dash_horizontal(self: BoxFont, img: *pixman.Image) void {
+    self.draw_dash_horizontal(
+        img,
+        2,
+        Thickness.heavy.height(self.thickness),
+        Thickness.heavy.height(self.thickness),
+    );
+}
+
+fn draw_light_double_dash_vertical(self: BoxFont, img: *pixman.Image) void {
+    self.draw_dash_vertical(
+        img,
+        2,
+        Thickness.light.height(self.thickness),
+        Thickness.heavy.height(self.thickness),
+    );
+}
+
+fn draw_heavy_double_dash_vertical(self: BoxFont, img: *pixman.Image) void {
+    self.draw_dash_vertical(
+        img,
+        2,
+        Thickness.heavy.height(self.thickness),
+        Thickness.heavy.height(self.thickness),
+    );
 }
 
 fn draw_dash_horizontal(

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -194,6 +194,12 @@ pub fn indexForCodepoint(
 
             // "Symbols for Legacy Computing" block
             0x1FB00...0x1FB3B => true,
+            0x1FB3C...0x1FB40,
+            0x1FB47...0x1FB4B,
+            0x1FB57...0x1FB5B,
+            0x1FB62...0x1FB66,
+            0x1FB6C...0x1FB6F,
+            => true,
 
             else => false,
         }) {

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -217,6 +217,8 @@ pub fn indexForCodepoint(
             0x1FB9B,
             => true,
 
+            0x1FB70...0x1FB8B => true,
+
             else => false,
         }) {
             return FontIndex.initSpecial(.box);

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -189,6 +189,9 @@ pub fn indexForCodepoint(
             // "Block Elements" block
             0x2580...0x259f => true,
 
+            // "Braille" block
+            0x2800...0x28FF => true,
+
             else => false,
         }) {
             return FontIndex.initSpecial(.box);

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -192,6 +192,9 @@ pub fn indexForCodepoint(
             // "Braille" block
             0x2800...0x28FF => true,
 
+            // "Symbols for Legacy Computing" block
+            0x1FB00...0x1FB3B => true,
+
             else => false,
         }) {
             return FontIndex.initSpecial(.box);

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -282,7 +282,6 @@ pub fn renderGlyph(
             alloc,
             atlas,
             glyph_index,
-            self.size,
         ),
     };
 

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -237,7 +237,19 @@ fn indexForCodepointExact(self: Group, cp: u32, style: Style, p: ?Presentation) 
     return null;
 }
 
-/// Return the Face represented by a given FontIndex.
+/// Returns the presentation for a specific font index. This is useful for
+/// determining what atlas is needed.
+pub fn presentationFromIndex(self: Group, index: FontIndex) !font.Presentation {
+    if (index.special()) |sp| switch (sp) {
+        .box => return .text,
+    };
+
+    const face = try self.faceFromIndex(index);
+    return face.presentation;
+}
+
+/// Return the Face represented by a given FontIndex. Note that special
+/// fonts (i.e. box glyphs) do not have a face.
 pub fn faceFromIndex(self: Group, index: FontIndex) !Face {
     if (index.special() != null) return error.SpecialHasNoFace;
     const deferred = &self.faces.get(index.style).items[@intCast(usize, index.idx)];

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -209,6 +209,14 @@ pub fn indexForCodepoint(
             0x1FB68...0x1FB6B,
             => true,
 
+            0x1FB46,
+            0x1FB51,
+            0x1FB5C,
+            0x1FB67,
+            0x1FB9A,
+            0x1FB9B,
+            => true,
+
             else => false,
         }) {
             return FontIndex.initSpecial(.box);

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -194,11 +194,19 @@ pub fn indexForCodepoint(
 
             // "Symbols for Legacy Computing" block
             0x1FB00...0x1FB3B => true,
+
             0x1FB3C...0x1FB40,
             0x1FB47...0x1FB4B,
             0x1FB57...0x1FB5B,
             0x1FB62...0x1FB66,
             0x1FB6C...0x1FB6F,
+            => true,
+
+            0x1FB41...0x1FB45,
+            0x1FB4C...0x1FB50,
+            0x1FB52...0x1FB56,
+            0x1FB5D...0x1FB61,
+            0x1FB68...0x1FB6B,
             => true,
 
             else => false,

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -282,6 +282,7 @@ pub fn renderGlyph(
             alloc,
             atlas,
             glyph_index,
+            self.size,
         ),
     };
 

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -185,6 +185,10 @@ pub fn indexForCodepoint(
         if (switch (cp) {
             // "Box Drawing" block
             0x2500...0x257F => true,
+
+            // "Block Elements" block
+            0x2580...0x259f => true,
+
             else => false,
         }) {
             return FontIndex.initSpecial(.box);

--- a/src/font/GroupCache.zig
+++ b/src/font/GroupCache.zig
@@ -132,8 +132,10 @@ pub fn renderGlyph(
     if (gop.found_existing) return gop.value_ptr.*;
 
     // Uncached, render it
-    const face = try self.group.faceFromIndex(index);
-    const atlas: *Atlas = if (face.presentation == .emoji) &self.atlas_color else &self.atlas_greyscale;
+    const atlas: *Atlas = switch (try self.group.presentationFromIndex(index)) {
+        .text => &self.atlas_greyscale,
+        .emoji => &self.atlas_color,
+    };
     const glyph = self.group.renderGlyph(
         alloc,
         atlas,

--- a/src/font/main.zig
+++ b/src/font/main.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const build_options = @import("build_options");
 
+pub const BoxFont = @import("BoxFont.zig");
 pub const discovery = @import("discovery.zig");
 pub const face = @import("face.zig");
 pub const DeferredFace = @import("DeferredFace.zig");

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -772,7 +772,7 @@ fn rebuildCells(
         var iter = self.font_shaper.runIterator(self.font_group, row);
         while (try iter.next(self.alloc)) |run| {
             for (try self.font_shaper.shape(run)) |shaper_cell| {
-                assert(try self.updateCell(
+                if (self.updateCell(
                     term_selection,
                     screen,
                     row.getCell(shaper_cell.x),
@@ -780,7 +780,15 @@ fn rebuildCells(
                     run,
                     shaper_cell.x,
                     y,
-                ));
+                )) |update| {
+                    assert(update);
+                } else |err| {
+                    log.warn("error building cell, will be invalid x={} y={}, err={}", .{
+                        shaper_cell.x,
+                        y,
+                        err,
+                    });
+                }
             }
         }
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -769,7 +769,7 @@ pub fn rebuildCells(
         var iter = self.font_shaper.runIterator(self.font_group, row);
         while (try iter.next(self.alloc)) |run| {
             for (try self.font_shaper.shape(run)) |shaper_cell| {
-                assert(try self.updateCell(
+                if (self.updateCell(
                     term_selection,
                     screen,
                     row.getCell(shaper_cell.x),
@@ -777,7 +777,15 @@ pub fn rebuildCells(
                     run,
                     shaper_cell.x,
                     y,
-                ));
+                )) |update| {
+                    assert(update);
+                } else |err| {
+                    log.warn("error building cell, will be invalid x={} y={}, err={}", .{
+                        shaper_cell.x,
+                        y,
+                        err,
+                    });
+                }
             }
         }
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -958,7 +958,6 @@ pub fn updateCell(
     // If the cell has a character, draw it
     if (cell.char > 0) {
         // Render
-        const face = try self.font_group.group.faceFromIndex(shaper_run.font_index);
         const glyph = try self.font_group.renderGlyph(
             self.alloc,
             shaper_run.font_index,
@@ -967,8 +966,11 @@ pub fn updateCell(
         );
 
         // If we're rendering a color font, we use the color atlas
-        var mode: GPUCellMode = .fg;
-        if (face.presentation == .emoji) mode = .fg_color;
+        const presentation = try self.font_group.group.presentationFromIndex(shaper_run.font_index);
+        var mode: GPUCellMode = switch (presentation) {
+            .text => .fg,
+            .emoji => .fg_color,
+        };
 
         self.cells.appendAssumeCapacity(.{
             .mode = mode,

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -967,7 +967,7 @@ pub fn updateCell(
 
         // If we're rendering a color font, we use the color atlas
         const presentation = try self.font_group.group.presentationFromIndex(shaper_run.font_index);
-        var mode: GPUCellMode = switch (presentation) {
+        const mode: GPUCellMode = switch (presentation) {
             .text => .fg,
             .emoji => .fg_color,
         };

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -501,6 +501,12 @@ pub fn setFontSize(self: *OpenGL, size: font.face.DesiredSize) !void {
     if (std.meta.eql(self.cell_size, new_cell_size)) return;
     self.cell_size = new_cell_size;
 
+    // Set the cell size of the box font
+    if (self.font_group.group.box_font) |*box| {
+        box.width = @floatToInt(u32, self.cell_size.width);
+        box.height = @floatToInt(u32, self.cell_size.height);
+    }
+
     // Notify the window that the cell size changed.
     _ = self.window_mailbox.push(.{
         .cell_size = new_cell_size,


### PR DESCRIPTION
This brings in [Pixman](http://www.pixman.org/) as a cross-platform dependency to procedurally draw all of the box-drawing glyphs. The box-drawing glyphs are drawn on-demand and cached in the glyph atlas and glyph cache. We always prefer our own box glyphs even if the font embeds any (this matches other terminals as far as I can tell).

<img width="723" alt="CleanShot 2022-11-25 at 15 31 34@2x" src="https://user-images.githubusercontent.com/1299/204063183-4ca143ff-3e8f-40a2-bd5c-777555f34639.png">
