### PR TITLE
gtk, macos: show confirmation dialog on surface close with active child process

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -221,7 +221,7 @@ typedef void (*ghostty_runtime_set_title_cb)(void *, const char *);
 typedef const char* (*ghostty_runtime_read_clipboard_cb)(void *);
 typedef void (*ghostty_runtime_write_clipboard_cb)(void *, const char *);
 typedef void (*ghostty_runtime_new_split_cb)(void *, ghostty_split_direction_e);
-typedef void (*ghostty_runtime_close_surface_cb)(void *);
+typedef void (*ghostty_runtime_close_surface_cb)(void *, bool);
 typedef void (*ghostty_runtime_focus_split_cb)(void *, ghostty_split_focus_direction_e);
 
 typedef struct {

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -133,10 +133,10 @@ extension Ghostty {
         }
         
         static func closeSurface(_ userdata: UnsafeMutableRawPointer?, processAlive: Bool) {
-            // TODO: handle processAlive to show confirmation dialog. We probably want to attach
-            // it to the notification and let downstream handle it.
             guard let surface = self.surfaceUserdata(from: userdata) else { return }
-            NotificationCenter.default.post(name: Notification.ghosttyCloseSurface, object: surface)
+            NotificationCenter.default.post(name: Notification.ghosttyCloseSurface, object: surface, userInfo: [
+                "process_alive": processAlive,
+            ])
         }
         
         static func focusSplit(_ userdata: UnsafeMutableRawPointer?, direction: ghostty_split_focus_direction_e) {

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -60,7 +60,7 @@ extension Ghostty {
                 read_clipboard_cb: { userdata in AppState.readClipboard(userdata) },
                 write_clipboard_cb: { userdata, str in AppState.writeClipboard(userdata, string: str) },
                 new_split_cb: { userdata, direction in AppState.newSplit(userdata, direction: direction) },
-                close_surface_cb: { userdata in AppState.closeSurface(userdata) },
+                close_surface_cb: { userdata, processAlive in AppState.closeSurface(userdata, processAlive: processAlive) },
                 focus_split_cb: { userdata, direction in AppState.focusSplit(userdata, direction: direction) }
             )
 
@@ -132,7 +132,9 @@ extension Ghostty {
             ])
         }
         
