### PR TITLE
Primary (selection) clipboard support

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -253,6 +253,7 @@ typedef void (*ghostty_runtime_toggle_fullscreen_cb)(void *, bool);
 
 typedef struct {
     void *userdata;
+    bool supports_selection_clipboard;
     ghostty_runtime_wakeup_cb wakeup_cb;
     ghostty_runtime_reload_config_cb reload_config_cb;
     ghostty_runtime_set_title_cb set_title_cb;

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -30,6 +30,11 @@ typedef void *ghostty_surface_t;
 
 // Enums are up top so we can reference them later.
 typedef enum {
+    GHOSTTY_CLIPBOARD_STANDARD,
+    GHOSTTY_CLIPBOARD_SELECTION,
+} ghostty_clipboard_e;
+
+typedef enum {
     GHOSTTY_SPLIT_RIGHT,
     GHOSTTY_SPLIT_DOWN
 } ghostty_split_direction_e;
@@ -238,8 +243,8 @@ typedef struct {
 typedef void (*ghostty_runtime_wakeup_cb)(void *);
 typedef const ghostty_config_t (*ghostty_runtime_reload_config_cb)(void *);
 typedef void (*ghostty_runtime_set_title_cb)(void *, const char *);
-typedef const char* (*ghostty_runtime_read_clipboard_cb)(void *);
-typedef void (*ghostty_runtime_write_clipboard_cb)(void *, const char *);
+typedef const char* (*ghostty_runtime_read_clipboard_cb)(void *, ghostty_clipboard_e);
+typedef void (*ghostty_runtime_write_clipboard_cb)(void *, const char *, ghostty_clipboard_e);
 typedef void (*ghostty_runtime_new_split_cb)(void *, ghostty_split_direction_e);
 typedef void (*ghostty_runtime_close_surface_cb)(void *, bool);
 typedef void (*ghostty_runtime_focus_split_cb)(void *, ghostty_split_focus_direction_e);

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -57,8 +57,8 @@ extension Ghostty {
                 wakeup_cb: { userdata in AppState.wakeup(userdata) },
                 reload_config_cb: { userdata in AppState.reloadConfig(userdata) },
                 set_title_cb: { userdata, title in AppState.setTitle(userdata, title: title) },
-                read_clipboard_cb: { userdata in AppState.readClipboard(userdata) },
-                write_clipboard_cb: { userdata, str in AppState.writeClipboard(userdata, string: str) },
+                read_clipboard_cb: { userdata, loc in AppState.readClipboard(userdata, location: loc) },
+                write_clipboard_cb: { userdata, str, loc in AppState.writeClipboard(userdata, string: str, location: loc) },
                 new_split_cb: { userdata, direction in AppState.newSplit(userdata, direction: direction) },
                 close_surface_cb: { userdata, processAlive in AppState.closeSurface(userdata, processAlive: processAlive) },
                 focus_split_cb: { userdata, direction in AppState.focusSplit(userdata, direction: direction) },
@@ -170,7 +170,10 @@ extension Ghostty {
             )
         }
         
-        static func readClipboard(_ userdata: UnsafeMutableRawPointer?) -> UnsafePointer<CChar>? {
+        static func readClipboard(_ userdata: UnsafeMutableRawPointer?, location: ghostty_clipboard_e) -> UnsafePointer<CChar>? {
+            // We only support the standard clipboard
+            if (location != GHOSTTY_CLIPBOARD_STANDARD) { return nil }
+            
             guard let appState = self.appState(fromSurface: userdata) else { return nil }
             guard let str = NSPasteboard.general.string(forType: .string) else { return nil }
             
@@ -180,7 +183,10 @@ extension Ghostty {
             return (str as NSString).utf8String
         }
         
-        static func writeClipboard(_ userdata: UnsafeMutableRawPointer?, string: UnsafePointer<CChar>?) {
+        static func writeClipboard(_ userdata: UnsafeMutableRawPointer?, string: UnsafePointer<CChar>?, location: ghostty_clipboard_e) {
+            // We only support the standard clipboard
+            if (location != GHOSTTY_CLIPBOARD_STANDARD) { return }
+            
             guard let valueStr = String(cString: string!, encoding: .utf8) else { return }
             let pb = NSPasteboard.general
             pb.declareTypes([.string], owner: nil)

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -54,6 +54,7 @@ extension Ghostty {
             // uses to interface with the application runtime environment.
             var runtime_cfg = ghostty_runtime_config_s(
                 userdata: Unmanaged.passUnretained(self).toOpaque(),
+                supports_selection_clipboard: false,
                 wakeup_cb: { userdata in AppState.wakeup(userdata) },
                 reload_config_cb: { userdata in AppState.reloadConfig(userdata) },
                 set_title_cb: { userdata, title in AppState.setTitle(userdata, title: title) },

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -849,6 +849,14 @@ fn setSelection(self: *Surface, sel_: ?terminal.Selection) void {
     const sel = sel_ orelse return;
     if (prev_) |prev| if (std.meta.eql(sel, prev)) return;
 
+    // Check if our runtime supports the selection clipboard at all.
+    // We can save a lot of work if it doesn't.
+    if (@hasDecl(apprt.runtime.Surface, "supportsClipboard")) {
+        if (!self.rt_surface.supportsClipboard(clipboard)) {
+            return;
+        }
+    }
+
     var buf = self.io.terminal.screen.selectionString(
         self.alloc,
         sel,

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -47,10 +47,10 @@ pub const App = struct {
         /// Read the clipboard value. The return value must be preserved
         /// by the host until the next call. If there is no valid clipboard
         /// value then this should return null.
-        read_clipboard: *const fn (SurfaceUD) callconv(.C) ?[*:0]const u8,
+        read_clipboard: *const fn (SurfaceUD, c_int) callconv(.C) ?[*:0]const u8,
 
         /// Write the clipboard value.
-        write_clipboard: *const fn (SurfaceUD, [*:0]const u8) callconv(.C) void,
+        write_clipboard: *const fn (SurfaceUD, [*:0]const u8, c_int) callconv(.C) void,
 
         /// Create a new split view. If the embedder doesn't support split
         /// views then this can be null.
@@ -239,13 +239,27 @@ pub const Surface = struct {
         );
     }
 
-    pub fn getClipboardString(self: *const Surface) ![:0]const u8 {
-        const ptr = self.app.opts.read_clipboard(self.opts.userdata) orelse return "";
+    pub fn getClipboardString(
+        self: *const Surface,
+        clipboard_type: apprt.Clipboard,
+    ) ![:0]const u8 {
+        const ptr = self.app.opts.read_clipboard(
+            self.opts.userdata,
+            @intCast(@intFromEnum(clipboard_type)),
+        ) orelse return "";
         return std.mem.sliceTo(ptr, 0);
     }
 
-    pub fn setClipboardString(self: *const Surface, val: [:0]const u8) !void {
-        self.app.opts.write_clipboard(self.opts.userdata, val.ptr);
+    pub fn setClipboardString(
+        self: *const Surface,
+        val: [:0]const u8,
+        clipboard_type: apprt.Clipboard,
+    ) !void {
+        self.app.opts.write_clipboard(
+            self.opts.userdata,
+            val.ptr,
+            @intCast(@intFromEnum(clipboard_type)),
+        );
     }
 
     pub fn setShouldClose(self: *Surface) void {

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -32,6 +32,9 @@ pub const App = struct {
         /// Userdata that is passed to all the callbacks.
         userdata: AppUD = null,
 
+        /// True if the selection clipboard is supported.
+        supports_selection_clipboard: bool = false,
+
         /// Callback called to wakeup the event loop. This should trigger
         /// a full tick of the app loop.
         wakeup: *const fn (AppUD) callconv(.C) void,
@@ -237,6 +240,16 @@ pub const Surface = struct {
             self.opts.userdata,
             slice.ptr,
         );
+    }
+
+    pub fn supportsClipboard(
+        self: *const Surface,
+        clipboard_type: apprt.Clipboard,
+    ) bool {
+        return switch (clipboard_type) {
+            .standard => true,
+            .selection => self.app.opts.supports_selection_clipboard,
+        };
     }
 
     pub fn getClipboardString(

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -526,7 +526,7 @@ pub const Surface = struct {
             .standard => glfw.setClipboardString(val),
             .selection => {
                 // Not supported except on Linux
-                if (comptime builtin.os.tag != .linux) return "";
+                if (comptime builtin.os.tag != .linux) return;
                 glfwNative.setX11SelectionString(val.ptr);
             },
         }

--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -940,6 +940,7 @@ pub const Surface = struct {
         val: [:0]const u8,
         clipboard_type: apprt.Clipboard,
     ) !void {
+        log.warn("SETTING CLIPBOARD: {s}", .{val});
         const clipboard = getClipboard(@ptrCast(self.gl_area), clipboard_type);
         c.gdk_clipboard_set_text(clipboard, val.ptr);
     }

--- a/src/apprt/structs.zig
+++ b/src/apprt/structs.zig
@@ -23,3 +23,11 @@ pub const IMEPos = struct {
     x: f64,
     y: f64,
 };
+
+/// The clipboard type.
+///
+/// If this is changed, you must also update ghostty.h
+pub const Clipboard = enum(u1) {
+    standard = 0, // ctrl+c/v
+    selection = 1, // also known as the "primary" clipboard
+};

--- a/src/config.zig
+++ b/src/config.zig
@@ -186,6 +186,17 @@ pub const Config = struct {
     /// This does not affect data sent to the clipboard via "clipboard-write".
     @"clipboard-trim-trailing-spaces": bool = true,
 
+    /// Whether to automatically copy selected text to the clipboard. "true"
+    /// will only copy on systems that support a selection clipboard.
+    ///
+    /// The value "clipboard" will copy to the system clipboard, making this
+    /// work on macOS. Note that middle-click will also paste from the system
+    /// clipboard in this case.
+    ///
+    /// Note that if this is disabled, middle-click paste will also be
+    /// disabled.
+    @"copy-on-select": CopyOnSelect = .true,
+
     /// The time in milliseconds between clicks to consider a click a repeat
     /// (double, triple, etc.) or an entirely new single click. A value of
     /// zero will use a platform-specific default. The default on macOS
@@ -1375,6 +1386,20 @@ pub const Keybinds = struct {
     }
 };
 
+/// Options for copy on select behavior.
+pub const CopyOnSelect = enum {
+    /// Disables copy on select entirely.
+    false,
+
+    /// Copy on select is enabled, but goes to the selection clipboard.
+    /// This is not supported on platforms such as macOS. This is the default.
+    true,
+
+    /// Copy on select is enabled and goes to the system clipboard.
+    clipboard,
+};
+
+/// Shell integration values
 pub const ShellIntegration = enum {
     none,
     detect,

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1417,7 +1417,7 @@ const StreamHandler = struct {
     }
 
     pub fn clipboardContents(self: *StreamHandler, kind: u8, data: []const u8) !void {
-        // Note: we ignore the "kind" field and always use the primary clipboard.
+        // Note: we ignore the "kind" field and always use the standard clipboard.
         // iTerm also appears to do this but other terminals seem to only allow
         // certain. Let's investigate more.
 


### PR DESCRIPTION
Fixes #265 

This adds support for the "primary" clipboard (as its called in X11, otherwise also known as the "selection" clipboard). This is the clipboard whose contents are set automatically for any selection and can be pasted using the middle-click button.

This also adds a `copy-on-select` configuration that can have one of three values:

  - `false` - disable copy (and paste!) on select completely
  - `true` - enable copy/paste if the system supports a selection clipboard (default)
  - `clipboard` - enable copy/paste but use the system standard clipboard 

https://github.com/mitchellh/ghostty/assets/1299/f69b45de-b2f6-4635-939e-44c886cc8714

