### PR TITLE
Detect command exit and close surface

### DIFF
--- a/src/Pty.zig
+++ b/src/Pty.zig
@@ -80,6 +80,7 @@ pub fn open(size: winsize) !Pty {
 
 pub fn deinit(self: *Pty) void {
     _ = std.os.system.close(self.master);
+    _ = std.os.system.close(self.slave);
     self.* = undefined;
 }
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -479,6 +479,14 @@ pub fn deinit(self: *Surface) void {
     log.info("surface closed addr={x}", .{@ptrToInt(self)});
 }
 
+/// Close this surface. This will trigger the runtime to start the
+/// close process, which should ultimately deinitialize this surface.
+pub fn close(self: *Surface) void {
+    if (@hasDecl(apprt.Surface, "closeSurface")) {
+        try self.rt_surface.closeSurface();
+    } else log.warn("runtime doesn't implement closeSurface", .{});
+}
+
 /// Called from the app thread to handle mailbox messages to our specific
 /// surface.
 pub fn handleMessage(self: *Surface, msg: Message) !void {
@@ -503,6 +511,8 @@ pub fn handleMessage(self: *Surface, msg: Message) !void {
                 try self.clipboardWrite(v.data);
             },
         },
+
+        .close => self.close(),
     }
 }
 
@@ -953,11 +963,7 @@ pub fn keyCallback(
                     } else log.warn("runtime doesn't implement gotoSplit", .{});
                 },
 
-                .close_surface => {
-                    if (@hasDecl(apprt.Surface, "closeSurface")) {
-                        try self.rt_surface.closeSurface();
-                    } else log.warn("runtime doesn't implement closeSurface", .{});
-                },
+                .close_surface => self.close(),
 
                 .close_window => {
                     _ = self.app_mailbox.push(.{ .close = self }, .{ .instant = {} });

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -482,9 +482,9 @@ pub fn deinit(self: *Surface) void {
 /// Close this surface. This will trigger the runtime to start the
 /// close process, which should ultimately deinitialize this surface.
 pub fn close(self: *Surface) void {
-    if (@hasDecl(apprt.Surface, "closeSurface")) {
-        try self.rt_surface.closeSurface();
-    } else log.warn("runtime doesn't implement closeSurface", .{});
+    if (@hasDecl(apprt.Surface, "close")) {
+        self.rt_surface.close();
+    } else log.warn("runtime doesn't implement close", .{});
 }
 
 /// Called from the app thread to handle mailbox messages to our specific

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -482,9 +482,7 @@ pub fn deinit(self: *Surface) void {
 /// Close this surface. This will trigger the runtime to start the
 /// close process, which should ultimately deinitialize this surface.
 pub fn close(self: *Surface) void {
-    if (@hasDecl(apprt.Surface, "close")) {
-        self.rt_surface.close();
-    } else log.warn("runtime doesn't implement close", .{});
+    self.rt_surface.close();
 }
 
 /// Called from the app thread to handle mailbox messages to our specific

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -167,7 +167,7 @@ pub const Surface = struct {
         func(self.opts.userdata, direction);
     }
 
-    pub fn closeSurface(self: *const Surface) !void {
+    pub fn close(self: *const Surface) void {
         const func = self.app.opts.close_surface orelse {
             log.info("runtime embedder does not support closing a surface", .{});
             return;

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -486,7 +486,7 @@ pub const CAPI = struct {
     /// Request that the surface become closed. This will go through the
     /// normal trigger process that a close surface input binding would.
     export fn ghostty_surface_request_close(ptr: *Surface) void {
-        ptr.closeSurface() catch {};
+        ptr.close();
     }
 
     /// Request that the surface split in the given direction.

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -378,6 +378,11 @@ pub const Surface = struct {
         try self.app.newTab(&self.core_surface);
     }
 
+    /// Close this surface.
+    pub fn close(self: *const Surface) void {
+        self.window.setShouldClose(true);
+    }
+
     /// Set the size limits of the window.
     /// Note: this interface is not good, we should redo it if we plan
     /// to use this more. i.e. you can't set max width but no max height,

--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -614,7 +614,7 @@ pub const Surface = struct {
     }
 
     /// Close this surface.
-    fn close(self: *Surface) void {
+    pub fn close(self: *Surface) void {
         self.window.closeSurface(self);
     }
 

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -23,6 +23,10 @@ pub const Message = union(enum) {
 
     /// Write the clipboard contents.
     clipboard_write: WriteReq,
+
+    /// Close the surface. This will only close the current surface that
+    /// receives this, not the full application.
+    close: void,
 };
 
 /// A surface mailbox.

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -346,8 +346,8 @@ const EventData = struct {
 
 fn processExit(
     ev_: ?*EventData,
-    loop: *xev.Loop,
-    completion: *xev.Completion,
+    _: *xev.Loop,
+    _: *xev.Completion,
     r: xev.Process.WaitError!u32,
 ) xev.CallbackAction {
     const code = r catch unreachable;
@@ -355,7 +355,6 @@ fn processExit(
 
     const ev = ev_.?;
     ev.process_exited = true;
-    ev.data_stream.close(loop, completion, EventData, ev, ttyClose);
 
     // Notify our surface we want to close
     _ = ev.surface_mailbox.push(.{

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -364,22 +364,6 @@ fn processExit(
     return .disarm;
 }
 
-fn ttyClose(
-    _: ?*EventData,
-    _: *xev.Loop,
-    _: *xev.Completion,
-    _: xev.Stream,
-    r: xev.Stream.CloseError!void,
-) xev.CallbackAction {
-    _ = r catch |err| {
-        log.warn("error closing tty err={}", .{err});
-        return .disarm;
-    };
-
-    log.debug("tty parent closed", .{});
-    return .disarm;
-}
-
 fn ttyWrite(
     ev_: ?*EventData,
     _: *xev.Loop,

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -185,9 +185,6 @@ pub fn threadExit(self: *Exec, data: ThreadData) void {
     if (data.ev.process_exited) self.subprocess.externalExit();
     self.subprocess.stop();
 
-    // Wait for our subprocess to report it exited.
-    // data.ev.loop.run(.once);
-
     // Wait for our reader thread to end
     data.read_thread.join();
 }


### PR DESCRIPTION
Fixes #101 

When the child process exits, the surface it is attached to is closed. 

This updates libxev so we can detect process exit in the event loop. On exit, this requests that the surface is closed from the app runtime. All app runtimes implement this.

Future: a configuration option to remain open after the process exits.