### PR TITLE
macos: ensure all components are updated on config reload

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -781,7 +781,7 @@ pub const CAPI = struct {
 
     /// Reload the configuration.
     export fn ghostty_app_reload_config(v: *App) void {
-        _ = v.reloadConfig() catch |err| {
+        _ = v.core_app.reloadConfig(v) catch |err| {
             log.err("error reloading config err={}", .{err});
             return;
         };

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -110,7 +110,7 @@ palette: Palette = .{},
 /// In order to fix it, we probably would want to add something similar to Kitty's
 /// shell integration options (no-cursor). For more information see:
 /// https://sw.kovidgoyal.net/kitty/conf/#opt-kitty.shell_integration
-@"cursor-style": terminal.Cursor.Style = .bar,
+@"cursor-style": terminal.Cursor.Style = .block,
 
 /// Whether the cursor shall blink
 @"cursor-style-blink": bool = true,


### PR DESCRIPTION
The config reload on macOS wasn't propagating through the core app which meant it wasn't being sent to the IO and renderer threads, so some things that should reload live were only taking affect on new surfaces. 