### PR TITLE
Confirm quit improvements, both macOS and GTK

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -316,6 +316,7 @@ bool ghostty_app_tick(ghostty_app_t);
 void *ghostty_app_userdata(ghostty_app_t);
 void ghostty_app_keyboard_changed(ghostty_app_t);
 void ghostty_app_reload_config(ghostty_app_t);
+bool ghostty_app_needs_confirm_quit(ghostty_app_t);
 
 ghostty_surface_config_s ghostty_surface_config_new();
 

--- a/macos/Sources/AppDelegate.swift
+++ b/macos/Sources/AppDelegate.swift
@@ -102,6 +102,9 @@ class AppDelegate: NSObject, ObservableObject, NSApplicationDelegate, GhosttyApp
             }
         }
         
+        // If our app says we don't need to confirm, we can exit now.
+        if (!ghostty.needsConfirmQuit) { return .terminateNow }
+        
         // We have some visible window, and all our windows will watch the confirmQuit.
         confirmQuit = true
         return .terminateLater

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -40,6 +40,12 @@ extension Ghostty {
             }
         }
         
+        /// True if we need to confirm before quitting.
+        var needsConfirmQuit: Bool {
+            guard let app = app else { return false }
+            return ghostty_app_needs_confirm_quit(app)
+        }
+        
         /// Cached clipboard string for `read_clipboard` callback.
         private var cached_clipboard_string: String? = nil
 

--- a/src/App.zig
+++ b/src/App.zig
@@ -168,6 +168,16 @@ pub fn focusedSurface(self: *const App) ?*Surface {
     return surface;
 }
 
+/// Returns true if confirmation is needed to quit the app. It is up to
+/// the apprt to call this.
+pub fn needsConfirmQuit(self: *const App) bool {
+    for (self.surfaces.items) |v| {
+        if (v.core_surface.needsConfirmQuit()) return true;
+    }
+
+    return false;
+}
+
 /// Initialize once and return the font discovery mechanism. This remains
 /// initialized throughout the lifetime of the application because some
 /// font discovery mechanisms (i.e. fontconfig) are unsafe to reinit.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -787,6 +787,11 @@ pub const CAPI = struct {
         };
     }
 
+    /// Returns true if the app needs to confirm quitting.
+    export fn ghostty_app_needs_confirm_quit(v: *App) bool {
+        return v.core_app.needsConfirmQuit();
+    }
+
     /// Returns initial surface options.
     export fn ghostty_surface_config_new() apprt.Surface.Options {
         return .{};

--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -594,6 +594,13 @@ const Window = struct {
         log.debug("window close request", .{});
         const self = userdataSelf(ud.?);
 
+        // If none of our surfaces need confirmation, we can just exit.
+        for (self.app.core_app.surfaces.items) |surface| {
+            if (surface.window == self) {
+                if (surface.core_surface.needsConfirmQuit()) break;
+            }
+        } else return false;
+
         // Setup our basic message
         const alert = c.gtk_message_dialog_new(
             self.window,

--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -228,6 +228,12 @@ pub const App = struct {
         }
         c.g_list_free(list);
 
+        // If the app says we don't need to confirm, then we can quit now.
+        if (!self.core_app.needsConfirmQuit()) {
+            self.quitNow();
+            return;
+        }
+
         // If we have windows, then we want to confirm that we want to exit.
         const alert = c.gtk_message_dialog_new(
             null,
@@ -259,20 +265,8 @@ pub const App = struct {
         c.gtk_widget_show(alert);
     }
 
-    fn gtkQuitConfirmation(
-        alert: *c.GtkMessageDialog,
-        response: c.gint,
-        ud: ?*anyopaque,
-    ) callconv(.C) void {
-        _ = ud;
-
-        // Close the alert window
-        c.gtk_window_destroy(@ptrCast(alert));
-
-        // If we didn't confirm then we're done
-        if (response != c.GTK_RESPONSE_YES) return;
-
-        // Force close all open windows
+    fn quitNow(self: *App) void {
+        _ = self;
         const list = c.gtk_window_list_toplevels();
         defer c.g_list_free(list);
         c.g_list_foreach(list, struct {
@@ -283,6 +277,23 @@ pub const App = struct {
                 c.gtk_window_destroy(window);
             }
         }.callback, null);
+    }
+
+    fn gtkQuitConfirmation(
+        alert: *c.GtkMessageDialog,
+        response: c.gint,
+        ud: ?*anyopaque,
+    ) callconv(.C) void {
+        const self: *App = @ptrCast(@alignCast(ud orelse return));
+
+        // Close the alert window
+        c.gtk_window_destroy(@ptrCast(alert));
+
+        // If we didn't confirm then we're done
+        if (response != c.GTK_RESPONSE_YES) return;
+
+        // Force close all open windows
+        self.quitNow();
     }
 
     /// This is called by the "activate" signal. This is sent on program


### PR DESCRIPTION
Fixes #306

This improves our confirm quit (app and window) logic so that if ALL surfaces in the given app or window wouldn't require confirmation to close _that individual surface_, then we do not ask for confirmation to close the window or app, either. This has the following effects:

  - With shell integration, if all surfaces (tabs, splits, etc.) are at a prompt, no confirmation is asked.
  - With or without shell integration, if `confirm-close-surface` is `false`, no confirmation is asked for the app/window (previously this only affected single surfaces).
  - GTK previously always asked for confirmation on window close even with one surface. This PR fixes that logic to follow the above.

## Demo


https://github.com/mitchellh/ghostty/assets/1299/8d028141-6f7c-4383-9016-1cd183e1099a

