### PR TITLE
renderer: always show cursor if window is not focused

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -494,6 +494,10 @@ pub fn render(
             // If the cursor isn't a blinking style, then never blink.
             if (!selected_cursor_style.blinking()) break :visible true;
 
+            // If we're not focused, our cursor is always visible so that
+            // we can show the hollow box.
+            if (!self.focused) break :visible true;
+
             // Otherwise, adhere to our current state.
             break :visible self.cursor_visible;
         };

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -736,6 +736,10 @@ pub fn render(
             // If the cursor isn't a blinking style, then never blink.
             if (!selected_cursor_style.blinking()) break :visible true;
 
+            // If we're not focused, our cursor is always visible so that
+            // we can show the hollow box.
+            if (!self.focused) break :visible true;
+
             // Otherwise, adhere to our current state.
             break :visible self.cursor_visible;
         };


### PR DESCRIPTION
Fixes #400

This ensures the hollow box is shown even if the cursor is not in a blinking state when unfocus happens. We still hide the cursor even on unfocus if the terminal mode explictly asks for a hidden cursor.