### PR TITLE
Inital windows CI support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,6 @@ jobs:
       # Nix breaks xcodebuild so this has to be run outside.
       - name: Build Ghostty.app
         run: cd macos && xcodebuild
-
   build-windows:
     runs-on: windows-2019
     # this will not stop other jobs from running
@@ -80,7 +79,7 @@ jobs:
           submodules: recursive
           fetch-depth: 0
       # This could be from a script if we wanted to but inlining here for now
-      # in one place. 
+      # in one place.
       # Using powershell so that we do not need to install WSL components. Also,
       # WSLv1 is only installed on Github runners.
       - name: Install zig

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,9 +98,27 @@ jobs:
           Rename-Item -Path ".\$version" -NewName ".\zig"
           Write-Host "Zig installed."
           ./zig/zig.exe version
+
+      - name: Generate build testing script
+        shell: pwsh
+        run: |
+          # Generate a script so that we can swallow the errors
+          $scriptContent = @"
+          .\zig\zig.exe build test 2>&1 | Out-File -FilePath "build.log" -Append
+          exit 0
+          "@
+          $scriptPath = "zigbuild.ps1"
+          # Write the script content to a file
+          $scriptContent | Set-Content -Path $scriptPath
+          Write-Host "Script generated at: $scriptPath"
+
       - name: Test Windows
         shell: pwsh
-        run: ./zig/zig.exe build test
+        run: .\zigbuild.ps1 -ErrorAction SiltentlyContinue
+
+      - name: Dump logs
+        shell: pwsh
+        run: Get-Content -Path ".\build.log"
 
   test:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,41 @@ jobs:
       - name: Build Ghostty.app
         run: cd macos && xcodebuild
 
+  build-windows:
+    runs-on: windows-2019
+    # this will not stop other jobs from running
+    continue-on-error: true
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      # This could be from a script if we wanted to but inlining here for now
+      # in one place. 
+      # Using powershell so that we do not need to install WSL components. Also,
+      # WSLv1 is only installed on Github runners.
+      - name: Install zig
+        shell: pwsh
+        run: |
+          # Get the zig version from build.zig so that it only needs to be updated
+          $fileContent = Get-Content -Path "build.zig" -Raw
+          $pattern = 'const required_zig = "(.*?)";'
+          $zigVersion = [regex]::Match($fileContent, $pattern).Groups[1].Value
+          Write-Output $version
+          $version = "zig-windows-x86_64-$zigVersion"
+          $uri = "https://ziglang.org/builds/$version.zip"
+          Invoke-WebRequest -Uri "$uri" -OutFile ".\zig-windows.zip"
+          Expand-Archive -Path ".\zig-windows.zip" -DestinationPath ".\" -Force
+          Remove-Item -Path ".\zig-windows.zip"
+          Rename-Item -Path ".\$version" -NewName ".\zig"
+          Write-Host "Zig installed."
+          ./zig/zig.exe version
+      - name: Test Windows
+        shell: pwsh
+        run: ./zig/zig.exe build test
+
   test:
     strategy:
       matrix:


### PR DESCRIPTION
This adds initial CI support for building on windows.  The builds and tests are still failing though:

> Build Summary: 76/82 steps succeeded; 3 failed; 35/36 tests passed; 1 skipped 

Some key things here:

- continue-on-error: true is being used so that it does not break other jobs and the failing windows builds will be ignored
- the Github windows-2019 runners only have WSLv1 on them and not the improved/faster WSLv2 yet.
- I am using powershell to install everything to keep the job run quick and not having to install a bunch of WSL things.
- I pull the zig version from build.zig so that we do not need to remember to update it anywhere.