### PR TITLE
renderer/opengl: need to release OpenGL context with glfw

### DIFF
--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -532,6 +532,12 @@ pub fn surfaceInit(surface: *apprt.Surface) !void {
 pub fn finalizeSurfaceInit(self: *const OpenGL, surface: *apprt.Surface) !void {
     _ = self;
     _ = surface;
+
+    // For GLFW, we grabbed the OpenGL context in surfaceInit and we
+    // need to release it before we start the renderer thread.
+    if (apprt.runtime == apprt.glfw) {
+        glfw.makeContextCurrent(null);
+    }
 }
 
 /// This is called if this renderer runs DevMode.


### PR DESCRIPTION
Fixes #228 

GTK doesn't have this problem because the renderer is forcibly single-threaded onto the main thread.

For GLFW, we grab the OpenGL context to initialize some OpenGL properties while on the main thread. We fail to release it (`makeContextCurrent(null)`) before starting up the second thread. While we never _simultaneously use_ the contexts, it appears that some drivers (i.e. nvidia) validate that only one thread even has the context at all. That seems sensible.