### PR TITLE
Set the mouse pointer to "text" (an I-beam) when it is over the gl_area

### DIFF
--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -85,6 +85,7 @@ im_len: u7 = 0,
 
 pub fn init(self: *Surface, app: *App, opts: Options) !void {
     const widget = @as(*c.GtkWidget, @ptrCast(opts.gl_area));
+    c.gtk_widget_set_cursor_from_name(@ptrCast(opts.gl_area), "text");
     c.gtk_gl_area_set_required_version(opts.gl_area, 3, 3);
     c.gtk_gl_area_set_has_stencil_buffer(opts.gl_area, 0);
     c.gtk_gl_area_set_has_depth_buffer(opts.gl_area, 0);
@@ -355,7 +356,7 @@ pub fn setMouseShape(
     shape: terminal.MouseShape,
 ) !void {
     const name: [:0]const u8 = switch (shape) {
-        .default => "default",
+        .default => "text",
         .help => "help",
         .pointer => "pointer",
         .context_menu => "context-menu",

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -226,6 +226,7 @@ pub fn newTab(self: *Window, parent_: ?*CoreSurface) !void {
     // wait for the "realize" callback from GTK to know that the OpenGL
     // context is ready. See Surface docs for more info.
     const gl_area = c.gtk_gl_area_new();
+    c.gtk_widget_set_cursor_from_name(gl_area, "text");
     try surface.init(self.app, .{
         .window = self,
         .gl_area = @ptrCast(gl_area),


### PR DESCRIPTION
which the terminal embeds into for the Gtk interface. Addresses https://github.com/mitchellh/ghostty/issues/596