### PR TITLE
font: grapheme clusters need to find a single font for all codepoints

### DIFF
--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -299,6 +299,20 @@ fn indexForCodepointExact(self: Group, cp: u32, style: Style, p: ?Presentation) 
     return null;
 }
 
+/// Check if a specific font index has a specific codepoint. This does not
+/// necessarily force the font to load.
+pub fn hasCodepoint(self: *Group, index: FontIndex, cp: u32, p: ?Presentation) bool {
+    const list = self.faces.getPtr(index.style);
+    const item = list.items[@intCast(index.idx)];
+    return switch (item) {
+        .deferred => |v| v.hasCodepoint(cp, p),
+        .loaded => |face| loaded: {
+            if (p) |desired| if (face.presentation != desired) break :loaded false;
+            break :loaded face.glyphIndex(cp) != null;
+        },
+    };
+}
+
 /// Returns the presentation for a specific font index. This is useful for
 /// determining what atlas is needed.
 pub fn presentationFromIndex(self: *Group, index: FontIndex) !font.Presentation {

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -137,7 +137,7 @@ pub const Shaper = struct {
                 .glyph_index = v.codepoint,
             };
 
-            //log.warn("i={} info={} pos={} cell={}", .{ i, v, pos[i], self.cell_buf[i] });
+            // log.warn("i={} info={} pos={} cell={}", .{ i, v, pos[i], self.cell_buf[i] });
         }
 
         return self.cell_buf[0..info.len];
@@ -154,6 +154,7 @@ pub const Shaper = struct {
         }
 
         pub fn addCodepoint(self: RunIteratorHook, cp: u32, cluster: u32) !void {
+            // log.warn("cluster={} cp={x}", .{ cluster, cp });
             self.shaper.hb_buf.add(cp, cluster);
         }
 

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -623,6 +623,10 @@ pub const CodepointIterator = struct {
             },
         }
     }
+
+    pub fn reset(self: *CodepointIterator) void {
+        self.i = 0;
+    }
 };
 
 /// RowIndex represents a row within the screen. There are various meanings


### PR DESCRIPTION
Fixes #337 

When font shaping grapheme clusters, we erroneously used the font index 
of a font that only matches the first codepoint in the cell. This led to the
combining characters being [usually] unknown and rendering as boxes. 

For a grapheme, we must find a font face that has a glyph for _all codepoints_
in the grapheme. 

This also fixes an issue where we now properly render the unicode replacement
character if we can't find a font satisfying a codepoint.

**Note: rendering still isn't perfect.** In these sorts of cases, we're usually
falling back to multiple fallback fonts which have a different set of metrics 
than our normal terminal font, so spacing is going to be weird. This is consistent
with other terminals.

## Before

![CleanShot 2023-08-26 at 09 29 15@2x](https://github.com/mitchellh/ghostty/assets/1299/8237b861-b0b9-4ecc-b951-2f53068ffcf0)

## After

![CleanShot 2023-08-26 at 09 29 47@2x](https://github.com/mitchellh/ghostty/assets/1299/20f64c2e-c6f7-49fa-bf1a-e1143f6cc07b)
