### PR TITLE
Implement cursor fg/bg for Metal renderer

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -71,6 +71,7 @@ pub const Config = struct {
 
     /// The color of the cursor. If this is not set, a default will be chosen.
     @"cursor-color": ?Color = null,
+    @"cursor-text": ?Color = null,
 
     /// The opacity level (opposite of transparency) of the background.
     /// A value of 1 is fully opaque and a value of 0 is fully transparent.

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -108,6 +108,7 @@ pub const DerivedConfig = struct {
     font_thicken: bool,
     font_features: std.ArrayList([]const u8),
     cursor_color: ?terminal.color.RGB,
+    cursor_text: ?terminal.color.RGB,
     background: terminal.color.RGB,
     background_opacity: f64,
     foreground: terminal.color.RGB,
@@ -132,6 +133,11 @@ pub const DerivedConfig = struct {
 
             .cursor_color = if (config.@"cursor-color") |col|
                 col.toTerminalRGB()
+            else
+                null,
+
+            .cursor_text = if (config.@"cursor-text") |txt|
+                txt.toTerminalRGB()
             else
                 null,
 
@@ -1222,8 +1228,10 @@ fn rebuildCells(
         }
 
         if (cursor_cell) |*cell| {
-            // We always invert the cell color under the cursor.
-            cell.color = .{ 0, 0, 0, 255 };
+            cell.color = if (self.config.cursor_text) |txt|
+                .{ txt.r, txt.g, txt.b, 255 }
+            else
+                .{ 0, 0, 0, 255 };
             self.cells.appendAssumeCapacity(cell.*);
         }
     }

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -237,6 +237,7 @@ pub const DerivedConfig = struct {
     font_thicken: bool,
     font_features: std.ArrayList([]const u8),
     cursor_color: ?terminal.color.RGB,
+    cursor_text: ?terminal.color.RGB,
     background: terminal.color.RGB,
     background_opacity: f64,
     foreground: terminal.color.RGB,
@@ -261,6 +262,11 @@ pub const DerivedConfig = struct {
 
             .cursor_color = if (config.@"cursor-color") |col|
                 col.toTerminalRGB()
+            else
+                null,
+
+            .cursor_text = if (config.@"cursor-text") |txt|
+                txt.toTerminalRGB()
             else
                 null,
 
@@ -999,10 +1005,17 @@ pub fn rebuildCells(
         }
 
         if (cursor_cell) |*cell| {
-            cell.fg_r = 0;
-            cell.fg_g = 0;
-            cell.fg_b = 0;
-            cell.fg_a = 255;
+            if (self.config.cursor_text) |txt| {
+                cell.fg_r = txt.r;
+                cell.fg_g = txt.g;
+                cell.fg_b = txt.b;
+                cell.fg_a = 255;
+            } else {
+                cell.fg_r = 0;
+                cell.fg_g = 0;
+                cell.fg_b = 0;
+                cell.fg_a = 255;
+            }
             self.cells.appendAssumeCapacity(cell.*);
         }
     }


### PR DESCRIPTION
An attempt to allow both foreground & background to be set for the cursor. In doing so, I break the current API for the configuration object and rename `cursor-color` to `cursor-background`. I also introduce a new configuration option, `cursor-foreground`, allowing you to set the foreground color.