### PR TITLE
DEC Protected Mode (DECSCA, DECSEL, DECSED)

### DIFF
--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -232,6 +232,7 @@ pub const Cell = struct {
         strikethrough: bool = false,
         underline: sgr.Attribute.Underline = .none,
         underline_color: bool = false,
+        protected: bool = false,
 
         /// True if this is a wide character. This char takes up
         /// two cells. The following cell ALWAYS is a space.

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -213,7 +213,7 @@ pub fn alternateScreen(
     self.screen.selection = null;
 
     if (options.clear_on_enter) {
-        self.eraseDisplay(alloc, .complete);
+        self.eraseDisplay(alloc, .complete, false);
     }
 }
 
@@ -232,7 +232,7 @@ pub fn primaryScreen(
     // TODO(mitchellh): what happens if we enter alternate screen multiple times?
     if (self.active_screen == .primary) return;
 
-    if (options.clear_on_exit) self.eraseDisplay(alloc, .complete);
+    if (options.clear_on_exit) self.eraseDisplay(alloc, .complete, false);
 
     // Switch the screens
     const old = self.screen;
@@ -279,7 +279,7 @@ pub fn deccolm(self: *Terminal, alloc: Allocator, mode: DeccolmMode) !void {
     try self.resize(alloc, 0, self.rows);
 
     // TODO: do not clear screen flag mode
-    self.eraseDisplay(alloc, .complete);
+    self.eraseDisplay(alloc, .complete, false);
     self.setCursorPos(1, 1);
 
     // TODO: left/right margins
@@ -1010,6 +1010,7 @@ pub fn eraseDisplay(
     self: *Terminal,
     alloc: Allocator,
     mode: csi.EraseDisplay,
+    protected: bool,
 ) void {
     const tracy = trace(@src());
     defer tracy.end();
@@ -1026,7 +1027,18 @@ pub fn eraseDisplay(
             while (it.next()) |row| {
                 row.setWrapped(false);
                 row.setDirty(true);
-                row.clear(pen);
+
+                if (!protected) {
+                    row.clear(pen);
+                    continue;
+                }
+
+                // Protected mode erase
+                for (0..row.lenCells()) |x| {
+                    const cell = row.getCellPtr(x);
+                    if (cell.attrs.protected) continue;
+                    cell.* = pen;
+                }
             }
 
             // Unsets pending wrap state
@@ -1045,6 +1057,7 @@ pub fn eraseDisplay(
                 for (self.screen.cursor.x..self.cols) |x| {
                     if (row.header().flags.grapheme) row.clearGraphemes(x);
                     const cell = row.getCellPtr(x);
+                    if (protected and cell.attrs.protected) continue;
                     cell.* = pen;
                     cell.char = 0;
                 }
@@ -1058,6 +1071,7 @@ pub fn eraseDisplay(
                 for (0..self.cols) |x| {
                     if (row.header().flags.grapheme) row.clearGraphemes(x);
                     const cell = row.getCellPtr(x);
+                    if (protected and cell.attrs.protected) continue;
                     cell.* = pen;
                     cell.char = 0;
                 }
@@ -1072,6 +1086,7 @@ pub fn eraseDisplay(
             var x: usize = 0;
             while (x <= self.screen.cursor.x) : (x += 1) {
                 const cell = self.screen.getCellPtr(.active, self.screen.cursor.y, x);
+                if (protected and cell.attrs.protected) continue;
                 cell.* = pen;
                 cell.char = 0;
             }
@@ -1082,6 +1097,7 @@ pub fn eraseDisplay(
                 x = 0;
                 while (x < self.cols) : (x += 1) {
                     const cell = self.screen.getCellPtr(.active, y, x);
+                    if (protected and cell.attrs.protected) continue;
                     cell.* = pen;
                     cell.char = 0;
                 }
@@ -1121,7 +1137,7 @@ test "Terminal: eraseDisplay above" {
     t.screen.cursor.y = 40;
     t.screen.cursor.x = 40;
     // erase above the cursor
-    t.eraseDisplay(testing.allocator, .above);
+    t.eraseDisplay(testing.allocator, .above, false);
     // check it was erased
     cell = t.screen.getCell(.active, 0, 0);
     try testing.expect(cell.bg.eql(pink));
@@ -1158,7 +1174,7 @@ test "Terminal: eraseDisplay below" {
     try testing.expect(cell.char == 'a');
     try testing.expect(cell.attrs.bold);
     // erase below the cursor
-    t.eraseDisplay(testing.allocator, .below);
+    t.eraseDisplay(testing.allocator, .below, false);
     // check it was erased
     cell = t.screen.getCell(.active, 60, 60);
     try testing.expect(cell.bg.eql(pink));
@@ -1202,7 +1218,7 @@ test "Terminal: eraseDisplay complete" {
     // position our cursor between the cells
     t.screen.cursor.y = 30;
     // erase everything
-    t.eraseDisplay(testing.allocator, .complete);
+    t.eraseDisplay(testing.allocator, .complete, false);
     // check they were erased
     cell = t.screen.getCell(.active, 60, 60);
     try testing.expect(cell.bg.eql(pink));
@@ -1781,8 +1797,8 @@ pub fn fullReset(self: *Terminal, alloc: Allocator) void {
     self.screen.kitty_keyboard = .{};
     self.scrolling_region = .{ .top = 0, .bottom = self.rows - 1 };
     self.previous_char = null;
-    self.eraseDisplay(alloc, .scrollback);
-    self.eraseDisplay(alloc, .complete);
+    self.eraseDisplay(alloc, .scrollback, false);
+    self.eraseDisplay(alloc, .complete, false);
     self.pwd.clearRetainingCapacity();
 }
 
@@ -3064,5 +3080,71 @@ test "Terminal: eraseLine protected complete" {
         var str = try t.plainString(testing.allocator);
         defer testing.allocator.free(str);
         try testing.expectEqualStrings("     X", str);
+    }
+}
+
+test "Terminal: eraseDisplay protected complete" {
+    const alloc = testing.allocator;
+    var t = try init(alloc, 10, 5);
+    defer t.deinit(alloc);
+
+    try t.print('A');
+    t.carriageReturn();
+    try t.linefeed();
+    for ("123456789") |c| try t.print(c);
+    t.setCursorColAbsolute(6);
+    t.setProtectedMode(.dec);
+    try t.print('X');
+    t.setCursorColAbsolute(4);
+    t.eraseDisplay(alloc, .complete, true);
+
+    {
+        var str = try t.plainString(testing.allocator);
+        defer testing.allocator.free(str);
+        try testing.expectEqualStrings("\n     X", str);
+    }
+}
+
+test "Terminal: eraseDisplay protected below" {
+    const alloc = testing.allocator;
+    var t = try init(alloc, 10, 5);
+    defer t.deinit(alloc);
+
+    try t.print('A');
+    t.carriageReturn();
+    try t.linefeed();
+    for ("123456789") |c| try t.print(c);
+    t.setCursorColAbsolute(6);
+    t.setProtectedMode(.dec);
+    try t.print('X');
+    t.setCursorColAbsolute(4);
+    t.eraseDisplay(alloc, .below, true);
+
+    {
+        var str = try t.plainString(testing.allocator);
+        defer testing.allocator.free(str);
+        try testing.expectEqualStrings("A\n123  X", str);
+    }
+}
+
+test "Terminal: eraseDisplay protected above" {
+    const alloc = testing.allocator;
+    var t = try init(alloc, 10, 5);
+    defer t.deinit(alloc);
+
+    try t.print('A');
+    t.carriageReturn();
+    try t.linefeed();
+    for ("123456789") |c| try t.print(c);
+    t.setCursorColAbsolute(6);
+    t.setProtectedMode(.dec);
+    try t.print('X');
+    t.setCursorColAbsolute(8);
+    t.eraseDisplay(alloc, .above, true);
+
+    {
+        var str = try t.plainString(testing.allocator);
+        defer testing.allocator.free(str);
+        try testing.expectEqualStrings("\n     X  9", str);
     }
 }

--- a/src/terminal/ansi.zig
+++ b/src/terminal/ansi.zig
@@ -111,3 +111,11 @@ pub const ModifyKeyFormat = union(enum) {
     function_keys: void,
     other_keys: enum { none, numeric_except, numeric },
 };
+
+/// The protection modes that can be set for the terminal. See DECSCA and
+/// ESC V, W.
+pub const ProtectedMode = enum {
+    off,
+    iso, // ESC V, W
+    dec, // CSI Ps " q
+};

--- a/src/terminal/main.zig
+++ b/src/terminal/main.zig
@@ -28,6 +28,7 @@ pub const DeviceAttributeReq = ansi.DeviceAttributeReq;
 pub const DeviceStatusReq = ansi.DeviceStatusReq;
 pub const Mode = modes.Mode;
 pub const ModifyKeyFormat = ansi.ModifyKeyFormat;
+pub const ProtectedMode = ansi.ProtectedMode;
 pub const StatusLineType = ansi.StatusLineType;
 pub const StatusDisplay = ansi.StatusDisplay;
 pub const EraseDisplay = csi.EraseDisplay;

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -259,45 +259,58 @@ pub fn Stream(comptime Handler: type) type {
                 ) else log.warn("unimplemented CSI callback: {}", .{action}),
 
                 // Erase Display
-                // TODO: test
-                'J' => if (@hasDecl(T, "eraseDisplay")) try self.handler.eraseDisplay(
-                    switch (action.params.len) {
-                        0 => .below,
-                        1 => mode: {
-                            // TODO: use meta to get enum max
-                            if (action.params[0] > 3) {
-                                log.warn("invalid erase display command: {}", .{action});
-                                return;
-                            }
+                'J' => if (@hasDecl(T, "eraseDisplay")) {
+                    const protected_: ?bool = switch (action.intermediates.len) {
+                        0 => false,
+                        1 => if (action.intermediates[0] == '?') true else null,
+                        else => null,
+                    };
 
-                            break :mode @enumFromInt(action.params[0]);
-                        },
-                        else => {
-                            log.warn("invalid erase display command: {}", .{action});
-                            return;
-                        },
-                    },
-                ) else log.warn("unimplemented CSI callback: {}", .{action}),
+                    const protected = protected_ orelse {
+                        log.warn("invalid erase display command: {}", .{action});
+                        return;
+                    };
+
+                    const mode_: ?csi.EraseDisplay = switch (action.params.len) {
+                        0 => .below,
+                        1 => if (action.params[0] <= 3) @enumFromInt(action.params[0]) else null,
+                        else => null,
+                    };
+
+                    const mode = mode_ orelse {
+                        log.warn("invalid erase display command: {}", .{action});
+                        return;
+                    };
+
+                    try self.handler.eraseDisplay(mode, protected);
+                } else log.warn("unimplemented CSI callback: {}", .{action}),
 
                 // Erase Line
-                'K' => if (@hasDecl(T, "eraseLine")) try self.handler.eraseLine(
-                    switch (action.params.len) {
-                        0 => .right,
-                        1 => mode: {
-                            // TODO: use meta to get enum max
-                            if (action.params[0] > 3) {
-                                log.warn("invalid erase line command: {}", .{action});
-                                return;
-                            }
+                'K' => if (@hasDecl(T, "eraseLine")) {
+                    const protected_: ?bool = switch (action.intermediates.len) {
+                        0 => false,
+                        1 => if (action.intermediates[0] == '?') true else null,
+                        else => null,
+                    };
 
-                            break :mode @enumFromInt(action.params[0]);
-                        },
-                        else => {
-                            log.warn("invalid erase line command: {}", .{action});
-                            return;
-                        },
-                    },
-                ) else log.warn("unimplemented CSI callback: {}", .{action}),
+                    const protected = protected_ orelse {
+                        log.warn("invalid erase line command: {}", .{action});
+                        return;
+                    };
+
+                    const mode_: ?csi.EraseLine = switch (action.params.len) {
+                        0 => .right,
+                        1 => if (action.params[0] < 3) @enumFromInt(action.params[0]) else null,
+                        else => null,
+                    };
+
+                    const mode = mode_ orelse {
+                        log.warn("invalid erase line command: {}", .{action});
+                        return;
+                    };
+
+                    try self.handler.eraseLine(mode, protected);
+                } else log.warn("unimplemented CSI callback: {}", .{action}),
 
                 // IL - Insert Lines
                 // TODO: test
@@ -1252,5 +1265,135 @@ test "stream: DECSCA" {
     {
         for ("\x1B[1\"q") |c| try s.next(c);
         try testing.expectEqual(ansi.ProtectedMode.dec, s.handler.v.?);
+    }
+}
+
+test "stream: DECED, DECSED" {
+    const H = struct {
+        const Self = @This();
+        mode: ?csi.EraseDisplay = null,
+        protected: ?bool = null,
+
+        pub fn eraseDisplay(
+            self: *Self,
+            mode: csi.EraseDisplay,
+            protected: bool,
+        ) !void {
+            self.mode = mode;
+            self.protected = protected;
+        }
+    };
+
+    var s: Stream(H) = .{ .handler = .{} };
+    {
+        for ("\x1B[?J") |c| try s.next(c);
+        try testing.expectEqual(csi.EraseDisplay.below, s.handler.mode.?);
+        try testing.expect(s.handler.protected.?);
+    }
+    {
+        for ("\x1B[?0J") |c| try s.next(c);
+        try testing.expectEqual(csi.EraseDisplay.below, s.handler.mode.?);
+        try testing.expect(s.handler.protected.?);
+    }
+    {
+        for ("\x1B[?1J") |c| try s.next(c);
+        try testing.expectEqual(csi.EraseDisplay.above, s.handler.mode.?);
+        try testing.expect(s.handler.protected.?);
+    }
+    {
+        for ("\x1B[?2J") |c| try s.next(c);
+        try testing.expectEqual(csi.EraseDisplay.complete, s.handler.mode.?);
+        try testing.expect(s.handler.protected.?);
+    }
+    {
+        for ("\x1B[?3J") |c| try s.next(c);
+        try testing.expectEqual(csi.EraseDisplay.scrollback, s.handler.mode.?);
+        try testing.expect(s.handler.protected.?);
+    }
+
+    {
+        for ("\x1B[J") |c| try s.next(c);
+        try testing.expectEqual(csi.EraseDisplay.below, s.handler.mode.?);
+        try testing.expect(!s.handler.protected.?);
+    }
+    {
+        for ("\x1B[0J") |c| try s.next(c);
+        try testing.expectEqual(csi.EraseDisplay.below, s.handler.mode.?);
+        try testing.expect(!s.handler.protected.?);
+    }
+    {
+        for ("\x1B[1J") |c| try s.next(c);
+        try testing.expectEqual(csi.EraseDisplay.above, s.handler.mode.?);
+        try testing.expect(!s.handler.protected.?);
+    }
+    {
+        for ("\x1B[2J") |c| try s.next(c);
+        try testing.expectEqual(csi.EraseDisplay.complete, s.handler.mode.?);
+        try testing.expect(!s.handler.protected.?);
+    }
+    {
+        for ("\x1B[3J") |c| try s.next(c);
+        try testing.expectEqual(csi.EraseDisplay.scrollback, s.handler.mode.?);
+        try testing.expect(!s.handler.protected.?);
+    }
+}
+
+test "stream: DECEL, DECSEL" {
+    const H = struct {
+        const Self = @This();
+        mode: ?csi.EraseLine = null,
+        protected: ?bool = null,
+
+        pub fn eraseLine(
+            self: *Self,
+            mode: csi.EraseLine,
+            protected: bool,
+        ) !void {
+            self.mode = mode;
+            self.protected = protected;
+        }
+    };
+
+    var s: Stream(H) = .{ .handler = .{} };
+    {
+        for ("\x1B[?K") |c| try s.next(c);
+        try testing.expectEqual(csi.EraseLine.right, s.handler.mode.?);
+        try testing.expect(s.handler.protected.?);
+    }
+    {
+        for ("\x1B[?0K") |c| try s.next(c);
+        try testing.expectEqual(csi.EraseLine.right, s.handler.mode.?);
+        try testing.expect(s.handler.protected.?);
+    }
+    {
+        for ("\x1B[?1K") |c| try s.next(c);
+        try testing.expectEqual(csi.EraseLine.left, s.handler.mode.?);
+        try testing.expect(s.handler.protected.?);
+    }
+    {
+        for ("\x1B[?2K") |c| try s.next(c);
+        try testing.expectEqual(csi.EraseLine.complete, s.handler.mode.?);
+        try testing.expect(s.handler.protected.?);
+    }
+
+    {
+        for ("\x1B[K") |c| try s.next(c);
+        try testing.expectEqual(csi.EraseLine.right, s.handler.mode.?);
+        try testing.expect(!s.handler.protected.?);
+    }
+    {
+        for ("\x1B[0K") |c| try s.next(c);
+        try testing.expectEqual(csi.EraseLine.right, s.handler.mode.?);
+        try testing.expect(!s.handler.protected.?);
+    }
+    {
+        for ("\x1B[1K") |c| try s.next(c);
+        try testing.expectEqual(csi.EraseLine.left, s.handler.mode.?);
+        try testing.expect(!s.handler.protected.?);
+    }
+    {
+        for ("\x1B[2K") |c| try s.next(c);
+        try testing.expectEqual(csi.EraseLine.complete, s.handler.mode.?);
+        try testing.expect(!s.handler.protected.?);
     }
 }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1317,8 +1317,7 @@ const StreamHandler = struct {
     }
 
     pub fn eraseLine(self: *StreamHandler, mode: terminal.EraseLine, protected: bool) !void {
-        _ = protected;
-        self.terminal.eraseLine(mode);
+        self.terminal.eraseLine(mode, protected);
     }
 
     pub fn deleteChars(self: *StreamHandler, count: usize) !void {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1305,15 +1305,13 @@ const StreamHandler = struct {
     }
 
     pub fn eraseDisplay(self: *StreamHandler, mode: terminal.EraseDisplay, protected: bool) !void {
-        _ = protected;
-
         if (mode == .complete) {
             // Whenever we erase the full display, scroll to bottom.
             try self.terminal.scrollViewport(.{ .bottom = {} });
             try self.queueRender();
         }
 
-        self.terminal.eraseDisplay(self.alloc, mode);
+        self.terminal.eraseDisplay(self.alloc, mode, protected);
     }
 
     pub fn eraseLine(self: *StreamHandler, mode: terminal.EraseLine, protected: bool) !void {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1583,6 +1583,10 @@ const StreamHandler = struct {
         }
     }
 
+    pub fn setProtectedMode(self: *StreamHandler, mode: terminal.ProtectedMode) !void {
+        self.terminal.setProtectedMode(mode);
+    }
+
     pub fn decaln(self: *StreamHandler) !void {
         try self.terminal.decaln();
     }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1304,7 +1304,9 @@ const StreamHandler = struct {
         self.terminal.setCursorPos(row, col);
     }
 
-    pub fn eraseDisplay(self: *StreamHandler, mode: terminal.EraseDisplay) !void {
+    pub fn eraseDisplay(self: *StreamHandler, mode: terminal.EraseDisplay, protected: bool) !void {
+        _ = protected;
+
         if (mode == .complete) {
             // Whenever we erase the full display, scroll to bottom.
             try self.terminal.scrollViewport(.{ .bottom = {} });
@@ -1314,7 +1316,8 @@ const StreamHandler = struct {
         self.terminal.eraseDisplay(self.alloc, mode);
     }
 
-    pub fn eraseLine(self: *StreamHandler, mode: terminal.EraseLine) !void {
+    pub fn eraseLine(self: *StreamHandler, mode: terminal.EraseLine, protected: bool) !void {
+        _ = protected;
         self.terminal.eraseLine(mode);
     }
 


### PR DESCRIPTION
Related to #526, fixes `selective_erasure` test.

The Alacritty assertion state is actually wrong if you consider `xterm` the source of truth. 

## Screenshots

As you can see below, Ghostty matches xterm but the rest are non-compliant.

![CleanShot 2023-09-25 at 11 31 42@2x](https://github.com/mitchellh/ghostty/assets/1299/417cbc0e-b10a-4bee-8e22-fe132cfff537)
![CleanShot 2023-09-25 at 11 32 55@2x](https://github.com/mitchellh/ghostty/assets/1299/efed24e7-3267-4155-be1c-10bbea3e8ea9)
