### PR TITLE
xterm audit: ECH

### DIFF
--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -56,6 +56,7 @@ const Allocator = std.mem.Allocator;
 
 const utf8proc = @import("utf8proc");
 const trace = @import("tracy").trace;
+const ansi = @import("ansi.zig");
 const sgr = @import("sgr.zig");
 const color = @import("color.zig");
 const kitty = @import("kitty.zig");
@@ -931,6 +932,13 @@ saved_charset: CharsetState = .{},
 /// because it's state is saved/restored with the cursor and must have a state
 /// independent to each screen (primary and alternate)
 saved_origin_mode: bool = false,
+
+/// The current or most recent protected mode. Once a protection mode is
+/// set, this will never become "off" again until the screen is reset.
+/// The current state of whether protection attributes should be set is
+/// set on the Cell pen; this is only used to determine the most recent
+/// protection mode since some sequences such as ECH depend on this.
+protected_mode: ansi.ProtectedMode = .off,
 
 /// Initialize a new screen.
 pub fn init(

--- a/website/app/vt/ech/page.mdx
+++ b/website/app/vt/ech/page.mdx
@@ -25,16 +25,16 @@ Both erased cells are colored with the current background color according
 to the current SGR state.
 
 If [Select Character Selection Attribute (DECSCA)](#TODO) is enabled
-or was the most recently enabled protection mode,
+or was the most recently enabled protection mode on the currently active screen,
 protected attributes are ignored as if they were never set and the cells
 with them are erased. It does not matter if DECSCA is currently disabled,
 protected attributes are still ignored so long as DECSCA was the
 _most recently enabled_ protection mode.
 
 If DECSCA is not currently enabled and was not the most recently enabled protection
-mode, cells with the protected attribute set are respected and not erased but
-still count towards `n`. It does not matter if the protection attribute for a
-cell was originally set from DECSCA.
+mode on the currently active screen, cells with the protected attribute set are
+respected and not erased but still count towards `n`. It does not matter if the
+protection attribute for a cell was originally set from DECSCA.
 
 ## Validation
 

--- a/website/app/vt/ech/page.mdx
+++ b/website/app/vt/ech/page.mdx
@@ -1,0 +1,157 @@
+import VTSequence from "@/components/VTSequence";
+
+# Erase Character (ECH)
+
+<VTSequence sequence={["CSI", "Pn", "X"]} />
+
+Blank `n` cells beginning with (including) and to the right of the cursor.
+
+The parameter `n` must be an integer greater than or equal to 1. If `n` is less than
+or equal to 0, adjust `n` to be 1. If `n` is omitted, `n` defaults to 1.
+
+The rightmost column that can be erased is the rightmost column of the screen.
+The [right margin](#) has no effect on this sequence.
+
+This sequence always unsets the pending wrap state.
+
+For `n` cells up to the rightmost column, blank the cell by replacing it
+with an empty character with the background color colored according to the
+current SGR state. No other SGR attributes are preserved.
+
+If a multi-cell character would be split, erase the full multi-cell
+character. For example, if "橋" is printed and ECH `n = 1` is issued,
+the full character should be erased even though it takes up two cells.
+Both erased cells are colored with the current background color according
+to the current SGR state.
+
+If [Select Character Selection Attribute (DECSCA)](#TODO) is enabled
+or was the most recently enabled protection mode,
+protected attributes are ignored as if they were never set and the cells
+with them are erased. It does not matter if DECSCA is currently disabled,
+protected attributes are still ignored so long as DECSCA was the
+_most recently enabled_ protection mode.
+
+If DECSCA is not currently enabled and was not the most recently enabled protection
+mode, cells with the protected attribute set are respected and not erased but
+still count towards `n`. It does not matter if the protection attribute for a
+cell was originally set from DECSCA.
+
+## Validation
+
+### ECH V-1: Simple Operation
+
+```bash
+printf "ABC"
+printf "\033[1G"
+printf "\033[2X"
+```
+
+```
+|c_C_____|
+```
+
+### ECH V-2: Erasing Beyond Edge of Screen
+
+```bash
+cols=$(tput cols)
+printf "\033[${cols}G"
+printf "\033[2D"
+printf "ABC"
+printf "\033[D"
+printf "\033[10X"
+```
+
+```
+|_____Ac_|
+```
+
+### ECH V-3: Reset Pending Wrap State
+
+```bash
+cols=$(tput cols)
+printf "\033[${cols}G" # move to last column
+printf "A" # set pending wrap state
+printf "\033[X"
+printf "X"
+```
+
+```
+|_______Xc
+```
+
+### ECH V-4: SGR State
+
+```bash
+printf "ABC"
+printf "\033[1G"
+printf "\033[41m"
+printf "\033[2X"
+```
+
+```
+|c_C_____|
+```
+
+The `c_` cells should both have a red background. All other cells
+remain unchanged in style.
+
+### ECH V-5: Multi-cell Character
+
+```bash
+printf "橋BC"
+printf "\033[1G"
+printf "\033[X"
+printf "X"
+```
+
+```
+|XcBC____|
+```
+
+### ECH V-6: Left/Right Scroll Region Ignored
+
+```bash
+printf "\033[1;1H" # move to top-left
+printf "\033[0J" # clear screen
+printf "\033[?69h" # enable left/right margins
+printf "\033[1;3s" # scroll region left/right
+printf "\033[4G"
+printf "ABC"
+printf "\033[1G"
+printf "\033[4X"
+```
+
+```
+|c___BC____|
+```
+
+### ECH V-7: Protected Attributes Ignored with DECSCA
+
+```bash
+printf "\033V"
+printf "ABC"
+printf "\033[1\"q"
+printf "\033[0\"q"
+printf "\033[1G"
+printf "\033[2X"
+```
+
+```
+|c_C_______|
+```
+
+### ECH V-8: Protected Attributes Respected without DECSCA
+
+```bash
+printf "\033[1\"q"
+printf "ABC"
+printf "\033V"
+printf "\033[1G"
+printf "\033[2X"
+```
+
+```
+|ABC_______|
+```
+
+The cursor remains at `A`.


### PR DESCRIPTION
Fixes:

  - BG color according to SGR for erased cells
  - Multi-cell characters are fully erased if split
  - Protection attribute handling 