### PR TITLE
wasm: Discovery, DeferredFace, Group, GroupCache

### DIFF
--- a/example/app.ts
+++ b/example/app.ts
@@ -32,6 +32,11 @@ fetch(url.href).then(response =>
     deferred_face_free,
     deferred_face_load,
     deferred_face_face,
+    group_new,
+    group_free,
+    group_add_face,
+    group_index_for_codepoint,
+    group_render_glyph,
     atlas_new,
     atlas_free,
     atlas_debug_canvas,
@@ -53,22 +58,28 @@ fetch(url.href).then(response =>
 
   // Initialize our deferred face
   const df = deferred_face_new(font_ptr, font.byteLength);
-  deferred_face_load(df, 72 /* size */);
-  const face = deferred_face_face(df);
+  //deferred_face_load(df, 72 /* size */);
+  //const face = deferred_face_face(df);
 
   // Initialize our font face
   //const face = face_new(font_ptr, font.byteLength, 72 /* size in px */);
   free(font_ptr);
 
+  // Create our group
+  const group = group_new(72 /* size */);
+  group_add_face(group, 0, df);
+
   // Render a glyph
   for (let i = 33; i <= 126; i++) {
-    face_render_glyph(face, atlas, i);
+    const font_idx = group_index_for_codepoint(group, i, 0, -1);
+    group_render_glyph(group, atlas, font_idx, i, 0);
+    //face_render_glyph(face, atlas, i);
   }
   //face_render_glyph(face, atlas, "橋".codePointAt(0));
   //face_render_glyph(face, atlas, "p".codePointAt(0));
 
   // Debug our canvas
-  face_debug_canvas(face);
+  //face_debug_canvas(face);
 
   // Debug our atlas canvas
   const id = atlas_debug_canvas(atlas);

--- a/example/app.ts
+++ b/example/app.ts
@@ -37,6 +37,11 @@ fetch(url.href).then(response =>
     group_add_face,
     group_index_for_codepoint,
     group_render_glyph,
+    group_cache_new,
+    group_cache_free,
+    group_cache_index_for_codepoint,
+    group_cache_render_glyph,
+    group_cache_atlas_greyscale,
     atlas_new,
     atlas_free,
     atlas_debug_canvas,
@@ -49,7 +54,7 @@ fetch(url.href).then(response =>
   zjs.memory = memory;
 
   // Create our atlas
-  const atlas = atlas_new(512, 0 /* greyscale */);
+  // const atlas = atlas_new(512, 0 /* greyscale */);
 
   // Create some memory for our string
   const font = new TextEncoder().encode("monospace");
@@ -69,10 +74,13 @@ fetch(url.href).then(response =>
   const group = group_new(72 /* size */);
   group_add_face(group, 0, df);
 
+  // Create our group cache
+  const group_cache = group_cache_new(group);
+
   // Render a glyph
   for (let i = 33; i <= 126; i++) {
-    const font_idx = group_index_for_codepoint(group, i, 0, -1);
-    group_render_glyph(group, atlas, font_idx, i, 0);
+    const font_idx = group_cache_index_for_codepoint(group_cache, i, 0, -1);
+    group_cache_render_glyph(group_cache, font_idx, i, 0);
     //face_render_glyph(face, atlas, i);
   }
   //face_render_glyph(face, atlas, "橋".codePointAt(0));
@@ -82,6 +90,7 @@ fetch(url.href).then(response =>
   //face_debug_canvas(face);
 
   // Debug our atlas canvas
+  const atlas = group_cache_atlas_greyscale(group_cache);
   const id = atlas_debug_canvas(atlas);
   document.getElementById("atlas-canvas").append(zjs.deleteValue(id));
 

--- a/example/app.ts
+++ b/example/app.ts
@@ -28,6 +28,10 @@ fetch(url.href).then(response =>
     face_free,
     face_render_glyph,
     face_debug_canvas,
+    deferred_face_new,
+    deferred_face_free,
+    deferred_face_load,
+    deferred_face_face,
     atlas_new,
     atlas_free,
     atlas_debug_canvas,
@@ -47,8 +51,13 @@ fetch(url.href).then(response =>
   const font_ptr = malloc(font.byteLength);
     new Uint8Array(memory.buffer, font_ptr).set(font);
 
+  // Initialize our deferred face
+  const df = deferred_face_new(font_ptr, font.byteLength);
+  deferred_face_load(df, 72 /* size */);
+  const face = deferred_face_face(df);
+
   // Initialize our font face
-  const face = face_new(font_ptr, font.byteLength, 72 /* size in px */);
+  //const face = face_new(font_ptr, font.byteLength, 72 /* size in px */);
   free(font_ptr);
 
   // Render a glyph

--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -10,9 +10,10 @@ const log = std.log.scoped(.discovery);
 
 /// Discover implementation for the compile options.
 pub const Discover = switch (options.backend) {
+    .freetype => void, // no discovery
     .fontconfig_freetype => Fontconfig,
-    .coretext => CoreText,
-    else => void,
+    .coretext, .coretext_freetype => CoreText,
+    .web_canvas => void, // no discovery
 };
 
 /// Descriptor is used to search for fonts. The only required field

--- a/src/font/main.zig
+++ b/src/font/main.zig
@@ -22,6 +22,7 @@ pub usingnamespace if (builtin.target.isWasm()) struct {
     pub usingnamespace Atlas.Wasm;
     pub usingnamespace DeferredFace.Wasm;
     pub usingnamespace Group.Wasm;
+    pub usingnamespace GroupCache.Wasm;
     pub usingnamespace face.web_canvas.Wasm;
 } else struct {};
 

--- a/src/font/main.zig
+++ b/src/font/main.zig
@@ -20,6 +20,7 @@ pub usingnamespace @import("library.zig");
 /// If we're targeting wasm then we export some wasm APIs.
 pub usingnamespace if (builtin.target.isWasm()) struct {
     pub usingnamespace Atlas.Wasm;
+    pub usingnamespace DeferredFace.Wasm;
     pub usingnamespace Group.Wasm;
     pub usingnamespace face.web_canvas.Wasm;
 } else struct {};


### PR DESCRIPTION
This increases the surface area of the font subsystem that compiles to wasm to the named structures. 

Discovery is not enabled (void) because browsers have no reliable way to search for fonts. There is a Chrome-only local font access API that might be fun to integrate with later (causes a permissions pop-up) but for now we'll just disable it.