### PR TITLE
selection: only clear when keypress has utf8

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -967,9 +967,9 @@ pub fn keyCallback(
     }, .{ .forever = {} });
     try self.io_thread.wakeup.notify();
 
-    // If we have a sequence to emit then we always want to clear the
+    // If we have printable text to emit then we always want to clear the
     // selection and scroll to the bottom.
-    {
+    if (event.utf8.len > 0) {
         self.renderer_state.mutex.lock();
         defer self.renderer_state.mutex.unlock();
         self.setSelection(null);


### PR DESCRIPTION
Currently, the selection on a surface is cleared on any keypress that generates a control sequence. For applications that enable kitty, this can mean that every keypress clears the current selection thereby making it impossible to copy text, since it will be cleared as soon as Control is pressed. This can be very confusing to terminal users: some applications I can shift+highlight and copy+paste, some I can't - and unless I know the implementation of the application I won't know why...very frustrating.

Only clear the selection when there is printable text, otherwise retain the selection. From my testing, this makes text selection feel the same between applications using kitty keyboard and applications that don't.