### PR TITLE
Stop double CI runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,3 @@
-on: [push, pull_request]
 on:
   pull_request:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,11 @@
 on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - 'main'
+      - 'mitchellh/**'
+
 name: Test
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,8 @@ on:
   pull_request:
   push:
     branches:
-      - 'main'
-      - 'mitchellh/**'
+      - "main"
+      - "mitchellh/**"
 
 name: Test
 jobs:


### PR DESCRIPTION
I noticed that when I put up a PR that I get double CI runs (image below). This PR should stop that and still trigger the tests to run when merging to main.

I assume that you may like that CI runs when you push a commit to your branch so I left a way to keep doing this. If you name your branches 'mitchellh/whatever-tmux-fix' then CI should run on push for you.  Note: there is no way to do 'on: push' with usernames.

The pattern can be whatever branch name style you want it to be, just let me know.

<img width="505" alt="Screenshot 2023-09-29 at 11 08 47 AM" src="https://github.com/mitchellh/ghostty/assets/431893/71e143dd-d053-4962-8ebf-f211524581ca">

