### PR TITLE
Option to hide mouse cursor while typing

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -302,6 +302,7 @@ typedef void (*ghostty_runtime_wakeup_cb)(void *);
 typedef const ghostty_config_t (*ghostty_runtime_reload_config_cb)(void *);
 typedef void (*ghostty_runtime_set_title_cb)(void *, const char *);
 typedef void (*ghostty_runtime_set_mouse_shape_cb)(void *, ghostty_mouse_shape_e);
+typedef void (*ghostty_runtime_set_mouse_visibility_cb)(void *, bool);
 typedef const char* (*ghostty_runtime_read_clipboard_cb)(void *, ghostty_clipboard_e);
 typedef void (*ghostty_runtime_write_clipboard_cb)(void *, const char *, ghostty_clipboard_e);
 typedef void (*ghostty_runtime_new_split_cb)(void *, ghostty_split_direction_e, ghostty_surface_config_s);
@@ -320,6 +321,7 @@ typedef struct {
     ghostty_runtime_reload_config_cb reload_config_cb;
     ghostty_runtime_set_title_cb set_title_cb;
     ghostty_runtime_set_mouse_shape_cb set_mouse_shape_cb;
+    ghostty_runtime_set_mouse_visibility_cb set_mouse_visibility_cb;
     ghostty_runtime_read_clipboard_cb read_clipboard_cb;
     ghostty_runtime_write_clipboard_cb write_clipboard_cb;
     ghostty_runtime_new_split_cb new_split_cb;

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -73,6 +73,7 @@ extension Ghostty {
                 reload_config_cb: { userdata in AppState.reloadConfig(userdata) },
                 set_title_cb: { userdata, title in AppState.setTitle(userdata, title: title) },
                 set_mouse_shape_cb: { userdata, shape in AppState.setMouseShape(userdata, shape: shape) },
+                set_mouse_visibility_cb: { userdata, visible in AppState.setMouseVisibility(userdata, visible: visible) },
                 read_clipboard_cb: { userdata, loc in AppState.readClipboard(userdata, location: loc) },
                 write_clipboard_cb: { userdata, str, loc in AppState.writeClipboard(userdata, string: str, location: loc) },
                 new_split_cb: { userdata, direction, surfaceConfig in AppState.newSplit(userdata, direction: direction, config: surfaceConfig) },
@@ -337,6 +338,11 @@ extension Ghostty {
         static func setMouseShape(_ userdata: UnsafeMutableRawPointer?, shape: ghostty_mouse_shape_e) {
             let surfaceView = Unmanaged<SurfaceView>.fromOpaque(userdata!).takeUnretainedValue()
             surfaceView.setCursorShape(shape)
+        }
+        
+        static func setMouseVisibility(_ userdata: UnsafeMutableRawPointer?, visible: Bool) {
+            let surfaceView = Unmanaged<SurfaceView>.fromOpaque(userdata!).takeUnretainedValue()
+            surfaceView.setCursorVisibility(visible)
         }
 
         static func toggleFullscreen(_ userdata: UnsafeMutableRawPointer?, nonNativeFullscreen: ghostty_non_native_fullscreen_e) {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -122,6 +122,9 @@ const Mouse = struct {
     /// Pending scroll amounts for high-precision scrolls
     pending_scroll_x: f64 = 0,
     pending_scroll_y: f64 = 0,
+
+    /// True if the mouse is hidden
+    hidden: bool = false,
 };
 
 /// The configuration that a surface has, this is copied from the main
@@ -138,6 +141,7 @@ const DerivedConfig = struct {
     copy_on_select: configpkg.CopyOnSelect,
     confirm_close_surface: bool,
     mouse_interval: u64,
+    mouse_hide_while_typing: bool,
     macos_non_native_fullscreen: configpkg.NonNativeFullscreen,
     macos_option_as_alt: configpkg.OptionAsAlt,
     window_padding_x: u32,
@@ -157,6 +161,7 @@ const DerivedConfig = struct {
             .copy_on_select = config.@"copy-on-select",
             .confirm_close_surface = config.@"confirm-close-surface",
             .mouse_interval = config.@"click-repeat-interval" * 1_000_000, // 500ms
+            .mouse_hide_while_typing = config.@"mouse-hide-while-typing",
             .macos_non_native_fullscreen = config.@"macos-non-native-fullscreen",
             .macos_option_as_alt = config.@"macos-option-as-alt",
             .window_padding_x = config.@"window-padding-x",
@@ -961,6 +966,14 @@ pub fn keyCallback(
         }
     }
 
+    // If this input event has text, then we hide the mouse if configured.
+    if (self.config.mouse_hide_while_typing and
+        !self.mouse.hidden and
+        event.utf8.len > 0)
+    {
+        self.hideMouse();
+    }
+
     // No binding, so we have to perform an encoding task. This
     // may still result in no encoding. Under different modes and
     // inputs there are many keybindings that result in no encoding
@@ -1048,6 +1061,9 @@ pub fn scrollCallback(
     defer tracy.end();
 
     // log.info("SCROLL: xoff={} yoff={} mods={}", .{ xoff, yoff, scroll_mods });
+
+    // Always show the mouse again if it is hidden
+    if (self.mouse.hidden) self.showMouse();
 
     const ScrollAmount = struct {
         // Positive is up, right
@@ -1446,6 +1462,9 @@ pub fn mouseButtonCallback(
     self.mouse.click_state[@intCast(@intFromEnum(button))] = action;
     self.mouse.mods = @bitCast(mods);
 
+    // Always show the mouse again if it is hidden
+    if (self.mouse.hidden) self.showMouse();
+
     // Shift-click continues the previous mouse state if we have a selection.
     // cursorPosCallback will also do a mouse report so we don't need to do any
     // of the logic below.
@@ -1593,6 +1612,9 @@ pub fn cursorPosCallback(
 ) !void {
     const tracy = trace(@src());
     defer tracy.end();
+
+    // Always show the mouse again if it is hidden
+    if (self.mouse.hidden) self.showMouse();
 
     // We are reading/writing state for the remainder
     self.renderer_state.mutex.lock();
@@ -1850,6 +1872,18 @@ fn posToViewport(self: Surface, xpos: f64, ypos: f64) terminal.point.Viewport {
 fn scrollToBottom(self: *Surface) !void {
     try self.io.terminal.scrollViewport(.{ .bottom = {} });
     try self.queueRender();
+}
+
+fn hideMouse(self: *Surface) void {
+    if (self.mouse.hidden) return;
+    self.mouse.hidden = true;
+    self.rt_surface.setMouseVisibility(false);
+}
+
+fn showMouse(self: *Surface) void {
+    if (!self.mouse.hidden) return;
+    self.mouse.hidden = false;
+    self.rt_surface.setMouseVisibility(true);
 }
 
 /// Perform a binding action. A binding is a keybinding. This function

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -571,6 +571,11 @@ fn changeConfig(self: *Surface, config: *const configpkg.Config) !void {
     self.config.deinit();
     self.config = derived;
 
+    // If our mouse is hidden but we disabled mouse hiding, then show it again.
+    if (!self.config.mouse_hide_while_typing and self.mouse.hidden) {
+        self.showMouse();
+    }
+
     // We need to store our configs in a heap-allocated pointer so that
     // our messages aren't huge.
     var renderer_config_ptr = try self.alloc.create(Renderer.DerivedConfig);

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -52,6 +52,9 @@ pub const App = struct {
         /// Called to set the cursor shape.
         set_mouse_shape: *const fn (SurfaceUD, terminal.MouseShape) callconv(.C) void,
 
+        /// Called to set the mouse visibility.
+        set_mouse_visibility: *const fn (SurfaceUD, bool) callconv(.C) void,
+
         /// Read the clipboard value. The return value must be preserved
         /// by the host until the next call. If there is no valid clipboard
         /// value then this should return null.
@@ -318,6 +321,14 @@ pub const Surface = struct {
         self.app.opts.set_mouse_shape(
             self.opts.userdata,
             shape,
+        );
+    }
+
+    /// Set the visibility of the mouse cursor.
+    pub fn setMouseVisibility(self: *Surface, visible: bool) void {
+        self.app.opts.set_mouse_visibility(
+            self.opts.userdata,
+            visible,
         );
     }
 

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -542,6 +542,11 @@ pub const Surface = struct {
         self.cursor = new;
     }
 
+    /// Set the visibility of the mouse cursor.
+    pub fn setMouseVisibility(self: *Surface, visible: bool) void {
+        self.window.setInputModeCursor(if (visible) .normal else .hidden);
+    }
+
     /// Read the clipboard. The windowing system is responsible for allocating
     /// a buffer as necessary. This should be a stable pointer until the next
     /// time getClipboardString is called.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -119,6 +119,10 @@ palette: Palette = .{},
 /// will be chosen.
 @"cursor-text": ?Color = null,
 
+/// Hide the mouse immediately when typing. The mouse becomes visible
+/// again when the mouse is used.
+@"mouse-hide-while-typing": bool = false,
+
 /// The opacity level (opposite of transparency) of the background.
 /// A value of 1 is fully opaque and a value of 0 is fully transparent.
 /// A value less than 0 or greater than 1 will be clamped to the nearest

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -120,7 +120,8 @@ palette: Palette = .{},
 @"cursor-text": ?Color = null,
 
 /// Hide the mouse immediately when typing. The mouse becomes visible
-/// again when the mouse is used.
+/// again when the mouse is used. The mouse is only hidden if the mouse
+/// cursor is over the active terminal surface.
 @"mouse-hide-while-typing": bool = false,
 
 /// The opacity level (opposite of transparency) of the background.


### PR DESCRIPTION
New config `mouse-hide-while-typing` (default false). If true, the mouse cursor will be hidden while typing. 

Implementation notes:

* The mouse will show again when a mouse button, scroll, or move event occurs.
* The configuration can be reloaded at runtime. If it goes from `true => false`, the mouse cursor immediately becomes visible again. `false => true` will set it hidden on the next keystroke.
* The mouse is only hidden while its actively over the terminal. It is not hidden if the mouse is outside of the window area.

```
mouse-hide-while-type = true
```

## Demo


https://github.com/mitchellh/ghostty/assets/1299/93670e16-3964-4df1-b369-cc3945ea03ba

