### PR TITLE
quirks: CodeNewRoman should disable ligatures by default

### DIFF
--- a/src/quirks.zig
+++ b/src/quirks.zig
@@ -19,9 +19,10 @@ pub fn disableDefaultFontFeatures(face: *const font.Face) bool {
         error.OutOfMemory => return false,
     };
 
-    // Menlo and Monaco both have a default ligature of "fi" that looks
-    // really bad in terminal grids, so we want to disable ligatures
+    // CodeNewRoman, Menlo and Monaco both have a default ligature of "fi" that
+    // looks really bad in terminal grids, so we want to disable ligatures
     // by default for these faces.
-    return std.mem.eql(u8, name, "Menlo") or
+    return std.mem.eql(u8, name, "CodeNewRoman") or
+        std.mem.eql(u8, name, "Menlo") or
         std.mem.eql(u8, name, "Monaco");
 }


### PR DESCRIPTION
Updated the quirks file to include my buggy font. Tested and it worked fine.