### PR TITLE
macos: add tab index labels

### DIFF
--- a/macos/Sources/Features/Primary Window/PrimaryWindowController.swift
+++ b/macos/Sources/Features/Primary Window/PrimaryWindowController.swift
@@ -1,6 +1,6 @@
 import Cocoa
 
-class PrimaryWindowController: NSWindowController {
+class PrimaryWindowController: NSWindowController, NSWindowDelegate {
     // This is used to programmatically control tabs.
     weak var windowManager: PrimaryWindowManager?
     
@@ -20,5 +20,13 @@ class PrimaryWindowController: NSWindowController {
         if let window = self.window {
             window.contentView = nil
         }
+    }
+
+    func windowDidBecomeKey(_ notification: Notification) {
+        self.windowManager?.indexTabs()
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        self.windowManager?.indexTabs()
     }
 }

--- a/macos/Sources/Features/Primary Window/PrimaryWindowController.swift
+++ b/macos/Sources/Features/Primary Window/PrimaryWindowController.swift
@@ -23,10 +23,13 @@ class PrimaryWindowController: NSWindowController, NSWindowDelegate {
     }
 
     func windowDidBecomeKey(_ notification: Notification) {
-        self.windowManager?.indexTabs()
+        self.windowManager?.relabelTabs()
     }
 
     func windowWillClose(_ notification: Notification) {
-        self.windowManager?.indexTabs()
+        // Tabs must be relabeled when a window is closed because this event
+        // does not fire the "windowDidBecomeKey" event on the newly focused
+        // window
+        self.windowManager?.relabelTabs()
     }
 }

--- a/macos/Sources/Features/Primary Window/PrimaryWindowManager.swift
+++ b/macos/Sources/Features/Primary Window/PrimaryWindowManager.swift
@@ -164,6 +164,7 @@ class PrimaryWindowManager {
         
         let managed = ManagedWindow(windowController: windowController, window: window, closePublisher: pubClose)
         managedWindows.append(managed)
+        window.delegate = windowController
 
         return managed
     }
@@ -176,6 +177,23 @@ class PrimaryWindowManager {
         if let focusedWindow = NSApplication.shared.keyWindow {
             let frame = focusedWindow.frame
             Self.lastCascadePoint = NSPoint(x: frame.minX, y: frame.maxY)
+        }
+    }
+
+    /// Update the accessory view of the first 9 tabs. This is called when the
+    /// key window changes and when a window is closed.
+    func indexTabs() {
+        if let windows = self.mainWindow?.tabbedWindows {
+            for (index, window) in windows.enumerated().prefix(9) {
+                let string = " ⌘\(index + 1) "
+                let attributes: [NSAttributedString.Key: Any] = [
+                    .font: NSFont.labelFont(ofSize: 0),
+                    .foregroundColor: window.isKeyWindow ? NSColor.labelColor : NSColor.secondaryLabelColor,
+                ]
+                let attributedString = NSAttributedString(string: string, attributes: attributes)
+                let text = NSTextField(labelWithAttributedString: attributedString)
+                window.tab.accessoryView = text
+            }
         }
     }
 }

