### PR TITLE
macOS: remove dead code from PrimaryWindowController

### DIFF
--- a/macos/Sources/Features/Primary Window/PrimaryWindowController.swift
+++ b/macos/Sources/Features/Primary Window/PrimaryWindowController.swift
@@ -1,11 +1,6 @@
 import Cocoa
 
 class PrimaryWindowController: NSWindowController {
-    // Keep track of the last point that our window was launched at so that new
-    // windows "cascade" over each other and don't just launch directly on top
-    // of each other.
-    static var lastCascadePoint = NSPoint(x: 0, y: 0)
-    
     // This is used to programmatically control tabs.
     weak var windowManager: PrimaryWindowManager?
     


### PR DESCRIPTION
I think this is a left-over from the refactor that moved this field to the `PrimaryWindowManager`.