### PR TITLE
font: shaper dynamically allocates cell buffer

### DIFF
--- a/src/font/shape.zig
+++ b/src/font/shape.zig
@@ -33,10 +33,6 @@ pub const Cell = struct {
 
 /// Options for shapers.
 pub const Options = struct {
-    /// The cell_buf argument is the buffer to use for storing shaped results.
-    /// This should be at least the number of columns in the terminal.
-    cell_buf: []Cell,
-
     /// Font features to use when shaping. These can be in the following
     /// formats: "-feat" "+feat" "feat". A "-"-prefix is used to disable
     /// a feature and the others are used to enable a feature. If a feature


### PR DESCRIPTION
Fixes #514

Pathlogical grapheme clusters can use a LOT of memory, so we need to be able to grow. This currently never reclaims the memory from the shaper so if you render huge grapheme clusters, that surface will be using a lot of memory for a long time. We'll implement memory reclaim another time, this is a rare case.