### PR TITLE
Synchronized Output Sequence

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -467,6 +467,12 @@ pub fn render(
         state.mutex.lock();
         defer state.mutex.unlock();
 
+        // If we're in a synchronized output state, we pause all rendering.
+        if (state.terminal.modes.get(.synchronized_output)) {
+            log.debug("synchronized output started, skipping render", .{});
+            return;
+        }
+
         self.cursor_visible = visible: {
             // If the cursor is explicitly not visible in the state,
             // then it is not visible.

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -709,6 +709,12 @@ pub fn render(
         state.mutex.lock();
         defer state.mutex.unlock();
 
+        // If we're in a synchronized output state, we pause all rendering.
+        if (state.terminal.modes.get(.synchronized_output)) {
+            log.debug("synchronized output started, skipping render", .{});
+            return;
+        }
+
         self.cursor_visible = visible: {
             // If the cursor is explicitly not visible in the state,
             // then it is not visible.

--- a/src/terminal/Parser.zig
+++ b/src/terminal/Parser.zig
@@ -694,6 +694,33 @@ test "csi: colon for non-m final" {
     try testing.expect(p.state == .ground);
 }
 
+test "csi: request mode decrqm" {
+    var p = init();
+    _ = p.next(0x1B);
+    for ("[?2026$") |c| {
+        const a = p.next(c);
+        try testing.expect(a[0] == null);
+        try testing.expect(a[1] == null);
+        try testing.expect(a[2] == null);
+    }
+
+    {
+        const a = p.next('p');
+        try testing.expect(p.state == .ground);
+        try testing.expect(a[0] == null);
+        try testing.expect(a[1].? == .csi_dispatch);
+        try testing.expect(a[2] == null);
+
+        const d = a[1].?.csi_dispatch;
+        try testing.expect(d.final == 'p');
+        try testing.expectEqual(@as(usize, 2), d.intermediates.len);
+        try testing.expectEqual(@as(usize, 1), d.params.len);
+        try testing.expectEqual(@as(u16, '?'), d.intermediates[0]);
+        try testing.expectEqual(@as(u16, '$'), d.intermediates[1]);
+        try testing.expectEqual(@as(u16, 2026), d.params[0]);
+    }
+}
+
 test "osc: change window title" {
     var p = init();
     _ = p.next(0x1B);

--- a/src/terminal/modes.zig
+++ b/src/terminal/modes.zig
@@ -170,6 +170,7 @@ const entries: []const ModeEntry = &.{
     .{ .name = "alt_sends_escape", .value = 1039 },
     .{ .name = "alt_screen_save_cursor_clear_enter", .value = 1049 },
     .{ .name = "bracketed_paste", .value = 2004 },
+    .{ .name = "synchronized_output", .value = 2026 },
 };
 
 test {

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -569,6 +569,35 @@ pub fn Stream(comptime Handler: type) type {
                     ),
                 },
 
+                // DECRQM - Request Mode
+                'p' => switch (action.intermediates.len) {
+                    2 => decrqm: {
+                        if (action.intermediates[0] != '?' and
+                            action.intermediates[1] != '$')
+                        {
+                            log.warn(
+                                "ignoring unimplemented CSI p with intermediates: {s}",
+                                .{action.intermediates},
+                            );
+                            break :decrqm;
+                        }
+
+                        if (action.params.len != 1) {
+                            log.warn("invalid DECRQM command: {}", .{action});
+                            break :decrqm;
+                        }
+
+                        if (@hasDecl(T, "requestMode")) {
+                            try self.handler.requestMode(action.params[0]);
+                        } else log.warn("unimplemented DECRQM callback: {}", .{action});
+                    },
+
+                    else => log.warn(
+                        "ignoring unimplemented CSI p with intermediates: {s}",
+                        .{action.intermediates},
+                    ),
+                },
+
                 // DECSCUSR - Select Cursor Style
                 // TODO: test
                 'q' => if (@hasDecl(T, "setCursorStyle")) try self.handler.setCursorStyle(

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -293,6 +293,13 @@ pub fn resize(
         // Update our pixel sizes
         self.terminal.width_px = padded_size.width;
         self.terminal.height_px = padded_size.height;
+
+        // Disable synchronized output mode so that we show changes
+        // immediately for a resize. This is allowed by the spec.
+        self.terminal.modes.set(.synchronized_output, false);
+
+        // Wake up our renderer so any changes will be shown asap
+        self.renderer_wakeup.notify() catch {};
     }
 }
 

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -29,7 +29,7 @@ const Coalesce = struct {
 
 /// The number of milliseconds before we reset the synchronized output flag
 /// if the running program hasn't already.
-const sync_reset_ms = 5000;
+const sync_reset_ms = 1000;
 
 /// Allocator used for some state
 alloc: std.mem.Allocator,

--- a/src/termio/message.zig
+++ b/src/termio/message.zig
@@ -51,6 +51,11 @@ pub const Message = union(enum) {
     /// Jump forward/backward n prompts.
     jump_to_prompt: isize,
 
+    /// Send this when a synchronized output mode is started. This will
+    /// start the timer so that the output mode is disabled after a
+    /// period of time so that a bad actor can't hang the terminal.
+    start_synchronized_output: void,
+
     /// Write where the data fits in the union.
     write_small: WriteReq.Small,
 


### PR DESCRIPTION
Fixes #324

This adds support for the [synchronized output spec](https://gist.github.com/christianparpart/d8a62cc1ab659194337d73e399004036).

This let's running programs pause rendering so that on the next rendered frame, all sequences during the pause are rendered atomically. This prevents tearing in highly interactive programs. This isn't a very widely supported feature in applications yet but its fairly well supported in terminal emulators (see the linked gist above).

Implementation notes:

  * iTerm2 DCS sequences aren't implemented (they're deprecated)
  * Synchronized output automatically disables after 1 second to prevent malicious behavior
  * Synchronized output disables if the window is resized to prevent distorted viewports

## Demo

Notice in the program below we echo _immediately_ (no sleep before), but when we run the program we don't see it for a slight delay. This delay is the 1s timeout for synchronized output. A real program would be using this time to setup complex screen state, and would explicitly end the frame with `CSI ? 2026 l`. My demo uses the timeout to exaggerate.

```
#!/usr/bin/env bash

function csi() {
  printf "\033[%s" "$*"
}

csi "?2026h"
echo "YOU CANT SEE ME!"
sleep 5
```

https://github.com/mitchellh/ghostty/assets/1299/5d1528ec-aa7c-40d0-ac7f-f5c47fa8ea4f

