### PR TITLE
CoreText Rasterizer 

### DIFF
--- a/pkg/macos/graphics/context.zig
+++ b/pkg/macos/graphics/context.zig
@@ -26,6 +26,27 @@ pub fn Context(comptime T: type) type {
             );
         }
 
+        pub fn setAllowsFontSmoothing(self: *T, v: bool) void {
+            c.CGContextSetAllowsFontSmoothing(
+                @ptrCast(self),
+                v,
+            );
+        }
+
+        pub fn setAllowsFontSubpixelPositioning(self: *T, v: bool) void {
+            c.CGContextSetAllowsFontSubpixelPositioning(
+                @ptrCast(self),
+                v,
+            );
+        }
+
+        pub fn setAllowsFontSubpixelQuantization(self: *T, v: bool) void {
+            c.CGContextSetAllowsFontSubpixelQuantization(
+                @ptrCast(self),
+                v,
+            );
+        }
+
         pub fn setShouldAntialias(self: *T, v: bool) void {
             c.CGContextSetShouldAntialias(
                 @ptrCast(self),
@@ -35,6 +56,20 @@ pub fn Context(comptime T: type) type {
 
         pub fn setShouldSmoothFonts(self: *T, v: bool) void {
             c.CGContextSetShouldSmoothFonts(
+                @ptrCast(self),
+                v,
+            );
+        }
+
+        pub fn setShouldSubpixelPositionFonts(self: *T, v: bool) void {
+            c.CGContextSetShouldSubpixelPositionFonts(
+                @ptrCast(self),
+                v,
+            );
+        }
+
+        pub fn setShouldSubpixelQuantizeFonts(self: *T, v: bool) void {
+            c.CGContextSetShouldSubpixelQuantizeFonts(
                 @ptrCast(self),
                 v,
             );

--- a/pkg/macos/graphics/context.zig
+++ b/pkg/macos/graphics/context.zig
@@ -101,6 +101,16 @@ pub fn Context(comptime T: type) type {
             );
         }
 
+        pub fn setRGBStrokeColor(self: *T, r: f64, g: f64, b: f64, alpha: f64) void {
+            c.CGContextSetRGBStrokeColor(
+                @ptrCast(self),
+                r,
+                g,
+                b,
+                alpha,
+            );
+        }
+
         pub fn setTextDrawingMode(self: *T, mode: TextDrawingMode) void {
             c.CGContextSetTextDrawingMode(
                 @ptrCast(self),

--- a/pkg/macos/text/font.zig
+++ b/pkg/macos/text/font.zig
@@ -130,6 +130,14 @@ pub const Font = opaque {
     pub fn getUnderlineThickness(self: *Font) f64 {
         return c.CTFontGetUnderlineThickness(@ptrCast(self));
     }
+
+    pub fn getUnitsPerEm(self: *Font) u32 {
+        return c.CTFontGetUnitsPerEm(@ptrCast(c.CTFontRef, self));
+    }
+
+    pub fn getSize(self: *Font) f64 {
+        return c.CTFontGetSize(@ptrCast(c.CTFontRef, self));
+    }
 };
 
 pub const FontOrientation = enum(c_uint) {

--- a/pkg/macos/text/font.zig
+++ b/pkg/macos/text/font.zig
@@ -132,11 +132,11 @@ pub const Font = opaque {
     }
 
     pub fn getUnitsPerEm(self: *Font) u32 {
-        return c.CTFontGetUnitsPerEm(@ptrCast(c.CTFontRef, self));
+        return c.CTFontGetUnitsPerEm(@ptrCast(self));
     }
 
     pub fn getSize(self: *Font) f64 {
-        return c.CTFontGetSize(@ptrCast(c.CTFontRef, self));
+        return c.CTFontGetSize(@ptrCast(self));
     }
 };
 

--- a/pkg/macos/text/line.zig
+++ b/pkg/macos/text/line.zig
@@ -30,29 +30,11 @@ pub const Line = opaque {
         self: *Line,
         opts: LineBoundsOptions,
     ) graphics.Rect {
-        // return @bitCast(c.CGRect, c.CTLineGetBoundsWithOptions(
-        //     @ptrCast(c.CTLineRef, self),
-        //     opts.cval(),
-        // ));
-
-        // We have to use a custom C wrapper here because there is some
-        // C ABI issue happening.
-        var result: graphics.Rect = undefined;
-        zig_cabi_CTLineGetBoundsWithOptions(
+        return @bitCast(c.CTLineGetBoundsWithOptions(
             @ptrCast(self),
             opts.cval(),
-            @ptrCast(&result),
-        );
-
-        return result;
+        ));
     }
-
-    // See getBoundsWithOptions
-    extern "c" fn zig_cabi_CTLineGetBoundsWithOptions(
-        c.CTLineRef,
-        c.CTLineBoundsOptions,
-        *c.CGRect,
-    ) void;
 
     pub fn getTypographicBounds(
         self: *Line,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -231,7 +231,7 @@ pub fn init(
                 if (try disco_it.next()) |face| {
                     log.info("font regular: {s}", .{try face.name()});
                     try group.addFace(alloc, .regular, face);
-                }
+                } else std.log.warn("font-family not found: {s}", .{family});
             }
             if (config.@"font-family-bold") |family| {
                 var disco_it = try disco.discover(.{
@@ -243,7 +243,7 @@ pub fn init(
                 if (try disco_it.next()) |face| {
                     log.info("font bold: {s}", .{try face.name()});
                     try group.addFace(alloc, .bold, face);
-                }
+                } else std.log.warn("font-family-bold not found: {s}", .{family});
             }
             if (config.@"font-family-italic") |family| {
                 var disco_it = try disco.discover(.{
@@ -255,7 +255,7 @@ pub fn init(
                 if (try disco_it.next()) |face| {
                     log.info("font italic: {s}", .{try face.name()});
                     try group.addFace(alloc, .italic, face);
-                }
+                } else std.log.warn("font-family-italic not found: {s}", .{family});
             }
             if (config.@"font-family-bold-italic") |family| {
                 var disco_it = try disco.discover(.{
@@ -268,7 +268,7 @@ pub fn init(
                 if (try disco_it.next()) |face| {
                     log.info("font bold+italic: {s}", .{try face.name()});
                     try group.addFace(alloc, .bold_italic, face);
-                }
+                } else std.log.warn("font-family-bold-italic not found: {s}", .{family});
             }
         }
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -34,6 +34,10 @@ pub const Config = struct {
         else => 12,
     },
 
+    /// Draw fonts with a thicker stroke, if supported. This is only supported
+    /// currently on macOS.
+    @"font-thicken": bool = false,
+
     /// Background color for the window.
     background: Color = .{ .r = 0x28, .g = 0x2C, .b = 0x34 },
 

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -269,7 +269,7 @@ pub fn renderGlyph(
     atlas: *font.Atlas,
     index: FontIndex,
     glyph_index: u32,
-    max_height: ?u16,
+    opts: font.face.RenderOptions,
 ) !Glyph {
     // Special-case fonts are rendered directly.
     if (index.special()) |sp| switch (sp) {
@@ -282,7 +282,7 @@ pub fn renderGlyph(
 
     const face = &self.faces.get(index.style).items[@intCast(index.idx)];
     try face.load(self.lib, self.size);
-    const glyph = try face.face.?.renderGlyph(alloc, atlas, glyph_index, max_height);
+    const glyph = try face.face.?.renderGlyph(alloc, atlas, glyph_index, opts);
     // log.warn("GLYPH={}", .{glyph});
     return glyph;
 }
@@ -383,7 +383,9 @@ pub const Wasm = struct {
     ) !*Glyph {
         const idx = @as(FontIndex, @bitCast(@as(u8, @intCast(idx_))));
         const max_height = if (max_height_ <= 0) null else max_height_;
-        const glyph = try self.renderGlyph(alloc, atlas, idx, cp, max_height);
+        const glyph = try self.renderGlyph(alloc, atlas, idx, cp, .{
+            .max_height = max_height,
+        });
 
         var result = try alloc.create(Glyph);
         errdefer alloc.destroy(result);
@@ -427,7 +429,7 @@ test {
             &atlas_greyscale,
             idx,
             glyph_index,
-            null,
+            .{},
         );
     }
 
@@ -483,7 +485,7 @@ test "box glyph" {
         &atlas_greyscale,
         idx,
         0x2500,
-        null,
+        .{},
     );
     try testing.expectEqual(@as(u32, 36), glyph.height);
 }
@@ -514,7 +516,7 @@ test "resize" {
             &atlas_greyscale,
             idx,
             glyph_index,
-            null,
+            .{},
         );
 
         try testing.expectEqual(@as(u32, 11), glyph.height);
@@ -531,7 +533,7 @@ test "resize" {
             &atlas_greyscale,
             idx,
             glyph_index,
-            null,
+            .{},
         );
 
         try testing.expectEqual(@as(u32, 21), glyph.height);
@@ -574,7 +576,7 @@ test "discover monospace with fontconfig and freetype" {
             &atlas_greyscale,
             idx,
             glyph_index,
-            null,
+            .{},
         );
     }
 }

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -282,7 +282,9 @@ pub fn renderGlyph(
 
     const face = &self.faces.get(index.style).items[@intCast(index.idx)];
     try face.load(self.lib, self.size);
-    return try face.face.?.renderGlyph(alloc, atlas, glyph_index, max_height);
+    const glyph = try face.face.?.renderGlyph(alloc, atlas, glyph_index, max_height);
+    // log.warn("GLYPH={}", .{glyph});
+    return glyph;
 }
 
 /// The wasm-compatible API.

--- a/src/font/GroupCache.zig
+++ b/src/font/GroupCache.zig
@@ -122,7 +122,7 @@ pub fn renderGlyph(
     alloc: Allocator,
     index: Group.FontIndex,
     glyph_index: u32,
-    max_height: ?u16,
+    opts: font.face.RenderOptions,
 ) !Glyph {
     const key: GlyphKey = .{ .index = index, .glyph = glyph_index };
     const gop = try self.glyphs.getOrPut(alloc, key);
@@ -140,7 +140,7 @@ pub fn renderGlyph(
         atlas,
         index,
         glyph_index,
-        max_height,
+        opts,
     ) catch |err| switch (err) {
         // If the atlas is full, we resize it
         error.AtlasFull => blk: {
@@ -150,7 +150,7 @@ pub fn renderGlyph(
                 atlas,
                 index,
                 glyph_index,
-                max_height,
+                opts,
             );
         },
 
@@ -203,7 +203,7 @@ test {
             alloc,
             idx,
             glyph_index,
-            null,
+            .{},
         );
     }
 
@@ -225,7 +225,7 @@ test {
                 alloc,
                 idx,
                 glyph_index,
-                null,
+                .{},
             );
         }
     }
@@ -300,7 +300,9 @@ pub const Wasm = struct {
     ) !*Glyph {
         const idx = @as(Group.FontIndex, @bitCast(@as(u8, @intCast(idx_))));
         const max_height = if (max_height_ <= 0) null else max_height_;
-        const glyph = try self.renderGlyph(alloc, idx, cp, max_height);
+        const glyph = try self.renderGlyph(alloc, idx, cp, .{
+            .max_height = max_height,
+        });
 
         var result = try alloc.create(Glyph);
         errdefer alloc.destroy(result);
@@ -352,7 +354,7 @@ test "resize" {
             alloc,
             idx,
             glyph_index,
-            null,
+            .{},
         );
 
         try testing.expectEqual(@as(u32, 11), glyph.height);
@@ -368,7 +370,7 @@ test "resize" {
             alloc,
             idx,
             glyph_index,
-            null,
+            .{},
         );
 
         try testing.expectEqual(@as(u32, 21), glyph.height);

--- a/src/font/face.zig
+++ b/src/font/face.zig
@@ -58,6 +58,20 @@ pub const Metrics = struct {
     strikethrough_thickness: f32,
 };
 
+/// Additional options for rendering glyphs.
+pub const RenderOptions = struct {
+    /// The maximum height of the glyph. If this is set, then any glyph
+    /// larger than this height will be shrunk to this height. The scaling
+    /// is typically naive, but ultimately up to the rasterizer.
+    max_height: ?u16 = null,
+
+    /// Thicken the glyph. This draws the glyph with a thicker stroke width.
+    /// This is purely an aesthetic setting.
+    ///
+    /// This only works with CoreText currently.
+    thicken: bool = false,
+};
+
 pub const Foo = if (options.backend == .coretext) coretext.Face else void;
 
 test {

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -161,11 +161,23 @@ pub const Face = struct {
         );
         defer ctx.release();
 
+        // Perform an initial fill so that we're sure it starts as we want.
+        ctx.setGrayFillColor(0, 0);
+        ctx.fillRect(.{
+            .origin = .{ .x = 0, .y = 0 },
+            .size = .{
+                .width = @intToFloat(f64, width),
+                .height = @intToFloat(f64, height),
+            },
+        });
+
         ctx.setAllowsAntialiasing(true);
         ctx.setShouldAntialias(true);
         ctx.setShouldSmoothFonts(true);
         ctx.setGrayFillColor(1, 1);
-        ctx.setGrayStrokeColor(1, 1);
+        // With this set the text gets chunky. With it unset the text doesn't
+        // look right at small font sizes. Something isn't right.
+        // ctx.setGrayStrokeColor(1, 1);
         ctx.setTextDrawingMode(.fill_stroke);
         ctx.setTextMatrix(macos.graphics.AffineTransform.identity());
         ctx.setTextPosition(0, 0);

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -102,10 +102,8 @@ pub const Face = struct {
         alloc: Allocator,
         atlas: *font.Atlas,
         glyph_index: u32,
-        max_height: ?u16,
+        opts: font.face.RenderOptions,
     ) !font.Glyph {
-        _ = max_height;
-
         var glyphs = [_]macos.graphics.Glyph{@intCast(glyph_index)};
 
         // Get the bounding rect for rendering this glyph.
@@ -205,7 +203,7 @@ pub const Face = struct {
         });
 
         ctx.setAllowsFontSmoothing(true);
-        ctx.setShouldSmoothFonts(false); // The amadeus "enthicken"
+        ctx.setShouldSmoothFonts(opts.thicken); // The amadeus "enthicken"
         ctx.setAllowsFontSubpixelQuantization(true);
         ctx.setShouldSubpixelQuantizeFonts(true);
         ctx.setAllowsFontSubpixelPositioning(true);
@@ -479,7 +477,7 @@ test {
     var i: u8 = 32;
     while (i < 127) : (i += 1) {
         try testing.expect(face.glyphIndex(i) != null);
-        _ = try face.renderGlyph(alloc, &atlas, face.glyphIndex(i).?, null);
+        _ = try face.renderGlyph(alloc, &atlas, face.glyphIndex(i).?, .{});
     }
 }
 
@@ -523,6 +521,6 @@ test "in-memory" {
     var i: u8 = 32;
     while (i < 127) : (i += 1) {
         try testing.expect(face.glyphIndex(i) != null);
-        _ = try face.renderGlyph(alloc, &atlas, face.glyphIndex(i).?, null);
+        _ = try face.renderGlyph(alloc, &atlas, face.glyphIndex(i).?, .{});
     }
 }

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -175,9 +175,7 @@ pub const Face = struct {
         ctx.setShouldAntialias(true);
         ctx.setShouldSmoothFonts(true);
         ctx.setGrayFillColor(1, 1);
-        // With this set the text gets chunky. With it unset the text doesn't
-        // look right at small font sizes. Something isn't right.
-        // ctx.setGrayStrokeColor(1, 1);
+        ctx.setGrayStrokeColor(1, 1);
         ctx.setTextDrawingMode(.fill_stroke);
         ctx.setTextMatrix(macos.graphics.AffineTransform.identity());
         ctx.setTextPosition(0, 0);

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -5,6 +5,8 @@ const macos = @import("macos");
 const harfbuzz = @import("harfbuzz");
 const font = @import("../main.zig");
 
+const log = std.log.scoped(.font_face);
+
 pub const Face = struct {
     /// Our font face
     font: *macos.text.Font,
@@ -171,6 +173,15 @@ pub const Face = struct {
                 @intFromEnum(macos.graphics.ImageAlphaInfo.premultiplied_first),
         };
         defer color.space.release();
+
+        // This is just a safety check.
+        if (atlas.format.depth() != color.depth) {
+            log.warn("font atlas color depth doesn't equal font color depth atlas={} font={}", .{
+                atlas.format.depth(),
+                color.depth,
+            });
+            return error.InvalidAtlasFormat;
+        }
 
         // Our buffer for rendering
         // TODO(perf): cache this buffer

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -317,6 +317,10 @@ pub const Face = struct {
         const strikethrough_position = cell_baseline * 0.6;
         const strikethrough_thickness = underline_thickness;
 
+        // Note: is this useful?
+        // const units_per_em = ct_font.getUnitsPerEm();
+        // const units_per_point = @intToFloat(f64, units_per_em) / ct_font.getSize();
+
         // std.log.warn("width={d}, height={d} baseline={d} underline_pos={d} underline_thickness={d}", .{
         //     cell_width,
         //     cell_height,

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -545,16 +545,22 @@ pub const Face = struct {
             // NOTE(mitchellh): For some reason, CTLineGetBoundsWithOptions
             // returns garbage and I can't figure out why... so we use the
             // raw ascender.
+            const bounds = line.getBoundsWithOptions(.{ .exclude_leading = true });
+            const bounds_ascent = bounds.size.height + bounds.origin.y;
+            const baseline = @floor(bounds_ascent + 0.5);
 
-            var ascent: f64 = 0;
-            var descent: f64 = 0;
-            var leading: f64 = 0;
-            _ = line.getTypographicBounds(&ascent, &descent, &leading);
+            // This is an alternate approach to the above to calculate the
+            // baseline by simply using the ascender. Using this approach led
+            // to less accurate results, but I'm leaving it here for reference.
+            // var ascent: f64 = 0;
+            // var descent: f64 = 0;
+            // var leading: f64 = 0;
+            // _ = line.getTypographicBounds(&ascent, &descent, &leading);
             //std.log.warn("ascent={} descent={} leading={}", .{ ascent, descent, leading });
 
             break :metrics .{
                 .height = @floatCast(points[0].y - points[1].y),
-                .ascent = @floatCast(ascent),
+                .ascent = @floatCast(baseline),
             };
         };
 

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -402,9 +402,7 @@ pub const Face = struct {
             const lines = frame.getLines();
             const line = lines.getValueAtIndex(macos.text.Line, 0);
 
-            // NOTE(mitchellh): For some reason, CTLineGetBoundsWithOptions
-            // returns garbage and I can't figure out why... so we use the
-            // raw ascender.
+            // Get the bounds of the line to determine the ascent.
             const bounds = line.getBoundsWithOptions(.{ .exclude_leading = true });
             const bounds_ascent = bounds.size.height + bounds.origin.y;
             const baseline = @floor(bounds_ascent + 0.5);

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -41,8 +41,10 @@ pub const Face = struct {
     /// because the font is loaded at a default size during discovery, and then
     /// adjusted to the final size for final load.
     pub fn initFontCopy(base: *macos.text.Font, size: font.face.DesiredSize) !Face {
-        // Create a copy
-        const ct_font = try base.copyWithAttributes(@floatFromInt(size.points), null);
+        // Create a copy. The copyWithAttributes docs say the size is in points,
+        // but we need to scale the points by the DPI and to do that we use our
+        // function called "pixels".
+        const ct_font = try base.copyWithAttributes(@floatFromInt(size.pixels()), null);
         errdefer ct_font.release();
 
         var hb_font = try harfbuzz.coretext.createFont(ct_font);

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -258,18 +258,6 @@ pub const Face = struct {
         atlas.set(region, buf);
 
         const offset_y: i32 = offset_y: {
-            // For non-scalable colorized fonts, we assume they are pictographic
-            // and just center the glyph. So far this has only applied to emoji
-            // fonts. Emoji fonts don't always report a correct ascender/descender
-            // (mainly Apple Emoji) so we just center them. Also, since emoji font
-            // aren't scalable, cell_baseline is incorrect anyways.
-            //
-            // NOTE(mitchellh): I don't know if this is right, this doesn't
-            // _feel_ right, but it makes all my limited test cases work.
-            if (color.color) {
-                break :offset_y @intFromFloat(self.metrics.cell_height);
-            }
-
             // Our Y coordinate in 3D is (0, 0) bottom left, +y is UP.
             // We need to calculate our baseline from the bottom of a cell.
             const baseline_from_bottom = self.metrics.cell_height - self.metrics.cell_baseline;
@@ -281,17 +269,17 @@ pub const Face = struct {
             break :offset_y @intFromFloat(@ceil(baseline_with_offset));
         };
 
-        log.warn("FONT FONT FONT rect={} width={} height={} render_x={} render_y={} offset_y={} ascent={} cell_height={} cell_baseline={}", .{
-            rect,
-            width,
-            height,
-            render_x,
-            render_y,
-            offset_y,
-            glyph_ascent,
-            self.metrics.cell_height,
-            self.metrics.cell_baseline,
-        });
+        // log.warn("renderGlyph rect={} width={} height={} render_x={} render_y={} offset_y={} ascent={} cell_height={} cell_baseline={}", .{
+        //     rect,
+        //     width,
+        //     height,
+        //     render_x,
+        //     render_y,
+        //     offset_y,
+        //     glyph_ascent,
+        //     self.metrics.cell_height,
+        //     self.metrics.cell_baseline,
+        // });
 
         return .{
             .width = width,

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -171,8 +171,10 @@ pub const Face = struct {
             return error.InvalidAtlasFormat;
         }
 
-        // Our buffer for rendering
-        // TODO(perf): cache this buffer
+        // Our buffer for rendering. We could cache this but glyph rasterization
+        // usually stabilizes pretty quickly and is very infrequent so I think
+        // the allocation overhead is acceptable compared to the cost of
+        // caching it forever or having to deal with a cache lifetime.
         var buf = try alloc.alloc(u8, width * height * color.depth);
         defer alloc.free(buf);
         @memset(buf, 0);

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -437,14 +437,15 @@ pub const Face = struct {
         // const units_per_em = ct_font.getUnitsPerEm();
         // const units_per_point = @intToFloat(f64, units_per_em) / ct_font.getSize();
 
-        std.log.warn("font size size={d}", .{ct_font.getSize()});
-        std.log.warn("font metrics width={d}, height={d} baseline={d} underline_pos={d} underline_thickness={d}", .{
-            cell_width,
-            cell_height,
-            cell_baseline,
-            underline_position,
-            underline_thickness,
-        });
+        // std.log.warn("font size size={d}", .{ct_font.getSize()});
+        // std.log.warn("font metrics width={d}, height={d} baseline={d} underline_pos={d} underline_thickness={d}", .{
+        //     cell_width,
+        //     cell_height,
+        //     cell_baseline,
+        //     underline_position,
+        //     underline_thickness,
+        // });
+
         return font.face.Metrics{
             .cell_width = cell_width,
             .cell_height = cell_height,

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -423,11 +423,16 @@ pub const Face = struct {
         // All of these metrics are based on our layout above.
         const cell_height = layout_metrics.height;
         const cell_baseline = layout_metrics.ascent;
-        const underline_position = @ceil(layout_metrics.ascent -
-            @as(f32, @floatCast(ct_font.getUnderlinePosition())));
         const underline_thickness = @ceil(@as(f32, @floatCast(ct_font.getUnderlineThickness())));
         const strikethrough_position = cell_baseline * 0.6;
         const strikethrough_thickness = underline_thickness;
+
+        // Underline position is based on our baseline because the font advertised
+        // underline position is based on a zero baseline. We add a small amount
+        // to the underline position to make it look better.
+        const underline_position = @ceil(cell_baseline -
+            @as(f32, @floatCast(ct_font.getUnderlinePosition())) +
+            1);
 
         // Note: is this useful?
         // const units_per_em = ct_font.getUnitsPerEm();

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -144,7 +144,7 @@ pub const Face = struct {
         // TODO(mitchellh): color is going to require a depth here
         var buf = try alloc.alloc(u8, width * height);
         defer alloc.free(buf);
-        std.mem.set(u8, buf, 0);
+        @memset(buf, 0);
 
         const space = try macos.graphics.ColorSpace.createDeviceGray();
         defer space.release();
@@ -166,8 +166,8 @@ pub const Face = struct {
         ctx.fillRect(.{
             .origin = .{ .x = 0, .y = 0 },
             .size = .{
-                .width = @intToFloat(f64, width),
-                .height = @intToFloat(f64, height),
+                .width = @floatFromInt(width),
+                .height = @floatFromInt(height),
             },
         });
 

--- a/src/font/face/freetype.zig
+++ b/src/font/face/freetype.zig
@@ -124,7 +124,7 @@ pub const Face = struct {
         alloc: Allocator,
         atlas: *font.Atlas,
         glyph_index: u32,
-        max_height: ?u16,
+        opts: font.face.RenderOptions,
     ) !Glyph {
         // If our glyph has color, we want to render the color
         try self.face.loadGlyph(glyph_index, .{
@@ -188,7 +188,7 @@ pub const Face = struct {
         // and copy the atlas.
         const bitmap_original = bitmap_converted orelse bitmap_ft;
         const bitmap_resized: ?freetype.c.struct_FT_Bitmap_ = resized: {
-            const max = max_height orelse break :resized null;
+            const max = opts.max_height orelse break :resized null;
             const bm = bitmap_original;
             if (bm.rows <= max) break :resized null;
 
@@ -522,16 +522,16 @@ test {
     // Generate all visible ASCII
     var i: u8 = 32;
     while (i < 127) : (i += 1) {
-        _ = try ft_font.renderGlyph(alloc, &atlas, ft_font.glyphIndex(i).?, null);
+        _ = try ft_font.renderGlyph(alloc, &atlas, ft_font.glyphIndex(i).?, .{});
     }
 
     // Test resizing
     {
-        const g1 = try ft_font.renderGlyph(alloc, &atlas, ft_font.glyphIndex('A').?, null);
+        const g1 = try ft_font.renderGlyph(alloc, &atlas, ft_font.glyphIndex('A').?, .{});
         try testing.expectEqual(@as(u32, 11), g1.height);
 
         try ft_font.setSize(.{ .points = 24, .xdpi = 96, .ydpi = 96 });
-        const g2 = try ft_font.renderGlyph(alloc, &atlas, ft_font.glyphIndex('A').?, null);
+        const g2 = try ft_font.renderGlyph(alloc, &atlas, ft_font.glyphIndex('A').?, .{});
         try testing.expectEqual(@as(u32, 21), g2.height);
     }
 }
@@ -551,11 +551,13 @@ test "color emoji" {
 
     try testing.expectEqual(Presentation.emoji, ft_font.presentation);
 
-    _ = try ft_font.renderGlyph(alloc, &atlas, ft_font.glyphIndex('🥸').?, null);
+    _ = try ft_font.renderGlyph(alloc, &atlas, ft_font.glyphIndex('🥸').?, .{});
 
     // resize
     {
-        const glyph = try ft_font.renderGlyph(alloc, &atlas, ft_font.glyphIndex('🥸').?, 24);
+        const glyph = try ft_font.renderGlyph(alloc, &atlas, ft_font.glyphIndex('🥸').?, .{
+            .max_height = 24,
+        });
         try testing.expectEqual(@as(u32, 24), glyph.height);
     }
 }
@@ -610,5 +612,5 @@ test "mono to rgba" {
     defer ft_font.deinit();
 
     // glyph 3 is mono in Noto
-    _ = try ft_font.renderGlyph(alloc, &atlas, 3, null);
+    _ = try ft_font.renderGlyph(alloc, &atlas, 3, .{});
 }

--- a/src/font/face/freetype.zig
+++ b/src/font/face/freetype.zig
@@ -467,15 +467,15 @@ pub const Face = struct {
             .thickness = underline_thickness,
         };
 
-        // log.warn("METRICS={} width={d} height={d} baseline={d} underline_pos={d} underline_thickness={d} strikethrough={}", .{
-        //     size_metrics,
-        //     cell_width,
-        //     cell_height,
-        //     cell_height - cell_baseline,
-        //     underline_position,
-        //     underline_thickness,
-        //     strikethrough,
-        // });
+        log.warn("METRICS={} width={d} height={d} baseline={d} underline_pos={d} underline_thickness={d} strikethrough={}", .{
+            size_metrics,
+            cell_width,
+            cell_height,
+            cell_height - cell_baseline,
+            underline_position,
+            underline_thickness,
+            strikethrough,
+        });
 
         return .{
             .cell_width = cell_width,

--- a/src/font/face/freetype.zig
+++ b/src/font/face/freetype.zig
@@ -475,15 +475,15 @@ pub const Face = struct {
             .thickness = underline_thickness,
         };
 
-        log.warn("METRICS={} width={d} height={d} baseline={d} underline_pos={d} underline_thickness={d} strikethrough={}", .{
-            size_metrics,
-            cell_width,
-            cell_height,
-            cell_height - cell_baseline,
-            underline_position,
-            underline_thickness,
-            strikethrough,
-        });
+        // log.warn("METRICS={} width={d} height={d} baseline={d} underline_pos={d} underline_thickness={d} strikethrough={}", .{
+        //     size_metrics,
+        //     cell_width,
+        //     cell_height,
+        //     cell_height - cell_baseline,
+        //     underline_position,
+        //     underline_thickness,
+        //     strikethrough,
+        // });
 
         return .{
             .cell_width = cell_width,

--- a/src/font/face/freetype.zig
+++ b/src/font/face/freetype.zig
@@ -328,6 +328,14 @@ pub const Face = struct {
             break :offset_y glyph_metrics.bitmap_top + @as(c_int, @intFromFloat(self.metrics.cell_baseline));
         };
 
+        // log.warn("renderGlyph width={} height={} offset_x={} offset_y={} glyph_metrics={}", .{
+        //     tgt_w,
+        //     tgt_h,
+        //     glyph_metrics.bitmap_left,
+        //     offset_y,
+        //     glyph_metrics,
+        // });
+
         // Store glyph metadata
         return Glyph{
             .width = tgt_w,

--- a/src/font/face/web_canvas.zig
+++ b/src/font/face/web_canvas.zig
@@ -190,9 +190,9 @@ pub const Face = struct {
         alloc: Allocator,
         atlas: *font.Atlas,
         glyph_index: u32,
-        max_height: ?u16,
+        opts: font.face.RenderOptions,
     ) !font.Glyph {
-        _ = max_height;
+        _ = opts;
 
         var render = try self.renderGlyphInternal(alloc, glyph_index);
         defer render.deinit();
@@ -551,7 +551,7 @@ pub const Wasm = struct {
     }
 
     fn face_render_glyph_(face: *Face, atlas: *font.Atlas, codepoint: u32) !*font.Glyph {
-        const glyph = try face.renderGlyph(alloc, atlas, codepoint, null);
+        const glyph = try face.renderGlyph(alloc, atlas, codepoint, .{});
 
         const result = try alloc.create(font.Glyph);
         errdefer alloc.destroy(result);

--- a/src/font/main.zig
+++ b/src/font/main.zig
@@ -71,12 +71,10 @@ pub const Backend = enum {
             };
         }
 
-        return if (target.isDarwin()) darwin: {
-            // On macOS right now, the coretext renderer is still pretty buggy
-            // so we default to coretext for font discovery and freetype for
-            // rasterization.
-            break :darwin .coretext_freetype;
-        } else .fontconfig_freetype;
+        // macOS also supports "coretext_freetype" but there is no scenario
+        // that is the default. It is only used by people who want to
+        // self-compile Ghostty and prefer the freetype aesthetic.
+        return if (target.isDarwin()) .coretext else .fontconfig_freetype;
     }
 
     // All the functions below can be called at comptime or runtime to

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -996,7 +996,9 @@ pub fn updateCell(
             self.alloc,
             shaper_run.font_index,
             shaper_cell.glyph_index,
-            @intFromFloat(@ceil(self.cell_size.height)),
+            .{
+                .max_height = @intFromFloat(@ceil(self.cell_size.height)),
+            },
         );
 
         // If we're rendering a color font, we use the color atlas
@@ -1031,7 +1033,7 @@ pub fn updateCell(
             self.alloc,
             font.sprite_index,
             @intFromEnum(sprite),
-            null,
+            .{},
         );
 
         const color = if (cell.attrs.underline_color) cell.underline_fg else colors.fg;
@@ -1083,7 +1085,7 @@ fn addCursor(self: *Metal, screen: *terminal.Screen) void {
         self.alloc,
         font.sprite_index,
         @intFromEnum(sprite),
-        null,
+        .{},
     ) catch |err| {
         log.warn("error rendering cursor glyph err={}", .{err});
         return;

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -129,6 +129,7 @@ const GPUCellMode = enum(u8) {
 /// configuration. This must be exported so that we don't need to
 /// pass around Config pointers which makes memory management a pain.
 pub const DerivedConfig = struct {
+    font_thicken: bool,
     cursor_color: ?terminal.color.RGB,
     background: terminal.color.RGB,
     foreground: terminal.color.RGB,
@@ -142,6 +143,8 @@ pub const DerivedConfig = struct {
         _ = alloc_gpa;
 
         return .{
+            .font_thicken = config.@"font-thicken",
+
             .cursor_color = if (config.@"cursor-color") |col|
                 col.toTerminalRGB()
             else
@@ -738,6 +741,14 @@ fn drawCells(
 
 /// Update the configuration.
 pub fn changeConfig(self: *Metal, config: *DerivedConfig) !void {
+    // If font thickening settings change, we need to reset our
+    // font texture completely because we need to re-render the glyphs.
+    if (self.config.font_thicken != config.font_thicken) {
+        self.font_group.reset();
+        self.font_group.atlas_greyscale.clear();
+        self.font_group.atlas_color.clear();
+    }
+
     self.config = config.*;
 }
 
@@ -998,6 +1009,7 @@ pub fn updateCell(
             shaper_cell.glyph_index,
             .{
                 .max_height = @intFromFloat(@ceil(self.cell_size.height)),
+                .thicken = self.config.font_thicken,
             },
         );
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -991,7 +991,7 @@ fn addCursor(self: *OpenGL, screen: *terminal.Screen) void {
         self.alloc,
         font.sprite_index,
         @intFromEnum(sprite),
-        null,
+        .{},
     ) catch |err| {
         log.warn("error rendering cursor glyph err={}", .{err});
         return;
@@ -1144,7 +1144,7 @@ pub fn updateCell(
             self.alloc,
             shaper_run.font_index,
             shaper_cell.glyph_index,
-            @intFromFloat(@ceil(self.cell_size.height)),
+            .{ .max_height = @intFromFloat(@ceil(self.cell_size.height)) },
         );
 
         // If we're rendering a color font, we use the color atlas
@@ -1190,7 +1190,7 @@ pub fn updateCell(
             self.alloc,
             font.sprite_index,
             @intFromEnum(sprite),
-            null,
+            .{},
         );
 
         const color = if (cell.attrs.underline_color) cell.underline_fg else colors.fg;


### PR DESCRIPTION
Fixes #93 

This PR completes and fixes all known issues with the CoreText rasterizer. This means that on macOS devices, Ghostty will now use CoreText instead of FreeType for rasterization. Rasterization is the process of "drawing" a single glyph (a glyph is anything from a letter to an emoji, a single drawable "letter"). 

# Why?

Previously, we used CoreText for _discovery_ (finding and loading fonts) but we used FreeType on both Mac and Linux for rasterization. The resulting text was pretty, but very subtle details meant that it would mismatch other native Mac applications. By switching to CoreText for rasterization, our glyphs should match any other native Mac application.

CoreText also gives us a lot more Mac-only control over how fonts look, and so to start I will expose one requested configuration option (per @amadeus) to enable font smoothing, which makes fonts thicker because it enables extra anti-aliasing. It is an aesthetic choice if you prefer that or not.

Finally, we don't need to build FreeType on macOS anymore, so the Mac builds should be slightly smaller. This also removes some other dependencies: zlib, libpng, etc.

# Comparison

There isn't a big difference between the two. The differences are quite subtle. Here is the same font at the same size with the two rasterizers compared. The primary difference is emoji layout and sizing. The baseline is also slightly differently (look where the "j" rests above the underline). The rest should look similar. But, the small details should _feel_ more natural to a Mac user.

![CleanShot 2023-06-30 at 22 07 35@2x](https://github.com/mitchellh/ghostty/assets/1299/580fb674-3f4a-49b0-9382-ec11c8b41606)
