### PR TITLE
Resize Fixes

### DIFF
--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -59,6 +59,13 @@ pub const App = struct {
         while (true) {
             // Wait for any events from the app event loop. wakeup will post
             // an empty event so that this will return.
+            //
+            // Warning: a known issue on macOS is that this will block while
+            // a resize event is actively happening, which will prevent the
+            // app tick from happening. I don't know know a way around this
+            // but its not a big deal since we don't use glfw for the official
+            // mac app, but noting it in case anyone builds for macos using
+            // glfw.
             glfw.waitEvents();
 
             // Tick the terminal app

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1922,10 +1922,14 @@ pub fn resize(self: *Screen, rows: usize, cols: usize) !void {
             var x: usize = old.cols;
             wrapping: while (iter.next()) |wrapped_row| {
                 // Trim the row from the right so that we ignore all trailing
-                // empty chars and don't wrap them.
+                // empty chars and don't wrap them. We only do this if the
+                // row is NOT wrapped again because the whitespace would be
+                // meaningful.
                 const wrapped_cells = trim: {
                     var i: usize = old.cols;
-                    while (i > 0) : (i -= 1) if (!wrapped_row.getCell(i - 1).empty()) break;
+                    if (!wrapped_row.header().flags.wrap) {
+                        while (i > 0) : (i -= 1) if (!wrapped_row.getCell(i - 1).empty()) break;
+                    }
                     break :trim wrapped_row.storage[1 .. i + 1];
                 };
 

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1718,6 +1718,10 @@ pub fn resizeWithoutReflow(self: *Screen, rows: usize, cols: usize) !void {
     // between terminal apps. I'm completely open to changing it as long
     // as resize behavior isn't regressed in a user-hostile way.
     const trailing_blank_lines = blank: {
+        // If we aren't changing row length, then don't bother calculating
+        // because we aren't going to trim.
+        if (self.rows == rows) break :blank 0;
+
         // If there is history, blank line counting is disabled and
         // we generate scrollback. Why? Terminal.app does it, seems... fine.
         if (self.history > 0) break :blank 0;

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1947,13 +1947,6 @@ pub fn resize(self: *Screen, rows: usize, cols: usize) !void {
                     if (copy_len == wrapped_cells_rem) {
                         // If this row isn't also wrapped, we're done!
                         if (!wrapped_row.header().flags.wrap) {
-                            // If we were able to copy the entire row then
-                            // we shortened the screen by one. We need to reflect
-                            // this in our viewport.
-                            if (wrapped_i == 0 and old.viewport > 0) {
-                                old.viewport -= 1;
-                            }
-
                             y += 1;
                             break :wrapping;
                         }
@@ -1980,12 +1973,6 @@ pub fn resize(self: *Screen, rows: usize, cols: usize) !void {
                 }
             }
         }
-
-        // During the resize, we just keep the viewport at the bottom. But
-        // we want to restore the viewport to what the user had when they
-        // started the resize. old.viewport is maintained for removed lines
-        // in the for loop above.
-        self.viewport = old.viewport;
 
         // If we have a new cursor, we need to convert that to a viewport
         // point and set it up.

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1894,8 +1894,19 @@ pub fn resize(self: *Screen, rows: usize, cols: usize) !void {
                 new_cursor = .{ .y = self.rowsWritten() - 1, .x = cursor_pos.x };
             }
 
-            // If no reflow, just keep going
+            // If no reflow, just keep going.
             if (!old_row.header().flags.wrap) {
+                // If we have no reflow, we attempt to extend any stylized
+                // cells at the end of the line if there is one.
+                const len = old_row.lenCells();
+                const end = new_row.getCell(len - 1);
+                if ((end.char == 0 or end.char == ' ') and !end.empty()) {
+                    for (len..self.cols) |x| {
+                        const cell = new_row.getCellPtr(x);
+                        cell.* = end;
+                    }
+                }
+
                 y += 1;
                 continue;
             }
@@ -4047,6 +4058,59 @@ test "Screen: resize more cols no reflow" {
         var contents = try s.testString(alloc, .screen);
         defer alloc.free(contents);
         try testing.expectEqualStrings(str, contents);
+    }
+}
+
+test "Screen: resize more cols trailing background colors" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, 3, 5, 0);
+    defer s.deinit();
+    const str = "1AB";
+    try s.testWriteString(str);
+    const cursor = s.cursor;
+
+    // Color our cells red
+    const pen: Cell = .{ .bg = .{ .r = 0xFF }, .attrs = .{ .has_bg = true } };
+    for (s.cursor.x..s.cols) |x| {
+        const row = s.getRow(.{ .active = s.cursor.y });
+        const cell = row.getCellPtr(x);
+        cell.* = pen;
+    }
+    for ((s.cursor.y + 1)..s.rows) |y| {
+        const row = s.getRow(.{ .active = y });
+        row.fill(pen);
+    }
+
+    try s.resize(3, 10);
+
+    // Cursor should not move
+    try testing.expectEqual(cursor, s.cursor);
+
+    {
+        var contents = try s.testString(alloc, .viewport);
+        defer alloc.free(contents);
+        try testing.expectEqualStrings(str, contents);
+    }
+    {
+        var contents = try s.testString(alloc, .screen);
+        defer alloc.free(contents);
+        try testing.expectEqualStrings(str, contents);
+    }
+
+    // Verify all our trailing cells have the color
+    for (s.cursor.x..s.cols) |x| {
+        const row = s.getRow(.{ .active = s.cursor.y });
+        const cell = row.getCellPtr(x);
+        try testing.expectEqual(pen, cell.*);
+    }
+    for ((s.cursor.y + 1)..s.rows) |y| {
+        const row = s.getRow(.{ .active = y });
+        for (0..s.cols) |x| {
+            const cell = row.getCellPtr(x);
+            try testing.expectEqual(pen, cell.*);
+        }
     }
 }
 

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -912,19 +912,26 @@ pub fn eraseDisplay(
 
         .below => {
             // All lines to the right (including the cursor)
-            var x: usize = self.screen.cursor.x;
-            while (x < self.cols) : (x += 1) {
-                const cell = self.screen.getCellPtr(.active, self.screen.cursor.y, x);
-                cell.* = self.screen.cursor.pen;
-                cell.char = 0;
+            {
+                const row = self.screen.getRow(.{ .active = self.screen.cursor.y });
+                row.setWrapped(false);
+                row.setDirty(true);
+                for (self.screen.cursor.x..self.cols) |x| {
+                    if (row.header().flags.grapheme) row.clearGraphemes(x);
+                    const cell = row.getCellPtr(x);
+                    cell.* = self.screen.cursor.pen;
+                    cell.char = 0;
+                }
             }
 
             // All lines below
-            var y: usize = self.screen.cursor.y + 1;
-            while (y < self.rows) : (y += 1) {
-                x = 0;
-                while (x < self.cols) : (x += 1) {
-                    const cell = self.screen.getCellPtr(.active, y, x);
+            for ((self.screen.cursor.y + 1)..self.rows) |y| {
+                const row = self.screen.getRow(.{ .active = y });
+                row.setWrapped(false);
+                row.setDirty(true);
+                for (0..self.cols) |x| {
+                    if (row.header().flags.grapheme) row.clearGraphemes(x);
+                    const cell = row.getCellPtr(x);
                     cell.* = self.screen.cursor.pen;
                     cell.char = 0;
                 }


### PR DESCRIPTION
Improves #76 significantly.

This contains almost a dozen fixes to resize behavior. There are still bugs I'm chasing down but resizing is now _significantly_ more correct and I felt it was a good idea to get this in now. Ghostty still fails the "grab the corner and resize like a wild man" test but for general resizing operations, moving around the screen, etc. it does quite well. I think that's a more practical reason to merge this now.