### PR TITLE
Reloadable Configuration

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -216,6 +216,7 @@ typedef struct {
 } ghostty_surface_config_s;
 
 typedef void (*ghostty_runtime_wakeup_cb)(void *);
+typedef const ghostty_config_t (*ghostty_runtime_reload_config_cb)(void *);
 typedef void (*ghostty_runtime_set_title_cb)(void *, const char *);
 typedef const char* (*ghostty_runtime_read_clipboard_cb)(void *);
 typedef void (*ghostty_runtime_write_clipboard_cb)(void *, const char *);
@@ -226,6 +227,7 @@ typedef void (*ghostty_runtime_focus_split_cb)(void *, ghostty_split_focus_direc
 typedef struct {
     void *userdata;
     ghostty_runtime_wakeup_cb wakeup_cb;
+    ghostty_runtime_reload_config_cb reload_config_cb;
     ghostty_runtime_set_title_cb set_title_cb;
     ghostty_runtime_read_clipboard_cb read_clipboard_cb;
     ghostty_runtime_write_clipboard_cb write_clipboard_cb;

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -243,6 +243,7 @@ int ghostty_init(void);
 
 ghostty_config_t ghostty_config_new();
 void ghostty_config_free(ghostty_config_t);
+void ghostty_config_load_cli_args(ghostty_config_t);
 void ghostty_config_load_string(ghostty_config_t, const char *, uintptr_t);
 void ghostty_config_load_default_files(ghostty_config_t);
 void ghostty_config_load_recursive_files(ghostty_config_t);

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -54,6 +54,7 @@ extension Ghostty {
             var runtime_cfg = ghostty_runtime_config_s(
                 userdata: Unmanaged.passUnretained(self).toOpaque(),
                 wakeup_cb: { userdata in AppState.wakeup(userdata) },
+                reload_config_cb: { userdata in AppState.reloadConfig(userdata) },
                 set_title_cb: { userdata, title in AppState.setTitle(userdata, title: title) },
                 read_clipboard_cb: { userdata in AppState.readClipboard(userdata) },
                 write_clipboard_cb: { userdata, str in AppState.writeClipboard(userdata, string: str) },
@@ -138,6 +139,13 @@ extension Ghostty {
             let pb = NSPasteboard.general
             pb.declareTypes([.string], owner: nil)
             pb.setString(valueStr, forType: .string)
+        }
+        
+        static func reloadConfig(_ userdata: UnsafeMutableRawPointer?) -> ghostty_config_t? {
+            // TODO: implement config reloading in the mac app
+            let state = Unmanaged<AppState>.fromOpaque(userdata!).takeUnretainedValue()
+            _ = state
+            return nil
         }
         
         static func wakeup(_ userdata: UnsafeMutableRawPointer?) {

--- a/src/App.zig
+++ b/src/App.zig
@@ -30,7 +30,9 @@ alloc: Allocator,
 /// The list of surfaces that are currently active.
 surfaces: SurfaceList,
 
-// The configuration for the app.
+// The configuration for the app. This may change (app runtimes are notified
+// via the callback), but the change will only ever happen during tick()
+// so app runtimes can ensure there are no data races in reading this.
 config: *const Config,
 
 /// The mailbox that can be used to send this thread messages. Note

--- a/src/App.zig
+++ b/src/App.zig
@@ -135,7 +135,9 @@ fn drainMailbox(self: *App, rt_app: *apprt.App) !void {
 }
 
 fn reloadConfig(self: *App, rt_app: *apprt.App) !void {
+    log.debug("reloading configuration", .{});
     if (try rt_app.reloadConfig()) |new| {
+        log.debug("new configuration received, applying", .{});
         try self.updateConfig(new);
     }
 }

--- a/src/DevMode.zig
+++ b/src/DevMode.zig
@@ -27,7 +27,7 @@ pub var instance: DevMode = .{};
 visible: bool = false,
 
 /// Our app config
-config: ?*const Config = null,
+config: ?Config = null,
 
 /// The surface we're tracking.
 surface: ?*Surface = null,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -570,7 +570,13 @@ fn changeConfig(self: *Surface, config: *const configpkg.Config) !void {
 
     // Update our derived configurations for the renderer and termio,
     // then send them a message to update.
-    // TODO
+    var renderer_config = try Renderer.DerivedConfig.init(self.alloc, config);
+    errdefer renderer_config.deinit();
+    // TODO: termio config
+
+    _ = self.renderer_thread.mailbox.push(.{
+        .change_config = renderer_config,
+    }, .{ .forever = {} });
 }
 
 /// Returns the x/y coordinate of where the IME (Input Method Editor)

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -852,6 +852,12 @@ pub fn keyCallback(
                 .unbind => unreachable,
                 .ignore => {},
 
+                .reload_config => {
+                    _ = self.app_mailbox.push(.{
+                        .reload_config = {},
+                    }, .{ .instant = {} });
+                },
+
                 .csi => |data| {
                     _ = self.io_thread.mailbox.push(.{
                         .write_stable = "\x1B[",

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -322,7 +322,7 @@ pub fn init(
 
     // Create our terminal grid with the initial size
     var renderer_impl = try Renderer.init(alloc, .{
-        .config = config,
+        .config = try Renderer.DerivedConfig.init(alloc, config),
         .font_group = font_group,
         .padding = .{
             .explicit = padding,

--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -137,6 +137,23 @@ pub const App = struct {
         glfw.terminate();
     }
 
+    /// Reload the configuration. This should return the new configuration.
+    /// The old value can be freed immediately at this point assuming a
+    /// successful return.
+    ///
+    /// The returned pointer value is only valid for a stable self pointer.
+    pub fn reloadConfig(self: *App) !?*const Config {
+        // Load our configuration
+        var config = try Config.load(self.core_app.alloc);
+        errdefer config.deinit();
+
+        // Update the existing config, be sure to clean up the old one.
+        self.config.deinit();
+        self.config = config;
+
+        return &self.config;
+    }
+
     pub fn wakeup(self: App) void {
         _ = self;
         c.g_main_context_wakeup(null);

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -2,6 +2,7 @@ const App = @import("../App.zig");
 const Surface = @import("../Surface.zig");
 const renderer = @import("../renderer.zig");
 const termio = @import("../termio.zig");
+const Config = @import("../config.zig").Config;
 
 /// The message types that can be sent to a single surface.
 pub const Message = union(enum) {
@@ -23,6 +24,11 @@ pub const Message = union(enum) {
 
     /// Write the clipboard contents.
     clipboard_write: WriteReq,
+
+    /// Change the configuration to the given configuration. The pointer is
+    /// not valid after receiving this message so any config must be used
+    /// and derived immediately.
+    change_config: *const Config,
 
     /// Close the surface. This will only close the current surface that
     /// receives this, not the full application.

--- a/src/config.zig
+++ b/src/config.zig
@@ -1,3 +1,4 @@
+const config = @This();
 const std = @import("std");
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
@@ -711,37 +712,6 @@ pub const Config = struct {
         return !equal(field.type, old_value, new_value);
     }
 
-    fn equal(comptime T: type, old: T, new: T) bool {
-        // Do known named types first
-        switch (T) {
-            inline []const u8,
-            [:0]const u8,
-            => return std.mem.eql(u8, old, new),
-
-            else => {},
-        }
-
-        // Back into types of types
-        switch (@typeInfo(T)) {
-            inline .Bool,
-            .Int,
-            => return old == new,
-
-            .Optional => |info| {
-                if (old == null and new == null) return true;
-                if (old == null or new == null) return false;
-                return equal(info.child, old.?, new.?);
-            },
-
-            .Struct => return old.equal(new),
-
-            else => {
-                @compileLog(T);
-                @compileError("unsupported field type");
-            },
-        }
-    }
-
     /// This yields a key for every changed field between old and new.
     pub const ChangeIterator = struct {
         old: *const Config,
@@ -798,6 +768,78 @@ pub const Config = struct {
         try testing.expect(!source.changed(&dest, .@"font-size"));
     }
 };
+
+/// A config-specific helper to determine if two values of the same
+/// type are equal. This isn't the same as std.mem.eql or std.testing.equals
+/// because we expect structs to implement their own equality.
+///
+/// This also doesn't support ALL Zig types, because we only add to it
+/// as we need types for the config.
+fn equal(comptime T: type, old: T, new: T) bool {
+    // Do known named types first
+    switch (T) {
+        inline []const u8,
+        [:0]const u8,
+        => return std.mem.eql(u8, old, new),
+
+        else => {},
+    }
+
+    // Back into types of types
+    switch (@typeInfo(T)) {
+        .Void => return true,
+
+        inline .Bool,
+        .Int,
+        .Enum,
+        => return old == new,
+
+        .Optional => |info| {
+            if (old == null and new == null) return true;
+            if (old == null or new == null) return false;
+            return equal(info.child, old.?, new.?);
+        },
+
+        .Struct => |info| {
+            if (@hasDecl(T, "equal")) return old.equal(new);
+
+            // If a struct doesn't declare an "equal" function, we fall back
+            // to a recursive field-by-field compare.
+            inline for (info.fields) |field_info| {
+                if (!equal(
+                    field_info.type,
+                    @field(old, field_info.name),
+                    @field(new, field_info.name),
+                )) return false;
+            }
+            return true;
+        },
+
+        .Union => |info| {
+            const tag_type = info.tag_type.?;
+            const old_tag = std.meta.activeTag(old);
+            const new_tag = std.meta.activeTag(new);
+            if (old_tag != new_tag) return false;
+
+            inline for (info.fields) |field_info| {
+                if (@field(tag_type, field_info.name) == old_tag) {
+                    return equal(
+                        field_info.type,
+                        @field(old, field_info.name),
+                        @field(new, field_info.name),
+                    );
+                }
+            }
+
+            unreachable;
+        },
+
+        else => {
+            @compileLog(T);
+            @compileError("unsupported field type");
+        },
+    }
+}
 
 /// Color represents a color using RGB.
 pub const Color = struct {
@@ -1006,9 +1048,21 @@ pub const Keybinds = struct {
 
     /// Compare if two of our value are requal. Required by Config.
     pub fn equal(self: Keybinds, other: Keybinds) bool {
-        // TODO
-        _ = self;
-        _ = other;
+        const self_map = self.set.bindings;
+        const other_map = other.set.bindings;
+        if (self_map.count() != other_map.count()) return false;
+
+        var it = self_map.iterator();
+        while (it.next()) |self_entry| {
+            const other_entry = other_map.getEntry(self_entry.key_ptr.*) orelse
+                return false;
+            if (!config.equal(
+                inputpkg.Binding.Action,
+                self_entry.value_ptr.*,
+                other_entry.value_ptr.*,
+            )) return false;
+        }
+
         return true;
     }
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -217,11 +217,7 @@ pub const Config = struct {
         try result.loadDefaultFiles(alloc_gpa);
 
         // Parse the config from the CLI args
-        {
-            var iter = try std.process.argsWithAllocator(alloc_gpa);
-            defer iter.deinit();
-            try cli_args.parse(Config, alloc_gpa, &result, &iter);
-        }
+        try result.loadCliArgs(alloc_gpa);
 
         // Parse the config files that were added from our file and CLI args.
         try result.loadRecursiveFiles(alloc_gpa);
@@ -562,6 +558,14 @@ pub const Config = struct {
                 .{ err, home_config_path },
             ),
         }
+    }
+
+    /// Load and parse the CLI args.
+    pub fn loadCliArgs(self: *Config, alloc_gpa: Allocator) !void {
+        // Parse the config from the CLI args
+        var iter = try std.process.argsWithAllocator(alloc_gpa);
+        defer iter.deinit();
+        try cli_args.parse(Config, alloc_gpa, self, &iter);
     }
 
     /// Load and parse the config files that were added in the "config-file" key.
@@ -1188,6 +1192,13 @@ pub const CAPI = struct {
             v.deinit();
             global.alloc.destroy(v);
         }
+    }
+
+    /// Load the configuration from the CLI args.
+    export fn ghostty_config_load_cli_args(self: *Config) void {
+        self.loadCliArgs(global.alloc) catch |err| {
+            log.err("error loading config err={}", .{err});
+        };
     }
 
     /// Load the configuration from a string in the same format as

--- a/src/config.zig
+++ b/src/config.zig
@@ -239,6 +239,12 @@ pub const Config = struct {
         const alloc = result._arena.?.allocator();
 
         // Add our default keybindings
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .space, .mods = .{ .super = true, .alt = true, .ctrl = true } },
+            .{ .reload_config = {} },
+        );
+
         {
             // On macOS we default to super but Linux ctrl+shift since
             // ctrl+c is to kill the process.

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -187,6 +187,12 @@ pub const Action = union(enum) {
     /// Focus on a split in a given direction.
     goto_split: SplitFocusDirection,
 
+    /// Reload the configuration. The exact meaning depends on the app runtime
+    /// in use but this usually involves re-reading the configuration file
+    /// and applying any changes. Note that not all changes can be applied at
+    /// runtime.
+    reload_config: void,
+
     /// Close the current "surface", whether that is a window, tab, split,
     /// etc. This only closes ONE surface.
     close_surface: void,

--- a/src/main.zig
+++ b/src/main.zig
@@ -14,8 +14,6 @@ const xdg = @import("xdg.zig");
 const apprt = @import("apprt.zig");
 
 const App = @import("App.zig");
-const cli_args = @import("cli_args.zig");
-const Config = @import("config.zig").Config;
 const Ghostty = @import("main_c.zig").Ghostty;
 
 /// Global process state. This is initialized in main() for exe artifacts
@@ -29,13 +27,8 @@ pub fn main() !void {
     defer state.deinit();
     const alloc = state.alloc;
 
-    // Try reading our config
-    var config = try Config.load(alloc);
-    defer config.deinit();
-    //std.log.debug("config={}", .{config});
-
     // Create our app state
-    var app = try App.create(alloc, &config);
+    var app = try App.create(alloc);
     defer app.destroy();
 
     // Create our runtime app

--- a/src/main.zig
+++ b/src/main.zig
@@ -30,22 +30,8 @@ pub fn main() !void {
     const alloc = state.alloc;
 
     // Try reading our config
-    var config = try Config.default(alloc);
+    var config = try Config.load(alloc);
     defer config.deinit();
-
-    // If we have a configuration file in our home directory, parse that first.
-    try config.loadDefaultFiles(alloc);
-
-    // Parse the config from the CLI args
-    {
-        var iter = try std.process.argsWithAllocator(alloc);
-        defer iter.deinit();
-        try cli_args.parse(Config, alloc, &config, &iter);
-    }
-
-    // Parse the config files that were added from our file and CLI args.
-    try config.loadRecursiveFiles(alloc);
-    try config.finalize();
     //std.log.debug("config={}", .{config});
 
     // Create our app state

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -724,6 +724,11 @@ fn drawCells(
     }
 }
 
+/// Update the configuration.
+pub fn changeConfig(self: *Metal, config: DerivedConfig) !void {
+    self.config = config;
+}
+
 /// Resize the screen.
 pub fn setScreenSize(self: *Metal, dim: renderer.ScreenSize) !void {
     // Store our screen size

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -725,8 +725,8 @@ fn drawCells(
 }
 
 /// Update the configuration.
-pub fn changeConfig(self: *Metal, config: DerivedConfig) !void {
-    self.config = config;
+pub fn changeConfig(self: *Metal, config: *DerivedConfig) !void {
+    self.config = config.*;
 }
 
 /// Resize the screen.

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -1232,6 +1232,11 @@ fn gridSize(self: *const OpenGL, screen_size: renderer.ScreenSize) renderer.Grid
     );
 }
 
+/// Update the configuration.
+pub fn changeConfig(self: *OpenGL, config: DerivedConfig) !void {
+    self.config = config;
+}
+
 /// Set the screen size for rendering. This will update the projection
 /// used for the shader so that the scaling of the grid is correct.
 pub fn setScreenSize(self: *OpenGL, dim: renderer.ScreenSize) !void {

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -8,6 +8,7 @@ const assert = std.debug.assert;
 const testing = std.testing;
 const Allocator = std.mem.Allocator;
 const apprt = @import("../apprt.zig");
+const configpkg = @import("../config.zig");
 const font = @import("../font/main.zig");
 const imgui = @import("imgui");
 const renderer = @import("../renderer.zig");
@@ -42,6 +43,9 @@ const DrawMutex = if (single_threaded_draw) std.Thread.Mutex else void;
 const drawMutexZero = if (DrawMutex == void) void{} else .{};
 
 alloc: std.mem.Allocator,
+
+/// The configuration we need derived from the main config.
+config: DerivedConfig,
 
 /// Current cell dimensions for this grid.
 cell_size: renderer.CellSize,
@@ -84,17 +88,6 @@ font_shaper: font.Shaper,
 /// blinking.
 cursor_visible: bool,
 cursor_style: renderer.CursorStyle,
-cursor_color: ?terminal.color.RGB,
-
-/// Default foreground color
-foreground: terminal.color.RGB,
-
-/// Default background color
-background: terminal.color.RGB,
-
-/// Default selection color
-selection_background: ?terminal.color.RGB,
-selection_foreground: ?terminal.color.RGB,
 
 /// True if the window is focused
 focused: bool,
@@ -232,6 +225,48 @@ const GPUCellMode = enum(u8) {
     }
 };
 
+/// The configuration for this renderer that is derived from the main
+/// configuration. This must be exported so that we don't need to
+/// pass around Config pointers which makes memory management a pain.
+pub const DerivedConfig = struct {
+    cursor_color: ?terminal.color.RGB,
+    background: terminal.color.RGB,
+    foreground: terminal.color.RGB,
+    selection_background: ?terminal.color.RGB,
+    selection_foreground: ?terminal.color.RGB,
+
+    pub fn init(
+        alloc_gpa: Allocator,
+        config: *const configpkg.Config,
+    ) !DerivedConfig {
+        _ = alloc_gpa;
+
+        return .{
+            .cursor_color = if (config.@"cursor-color") |col|
+                col.toTerminalRGB()
+            else
+                null,
+
+            .background = config.background.toTerminalRGB(),
+            .foreground = config.foreground.toTerminalRGB(),
+
+            .selection_background = if (config.@"selection-background") |bg|
+                bg.toTerminalRGB()
+            else
+                null,
+
+            .selection_foreground = if (config.@"selection-foreground") |bg|
+                bg.toTerminalRGB()
+            else
+                null,
+        };
+    }
+
+    pub fn deinit(self: *DerivedConfig) void {
+        _ = self;
+    }
+};
+
 pub fn init(alloc: Allocator, options: renderer.Options) !OpenGL {
     // Create the initial font shaper
     var shape_buf = try alloc.alloc(font.shape.Cell, 1);
@@ -354,6 +389,7 @@ pub fn init(alloc: Allocator, options: renderer.Options) !OpenGL {
 
     return OpenGL{
         .alloc = alloc,
+        .config = options.config,
         .cells_bg = .{},
         .cells = .{},
         .cells_lru = CellsLRU.init(0),
@@ -369,18 +405,7 @@ pub fn init(alloc: Allocator, options: renderer.Options) !OpenGL {
         .font_shaper = shaper,
         .cursor_visible = true,
         .cursor_style = .box,
-        .cursor_color = if (options.config.@"cursor-color") |col| col.toTerminalRGB() else null,
-        .background = options.config.background.toTerminalRGB(),
-        .foreground = options.config.foreground.toTerminalRGB(),
-        .draw_background = options.config.background.toTerminalRGB(),
-        .selection_background = if (options.config.@"selection-background") |bg|
-            bg.toTerminalRGB()
-        else
-            null,
-        .selection_foreground = if (options.config.@"selection-foreground") |bg|
-            bg.toTerminalRGB()
-        else
-            null,
+        .draw_background = options.config.background,
         .focused = true,
         .padding = options.padding,
         .surface_mailbox = options.surface_mailbox,
@@ -404,6 +429,9 @@ pub fn deinit(self: *OpenGL) void {
 
     self.cells.deinit(self.alloc);
     self.cells_bg.deinit(self.alloc);
+
+    self.config.deinit();
+
     self.* = undefined;
 }
 
@@ -673,15 +701,15 @@ pub fn render(
         }
 
         // Swap bg/fg if the terminal is reversed
-        const bg = self.background;
-        const fg = self.foreground;
+        const bg = self.config.background;
+        const fg = self.config.foreground;
         defer {
-            self.background = bg;
-            self.foreground = fg;
+            self.config.background = bg;
+            self.config.foreground = fg;
         }
         if (state.terminal.modes.reverse_colors) {
-            self.background = fg;
-            self.foreground = bg;
+            self.config.background = fg;
+            self.config.foreground = bg;
         }
 
         // Build our devmode draw data
@@ -723,7 +751,7 @@ pub fn render(
             null;
 
         break :critical .{
-            .gl_bg = self.background,
+            .gl_bg = self.config.background,
             .devmode_data = devmode_data,
             .active_screen = state.terminal.active_screen,
             .selection = selection,
@@ -944,7 +972,7 @@ fn addCursor(self: *OpenGL, screen: *terminal.Screen) void {
         screen.cursor.x,
     );
 
-    const color = self.cursor_color orelse terminal.color.RGB{
+    const color = self.config.cursor_color orelse terminal.color.RGB{
         .r = 0xFF,
         .g = 0xFF,
         .b = 0xFF,
@@ -1031,8 +1059,8 @@ pub fn updateCell(
             // If we are selected, we use the selection colors
             if (sel.contains(screen_point)) {
                 break :colors BgFg{
-                    .bg = self.selection_background orelse self.foreground,
-                    .fg = self.selection_foreground orelse self.background,
+                    .bg = self.config.selection_background orelse self.config.foreground,
+                    .fg = self.config.selection_foreground orelse self.config.background,
                 };
             }
         }
@@ -1041,13 +1069,13 @@ pub fn updateCell(
             // In normal mode, background and fg match the cell. We
             // un-optionalize the fg by defaulting to our fg color.
             .bg = if (cell.attrs.has_bg) cell.bg else null,
-            .fg = if (cell.attrs.has_fg) cell.fg else self.foreground,
+            .fg = if (cell.attrs.has_fg) cell.fg else self.config.foreground,
         } else .{
             // In inverted mode, the background MUST be set to something
             // (is never null) so it is either the fg or default fg. The
             // fg is either the bg or default background.
-            .bg = if (cell.attrs.has_fg) cell.fg else self.foreground,
-            .fg = if (cell.attrs.has_bg) cell.bg else self.background,
+            .bg = if (cell.attrs.has_fg) cell.fg else self.config.foreground,
+            .fg = if (cell.attrs.has_bg) cell.bg else self.config.background,
         };
         break :colors res;
     };

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -1233,8 +1233,8 @@ fn gridSize(self: *const OpenGL, screen_size: renderer.ScreenSize) renderer.Grid
 }
 
 /// Update the configuration.
-pub fn changeConfig(self: *OpenGL, config: DerivedConfig) !void {
-    self.config = config;
+pub fn changeConfig(self: *OpenGL, config: *DerivedConfig) !void {
+    self.config = config.*;
 }
 
 /// Set the screen size for rendering. This will update the projection

--- a/src/renderer/Options.zig
+++ b/src/renderer/Options.zig
@@ -5,7 +5,9 @@ const font = @import("../font/main.zig");
 const renderer = @import("../renderer.zig");
 const Config = @import("../config.zig").Config;
 
-/// The app configuration.
+/// The app configuration. This must NOT be stored by any termio implementation.
+/// The memory it points to is NOT stable after the init call so any values
+/// in here must be copied.
 config: *const Config,
 
 /// The font group that should be used.

--- a/src/renderer/Options.zig
+++ b/src/renderer/Options.zig
@@ -5,10 +5,8 @@ const font = @import("../font/main.zig");
 const renderer = @import("../renderer.zig");
 const Config = @import("../config.zig").Config;
 
-/// The app configuration. This must NOT be stored by any termio implementation.
-/// The memory it points to is NOT stable after the init call so any values
-/// in here must be copied.
-config: *const Config,
+/// The derived configuration for this renderer implementation.
+config: renderer.Renderer.DerivedConfig,
 
 /// The font group that should be used.
 font_group: *font.GroupCache,

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -255,6 +255,10 @@ fn drainMailbox(self: *Thread) !void {
             .screen_size => |size| {
                 try self.renderer.setScreenSize(size);
             },
+
+            .change_config => |config| {
+                try self.renderer.changeConfig(config);
+            },
         }
     }
 }

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -257,7 +257,8 @@ fn drainMailbox(self: *Thread) !void {
             },
 
             .change_config => |config| {
-                try self.renderer.changeConfig(config);
+                defer config.alloc.destroy(config.ptr);
+                try self.renderer.changeConfig(config.ptr);
             },
         }
     }

--- a/src/renderer/message.zig
+++ b/src/renderer/message.zig
@@ -22,4 +22,7 @@ pub const Message = union(enum) {
 
     /// Change the screen size.
     screen_size: renderer.ScreenSize,
+
+    /// The derived configuration to update the renderer with.
+    change_config: renderer.Renderer.DerivedConfig,
 };

--- a/src/renderer/message.zig
+++ b/src/renderer/message.zig
@@ -24,5 +24,8 @@ pub const Message = union(enum) {
     screen_size: renderer.ScreenSize,
 
     /// The derived configuration to update the renderer with.
-    change_config: renderer.Renderer.DerivedConfig,
+    change_config: struct {
+        alloc: Allocator,
+        ptr: *renderer.Renderer.DerivedConfig,
+    },
 };

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -218,9 +218,8 @@ pub fn threadExit(self: *Exec, data: ThreadData) void {
 }
 
 /// Update the configuration.
-pub fn changeConfig(self: *Exec, config: DerivedConfig) !void {
-    var copy = config;
-    defer copy.deinit();
+pub fn changeConfig(self: *Exec, config: *DerivedConfig) !void {
+    defer config.deinit();
 
     // Update the configuration that we know about.
     //

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -222,6 +222,14 @@ pub fn changeConfig(self: *Exec, config: DerivedConfig) !void {
     var copy = config;
     defer copy.deinit();
 
+    // Update the configuration that we know about.
+    //
+    // Specific things we don't update:
+    //   - command, working-directory: we never restart the underlying
+    //   process so we don't care or need to know about these.
+
+    // Update the palette. Note this will only apply to new colors drawn
+    // since we decode all palette colors to RGB on usage.
     self.terminal.color_palette = config.palette;
 }
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -6,6 +6,7 @@ const builtin = @import("builtin");
 const build_config = @import("../build_config.zig");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
+const ArenaAllocator = std.heap.ArenaAllocator;
 const EnvMap = std.process.EnvMap;
 const termio = @import("../termio.zig");
 const Command = @import("../Command.zig");
@@ -19,6 +20,7 @@ const trace = tracy.trace;
 const apprt = @import("../apprt.zig");
 const fastmem = @import("../fastmem.zig");
 const internal_os = @import("../os/main.zig");
+const configpkg = @import("../config.zig");
 
 const log = std.log.scoped(.io_exec);
 
@@ -62,9 +64,35 @@ grid_size: renderer.GridSize,
 /// The data associated with the currently running thread.
 data: ?*EventData,
 
+/// The configuration for this IO that is derived from the main
+/// configuration. This must be exported so that we don't need to
+/// pass around Config pointers which makes memory management a pain.
+pub const DerivedConfig = struct {
+    palette: terminal.color.Palette,
+
+    pub fn init(
+        alloc_gpa: Allocator,
+        config: *const configpkg.Config,
+    ) !DerivedConfig {
+        _ = alloc_gpa;
+
+        return .{
+            .palette = config.palette.value,
+        };
+    }
+
+    pub fn deinit(self: *DerivedConfig) void {
+        _ = self;
+    }
+};
+
 /// Initialize the exec implementation. This will also start the child
 /// process.
 pub fn init(alloc: Allocator, opts: termio.Options) !Exec {
+    // Clean up our derived config because we don't need it after this.
+    var config = opts.config;
+    defer config.deinit();
+
     // Create our terminal
     var term = try terminal.Terminal.init(
         alloc,
@@ -72,7 +100,7 @@ pub fn init(alloc: Allocator, opts: termio.Options) !Exec {
         opts.grid_size.rows,
     );
     errdefer term.deinit(alloc);
-    term.color_palette = opts.config.palette.value;
+    term.color_palette = opts.config.palette;
 
     var subprocess = try Subprocess.init(alloc, opts);
     errdefer subprocess.deinit();
@@ -187,6 +215,14 @@ pub fn threadExit(self: *Exec, data: ThreadData) void {
 
     // Wait for our reader thread to end
     data.read_thread.join();
+}
+
+/// Update the configuration.
+pub fn changeConfig(self: *Exec, config: DerivedConfig) !void {
+    var copy = config;
+    defer copy.deinit();
+
+    self.terminal.color_palette = config.palette;
 }
 
 /// Resize the terminal.
@@ -413,7 +449,7 @@ const Subprocess = struct {
         const alloc = arena.allocator();
 
         // Determine the path to the binary we're executing
-        const path = (try Command.expandPath(alloc, opts.config.command orelse "sh")) orelse
+        const path = (try Command.expandPath(alloc, opts.full_config.command orelse "sh")) orelse
             return error.CommandNotFound;
 
         // On macOS, we launch the program as a login shell. This is a Mac-specific
@@ -487,10 +523,17 @@ const Subprocess = struct {
             break :args try args.toOwnedSlice();
         };
 
+        // We have to copy the cwd because there is no guarantee that
+        // pointers in full_config remain valid.
+        var cwd: ?[]u8 = if (opts.full_config.@"working-directory") |cwd|
+            try alloc.dupe(u8, cwd)
+        else
+            null;
+
         return .{
             .arena = arena,
             .env = env,
-            .cwd = opts.config.@"working-directory",
+            .cwd = cwd,
             .path = if (internal_os.isFlatpak()) args[0] else path,
             .args = args,
             .grid_size = opts.grid_size,

--- a/src/termio/Options.zig
+++ b/src/termio/Options.zig
@@ -11,7 +11,9 @@ grid_size: renderer.GridSize,
 /// The size of the viewport in pixels.
 screen_size: renderer.ScreenSize,
 
-/// The app configuration.
+/// The app configuration. This must NOT be stored by any termio implementation.
+/// The memory it points to is NOT stable after the init call so any values
+/// in here must be copied.
 config: *const Config,
 
 /// The render state. The IO implementation can modify anything here. The

--- a/src/termio/Options.zig
+++ b/src/termio/Options.zig
@@ -4,6 +4,7 @@ const xev = @import("xev");
 const apprt = @import("../apprt.zig");
 const renderer = @import("../renderer.zig");
 const Config = @import("../config.zig").Config;
+const termio = @import("../termio.zig");
 
 /// The size of the terminal grid.
 grid_size: renderer.GridSize,
@@ -11,10 +12,13 @@ grid_size: renderer.GridSize,
 /// The size of the viewport in pixels.
 screen_size: renderer.ScreenSize,
 
-/// The app configuration. This must NOT be stored by any termio implementation.
+/// The full app configuration. This is only available during initialization.
 /// The memory it points to is NOT stable after the init call so any values
 /// in here must be copied.
-config: *const Config,
+full_config: *const Config,
+
+/// The derived configuration for this termio implementation.
+config: termio.Impl.DerivedConfig,
 
 /// The render state. The IO implementation can modify anything here. The
 /// surface thread will setup the initial "terminal" pointer but the IO impl

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -150,7 +150,10 @@ fn drainMailbox(self: *Thread) !void {
 
         log.debug("mailbox message={}", .{message});
         switch (message) {
-            .change_config => |config| try self.impl.changeConfig(config),
+            .change_config => |config| {
+                defer config.alloc.destroy(config.ptr);
+                try self.impl.changeConfig(config.ptr);
+            },
             .resize => |v| self.handleResize(v),
             .clear_screen => |v| try self.impl.clearScreen(v.history),
             .write_small => |v| try self.impl.queueWrite(v.data[0..v.len]),

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -150,6 +150,7 @@ fn drainMailbox(self: *Thread) !void {
 
         log.debug("mailbox message={}", .{message});
         switch (message) {
+            .change_config => |config| try self.impl.changeConfig(config),
             .resize => |v| self.handleResize(v),
             .clear_screen => |v| try self.impl.clearScreen(v.history),
             .write_small => |v| try self.impl.queueWrite(v.data[0..v.len]),

--- a/src/termio/message.zig
+++ b/src/termio/message.zig
@@ -29,8 +29,12 @@ pub const Message = union(enum) {
         padding: renderer.Padding,
     };
 
-    /// The derived configuration to update the implementation with.
-    change_config: termio.Impl.DerivedConfig,
+    /// The derived configuration to update the implementation with. This
+    /// is allocated via the allocator and is expected to be freed when done.
+    change_config: struct {
+        alloc: Allocator,
+        ptr: *termio.Impl.DerivedConfig,
+    },
 
     /// Resize the window.
     resize: Resize,

--- a/src/termio/message.zig
+++ b/src/termio/message.zig
@@ -3,6 +3,7 @@ const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const renderer = @import("../renderer.zig");
 const terminal = @import("../terminal/main.zig");
+const termio = @import("../termio.zig");
 
 /// The messages that can be sent to an IO thread.
 ///
@@ -27,6 +28,9 @@ pub const Message = union(enum) {
         /// this to send to the pty.
         padding: renderer.Padding,
     };
+
+    /// The derived configuration to update the implementation with.
+    change_config: termio.Impl.DerivedConfig,
 
     /// Resize the window.
     resize: Resize,


### PR DESCRIPTION
This implements runtime-reloadable configuration. This introduces a new keybind action `reload_config`, default bound to `Ctrl+Shift+Alt+Space`. This will reload all the configuration and apply it to Ghostty.

Currently, everything reloads immediately _except_:

* Font family - This is more complicated so its a TODO for future changes.
* Window padding - Related to font family metrics so we don't update this yet
* Command and working directory - Only applies to new terminal windows
* Font size - Only applies to new windows

Everything else takes effect immediately, i.e. color settings, keybindings, etc.

From a core architecture standpoint, this cleans up something important: only the main app thread (1 thread) "owns" the `Config` pointer. Previously, this pointer was shared across the renderer and terminal IO threads (N, or 1 per surface). This made reloading config a mess because ownership was unclear. 

Now, when config changes or initially loads, we derive a copied config of only the settings that are necessary (which are very small!) for the renderer and IO threads. This uses slightly more memory, but it turns out the config settings a renderer or termio needs is extremely small.