### PR TITLE
Confirmation Dialog on App Quit

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -251,7 +251,7 @@ void ghostty_config_finalize(ghostty_config_t);
 
 ghostty_app_t ghostty_app_new(const ghostty_runtime_config_s *, ghostty_config_t);
 void ghostty_app_free(ghostty_app_t);
-int ghostty_app_tick(ghostty_app_t);
+bool ghostty_app_tick(ghostty_app_t);
 void *ghostty_app_userdata(ghostty_app_t);
 
 ghostty_surface_t ghostty_surface_new(ghostty_app_t, ghostty_surface_config_s*);

--- a/macos/Ghostty.xcodeproj/project.pbxproj
+++ b/macos/Ghostty.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		A5CEAFFF29C2410700646FDA /* Backport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CEAFFE29C2410700646FDA /* Backport.swift */; };
 		A5D495A2299BEC7E00DD1313 /* GhosttyKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5D495A1299BEC7E00DD1313 /* GhosttyKit.xcframework */; };
 		A5FECBD729D1FC3900022361 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FECBD629D1FC3900022361 /* ContentView.swift */; };
+		A5FECBD929D2010400022361 /* WindowAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FECBD829D2010400022361 /* WindowAccessor.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -40,6 +41,7 @@
 		A5CEAFFE29C2410700646FDA /* Backport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Backport.swift; sourceTree = "<group>"; };
 		A5D495A1299BEC7E00DD1313 /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = GhosttyKit.xcframework; sourceTree = "<group>"; };
 		A5FECBD629D1FC3900022361 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		A5FECBD829D2010400022361 /* WindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAccessor.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -66,6 +68,7 @@
 				A59444F629A2ED5200725BBA /* SettingsView.swift */,
 				A5CEAFFE29C2410700646FDA /* Backport.swift */,
 				A5FECBD629D1FC3900022361 /* ContentView.swift */,
+				A5FECBD829D2010400022361 /* WindowAccessor.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -201,6 +204,7 @@
 				A55B7BB629B6F47F0055DE60 /* AppState.swift in Sources */,
 				A5CEAFDC29B8009000646FDA /* SplitView.swift in Sources */,
 				A55685E029A03A9F004303CE /* AppError.swift in Sources */,
+				A5FECBD929D2010400022361 /* WindowAccessor.swift in Sources */,
 				A535B9DA299C569B0017E2E4 /* ErrorView.swift in Sources */,
 				A5B30535299BEAAA0047F10C /* GhosttyApp.swift in Sources */,
 				A5CEAFFF29C2410700646FDA /* Backport.swift in Sources */,

--- a/macos/Ghostty.xcodeproj/project.pbxproj
+++ b/macos/Ghostty.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		A5CEAFDE29B8058B00646FDA /* SplitView.Divider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CEAFDD29B8058B00646FDA /* SplitView.Divider.swift */; };
 		A5CEAFFF29C2410700646FDA /* Backport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CEAFFE29C2410700646FDA /* Backport.swift */; };
 		A5D495A2299BEC7E00DD1313 /* GhosttyKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5D495A1299BEC7E00DD1313 /* GhosttyKit.xcframework */; };
+		A5FECBD729D1FC3900022361 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FECBD629D1FC3900022361 /* ContentView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -38,6 +39,7 @@
 		A5CEAFDD29B8058B00646FDA /* SplitView.Divider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitView.Divider.swift; sourceTree = "<group>"; };
 		A5CEAFFE29C2410700646FDA /* Backport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Backport.swift; sourceTree = "<group>"; };
 		A5D495A1299BEC7E00DD1313 /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = GhosttyKit.xcframework; sourceTree = "<group>"; };
+		A5FECBD629D1FC3900022361 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -63,6 +65,7 @@
 				A55685DF29A03A9F004303CE /* AppError.swift */,
 				A59444F629A2ED5200725BBA /* SettingsView.swift */,
 				A5CEAFFE29C2410700646FDA /* Backport.swift */,
+				A5FECBD629D1FC3900022361 /* ContentView.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -192,6 +195,7 @@
 			files = (
 				A55B7BBC29B6FC330055DE60 /* SurfaceView.swift in Sources */,
 				A59444F729A2ED5200725BBA /* SettingsView.swift in Sources */,
+				A5FECBD729D1FC3900022361 /* ContentView.swift in Sources */,
 				A55B7BB829B6F53A0055DE60 /* Package.swift in Sources */,
 				A55B7BBE29B701360055DE60 /* Ghostty.SplitView.swift in Sources */,
 				A55B7BB629B6F47F0055DE60 /* AppState.swift in Sources */,

