### PR TITLE
Async clipboard read

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -316,7 +316,7 @@ typedef const ghostty_config_t (*ghostty_runtime_reload_config_cb)(void *);
 typedef void (*ghostty_runtime_set_title_cb)(void *, const char *);
 typedef void (*ghostty_runtime_set_mouse_shape_cb)(void *, ghostty_mouse_shape_e);
 typedef void (*ghostty_runtime_set_mouse_visibility_cb)(void *, bool);
-typedef const char* (*ghostty_runtime_read_clipboard_cb)(void *, ghostty_clipboard_e);
+typedef void (*ghostty_runtime_read_clipboard_cb)(void *, ghostty_clipboard_e, void *);
 typedef void (*ghostty_runtime_write_clipboard_cb)(void *, const char *, ghostty_clipboard_e);
 typedef void (*ghostty_runtime_new_split_cb)(void *, ghostty_split_direction_e, ghostty_surface_config_s);
 typedef void (*ghostty_runtime_new_tab_cb)(void *, ghostty_surface_config_s);
@@ -393,6 +393,7 @@ void ghostty_surface_request_close(ghostty_surface_t);
 void ghostty_surface_split(ghostty_surface_t, ghostty_split_direction_e);
 void ghostty_surface_split_focus(ghostty_surface_t, ghostty_split_focus_direction_e);
 bool ghostty_surface_binding_action(ghostty_surface_t, const char *, uintptr_t);
+void ghostty_surface_complete_clipboard_request(ghostty_surface_t, const char *, uintptr_t, void *);
 
 // APIs I'd like to get rid of eventually but are still needed for now.
 // Don't use these unless you know what you're doing.

--- a/src/apprt/structs.zig
+++ b/src/apprt/structs.zig
@@ -31,3 +31,13 @@ pub const Clipboard = enum(u1) {
     standard = 0, // ctrl+c/v
     selection = 1, // also known as the "primary" clipboard
 };
+
+/// Clipboard request. This is used to request clipboard contents and must
+/// be sent as a response to a ClipboardRequest event.
+pub const ClipboardRequest = union(enum) {
+    /// A direct paste of clipboard contents.
+    paste: void,
+
+    /// A request to write clipboard contents via OSC 52.
+    osc_52: u8,
+};


### PR DESCRIPTION
Fixes #404 
Fixes #402 

This changes our clipboard read API for `apprt` implementations to be an async request/response system rather than a synchronous "read string" API. This allows us to use GTK's recommended clipboard read mechanism which is async, fixing a couple issues. For other platforms, this has the benefit that we no longer need to keep a cached copy of the clipboard contents around -- significantly saving on memory for large pastes.

The background of why we did it the way we did before: Ghostty started as GLFW only, and as we abstracted `apprt`, we kept the GLFW semantics. The GLFW API is such that it caches the string and returns a string pointer. We copied that. When we adopted GTK, we _forced_ these semantics but they didn't work well, resulting in bugs. **TLDR: legacy debt, now repaid.** 