### PR TITLE
Semantic Prompt (OSC 133) Integration

### DIFF
--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1401,6 +1401,7 @@ pub fn setScrollingRegion(self: *Terminal, top: usize, bottom: usize) void {
 /// (OSC 133) only allow setting this for wherever the current active cursor
 /// is located.
 pub fn markSemanticPrompt(self: *Terminal, p: SemanticPrompt) void {
+    log.warn("semantic_prompt: {}", .{p});
     const row = self.screen.getRow(.{ .active = self.screen.cursor.y });
     row.setSemanticPrompt(switch (p) {
         .prompt => .prompt,

--- a/src/terminal/osc.zig
+++ b/src/terminal/osc.zig
@@ -276,6 +276,7 @@ pub const Parser = struct {
                     self.command = .{ .end_of_command = .{} };
                     self.complete = true;
                 },
+
                 else => self.state = .invalid,
             },
 

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -483,6 +483,12 @@ pub fn Stream(comptime Handler: type) type {
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
 
+                .end_of_input => {
+                    if (@hasDecl(T, "endOfInput")) {
+                        try self.handler.endOfInput();
+                    } else log.warn("unimplemented OSC callback: {}", .{cmd});
+                },
+
                 .end_of_command => |end| {
                     if (@hasDecl(T, "endOfCommand")) {
                         try self.handler.endOfCommand(end.exit_code);

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -471,6 +471,24 @@ pub fn Stream(comptime Handler: type) type {
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
 
+                .prompt_start => {
+                    if (@hasDecl(T, "promptStart")) {
+                        try self.handler.promptStart();
+                    } else log.warn("unimplemented OSC callback: {}", .{cmd});
+                },
+
+                .prompt_end => {
+                    if (@hasDecl(T, "promptEnd")) {
+                        try self.handler.promptEnd();
+                    } else log.warn("unimplemented OSC callback: {}", .{cmd});
+                },
+
+                .end_of_command => |end| {
+                    if (@hasDecl(T, "endOfCommand")) {
+                        try self.handler.endOfCommand(end.exit_code);
+                    } else log.warn("unimplemented OSC callback: {}", .{cmd});
+                },
+
                 else => if (@hasDecl(T, "oscUnimplemented"))
                     try self.handler.oscUnimplemented(cmd)
                 else

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1235,4 +1235,16 @@ const StreamHandler = struct {
             ),
         }, .{ .forever = {} });
     }
+
+    pub fn promptStart(self: *StreamHandler) !void {
+        self.terminal.markSemanticPrompt(.prompt);
+    }
+
+    pub fn promptEnd(self: *StreamHandler) !void {
+        self.terminal.markSemanticPrompt(.input);
+    }
+
+    pub fn endOfInput(self: *StreamHandler) !void {
+        self.terminal.markSemanticPrompt(.command);
+    }
 };


### PR DESCRIPTION
This implements http://per.bothner.com/blog/2019/shell-integration-proposal/ (partially)

If you run the Kitty shell integration with your shell, then Ghostty is now aware if a process is actively running or you're just sitting at the prompt input. If you're sitting at the prompt input, Ghostty will _no longer ask you to confirm close_. An example video is below.

For now, I recommend just using Kitty's shell integration directly, i.e. for fish its: https://github.com/kovidgoyal/kitty/blob/master/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish

If a shell integration isn't enabled, then we always confirm. 

https://github.com/mitchellh/ghostty/assets/1299/431ab00d-be24-44d4-ac08-80183d21f52c

