### PR TITLE
apprt/embedded: keycallback should use nomod text to determine key

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1134,6 +1134,13 @@ pub fn keyCallback(
     const tracy = trace(@src());
     defer tracy.end();
 
+    // log.warn("KEY CALLBACK action={} key={} physical_key={} mods={}", .{
+    //     action,
+    //     key,
+    //     physical_key,
+    //     mods,
+    // });
+
     // Dev Mode
     if (DevMode.enabled and DevMode.instance.visible) {
         // If the event was handled by imgui, ignore it.


### PR DESCRIPTION
To determine the logical key that was pressed, we previously just trusted that the translated text would have the right value. But if modifiers are pressed, the text may not translate.

For example on macOS, Ctrl+C does not produce any text. As a result, we would fall back to the physical key. On layouts like Dvorak, the physical key for "C" is "I". This means "Ctrl+C" sequences weren't working.

Instead, if there is no text or the text doesn't map to a key, we translate again using no modifiers to try to get the raw text of the input and then base the key on that.