### PR TITLE
Background Transparency and Blurring (1337 h4x0r mode 🤪)

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -276,6 +276,7 @@ void *ghostty_app_userdata(ghostty_app_t);
 ghostty_surface_t ghostty_surface_new(ghostty_app_t, ghostty_surface_config_s*);
 void ghostty_surface_free(ghostty_surface_t);
 ghostty_app_t ghostty_surface_app(ghostty_surface_t);
+bool ghostty_surface_transparent(ghostty_surface_t);
 void ghostty_surface_refresh(ghostty_surface_t);
 void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);
 void ghostty_surface_set_focus(ghostty_surface_t, bool);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -291,6 +291,10 @@ void ghostty_surface_request_close(ghostty_surface_t);
 void ghostty_surface_split(ghostty_surface_t, ghostty_split_direction_e);
 void ghostty_surface_split_focus(ghostty_surface_t, ghostty_split_focus_direction_e);
 
+// APIs I'd like to get rid of eventually but are still needed for now.
+// Don't use these unless you know what you're doing.
+void ghostty_set_window_background_blur(ghostty_surface_t, void *);
+
 #ifdef __cplusplus
 }
 #endif

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -197,6 +197,15 @@ extension Ghostty {
             ghostty_surface_set_size(surface, UInt32(scaledSize.width), UInt32(scaledSize.height))
         }
         
