### PR TITLE
Alternate scroll disabled by default, only sends up/down

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1195,15 +1195,6 @@ pub fn scrollCallback(
                 }
             }
 
-            if (x.delta_unsigned > 0) {
-                const seq = if (x.delta < 0) "\x1bOC" else "\x1bOD";
-                for (0..x.delta_unsigned) |_| {
-                    _ = self.io_thread.mailbox.push(.{
-                        .write_stable = seq,
-                    }, .{ .forever = {} });
-                }
-            }
-
             // After sending all our messages we have to notify our IO thread
             try self.io_thread.wakeup.notify();
             return;

--- a/src/terminal/modes.zig
+++ b/src/terminal/modes.zig
@@ -165,7 +165,7 @@ const entries: []const ModeEntry = &.{
     .{ .name = "focus_event", .value = 1004 },
     .{ .name = "mouse_format_utf8", .value = 1005 },
     .{ .name = "mouse_format_sgr", .value = 1006 },
-    .{ .name = "mouse_alternate_scroll", .value = 1007, .default = true },
+    .{ .name = "mouse_alternate_scroll", .value = 1007 },
     .{ .name = "mouse_format_urxvt", .value = 1015 },
     .{ .name = "mouse_format_sgr_pixels", .value = 1016 },
     .{ .name = "alt_esc_prefix", .value = 1036, .default = true },


### PR DESCRIPTION
Fixes #633

A couple bugs with our alternate scroll (mode 1007) implementation:

  - This should be disabled by default. Verified with iTerm, Kitty, xterm
  - This should only send up/down arrows, not left/right. Verified with Kitty, xterm. Other terminals do send left/right but I don't think that is correct.