### PR TITLE
Ability to disable font styles 

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -229,6 +229,11 @@ pub fn init(
             group.codepoint_map = config.@"font-codepoint-map".map;
         }
 
+        // Set our styles
+        group.styles.set(.bold, config.@"font-style-bold" != .false);
+        group.styles.set(.italic, config.@"font-style-italic" != .false);
+        group.styles.set(.bold_italic, config.@"font-style-bold-italic" != .false);
+
         // Search for fonts
         if (font.Discover != void) discover: {
             const disco = try app.fontDiscover() orelse {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -243,7 +243,7 @@ pub fn init(
             if (config.@"font-family") |family| {
                 var disco_it = try disco.discover(.{
                     .family = family,
-                    .style = config.@"font-style",
+                    .style = config.@"font-style".nameValue(),
                     .size = font_size.points,
                     .variations = config.@"font-variation".list.items,
                 });
@@ -256,7 +256,7 @@ pub fn init(
             if (config.@"font-family-bold") |family| {
                 var disco_it = try disco.discover(.{
                     .family = family,
-                    .style = config.@"font-style-bold",
+                    .style = config.@"font-style-bold".nameValue(),
                     .size = font_size.points,
                     .bold = true,
                     .variations = config.@"font-variation-bold".list.items,
@@ -270,7 +270,7 @@ pub fn init(
             if (config.@"font-family-italic") |family| {
                 var disco_it = try disco.discover(.{
                     .family = family,
-                    .style = config.@"font-style-italic",
+                    .style = config.@"font-style-italic".nameValue(),
                     .size = font_size.points,
                     .italic = true,
                     .variations = config.@"font-variation-italic".list.items,
@@ -284,7 +284,7 @@ pub fn init(
             if (config.@"font-family-bold-italic") |family| {
                 var disco_it = try disco.discover(.{
                     .family = family,
-                    .style = config.@"font-style-bold-italic",
+                    .style = config.@"font-style-bold-italic".nameValue(),
                     .size = font_size.points,
                     .bold = true,
                     .italic = true,

--- a/src/cli/args.zig
+++ b/src/cli/args.zig
@@ -154,10 +154,11 @@ fn parseIntoField(
                 else => field.type,
             };
 
-            // If we are a struct and have parseCLI, we call that and use
-            // that to set the value.
-            switch (@typeInfo(Field)) {
-                .Struct => if (@hasDecl(Field, "parseCLI")) {
+            // If we are a type that can have decls and have a parseCLI decl,
+            // we call that and use that to set the value.
+            const fieldInfo = @typeInfo(Field);
+            if (fieldInfo == .Struct or fieldInfo == .Union or fieldInfo == .Enum) {
+                if (@hasDecl(Field, "parseCLI")) {
                     const fnInfo = @typeInfo(@TypeOf(Field.parseCLI)).Fn;
                     switch (fnInfo.params.len) {
                         // 1 arg = (input) => output
@@ -182,8 +183,10 @@ fn parseIntoField(
                     }
 
                     return;
-                },
+                }
+            }
 
+            switch (fieldInfo) {
                 .Enum => {
                     @field(dst, field.name) = std.meta.stringToEnum(
                         Field,

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -33,8 +33,15 @@ const c = @cImport({
 /// styles. This looks up the style based on the font style string advertised
 /// by the font itself. For example, "Iosevka Heavy" has a style of "Heavy".
 ///
+/// You can also use these fields to completely disable a font style. If
+/// you set the value of the configuration below to literal "false" then
+/// that font style will be disabled. If the running program in the terminal
+/// requests a disabled font style, the regular font style will be used
+/// instead.
+///
 /// These are only valid if there is an exact font-family also specified.
-/// If no font-family is specified, then the font-style is ignored.
+/// If no font-family is specified, then the font-style is ignored unless
+/// you're disabling the font style.
 @"font-style": FontStyle = .{ .default = {} },
 @"font-style-bold": FontStyle = .{ .default = {} },
 @"font-style-italic": FontStyle = .{ .default = {} },

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -34,7 +34,7 @@ const log = std.log.scoped(.font_group);
 const StyleArray = std.EnumArray(Style, std.ArrayListUnmanaged(GroupFace));
 
 /// Packed array of booleans to indicate if a style is enabled or not.
-const StyleStatus = std.EnumArray(Style, bool);
+pub const StyleStatus = std.EnumArray(Style, bool);
 
 /// Map of descriptors to faces. This is used with manual codepoint maps
 /// to ensure that we don't load the same font multiple times.

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -975,13 +975,14 @@ fn prepKittyGraphics(
 
 /// Update the configuration.
 pub fn changeConfig(self: *Metal, config: *DerivedConfig) !void {
-    // If font thickening settings change, we need to reset our
-    // font texture completely because we need to re-render the glyphs.
-    if (self.config.font_thicken != config.font_thicken) {
-        self.font_group.reset();
-        self.font_group.atlas_greyscale.clear();
-        self.font_group.atlas_color.clear();
-    }
+    // On configuration change we always reset our font group. There
+    // are a variety of configurations that can change font settings
+    // so to be safe we just always reset it. This has a performance hit
+    // when its not necessary but config reloading shouldn't be so
+    // common to cause a problem.
+    self.font_group.reset();
+    self.font_group.atlas_greyscale.clear();
+    self.font_group.atlas_color.clear();
 
     // We always redo the font shaper in case font features changed. We
     // could check to see if there was an actual config change but this is

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -102,6 +102,7 @@ texture_color: objc.Object, // MTLTexture
 pub const DerivedConfig = struct {
     font_thicken: bool,
     font_features: std.ArrayList([]const u8),
+    font_styles: font.Group.StyleStatus,
     cursor_color: ?terminal.color.RGB,
     cursor_text: ?terminal.color.RGB,
     background: terminal.color.RGB,
@@ -121,10 +122,17 @@ pub const DerivedConfig = struct {
         };
         errdefer font_features.deinit();
 
+        // Get our font styles
+        var font_styles = font.Group.StyleStatus.initFill(true);
+        font_styles.set(.bold, config.@"font-style-bold" != .false);
+        font_styles.set(.italic, config.@"font-style-italic" != .false);
+        font_styles.set(.bold_italic, config.@"font-style-bold-italic" != .false);
+
         return .{
             .background_opacity = @max(0, @min(1, config.@"background-opacity")),
             .font_thicken = config.@"font-thicken",
             .font_features = font_features,
+            .font_styles = font_styles,
 
             .cursor_color = if (config.@"cursor-color") |col|
                 col.toTerminalRGB()
@@ -981,6 +989,7 @@ pub fn changeConfig(self: *Metal, config: *DerivedConfig) !void {
     // when its not necessary but config reloading shouldn't be so
     // common to cause a problem.
     self.font_group.reset();
+    self.font_group.group.styles = config.font_styles;
     self.font_group.atlas_greyscale.clear();
     self.font_group.atlas_color.clear();
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -216,6 +216,7 @@ const GPUCellMode = enum(u8) {
 pub const DerivedConfig = struct {
     font_thicken: bool,
     font_features: std.ArrayList([]const u8),
+    font_styles: font.Group.StyleStatus,
     cursor_color: ?terminal.color.RGB,
     cursor_text: ?terminal.color.RGB,
     background: terminal.color.RGB,
@@ -235,10 +236,17 @@ pub const DerivedConfig = struct {
         };
         errdefer font_features.deinit();
 
+        // Get our font styles
+        var font_styles = font.Group.StyleStatus.initFill(true);
+        font_styles.set(.bold, config.@"font-style-bold" != .false);
+        font_styles.set(.italic, config.@"font-style-italic" != .false);
+        font_styles.set(.bold_italic, config.@"font-style-bold-italic" != .false);
+
         return .{
             .background_opacity = @max(0, @min(1, config.@"background-opacity")),
             .font_thicken = config.@"font-thicken",
             .font_features = font_features,
+            .font_styles = font_styles,
 
             .cursor_color = if (config.@"cursor-color") |col|
                 col.toTerminalRGB()
@@ -1211,6 +1219,7 @@ pub fn changeConfig(self: *OpenGL, config: *DerivedConfig) !void {
     // when its not necessary but config reloading shouldn't be so
     // common to cause a problem.
     self.font_group.reset();
+    self.font_group.group.styles = config.font_styles;
     self.font_group.atlas_greyscale.clear();
     self.font_group.atlas_color.clear();
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -1205,13 +1205,14 @@ fn gridSize(self: *const OpenGL, screen_size: renderer.ScreenSize) renderer.Grid
 
 /// Update the configuration.
 pub fn changeConfig(self: *OpenGL, config: *DerivedConfig) !void {
-    // If font thickening settings change, we need to reset our
-    // font texture completely because we need to re-render the glyphs.
-    if (self.config.font_thicken != config.font_thicken) {
-        self.font_group.reset();
-        self.font_group.atlas_greyscale.clear();
-        self.font_group.atlas_color.clear();
-    }
+    // On configuration change we always reset our font group. There
+    // are a variety of configurations that can change font settings
+    // so to be safe we just always reset it. This has a performance hit
+    // when its not necessary but config reloading shouldn't be so
+    // common to cause a problem.
+    self.font_group.reset();
+    self.font_group.atlas_greyscale.clear();
+    self.font_group.atlas_color.clear();
 
     // We always redo the font shaper in case font features changed. We
     // could check to see if there was an actual config change but this is


### PR DESCRIPTION
Fixes #540 

You can now set `font-style-bold`, `italic`, and `bold-italic` to `false` to completely disable the font style. The internal terminal state still records the font style but when rendering the regular font will be used instead. 

This value can be changed at runtime and changes take effect immediately.

This adds very slight runtime overhead on every initial codepoint lookup (a boolean check) but these are cached so subsequent lookups are unaffected. 

## Demo

The styling is a bit subtle but you can see it changing.


https://github.com/mitchellh/ghostty/assets/1299/6eaa096c-62d1-407c-a6fc-4bf7607492ce

