### PR TITLE
macOS: explicitly name the NSMainNibFile in plist

### DIFF
--- a/macos/Ghostty-Info.plist
+++ b/macos/Ghostty-Info.plist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>NSMainNibFile</key>
+	<string>MainMenu</string>
+</dict>
 </plist>


### PR DESCRIPTION
According to [this answer][0] here and [this blogpost][1], if the `NSMainNibFile` is not specified in the `*.plist` file, then `NSApplicationMain` will look through the bundle to get the first nib file it finds.

I like the explicitness of naming it and it probably also saves a miniscule amount of CPU/IO when we can skip finding the file.

[0]: https://stackoverflow.com/questions/42886400/how-does-nsapplicationmain-find-the-main-nib-file
[1]: https://jameshfisher.com/2017/03/20/how-is-mainmenu-xib-loaded/