### PR TITLE
clear_screen keybinding works even when not at shell prompt

### DIFF
--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1063,7 +1063,10 @@ pub fn eraseDisplay(
             self.screen.cursor.pending_wrap = false;
         },
 
-        .scrollback => self.screen.clearHistory(),
+        .scrollback => self.screen.clear(.history) catch |err| {
+            // This isn't a huge issue, so just log it.
+            log.err("failed to clear scrollback: {}", .{err});
+        },
     }
 }
 


### PR DESCRIPTION
Fixes #184

This is the `Cmd+k` mac-only feature that iTerm and Terminal support. I can't find any other terminal that supports this feature. Instead of sending formfeed (0x0C), clear_screen actually does a terminal emulator level clear instead. This MOSTLY matches the behavior of iTerm and Terminal.app, with some differences:

  1. I do not clear _below_ the cursor. I feel like the use case for this feature is primarily to clear above the cursor. Happy to be wrong here but I want it proven to me!

  2. I do not clear in alternate screen mode. Clearing alt screens breaks rendering in Vim, less, etc. and it feels like the wrong behavior.