### PR TITLE
Update font DPI when the content scale is updated

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1192,6 +1192,15 @@ pub fn scrollCallback(
     try self.queueRender();
 }
 
+pub fn contentScaleCallback(self: *Surface, content_scale: apprt.ContentScale) void {
+    var size = self.font_size;
+    const x_dpi = content_scale.x * font.face.default_dpi;
+    const y_dpi = content_scale.y * font.face.default_dpi;
+    size.xdpi = @intFromFloat(x_dpi);
+    size.ydpi = @intFromFloat(y_dpi);
+    self.setFontSize(size);
+}
+
 /// The type of action to report for a mouse event.
 const MouseReportAction = enum { press, release, motion };
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1193,11 +1193,14 @@ pub fn scrollCallback(
 }
 
 pub fn contentScaleCallback(self: *Surface, content_scale: apprt.ContentScale) void {
-    var size = self.font_size;
     const x_dpi = content_scale.x * font.face.default_dpi;
     const y_dpi = content_scale.y * font.face.default_dpi;
-    size.xdpi = @intFromFloat(x_dpi);
-    size.ydpi = @intFromFloat(y_dpi);
+    const size = size: {
+        var size = self.font_size;
+        size.xdpi = @intFromFloat(x_dpi);
+        size.ydpi = @intFromFloat(y_dpi);
+        break :size size;
+    };
     self.setFontSize(size);
 }
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -348,6 +348,8 @@ pub const Surface = struct {
             .x = @floatCast(x),
             .y = @floatCast(y),
         };
+
+        self.core_surface.contentScaleCallback(self.content_scale);
     }
 
     pub fn updateSize(self: *Surface, width: u32, height: u32) void {


### PR DESCRIPTION
Fixes #372 

The content scale was already being updated when the terminal was moved between displays, so all that was left was to update the font size's DPI.

Added the logic under a `contentScaleCallback` since that seems like the primary mechanism that the embedded surface interacts with the `Surface`

Nits welcome! :D