### PR TITLE
Underline styles: singe, double, dashed, dotted, curly

### DIFF
--- a/src/Window.zig
+++ b/src/Window.zig
@@ -289,13 +289,6 @@ pub fn create(alloc: Allocator, app: *App, config: *const Config) !*Window {
     // Pre-calculate our initial cell size ourselves.
     const cell_size = try renderer.CellSize.init(alloc, font_group);
 
-    // Setup our box font
-    font_group.group.sprite = font.sprite.Face{
-        .width = @floatToInt(u32, cell_size.width),
-        .height = @floatToInt(u32, cell_size.height),
-        .thickness = 2,
-    };
-
     // Convert our padding from points to pixels
     const padding_x = (@intToFloat(f32, config.@"window-padding-x") * x_dpi) / 72;
     const padding_y = (@intToFloat(f32, config.@"window-padding-y") * y_dpi) / 72;

--- a/src/font/main.zig
+++ b/src/font/main.zig
@@ -11,6 +11,7 @@ pub const Glyph = @import("Glyph.zig");
 pub const Library = @import("Library.zig");
 pub const Shaper = @import("Shaper.zig");
 pub const sprite = @import("sprite.zig");
+pub const Sprite = sprite.Sprite;
 pub const Descriptor = discovery.Descriptor;
 pub const Discover = discovery.Discover;
 
@@ -59,6 +60,9 @@ pub const Presentation = enum(u1) {
     text = 0, // U+FE0E
     emoji = 1, // U+FEOF
 };
+
+/// A FontIndex that can be used to use the sprite font directly.
+pub const sprite_index = Group.FontIndex.initSpecial(.sprite);
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/font/sprite.zig
+++ b/src/font/sprite.zig
@@ -11,10 +11,11 @@ pub const Face = @import("sprite/Face.zig");
 /// Area of Unicode.
 pub const Sprite = enum(u32) {
     // Start 1 above the maximum Unicode codepoint.
-    const start: u32 = std.math.maxInt(u21) + 1;
-    const end: u32 = std.math.maxInt(u32);
+    pub const start: u32 = std.math.maxInt(u21) + 1;
+    pub const end: u32 = std.math.maxInt(u32);
 
     underline = start,
+    underline_double = start + 1,
 
     // Note: we don't currently put the box drawing glyphs in here because
     // there are a LOT and I'm lazy. What I want to do is spend more time

--- a/src/font/sprite.zig
+++ b/src/font/sprite.zig
@@ -18,6 +18,7 @@ pub const Sprite = enum(u32) {
     underline_double = start + 1,
     underline_dotted = start + 2,
     underline_dashed = start + 3,
+    underline_curly = start + 4,
 
     // Note: we don't currently put the box drawing glyphs in here because
     // there are a LOT and I'm lazy. What I want to do is spend more time

--- a/src/font/sprite.zig
+++ b/src/font/sprite.zig
@@ -17,6 +17,7 @@ pub const Sprite = enum(u32) {
     underline = start,
     underline_double = start + 1,
     underline_dotted = start + 2,
+    underline_dashed = start + 3,
 
     // Note: we don't currently put the box drawing glyphs in here because
     // there are a LOT and I'm lazy. What I want to do is spend more time

--- a/src/font/sprite.zig
+++ b/src/font/sprite.zig
@@ -16,6 +16,7 @@ pub const Sprite = enum(u32) {
 
     underline = start,
     underline_double = start + 1,
+    underline_dotted = start + 2,
 
     // Note: we don't currently put the box drawing glyphs in here because
     // there are a LOT and I'm lazy. What I want to do is spend more time

--- a/src/font/sprite/Canvas.zig
+++ b/src/font/sprite/Canvas.zig
@@ -117,13 +117,13 @@ pub fn writeAtlas(self: *Canvas, alloc: Allocator, atlas: *Atlas) !Atlas.Region 
 
 /// Draw and fill a rectangle. This is the main primitive for drawing
 /// lines as well (which are just generally skinny rectangles...)
-pub fn rect(self: *Canvas, v: Rect, color: pixman.Color) void {
+pub fn rect(self: *Canvas, v: Rect, color: Color) void {
     const boxes = &[_]pixman.Box32{
         .{
             .x1 = @intCast(i32, v.x),
             .y1 = @intCast(i32, v.y),
-            .x2 = @intCast(i32, v.width),
-            .y2 = @intCast(i32, v.height),
+            .x2 = @intCast(i32, v.x + v.width),
+            .y2 = @intCast(i32, v.y + v.height),
         },
     };
 

--- a/src/font/sprite/Face.zig
+++ b/src/font/sprite/Face.zig
@@ -86,6 +86,7 @@ const Kind = enum {
                 .underline,
                 .underline_double,
                 .underline_dotted,
+                .underline_dashed,
                 => .underline,
             },
 

--- a/src/font/sprite/Face.zig
+++ b/src/font/sprite/Face.zig
@@ -87,6 +87,7 @@ const Kind = enum {
                 .underline_double,
                 .underline_dotted,
                 .underline_dashed,
+                .underline_curly,
                 => .underline,
             },
 

--- a/src/font/sprite/Face.zig
+++ b/src/font/sprite/Face.zig
@@ -85,6 +85,7 @@ const Kind = enum {
             Sprite.start...Sprite.end => switch (@intToEnum(Sprite, cp)) {
                 .underline,
                 .underline_double,
+                .underline_dotted,
                 => .underline,
             },
 

--- a/src/font/sprite/underline.zig
+++ b/src/font/sprite/underline.zig
@@ -1,0 +1,119 @@
+//! This file renders underline sprites. To draw underlines, we render the
+//! full cell-width as a sprite and then draw it as a separate pass to the
+//! text.
+//!
+//! We used to render the underlines directly in the GPU shaders but its
+//! annoying to support multiple types of underlines and its also annoying
+//! to maintain and debug another set of shaders for each renderer instead of
+//! just relying on the glyph system we already need to support for text
+//! anyways.
+const std = @import("std");
+const builtin = @import("builtin");
+const assert = std.debug.assert;
+const Allocator = std.mem.Allocator;
+const font = @import("../main.zig");
+const Sprite = font.sprite.Sprite;
+const Atlas = @import("../../Atlas.zig");
+
+/// Draw an underline.
+pub fn renderGlyph(
+    alloc: Allocator,
+    atlas: *Atlas,
+    sprite: Sprite,
+    width: u32,
+    height: u32,
+    line_pos: u32,
+    line_thickness: u32,
+) !font.Glyph {
+    // Create the canvas we'll use to draw. We draw the underline in
+    // a full cell size and position it according to "pos".
+    var canvas = try font.sprite.Canvas.init(alloc, width, height);
+    defer canvas.deinit(alloc);
+
+    // Perform the actual drawing
+    (Draw{
+        .width = width,
+        .height = height,
+        .pos = line_pos,
+        .thickness = line_thickness,
+    }).draw(&canvas, sprite);
+
+    // Write the drawing to the atlas
+    const region = try canvas.writeAtlas(alloc, atlas);
+
+    // Our coordinates start at the BOTTOM for our renderers so we have to
+    // specify an offset of the full height because we rendered a full size
+    // cell.
+    const offset_y = @intCast(i32, height);
+
+    return font.Glyph{
+        .width = width,
+        .height = height,
+        .offset_x = 0,
+        .offset_y = offset_y,
+        .atlas_x = region.x,
+        .atlas_y = region.y,
+        .advance_x = @intToFloat(f32, width),
+    };
+}
+
+/// Stores drawing state.
+const Draw = struct {
+    width: u32,
+    height: u32,
+    pos: u32,
+    thickness: u32,
+
+    /// Draw a specific underline sprite to the canvas.
+    fn draw(self: Draw, canvas: *font.sprite.Canvas, sprite: Sprite) void {
+        switch (sprite) {
+            .underline => self.drawSingle(canvas),
+            .underline_double => self.drawDouble(canvas),
+        }
+    }
+
+    /// Draw a single underline.
+    fn drawSingle(self: Draw, canvas: *font.sprite.Canvas) void {
+        canvas.rect(.{
+            .x = 0,
+            .y = self.pos,
+            .width = self.width,
+            .height = self.thickness,
+        }, .on);
+    }
+
+    /// Draw a double underline.
+    fn drawDouble(self: Draw, canvas: *font.sprite.Canvas) void {
+        canvas.rect(.{
+            .x = 0,
+            .y = self.pos,
+            .width = self.width,
+            .height = self.thickness,
+        }, .on);
+
+        canvas.rect(.{
+            .x = 0,
+            .y = self.pos + (self.thickness * 2),
+            .width = self.width,
+            .height = self.thickness,
+        }, .on);
+    }
+};
+
+test "single" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var atlas_greyscale = try Atlas.init(alloc, 512, .greyscale);
+    defer atlas_greyscale.deinit(alloc);
+
+    _ = try renderGlyph(
+        alloc,
+        &atlas_greyscale,
+        .underline,
+        36,
+        18,
+        9,
+        2,
+    );
+}

--- a/src/font/sprite/underline.zig
+++ b/src/font/sprite/underline.zig
@@ -70,6 +70,7 @@ const Draw = struct {
             .underline => self.drawSingle(canvas),
             .underline_double => self.drawDouble(canvas),
             .underline_dotted => self.drawDotted(canvas),
+            .underline_dashed => self.drawDashed(canvas),
         }
     }
 
@@ -110,6 +111,21 @@ const Draw = struct {
                 .x = i * dot_width,
                 .y = self.pos,
                 .width = dot_width,
+                .height = self.thickness,
+            }, .on);
+        }
+    }
+
+    /// Draw a dashed underline.
+    fn drawDashed(self: Draw, canvas: *font.sprite.Canvas) void {
+        const dash_width = self.width / 3 + 1;
+        const dash_count = (self.width / dash_width) + 1;
+        var i: u32 = 0;
+        while (i < dash_count) : (i += 2) {
+            canvas.rect(.{
+                .x = i * dash_width,
+                .y = self.pos,
+                .width = dash_width,
                 .height = self.thickness,
             }, .on);
         }

--- a/src/font/sprite/underline.zig
+++ b/src/font/sprite/underline.zig
@@ -69,6 +69,7 @@ const Draw = struct {
         switch (sprite) {
             .underline => self.drawSingle(canvas),
             .underline_double => self.drawDouble(canvas),
+            .underline_dotted => self.drawDotted(canvas),
         }
     }
 
@@ -97,6 +98,21 @@ const Draw = struct {
             .width = self.width,
             .height = self.thickness,
         }, .on);
+    }
+
+    /// Draw a dotted underline.
+    fn drawDotted(self: Draw, canvas: *font.sprite.Canvas) void {
+        const dot_width = @max(self.thickness, 3);
+        const dot_count = self.width / dot_width;
+        var i: u32 = 0;
+        while (i < dot_count) : (i += 2) {
+            canvas.rect(.{
+                .x = i * dot_width,
+                .y = self.pos,
+                .width = dot_width,
+                .height = self.thickness,
+            }, .on);
+        }
     }
 };
 

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -102,8 +102,6 @@ const GPUUniforms = extern struct {
     cell_size: [2]f32,
 
     /// Metrics for underline/strikethrough
-    underline_position: f32,
-    underline_thickness: f32,
     strikethrough_position: f32,
     strikethrough_thickness: f32,
 };
@@ -115,7 +113,6 @@ const GPUCellMode = enum(u8) {
     cursor_rect = 3,
     cursor_rect_hollow = 4,
     cursor_bar = 5,
-    underline = 6,
     strikethrough = 8,
 
     pub fn fromCursor(cursor: renderer.CursorStyle) GPUCellMode {
@@ -267,8 +264,6 @@ pub fn init(alloc: Allocator, options: renderer.Options) !Metal {
         .uniforms = .{
             .projection_matrix = undefined,
             .cell_size = undefined,
-            .underline_position = metrics.underline_position,
-            .underline_thickness = metrics.underline_thickness,
             .strikethrough_position = metrics.strikethrough_position,
             .strikethrough_thickness = metrics.strikethrough_thickness,
         },
@@ -405,8 +400,6 @@ pub fn setFontSize(self: *Metal, size: font.face.DesiredSize) !void {
     self.uniforms = .{
         .projection_matrix = self.uniforms.projection_matrix,
         .cell_size = .{ new_cell_size.width, new_cell_size.height },
-        .underline_position = metrics.underline_position,
-        .underline_thickness = metrics.underline_thickness,
         .strikethrough_position = metrics.strikethrough_position,
         .strikethrough_thickness = metrics.strikethrough_thickness,
     };
@@ -717,8 +710,6 @@ pub fn setScreenSize(self: *Metal, _: renderer.ScreenSize) !void {
             -1 * padding.top,
         ),
         .cell_size = .{ self.cell_size.width, self.cell_size.height },
-        .underline_position = old.underline_position,
-        .underline_thickness = old.underline_thickness,
         .strikethrough_position = old.strikethrough_position,
         .strikethrough_thickness = old.strikethrough_thickness,
     };

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -911,7 +911,7 @@ pub fn updateCell(
         });
     }
 
-    if (cell.attrs.underline) {
+    if (cell.attrs.underline != .none) {
         self.cells.appendAssumeCapacity(.{
             .mode = .underline,
             .grid_pos = .{ @intToFloat(f32, x), @intToFloat(f32, y) },

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -137,7 +137,6 @@ const GPUCellMode = enum(u8) {
     cursor_rect = 3,
     cursor_rect_hollow = 4,
     cursor_bar = 5,
-    underline = 6,
     strikethrough = 8,
 
     // Non-exhaustive because masks change it
@@ -180,8 +179,6 @@ pub fn init(alloc: Allocator, options: renderer.Options) !OpenGL {
     const pbind = try program.use();
     defer pbind.unbind();
     try program.setUniform("cell_size", @Vector(2, f32){ metrics.cell_width, metrics.cell_height });
-    try program.setUniform("underline_position", metrics.underline_position);
-    try program.setUniform("underline_thickness", metrics.underline_thickness);
     try program.setUniform("strikethrough_position", metrics.strikethrough_position);
     try program.setUniform("strikethrough_thickness", metrics.strikethrough_thickness);
 
@@ -536,8 +533,6 @@ fn resetFontMetrics(
     const pbind = try program.use();
     defer pbind.unbind();
     try program.setUniform("cell_size", @Vector(2, f32){ metrics.cell_width, metrics.cell_height });
-    try program.setUniform("underline_position", metrics.underline_position);
-    try program.setUniform("underline_thickness", metrics.underline_thickness);
     try program.setUniform("strikethrough_position", metrics.strikethrough_position);
     try program.setUniform("strikethrough_thickness", metrics.strikethrough_thickness);
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -1011,7 +1011,7 @@ pub fn updateCell(
             .double => .underline_double,
             .dotted => .underline_dotted,
             .dashed => .underline_dashed,
-            else => .underline,
+            .curly => .underline_curly,
         };
 
         const underline_glyph = try self.font_group.renderGlyph(

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -1009,6 +1009,7 @@ pub fn updateCell(
             .none => unreachable,
             .single => .underline,
             .double => .underline_double,
+            .dotted => .underline_dotted,
             else => .underline,
         };
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -1010,6 +1010,7 @@ pub fn updateCell(
             .single => .underline,
             .double => .underline_double,
             .dotted => .underline_dotted,
+            .dashed => .underline_dashed,
             else => .underline,
         };
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -928,7 +928,7 @@ pub fn updateCell(
         var i: usize = 0;
         if (colors.bg != null) i += 1;
         if (!cell.empty()) i += 1;
-        if (cell.attrs.underline) i += 1;
+        if (cell.attrs.underline != .none) i += 1;
         if (cell.attrs.strikethrough) i += 1;
         break :needed i;
     };
@@ -1002,7 +1002,7 @@ pub fn updateCell(
         });
     }
 
-    if (cell.attrs.underline) {
+    if (cell.attrs.underline != .none) {
         self.cells.appendAssumeCapacity(.{
             .mode = .underline,
             .grid_col = @intCast(u16, x),

--- a/src/renderer/shaders/cell.f.glsl
+++ b/src/renderer/shaders/cell.f.glsl
@@ -30,7 +30,6 @@ const uint MODE_FG_COLOR = 7u;
 const uint MODE_CURSOR_RECT = 3u;
 const uint MODE_CURSOR_RECT_HOLLOW = 4u;
 const uint MODE_CURSOR_BAR = 5u;
-const uint MODE_UNDERLINE = 6u;
 const uint MODE_STRIKETHROUGH = 8u;
 
 void main() {
@@ -91,10 +90,6 @@ void main() {
         break;
 
     case MODE_CURSOR_BAR:
-        out_FragColor = color;
-        break;
-
-    case MODE_UNDERLINE:
         out_FragColor = color;
         break;
 

--- a/src/renderer/shaders/cell.metal
+++ b/src/renderer/shaders/cell.metal
@@ -8,15 +8,12 @@ enum Mode : uint8_t {
     MODE_CURSOR_RECT = 3u,
     MODE_CURSOR_RECT_HOLLOW = 4u,
     MODE_CURSOR_BAR = 5u,
-    MODE_UNDERLINE = 6u,
     MODE_STRIKETHROUGH = 8u,
 };
 
 struct Uniforms {
   float4x4 projection_matrix;
   float2 cell_size;
-  float underline_position;
-  float underline_thickness;
   float strikethrough_position;
   float strikethrough_thickness;
 };
@@ -154,22 +151,6 @@ vertex VertexOut uber_vertex(
     break;
   }
 
-  case MODE_UNDERLINE: {
-    // Underline Y value is just our thickness
-    float2 underline_size = float2(cell_size_scaled.x, uniforms.underline_thickness);
-
-    // Position the underline where we are told to
-    float2 underline_offset = float2(cell_size_scaled.x, uniforms.underline_position);
-
-    // Go to the bottom of the cell, take away the size of the
-    // underline, and that is our position. We also float it slightly
-    // above the bottom.
-    cell_pos = cell_pos + underline_offset - (underline_size * position);
-
-    out.position = uniforms.projection_matrix * float4(cell_pos, 0.0f, 1.0);
-    break;
-  }
-
   case MODE_STRIKETHROUGH: {
     // Strikethrough Y value is just our thickness
     float2 strikethrough_size = float2(cell_size_scaled.x, uniforms.strikethrough_thickness);
@@ -257,9 +238,6 @@ fragment float4 uber_fragment(
   }
 
   case MODE_CURSOR_BAR:
-    return in.color;
-
-  case MODE_UNDERLINE:
     return in.color;
 
   case MODE_STRIKETHROUGH:

--- a/src/renderer/shaders/cell.v.glsl
+++ b/src/renderer/shaders/cell.v.glsl
@@ -10,7 +10,6 @@ const uint MODE_FG_COLOR = 7u;
 const uint MODE_CURSOR_RECT = 3u;
 const uint MODE_CURSOR_RECT_HOLLOW = 4u;
 const uint MODE_CURSOR_BAR = 5u;
-const uint MODE_UNDERLINE = 6u;
 const uint MODE_STRIKETHROUGH = 8u;
 
 // The grid coordinates (x, y) where x < columns and y < rows
@@ -58,8 +57,6 @@ uniform sampler2D text;
 uniform sampler2D text_color;
 uniform vec2 cell_size;
 uniform mat4 projection;
-uniform float underline_position;
-uniform float underline_thickness;
 uniform float strikethrough_position;
 uniform float strikethrough_thickness;
 
@@ -198,22 +195,6 @@ void main() {
 
         gl_Position = projection * vec4(cell_pos, cell_z, 1.0);
         color = bg_color_in / 255.0;
-        break;
-
-    case MODE_UNDERLINE:
-        // Underline Y value is just our thickness
-        vec2 underline_size = vec2(cell_size_scaled.x, underline_thickness);
-
-        // Position the underline where we are told to
-        vec2 underline_offset = vec2(cell_size_scaled.x, underline_position) ;
-
-        // Go to the bottom of the cell, take away the size of the
-        // underline, and that is our position. We also float it slightly
-        // above the bottom.
-        cell_pos = cell_pos + underline_offset - (underline_size * position);
-
-        gl_Position = projection * vec4(cell_pos, cell_z, 1.0);
-        color = fg_color_in / 255.0;
         break;
 
     case MODE_STRIKETHROUGH:

--- a/src/terminal/Parser.zig
+++ b/src/terminal/Parser.zig
@@ -79,6 +79,10 @@ pub const Action = union(enum) {
         intermediates: []u8,
         params: []u16,
         final: u8,
+        sep: Sep,
+
+        /// The separator used for CSI params.
+        pub const Sep = enum { semicolon, colon };
 
         // Implement formatter for logging
         pub fn format(
@@ -392,6 +396,11 @@ fn doAction(self: *Parser, action: TransitionAction, c: u8) ?Action {
                     .intermediates = self.intermediates[0..self.intermediates_idx],
                     .params = self.params[0..self.params_idx],
                     .final = c,
+                    .sep = switch (self.params_sep) {
+                        .none, .semicolon => .semicolon,
+                        .colon => .colon,
+                        .mixed => unreachable,
+                    },
                 },
             };
         },

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -56,6 +56,7 @@ const Allocator = std.mem.Allocator;
 
 const utf8proc = @import("utf8proc");
 const trace = @import("tracy").trace;
+const sgr = @import("sgr.zig");
 const color = @import("color.zig");
 const point = @import("point.zig");
 const CircBuf = @import("circ_buf.zig").CircBuf;
@@ -167,10 +168,10 @@ pub const Cell = struct {
         bold: bool = false,
         italic: bool = false,
         faint: bool = false,
-        underline: bool = false,
         blink: bool = false,
         inverse: bool = false,
         strikethrough: bool = false,
+        underline: sgr.Attribute.Underline = .none,
 
         /// True if this is a wide character. This char takes up
         /// two cells. The following cell ALWAYS is a space.
@@ -241,7 +242,7 @@ pub const Cell = struct {
     }
 
     test {
-        //log.warn("CELL={} {}", .{ @sizeOf(Cell), @alignOf(Cell) });
+        //log.warn("CELL={} bits={} {}", .{ @sizeOf(Cell), @bitSizeOf(Cell), @alignOf(Cell) });
         try std.testing.expectEqual(12, @sizeOf(Cell));
     }
 };

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -379,12 +379,12 @@ pub fn setAttribute(self: *Terminal, attr: sgr.Attribute) !void {
             self.screen.cursor.pen.attrs.faint = true;
         },
 
-        .underline => {
-            self.screen.cursor.pen.attrs.underline = true;
+        .underline => |v| {
+            self.screen.cursor.pen.attrs.underline = v;
         },
 
         .reset_underline => {
-            self.screen.cursor.pen.attrs.underline = false;
+            self.screen.cursor.pen.attrs.underline = .none;
         },
 
         .blink => {

--- a/src/terminal/sgr.zig
+++ b/src/terminal/sgr.zig
@@ -137,7 +137,10 @@ pub const Parser = struct {
                                 0 => return Attribute{ .reset_underline = {} },
                                 1 => return Attribute{ .underline = .single },
                                 2 => return Attribute{ .underline = .double },
-                                else => break :blk,
+
+                                // For unknown underline styles, just render
+                                // a single underline.
+                                else => return Attribute{ .underline = .single },
                             }
                         },
 

--- a/src/terminal/sgr.zig
+++ b/src/terminal/sgr.zig
@@ -137,6 +137,7 @@ pub const Parser = struct {
                                 0 => return Attribute{ .reset_underline = {} },
                                 1 => return Attribute{ .underline = .single },
                                 2 => return Attribute{ .underline = .double },
+                                3 => return Attribute{ .underline = .curly },
                                 4 => return Attribute{ .underline = .dotted },
                                 5 => return Attribute{ .underline = .dashed },
 

--- a/src/terminal/sgr.zig
+++ b/src/terminal/sgr.zig
@@ -137,6 +137,8 @@ pub const Parser = struct {
                                 0 => return Attribute{ .reset_underline = {} },
                                 1 => return Attribute{ .underline = .single },
                                 2 => return Attribute{ .underline = .double },
+                                4 => return Attribute{ .underline = .dotted },
+                                5 => return Attribute{ .underline = .dashed },
 
                                 // For unknown underline styles, just render
                                 // a single underline.
@@ -339,6 +341,18 @@ test "sgr: underline styles" {
         const v = testParseColon(&[_]u16{ 4, 1 });
         try testing.expect(v == .underline);
         try testing.expect(v.underline == .single);
+    }
+
+    {
+        const v = testParseColon(&[_]u16{ 4, 4 });
+        try testing.expect(v == .underline);
+        try testing.expect(v.underline == .dotted);
+    }
+
+    {
+        const v = testParseColon(&[_]u16{ 4, 5 });
+        try testing.expect(v == .underline);
+        try testing.expect(v.underline == .dashed);
     }
 }
 

--- a/src/terminal/sgr.zig
+++ b/src/terminal/sgr.zig
@@ -31,7 +31,7 @@ pub const Attribute = union(enum) {
     faint: void,
 
     /// Underline the text
-    underline: void,
+    underline: Underline,
     reset_underline: void,
 
     /// Blink the text
@@ -75,6 +75,15 @@ pub const Attribute = union(enum) {
         g: u8,
         b: u8,
     };
+
+    pub const Underline = enum(u3) {
+        none = 0,
+        single = 1,
+        double = 2,
+        curly = 3,
+        dotted = 4,
+        dashed = 5,
+    };
 };
 
 /// Parser parses the attributes from a list of SGR parameters.
@@ -107,7 +116,7 @@ pub const Parser = struct {
 
             3 => return Attribute{ .italic = {} },
 
-            4 => return Attribute{ .underline = {} },
+            4 => return Attribute{ .underline = .single },
 
             5 => return Attribute{ .blink = {} },
 

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -383,7 +383,7 @@ pub fn Stream(comptime Handler: type) type {
 
                 // SGR - Select Graphic Rendition
                 'm' => if (@hasDecl(T, "setAttribute")) {
-                    var p: sgr.Parser = .{ .params = action.params };
+                    var p: sgr.Parser = .{ .params = action.params, .colon = action.sep == .colon };
                     while (p.next()) |attr| try self.handler.setAttribute(attr);
                 } else log.warn("unimplemented CSI callback: {}", .{action}),
 


### PR DESCRIPTION
This adds support for fancier underling styling. We've supported regular underlines for a very long time but this adds support for double, dashed, dotted, and curly underlines. 

Previously, underlines were rendered and created in the shader. We now generate sprites for the underlines just-in-time and store them in the font atlas. We then render them alongside the glyphs using the GPU texture. This just makes it easier to draw underlines instead of doing it all in a shader.

<img width="655" alt="CleanShot 2022-11-27 at 16 20 35@2x" src="https://user-images.githubusercontent.com/1299/204167903-7a5173e2-21ff-45f7-9c66-9ae344efd182.png">
