### PR TITLE
Multiple fixes to bugs found while reading random bytes

### DIFF
--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1071,12 +1071,12 @@ pub fn copyRow(self: *Screen, dst: RowIndex, src: RowIndex) !void {
 /// the top/bottom are within it).
 ///
 /// This can be used to implement terminal scroll regions efficiently.
-pub fn scrollRegionUp(self: *Screen, top: RowIndex, bottom: RowIndex, count: usize) void {
+pub fn scrollRegionUp(self: *Screen, top: RowIndex, bottom: RowIndex, count_req: usize) void {
     const tracy = trace(@src());
     defer tracy.end();
 
     // Avoid a lot of work if we're doing nothing.
-    if (count == 0) return;
+    if (count_req == 0) return;
 
     // Convert our top/bottom to screen y values. This is the y offset
     // in the entire screen buffer.
@@ -1088,7 +1088,7 @@ pub fn scrollRegionUp(self: *Screen, top: RowIndex, bottom: RowIndex, count: usi
 
     // We can only scroll up to the number of rows in the region. The "+ 1"
     // is because our y values are 0-based and count is 1-based.
-    assert(count <= (bot_y - top_y + 1));
+    const count = @min(count_req, bot_y - top_y + 1);
 
     // Get the storage pointer for the full scroll region. We're going to
     // be modifying the whole thing so we get it right away.
@@ -4014,6 +4014,22 @@ test "Screen: scrollRegionUp multiple count" {
     }
 }
 
+test "Screen: scrollRegionUp count greater than available lines" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, 4, 5, 0);
+    defer s.deinit();
+    try s.testWriteString("1ABCD\n2EFGH\n3IJKL\n4ABCD");
+
+    s.scrollRegionUp(.{ .active = 1 }, .{ .active = 2 }, 10);
+    {
+        // Test our contents rotated
+        var contents = try s.testString(alloc, .screen);
+        defer alloc.free(contents);
+        try testing.expectEqualStrings("1ABCD\n\n\n4ABCD", contents);
+    }
+}
 test "Screen: scrollRegionUp fills with pen" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -412,6 +412,8 @@ pub const Row = struct {
 
     /// Attach a grapheme codepoint to the given cell.
     pub fn attachGrapheme(self: Row, x: usize, cp: u21) !void {
+        assert(x < self.storage.len - 1);
+
         const cell = &self.storage[x + 1].cell;
         const key = self.getId() + x + 1;
         const gop = try self.screen.graphemes.getOrPut(self.screen.alloc, key);
@@ -448,6 +450,8 @@ pub const Row = struct {
 
     /// Removes all graphemes associated with a cell.
     pub fn clearGraphemes(self: Row, x: usize) void {
+        assert(x < self.storage.len - 1);
+
         // Our row is now dirty
         self.storage[0].header.flags.dirty = true;
 

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -990,7 +990,11 @@ pub fn setCursorColAbsolute(self: *Terminal, col_req: usize) void {
 
     // TODO: test
 
-    assert(!self.modes.get(.origin)); // TODO
+    // TODO
+    if (!self.modes.get(.origin)) {
+        log.err("setCursorColAbsolute: cursor origin mode handling not implemented yet", .{});
+        return;
+    }
 
     if (self.status_display != .main) return; // TODO
 
@@ -1116,7 +1120,6 @@ pub fn eraseLine(
 
         else => {
             log.err("unimplemented erase line mode: {}", .{mode});
-            @panic("unimplemented");
         },
     }
 }

--- a/src/terminal/charsets.zig
+++ b/src/terminal/charsets.zig
@@ -85,14 +85,15 @@ const dec_special = tech: {
     break :tech table;
 };
 
-const max_u8 = std.math.maxInt(u8);
+/// Our table length is 256 so we can contain all ASCII chars.
+const table_len = std.math.maxInt(u8) + 1;
 
 /// Creates a table that maps ASCII to ASCII as a getting started point.
-fn initTable() [max_u8]u16 {
-    var result: [max_u8]u16 = undefined;
+fn initTable() [table_len]u16 {
+    var result: [table_len]u16 = undefined;
     var i: usize = 0;
-    while (i < max_u8) : (i += 1) result[i] = @intCast(i);
-    assert(i == max_u8);
+    while (i < table_len) : (i += 1) result[i] = @intCast(i);
+    assert(i == table_len);
     return result;
 }
 
@@ -105,9 +106,9 @@ test {
 
         const table = @field(Charset, field.name).table();
 
-        // Yes, I could use `max_u8` here, but I want to explicitly use a
+        // Yes, I could use `table_len` here, but I want to explicitly use a
         // hardcoded constant so that if there are miscompilations or a comptime
         // issue, we catch it.
-        try testing.expectEqual(@as(usize, 255), table.len);
+        try testing.expectEqual(@as(usize, 256), table.len);
     }
 }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1216,8 +1216,7 @@ const StreamHandler = struct {
     pub fn setCursorRow(self: *StreamHandler, row: u16) !void {
         if (self.terminal.modes.get(.origin)) {
             // TODO
-            log.err("setCursorRow: implement origin mode", .{});
-            unreachable;
+            log.err("setCursorRow: unimplemented origin mode handling, misrendering may occur", .{});
         }
 
         self.terminal.setCursorPos(row, self.terminal.screen.cursor.x + 1);


### PR DESCRIPTION
Related to #367 

This fixes numerous issues found. There are a couple big ones! Every bug fix is accompanied with one or more associated unit tests.

* `CSI S` didn't allow a count greater than scroll region height. In debug this triggered an assertion and in releasefast would result in memory corruption.
* `CSI P` was actually totally broken and untested. This adds unit tests and fixes all the known issues.
* `CSI M` would trigger an int underflow if the cursor was outside of the scroll region.
* When switching charsets, we would trigger an OOB access if we used ASCII `255`. Our charset tables were one size too small.
* Convert all VT functionality TODOs from unreachables to error logs. They should not crash the terminal, even if they result in state issues.
