### PR TITLE
Update mouse shape based on ability to use native text selection

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1121,6 +1121,17 @@ pub fn keyCallback(
         self.hideMouse();
     }
 
+    if (self.io.terminal.flags.mouse_event != .none and
+        event.physical_key == .left_shift or
+        event.physical_key == .right_shift)
+    {
+        switch (event.action) {
+            .press => try self.rt_surface.setMouseShape(.text),
+            .release => try self.rt_surface.setMouseShape(self.io.terminal.mouse_shape),
+            else => {},
+        }
+    }
+
     // No binding, so we have to perform an encoding task. This
     // may still result in no encoding. Under different modes and
     // inputs there are many keybindings that result in no encoding

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1121,6 +1121,9 @@ pub fn keyCallback(
         self.hideMouse();
     }
 
+    // When we are in the middle of a mouse event and we press shift,
+    // we change the mouse to a text shape so that selection appears
+    // possible.
     if (self.io.terminal.flags.mouse_event != .none and
         event.physical_key == .left_shift or
         event.physical_key == .right_shift)
@@ -1128,7 +1131,7 @@ pub fn keyCallback(
         switch (event.action) {
             .press => try self.rt_surface.setMouseShape(.text),
             .release => try self.rt_surface.setMouseShape(self.io.terminal.mouse_shape),
-            else => {},
+            .repeat => {},
         }
     }
 

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -424,7 +424,7 @@ pub fn setMouseShape(
     shape: terminal.MouseShape,
 ) !void {
     const name: [:0]const u8 = switch (shape) {
-        .default => "text",
+        .default => "default",
         .help => "help",
         .pointer => "pointer",
         .context_menu => "context-menu",

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -85,6 +85,7 @@ previous_char: ?u21 = null,
 /// The modes that this terminal currently has active.
 modes: modes.ModeState = .{},
 
+/// The most recently set mouse shape for the terminal.
 mouse_shape: mouse_shape.MouseShape = .text,
 
 /// These are just a packed set of flags we may set on the terminal.

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -21,6 +21,7 @@ const Tabstops = @import("Tabstops.zig");
 const trace = @import("tracy").trace;
 const color = @import("color.zig");
 const Screen = @import("Screen.zig");
+const mouse_shape = @import("mouse_shape.zig");
 
 const log = std.log.scoped(.terminal);
 
@@ -83,6 +84,8 @@ previous_char: ?u21 = null,
 
 /// The modes that this terminal currently has active.
 modes: modes.ModeState = .{},
+
+mouse_shape: mouse_shape.MouseShape = .text,
 
 /// These are just a packed set of flags we may set on the terminal.
 flags: packed struct {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1902,7 +1902,7 @@ const StreamHandler = struct {
         self: *StreamHandler,
     ) !void {
         self.terminal.fullReset(self.alloc);
-        try self.setMouseShape(.default);
+        try self.setMouseShape(.text);
     }
 
     pub fn queryKittyKeyboard(self: *StreamHandler) !void {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -2024,6 +2024,7 @@ const StreamHandler = struct {
         self: *StreamHandler,
         shape: terminal.MouseShape,
     ) !void {
+        self.terminal.mouse_shape = shape;
         _ = self.ev.surface_mailbox.push(.{
             .set_mouse_shape = shape,
         }, .{ .forever = {} });

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1698,10 +1698,42 @@ const StreamHandler = struct {
                 self.messageWriter(.{ .linefeed_mode = enabled });
             },
 
-            .mouse_event_x10 => self.terminal.flags.mouse_event = if (enabled) .x10 else .none,
-            .mouse_event_normal => self.terminal.flags.mouse_event = if (enabled) .normal else .none,
-            .mouse_event_button => self.terminal.flags.mouse_event = if (enabled) .button else .none,
-            .mouse_event_any => self.terminal.flags.mouse_event = if (enabled) .any else .none,
+            .mouse_event_x10 => {
+                if (enabled) {
+                    self.terminal.flags.mouse_event = .x10;
+                    try self.setMouseShape(.default);
+                } else {
+                    self.terminal.flags.mouse_event = .none;
+                    try self.setMouseShape(.text);
+                }
+            },
+            .mouse_event_normal => {
+                if (enabled) {
+                    self.terminal.flags.mouse_event = .normal;
+                    try self.setMouseShape(.default);
+                } else {
+                    self.terminal.flags.mouse_event = .none;
+                    try self.setMouseShape(.text);
+                }
+            },
+            .mouse_event_button => {
+                if (enabled) {
+                    self.terminal.flags.mouse_event = .button;
+                    try self.setMouseShape(.default);
+                } else {
+                    self.terminal.flags.mouse_event = .none;
+                    try self.setMouseShape(.text);
+                }
+            },
+            .mouse_event_any => {
+                if (enabled) {
+                    self.terminal.flags.mouse_event = .any;
+                    try self.setMouseShape(.default);
+                } else {
+                    self.terminal.flags.mouse_event = .none;
+                    try self.setMouseShape(.text);
+                }
+            },
 
             .mouse_format_utf8 => self.terminal.flags.mouse_format = if (enabled) .utf8 else .x10,
             .mouse_format_sgr => self.terminal.flags.mouse_format = if (enabled) .sgr else .x10,


### PR DESCRIPTION
This PR expands on #597 by modifying the current mouse shape based on if native selection is in effect. This is a quality-of-life feature which gives the user some hint that they can select raw text on the terminal screen. The "default" mouse shape is .text. Whenever we enter _any_ mouse reporting mode, the mouse shape is set to .default. When shift is pressed, we go back to .text. On release, we restore back to the previous state. We store the state of our mouse shape so that if a user sets it via `CSI 22` we can return the shape back to that.

[Screencast from 2023-10-02 17-07-32.webm](https://github.com/mitchellh/ghostty/assets/476352/39b2f81c-fe84-4f9e-9ede-8cea408abf22)

Note: I was not sure where is best to store the mouse shape state...Terminal seemed to make the most sense. I was also unsure if this should be saved on a per-Screen basis...I decided against it because applications entering and exiting the alt-screen will nearly always modify the mouse reporting state, which we will then set - and they would want to set to their custom shape. It seems to be more of a terminal value than a screen value in that sense.

Also not thrilled with the control flow of setting the mouse shape when we set a reporting mode, but this reads clean to me so I went with it. I'm perfectly fine modifying if needed though
