### PR TITLE
gtk: add missing space in close dialog and add newline

### DIFF
--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -806,7 +806,7 @@ pub const Surface = struct {
             @ptrCast(alert),
             "There is still a running process in the terminal. " ++
                 "Closing the terminal will kill this process. " ++
-                "Are you sure you want to close the terminal?" ++
+                "Are you sure you want to close the terminal?\n\n" ++
                 "Click 'No' to cancel and return to your terminal.",
         );
 


### PR DESCRIPTION
See before/after screenshots. Before, without the space, it's wrong. I fixed that and added a newline, since a big paragraph like that looks a bit wrong in a dialog popup.

### Before
![gtk_dialog_before](https://github.com/mitchellh/ghostty/assets/1185253/04b12b45-f140-46c8-9d17-3fd13efb6452)


### After
![gtk_dialog_after](https://github.com/mitchellh/ghostty/assets/1185253/fa9941d5-552f-4283-a607-a23f44e96a41)

