### PR TITLE
 Do not show exit prompt when only a single surface exists 

### DIFF
--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -577,7 +577,7 @@ const Window = struct {
         const self = userdataSelf(ud.?);
 
         if (self.app.core_app.surfaces.items.len == 1) {
-            log.debug("Exiting without promt - only a single surface registered", .{});
+            log.debug("Exiting without prompt - only a single surface registered", .{});
             c.gtk_window_destroy(self.window);
             return true;
         }

--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -576,6 +576,12 @@ const Window = struct {
         log.debug("window close request", .{});
         const self = userdataSelf(ud.?);
 
+        if (self.app.core_app.surfaces.items.len == 1) {
+            log.debug("Exiting without promt - only a single surface registered", .{});
+            c.gtk_window_destroy(self.window);
+            return true;
+        }
+
         // Setup our basic message
         const alert = c.gtk_message_dialog_new(
             self.window,


### PR DESCRIPTION
Right now my workflow consists of creating multiple ghostty windows & killing them when no longer needed via my WM.
This makes that less painful.
Note that this does not apply to Swift, which seems to have a similar box, only GTK. I have no way of testing swift right now, so I've not made any changes there.

I think in the future I'd prefer if there was a way to start ghostty in the background (= no window at all) and then have a separate script that notifies that instance to create windows.
Maybe there's also a way to get the signal to only apply to the window I'm targeting, not sure what the "correct" behavior is. 

(Obviously feel free to close this if you don't agree this makes more sense, I'm just speaking from my point of view)