### PR TITLE
terminal: fix alacritty tests insert_blank_reset and saved_cursor

### DIFF
--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -77,6 +77,10 @@ pwd: std.ArrayList(u8),
 /// The charset state
 charset: CharsetState = .{},
 
+/// The saved charset state. This state is saved / restored along with the
+/// cursor state
+saved_charset: CharsetState = .{},
+
 /// The color palette to use
 color_palette: color.Palette = color.default,
 
@@ -419,6 +423,8 @@ fn plainString(self: *Terminal, alloc: Allocator) ![]const u8 {
 /// was already saved it is overwritten.
 pub fn saveCursor(self: *Terminal) void {
     self.screen.saved_cursor = self.screen.cursor;
+    self.saved_charset = self.charset;
+    self.modes.save(.origin);
 }
 
 /// Restore cursor position and other state.
@@ -427,6 +433,8 @@ pub fn saveCursor(self: *Terminal) void {
 /// If no save was done before values are reset to their initial values.
 pub fn restoreCursor(self: *Terminal) void {
     self.screen.cursor = self.screen.saved_cursor;
+    self.charset = self.saved_charset;
+    _ = self.modes.restore(.origin);
 }
 
 /// TODO: test
@@ -1442,6 +1450,8 @@ pub fn linefeed(self: *Terminal) !void {
 /// region are lost. The cursor position is not changed.
 ///
 /// This unsets the pending wrap state without wrapping.
+///
+/// The inserted cells are colored according to the current SGR state.
 pub fn insertBlanks(self: *Terminal, count: usize) void {
     const tracy = trace(@src());
     defer tracy.end();
@@ -2912,4 +2922,22 @@ test "Terminal: resize less cols with wide char then print" {
     try t.resize(alloc, 2, 3);
     t.setCursorPos(1, 2);
     try t.print('😀'); // 0x1F600
+}
+
+test "Terminal: saveCursor" {
+    const alloc = testing.allocator;
+    var t = try init(alloc, 3, 3);
+    defer t.deinit(alloc);
+
+    t.screen.cursor.pen.attrs.bold = true;
+    t.charset.gr = .G3;
+    t.modes.set(.origin, true);
+    t.saveCursor();
+    t.charset.gr = .G0;
+    t.screen.cursor.pen.attrs.bold = false;
+    t.modes.set(.origin, false);
+    t.restoreCursor();
+    try testing.expect(t.screen.cursor.pen.attrs.bold);
+    try testing.expect(t.charset.gr == .G3);
+    try testing.expect(t.modes.get(.origin));
 }

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1442,8 +1442,6 @@ pub fn linefeed(self: *Terminal) !void {
 /// region are lost. The cursor position is not changed.
 ///
 /// This unsets the pending wrap state without wrapping.
-///
-/// The inserted cells are colored according to the current SGR state.
 pub fn insertBlanks(self: *Terminal, count: usize) void {
     const tracy = trace(@src());
     defer tracy.end();
@@ -1483,9 +1481,7 @@ pub fn insertBlanks(self: *Terminal, count: usize) void {
     }
 
     // Insert zero
-    var pen = self.screen.cursor.pen;
-    pen.char = ' '; // NOTE: this should be 0 but we need space for tests
-    row.fillSlice(pen, start, pivot);
+    row.fillSlice(.{}, start, pivot);
 }
 
 /// Insert amount lines at the current cursor row. The contents of the line
@@ -2615,6 +2611,7 @@ test "Terminal: insertBlanks" {
     try t.print('A');
     try t.print('B');
     try t.print('C');
+    t.screen.cursor.pen.attrs.bold = true;
     t.setCursorPos(1, 1);
     t.insertBlanks(2);
 
@@ -2622,6 +2619,8 @@ test "Terminal: insertBlanks" {
         var str = try t.plainString(testing.allocator);
         defer testing.allocator.free(str);
         try testing.expectEqualStrings("  ABC", str);
+        const cell = t.screen.getCell(.active, 0, 0);
+        try testing.expect(!cell.attrs.bold);
     }
 }
 


### PR DESCRIPTION
Fix alacritty/insert_blank_reset and alacritty/saved_cursor. There will need to be some changes to how the cursor is saved to handle saving of cursor/mode/charset state for the primary screen and the alternate screen (each screen should have it's own state). Those fixes, are not implemented here, but this does add the necessary tests to ensure we don't regress when we have to change that.