### PR TITLE
only initialize font discovery mechanism once, cache on App

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -196,8 +196,8 @@ pub const Surface = struct {
         try self.core_surface.init(
             app.core_app.alloc,
             &config,
+            app.core_app,
             .{ .rt_app = app, .mailbox = &app.core_app.mailbox },
-            app.core_app.resources_dir,
             self,
         );
         errdefer self.core_surface.deinit();

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -374,8 +374,8 @@ pub const Surface = struct {
         try self.core_surface.init(
             app.app.alloc,
             &config,
+            app.app,
             .{ .rt_app = app, .mailbox = &app.app.mailbox },
-            app.app.resources_dir,
             self,
         );
         errdefer self.core_surface.deinit();

--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -789,8 +789,8 @@ pub const Surface = struct {
         try self.core_surface.init(
             self.app.core_app.alloc,
             &config,
+            self.app.core_app,
             .{ .rt_app = self.app, .mailbox = &self.app.core_app.mailbox },
-            self.app.core_app.resources_dir,
             self,
         );
         errdefer self.core_surface.deinit();
@@ -1203,6 +1203,14 @@ pub const Surface = struct {
             break :key input.Key.fromASCII(self.im_buf[0]) orelse physical_key;
         } else .invalid;
 
+        // log.debug("key pressed key={} physical_key={} composing={} text_len={} mods={}", .{
+        //     key,
+        //     physical_key,
+        //     self.im_composing,
+        //     self.im_len,
+        //     mods,
+        // });
+
         // If both keys are invalid then we won't call the key callback. But
         // if either one is valid, we want to give it a chance.
         if (key != .invalid or physical_key != .invalid) {
@@ -1342,6 +1350,8 @@ pub const Surface = struct {
             if (str.len <= self.im_buf.len) {
                 @memcpy(self.im_buf[0..str.len], str);
                 self.im_len = @intCast(str.len);
+
+                // log.debug("input commit: {x}", .{self.im_buf[0]});
             } else {
                 log.warn("not enough buffer space for input method commit", .{});
             }

--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -168,7 +168,7 @@ pub const Fontconfig = struct {
 
     /// Discover fonts from a descriptor. This returns an iterator that can
     /// be used to build up the deferred fonts.
-    pub fn discover(self: *Fontconfig, desc: Descriptor) !DiscoverIterator {
+    pub fn discover(self: *const Fontconfig, desc: Descriptor) !DiscoverIterator {
         // Build our pattern that we'll search for
         const pat = desc.toFcPattern();
         errdefer pat.destroy();


### PR DESCRIPTION
Fixes #274

Fontconfig in particular appears unsafe to initialize multiple times.

Font discovery is a singleton object in an application and only ever accessed from the main thread so we can work around this by only initializing and caching the font discovery mechanism exactly once on the app singleton.