+        override func viewDidMoveToWindow() {
+            guard let window = self.window else { return }
+            guard let surface = self.surface else { return }
+            guard ghostty_surface_transparent(surface) else { return }
+            window.isOpaque = false
+            window.hasShadow = false
+            window.backgroundColor = .clear
+        }
+        
         override func resignFirstResponder() -> Bool {
             let result = super.resignFirstResponder()
             

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -201,9 +201,14 @@ extension Ghostty {
             guard let window = self.window else { return }
             guard let surface = self.surface else { return }
             guard ghostty_surface_transparent(surface) else { return }
+            
+            // Set the window transparency settings
             window.isOpaque = false
             window.hasShadow = false
             window.backgroundColor = .clear
+            
+            // If we have a blur, set the blur
+            ghostty_set_window_background_blur(surface, Unmanaged.passUnretained(window).toOpaque())
         }
         
         override func resignFirstResponder() -> Bool {

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -470,6 +470,11 @@ pub const CAPI = struct {
         return surface.app;
     }
 
+    /// Returns ture if the surface has transparency set.
+    export fn ghostty_surface_transparent(surface: *Surface) bool {
+        return surface.app.config.@"background-opacity" < 1.0;
+    }
+
     /// Tell the surface that it needs to schedule a render
     export fn ghostty_surface_refresh(surface: *Surface) void {
         surface.refresh();

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -570,4 +570,34 @@ pub const CAPI = struct {
     export fn ghostty_surface_split_focus(ptr: *Surface, direction: input.SplitFocusDirection) void {
         ptr.gotoSplit(direction);
     }
+
+    /// Sets the window background blur on macOS to the desired value.
+    /// I do this in Zig as an extern function because I don't know how to
+    /// call these functions in Swift.
+    ///
+    /// This uses an undocumented, non-public API because this is what
+    /// every terminal appears to use, including Terminal.app.
+    export fn ghostty_set_window_background_blur(
+        ptr: *Surface,
+        window: *anyopaque,
+    ) void {
+        const config = ptr.app.config;
+
+        // Do nothing if we don't have background transparency enabled
+        if (config.@"background-opacity" >= 1.0) return;
+
+        // Do nothing if our blur value is zero
+        if (config.@"background-blur-radius" == 0) return;
+
+        const nswindow = objc.Object.fromId(window);
+        _ = CGSSetWindowBackgroundBlurRadius(
+            CGSDefaultConnectionForThread(),
+            nswindow.msgSend(usize, objc.sel("windowNumber"), .{}),
+            @intCast(config.@"background-blur-radius"),
+        );
+    }
+
+    /// See ghostty_set_window_background_blur
+    extern "c" fn CGSSetWindowBackgroundBlurRadius(*anyopaque, usize, c_int) i32;
+    extern "c" fn CGSDefaultConnectionForThread() *anyopaque;
 };

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -278,7 +278,7 @@ pub const Surface = struct {
             "ghostty",
             null,
             null,
-            Renderer.glfwWindowHints(),
+            Renderer.glfwWindowHints(&app.config),
         ) orelse return glfw.mustGetErrorCode();
         errdefer win.destroy();
 

--- a/src/cli_args.zig
+++ b/src/cli_args.zig
@@ -144,6 +144,11 @@ fn parseIntoField(
                     0,
                 ),
 
+                f64 => try std.fmt.parseFloat(
+                    f64,
+                    value orelse return error.ValueRequired,
+                ),
+
                 else => unreachable,
             };
 
@@ -296,6 +301,20 @@ test "parseIntoField: unsigned numbers" {
 
     try parseIntoField(@TypeOf(data), alloc, &data, "u8", "1");
     try testing.expectEqual(@as(u8, 1), data.u8);
+}
+
+test "parseIntoField: floats" {
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var data: struct {
+        f64: f64,
+    } = undefined;
+
+    try parseIntoField(@TypeOf(data), alloc, &data, "f64", "1");
+    try testing.expectEqual(@as(f64, 1.0), data.f64);
 }
 
 test "parseIntoField: optional field" {

--- a/src/config.zig
+++ b/src/config.zig
@@ -68,8 +68,8 @@ pub const Config = struct {
     /// A value less than 0 or greater than 1 will be clamped to the nearest
     /// valid value.
     ///
-    /// This can be changed at runtime for native macOS and Linux GTK builds.
-    /// This can NOT be changed at runtime for GLFW builds (not common).
+    /// Changing this value at runtime (and reloading config) will only
+    /// affect new windows, tabs, and splits.
     @"background-opacity": f64 = 1.0,
 
     /// The command to run, usually a shell. If this is not an absolute path,

--- a/src/config.zig
+++ b/src/config.zig
@@ -65,6 +65,11 @@ pub const Config = struct {
 
     /// The opacity level (opposite of transparency) of the background.
     /// A value of 1 is fully opaque and a value of 0 is fully transparent.
+    /// A value less than 0 or greater than 1 will be clamped to the nearest
+    /// valid value.
+    ///
+    /// This can be changed at runtime for native macOS and Linux GTK builds.
+    /// This can NOT be changed at runtime for GLFW builds (not common).
     @"background-opacity": f64 = 1.0,
 
     /// The command to run, usually a shell. If this is not an absolute path,

--- a/src/config.zig
+++ b/src/config.zig
@@ -72,6 +72,15 @@ pub const Config = struct {
     /// affect new windows, tabs, and splits.
     @"background-opacity": f64 = 1.0,
 
+    /// A positive value enables blurring of the background when
+    /// background-opacity is less than 1. The value is the blur radius to
+    /// apply. A value of 20 is reasonable for a good looking blur.
+    /// Higher values will cause strange rendering issues as well as
+    /// performance issues.
+    ///
+    /// This is only supported on macOS.
+    @"background-blur-radius": u8 = 0,
+
     /// The command to run, usually a shell. If this is not an absolute path,
     /// it'll be looked up in the PATH. If this is not set, a default will
     /// be looked up from your system. The rules for the default lookup are:

--- a/src/config.zig
+++ b/src/config.zig
@@ -63,6 +63,10 @@ pub const Config = struct {
     /// The color of the cursor. If this is not set, a default will be chosen.
     @"cursor-color": ?Color = null,
 
+    /// The opacity level (opposite of transparency) of the background.
+    /// A value of 1 is fully opaque and a value of 0 is fully transparent.
+    @"background-opacity": f64 = 1.0,
+
     /// The command to run, usually a shell. If this is not an absolute path,
     /// it'll be looked up in the PATH. If this is not set, a default will
     /// be looked up from your system. The rules for the default lookup are:
@@ -754,6 +758,7 @@ pub const Config = struct {
         switch (@typeInfo(T)) {
             inline .Bool,
             .Int,
+            .Float,
             => return src,
 
             .Optional => |info| return try cloneValue(
@@ -879,6 +884,7 @@ fn equal(comptime T: type, old: T, new: T) bool {
 
         inline .Bool,
         .Int,
+        .Float,
         .Enum,
         => return old == new,
 


### PR DESCRIPTION
This one was just for fun. This adds two new features: **background transparency** and **background blurring**.

**Background transparency** is what it sounds like. It enables you to have a semi-transparent window background. This is supported on Mac and Linux (both GLFW and GTK). You can set this with the new `background-opacity` config with a value from 0 (fully transparent) to 1 (fully opaque).

**Background blur** does a radial blur on the background. This only works for macOS. It uses a non-public, undocumented API but every terminal that supports blurring uses this (including Terminal.app itself). You can set this with `background-blur-radius`.

## Example 1

```
background-opacity = 0.8
background-blur-radius = 20
```

<img width="883" alt="CleanShot 2023-07-03 at 20 56 02@2x" src="https://github.com/mitchellh/ghostty/assets/1299/2945fd28-5875-4dcc-953b-7ad408422508">

## Example 2

```
background-opacity = 0.8
```

![CleanShot 2023-07-03 at 20 50 10@2x](https://github.com/mitchellh/ghostty/assets/1299/d8c81bf7-ff9c-4595-8f8f-a659535677c8)

## Example 3

```
background-opacity = 0.5
background-blur-radius = 20
```

(A pretty bad idea)

<img width="878" alt="CleanShot 2023-07-03 at 20 53 27@2x" src="https://github.com/mitchellh/ghostty/assets/1299/c0f7e109-20ec-4772-a476-98edc22893db">

