### PR TITLE
xterm audit: dch

### DIFF
--- a/website/app/vt/dch/page.mdx
+++ b/website/app/vt/dch/page.mdx
@@ -1,0 +1,106 @@
+import VTSequence from "@/components/VTSequence";
+
+# Delete Character (DCH)
+
+<VTSequence sequence={["CSI", "Pn", "P"]} />
+
+Deletes `n` characters at the current cursor position and shifts existing
+cell contents left.
+
+The parameter `n` must be an integer greater than or equal to 1. If `n` is less than
+or equal to 0, adjust `n` to be 1. If `n` is omitted, `n` defaults to 1.
+
+If the current cursor position is outside of the current scroll region,
+this sequence does nothing. The cursor is outside of the current scroll
+region if it is left of the [left margin](#TODO), or right of the
+[right margin](#TODO).
+
+This sequence unsets the pending wrap state. This sequence does _not_ unset
+the pending wrap state if the cursor position is outside of the current
+scroll region. This has to be called out explicitly because this behavior
+differs from [Insert Character (ICH)](/vt/ich).
+
+Only cells within the scroll region are deleted or shifted. Cells to the
+right of the right margin are unmodified.
+The blank cells inserted from the right margin are blank with the backgroud
+color colored according to the current SGR state.
+
+If a multi-cell character (such as "橋") is shifted so that the cell is split
+in half, the multi-cell character can either be clipped or erased. Typical
+behavior is to clip at the right edge of the screen and erase at a right
+margin, but either behavior is acceptable.
+
+## Validation
+
+### DCH V-1: Simple Delete Character
+
+```bash
+printf "ABC123"
+printf "\033[3G"
+printf "\033[2P"
+```
+
+```
+|AB23____|
+```
+
+### DCH V-2: SGR State
+
+```bash
+printf "ABC123"
+printf "\033[3G"
+printf "\033[41m"
+printf "\033[2P"
+```
+
+```
+|AB23____|
+```
+
+The two rightmost cells should have a red background color.
+
+### DCH V-3: Outside Left/Right Scroll Region
+
+```bash
+printf "\033[1;1H" # move to top-left
+printf "\033[0J" # clear screen
+printf "ABC123"
+printf "\033[?69h" # enable left/right margins
+printf "\033[3;5s" # scroll region left/right
+printf "\033[2G"
+printf "\033[P"
+```
+
+```
+|ABC123__|
+```
+
+### DCH V-4: Inside Left/Right Scroll Region
+
+```bash
+printf "\033[1;1H" # move to top-left
+printf "\033[0J" # clear screen
+printf "ABC123"
+printf "\033[?69h" # enable left/right margins
+printf "\033[3;5s" # scroll region left/right
+printf "\033[4G"
+printf "\033[P"
+```
+
+```
+|ABC2_3__|
+```
+
+### DCH V-5: Split Wide Character
+
+```bash
+printf "\033[1;1H" # move to top-left
+printf "\033[0J" # clear screen
+printf "A橋123"
+printf "\033[3G"
+printf "\033[P"
+```
+
+```
+|A_123_____|
+```


### PR DESCRIPTION
- Blank cells should have SGR bg color
- Correct behavior splitting multi-cell chars
- Left/right scroll region respected
- Does nothing if outside of the scroll region