### PR TITLE
Add `window-width`, `window-height` configurations for initial window size

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -291,15 +291,6 @@ typedef enum {
     GHOSTTY_BUILD_MODE_RELEASE_SMALL,
 } ghostty_build_mode_e;
 
-typedef struct {
-    bool origin;
-    bool size;
-    uint32_t x;
-    uint32_t y;
-    uint32_t w;
-    uint32_t h;
-} ghostty_rect_s;
-
 // Fully defined types. This MUST be kept in sync with equivalent Zig
 // structs. To find the Zig struct, grep for this type name. The documentation
 // for all of these types is available in the Zig source.
@@ -335,6 +326,7 @@ typedef void (*ghostty_runtime_focus_split_cb)(void *, ghostty_split_focus_direc
 typedef void (*ghostty_runtime_toggle_split_zoom_cb)(void *);
 typedef void (*ghostty_runtime_goto_tab_cb)(void *, int32_t);
 typedef void (*ghostty_runtime_toggle_fullscreen_cb)(void *, ghostty_non_native_fullscreen_e);
+typedef void (*ghostty_runtime_set_initial_window_size_cb)(void *, uint32_t, uint32_t);
 
 typedef struct {
     void *userdata;
@@ -354,6 +346,7 @@ typedef struct {
     ghostty_runtime_toggle_split_zoom_cb toggle_split_zoom_cb;
     ghostty_runtime_goto_tab_cb goto_tab_cb;
     ghostty_runtime_toggle_fullscreen_cb toggle_fullscreen_cb;
+    ghostty_runtime_set_initial_window_size_cb set_initial_window_size_cb;
 } ghostty_runtime_config_s;
 
 //-------------------------------------------------------------------
@@ -389,7 +382,6 @@ ghostty_surface_t ghostty_surface_new(ghostty_app_t, ghostty_surface_config_s*);
 void ghostty_surface_free(ghostty_surface_t);
 ghostty_app_t ghostty_surface_app(ghostty_surface_t);
 bool ghostty_surface_transparent(ghostty_surface_t);
-ghostty_rect_s ghostty_surface_window_frame(ghostty_surface_t);
 void ghostty_surface_refresh(ghostty_surface_t);
 void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);
 void ghostty_surface_set_focus(ghostty_surface_t, bool);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -291,6 +291,15 @@ typedef enum {
     GHOSTTY_BUILD_MODE_RELEASE_SMALL,
 } ghostty_build_mode_e;
 
+typedef struct {
+    bool origin;
+    bool size;
+    uint32_t x;
+    uint32_t y;
+    uint32_t w;
+    uint32_t h;
+} ghostty_rect_s;
+
 // Fully defined types. This MUST be kept in sync with equivalent Zig
 // structs. To find the Zig struct, grep for this type name. The documentation
 // for all of these types is available in the Zig source.
@@ -380,6 +389,7 @@ ghostty_surface_t ghostty_surface_new(ghostty_app_t, ghostty_surface_config_s*);
 void ghostty_surface_free(ghostty_surface_t);
 ghostty_app_t ghostty_surface_app(ghostty_surface_t);
 bool ghostty_surface_transparent(ghostty_surface_t);
+ghostty_rect_s ghostty_surface_window_frame(ghostty_surface_t);
 void ghostty_surface_refresh(ghostty_surface_t);
 void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);
 void ghostty_surface_set_focus(ghostty_surface_t, bool);

