### PR TITLE
windows: fix fontconfig into libxml runtime crash from implicit func decl

### DIFF
--- a/pkg/fontconfig/build.zig
+++ b/pkg/fontconfig/build.zig
@@ -160,7 +160,15 @@ pub fn buildFontconfig(
     if (opt.libxml2) {
         try flags.appendSlice(&.{
             "-DENABLE_LIBXML2",
+            "-DLIBXML_STATIC",
+            "-DLIBXML_PUSH_ENABLED",
         });
+        if (target.isWindows()) {
+            // NOTE: this should be defined on all targets
+            try flags.appendSlice(&.{
+                "-Werror=implicit-function-declaration",
+            });
+        }
     }
 
     if (target.isWindows()) {


### PR DESCRIPTION
Fixes the next issue on windows.  The fontconfig library is calling the function `xmlCreatePushParserCtxt` from `libxml2`, however, the function declaration was being omitted because fontconfig was not defining the `LIBXML_PUSH_ENABLED` preprocessor symbol.  However, instead of a compile error, C's support for implicit function declrations allows it to happily call the function anyway, with the wrong ABI.  The main issue was the return type being implicitly declared as "int" instead of a pointer.  On my system this was causing the return pointer to be truncated to 32 bits and then sign-extended which caused a segfault once it was dereferenced.

I've gone ahead and added the `-Werror=implicit-function-declaration` to fontconfig to avoid these issues in the future.  However, this flag didn't compile on linux so I've left it as Windows only for now.

I also needed to add the `LIBXML_STATIC` define because not defining it causes some functions on windows to be declared with `__declspec(dllimport)` which results in linker errors since we are actually statically linking libxml2.