### PR TITLE
Configurations to adjust various font metrics

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -231,6 +231,10 @@ pub fn init(
             if (config.@"adjust-cell-width") |m| try set.put(alloc, .cell_width, m);
             if (config.@"adjust-cell-height") |m| try set.put(alloc, .cell_height, m);
             if (config.@"adjust-font-baseline") |m| try set.put(alloc, .cell_baseline, m);
+            if (config.@"adjust-underline-position") |m| try set.put(alloc, .underline_position, m);
+            if (config.@"adjust-underline-thickness") |m| try set.put(alloc, .underline_thickness, m);
+            if (config.@"adjust-strikethrough-position") |m| try set.put(alloc, .strikethrough_position, m);
+            if (config.@"adjust-strikethrough-thickness") |m| try set.put(alloc, .strikethrough_thickness, m);
             break :set set;
         };
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -228,7 +228,10 @@ pub fn init(
         group.metric_modifiers = set: {
             var set: font.face.Metrics.ModifierSet = .{};
             errdefer set.deinit(alloc);
-            break :set null;
+            if (config.@"adjust-cell-width") |m| try set.put(alloc, .cell_width, m);
+            if (config.@"adjust-cell-height") |m| try set.put(alloc, .cell_height, m);
+            if (config.@"adjust-font-baseline") |m| try set.put(alloc, .cell_baseline, m);
+            break :set set;
         };
 
         // If we have codepoint mappings, set those.

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -224,6 +224,13 @@ pub fn init(
         var group = try font.Group.init(alloc, font_lib, font_size);
         errdefer group.deinit();
 
+        // Setup our font metric modifiers if we have any.
+        group.metric_modifiers = set: {
+            var set: font.face.Metrics.ModifierSet = .{};
+            errdefer set.deinit(alloc);
+            break :set null;
+        };
+
         // If we have codepoint mappings, set those.
         if (config.@"font-codepoint-map".map.list.len > 0) {
             group.codepoint_map = config.@"font-codepoint-map".map;
@@ -306,11 +313,11 @@ pub fn init(
         // Our built-in font will be used as a backup
         _ = try group.addFace(
             .regular,
-            .{ .loaded = try font.Face.init(font_lib, face_ttf, font_size) },
+            .{ .loaded = try font.Face.init(font_lib, face_ttf, group.faceOptions()) },
         );
         _ = try group.addFace(
             .bold,
-            .{ .loaded = try font.Face.init(font_lib, face_bold_ttf, font_size) },
+            .{ .loaded = try font.Face.init(font_lib, face_bold_ttf, group.faceOptions()) },
         );
 
         // Auto-italicize if we have to.
@@ -321,11 +328,11 @@ pub fn init(
         if (builtin.os.tag != .macos or font.Discover == void) {
             _ = try group.addFace(
                 .regular,
-                .{ .loaded = try font.Face.init(font_lib, face_emoji_ttf, font_size) },
+                .{ .loaded = try font.Face.init(font_lib, face_emoji_ttf, group.faceOptions()) },
             );
             _ = try group.addFace(
                 .regular,
-                .{ .loaded = try font.Face.init(font_lib, face_emoji_text_ttf, font_size) },
+                .{ .loaded = try font.Face.init(font_lib, face_emoji_text_ttf, group.faceOptions()) },
             );
         }
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -138,6 +138,10 @@ const c = @cImport({
 @"adjust-cell-width": ?MetricModifier = null,
 @"adjust-cell-height": ?MetricModifier = null,
 @"adjust-font-baseline": ?MetricModifier = null,
+@"adjust-underline-position": ?MetricModifier = null,
+@"adjust-underline-thickness": ?MetricModifier = null,
+@"adjust-strikethrough-position": ?MetricModifier = null,
+@"adjust-strikethrough-thickness": ?MetricModifier = null,
 
 /// Background color for the window.
 background: Color = .{ .r = 0x28, .g = 0x2C, .b = 0x34 },

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -135,6 +135,12 @@ const c = @cImport({
 /// There is little to no validation on these values so the wrong values
 /// (i.e. "-100%") can cause the terminal to be unusable. Use with caution
 /// and reason.
+///
+/// Some values are clamped to minimum or maximum values. This can make it
+/// appear that certain values are ignored. For example, the underline
+/// position is clamped to the height of a cell. If you set the underline
+/// position so high that it extends beyond the bottom of the cell size,
+/// it will be clamped to the bottom of the cell.
 @"adjust-cell-width": ?MetricModifier = null,
 @"adjust-cell-height": ?MetricModifier = null,
 @"adjust-font-baseline": ?MetricModifier = null,

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -15,6 +15,7 @@ const cli = @import("../cli.zig");
 const Key = @import("key.zig").Key;
 const KeyValue = @import("key.zig").Value;
 const ErrorList = @import("ErrorList.zig");
+const MetricModifier = fontpkg.face.Metrics.Modifier;
 
 const log = std.log.scoped(.config);
 
@@ -121,6 +122,22 @@ const c = @cImport({
 /// Draw fonts with a thicker stroke, if supported. This is only supported
 /// currently on macOS.
 @"font-thicken": bool = false,
+
+/// All of the configurations behavior adjust various metrics determined
+/// by the font. The values can be integers (1, -1, etc.) or a percentage
+/// (20%, -15%, etc.). In each case, the values represent the amount to
+/// change the original value.
+///
+/// For example, a value of "1" increases the value by 1; it does not set
+/// it to literally 1. A value of "20%" increases the value by 20%. And so
+/// on.
+///
+/// There is little to no validation on these values so the wrong values
+/// (i.e. "-100%") can cause the terminal to be unusable. Use with caution
+/// and reason.
+@"adjust-cell-width": ?MetricModifier = null,
+@"adjust-cell-height": ?MetricModifier = null,
+@"adjust-font-baseline": ?MetricModifier = null,
 
 /// Background color for the window.
 background: Color = .{ .r = 0x28, .g = 0x2C, .b = 0x34 },

--- a/src/font/DeferredFace.zig
+++ b/src/font/DeferredFace.zig
@@ -181,7 +181,7 @@ fn loadFontconfig(
 
     var face = try Face.initFile(lib, filename, face_index, opts);
     errdefer face.deinit();
-    try face.setVariations(fc.variations);
+    try face.setVariations(fc.variations, opts);
     return face;
 }
 
@@ -400,7 +400,7 @@ test "fontconfig" {
     try testing.expect(n.len > 0);
 
     // Load it and verify it works
-    const face = try def.load(lib, .{ .points = 12 });
+    const face = try def.load(lib, .{ .size = .{ .points = 12 } });
     try testing.expect(face.glyphIndex(' ') != null);
 }
 

--- a/src/font/DeferredFace.zig
+++ b/src/font/DeferredFace.zig
@@ -192,7 +192,8 @@ fn loadCoreText(
 ) !Face {
     _ = lib;
     const ct = self.ct.?;
-    return try Face.initFontCopy(ct.font, size);
+    // TODO: make options
+    return try Face.initFontCopy(ct.font, .{ .size = size });
 }
 
 fn loadCoreTextFreetype(

--- a/src/font/GroupCache.zig
+++ b/src/font/GroupCache.zig
@@ -184,7 +184,7 @@ test {
     // Setup group
     _ = try cache.group.addFace(
         .regular,
-        .{ .loaded = try Face.init(lib, testFont, .{ .points = 12 }) },
+        .{ .loaded = try Face.init(lib, testFont, .{ .size = .{ .points = 12 } }) },
     );
     var group = cache.group;
 
@@ -340,7 +340,11 @@ test "resize" {
     // Setup group
     _ = try cache.group.addFace(
         .regular,
-        .{ .loaded = try Face.init(lib, testFont, .{ .points = 12, .xdpi = 96, .ydpi = 96 }) },
+        .{ .loaded = try Face.init(
+            lib,
+            testFont,
+            .{ .size = .{ .points = 12, .xdpi = 96, .ydpi = 96 } },
+        ) },
     );
 
     // Load a letter

--- a/src/font/face.zig
+++ b/src/font/face.zig
@@ -22,6 +22,12 @@ pub const Face = switch (options.backend) {
 /// using whatever platform method you can.
 pub const default_dpi = if (builtin.os.tag == .macos) 72 else 96;
 
+/// Options for initializing a font face.
+pub const Options = struct {
+    size: DesiredSize,
+    metric_modifiers: ?*const Metrics.ModifierSet = null,
+};
+
 /// The desired size for loading a font.
 pub const DesiredSize = struct {
     // Desired size in points

--- a/src/font/face.zig
+++ b/src/font/face.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const options = @import("main.zig").options;
+pub const Metrics = @import("face/Metrics.zig");
 const freetype = @import("face/freetype.zig");
 const coretext = @import("face/coretext.zig");
 pub const web_canvas = @import("face/web_canvas.zig");
@@ -60,28 +61,6 @@ pub const Variation = struct {
             return .{ self.a, self.b, self.c, self.d };
         }
     };
-};
-
-/// Metrics associated with the font that are useful for renderers to know.
-pub const Metrics = struct {
-    /// Recommended cell width and height for a monospace grid using this font.
-    cell_width: u32,
-    cell_height: u32,
-
-    /// For monospace grids, the recommended y-value from the bottom to set
-    /// the baseline for font rendering. This is chosen so that things such
-    /// as the bottom of a "g" or "y" do not drop below the cell.
-    cell_baseline: u32,
-
-    /// The position of the underline from the top of the cell and the
-    /// thickness in pixels.
-    underline_position: u32,
-    underline_thickness: u32,
-
-    /// The position and thickness of a strikethrough. Same units/style
-    /// as the underline fields.
-    strikethrough_position: u32,
-    strikethrough_thickness: u32,
 };
 
 /// Additional options for rendering glyphs.

--- a/src/font/face/Metrics.zig
+++ b/src/font/face/Metrics.zig
@@ -26,6 +26,18 @@ pub fn apply(self: *Metrics, mods: ModifierSet) void {
     var it = mods.iterator();
     while (it.next()) |entry| {
         switch (entry.key_ptr.*) {
+            // We clamp these values to a minimum of 1 to prevent divide-by-zero
+            // in downstream operations.
+            inline .cell_width,
+            .cell_height,
+            => |tag| {
+                const original = @field(self, @tagName(tag));
+                @field(self, @tagName(tag)) = @max(
+                    entry.value_ptr.apply(original),
+                    1,
+                );
+            },
+
             inline else => |tag| {
                 @field(self, @tagName(tag)) = entry.value_ptr.apply(@field(self, @tagName(tag)));
             },

--- a/src/font/face/Metrics.zig
+++ b/src/font/face/Metrics.zig
@@ -1,0 +1,142 @@
+const Metrics = @This();
+
+const std = @import("std");
+
+/// Recommended cell width and height for a monospace grid using this font.
+cell_width: u32,
+cell_height: u32,
+
+/// For monospace grids, the recommended y-value from the bottom to set
+/// the baseline for font rendering. This is chosen so that things such
+/// as the bottom of a "g" or "y" do not drop below the cell.
+cell_baseline: u32,
+
+/// The position of the underline from the top of the cell and the
+/// thickness in pixels.
+underline_position: u32,
+underline_thickness: u32,
+
+/// The position and thickness of a strikethrough. Same units/style
+/// as the underline fields.
+strikethrough_position: u32,
+strikethrough_thickness: u32,
+
+/// A modifier to apply to a metrics value. The modifier value represents
+/// a delta, so percent is a percentage to change, not a percentage of.
+/// For example, "20%" is 20% larger, not 20% of the value. Likewise,
+/// an absolute value of "20" is 20 larger, not literally 20.
+pub const Modifier = union(enum) {
+    percent: f64,
+    absolute: i32,
+
+    /// Parses the modifier value. If the value ends in "%" it is assumed
+    /// to be a percent, otherwise the value is parsed as an integer.
+    pub fn parse(input: []const u8) !Modifier {
+        if (input.len == 0) return error.InvalidFormat;
+
+        if (input[input.len - 1] == '%') {
+            var percent = std.fmt.parseFloat(
+                f64,
+                input[0 .. input.len - 1],
+            ) catch return error.InvalidFormat;
+            percent /= 100;
+
+            if (percent <= -1) return .{ .percent = 0 };
+            if (percent < 0) return .{ .percent = 1 + percent };
+            return .{ .percent = 1 + percent };
+        }
+
+        return .{
+            .absolute = std.fmt.parseInt(i32, input, 10) catch
+                return error.InvalidFormat,
+        };
+    }
+
+    /// Apply a modifier to a numeric value.
+    pub fn apply(self: Modifier, v: u32) u32 {
+        return switch (self) {
+            .percent => |p| percent: {
+                const p_clamped: f64 = @max(0, p);
+                const v_f64: f64 = @floatFromInt(v);
+                const applied_f64: f64 = @round(v_f64 * p_clamped);
+                const applied_u32: u32 = @intFromFloat(applied_f64);
+                break :percent applied_u32;
+            },
+
+            .absolute => |abs| absolute: {
+                const v_i64: i64 = @intCast(v);
+                const abs_i64: i64 = @intCast(abs);
+                const applied_i64: i64 = @max(0, v_i64 +| abs_i64);
+                const applied_u32: u32 = std.math.cast(u32, applied_i64) orelse
+                    std.math.maxInt(u32);
+                break :absolute applied_u32;
+            },
+        };
+    }
+};
+
+test "Modifier: parse absolute" {
+    const testing = std.testing;
+
+    {
+        const m = try Modifier.parse("100");
+        try testing.expectEqual(Modifier{ .absolute = 100 }, m);
+    }
+
+    {
+        const m = try Modifier.parse("-100");
+        try testing.expectEqual(Modifier{ .absolute = -100 }, m);
+    }
+}
+
+test "Modifier: parse percent" {
+    const testing = std.testing;
+
+    {
+        const m = try Modifier.parse("20%");
+        try testing.expectEqual(Modifier{ .percent = 1.2 }, m);
+    }
+    {
+        const m = try Modifier.parse("-20%");
+        try testing.expectEqual(Modifier{ .percent = 0.8 }, m);
+    }
+    {
+        const m = try Modifier.parse("0%");
+        try testing.expectEqual(Modifier{ .percent = 1 }, m);
+    }
+}
+
+test "Modifier: percent" {
+    const testing = std.testing;
+
+    {
+        const m: Modifier = .{ .percent = 0.8 };
+        const v: u32 = m.apply(100);
+        try testing.expectEqual(@as(u32, 80), v);
+    }
+    {
+        const m: Modifier = .{ .percent = 1.8 };
+        const v: u32 = m.apply(100);
+        try testing.expectEqual(@as(u32, 180), v);
+    }
+}
+
+test "Modifier: absolute" {
+    const testing = std.testing;
+
+    {
+        const m: Modifier = .{ .absolute = -100 };
+        const v: u32 = m.apply(100);
+        try testing.expectEqual(@as(u32, 0), v);
+    }
+    {
+        const m: Modifier = .{ .absolute = -120 };
+        const v: u32 = m.apply(100);
+        try testing.expectEqual(@as(u32, 0), v);
+    }
+    {
+        const m: Modifier = .{ .absolute = 100 };
+        const v: u32 = m.apply(100);
+        try testing.expectEqual(@as(u32, 200), v);
+    }
+}

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -899,11 +899,19 @@ fn testShaper(alloc: Allocator) !TestShaper {
     errdefer cache_ptr.*.deinit(alloc);
 
     // Setup group
-    _ = try cache_ptr.group.addFace(.regular, .{ .loaded = try Face.init(lib, testFont, .{ .points = 12 }) });
+    _ = try cache_ptr.group.addFace(.regular, .{ .loaded = try Face.init(
+        lib,
+        testFont,
+        .{ .size = .{ .points = 12 } },
+    ) });
 
     if (font.options.backend != .coretext) {
         // Coretext doesn't support Noto's format
-        _ = try cache_ptr.group.addFace(.regular, .{ .loaded = try Face.init(lib, testEmoji, .{ .points = 12 }) });
+        _ = try cache_ptr.group.addFace(.regular, .{ .loaded = try Face.init(
+            lib,
+            testEmoji,
+            .{ .size = .{ .points = 12 } },
+        ) });
     } else {
         // On CoreText we want to load Apple Emoji, we should have it.
         var disco = font.Discover.init();
@@ -918,7 +926,11 @@ fn testShaper(alloc: Allocator) !TestShaper {
         errdefer face.deinit();
         _ = try cache_ptr.group.addFace(.regular, .{ .deferred = face });
     }
-    _ = try cache_ptr.group.addFace(.regular, .{ .loaded = try Face.init(lib, testEmojiText, .{ .points = 12 }) });
+    _ = try cache_ptr.group.addFace(.regular, .{ .loaded = try Face.init(
+        lib,
+        testEmojiText,
+        .{ .size = .{ .points = 12 } },
+    ) });
 
     var shaper = try Shaper.init(alloc, .{});
     errdefer shaper.deinit();

--- a/src/font/sprite/underline.zig
+++ b/src/font/sprite/underline.zig
@@ -171,8 +171,9 @@ const Draw = struct {
         // wave. This constant is arbitrary, change it for aesthetics.
         const pos = pos: {
             const MIN_HEIGHT = 7;
-            const height = y_max - self.pos;
-            break :pos if (height < MIN_HEIGHT) self.pos -| MIN_HEIGHT else self.pos;
+            const clamped_pos = @min(y_max, self.pos);
+            const height = y_max - clamped_pos;
+            break :pos if (height < MIN_HEIGHT) clamped_pos -| MIN_HEIGHT else clamped_pos;
         };
 
         // The full heightof the wave can be from the bottom to the

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -211,7 +211,8 @@ pub fn init(alloc: Allocator, options: renderer.Options) !Metal {
     options.font_group.group.sprite = font.sprite.Face{
         .width = metrics.cell_width,
         .height = metrics.cell_height,
-        .thickness = 2 * @as(u32, if (options.config.font_thicken) 2 else 1),
+        .thickness = metrics.underline_thickness *
+            @as(u32, if (options.config.font_thicken) 2 else 1),
         .underline_position = metrics.underline_position,
     };
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -548,7 +548,7 @@ fn resetFontMetrics(
     font_group.group.sprite = font.sprite.Face{
         .width = metrics.cell_width,
         .height = metrics.cell_height,
-        .thickness = 2 * @as(u32, if (font_thicken) 2 else 1),
+        .thickness = metrics.underline_thickness * @as(u32, if (font_thicken) 2 else 1),
         .underline_position = metrics.underline_position,
     };
 


### PR DESCRIPTION
This introduces some advanced configurations to fine-tune font metrics: `adjust-cell-width`, `adjust-cell-height`, `adjust-font-baseline`, `adjust-underline-position`, `adjust-underline-thickness`, `adjust-strikethrough-position`, `adust-strikethrough-thickness`.

The values of these configurations are either an integer or a percentage (suffixed with "%"). In either case, the value represents the _delta_ to apply to the original calculated value. For example, `adjust-cell-width = 5` does not make the cell width literally 5, it _adds 5_ to the cell width. Another example, `adjust-cell-width = 20%` does not make the cell width 20% of the original value, it _adds 20%_ to the cell width.

As the documentation states, it is very possible to get Ghostty into a really broken rendering state with these configurations. Ghostty should not crash, but it can become rendered into an unusable state. Users should take caution.

## Demo


https://github.com/mitchellh/ghostty/assets/1299/db07a16f-cf9f-491f-8d75-8dd92f80004d

