### PR TITLE
gtk: app icon

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -182,6 +182,7 @@ pub fn init(
     alloc: Allocator,
     config: *const configpkg.Config,
     app_mailbox: App.Mailbox,
+    app_resources_dir: ?[]const u8,
     rt_surface: *apprt.runtime.Surface,
 ) !void {
     // Initialize our renderer with our initialized surface.
@@ -405,6 +406,7 @@ pub fn init(
         .screen_size = screen_size,
         .full_config = config,
         .config = try termio.Impl.DerivedConfig.init(alloc, config),
+        .resources_dir = app_resources_dir,
         .renderer_state = &self.renderer_state,
         .renderer_wakeup = render_thread.wakeup,
         .renderer_mailbox = render_thread.mailbox,

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -177,6 +177,7 @@ pub const Surface = struct {
             app.core_app.alloc,
             &config,
             .{ .rt_app = app, .mailbox = &app.core_app.mailbox },
+            app.core_app.resources_dir,
             self,
         );
         errdefer self.core_surface.deinit();

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -363,6 +363,7 @@ pub const Surface = struct {
             app.app.alloc,
             &config,
             .{ .rt_app = app, .mailbox = &app.app.mailbox },
+            app.app.resources_dir,
             self,
         );
         errdefer self.core_surface.deinit();

--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -298,6 +298,9 @@ const Window = struct {
     /// The background CSS for the window (if any).
     css_window_background: ?[]u8 = null,
 
+    /// The resources directory for the icon (if any).
+    icon_search_dir: ?[:0]const u8 = null,
+
     pub fn init(self: *Window, app: *App) !void {
         // Set up our own state
         self.* = .{
@@ -313,6 +316,31 @@ const Window = struct {
         self.window = gtk_window;
         c.gtk_window_set_title(gtk_window, "Ghostty");
         c.gtk_window_set_default_size(gtk_window, 1000, 600);
+
+        // If we don't have the icon then we'll try to add our resources dir
+        // to the search path and see if we can find it there.
+        const icon_name = "com.mitchellh.ghostty";
+        const icon_theme = c.gtk_icon_theme_get_for_display(c.gtk_widget_get_display(window));
+        if (c.gtk_icon_theme_has_icon(icon_theme, icon_name) == 0) icon: {
+            const base = self.app.core_app.resources_dir orelse {
+                log.info("gtk app missing Ghostty icon and no resources dir detected", .{});
+                log.info("gtk app will not have Ghostty icon", .{});
+                break :icon;
+            };
+
+            // Note that this method for adding the icon search path is
+            // a fallback mechanism. The recommended mechanism is the
+            // Freedesktop Icon Theme Specification. We distribute a ".desktop"
+            // file in zig-out/share that should be installed to the proper
+            // place.
+            const dir = try std.fmt.allocPrintZ(app.core_app.alloc, "{s}/icons", .{base});
+            self.icon_search_dir = dir;
+            c.gtk_icon_theme_add_search_path(icon_theme, dir.ptr);
+            if (c.gtk_icon_theme_has_icon(icon_theme, icon_name) == 0) {
+                log.warn("Ghostty icon for gtk app not found", .{});
+            }
+        }
+        c.gtk_window_set_icon_name(gtk_window, icon_name);
 
         // Apply background opacity if we have it
         if (app.config.@"background-opacity" < 1) {
@@ -361,6 +389,7 @@ const Window = struct {
 
     pub fn deinit(self: *Window) void {
         if (self.css_window_background) |ptr| self.app.core_app.alloc.free(ptr);
+        if (self.icon_search_dir) |ptr| self.app.core_app.alloc.free(ptr);
     }
 
     /// Add a new tab to this window.

--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -765,6 +765,7 @@ pub const Surface = struct {
             self.app.core_app.alloc,
             &config,
             .{ .rt_app = self.app, .mailbox = &self.app.core_app.mailbox },
+            self.app.core_app.resources_dir,
             self,
         );
         errdefer self.core_surface.deinit();

--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -7,6 +7,7 @@ pub usingnamespace @import("homedir.zig");
 pub usingnamespace @import("locale.zig");
 pub usingnamespace @import("macos_version.zig");
 pub usingnamespace @import("mouse.zig");
+pub usingnamespace @import("resourcesdir.zig");
 pub const TempDir = @import("TempDir.zig");
 pub const passwd = @import("passwd.zig");
 pub const xdg = @import("xdg.zig");

--- a/src/os/resourcesdir.zig
+++ b/src/os/resourcesdir.zig
@@ -8,6 +8,9 @@ const Allocator = std.mem.Allocator;
 /// the output is not ALWAYS written to the buffer and may refer to
 /// static memory.
 ///
+/// This is highly Ghostty-specific and can likely be generalized at
+/// some point but we can cross that bridge if we ever need to.
+///
 /// This returns error.OutOfMemory is buffer is not big enough.
 pub fn resourcesDir(buf: []u8) !?[]const u8 {
     // If we have an environment variable set, we always use that.
@@ -60,7 +63,7 @@ pub fn maybeDir(
     sub: []const u8,
     suffix: []const u8,
 ) !?[]const u8 {
-    const path = try std.fmt.bufPrint(&buf, "{s}/{s}/{s}", .{ base, sub, suffix });
+    const path = try std.fmt.bufPrint(buf, "{s}/{s}/{s}", .{ base, sub, suffix });
 
     if (std.fs.accessAbsolute(path, .{})) {
         const len = path.len - suffix.len - 1;

--- a/src/os/resourcesdir.zig
+++ b/src/os/resourcesdir.zig
@@ -1,0 +1,74 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const Allocator = std.mem.Allocator;
+
+/// Gets the directory to the bundled resources directory, if it
+/// exists (not all platforms or packages have it). The output is
+/// written to the given buffer if we need to allocate. Note that
+/// the output is not ALWAYS written to the buffer and may refer to
+/// static memory.
+///
+/// This returns error.OutOfMemory is buffer is not big enough.
+pub fn resourcesDir(buf: []u8) !?[]const u8 {
+    // If we have an environment variable set, we always use that.
+    if (std.os.getenv("GHOSTTY_RESOURCES_DIR")) |dir| {
+        if (dir.len > 0) {
+            return dir;
+        }
+    }
+
+    // This is the sentinel value we look for in the path to know
+    // we've found the resources directory.
+    const sentinel = "terminfo/ghostty.termcap";
+
+    // Get the path to our running binary
+    var exe_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var exe: []const u8 = std.fs.selfExePath(&exe_buf) catch return null;
+
+    // We have an exe path! Climb the tree looking for the terminfo
+    // bundle as we expect it.
+    while (std.fs.path.dirname(exe)) |dir| {
+        exe = dir;
+
+        // On MacOS, we look for the app bundle path.
+        if (comptime builtin.target.isDarwin()) {
+            if (try maybeDir(buf, dir, "Contents/Resources", sentinel)) |v| {
+                return v;
+            }
+        }
+
+        // On all platforms, we look for a /usr/share style path. This
+        // is valid even on Mac since there is nothing that requires
+        // Ghostty to be in an app bundle.
+        if (try maybeDir(buf, dir, "share", sentinel)) |v| {
+            return v;
+        }
+    }
+
+    return null;
+}
+
+/// Little helper to check if the "base/sub/suffix" directory exists and
+/// if so return true. The "suffix" is just used as a way to verify a directory
+/// seems roughly right.
+///
+/// "buf" must be large enough to fit base + sub + suffix. This is generally
+/// MAX_PATH_BYTES so its not a big deal.
+pub fn maybeDir(
+    buf: []u8,
+    base: []const u8,
+    sub: []const u8,
+    suffix: []const u8,
+) !?[]const u8 {
+    const path = try std.fmt.bufPrint(&buf, "{s}/{s}/{s}", .{ base, sub, suffix });
+
+    if (std.fs.accessAbsolute(path, .{})) {
+        const len = path.len - suffix.len - 1;
+        return buf[0..len];
+    } else |_| {
+        // Folder doesn't exist. If a different error happens its okay
+        // we just ignore it and move on.
+    }
+
+    return null;
+}

--- a/src/termio/Options.zig
+++ b/src/termio/Options.zig
@@ -20,6 +20,9 @@ full_config: *const Config,
 /// The derived configuration for this termio implementation.
 config: termio.Impl.DerivedConfig,
 
+/// The application resources directory.
+resources_dir: ?[]const u8,
+
 /// The render state. The IO implementation can modify anything here. The
 /// surface thread will setup the initial "terminal" pointer but the IO impl
 /// is free to change that if that is useful (i.e. doing some sort of dual


### PR DESCRIPTION
Fixes #248 

This makes the Ghostty icon visible for the GTK application. This uses the #241 feature that we implemented yesterday to find the icons. **Note this a fallback mechanism and not the recommended GTK approach.** The recommended approach now is to conform to the [Freedesktop Icon Theme Specification](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html) which requires a system package to do properly. We output all the correct files in `zig-out/share`, though.

I use a tiling wm so not a good screenshot, but before/after of `rofi`...

## Before

<img width="228" alt="CleanShot 2023-08-08 at 09 53 39@2x" src="https://github.com/mitchellh/ghostty/assets/1299/66c9d871-176d-4b6f-b7a2-8a38a34fb638">

## After

<img width="239" alt="CleanShot 2023-08-08 at 09 52 55@2x" src="https://github.com/mitchellh/ghostty/assets/1299/d3dbb127-ade7-4754-afe2-ebd6c1a6c703">
