### PR TITLE
update to nix 23.05

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -61,11 +61,6 @@ pub fn build(b: *std.Build) !void {
     const target = target: {
         var result = b.standardTargetOptions(.{});
 
-        if (result.isLinux() and result.isGnuLibC()) {
-            // https://github.com/ziglang/zig/issues/9485
-            result.glibc_version = .{ .major = 2, .minor = 28, .patch = 0 };
-        }
-
         if (result.isDarwin()) {
             if (result.os_version_min == null) {
                 result.os_version_min = .{ .semver = .{ .major = 12, .minor = 0, .patch = 0 } };

--- a/flake.lock
+++ b/flake.lock
@@ -64,16 +64,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688392541,
-        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
+        "lastModified": 1691950488,
+        "narHash": "sha256-iUNEeudc4dGjx+HsHccnGiuZUVE/nhjXuQ1DVCsHIUY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
+        "rev": "720e61ed8de116eec48d6baea1d54469b536b985",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "release-22.11",
+        "ref": "release-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
     # We want to stay as up to date as possible but need to be careful
     # that the glibc versions used by our dependencies from Nix are compatible
     # with the system glibc that the user is building for.
-    nixpkgs.url = "github:nixos/nixpkgs/release-22.11";
+    nixpkgs.url = "github:nixos/nixpkgs/release-23.05";
 
     # Used for shell.nix
     flake-compat = { url = github:edolstra/flake-compat; flake = false; };


### PR DESCRIPTION
Fixes #175 

Again. We reverted this last time because it broke @mrnugget's build, but we have more NixOS users than not now so I think we have to get this going otherwise GTK is very broken for more people.

I am trying one different thing that I hope will help which is to stop specifying a specific glibc version. I'm unsure if that'll make a difference for you but at the very least I do not think it is necessary anymore.