### PR TITLE
set WM_CLASS in glfw runtime

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -284,6 +284,10 @@ pub const Config = struct {
     /// The default value is "detect".
     @"shell-integration": ShellIntegration = .detect,
 
+    /// X11 WM_CLASS
+    /// currently only affects glfw backend on linux + X11
+    class: [:0]const u8 = "ghostty",
+
     /// If anything other than false, fullscreen mode on macOS will not use the
     /// native fullscreen, but make the window fullscreen without animations and
     /// using a new space. It's faster than the native fullscreen mode since it

--- a/src/config.zig
+++ b/src/config.zig
@@ -285,8 +285,7 @@ pub const Config = struct {
     @"shell-integration": ShellIntegration = .detect,
 
     /// X11 WM_CLASS
-    /// currently only affects glfw backend on linux + X11
-    class: [:0]const u8 = "ghostty",
+    @"x11-wm-class": [:0]const u8 = "ghostty",
 
     /// If anything other than false, fullscreen mode on macOS will not use the
     /// native fullscreen, but make the window fullscreen without animations and

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -488,6 +488,8 @@ pub fn glfwWindowHints(config: *const configpkg.Config) glfw.Window.Hints {
     return .{
         .context_version_major = 3,
         .context_version_minor = 3,
+        .x11_instance_name = "ghostty",
+        .x11_class_name = config.class,
         .opengl_profile = .opengl_core_profile,
         .opengl_forward_compat = true,
         .cocoa_graphics_switching = builtin.os.tag == .macos,

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -489,7 +489,7 @@ pub fn glfwWindowHints(config: *const configpkg.Config) glfw.Window.Hints {
         .context_version_major = 3,
         .context_version_minor = 3,
         .x11_instance_name = "ghostty",
-        .x11_class_name = config.class,
+        .x11_class_name = config.@"x11-wm-class",
         .opengl_profile = .opengl_core_profile,
         .opengl_forward_compat = true,
         .cocoa_graphics_switching = builtin.os.tag == .macos,


### PR DESCRIPTION
I'm a little stuck on gtk. Gtk3 had something like set_wm_class(), but it's no longer available.

Options appear to be:
-  [extended window manager hints](https://specifications.freedesktop.org/wm-spec/wm-spec-latest.html)
   I _think_ these are applied by sending messages (Xlib?) to the x11 server
   Wouldn't set WM_CLASS, but would achieve the desired objective of telling a TWM how to treat a ghostty window
- gdk4-x11 [X11Surface.set_utf8_property](https://docs.gtk.org/gdk4-x11/method.X11Surface.set_utf8_property.html)

I don't want to go adding extra dependencies without discussion first! Not even sure it's necessary, I might be missing something simple

As for this PR, I'm not sure taking 'class' as the setting name is correct, maybe it should be more specific. 'x11-wm-class'?