### PR TITLE
Properly render curly underline and double underline with fonts with very low underline position metric

### DIFF
--- a/src/font/sprite/underline.zig
+++ b/src/font/sprite/underline.zig
@@ -91,16 +91,26 @@ const Draw = struct {
 
     /// Draw a double underline.
     fn drawDouble(self: Draw, canvas: *font.sprite.Canvas) void {
+        // The maximum y value has to have space for the bottom underline.
+        // If we underflow (saturated) to 0, then we don't draw. This should
+        // never happen but we don't want to draw something undefined.
+        const y_max = self.height -| 1 -| self.thickness;
+        if (y_max == 0) return;
+
+        const space = self.thickness * 2;
+        const bottom = @min(self.pos + space, y_max);
+        const top = bottom - space;
+
         canvas.rect(.{
             .x = 0,
-            .y = @intCast(i32, self.pos),
+            .y = @intCast(i32, top),
             .width = self.width,
             .height = self.thickness,
         }, .on);
 
         canvas.rect(.{
             .x = 0,
-            .y = @intCast(i32, self.pos + (self.thickness * 2)),
+            .y = @intCast(i32, bottom),
             .width = self.width,
             .height = self.thickness,
         }, .on);

--- a/src/font/sprite/underline.zig
+++ b/src/font/sprite/underline.zig
@@ -24,10 +24,6 @@ pub fn renderGlyph(
     line_pos: u32,
     line_thickness: u32,
 ) !font.Glyph {
-    // Berkeley: warning: UNDERLINE RENDER width:18 height:37 pos:35 thickness:2
-    // Normal: warning: UNDERLINE RENDER width:18 height:38 pos:30 thickness:2
-    std.log.warn("UNDERLINE RENDER width:{} height:{} pos:{} thickness:{}", .{ width, height, line_pos, line_thickness });
-
     // Create the canvas we'll use to draw. We draw the underline in
     // a full cell size and position it according to "pos".
     var canvas = try font.sprite.Canvas.init(alloc, width, height);


### PR DESCRIPTION
Bug found by @mrnugget 

Certain fonts report a very low (in the cell) underline position, causing our underline drawing math to do the wrong thing. For example, Berkeley Mono at font size 12 advertises an underline position of y=35 but our calculated cell height is h=38. Previously, we'd draw an undercurl with maximum wave height (crest to trough) of `h - 1 - y`. This results in a maximum height of 2 meaning each half-wave is only 1 pixel high, basically... flat. **This changes our calculation to force a minimum wave height for undercurls.**

While doing this, I also found double-underlines were broken in the same scenario, since we'd draw the second underline out of the cell bounds. So I changed the double-underline algorithm to take into account the maximum y better and always accommodate both underlines.

In both scenarios, these fonts that report low underline positions may result in the underlines slightly clipping the bottom of certain glyphs (see the comma character in the comparisons below). I think this is okay for a properly rendered underline.

Another question to ask: are we calculating cell metrics _wrong_? The underline position is advertised directly from the font but the cell height is computed by us. Should the latter actually be slightly higher? Or... is the font advertising a bad underline position in the consideration of things such as double-underline or curls? There are a bunch of ways to clean this up. I think this protection in the underline sprite drawing is good to have in any case.

## Before

**Note the curly and double underlines in the comparison.**

![CleanShot 2023-06-22 at 16 08 55@2x](https://github.com/mitchellh/ghostty/assets/1299/7b4eb58b-bece-4591-b82b-79fd080ef865)

## After

![CleanShot 2023-06-22 at 16 08 24@2x](https://github.com/mitchellh/ghostty/assets/1299/62d6bfcb-3ca9-4856-a1c8-0a291f49cfdc)
