### PR TITLE
Semantic Prompt Redraw

### DIFF
--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -2027,6 +2027,7 @@ pub fn resize(self: *Screen, rows: usize, cols: usize) !void {
                         try self.scroll(.{ .delta = 1 });
                     }
                     new_row = self.getRow(.{ .active = y });
+                    new_row.setSemanticPrompt(old_row.getSemanticPrompt());
                 }
             }
         }
@@ -2112,6 +2113,8 @@ pub fn resize(self: *Screen, rows: usize, cols: usize) !void {
                 }
 
                 const row = self.getRow(.{ .active = y });
+                row.setSemanticPrompt(old_row.getSemanticPrompt());
+
                 fastmem.copy(
                     StorageCell,
                     row.storage[1..],
@@ -2125,6 +2128,7 @@ pub fn resize(self: *Screen, rows: usize, cols: usize) !void {
             // Slow path: the row is wrapped or doesn't fit so we have to
             // wrap ourselves. In this case, we basically just "print and wrap"
             var row = self.getRow(.{ .active = y });
+            row.setSemanticPrompt(old_row.getSemanticPrompt());
             var x: usize = 0;
             var cur_old_row = old_row;
             var cur_old_row_wrapped = old_row_wrapped;
@@ -2145,6 +2149,7 @@ pub fn resize(self: *Screen, rows: usize, cols: usize) !void {
                         }
 
                         row = self.getRow(.{ .active = y });
+                        row.setSemanticPrompt(cur_old_row.getSemanticPrompt());
                     }
 
                     // If our cursor is on this char, then set the new cursor.

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -471,9 +471,9 @@ pub fn Stream(comptime Handler: type) type {
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
 
-                .prompt_start => {
+                .prompt_start => |v| {
                     if (@hasDecl(T, "promptStart")) {
-                        try self.handler.promptStart();
+                        try self.handler.promptStart(v.aid, v.redraw);
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1236,8 +1236,10 @@ const StreamHandler = struct {
         }, .{ .forever = {} });
     }
 
-    pub fn promptStart(self: *StreamHandler) !void {
+    pub fn promptStart(self: *StreamHandler, aid: ?[]const u8, redraw: bool) !void {
+        _ = aid;
         self.terminal.markSemanticPrompt(.prompt);
+        self.terminal.modes.shell_redraws_prompt = redraw;
     }
 
     pub fn promptEnd(self: *StreamHandler) !void {


### PR DESCRIPTION
**This requires shell integration (see #146).**

For shells that integrate (all modern shells support this feature), resizing no longer creates artifacts with complex prompts. On resize, we now detect if our cursor is at an active prompt and erase the prompt lines, allowing the shell to redraw them. Modern shells work this way. 

If a shell does not notify us it is capable of doing this (by not integrating with semantic prompts, or OSC 133), then we attempt to reflow as we did before.

## Demo: Before (No shell integration, glitchy resize)

https://github.com/mitchellh/ghostty/assets/1299/f26cc5f3-f6ab-432b-834c-7301b836883d

## Demo: After (with this PR)

https://github.com/mitchellh/ghostty/assets/1299/63ee8e03-c60e-4f47-b0b7-2f342525f15c

(Note: the resizing is more "flashy" not, see/similar to #42)