### PR TITLE
macos: Cmd-Q without any window focus works

### DIFF
--- a/macos/Sources/AppDelegate.swift
+++ b/macos/Sources/AppDelegate.swift
@@ -48,8 +48,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         if (windows.allSatisfy { !$0.isVisible }) { return .terminateNow }
         
         // If the user is shutting down, restarting, or logging out, we don't confirm quit.
-        if let event = NSAppleEventManager.shared().currentAppleEvent {
-            if let why = event.attributeDescriptor(forKeyword: AEKeyword("why?")!) {
+        why: if let event = NSAppleEventManager.shared().currentAppleEvent {
+            // If all Ghostty windows are in the background (i.e. you Cmd-Q from the Cmd-Tab
+            // view), then this is null. I don't know why (pun intended) but we have to
+            // guard against it.
+            guard let keyword = AEKeyword("why?") else { break why }
+            
+            if let why = event.attributeDescriptor(forKeyword: keyword) {
                 switch (why.typeCodeValue) {
                 case kAEShutDown:
                     fallthrough


### PR DESCRIPTION
Previously, this would crash. Once the crash was fixed, it would hang because we would only show confirmation if the terminal window had focus.

This introduces some medium complexity logic to work around this:

  1. If we are the key window, then show the confirmation dialog. Done.
  2. Otherwise, if any other window is a terminal window and is key, they're going to take it so we do nothing.
  3. Otherwise, if we are the first terminal window in the application windows list, we show it even if we're not focused.