### PR TITLE
Allow setting "jump_to_prompt" binding in config, bind on Linux, and easier shell integration on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,6 @@ Ghostty supports some features that require shell integration. I am aiming
 to support many of the features that
 [Kitty supports for shell integration](https://sw.kovidgoyal.net/kitty/shell-integration/).
 
-Ghostty will automatically inject the shell integration code for `zsh` and
-`fish`. Other shells are not supported. You can also manually load them
-in many cases (see `src/shell-integration`). **If you want to disable this feature,**
-set `shell-integration = none` in your configuration file.
-
 The currently support shell integration features in Ghostty:
 
   * We do not confirm close for windows where the cursor is at a prompt.
@@ -135,6 +130,38 @@ The currently support shell integration features in Ghostty:
   * The cursor at the prompt is turned into a bar.
   * The `scroll_to_prompt` keybinding can be used to scroll the terminal window
     forward and back through prompts.
+
+#### Shell Integration Installation and Verification
+
+**On macOS,** Ghostty will automatically inject the shell integration code for `zsh` and
+`fish`. Other shells are not supported. You can also manually load them
+in many cases (see `src/shell-integration`). **If you want to disable this feature,**
+set `shell-integration = none` in your configuration file.
+
+**On Linux,** automatic shell integration requires that you set the
+`GHOSTTY_RESOURCES_DIR` environment variable to point to the
+`zig-out/share` directory after building Ghostty from source.
+To validate this directory the file `$GHOSTTY_RESOURCES_DIR/terminfo/ghostty.terminfo`
+should exist.
+
+To verify shell integration is working, look for the following log lines:
+
+```
+info(io_exec): using Ghostty resources dir from env var: /Applications/Ghostty.app/Contents/Resources
+info(io_exec): shell integration automatically injected shell=termio.shell_integration.Shell.fish
+```
+
+If you see any of the following, something is not working correctly.
+The main culprit is usually that `GHOSTTY_RESOURCES_DIR` is not pointing
+to the right place.
+
+```
+ghostty terminfo not found, using xterm-256color
+
+or
+
+shell could not be detected, no automatic shell integration will be injected
+```
 
 ## Roadmap and Status
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -480,6 +480,18 @@ pub const Config = struct {
                 .{ .key = .right, .mods = .{ .ctrl = true, .alt = true } },
                 .{ .goto_split = .right },
             );
+
+            // Semantic prompts
+            try result.keybind.set.put(
+                alloc,
+                .{ .key = .page_up, .mods = .{ .shift = true } },
+                .{ .jump_to_prompt = -1 },
+            );
+            try result.keybind.set.put(
+                alloc,
+                .{ .key = .page_down, .mods = .{ .shift = true } },
+                .{ .jump_to_prompt = 1 },
+            );
         }
         {
             // Cmd+N for goto tab N

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -124,6 +124,14 @@ pub fn parse(input: []const u8) !Binding {
                             break :action @unionInit(Action, field.name, value);
                         },
 
+                        .Int => {
+                            const idx = colonIdx orelse return Error.InvalidFormat;
+                            const param = actionRaw[idx + 1 ..];
+                            const value = std.fmt.parseInt(field.type, param, 10) catch
+                                return Error.InvalidFormat;
+                            break :action @unionInit(Action, field.name, value);
+                        },
+
                         else => unreachable,
                     },
                 }
@@ -416,5 +424,21 @@ test "parse: action with enum" {
         const binding = try parse("a=new_split:right");
         try testing.expect(binding.action == .new_split);
         try testing.expectEqual(Action.SplitDirection.right, binding.action.new_split);
+    }
+}
+
+test "parse: action with int" {
+    const testing = std.testing;
+
+    // parameter
+    {
+        const binding = try parse("a=jump_to_prompt:-1");
+        try testing.expect(binding.action == .jump_to_prompt);
+        try testing.expectEqual(@as(i16, -1), binding.action.jump_to_prompt);
+    }
+    {
+        const binding = try parse("a=jump_to_prompt:10");
+        try testing.expect(binding.action == .jump_to_prompt);
+        try testing.expectEqual(@as(i16, 10), binding.action.jump_to_prompt);
     }
 }


### PR DESCRIPTION
Fixes #227 

This has three major changes to improve shell integration functionality on Linux.

You can now set the `jump_to_prompt` binding (on all platforms) to jump back/forward between prompts. You can change this binding by setting `keybind = shift+whatever=jump_to_prompt:-1` where `-1` is the amount to jump (negative is back).

On macOS, this was always automatically bound to `Cmd+Shift+Up/Down`. On Linux, this is now set to `Shift+Page-Up/Down`. The Linux binding is new in this PR.

This feature requires shell integration and shell integration on Linux is now easier (its automatic on macOS). On Linux, you can now set the `GHOSTTY_RESOURCES_DIR` env var to point to the `zig-out/share` directory from building Ghostty. Ghostty will detect this and set the proper terminfo and shell integration configs for fish and zsh.