### PR TITLE
terminal: CSI E and F

### DIFF
--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -163,6 +163,7 @@ pub fn Stream(comptime Handler: type) type {
                             return;
                         },
                     },
+                    false,
                 ) else log.warn("unimplemented CSI callback: {}", .{action}),
 
                 // CUD - Cursor Down
@@ -175,6 +176,7 @@ pub fn Stream(comptime Handler: type) type {
                             return;
                         },
                     },
+                    false,
                 ) else log.warn("unimplemented CSI callback: {}", .{action}),
 
                 // CUF - Cursor Right
@@ -199,6 +201,32 @@ pub fn Stream(comptime Handler: type) type {
                             return;
                         },
                     },
+                ) else log.warn("unimplemented CSI callback: {}", .{action}),
+
+                // CNL - Cursor Next Line
+                'E' => if (@hasDecl(T, "setCursorDown")) try self.handler.setCursorDown(
+                    switch (action.params.len) {
+                        0 => 1,
+                        1 => action.params[0],
+                        else => {
+                            log.warn("invalid cursor up command: {}", .{action});
+                            return;
+                        },
+                    },
+                    true,
+                ) else log.warn("unimplemented CSI callback: {}", .{action}),
+
+                // CPL - Cursor Previous Line
+                'F' => if (@hasDecl(T, "setCursorUp")) try self.handler.setCursorUp(
+                    switch (action.params.len) {
+                        0 => 1,
+                        1 => action.params[0],
+                        else => {
+                            log.warn("invalid cursor down command: {}", .{action});
+                            return;
+                        },
+                    },
+                    true,
                 ) else log.warn("unimplemented CSI callback: {}", .{action}),
 
                 // HPA - Cursor Horizontal Position Absolute

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1277,12 +1277,14 @@ const StreamHandler = struct {
         self.terminal.cursorRight(amount);
     }
 
-    pub fn setCursorDown(self: *StreamHandler, amount: u16) !void {
+    pub fn setCursorDown(self: *StreamHandler, amount: u16, carriage: bool) !void {
         self.terminal.cursorDown(amount);
+        if (carriage) self.terminal.carriageReturn();
     }
 
-    pub fn setCursorUp(self: *StreamHandler, amount: u16) !void {
+    pub fn setCursorUp(self: *StreamHandler, amount: u16, carriage: bool) !void {
         self.terminal.cursorUp(amount);
+        if (carriage) self.terminal.carriageReturn();
     }
 
     pub fn setCursorCol(self: *StreamHandler, col: u16) !void {


### PR DESCRIPTION
Fixes #505 

Test script:

```
#!/usr/bin/env bash

function csi() {
  printf "\033[%s" "$*"
}

echo A
echo B
echo C
echo D
printf E
csi "2F"
printf X
csi "3E"
```