### PR TITLE
Set TERM_PROGRAM and TERM_PROGRAM_VERSION environment variables

### DIFF
--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -612,6 +612,8 @@ const Subprocess = struct {
             try env.put("COLORTERM", "truecolor");
         }
 
+        // Set environment variables used by some programs (such as neovim) to detect
+        // which terminal emulator and version they're running under.
         try env.put("TERM_PROGRAM", "ghostty");
         try env.put("TERM_PROGRAM_VERSION", build_config.version_string);
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -612,6 +612,9 @@ const Subprocess = struct {
             try env.put("COLORTERM", "truecolor");
         }
 
+        try env.put("TERM_PROGRAM", "ghostty");
+        try env.put("TERM_PROGRAM_VERSION", build_config.version_string);
+
         // When embedding in macOS and running via XCode, XCode injects
         // a bunch of things that break our shell process. We remove those.
         if (comptime builtin.target.isDarwin() and build_config.artifact == .lib) {


### PR DESCRIPTION
WezTerm claims this is an emerging de-facto standard for terminal emulator identification: https://github.com/wez/wezterm/blob/a103b6d97adcc439e27cec0d3bb2c0f72a79095d/config/src/config.rs#L1526-L1529

One example of usage in the wild is neovim doing capability detection: https://github.com/neovim/neovim/blob/f050aaabbb31b58ebac519a6f7014610f2b119f0/src/nvim/tui/tui.c#L206-L211

Ghostty now reports this:

$echo $TERM_PROGRAM
ghostty

$echo $TERM_PROGRAM_VERSION
0.1.0-main+aa08f3c

I think it's really nice that the commit hash is included, as users can provide this in issue reports. WezTerm does the same.

I use these variables in my tui library in addition to $TERM and $COLORTERM for capability detection, which is what motivated this PR.