### PR TITLE
config: add term config option

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -411,6 +411,9 @@ keybind: Keybinds = .{},
 /// Debug builds of Ghostty have a separate single-instance ID.
 @"gtk-single-instance": bool = true,
 
+/// This will be used to set the TERM environment variable
+term: []const u8 = "ghostty",
+
 /// This is set by the CLI parser for deinit.
 _arena: ?ArenaAllocator = null,
 
@@ -897,6 +900,11 @@ pub fn finalize(self: *Config) !void {
                 @field(self, field) = family;
             }
         }
+    }
+
+    // Prevent setting TERM to an empty string
+    if (self.term.len == 0) {
+        self.term = "ghostty";
     }
 
     // The default for the working directory depends on the system.

--- a/src/terminfo/ghostty.zig
+++ b/src/terminfo/ghostty.zig
@@ -98,6 +98,12 @@ pub const ghostty: Source = .{
         // Colored underlines
         .{ .name = "Setulc", .value = .{ .string = "\\E[58:2::%p1%{65536}%/%d:%p1%{256}%/%{255}%&%d:%p1%{255}%&%d%;m" } },
 
+        // Cursor styles
+        .{ .name = "Ss", .value = .{ .string = "\\E[%p1%d q" } },
+
+        // Cursor style reset
+        .{ .name = "Se", .value = .{ .string = "\\E[2 q" } },
+
         // These are all capabilities that should be pretty straightforward
         // and map to input sequences.
         .{ .name = "bel", .value = .{ .string = "^G" } },

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -91,6 +91,7 @@ pub const DerivedConfig = struct {
     foreground: configpkg.Config.Color,
     background: configpkg.Config.Color,
     osc_color_report_format: configpkg.Config.OSCColorReportFormat,
+    term: []const u8,
 
     pub fn init(
         alloc_gpa: Allocator,
@@ -106,6 +107,7 @@ pub const DerivedConfig = struct {
             .foreground = config.foreground,
             .background = config.background,
             .osc_color_report_format = config.@"osc-color-report-format",
+            .term = config.term,
         };
     }
 
@@ -663,7 +665,7 @@ const Subprocess = struct {
         if (opts.resources_dir) |base| {
             var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
             const dir = try std.fmt.bufPrint(&buf, "{s}/terminfo", .{base});
-            try env.put("TERM", "xterm-ghostty");
+            try env.put("TERM", opts.config.term);
             try env.put("COLORTERM", "truecolor");
             try env.put("TERMINFO", dir);
         } else {


### PR DESCRIPTION
Add a configuration key for the TERM environment variable. Default this to "ghostty". Most TEs are using their name as the default TERM value. Most modern termulators aren't even providing "xterm-" as an alias anymore, after some drama between kitty / ncurses.

Notably, this also has issues for tcell-based applications (I've submitted a PR to tcell to fix) because it fails if the TERM value doesn't match the _primary_ name of the terminal in the terminfo file.

Providing a config option allows users to modify-with-persistence if they have issues, but Ghostty should be known as Ghostty by default!