### PR TITLE
Scrolling screen with full scrollback should modify selection if set

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -537,7 +537,7 @@ pub fn render(
 
         // Convert our selection to viewport points because we copy only
         // the viewport above.
-        const selection: ?terminal.Selection = if (state.terminal.selection) |sel|
+        const selection: ?terminal.Selection = if (state.terminal.screen.selection) |sel|
             sel.toViewport(&state.terminal.screen)
         else
             null;

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -745,7 +745,7 @@ pub fn render(
 
         // Convert our selection to viewport points because we copy only
         // the viewport above.
-        const selection: ?terminal.Selection = if (state.terminal.selection) |sel|
+        const selection: ?terminal.Selection = if (state.terminal.screen.selection) |sel|
             sel.toViewport(&state.terminal.screen)
         else
             null;

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -774,6 +774,9 @@ cursor: Cursor = .{},
 /// Saved cursor saved with DECSC (ESC 7).
 saved_cursor: Cursor = .{},
 
+/// The selection for this screen (if any).
+selection: ?Selection = null,
+
 /// Initialize a new screen.
 pub fn init(
     alloc: Allocator,

--- a/src/terminal/Selection.zig
+++ b/src/terminal/Selection.zig
@@ -33,6 +33,11 @@ pub fn toViewport(self: Selection, screen: *const Screen) ?Selection {
     };
 }
 
+/// Returns true if the selection is empty.
+pub fn empty(self: Selection) bool {
+    return self.start.x == self.end.x and self.start.y == self.end.y;
+}
+
 /// Returns true if the selection contains the given point.
 ///
 /// This recalculates top left and bottom right each call. If you have

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -15,7 +15,6 @@ const ansi = @import("ansi.zig");
 const charsets = @import("charsets.zig");
 const csi = @import("csi.zig");
 const sgr = @import("sgr.zig");
-const Selection = @import("Selection.zig");
 const Tabstops = @import("Tabstops.zig");
 const trace = @import("tracy").trace;
 const color = @import("color.zig");
@@ -38,9 +37,6 @@ pub const ScreenType = enum {
 active_screen: ScreenType,
 screen: Screen,
 secondary_screen: Screen,
-
-/// The current selection (if any).
-selection: ?Selection = null,
 
 /// Whether we're currently writing to the status line (DECSASD and DECSSDT).
 /// We don't support a status line currently so we just black hole this
@@ -204,7 +200,7 @@ pub fn alternateScreen(self: *Terminal, options: AlternateScreenOptions) void {
     self.screen.cursor = .{};
 
     // Clear our selection
-    self.selection = null;
+    self.screen.selection = null;
 
     if (options.clear_on_enter) {
         self.eraseDisplay(.complete);
@@ -231,7 +227,7 @@ pub fn primaryScreen(self: *Terminal, options: AlternateScreenOptions) void {
     self.active_screen = .primary;
 
     // Clear our selection
-    self.selection = null;
+    self.screen.selection = null;
 
     // Restore the cursor from the primary screen
     if (options.cursor_save) self.restoreCursor();
@@ -1393,7 +1389,6 @@ pub fn setScrollingRegion(self: *Terminal, top: usize, bottom: usize) void {
 /// Full reset
 pub fn fullReset(self: *Terminal) void {
     self.primaryScreen(.{ .clear_on_exit = true, .cursor_save = true });
-    self.selection = null;
     self.charset = .{};
     self.eraseDisplay(.scrollback);
     self.eraseDisplay(.complete);
@@ -1401,6 +1396,7 @@ pub fn fullReset(self: *Terminal) void {
     self.tabstops.reset(0);
     self.screen.cursor = .{};
     self.screen.saved_cursor = .{};
+    self.screen.selection = null;
     self.scrolling_region = .{ .top = 0, .bottom = self.rows - 1 };
     self.previous_char = null;
 }


### PR DESCRIPTION
Fixes #122 

Tests explain it all.

The main architectural change here is that selection needs to be part of the screen structure rather than the terminal structure, because the screen is the only thing that is aware when we're pruning scrollback.