### PR TITLE
Track and log configuration errors, non-fatal

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -251,6 +251,10 @@ typedef struct {
 // structs. To find the Zig struct, grep for this type name. The documentation
 // for all of these types is available in the Zig source.
 typedef struct {
+    const char *message;
+} ghostty_error_s;
+
+typedef struct {
     void *userdata;
     void *nsview;
     double scale_factor;
@@ -303,6 +307,8 @@ void ghostty_config_load_recursive_files(ghostty_config_t);
 void ghostty_config_finalize(ghostty_config_t);
 bool ghostty_config_get(ghostty_config_t, void *, const char *, uintptr_t);
 ghostty_input_trigger_s ghostty_config_trigger(ghostty_config_t, const char *, uintptr_t);
+uint32_t ghostty_config_errors_count(ghostty_config_t);
+ghostty_error_s ghostty_config_get_error(ghostty_config_t, uint32_t);
 
 ghostty_app_t ghostty_app_new(const ghostty_runtime_config_s *, ghostty_config_t);
 void ghostty_app_free(ghostty_app_t);

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -128,6 +128,20 @@ extension Ghostty {
             // Finalize will make our defaults available.
             ghostty_config_finalize(cfg)
             
+            // Log any configuration errors. These will be automatically shown in a
+            // pop-up window too.
+            let errCount = ghostty_config_errors_count(cfg)
+            if errCount > 0 {
+                AppDelegate.logger.warning("config error: \(errCount) configuration errors on reload")
+                var errors: [String] = [];
+                for i in 0..<errCount {
+                    let err = ghostty_config_get_error(cfg, UInt32(i))
+                    let message = String(cString: err.message)
+                    errors.append(message)
+                    AppDelegate.logger.warning("config error: \(message)")
+                }
+            }
+            
             return cfg
         }
         

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -67,6 +67,13 @@ pub const App = struct {
         var config = try Config.load(core_app.alloc);
         errdefer config.deinit();
 
+        // If we had configuration errors, then log them.
+        if (!config._errors.empty()) {
+            for (config._errors.list.items) |err| {
+                log.warn("configuration error: {s}", .{err.message});
+            }
+        }
+
         // Queue a single new window that starts on launch
         _ = core_app.mailbox.push(.{
             .new_window = .{},

--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -63,6 +63,13 @@ pub const App = struct {
         var config = try Config.load(core_app.alloc);
         errdefer config.deinit();
 
+        // If we had configuration errors, then log them.
+        if (!config._errors.empty()) {
+            for (config._errors.list.items) |err| {
+                log.warn("configuration error: {s}", .{err.message});
+            }
+        }
+
         // Our uniqueness ID is based on whether we're in a debug mode or not.
         // In debug mode we want to be separate so we can develop Ghostty in
         // Ghostty.

--- a/src/config/CAPI.zig
+++ b/src/config/CAPI.zig
@@ -108,3 +108,18 @@ fn config_trigger_(
     const action = try inputpkg.Binding.Action.parse(str);
     return self.keybind.set.getTrigger(action) orelse .{};
 }
+
+export fn ghostty_config_errors_count(self: *Config) u32 {
+    return @intCast(self._errors.list.items.len);
+}
+
+export fn ghostty_config_get_error(self: *Config, idx: u32) Error {
+    if (idx >= self._errors.list.items.len) return .{};
+    const err = self._errors.list.items[idx];
+    return .{ .message = err.message.ptr };
+}
+
+/// Sync with ghostty_error_s
+const Error = extern struct {
+    message: [*:0]const u8 = "",
+};

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -14,6 +14,7 @@ const cli_args = @import("../cli_args.zig");
 
 const Key = @import("key.zig").Key;
 const KeyValue = @import("key.zig").Value;
+const ErrorList = @import("ErrorList.zig");
 
 const log = std.log.scoped(.config);
 
@@ -340,6 +341,11 @@ keybind: Keybinds = .{},
 
 /// This is set by the CLI parser for deinit.
 _arena: ?ArenaAllocator = null,
+
+/// List of errors that occurred while loading. This can be accessed directly
+/// by callers. It is only underscore-prefixed so it can't be set by the
+/// configuration file.
+_errors: ErrorList = .{},
 
 pub fn deinit(self: *Config) void {
     if (self._arena) |arena| arena.deinit();

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -764,16 +764,25 @@ pub fn loadCliArgs(self: *Config, alloc_gpa: Allocator) !void {
 
 /// Load and parse the config files that were added in the "config-file" key.
 pub fn loadRecursiveFiles(self: *Config, alloc: Allocator) !void {
-    // TODO(mitchellh): we should parse the files form the homedir first
     // TODO(mitchellh): support nesting (config-file in a config file)
     // TODO(mitchellh): detect cycles when nesting
 
     if (self.@"config-file".list.items.len == 0) return;
 
+    const arena_alloc = self._arena.?.allocator();
     const cwd = std.fs.cwd();
     const len = self.@"config-file".list.items.len;
     for (self.@"config-file".list.items) |path| {
-        var file = try cwd.openFile(path, .{});
+        var file = cwd.openFile(path, .{}) catch |err| {
+            try self._errors.add(arena_alloc, .{
+                .message = try std.fmt.allocPrintZ(
+                    arena_alloc,
+                    "error opening config-file {s}: {}",
+                    .{ path, err },
+                ),
+            });
+            continue;
+        };
         defer file.close();
 
         var buf_reader = std.io.bufferedReader(file.reader());
@@ -783,8 +792,15 @@ pub fn loadRecursiveFiles(self: *Config, alloc: Allocator) !void {
         // We don't currently support adding more config files to load
         // from within a loaded config file. This can be supported
         // later.
-        if (self.@"config-file".list.items.len > len)
-            return error.ConfigFileInConfigFile;
+        if (self.@"config-file".list.items.len > len) {
+            try self._errors.add(arena_alloc, .{
+                .message = try std.fmt.allocPrintZ(
+                    arena_alloc,
+                    "config-file cannot be used in a config-file. Found in {s}",
+                    .{path},
+                ),
+            });
+        }
     }
 }
 

--- a/src/config/ErrorList.zig
+++ b/src/config/ErrorList.zig
@@ -1,0 +1,23 @@
+const ErrorList = @This();
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+pub const Error = struct {
+    message: [:0]const u8,
+};
+
+/// The list of errors. This will use the arena allocator associated
+/// with the config structure (or whatever allocated used to call ErrorList
+/// functions).
+list: std.ArrayListUnmanaged(Error) = .{},
+
+/// True if there are no errors.
+pub fn empty(self: ErrorList) bool {
+    return self.list.items.len == 0;
+}
+
+/// Add a new error to the list.
+pub fn add(self: *ErrorList, alloc: Allocator, err: Error) !void {
+    try self.list.append(alloc, err);
+}

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -393,7 +393,7 @@ pub const Set = struct {
         alloc: Allocator,
         t: Trigger,
         action: Action,
-    ) !void {
+    ) Allocator.Error!void {
         // unbind should never go into the set, it should be handled prior
         assert(action != .unbind);
 


### PR DESCRIPTION
Fixes #243 

This changes configuration loading so that invalid fields, values, etc. are no longer fatal errors. The errors are now accumulated and logged. Any erroneous fields are ignored and previously set values are used instead. This also applies to reloading configuration.

Configuration errors for now are only shown in the log. This is not a particularly easy place to find configuration errors. A future PR will bring them to the GUI when they exist.

The messages themselves are also fairly rudimentary right now. They can be approved, "notes" can be added, etc. The important thing is that this PR brings in a mechanism to do so.