### PR TITLE
macos: force new window for "New Window" action

### DIFF
--- a/macos/Sources/Features/Primary Window/PrimaryWindowManager.swift
+++ b/macos/Sources/Features/Primary Window/PrimaryWindowManager.swift
@@ -96,6 +96,14 @@ class PrimaryWindowManager {
     
     func addNewWindow(withBaseConfig config: Ghostty.SurfaceConfiguration? = nil) {
         guard let controller = createWindowController(withBaseConfig: config) else { return }
+
+        // For new windows, explicitly disallow tabbing with other windows.
+        // This overrides the value of userTabbingPreference. Rationale:
+        // Ghostty explicitly provides both "New Tab" and "New Window"
+        // functionality, so there's no reason to make "New Window" open in a
+        // tab.
+        controller.window?.tabbingMode = .disallowed;
+
         controller.showWindow(self)
         guard let newWindow = addManagedWindow(windowController: controller)?.window else { return }
         newWindow.makeKeyAndOrderFront(nil)


### PR DESCRIPTION
There is a setting in the macOS System Preferences called "Prefer tabs
when opening documents" (accessed through the userTabbingPreference
field of NSWindow) which, when set to "Always", makes the "New Window"
action open windows in tabs.

Ideally, this setting would be controlled on a per-app basis in macOS,
but unfortunately that is not the case. Because Ghostty explicitly
offers both "New Tab" and "New Window" actions, this user setting should
be ignored when creating new windows.
