### PR TITLE
flatpak: allow build step to use network

### DIFF
--- a/com.mitchellh.ghostty.yml
+++ b/com.mitchellh.ghostty.yml
@@ -5,6 +5,8 @@ sdk: org.gnome.Sdk
 default-branch: tip
 command: ghostty
 build-options:
+  build-args:
+    - --share=network
   append-path: /app/tmp/zig
   strip: false
   no-debuginfo: true


### PR DESCRIPTION
I'm not sure about this, but when I tried to use `flatpak-builder` locally I ran into this problem:

    $ flatpak-builder --user --install --force-clean build-dir com.mitchellh.ghostty.yml
    Emptying app dir 'build-dir'
    Downloading sources
    Starting build of com.mitchellh.ghostty
    Cache hit for zig, skipping build
    Cache miss, checking out last cache hit
    ========================================================================
    Building module ghostty in /home/mrnugget/code/clones/ghostty/.flatpak-builder/build/ghostty-4
    ========================================================================
    Running: MACH_SDK_PATH="$(pwd)/vendor/mach-sdk" zig build -Doptimize=ReleaseSafe -Dcpu=baseline -Dflatpak=true -Dapp-runtime=gtk --prefix /app
    fatal: unable to access 'https://github.com/hexops/sdk-linux-x86_64.git/': Could not resolve host: github.com
    fatal: unable to access 'https://github.com/hexops/sdk-linux-x86_64.git/': Could not resolve host: github.com
    fatal: unable to access 'https://github.com/hexops/sdk-linux-x86_64.git/': Could not resolve host: github.com
    fatal: unable to access 'https://github.com/hexops/sdk-linux-x86_64.git/': Could not resolve host: github.com
    fatal: unable to access 'https://github.com/hexops/sdk-linux-x86_64.git/': Could not resolve host: github.com
    fatal: unable to access 'https://github.com/hexops/sdk-linux-x86_64.git/': Could not resolve host: github.com
    steps [29/31] zig build-exe ghostty ReleaseSafe native-native-gnu.2.28... LLVM Emit Obj... ^C

That's even though I use Nix locally to setup my env and after I ran `make`.

With the change in here the `fatal` errors go away and it builds successfully.