### PR TITLE
Reset pending wrap state audit

### DIFF
--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1601,6 +1601,7 @@ pub fn deleteLines(self: *Terminal, count: usize) !void {
 
     // Move the cursor to the left margin
     self.screen.cursor.x = 0;
+    self.screen.cursor.pending_wrap = false;
 
     // Perform the scroll
     self.screen.scrollRegionUp(
@@ -2364,6 +2365,24 @@ test "Terminal: deleteLines with scroll region, cursor outside of region" {
         var str = try t.plainString(testing.allocator);
         defer testing.allocator.free(str);
         try testing.expectEqualStrings("A\nB\nC\nD", str);
+    }
+}
+
+test "Terminal: deleteLines resets wrap" {
+    const alloc = testing.allocator;
+    var t = try init(alloc, 5, 5);
+    defer t.deinit(alloc);
+
+    for ("ABCDE") |c| try t.print(c);
+    try testing.expect(t.screen.cursor.pending_wrap);
+    try t.deleteLines(1);
+    try testing.expect(!t.screen.cursor.pending_wrap);
+    try t.print('B');
+
+    {
+        var str = try t.plainString(testing.allocator);
+        defer testing.allocator.free(str);
+        try testing.expectEqualStrings("B", str);
     }
 }
 

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1546,6 +1546,7 @@ pub fn insertLines(self: *Terminal, count: usize) !void {
 
     // Move the cursor to the left margin
     self.screen.cursor.x = 0;
+    self.screen.cursor.pending_wrap = false;
 
     // Remaining rows from our cursor
     const rem = self.scrolling_region.bottom - self.screen.cursor.y + 1;
@@ -2492,6 +2493,24 @@ test "Terminal: insertLines more than remaining" {
         var str = try t.plainString(testing.allocator);
         defer testing.allocator.free(str);
         try testing.expectEqualStrings("A", str);
+    }
+}
+
+test "Terminal: insertLines resets wrap" {
+    const alloc = testing.allocator;
+    var t = try init(alloc, 5, 5);
+    defer t.deinit(alloc);
+
+    for ("ABCDE") |c| try t.print(c);
+    try testing.expect(t.screen.cursor.pending_wrap);
+    try t.insertLines(1);
+    try testing.expect(!t.screen.cursor.pending_wrap);
+    try t.print('B');
+
+    {
+        var str = try t.plainString(testing.allocator);
+        defer testing.allocator.free(str);
+        try testing.expectEqualStrings("B\nABCDE", str);
     }
 }
 

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1356,9 +1356,9 @@ pub fn cursorLeft(self: *Terminal, count: usize) void {
     const tracy = trace(@src());
     defer tracy.end();
 
-    // TODO: scroll region, wrap
-
+    // TODO: scroll region
     self.screen.cursor.x -|= if (count == 0) 1 else count;
+    self.screen.cursor.pending_wrap = false;
 }
 
 /// Move the cursor right amount columns. If amount is greater than the
@@ -1385,6 +1385,7 @@ pub fn cursorDown(self: *Terminal, count: usize) void {
     const tracy = trace(@src());
     defer tracy.end();
 
+    self.screen.cursor.pending_wrap = false;
     self.screen.cursor.y += if (count == 0) 1 else count;
     if (self.screen.cursor.y >= self.rows) {
         self.screen.cursor.y = self.rows - 1;


### PR DESCRIPTION
Fixes #532
Related to #315 

I cracked open the xterm source code and found all the places they reset their wrap state (code paths that lead to calling `ResetWrap()`). I then went through our sequences and verified if we do or not. I also verified with shell scripts. I added test cases for all cases. I hope I got them all!

This would cause some really horrible rendering issues if they were exercised and they would be fairly insidious because it requires the perfect terminal state (though, not rare!) to witness it happening: you'd have to have the cursor at the edge of the screen, print a single character to set the wrap state, then invoke one of these affected sequences.