### PR TITLE
`--version` and general framework for CLI subcommands

### DIFF
--- a/src/cli_action.zig
+++ b/src/cli_action.zig
@@ -1,7 +1,9 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const xev = @import("xev");
 const Allocator = std.mem.Allocator;
 const build_config = @import("build_config.zig");
+const renderer = @import("renderer.zig");
 
 /// Special commands that can be invoked via CLI flags. These are all
 /// invoked by using `+<action>` as a CLI flag. The only exception is
@@ -54,7 +56,13 @@ pub const Action = enum {
 
 fn runVersion() !u8 {
     const stdout = std.io.getStdOut().writer();
-    try stdout.print("Ghostty {s}\n", .{build_config.version_string});
+    try stdout.print("Ghostty {s}\n\n", .{build_config.version_string});
+    try stdout.print("Build Config\n", .{});
+    try stdout.print("  - build mode : {}\n", .{builtin.mode});
+    try stdout.print("  - app runtime: {}\n", .{build_config.app_runtime});
+    try stdout.print("  - font engine: {}\n", .{build_config.font_backend});
+    try stdout.print("  - renderer   : {}\n", .{renderer.Renderer});
+    try stdout.print("  - libxev     : {}\n", .{xev.backend});
     return 0;
 }
 

--- a/src/cli_action.zig
+++ b/src/cli_action.zig
@@ -40,7 +40,7 @@ pub const Action = enum {
             pending = std.meta.stringToEnum(Action, arg[1..]) orelse return Error.InvalidAction;
         }
 
-        return null;
+        return pending;
     }
 
     /// Run the action. This returns the exit code to exit with.
@@ -99,6 +99,41 @@ test "parse action version" {
         var iter = try std.process.ArgIteratorGeneral(.{}).init(
             alloc,
             "--c=84 --d --version --a=42 --b --b-f=false",
+        );
+        defer iter.deinit();
+        const action = try Action.detectIter(&iter);
+        try testing.expect(action.? == .version);
+    }
+}
+
+test "parse action plus" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(
+            alloc,
+            "--a=42 --b --b-f=false +version",
+        );
+        defer iter.deinit();
+        const action = try Action.detectIter(&iter);
+        try testing.expect(action.? == .version);
+    }
+
+    {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(
+            alloc,
+            "+version --a=42 --b --b-f=false",
+        );
+        defer iter.deinit();
+        const action = try Action.detectIter(&iter);
+        try testing.expect(action.? == .version);
+    }
+
+    {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(
+            alloc,
+            "--c=84 --d +version --a=42 --b --b-f=false",
         );
         defer iter.deinit();
         const action = try Action.detectIter(&iter);

--- a/src/cli_action.zig
+++ b/src/cli_action.zig
@@ -1,0 +1,107 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const Allocator = std.mem.Allocator;
+const build_config = @import("build_config.zig");
+
+/// Special commands that can be invoked via CLI flags. These are all
+/// invoked by using `+<action>` as a CLI flag. The only exception is
+/// "version" which can be invoked additionally with `--version`.
+pub const Action = enum {
+    /// Output the version and exit
+    version,
+
+    pub const Error = error{
+        /// Multiple actions were detected. You can specify at most one
+        /// action on the CLI otherwise the behavior desired is ambiguous.
+        MultipleActions,
+
+        /// An unknown action was specified.
+        InvalidAction,
+    };
+
+    /// Detect the action from CLI args.
+    pub fn detectCLI(alloc: Allocator) !?Action {
+        var iter = try std.process.argsWithAllocator(alloc);
+        defer iter.deinit();
+        return try detectIter(&iter);
+    }
+
+    /// Detect the action from any iterator, used primarily for tests.
+    pub fn detectIter(iter: anytype) Error!?Action {
+        var pending: ?Action = null;
+        while (iter.next()) |arg| {
+            // Special case, --version always outputs the version no
+            // matter what, no matter what other args exist.
+            if (std.mem.eql(u8, arg, "--version")) return .version;
+
+            // Commands must start with "+"
+            if (arg.len == 0 or arg[0] != '+') continue;
+            if (pending != null) return Error.MultipleActions;
+            pending = std.meta.stringToEnum(Action, arg[1..]) orelse return Error.InvalidAction;
+        }
+
+        return null;
+    }
+
+    /// Run the action. This returns the exit code to exit with.
+    pub fn run(self: Action, alloc: Allocator) !u8 {
+        _ = alloc;
+        return switch (self) {
+            .version => try runVersion(),
+        };
+    }
+};
+
+fn runVersion() !u8 {
+    const stdout = std.io.getStdOut().writer();
+    try stdout.print("Ghostty {s}\n", .{build_config.version_string});
+    return 0;
+}
+
+test "parse action none" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var iter = try std.process.ArgIteratorGeneral(.{}).init(
+        alloc,
+        "--a=42 --b --b-f=false",
+    );
+    defer iter.deinit();
+    const action = try Action.detectIter(&iter);
+    try testing.expect(action == null);
+}
+
+test "parse action version" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(
+            alloc,
+            "--a=42 --b --b-f=false --version",
+        );
+        defer iter.deinit();
+        const action = try Action.detectIter(&iter);
+        try testing.expect(action.? == .version);
+    }
+
+    {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(
+            alloc,
+            "--version --a=42 --b --b-f=false",
+        );
+        defer iter.deinit();
+        const action = try Action.detectIter(&iter);
+        try testing.expect(action.? == .version);
+    }
+
+    {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(
+            alloc,
+            "--c=84 --d --version --a=42 --b --b-f=false",
+        );
+        defer iter.deinit();
+        const action = try Action.detectIter(&iter);
+        try testing.expect(action.? == .version);
+    }
+}

--- a/src/main_c.zig
+++ b/src/main_c.zig
@@ -27,6 +27,9 @@ pub usingnamespace apprt.runtime.CAPI;
 /// one global state but it has zero practical benefit.
 export fn ghostty_init() c_int {
     assert(builtin.link_libc);
-    main.state.init();
+    main.state.init() catch |err| {
+        std.log.err("failed to initialize ghostty error={}", .{err});
+        return 1;
+    };
     return 0;
 }


### PR DESCRIPTION
This makes `--version` work, also available as `+version`. The `+<command>` syntax will be the general subcommand syntax for helper programs. This PR includes a small framework to make it easy to add new commands, so we can add things such as font debugging.

<img width="912" alt="CleanShot 2023-09-15 at 12 23 27@2x" src="https://github.com/mitchellh/ghostty/assets/1299/49a65858-91f6-4c3c-b856-c5d9f211cfb6">
