### PR TITLE
Fix references to jump_to_prompt binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The currently support shell integration features in Ghostty:
   * New terminals start in the working directory of the previously focused terminal.
   * Complex prompts resize correctly by allowing the shell to redraw the prompt line.
   * The cursor at the prompt is turned into a bar.
-  * The `scroll_to_prompt` keybinding can be used to scroll the terminal window
+  * The `jump_to_prompt` keybinding can be used to scroll the terminal window
     forward and back through prompts.
 
 #### Shell Integration Installation and Verification

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -294,7 +294,7 @@ keybind: Keybinds = .{},
 ///
 ///   * Working directory reporting so new tabs, splits inherit the
 ///     previous terminal's working directory.
-///   * Prompt marking that enables the "scroll_to_prompt" keybinding.
+///   * Prompt marking that enables the "jump_to_prompt" keybinding.
 ///   * If you're sitting at a prompt, closing a terminal will not ask
 ///     for confirmation.
 ///   * Resizing the window with a complex prompt usually paints much


### PR DESCRIPTION
I spent an unfortunate amount of time thinking I was doing keybinds wrong, when really I was just trying to bind a command that doesn't exist! 😂 

EDIT: It occurred to me only once I saw the builds running for this PR that I should probably just have included this in another PR with actual code changes... doesn't seem worth the cost of running CI for this one! Sorry. Will be more mindful about that in the future.