### PR TITLE
macos: split traversal uses direction to determine proper focus target

### DIFF
--- a/macos/Sources/Features/Primary Window/PrimaryWindowManager.swift
+++ b/macos/Sources/Features/Primary Window/PrimaryWindowManager.swift
@@ -32,10 +32,6 @@ class PrimaryWindowManager {
         let mainManagedWindow = managedWindows
             .first { $0.window.isMainWindow }
 
-        // In case we run into the inconsistency, let it crash in debug mode so we
-        // can fix our window management setup to prevent this from happening.
-        assert(mainManagedWindow != nil || !managedWindows.isEmpty)
-
         return (mainManagedWindow ?? managedWindows.first)
             .map { $0.window }
     }


### PR DESCRIPTION
Fixes #415


https://github.com/mitchellh/ghostty/assets/1299/96afa269-96eb-4aae-a452-53a86c76c1d9

