### PR TITLE
macos: free surface as soon as split is closed, properly track focus state

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -153,6 +153,16 @@ extension Ghostty {
             ghostty_surface_free(surface)
         }
         
+        /// Close the surface early. This will free the associated Ghostty surface and the view will
+        /// no longer render. The view can never be used again. This is a way for us to free the
+        /// Ghostty resources while references may still be held to this view. I've found that SwiftUI
+        /// tends to hold this view longer than it should so we free the expensive stuff explicitly.
+        func close() {
+            guard let surface = self.surface else { return }
+            ghostty_surface_free(surface)
+            self.surface = nil
+        }
+        
         func focusDidChange(_ focused: Bool) {
             guard let surface = self.surface else { return }
             ghostty_surface_set_focus(surface, focused)


### PR DESCRIPTION
Fixes #96 

This was part two to #96 that was causing high CPU usage. This also fixes the memory leak noted in #89! They are related.

The first issue (memory leak #89) was causing closed surfaces to remain "focused" in the background. So in the background, the cursor was still "blinking" and this was using some small amount of CPU. We now explicitly free the surface as soon as the split/tab/window is closed and this resolves both the memory leak and the focus state.

The second issue is that our key window tracking was broken. This meant that when you had tabs, EVERY TAB was "focused" so the cursors were blinking in all the tabs. SwiftUI doesn't provide a great way to track this but I think I've finally figured it out by using NotificationCenter and comparing to the Surface view window parent. At least, I can no longer reproduce the high CPU usage. They properly defocus and stop rendering.