### PR TITLE
Use the precision calculation to determine when to send mouse events

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1337,6 +1337,7 @@ pub fn scrollCallback(
         self.mouse.pending_scroll_y = poff - (amount * cell_size);
 
         break :y .{
+            .sign = if (yoff > 0) 1 else -1,
             .delta_unsigned = @intFromFloat(@fabs(amount)),
             .delta = @intFromFloat(amount),
         };
@@ -1420,13 +1421,13 @@ pub fn scrollCallback(
 
         // If we're scrolling up or down, then send a mouse event. This requires
         // a lock since we read terminal state.
-        if (yoff != 0) {
+        if (y.delta != 0) {
             const pos = try self.rt_surface.getCursorPos();
-            try self.mouseReport(if (yoff < 0) .five else .four, .press, self.mouse.mods, pos);
+            try self.mouseReport(if (y.sign < 0) .five else .four, .press, self.mouse.mods, pos);
         }
-        if (xoff != 0) {
+        if (x.delta != 0) {
             const pos = try self.rt_surface.getCursorPos();
-            try self.mouseReport(if (xoff > 0) .six else .seven, .press, self.mouse.mods, pos);
+            try self.mouseReport(if (x.delta > 0) .six else .seven, .press, self.mouse.mods, pos);
         }
     }
 


### PR DESCRIPTION
The precision mouse event change works great, but it neglected to clamp sending the "high speed" events via the ANSI mouse events, which tmux uses. Ergo tmux still showed the previous "over powered" scroll behavior. This uses the newly calculated delta's to determine if the mouse events should be sent, which brings tmux inline with the new, normal scroll behavior.

This also uses sign to figure out which direction is the "natural" direction. On on macos, where the OS behavior is "pull down to scroll up", sign correctly represents that OS expectation, sending the up-wheel-mouse-button when the scroll offset his moved downward.