### PR TITLE
macos: AppState config must be published and observed

### DIFF
--- a/macos/Sources/Features/Primary Window/PrimaryView.swift
+++ b/macos/Sources/Features/Primary Window/PrimaryView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import GhosttyKit
 
 struct PrimaryView: View {
-    let ghostty: Ghostty.AppState
+    @ObservedObject var ghostty: Ghostty.AppState
     
     // We need access to our app delegate to know if we're quitting or not.
     // Make sure to use `@ObservedObject` so we can keep track of `appDelegate.confirmQuit`.

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -23,7 +23,7 @@ extension Ghostty {
         /// The ghostty global configuration. This should only be changed when it is definitely
         /// safe to change. It is definite safe to change only when the embedded app runtime
         /// in Ghostty says so (usually, only in a reload configuration callback).
-        var config: ghostty_config_t? = nil {
+        @Published var config: ghostty_config_t? = nil {
             didSet {
                 // Free the old value whenever we change
                 guard let old = oldValue else { return }
@@ -33,7 +33,7 @@ extension Ghostty {
         
         /// The ghostty app instance. We only have one of these for the entire app, although I guess
         /// in theory you can have multiple... I don't know why you would...
-        var app: ghostty_app_t? = nil {
+        @Published var app: ghostty_app_t? = nil {
             didSet {
                 guard let old = oldValue else { return }
                 ghostty_app_free(old)


### PR DESCRIPTION
Fixes #440

We previously weren't observing changes so they weren't being automatically propagated. We were using an old pointer which at best returned the wrong value and at worst crashed. I was able to make it crash eventually, too.

This changes the fields to be properly published and observed and as a result the config is immediately available to all users.

## Before


https://github.com/mitchellh/ghostty/assets/1299/0b08ad3d-2e57-4469-937e-bddc6a766546



## After


https://github.com/mitchellh/ghostty/assets/1299/a76015b8-1722-498a-b09d-385deb158ea1

