### PR TITLE
GTK single instance, fix UB in termio read thread termination

### DIFF
--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -65,6 +65,14 @@ pub const App = struct {
         // up when we take a pass at cleaning up the dev mode.
         if (DevMode.enabled) DevMode.instance.config = config;
 
+        // Queue a single new window that starts on launch
+        _ = core_app.mailbox.push(.{
+            .new_window = .{},
+        }, .{ .forever = {} });
+
+        // We want the event loop to wake up instantly so we can process our tick.
+        glfw.postEmptyEvent();
+
         return .{
             .app = core_app,
             .config = config,

--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -31,11 +31,7 @@ const log = std.log.scoped(.gtk);
 /// application frameworks also have this restriction so it simplifies
 /// the assumptions.
 pub const App = struct {
-    pub const Options = struct {
-        /// GTK app ID. This is currently unused but should remain populated
-        /// for the future.
-        id: [:0]const u8 = "com.mitchellh.ghostty",
-    };
+    pub const Options = struct {};
 
     core_app: *CoreApp,
     config: Config,
@@ -62,9 +58,14 @@ pub const App = struct {
         var config = try Config.load(core_app.alloc);
         errdefer config.deinit();
 
+        // Our uniqueness ID is based on whether we're in a debug mode or not.
+        // In debug mode we want to be separate so we can develop Ghostty in
+        // Ghostty.
+        const uniqueness_id = "com.mitchellh.ghostty" ++ if (builtin.mode == .Debug) "-debug" else "";
+
         // Create our GTK Application which encapsulates our process.
         const app = @as(?*c.GtkApplication, @ptrCast(c.gtk_application_new(
-            null,
+            uniqueness_id,
 
             // GTK >= 2.74
             if (@hasDecl(c, "G_APPLICATION_DEFAULT_FLAGS"))
@@ -77,7 +78,7 @@ pub const App = struct {
             app,
             "activate",
             c.G_CALLBACK(&activate),
-            null,
+            core_app,
             null,
             G_CONNECT_DEFAULT,
         );
@@ -121,12 +122,19 @@ pub const App = struct {
             .ctx = ctx,
             .cursor_default = cursor_default,
             .cursor_ibeam = cursor_ibeam,
+
+            // If we are NOT the primary instance, then we never want to run.
+            // This means that another instance of the GTK app is running and
+            // our "activate" call above will open a window.
+            .running = c.g_application_get_is_remote(gapp) == 0,
         };
     }
 
     // Terminate the application. The application will not be restarted after
     // this so all global state can be cleaned up.
     pub fn terminate(self: *App) void {
+        c.g_signal_emit(self.app, c.g_signal_lookup("shutdown", c.g_application_get_type()), 0);
+
         c.g_settings_sync();
         while (c.g_main_context_iteration(self.ctx, 0) != 0) {}
         c.g_main_context_release(self.ctx);
@@ -182,6 +190,9 @@ pub const App = struct {
     pub fn newWindow(self: *App, parent_: ?*CoreSurface) !void {
         _ = parent_;
         const alloc = self.core_app.alloc;
+
+        // If we're trying to quit, then do not open any new windows.
+        if (!self.running) return;
 
         // Allocate a fixed pointer for our window. We try to minimize
         // allocations but windows and other GUI requirements are so minimal
@@ -261,15 +272,18 @@ pub const App = struct {
         }.callback, null);
     }
 
+    /// This is called by the "activate" signal. This is sent on program
+    /// startup and also when a secondary instance launches and requests
+    /// a new window.
     fn activate(app: *c.GtkApplication, ud: ?*anyopaque) callconv(.C) void {
         _ = app;
-        _ = ud;
 
-        // We purposely don't do anything on activation right now. We have
-        // this callback because if we don't then GTK emits a warning to
-        // stderr that we don't want. We emit a debug log just so that we know
-        // we reached this point.
-        log.debug("application activated", .{});
+        const core_app: *CoreApp = @ptrCast(@alignCast(ud orelse return));
+
+        // Queue a new window
+        _ = core_app.mailbox.push(.{
+            .new_window = .{},
+        }, .{ .instant = {} });
     }
 };
 

--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -133,8 +133,6 @@ pub const App = struct {
     // Terminate the application. The application will not be restarted after
     // this so all global state can be cleaned up.
     pub fn terminate(self: *App) void {
-        c.g_signal_emit(self.app, c.g_signal_lookup("shutdown", c.g_application_get_type()), 0);
-
         c.g_settings_sync();
         while (c.g_main_context_iteration(self.ctx, 0) != 0) {}
         c.g_main_context_release(self.ctx);
@@ -190,9 +188,6 @@ pub const App = struct {
     pub fn newWindow(self: *App, parent_: ?*CoreSurface) !void {
         _ = parent_;
         const alloc = self.core_app.alloc;
-
-        // If we're trying to quit, then do not open any new windows.
-        if (!self.running) return;
 
         // Allocate a fixed pointer for our window. We try to minimize
         // allocations but windows and other GUI requirements are so minimal

--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -283,7 +283,7 @@ pub const App = struct {
         // Queue a new window
         _ = core_app.mailbox.push(.{
             .new_window = .{},
-        }, .{ .instant = {} });
+        }, .{ .forever = {} });
     }
 };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -34,9 +34,6 @@ pub fn main() !void {
     var app_runtime = try apprt.App.init(app, .{});
     defer app_runtime.terminate();
 
-    // Create an initial window
-    try app_runtime.newWindow(null);
-
     // Run the GUI event loop
     try app_runtime.run();
 }


### PR DESCRIPTION
This PR first set out to enable GTK single instance mode, and does that. While doing that, I discovered some serious issues with the way we were shutting down our pty read thread and I'm unsure why that never bit us before. I'll describe both.

## GTK Single Instance

GTK single instance is a mode where GTK runs only a single process for an application. When you try to start another instance, it notifies the main process via dbus and opens a new window instead, immediately exiting the newly started process. This makes opening the app multiple times VERY fast because it just has to open a new window; all the app initialization is complete already.

This is the _recommended_ way GTK applications are supposed to work, and behaves nicely with various desktop features that we don't take advantage of yet.

We use a different uniqueness ID for debug and release builds. This will allow us to develop Ghostty in Ghostty w/o interfering with the release build that is running.

## Termio Read Thread Termination

While building the above, I noticed that whenever I created a new window in GTK, then closed a previous window, the GTK app would hang. I could reproduce this on main without the single instance changes. 

Looking into this further, I determined that the way we were shutting down our PTY IO read thread was unsound: we were closing the primary pty fd and expecting the `read` syscall to exit. This surprisingly works in most cases, and kind of also surprisingly doesn't work _at all_ when running via GTK. Simultaneously `close()` and `read()`-ing a fd across multiple threads is undefined behavior (UB). The recommended approach is to use some signaling method to a thread so synchronize so they're not simultaneous.

To do this, I introduced a `pipe()` solely for signaling quit. The read thread now marks the primary pty fd as `O_NONBLOCK` and its in a tight `read()` loop until it gets an `EAGAIN`. Once we get an `EAGAIN`, we drop down to `poll()` on our two file descriptors. If we receive a ready for the quit fd, we quit. Otherwise, we read. 

The tight read loop doesn't cause problems because when we quit, we always kill the subprocess first. Therefore, the fd always exhausts itself of data relatively quickly in order to process the quit fd.

The reason I do the tight loop is because without it, I was seeing a ~5% performance drop on both Mac and Linux on IO-bound terminal tasks. With the tight loop, the performance drop is gone (likely because its behaving exactly like the old code). 