### PR TITLE
Ligature shaping fixes

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1148,6 +1148,11 @@ fn rebuildCells(
             screen.viewportIsBottom() and
             y == screen.cursor.y;
 
+        // True if we want to do font shaping around the cursor. We want to
+        // do font shaping as long as the cursor is enabled.
+        const shape_cursor = screen.viewportIsBottom() and
+            y == screen.cursor.y;
+
         // If this is the row with our cursor, then we may have to modify
         // the cell with the cursor.
         const start_i: usize = self.cells.items.len;
@@ -1183,7 +1188,7 @@ fn rebuildCells(
             self.font_group,
             row,
             row_selection,
-            if (cursor_row) screen.cursor.x else null,
+            if (shape_cursor) screen.cursor.x else null,
         );
         while (try iter.next(self.alloc)) |run| {
             for (try self.font_shaper.shape(run)) |shaper_cell| {

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -902,6 +902,11 @@ pub fn rebuildCells(
             screen.viewportIsBottom() and
             y == screen.cursor.y;
 
+        // True if we want to do font shaping around the cursor. We want to
+        // do font shaping as long as the cursor is enabled.
+        const shape_cursor = screen.viewportIsBottom() and
+            y == screen.cursor.y;
+
         // If this is the row with our cursor, then we may have to modify
         // the cell with the cursor.
         const start_i: usize = self.cells.items.len;
@@ -940,7 +945,7 @@ pub fn rebuildCells(
             self.font_group,
             row,
             selection,
-            if (cursor_row) screen.cursor.x else null,
+            if (shape_cursor) screen.cursor.x else null,
         );
         while (try iter.next(self.alloc)) |run| {
             for (try self.font_shaper.shape(run)) |shaper_cell| {

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -218,6 +218,16 @@ pub const Cell = struct {
         /// also be true. The grapheme code points can be looked up in the
         /// screen grapheme map.
         grapheme: bool = false,
+
+        /// Returns only the attributes related to style.
+        pub fn styleAttrs(self: @This()) @This() {
+            var copy = self;
+            copy.wide = false;
+            copy.wide_spacer_tail = false;
+            copy.wide_spacer_head = false;
+            copy.grapheme = false;
+            return copy;
+        }
     } = .{},
 
     /// True if the cell should be skipped for drawing
@@ -2666,6 +2676,7 @@ pub fn testWriteString(self: *Screen, text: []const u8) !void {
         switch (width) {
             1 => {
                 const cell = row.getCellPtr(x);
+                cell.* = self.cursor.pen;
                 cell.char = @intCast(c);
 
                 grapheme.x = x;
@@ -2691,6 +2702,7 @@ pub fn testWriteString(self: *Screen, text: []const u8) !void {
 
                 {
                     const cell = row.getCellPtr(x);
+                    cell.* = self.cursor.pen;
                     cell.char = @intCast(c);
                     cell.attrs.wide = true;
 

--- a/src/terminal/color.zig
+++ b/src/terminal/color.zig
@@ -99,6 +99,10 @@ pub const RGB = struct {
     g: u8 = 0,
     b: u8 = 0,
 
+    pub fn eql(self: RGB, other: RGB) bool {
+        return self.r == other.r and self.g == other.g and self.b == other.b;
+    }
+
     test "size" {
         try std.testing.expectEqual(@as(usize, 24), @bitSizeOf(RGB));
         try std.testing.expectEqual(@as(usize, 3), @sizeOf(RGB));


### PR DESCRIPTION
Fixes #356 
Fixes #357 

## 1. Ligature should split if cursor is on it but flashing

### Before


https://github.com/mitchellh/ghostty/assets/1299/934cd2f0-8d26-4b53-b26c-e1c9a1e8ecf9



### After


https://github.com/mitchellh/ghostty/assets/1299/9c869bef-d696-4465-ae0c-43c73ce009c6



## 2. Ligature should split if components of the ligature differ in styling

### Before

![CleanShot 2023-08-29 at 14 12 38@2x](https://github.com/mitchellh/ghostty/assets/1299/ab3aed71-c3b9-46a6-84c1-a20139671498)

### After

![CleanShot 2023-08-29 at 14 12 06@2x](https://github.com/mitchellh/ghostty/assets/1299/8c39e37b-9a48-4a99-9b21-a2cd0e0d74e7)
