### PR TITLE
Allow configuring confirm close surface

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -164,6 +164,10 @@ pub const Config = struct {
     /// Additional configuration files to read.
     @"config-file": RepeatableString = .{},
 
+    // Confirms that a surface should be closed before closing it. This defaults
+    // to true. If set to false, surfaces will close without any confirmation.
+    @"confirm-close-surface": bool = true,
+
     /// This is set by the CLI parser for deinit.
     _arena: ?ArenaAllocator = null,
 


### PR DESCRIPTION
Some users may not worry about closing a surface (eg. window, split) and will just want it to close right away. This adds a configuration option and passes through the option when `close()` is called, by overriding the exit state of the child to always close the surface if it is configured not confirm on close.

Note: build is broken right now due to a dependency issue so haven't actually tested this. 