### PR TITLE
macos: option-as-alt can specify left or right option key

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -83,6 +83,10 @@ typedef enum {
     GHOSTTY_MODS_SUPER = 1 << 3,
     GHOSTTY_MODS_CAPS  = 1 << 4,
     GHOSTTY_MODS_NUM   = 1 << 5,
+    GHOSTTY_MODS_SHIFT_RIGHT = 1 << 6,
+    GHOSTTY_MODS_CTRL_RIGHT  = 1 << 7,
+    GHOSTTY_MODS_ALT_RIGHT   = 1 << 8,
+    GHOSTTY_MODS_SUPER_RIGHT = 1 << 9,
 } ghostty_input_mods_e;
 
 typedef enum {

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -480,11 +480,20 @@ extension Ghostty {
         
         private static func translateFlags(_ flags: NSEvent.ModifierFlags) -> ghostty_input_mods_e {
             var mods: UInt32 = GHOSTTY_MODS_NONE.rawValue
+            
             if (flags.contains(.shift)) { mods |= GHOSTTY_MODS_SHIFT.rawValue }
             if (flags.contains(.control)) { mods |= GHOSTTY_MODS_CTRL.rawValue }
             if (flags.contains(.option)) { mods |= GHOSTTY_MODS_ALT.rawValue }
             if (flags.contains(.command)) { mods |= GHOSTTY_MODS_SUPER.rawValue }
             if (flags.contains(.capsLock)) { mods |= GHOSTTY_MODS_CAPS.rawValue }
+            
+            // Handle sided input. We can't tell that both are pressed in the
+            // Ghostty structure but thats okay -- we don't use that information.
+            let rawFlags = flags.rawValue
+            if (rawFlags & UInt(NX_DEVICERSHIFTKEYMASK) != 0) { mods |= GHOSTTY_MODS_SHIFT_RIGHT.rawValue }
+            if (rawFlags & UInt(NX_DEVICERCTLKEYMASK) != 0) { mods |= GHOSTTY_MODS_CTRL_RIGHT.rawValue }
+            if (rawFlags & UInt(NX_DEVICERALTKEYMASK) != 0) { mods |= GHOSTTY_MODS_ALT_RIGHT.rawValue }
+            if (rawFlags & UInt(NX_DEVICERCMDKEYMASK) != 0) { mods |= GHOSTTY_MODS_SUPER_RIGHT.rawValue }   
             
             return ghostty_input_mods_e(mods)
         }

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -142,7 +142,7 @@ const DerivedConfig = struct {
     confirm_close_surface: bool,
     mouse_interval: u64,
     macos_non_native_fullscreen: bool,
-    macos_option_as_alt: bool,
+    macos_option_as_alt: configpkg.OptionAsAlt,
 
     pub fn init(alloc_gpa: Allocator, config: *const configpkg.Config) !DerivedConfig {
         var arena = ArenaAllocator.init(alloc_gpa);
@@ -1042,9 +1042,11 @@ pub fn charCallback(
         // On macOS, we have to opt-in to using alt because option
         // by default is a unicode character sequence.
         if (comptime builtin.target.isDarwin()) {
-            if (!self.config.macos_option_as_alt) {
-                log.debug("macos_option_as_alt disabled, not sending esc prefix", .{});
-                break :alt;
+            switch (self.config.macos_option_as_alt) {
+                .false => break :alt,
+                .true => {},
+                .left => if (mods.sides.alt != .left) break :alt,
+                .right => if (mods.sides.alt != .right) break :alt,
             }
         }
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1149,8 +1149,8 @@ pub fn keyCallback(
             .set_other => if (!modify_other_keys) continue,
         }
 
-        const mods_int: u8 = @bitCast(binding_mods);
-        const entry_mods_int: u8 = @bitCast(entry.mods);
+        const mods_int = binding_mods.int();
+        const entry_mods_int = entry.mods.int();
         if (entry_mods_int == 0) {
             if (mods_int != 0 and !entry.mods_empty_is_any) continue;
             // mods are either empty, or empty means any so we allow it.
@@ -1186,8 +1186,8 @@ pub fn keyCallback(
 
     // Handle non-printables
     const char: u8 = char: {
-        const mods_int: u8 = @bitCast(unalt_mods);
-        const ctrl_only: u8 = @bitCast(input.Mods{ .ctrl = true });
+        const mods_int = unalt_mods.int();
+        const ctrl_only = (input.Mods{ .ctrl = true }).int();
 
         // If we're only pressing control, check if this is a character
         // we convert to a non-printable. The best table I've found for

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1094,12 +1094,7 @@ pub fn keyCallback(
     if (action != .press and action != .repeat) return false;
 
     // Mods for bindings never include caps/num lock.
-    const binding_mods = mods: {
-        var binding_mods = mods;
-        binding_mods.caps_lock = false;
-        binding_mods.num_lock = false;
-        break :mods binding_mods;
-    };
+    const binding_mods = mods.binding();
 
     // Check if we're processing a binding first. If so, that negates
     // any further key processing.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -394,8 +394,16 @@ pub const Surface = struct {
         // then we strip the alt modifier from the mods for translation.
         const translate_mods = translate_mods: {
             var translate_mods = mods;
-            if (self.app.config.@"macos-option-as-alt")
-                translate_mods.alt = false;
+            switch (self.app.config.@"macos-option-as-alt") {
+                .false => {},
+                .true => translate_mods.alt = false,
+                .left => if (mods.sides.alt == .left) {
+                    translate_mods.alt = false;
+                },
+                .right => if (mods.sides.alt == .right) {
+                    translate_mods.alt = false;
+                },
+            }
 
             break :translate_mods translate_mods;
         };

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -660,7 +660,10 @@ pub const CAPI = struct {
         surface.keyCallback(
             action,
             keycode,
-            @bitCast(@as(u8, @truncate(@as(c_uint, @bitCast(c_mods))))),
+            @bitCast(@as(
+                input.Mods.Backing,
+                @truncate(@as(c_uint, @bitCast(c_mods))),
+            )),
         ) catch |err| {
             log.err("error processing key event err={}", .{err});
             return;
@@ -684,7 +687,10 @@ pub const CAPI = struct {
         surface.mouseButtonCallback(
             action,
             button,
-            @bitCast(@as(u8, @truncate(@as(c_uint, @bitCast(mods))))),
+            @bitCast(@as(
+                input.Mods.Backing,
+                @truncate(@as(c_uint, @bitCast(mods))),
+            )),
         );
     }
 

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -618,7 +618,12 @@ pub const Surface = struct {
         const core_win = window.getUserPointer(CoreSurface) orelse return;
 
         // Convert our glfw types into our input types
-        const mods: input.Mods = @bitCast(glfw_mods);
+        const mods: input.Mods = .{
+            .shift = glfw_mods.shift,
+            .ctrl = glfw_mods.control,
+            .alt = glfw_mods.alt,
+            .super = glfw_mods.super,
+        };
         const action: input.Action = switch (glfw_action) {
             .release => .release,
             .press => .press,
@@ -843,7 +848,12 @@ pub const Surface = struct {
         const core_win = window.getUserPointer(CoreSurface) orelse return;
 
         // Convert glfw button to input button
-        const mods: input.Mods = @bitCast(glfw_mods);
+        const mods: input.Mods = .{
+            .shift = glfw_mods.shift,
+            .ctrl = glfw_mods.control,
+            .alt = glfw_mods.alt,
+            .super = glfw_mods.super,
+        };
         const button: input.MouseButton = switch (glfw_button) {
             .left => .left,
             .right => .right,

--- a/src/config.zig
+++ b/src/config.zig
@@ -249,7 +249,7 @@ pub const Config = struct {
     /// (i.e. alt+ctrl+a).
     ///
     /// This does not work with GLFW builds.
-    @"macos-option-as-alt": bool = false,
+    @"macos-option-as-alt": OptionAsAlt = .false,
 
     /// This is set by the CLI parser for deinit.
     _arena: ?ArenaAllocator = null,
@@ -1035,6 +1035,14 @@ fn equal(comptime T: type, old: T, new: T) bool {
         },
     }
 }
+
+/// Valid values for macos-option-as-alt.
+pub const OptionAsAlt = enum {
+    false,
+    true,
+    left,
+    right,
+};
 
 /// Color represents a color using RGB.
 pub const Color = struct {

--- a/src/input/key.zig
+++ b/src/input/key.zig
@@ -24,6 +24,16 @@ pub const Mods = packed struct(u8) {
         return @as(u8, @bitCast(self)) == @as(u8, @bitCast(other));
     }
 
+    /// Return mods that are only relevant for bindings.
+    pub fn binding(self: Mods) Mods {
+        return .{
+            .shift = self.shift,
+            .ctrl = self.ctrl,
+            .alt = self.alt,
+            .super = self.super,
+        };
+    }
+
     /// Returns the mods without locks set.
     pub fn withoutLocks(self: Mods) Mods {
         var copy = self;

--- a/src/input/key.zig
+++ b/src/input/key.zig
@@ -5,23 +5,45 @@ const Allocator = std.mem.Allocator;
 /// GLFW representation, but we use this generically.
 ///
 /// IMPORTANT: Any changes here update include/ghostty.h
-pub const Mods = packed struct(u8) {
+pub const Mods = packed struct(Mods.Backing) {
+    pub const Backing = u16;
+
     shift: bool = false,
     ctrl: bool = false,
     alt: bool = false,
     super: bool = false,
     caps_lock: bool = false,
     num_lock: bool = false,
-    _padding: u2 = 0,
+    sides: side = .{},
+    _padding: u6 = 0,
+
+    /// Tracks the side that is active for any given modifier. Note
+    /// that this doesn't confirm a modifier is pressed; you must check
+    /// the bool for that in addition to this.
+    ///
+    /// Not all platforms support this, check apprt for more info.
+    pub const side = packed struct(u4) {
+        shift: Side = .left,
+        ctrl: Side = .left,
+        alt: Side = .left,
+        super: Side = .left,
+    };
+
+    pub const Side = enum { left, right };
+
+    /// Integer value of this struct.
+    pub fn int(self: Mods) Backing {
+        return @bitCast(self);
+    }
 
     /// Returns true if no modifiers are set.
     pub fn empty(self: Mods) bool {
-        return @as(u8, @bitCast(self)) == 0;
+        return self.int() == 0;
     }
 
     /// Returns true if two mods are equal.
     pub fn equal(self: Mods, other: Mods) bool {
-        return @as(u8, @bitCast(self)) == @as(u8, @bitCast(other));
+        return self.int() == other.int();
     }
 
     /// Return mods that are only relevant for bindings.
@@ -45,10 +67,10 @@ pub const Mods = packed struct(u8) {
     // For our own understanding
     test {
         const testing = std.testing;
-        try testing.expectEqual(@as(u8, @bitCast(Mods{})), @as(u8, 0b0));
+        try testing.expectEqual(@as(Backing, @bitCast(Mods{})), @as(Backing, 0b0));
         try testing.expectEqual(
-            @as(u8, @bitCast(Mods{ .shift = true })),
-            @as(u8, 0b0000_0001),
+            @as(Backing, @bitCast(Mods{ .shift = true })),
+            @as(Backing, 0b0000_0001),
         );
     }
 };


### PR DESCRIPTION
Fixes #284 

This adds two new values two `macos-option-as-alt` in addition to the existing boolean values: `left` and `right`. When a position is chosen, only the option key on that side will act as alt. 

This replaces #244 (which was reported due to bugs) by having a much smaller scope: you can't have bindings targeting left/right, and the on/off states are preserved rather than modifying so that binding configuration doesn't have to be touched everywhere.