### PR TITLE
fabs builtin was renamed

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -35,7 +35,7 @@ const system_sdk = @import("vendor/mach-glfw/system_sdk.zig");
 // but we liberally update it. In the future, we'll be more careful about
 // using released versions so that package managers can integrate better.
 comptime {
-    const required_zig = "0.12.0-dev.602+15ce96525";
+    const required_zig = "0.12.0-dev.640+937138cb9";
     const current_zig = builtin.zig_version;
     const min_zig = std.SemanticVersion.parse(required_zig) catch unreachable;
     if (current_zig.order(min_zig) == .lt) {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1061,7 +1061,7 @@ pub fn scrollCallback(
         // If the new offset is less than a single unit of scroll, we save
         // the new pending value and do not scroll yet.
         const cell_size: f64 = @floatFromInt(self.cell_size.height);
-        if (@fabs(poff) < cell_size) {
+        if (@abs(poff) < cell_size) {
             self.mouse.pending_scroll_y = poff;
             break :y .{};
         }
@@ -1072,7 +1072,7 @@ pub fn scrollCallback(
 
         break :y .{
             .sign = if (yoff > 0) 1 else -1,
-            .delta_unsigned = @intFromFloat(@fabs(amount)),
+            .delta_unsigned = @intFromFloat(@abs(amount)),
             .delta = @intFromFloat(amount),
         };
     };
@@ -1088,7 +1088,7 @@ pub fn scrollCallback(
 
         const poff = self.mouse.pending_scroll_x + (xoff * -1);
         const cell_size: f64 = @floatFromInt(self.cell_size.width);
-        if (@fabs(poff) < cell_size) {
+        if (@abs(poff) < cell_size) {
             self.mouse.pending_scroll_x = poff;
             break :x .{};
         }
@@ -1097,7 +1097,7 @@ pub fn scrollCallback(
         self.mouse.pending_scroll_x = poff - (amount * cell_size);
 
         break :x .{
-            .delta_unsigned = @intFromFloat(@fabs(amount)),
+            .delta_unsigned = @intFromFloat(@abs(amount)),
             .delta = @intFromFloat(amount),
         };
     };


### PR DESCRIPTION
https://github.com/ziglang/zig/pull/17248

I just tried installing from source and ran into the error:

> error: invalid builtin function: '@fabs'