### PR TITLE
Don't show hollow cursor in inactive windows when cursor is hidden.

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -528,22 +528,21 @@ pub fn render(
         state.mutex.lock();
         defer state.mutex.unlock();
 
-        // Setup our cursor state
+        self.cursor_visible = visible: {
+            // If the cursor is explicitly not visible in the state,
+            // then it is not visible.
+            if (!state.cursor.visible) break :visible false;
+
+            // If the cursor isn't a blinking style, then never blink.
+            if (!state.cursor.style.blinking()) break :visible true;
+
+            // Otherwise, adhere to our current state.
+            break :visible self.cursor_visible;
+        };
+
         if (self.focused) {
-            self.cursor_visible = visible: {
-                // If the cursor is explicitly not visible in the state,
-                // then it is not visible.
-                if (!state.cursor.visible) break :visible false;
-
-                // If the cursor isn't a blinking style, then never blink.
-                if (!state.cursor.style.blinking()) break :visible true;
-
-                // Otherwise, adhere to our current state.
-                break :visible self.cursor_visible;
-            };
             self.cursor_style = renderer.CursorStyle.fromTerminal(state.cursor.style) orelse .box;
         } else {
-            self.cursor_visible = true;
             self.cursor_style = .box_hollow;
         }
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -728,22 +728,21 @@ pub fn render(
         state.mutex.lock();
         defer state.mutex.unlock();
 
-        // Setup our cursor state
+        self.cursor_visible = visible: {
+            // If the cursor is explicitly not visible in the state,
+            // then it is not visible.
+            if (!state.cursor.visible) break :visible false;
+
+            // If the cursor isn't a blinking style, then never blink.
+            if (!state.cursor.style.blinking()) break :visible true;
+
+            // Otherwise, adhere to our current state.
+            break :visible self.cursor_visible;
+        };
+
         if (self.focused) {
-            self.cursor_visible = visible: {
-                // If the cursor is explicitly not visible in the state,
-                // then it is not visible.
-                if (!state.cursor.visible) break :visible false;
-
-                // If the cursor isn't a blinking style, then never blink.
-                if (!state.cursor.style.blinking()) break :visible true;
-
-                // Otherwise, adhere to our current state.
-                break :visible self.cursor_visible;
-            };
             self.cursor_style = renderer.CursorStyle.fromTerminal(state.cursor.style) orelse .box;
         } else {
-            self.cursor_visible = true;
             self.cursor_style = .box_hollow;
         }
 


### PR DESCRIPTION
This is the behavior of the other terminals I have, such as iTerm, allcritty, WezTerm, and Kitty. The hollow cursor is especially noticable when running in two panes, one of them inactive with animations (such as a progress bar)