### PR TITLE
gtk: allow hiding window decoration in configuration

### DIFF
--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -354,6 +354,12 @@ const Window = struct {
             c.gtk_widget_set_opacity(@ptrCast(window), app.config.@"background-opacity");
         }
 
+        // Hide window decoration if configured. This has to happen before
+        // `gtk_widget_show`.
+        if (!app.config.@"window-decoration") {
+            c.gtk_window_set_decorated(gtk_window, 0);
+        }
+
         c.gtk_widget_show(window);
         _ = c.g_signal_connect_data(window, "close-request", c.G_CALLBACK(&gtkCloseRequest), self, null, G_CONNECT_DEFAULT);
         _ = c.g_signal_connect_data(window, "destroy", c.G_CALLBACK(&gtkDestroy), self, null, G_CONNECT_DEFAULT);

--- a/src/config.zig
+++ b/src/config.zig
@@ -213,6 +213,11 @@ pub const Config = struct {
     /// specified in the configuration "font-size" will be used.
     @"window-inherit-font-size": bool = true,
 
+    /// If false, windows won't have native decorations, i.e. titlebar and
+    /// borders.
+    /// Currently only supported with GTK.
+    @"window-decoration": bool = true,
+
     /// Whether to allow programs running in the terminal to read/write to
     /// the system clipboard (OSC 52, for googling). The default is to
     /// disallow clipboard reading but allow writing.


### PR DESCRIPTION
This is part of #319 by fixing it for GTK and introducing the configuration option.

This adds `window-decoration = false` as a possible configuration option. If set to `false`, then no window decorations are used.

### Before
![before](https://github.com/mitchellh/ghostty/assets/1185253/c37a7f15-35f1-4b21-825f-a178c4fbb916)

### After

![after](https://github.com/mitchellh/ghostty/assets/1185253/740d278f-f2da-4047-ab20-c3f00b04a2d6)
![after_with_tabs](https://github.com/mitchellh/ghostty/assets/1185253/237d2b9d-8432-436f-a3ff-e61a43bab459)
