### PR TITLE
macos: fade unfocused splits

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.SplitView.swift
+++ b/macos/Sources/Ghostty/Ghostty.SplitView.swift
@@ -183,6 +183,11 @@ extension Ghostty {
                 }
                 return clone
             }
+            
+            /// True if there are no neighbors
+            func isEmpty() -> Bool {
+                return self.previous == nil && self.next == nil
+            }
         }
     }
 
@@ -341,7 +346,7 @@ extension Ghostty {
             let pubClose = center.publisher(for: Notification.ghosttyCloseSurface, object: leaf.surface)
             let pubFocus = center.publisher(for: Notification.ghosttyFocusSplit, object: leaf.surface)
 
-            SurfaceWrapper(surfaceView: leaf.surface)
+            SurfaceWrapper(surfaceView: leaf.surface, isSplit: !neighbors.isEmpty())
                 .onReceive(pub) { onNewSplit(notification: $0) }
                 .onReceive(pubClose) { onClose(notification: $0) }
                 .onReceive(pubFocus) { onMoveFocus(notification: $0) }


### PR DESCRIPTION
Fixes #353

The opacity value isn't configurable yet.

https://github.com/mitchellh/ghostty/assets/1299/8ecdca07-d6cc-4328-9589-a1ec80a72d33

