### PR TITLE
terminal: use larger buffer for xtversion response

### DIFF
--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1692,16 +1692,16 @@ const StreamHandler = struct {
         self: *StreamHandler,
     ) !void {
         log.debug("reporting XTVERSION: ghostty {s}", .{build_config.version_string});
-        var msg: termio.Message = .{ .write_small = .{} };
+        var buf: [288]u8 = undefined;
         const resp = try std.fmt.bufPrint(
-            &msg.write_small.data,
+            &buf,
             "\x1BP>|{s} {s}\x07",
             .{
                 "ghostty",
                 build_config.version_string,
             },
         );
-        msg.write_small.len = @intCast(resp.len);
+        var msg = try termio.Message.writeReq(self.alloc, resp);
         self.messageWriter(msg);
     }
 


### PR DESCRIPTION
Commit fbe030d85a80 ("terminal: respond to XTVERSION query") introduced responding to XTVERSION queries. The implementation uses the .write_small method, which has a limit of 38 bytes. This works well if your branch is named "main", since the branch is part of the version_string variable. If you start using longer branch names, you can quickly run into the limit.

The XTVERSION response is:

  "\x1bP>|ghostty d.d.d-<branch>+<12-digit-hash>\x07"

Which has an overhead of 32 bytes, meaning the natural branch limit is 6 bytes (6 characters, assuming you use ASCII branch names). Github has a limit of 256 chars, so let's set a max XTVERSION buffer of 256+32 = 288

Fixes: fbe030d85a80 ("terminal: respond to XTVERSION query")