### PR TITLE
macos: break reference cycle to window to allow window to free memory

### DIFF
--- a/macos/Sources/Features/Primary Window/PrimaryWindowController.swift
+++ b/macos/Sources/Features/Primary Window/PrimaryWindowController.swift
@@ -11,4 +11,14 @@ class PrimaryWindowController: NSWindowController {
         guard let manager = self.windowManager else { return }
         manager.triggerNewTab(for: window)
     }
+    
+    deinit {
+        // I don't know if this is the right place, but because of WindowAccessor in our
+        // SwiftUI hierarchy, we have a reference cycle between view and window and windows
+        // are never freed. When the window is closed, the window controller is deinitialized,
+        // so we can use this opportunity detach the view from the window and break the cycle.
+        if let window = self.window {
+            window.contentView = nil
+        }
+    }
 }


### PR DESCRIPTION
Fixes #366

The comment in the Swift code explains what was happening here:

> I don't know if this is the right place, but because of WindowAccessor in our
> SwiftUI hierarchy, we have a reference cycle between view and window and windows
> are never freed. When the window is closed, the window controller is deinitialized,
> so we can use this opportunity detach the view from the window and break the cycle.

An alternate solution would be to make our reference back to the window "weak" but we appear to not be able to do that with SwiftUI property wrappers such as `@State` and `@Binding` and so on.

## Before 

(Open 20 windows, close all)

<img width="467" alt="CleanShot 2023-09-01 at 09 16 17@2x" src="https://github.com/mitchellh/ghostty/assets/1299/b6e7935c-263a-4aaa-a2c2-1f6784f2c3ce">


## After

(Open 20 windows, close all)

<img width="483" alt="CleanShot 2023-09-01 at 09 15 17@2x" src="https://github.com/mitchellh/ghostty/assets/1299/e1fc56c0-33c8-4012-96fc-ba6a0f70196c">
