### PR TITLE
macos: fix split focus when toggling fullscreen

### DIFF
--- a/macos/Sources/Features/Primary Window/PrimaryView.swift
+++ b/macos/Sources/Features/Primary Window/PrimaryView.swift
@@ -170,5 +170,11 @@ struct PrimaryView: View {
         self.fullScreen.toggleFullscreen(window: window, nonNativeFullscreen: useNonNativeFullscreen)
         // After toggling fullscreen we need to focus the terminal again.
         self.focused = true
+        
+        // For some reason focus always gets moved to the first split when
+        // toggling fullscreen, so we set it back to the correct one.
+        if let focusedSurface {
+            Ghostty.moveFocus(to: focusedSurface)
+        }
     }
 }

--- a/macos/Sources/Ghostty/Ghostty.SplitView.swift
+++ b/macos/Sources/Ghostty/Ghostty.SplitView.swift
@@ -502,11 +502,11 @@ extension Ghostty {
         }
     }
     
-    /// There is a bug I can't figure out where when changing the split state, the terminal view
+    /// When changing the split state, or going full screen (native or non), the terminal view
     /// will lose focus. There has to be some nice SwiftUI-native way to fix this but I can't
     /// figure it out so we're going to do this hacky thing to bring focus back to the terminal
     /// that should have it.
-    fileprivate static func moveFocus(to: SurfaceView, from: SurfaceView? = nil) {
+    static func moveFocus(to: SurfaceView, from: SurfaceView? = nil) {
         DispatchQueue.main.async {
             // If the callback runs before the surface is attached to a view
             // then the window will be nil. We just reschedule in that case.


### PR DESCRIPTION
Fixes one of the issues in #392 where focus is moved to the wrong split when toggling fullscreen. It turns out that this particular issue was happening for both native and non-native fullscreen - seems like a SwiftUI issue similar to the one that happens when split state changes.

This is very much the quick and dirty fix. I didn't think too hard about whether there's a better way to do this, so feel free to push back if this feels a bit too gross!