### PR TITLE
macos: enable copy/paste menu items in "Edit"

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -221,6 +221,11 @@ typedef enum {
     GHOSTTY_KEY_RIGHT_SUPER,
 } ghostty_input_key_e;
 
+typedef enum {
+    GHOSTTY_BINDING_COPY_TO_CLIPBOARD,
+    GHOSTTY_BINDING_PASTE_FROM_CLIPBOARD,
+} ghostty_binding_action_e;
+
 // Fully defined types. This MUST be kept in sync with equivalent Zig
 // structs. To find the Zig struct, grep for this type name. The documentation
 // for all of these types is available in the Zig source.
@@ -290,6 +295,7 @@ void ghostty_surface_ime_point(ghostty_surface_t, double *, double *);
 void ghostty_surface_request_close(ghostty_surface_t);
 void ghostty_surface_split(ghostty_surface_t, ghostty_split_direction_e);
 void ghostty_surface_split_focus(ghostty_surface_t, ghostty_split_focus_direction_e);
+void ghostty_surface_binding_action(ghostty_surface_t, ghostty_binding_action_e, void *);
 
 // APIs I'd like to get rid of eventually but are still needed for now.
 // Don't use these unless you know what you're doing.

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -381,6 +381,23 @@ extension Ghostty {
             ghostty_surface_key(surface, action, key, unmapped_key, mods)
         }
         
+        // MARK: Menu Handlers
+        
+        @IBAction func copy(_ sender: Any?) {
+            guard let surface = self.surface else { return }
+            ghostty_surface_binding_action(surface, GHOSTTY_BINDING_COPY_TO_CLIPBOARD, nil)
+        }
+        
+        @IBAction func paste(_ sender: Any?) {
+            guard let surface = self.surface else { return }
+            ghostty_surface_binding_action(surface, GHOSTTY_BINDING_PASTE_FROM_CLIPBOARD, nil)
+        }
+        
+        @IBAction func pasteAsPlainText(_ sender: Any?) {
+            guard let surface = self.surface else { return }
+            ghostty_surface_binding_action(surface, GHOSTTY_BINDING_PASTE_FROM_CLIPBOARD, nil)
+        }
+        
         // MARK: NSTextInputClient
         
         func hasMarkedText() -> Bool {

--- a/macos/Sources/MainMenu.xib
+++ b/macos/Sources/MainMenu.xib
@@ -94,9 +94,29 @@
                         </items>
                     </menu>
                 </menuItem>
-                <menuItem title="Edit" id="l1C-ez-1tg">
+                <menuItem title="Edit" id="ZUG-Nx-Wkj">
                     <modifierMask key="keyEquivalentModifierMask"/>
-                    <menu key="submenu" title="Edit" id="yo0-cI-6cQ"/>
+                    <menu key="submenu" title="Edit" id="iU4-OB-ccf">
+                        <items>
+                            <menuItem title="Copy" keyEquivalent="c" id="Jqf-pv-Zcu">
+                                <connections>
+                                    <action selector="copy:" target="-1" id="B4F-hg-R4T"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Paste" keyEquivalent="v" id="i27-pK-umN">
+                                <connections>
+                                    <action selector="paste:" target="-1" id="ZKe-2B-mel"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Paste and Match Style" keyEquivalent="V" id="FFo-bM-GXj">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="pasteAsPlainText:" target="-1" id="Sfp-aT-ZgM"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="VYS-RG-uZD"/>
+                        </items>
+                    </menu>
                 </menuItem>
                 <menuItem title="Window" id="aUF-d1-5bR">
                     <modifierMask key="keyEquivalentModifierMask"/>

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -571,6 +571,25 @@ pub const CAPI = struct {
         ptr.gotoSplit(direction);
     }
 
+    /// Invoke an action on the surface.
+    export fn ghostty_surface_binding_action(
+        ptr: *Surface,
+        key: input.Binding.Key,
+        unused: *anyopaque,
+    ) void {
+        // For future arguments
+        _ = unused;
+
+        const action: input.Binding.Action = switch (key) {
+            .copy_to_clipboard => .{ .copy_to_clipboard = {} },
+            .paste_from_clipboard => .{ .paste_from_clipboard = {} },
+        };
+
+        ptr.core_surface.performBindingAction(action) catch |err| {
+            log.err("error performing binding action action={} err={}", .{ action, err });
+        };
+    }
+
     /// Sets the window background blur on macOS to the desired value.
     /// I do this in Zig as an extern function because I don't know how to
     /// call these functions in Swift.

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -248,6 +248,13 @@ pub const Action = union(enum) {
     };
 };
 
+// A key for the C API to execute an action. This must be kept in sync
+// with include/ghostty.h.
+pub const Key = enum(c_int) {
+    copy_to_clipboard,
+    paste_from_clipboard,
+};
+
 /// Trigger is the associated key state that can trigger an action.
 pub const Trigger = struct {
     /// The key that has to be pressed for a binding to take action.


### PR DESCRIPTION
Fixes #73 

This makes the "Copy", "Paste", "Paste as Plain Text" and "Start Dictation" (since it just acts as Paste) work in macOS from the menu. This doesn't disable the copy or paste items if there is no selection or nothing on the clipboard. That is left as a future TODO.

## Demo

https://github.com/mitchellh/ghostty/assets/1299/958ef0b9-d418-48b3-abdc-e6f62afa1649