-        static func closeSurface(_ userdata: UnsafeMutableRawPointer?) {
+        static func closeSurface(_ userdata: UnsafeMutableRawPointer?, processAlive: Bool) {
+            // TODO: handle processAlive to show confirmation dialog. We probably want to attach
+            // it to the notification and let downstream handle it.
             guard let surface = self.surfaceUserdata(from: userdata) else { return }
             NotificationCenter.default.post(name: Notification.ghosttyCloseSurface, object: surface)
         }

--- a/macos/Sources/GhosttyApp.swift
+++ b/macos/Sources/GhosttyApp.swift
@@ -82,7 +82,11 @@ struct GhosttyApp: App {
     }
     
     func close() {
-        guard let surfaceView = focusedSurface else { return }
+        guard let surfaceView = focusedSurface else {
+            Self.closeWindow()
+            return
+        }
+        
         guard let surface = surfaceView.surface else { return }
         ghostty.requestClose(surface: surface)
     }

--- a/src/App.zig
+++ b/src/App.zig
@@ -74,7 +74,7 @@ pub fn tick(self: *App, rt_app: *apprt.App) !bool {
     while (i < self.surfaces.items.len) {
         const surface = self.surfaces.items[i];
         if (surface.shouldClose()) {
-            rt_app.closeSurface(surface);
+            surface.close(false);
             continue;
         }
 
@@ -143,8 +143,10 @@ fn reloadConfig(self: *App, rt_app: *apprt.App) !void {
 }
 
 fn closeSurface(self: *App, rt_app: *apprt.App, surface: *Surface) !void {
+    _ = rt_app;
+
     if (!self.hasSurface(surface)) return;
-    rt_app.closeSurface(surface.rt_surface);
+    surface.close();
 }
 
 fn redrawSurface(self: *App, rt_app: *apprt.App, surface: *apprt.Surface) !void {

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -56,7 +56,7 @@ pub const App = struct {
         new_split: ?*const fn (SurfaceUD, input.SplitDirection) callconv(.C) void = null,
 
         /// Close the current surface given by this function.
-        close_surface: ?*const fn (SurfaceUD) callconv(.C) void = null,
+        close_surface: ?*const fn (SurfaceUD, bool) callconv(.C) void = null,
 
         /// Focus the previous/next split (if any).
         focus_split: ?*const fn (SurfaceUD, input.SplitFocusDirection) callconv(.C) void = null,
@@ -188,13 +188,13 @@ pub const Surface = struct {
         func(self.opts.userdata, direction);
     }
 
-    pub fn close(self: *const Surface) void {
+    pub fn close(self: *const Surface, process_alive: bool) void {
         const func = self.app.opts.close_surface orelse {
             log.info("runtime embedder does not support closing a surface", .{});
             return;
         };
 
-        func(self.opts.userdata);
+        func(self.opts.userdata, process_alive);
     }
 
     pub fn gotoSplit(self: *const Surface, direction: input.SplitFocusDirection) void {
@@ -506,7 +506,7 @@ pub const CAPI = struct {
     /// Request that the surface become closed. This will go through the
     /// normal trigger process that a close surface input binding would.
     export fn ghostty_surface_request_close(ptr: *Surface) void {
-        ptr.close();
+        ptr.core_surface.close();
     }
 
     /// Request that the surface split in the given direction.

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -409,8 +409,11 @@ pub const Surface = struct {
     }
 
     /// Close this surface.
-    pub fn close(self: *const Surface) void {
-        self.window.setShouldClose(true);
+    pub fn close(self: *Surface, processActive: bool) void {
+        _ = processActive;
+        self.setShouldClose();
+        self.deinit();
+        self.app.app.alloc.destroy(self);
     }
 
     /// Set the size limits of the window.

--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -636,10 +636,7 @@ pub const Surface = struct {
             return;
         }
 
-        // I'd like to make this prettier one day:
-        //   - Make the "Yes" button red
-        //   - Make the "No" button default
-        //
+        // Setup our basic message
         const alert = c.gtk_message_dialog_new(
             self.window.window,
             c.GTK_DIALOG_MODAL,
@@ -653,6 +650,19 @@ pub const Surface = struct {
                 "Closing the terminal will kill this process. " ++
                 "Are you sure you want to close the terminal?" ++
                 "Click 'No' to cancel and return to your terminal.",
+        );
+
+        // We want the "yes" to appear destructive.
+        const yes_widget = c.gtk_dialog_get_widget_for_response(
+            @ptrCast(*c.GtkDialog, alert),
+            c.GTK_RESPONSE_YES,
+        );
+        c.gtk_widget_add_css_class(yes_widget, "destructive-action");
+
+        // We want the "no" to be the default action
+        c.gtk_dialog_set_default_response(
+            @ptrCast(*c.GtkDialog, alert),
+            c.GTK_RESPONSE_NO,
         );
 
         _ = c.g_signal_connect_data(alert, "response", c.G_CALLBACK(&gtkCloseConfirmation), self, null, G_CONNECT_DEFAULT);

--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -171,11 +171,6 @@ pub const App = struct {
     }
 
     /// Close the given surface.
-    pub fn closeSurface(self: *App, surface: *Surface) void {
-        _ = self;
-        surface.close();
-    }
-
     pub fn redrawSurface(self: *App, surface: *Surface) void {
         _ = self;
         surface.invalidate();
@@ -635,7 +630,12 @@ pub const Surface = struct {
     }
 
     /// Close this surface.
-    pub fn close(self: *Surface) void {
+    pub fn close(self: *Surface, processActive: bool) void {
+        if (!processActive) {
+            self.window.closeSurface(self);
+            return;
+        }
+
         // I'd like to make this prettier one day:
         //   - Make the "Yes" button red
         //   - Make the "No" button default
@@ -658,7 +658,6 @@ pub const Surface = struct {
         _ = c.g_signal_connect_data(alert, "response", c.G_CALLBACK(&gtkCloseConfirmation), self, null, G_CONNECT_DEFAULT);
 
         c.gtk_widget_show(alert);
-        //self.window.closeSurface(self);
     }
 
     pub fn newTab(self: *Surface) !void {

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -33,6 +33,10 @@ pub const Message = union(enum) {
     /// Close the surface. This will only close the current surface that
     /// receives this, not the full application.
     close: void,
+
+    /// The child process running in the surface has exited. This may trigger
+    /// a surface close, it may not.
+    child_exited: void,
 };
 
 /// A surface mailbox.

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -401,7 +401,7 @@ fn processExit(
 
     // Notify our surface we want to close
     _ = ev.surface_mailbox.push(.{
-        .close = {},
+        .child_exited = {},
     }, .{ .forever = {} });
 
     return .disarm;


### PR DESCRIPTION
Fixes #119 for both macOS and GTK.

macOS screenshot:

![CleanShot 2023-03-26 at 10 41 44@2x](https://user-images.githubusercontent.com/1299/227794004-71b7577f-ed9f-4752-bd38-4108cf8d4954.png)

