### PR TITLE
macOS: change quit dialog to handle return by removing role

### DIFF
--- a/macos/Sources/ContentView.swift
+++ b/macos/Sources/ContentView.swift
@@ -38,7 +38,7 @@ struct ContentView: View {
                 .confirmationDialog(
                     "Quit Ghostty?",
                     isPresented: confirmQuitting) {
-                        Button("Close Ghostty", role: .destructive) {
+                        Button("Close Ghostty") {
                             NSApplication.shared.reply(toApplicationShouldTerminate: true)
                         }
                         .keyboardShortcut(.defaultAction)


### PR DESCRIPTION
This is, as it turns out, the simple version of #166.

It changes the quit dialog to handle return by removing the `.destructive` role from the `Quit` button.

When that role is set, the `keyboardShortcut(.defaultAction)` doesn't have an effect.

With the role removed, the dialog handles the return key to quit the application

As I wrote in #166, I can understand if you don't want this change, but I personally think it's nice to be able to only use the keyboard. iTerm2 also handles return like this in the "Are you sure?" dialog.

### Before


https://github.com/mitchellh/ghostty/assets/1185253/b9c44361-d6fa-495a-ba2b-a40bf5ca673f

### After


https://github.com/mitchellh/ghostty/assets/1185253/23e1f894-c23f-4362-badd-ce6486a44418

