### PR TITLE
Revert default TERM to "xterm-ghostty"

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -411,8 +411,13 @@ keybind: Keybinds = .{},
 /// Debug builds of Ghostty have a separate single-instance ID.
 @"gtk-single-instance": bool = true,
 
-/// This will be used to set the TERM environment variable
-term: []const u8 = "ghostty",
+/// This will be used to set the TERM environment variable.
+/// HACK: We set this with an "xterm" prefix because vim uses that to enable key
+/// protocols (specifically this will enable 'modifyOtherKeys'), among other
+/// features. An option exists in vim to modify this: `:set
+/// keyprotocol=ghostty:kitty`, however a bug in the implementation prevents it
+/// from working properly. https://github.com/vim/vim/pull/13211 fixes this.
+term: []const u8 = "xterm-ghostty",
 
 /// This is set by the CLI parser for deinit.
 _arena: ?ArenaAllocator = null,
@@ -904,7 +909,8 @@ pub fn finalize(self: *Config) !void {
 
     // Prevent setting TERM to an empty string
     if (self.term.len == 0) {
-        self.term = "ghostty";
+        // HACK: See comment above at definition
+        self.term = "xterm-ghostty";
     }
 
     // The default for the working directory depends on the system.

--- a/src/terminfo/ghostty.zig
+++ b/src/terminfo/ghostty.zig
@@ -4,13 +4,19 @@ const Source = @import("Source.zig");
 /// Ghostty's terminfo entry.
 pub const ghostty: Source = .{
     .names = &.{
-        // The preferred name
-        "ghostty",
-
         // We support the "xterm-" prefix because some poorly behaved programs
         // use this to detect if the terminal supports 256 colors and other
         // features.
+        // HACK: This is a hack on a hack...we use "xterm-ghostty" to prevent
+        // vim from breaking, and when we do this as the default we break
+        // tcell-based applications (lazygit, aerc, etc). tcell has a bug where
+        // the primary terminfo name must be the value of TERM.
+        // https://github.com/gdamore/tcell/pull/639 fixes the issue but is not
+        // merged yet. Consider switching these in the future.
         "xterm-ghostty",
+
+        // The preferred name
+        "ghostty",
 
         // Our "formal" name
         "Ghostty",

--- a/src/terminfo/ghostty.zig
+++ b/src/terminfo/ghostty.zig
@@ -127,6 +127,14 @@ pub const ghostty: Source = .{
         .{ .name = "XM", .value = .{ .string = "\\E[?1006;1004;1000%?%p1%{1}%=%th%el%;" } },
         .{ .name = "xm", .value = .{ .string = "\\E[<%i%p3%d;%p1%d;%p2%d;%?%p4%tM%em%;" } },
 
+        // Secondary device attributes request / response
+        .{ .name = "RV", .value = .{ .string = "\\E[>c" } },
+        .{ .name = "rv", .value = .{ .string = "\\E\\[[0-9]+;[0-9]+;[0-9]+c" } },
+
+        // XTVERSION
+        .{ .name = "XR", .value = .{ .string = "\\E[>0q" } },
+        .{ .name = "xr", .value = .{ .string = "\\EP>\\|[ -~]+a\\E\\\\" } },
+
         // These are all capabilities that should be pretty straightforward
         // and map to input sequences.
         .{ .name = "bel", .value = .{ .string = "^G" } },
@@ -165,6 +173,7 @@ pub const ghostty: Source = .{
         .{ .name = "ht", .value = .{ .string = "^I" } },
         .{ .name = "hts", .value = .{ .string = "\\EH" } },
         .{ .name = "ich", .value = .{ .string = "\\E[%p1%d@" } },
+        .{ .name = "ich1", .value = .{ .string = "\\E[@" } },
         .{ .name = "il", .value = .{ .string = "\\E[%p1%dL" } },
         .{ .name = "il1", .value = .{ .string = "\\E[L" } },
         .{ .name = "ind", .value = .{ .string = "\\n" } },
@@ -183,7 +192,7 @@ pub const ghostty: Source = .{
         .{ .name = "rmam", .value = .{ .string = "\\E[?7l" } },
         .{ .name = "rmcup", .value = .{ .string = "\\E[?1049l" } },
         .{ .name = "rmir", .value = .{ .string = "\\E[4l" } },
-        .{ .name = "rmkx", .value = .{ .string = "\\E[?1l" } },
+        .{ .name = "rmkx", .value = .{ .string = "\\E[?1l\\E>" } },
         .{ .name = "rmso", .value = .{ .string = "\\E[27m" } },
         .{ .name = "rmul", .value = .{ .string = "\\E[24m" } },
         .{ .name = "rmxx", .value = .{ .string = "\\E[29m" } },
@@ -198,7 +207,7 @@ pub const ghostty: Source = .{
         .{ .name = "smam", .value = .{ .string = "\\E[?7h" } },
         .{ .name = "smcup", .value = .{ .string = "\\E[?1049h" } },
         .{ .name = "smir", .value = .{ .string = "\\E[4h" } },
-        .{ .name = "smkx", .value = .{ .string = "\\E[?1h" } },
+        .{ .name = "smkx", .value = .{ .string = "\\E[?1h\\E=" } },
         .{ .name = "smso", .value = .{ .string = "\\E[7m" } },
         .{ .name = "smul", .value = .{ .string = "\\E[4m" } },
         .{ .name = "smxx", .value = .{ .string = "\\E[9m" } },


### PR DESCRIPTION
Vim heavily relies on "xterm" prefix for some features. In order to not break other applications as a result of this hack, also change the order of our terminfo name entries (ick).

This can be re-reverted back to "ghostty" as the default TERM and the primary terminfo name when Vim releases with https://github.com/vim/vim/pull/13211 applied