### PR TITLE
gtk: remove thin, white border

### DIFF
--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -336,6 +336,7 @@ const Window = struct {
         c.gtk_notebook_set_tab_pos(notebook, c.GTK_POS_TOP);
         c.gtk_notebook_set_scrollable(notebook, 1);
         c.gtk_notebook_set_show_tabs(notebook, 0);
+        c.gtk_notebook_set_show_border(notebook, 0);
 
         // Create our add button for new tabs
         const notebook_add_btn = c.gtk_button_new_from_icon_name("list-add-symbolic");


### PR DESCRIPTION
The GTK app has a really thin, white border around the terminal contents. It's really distracting when in fullscreen.

At first I thought it's the window that has a border, but turns out that's not it. It's the GTK Notebook widget. Luckily for us, GTK4 has a single API call that allows us to turn off the border.

### Before

![before](https://github.com/mitchellh/ghostty/assets/1185253/4600cb7d-87e3-419a-811c-8540c7e66fb3)


### Proof

Here's how I found out that it's the notebook widget that has a border: I added CSS classes to the window, adding/removing margin/padding until I realised that I can make the border visible by giving the window itself a `border: 10px darkblue`:

![before_with_blue_border](https://github.com/mitchellh/ghostty/assets/1185253/34226e0c-f372-459d-9cc6-2dcba3929142)

### After
![after](https://github.com/mitchellh/ghostty/assets/1185253/4ee1fbdd-8921-4bb5-aac6-78d2a5603efb)

