### PR TITLE
font: Improve quirks mode performance, DeferredFace, Group refactor

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -230,7 +230,7 @@ pub fn init(
                 defer disco_it.deinit();
                 if (try disco_it.next()) |face| {
                     log.info("font regular: {s}", .{try face.name()});
-                    try group.addFace(.regular, face);
+                    try group.addFace(.regular, .{ .deferred = face });
                 } else log.warn("font-family not found: {s}", .{family});
             }
             if (config.@"font-family-bold") |family| {
@@ -242,7 +242,7 @@ pub fn init(
                 defer disco_it.deinit();
                 if (try disco_it.next()) |face| {
                     log.info("font bold: {s}", .{try face.name()});
-                    try group.addFace(.bold, face);
+                    try group.addFace(.bold, .{ .deferred = face });
                 } else log.warn("font-family-bold not found: {s}", .{family});
             }
             if (config.@"font-family-italic") |family| {
@@ -254,7 +254,7 @@ pub fn init(
                 defer disco_it.deinit();
                 if (try disco_it.next()) |face| {
                     log.info("font italic: {s}", .{try face.name()});
-                    try group.addFace(.italic, face);
+                    try group.addFace(.italic, .{ .deferred = face });
                 } else log.warn("font-family-italic not found: {s}", .{family});
             }
             if (config.@"font-family-bold-italic") |family| {
@@ -267,7 +267,7 @@ pub fn init(
                 defer disco_it.deinit();
                 if (try disco_it.next()) |face| {
                     log.info("font bold+italic: {s}", .{try face.name()});
-                    try group.addFace(.bold_italic, face);
+                    try group.addFace(.bold_italic, .{ .deferred = face });
                 } else log.warn("font-family-bold-italic not found: {s}", .{family});
             }
         }
@@ -275,11 +275,11 @@ pub fn init(
         // Our built-in font will be used as a backup
         try group.addFace(
             .regular,
-            font.DeferredFace.initLoaded(try font.Face.init(font_lib, face_ttf, font_size)),
+            .{ .loaded = try font.Face.init(font_lib, face_ttf, font_size) },
         );
         try group.addFace(
             .bold,
-            font.DeferredFace.initLoaded(try font.Face.init(font_lib, face_bold_ttf, font_size)),
+            .{ .loaded = try font.Face.init(font_lib, face_bold_ttf, font_size) },
         );
 
         // Auto-italicize if we have to.
@@ -290,11 +290,11 @@ pub fn init(
         if (builtin.os.tag != .macos or font.Discover == void) {
             try group.addFace(
                 .regular,
-                font.DeferredFace.initLoaded(try font.Face.init(font_lib, face_emoji_ttf, font_size)),
+                .{ .loaded = try font.Face.init(font_lib, face_emoji_ttf, font_size) },
             );
             try group.addFace(
                 .regular,
-                font.DeferredFace.initLoaded(try font.Face.init(font_lib, face_emoji_text_ttf, font_size)),
+                .{ .loaded = try font.Face.init(font_lib, face_emoji_text_ttf, font_size) },
             );
         }
 
@@ -308,7 +308,7 @@ pub fn init(
                 defer disco_it.deinit();
                 if (try disco_it.next()) |face| {
                     log.info("font emoji: {s}", .{try face.name()});
-                    try group.addFace(.regular, face);
+                    try group.addFace(.regular, .{ .deferred = face });
                 }
             }
         }

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -222,6 +222,9 @@ pub fn init(
             };
             group.discover = disco;
 
+            // A buffer we use to store the font names for logging.
+            var name_buf: [256]u8 = undefined;
+
             if (config.@"font-family") |family| {
                 var disco_it = try disco.discover(.{
                     .family = family,
@@ -229,7 +232,7 @@ pub fn init(
                 });
                 defer disco_it.deinit();
                 if (try disco_it.next()) |face| {
-                    log.info("font regular: {s}", .{try face.name()});
+                    log.info("font regular: {s}", .{try face.name(&name_buf)});
                     try group.addFace(.regular, .{ .deferred = face });
                 } else log.warn("font-family not found: {s}", .{family});
             }
@@ -241,7 +244,7 @@ pub fn init(
                 });
                 defer disco_it.deinit();
                 if (try disco_it.next()) |face| {
-                    log.info("font bold: {s}", .{try face.name()});
+                    log.info("font bold: {s}", .{try face.name(&name_buf)});
                     try group.addFace(.bold, .{ .deferred = face });
                 } else log.warn("font-family-bold not found: {s}", .{family});
             }
@@ -253,7 +256,7 @@ pub fn init(
                 });
                 defer disco_it.deinit();
                 if (try disco_it.next()) |face| {
-                    log.info("font italic: {s}", .{try face.name()});
+                    log.info("font italic: {s}", .{try face.name(&name_buf)});
                     try group.addFace(.italic, .{ .deferred = face });
                 } else log.warn("font-family-italic not found: {s}", .{family});
             }
