### PR TITLE
Bug fixes

### DIFF
--- a/src/font/shaper/web_canvas.zig
+++ b/src/font/shaper/web_canvas.zig
@@ -287,7 +287,7 @@ pub const Wasm = struct {
         while (rowIter.next()) |row| {
             defer y += 1;
 
-            var iter = self.runIterator(group, row);
+            var iter = self.runIterator(group, row, null);
             while (try iter.next(alloc)) |run| {
                 const cells = try self.shape(run);
                 log.info("y={} run={d} shape={any} idx={}", .{

--- a/src/font/shaper/web_canvas.zig
+++ b/src/font/shaper/web_canvas.zig
@@ -57,8 +57,14 @@ pub const Shaper = struct {
         self: *Shaper,
         group: *font.GroupCache,
         row: terminal.Screen.Row,
+        selection: ?terminal.Selection,
     ) font.shape.RunIterator {
-        return .{ .hooks = .{ .shaper = self }, .group = group, .row = row };
+        return .{
+            .hooks = .{ .shaper = self },
+            .group = group,
+            .row = row,
+            .selection = selection,
+        };
     }
 
     /// Shape the given text run. The text run must be the immediately

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -844,8 +844,24 @@ fn rebuildCells(
             }
         };
 
+        // We need to get this row's selection if there is one for proper
+        // run splitting.
+        const row_selection = sel: {
+            if (term_selection) |sel| {
+                const screen_point = (terminal.point.Viewport{
+                    .x = 0,
+                    .y = y,
+                }).toScreen(screen);
+                if (sel.containedRow(screen, screen_point)) |row_sel| {
+                    break :sel row_sel;
+                }
+            }
+
+            break :sel null;
+        };
+
         // Split our row into runs and shape each one.
-        var iter = self.font_shaper.runIterator(self.font_group, row);
+        var iter = self.font_shaper.runIterator(self.font_group, row, row_selection);
         while (try iter.next(self.alloc)) |run| {
             for (try self.font_shaper.shape(run)) |shaper_cell| {
                 if (self.updateCell(

--- a/src/terminal/Selection.zig
+++ b/src/terminal/Selection.zig
@@ -3,6 +3,7 @@
 const Selection = @This();
 
 const std = @import("std");
+const assert = std.debug.assert;
 const point = @import("point.zig");
 const Screen = @import("Screen.zig");
 const ScreenPoint = point.ScreenPoint;
@@ -93,6 +94,42 @@ pub fn containsRow(self: Selection, p: ScreenPoint) bool {
     return p.y >= tl.y and p.y <= br.y;
 }
 
+/// Get a selection for a single row in the screen. This will return null
+/// if the row is not included in the selection.
+pub fn containedRow(self: Selection, screen: *const Screen, p: ScreenPoint) ?Selection {
+    const tl = self.topLeft();
+    const br = self.bottomRight();
+    if (p.y < tl.y or p.y > br.y) return null;
+
+    if (p.y == tl.y) {
+        // If the selection is JUST this line, return it as-is.
+        if (p.y == br.y) return self;
+
+        // Selection top-left line matches only.
+        return .{
+            .start = tl,
+            .end = .{ .y = tl.y, .x = screen.cols - 1 },
+        };
+    }
+
+    // Row is our bottom selection, so we return the selection from the
+    // beginning of the line to the br. We know our selection is more than
+    // one line (due to conditionals above)
+    if (p.y == br.y) {
+        assert(p.y != tl.y);
+        return .{
+            .start = .{ .y = br.y, .x = 0 },
+            .end = br,
+        };
+    }
+
+    // Row is somewhere between our selection lines so we return the full line.
+    return .{
+        .start = .{ .y = p.y, .x = 0 },
+        .end = .{ .y = p.y, .x = screen.cols - 1 },
+    };
+}
+
 /// Returns the top left point of the selection.
 pub fn topLeft(self: Selection) ScreenPoint {
     return switch (self.order()) {
@@ -159,6 +196,58 @@ test "Selection: contains" {
         try testing.expect(sel.contains(.{ .x = 6, .y = 1 }));
         try testing.expect(!sel.contains(.{ .x = 2, .y = 1 }));
         try testing.expect(!sel.contains(.{ .x = 12, .y = 1 }));
+    }
+}
+
+test "Selection: containedRow" {
+    const testing = std.testing;
+    var screen = try Screen.init(testing.allocator, 5, 10, 0);
+    defer screen.deinit();
+
+    {
+        const sel: Selection = .{
+            .start = .{ .x = 5, .y = 1 },
+            .end = .{ .x = 3, .y = 3 },
+        };
+
+        // Not contained
+        try testing.expect(sel.containedRow(&screen, .{ .x = 1, .y = 4 }) == null);
+
+        // Start line
+        try testing.expectEqual(Selection{
+            .start = sel.start,
+            .end = .{ .x = screen.cols - 1, .y = 1 },
+        }, sel.containedRow(&screen, .{ .x = 1, .y = 1 }).?);
+
+        // End line
+        try testing.expectEqual(Selection{
+            .start = .{ .x = 0, .y = 3 },
+            .end = sel.end,
+        }, sel.containedRow(&screen, .{ .x = 2, .y = 3 }).?);
+
+        // Middle line
+        try testing.expectEqual(Selection{
+            .start = .{ .x = 0, .y = 2 },
+            .end = .{ .x = screen.cols - 1, .y = 2 },
+        }, sel.containedRow(&screen, .{ .x = 2, .y = 2 }).?);
+    }
+
+    // Single-line selection
+    {
+        const sel: Selection = .{
+            .start = .{ .x = 2, .y = 1 },
+            .end = .{ .x = 6, .y = 1 },
+        };
+
+        // Not contained
+        try testing.expect(sel.containedRow(&screen, .{ .x = 1, .y = 0 }) == null);
+        try testing.expect(sel.containedRow(&screen, .{ .x = 1, .y = 2 }) == null);
+
+        // Contained
+        try testing.expectEqual(Selection{
+            .start = sel.start,
+            .end = sel.end,
+        }, sel.containedRow(&screen, .{ .x = 1, .y = 1 }).?);
     }
 }
 

--- a/src/terminal/Selection.zig
+++ b/src/terminal/Selection.zig
@@ -146,8 +146,19 @@ pub fn bottomRight(self: Selection) ScreenPoint {
     };
 }
 
+/// Returns the selection in the given order.
+pub fn ordered(self: Selection, desired: Order) Selection {
+    if (self.order() == desired) return self;
+    const tl = self.topLeft();
+    const br = self.bottomRight();
+    return switch (desired) {
+        .forward => .{ .start = tl, .end = br },
+        .reverse => .{ .start = br, .end = tl },
+    };
+}
+
 /// The order of the selection (whether it is selecting forward or back).
-const Order = enum { forward, reverse };
+pub const Order = enum { forward, reverse };
 
 fn order(self: Selection) Order {
     if (self.start.y < self.end.y) return .forward;


### PR DESCRIPTION
Fixes #129 
Fixes #127 

I think #129 was a really interesting bug. The bug there was that our text run iterator was not splitting runs by selection boundaries, so we were inverting the whole ligature glyph rather than by-character. This is now fixed and the behavior looks like this, which I think is correct:

https://user-images.githubusercontent.com/1299/227298984-4a9fd5fa-07b6-47de-92a4-9029a0742eb0.mp4
