### PR TITLE
apprt/gtk: make wide-style gtk tabs configurable

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -203,13 +203,17 @@ pub fn newTab(self: *Window, parent_: ?*CoreSurface) !void {
 
     // Build our tab label
     const label_box_widget = c.gtk_box_new(c.GTK_ORIENTATION_HORIZONTAL, 0);
-    c.gtk_widget_set_hexpand(label_box_widget, 1);
-    c.gtk_widget_set_halign(label_box_widget, c.GTK_ALIGN_FILL);
     const label_box = @as(*c.GtkBox, @ptrCast(label_box_widget));
     const label_text = c.gtk_label_new("Ghostty");
-    c.gtk_widget_set_hexpand(label_text, 1);
-    c.gtk_widget_set_halign(label_text, c.GTK_ALIGN_FILL);
     c.gtk_box_append(label_box, label_text);
+
+    // Wide style GTK tabs
+    if (self.app.config.@"gtk-wide-tabs") {
+        c.gtk_widget_set_hexpand(label_box_widget, 1);
+        c.gtk_widget_set_halign(label_box_widget, c.GTK_ALIGN_FILL);
+        c.gtk_widget_set_hexpand(label_text, 1);
+        c.gtk_widget_set_halign(label_text, c.GTK_ALIGN_FILL);
+    }
 
     const label_close_widget = c.gtk_button_new_from_icon_name("window-close");
     const label_close = @as(*c.GtkButton, @ptrCast(label_close_widget));

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -411,6 +411,12 @@ keybind: Keybinds = .{},
 /// Debug builds of Ghostty have a separate single-instance ID.
 @"gtk-single-instance": bool = true,
 
+/// If true (default), then the Ghostty GTK tabs will be "wide." Wide tabs
+/// are the new typical Gnome style where tabs fill their available space.
+/// If you set this to false then tabs will only take up space they need,
+/// which is the old style.
+@"gtk-wide-tabs": bool = true,
+
 /// This will be used to set the TERM environment variable.
 /// HACK: We set this with an "xterm" prefix because vim uses that to enable key
 /// protocols (specifically this will enable 'modifyOtherKeys'), among other


### PR DESCRIPTION
Related to #569 

cc @moderation 

This adds `gtk-wide-tabs`. Set this to false to go back to old style tabs.