--- a/macos/Sources/Features/Primary Window/PrimaryWindowController.swift
+++ b/macos/Sources/Features/Primary Window/PrimaryWindowController.swift
@@ -4,6 +4,9 @@ class PrimaryWindowController: NSWindowController, NSWindowDelegate {
     // This is used to programmatically control tabs.
     weak var windowManager: PrimaryWindowManager?
     
+    // This should be set to true once a surface has been initialized once.
+    var didInitializeFromSurface: Bool = false
+    
     // This is required for the "+" button to show up in the tab bar to add a
     // new tab.
     override func newWindowForTab(_ sender: Any?) {

--- a/macos/Sources/Features/Settings/ConfigurationErrors.xib
+++ b/macos/Sources/Features/Settings/ConfigurationErrors.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22154" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22154"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -125,7 +125,8 @@ extension Ghostty {
                 focus_split_cb: { userdata, direction in AppState.focusSplit(userdata, direction: direction) },
                 toggle_split_zoom_cb: { userdata in AppState.toggleSplitZoom(userdata) },
                 goto_tab_cb: { userdata, n in AppState.gotoTab(userdata, n: n) },
-                toggle_fullscreen_cb: { userdata, nonNativeFullscreen in AppState.toggleFullscreen(userdata, nonNativeFullscreen: nonNativeFullscreen) }
+                toggle_fullscreen_cb: { userdata, nonNativeFullscreen in AppState.toggleFullscreen(userdata, nonNativeFullscreen: nonNativeFullscreen) },
+                set_initial_window_size_cb: { userdata, width, height in AppState.setInitialWindowSize(userdata, width: width, height: height) }
             )
 
             // Create the ghostty app.
@@ -412,6 +413,12 @@ extension Ghostty {
                     Notification.NonNativeFullscreenKey: nonNativeFullscreen,
                 ]
             )
+        }
+        
+        static func setInitialWindowSize(_ userdata: UnsafeMutableRawPointer?, width: UInt32, height: UInt32) {
+            // We need a window to set the frame
+            guard let surfaceView = self.surfaceUserdata(from: userdata) else { return }
+            surfaceView.initialSize = NSMakeSize(Double(width), Double(height))
         }
 
         static func newTab(_ userdata: UnsafeMutableRawPointer?, config: ghostty_surface_config_s) {

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -98,6 +98,10 @@ extension Ghostty.Notification {
     
     /// Notification sent to toggle split maximize/unmaximize.
     static let didToggleSplitZoom = Notification.Name("com.mitchellh.ghostty.didToggleSplitZoom")
+    
+    /// Notification
+    static let didReceiveInitialWindowFrame = Notification.Name("com.mitchellh.ghostty.didReceiveInitialWindowFrame")
+    static let FrameKey = "com.mitchellh.ghostty.frame"
 }
 
 // Make the input enum hashable.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -757,6 +757,16 @@ pub const Surface = struct {
 pub const CAPI = struct {
     const global = &@import("../main.zig").state;
 
+    /// ghostty_rect_s
+    const Rect = extern struct {
+        origin: bool = false,
+        size: bool = false,
+        x: u32 = 0,
+        y: u32 = 0,
+        w: u32 = 0,
+        h: u32 = 0,
+    };
+
     /// Create a new app.
     export fn ghostty_app_new(
         opts: *const apprt.runtime.App.Options,
@@ -862,6 +872,21 @@ pub const CAPI = struct {
     /// Returns true if the surface has transparency set.
     export fn ghostty_surface_transparent(surface: *Surface) bool {
         return surface.app.config.@"background-opacity" < 1.0;
+    }
+
+    /// The desired window frame for a new window.
+    export fn ghostty_surface_window_frame(surface: *Surface) Rect {
+        const config = surface.app.config;
+
+        // If the desired height/width isn't configured, return 0.
+        if (config.@"window-height" == 0 or config.@"window-width" == 0) return .{};
+
+        // Return the desired rect
+        return .{
+            .size = true,
+            .h = @max(config.@"window-height" * surface.core_surface.cell_size.height, 480),
+            .w = @max(config.@"window-width" * surface.core_surface.cell_size.width, 640),
+        };
     }
 
     /// Tell the surface that it needs to schedule a render

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -376,6 +376,15 @@ pub const Surface = struct {
             self,
         );
         errdefer self.core_surface.deinit();
+
+        // If we have a desired window size, we can now calculate the size
+        // because we have the cell size.
+        if (config.@"window-height" > 0 or config.@"window-width" > 0) {
+            self.window.setSize(.{
+                .height = @max(config.@"window-height" * self.core_surface.cell_size.height, 480),
+                .width = @max(config.@"window-width" * self.core_surface.cell_size.width, 640),
+            });
+        }
     }
 
     pub fn deinit(self: *Surface) void {

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -376,15 +376,6 @@ pub const Surface = struct {
             self,
         );
         errdefer self.core_surface.deinit();
-
-        // If we have a desired window size, we can now calculate the size
-        // because we have the cell size.
-        if (config.@"window-height" > 0 or config.@"window-width" > 0) {
-            self.window.setSize(.{
-                .height = @max(config.@"window-height" * self.core_surface.cell_size.height, 480),
-                .width = @max(config.@"window-width" * self.core_surface.cell_size.width, 640),
-            });
-        }
     }
 
     pub fn deinit(self: *Surface) void {
@@ -454,6 +445,13 @@ pub const Surface = struct {
         self.setShouldClose();
         self.deinit();
         self.app.app.alloc.destroy(self);
+    }
+
+    /// Set the initial window size. This is called exactly once at
+    /// surface initialization time. This may be called before "self"
+    /// is fully initialized.
+    pub fn setInitialWindowSize(self: *const Surface, width: u32, height: u32) !void {
+        self.window.setSize(.{ .width = width, .height = height });
     }
 
     /// Set the size limits of the window.

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -325,6 +325,16 @@ pub fn getSize(self: *const Surface) !apprt.SurfaceSize {
     return self.size;
 }
 
+pub fn setInitialWindowSize(self: *const Surface, width: u32, height: u32) !void {
+    // Note: this doesn't properly take into account the window decorations.
+    // I'm not currently sure how to do that.
+    c.gtk_window_set_default_size(
+        @ptrCast(self.window.window),
+        @intCast(width),
+        @intCast(height),
+    );
+}
+
 pub fn setSizeLimits(self: *Surface, min: apprt.SurfaceSize, max_: ?apprt.SurfaceSize) !void {
     _ = self;
     _ = min;

--- a/src/config/CAPI.zig
+++ b/src/config/CAPI.zig
@@ -86,6 +86,7 @@ export fn ghostty_config_get(
     key_str: [*]const u8,
     len: usize,
 ) bool {
+    @setEvalBranchQuota(10_000);
     const key = std.meta.stringToEnum(Key, key_str[0..len]) orelse return false;
     return c_get.get(self, key, ptr);
 }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -316,6 +316,11 @@ keybind: Keybinds = .{},
 /// Changing this value will not affect the size of the window after
 /// it has been created. This is only used for the initial size.
 ///
+/// BUG: On Linux with GTK, the calculated window size will not properly
+/// take into account window decorations. As a result, the grid dimensions
+/// will not exactly match this configuration. If window decorations are
+/// disabled (see window-decorations), then this will work as expected.
+///
 /// Windows smaller than 10 wide by 4 high are not allowed.
 @"window-height": u32 = 0,
 @"window-width": u32 = 0,

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -300,6 +300,26 @@ keybind: Keybinds = .{},
 /// This is currently only supported on macOS.
 @"window-theme": WindowTheme = .system,
 
+/// The initial window size. This size is in terminal grid cells by default.
+///
+/// We don't currently support specifying a size in pixels but a future
+/// change can enable that. If this isn't specified, the app runtime will
+/// determine some default size.
+///
+/// Note that the window manager may put limits on the size or override
+/// the size. For example, a tiling window manager may force the window
+/// to be a certain size to fit within the grid. There is nothing Ghostty
+/// will do about this, but it will make an effort.
+///
+/// This will not affect new tabs, splits, or other nested terminal
+/// elements. This only affects the initial window size of any new window.
+/// Changing this value will not affect the size of the window after
+/// it has been created. This is only used for the initial size.
+///
+/// Windows smaller than 10 wide by 4 high are not allowed.
+@"window-height": u32 = 0,
+@"window-width": u32 = 0,
+
 /// Whether to allow programs running in the terminal to read/write to
 /// the system clipboard (OSC 52, for googling). The default is to
 /// disallow clipboard reading but allow writing.
@@ -1007,6 +1027,10 @@ pub fn finalize(self: *Config) !void {
 
     // Clamp our split opacity
     self.@"unfocused-split-opacity" = @min(1.0, @max(0.15, self.@"unfocused-split-opacity"));
+
+    // Minimmum window size
+    if (self.@"window-width" > 0) self.@"window-width" = @max(10, self.@"window-width");
+    if (self.@"window-height" > 0) self.@"window-height" = @max(4, self.@"window-height");
 }
 
 /// Create a shallow copy of this config. This will share all the memory


### PR DESCRIPTION
This adds two new configurations `window-width` and `window-height` that configure the size of new Ghostty windows _in cells_. This configuration _only_ affects new windows and _does not affect_ splits or tabs.

This is particularly useful with the CLI: `ghostty --window-width=X --window-height=y` when testing specific commands or desiring a certain layout for a TUI app.

**GTK bug:** This does not currently take into account window decorations so the sizing may be off by a few cells. If window decorations are disabled then the size is correct. This issue does not affect macOS; macOS makes the correct calculations as can be seen in the demo below.

## Demo

https://github.com/mitchellh/ghostty/assets/1299/fb7d82de-fb1f-4c87-8ca0-601a08ff49f1

