### PR TITLE
quirks: Menlo/Monaco should disable ligatures by default

### DIFF
--- a/pkg/freetype/face.zig
+++ b/pkg/freetype/face.zig
@@ -83,6 +83,18 @@ pub const Face = struct {
             @intFromEnum(tag),
         )));
     }
+
+    /// Retrieve the number of name strings in the SFNT ‘name’ table.
+    pub fn getSfntNameCount(self: Face) usize {
+        return @intCast(c.FT_Get_Sfnt_Name_Count(self.handle));
+    }
+
+    /// Retrieve a string of the SFNT ‘name’ table for a given index.
+    pub fn getSfntName(self: Face, i: usize) Error!c.FT_SfntName {
+        var name: c.FT_SfntName = undefined;
+        const res = c.FT_Get_Sfnt_Name(self.handle, @intCast(i), &name);
+        return if (intToError(res)) |_| name else |err| err;
+    }
 };
 
 /// An enumeration to specify indices of SFNT tables loaded and parsed by

--- a/pkg/freetype/freetype-zig.h
+++ b/pkg/freetype/freetype-zig.h
@@ -1,3 +1,5 @@
 #include <ft2build.h>
 #include FT_FREETYPE_H
 #include FT_TRUETYPE_TABLES_H
+#include <freetype/ftsnames.h>
+#include <freetype/ttnameid.h>

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -87,6 +87,19 @@ pub const Face = struct {
         return try initFontCopy(ct_font, .{ .points = 0 });
     }
 
+    /// Returns the font name. If allocation is required, buf will be used,
+    /// but sometimes allocation isn't required and a static string is
+    /// returned.
+    pub fn name(self: *const Face, buf: []u8) Allocator.Error![]const u8 {
+        const display_name = self.font.copyDisplayName();
+        if (display_name.cstringPtr(.utf8)) |str| return str;
+
+        // "NULL if the internal storage of theString does not allow
+        // this to be returned efficiently." In this case, we need
+        // to allocate.
+        return display_name.cstring(buf, .utf8) orelse error.OutOfMemory;
+    }
+
     /// Resize the font in-place. If this succeeds, the caller is responsible
     /// for clearing any glyph caches, font atlas data, etc.
     pub fn setSize(self: *Face, size: font.face.DesiredSize) !void {

--- a/src/font/face/freetype.zig
+++ b/src/font/face/freetype.zig
@@ -74,9 +74,20 @@ pub const Face = struct {
     /// but sometimes allocation isn't required and a static string is
     /// returned.
     pub fn name(self: *const Face, buf: []u8) Allocator.Error![]const u8 {
-        // TODO
-        _ = self;
+        // We don't use this today but its possible the table below
+        // returns UTF-16 in which case we'd want to use this for conversion.
         _ = buf;
+
+        const count = self.face.getSfntNameCount();
+
+        // We look for the font family entry.
+        for (0..count) |i| {
+            const entry = self.face.getSfntName(i) catch continue;
+            if (entry.name_id == freetype.c.TT_NAME_ID_FONT_FAMILY) {
+                return entry.string[0..entry.string_len];
+            }
+        }
+
         return "";
     }
 

--- a/src/font/face/freetype.zig
+++ b/src/font/face/freetype.zig
@@ -70,6 +70,16 @@ pub const Face = struct {
         self.* = undefined;
     }
 
+    /// Returns the font name. If allocation is required, buf will be used,
+    /// but sometimes allocation isn't required and a static string is
+    /// returned.
+    pub fn name(self: *const Face, buf: []u8) Allocator.Error![]const u8 {
+        // TODO
+        _ = self;
+        _ = buf;
+        return "";
+    }
+
     /// Resize the font in-place. If this succeeds, the caller is responsible
     /// for clearing any glyph caches, font atlas data, etc.
     pub fn setSize(self: *Face, size: font.face.DesiredSize) !void {

--- a/src/quirks.zig
+++ b/src/quirks.zig
@@ -1,0 +1,24 @@
+//! Inspired by WebKit's quirks.cpp[1], this file centralizes all our
+//! sad environment-specific hacks that we have to do to make things work.
+//! This is a last resort; if we can find a general solution to a problem,
+//! we of course prefer that, but sometimes other software, fonts, etc. are
+//! just broken or weird and we have to work around it.
+//!
+//! [1]: https://github.com/WebKit/WebKit/blob/main/Source/WebCore/page/Quirks.cpp
+
+const std = @import("std");
+
+const font = @import("font/main.zig");
+
+/// If true, the default font features should be disabled for the given face.
+pub fn disableDefaultFontFeatures(face: *const font.Face) bool {
+    var buf: [64]u8 = undefined;
+    const name = face.name(&buf) catch |err| switch (err) {
+        // If the name doesn't fit in buf we know this will be false
+        // because we have no quirks fonts that are longer than buf!
+        error.OutOfMemory => return false,
+    };
+
+    return std.mem.eql(u8, name, "Menlo") or
+        std.mem.eql(u8, name, "Monaco");
+}

--- a/src/quirks.zig
+++ b/src/quirks.zig
@@ -19,6 +19,9 @@ pub fn disableDefaultFontFeatures(face: *const font.Face) bool {
         error.OutOfMemory => return false,
     };
 
+    // Menlo and Monaco both have a default ligature of "fi" that looks
+    // really bad in terminal grids, so we want to disable ligatures
+    // by default for these faces.
     return std.mem.eql(u8, name, "Menlo") or
         std.mem.eql(u8, name, "Monaco");
 }


### PR DESCRIPTION
Both of these faces have a weird "fi" ligature by default (their only ligature it appears) that really messes up terminal grids. Strange for a monospace font. Other terminals also special case these fonts. 

## Before 

![CleanShot 2023-08-25 at 09 11 14@2x](https://github.com/mitchellh/ghostty/assets/1299/a6fa912d-7cca-4572-a3c1-74b935ba72e5)

## After

(I still think Monaco is an ugly font for a terminal, but at least its _less_ ugly)

![CleanShot 2023-08-25 at 09 11 51@2x](https://github.com/mitchellh/ghostty/assets/1299/585150bf-6d47-4951-bffc-a04941e05b41)
