### PR TITLE
linux: don't presume install location in desktop file

### DIFF
--- a/dist/linux/app.desktop
+++ b/dist/linux/app.desktop
@@ -2,7 +2,7 @@
 Name=Ghostty
 Type=Application
 Comment=A terminal emulator
-Exec=/usr/bin/ghostty
+Exec=ghostty
 Icon=com.mitchellh.ghostty
 Keywords=terminal;tty;pty;
 StartupNotify=true
@@ -11,4 +11,4 @@ Actions=new-window
 
 [Desktop Action new-window]
 Actions=new-window
-Exec=/usr/bin/ghostty
+Exec=ghostty


### PR DESCRIPTION
The app.desktop file shipped with the default build presumes the install location of the binary. Let the OS determine the executable through it's normal PATH variables.