### PR TITLE
Auto-italicize regular font if no italic font is found (CoreText only)

### DIFF
--- a/pkg/macos/text/font.zig
+++ b/pkg/macos/text/font.zig
@@ -18,13 +18,18 @@ pub const Font = opaque {
         ) orelse Allocator.Error.OutOfMemory;
     }
 
-    pub fn copyWithAttributes(self: *Font, size: f32, attrs: ?*text.FontDescriptor) Allocator.Error!*Font {
+    pub fn copyWithAttributes(
+        self: *Font,
+        size: f32,
+        matrix: ?*const graphics.AffineTransform,
+        attrs: ?*text.FontDescriptor,
+    ) Allocator.Error!*Font {
         return @as(
             ?*Font,
             @ptrFromInt(@intFromPtr(c.CTFontCreateCopyWithAttributes(
                 @ptrCast(self),
                 size,
-                null,
+                @ptrCast(matrix),
                 @ptrCast(attrs),
             ))),
         ) orelse Allocator.Error.OutOfMemory;
@@ -217,6 +222,6 @@ test "copy" {
     const font = try Font.createWithFontDescriptor(desc, 12);
     defer font.release();
 
-    const f2 = try font.copyWithAttributes(14, null);
+    const f2 = try font.copyWithAttributes(14, null, null);
     defer f2.release();
 }

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -296,6 +296,9 @@ pub fn init(
                 }
             }
         } else {
+            // We don't support auto-italics. If we don't have an italic font
+            // face let the user know so they aren't surprised (if they look
+            // at logs).
             if (group.getFace(.italic) == null) {
                 log.warn("no italic font face available, italics will not render", .{});
             }

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -231,7 +231,7 @@ pub fn init(
                 if (try disco_it.next()) |face| {
                     log.info("font regular: {s}", .{try face.name()});
                     try group.addFace(alloc, .regular, face);
-                } else std.log.warn("font-family not found: {s}", .{family});
+                } else log.warn("font-family not found: {s}", .{family});
             }
             if (config.@"font-family-bold") |family| {
                 var disco_it = try disco.discover(.{
@@ -243,7 +243,7 @@ pub fn init(
                 if (try disco_it.next()) |face| {
                     log.info("font bold: {s}", .{try face.name()});
                     try group.addFace(alloc, .bold, face);
-                } else std.log.warn("font-family-bold not found: {s}", .{family});
+                } else log.warn("font-family-bold not found: {s}", .{family});
             }
             if (config.@"font-family-italic") |family| {
                 var disco_it = try disco.discover(.{
@@ -255,7 +255,7 @@ pub fn init(
                 if (try disco_it.next()) |face| {
                     log.info("font italic: {s}", .{try face.name()});
                     try group.addFace(alloc, .italic, face);
-                } else std.log.warn("font-family-italic not found: {s}", .{family});
+                } else log.warn("font-family-italic not found: {s}", .{family});
             }
             if (config.@"font-family-bold-italic") |family| {
                 var disco_it = try disco.discover(.{
@@ -268,7 +268,7 @@ pub fn init(
                 if (try disco_it.next()) |face| {
                     log.info("font bold+italic: {s}", .{try face.name()});
                     try group.addFace(alloc, .bold_italic, face);
-                } else std.log.warn("font-family-bold-italic not found: {s}", .{family});
+                } else log.warn("font-family-bold-italic not found: {s}", .{family});
             }
         }
 
@@ -283,6 +283,23 @@ pub fn init(
             .bold,
             font.DeferredFace.initLoaded(try font.Face.init(font_lib, face_bold_ttf, font_size)),
         );
+
+        // If we support auto-italicization and we don't have an italic face,
+        // then we can try to auto-italicize our regular face.
+        if (comptime font.DeferredFace.canItalicize()) {
+            if (group.getFace(.italic) == null) {
+                if (group.getFace(.regular)) |regular| {
+                    if (try regular.italicize()) |face| {
+                        log.info("font auto-italicized: {s}", .{try face.name()});
+                        try group.addFace(alloc, .italic, face);
+                    }
+                }
+            }
+        } else {
+            if (group.getFace(.italic) == null) {
+                log.warn("no italic font face available, italics will not render", .{});
+            }
+        }
 
         // Emoji fallback. We don't include this on Mac since Mac is expected
         // to always have the Apple Emoji available.

--- a/src/font/DeferredFace.zig
+++ b/src/font/DeferredFace.zig
@@ -75,16 +75,7 @@ pub const CoreText = struct {
 
     /// Auto-italicize the font by applying a skew.
     pub fn italicize(self: *const CoreText) !CoreText {
-        const skew = macos.graphics.AffineTransform{
-            .a = 1,
-            .b = 0,
-            .c = 0.267949, // approx. tan(15)
-            .d = 1,
-            .tx = 0,
-            .ty = 0,
-        };
-
-        const ct_font = try self.font.copyWithAttributes(0.0, &skew, null);
+        const ct_font = try self.font.copyWithAttributes(0.0, &Face.italic_skew, null);
         errdefer ct_font.release();
         return .{ .font = ct_font };
     }

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -198,8 +198,15 @@ pub fn indexForCodepoint(
     // If we can find the exact value, then return that.
     if (self.indexForCodepointExact(cp, style, p)) |value| return value;
 
-    // Try looking for another font that will satisfy this request.
-    if (font.Discover != void) {
+    // If we're not a regular font style, try looking for a regular font
+    // that will satisfy this request. Blindly looking for unmatched styled
+    // fonts to satisfy one codepoint results in some ugly rendering.
+    if (style != .regular) {
+        if (self.indexForCodepoint(cp, .regular, p)) |value| return value;
+    }
+
+    // If we are regular, try looking for a fallback using discovery.
+    if (style == .regular and font.Discover != void) {
         if (self.discover) |*disco| discover: {
             var disco_it = disco.discover(.{
                 .codepoint = cp,

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -99,6 +99,15 @@ pub fn addFace(self: *Group, alloc: Allocator, style: Style, face: DeferredFace)
     try list.append(alloc, face);
 }
 
+/// Get the face for the given style. This will always return the first
+/// face (if it exists). The returned pointer is only valid as long as
+/// the faces do not change.
+pub fn getFace(self: *Group, style: Style) ?*DeferredFace {
+    const list = self.faces.getPtr(style);
+    if (list.items.len == 0) return null;
+    return &list.items[0];
+}
+
 /// Resize the fonts to the desired size.
 pub fn setSize(self: *Group, size: font.face.DesiredSize) !void {
     // Note: there are some issues here with partial failure. We don't


### PR DESCRIPTION
This automatically applies a 15 degree skew to the regular font face if no italic variant is found, enabling fake italics. This only works for CoreText for now. For other font backends, we now no longer fall back to any codepoint that can satisfy the italics.

## Comparison (CoreText)

We skew the regular font:

![CleanShot 2023-07-03 at 16 02 35@2x](https://github.com/mitchellh/ghostty/assets/1299/2045218b-421e-4703-a6e4-4d1a0325b403)

## Comparison (FreeType)

FreeType doesn't support this [for now], so we no longer render italics:

![CleanShot 2023-07-03 at 16 04 12@2x](https://github.com/mitchellh/ghostty/assets/1299/881b56ae-d313-4bbe-8741-92e30ef38dac)

