### PR TITLE
config: add option to disable working directory inheritance

### DIFF
--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -79,8 +79,10 @@ pub fn newConfig(app: *const App, config: *const Config) !Config {
     // Get our previously focused surface for some inherited values.
     const prev = app.focusedSurface();
     if (prev) |p| {
-        if (try p.pwd(alloc)) |pwd| {
-            copy.@"working-directory" = pwd;
+        if (config.@"window-inherit-working-directory") {
+            if (try p.pwd(alloc)) |pwd| {
+                copy.@"working-directory" = pwd;
+            }
         }
     }
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -309,6 +309,12 @@ keybind: Keybinds = .{},
 /// to balance the padding given a certain viewport size and grid cell size.
 @"window-padding-balance": bool = false,
 
+/// If true, new windows and tabs will inherit the working directory of
+/// the previously focused window. If no window was previously focused,
+/// the default working directory will be used (the "working-directory"
+/// option).
+@"window-inherit-working-directory": bool = true,
+
 /// If true, new windows and tabs will inherit the font size of the previously
 /// focused window. If no window was previously focused, the default
 /// font size will be used. If this is false, the default font size


### PR DESCRIPTION
Fixes #618

This adds a new config option `window-inherit-working-directory` (alongside the previously already existing `window-inherit-font-size`) to disable inheriting the working directory from a previously focused tab/window.

## Demo


https://github.com/mitchellh/ghostty/assets/1299/979b9b9d-3bd7-43b7-8a97-cb9a07da44af