@@ -266,7 +269,7 @@ pub fn init(
                 });
                 defer disco_it.deinit();
                 if (try disco_it.next()) |face| {
-                    log.info("font bold+italic: {s}", .{try face.name()});
+                    log.info("font bold+italic: {s}", .{try face.name(&name_buf)});
                     try group.addFace(.bold_italic, .{ .deferred = face });
                 } else log.warn("font-family-bold-italic not found: {s}", .{family});
             }
@@ -307,7 +310,8 @@ pub fn init(
                 });
                 defer disco_it.deinit();
                 if (try disco_it.next()) |face| {
-                    log.info("font emoji: {s}", .{try face.name()});
+                    var name_buf: [256]u8 = undefined;
+                    log.info("font emoji: {s}", .{try face.name(&name_buf)});
                     try group.addFace(.regular, .{ .deferred = face });
                 }
             }

--- a/src/font/DeferredFace.zig
+++ b/src/font/DeferredFace.zig
@@ -72,13 +72,6 @@ pub const CoreText = struct {
         self.font.release();
         self.* = undefined;
     }
-
-    /// Auto-italicize the font by applying a skew.
-    pub fn italicize(self: *const CoreText) !CoreText {
-        const ct_font = try self.font.copyWithAttributes(0.0, &Face.italic_skew, null);
-        errdefer ct_font.release();
-        return .{ .font = ct_font };
-    }
 };
 
 /// WebCanvas specific data. This is only present when building with canvas.
@@ -349,40 +342,6 @@ pub fn hasCodepoint(self: DeferredFace, cp: u32, p: ?Presentation) bool {
     // This is unreachable because discovery mechanisms terminate, and
     // if we're not using a discovery mechanism, the face MUST be loaded.
     unreachable;
-}
-
-/// Returns true if our deferred font implementation supports auto-itacilization.
-pub fn canItalicize() bool {
-    return @hasDecl(FaceState, "italicize") and @hasDecl(Face, "italicize");
-}
-
-/// Returns a new deferred face with the italicized version of this face
-/// by applying a skew. This is NOT TRUE italics. You should use the discovery
-/// mechanism to try to find an italic font. This is a fallback for when
-/// that fails.
-pub fn italicize(self: *const DeferredFace) !?DeferredFace {
-    if (comptime !canItalicize()) return null;
-
-    var result: DeferredFace = .{};
-
-    if (self.face) |face| {
-        result.face = try face.italicize();
-    }
-
-    switch (options.backend) {
-        .freetype => {},
-        .fontconfig_freetype => if (self.fc) |*fc| {
-            result.fc = try fc.italicize();
-        },
-        .coretext, .coretext_freetype => if (self.ct) |*ct| {
-            result.ct = try ct.italicize();
-        },
-        .web_canvas => if (self.wc) |*wc| {
-            result.wc = try wc.italicize();
-        },
-    }
-
-    return result;
 }
 
 /// The wasm-compatible API.

