### PR TITLE
core: surface should not use app mailbox

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -199,8 +199,7 @@ fn drainMailbox(self: *App, rt_app: *apprt.App) !void {
         switch (message) {
             .reload_config => try self.reloadConfig(rt_app),
             .new_window => |msg| try self.newWindow(rt_app, msg),
-            .close => |surface| try self.closeSurface(rt_app, surface),
-            .focus => |surface| try self.focusSurface(rt_app, surface),
+            .close => |surface| try self.closeSurface(surface),
             .quit => try self.setQuit(),
             .surface_message => |msg| try self.surfaceMessage(msg.surface, msg.message),
             .redraw_surface => |surface| try self.redrawSurface(rt_app, surface),
@@ -208,7 +207,7 @@ fn drainMailbox(self: *App, rt_app: *apprt.App) !void {
     }
 }
 
-fn reloadConfig(self: *App, rt_app: *apprt.App) !void {
+pub fn reloadConfig(self: *App, rt_app: *apprt.App) !void {
     log.debug("reloading configuration", .{});
     if (try rt_app.reloadConfig()) |new| {
         log.debug("new configuration received, applying", .{});
@@ -216,16 +215,12 @@ fn reloadConfig(self: *App, rt_app: *apprt.App) !void {
     }
 }
 
-fn closeSurface(self: *App, rt_app: *apprt.App, surface: *Surface) !void {
-    _ = rt_app;
-
+pub fn closeSurface(self: *App, surface: *Surface) !void {
     if (!self.hasSurface(surface)) return;
     surface.close();
 }
 
-fn focusSurface(self: *App, rt_app: *apprt.App, surface: *Surface) !void {
-    _ = rt_app;
-
+pub fn focusSurface(self: *App, surface: *Surface) void {
     if (!self.hasSurface(surface)) return;
     self.focused_surface = surface;
 }
@@ -236,7 +231,7 @@ fn redrawSurface(self: *App, rt_app: *apprt.App, surface: *apprt.Surface) !void 
 }
 
 /// Create a new window
-fn newWindow(self: *App, rt_app: *apprt.App, msg: Message.NewWindow) !void {
+pub fn newWindow(self: *App, rt_app: *apprt.App, msg: Message.NewWindow) !void {
     if (!@hasDecl(apprt.App, "newWindow")) {
         log.warn("newWindow is not supported by this runtime", .{});
         return;
@@ -253,7 +248,7 @@ fn newWindow(self: *App, rt_app: *apprt.App, msg: Message.NewWindow) !void {
 }
 
 /// Start quitting
-fn setQuit(self: *App) !void {
+pub fn setQuit(self: *App) !void {
     if (self.quit) return;
     self.quit = true;
 }
@@ -291,11 +286,6 @@ pub const Message = union(enum) {
     /// Close a surface. This notifies the runtime that a surface
     /// should close.
     close: *Surface,
-
-    /// The last focused surface. The app keeps track of this to
-    /// enable "inheriting" various configurations from the last
-    /// surface.
-    focus: *Surface,
 
     /// Quit
     quit: void,

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -231,7 +231,7 @@ pub const Surface = struct {
             app.core_app.alloc,
             &config,
             app.core_app,
-            .{ .rt_app = app, .mailbox = &app.core_app.mailbox },
+            app,
             self,
         );
         errdefer self.core_surface.deinit();

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -378,7 +378,7 @@ pub const Surface = struct {
             app.app.alloc,
             &config,
             app.app,
-            .{ .rt_app = app, .mailbox = &app.app.mailbox },
+            app,
             self,
         );
         errdefer self.core_surface.deinit();

--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -852,7 +852,7 @@ pub const Surface = struct {
             self.app.core_app.alloc,
             &config,
             self.app.core_app,
-            .{ .rt_app = self.app, .mailbox = &self.app.core_app.mailbox },
+            self.app,
             self,
         );
         errdefer self.core_surface.deinit();


### PR DESCRIPTION
Fixes #433

The surface runs on the same thread as the app so if we use the app mailbox then we risk filling the queue before it can drain. The surface should use the app directly.

This commit just changes all the calls to use the app directly. We may also want to coalesce certain changes to avoid too much CPU but I defer that to a future change.