### PR TITLE
Add Categories entry to .desktop file so Linux desktops have a better

### DIFF
--- a/dist/linux/app.desktop
+++ b/dist/linux/app.desktop
@@ -4,6 +4,7 @@ Type=Application
 Comment=A terminal emulator
 Exec=ghostty
 Icon=com.mitchellh.ghostty
+Categories=System;TerminalEmulator;
 Keywords=terminal;tty;pty;
 StartupNotify=true
 Terminal=false


### PR DESCRIPTION
chance of placing the menu entry into an appropriate category

Small quality of life improvement on Linux. I noticed that Plasma desktop was putting the Ghostty menu entry in "lost&found". This just adds a "Categories" entry so that FreeDesktop compliant environments which still have hierarchical menus (most except Gnome) can place it in the correct subcategory. 