### PR TITLE
macos: hacks for split focus to work correctly on macos 12

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.SplitView.swift
+++ b/macos/Sources/Ghostty/Ghostty.SplitView.swift
@@ -322,6 +322,19 @@ extension Ghostty {
                 if previous != view {
                     _ = previous.resignFirstResponder()
                 }
+                
+                // On newer versions of macOS everything above works great so we're done.
+                if #available(macOS 13, *) { return }
+                
+                // On macOS 12, splits do not properly gain focus. I don't know why, but
+                // it seems like the `focused` SwiftUI method doesn't work. We use
+                // NotificationCenter as a blunt force instrument to make it work.
+                if #available(macOS 12, *) {
+                    NotificationCenter.default.post(
+                        name: Notification.didBecomeFocusedSurface,
+                        object: view
+                    )
+                }
             }
         }
     }

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -91,6 +91,10 @@ extension Ghostty.Notification {
     /// Toggle fullscreen of current window
     static let ghosttyToggleFullscreen = Notification.Name("com.mitchellh.ghostty.toggleFullscreen")
     static let NonNativeFullscreenKey = ghosttyToggleFullscreen.rawValue
+    
+    /// Notification that a surface is becoming focused. This is only sent on macOS 12 to
+    /// work around bugs. macOS 13+ should use the ".focused()" attribute.
+    static let didBecomeFocusedSurface = Notification.Name("com.mitchellh.ghostty.didBecomeFocusedSurface")
 }
 
 // Make the input enum hashable.


### PR DESCRIPTION
Fixes #381