### PR TITLE
macos: update libxev to fix idle CPU usage to 0% in certain scenarios

### DIFF
--- a/macos/Ghostty.xcodeproj/project.pbxproj
+++ b/macos/Ghostty.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		A5B30539299BEAAB0047F10C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A5B30538299BEAAB0047F10C /* Assets.xcassets */; };
 		A5CEAFDC29B8009000646FDA /* SplitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CEAFDB29B8009000646FDA /* SplitView.swift */; };
 		A5CEAFDE29B8058B00646FDA /* SplitView.Divider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CEAFDD29B8058B00646FDA /* SplitView.Divider.swift */; };
+		A5CEAFFF29C2410700646FDA /* Backport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CEAFFE29C2410700646FDA /* Backport.swift */; };
 		A5D495A2299BEC7E00DD1313 /* GhosttyKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5D495A1299BEC7E00DD1313 /* GhosttyKit.xcframework */; };
 /* End PBXBuildFile section */
 
@@ -35,6 +36,7 @@
 		A5B3053D299BEAAB0047F10C /* Ghostty.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Ghostty.entitlements; sourceTree = "<group>"; };
 		A5CEAFDB29B8009000646FDA /* SplitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitView.swift; sourceTree = "<group>"; };
 		A5CEAFDD29B8058B00646FDA /* SplitView.Divider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitView.Divider.swift; sourceTree = "<group>"; };
+		A5CEAFFE29C2410700646FDA /* Backport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Backport.swift; sourceTree = "<group>"; };
 		A5D495A1299BEC7E00DD1313 /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = GhosttyKit.xcframework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -60,6 +62,7 @@
 				A535B9D9299C569B0017E2E4 /* ErrorView.swift */,
 				A55685DF29A03A9F004303CE /* AppError.swift */,
 				A59444F629A2ED5200725BBA /* SettingsView.swift */,
+				A5CEAFFE29C2410700646FDA /* Backport.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -196,6 +199,7 @@
 				A55685E029A03A9F004303CE /* AppError.swift in Sources */,
 				A535B9DA299C569B0017E2E4 /* ErrorView.swift in Sources */,
 				A5B30535299BEAAA0047F10C /* GhosttyApp.swift in Sources */,
+				A5CEAFFF29C2410700646FDA /* Backport.swift in Sources */,
 				A5CEAFDE29B8058B00646FDA /* SplitView.Divider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/macos/Sources/Backport.swift
+++ b/macos/Sources/Backport.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+// All backport view/scene modifiers go as an extension on this. We use this
+// so we can easily track and centralize all backports.
+struct Backport<Content> {
+    let content: Content
+}
+
+extension View {
+    var backport: Backport<Self> { Backport(content: self) }
+}
+
+extension Scene {
+    var backport: Backport<Self> { Backport(content: self) }
+}
+
+extension Backport where Content: Scene {
+    func defaultSize(width: CGFloat, height: CGFloat) -> some Scene {
+        if #available(macOS 13, *) {
+            return content.defaultSize(width: width, height: height)
+        } else {
+            return content
+        }
+    }
+}

--- a/macos/Sources/GhosttyApp.swift
+++ b/macos/Sources/GhosttyApp.swift
@@ -27,7 +27,9 @@ struct GhosttyApp: App {
                 Ghostty.TerminalSplit(onClose: Self.closeWindow)
                     .ghosttyApp(ghostty.app!)
             }
-        }.commands {
+        }
+        .backport.defaultSize(width: 800, height: 600)
+        .commands {
             CommandGroup(after: .newItem) {
                 Button("New Tab", action: Self.newTab).keyboardShortcut("t", modifiers: [.command])
                 Divider()


### PR DESCRIPTION
Fixes #96 

This includes an important libxev fix: https://github.com/mitchellh/libxev/pull/25

The issue was that during periods of high activity, the IO thread was "queueing" renders much more rapidly than the render timer. The async mechanism for this queue is supposed to drain on every tick, but it was only dequeuing one. The result was that under heavy load, thousands of renders would be queued, and one render would be done for each queued render. Instead, we should've been coalescing all the queued renders at the time.

The deeper technical issue is noted in the libxev fix.