### PR TITLE
gtk: add gtk-single-instance setting to allow disabling of it

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,9 @@ than 5 MB on all platforms. The debug version is around 70MB.
 use a [single-instance application](https://developer.gnome.org/documentation/tutorials/application.html).
 If you're developing Ghostty from _inside_ a release build and build & launch a
 new one that will not reflect the changes you made, but instead launch a new
-window for the existing instance.**
+window for the existing instance. You can disable this behaviour with the
+`--gtk-single-instance=false` flag or by adding `gtk-single-instance = false` to
+the configuration file.**
 
 ### Mac `.app`
 

--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -66,11 +66,15 @@ pub const App = struct {
         // Our uniqueness ID is based on whether we're in a debug mode or not.
         // In debug mode we want to be separate so we can develop Ghostty in
         // Ghostty.
-        const uniqueness_id = "com.mitchellh.ghostty" ++ if (builtin.mode == .Debug) "-debug" else "";
+        const uniqueness_id: ?[*c]const u8 = uniqueness_id: {
+            if (!config.@"gtk-single-instance") break :uniqueness_id null;
+
+            break :uniqueness_id "com.mitchellh.ghostty" ++ if (builtin.mode == .Debug) "-debug" else "";
+        };
 
         // Create our GTK Application which encapsulates our process.
         const app = @as(?*c.GtkApplication, @ptrCast(c.gtk_application_new(
-            uniqueness_id,
+            uniqueness_id orelse null,
 
             // GTK >= 2.74
             if (@hasDecl(c, "G_APPLICATION_DEFAULT_FLAGS"))

--- a/src/config.zig
+++ b/src/config.zig
@@ -314,6 +314,15 @@ pub const Config = struct {
     /// This does not work with GLFW builds.
     @"macos-option-as-alt": OptionAsAlt = .false,
 
+    /// If true (default), then the Ghostty GTK application will run in
+    /// single-instance mode: each new `ghostty` process launched will result
+    /// in a new window, if there is already a running process.
+    ///
+    /// If false, each new ghostty process will launch a separate application.
+    ///
+    /// Debug builds of Ghostty have a separate single-instance ID.
+    @"gtk-single-instance": bool = true,
+
     /// This is set by the CLI parser for deinit.
     _arena: ?ArenaAllocator = null,
 


### PR DESCRIPTION
This is based on our conversation on Discord and adds a setting for GTK that allows disabling the GTK single-instance mode.

If this is off, it's possible to start multiple applications from the same release binary.

Tested like this:

```
$ zig build -Dapp-runtime=gtk -Doptimize=ReleaseFast && ./zig-out/bin/ghostty --gtk-single-instance=false

[... starts new application ...]
```

and

```
$ zig build -Dapp-runtime=gtk -Doptimize=ReleaseFast && ./zig-out/bin/ghostty --gtk-single-instance=true
info: ghostty version=0.1.0-main+42a22893
info: runtime=apprt.Runtime.gtk
info: font_backend=font.main.Backend.fontconfig_freetype
info: dependency harfbuzz=8.0.0
info: dependency fontconfig=21400
info: renderer=renderer.OpenGL
info: libxev backend=main.Backend.io_uring
info(os): LANG is not valid according to libc, will use en_US.UTF-8
info: reading configuration file path=/home/mrnugget/.config/ghostty/config
info(config): default shell source=env value=/usr/bin/zsh

(process:49045): GLib-GIO-WARNING **: 13:55:56.116: Your application did not unregister from D-Bus before destruction. Consider using g_application_run().

[exits]
```

### Screenshots

With `--gtk-single-instance=true`:

![image](https://github.com/mitchellh/ghostty/assets/1185253/913e34d1-ba4b-47af-99d6-021a4f7824a3)

With `--gtk-single-instance=false`:

![image](https://github.com/mitchellh/ghostty/assets/1185253/b684ca50-b439-4d2b-ab76-9b42a6b5b010)

