### PR TITLE
macOS: change quit dialog to handle return key

### DIFF
--- a/macos/Ghostty.xcodeproj/project.pbxproj
+++ b/macos/Ghostty.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		859D96B92A504517003B74CA /* QuitConfirmationDialogPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 859D96B82A504517003B74CA /* QuitConfirmationDialogPresenter.swift */; };
 		A535B9DA299C569B0017E2E4 /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A535B9D9299C569B0017E2E4 /* ErrorView.swift */; };
 		A55685E029A03A9F004303CE /* AppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55685DF29A03A9F004303CE /* AppError.swift */; };
 		A55B7BB629B6F47F0055DE60 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55B7BB529B6F47F0055DE60 /* AppState.swift */; };
@@ -26,6 +27,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		859D96B82A504517003B74CA /* QuitConfirmationDialogPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuitConfirmationDialogPresenter.swift; sourceTree = "<group>"; };
 		A535B9D9299C569B0017E2E4 /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
 		A55685DF29A03A9F004303CE /* AppError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppError.swift; sourceTree = "<group>"; };
 		A55B7BB529B6F47F0055DE60 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
@@ -71,6 +73,7 @@
 				A59444F629A2ED5200725BBA /* SettingsView.swift */,
 				A5CEAFFE29C2410700646FDA /* Backport.swift */,
 				A5FECBD629D1FC3900022361 /* ContentView.swift */,
+				859D96B82A504517003B74CA /* QuitConfirmationDialogPresenter.swift */,
 				A5FECBD829D2010400022361 /* WindowAccessor.swift */,
 			);
 			path = Sources;
@@ -210,6 +213,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				859D96B92A504517003B74CA /* QuitConfirmationDialogPresenter.swift in Sources */,
 				A55B7BBC29B6FC330055DE60 /* SurfaceView.swift in Sources */,
 				A59444F729A2ED5200725BBA /* SettingsView.swift in Sources */,
 				A5FECBD729D1FC3900022361 /* ContentView.swift in Sources */,

--- a/macos/Sources/QuitConfirmationDialogPresenter.swift
+++ b/macos/Sources/QuitConfirmationDialogPresenter.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+// We use an NSAlert instead of a SwiftUI confirmationDialog because the
+// alert can accept return-key to confirm.
+class QuitConfirmationDialogPresenter: ObservableObject {
+    func showDialog() {
+        let alert = NSAlert()
+        alert.messageText = "Quit Ghostty?"
+
+        alert.informativeText = "All terminal sessions will be terminated."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Quit")
+        alert.addButton(withTitle: "Cancel")
+
+        NSApp.activate(ignoringOtherApps: true)
+
+        let response = alert.runModal()
+
+        if response == .alertFirstButtonReturn {
+            NSApplication.shared.reply(toApplicationShouldTerminate: true)
+        } else {
+            NSApplication.shared.reply(toApplicationShouldTerminate: false)
+        }
+    }
+}


### PR DESCRIPTION
Ghostty does handle `Cmd+q` to quit the application on macOS, but the dialog it presented didn't accept the return key to confirm.

That drove me a bit mad, so I went down the rabbithole to find out how to handle that correctly.

Turns out: `.keyboardShortcut(.defaultAction)` _is_ the recommended way, but it doesn't work on macOS. At least not on macOS 13. I also found comments saying that it stopped working on macOS 12.

So, what this here does it to replace the SwiftUI `confirmationDialog` with an `NSAlert` that pops up whenever the user presses `Cmd+q`.

It's up to you to accept this or not. I'd understand if you want to keep this SwiftUI only.

My motiviation is it did annoy me quite a bit having to reach for the mouse when hitting `Cmd+q` :)

### Drawback

The dialog doesn't show up in the middle of the window, it shows up top-middle of the screen. Actually, I'm not sure how `NSAlert` position is determined.

### Before


https://github.com/mitchellh/ghostty/assets/1185253/b9c44361-d6fa-495a-ba2b-a40bf5ca673f



### After

https://github.com/mitchellh/ghostty/assets/1185253/8e231263-fad7-4ceb-ae01-40a746c14d2c


