### PR TITLE
gtk: add new-window action to .desktop files

### DIFF
--- a/dist/linux/app-flatpak.desktop
+++ b/dist/linux/app-flatpak.desktop
@@ -7,3 +7,8 @@ Icon=com.mitchellh.ghostty
 Keywords=terminal;tty;pty;
 StartupNotify=true
 Terminal=false
+Actions=new-window
+
+[Desktop Action new-window]
+Actions=new-window
+Exec=/app/bin/ghostty

--- a/dist/linux/app.desktop
+++ b/dist/linux/app.desktop
@@ -7,3 +7,8 @@ Icon=com.mitchellh.ghostty
 Keywords=terminal;tty;pty;
 StartupNotify=true
 Terminal=false
+Actions=new-window
+
+[Desktop Action new-window]
+Actions=new-window
+Exec=/usr/bin/ghostty


### PR DESCRIPTION
Inspired by #413.

This modifies the .desktop files so that it's possible to right-click on the Ghostty icon in a dock and get the "New window" action.

Apparently this is how you implement that in GTK applications. In order for us to also get "New tab", we'd have to implement a CLI flag, I think.

## Screenshot

![Pasted image](https://github.com/mitchellh/ghostty/assets/1185253/22f050c0-bbb6-49b9-9fa6-daf49338af53)
