### PR TITLE
content scale change events should also impact viewport padding

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -350,7 +350,10 @@ pub const Surface = struct {
             .y = @floatCast(y),
         };
 
-        self.core_surface.contentScaleCallback(self.content_scale);
+        self.core_surface.contentScaleCallback(self.content_scale) catch |err| {
+            log.err("error in content scale callback err={}", .{err});
+            return;
+        };
     }
 
     pub fn updateSize(self: *Surface, width: u32, height: u32) void {

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1048,9 +1048,14 @@ pub fn changeConfig(self: *Metal, config: *DerivedConfig) !void {
 }
 
 /// Resize the screen.
-pub fn setScreenSize(self: *Metal, dim: renderer.ScreenSize) !void {
-    // Store our screen size
+pub fn setScreenSize(
+    self: *Metal,
+    dim: renderer.ScreenSize,
+    pad: renderer.Padding,
+) !void {
+    // Store our sizes
     self.screen_size = dim;
+    self.padding.explicit = pad;
 
     // Recalculate the rows/columns. This can't fail since we just set
     // the screen size above.

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -1427,12 +1427,17 @@ pub fn changeConfig(self: *OpenGL, config: *DerivedConfig) !void {
 
 /// Set the screen size for rendering. This will update the projection
 /// used for the shader so that the scaling of the grid is correct.
-pub fn setScreenSize(self: *OpenGL, dim: renderer.ScreenSize) !void {
+pub fn setScreenSize(
+    self: *OpenGL,
+    dim: renderer.ScreenSize,
+    pad: renderer.Padding,
+) !void {
     if (single_threaded_draw) self.draw_mutex.lock();
     defer if (single_threaded_draw) self.draw_mutex.unlock();
 
     // Store our screen size
     self.screen_size = dim;
+    self.padding.explicit = pad;
 
     // Recalculate the rows/columns.
     const grid_size = self.gridSize(dim);

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -252,8 +252,8 @@ fn drainMailbox(self: *Thread) !void {
                 try self.renderer.setFontSize(size);
             },
 
-            .screen_size => |size| {
-                try self.renderer.setScreenSize(size);
+            .resize => |v| {
+                try self.renderer.setScreenSize(v.screen_size, v.padding);
             },
 
             .change_config => |config| {

--- a/src/renderer/message.zig
+++ b/src/renderer/message.zig
@@ -20,8 +20,14 @@ pub const Message = union(enum) {
     /// the size changes.
     font_size: font.face.DesiredSize,
 
-    /// Change the screen size.
-    screen_size: renderer.ScreenSize,
+    /// Changes the screen size.
+    resize: struct {
+        /// The full screen (drawable) size. This does NOT include padding.
+        screen_size: renderer.ScreenSize,
+
+        /// The explicit padding values.
+        padding: renderer.Padding,
+    },
 
     /// The derived configuration to update the renderer with.
     change_config: struct {

--- a/src/renderer/size.zig
+++ b/src/renderer/size.zig
@@ -143,6 +143,14 @@ pub const Padding = struct {
             .left = self.left + other.left,
         };
     }
+
+    /// Equality test between two paddings.
+    pub fn eql(self: Padding, other: Padding) bool {
+        return self.top == other.top and
+            self.bottom == other.bottom and
+            self.right == other.right and
+            self.left == other.left;
+    }
 };
 
 test "Padding balanced on zero" {


### PR DESCRIPTION
This calculates the new padding pixel values and propogates those changes to the renderer.

@mgeist: can you verify everything still works with these changes?