### PR TITLE
termio: reset mouse shape on terminal reset

### DIFF
--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1680,6 +1680,7 @@ const StreamHandler = struct {
         self: *StreamHandler,
     ) !void {
         self.terminal.fullReset(self.alloc);
+        try self.setMouseShape(.default);
     }
 
     pub fn queryKittyKeyboard(self: *StreamHandler) !void {


### PR DESCRIPTION
Reset the mouse shape to `.default` when a full reset is done on the terminal. Prevents the terminal from appearing to be in a persistent hang

https://github.com/mitchellh/ghostty/assets/476352/84f911b9-5c98-430a-a07a-b6ce8468bdd1