--- a/macos/Sources/ContentView.swift
+++ b/macos/Sources/ContentView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+import GhosttyKit
+
+struct ContentView: View {
+    let ghostty: Ghostty.AppState
+    
+    @EnvironmentObject private var appDelegate: AppDelegate
+    
+    var body: some View {
+        switch ghostty.readiness {
+        case .loading:
+            Text("Loading")
+                .onChange(of: appDelegate.confirmQuit) { value in
+                    guard value else { return }
+                    NSApplication.shared.reply(toApplicationShouldTerminate: true)
+                }
+        case .error:
+            ErrorView()
+                .onChange(of: appDelegate.confirmQuit) { value in
+                    guard value else { return }
+                    NSApplication.shared.reply(toApplicationShouldTerminate: true)
+                }
+        case .ready:
+            Ghostty.TerminalSplit(onClose: Self.closeWindow)
+                .ghosttyApp(ghostty.app!)
+                .confirmationDialog(
+                    "Quit Ghostty?",
+                    isPresented: $appDelegate.confirmQuit) {
+                        Button("Close Ghostty", role: .destructive) {
+                            NSApplication.shared.reply(toApplicationShouldTerminate: true)
+                        }
+                        .keyboardShortcut(.defaultAction)
+                        
+                        Button("Cancel", role: .cancel) {
+                            NSApplication.shared.reply(toApplicationShouldTerminate: false)
+                        }
+                        .keyboardShortcut(.cancelAction)
+                    } message: {
+                        Text("All terminal sessions will be terminated.")
+                    }
+        }
+    }
+    
+    static func closeWindow() {
+        guard let currentWindow = NSApp.keyWindow else { return }
+        currentWindow.close()
+    }
+}

