### PR TITLE
Implement SGR 8/28 Invisible

### DIFF
--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -1056,22 +1056,26 @@ pub fn updateCell(
         // cell is selected.
         // TODO(perf): we can check in advance if selection is in
         // our viewport at all and not run this on every point.
-        if (selection) |sel| {
-            const screen_point = (terminal.point.Viewport{
-                .x = x,
-                .y = y,
-            }).toScreen(screen);
+        var selection_res: ?BgFg = sel_colors: {
+            if (selection) |sel| {
+                const screen_point = (terminal.point.Viewport{
+                    .x = x,
+                    .y = y,
+                }).toScreen(screen);
 
-            // If we are selected, we use the selection colors
-            if (sel.contains(screen_point)) {
-                break :colors BgFg{
-                    .bg = self.config.selection_background orelse self.config.foreground,
-                    .fg = self.config.selection_foreground orelse self.config.background,
-                };
+                // If we are selected, we our colors are just inverted fg/bg
+                if (sel.contains(screen_point)) {
+                    break :sel_colors BgFg{
+                        .bg = self.config.selection_background orelse self.config.foreground,
+                        .fg = self.config.selection_foreground orelse self.config.background,
+                    };
+                }
             }
-        }
 
-        const res: BgFg = if (!cell.attrs.inverse) .{
+            break :sel_colors null;
+        };
+
+        const res: BgFg = selection_res orelse if (!cell.attrs.inverse) .{
             // In normal mode, background and fg match the cell. We
             // un-optionalize the fg by defaulting to our fg color.
             .bg = if (cell.attrs.has_bg) cell.bg else null,
@@ -1083,6 +1087,16 @@ pub fn updateCell(
             .bg = if (cell.attrs.has_fg) cell.fg else self.config.foreground,
             .fg = if (cell.attrs.has_bg) cell.bg else self.config.background,
         };
+
+        // If the cell is "invisible" then we just make fg = bg so that
+        // the cell is transparent but still copy-able.
+        if (cell.attrs.invisible) {
+            break :colors BgFg{
+                .bg = res.bg,
+                .fg = res.bg orelse self.config.background,
+            };
+        }
+
         break :colors res;
     };
 

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -198,6 +198,7 @@ pub const Cell = struct {
         faint: bool = false,
         blink: bool = false,
         inverse: bool = false,
+        invisible: bool = false,
         strikethrough: bool = false,
         underline: sgr.Attribute.Underline = .none,
         underline_color: bool = false,
@@ -272,7 +273,7 @@ pub const Cell = struct {
 
     test {
         //log.warn("CELL={} bits={} {}", .{ @sizeOf(Cell), @bitSizeOf(Cell), @alignOf(Cell) });
-        try std.testing.expectEqual(16, @sizeOf(Cell));
+        try std.testing.expectEqual(20, @sizeOf(Cell));
     }
 };
 

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -491,6 +491,14 @@ pub fn setAttribute(self: *Terminal, attr: sgr.Attribute) !void {
             self.screen.cursor.pen.attrs.inverse = false;
         },
 
+        .invisible => {
+            self.screen.cursor.pen.attrs.invisible = true;
+        },
+
+        .reset_invisible => {
+            self.screen.cursor.pen.attrs.invisible = false;
+        },
+
         .strikethrough => {
             self.screen.cursor.pen.attrs.strikethrough = true;
         },

--- a/src/terminal/sgr.zig
+++ b/src/terminal/sgr.zig
@@ -1,4 +1,4 @@
-//! SGR (Select Graphic Rendition) attribute parsing and types.
+//! SGR (Select Graphic Rendition) attrinvbute parsing and types.
 
 const std = @import("std");
 const testing = std.testing;
@@ -43,6 +43,10 @@ pub const Attribute = union(enum) {
     /// Invert fg/bg colors.
     inverse: void,
     reset_inverse: void,
+
+    /// Invisible
+    invisible: void,
+    reset_invisible: void,
 
     /// Strikethrough the text.
     strikethrough: void,
@@ -163,6 +167,8 @@ pub const Parser = struct {
 
             7 => return Attribute{ .inverse = {} },
 
+            8 => return Attribute{ .invisible = {} },
+
             9 => return Attribute{ .strikethrough = {} },
 
             22 => return Attribute{ .reset_bold = {} },
@@ -174,6 +180,8 @@ pub const Parser = struct {
             25 => return Attribute{ .reset_blink = {} },
 
             27 => return Attribute{ .reset_inverse = {} },
+
+            28 => return Attribute{ .reset_invisible = {} },
 
             29 => return Attribute{ .reset_strikethrough = {} },
 
@@ -498,4 +506,10 @@ test "sgr: underline color" {
 test "sgr: reset underline color" {
     var p: Parser = .{ .params = &[_]u16{59} };
     try testing.expect(p.next().? == .reset_underline_color);
+}
+
+test "sgr: invisible" {
+    var p: Parser = .{ .params = &[_]u16{ 8, 28 } };
+    try testing.expect(p.next().? == .invisible);
+    try testing.expect(p.next().? == .reset_invisible);
 }


### PR DESCRIPTION
Fixes #155 

This follows the xterm and terminal.app behavior: the fg text is invisible but still copy-able. I do this by making invisible cells fg match their bg (even when selected). 

This unfortunately bumped our Cell memory requirements by 25% 😢 since our 1-bit addition pushed us over alignment. There are a lot of optimization opportunities on the cell structure and its a TODO to take that pass later.