### PR TITLE
macos: Ghostty binary is also a CLI app

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -351,6 +351,7 @@ typedef struct {
 // Published API
 
 int ghostty_init(void);
+void ghostty_cli_main(uintptr_t, char **);
 ghostty_info_s ghostty_info(void);
 
 ghostty_config_t ghostty_config_new();

--- a/macos/Ghostty-Info.plist
+++ b/macos/Ghostty-Info.plist
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>NSMainNibFile</key>
-	<string>MainMenu</string>
-</dict>
+<dict/>
 </plist>

--- a/macos/Ghostty-Info.plist
+++ b/macos/Ghostty-Info.plist
@@ -2,9 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>GHOSTTY_MAC_APP</key>
-	<string>1</string>
 	<key>LSEnvironment</key>
-	<dict/>
+	<dict>
+		<key>GHOSTTY_MAC_APP</key>
+		<string>1</string>
+	</dict>
 </dict>
 </plist>

--- a/macos/Ghostty-Info.plist
+++ b/macos/Ghostty-Info.plist
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>GHOSTTY_MAC_APP</key>
+	<string>1</string>
+	<key>LSEnvironment</key>
+	<dict/>
+</dict>
 </plist>

--- a/macos/Ghostty.xcodeproj/project.pbxproj
+++ b/macos/Ghostty.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		A5CEAFDC29B8009000646FDA /* SplitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CEAFDB29B8009000646FDA /* SplitView.swift */; };
 		A5CEAFDE29B8058B00646FDA /* SplitView.Divider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CEAFDD29B8058B00646FDA /* SplitView.Divider.swift */; };
 		A5CEAFFF29C2410700646FDA /* Backport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CEAFFE29C2410700646FDA /* Backport.swift */; };
+		A5FEB3002ABB69450068369E /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FEB2FF2ABB69450068369E /* main.swift */; };
 		A5FECBD729D1FC3900022361 /* PrimaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FECBD629D1FC3900022361 /* PrimaryView.swift */; };
 		A5FECBD929D2010400022361 /* WindowAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FECBD829D2010400022361 /* WindowAccessor.swift */; };
 /* End PBXBuildFile section */
@@ -65,6 +66,7 @@
 		A5CEAFDD29B8058B00646FDA /* SplitView.Divider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitView.Divider.swift; sourceTree = "<group>"; };
 		A5CEAFFE29C2410700646FDA /* Backport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Backport.swift; sourceTree = "<group>"; };
 		A5D495A1299BEC7E00DD1313 /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = GhosttyKit.xcframework; sourceTree = "<group>"; };
+		A5FEB2FF2ABB69450068369E /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		A5FECBD629D1FC3900022361 /* PrimaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryView.swift; sourceTree = "<group>"; };
 		A5FECBD829D2010400022361 /* WindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAccessor.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -128,6 +130,7 @@
 		A54CD6ED299BEB14008C95BB /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				A5FEB2FF2ABB69450068369E /* main.swift */,
 				A53426342A7DA53D00EBB7A2 /* AppDelegate.swift */,
 				857F63802A5E64F200CA4815 /* MainMenu.xib */,
 				A53426362A7DC53000EBB7A2 /* Features */,
@@ -279,6 +282,7 @@
 				A55B7BBC29B6FC330055DE60 /* SurfaceView.swift in Sources */,
 				A59444F729A2ED5200725BBA /* SettingsView.swift in Sources */,
 				A5FECBD729D1FC3900022361 /* PrimaryView.swift in Sources */,
+				A5FEB3002ABB69450068369E /* main.swift in Sources */,
 				A55B7BB829B6F53A0055DE60 /* Package.swift in Sources */,
 				A55B7BBE29B701360055DE60 /* Ghostty.SplitView.swift in Sources */,
 				A55B7BB629B6F47F0055DE60 /* AppState.swift in Sources */,