--- a/macos/Sources/ContentView.swift
+++ b/macos/Sources/ContentView.swift
@@ -4,7 +4,12 @@ import GhosttyKit
 struct ContentView: View {
     let ghostty: Ghostty.AppState
     
+    // We need access to our app delegate to know if we're quitting or not.
     @EnvironmentObject private var appDelegate: AppDelegate
+    
+    // We need access to our window to know if we're the key window to determine
+    // if we show the quit confirmation or not.
+    @State private var window: NSWindow?
     
     var body: some View {
         switch ghostty.readiness {
@@ -21,11 +26,18 @@ struct ContentView: View {
                     NSApplication.shared.reply(toApplicationShouldTerminate: true)
                 }
         case .ready:
+            let confirmQuitting = Binding<Bool>(get: {
+                self.appDelegate.confirmQuit && (self.window?.isKeyWindow ?? false)
+            }, set: {
+                self.appDelegate.confirmQuit = $0
+            })
+                                                        
             Ghostty.TerminalSplit(onClose: Self.closeWindow)
                 .ghosttyApp(ghostty.app!)
+                .background(WindowAccessor(window: $window))
                 .confirmationDialog(
                     "Quit Ghostty?",
-                    isPresented: $appDelegate.confirmQuit) {
+                    isPresented: confirmQuitting) {
                         Button("Close Ghostty", role: .destructive) {
                             NSApplication.shared.reply(toApplicationShouldTerminate: true)
                         }

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -106,7 +106,13 @@ extension Ghostty {
         
         func appTick() {
             guard let app = self.app else { return }
-            ghostty_app_tick(app)
+            
+            // Tick our app, which lets us know if we want to quit
+            let exit = ghostty_app_tick(app)
+            if (!exit) { return }
+                
+            // We want to quit, start that process
+            NSApplication.shared.terminate(nil)
         }
         
         /// Request that the given surface is closed. This will trigger the full normal surface close event

--- a/macos/Sources/GhosttyApp.swift
+++ b/macos/Sources/GhosttyApp.swift
@@ -18,15 +18,7 @@ struct GhosttyApp: App {
     
     var body: some Scene {
         WindowGroup {
-            switch ghostty.readiness {
-            case .loading:
-                Text("Loading")
-            case .error:
-                ErrorView()
-            case .ready:
-                Ghostty.TerminalSplit(onClose: Self.closeWindow)
-                    .ghosttyApp(ghostty.app!)
-            }
+            ContentView(ghostty: ghostty)
         }
         .backport.defaultSize(width: 800, height: 600)
         .commands {
@@ -110,7 +102,9 @@ struct GhosttyApp: App {
     }
 }
 
-class AppDelegate: NSObject, NSApplicationDelegate {
+class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
+    @Published var confirmQuit: Bool = false
+    
     // See CursedMenuManager for more information.
     private var menuManager: CursedMenuManager?
     
@@ -123,6 +117,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Create our menu manager to create some custom menu items that
         // we can't create from SwiftUI.
         menuManager = CursedMenuManager()
+    }
+    
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        confirmQuit = true
+        return .terminateLater
     }
 }
 

--- a/macos/Sources/GhosttyApp.swift
+++ b/macos/Sources/GhosttyApp.swift
@@ -120,6 +120,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     }
     
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        let windows = NSApplication.shared.windows
+        if (windows.isEmpty) { return .terminateNow }
+        
+        // This probably isn't fully safe. The isEmpty check above is aspirational, it doesn't
+        // quit work with SwiftUI because windows are retained on close. So instead we check
+        // if there are any that are visible. I'm guessing this breaks under certain scenarios.
+        if (windows.allSatisfy { !$0.isVisible }) { return .terminateNow }
+        
+        // We have some visible window, and all our windows will watch the confirmQuit.
         confirmQuit = true
         return .terminateLater
     }

--- a/macos/Sources/SettingsView.swift
+++ b/macos/Sources/SettingsView.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 
 struct SettingsView: View {
+    // We need access to our app delegate to know if we're quitting or not.
+    @EnvironmentObject private var appDelegate: AppDelegate
+    
     var body: some View {
         HStack {
             Image("AppIconImage")
@@ -18,6 +21,10 @@ struct SettingsView: View {
         }
         .padding()
         .frame(minWidth: 500, maxWidth: 500, minHeight: 156, maxHeight: 156)
+        .onChange(of: appDelegate.confirmQuit) { value in
+            guard value else { return }
+            NSApplication.shared.reply(toApplicationShouldTerminate: true)
+        }
     }
 }
 

--- a/macos/Sources/WindowAccessor.swift
+++ b/macos/Sources/WindowAccessor.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+/// Allows accessing the window that this view is a part of.
+struct WindowAccessor: NSViewRepresentable {
+    @Binding var window: NSWindow?
+    
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async {
+            self.window = view.window
+        }
+        return view
+    }
+    
+    func updateNSView(_ nsView: NSView, context: Context) {}
+}

--- a/src/App.zig
+++ b/src/App.zig
@@ -81,8 +81,12 @@ pub fn tick(self: *App, rt_app: *apprt.App) !bool {
         i += 1;
     }
 
-    // Drain our mailbox only if we're not quitting.
-    if (!self.quit) try self.drainMailbox(rt_app);
+    // Drain our mailbox
+    try self.drainMailbox(rt_app);
+
+    // No matter what, we reset the quit flag after a tick. If the apprt
+    // doesn't want to quit, then we can't force it to.
+    defer self.quit = false;
 
     // We quit if our quit flag is on or if we have closed all surfaces.
     return self.quit or self.surfaces.items.len == 0;
@@ -175,11 +179,6 @@ fn newWindow(self: *App, rt_app: *apprt.App, msg: Message.NewWindow) !void {
 fn setQuit(self: *App) !void {
     if (self.quit) return;
     self.quit = true;
-
-    // Mark that all our surfaces should close
-    for (self.surfaces.items) |surface| {
-        surface.setShouldClose();
-    }
 }
 
 /// Handle a window message

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -390,9 +390,10 @@ pub const CAPI = struct {
 
     /// Tick the event loop. This should be called whenever the "wakeup"
     /// callback is invoked for the runtime.
-    export fn ghostty_app_tick(v: *App) void {
-        _ = v.core_app.tick(v) catch |err| {
+    export fn ghostty_app_tick(v: *App) bool {
+        return v.core_app.tick(v) catch |err| err: {
             log.err("error app tick err={}", .{err});
+            break :err false;
         };
     }
 

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -93,7 +93,13 @@ pub const App = struct {
 
             // Tick the terminal app
             const should_quit = try self.app.tick(self);
-            if (should_quit) return;
+            if (should_quit) {
+                for (self.app.surfaces.items) |surface| {
+                    surface.close(false);
+                }
+
+                return;
+            }
         }
     }
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -348,6 +348,11 @@ pub const Config = struct {
             );
             try result.keybind.set.put(
                 alloc,
+                .{ .key = .q, .mods = .{ .ctrl = true, .shift = true } },
+                .{ .quit = {} },
+            );
+            try result.keybind.set.put(
+                alloc,
                 .{ .key = .f4, .mods = .{ .alt = true } },
                 .{ .close_window = {} },
             );


### PR DESCRIPTION
Fixes #136 

This fixes numerous issues around quit confirmation:

  * The `quit` keybinding is now fully functional. `Cmd+Q` on macOS, `Ctrl+Shift+Q` on Linux
  * macos: a quit confirmation dialog is now shown
  * gtk: a quit confirmation dialog is now shown for tab close
  * gtk: a quit confirmation dialog is now shown for app close
  * glfw: quit keybinding doesn't crash

Previously, all quits were hard quits, this makes all quits graceful.

![CleanShot 2023-03-27 at 10 51 31@2x](https://user-images.githubusercontent.com/1299/228025051-6fa462a5-615d-4de4-970b-9ae32329e2fb.png)
