### PR TITLE
Fix blurry fonts by flooring padding of surface

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -344,8 +344,14 @@ pub fn init(
     const cell_size = try renderer.CellSize.init(alloc, font_group);
 
     // Convert our padding from points to pixels
-    const padding_x = std.math.floor((@as(f32, @floatFromInt(config.@"window-padding-x")) * x_dpi) / 72);
-    const padding_y = std.math.floor((@as(f32, @floatFromInt(config.@"window-padding-y")) * y_dpi) / 72);
+    const padding_x: u32 = padding_x: {
+        const padding_x: f32 = @floatFromInt(config.@"window-padding-x");
+        break :padding_x @intFromFloat(@floor(padding_x * x_dpi / 72));
+    };
+    const padding_y: u32 = padding_y: {
+        const padding_y: f32 = @floatFromInt(config.@"window-padding-y");
+        break :padding_y @intFromFloat(@floor(padding_y * y_dpi / 72));
+    };
     const padding: renderer.Padding = .{
         .top = padding_y,
         .bottom = padding_y,
@@ -2102,8 +2108,8 @@ fn posToViewport(self: Surface, xpos: f64, ypos: f64) terminal.point.Viewport {
     // amount from the renderer. This is a bug but realistically balanced
     // padding is so small it doesn't affect selection. This may not be true
     // at large font sizes...
-    const xpos_adjusted: f64 = xpos - @as(f64, @floatCast(self.padding.left));
-    const ypos_adjusted: f64 = ypos - @as(f64, @floatCast(self.padding.top));
+    const xpos_adjusted: f64 = xpos - @as(f64, @floatFromInt(self.padding.left));
+    const ypos_adjusted: f64 = ypos - @as(f64, @floatFromInt(self.padding.top));
 
     // xpos and ypos can be negative if while dragging, the user moves the
     // mouse off the surface. Likewise, they can be larger than our surface

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -344,8 +344,8 @@ pub fn init(
     const cell_size = try renderer.CellSize.init(alloc, font_group);
 
     // Convert our padding from points to pixels
-    const padding_x = (@as(f32, @floatFromInt(config.@"window-padding-x")) * x_dpi) / 72;
-    const padding_y = (@as(f32, @floatFromInt(config.@"window-padding-y")) * y_dpi) / 72;
+    const padding_x = std.math.floor((@as(f32, @floatFromInt(config.@"window-padding-x")) * x_dpi) / 72);
+    const padding_y = std.math.floor((@as(f32, @floatFromInt(config.@"window-padding-y")) * y_dpi) / 72);
     const padding: renderer.Padding = .{
         .top = padding_y,
         .bottom = padding_y,

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -821,10 +821,10 @@ pub fn setScreenSize(self: *Metal, dim: renderer.ScreenSize) !void {
     const old = self.uniforms;
     self.uniforms = .{
         .projection_matrix = math.ortho2d(
-            -1 * padding.left,
-            @as(f32, @floatFromInt(padded_dim.width)) + padding.right,
-            @as(f32, @floatFromInt(padded_dim.height)) + padding.bottom,
-            -1 * padding.top,
+            -1 * @as(f32, @floatFromInt(padding.left)),
+            @floatFromInt(padded_dim.width + padding.right),
+            @floatFromInt(padded_dim.height + padding.bottom),
+            -1 * @as(f32, @floatFromInt(padding.top)),
         ),
         .cell_size = .{
             @floatFromInt(self.cell_size.width),

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -146,10 +146,10 @@ const SetScreenSize = struct {
 
             // 2D orthographic projection with the full w/h
             math.ortho2d(
-                -1 * padding.left,
-                @as(f32, @floatFromInt(padded_size.width)) + padding.right,
-                @as(f32, @floatFromInt(padded_size.height)) + padding.bottom,
-                -1 * padding.top,
+                -1 * @as(f32, @floatFromInt(padding.left)),
+                @floatFromInt(padded_size.width + padding.right),
+                @floatFromInt(padded_size.height + padding.bottom),
+                -1 * @as(f32, @floatFromInt(padding.top)),
             ),
         );
     }

--- a/src/renderer/size.zig
+++ b/src/renderer/size.zig
@@ -48,8 +48,8 @@ pub const ScreenSize = struct {
     /// Subtract padding from the screen size.
     pub fn subPadding(self: ScreenSize, padding: Padding) ScreenSize {
         return .{
-            .width = self.width -| @as(u32, @intFromFloat(padding.left + padding.right)),
-            .height = self.height -| @as(u32, @intFromFloat(padding.top + padding.bottom)),
+            .width = self.width -| (padding.left + padding.right),
+            .height = self.height -| (padding.top + padding.bottom),
         };
     }
 };
@@ -84,10 +84,10 @@ pub const GridSize = struct {
 
 /// The padding to add to a screen.
 pub const Padding = struct {
-    top: f32 = 0,
-    bottom: f32 = 0,
-    right: f32 = 0,
-    left: f32 = 0,
+    top: u32 = 0,
+    bottom: u32 = 0,
+    right: u32 = 0,
+    left: u32 = 0,
 
     /// Returns padding that balances the whitespace around the screen
     /// for the given grid and cell sizes.
@@ -117,10 +117,10 @@ pub const Padding = struct {
 
         const zero = @as(f32, 0);
         return .{
-            .top = @max(zero, padding_top),
-            .bottom = @max(zero, padding_bot),
-            .right = @max(zero, padding_right),
-            .left = @max(zero, padding_left),
+            .top = @intFromFloat(@max(zero, padding_top)),
+            .bottom = @intFromFloat(@max(zero, padding_bot)),
+            .right = @intFromFloat(@max(zero, padding_right)),
+            .left = @intFromFloat(@max(zero, padding_left)),
         };
     }
 


### PR DESCRIPTION
This fixes #99 for me.

Without this fix I end up with paddings of `3.333333` because my DPI is `125.0` on Linux. If I set it to `144.0` manually so that the `/ 72` gives me a clean `2.0`, the blurry fonts are gone.

I do think the calculation here is correct (even though I'm not sure whether we should use 72? Why not 96? Or another system value?), so let's use `std.math.floor` to get us to a "clean" padding of `3.0`.

That also solves blurry fonts for me.

### Before/After

Top one has padding of `3.333333`, bottom one has `3.0`:
![image](https://github.com/mitchellh/ghostty/assets/1185253/00f9b0aa-b326-4627-b478-95548e090fcf)
