### PR TITLE
Fix some Linux build issues

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -718,7 +718,14 @@ fn addDeps(
         step.linkSystemLibrary("pixman-1");
         step.linkSystemLibrary("zlib");
 
-        if (font_backend.hasFontconfig()) step.linkSystemLibrary("fontconfig");
+        if (font_backend.hasFontconfig()) {
+            step.linkSystemLibrary("fontconfig");
+
+            // Required on some systems, and pkg-config for fontconfig
+            // doesn't include it
+            step.linkSystemLibrary("libxml-2.0");
+            step.linkSystemLibrary("uuid");
+        }
     }
 
     // Other dependencies, we may dynamically link

--- a/flake.lock
+++ b/flake.lock
@@ -126,11 +126,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1690978078,
-        "narHash": "sha256-+S9s6sjOGuGCtA9njTdduJ7KjZm2tskxKhwGRKBK/xM=",
+        "lastModified": 1691410097,
+        "narHash": "sha256-HoZ/JwddeysSKNYr7h3AqReCMXPcqgqW/eBVOekxhFM=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "c9f51464f2c2c9c75f3d7fdc58c157d252545dec",
+        "rev": "9eda53e9001c54c810e24efe256c28d57a75d20d",
         "type": "github"
       },
       "original": {

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -30,8 +30,6 @@
 , harfbuzz
 , libpng
 , libGL
-, libuuid
-, libxml2
 , libX11
 , libXcursor
 , libXext
@@ -52,8 +50,6 @@ let
     freetype
     harfbuzz
     libpng
-    libuuid
-    libxml2
     zlib
 
     libX11
@@ -107,8 +103,6 @@ in mkShell rec {
     freetype
     harfbuzz
     libpng
-    libuuid
-    libxml2
     pixman
     zlib
 

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -30,7 +30,8 @@
 , harfbuzz
 , libpng
 , libGL
-, libuv
+, libuuid
+, libxml2
 , libX11
 , libXcursor
 , libXext
@@ -51,7 +52,8 @@ let
     freetype
     harfbuzz
     libpng
-    libuv
+    libuuid
+    libxml2
     zlib
 
     libX11
@@ -105,7 +107,8 @@ in mkShell rec {
     freetype
     harfbuzz
     libpng
-    libuv
+    libuuid
+    libxml2
     pixman
     zlib
 


### PR DESCRIPTION
1. On some systems, dynamic libraries are installed by default in `/usr/lib/{triple}`, so add that to our search path. I reported this as an upstream issue since I think Zig should do this by default: https://github.com/ziglang/zig/issues/16733

2. When linking system libraries, we have to explicitly request that we prefer dynamic linking first. This causes Zig to search all paths for a dynamic lib before going back and searching for static libs. We have to do this because dynamic libs will automatically link to their dependencies and static will not, and `-Dstatic=false` we prefer dynamic anyways. This is a new Zig 0.11 behavior.