### PR TITLE
macos: adjust fullscreen frame height for notch

### DIFF
--- a/macos/Sources/Helpers/FullScreenHandler.swift
+++ b/macos/Sources/Helpers/FullScreenHandler.swift
@@ -93,7 +93,7 @@ class FullScreenHandler {    var previousTabGroup: NSWindowTabGroup?
         window.styleMask.remove(.titled)
         
         // Set frame to screen size, accounting for the menu bar if needed
-        let frame = calculateFullscreenFrame(screenFrame: screen.frame, subtractMenu: !hideMenu)
+        let frame = calculateFullscreenFrame(screen: screen, subtractMenu: !hideMenu)
         window.setFrame(frame, display: true)
         
         // Focus window
@@ -116,12 +116,23 @@ class FullScreenHandler {    var previousTabGroup: NSWindowTabGroup?
         NSApp.presentationOptions.remove(.autoHideDock)
     }
     
-    func calculateFullscreenFrame(screenFrame: NSRect, subtractMenu: Bool)->NSRect {
+    func calculateFullscreenFrame(screen: NSScreen, subtractMenu: Bool)->NSRect {
         if (subtractMenu) {
-            let menuHeight = NSApp.mainMenu?.menuBarHeight ?? 0
-            return NSMakeRect(screenFrame.minX, screenFrame.minY, screenFrame.width, screenFrame.height - menuHeight)
+            if let menuHeight = NSApp.mainMenu?.menuBarHeight {
+                var padding: CGFloat = 0
+                if #available(macOS 12, *) {
+                    padding = screen.safeAreaInsets.top;
+                }
+
+                return NSMakeRect(
+                    screen.frame.minX,
+                    screen.frame.minY,
+                    screen.frame.width,
+                    screen.frame.height - (menuHeight + padding)
+                )
+            }
         }
-        return screenFrame
+        return screen.frame
     }
     
     func leaveFullscreen(window: NSWindow) {

--- a/macos/Sources/Helpers/FullScreenHandler.swift
+++ b/macos/Sources/Helpers/FullScreenHandler.swift
@@ -120,8 +120,11 @@ class FullScreenHandler {    var previousTabGroup: NSWindowTabGroup?
         if (subtractMenu) {
             if let menuHeight = NSApp.mainMenu?.menuBarHeight {
                 var padding: CGFloat = 0
-                if #available(macOS 12, *) {
-                    padding = screen.safeAreaInsets.top;
+                
+                // Detect the notch. If there is a safe area on top it includes the
+                // menu height as a safe area so we also subtract that from it.
+                if (screen.safeAreaInsets.top > 0) {
+                    padding = screen.safeAreaInsets.top - menuHeight;
                 }
 
                 return NSMakeRect(


### PR DESCRIPTION
NOTE: Need someone with a notched MacBook display to test.

The macOS desktop menu-bar grows in total height by adding extra padding to deal with the physical notch found on various MacBook displays.

When config `macos-non-native-fullscreen = visible-menu` we apply `safeAreaInsets.top` to reduce frame height.