### PR TITLE
Can configure keybinds to not consume input, a fix for clear screen and form feed

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1524,7 +1524,11 @@ pub const Keybinds = struct {
         const binding = try inputpkg.Binding.parse(value);
         switch (binding.action) {
             .unbind => self.set.remove(binding.trigger),
-            else => try self.set.put(alloc, binding.trigger, binding.action),
+            else => if (binding.consumed) {
+                try self.set.put(alloc, binding.trigger, binding.action);
+            } else {
+                try self.set.putUnconsumed(alloc, binding.trigger, binding.action);
+            },
         }
     }
 

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -372,6 +372,13 @@ pub const Set = struct {
         std.hash_map.default_max_load_percentage,
     );
 
+    const UnconsumedMap = std.HashMapUnmanaged(
+        Trigger,
+        void,
+        Context(Trigger),
+        std.hash_map.default_max_load_percentage,
+    );
+
     /// The set of bindings.
     bindings: HashMap = .{},
 
@@ -380,9 +387,23 @@ pub const Set = struct {
     /// the most recently added binding for an action.
     reverse: ReverseMap = .{},
 
+    /// The map of triggers that explicitly do not want to be consumed
+    /// when matched. A trigger is "consumed" when it is not further
+    /// processed and potentially sent to the terminal. An "unconsumed"
+    /// trigger will perform both its action and also continue normal
+    /// encoding processing (if any).
+    ///
+    /// This is stored as a separate map since unconsumed triggers are
+    /// rare and we don't want to bloat our map with a byte per entry
+    /// (for boolean state) when most entries will be consumed.
+    ///
+    /// Assert: trigger in this map is also in bindings.
+    unconsumed: UnconsumedMap = .{},
+
     pub fn deinit(self: *Set, alloc: Allocator) void {
         self.bindings.deinit(alloc);
         self.reverse.deinit(alloc);
+        self.unconsumed.deinit(alloc);
         self.* = undefined;
     }
 
@@ -394,10 +415,35 @@ pub const Set = struct {
         t: Trigger,
         action: Action,
     ) Allocator.Error!void {
+        try self.put_(alloc, t, action, true);
+    }
+
+    /// Same as put but marks the trigger as unconsumed. An unconsumed
+    /// trigger will evaluate the action and continue to encode for the
+    /// terminal.
+    ///
+    /// This is a separate function because this case is rare.
+    pub fn putUnconsumed(
+        self: *Set,
+        alloc: Allocator,
+        t: Trigger,
+        action: Action,
+    ) Allocator.Error!void {
+        try self.put_(alloc, t, action, false);
+    }
+
+    fn put_(
+        self: *Set,
+        alloc: Allocator,
+        t: Trigger,
+        action: Action,
+        consumed: bool,
+    ) Allocator.Error!void {
         // unbind should never go into the set, it should be handled prior
         assert(action != .unbind);
 
         const gop = try self.bindings.getOrPut(alloc, t);
+        if (!consumed) try self.unconsumed.put(alloc, t, {});
 
         // If we have an existing binding for this trigger, we have to
         // update the reverse mapping to remove the old action.
@@ -410,6 +456,9 @@ pub const Set = struct {
                     break :it;
                 }
             }
+
+            // We also have to remove the unconsumed state if it exists.
+            if (consumed) _ = self.unconsumed.remove(t);
         }
 
         gop.value_ptr.* = action;
@@ -429,10 +478,18 @@ pub const Set = struct {
         return self.reverse.get(a);
     }
 
+    /// Returns true if the given trigger should be consumed. Requires
+    /// that trigger is in the set to be valid so this should only follow
+    /// a non-null get.
+    pub fn getConsumed(self: Set, t: Trigger) bool {
+        return self.unconsumed.get(t) == null;
+    }
+
     /// Remove a binding for a given trigger.
     pub fn remove(self: *Set, t: Trigger) void {
         const action = self.bindings.get(t) orelse return;
         _ = self.bindings.remove(t);
+        _ = self.unconsumed.remove(t);
 
         // Look for a matching action in bindings and use that.
         // Note: we'd LIKE to replace this with the most recent binding but
@@ -653,4 +710,21 @@ test "set: overriding a mapping updates reverse" {
         const trigger = s.getTrigger(.{ .new_window = {} });
         try testing.expect(trigger == null);
     }
+}
+
+test "set: consumed state" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s: Set = .{};
+    defer s.deinit(alloc);
+
+    try s.put(alloc, .{ .key = .a }, .{ .new_window = {} });
+    try testing.expect(s.getConsumed(.{ .key = .a }));
+
+    try s.putUnconsumed(alloc, .{ .key = .a }, .{ .new_window = {} });
+    try testing.expect(!s.getConsumed(.{ .key = .a }));
+
+    try s.put(alloc, .{ .key = .a }, .{ .new_window = {} });
+    try testing.expect(s.getConsumed(.{ .key = .a }));
 }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -379,20 +379,12 @@ pub fn clearScreen(self: *Exec, history: bool) !void {
         // Clear our scrollback
         if (history) try self.terminal.screen.clear(.history);
 
-        // If we're not at a prompt, we clear the screen manually using
-        // the terminal screen state. If we are at a prompt, we send
-        // form-feed so that the shell can repaint the entire screen.
-        if (!self.terminal.cursorIsAtPrompt()) {
-            // Clear above the cursor
-            try self.terminal.screen.clear(.above_cursor);
-
-            // Exit
-            return;
-        }
+        // Clear our screen using terminal state.
+        try self.terminal.screen.clear(.above_cursor);
     }
 
-    // If we reached here it means we're at a prompt, so we send a form-feed.
-    assert(self.terminal.cursorIsAtPrompt());
+    // We also always send form feed so that the terminal can repaint
+    // our prompt.
     try self.queueWrite(&[_]u8{0x0C});
 }
 


### PR DESCRIPTION
Fixes #555.

This has two things. First is a fix for #555. The clear screen action now also _always_ sends form feed `0x0C`. This makes it so that clear screen always acts like Ctrl+L but I think that should be expected (form feed _is_ a clear screen command). This makes it so Ctrl+L bindings always get triggered by Cmd+K instead of sometimes. There isn't a clean way to make Ctrl+L bindings work AND the previous clear screen functionality.

Second thing in this PR: key bindings can now be prefixed with `unconsumed:` signaling that when the action is evaluating, Ghostty should continue processing the keybind (i.e. sending a key encoding if it has one) rather than consuming it. This isn't used in this PR but its exposed and will be used for other features in the future. I did it here because I originally thought thats how we'd handle #555 but it turned out to not be the case.