### PR TITLE
coretext: score fonts to prefer bold over other bold styles

### DIFF
--- a/pkg/macos/build.zig
+++ b/pkg/macos/build.zig
@@ -28,7 +28,7 @@ pub fn build(b: *std.Build) !void {
     lib.linkFramework("CoreFoundation");
     lib.linkFramework("CoreGraphics");
     lib.linkFramework("CoreText");
-    try apple_sdk.addPaths(b, lib);
+    if (!target.isNative()) try apple_sdk.addPaths(b, lib);
 
     b.installArtifact(lib);
 

--- a/pkg/macos/foundation/array.zig
+++ b/pkg/macos/foundation/array.zig
@@ -63,7 +63,7 @@ pub const MutableArray = opaque {
             a: *const Elem,
             b: *const Elem,
             context: ?*Context,
-        ) ComparisonResult,
+        ) callconv(.C) ComparisonResult,
     ) void {
         CFArraySortValues(
             self,
@@ -122,7 +122,7 @@ test "array sorting" {
         void,
         null,
         struct {
-            fn compare(a: *const u8, b: *const u8, _: ?*void) ComparisonResult {
+            fn compare(a: *const u8, b: *const u8, _: ?*void) callconv(.C) ComparisonResult {
                 if (a.* > b.*) return .greater;
                 if (a.* == b.*) return .equal;
                 return .less;

--- a/pkg/macos/foundation/array.zig
+++ b/pkg/macos/foundation/array.zig
@@ -1,6 +1,9 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const base = @import("base.zig");
 const cftype = @import("type.zig");
+const ComparisonResult = base.ComparisonResult;
+const Range = base.Range;
 
 pub const Array = opaque {
     pub fn create(comptime T: type, values: []*const T) Allocator.Error!*Array {
@@ -38,6 +41,52 @@ pub const Array = opaque {
     extern "c" var kCFTypeArrayCallBacks: anyopaque;
 };
 
+pub const MutableArray = opaque {
+    pub fn createCopy(array: *Array) Allocator.Error!*MutableArray {
+        return CFArrayCreateMutableCopy(
+            null,
+            0,
+            array,
+        ) orelse error.OutOfMemory;
+    }
+
+    pub fn release(self: *MutableArray) void {
+        cftype.CFRelease(self);
+    }
+
+    pub fn sortValues(
+        self: *MutableArray,
+        comptime Elem: type,
+        comptime Context: type,
+        context: ?*Context,
+        comptime comparator: ?*const fn (
+            a: *const Elem,
+            b: *const Elem,
+            context: ?*Context,
+        ) ComparisonResult,
+    ) void {
+        CFArraySortValues(
+            self,
+            Range.init(0, Array.CFArrayGetCount(@ptrCast(self))),
+            comparator,
+            context,
+        );
+    }
+
+    extern "c" fn CFArrayCreateMutableCopy(
+        allocator: ?*anyopaque,
+        capacity: usize,
+        array: *Array,
+    ) ?*MutableArray;
+
+    extern "c" fn CFArraySortValues(
+        array: *MutableArray,
+        range: Range,
+        comparator: ?*const anyopaque,
+        context: ?*anyopaque,
+    ) void;
+};
+
 test "array" {
     const testing = std.testing;
 
@@ -50,6 +99,45 @@ test "array" {
 
     {
         const ch = arr.getValueAtIndex(u8, 0);
+        try testing.expectEqual(@as(u8, 'h'), ch.*);
+    }
+
+    // Can make it mutable
+    var mut = try MutableArray.createCopy(arr);
+    defer mut.release();
+}
+
+test "array sorting" {
+    const testing = std.testing;
+
+    const str = "hello";
+    var values = [_]*const u8{ &str[0], &str[1] };
+    const arr = try Array.create(u8, &values);
+    defer arr.release();
+    const mut = try MutableArray.createCopy(arr);
+    defer mut.release();
+
+    mut.sortValues(
+        u8,
+        void,
+        null,
+        struct {
+            fn compare(a: *const u8, b: *const u8, _: ?*void) ComparisonResult {
+                if (a.* > b.*) return .greater;
+                if (a.* == b.*) return .equal;
+                return .less;
+            }
+        }.compare,
+    );
+
+    {
+        const mutarr: *Array = @ptrCast(mut);
+        const ch = mutarr.getValueAtIndex(u8, 0);
+        try testing.expectEqual(@as(u8, 'e'), ch.*);
+    }
+    {
+        const mutarr: *Array = @ptrCast(mut);
+        const ch = mutarr.getValueAtIndex(u8, 1);
         try testing.expectEqual(@as(u8, 'h'), ch.*);
     }
 }

--- a/pkg/macos/text/font_descriptor.zig
+++ b/pkg/macos/text/font_descriptor.zig
@@ -46,18 +46,22 @@ pub const FontDescriptor = opaque {
         ) orelse Allocator.Error.OutOfMemory;
     }
 
+    pub fn retain(self: *FontDescriptor) void {
+        _ = c.CFRetain(self);
+    }
+
     pub fn release(self: *FontDescriptor) void {
         c.CFRelease(self);
     }
 
-    pub fn copyAttribute(self: *FontDescriptor, comptime attr: FontAttribute) attr.Value() {
+    pub fn copyAttribute(self: *const FontDescriptor, comptime attr: FontAttribute) attr.Value() {
         return @ptrFromInt(@intFromPtr(c.CTFontDescriptorCopyAttribute(
             @ptrCast(self),
             @ptrCast(attr.key()),
         )));
     }
 
-    pub fn copyAttributes(self: *FontDescriptor) *foundation.Dictionary {
+    pub fn copyAttributes(self: *const FontDescriptor) *foundation.Dictionary {
         return @ptrFromInt(@intFromPtr(c.CTFontDescriptorCopyAttributes(
             @ptrCast(self),
         )));

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -246,7 +246,7 @@ pub fn init(
             var name_buf: [256]u8 = undefined;
 
             if (config.@"font-family") |family| {
-                var disco_it = try disco.discover(.{
+                var disco_it = try disco.discover(alloc, .{
                     .family = family,
                     .style = config.@"font-style".nameValue(),
                     .size = font_size.points,
@@ -259,7 +259,7 @@ pub fn init(
                 } else log.warn("font-family not found: {s}", .{family});
             }
             if (config.@"font-family-bold") |family| {
-                var disco_it = try disco.discover(.{
+                var disco_it = try disco.discover(alloc, .{
                     .family = family,
                     .style = config.@"font-style-bold".nameValue(),
                     .size = font_size.points,
@@ -273,7 +273,7 @@ pub fn init(
                 } else log.warn("font-family-bold not found: {s}", .{family});
             }
             if (config.@"font-family-italic") |family| {
-                var disco_it = try disco.discover(.{
+                var disco_it = try disco.discover(alloc, .{
                     .family = family,
                     .style = config.@"font-style-italic".nameValue(),
                     .size = font_size.points,
@@ -287,7 +287,7 @@ pub fn init(
                 } else log.warn("font-family-italic not found: {s}", .{family});
             }
             if (config.@"font-family-bold-italic") |family| {
-                var disco_it = try disco.discover(.{
+                var disco_it = try disco.discover(alloc, .{
                     .family = family,
                     .style = config.@"font-style-bold-italic".nameValue(),
                     .size = font_size.points,

--- a/src/cli/list_fonts.zig
+++ b/src/cli/list_fonts.zig
@@ -85,7 +85,7 @@ fn runArgs(alloc_gpa: Allocator, argsIter: anytype) !u8 {
     // Look up all available fonts
     var disco = font.Discover.init();
     defer disco.deinit();
-    var disco_it = try disco.discover(.{
+    var disco_it = try disco.discover(alloc, .{
         .family = config.family,
         .style = config.style,
         .bold = config.bold,

--- a/src/font/DeferredFace.zig
+++ b/src/font/DeferredFace.zig
@@ -408,6 +408,7 @@ test "coretext" {
 
     const discovery = @import("main.zig").discovery;
     const testing = std.testing;
+    const alloc = testing.allocator;
 
     // Load freetype
     var lib = try Library.init();
@@ -416,7 +417,7 @@ test "coretext" {
     // Get a deferred face from fontconfig
     var def = def: {
         var fc = discovery.CoreText.init();
-        var it = try fc.discover(.{ .family = "Monaco", .size = 12 });
+        var it = try fc.discover(alloc, .{ .family = "Monaco", .size = 12 });
         defer it.deinit();
         break :def (try it.next()).?;
     };

--- a/src/font/DeferredFace.zig
+++ b/src/font/DeferredFace.zig
@@ -379,6 +379,7 @@ test "fontconfig" {
 
     const discovery = @import("main.zig").discovery;
     const testing = std.testing;
+    const alloc = testing.allocator;
 
     // Load freetype
     var lib = try Library.init();
@@ -387,7 +388,7 @@ test "fontconfig" {
     // Get a deferred face from fontconfig
     var def = def: {
         var fc = discovery.Fontconfig.init();
-        var it = try fc.discover(.{ .family = "monospace", .size = 12 });
+        var it = try fc.discover(alloc, .{ .family = "monospace", .size = 12 });
         defer it.deinit();
         break :def (try it.next()).?;
     };

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -313,7 +313,7 @@ pub fn indexForCodepoint(
     // If we are regular, try looking for a fallback using discovery.
     if (style == .regular and font.Discover != void) {
         if (self.discover) |disco| discover: {
-            var disco_it = disco.discover(.{
+            var disco_it = disco.discover(self.alloc, .{
                 .codepoint = cp,
                 .size = self.size.points,
                 .bold = style == .bold or style == .bold_italic,
@@ -382,7 +382,7 @@ fn indexForCodepointOverride(self: *Group, cp: u32) !?FontIndex {
     const idx_: ?FontIndex = self.descriptor_cache.get(desc) orelse idx: {
         // Slow path: we have to find this descriptor and load the font
         const discover = self.discover orelse return null;
-        var disco_it = try discover.discover(desc);
+        var disco_it = try discover.discover(self.alloc, desc);
         defer disco_it.deinit();
 
         const face = (try disco_it.next()) orelse {

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -835,7 +835,7 @@ test "discover monospace with fontconfig and freetype" {
 
     // Search for fonts
     var fc = Discover.init();
-    var it = try fc.discover(.{ .family = "monospace", .size = 12 });
+    var it = try fc.discover(alloc, .{ .family = "monospace", .size = 12 });
     defer it.deinit();
 
     // Initialize the group with the deferred face

--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -234,7 +234,9 @@ pub const Fontconfig = struct {
 
     /// Discover fonts from a descriptor. This returns an iterator that can
     /// be used to build up the deferred fonts.
-    pub fn discover(self: *const Fontconfig, desc: Descriptor) !DiscoverIterator {
+    pub fn discover(self: *const Fontconfig, alloc: Allocator, desc: Descriptor) !DiscoverIterator {
+        _ = alloc;
+
         // Build our pattern that we'll search for
         const pat = desc.toFcPattern();
         errdefer pat.destroy();

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -908,7 +908,7 @@ fn testShaper(alloc: Allocator) !TestShaper {
         // On CoreText we want to load Apple Emoji, we should have it.
         var disco = font.Discover.init();
         defer disco.deinit();
-        var disco_it = try disco.discover(.{
+        var disco_it = try disco.discover(alloc, .{
             .family = "Apple Color Emoji",
             .size = 12,
             .monospace = false,


### PR DESCRIPTION
Fixes #604 

CoreText font discovery doesn't have the same scoring mechanism that fontconfig does and results in semi-bold being picked over bold. We want to prefer the "bold" font if available for bold styles. This PR introduces a general mechanism for scoring font discovery results for CoreText. In this PR I just implement a really basic, fairly naive scoring algorithm to prefer exact match styles over partial.

Result:

```
$ ./zig-out/bin/ghostty +list-fonts --family="JetBrains Mono" --bold
JetBrains Mono
  JetBrains Mono Bold
  JetBrains Mono SemiBold
  JetBrains Mono ExtraBold
  JetBrains Mono Bold Italic
  JetBrains Mono SemiBold Italic
  JetBrains Mono ExtraBold Italic
```