### PR TITLE
Semantic prompt resize should only clear most recent prompt

### DIFF
--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -155,13 +155,14 @@ pub const RowHeader = struct {
         /// This is a prompt line, meaning it only contains the shell prompt.
         /// For poorly behaving shells, this may also be the input.
         prompt = 1,
+        prompt_continuation = 2,
 
         /// This line contains the input area. We don't currently track
         /// where this actually is in the line, so we just assume it is somewhere.
-        input = 2,
+        input = 3,
 
         /// This line is the start of command output.
-        command = 3,
+        command = 4,
     };
 };
 
@@ -1762,7 +1763,7 @@ fn jumpPrompt(self: *Screen, delta: isize) bool {
     while (y >= 0 and y <= max_y and delta_rem > 0) : (y += step) {
         const row = self.getRow(.{ .screen = @intCast(y) });
         switch (row.getSemanticPrompt()) {
-            .prompt, .input => delta_rem -= 1,
+            .prompt, .prompt_continuation, .input => delta_rem -= 1,
             .command, .unknown => {},
         }
     }

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -53,10 +53,10 @@ pub fn Stream(comptime Handler: type) type {
             // log.debug("char: {c}", .{c});
             const actions = self.parser.next(c);
             for (actions) |action_opt| {
-                // if (action_opt) |action| {
-                //     if (action != .print)
-                //         log.info("action: {}", .{action});
-                // }
+                if (action_opt) |action| {
+                    if (action != .print and action == .osc_dispatch)
+                        log.info("action: {}", .{action});
+                }
                 switch (action_opt orelse continue) {
                     .print => |p| if (@hasDecl(T, "print")) try self.handler.print(p),
                     .execute => |code| try self.execute(code),
@@ -802,8 +802,9 @@ pub fn Stream(comptime Handler: type) type {
                 },
 
                 .prompt_start => |v| {
-                    if (@hasDecl(T, "promptStart")) {
-                        try self.handler.promptStart(v.aid, v.redraw);
+                    if (@hasDecl(T, "promptStart")) switch (v.kind) {
+                        .primary, .right => try self.handler.promptStart(v.aid, v.redraw),
+                        .continuation => try self.handler.promptContinuation(v.aid),
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
 

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -53,10 +53,10 @@ pub fn Stream(comptime Handler: type) type {
             // log.debug("char: {c}", .{c});
             const actions = self.parser.next(c);
             for (actions) |action_opt| {
-                if (action_opt) |action| {
-                    if (action != .print and action == .osc_dispatch)
-                        log.info("action: {}", .{action});
-                }
+                // if (action_opt) |action| {
+                //     if (action != .print)
+                //         log.info("action: {}", .{action});
+                // }
                 switch (action_opt orelse continue) {
                     .print => |p| if (@hasDecl(T, "print")) try self.handler.print(p),
                     .execute => |code| try self.execute(code),

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1623,6 +1623,11 @@ const StreamHandler = struct {
         self.terminal.flags.shell_redraws_prompt = redraw;
     }
 
+    pub fn promptContinuation(self: *StreamHandler, aid: ?[]const u8) !void {
+        _ = aid;
+        self.terminal.markSemanticPrompt(.prompt_continuation);
+    }
+
     pub fn promptEnd(self: *StreamHandler) !void {
         self.terminal.markSemanticPrompt(.input);
     }


### PR DESCRIPTION
Fixes #399 

This also adds support for parsing "prompt continuation" lines because we needed those for zsh. When we see a prompt primary or continuation line, we clear from that point down. Previous logic was incorrectly clearing every blank prompt, see #399 for a screenshot.