--- a/macos/Ghostty.xcodeproj/project.pbxproj
+++ b/macos/Ghostty.xcodeproj/project.pbxproj
@@ -424,11 +424,13 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
+				EXECUTABLE_NAME = ghostty;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Ghostty-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = Ghostty;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSMainNibFile = MainMenu;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -457,12 +459,14 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
+				EXECUTABLE_NAME = ghostty;
 				GCC_OPTIMIZATION_LEVEL = fast;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Ghostty-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = Ghostty;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSMainNibFile = MainMenu;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",

--- a/macos/Sources/AppDelegate.swift
+++ b/macos/Sources/AppDelegate.swift
@@ -2,7 +2,6 @@ import AppKit
 import OSLog
 import GhosttyKit
 
-@NSApplicationMain
 class AppDelegate: NSObject, ObservableObject, NSApplicationDelegate, GhosttyAppStateDelegate {
     // The application logger. We should probably move this at some point to a dedicated
     // class/struct but for now it lives here! 🤷‍♂️

--- a/macos/Sources/main.swift
+++ b/macos/Sources/main.swift
@@ -6,7 +6,7 @@ import GhosttyKit
 // whether we launch from the app or not. A user can fake this if
 // they want but they're doing so at their own detriment...
 let process = ProcessInfo.processInfo
-if (process.environment["GHOSTTY_MAC_APP"] == "") {
+if ((process.environment["GHOSTTY_MAC_APP"] ?? "") == "") {
     ghostty_cli_main(UInt(CommandLine.argc), CommandLine.unsafeArgv)
     exit(1)
 }

--- a/macos/Sources/main.swift
+++ b/macos/Sources/main.swift
@@ -1,0 +1,12 @@
+import AppKit
+import Cocoa
+
+// We put the GHOSTTY_MAC_APP env var into the Info.plist to detect
+// whether we launch from the app or not. A user can fake this if
+// they want but they're doing so at their own detriment...
+let process = ProcessInfo.processInfo
+if (process.environment["GHOSTTY_MAC_APP"] == "") {
+    AppDelegate.logger.warning("NOT IN THE MAC APP")
+}
+
+_ = NSApplicationMain(CommandLine.argc, CommandLine.unsafeArgv)

--- a/macos/Sources/main.swift
+++ b/macos/Sources/main.swift
@@ -1,12 +1,14 @@
 import AppKit
 import Cocoa
+import GhosttyKit
 
 // We put the GHOSTTY_MAC_APP env var into the Info.plist to detect
 // whether we launch from the app or not. A user can fake this if
 // they want but they're doing so at their own detriment...
 let process = ProcessInfo.processInfo
 if (process.environment["GHOSTTY_MAC_APP"] == "") {
-    AppDelegate.logger.warning("NOT IN THE MAC APP")
+    ghostty_cli_main(UInt(CommandLine.argc), CommandLine.unsafeArgv)
+    exit(1)
 }
 
 _ = NSApplicationMain(CommandLine.argc, CommandLine.unsafeArgv)

--- a/src/main.zig
+++ b/src/main.zig
@@ -233,6 +233,11 @@ pub const GlobalState = struct {
         // output.
         if (self.action != null) self.logging = .{ .disabled = {} };
 
+        // For lib mode we always disable stderr logging by default.
+        if (comptime build_config.app_runtime == .none) {
+            self.logging = .{ .disabled = {} };
+        }
+
         // I don't love the env var name but I don't have it in my heart
         // to parse CLI args 3 times (once for actions, once for config,
         // maybe once for logging) so for now this is an easy way to do

--- a/src/main.zig
+++ b/src/main.zig
@@ -23,7 +23,13 @@ const Ghostty = @import("main_c.zig").Ghostty;
 /// rely on allocators being passed in as parameters.
 pub var state: GlobalState = undefined;
 
-pub fn main() !void {
+/// The return type for main() depends on the build artifact.
+const MainReturn = switch (build_config.artifact) {
+    .lib => noreturn,
+    else => void,
+};
+
+pub fn main() !MainReturn {
     // We first start by initializing our global state. This will setup
     // process-level state we need to run the terminal. The reason we use
     // a global is because the C API needs to be able to access this state;
@@ -65,6 +71,24 @@ pub fn main() !void {
             break :err 1;
         });
         return;
+    }
+
+    if (comptime build_config.app_runtime == .none) {
+        const stdout = std.io.getStdOut().writer();
+        try stdout.print("Usage: ghostty +<action> [flags]\n\n", .{});
+        try stdout.print(
+            \\This is the Ghostty helper CLI that accompanies the graphical Ghostty app.
+            \\To launch the terminal directly, please launch the graphical app
+            \\(i.e. Ghostty.app on macOS). This CLI can be used to perform various
+            \\actions such as inspecting the version, listing fonts, etc.
+            \\
+            \\We don't have proper help output yet, sorry! Please refer to the
+            \\source code or Discord community for help for now. We'll fix this in time.
+        ,
+            .{},
+        );
+
+        std.os.exit(0);
     }
 
     // Create our app state
@@ -156,6 +180,7 @@ pub const GlobalState = struct {
         stderr: void,
     };
 
+    /// Initialize the global state.
     pub fn init(self: *GlobalState) !void {
         // Initialize ourself to nothing so we don't have any extra state.
         // IMPORTANT: this MUST be initialized before any log output because
@@ -201,15 +226,12 @@ pub const GlobalState = struct {
         };
 
         // We first try to parse any action that we may be executing.
-        // We do not execute this in the lib because os.argv is not set.
-        if (comptime build_config.artifact != .lib) {
-            self.action = try cli_action.Action.detectCLI(self.alloc);
+        self.action = try cli_action.Action.detectCLI(self.alloc);
 
-            // If we have an action executing, we disable logging by default
-            // since we write to stderr we don't want logs messing up our
-            // output.
-            if (self.action != null) self.logging = .{ .disabled = {} };
-        }
+        // If we have an action executing, we disable logging by default
+        // since we write to stderr we don't want logs messing up our
+        // output.
+        if (self.action != null) self.logging = .{ .disabled = {} };
 
         // I don't love the env var name but I don't have it in my heart
         // to parse CLI args 3 times (once for actions, once for config,

--- a/src/os/env.zig
+++ b/src/os/env.zig
@@ -1,0 +1,48 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const Allocator = std.mem.Allocator;
+
+/// Append a value to an environment variable such as PATH.
+/// The returned value is always allocated so it must be freed.
+pub fn appendEnv(
+    alloc: Allocator,
+    current: []const u8,
+    value: []const u8,
+) ![]u8 {
+    // If there is no prior value, we return it as-is
+    if (current.len == 0) return try alloc.dupe(u8, value);
+
+    // Otherwise we must prefix.
+    const sep = switch (builtin.os.tag) {
+        .windows => ";",
+        else => ":",
+    };
+
+    return try std.fmt.allocPrint(alloc, "{s}{s}{s}", .{
+        current,
+        sep,
+        value,
+    });
+}
+
+test "appendEnv empty" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const result = try appendEnv(alloc, "", "foo");
+    defer alloc.free(result);
+    try testing.expectEqualStrings(result, "foo");
+}
+
+test "appendEnv existing" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const result = try appendEnv(alloc, "a:b", "foo");
+    defer alloc.free(result);
+    if (builtin.os.tag == .windows) {
+        try testing.expectEqualStrings(result, "a:b;foo");
+    } else {
+        try testing.expectEqualStrings(result, "a:b:foo");
+    }
+}

--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -1,6 +1,7 @@
 //! The "os" package contains utilities for interfacing with the operating
 //! system.
 
+pub usingnamespace @import("env.zig");
 pub usingnamespace @import("file.zig");
 pub usingnamespace @import("flatpak.zig");
 pub usingnamespace @import("homedir.zig");


### PR DESCRIPTION
This makes it so that `Ghostty.app/Contents/MacOS/ghostty` can also be executed via the CLI. The user must still manually add this to their `PATH`. This helps lay further groundwork for things such as #495. 