### PR TITLE
terminal: mode 2027

### DIFF
--- a/src/terminal/modes.zig
+++ b/src/terminal/modes.zig
@@ -172,6 +172,7 @@ const entries: []const ModeEntry = &.{
     .{ .name = "alt_screen_save_cursor_clear_enter", .value = 1049 },
     .{ .name = "bracketed_paste", .value = 2004 },
     .{ .name = "synchronized_output", .value = 2026 },
+    .{ .name = "grapheme_cluster", .value = 2027 },
 };
 
 test {


### PR DESCRIPTION
Implements Mode 2027, which explicitly enables grapheme cluster support.

Ghostty defaults to mode 2027 _off_ because I've found some shell environments expect the legacy behavior. The legacy behavior is to use `wcwidth` for each input character and move the cursor accordingly. `wcwidth` doesn't properly take into account [grapheme breaking](https://unicode.org/reports/tr29/) so it is wrong. For example, the emoji "🧑‍🌾" is reported as width 4 by `wcwidth`, but with proper Unicode Text Segmentation it is actually width 2 (1 grapheme, wide character).

Reference: https://github.com/contour-terminal/terminal-unicode-core

## Demo

Script after the video. The last number before the "R" reports the column the cursor is on.

![CleanShot 2023-10-02 at 09 14 16@2x](https://github.com/mitchellh/ghostty/assets/1299/e694a18d-f1bd-4874-818d-c22f20add012)

Note the emoji reports as width 2 with grapheme clustering on. Yay! 

A table showing the width reported for "🧑‍🌾" (a 3 codepoint grapheme U+1F9D1 U+200D U+1F33E) by terminal. The width is the number of cells the cursor moves forward after printing the emoji. The table is using all the latest versions as of October 1, 2023.

| Terminal | Width | Mode 2027 | Notes |
|---------|--------|--------|---------|
| Ghostty | 2 | ✅ | Falls back to `wcwidth` if mode 2027 is disabled |
| Alacritty | 4 | ❌ | Doesn't support shaping, displays as two separate emoji |
| Contour | 2| ✅ | Invented Mode 2027, always performs grapheme clustering |
| Foot | 2| ✅ | Falls back to `wcwidth` if mode 2027 is disabled |
| Gnome | 4 | ❌ | |
| iTerm | 2 | ❌ | Always performs grapheme clustering |
| Kitty | 4 | ❌ | |
| Terminal.app | 6 | ❌ | 🤡 just living in its own fucked up little world |
| Warp | 4 | ❌ | Doesn't support shaping, displays as two separate emoji |
| Wezterm | 2 | ✅ | Always performs grapheme clustering |
| Windows Terminal | 5 | ❌ | Considers ZWJ one cell. Displays as two separate emoji |
| Xfce | 4 | ❌ | |

```bash
#!/usr/bin/env bash

function csi() {
  printf "\033[%s" "$*"
}

echo "NO GRAPHEME:"
csi "?2027l" # grapheme support
printf '\U1F9D1\U200D\U1F33E'
csi "6n" # report cursor
sleep 1

echo
echo "WITH GRAPHEME:"
csi "?2027h" # grapheme support
printf '\U1F9D1\U200D\U1F33E'
csi "6n" # report cursor
sleep 1
csi "?2027l"
```