### PR TITLE
gtk: handle all close-requests

### DIFF
--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -596,7 +596,10 @@ const Window = struct {
             if (surface.window == self) {
                 if (surface.core_surface.needsConfirmQuit()) break;
             }
-        } else return false;
+        } else {
+            c.gtk_window_destroy(self.window);
+            return true;
+        }
 
         // Setup our basic message
         const alert = c.gtk_message_dialog_new(


### PR DESCRIPTION
When compiling in any Release mode, the default gtk close-request handler does not properly fire. We only rely on the default handler if we aren't confirming the close. Replace the default handler with our own in all cases (and just destroy the window if we don't need confirmation).

Fixes #458