### PR TITLE
wasm: use shared, imported memory

### DIFF
--- a/example/app.ts
+++ b/example/app.ts
@@ -4,9 +4,11 @@ const zjs = new ZigJS();
 const importObject = {
   module: {},
   env: {
+    memory: new WebAssembly.Memory({ initial: 25, maximum: 65536, shared: true }),
     log: (ptr: number, len: number) => {
-      const view = new DataView(zjs.memory.buffer, ptr, Number(len));
-      const str = new TextDecoder('utf-8').decode(view);
+      const arr = new Uint8ClampedArray(zjs.memory.buffer, ptr, len);
+      const data = arr.slice();
+      const str = new TextDecoder('utf-8').decode(data);
       console.log(str);
     },
   },
@@ -20,8 +22,8 @@ fetch(url.href).then(response =>
 ).then(bytes =>
   WebAssembly.instantiate(bytes, importObject)
 ).then(results => {
+  const memory = importObject.env.memory;
   const {
-    memory,
     malloc,
     free,
     face_new,

--- a/src/os/wasm.zig
+++ b/src/os/wasm.zig
@@ -1,12 +1,17 @@
 //! This file contains helpers for wasm compilation.
 const std = @import("std");
 const builtin = @import("builtin");
+const options = @import("build_options");
 
 comptime {
     if (!builtin.target.isWasm()) {
         @compileError("wasm.zig should only be analyzed for wasm32 builds");
     }
 }
+
+/// True if we're in shared memory mode. If true, then the memory buffer
+/// in JS will be backed by a SharedArrayBuffer and some behaviors change.
+pub const shared_mem = options.wasm_shared;
 
 /// The allocator to use in wasm environments.
 ///


### PR DESCRIPTION
This switches our wasm build to use "shared" memory. Shared memory can be shared across multiple web workers, which is something we'll want to support for our multi-threaded behaviors later.

Shared memory has a number of different restrictions so this updates zig-js to support it as well as updates some of our functions that need to be aware of it.