### PR TITLE
macos: multiple mouse-hide-while-typing fixes

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -419,12 +419,13 @@ extension Ghostty {
                 options: [
                     .mouseEnteredAndExited,
                     .mouseMoved,
+                    
+                    // Only send mouse events that happen in our visible (not obscured) rect
                     .inVisibleRect,
 
-                    // It is possible this is incorrect when we have splits. This will make
-                    // mouse events only happen while the terminal is focused. Is that what
-                    // we want?
-                    .activeWhenFirstResponder,
+                    // We want active always because we want to still send mouse reports
+                    // even if we're not focused or key.
+                    .activeAlways,
                 ],
                 owner: self,
                 userInfo: nil))


### PR DESCRIPTION
Fixes #510 

* Mouse tracking areas should send events even if the view is not in the responder chain
* Manually detect mouse exit/enter on frame change since Cocoa does not do this
* Update the cursor even if the view isn't focused, so that invisible can become visible 