### PR TITLE
only send resize messages to renderer/io thread if changes happen

### DIFF
--- a/src/renderer/size.zig
+++ b/src/renderer/size.zig
@@ -52,6 +52,11 @@ pub const ScreenSize = struct {
             .height = self.height -| (padding.top + padding.bottom),
         };
     }
+
+    /// Returns true if two sizes are equal.
+    pub fn equals(self: ScreenSize, other: ScreenSize) bool {
+        return self.width == other.width and self.height == other.height;
+    }
 };
 
 /// The dimensions of the grid itself, in rows/columns units.
@@ -79,6 +84,11 @@ pub const GridSize = struct {
         const calc_rows: Unit = @intFromFloat(screen_height / cell_height);
         self.columns = @max(1, calc_cols);
         self.rows = @max(1, calc_rows);
+    }
+
+    /// Returns true if two sizes are equal.
+    pub fn equals(self: GridSize, other: GridSize) bool {
+        return self.columns == other.columns and self.rows == other.rows;
     }
 };
 


### PR DESCRIPTION
Previously, we'd send renderer screen size updates and termio sigwnch updates on every single resize event even if the screen size or grid sizes didn't change. This is super noisy and given how many resize events macOS sends, its also very expensive.

This commit makes it so that we only update the renderer if the screen changed. If the screen size didn't change, the grid size couldn't have changed either.

If the screen size did change, its still possible the grid size didn't change since Ghostty supports fluid pixel-level resizing. We have to send the screen size event to the renderer so all the GPU shader vars are right but we do not have to send a termio event.

So, only if the grid size changed do we then notify the pty that the terminal dimensions changed. Note that the resize event for ptys does have a pixel-level x/y but I don't think the granularity is useful beyond grid changes.