### PR TITLE
build: make glfw opt-in on all platforms, default to GTK on Linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     # Cross-compile the binary. We always use static building for this
     # because its the only way to access the headers.
     - name: Test Build
-      run: nix develop -c zig build -Dstatic=true -Dtarget=${{ matrix.target }}
+      run: nix develop -c zig build -Dstatic=true -Dapp-runtime=glfw -Dtarget=${{ matrix.target }}
 
   build-macos:
     runs-on: macos-12
@@ -88,6 +88,12 @@ jobs:
 
     - name: test
       run: nix develop -c zig build test
+
+    - name: Test GTK Build
+      run: nix develop -c zig build -Dapp-runtime=gtk
+
+    - name: Test GLFW Build
+      run: nix develop -c zig build -Dapp-runtime=glfw
 
     - name: Test Dynamic Build
       run: nix develop -c zig build -Dstatic=false

--- a/src/apprt.zig
+++ b/src/apprt.zig
@@ -53,8 +53,13 @@ pub const Runtime = enum {
     gtk,
 
     pub fn default(target: std.zig.CrossTarget) Runtime {
-        _ = target;
-        return .glfw;
+        // The Linux default is GTK because it is full featured.
+        if (target.isLinux()) return .gtk;
+
+        // Otherwise, we do NONE so we don't create an exe. The GLFW
+        // build is opt-in because it is missing so many features compared
+        // to the other builds that are impossible due to the GLFW interface.
+        return .none;
     }
 };
 


### PR DESCRIPTION
The GLFW build has grown farther and farther from feature parity with GTK on Linux. And on macOS, the GLFW build has been unstable (crashes) for months.

I still find the GLFW build useful for testing some core terminal work, but it is increasingly user-hostile in case someone just downloads the project and does a `zig build`.

I keep GLFW as up to date as I can, but the features that are missing are due to fundamental limitations:

  - GLFW has no tabs, splits, etc. because it has no UI elements. I am not interested in painting UI widgets from scratch.

  - GLFW cannot support keyboard layouts robustly because it has no hooks to detect keyboard layouts or functions to get keymaps.

  - GLFW cannot support the Kitty keyboard protocol because the key/char API is too high level and it provides no low-level alternatives.

  - GLFW crashes on macOS under certain scenarios (this is my problem). I'm not interested in fixing it because the AppKit-based build is highly recommended.

To build or run the GLFW build you must now explicitly pass in `-Dapp-runtime=glfw` to `zig build`.