### PR TITLE
gtk: fix arrow-up stealing focus

### DIFF
--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -1171,6 +1171,9 @@ pub const Surface = struct {
             // If the key is tab, we say we handled it because we don't want
             // tab to move focus from our surface.
             c.GDK_KEY_Tab => 1,
+            // We do the same for up, because that steals focus from the surface,
+            // in case we have multiple tabs open.
+            c.GDK_KEY_Up => 1,
 
             else => 0,
         };


### PR DESCRIPTION
This fixes #253 -- with essentially a single line! Just took me a while to find out where to add this line.

Turns out we already solved this problem for `<Tab>` so now we do the same thing for `<Up>`: we tell the `GtkApplication` we handled the event so it doesn't propagate any further.

## Before

[before.webm](https://github.com/mitchellh/ghostty/assets/1185253/33c54fe8-4a80-43fe-aa88-2228b71a4988)

## After

[after.webm](https://github.com/mitchellh/ghostty/assets/1185253/84c5e995-4a4f-44d8-bf30-2c94cd8bf99f)

