### PR TITLE
config: change default keybind for goto-split on non-Darwin

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -446,12 +446,12 @@ pub const Config = struct {
             );
             try result.keybind.set.put(
                 alloc,
-                .{ .key = .left_bracket, .mods = .{ .ctrl = true } },
+                .{ .key = .left_bracket, .mods = .{ .ctrl = true, .super = true } },
                 .{ .goto_split = .previous },
             );
             try result.keybind.set.put(
                 alloc,
-                .{ .key = .right_bracket, .mods = .{ .ctrl = true } },
+                .{ .key = .right_bracket, .mods = .{ .ctrl = true, .super = true } },
                 .{ .goto_split = .next },
             );
             try result.keybind.set.put(


### PR DESCRIPTION
Feel free to ignore or close this, because this is personal and if I could figure out the syntax, I'm sure I could overwrite the keybindings in the config myself.

But here's my case: `Ctrl+[` sends escape and I use that instead of `Esc` because it's easier to reach (capslock is remapped to `ctrl`, so `ctrl+[` is homerow only).

Kitty uses it's own "kittymod" combo for a lot of keybindings and for the equivalent of these two, it uses `Ctrl+shift`. That's already taken by other keybindings, so I added `.super` here.

Again: feel free to ignore. Personal preference. If you close this PR, I'll have to tweak my config on Linux.