--- a/src/font/DeferredFace.zig
+++ b/src/font/DeferredFace.zig
@@ -360,13 +360,13 @@ test "fontconfig" {
     defer def.deinit();
 
     // Verify we can get the name
-    const n = try def.name();
+    var buf: [1024]u8 = undefined;
+    const n = try def.name(&buf);
     try testing.expect(n.len > 0);
 
     // Load it and verify it works
-    try def.load(lib, .{ .points = 12 });
-    try testing.expect(def.hasCodepoint(' ', null));
-    try testing.expect(def.face.?.glyphIndex(' ') != null);
+    const face = try def.load(lib, .{ .points = 12 });
+    try testing.expect(face.glyphIndex(' ') != null);
 }
 
 test "coretext" {

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -259,9 +259,10 @@ pub fn indexForCodepoint(
             defer disco_it.deinit();
 
             if (disco_it.next() catch break :discover) |face| {
+                var buf: [256]u8 = undefined;
                 log.info("found codepoint 0x{x} in fallback face={s}", .{
                     cp,
-                    face.name() catch "<error>",
+                    face.name(&buf) catch "<error>",
                 });
                 self.addFace(style, .{ .deferred = face }) catch break :discover;
                 if (self.indexForCodepointExact(cp, style, p)) |value| return value;

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -638,7 +638,7 @@ test "discover monospace with fontconfig and freetype" {
     defer lib.deinit();
     var group = try init(alloc, lib, .{ .points = 12 });
     defer group.deinit();
-    try group.addFace(.regular, (try it.next()).?);
+    try group.addFace(.regular, .{ .deferred = (try it.next()).? });
 
     // Should find all visible ASCII
     var atlas_greyscale = try font.Atlas.init(alloc, 512, .greyscale);

--- a/src/font/GroupCache.zig
+++ b/src/font/GroupCache.zig
@@ -184,7 +184,7 @@ test {
     // Setup group
     try cache.group.addFace(
         .regular,
-        DeferredFace.initLoaded(try Face.init(lib, testFont, .{ .points = 12 })),
+        .{ .loaded = try Face.init(lib, testFont, .{ .points = 12 }) },
     );
     var group = cache.group;
 
@@ -340,7 +340,7 @@ test "resize" {
     // Setup group
     try cache.group.addFace(
         .regular,
-        DeferredFace.initLoaded(try Face.init(lib, testFont, .{ .points = 12, .xdpi = 96, .ydpi = 96 })),
+        .{ .loaded = try Face.init(lib, testFont, .{ .points = 12, .xdpi = 96, .ydpi = 96 }) },
     );
 
     // Load a letter

--- a/src/font/GroupCache.zig
+++ b/src/font/GroupCache.zig
@@ -187,7 +187,7 @@ test {
         .regular,
         DeferredFace.initLoaded(try Face.init(lib, testFont, .{ .points = 12 })),
     );
-    const group = cache.group;
+    var group = cache.group;
 
     // Visible ASCII. Do it twice to verify cache.
     var i: u32 = 32;

--- a/src/font/GroupCache.zig
+++ b/src/font/GroupCache.zig
@@ -183,7 +183,6 @@ test {
 
     // Setup group
     try cache.group.addFace(
-        alloc,
         .regular,
         DeferredFace.initLoaded(try Face.init(lib, testFont, .{ .points = 12 })),
     );
@@ -340,7 +339,6 @@ test "resize" {
 
     // Setup group
     try cache.group.addFace(
-        alloc,
         .regular,
         DeferredFace.initLoaded(try Face.init(lib, testFont, .{ .points = 12, .xdpi = 96, .ydpi = 96 })),
     );

--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -301,7 +301,6 @@ pub const CoreText = struct {
             defer self.i += 1;
 
             return DeferredFace{
-                .face = null,
                 .ct = .{ .font = font },
             };
         }
@@ -311,14 +310,9 @@ pub const CoreText = struct {
 test "fontconfig" {
     if (options.backend != .fontconfig_freetype) return error.SkipZigTest;
 
-    const testing = std.testing;
-
     var fc = Fontconfig.init();
     var it = try fc.discover(.{ .family = "monospace", .size = 12 });
     defer it.deinit();
-    while (try it.next()) |face| {
-        try testing.expect(!face.loaded());
-    }
 }
 
 test "fontconfig codepoint" {
@@ -333,7 +327,6 @@ test "fontconfig codepoint" {
     // The first result should have the codepoint. Later ones may not
     // because fontconfig returns all fonts sorted.
     const face = (try it.next()).?;
-    try testing.expect(!face.loaded());
     try testing.expect(face.hasCodepoint('A', null));
 
     // Should have other codepoints too
@@ -351,9 +344,8 @@ test "coretext" {
     var it = try ct.discover(.{ .family = "Monaco", .size = 12 });
     defer it.deinit();
     var count: usize = 0;
-    while (try it.next()) |face| {
+    while (try it.next()) |_| {
         count += 1;
-        try testing.expect(!face.loaded());
     }
     try testing.expect(count > 0);
 }
@@ -372,7 +364,6 @@ test "coretext codepoint" {
     // The first result should have the codepoint. Later ones may not
     // because fontconfig returns all fonts sorted.
     const face = (try it.next()).?;
-    try testing.expect(!face.loaded());
     try testing.expect(face.hasCodepoint('A', null));
 
     // Should have other codepoints too

--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -217,7 +217,6 @@ pub const Fontconfig = struct {
             defer self.i += 1;
 
             return DeferredFace{
-                .face = null,
                 .fc = .{
                     .pattern = font_pattern,
                     .charset = (try font_pattern.get(.charset, 0)).char_set,

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -795,12 +795,13 @@ fn testShaper(alloc: Allocator) !TestShaper {
     errdefer cache_ptr.*.deinit(alloc);
 
     // Setup group
-    try cache_ptr.group.addFace(.regular, DeferredFace.initLoaded(try Face.init(lib, testFont, .{ .points = 12 })));
+    try cache_ptr.group.addFace(.regular, .{ .loaded = try Face.init(lib, testFont, .{ .points = 12 }) });
+
     if (font.options.backend != .coretext) {
         // Coretext doesn't support Noto's format
-        try cache_ptr.group.addFace(.regular, DeferredFace.initLoaded(try Face.init(lib, testEmoji, .{ .points = 12 })));
+        try cache_ptr.group.addFace(.regular, .{ .loaded = try Face.init(lib, testEmoji, .{ .points = 12 }) });
     }
-    try cache_ptr.group.addFace(.regular, DeferredFace.initLoaded(try Face.init(lib, testEmojiText, .{ .points = 12 })));
+    try cache_ptr.group.addFace(.regular, .{ .loaded = try Face.init(lib, testEmojiText, .{ .points = 12 }) });
 
     var cell_buf = try alloc.alloc(font.shape.Cell, 80);
     errdefer alloc.free(cell_buf);

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -12,7 +12,6 @@ const Library = font.Library;
 const Style = font.Style;
 const Presentation = font.Presentation;
 const terminal = @import("../../terminal/main.zig");
-const quirks = @import("../../quirks.zig");
 
 const log = std.log.scoped(.font_shaper);
 
@@ -108,7 +107,7 @@ pub const Shaper = struct {
         // fonts, the codepoint == glyph_index so we don't need to run any shaping.
         if (run.font_index.special() == null) {
             const face = try run.group.group.faceFromIndex(run.font_index);
-            const i = if (!quirks.disableDefaultFontFeatures(face)) 0 else i: {
+            const i = if (!face.quirks_disable_default_font_features) 0 else i: {
                 // If we are disabling default font features we just offset
                 // our features by the hardcoded items because always
                 // add those at the beginning.

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -795,12 +795,12 @@ fn testShaper(alloc: Allocator) !TestShaper {
     errdefer cache_ptr.*.deinit(alloc);
 
     // Setup group
-    try cache_ptr.group.addFace(alloc, .regular, DeferredFace.initLoaded(try Face.init(lib, testFont, .{ .points = 12 })));
+    try cache_ptr.group.addFace(.regular, DeferredFace.initLoaded(try Face.init(lib, testFont, .{ .points = 12 })));
     if (font.options.backend != .coretext) {
         // Coretext doesn't support Noto's format
-        try cache_ptr.group.addFace(alloc, .regular, DeferredFace.initLoaded(try Face.init(lib, testEmoji, .{ .points = 12 })));
+        try cache_ptr.group.addFace(.regular, DeferredFace.initLoaded(try Face.init(lib, testEmoji, .{ .points = 12 })));
     }
-    try cache_ptr.group.addFace(alloc, .regular, DeferredFace.initLoaded(try Face.init(lib, testEmojiText, .{ .points = 12 })));
+    try cache_ptr.group.addFace(.regular, DeferredFace.initLoaded(try Face.init(lib, testEmojiText, .{ .points = 12 })));
 
     var cell_buf = try alloc.alloc(font.shape.Cell, 80);
     errdefer alloc.free(cell_buf);


### PR DESCRIPTION
This was motivated by #331. I realized with #331 that this added a lot of overhead on every render frame, because for each text run being rendered, we were (1) reloading the font name (unknown performance cost on macOS due to closed source, looks like [it ain't exactly free in Freetype](https://sourcegraph.com/github.com/freetype/freetype@4d8db130ea4342317581bab65fc96365ce806b77/-/blob/src/base/ftsnames.c?L44)) (2) doing multiple string compares (3) multiple function call overhead. And realistically, quirks mode will be _rare_, so paying a very active cost for a rare thing is 💩 .

In investigating that I finally shaved some yaks I've been wanting to shave on this path... the end result is that overall we should be doing [very] slightly less work no matter what and using slightly less memory. And on the renderer path, we're doing _way_ less work. 

- All loaded font `Face` structures must also check and cache their quirks mode settings. This makes #331 a single boolean check per text run which is effectively free compared to the actual shaping task. The cost is one additional byte on the face structure (well, whatever the alignment is).
- `DeferredFace` now only represents an _unloaded_ face (that can be loaded multiple times). This lowers memory usage significantly (`Face` was large) per deferred face.
- `DeferredFace.name()` now takes a buffer for output instead of just failing on no static space, weird decision. No performance impact but makes this function more robust.
- `Group.addFace` now takes a tagged union representing either a deferred or loaded face, this gets rid of all the weird `DeferredFace.initLoaded` wrappers that were unnecessary and dumb. No real performance impact.
- When a font face is loaded in `Group` (lots of things trigger this), the DeferredFace it came from is now deinitialized immediately. This should save on memory significantly because we free all the font discovery information. We can do this because a deferred face is only ever loaded _once_ when its part of a `Group`, and the group owns the deferred face.
- Auto-italicize moves into `Group` and is no longer duplicated between Deferred and normal Face. No performance change, less code.