### PR TITLE
apprt/embedded: do not translate control characters

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -480,6 +480,13 @@ pub const Surface = struct {
                 // If we aren't composing, then we set our preedit to
                 // empty no matter what.
                 self.core_surface.preeditCallback(null) catch {};
+
+                // If the text is just a single non-printable ASCII character
+                // then we clear the text. We handle non-printables in the
+                // key encoder manual (such as tab, ctrl+c, etc.)
+                if (result.text.len == 1 and result.text[0] < 0x20) {
+                    break :translate .{ .composing = false, .text = "" };
+                }
             }
 
             break :translate result;


### PR DESCRIPTION
macOS translates inputs such as shift+tab into the control character tab (ascii 0x09). Linux/GTK does not translate character inputs except to printable characters. We don't want control character translations because these are all handled manually by our key encoder (i.e. translating ctrl+c to 0x03).