### PR TITLE
Specify font for specific codepoint ranges

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -224,6 +224,11 @@ pub fn init(
         var group = try font.Group.init(alloc, font_lib, font_size);
         errdefer group.deinit();
 
+        // If we have codepoint mappings, set those.
+        if (config.@"font-codepoint-map".map.list.len > 0) {
+            group.codepoint_map = config.@"font-codepoint-map".map;
+        }
+
         // Search for fonts
         if (font.Discover != void) discover: {
             const disco = try app.fontDiscover() orelse {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -104,6 +104,9 @@ const c = @cImport({
 ///
 /// This configuration can be repeated multiple times to specify multiple
 /// codepoint mappings.
+///
+/// Changing this configuration at runtime will only affect new terminals,
+/// i.e. new windows, tabs, etc.
 @"font-codepoint-map": RepeatableCodepointMap = .{},
 
 /// Draw fonts with a thicker stroke, if supported. This is only supported

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1543,7 +1543,10 @@ pub const RepeatableCodepointMap = struct {
         while (try p.next()) |range| {
             try self.map.add(alloc, .{
                 .range = range,
-                .descriptor = .{ .family = valueZ },
+                .descriptor = .{
+                    .family = valueZ,
+                    .monospace = false, // we allow any font
+                },
             });
         }
     }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1678,8 +1678,8 @@ pub const RepeatableCodepointMap = struct {
 
         var list: Self = .{};
         try list.parseCLI(alloc, "U+ABCD=Comic Sans");
-        try list.parseCLI(alloc, "U+0001-U+0005=Verdana");
-        try list.parseCLI(alloc, "U+0006-U+0009,U+ABCD=Courier");
+        try list.parseCLI(alloc, "U+0001 - U+0005=Verdana");
+        try list.parseCLI(alloc, "U+0006-U+0009, U+ABCD=Courier");
 
         try testing.expectEqual(@as(usize, 4), list.map.list.len);
         {
@@ -1703,27 +1703,6 @@ pub const RepeatableCodepointMap = struct {
             try testing.expectEqualStrings("Courier", entry.descriptor.family.?);
         }
     }
-
-    // test "parseCLI with whitespace" {
-    //     const testing = std.testing;
-    //     var arena = ArenaAllocator.init(testing.allocator);
-    //     defer arena.deinit();
-    //     const alloc = arena.allocator();
-    //
-    //     var list: Self = .{};
-    //     try list.parseCLI(alloc, "wght =200");
-    //     try list.parseCLI(alloc, "slnt= -15");
-    //
-    //     try testing.expectEqual(@as(usize, 2), list.list.items.len);
-    //     try testing.expectEqual(fontpkg.face.Variation{
-    //         .id = fontpkg.face.Variation.Id.init("wght"),
-    //         .value = 200,
-    //     }, list.list.items[0]);
-    //     try testing.expectEqual(fontpkg.face.Variation{
-    //         .id = fontpkg.face.Variation.Id.init("slnt"),
-    //         .value = -15,
-    //     }, list.list.items[1]);
-    // }
 };
 
 /// Options for copy on select behavior.

--- a/src/font/CodepointMap.zig
+++ b/src/font/CodepointMap.zig
@@ -1,0 +1,48 @@
+/// CodepointMap is a map of codepoints to a discovery descriptor of a font
+/// to use for that codepoint. If the descriptor doesn't return any matching
+/// font, the codepoint is rendered using the default font.
+const CodepointMap = @This();
+
+const std = @import("std");
+const assert = std.debug.assert;
+const Allocator = std.mem.Allocator;
+const discovery = @import("discovery.zig");
+
+pub const Entry = struct {
+    /// Unicode codepoint range. Asserts range[0] <= range[1].
+    range: [2]u21,
+
+    /// The discovery descriptor of the font to use for this range.
+    descriptor: discovery.Descriptor,
+};
+
+/// The list of entries. We use a multiarraylist because Descriptors are
+/// quite large and we will very rarely match, so we'd rather pack our
+/// ranges together to make everything more cache friendly for lookups.
+///
+/// Note: we just do a linear search because we expect to always have very
+/// few entries, so the overhead of a binary search is not worth it. This is
+/// possible to defeat with some pathological inputs, but there is no realistic
+/// scenario where this will be a problem except people trying to fuck around.
+list: std.MultiArrayList(Entry) = .{},
+
+/// Add an entry to the map.
+///
+/// For conflicting codepoints, entries added later take priority over
+/// entries added earlier.
+pub fn add(self: *CodepointMap, alloc: Allocator, entry: Entry) !void {
+    assert(entry.range[0] <= entry.range[1]);
+    try self.list.append(alloc, entry);
+}
+
+/// Get a descriptor for a codepoint.
+pub fn get(self: *const CodepointMap, cp: u21) ?discovery.Descriptor {
+    for (self.list.items(.range), 0..) |range, i| {
+        if (range[0] <= cp and cp <= range[1]) {
+            const descs = self.list.items(.descriptor);
+            return descs[i];
+        }
+    }
+
+    return null;
+}

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -32,6 +32,7 @@ const log = std.log.scoped(.font_group);
 // most important memory efficiency we can look for. This is totally opaque
 // to the user so we can change this later.
 const StyleArray = std.EnumArray(Style, std.ArrayListUnmanaged(GroupFace));
+
 /// The allocator for this group
 alloc: Allocator,
 

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -213,7 +213,7 @@ pub fn setSize(self: *Group, size: font.face.DesiredSize) !void {
 
 /// This represents a specific font in the group.
 pub const FontIndex = packed struct(FontIndex.Backing) {
-    const Backing = u8;
+    const Backing = u16;
     const backing_bits = @typeInfo(Backing).Int.bits;
 
     /// The number of bits we use for the index.
@@ -255,6 +255,10 @@ pub const FontIndex = packed struct(FontIndex.Backing) {
         // everywhere so if we increase the size of this we'll dramatically
         // increase our memory usage.
         try std.testing.expectEqual(@sizeOf(Backing), @sizeOf(FontIndex));
+
+        // Just so we're aware when this changes. The current maximum number
+        // of fonts for a style is 13 bits or 8192 fonts.
+        try std.testing.expectEqual(13, idx_bits);
     }
 };
 

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -402,7 +402,16 @@ fn indexForCodepointOverride(self: *Group, cp: u32) !?FontIndex {
     const idx = idx_ orelse return null;
 
     // We need to verify that this index has the codepoint we want.
-    return if (self.hasCodepoint(idx, cp, null)) idx else null;
+    if (self.hasCodepoint(idx, cp, null)) {
+        log.debug("codepoint override based on config codepoint={} family={s}", .{
+            cp,
+            desc.family orelse "",
+        });
+
+        return idx;
+    }
+
+    return null;
 }
 
 /// Check if a specific font index has a specific codepoint. This does not

--- a/src/font/main.zig
+++ b/src/font/main.zig
@@ -5,6 +5,7 @@ const build_config = @import("../build_config.zig");
 pub const Atlas = @import("Atlas.zig");
 pub const discovery = @import("discovery.zig");
 pub const face = @import("face.zig");
+pub const CodepointMap = @import("CodepointMap.zig");
 pub const DeferredFace = @import("DeferredFace.zig");
 pub const Face = face.Face;
 pub const Group = @import("Group.zig");


### PR DESCRIPTION
Fixes #446 

This adds a new `font-codepoint-map` configuration which lets you specify a font to use for specific codepoint ranges. This configuration can be repeated to add multiple mappings. This feature is useful for bringing in certain private use codepoints (such as Powerline symbols), overriding the font discovery mechanism for a codepoint to use the exact font you want, or just choosing a font for a symbol you think renders better.

Example configurations:

```
font-codepoint-map = U+1234 = Source Code Pro
font-codepoint-map = U+1234-U+5678 = Verdana
font-codepoint-map = U+1234,U+5678 = Arial Black
font-codepoint-map = U+1234,U+5678-U+9ABC = Iosevka
# etc...
```

## Performance

If you don't use this configuration, this has almost no runtime performance. There is a very small memory cost (a handful of bytes) and a very small CPU cost (one boolean check) and otherwise nothing.

If you do use this configuration, we do some things to make performance quite good:

  * Specific codepoint lookups are cached
  * Matching font descriptors are deduped so if a font was already loaded for the matching font, it is reused
  * Non-matching fonts are also cached, so if you use a bogus font name then we don't waste every codepoint looking for it

## Demo

A toy example that is exaggerated to show this working.

https://github.com/mitchellh/ghostty/assets/1299/e1248ae9-9dc6-4eaf-936b-d2263bec6387

