### PR TITLE
Mouse Alt Scroll (mode 1007) and Horizontal Scroll

### DIFF
--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -80,6 +80,7 @@ modes: packed struct {
     deccolm: bool = false, // 3,
     deccolm_supported: bool = false, // 40
 
+    mouse_alternate_scroll: bool = true, // 1007
     mouse_event: MouseEvents = .none,
     mouse_format: MouseFormat = .x10,
 

--- a/src/terminal/ansi.zig
+++ b/src/terminal/ansi.zig
@@ -101,6 +101,10 @@ pub const Mode = enum(u16) {
     /// Report mouse position in the SGR format.
     mouse_format_sgr = 1006,
 
+    /// Report mouse scroll events as cursor up/down keys. Any other mouse
+    /// mode overrides this.
+    mouse_alternate_scroll = 1007,
+
     /// Report mouse position in the urxvt format.
     mouse_format_urxvt = 1015,
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -951,6 +951,8 @@ const StreamHandler = struct {
             .mouse_format_urxvt => self.terminal.modes.mouse_format = if (enabled) .urxvt else .x10,
             .mouse_format_sgr_pixels => self.terminal.modes.mouse_format = if (enabled) .sgr_pixels else .x10,
 
+            .mouse_alternate_scroll => self.terminal.modes.mouse_alternate_scroll = enabled,
+
             else => if (enabled) log.warn("unimplemented mode: {}", .{mode}),
         }
     }


### PR DESCRIPTION
Fixes #112 

This implements the "mouse alternate scroll" mode. When the following conditions are true:

  1. Alternate screen active
  2. No mouse reporting mode enabled
  3. Mouse alternate scroll enabled

Then mouse scroll events are encoded as arrow key up, down, left, right. This is documented here: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-Mouse-Tracking

This also updates our scroll events to support horizontal scrolling.