### PR TITLE
Fix multiple bugs related to selecting, copying grapheme clusters

### DIFF
--- a/src/font/shaper/run.zig
+++ b/src/font/shaper/run.zig
@@ -63,8 +63,14 @@ pub const RunIterator = struct {
             if (self.selection) |unordered_sel| {
                 if (j > self.i) {
                     const sel = unordered_sel.ordered(.forward);
-                    if (sel.start.x > 0 and j == sel.start.x) break;
-                    if (sel.end.x > 0 and j == sel.end.x + 1) break;
+
+                    if (sel.start.x > 0 and
+                        j == sel.start.x and
+                        self.row.graphemeBreak(sel.start.x)) break;
+
+                    if (sel.end.x > 0 and
+                        j == sel.end.x + 1 and
+                        self.row.graphemeBreak(sel.end.x)) break;
                 }
             }
 

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1630,6 +1630,61 @@ test "Terminal: print over wide char at 0,0" {
     try testing.expectEqual(@as(usize, 1), t.screen.cursor.x);
 }
 
+test "Terminal: print multicodepoint grapheme" {
+    var t = try init(testing.allocator, 80, 80);
+    defer t.deinit(testing.allocator);
+
+    // https://github.com/mitchellh/ghostty/issues/289
+    // This is: 👨‍👩‍👧 (which may or may not render correctly)
+    try t.print(0x1F468);
+    try t.print(0x200D);
+    try t.print(0x1F469);
+    try t.print(0x200D);
+    try t.print(0x1F467);
+
+    // We should have 6 cells taken up
+    try testing.expectEqual(@as(usize, 0), t.screen.cursor.y);
+    try testing.expectEqual(@as(usize, 6), t.screen.cursor.x);
+
+    // Assert various properties about our screen to verify
+    // we have all expected cells.
+    const row = t.screen.getRow(.{ .screen = 0 });
+    {
+        const cell = row.getCell(0);
+        try testing.expectEqual(@as(u32, 0x1F468), cell.char);
+        try testing.expect(cell.attrs.wide);
+        try testing.expectEqual(@as(usize, 2), row.codepointLen(0));
+    }
+    {
+        const cell = row.getCell(1);
+        try testing.expectEqual(@as(u32, ' '), cell.char);
+        try testing.expect(cell.attrs.wide_spacer_tail);
+        try testing.expectEqual(@as(usize, 1), row.codepointLen(1));
+    }
+    {
+        const cell = row.getCell(2);
+        try testing.expectEqual(@as(u32, 0x1F469), cell.char);
+        try testing.expect(cell.attrs.wide);
+        try testing.expectEqual(@as(usize, 2), row.codepointLen(2));
+    }
+    {
+        const cell = row.getCell(3);
+        try testing.expectEqual(@as(u32, ' '), cell.char);
+        try testing.expect(cell.attrs.wide_spacer_tail);
+    }
+    {
+        const cell = row.getCell(4);
+        try testing.expectEqual(@as(u32, 0x1F467), cell.char);
+        try testing.expect(cell.attrs.wide);
+        try testing.expectEqual(@as(usize, 1), row.codepointLen(4));
+    }
+    {
+        const cell = row.getCell(5);
+        try testing.expectEqual(@as(u32, ' '), cell.char);
+        try testing.expect(cell.attrs.wide_spacer_tail);
+    }
+}
+
 test "Terminal: soft wrap" {
     var t = try init(testing.allocator, 3, 80);
     defer t.deinit(testing.allocator);


### PR DESCRIPTION
Fixes #289 

A few fixes:

1. Copy of grapheme clusters with zero-width-joiners will properly copy the ZWJs.
2. Selection will not split a grapheme cluster (but it will split ligatures -- which are not grapheme clusters!)
3. Fixes a crash when selecting an emoji with a ZWJ on a soft-wrapped line.

## Video 1: Copy of grapheme cluster with ZWJ

### Before

https://github.com/mitchellh/ghostty/assets/1299/39bf1983-8f1d-41b2-8e25-0ec15c9d9ff4

### After

https://github.com/mitchellh/ghostty/assets/1299/d4a03484-6ede-4ed2-92d9-40823af9bede

## Video 2: Splitting of Grapheme on Selection

### Before

https://github.com/mitchellh/ghostty/assets/1299/f02ae005-b3a4-4bd1-9d0e-bda3d52a2048

### After

https://github.com/mitchellh/ghostty/assets/1299/c380655d-c8ea-47b7-9f72-0e02b50ac917