### PR TITLE
Use procedurally generated sprites for cursors rather than shader logic

### DIFF
--- a/src/font/sprite.zig
+++ b/src/font/sprite.zig
@@ -20,6 +20,10 @@ pub const Sprite = enum(u32) {
     underline_dashed,
     underline_curly,
 
+    cursor_rect,
+    cursor_hollow_rect,
+    cursor_bar,
+
     // Note: we don't currently put the box drawing glyphs in here because
     // there are a LOT and I'm lazy. What I want to do is spend more time
     // studying the patterns to see if we can programmatically build our

--- a/src/font/sprite/Face.zig
+++ b/src/font/sprite/Face.zig
@@ -95,6 +95,11 @@ const Kind = enum {
                 .underline_dashed,
                 .underline_curly,
                 => .underline,
+
+                .cursor_rect,
+                .cursor_hollow_rect,
+                .cursor_bar,
+                => .box,
             },
 
             // Box fonts

--- a/src/font/sprite/underline.zig
+++ b/src/font/sprite/underline.zig
@@ -71,6 +71,7 @@ const Draw = struct {
             .underline_dotted => self.drawDotted(canvas),
             .underline_dashed => self.drawDashed(canvas),
             .underline_curly => self.drawCurly(canvas),
+            else => unreachable,
         }
     }
 

--- a/src/renderer/shaders/cell.f.glsl
+++ b/src/renderer/shaders/cell.f.glsl
@@ -27,9 +27,6 @@ uniform vec2 cell_size;
 const uint MODE_BG = 1u;
 const uint MODE_FG = 2u;
 const uint MODE_FG_COLOR = 7u;
-const uint MODE_CURSOR_RECT = 3u;
-const uint MODE_CURSOR_RECT_HOLLOW = 4u;
-const uint MODE_CURSOR_BAR = 5u;
 const uint MODE_STRIKETHROUGH = 8u;
 
 void main() {
@@ -47,50 +44,6 @@ void main() {
 
     case MODE_FG_COLOR:
         out_FragColor = texture(text_color, glyph_tex_coords);
-        break;
-
-    case MODE_CURSOR_RECT:
-        out_FragColor = color;
-        break;
-
-    case MODE_CURSOR_RECT_HOLLOW:
-        // Okay so yeah this is probably horrendously slow and a shader
-        // should never do this, but we only ever render a cursor for ONE
-        // rectangle so we take the slowdown for that one.
-
-        // Default to no color.
-        out_FragColor = vec4(0., 0., 0., 0.);
-
-        // We subtracted one from cell size because our coordinates start at 0.
-        // So a width of 50 means max pixel of 49.
-        vec2 cell_size_coords = cell_size - 1;
-
-        // Apply padding
-        vec2 padding = vec2(1.,1.);
-        cell_size_coords = cell_size_coords - (padding * 2);
-        vec2 screen_cell_pos_padded = screen_cell_pos + padding;
-
-        // Convert our frag coord to offset of this cell. We have to subtract
-        // 0.5 because the frag coord is in center pixels.
-        vec2 cell_frag_coord = gl_FragCoord.xy - screen_cell_pos_padded - 0.5;
-
-        // If the frag coords are in the bounds, then we color it.
-        const float eps = 0.1;
-        if (cell_frag_coord.x >= 0 && cell_frag_coord.y >= 0 &&
-                cell_frag_coord.x <= cell_size_coords.x &&
-                cell_frag_coord.y <= cell_size_coords.y) {
-            if (abs(cell_frag_coord.x) < eps ||
-                    abs(cell_frag_coord.x - cell_size_coords.x) < eps ||
-                    abs(cell_frag_coord.y) < eps ||
-                    abs(cell_frag_coord.y - cell_size_coords.y) < eps) {
-                out_FragColor = color;
-            }
-        }
-
-        break;
-
-    case MODE_CURSOR_BAR:
-        out_FragColor = color;
         break;
 
     case MODE_STRIKETHROUGH:

--- a/src/renderer/shaders/cell.v.glsl
+++ b/src/renderer/shaders/cell.v.glsl
@@ -7,9 +7,6 @@
 const uint MODE_BG = 1u;
 const uint MODE_FG = 2u;
 const uint MODE_FG_COLOR = 7u;
-const uint MODE_CURSOR_RECT = 3u;
-const uint MODE_CURSOR_RECT_HOLLOW = 4u;
-const uint MODE_CURSOR_BAR = 5u;
 const uint MODE_STRIKETHROUGH = 8u;
 
 // The grid coordinates (x, y) where x < columns and y < rows
@@ -165,36 +162,6 @@ void main() {
 
         // Set our foreground color output
         color = fg_color_in / 255.;
-        break;
-
-    case MODE_CURSOR_RECT:
-        // Same as background since we're taking up the whole cell.
-        cell_pos = cell_pos + cell_size_scaled * position;
-
-        gl_Position = projection * vec4(cell_pos, cell_z, 1.0);
-        color = bg_color_in / 255.0;
-        break;
-
-    case MODE_CURSOR_RECT_HOLLOW:
-        // Top-left position of this cell is needed for the hollow rect.
-        screen_cell_pos = cell_pos;
-
-        // Same as background since we're taking up the whole cell.
-        cell_pos = cell_pos + cell_size_scaled * position;
-
-        gl_Position = projection * vec4(cell_pos, cell_z, 1.0);
-        color = bg_color_in / 255.0;
-        break;
-
-    case MODE_CURSOR_BAR:
-        // Make the bar a smaller version of our cell
-        vec2 bar_size = vec2(cell_size.x * 0.2, cell_size.y);
-
-        // Same as background since we're taking up the whole cell.
-        cell_pos = cell_pos + bar_size * position;
-
-        gl_Position = projection * vec4(cell_pos, cell_z, 1.0);
-        color = bg_color_in / 255.0;
         break;
 
     case MODE_STRIKETHROUGH:


### PR DESCRIPTION
This procedurally generates cursors as glyphs that are put into the font atlas rather than doing bespoke shader logic. This makes our shaders almost 50% smaller and just in general simplifies the code.