### PR TITLE
Colored Underlines

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -30,4 +30,3 @@ Major Features:
 * Sixels: https://saitoha.github.io/libsixel/
 * Kitty keyboard protocol: https://sw.kovidgoyal.net/kitty/keyboard-protocol/
 * Kitty graphics protocol: https://sw.kovidgoyal.net/kitty/graphics-protocol/
-* Colored underlines: https://sw.kovidgoyal.net/kitty/underlines/

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1023,11 +1023,13 @@ pub fn updateCell(
             null,
         );
 
+        const color = if (cell.attrs.underline_color) cell.underline_fg else colors.fg;
+
         self.cells.appendAssumeCapacity(.{
             .mode = .fg,
             .grid_pos = .{ @intToFloat(f32, x), @intToFloat(f32, y) },
             .cell_width = cell.widthLegacy(),
-            .color = .{ colors.fg.r, colors.fg.g, colors.fg.b, alpha },
+            .color = .{ color.r, color.g, color.b, alpha },
             .glyph_pos = .{ glyph.atlas_x, glyph.atlas_y },
             .glyph_size = .{ glyph.width, glyph.height },
             .glyph_offset = .{ glyph.offset_x, glyph.offset_y },

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -1181,6 +1181,9 @@ pub fn updateCell(
             @enumToInt(sprite),
             null,
         );
+
+        const color = if (cell.attrs.underline_color) cell.underline_fg else colors.fg;
+
         self.cells.appendAssumeCapacity(.{
             .mode = .fg,
             .grid_col = @intCast(u16, x),
@@ -1192,9 +1195,9 @@ pub fn updateCell(
             .glyph_height = underline_glyph.height,
             .glyph_offset_x = underline_glyph.offset_x,
             .glyph_offset_y = underline_glyph.offset_y,
-            .fg_r = colors.fg.r,
-            .fg_g = colors.fg.g,
-            .fg_b = colors.fg.b,
+            .fg_r = color.r,
+            .fg_g = color.g,
+            .fg_b = color.b,
             .fg_a = alpha,
             .bg_r = 0,
             .bg_g = 0,

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -182,6 +182,12 @@ pub const Cell = struct {
     fg: color.RGB = .{},
     bg: color.RGB = .{},
 
+    /// Underline color.
+    /// NOTE(mitchellh): This is very rarely set so ideally we wouldn't waste
+    /// cell space for this. For now its on this struct because it is convenient
+    /// but we should consider a lookaside table for this.
+    underline_fg: color.RGB = .{},
+
     /// On/off attributes that can be set
     attrs: packed struct {
         has_bg: bool = false,
@@ -194,6 +200,7 @@ pub const Cell = struct {
         inverse: bool = false,
         strikethrough: bool = false,
         underline: sgr.Attribute.Underline = .none,
+        underline_color: bool = false,
 
         /// True if this is a wide character. This char takes up
         /// two cells. The following cell ALWAYS is a space.
@@ -265,7 +272,7 @@ pub const Cell = struct {
 
     test {
         //log.warn("CELL={} bits={} {}", .{ @sizeOf(Cell), @bitSizeOf(Cell), @alignOf(Cell) });
-        try std.testing.expectEqual(12, @sizeOf(Cell));
+        try std.testing.expectEqual(16, @sizeOf(Cell));
     }
 };
 

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -461,8 +461,18 @@ pub fn setAttribute(self: *Terminal, attr: sgr.Attribute) !void {
             self.screen.cursor.pen.attrs.underline = .none;
         },
 
-        // TODO
-        .underline_color, .reset_underline_color => {},
+        .underline_color => |rgb| {
+            self.screen.cursor.pen.attrs.underline_color = true;
+            self.screen.cursor.pen.underline_fg = .{
+                .r = rgb.r,
+                .g = rgb.g,
+                .b = rgb.b,
+            };
+        },
+
+        .reset_underline_color => {
+            self.screen.cursor.pen.attrs.underline_color = false;
+        },
 
         .blink => {
             log.warn("blink requested, but not implemented", .{});

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -461,6 +461,9 @@ pub fn setAttribute(self: *Terminal, attr: sgr.Attribute) !void {
             self.screen.cursor.pen.attrs.underline = .none;
         },
 
+        // TODO
+        .underline_color, .reset_underline_color => {},
+
         .blink => {
             log.warn("blink requested, but not implemented", .{});
             self.screen.cursor.pen.attrs.blink = true;

--- a/src/terminal/sgr.zig
+++ b/src/terminal/sgr.zig
@@ -33,6 +33,8 @@ pub const Attribute = union(enum) {
     /// Underline the text
     underline: Underline,
     reset_underline: void,
+    underline_color: RGB,
+    reset_underline_color: void,
 
     /// Blink the text
     blink: void,
@@ -210,8 +212,12 @@ pub const Parser = struct {
             48 => if (slice.len >= 5 and slice[1] == 2) {
                 self.idx += 4;
 
-                // In the 6-len form, ignore the 3rd param.
-                const rgb = slice[2..5];
+                // In the 6-len form, ignore the 3rd param. Otherwise, use it.
+                const rgb = if (slice.len == 5) slice[2..5] else rgb: {
+                    // Consume one more element
+                    self.idx += 1;
+                    break :rgb slice[3..6];
+                };
 
                 // We use @truncate because the value should be 0 to 255. If
                 // it isn't, the behavior is undefined so we just... truncate it.
@@ -230,6 +236,29 @@ pub const Parser = struct {
             },
 
             49 => return Attribute{ .reset_bg = {} },
+
+            58 => if (slice.len >= 5 and slice[1] == 2) {
+                self.idx += 4;
+
+                // In the 6-len form, ignore the 3rd param. Otherwise, use it.
+                const rgb = if (slice.len == 5) slice[2..5] else rgb: {
+                    // Consume one more element
+                    self.idx += 1;
+                    break :rgb slice[3..6];
+                };
+
+                // We use @truncate because the value should be 0 to 255. If
+                // it isn't, the behavior is undefined so we just... truncate it.
+                return Attribute{
+                    .underline_color = .{
+                        .r = @truncate(u8, rgb[0]),
+                        .g = @truncate(u8, rgb[1]),
+                        .b = @truncate(u8, rgb[2]),
+                    },
+                };
+            },
+
+            59 => return Attribute{ .reset_underline_color = {} },
 
             90...97 => return Attribute{
                 // 82 instead of 90 to offset to "bright" colors
@@ -436,4 +465,27 @@ test "sgr: 256 color" {
     var p: Parser = .{ .params = &[_]u16{ 38, 5, 161, 48, 5, 236 } };
     try testing.expect(p.next().? == .@"256_fg");
     try testing.expect(p.next().? == .@"256_bg");
+}
+
+test "sgr: underline color" {
+    {
+        const v = testParseColon(&[_]u16{ 58, 2, 1, 2, 3 });
+        try testing.expect(v == .underline_color);
+        try testing.expectEqual(@as(u8, 1), v.underline_color.r);
+        try testing.expectEqual(@as(u8, 2), v.underline_color.g);
+        try testing.expectEqual(@as(u8, 3), v.underline_color.b);
+    }
+
+    {
+        const v = testParseColon(&[_]u16{ 58, 2, 0, 1, 2, 3 });
+        try testing.expect(v == .underline_color);
+        try testing.expectEqual(@as(u8, 1), v.underline_color.r);
+        try testing.expectEqual(@as(u8, 2), v.underline_color.g);
+        try testing.expectEqual(@as(u8, 3), v.underline_color.b);
+    }
+}
+
+test "sgr: reset underline color" {
+    var p: Parser = .{ .params = &[_]u16{59} };
+    try testing.expect(p.next().? == .reset_underline_color);
 }

--- a/src/terminal/sgr.zig
+++ b/src/terminal/sgr.zig
@@ -345,6 +345,12 @@ test "sgr: underline styles" {
     }
 
     {
+        const v = testParseColon(&[_]u16{ 4, 3 });
+        try testing.expect(v == .underline);
+        try testing.expect(v.underline == .curly);
+    }
+
+    {
         const v = testParseColon(&[_]u16{ 4, 4 });
         try testing.expect(v == .underline);
         try testing.expect(v.underline == .dotted);

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -386,7 +386,7 @@ pub fn Stream(comptime Handler: type) type {
                 'm' => if (@hasDecl(T, "setAttribute")) {
                     var p: sgr.Parser = .{ .params = action.params, .colon = action.sep == .colon };
                     while (p.next()) |attr| {
-                        log.info("SGR attribute: {}", .{attr});
+                        // log.info("SGR attribute: {}", .{attr});
                         try self.handler.setAttribute(attr);
                     }
                 } else log.warn("unimplemented CSI callback: {}", .{action}),

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -386,7 +386,7 @@ pub fn Stream(comptime Handler: type) type {
                 'm' => if (@hasDecl(T, "setAttribute")) {
                     var p: sgr.Parser = .{ .params = action.params, .colon = action.sep == .colon };
                     while (p.next()) |attr| {
-                        //log.info("SGR attribute: {}", .{attr});
+                        log.info("SGR attribute: {}", .{attr});
                         try self.handler.setAttribute(attr);
                     }
                 } else log.warn("unimplemented CSI callback: {}", .{action}),

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -385,7 +385,10 @@ pub fn Stream(comptime Handler: type) type {
                 // SGR - Select Graphic Rendition
                 'm' => if (@hasDecl(T, "setAttribute")) {
                     var p: sgr.Parser = .{ .params = action.params, .colon = action.sep == .colon };
-                    while (p.next()) |attr| try self.handler.setAttribute(attr);
+                    while (p.next()) |attr| {
+                        //log.info("SGR attribute: {}", .{attr});
+                        try self.handler.setAttribute(attr);
+                    }
                 } else log.warn("unimplemented CSI callback: {}", .{action}),
 
                 // CPR - Request Cursor Postion Report

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1081,7 +1081,7 @@ const StreamHandler = struct {
 
     pub fn setAttribute(self: *StreamHandler, attr: terminal.Attribute) !void {
         switch (attr) {
-            .unknown => |unk| log.warn("unimplemented or unknown attribute: {any}", .{unk}),
+            .unknown => |unk| log.warn("unimplemented or unknown SGR attribute: {any}", .{unk}),
 
             else => self.terminal.setAttribute(attr) catch |err|
                 log.warn("error setting attribute {}: {}", .{ attr, err }),


### PR DESCRIPTION
Fixes bug found by @mrnugget 

Test script:

```sh
#!/usr/bin/env bash
echo -e '\e[4:3m\e[58:2::240:143:104mfoobarbaz\e[59m\e[4:0m\n'
```

Before fix:

![CleanShot 2023-06-20 at 09 42 25@2x](https://github.com/mitchellh/ghostty/assets/1299/d4381850-f991-44a5-a6f6-1b5ae5d510e7)

After fix:

![CleanShot 2023-06-20 at 09 42 47@2x](https://github.com/mitchellh/ghostty/assets/1299/d7a4c850-cea3-4a95-b49d-df09ceaa442e)
