### PR TITLE
update zig to 0.12.0-dev.464+a63a1c5cb

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -35,7 +35,7 @@ const system_sdk = @import("vendor/mach-glfw/system_sdk.zig");
 // but we liberally update it. In the future, we'll be more careful about
 // using released versions so that package managers can integrate better.
 comptime {
-    const required_zig = "0.12.0-dev.141+ddf5859c2";
+    const required_zig = "0.12.0-dev.464+a63a1c5cb";
     const current_zig = builtin.zig_version;
     const min_zig = std.SemanticVersion.parse(required_zig) catch unreachable;
     if (current_zig.order(min_zig) == .lt) {

--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1693742842,
-        "narHash": "sha256-s0CLuq9xPQcLug9QLp2eXSo0J3RMkaCC6BwGmDkBWrA=",
+        "lastModified": 1695298117,
+        "narHash": "sha256-Yuyd7KBO+NWf9gckdxdIfw06ZCX2Chz7VtlqLyRuH14=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "8ceb37ec78b7ed723012bf71802abab9e50d9726",
+        "rev": "23c96506c8e652a59c88906b41b593c789f15680",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This brings in LLVM17, destructuring syntax (we don't use this yet), and some package manager fixes.