### PR TITLE
Handle non-printable characters when ctrl is pressed

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1148,6 +1148,9 @@ pub fn keyCallback(
             // we convert to a non-printable.
             if (mods_int == ctrl_only) {
                 const val: u8 = switch (key) {
+                    .left_bracket => 0x1B,
+                    .backslash => 0x1C,
+                    .right_bracket => 0x1D,
                     .a => 0x01,
                     .b => 0x02,
                     .c => 0x03,


### PR DESCRIPTION
This extends the list of characters we convert to non-printable characters when control is pressed by adding `backslash`, `left_bracket`, `right_bracket` to the list.

This is based on the ["Legacy `ctrl` mapping of ASCII keys" section in the Kitty documentation](https://sw.kovidgoyal.net/kitty/keyboard-protocol/#legacy-ctrl-mapping-of-ascii-keys). That page also links to the [VT100 documentation](https://vt100.net/docs/vt100-ug/chapter3.html) that contains Table 3-5, which shows the same mappings at the Kitty documentation.

I started out wanting to add only `left_bracket` because I very often use ctrl+[ to escape insert mode in Vim (it maps to escape), but then added `backslash`, `right_bracket` too because they're next in the list and having `ctrl+right_bracket` mapped also makes it work in Vim as the default go-to-def combination.

Why not complete the whole table? Some keys aren't yet handled in `input.zig`, such as `circumflex` (not defined), and mitchellh said that it'd require more elaborate handling of different keyboard layouts. So instead of adding something that might be wrong, I tried to add what I knew (and tested) to work.