### PR TITLE
renderer: hide cursor is state explicit asks for invisible cursor

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -531,11 +531,15 @@ pub fn render(
         // Setup our cursor state
         if (self.focused) {
             self.cursor_visible = visible: {
+                // If the cursor is explicitly not visible in the state,
+                // then it is not visible.
+                if (!state.cursor.visible) break :visible false;
+
                 // If the cursor isn't a blinking style, then never blink.
                 if (!state.cursor.style.blinking()) break :visible true;
 
                 // Otherwise, adhere to our current state.
-                break :visible self.cursor_visible and state.cursor.visible;
+                break :visible self.cursor_visible;
             };
             self.cursor_style = renderer.CursorStyle.fromTerminal(state.cursor.style) orelse .box;
         } else {

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -731,11 +731,15 @@ pub fn render(
         // Setup our cursor state
         if (self.focused) {
             self.cursor_visible = visible: {
+                // If the cursor is explicitly not visible in the state,
+                // then it is not visible.
+                if (!state.cursor.visible) break :visible false;
+
                 // If the cursor isn't a blinking style, then never blink.
                 if (!state.cursor.style.blinking()) break :visible true;
 
                 // Otherwise, adhere to our current state.
-                break :visible self.cursor_visible and state.cursor.visible;
+                break :visible self.cursor_visible;
             };
             self.cursor_style = renderer.CursorStyle.fromTerminal(state.cursor.style) orelse .box;
         } else {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1173,6 +1173,10 @@ const StreamHandler = struct {
     }
 
     pub fn setMode(self: *StreamHandler, mode: terminal.Mode, enabled: bool) !void {
+        // Note: this function doesn't need to grab the render state or
+        // terminal locks because it is only called from process() which
+        // grabs the lock.
+
         switch (mode) {
             .cursor_keys => {
                 self.terminal.modes.cursor_keys = enabled;


### PR DESCRIPTION
This was a regression. The previous logic would always show the cursor if we were using a non-blinking cursor. But, if the terminal state is explicitly requesting an invisible cursor (mode 25) then we need to hide the cursor.

Test program:

```
#!/usr/bin/env bash
printf 'cursor is visible: '
printf '\x1b[?25h'
sleep 2
printf '\n'
printf 'cursor is invisible: '
printf '\x1b[?25l'
sleep 2
printf '\x1b[?25h' # reset
printf '\n'
```

Demo:

https://github.com/mitchellh/ghostty/assets/1299/04f59515-b4e4-4758-92e1-3b1c051dac30


