### PR TITLE
Use bg attribute when erasing cells line-wise, or inserting new lines

### DIFF
--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1283,10 +1283,15 @@ pub fn eraseLine(
         },
     };
 
+    const pen: Screen.Cell = if (!self.screen.cursor.pen.attrs.has_bg) .{} else .{
+        .bg = self.screen.cursor.pen.bg,
+        .attrs = .{ .has_bg = true },
+    };
+
     for (start..end) |x| {
         const cell = row.getCellPtr(x);
         if (cell.attrs.protected) continue;
-        cell.* = self.screen.cursor.pen;
+        cell.* = pen;
     }
 }
 


### PR DESCRIPTION
Similar to eraseDisplay, the eraseLine method and scrollRegion method both erase and/or insert new cells. The new cells should have _only_ the bg attribute of the current cursor. Update tests to reflect this behavior.

Fixes: alacritty/scroll_up_reset in #526 