### PR TITLE
macos: default to sRGB color space

### DIFF
--- a/macos/Sources/Features/Primary Window/PrimaryWindow.swift
+++ b/macos/Sources/Features/Primary Window/PrimaryWindow.swift
@@ -23,7 +23,12 @@ class PrimaryWindow: NSWindow {
             backing: .buffered,
             defer: false)
         window.center()
-        
+
+        // Terminals typically operate in sRGB color space and macOS defaults
+        // to "native" which is typically P3. There is a lot more resources
+        // covered in thie GitHub issue: https://github.com/mitchellh/ghostty/pull/376
+        window.colorSpace = NSColorSpace.sRGB
+
         window.contentView = NSHostingView(rootView: PrimaryView(
             ghostty: ghostty,
             appDelegate: appDelegate,


### PR DESCRIPTION
Ghostty is currently using the native color space on MacOS. For some Apple devices that means DCI-P3.

When specifying a hex color, it gets mapped incorrectly, because the color space is about 25% wider. As an example:
`#0000FF` needs to be shown as "maximally blue in sRGB space". P3 is a much wider gamut, and the same hex code will result in a different color, since P3 can show "more blue".

A lot of useful information about this has been already written down in the following threads:
- https://github.com/alacritty/alacritty/pull/6602
- https://github.com/kovidgoyal/kitty/issues/2249

To illustrate (screenshots taken on a 2021 MacBook 14" using "Digital Color Meter"):

Ghostty **before** this PR in native P3 color space:
<img width="656" alt="Screenshot 2023-09-01 at 17 21 52" src="https://github.com/mitchellh/ghostty/assets/45123458/94171909-5452-4544-9699-d7c0a5c025b1">

Ghostty **before** this PR in sRGB color space:
<img width="656" alt="Screenshot 2023-09-01 at 17 22 08" src="https://github.com/mitchellh/ghostty/assets/45123458/6766d19f-8004-4360-94b5-eeff49695fcc">

Ghostty **after** this PR in P3:
<img width="505" alt="Screenshot 2023-09-01 at 17 27 49" src="https://github.com/mitchellh/ghostty/assets/45123458/9012427d-5639-4722-945c-e55ffcb684a5">

Ghostty **after** this PR in sRGB:
<img width="505" alt="Screenshot 2023-09-01 at 17 27 55" src="https://github.com/mitchellh/ghostty/assets/45123458/84f4857a-1a4e-4c7d-8b0e-92f7ef94ef16">

Here's a side by side with `onehalfdark` in neovim:
<img width="1512" alt="Screenshot 2023-09-01 at 18 20 27" src="https://github.com/mitchellh/ghostty/assets/45123458/daf7302d-81e1-4910-b3c3-bbac3228f6b7">
Left is this PR, right is `main`

Color schemes are generally designed with sRGB in mind. [onehalf](https://github.com/sonph/onehalf) for example specifies sRGB for [iTerm2](https://github.com/sonph/onehalf/blob/75eb2e97acd74660779fed8380989ee7891eec56/iterm/OneHalfDark.itermcolors#L22) and [VSCode](https://github.com/sonph/onehalf/blob/75eb2e97acd74660779fed8380989ee7891eec56/vscode/OneHalfDark.tmTheme#L37).

Behaviour of other terminals:

- iTerm (beta) allows to specify the color space, but it doesn't work in TUI applications, since (I suspect) they would also need to handle color spaces. This leads to a situation where `onehalf` would render correctly in the terminal, but incorrectly in neovim running in the same terminal. There's also a global config option to choose which color space to use. The stable release uses sRGB.
- Alacritty uses sRGB (post v0.12.0)
- Kitty allows to configure if sRGB or P3 is used globally.