### PR TITLE
Write scrollback to file, output to tty ("write_scrollback_file" binding)

### DIFF
--- a/src/Command.zig
+++ b/src/Command.zig
@@ -23,8 +23,8 @@ const Command = @This();
 
 const std = @import("std");
 const builtin = @import("builtin");
-const TempDir = @import("TempDir.zig");
 const internal_os = @import("os/main.zig");
+const TempDir = internal_os.TempDir;
 const mem = std.mem;
 const os = std.os;
 const debug = std.debug;

--- a/src/config.zig
+++ b/src/config.zig
@@ -393,6 +393,12 @@ pub const Config = struct {
             .{ .toggle_dev_mode = {} },
         );
 
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .j, .mods = ctrlOrSuper(.{ .shift = true }) },
+            .{ .write_scrollback_file = {} },
+        );
+
         // Windowing
         if (comptime !builtin.target.isDarwin()) {
             try result.keybind.set.put(

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -174,6 +174,10 @@ pub const Action = union(enum) {
     /// is backwards.
     jump_to_prompt: i16,
 
+    /// Write the entire scrollback into a temporary file and write the
+    /// path to the file to the tty.
+    write_scrollback_file: void,
+
     /// Dev mode
     toggle_dev_mode: void,
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -181,7 +181,6 @@ pub const GlobalState = struct {
 test {
     _ = @import("Pty.zig");
     _ = @import("Command.zig");
-    _ = @import("TempDir.zig");
     _ = @import("font/main.zig");
     _ = @import("renderer.zig");
     _ = @import("termio.zig");

--- a/src/os/TempDir.zig
+++ b/src/os/TempDir.zig
@@ -6,6 +6,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const testing = std.testing;
 const Dir = std.fs.Dir;
+const internal_os = @import("main.zig");
 
 const log = std.log.scoped(.tempdir);
 
@@ -28,8 +29,11 @@ pub fn init() !TempDir {
     var tmp_path_buf: [TMP_PATH_LEN:0]u8 = undefined;
     var rand_buf: [RANDOM_BYTES]u8 = undefined;
 
-    // TODO: use the real temp dir not cwd
-    const dir = std.fs.cwd();
+    const dir = dir: {
+        const cwd = std.fs.cwd();
+        const tmp_dir = internal_os.tmpDir() orelse break :dir cwd;
+        break :dir try cwd.openDir(tmp_dir, .{});
+    };
 
     // We now loop forever until we can find a directory that we can create.
     while (true) {

--- a/src/os/file.zig
+++ b/src/os/file.zig
@@ -50,3 +50,10 @@ pub fn fixMaxFiles() void {
 
     log.debug("file handle limit raised value={}", .{lim.cur});
 }
+
+/// Return the recommended path for temporary files.
+pub fn tmpDir() ?[]const u8 {
+    if (std.os.getenv("TMPDIR")) |v| return v;
+    if (std.os.getenv("TMP")) |v| return v;
+    return "/tmp";
+}

--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -6,3 +6,4 @@ pub usingnamespace @import("flatpak.zig");
 pub usingnamespace @import("locale.zig");
 pub usingnamespace @import("macos_version.zig");
 pub usingnamespace @import("mouse.zig");
+pub const TempDir = @import("TempDir.zig");

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -398,7 +398,7 @@ fn clearPromptForResize(self: *Terminal) void {
 /// encoded as "\n". This omits any formatting such as fg/bg.
 ///
 /// The caller must free the string.
-pub fn plainString(self: *Terminal, alloc: Allocator) ![]const u8 {
+fn plainString(self: *Terminal, alloc: Allocator) ![]const u8 {
     return try self.screen.testString(alloc, .viewport);
 }
 

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1634,6 +1634,7 @@ test "Terminal: print writes to bottom if scrolled" {
 
     // Basic grid writing
     for ("hello") |c| try t.print(c);
+    t.setCursorPos(0, 0);
 
     // Make newlines so we create scrollback
     // 3 pushes hello off the screen
@@ -1704,7 +1705,7 @@ test "Terminal: print charset outside of ASCII" {
     {
         var str = try t.plainString(testing.allocator);
         defer testing.allocator.free(str);
-        try testing.expectEqualStrings("◆  ", str);
+        try testing.expectEqualStrings("◆ ", str);
     }
 }
 
@@ -2192,6 +2193,7 @@ test "Terminal: index from the bottom" {
 
     t.setCursorPos(5, 1);
     try t.print('A');
+    t.cursorLeft(1); // undo moving right from 'A'
     try t.index();
 
     try t.print('B');


### PR DESCRIPTION
Fixes #196 
Helps #189 

This introduces a new keybinding `write_scrollback_file` bound to `Cmd+Shift+j` by default (Ctrl on Linux). This action will write the entire scrollback to a temporary file, and then output the path to that file to the terminal. This can be used to save your scrollback, search it, modify it (in the file, not the terminal), etc.

ANSI escape sequences are stripped -- we can add an option to add them later but I think its more useful without.

## Demo

https://github.com/mitchellh/ghostty/assets/1299/513b6c77-aacb-4371-b665-c8917571ec8d

