### PR TITLE
OSC 7 (report pwd) and new Window/Tab/Split uses current cwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ April 2022.
 
 To configure Ghostty, you must use a configuration file. GUI-based configuration
 is on the roadmap but not yet supported. The configuration file must be
-placed at `$XDG_CONFIG_HOME/ghostty/config`, which defaults to 
+placed at `$XDG_CONFIG_HOME/ghostty/config`, which defaults to
 `~/.config/ghostty/config` if the [XDG environment is not set](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
 
 The file format is documented below as an example:
@@ -90,16 +90,18 @@ Eventually, we'll have a better mecanism for showing errors to the user.
 ### Shell Integration
 
 Ghostty supports some features that require shell integration. I am aiming
-to support many of the features that 
+to support many of the features that
 [Kitty supports for shell integration](https://sw.kovidgoyal.net/kitty/shell-integration/).
-
-Today, the most important quality-of-life feature is that Ghostty will
-not confirm window close if it detects that the cursor is sitting at a prompt
-input (i.e. no subprocess is running). 
 
 To enable this functionality, I recommend sourcing Kitty's shell integration
 files directly for your shell configuration when running Ghostty. For
 example, for fish, [source this file](https://github.com/kovidgoyal/kitty/blob/master/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish).
+
+The currently support shell integration features in Ghostty:
+
+  * We do not confirm close for windows where the cursor is at a prompt.
+  * New terminals start in the working directory of the previously focused terminal.
+  * The cursor at the prompt is turned into a bar.
 
 ## Roadmap and Status
 

--- a/src/App.zig
+++ b/src/App.zig
@@ -129,7 +129,7 @@ pub fn deleteSurface(self: *App, rt_surface: *apprt.Surface) void {
 
 /// The last focused surface. This is only valid while on the main thread
 /// before tick is called.
-pub fn focusedSurface(self: *App) ?*Surface {
+pub fn focusedSurface(self: *const App) ?*Surface {
     const surface = self.focused_surface orelse return null;
     if (!self.hasSurface(surface)) return null;
     return surface;
@@ -214,7 +214,7 @@ fn surfaceMessage(self: *App, surface: *Surface, msg: apprt.surface.Message) !vo
     // Not a problem.
 }
 
-fn hasSurface(self: *App, surface: *Surface) bool {
+fn hasSurface(self: *const App, surface: *const Surface) bool {
     for (self.surfaces.items) |v| {
         if (&v.core_surface == surface) return true;
     }

--- a/src/App.zig
+++ b/src/App.zig
@@ -127,6 +127,14 @@ pub fn deleteSurface(self: *App, rt_surface: *apprt.Surface) void {
     }
 }
 
+/// The last focused surface. This is only valid while on the main thread
+/// before tick is called.
+pub fn focusedSurface(self: *App) ?*Surface {
+    const surface = self.focused_surface orelse return null;
+    if (!self.hasSurface(surface)) return null;
+    return surface;
+}
+
 /// Drain the mailbox.
 fn drainMailbox(self: *App, rt_app: *apprt.App) !void {
     while (self.mailbox.pop()) |message| {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -631,6 +631,16 @@ fn changeConfig(self: *Surface, config: *const configpkg.Config) !void {
     };
 }
 
+/// Returns the pwd of the terminal, if any. This is always copied because
+/// the pwd can change at any point from termio. If we are calling from the IO
+/// thread you should just check the terminal directly.
+pub fn pwd(self: *const Surface, alloc: Allocator) !?[]const u8 {
+    self.renderer_state.mutex.lock();
+    defer self.renderer_state.mutex.unlock();
+    const terminal_pwd = self.io.terminal.getPwd() orelse return null;
+    return try alloc.dupe(u8, terminal_pwd);
+}
+
 /// Returns the x/y coordinate of where the IME (Input Method Editor)
 /// keyboard should be rendered.
 pub fn imePoint(self: *const Surface) apprt.IMEPos {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1224,6 +1224,13 @@ pub fn focusCallback(self: *Surface, focused: bool) !void {
         .focus = focused,
     }, .{ .forever = {} });
 
+    // Notify our app if we gained focus.
+    if (focused) {
+        _ = self.app_mailbox.push(.{
+            .focus = self,
+        }, .{ .forever = {} });
+    }
+
     // Schedule render which also drains our mailbox
     try self.queueRender();
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -144,6 +144,8 @@ pub const Surface = struct {
     };
 
     pub fn init(self: *Surface, app: *App, opts: Options) !void {
+        const alloc = app.core_app.alloc;
+
         self.* = .{
             .app = app,
             .core_surface = undefined,
@@ -161,11 +163,25 @@ pub const Surface = struct {
         try app.core_app.addSurface(self);
         errdefer app.core_app.deleteSurface(self);
 
+        // Our parent pwd will be tracked here
+        var parent_pwd: ?[]const u8 = null;
+        defer if (parent_pwd) |v| alloc.free(v);
+
+        // Shallow copy the config so that we can modify it.
+        var config = app.config.*;
+
+        // Get our previously focused surface
+        const parent = app.core_app.focusedSurface();
+        if (parent) |p| {
+            parent_pwd = try p.pwd(alloc);
+            if (parent_pwd) |v| config.@"working-directory" = v;
+        }
+
         // Initialize our surface right away. We're given a view that is
         // ready to use.
         try self.core_surface.init(
-            app.core_app.alloc,
-            app.config,
+            alloc,
+            &config,
             .{ .rt_app = app, .mailbox = &app.core_app.mailbox },
             self,
         );

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -346,24 +346,13 @@ pub const Surface = struct {
         try app.app.addSurface(self);
         errdefer app.app.deleteSurface(self);
 
-        // Our parent pwd will be tracked here
-        const alloc = app.app.alloc;
-        var parent_pwd: ?[]const u8 = null;
-        defer if (parent_pwd) |v| alloc.free(v);
-
-        // Shallow copy the config so that we can modify it.
-        var config = app.config;
-
-        // Get our previously focused surface
-        const parent = app.app.focusedSurface();
-        if (parent) |p| {
-            parent_pwd = try p.pwd(alloc);
-            if (parent_pwd) |v| config.@"working-directory" = v;
-        }
+        // Get our new surface config
+        var config = try apprt.surface.newConfig(app.app, &app.config);
+        defer config.deinit();
 
         // Initialize our surface now that we have the stable pointer.
         try self.core_surface.init(
-            alloc,
+            app.app.alloc,
             &config,
             .{ .rt_app = app, .mailbox = &app.app.mailbox },
             self,

--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -722,10 +722,14 @@ pub const Surface = struct {
         try self.app.core_app.addSurface(self);
         errdefer self.app.core_app.deleteSurface(self);
 
+        // Get our new surface config
+        var config = try apprt.surface.newConfig(self.app.core_app, &self.app.config);
+        defer config.deinit();
+
         // Initialize our surface now that we have the stable pointer.
         try self.core_surface.init(
             self.app.core_app.alloc,
-            &self.app.config,
+            &config,
             .{ .rt_app = self.app, .mailbox = &self.app.core_app.mailbox },
             self,
         );

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -61,3 +61,24 @@ pub const Mailbox = struct {
         }, timeout);
     }
 };
+
+/// Returns a new config for a surface for the given app that should be
+/// used for any new surfaces. The resulting config should be deinitialized
+/// after the surface is initialized.
+pub fn newConfig(app: *const App, config: *const Config) !Config {
+    // Create a shallow clone
+    var copy = config.shallowClone(app.alloc);
+
+    // Our allocator is our config's arena
+    const alloc = copy._arena.?.allocator();
+
+    // Get our previously focused surface for some inherited values.
+    const prev = app.focusedSurface();
+    if (prev) |p| {
+        if (try p.pwd(alloc)) |pwd| {
+            copy.@"working-directory" = pwd;
+        }
+    }
+
+    return copy;
+}

--- a/src/config.zig
+++ b/src/config.zig
@@ -691,6 +691,21 @@ pub const Config = struct {
         }
     }
 
+    /// Create a shallow copy of this config. This will share all the memory
+    /// allocated with the previous config but will have a new arena for
+    /// any changes or new allocations. The config should have `deinit`
+    /// called when it is complete.
+    ///
+    /// Beware: these shallow clones are not meant for a long lifetime,
+    /// they are just meant to exist temporarily for the duration of some
+    /// modifications. It is very important that the original config not
+    /// be deallocated while shallow clones exist.
+    pub fn shallowClone(self: *const Config, alloc_gpa: Allocator) Config {
+        var result = self.*;
+        result._arena = ArenaAllocator.init(alloc_gpa);
+        return result;
+    }
+
     /// Create a copy of this configuration. This is useful as a starting
     /// point for modifying a configuration since a config can NOT be
     /// modified once it is in use by an app or surface.

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1514,7 +1514,7 @@ pub fn setPwd(self: *Terminal, pwd: []const u8) !void {
 
 /// Returns the pwd for the terminal, if any. The memory is owned by the
 /// Terminal and is not copied. It is safe until a reset or setPwd.
-pub fn getPwd(self: *Terminal) ?[]const u8 {
+pub fn getPwd(self: *const Terminal) ?[]const u8 {
     if (self.pwd.items.len == 0) return null;
     return self.pwd.items;
 }

--- a/src/terminal/osc.zig
+++ b/src/terminal/osc.zig
@@ -242,7 +242,7 @@ pub const Parser = struct {
 
             .@"7" => switch (c) {
                 ';' => {
-                    self.command = .{ .report_pwd = .{ .value = undefined } };
+                    self.command = .{ .report_pwd = .{ .value = "" } };
 
                     self.state = .string;
                     self.temp_state = .{ .str = &self.command.report_pwd.value };
@@ -591,6 +591,17 @@ test "OSC: report pwd" {
     const cmd = p.end().?;
     try testing.expect(cmd == .report_pwd);
     try testing.expect(std.mem.eql(u8, "file:///tmp/example", cmd.report_pwd.value));
+}
+
+test "OSC: report pwd empty" {
+    const testing = std.testing;
+
+    var p: Parser = .{};
+
+    const input = "7;";
+    for (input) |ch| p.next(ch);
+
+    try testing.expect(p.end() == null);
 }
 
 test "OSC: longer than buffer" {

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -495,6 +495,12 @@ pub fn Stream(comptime Handler: type) type {
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
 
+                .report_pwd => |v| {
+                    if (@hasDecl(T, "reportPwd")) {
+                        try self.handler.reportPwd(v.value);
+                    } else log.warn("unimplemented OSC callback: {}", .{cmd});
+                },
+
                 else => if (@hasDecl(T, "oscUnimplemented"))
                     try self.handler.oscUnimplemented(cmd)
                 else


### PR DESCRIPTION
This implements parsing and storing [OSC 7](https://gitlab.freedesktop.org/terminal-wg/specifications/-/issues/20), which reports the currently active working directory in a shell. We parse both the regular (Terminal.app) and Kitty-style OSC 7 syntax.

The app is augmented to track the last focused surface.

When creating a new surface (window, tab, split), if we have a last-reported working directory for the previously-focused surface, then we will use that to initialize the new surface. 

**Note: this currently cannot be disabled, and there are no separate keybindings to launch with the default (or different) working directory. That's left as a future exercise if its useful.**

# Demo

https://github.com/mitchellh/ghostty/assets/1299/cc3c50c4-cf45-4197-9d4e-ed1c6b127ce2