### PR TITLE
Many keyboard input improvements (no Kitty protocol yet)

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1092,11 +1092,25 @@ pub fn keyCallback(
             const ctrl_only: u8 = @bitCast(input.Mods{ .ctrl = true });
 
             // If we're only pressing control, check if this is a character
-            // we convert to a non-printable.
+            // we convert to a non-printable. The best table I've found for
+            // this is:
+            // https://sw.kovidgoyal.net/kitty/keyboard-protocol/#legacy-ctrl-mapping-of-ascii-keys
             if (mods_int == ctrl_only) {
                 const val: u8 = switch (key) {
-                    .left_bracket => 0x1B,
+                    .space => 0,
+                    .slash => 0x1F,
+                    .zero => 0x30,
+                    .one => 0x31,
+                    .two => 0x00,
+                    .three => 0x1B,
+                    .four => 0x1C,
+                    .five => 0x1D,
+                    .six => 0x1E,
+                    .seven => 0x1F,
+                    .eight => 0x7F,
+                    .nine => 0x39,
                     .backslash => 0x1C,
+                    .left_bracket => 0x1B,
                     .right_bracket => 0x1D,
                     .backspace => 0x08,
                     .a => 0x01,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1115,6 +1115,7 @@ pub fn keyCallback(
     self.renderer_state.mutex.lock();
     const cursor_key_application = self.io.terminal.modes.cursor_keys;
     const keypad_key_application = self.io.terminal.modes.keypad_keys;
+    const modify_other_keys = self.io.terminal.modes.modify_other_keys;
     self.renderer_state.mutex.unlock();
 
     // Check if we're processing a function key.
@@ -1133,10 +1134,8 @@ pub fn keyCallback(
 
         switch (entry.modify_other_keys) {
             .any => {},
-
-            // TODO
-            .set => {},
-            .set_other => continue,
+            .set => if (modify_other_keys) continue,
+            .set_other => if (!modify_other_keys) continue,
         }
 
         const mods_int: u8 = @bitCast(binding_mods);

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1114,6 +1114,7 @@ pub fn keyCallback(
     // We'll need to know these values here on.
     self.renderer_state.mutex.lock();
     const cursor_key_application = self.io.terminal.modes.cursor_keys;
+    const keypad_key_application = self.io.terminal.modes.keypad_keys;
     self.renderer_state.mutex.unlock();
 
     // Check if we're processing a function key.
@@ -1126,7 +1127,8 @@ pub fn keyCallback(
 
         switch (entry.keypad) {
             .any => {},
-            else => {}, // TODO
+            .normal => if (keypad_key_application) continue,
+            .application => if (!keypad_key_application) continue,
         }
 
         switch (entry.modify_other_keys) {

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -597,7 +597,8 @@ pub const Surface = struct {
             return;
         }
 
-        core_win.charCallback(codepoint) catch |err| {
+        // TODO: mods
+        core_win.charCallback(codepoint, .{}) catch |err| {
             log.err("error in char callback err={}", .{err});
             return;
         };

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -611,15 +611,11 @@ pub const Surface = struct {
         glfw_action: glfw.Action,
         glfw_mods: glfw.Mods,
     ) void {
+        const tracy = trace(@src());
+        defer tracy.end();
         _ = scancode;
 
         const core_win = window.getUserPointer(CoreSurface) orelse return;
-
-        // Reset our consumption state
-        core_win.rt_surface.key_consumed = false;
-
-        const tracy = trace(@src());
-        defer tracy.end();
 
         // Convert our glfw types into our input types
         const mods: input.Mods = @bitCast(glfw_mods);
@@ -756,6 +752,7 @@ pub const Surface = struct {
 
         // TODO: we need to do mapped keybindings
 
+        core_win.rt_surface.key_mods = mods;
         core_win.rt_surface.key_consumed = core_win.keyCallback(
             action,
             key,

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -285,6 +285,7 @@ pub const Surface = struct {
     /// This is set to true when keyCallback consumes the input, suppressing
     /// the charCallback from being fired.
     key_consumed: bool = false,
+    key_mods: input.Mods = .{},
 
     pub const Options = struct {};
 
@@ -597,8 +598,7 @@ pub const Surface = struct {
             return;
         }
 
-        // TODO: mods
-        core_win.charCallback(codepoint, .{}) catch |err| {
+        core_win.charCallback(codepoint, core_win.rt_surface.key_mods) catch |err| {
             log.err("error in char callback err={}", .{err});
             return;
         };

--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -1282,7 +1282,7 @@ pub const Surface = struct {
             };
             var it = view.iterator();
             while (it.nextCodepoint()) |cp| {
-                self.core_surface.charCallback(cp) catch |err| {
+                self.core_surface.charCallback(cp, mods) catch |err| {
                     log.err("error in char callback err={}", .{err});
                     return 0;
                 };
@@ -1390,7 +1390,7 @@ pub const Surface = struct {
         };
         var it = view.iterator();
         while (it.nextCodepoint()) |cp| {
-            self.core_surface.charCallback(cp) catch |err| {
+            self.core_surface.charCallback(cp, .{}) catch |err| {
                 log.err("error in char callback err={}", .{err});
                 return;
             };

--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -1184,7 +1184,7 @@ pub const Surface = struct {
     /// in a keypress, we let those automatically work.
     fn gtkKeyPressed(
         ec_key: *c.GtkEventControllerKey,
-        _: c.guint,
+        keyval: c.guint,
         keycode: c.guint,
         gtk_mods: c.GdkModifierType,
         ud: ?*anyopaque,
@@ -1225,8 +1225,9 @@ pub const Surface = struct {
             break :key input.Key.fromASCII(self.im_buf[0]) orelse physical_key;
         } else .invalid;
 
-        // log.debug("key pressed key={} physical_key={} composing={} text_len={} mods={}", .{
+        // log.debug("key pressed key={} keyval={x} physical_key={} composing={} text_len={} mods={}", .{
         //     key,
+        //     keyval,
         //     physical_key,
         //     self.im_composing,
         //     self.im_len,
@@ -1271,6 +1272,21 @@ pub const Surface = struct {
             };
 
             return 0;
+        }
+
+        // If we aren't composing and have no text, we try to convert the keyval
+        // to a text value. We have to do this because GTK will not process
+        // "Ctrl+Shift+1" (on US keyboards) as "Ctrl+!" but instead as "".
+        // But the keyval is set correctly so we can at least extract that.
+        if (self.im_len == 0) {
+            const keyval_unicode = c.gdk_keyval_to_unicode(keyval);
+            if (keyval_unicode != 0) {
+                if (std.math.cast(u21, keyval_unicode)) |cp| {
+                    if (std.unicode.utf8Encode(cp, &self.im_buf)) |len| {
+                        self.im_len = len;
+                    } else |_| {}
+                }
+            }
         }
 
         // Next, we want to call the char callback with each codepoint.

--- a/src/config.zig
+++ b/src/config.zig
@@ -238,6 +238,19 @@ pub const Config = struct {
     /// animations.
     @"macos-non-native-fullscreen": bool = false,
 
+    /// If true, the Option key will be treated as Alt. This makes terminal
+    /// sequences expecting Alt to work properly, but will break Unicode
+    /// input sequences on macOS if you use them via the alt key. You may
+    /// set this to false to restore the macOS alt-key unicode sequences
+    /// but this will break terminal sequences expecting Alt to work.
+    ///
+    /// Note that if an Option-sequence doesn't produce a printable
+    /// character, it will be treated as Alt regardless of this setting.
+    /// (i.e. alt+ctrl+a).
+    ///
+    /// This does not work with GLFW builds.
+    @"macos-option-as-alt": bool = false,
+
     /// This is set by the CLI parser for deinit.
     _arena: ?ArenaAllocator = null,
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -321,9 +321,6 @@ pub const Config = struct {
         errdefer result.deinit();
         const alloc = result._arena.?.allocator();
 
-        // Add the PC style function keys first so that we can override any later.
-        try result.defaultPCStyleFunctionKeys(alloc);
-
         // Add our default keybindings
         try result.keybind.set.put(
             alloc,
@@ -643,129 +640,6 @@ pub const Config = struct {
         }
 
         return result;
-    }
-
-    fn defaultPCStyleFunctionKeys(result: *Config, alloc: Allocator) !void {
-        // Some control keys
-        try result.keybind.set.put(alloc, .{ .key = .up }, .{ .cursor_key = .{
-            .normal = "\x1b[A",
-            .application = "\x1bOA",
-        } });
-        try result.keybind.set.put(alloc, .{ .key = .down }, .{ .cursor_key = .{
-            .normal = "\x1b[B",
-            .application = "\x1bOB",
-        } });
-        try result.keybind.set.put(alloc, .{ .key = .right }, .{ .cursor_key = .{
-            .normal = "\x1b[C",
-            .application = "\x1bOC",
-        } });
-        try result.keybind.set.put(alloc, .{ .key = .left }, .{ .cursor_key = .{
-            .normal = "\x1b[D",
-            .application = "\x1bOD",
-        } });
-        try result.keybind.set.put(alloc, .{ .key = .home }, .{ .cursor_key = .{
-            .normal = "\x1b[H",
-            .application = "\x1bOH",
-        } });
-        try result.keybind.set.put(alloc, .{ .key = .end }, .{ .cursor_key = .{
-            .normal = "\x1b[F",
-            .application = "\x1bOF",
-        } });
-
-        try result.keybind.set.put(
-            alloc,
-            .{ .key = .tab, .mods = .{ .shift = true } },
-            .{ .csi = "Z" },
-        );
-
-        try result.keybind.set.put(alloc, .{ .key = .insert }, .{ .csi = "2~" });
-        try result.keybind.set.put(alloc, .{ .key = .delete }, .{ .csi = "3~" });
-        try result.keybind.set.put(alloc, .{ .key = .page_up }, .{ .csi = "5~" });
-        try result.keybind.set.put(alloc, .{ .key = .page_down }, .{ .csi = "6~" });
-
-        // From xterm:
-        // Note that F1 through F4 are prefixed with SS3 , while the other keys are
-        // prefixed with CSI .  Older versions of xterm implement different escape
-        // sequences for F1 through F4, with a CSI  prefix.  These can be activated
-        // by setting the oldXtermFKeys resource.  However, since they do not
-        // correspond to any hardware terminal, they have been deprecated.  (The
-        // DEC VT220 reserves F1 through F5 for local functions such as Setup).
-        try result.keybind.set.put(alloc, .{ .key = .f1 }, .{ .csi = "11~" });
-        try result.keybind.set.put(alloc, .{ .key = .f2 }, .{ .csi = "12~" });
-        try result.keybind.set.put(alloc, .{ .key = .f3 }, .{ .csi = "13~" });
-        try result.keybind.set.put(alloc, .{ .key = .f4 }, .{ .csi = "14~" });
-        try result.keybind.set.put(alloc, .{ .key = .f5 }, .{ .csi = "15~" });
-        try result.keybind.set.put(alloc, .{ .key = .f6 }, .{ .csi = "17~" });
-        try result.keybind.set.put(alloc, .{ .key = .f7 }, .{ .csi = "18~" });
-        try result.keybind.set.put(alloc, .{ .key = .f8 }, .{ .csi = "19~" });
-        try result.keybind.set.put(alloc, .{ .key = .f9 }, .{ .csi = "20~" });
-        try result.keybind.set.put(alloc, .{ .key = .f10 }, .{ .csi = "21~" });
-        try result.keybind.set.put(alloc, .{ .key = .f11 }, .{ .csi = "23~" });
-        try result.keybind.set.put(alloc, .{ .key = .f12 }, .{ .csi = "24~" });
-
-        // From: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
-        //
-        // In normal mode, i.e., a Sun/PC keyboard when the sunKeyboard resource is
-        // false (and none of the other keyboard resources such as oldXtermFKeys
-        // resource is set), xterm encodes function key modifiers as parameters
-        // appended before the final character of the control sequence.  As a
-        // special case, the SS3  sent before F1 through F4 is altered to CSI  when
-        // sending a function key modifier as a parameter.
-        //
-        //      Code     Modifiers
-        //    ---------+---------------------------
-        //       2     | Shift
-        //       3     | Alt
-        //       4     | Shift + Alt
-        //       5     | Control
-        //       6     | Shift + Control
-        //       7     | Alt + Control
-        //       8     | Shift + Alt + Control
-        //       9     | Meta
-        //       10    | Meta + Shift
-        //       11    | Meta + Alt
-        //       12    | Meta + Alt + Shift
-        //       13    | Meta + Ctrl
-        //       14    | Meta + Ctrl + Shift
-        //       15    | Meta + Ctrl + Alt
-        //       16    | Meta + Ctrl + Alt + Shift
-        //    ---------+---------------------------
-        const modifiers: []const inputpkg.Mods = &.{
-            .{ .shift = true },
-            .{ .alt = true },
-            .{ .shift = true, .alt = true },
-            .{ .ctrl = true },
-            .{ .shift = true, .ctrl = true },
-            .{ .alt = true, .ctrl = true },
-            .{ .shift = true, .alt = true, .ctrl = true },
-            // todo: do we do meta or not?
-        };
-        inline for (modifiers, 2..) |mods, code| {
-            const m: []const u8 = &.{code + 48};
-            const set = &result.keybind.set;
-            try set.put(alloc, .{ .key = .end, .mods = mods }, .{ .csi = "1;" ++ m ++ "F" });
-            try set.put(alloc, .{ .key = .home, .mods = mods }, .{ .csi = "1;" ++ m ++ "H" });
-            try set.put(alloc, .{ .key = .insert, .mods = mods }, .{ .csi = "2;" ++ m ++ "~" });
-            try set.put(alloc, .{ .key = .delete, .mods = mods }, .{ .csi = "3;" ++ m ++ "~" });
-            try set.put(alloc, .{ .key = .page_up, .mods = mods }, .{ .csi = "5;" ++ m ++ "~" });
-            try set.put(alloc, .{ .key = .page_down, .mods = mods }, .{ .csi = "6;" ++ m ++ "~" });
-            try set.put(alloc, .{ .key = .up, .mods = mods }, .{ .csi = "1;" ++ m ++ "A" });
-            try set.put(alloc, .{ .key = .down, .mods = mods }, .{ .csi = "1;" ++ m ++ "B" });
-            try set.put(alloc, .{ .key = .right, .mods = mods }, .{ .csi = "1;" ++ m ++ "C" });
-            try set.put(alloc, .{ .key = .left, .mods = mods }, .{ .csi = "1;" ++ m ++ "D" });
-            try set.put(alloc, .{ .key = .f1, .mods = mods }, .{ .csi = "11;" ++ m ++ "~" });
-            try set.put(alloc, .{ .key = .f2, .mods = mods }, .{ .csi = "12;" ++ m ++ "~" });
-            try set.put(alloc, .{ .key = .f3, .mods = mods }, .{ .csi = "13;" ++ m ++ "~" });
-            try set.put(alloc, .{ .key = .f4, .mods = mods }, .{ .csi = "14;" ++ m ++ "~" });
-            try set.put(alloc, .{ .key = .f5, .mods = mods }, .{ .csi = "15;" ++ m ++ "~" });
-            try set.put(alloc, .{ .key = .f6, .mods = mods }, .{ .csi = "17;" ++ m ++ "~" });
-            try set.put(alloc, .{ .key = .f7, .mods = mods }, .{ .csi = "18;" ++ m ++ "~" });
-            try set.put(alloc, .{ .key = .f8, .mods = mods }, .{ .csi = "19;" ++ m ++ "~" });
-            try set.put(alloc, .{ .key = .f9, .mods = mods }, .{ .csi = "20;" ++ m ++ "~" });
-            try set.put(alloc, .{ .key = .f10, .mods = mods }, .{ .csi = "21;" ++ m ++ "~" });
-            try set.put(alloc, .{ .key = .f11, .mods = mods }, .{ .csi = "23;" ++ m ++ "~" });
-            try set.put(alloc, .{ .key = .f12, .mods = mods }, .{ .csi = "24;" ++ m ++ "~" });
-        }
     }
 
     /// This sets either "ctrl" or "super" to true (but not both)

--- a/src/input.zig
+++ b/src/input.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 
 pub usingnamespace @import("input/mouse.zig");
 pub usingnamespace @import("input/key.zig");
+pub const function_keys = @import("input/function_keys.zig");
 pub const keycodes = @import("input/keycodes.zig");
 pub const Binding = @import("input/Binding.zig");
 pub const SplitDirection = Binding.Action.SplitDirection;

--- a/src/input/function_keys.zig
+++ b/src/input/function_keys.zig
@@ -1,0 +1,275 @@
+//! This is the list of "PC style function keys" that xterm supports for
+//! the legacy keyboard protocols. These always take priority since at the
+//! time of writing this, even the most modern keyboard protocols still
+//! are backwards compatible with regards to these sequences.
+//!
+//! This is based on a variety of sources cross-referenced but mostly
+//! based on foot's keymap.h: https://codeberg.org/dnkl/foot/src/branch/master/keymap.h
+
+const std = @import("std");
+const key = @import("key.zig");
+
+pub const CursorMode = enum { any, normal, application };
+pub const KeypadMode = enum { any, normal, application };
+
+/// A bit confusing so I'll document this one: this is the "modify other keys"
+/// setting. We only change behavior for "set_other" which is ESC [ 4; 2 m.
+/// So this can be "any" which means we don't care what's going on. Or it
+/// can be "set" which means modify keys must be set EXCEPT FOR "other keys"
+/// mode, and "set_other" which means modify keys must be set to "other keys"
+/// mode.
+///
+/// See: https://invisible-island.net/xterm/modified-keys.html
+pub const ModifyKeys = enum {
+    any,
+    set,
+    set_other,
+};
+
+/// A single entry in the table of keys.
+pub const Entry = struct {
+    /// The exact set of modifiers that must be active for this entry to match.
+    /// If mods_empty_is_any is true then empty mods means any set of mods can
+    /// match. Otherwise, empty mods means no mods must be active.
+    mods: key.Mods = .{},
+    mods_empty_is_any: bool = true,
+
+    /// The state required for cursor/keypad mode.
+    cursor: CursorMode = .any,
+    keypad: KeypadMode = .any,
+
+    /// Whether or not this entry should be used
+    modify_other_keys: ModifyKeys = .any,
+
+    /// The sequence to send to the pty if this entry matches.
+    sequence: []const u8,
+};
+
+/// This is the array of entries for the PC style function keys as mapped to
+/// our set of possible key codes. Not every key has any entries.
+pub const KeyEntryArray = std.EnumArray(key.Key, []const Entry);
+
+// The list of keys that we support and their entry values. It is expected
+// that you'll just use a for loop through the entry values, there are never
+// more than a couple dozen or so.
+pub const keys = keys: {
+    var result = KeyEntryArray.initFill(&.{});
+
+    result.set(.up, pcStyle("\x1b[1;{}A") ++ cursorKey("\x1b[A", "\x1bOA"));
+    result.set(.down, pcStyle("\x1b[1;{}B") ++ cursorKey("\x1b[B", "\x1bOB"));
+    result.set(.right, pcStyle("\x1b[1;{}C") ++ cursorKey("\x1b[C", "\x1bOC"));
+    result.set(.left, pcStyle("\x1b[1;{}D") ++ cursorKey("\x1b[D", "\x1bOD"));
+    result.set(.home, pcStyle("\x1b[1;{}H") ++ cursorKey("\x1b[H", "\x1bOH"));
+    result.set(.end, pcStyle("\x1b[1;{}F") ++ cursorKey("\x1b[F", "\x1bOF"));
+    result.set(.insert, pcStyle("\x1b[2;{}~") ++ .{.{ .sequence = "\x1B[2~" }});
+    result.set(.delete, pcStyle("\x1b[3;{}~") ++ .{.{ .sequence = "\x1B[3~" }});
+    result.set(.page_up, pcStyle("\x1b[5;{}~") ++ .{.{ .sequence = "\x1B[5~" }});
+    result.set(.page_down, pcStyle("\x1b[6;{}~") ++ .{.{ .sequence = "\x1B[6~" }});
+
+    // Function Keys. todo: f13-f35 but we need to add to input.Key
+    result.set(.f1, pcStyle("\x1b[11;{}~") ++ .{.{ .sequence = "\x1BOP" }});
+    result.set(.f2, pcStyle("\x1b[12;{}~") ++ .{.{ .sequence = "\x1BOQ" }});
+    result.set(.f3, pcStyle("\x1b[13;{}~") ++ .{.{ .sequence = "\x1BOR" }});
+    result.set(.f4, pcStyle("\x1b[14;{}~") ++ .{.{ .sequence = "\x1BOS" }});
+    result.set(.f5, pcStyle("\x1b[15;{}~") ++ .{.{ .sequence = "\x1B[15~" }});
+    result.set(.f6, pcStyle("\x1b[17;{}~") ++ .{.{ .sequence = "\x1B[17~" }});
+    result.set(.f7, pcStyle("\x1b[18;{}~") ++ .{.{ .sequence = "\x1B[18~" }});
+    result.set(.f8, pcStyle("\x1b[19;{}~") ++ .{.{ .sequence = "\x1B[19~" }});
+    result.set(.f9, pcStyle("\x1b[20;{}~") ++ .{.{ .sequence = "\x1B[20~" }});
+    result.set(.f10, pcStyle("\x1b[21;{}~") ++ .{.{ .sequence = "\x1B[21~" }});
+    result.set(.f11, pcStyle("\x1b[23;{}~") ++ .{.{ .sequence = "\x1B[23~" }});
+    result.set(.f12, pcStyle("\x1b[24;{}~") ++ .{.{ .sequence = "\x1B[24~" }});
+
+    // Keypad keys
+    result.set(.kp_0, kpDefault("p") ++ pcStyle("\x1bO{}p"));
+    result.set(.kp_1, kpDefault("q") ++ pcStyle("\x1bO{}q"));
+    result.set(.kp_2, kpDefault("r") ++ pcStyle("\x1bO{}r"));
+    result.set(.kp_3, kpDefault("s") ++ pcStyle("\x1bO{}s"));
+    result.set(.kp_4, kpDefault("t") ++ pcStyle("\x1bO{}t"));
+    result.set(.kp_5, kpDefault("u") ++ pcStyle("\x1bO{}u"));
+    result.set(.kp_6, kpDefault("v") ++ pcStyle("\x1bO{}v"));
+    result.set(.kp_7, kpDefault("w") ++ pcStyle("\x1bO{}w"));
+    result.set(.kp_8, kpDefault("x") ++ pcStyle("\x1bO{}x"));
+    result.set(.kp_9, kpDefault("y") ++ pcStyle("\x1bO{}y"));
+    result.set(.kp_decimal, kpDefault("n") ++ pcStyle("\x1bO{}n"));
+    result.set(.kp_divide, kpDefault("o") ++ pcStyle("\x1bO{}o"));
+    result.set(.kp_multiply, kpDefault("j") ++ pcStyle("\x1bO{}j"));
+    result.set(.kp_subtract, kpDefault("m") ++ pcStyle("\x1bO{}m"));
+    result.set(.kp_add, kpDefault("k") ++ pcStyle("\x1bO{}k"));
+    result.set(.kp_enter, kpDefault("M") ++ pcStyle("\x1bO{}M"));
+
+    result.set(.backspace, &.{
+        // Modify Keys Normal
+        .{ .mods = .{ .shift = true }, .modify_other_keys = .set, .sequence = "\x7f" },
+        .{ .mods = .{ .alt = true }, .modify_other_keys = .set, .sequence = "\x1b\x7f" },
+        .{ .mods = .{ .alt = true, .shift = true }, .modify_other_keys = .set, .sequence = "\x1b\x7f" },
+        .{ .mods = .{ .ctrl = true, .shift = true }, .modify_other_keys = .set, .sequence = "\x08" },
+        .{ .mods = .{ .alt = true, .ctrl = true }, .modify_other_keys = .set, .sequence = "\x1b\x08" },
+        .{ .mods = .{ .super = true }, .modify_other_keys = .set, .sequence = "\x7f" },
+        .{ .mods = .{ .super = true, .shift = true }, .modify_other_keys = .set, .sequence = "\x7f" },
+        .{ .mods = .{ .alt = true, .super = true }, .modify_other_keys = .set, .sequence = "\x1b\x7f" },
+        .{ .mods = .{ .alt = true, .super = true, .shift = true }, .modify_other_keys = .set, .sequence = "\x1b\x7f" },
+        .{ .mods = .{ .super = true, .ctrl = true }, .modify_other_keys = .set, .sequence = "\x08" },
+        .{ .mods = .{ .super = true, .ctrl = true, .shift = true }, .modify_other_keys = .set, .sequence = "\x08" },
+        .{ .mods = .{ .alt = true, .super = true, .ctrl = true }, .modify_other_keys = .set, .sequence = "\x1b\x08" },
+        .{ .mods = .{ .alt = true, .super = true, .ctrl = true, .shift = true }, .modify_other_keys = .set, .sequence = "\x1b\x08" },
+
+        // Modify Keys Other
+        .{ .mods = .{ .shift = true }, .modify_other_keys = .set_other, .sequence = "\x1b[27;2;127~" },
+        .{ .mods = .{ .alt = true }, .modify_other_keys = .set_other, .sequence = "\x1b[27;3;127~" },
+        .{ .mods = .{ .alt = true, .shift = true }, .modify_other_keys = .set_other, .sequence = "\x1b[27;4;127~" },
+        .{ .mods = .{ .ctrl = true, .shift = true }, .modify_other_keys = .set_other, .sequence = "\x1b[27;6;127~" },
+        .{ .mods = .{ .alt = true, .ctrl = true }, .modify_other_keys = .set_other, .sequence = "\x1b[27;7;127~" },
+        .{ .mods = .{ .alt = true, .shift = true, .ctrl = true }, .modify_other_keys = .set_other, .sequence = "\x1b[27;8;127~" },
+        .{ .mods = .{ .super = true }, .modify_other_keys = .set_other, .sequence = "\x1b[27;9;127~" },
+        .{ .mods = .{ .super = true, .shift = true }, .modify_other_keys = .set_other, .sequence = "\x1b[27;10;127~" },
+        .{ .mods = .{ .alt = true, .super = true }, .modify_other_keys = .set_other, .sequence = "\x1b[27;11;127~" },
+        .{ .mods = .{ .alt = true, .super = true, .shift = true }, .modify_other_keys = .set_other, .sequence = "\x1b[27;12;127~" },
+        .{ .mods = .{ .super = true, .ctrl = true }, .modify_other_keys = .set_other, .sequence = "\x1b[27;13;127~" },
+        .{ .mods = .{ .super = true, .ctrl = true, .shift = true }, .modify_other_keys = .set_other, .sequence = "\x1b[27;14;127~" },
+        .{ .mods = .{ .alt = true, .super = true, .ctrl = true }, .modify_other_keys = .set_other, .sequence = "\x1b[27;15;127~" },
+        .{ .mods = .{ .alt = true, .super = true, .ctrl = true, .shift = true }, .modify_other_keys = .set_other, .sequence = "\x1b[27;16;127~" },
+
+        .{ .mods = .{ .ctrl = true }, .sequence = "\x08" },
+        .{ .sequence = "\x7f" },
+    });
+
+    result.set(.tab, &.{
+        // Modify Keys Normal
+        .{ .mods = .{ .shift = true }, .modify_other_keys = .set, .sequence = "\x1b[Z" },
+        .{ .mods = .{ .alt = true }, .modify_other_keys = .set, .sequence = "\x1b\t" },
+
+        // Modify Keys Other
+        .{ .mods = .{ .shift = true }, .modify_other_keys = .set_other, .sequence = "\x1b[27;2;9~" },
+        .{ .mods = .{ .alt = true }, .modify_other_keys = .set_other, .sequence = "\x1b[27;3;9~" },
+
+        // Everything else
+        .{ .mods = .{ .alt = true, .shift = true }, .sequence = "\x1b[27;4;9~" },
+        .{ .mods = .{ .ctrl = true }, .sequence = "\x1b[27;5;9~" },
+        .{ .mods = .{ .ctrl = true, .shift = true }, .sequence = "\x1b[27;6;9~" },
+        .{ .mods = .{ .alt = true, .ctrl = true }, .sequence = "\x1b[27;7;9~" },
+        .{ .mods = .{ .alt = true, .ctrl = true, .shift = true }, .sequence = "\x1b[27;8;9~" },
+        .{ .mods = .{ .super = true }, .sequence = "\x1b[27;9;9~" },
+        .{ .mods = .{ .super = true, .shift = true }, .sequence = "\x1b[27;10;9~" },
+        .{ .mods = .{ .alt = true, .super = true }, .sequence = "\x1b[27;11;9~" },
+        .{ .mods = .{ .alt = true, .super = true, .shift = true }, .sequence = "\x1b[27;12;9~" },
+        .{ .mods = .{ .super = true, .ctrl = true }, .sequence = "\x1b[27;13;9~" },
+        .{ .mods = .{ .super = true, .ctrl = true, .shift = true }, .sequence = "\x1b[27;14;9~" },
+        .{ .mods = .{ .alt = true, .super = true, .ctrl = true }, .sequence = "\x1b[27;15;9~" },
+        .{ .mods = .{ .alt = true, .super = true, .ctrl = true, .shift = true }, .sequence = "\x1b[27;16;9~" },
+
+        .{ .sequence = "\t" },
+    });
+
+    result.set(.enter, &.{
+        .{ .mods = .{ .shift = true }, .sequence = "\x1b[27;2;13~" },
+
+        // Modify Keys Normal
+        .{ .mods = .{ .alt = true }, .modify_other_keys = .set, .sequence = "\x1b\r" },
+
+        // Modify Keys Other
+        .{ .mods = .{ .alt = true }, .modify_other_keys = .set_other, .sequence = "\x1b[27;3;13~" },
+
+        // Everything else
+        .{ .mods = .{ .alt = true, .shift = true }, .sequence = "\x1b[27;4;13~" },
+        .{ .mods = .{ .ctrl = true }, .sequence = "\x1b[27;5;13~" },
+        .{ .mods = .{ .ctrl = true, .shift = true }, .sequence = "\x1b[27;6;13~" },
+        .{ .mods = .{ .alt = true, .ctrl = true }, .sequence = "\x1b[27;7;13~" },
+        .{ .mods = .{ .alt = true, .ctrl = true, .shift = true }, .sequence = "\x1b[27;8;13~" },
+        .{ .mods = .{ .super = true }, .sequence = "\x1b[27;9;13~" },
+        .{ .mods = .{ .super = true, .shift = true }, .sequence = "\x1b[27;10;13~" },
+        .{ .mods = .{ .alt = true, .super = true }, .sequence = "\x1b[27;11;13~" },
+        .{ .mods = .{ .alt = true, .super = true, .shift = true }, .sequence = "\x1b[27;12;13~" },
+        .{ .mods = .{ .super = true, .ctrl = true }, .sequence = "\x1b[27;13;13~" },
+        .{ .mods = .{ .super = true, .ctrl = true, .shift = true }, .sequence = "\x1b[27;14;13~" },
+        .{ .mods = .{ .alt = true, .super = true, .ctrl = true }, .sequence = "\x1b[27;15;13~" },
+        .{ .mods = .{ .alt = true, .super = true, .ctrl = true, .shift = true }, .sequence = "\x1b[27;16;13~" },
+
+        .{ .sequence = "\r" },
+    });
+
+    result.set(.escape, &.{
+        .{ .mods = .{ .shift = true }, .sequence = "\x1b[27;2;27~" },
+        .{ .mods = .{ .alt = true }, .sequence = "\x1b\x1b" },
+        .{ .mods = .{ .alt = true, .shift = true }, .sequence = "\x1b[27;4;27~" },
+        .{ .mods = .{ .ctrl = true }, .sequence = "\x1b[27;5;27~" },
+        .{ .mods = .{ .ctrl = true, .shift = true }, .sequence = "\x1b[27;6;27~" },
+        .{ .mods = .{ .alt = true, .ctrl = true }, .sequence = "\x1b[27;7;27~" },
+        .{ .mods = .{ .alt = true, .ctrl = true, .shift = true }, .sequence = "\x1b[27;8;27~" },
+        .{ .mods = .{ .super = true }, .sequence = "\x1b[27;9;27~" },
+        .{ .mods = .{ .super = true, .shift = true }, .sequence = "\x1b[27;10;27~" },
+        .{ .mods = .{ .alt = true, .super = true }, .sequence = "\x1b[27;11;27~" },
+        .{ .mods = .{ .alt = true, .super = true, .shift = true }, .sequence = "\x1b[27;12;27~" },
+        .{ .mods = .{ .super = true, .ctrl = true }, .sequence = "\x1b[27;13;27~" },
+        .{ .mods = .{ .super = true, .ctrl = true, .shift = true }, .sequence = "\x1b[27;14;27~" },
+        .{ .mods = .{ .alt = true, .super = true, .ctrl = true }, .sequence = "\x1b[27;15;27~" },
+        .{ .mods = .{ .alt = true, .super = true, .ctrl = true, .shift = true }, .sequence = "\x1b[27;16;27~" },
+        .{ .sequence = "\x1b" },
+    });
+
+    break :keys result;
+};
+
+/// Returns the default keypad application mode entry.
+fn kpDefault(comptime suffix: []const u8) []const Entry {
+    return &.{
+        .{
+            .mods_empty_is_any = false,
+            .keypad = .application,
+            .sequence = "\x1bO" ++ suffix,
+        },
+    };
+}
+
+/// Returns entries that are dependent on cursor key settings.
+fn cursorKey(
+    comptime normal: []const u8,
+    comptime application: []const u8,
+) []const Entry {
+    return &.{
+        .{ .cursor = .normal, .sequence = normal },
+        .{ .cursor = .application, .sequence = application },
+    };
+}
+
+/// Constructs a set of pcStyle function keys using the given format. The
+/// format should have exactly one "hole" for the mods code.
+/// Example: "\x1b[11;{}~" for F1.
+fn pcStyle(comptime fmt: []const u8) []const Entry {
+    // The comptime {} wrapper is superflous but it prevents us from
+    // accidentally running this function at runtime.
+    comptime {
+        const modifiers: []const key.Mods = &.{
+            .{ .shift = true },
+            .{ .alt = true },
+            .{ .shift = true, .alt = true },
+            .{ .ctrl = true },
+            .{ .shift = true, .ctrl = true },
+            .{ .alt = true, .ctrl = true },
+            .{ .shift = true, .alt = true, .ctrl = true },
+            .{ .super = true },
+            .{ .shift = true, .super = true },
+            .{ .alt = true, .super = true },
+            .{ .shift = true, .alt = true, .super = true },
+            .{ .ctrl = true, .super = true },
+            .{ .shift = true, .ctrl = true, .super = true },
+            .{ .alt = true, .ctrl = true, .super = true },
+            .{ .shift = true, .alt = true, .ctrl = true, .super = true },
+        };
+
+        var entries: [modifiers.len]Entry = undefined;
+        for (modifiers, 2.., 0..) |mods, code, i| {
+            entries[i] = .{
+                .mods = mods,
+                .sequence = std.fmt.comptimePrint(fmt, .{code}),
+            };
+        }
+
+        return &entries;
+    }
+}
+
+test "keys" {
+    // Force resolution for comptime evaluation.
+    _ = keys;
+}

--- a/src/input/function_keys.zig
+++ b/src/input/function_keys.zig
@@ -270,6 +270,16 @@ fn pcStyle(comptime fmt: []const u8) []const Entry {
 }
 
 test "keys" {
+    const testing = std.testing;
+
     // Force resolution for comptime evaluation.
     _ = keys;
+
+    // All key sequences must fit into a termio array.
+    const max = @import("../termio.zig").Message.WriteReq.Small.Max;
+    for (keys.values) |entries| {
+        for (entries) |entry| {
+            try testing.expect(entry.sequence.len <= max);
+        }
+    }
 }

--- a/src/input/function_keys.zig
+++ b/src/input/function_keys.zig
@@ -45,6 +45,26 @@ pub const Entry = struct {
     sequence: []const u8,
 };
 
+/// The list of modifier combinations for modify other key sequences.
+/// The mode value is index + 2.
+pub const modifiers: []const key.Mods = &.{
+    .{ .shift = true },
+    .{ .alt = true },
+    .{ .shift = true, .alt = true },
+    .{ .ctrl = true },
+    .{ .shift = true, .ctrl = true },
+    .{ .alt = true, .ctrl = true },
+    .{ .shift = true, .alt = true, .ctrl = true },
+    .{ .super = true },
+    .{ .shift = true, .super = true },
+    .{ .alt = true, .super = true },
+    .{ .shift = true, .alt = true, .super = true },
+    .{ .ctrl = true, .super = true },
+    .{ .shift = true, .ctrl = true, .super = true },
+    .{ .alt = true, .ctrl = true, .super = true },
+    .{ .shift = true, .alt = true, .ctrl = true, .super = true },
+};
+
 /// This is the array of entries for the PC style function keys as mapped to
 /// our set of possible key codes. Not every key has any entries.
 pub const KeyEntryArray = std.EnumArray(key.Key, []const Entry);
@@ -239,24 +259,6 @@ fn pcStyle(comptime fmt: []const u8) []const Entry {
     // The comptime {} wrapper is superflous but it prevents us from
     // accidentally running this function at runtime.
     comptime {
-        const modifiers: []const key.Mods = &.{
-            .{ .shift = true },
-            .{ .alt = true },
-            .{ .shift = true, .alt = true },
-            .{ .ctrl = true },
-            .{ .shift = true, .ctrl = true },
-            .{ .alt = true, .ctrl = true },
-            .{ .shift = true, .alt = true, .ctrl = true },
-            .{ .super = true },
-            .{ .shift = true, .super = true },
-            .{ .alt = true, .super = true },
-            .{ .shift = true, .alt = true, .super = true },
-            .{ .ctrl = true, .super = true },
-            .{ .shift = true, .ctrl = true, .super = true },
-            .{ .alt = true, .ctrl = true, .super = true },
-            .{ .shift = true, .alt = true, .ctrl = true, .super = true },
-        };
-
         var entries: [modifiers.len]Entry = undefined;
         for (modifiers, 2.., 0..) |mods, code, i| {
             entries[i] = .{

--- a/src/input/key.zig
+++ b/src/input/key.zig
@@ -14,6 +14,24 @@ pub const Mods = packed struct(u8) {
     num_lock: bool = false,
     _padding: u2 = 0,
 
+    /// Returns true if no modifiers are set.
+    pub fn empty(self: Mods) bool {
+        return @as(u8, @bitCast(self)) == 0;
+    }
+
+    /// Returns true if two mods are equal.
+    pub fn equal(self: Mods, other: Mods) bool {
+        return @as(u8, @bitCast(self)) == @as(u8, @bitCast(other));
+    }
+
+    /// Returns the mods without locks set.
+    pub fn withoutLocks(self: Mods) Mods {
+        var copy = self;
+        copy.caps_lock = false;
+        copy.num_lock = false;
+        return copy;
+    }
+
     // For our own understanding
     test {
         const testing = std.testing;

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -99,6 +99,10 @@ modes: packed struct {
 
     bracketed_paste: bool = false, // 2004
 
+    // This is set via ESC[4;2m. Any other modify key mode just sets
+    // this to false.
+    modify_other_keys: bool = false,
+
     // This isn't a mode, this is set by OSC 133 using the "A" event.
     // If this is true, it tells us that the shell supports redrawing
     // the prompt and that when we resize, if the cursor is at a prompt,

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -91,6 +91,7 @@ modes: packed struct {
     deccolm: bool = false, // 3,
     deccolm_supported: bool = false, // 40
     keypad_keys: bool = false, // 66
+    alt_esc_prefix: bool = true, // 1036
 
     focus_event: bool = false, // 1004
     mouse_alternate_scroll: bool = true, // 1007

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -90,6 +90,7 @@ modes: packed struct {
 
     deccolm: bool = false, // 3,
     deccolm_supported: bool = false, // 40
+    keypad_keys: bool = false, // 66
 
     focus_event: bool = false, // 1004
     mouse_alternate_scroll: bool = true, // 1007

--- a/src/terminal/ansi.zig
+++ b/src/terminal/ansi.zig
@@ -192,3 +192,12 @@ pub const StatusDisplay = enum(u16) {
     // Non-exhaustive so that @intToEnum never fails for unsupported values.
     _,
 };
+
+/// The possible modify key formats to ESC[>{a};{b}m
+/// Note: this is not complete, we should add more as we support more
+pub const ModifyKeyFormat = union(enum) {
+    legacy: void,
+    cursor_keys: void,
+    function_keys: void,
+    other_keys: enum { none, numeric_except, numeric },
+};

--- a/src/terminal/ansi.zig
+++ b/src/terminal/ansi.zig
@@ -121,6 +121,9 @@ pub const Mode = enum(u16) {
     /// Report mouse position in the SGR format as pixels, instead of cells.
     mouse_format_sgr_pixels = 1016,
 
+    /// The alt key sends esc as a prefix before any character. On by default.
+    alt_esc_prefix = 1036,
+
     /// Alternate screen mode with save cursor and clear on enter.
     alt_screen_save_cursor_clear_enter = 1049,
 

--- a/src/terminal/ansi.zig
+++ b/src/terminal/ansi.zig
@@ -88,6 +88,9 @@ pub const Mode = enum(u16) {
     /// mode ?3 is set or unset.
     enable_mode_3 = 40,
 
+    /// DECNKM. Sets application keypad mode if enabled.
+    keypad_keys = 66,
+
     /// "Normal" mouse events: click/release, scroll
     mouse_event_normal = 1000,
 

--- a/src/terminal/ansi.zig
+++ b/src/terminal/ansi.zig
@@ -124,6 +124,9 @@ pub const Mode = enum(u16) {
     /// The alt key sends esc as a prefix before any character. On by default.
     alt_esc_prefix = 1036,
 
+    /// altSendsEscape xterm (https://invisible-island.net/xterm/manpage/xterm.html)
+    alt_sends_escape = 1039,
+
     /// Alternate screen mode with save cursor and clear on enter.
     alt_screen_save_cursor_clear_enter = 1049,
 

--- a/src/terminal/main.zig
+++ b/src/terminal/main.zig
@@ -21,6 +21,7 @@ pub const CursorStyle = ansi.CursorStyle;
 pub const DeviceAttributeReq = ansi.DeviceAttributeReq;
 pub const DeviceStatusReq = ansi.DeviceStatusReq;
 pub const Mode = ansi.Mode;
+pub const ModifyKeyFormat = ansi.ModifyKeyFormat;
 pub const StatusLineType = ansi.StatusLineType;
 pub const StatusDisplay = ansi.StatusDisplay;
 pub const EraseDisplay = csi.EraseDisplay;

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -850,6 +850,10 @@ pub fn Stream(comptime Handler: type) type {
                     try self.handler.escUnimplemented(action)
                 else
                     log.warn("unimplemented ESC action: {}", .{action}),
+
+                // Sets ST (string terminator). We don't have to do anything
+                // because our parser always accepts ST.
+                '\\' => {},
             }
         }
     };

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -765,6 +765,16 @@ pub fn Stream(comptime Handler: type) type {
                     },
                 } else log.warn("unimplemented invokeCharset: {}", .{action}),
 
+                // Set application keypad mode
+                '=' => if (@hasDecl(T, "setMode")) {
+                    try self.handler.setMode(.keypad_keys, true);
+                } else log.warn("unimplemented setMode: {}", .{action}),
+
+                // Reset application keypad mode
+                '>' => if (@hasDecl(T, "setMode")) {
+                    try self.handler.setMode(.keypad_keys, false);
+                } else log.warn("unimplemented setMode: {}", .{action}),
+
                 else => if (@hasDecl(T, "escUnimplemented"))
                     try self.handler.escUnimplemented(action)
                 else

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1183,6 +1183,17 @@ const StreamHandler = struct {
         self.terminal.setScrollingRegion(top, bot);
     }
 
+    pub fn setModifyKeyFormat(self: *StreamHandler, format: terminal.ModifyKeyFormat) !void {
+        self.terminal.modes.modify_other_keys = false;
+        switch (format) {
+            .other_keys => |v| switch (v) {
+                .numeric => self.terminal.modes.modify_other_keys = true,
+                else => {},
+            },
+            else => {},
+        }
+    }
+
     pub fn setMode(self: *StreamHandler, mode: terminal.Mode, enabled: bool) !void {
         // Note: this function doesn't need to grab the render state or
         // terminal locks because it is only called from process() which

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1274,8 +1274,8 @@ const StreamHandler = struct {
             .mouse_format_sgr_pixels => self.terminal.modes.mouse_format = if (enabled) .sgr_pixels else .x10,
 
             .mouse_alternate_scroll => self.terminal.modes.mouse_alternate_scroll = enabled,
-
             .focus_event => self.terminal.modes.focus_event = enabled,
+            .alt_esc_prefix => self.terminal.modes.alt_esc_prefix = enabled,
 
             else => if (enabled) log.warn("unimplemented mode: {}", .{mode}),
         }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1193,6 +1193,10 @@ const StreamHandler = struct {
                 self.terminal.modes.cursor_keys = enabled;
             },
 
+            .keypad_keys => {
+                self.terminal.modes.keypad_keys = enabled;
+            },
+
             .insert => {
                 self.terminal.modes.insert = enabled;
             },


### PR DESCRIPTION
Fixes #242 
Fixes #218 

This brings in a lot of keyboard input improvements, listed below. Note that we don't _yet_ implement the Kitty keyboard protocol. I was planning to do it in this PR (see the branch name!) but I realized that I had already implemented so much that the PR would be too big. So I'm splitting them.

Note that this PR _only_ adds the xterm `ESC [ 27 ~` format for keys, and **does not add** `CSI u` support. `CSI u` support goes hand-in-hand with Kitty's protocol so I'll be looking into that with Kitty support, and maybe just only support it when Kitty keyboard enhancements are on.

In this PR:

 * `alt-` key prefix will send ESC (`\x1b`) before a character as expected
 * a new macos option `macos-option-as-alt` (default `false`) will turn option into alt and disable unicode input
 * mode 1036 is handled to disable `alt-` key processing
 * xterm `modifyOtherKeys` support. Ghostty always acts in "mode 1" by default similar to Foot, but can opt-in to mode 2.
 * keypad application mode works
 * mode 1039 is parsed but ignored (we don't use it)
 * `ESC \` is parsed and ignored (we're always in that mode)

I don't think this PR is perfect, but it brings us a long way forward macOS and GTK do quite well and should be at parity. The GLFW keyboard handling is strictly worse due to limitations of glfw.