### PR TITLE
macos: support dropping files onto terminal to paste path

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -388,7 +388,7 @@ void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);
 void ghostty_surface_set_focus(ghostty_surface_t, bool);
 void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t);
 void ghostty_surface_key(ghostty_surface_t, ghostty_input_action_e, uint32_t, ghostty_input_mods_e);
-void ghostty_surface_char(ghostty_surface_t, uint32_t);
+void ghostty_surface_text(ghostty_surface_t, const char *, uintptr_t);
 void ghostty_surface_mouse_button(ghostty_surface_t, ghostty_input_mouse_state_e, ghostty_input_mouse_button_e, ghostty_input_mods_e);
 void ghostty_surface_mouse_pos(ghostty_surface_t, double, double);
 void ghostty_surface_mouse_scroll(ghostty_surface_t, double, double, ghostty_input_scroll_mods_t);

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -129,6 +129,16 @@ extension Ghostty {
                             // I don't know how older macOS versions behave but Ghostty only
                             // supports back to macOS 12 so its moot.
                         }
+                        .onDrop(of: [.fileURL], isTargeted: nil) { providers in
+                            providers.forEach { provider in
+                                _ = provider.loadObject(ofClass: URL.self) { url, _ in
+                                    guard let url = url else { return }
+                                    AppDelegate.logger.warning("OPEN url=\(url.path)")
+                                }
+                            }
+                            
+                            return true
+                        }
                 }
                 .ghosttySurfaceView(surfaceView)
 

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -836,8 +836,9 @@ extension Ghostty {
                 return
             }
 
-            for codepoint in chars.unicodeScalars {
-                ghostty_surface_char(surface, codepoint.value)
+            let len = chars.utf8CString.count
+            chars.withCString { ptr in
+                ghostty_surface_text(surface, ptr, UInt(len))
             }
         }
 

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -133,7 +133,12 @@ extension Ghostty {
                             providers.forEach { provider in
                                 _ = provider.loadObject(ofClass: URL.self) { url, _ in
                                     guard let url = url else { return }
-                                    AppDelegate.logger.warning("OPEN url=\(url.path)")
+                                    DispatchQueue.main.async {
+                                        surfaceView.insertText(
+                                            url.path,
+                                            replacementRange: NSMakeRange(0, 0)
+                                        )
+                                    }
                                 }
                             }
                             

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1020,6 +1020,15 @@ pub fn keyCallback(
     return true;
 }
 
+/// Sends text as-is to the terminal without triggering any keyboard
+/// protocol. This will treat the input text as if it was pasted
+/// from the clipboard so the same logic will be applied. Namely,
+/// if bracketed mode is on this will do a bracketed paste. Otherwise,
+/// this will filter newlines to '\r'.
+pub fn textCallback(self: *Surface, text: []const u8) !void {
+    try self.completeClipboardPaste(text);
+}
+
 pub fn focusCallback(self: *Surface, focused: bool) !void {
     // Notify our render thread of the new state
     _ = self.renderer_thread.mailbox.push(.{

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -686,19 +686,7 @@ pub const Surface = struct {
             return;
         };
 
-        // For a char callback we just construct a key event with invalid
-        // keys but with text. This should result in the text being sent
-        // as-is.
-        _ = self.core_surface.keyCallback(.{
-            .action = .press,
-            .key = .invalid,
-            .physical_key = .invalid,
-            .mods = .{},
-            .consumed_mods = .{},
-            .composing = false,
-            .utf8 = buf[0..len],
-            .unshifted_codepoint = 0,
-        }) catch |err| {
+        _ = self.core_surface.textCallback(buf[0..len]) catch |err| {
             log.err("error in key callback err={}", .{err});
             return;
         };

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -678,15 +678,8 @@ pub const Surface = struct {
         }
     }
 
-    pub fn charCallback(self: *Surface, cp_: u32) void {
-        const cp = std.math.cast(u21, cp_) orelse return;
-        var buf: [4]u8 = undefined;
-        const len = std.unicode.utf8Encode(cp, &buf) catch |err| {
-            log.err("error encoding codepoint={} err={}", .{ cp, err });
-            return;
-        };
-
-        _ = self.core_surface.textCallback(buf[0..len]) catch |err| {
+    pub fn textCallback(self: *Surface, text: []const u8) void {
+        _ = self.core_surface.textCallback(text) catch |err| {
             log.err("error in key callback err={}", .{err});
             return;
         };
@@ -946,11 +939,15 @@ pub const CAPI = struct {
         };
     }
 
-    /// Send for a unicode character. This is used for IME input. This
-    /// should only be sent for characters that are not the result of
-    /// key events.
-    export fn ghostty_surface_char(surface: *Surface, codepoint: u32) void {
-        surface.charCallback(codepoint);
+    /// Send raw text to the terminal. This is treated like a paste
+    /// so this isn't useful for sending escape sequences. For that,
+    /// individual key input should be used.
+    export fn ghostty_surface_text(
+        surface: *Surface,
+        ptr: [*]const u8,
+        len: usize,
+    ) void {
+        surface.textCallback(ptr[0..len]);
     }
 
     /// Tell the surface that it needs to schedule a render


### PR DESCRIPTION
Fixes #231 

This adds support for dropping any folder/file onto the terminal and Ghostty will paste the path. The paste is treated just like a clipboard paste: it will be bracketed if bracketed mode is on, otherwise it will be "pasted" as raw text.

# Demo

https://github.com/mitchellh/ghostty/assets/1299/eca0fbf1-6890-4df5-ad43-6c2f141d2802


