### PR TITLE
flatpak: install icon files to `/apps` path

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -378,15 +378,15 @@ pub fn build(b: *std.Build) !void {
 
         // Various icons that our application can use, including the icon
         // that will be used for the desktop.
-        b.installFile("images/icons/icon_16x16.png", "share/icons/hicolor/16x16/com.mitchellh.ghostty.png");
-        b.installFile("images/icons/icon_32x32.png", "share/icons/hicolor/32x32/com.mitchellh.ghostty.png");
-        b.installFile("images/icons/icon_128x128.png", "share/icons/hicolor/128x128/com.mitchellh.ghostty.png");
-        b.installFile("images/icons/icon_256x256.png", "share/icons/hicolor/256x256/com.mitchellh.ghostty.png");
-        b.installFile("images/icons/icon_512x512.png", "share/icons/hicolor/512x512/com.mitchellh.ghostty.png");
-        b.installFile("images/icons/icon_16x16@2x@2x.png", "share/icons/hicolor/16x16@2/com.mitchellh.ghostty.png");
-        b.installFile("images/icons/icon_32x32@2x@2x.png", "share/icons/hicolor/32x32@2/com.mitchellh.ghostty.png");
-        b.installFile("images/icons/icon_128x128@2x@2x.png", "share/icons/hicolor/128x128@2/com.mitchellh.ghostty.png");
-        b.installFile("images/icons/icon_256x256@2x@2x.png", "share/icons/hicolor/256x256@2/com.mitchellh.ghostty.png");
+        b.installFile("images/icons/icon_16x16.png", "share/icons/hicolor/16x16/apps/com.mitchellh.ghostty.png");
+        b.installFile("images/icons/icon_32x32.png", "share/icons/hicolor/32x32/apps/com.mitchellh.ghostty.png");
+        b.installFile("images/icons/icon_128x128.png", "share/icons/hicolor/128x128/apps/com.mitchellh.ghostty.png");
+        b.installFile("images/icons/icon_256x256.png", "share/icons/hicolor/256x256/apps/com.mitchellh.ghostty.png");
+        b.installFile("images/icons/icon_512x512.png", "share/icons/hicolor/512x512/apps/com.mitchellh.ghostty.png");
+        b.installFile("images/icons/icon_16x16@2x@2x.png", "share/icons/hicolor/16x16@2/apps/com.mitchellh.ghostty.png");
+        b.installFile("images/icons/icon_32x32@2x@2x.png", "share/icons/hicolor/32x32@2/apps/com.mitchellh.ghostty.png");
+        b.installFile("images/icons/icon_128x128@2x@2x.png", "share/icons/hicolor/128x128@2/apps/com.mitchellh.ghostty.png");
+        b.installFile("images/icons/icon_256x256@2x@2x.png", "share/icons/hicolor/256x256@2/apps/com.mitchellh.ghostty.png");
     }
 
     // App (Mac)


### PR DESCRIPTION
I couldn't get icons to work for the flatpak version, so I looked at the reference here: https://docs.flatpak.org/en/latest/freedesktop-quick-reference.html

That says the path format is `share/icons/hicolor/<resolution>/apps/<icon>`.

That also matches what I have on my Ubuntu machines: icons are, for example, located in these two locations:

- `/usr/share/icons/hicolor/128x128/apps`
- `~/.local/share/icons/hicolor/128x128/apps`

Note the `/apps`.

## Proof

This is the flatpak version running, after I purged my local desktop db:

![image](https://github.com/mitchellh/ghostty/assets/1185253/8380c5b3-4ecb-475c-8efe-fe710a5da8d8)
