### PR TITLE
Implement OSC 10 and OSC 11 default color queries

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -315,11 +315,11 @@ keybind: Keybinds = .{},
 /// Allowable values are:
 ///
 ///   * "none" - OSC 10/11 queries receive no reply
-///   * "bits8" - Color components are return unscaled, i.e. rr/gg/bb
-///   * "bits16" - Color components are returned scaled, e.g. rrrr/gggg/bbbb
+///   * "8-bit" - Color components are return unscaled, i.e. rr/gg/bb
+///   * "16-bit" - Color components are returned scaled, e.g. rrrr/gggg/bbbb
 ///
-/// The default value is "bits16".
-@"osc-color-report-format": OSCColorReportFormat = .bits16,
+/// The default value is "16-bit".
+@"osc-color-report-format": OSCColorReportFormat = .@"16-bit",
 
 /// If anything other than false, fullscreen mode on macOS will not use the
 /// native fullscreen, but make the window fullscreen without animations and
@@ -1500,6 +1500,6 @@ pub const ShellIntegration = enum {
 /// OSC 10 and 11 default color reporting format.
 pub const OSCColorReportFormat = enum {
     none,
-    bits8,
-    bits16,
+    @"8-bit",
+    @"16-bit",
 };

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -305,6 +305,22 @@ keybind: Keybinds = .{},
 /// The default value is "detect".
 @"shell-integration": ShellIntegration = .detect,
 
+/// Sets the reporting format for OSC sequences that request color information.
+/// Ghostty currently supports OSC 10 (foreground) and OSC 11 (background) queries,
+/// and by default the reported values are scaled-up RGB values, where each component
+/// are 16 bits. This is how most terminals report these values. However, some legacy
+/// applications may require 8-bit, unscaled, components. We also support turning off
+/// reporting alltogether. The components are lowercase hex values.
+///
+/// Allowable values are:
+///
+///   * "none" - OSC 10/11 queries receive no reply
+///   * "bits8" - Color components are return unscaled, i.e. rr/gg/bb
+///   * "bits16" - Color components are returned scaled, e.g. rrrr/gggg/bbbb
+///
+/// The default value is "bits16".
+@"osc-color-report-format": OSCColorReportFormat = .bits16,
+
 /// If anything other than false, fullscreen mode on macOS will not use the
 /// native fullscreen, but make the window fullscreen without animations and
 /// using a new space. It's faster than the native fullscreen mode since it
@@ -1479,4 +1495,11 @@ pub const ShellIntegration = enum {
     detect,
     fish,
     zsh,
+};
+
+/// OSC 10 and 11 default color reporting format.
+pub const OSCColorReportFormat = enum {
+    none,
+    bits8,
+    bits16,
 };

--- a/src/terminal/Parser.zig
+++ b/src/terminal/Parser.zig
@@ -248,7 +248,7 @@ pub fn next(self: *Parser, c: u8) [3]?Action {
     return [3]?Action{
         // Exit depends on current state
         if (self.state == next_state) null else switch (self.state) {
-            .osc_string => if (self.osc_parser.endWithStringTerminator(c)) |cmd|
+            .osc_string => if (self.osc_parser.end(c)) |cmd|
                 Action{ .osc_dispatch = cmd }
             else
                 null,

--- a/src/terminal/Parser.zig
+++ b/src/terminal/Parser.zig
@@ -248,7 +248,7 @@ pub fn next(self: *Parser, c: u8) [3]?Action {
     return [3]?Action{
         // Exit depends on current state
         if (self.state == next_state) null else switch (self.state) {
-            .osc_string => if (self.osc_parser.end()) |cmd|
+            .osc_string => if (self.osc_parser.endWithStringTerminator(c)) |cmd|
                 Action{ .osc_dispatch = cmd }
             else
                 null,

--- a/src/terminal/main.zig
+++ b/src/terminal/main.zig
@@ -6,6 +6,7 @@ const ansi = @import("ansi.zig");
 const csi = @import("csi.zig");
 const sgr = @import("sgr.zig");
 pub const apc = @import("apc.zig");
+pub const osc = @import("osc.zig");
 pub const point = @import("point.zig");
 pub const color = @import("color.zig");
 pub const kitty = @import("kitty.zig");

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -863,7 +863,10 @@ pub fn Stream(comptime Handler: type) type {
 
                 .report_default_color => |v| {
                     if (@hasDecl(T, "reportDefaultColor")) {
-                        try self.handler.reportDefaultColor(if (v.kind == .foreground) "10" else "11", v.string_terminator);
+                        try self.handler.reportDefaultColor(
+                            if (v.kind == .foreground) "10" else "11",
+                            if (v.string_terminator == .st) "\x1b\\" else "\x07",
+                        );
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
 

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -861,6 +861,12 @@ pub fn Stream(comptime Handler: type) type {
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
 
+                .report_default_color => |v| {
+                    if (@hasDecl(T, "reportDefaultColor")) {
+                        try self.handler.reportDefaultColor(if (v.kind == .foreground) "10" else "11", v.string_terminator);
+                    } else log.warn("unimplemented OSC callback: {}", .{cmd});
+                },
+
                 else => if (@hasDecl(T, "oscUnimplemented"))
                     try self.handler.oscUnimplemented(cmd)
                 else

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -863,10 +863,7 @@ pub fn Stream(comptime Handler: type) type {
 
                 .report_default_color => |v| {
                     if (@hasDecl(T, "reportDefaultColor")) {
-                        try self.handler.reportDefaultColor(
-                            if (v.kind == .foreground) "10" else "11",
-                            if (v.string_terminator == .st) "\x1b\\" else "\x07",
-                        );
+                        try self.handler.reportDefaultColor(v.kind, v.terminator);
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1820,7 +1820,7 @@ const StreamHandler = struct {
 
         var msg: termio.Message = .{ .write_small = .{} };
         const resp = switch (self.osc_color_report_format) {
-            .bits16 => try std.fmt.bufPrint(
+            .@"16-bit" => try std.fmt.bufPrint(
                 &msg.write_small.data,
                 "\x1B]{s};rgb:{x:0>4}/{x:0>4}/{x:0>4}{s}",
                 .{
@@ -1832,7 +1832,7 @@ const StreamHandler = struct {
                 },
             ),
 
-            else => try std.fmt.bufPrint(
+            .@"8-bit" => try std.fmt.bufPrint(
                 &msg.write_small.data,
                 "\x1B]{s};rgb:{x:0>2}/{x:0>2}/{x:0>2}{s}",
                 .{
@@ -1843,6 +1843,8 @@ const StreamHandler = struct {
                     terminator.string(),
                 },
             ),
+
+            .none => unreachable, // early return above
         };
         msg.write_small.len = @intCast(resp.len);
         self.messageWriter(msg);

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1808,22 +1808,22 @@ const StreamHandler = struct {
     pub fn reportDefaultColor(self: *StreamHandler, osc_code: []const u8, string_terminator: ?[]const u8) !void {
         if (self.osc_color_report_format == .none) return;
         var msg: termio.Message = .{ .write_small = .{} };
-
+        const color = if (std.mem.eql(u8, osc_code, "10")) self.default_foreground_color else self.default_background_color;
         const resp = resp: {
             if (self.osc_color_report_format == .bits16) {
                 break :resp try std.fmt.bufPrint(&msg.write_small.data, "\x1B]{s};rgb:{x:0>4}/{x:0>4}/{x:0>4}{s}", .{
                     osc_code,
-                    @as(u16, self.default_foreground_color.r) * 257,
-                    @as(u16, self.default_foreground_color.g) * 257,
-                    @as(u16, self.default_foreground_color.b) * 257,
+                    @as(u16, color.r) * 257,
+                    @as(u16, color.g) * 257,
+                    @as(u16, color.b) * 257,
                     if (string_terminator) |st| st else "\x1b\\",
                 });
             } else {
                 break :resp try std.fmt.bufPrint(&msg.write_small.data, "\x1B]{s};rgb:{x:0>2}/{x:0>2}/{x:0>2}{s}", .{
                     osc_code,
-                    @as(u16, self.default_foreground_color.r),
-                    @as(u16, self.default_foreground_color.g),
-                    @as(u16, self.default_foreground_color.b),
+                    @as(u16, color.r),
+                    @as(u16, color.g),
+                    @as(u16, color.b),
                     if (string_terminator) |st| st else "\x1b\\",
                 });
             }


### PR DESCRIPTION
These OSC commands report the default foreground and background colors.

Most terminals return the RGB components scaled up to 16-bit components, because some legacy software are unable to read 8-bit components. The PR follows this convention by default.

iTerm2 allow 8-bit reporting through a config option, and a similar option is added here. In addition to picking between scaled and unscaled reporting, the user can also turn off OSC 10/11 replies altogether.

Scaling is essentially `c / 1 * 65535`, where `c` is the 8-bit component, and reporting is left-padded with zeros if necessary. This format appears to stem from the XParseColor format.