### PR TITLE
zsh window title integration, better general title defaults

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -123,7 +123,7 @@ extension Ghostty {
         // The current title of the surface as defined by the pty. This can be
         // changed with escape codes. This is public because the callbacks go
         // to the app level and it is set from there.
-        @Published var title: String = ""
+        @Published var title: String = "👻"
         
         private(set) var surface: ghostty_surface_t?
         var error: Error? = nil

--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -194,6 +194,12 @@ _ghostty_deferred_init() {
         _ghostty_report_pwd"
     _ghostty_report_pwd
 
+    # Enable terminal title changes.
+    functions[_ghostty_precmd]+="
+        builtin print -rnu $_ghostty_fd \$'\\e]2;'\"\${(%):-%(4~|…/%3~|%~)}\"\$'\\a'"
+    functions[_ghostty_preexec]+="
+        builtin print -rnu $_ghostty_fd \$'\\e]2;'\"\${(V)1}\"\$'\\a'"
+
     # Enable cursor shape changes depending on the current keymap.
     # This implementation leaks blinking block cursor into external commands
     # executed from zle. For example, users of fzf-based widgets may find


### PR DESCRIPTION
Fixes #220. Multiple improvements:

  1. **zsh shell integration** automatically performs title escape sequences now.
  2. If a shell isn't reporting titles, but is reporting working directories, we set the title to the working directory.
  3. If a shell isn't reporting titles AND isn't reporting working directories, we set the title to "👻" just so its not blank.