### PR TITLE
xterm audit: insert characters (ICH)

### DIFF
--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1620,7 +1620,9 @@ pub fn insertBlanks(self: *Terminal, count: usize) void {
         while (i < copyable) : (i += 1) {
             const to = right_limit - 1 - i;
             const from = copyable_end - i;
-            row.getCellPtr(to).* = row.getCell(from);
+            const src = row.getCell(from);
+            const dst = row.getCellPtr(to);
+            dst.* = src;
         }
     }
 

--- a/website/app/vt/ich/page.mdx
+++ b/website/app/vt/ich/page.mdx
@@ -1,0 +1,103 @@
+import VTSequence from "@/components/VTSequence";
+
+# Insert Character (ICH)
+
+<VTSequence sequence={["CSI", "Pn", "@"]} />
+
+Insert `n` blank characters at the current cursor position and shift
+existing cell contents right.
+
+The parameter `n` must be an integer greater than or equal to 1. If `n` is less than
+or equal to 0, adjust `n` to be 1. If `n` is omitted, `n` defaults to 1.
+
+This sequence always unsets the pending wrap state.
+
+If the cursor position is outside of the [left and right margins](#TODO),
+this sequence does not change the screen, but the pending wrap state is
+still reset.
+
+Existing cells shifted beyond the right margin are deleted. Inserted cells
+are blank with the background color colored according to the current SGR state.
+
+## Validation
+
+### ICH V-1: No Scroll Region, Fits on Screen
+
+```bash
+printf "ABC"
+printf "\033[1G"
+printf "\033[2@"
+```
+
+```
+|XcABC_____|
+```
+
+### ICH V-2: SGR State
+
+```bash
+printf "ABC"
+printf "\033[1G"
+printf "\033[41m"
+printf "\033[2@"
+printf "X"
+```
+
+```
+|c_ABC_____|
+```
+
+The `c_` cells should both have a red background. The `ABC` cells should
+remain unchanged in style.
+
+### ICH V-3: Shifting Content Off the Screen
+
+```bash
+cols=$(tput cols)
+printf "\033[${cols}G"
+printf "\033[2D"
+printf "ABC"
+printf "\033[2D"
+printf "\033[2@"
+printf "X"
+```
+
+```
+|_______XcA|
+```
+
+### ICH V-4: Inside Left/Right Scroll Region
+
+```bash
+printf "\033[1;1H" # move to top-left
+printf "\033[0J" # clear screen
+printf "\033[?69h" # enable left/right margins
+printf "\033[3;5s" # scroll region left/right
+printf "\033[3G"
+printf "ABC"
+printf "\033[3G"
+printf "\033[2@"
+printf "X"
+```
+
+```
+|__XcA_____|
+```
+
+### ICH V-5: Outside Left/Right Scroll Region
+
+```bash
+printf "\033[1;1H" # move to top-left
+printf "\033[0J" # clear screen
+printf "\033[?69h" # enable left/right margins
+printf "\033[3;5s" # scroll region left/right
+printf "\033[3G"
+printf "ABC"
+printf "\033[1G"
+printf "\033[2@"
+printf "X"
+```
+
+```
+|XcABC_____|
+```

--- a/website/app/vt/ich/page.mdx
+++ b/website/app/vt/ich/page.mdx
@@ -19,6 +19,11 @@ still reset.
 Existing cells shifted beyond the right margin are deleted. Inserted cells
 are blank with the background color colored according to the current SGR state.
 
+If a multi-cell character (such as "橋") is shifted so that the cell is split
+in half, the multi-cell character can either be clipped or erased. Typical
+behavior is to clip at the right edge of the screen and erase at a right
+margin, but either behavior is acceptable.
+
 ## Validation
 
 ### ICH V-1: No Scroll Region, Fits on Screen
@@ -101,3 +106,23 @@ printf "X"
 ```
 |XcABC_____|
 ```
+
+### ICH V-6: Split Wide Character
+
+```bash
+cols=$(tput cols)
+printf "\033[${cols}G"
+printf "\033[1D"
+printf "橋"
+printf "\033[2D"
+printf "\033[@"
+printf "X"
+```
+
+```
+|_______Xc_|
+```
+
+In this case, it is valid for the last cell to be blank or to clip the
+multi-cell character. xterm clips the character but many other terminals
+erase the cell.


### PR DESCRIPTION
Two changes:

  - Blank cells inserted should have the background color of the SGR state
  - Handle left/right margins
