### PR TITLE
Underline cursor, fix CSI q parsing

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -15,6 +15,4 @@ pub const Wasm = if (!builtin.target.isWasm()) struct {} else @import("config/Wa
 
 test {
     @import("std").testing.refAllDecls(@This());
-
-    _ = @import("config/c_get.zig");
 }

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1423,6 +1423,7 @@ fn addCursor(
         .block => .cursor_rect,
         .block_hollow => .cursor_hollow_rect,
         .bar => .cursor_bar,
+        .underline => .underline,
     };
 
     const glyph = self.font_group.renderGlyph(

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -1024,6 +1024,7 @@ fn addCursor(
         .block => .cursor_rect,
         .block_hollow => .cursor_hollow_rect,
         .bar => .cursor_bar,
+        .underline => .underline,
     };
 
     const glyph = self.font_group.renderGlyph(

--- a/src/renderer/cursor.zig
+++ b/src/renderer/cursor.zig
@@ -9,13 +9,14 @@ pub const CursorStyle = enum {
     block,
     block_hollow,
     bar,
+    underline,
 
     /// Create a cursor style from the terminal style request.
     pub fn fromTerminal(style: terminal.Cursor.Style) ?CursorStyle {
         return switch (style) {
             .bar => .bar,
             .block => .block,
-            .underline => null, // TODO
+            .underline => .underline,
         };
     }
 };

--- a/src/terminal/Parser.zig
+++ b/src/terminal/Parser.zig
@@ -721,6 +721,32 @@ test "csi: request mode decrqm" {
     }
 }
 
+test "csi: change cursor" {
+    var p = init();
+    _ = p.next(0x1B);
+    for ("[3 ") |c| {
+        const a = p.next(c);
+        try testing.expect(a[0] == null);
+        try testing.expect(a[1] == null);
+        try testing.expect(a[2] == null);
+    }
+
+    {
+        const a = p.next('q');
+        try testing.expect(p.state == .ground);
+        try testing.expect(a[0] == null);
+        try testing.expect(a[1].? == .csi_dispatch);
+        try testing.expect(a[2] == null);
+
+        const d = a[1].?.csi_dispatch;
+        try testing.expect(d.final == 'q');
+        try testing.expectEqual(@as(usize, 1), d.intermediates.len);
+        try testing.expectEqual(@as(usize, 1), d.params.len);
+        try testing.expectEqual(@as(u16, ' '), d.intermediates[0]);
+        try testing.expectEqual(@as(u16, 3), d.params[0]);
+    }
+}
+
 test "osc: change window title" {
     var p = init();
     _ = p.next(0x1B);

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -600,16 +600,33 @@ pub fn Stream(comptime Handler: type) type {
 
                 // DECSCUSR - Select Cursor Style
                 // TODO: test
-                'q' => if (@hasDecl(T, "setCursorStyle")) try self.handler.setCursorStyle(
-                    switch (action.params.len) {
-                        0 => ansi.CursorStyle.default,
-                        1 => @enumFromInt(action.params[0]),
-                        else => {
-                            log.warn("invalid set curor style command: {}", .{action});
-                            return;
-                        },
+                'q' => switch (action.intermediates.len) {
+                    1 => cursor: {
+                        if (action.intermediates[0] != ' ') {
+                            log.warn(
+                                "ignoring unimplemented CSI q with intermediates: {s}",
+                                .{action.intermediates},
+                            );
+                            break :cursor;
+                        }
+
+                        if (@hasDecl(T, "setCursorStyle")) try self.handler.setCursorStyle(
+                            switch (action.params.len) {
+                                0 => ansi.CursorStyle.default,
+                                1 => @enumFromInt(action.params[0]),
+                                else => {
+                                    log.warn("invalid set curor style command: {}", .{action});
+                                    return;
+                                },
+                            },
+                        ) else log.warn("unimplemented CSI callback: {}", .{action});
                     },
-                ) else log.warn("unimplemented CSI callback: {}", .{action}),
+
+                    else => log.warn(
+                        "ignoring unimplemented CSI p with intermediates: {s}",
+                        .{action.intermediates},
+                    ),
+                },
 
                 'r' => switch (action.intermediates.len) {
                     // DECSTBM - Set Top and Bottom Margins


### PR DESCRIPTION
This implements the underline cursor (`CSI 3 q`, and `4`). In doing so, I also noticed our CSI q parsing was not ensuring there is a space between the param and `q`. This fixes that.

## Demo


https://github.com/mitchellh/ghostty/assets/1299/ba8d4487-553f-49be-84c2-442e5e297545

