### PR TITLE
terminal: tabstops were off by one

### DIFF
--- a/src/terminal/Tabstops.zig
+++ b/src/terminal/Tabstops.zig
@@ -149,7 +149,7 @@ pub fn reset(self: *Tabstops, interval: usize) void {
     @memset(self.dynamic_stops, 0);
 
     if (interval > 0) {
-        var i: usize = interval - 1;
+        var i: usize = interval;
         while (i < self.cols - 1) : (i += interval) {
             self.set(i);
         }
@@ -203,9 +203,9 @@ test "Tabstops: interval" {
     var t: Tabstops = try init(testing.allocator, 80, 4);
     defer t.deinit(testing.allocator);
     try testing.expect(!t.get(0));
-    try testing.expect(t.get(3));
-    try testing.expect(!t.get(4));
-    try testing.expect(t.get(7));
+    try testing.expect(t.get(4));
+    try testing.expect(!t.get(5));
+    try testing.expect(t.get(8));
 }
 
 test "Tabstops: count on 80" {

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1901,11 +1901,11 @@ test "Terminal: horizontal tabs" {
     // HT
     try t.print('1');
     try t.horizontalTab();
-    try testing.expectEqual(@as(usize, 7), t.screen.cursor.x);
+    try testing.expectEqual(@as(usize, 8), t.screen.cursor.x);
 
     // HT
     try t.horizontalTab();
-    try testing.expectEqual(@as(usize, 15), t.screen.cursor.x);
+    try testing.expectEqual(@as(usize, 16), t.screen.cursor.x);
 
     // HT at the end
     try t.horizontalTab();
@@ -1924,11 +1924,11 @@ test "Terminal: horizontal tabs back" {
 
     // HT
     try t.horizontalTabBack();
-    try testing.expectEqual(@as(usize, 15), t.screen.cursor.x);
+    try testing.expectEqual(@as(usize, 16), t.screen.cursor.x);
 
     // HT
     try t.horizontalTabBack();
-    try testing.expectEqual(@as(usize, 7), t.screen.cursor.x);
+    try testing.expectEqual(@as(usize, 8), t.screen.cursor.x);
 
     // HT
     try t.horizontalTabBack();


### PR DESCRIPTION
Fixes #359

See #359 for a test script. The unit tests were also wrong. I used the test script in #359 to verify the exact column that tabstops should be set at.