### PR TITLE
macos, gtk: show warning when running with debug build

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -284,9 +284,22 @@ typedef struct {
     bool physical;
 } ghostty_input_trigger_s;
 
+typedef enum {
+    GHOSTTY_BUILD_MODE_DEBUG,
+    GHOSTTY_BUILD_MODE_RELEASE_SAFE,
+    GHOSTTY_BUILD_MODE_RELEASE_FAST,
+    GHOSTTY_BUILD_MODE_RELEASE_SMALL,
+} ghostty_build_mode_e;
+
 // Fully defined types. This MUST be kept in sync with equivalent Zig
 // structs. To find the Zig struct, grep for this type name. The documentation
 // for all of these types is available in the Zig source.
+typedef struct {
+    ghostty_build_mode_e build_mode;
+    const char *version;
+    uintptr_t version_len;
+} ghostty_info_s;
+
 typedef struct {
     const char *message;
 } ghostty_error_s;
@@ -338,6 +351,7 @@ typedef struct {
 // Published API
 
 int ghostty_init(void);
+ghostty_info_s ghostty_info(void);
 
 ghostty_config_t ghostty_config_new();
 void ghostty_config_free(ghostty_config_t);

--- a/macos/Sources/Features/Primary Window/PrimaryView.swift
+++ b/macos/Sources/Features/Primary Window/PrimaryView.swift
@@ -215,7 +215,7 @@ struct DebugBuildWarningView: View {
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundColor(.yellow)
             
-            Text("You're running a debug build of Ghostty!")
+            Text("You're running a debug build of Ghostty! Performance will be degraded.")
                 .padding(.all, 8)
                 .popover(isPresented: $isPopover, arrowEdge: .bottom) {
                     Text("""

--- a/macos/Sources/Features/Primary Window/PrimaryView.swift
+++ b/macos/Sources/Features/Primary Window/PrimaryView.swift
@@ -94,38 +94,46 @@ struct PrimaryView: View {
                 self.appDelegate.confirmQuit = $0
             })
             
-            Ghostty.TerminalSplit(onClose: Self.closeWindow, baseConfig: self.baseConfig)
-                .ghosttyApp(ghostty.app!)
-                .ghosttyConfig(ghostty.config!)
-                .background(WindowAccessor(window: $window))
-                .onReceive(gotoTab) { onGotoTab(notification: $0) }
-                .onReceive(toggleFullscreen) { onToggleFullscreen(notification: $0) }
-                .focused($focused)
-                .onAppear { self.focused = true }
-                .onChange(of: focusedSurface) { newValue in
-                    self.focusedSurfaceWrapper.surface = newValue?.surface
+            VStack(spacing: 0) {
+                // If we're running in debug mode we show a warning so that users
+                // know that performance will be degraded.
+                if (ghostty.info.mode == GHOSTTY_BUILD_MODE_DEBUG) {
+                    DebugBuildWarningView()
                 }
-                .onChange(of: title) { newValue in
-                    // We need to handle this manually because we are using AppKit lifecycle
-                    // so navigationTitle no longer works.
-                    guard let window = self.window else { return }
-                    window.title = newValue
-                }
-                .confirmationDialog(
-                    "Quit Ghostty?",
-                    isPresented: confirmQuitting) {
-                        Button("Close Ghostty") {
-                            NSApplication.shared.reply(toApplicationShouldTerminate: true)
-                        }
-                        .keyboardShortcut(.defaultAction)
-                        
-                        Button("Cancel", role: .cancel) {
-                            NSApplication.shared.reply(toApplicationShouldTerminate: false)
-                        }
-                        .keyboardShortcut(.cancelAction)
-                    } message: {
-                        Text("All terminal sessions will be terminated.")
+                
+                Ghostty.TerminalSplit(onClose: Self.closeWindow, baseConfig: self.baseConfig)
+                    .ghosttyApp(ghostty.app!)
+                    .ghosttyConfig(ghostty.config!)
+                    .background(WindowAccessor(window: $window))
+                    .onReceive(gotoTab) { onGotoTab(notification: $0) }
+                    .onReceive(toggleFullscreen) { onToggleFullscreen(notification: $0) }
+                    .focused($focused)
+                    .onAppear { self.focused = true }
+                    .onChange(of: focusedSurface) { newValue in
+                        self.focusedSurfaceWrapper.surface = newValue?.surface
                     }
+                    .onChange(of: title) { newValue in
+                        // We need to handle this manually because we are using AppKit lifecycle
+                        // so navigationTitle no longer works.
+                        guard let window = self.window else { return }
+                        window.title = newValue
+                    }
+                    .confirmationDialog(
+                        "Quit Ghostty?",
+                        isPresented: confirmQuitting) {
+                            Button("Close Ghostty") {
+                                NSApplication.shared.reply(toApplicationShouldTerminate: true)
+                            }
+                            .keyboardShortcut(.defaultAction)
+                            
+                            Button("Cancel", role: .cancel) {
+                                NSApplication.shared.reply(toApplicationShouldTerminate: false)
+                            }
+                            .keyboardShortcut(.cancelAction)
+                        } message: {
+                            Text("All terminal sessions will be terminated.")
+                        }
+            }
         }
     }
     
@@ -193,6 +201,37 @@ struct PrimaryView: View {
         // toggling fullscreen, so we set it back to the correct one.
         if let focusedSurface {
             Ghostty.moveFocus(to: focusedSurface)
+        }
+    }
+}
+
+struct DebugBuildWarningView: View {
+    @State private var isPopover = false
+    
+    var body: some View {
+        HStack {
+            Spacer()
+            
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundColor(.yellow)
+            
+            Text("You're running a debug build of Ghostty!")
+                .padding(.all, 8)
+                .popover(isPresented: $isPopover, arrowEdge: .bottom) {
+                    Text("""
+                    Debug builds of Ghostty are very slow and you may experience
+                    performance problems. Debug builds are only recommended during
+                    development.
+                    """)
+                    .padding(.all)
+                }
+            
+            Spacer()
+        }
+        .background(Color(.windowBackgroundColor))
+        .frame(maxWidth: .infinity)
+        .onTapGesture {
+            isPopover = true
         }
     }
 }

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -11,6 +11,11 @@ extension Ghostty {
         case loading, error, ready
     }
     
+    struct Info {
+        var mode: ghostty_build_mode_e
+        var version: String
+    }
+    
     /// The AppState is the global state that is associated with the Swift app. This handles initially
     /// initializing Ghostty, loading the configuration, etc.
     class AppState: ObservableObject {
@@ -44,6 +49,18 @@ extension Ghostty {
         var needsConfirmQuit: Bool {
             guard let app = app else { return false }
             return ghostty_app_needs_confirm_quit(app)
+        }
+        
+        /// Build information
+        var info: Info {
+            let raw = ghostty_info()
+            let version = NSString(
+                bytes: raw.version,
+                length: Int(raw.version_len),
+                encoding: NSUTF8StringEncoding
+            ) ?? "unknown"
+            
+            return Info(mode: raw.build_mode, version: String(version))
         }
         
         /// Cached clipboard string for `read_clipboard` callback.

--- a/src/main_c.zig
+++ b/src/main_c.zig
@@ -9,6 +9,7 @@
 const std = @import("std");
 const assert = std.debug.assert;
 const builtin = @import("builtin");
+const build_config = @import("build_config.zig");
 const main = @import("main.zig");
 const apprt = @import("apprt.zig");
 
@@ -23,10 +24,37 @@ pub const std_options = main.std_options;
 pub usingnamespace @import("config.zig").CAPI;
 pub usingnamespace apprt.runtime.CAPI;
 
+/// ghostty_info_s
+const Info = extern struct {
+    mode: BuildMode,
+    version: [*]const u8,
+    version_len: usize,
+
+    const BuildMode = enum(c_int) {
+        debug,
+        release_safe,
+        release_fast,
+        release_small,
+    };
+};
+
 /// Initialize ghostty global state. It is possible to have more than
 /// one global state but it has zero practical benefit.
 export fn ghostty_init() c_int {
     assert(builtin.link_libc);
     main.state.init();
     return 0;
+}
+
+export fn ghostty_info() Info {
+    return .{
+        .mode = switch (builtin.mode) {
+            .Debug => .debug,
+            .ReleaseSafe => .release_safe,
+            .ReleaseFast => .release_fast,
+            .ReleaseSmall => .release_small,
+        },
+        .version = build_config.version_string.ptr,
+        .version_len = build_config.version_string.len,
+    };
 }


### PR DESCRIPTION
This is far too common an issue for newcomers. 

Note the strings don't match in the screenshot but they do in the code. The screenshots are just old.

<img width="800" alt="CleanShot 2023-09-15 at 15 57 23@2x" src="https://github.com/mitchellh/ghostty/assets/1299/fbc8d60d-20a2-45ce-bdcf-baa4db0dda3a">

![CleanShot 2023-09-15 at 15 54 51@2x](https://github.com/mitchellh/ghostty/assets/1299/fa27c770-2529-4ae9-bdd5-a098b072a47e)

