### PR TITLE
macos: window-theme setting to force light or dark theme

### DIFF
--- a/macos/Sources/AppDelegate.swift
+++ b/macos/Sources/AppDelegate.swift
@@ -187,6 +187,9 @@ class AppDelegate: NSObject, ObservableObject, NSApplicationDelegate, GhosttyApp
         // Config could change keybindings, so update our menu
         syncMenuShortcuts()
         
+        // Config could change window appearance
+        syncAppearance()
+        
         // If we have configuration errors, we need to show them.
         let c = ConfigurationErrorsController.sharedInstance
         c.model.errors = state.configErrors()
@@ -194,6 +197,23 @@ class AppDelegate: NSObject, ObservableObject, NSApplicationDelegate, GhosttyApp
             if (c.window == nil || !c.window!.isVisible) {
                 c.showWindow(self)
             }
+        }
+    }
+    
+    /// Sync the appearance of our app with the theme specified in the config.
+    private func syncAppearance() {
+        guard let theme = ghostty.windowTheme else { return }
+        switch (theme) {
+        case "dark":
+            let appearance = NSAppearance(named: .darkAqua)
+            NSApplication.shared.appearance = appearance
+            
+        case "light":
+            let appearance = NSAppearance(named: .aqua)
+            NSApplication.shared.appearance = appearance
+            
+        default:
+            NSApplication.shared.appearance = nil
         }
     }
     

--- a/macos/Sources/Features/Primary Window/PrimaryWindow.swift
+++ b/macos/Sources/Features/Primary Window/PrimaryWindow.swift
@@ -15,6 +15,14 @@ class FocusedSurfaceWrapper {
 // such as non-native fullscreen.
 class PrimaryWindow: NSWindow {
     var focusedSurfaceWrapper: FocusedSurfaceWrapper = FocusedSurfaceWrapper()
+    
+    override var canBecomeKey: Bool {
+        return true
+    }
+
+    override var canBecomeMain: Bool {
+        return true
+    }
 
     static func create(ghostty: Ghostty.AppState, appDelegate: AppDelegate, baseConfig: ghostty_surface_config_s? = nil) -> PrimaryWindow {
         let window = PrimaryWindow(
@@ -52,13 +60,5 @@ class PrimaryWindow: NSWindow {
         }
         
         return mask
-    }
-    
-    override var canBecomeKey: Bool {
-        return true
-    }
-
-    override var canBecomeMain: Bool {
-        return true
     }
 }

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -81,7 +81,16 @@ extension Ghostty {
             guard let ptr = v else { return nil }
             return String(cString: ptr)
         }
-
+        
+        /// The background opacity.
+        var backgroundOpacity: Double {
+            guard let config = self.config else { return 1 }
+            var v: Double = 1
+            let key = "background-opacity"
+            _ = ghostty_config_get(config, &v, key, UInt(key.count))
+            return v;
+        }
+        
         init() {
             // Initialize ghostty global state. This happens once per process.
             guard ghostty_init() == GHOSTTY_SUCCESS else {

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -71,6 +71,16 @@ extension Ghostty {
             _ = ghostty_config_get(config, &v, key, UInt(key.count))
             return v;
         }
+        
+        /// The window theme as a string.
+        var windowTheme: String? {
+            guard let config = self.config else { return nil }
+            var v: UnsafePointer<Int8>? = nil
+            let key = "window-theme"
+            guard ghostty_config_get(config, &v, key, UInt(key.count)) else { return nil }
+            guard let ptr = v else { return nil }
+            return String(cString: ptr)
+        }
 
         init() {
             // Initialize ghostty global state. This happens once per process.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -244,6 +244,14 @@ keybind: Keybinds = .{},
 /// borders.
 @"window-decoration": bool = true,
 
+/// The theme to use for the windows. The default is "system" which
+/// means that whatever the system theme is will be used. This can
+/// also be set to "light" or "dark" to force a specific theme regardless
+/// of the system settings.
+///
+/// This is currently only supported on macOS.
+@"window-theme": WindowTheme = .system,
+
 /// Whether to allow programs running in the terminal to read/write to
 /// the system clipboard (OSC 52, for googling). The default is to
 /// disallow clipboard reading but allow writing.
@@ -1506,4 +1514,11 @@ pub const OSCColorReportFormat = enum {
     none,
     @"8-bit",
     @"16-bit",
+};
+
+/// The default window theme.
+pub const WindowTheme = enum {
+    system,
+    light,
+    dark,
 };


### PR DESCRIPTION
This adds a new config `window-theme` that initially only works for macOS. This can be used to configure the macOS appearance and valid values are `system`, `light`, and `dark`. They do what you expect. The configuration supports runtime reloading.

There is actually a lot more we can do with theming here, but this is a quick one to get in.

In the future, I'd love to expand support of this to GTK to support arbitrary themes (unsure if possible on first glance). I also want to expand our appearance in general to support colored titlebars and so on.

## Demo


https://github.com/mitchellh/ghostty/assets/1299/8ea1951c-5118-4ac9-a2ee-8c7dbd1d0ba0

