### PR TITLE
terminal: use ST instead of BEL terminator for XTVERSION

### DIFF
--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1697,7 +1697,7 @@ const StreamHandler = struct {
         var buf: [288]u8 = undefined;
         const resp = try std.fmt.bufPrint(
             &buf,
-            "\x1BP>|{s} {s}\x07",
+            "\x1BP>|{s} {s}\x1B\\",
             .{
                 "ghostty",
                 build_config.version_string,


### PR DESCRIPTION
The XTVERSION response should use a string terminator instead of a bell. Most terminals can handle the bell, however specifically tmux does not like it.

Fixes: #534