### PR TITLE
Windows: implement tmpDir and expandPath

### DIFF
--- a/src/Command.zig
+++ b/src/Command.zig
@@ -232,9 +232,19 @@ pub fn expandPath(alloc: Allocator, cmd: []const u8) !?[]u8 {
         return try alloc.dupe(u8, cmd);
     }
 
-    const PATH = os.getenvZ("PATH") orelse return null;
+    const PATH = switch (builtin.os.tag) {
+        .windows => blk: {
+            const win_path = os.getenvW(std.unicode.utf8ToUtf16LeStringLiteral("PATH")) orelse return null;
+            const path = try std.unicode.utf16leToUtf8Alloc(alloc, win_path);
+            break :blk path;
+        },
+        else => os.getenvZ("PATH") orelse return null,
+    };
+    defer if (builtin.os.tag == .windows) alloc.free(PATH);
+
     var path_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
-    var it = std.mem.tokenize(u8, PATH, ":");
+    const path_separator = if (builtin.os.tag == .windows) ";" else ":";
+    var it = std.mem.tokenize(u8, PATH, path_separator);
     var seen_eacces = false;
     while (it.next()) |search_path| {
         // We need enough space in our path buffer to store this
@@ -243,7 +253,7 @@ pub fn expandPath(alloc: Allocator, cmd: []const u8) !?[]u8 {
 
         // Copy in the full path
         mem.copy(u8, &path_buf, search_path);
-        path_buf[search_path.len] = '/';
+        path_buf[search_path.len] = if (builtin.os.tag == .windows) '\\' else '/';
         mem.copy(u8, path_buf[search_path.len + 1 ..], cmd);
         path_buf[path_len] = 0;
         const full_path = path_buf[0..path_len :0];
@@ -276,10 +286,12 @@ fn isExecutable(mode: std.fs.File.Mode) bool {
     return mode & 0o0111 != 0;
 }
 
-test "expandPath: env" {
-    const path = (try expandPath(testing.allocator, "env")).?;
+// `hostname` is present on both *nix and windows
+test "expandPath: hostname" {
+    const executable = if (builtin.os.tag == .windows) "hostname.exe" else "hostname";
+    const path = (try expandPath(testing.allocator, executable)).?;
     defer testing.allocator.free(path);
-    try testing.expect(path.len > 0);
+    try testing.expect(path.len > executable.len);
 }
 
 test "expandPath: does not exist" {

--- a/src/os/TempDir.zig
+++ b/src/os/TempDir.zig
@@ -61,8 +61,9 @@ pub fn name(self: *TempDir) []const u8 {
 }
 
 /// Finish with the temporary directory. This deletes all contents in the
-/// directory. This is safe to call multiple times.
+/// directory.
 pub fn deinit(self: *TempDir) void {
+    self.dir.close();
     self.parent.deleteTree(self.name()) catch |err|
         log.err("error deleting temp dir err={}", .{err});
 }
@@ -78,13 +79,14 @@ const b64_alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz012345
 
 test {
     var td = try init();
-    defer td.deinit();
+    errdefer td.deinit();
 
     const nameval = td.name();
     try testing.expect(nameval.len > 0);
 
     // Can open a new handle to it proves it exists.
-    _ = try td.parent.openDir(nameval, .{});
+    var dir = try td.parent.openDir(nameval, .{});
+    dir.close();
 
     // Should be deleted after we deinit
     td.deinit();

--- a/src/os/file.zig
+++ b/src/os/file.zig
@@ -53,6 +53,16 @@ pub fn fixMaxFiles() void {
 
 /// Return the recommended path for temporary files.
 pub fn tmpDir() ?[]const u8 {
+    if (builtin.os.tag == .windows) {
+        // TODO: what is a good fallback path on windows?
+        const w_temp = std.os.getenvW(std.unicode.utf8ToUtf16LeStringLiteral("TMP")) orelse return null;
+        var buf = [_]u8{0} ** 256; // 256 is the maximum path length on windows
+        const len = std.unicode.utf16leToUtf8(buf[0..], w_temp[0..w_temp.len]) catch {
+            log.warn("failed to convert temp dir path from windows string", .{});
+            return null;
+        };
+        return buf[0..len];
+    }
     if (std.os.getenv("TMPDIR")) |v| return v;
     if (std.os.getenv("TMP")) |v| return v;
     return "/tmp";

--- a/src/os/homedir.zig
+++ b/src/os/homedir.zig
@@ -84,8 +84,7 @@ fn homeWindows(buf: []u8) !?[]u8 {
         const fba = fba_instance.allocator();
         const drive = std.process.getEnvVarOwned(fba, "HOMEDRIVE") catch |err| switch (err) {
             error.OutOfMemory => return Error.BufferTooSmall,
-            error.InvalidUtf8,
-            error.EnvironmentVariableNotFound => return null,
+            error.InvalidUtf8, error.EnvironmentVariableNotFound => return null,
         };
         // could shift the contents if this ever happens
         if (drive.ptr != buf.ptr) @panic("codebug");
@@ -98,8 +97,7 @@ fn homeWindows(buf: []u8) !?[]u8 {
         const fba = fba_instance.allocator();
         const homepath = std.process.getEnvVarOwned(fba, "HOMEPATH") catch |err| switch (err) {
             error.OutOfMemory => return Error.BufferTooSmall,
-            error.InvalidUtf8,
-            error.EnvironmentVariableNotFound => return null,
+            error.InvalidUtf8, error.EnvironmentVariableNotFound => return null,
         };
         // could shift the contents if this ever happens
         if (homepath.ptr != path_buf.ptr) @panic("codebug");


### PR DESCRIPTION
You can't see the additional tests pass from `build run test` because of other compilation errors getting in the way, but if you run the tests for these files directly with `zig test` they now pass in some cases where they previously failed or didn't compile.

It might be nicer to separate the code by platform into separate functions and switch at the function call level rather than having these blocks of Windows specific code in the middle of existing functions. Very open to doing that if that would be preferred. For now I imitated what the zig standard library seems to do, though.

Am curious to hear from @marler8997 about the temp dir stuff, since there seem to be about 18 different env vars that you can use on Windows to get a temp dir path! A bit of searching lead me to believe that `$TMP` was the most commonly used one, but I could be missing something. Also, I have no idea what a sensible fallback path is if we don't get anything from `$TMP`... I left a `TODO` in there for that, but would love to figure it out.

As always, any feedback is more than welcome!