### PR TITLE
terminfo: add Smulx (underline styles) entry

### DIFF
--- a/src/terminfo/ghostty.zig
+++ b/src/terminfo/ghostty.zig
@@ -92,6 +92,9 @@ pub const ghostty: Source = .{
         // verified with some other terminals (looks similar).
         .{ .name = "acsc", .value = .{ .string = "++\\,\\,--..00``aaffgghhiijjkkllmmnnooppqqrrssttuuvvwwxxyyzz{{||}}~~" } },
 
+        // Curly, dashed, etc underlines
+        .{ .name = "Smulx", .value = .{ .string = "\\E[4:%p1%dm" } },
+
         // These are all capabilities that should be pretty straightforward
         // and map to input sequences.
         .{ .name = "bel", .value = .{ .string = "^G" } },


### PR DESCRIPTION
Add a terminfo entry for Smulx, which advertises support for curly, dashed, dotted, etc underlines