### PR TITLE
Set gtk window title on change and tab swap (by key command)

### DIFF
--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -531,6 +531,11 @@ const Window = struct {
         const page_idx = c.gtk_notebook_get_current_page(self.notebook);
         const widget = c.gtk_notebook_get_nth_page(self.notebook, page_idx);
         _ = c.gtk_widget_grab_focus(widget);
+
+        const gtk_label_box = @as(*c.GtkWidget, @ptrCast(c.gtk_notebook_get_tab_label(self.notebook, widget)));
+        const gtk_label = @as(*c.GtkLabel, @ptrCast(c.gtk_widget_get_first_child(gtk_label_box)));
+        const label_text = c.gtk_label_get_text(gtk_label);
+        c.gtk_window_set_title(self.window, label_text);
     }
 
     fn gtkTabAddClick(_: *c.GtkButton, ud: ?*anyopaque) callconv(.C) void {
@@ -939,6 +944,11 @@ pub const Surface = struct {
 
             .label => |label| {
                 c.gtk_label_set_text(label, slice.ptr);
+
+                const widget = @as(*c.GtkWidget, @ptrCast(self.gl_area));
+                if (c.gtk_widget_is_focus(widget) == 1) {
+                    c.gtk_window_set_title(self.window.window, c.gtk_label_get_text(label));
+                }
             },
         }
 


### PR DESCRIPTION
Fixes a significant portion of #316 

Does:
- changes window title when the active tab changes its title
- changes window title when the tab focused is changed by keyboard shortcut

Does not:
- change window title from clicking the gtk tabs

I figure this needs to be done in one of the G_CALLBACK functions, but I'm not entirely sure where. Guidance?