--- a/macos/Sources/Features/Primary Window/PrimaryWindowManager.swift
+++ b/macos/Sources/Features/Primary Window/PrimaryWindowManager.swift
@@ -184,17 +184,22 @@ class PrimaryWindowManager {
     /// shortcut that activates it (if any). This is called when the key window
     /// changes and when a window is closed.
     func relabelTabs() {
-        if let windows = self.mainWindow?.tabbedWindows {
-            for (index, window) in windows.enumerated().prefix(9) {
-                let string = " ⌘\(index + 1) "
-                let attributes: [NSAttributedString.Key: Any] = [
-                    .font: NSFont.labelFont(ofSize: 0),
-                    .foregroundColor: window.isKeyWindow ? NSColor.labelColor : NSColor.secondaryLabelColor,
-                ]
-                let attributedString = NSAttributedString(string: string, attributes: attributes)
-                let text = NSTextField(labelWithAttributedString: attributedString)
-                window.tab.accessoryView = text
+        guard let windows = self.mainWindow?.tabbedWindows else { return }
+        guard let cfg = ghostty.config else { return }
+        for (index, window) in windows.enumerated().prefix(9) {
+            let action = "goto_tab:\(index + 1)"
+            let trigger = ghostty_config_trigger(cfg, action, UInt(action.count))
+            guard let equiv = Ghostty.keyEquivalent(key: trigger.key, mods: trigger.mods) else {
+                continue
             }
+
+            let attributes: [NSAttributedString.Key: Any] = [
+                .font: NSFont.labelFont(ofSize: 0),
+                .foregroundColor: window.isKeyWindow ? NSColor.labelColor : NSColor.secondaryLabelColor,
+            ]
+            let attributedString = NSAttributedString(string: " \(equiv) ", attributes: attributes)
+            let text = NSTextField(labelWithAttributedString: attributedString)
+            window.tab.accessoryView = text
         }
     }
 }

--- a/macos/Sources/Features/Primary Window/PrimaryWindowManager.swift
+++ b/macos/Sources/Features/Primary Window/PrimaryWindowManager.swift
@@ -180,9 +180,10 @@ class PrimaryWindowManager {
         }
     }
 
-    /// Update the accessory view of the first 9 tabs. This is called when the
-    /// key window changes and when a window is closed.
-    func indexTabs() {
+    /// Update the accessory view of each tab according to the keyboard
+    /// shortcut that activates it (if any). This is called when the key window
+    /// changes and when a window is closed.
+    func relabelTabs() {
         if let windows = self.mainWindow?.tabbedWindows {
             for (index, window) in windows.enumerated().prefix(9) {
                 let string = " ⌘\(index + 1) "

--- a/macos/Sources/Ghostty/Ghostty.Input.swift
+++ b/macos/Sources/Ghostty/Ghostty.Input.swift
@@ -7,6 +7,28 @@ extension Ghostty {
         return Self.keyToEquivalent[key]
     }
 
+    static func keyEquivalent(key: ghostty_input_key_e, mods: ghostty_input_mods_e) -> String? {
+        guard var key = Self.keyEquivalent(key: key) else { return nil }
+        let flags = Self.eventModifierFlags(mods: mods)
+        if flags.contains(.command) {
+            key = "⌘\(key)"
+        }
+
+        if flags.contains(.shift) {
+            key = "⇧\(key)"
+        }
+
+        if flags.contains(.option) {
+            key = "⌥\(key)"
+        }
+
+        if flags.contains(.control) {
+            key = "⌃\(key)"
+        }
+
+        return key
+    }
+
     /// Returns the event modifier flags set for the Ghostty mods enum.
     static func eventModifierFlags(mods: ghostty_input_mods_e) -> NSEvent.ModifierFlags {
         var flags = NSEvent.ModifierFlags(rawValue: 0);

--- a/macos/Sources/Ghostty/Ghostty.Input.swift
+++ b/macos/Sources/Ghostty/Ghostty.Input.swift
@@ -9,12 +9,12 @@ extension Ghostty {
 
     /// Returns the event modifier flags set for the Ghostty mods enum.
     static func eventModifierFlags(mods: ghostty_input_mods_e) -> NSEvent.ModifierFlags {
-        var flags: [NSEvent.ModifierFlags] = [];
-        if (mods.rawValue & GHOSTTY_MODS_SHIFT.rawValue != 0) { flags.append(.shift) }
-        if (mods.rawValue & GHOSTTY_MODS_CTRL.rawValue != 0) { flags.append(.control) }
-        if (mods.rawValue & GHOSTTY_MODS_ALT.rawValue != 0) { flags.append(.option) }
-        if (mods.rawValue & GHOSTTY_MODS_SUPER.rawValue != 0) { flags.append(.command) }
-        return NSEvent.ModifierFlags(flags)
+        var flags = NSEvent.ModifierFlags(rawValue: 0);
+        if (mods.rawValue & GHOSTTY_MODS_SHIFT.rawValue != 0) { flags.insert(.shift) }
+        if (mods.rawValue & GHOSTTY_MODS_CTRL.rawValue != 0) { flags.insert(.control) }
+        if (mods.rawValue & GHOSTTY_MODS_ALT.rawValue != 0) { flags.insert(.option) }
+        if (mods.rawValue & GHOSTTY_MODS_SUPER.rawValue != 0) { flags.insert(.command) }
+        return flags
     }
 
     /// A map from the Ghostty key enum to the keyEquivalent string for shortcuts.


### PR DESCRIPTION
I mentioned this on Discord but didn't get a response if this is a desired feature. I went ahead and made an attempt to implement it and it wasn't too difficult.

I don't have much (read: any) experience with macOS UI development, so if there's a better way to do this please tell me.

---

Adds labels to the window tabs that indicate the tab index and the key to press to activate that tab.

Screenshot:

<img width="1712" alt="Screenshot 2023-09-27 at 9 05 43 PM" src="https://github.com/mitchellh/ghostty/assets/8965202/795c3ed3-e587-4e3e-b281-7370c6a2ddd5">

Indices only go up to 9 (which is what is supported via the default keyboard shortcuts):

<img width="1712" alt="Screenshot 2023-09-27 at 9 09 27 PM" src="https://github.com/mitchellh/ghostty/assets/8965202/a4c4335e-ac1d-4a1b-a8a1-0ff9ebae0ab4">
