### PR TITLE
shell.nix: use system packages

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,10 @@
-(import
-  (
-    let flake-compat = (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.flake-compat; in
-    fetchTarball {
-      url = "https://github.com/edolstra/flake-compat/archive/${flake-compat.locked.rev}.tar.gz";
-      sha256 = flake-compat.locked.narHash;
-    }
-  )
-  { src = ./.; }).shellNix
+with import <nixpkgs> {};
+
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs; [
+    pkgconfig
+    gtk4.dev
+  ];
+
+  hardeningDisable = [ "all" ];
+}


### PR DESCRIPTION
was previously getting a lot of weird glibc symbol or version errors

as of this patch `nix-shell --run 'zig build -Doptimize=ReleaseSafe'` runs successfully and links with system packages rather than through the flake

the user can then open a ghostty window as normal by running `./zig-out/bin/ghostty`