### PR TITLE
macos: split keyboard navigation up/down/left/right and previous/next

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -32,8 +32,7 @@ typedef const char* (*ghostty_runtime_read_clipboard_cb)(void *);
 typedef void (*ghostty_runtime_write_clipboard_cb)(void *, const char *);
 typedef void (*ghostty_runtime_new_split_cb)(void *, ghostty_split_direction_e);
 typedef void (*ghostty_runtime_close_surface_cb)(void *);
-typedef void (*ghostty_runtime_focus_next_split_cb)(void *);
-typedef void (*ghostty_runtime_focus_previous_split_cb)(void *);
+typedef void (*ghostty_runtime_focus_split_cb)(void *, ghostty_split_focus_direction_e);
 
 typedef struct {
     void *userdata;
@@ -43,8 +42,7 @@ typedef struct {
     ghostty_runtime_write_clipboard_cb write_clipboard_cb;
     ghostty_runtime_new_split_cb new_split_cb;
     ghostty_runtime_close_surface_cb close_surface_cb;
-    ghostty_runtime_focus_next_split_cb focus_next_split_cb;
-    ghostty_runtime_focus_previous_split_cb focus_previous_split_cb;
+    ghostty_runtime_focus_split_cb focus_split_cb;
 } ghostty_runtime_config_s;
 
 typedef struct {
@@ -57,6 +55,15 @@ typedef enum {
     GHOSTTY_SPLIT_RIGHT,
     GHOSTTY_SPLIT_DOWN
 } ghostty_split_direction_e;
+
+typedef enum {
+    GHOSTTY_SPLIT_FOCUS_PREVIOUS,
+    GHOSTTY_SPLIT_FOCUS_NEXT,
+    GHOSTTY_SPLIT_FOCUS_TOP,
+    GHOSTTY_SPLIT_FOCUS_LEFT,
+    GHOSTTY_SPLIT_FOCUS_BOTTOM,
+    GHOSTTY_SPLIT_FOCUS_RIGHT,
+} ghostty_split_focus_direction_e;
 
 typedef enum {
     GHOSTTY_MOUSE_RELEASE,
@@ -258,8 +265,7 @@ void ghostty_surface_mouse_scroll(ghostty_surface_t, double, double);
 void ghostty_surface_ime_point(ghostty_surface_t, double *, double *);
 void ghostty_surface_request_close(ghostty_surface_t);
 void ghostty_surface_split(ghostty_surface_t, ghostty_split_direction_e);
-void ghostty_surface_split_focus_previous(ghostty_surface_t);
-void ghostty_surface_split_focus_next(ghostty_surface_t);
+void ghostty_surface_split_focus(ghostty_surface_t, ghostty_split_focus_direction_e);
 
 #ifdef __cplusplus
 }

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -32,6 +32,8 @@ typedef const char* (*ghostty_runtime_read_clipboard_cb)(void *);
 typedef void (*ghostty_runtime_write_clipboard_cb)(void *, const char *);
 typedef void (*ghostty_runtime_new_split_cb)(void *, ghostty_split_direction_e);
 typedef void (*ghostty_runtime_close_surface_cb)(void *);
+typedef void (*ghostty_runtime_focus_next_split_cb)(void *);
+typedef void (*ghostty_runtime_focus_previous_split_cb)(void *);
 
 typedef struct {
     void *userdata;
@@ -41,6 +43,8 @@ typedef struct {
     ghostty_runtime_write_clipboard_cb write_clipboard_cb;
     ghostty_runtime_new_split_cb new_split_cb;
     ghostty_runtime_close_surface_cb close_surface_cb;
+    ghostty_runtime_focus_next_split_cb focus_next_split_cb;
+    ghostty_runtime_focus_previous_split_cb focus_previous_split_cb;
 } ghostty_runtime_config_s;
 
 typedef struct {

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -258,6 +258,8 @@ void ghostty_surface_mouse_scroll(ghostty_surface_t, double, double);
 void ghostty_surface_ime_point(ghostty_surface_t, double *, double *);
 void ghostty_surface_request_close(ghostty_surface_t);
 void ghostty_surface_split(ghostty_surface_t, ghostty_split_direction_e);
+void ghostty_surface_split_focus_previous(ghostty_surface_t);
+void ghostty_surface_split_focus_next(ghostty_surface_t);
 
 #ifdef __cplusplus
 }

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -94,6 +94,16 @@ extension Ghostty {
             ghostty_surface_split(surface, direction)
         }
         
+        func splitMoveFocus(surface: ghostty_surface_t, direction: SplitFocusDirection) {
+            switch (direction) {
+            case .previous:
+                ghostty_surface_split_focus_previous(surface)
+                
+            case .next:
+                ghostty_surface_split_focus_next(surface)
+            }
+        }
+        
         // MARK: Ghostty Callbacks
         
         static func newSplit(_ userdata: UnsafeMutableRawPointer?, direction: ghostty_split_direction_e) {

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -58,7 +58,9 @@ extension Ghostty {
                 read_clipboard_cb: { userdata in AppState.readClipboard(userdata) },
                 write_clipboard_cb: { userdata, str in AppState.writeClipboard(userdata, string: str) },
                 new_split_cb: { userdata, direction in AppState.newSplit(userdata, direction: ghostty_split_direction_e(UInt32(direction))) },
-                close_surface_cb: { userdata in AppState.closeSurface(userdata) }
+                close_surface_cb: { userdata in AppState.closeSurface(userdata) },
+                focus_next_split_cb: { userdata in AppState.focusSplit(userdata, direction: .next) },
+                focus_previous_split_cb: { userdata in AppState.focusSplit(userdata, direction: .previous) }
             )
 
             // Create the ghostty app.
@@ -104,6 +106,17 @@ extension Ghostty {
         static func closeSurface(_ userdata: UnsafeMutableRawPointer?) {
             guard let surface = self.surfaceUserdata(from: userdata) else { return }
             NotificationCenter.default.post(name: Notification.ghosttyCloseSurface, object: surface)
+        }
+        
+        static func focusSplit(_ userdata: UnsafeMutableRawPointer?, direction: SplitFocusDirection) {
+            guard let surface = self.surfaceUserdata(from: userdata) else { return }
+            NotificationCenter.default.post(
+                name: Notification.ghosttyFocusSplit,
+                object: surface,
+                userInfo: [
+                    Notification.SplitDirectionKey: direction,
+                ]
+            )
         }
         
         static func readClipboard(_ userdata: UnsafeMutableRawPointer?) -> UnsafePointer<CChar>? {

--- a/macos/Sources/Ghostty/Ghostty.SplitView.swift
+++ b/macos/Sources/Ghostty/Ghostty.SplitView.swift
@@ -92,6 +92,21 @@ extension Ghostty {
             /// No neighbors, used by the root node.
             static let empty: Self = .init()
             
+            /// Get the node for a given direction.
+            func get(direction: SplitFocusDirection) -> SplitNode? {
+                let map: [SplitFocusDirection : KeyPath<Self, SplitNode?>] = [
+                    .previous: \.previous,
+                    .next: \.next,
+                    .top: \.top,
+                    .bottom: \.bottom,
+                    .left: \.left,
+                    .right: \.right,
+                ]
+                
+                guard let path = map[direction] else { return nil }
+                return self[keyPath: path]
+            }
+            
             /// Update multiple keys and return a new copy.
             func update(_ attrs: [WritableKeyPath<Self, SplitNode?>: SplitNode?]) -> Self {
                 var clone = self
@@ -216,15 +231,8 @@ extension Ghostty {
             // Determine our desired direction
             guard let directionAny = notification.userInfo?[Notification.SplitDirectionKey] else { return }
             guard let direction = directionAny as? SplitFocusDirection else { return }
-            switch (direction) {
-            case .previous:
-                guard let next = neighbors.previous else { return }
-                Self.moveFocus(next, previous: node)
-                
-            case .next:
-                guard let next = neighbors.next else { return }
-                Self.moveFocus(next, previous: node)
-            }
+            guard let next = neighbors.get(direction: direction) else { return }
+            Self.moveFocus(next, previous: node)
         }
         
         /// There is a bug I can't figure out where when changing the split state, the terminal view

--- a/macos/Sources/Ghostty/Ghostty.SplitView.swift
+++ b/macos/Sources/Ghostty/Ghostty.SplitView.swift
@@ -123,11 +123,14 @@ extension Ghostty {
         @Binding var requestClose: Bool
         
         var body: some View {
-            let pub = NotificationCenter.default.publisher(for: Notification.ghosttyNewSplit, object: leaf.surface)
-            let pubClose = NotificationCenter.default.publisher(for: Notification.ghosttyCloseSurface, object: leaf.surface)
+            let center = NotificationCenter.default
+            let pub = center.publisher(for: Notification.ghosttyNewSplit, object: leaf.surface)
+            let pubClose = center.publisher(for: Notification.ghosttyCloseSurface, object: leaf.surface)
+            let pubFocus = center.publisher(for: Notification.ghosttyFocusSplit, object: leaf.surface)
             SurfaceWrapper(surfaceView: leaf.surface)
                 .onReceive(pub) { onNewSplit(notification: $0) }
                 .onReceive(pubClose) { _ in requestClose = true }
+                .onReceive(pubFocus) { onMoveFocus(notification: $0) }
         }
         
         private func onNewSplit(notification: SwiftUI.Notification) {
@@ -160,6 +163,13 @@ extension Ghostty {
             
             // See fixFocus comment, we have to run this whenever split changes.
             Self.fixFocus(container.bottomRight, previous: node)
+        }
+        
+        private func onMoveFocus(notification: SwiftUI.Notification) {
+            // Determine our desired direction
+            guard let directionAny = notification.userInfo?[Notification.SplitDirectionKey] else { return }
+            guard let direction = directionAny as? SplitFocusDirection else { return }
+            print("MOVE FOCUS: \(direction)")
         }
         
         /// There is a bug I can't figure out where when changing the split state, the terminal view

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import GhosttyKit
 
 struct Ghostty {
     // All the notifications that will be emitted will be put here.
@@ -11,6 +12,30 @@ extension Ghostty {
     /// An enum that is used for the directions that a split focus event can change.
     enum SplitFocusDirection {
         case previous, next
+        
+        /// Initialize from a Ghostty API enum.
+        static func from(direction: ghostty_split_focus_direction_e) -> Self? {
+            switch (direction) {
+            case GHOSTTY_SPLIT_FOCUS_PREVIOUS:
+                return .previous
+                
+            case GHOSTTY_SPLIT_FOCUS_NEXT:
+                return .next
+                
+            default:
+                return nil
+            }
+        }
+        
+        func toNative() -> ghostty_split_focus_direction_e {
+            switch (self) {
+            case .previous:
+                return GHOSTTY_SPLIT_FOCUS_PREVIOUS
+                
+            case .next:
+                return GHOSTTY_SPLIT_FOCUS_NEXT
+            }
+        }
     }
 }
 

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -11,7 +11,7 @@ struct Ghostty {
 extension Ghostty {
     /// An enum that is used for the directions that a split focus event can change.
     enum SplitFocusDirection {
-        case previous, next
+        case previous, next, top, bottom, left, right
         
         /// Initialize from a Ghostty API enum.
         static func from(direction: ghostty_split_focus_direction_e) -> Self? {
@@ -21,6 +21,18 @@ extension Ghostty {
                 
             case GHOSTTY_SPLIT_FOCUS_NEXT:
                 return .next
+                
+            case GHOSTTY_SPLIT_FOCUS_TOP:
+                return .top
+                
+            case GHOSTTY_SPLIT_FOCUS_BOTTOM:
+                return .bottom
+                
+            case GHOSTTY_SPLIT_FOCUS_LEFT:
+                return .left
+                
+            case GHOSTTY_SPLIT_FOCUS_RIGHT:
+                return .right
                 
             default:
                 return nil
@@ -34,6 +46,18 @@ extension Ghostty {
                 
             case .next:
                 return GHOSTTY_SPLIT_FOCUS_NEXT
+                
+            case .top:
+                return GHOSTTY_SPLIT_FOCUS_TOP
+                
+            case .bottom:
+                return GHOSTTY_SPLIT_FOCUS_BOTTOM
+                
+            case .left:
+                return GHOSTTY_SPLIT_FOCUS_LEFT
+                
+            case .right:
+                return GHOSTTY_SPLIT_FOCUS_RIGHT
             }
         }
     }

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -1,4 +1,28 @@
+import SwiftUI
+
 struct Ghostty {
     // All the notifications that will be emitted will be put here.
     struct Notification {}
+}
+
+// MARK: Surface Notifications
+
+extension Ghostty {
+    /// An enum that is used for the directions that a split focus event can change.
+    enum SplitFocusDirection {
+        case previous, next
+    }
+}
+
+extension Ghostty.Notification {
+    /// Posted when a new split is requested. The sending object will be the surface that had focus. The
+    /// userdata has one key "direction" with the direction to split to.
+    static let ghosttyNewSplit = Notification.Name("com.mitchellh.ghostty.newSplit")
+    
+    /// Close the calling surface.
+    static let ghosttyCloseSurface = Notification.Name("com.mitchellh.ghostty.closeSurface")
+    
+    /// Focus previous/next split. Has a SplitFocusDirection in the userinfo.
+    static let ghosttyFocusSplit = Notification.Name("com.mitchellh.ghostty.focusSplit")
+    static let SplitDirectionKey = ghosttyFocusSplit.rawValue
 }

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -509,18 +509,6 @@ extension Ghostty {
             0x4E: GHOSTTY_KEY_KP_SUBTRACT,
         ];
     }
-
-}
-
-// MARK: Surface Notifications
-
-extension Ghostty.Notification {
-    /// Posted when a new split is requested. The sending object will be the surface that had focus. The
-    /// userdata has one key "direction" with the direction to split to.
-    static let ghosttyNewSplit = Notification.Name("com.mitchellh.ghostty.newSplit")
-    
-    /// Close the calling surface.
-    static let ghosttyCloseSurface = Notification.Name("com.mitchellh.ghostty.closeSurface")
 }
 
 // MARK: Surface Environment Keys

--- a/macos/Sources/GhosttyApp.swift
+++ b/macos/Sources/GhosttyApp.swift
@@ -40,8 +40,21 @@ struct GhosttyApp: App {
             
             CommandGroup(before: .windowArrangement) {
                 Divider()
-                Button("Select Previous Split", action: splitMoveFocusPrevious).keyboardShortcut("[", modifiers: .command)
-                Button("Select Next Split", action: splitMoveFocusNext).keyboardShortcut("]", modifiers: .command)
+                Button("Select Previous Split") { splitMoveFocus(direction: .previous) }
+                    .keyboardShortcut("[", modifiers: .command)
+                Button("Select Next Split") { splitMoveFocus(direction: .next) }
+                    .keyboardShortcut("]", modifiers: .command)
+                Menu("Select Split") {
+                    Button("Select Split Above") { splitMoveFocus(direction: .top) }
+                        .keyboardShortcut(.upArrow, modifiers: [.command, .option])
+                    Button("Select Split Below") { splitMoveFocus(direction: .bottom) }
+                        .keyboardShortcut(.downArrow, modifiers: [.command, .option])
+                    Button("Select Split Left") { splitMoveFocus(direction: .left) }
+                        .keyboardShortcut(.leftArrow, modifiers: [.command, .option])
+                    Button("Select Split Right") { splitMoveFocus(direction: .right)}
+                        .keyboardShortcut(.rightArrow, modifiers: [.command, .option])
+                }
+                
                 Divider()
             }
         }
@@ -84,16 +97,10 @@ struct GhosttyApp: App {
         ghostty.split(surface: surface, direction: GHOSTTY_SPLIT_DOWN)
     }
     
-    func splitMoveFocusPrevious() {
+    func splitMoveFocus(direction: Ghostty.SplitFocusDirection) {
         guard let surfaceView = focusedSurface else { return }
         guard let surface = surfaceView.surface else { return }
-        ghostty.splitMoveFocus(surface: surface, direction: .previous)
-    }
-    
-    func splitMoveFocusNext() {
-        guard let surfaceView = focusedSurface else { return }
-        guard let surface = surfaceView.surface else { return }
-        ghostty.splitMoveFocus(surface: surface, direction: .next)
+        ghostty.splitMoveFocus(surface: surface, direction: direction)
     }
 }
 

--- a/macos/Sources/GhosttyApp.swift
+++ b/macos/Sources/GhosttyApp.swift
@@ -37,6 +37,13 @@ struct GhosttyApp: App {
                 Button("Close", action: close).keyboardShortcut("w", modifiers: [.command])
                 Button("Close Window", action: Self.closeWindow).keyboardShortcut("w", modifiers: [.command, .shift])
              }
+            
+            CommandGroup(before: .windowArrangement) {
+                Divider()
+                Button("Select Previous Split", action: splitMoveFocusPrevious).keyboardShortcut("[", modifiers: .command)
+                Button("Select Next Split", action: splitMoveFocusNext).keyboardShortcut("]", modifiers: .command)
+                Divider()
+            }
         }
         
         Settings {
@@ -75,6 +82,18 @@ struct GhosttyApp: App {
         guard let surfaceView = focusedSurface else { return }
         guard let surface = surfaceView.surface else { return }
         ghostty.split(surface: surface, direction: GHOSTTY_SPLIT_DOWN)
+    }
+    
+    func splitMoveFocusPrevious() {
+        guard let surfaceView = focusedSurface else { return }
+        guard let surface = surfaceView.surface else { return }
+        ghostty.splitMoveFocus(surface: surface, direction: .previous)
+    }
+    
+    func splitMoveFocusNext() {
+        guard let surfaceView = focusedSurface else { return }
+        guard let surface = surfaceView.surface else { return }
+        ghostty.splitMoveFocus(surface: surface, direction: .next)
     }
 }
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -947,16 +947,10 @@ pub fn keyCallback(
                     } else log.warn("runtime doesn't implement newSplit", .{});
                 },
 
-                .next_split => {
-                    if (@hasDecl(apprt.Surface, "gotoNextSplit")) {
-                        self.rt_surface.gotoNextSplit();
-                    } else log.warn("runtime doesn't implement gotoNextSplit", .{});
-                },
-
-                .previous_split => {
-                    if (@hasDecl(apprt.Surface, "gotoPreviousSplit")) {
-                        self.rt_surface.gotoPreviousSplit();
-                    } else log.warn("runtime doesn't implement gotoPreviousSplit", .{});
+                .goto_split => |direction| {
+                    if (@hasDecl(apprt.Surface, "gotoSplit")) {
+                        self.rt_surface.gotoSplit(direction);
+                    } else log.warn("runtime doesn't implement gotoSplit", .{});
                 },
 
                 .close_surface => {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -947,6 +947,18 @@ pub fn keyCallback(
                     } else log.warn("runtime doesn't implement newSplit", .{});
                 },
 
+                .next_split => {
+                    if (@hasDecl(apprt.Surface, "gotoNextSplit")) {
+                        self.rt_surface.gotoNextSplit();
+                    } else log.warn("runtime doesn't implement gotoNextSplit", .{});
+                },
+
+                .previous_split => {
+                    if (@hasDecl(apprt.Surface, "gotoPreviousSplit")) {
+                        self.rt_surface.gotoPreviousSplit();
+                    } else log.warn("runtime doesn't implement gotoPreviousSplit", .{});
+                },
+
                 .close_surface => {
                     if (@hasDecl(apprt.Surface, "closeSurface")) {
                         try self.rt_surface.closeSurface();

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -53,8 +53,7 @@ pub const App = struct {
         close_surface: ?*const fn (SurfaceUD) callconv(.C) void = null,
 
         /// Focus the previous/next split (if any).
-        focus_next_split: ?*const fn (SurfaceUD) callconv(.C) void = null,
-        focus_previous_split: ?*const fn (SurfaceUD) callconv(.C) void = null,
+        focus_split: ?*const fn (SurfaceUD, input.SplitFocusDirection) callconv(.C) void = null,
     };
 
     core_app: *CoreApp,
@@ -177,22 +176,13 @@ pub const Surface = struct {
         func(self.opts.userdata);
     }
 
-    pub fn gotoNextSplit(self: *const Surface) void {
-        const func = self.app.opts.focus_next_split orelse {
-            log.info("runtime embedder does not support focus next split", .{});
+    pub fn gotoSplit(self: *const Surface, direction: input.SplitFocusDirection) void {
+        const func = self.app.opts.focus_split orelse {
+            log.info("runtime embedder does not support focus split", .{});
             return;
         };
 
-        func(self.opts.userdata);
-    }
-
-    pub fn gotoPreviousSplit(self: *const Surface) void {
-        const func = self.app.opts.focus_previous_split orelse {
-            log.info("runtime embedder does not support focus previous split", .{});
-            return;
-        };
-
-        func(self.opts.userdata);
+        func(self.opts.userdata, direction);
     }
 
     pub fn getContentScale(self: *const Surface) !apprt.ContentScale {
@@ -505,12 +495,7 @@ pub const CAPI = struct {
     }
 
     /// Focus on the next split (if any).
-    export fn ghostty_surface_split_focus_next(ptr: *Surface) void {
-        ptr.gotoNextSplit();
-    }
-
-    /// Focus on the previous split (if any).
-    export fn ghostty_surface_split_focus_previous(ptr: *Surface) void {
-        ptr.gotoPreviousSplit();
+    export fn ghostty_surface_split_focus(ptr: *Surface, direction: input.SplitFocusDirection) void {
+        ptr.gotoSplit(direction);
     }
 };

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -51,6 +51,10 @@ pub const App = struct {
 
         /// Close the current surface given by this function.
         close_surface: ?*const fn (SurfaceUD) callconv(.C) void = null,
+
+        /// Focus the previous/next split (if any).
+        focus_next_split: ?*const fn (SurfaceUD) callconv(.C) void = null,
+        focus_previous_split: ?*const fn (SurfaceUD) callconv(.C) void = null,
     };
 
     core_app: *CoreApp,
@@ -166,7 +170,25 @@ pub const Surface = struct {
 
     pub fn closeSurface(self: *const Surface) !void {
         const func = self.app.opts.close_surface orelse {
-            log.info("runtime embedder does not closing a surface", .{});
+            log.info("runtime embedder does not support closing a surface", .{});
+            return;
+        };
+
+        func(self.opts.userdata);
+    }
+
+    pub fn gotoNextSplit(self: *const Surface) void {
+        const func = self.app.opts.focus_next_split orelse {
+            log.info("runtime embedder does not support focus next split", .{});
+            return;
+        };
+
+        func(self.opts.userdata);
+    }
+
+    pub fn gotoPreviousSplit(self: *const Surface) void {
+        const func = self.app.opts.focus_previous_split orelse {
+            log.info("runtime embedder does not support focus previous split", .{});
             return;
         };
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -503,4 +503,14 @@ pub const CAPI = struct {
     export fn ghostty_surface_split(ptr: *Surface, direction: input.SplitDirection) void {
         ptr.newSplit(direction) catch {};
     }
+
+    /// Focus on the next split (if any).
+    export fn ghostty_surface_split_focus_next(ptr: *Surface) void {
+        ptr.gotoNextSplit();
+    }
+
+    /// Focus on the previous split (if any).
+    export fn ghostty_surface_split_focus_previous(ptr: *Surface) void {
+        ptr.gotoPreviousSplit();
+    }
 };

--- a/src/config.zig
+++ b/src/config.zig
@@ -321,6 +321,26 @@ pub const Config = struct {
             .{ .key = .right_bracket, .mods = .{ .super = true } },
             .{ .goto_split = .next },
         );
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .up, .mods = .{ .super = true, .alt = true } },
+            .{ .goto_split = .top },
+        );
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .down, .mods = .{ .super = true, .alt = true } },
+            .{ .goto_split = .bottom },
+        );
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .left, .mods = .{ .super = true, .alt = true } },
+            .{ .goto_split = .left },
+        );
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .right, .mods = .{ .super = true, .alt = true } },
+            .{ .goto_split = .right },
+        );
         {
             // Cmd+N for goto tab N
             const start = @enumToInt(inputpkg.Key.one);

--- a/src/config.zig
+++ b/src/config.zig
@@ -314,12 +314,12 @@ pub const Config = struct {
         try result.keybind.set.put(
             alloc,
             .{ .key = .left_bracket, .mods = .{ .super = true } },
-            .{ .previous_split = {} },
+            .{ .goto_split = .previous },
         );
         try result.keybind.set.put(
             alloc,
             .{ .key = .right_bracket, .mods = .{ .super = true } },
-            .{ .next_split = {} },
+            .{ .goto_split = .next },
         );
         {
             // Cmd+N for goto tab N

--- a/src/config.zig
+++ b/src/config.zig
@@ -311,6 +311,16 @@ pub const Config = struct {
             .{ .key = .d, .mods = .{ .super = true, .shift = true } },
             .{ .new_split = .down },
         );
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .left_bracket, .mods = .{ .super = true } },
+            .{ .previous_split = {} },
+        );
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .right_bracket, .mods = .{ .super = true } },
+            .{ .next_split = {} },
+        );
         {
             // Cmd+N for goto tab N
             const start = @enumToInt(inputpkg.Key.one);

--- a/src/input.zig
+++ b/src/input.zig
@@ -4,6 +4,7 @@ pub usingnamespace @import("input/mouse.zig");
 pub usingnamespace @import("input/key.zig");
 pub const Binding = @import("input/Binding.zig");
 pub const SplitDirection = Binding.Action.SplitDirection;
+pub const SplitFocusDirection = Binding.Action.SplitFocusDirection;
 
 test {
     std.testing.refAllDecls(@This());

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -184,11 +184,8 @@ pub const Action = union(enum) {
     /// in the direction given.
     new_split: SplitDirection,
 
-    /// Go to the previous split.
-    previous_split: void,
-
-    /// Go to the next split.
-    next_split: void,
+    /// Focus on a split in a given direction.
+    goto_split: SplitFocusDirection,
 
     /// Close the current "surface", whether that is a window, tab, split,
     /// etc. This only closes ONE surface.
@@ -212,6 +209,17 @@ pub const Action = union(enum) {
         down,
 
         // Note: we don't support top or left yet
+    };
+
+    // Extern because it is used in the embedded runtime ABI.
+    pub const SplitFocusDirection = enum(c_int) {
+        previous,
+        next,
+
+        top,
+        left,
+        bottom,
+        right,
     };
 };
 

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -184,6 +184,12 @@ pub const Action = union(enum) {
     /// in the direction given.
     new_split: SplitDirection,
 
+    /// Go to the previous split.
+    previous_split: void,
+
+    /// Go to the next split.
+    next_split: void,
+
     /// Close the current "surface", whether that is a window, tab, split,
     /// etc. This only closes ONE surface.
     close_surface: void,


### PR DESCRIPTION
Closes #90 

The only outstanding missing feature here is that previous/next do not cycle.

![CleanShot 2023-03-11 at 17 56 18@2x](https://user-images.githubusercontent.com/1299/224519936-9e421835-5c96-41cc-8df1-857a05770c10.png)
