### PR TITLE
xterm audit: DECALN, Top/Bot Margins, Left/Right Margins

### DIFF
--- a/src/terminal/modes.zig
+++ b/src/terminal/modes.zig
@@ -134,10 +134,12 @@ const ModeTag = packed struct(u16) {
 
 pub fn modeFromInt(v: u16, ansi: bool) ?Mode {
     inline for (entries) |entry| {
-        if (entry.value == v and entry.ansi == ansi) {
-            const tag: ModeTag = .{ .ansi = ansi, .value = entry.value };
-            const int: ModeTag.Backing = @bitCast(tag);
-            return @enumFromInt(int);
+        if (comptime !entry.disabled) {
+            if (entry.value == v and entry.ansi == ansi) {
+                const tag: ModeTag = .{ .ansi = ansi, .value = entry.value };
+                const int: ModeTag.Backing = @bitCast(tag);
+                return @enumFromInt(int);
+            }
         }
     }
 
@@ -160,6 +162,7 @@ const ModeEntry = struct {
     value: comptime_int,
     default: bool = false,
     ansi: bool = false,
+    disabled: bool = false,
 };
 
 /// The full list of available entries. For documentation see how
@@ -195,6 +198,10 @@ const entries: []const ModeEntry = &.{
     .{ .name = "bracketed_paste", .value = 2004 },
     .{ .name = "synchronized_output", .value = 2026 },
     .{ .name = "grapheme_cluster", .value = 2027 },
+
+    // Disabled for now until we ensure we get left/right margins working
+    // correctly in all sequences.
+    .{ .name = "enable_left_and_right_margin", .value = 69, .disabled = true },
 };
 
 test {

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -787,8 +787,20 @@ pub fn Stream(comptime Handler: type) type {
                     ),
                 },
 
-                // Save Mode
                 's' => switch (action.intermediates.len) {
+                    // DECSLRM
+                    0 => if (@hasDecl(T, "setLeftAndRightMargin")) {
+                        switch (action.params.len) {
+                            0 => try self.handler.setLeftAndRightMargin(0, 0),
+                            1 => try self.handler.setLeftAndRightMargin(action.params[0], 0),
+                            2 => try self.handler.setLeftAndRightMargin(action.params[0], action.params[1]),
+                            else => log.warn("invalid DECSLRM command: {}", .{action}),
+                        }
+                    } else log.warn(
+                        "unimplemented CSI callback: {}",
+                        .{action},
+                    ),
+
                     1 => switch (action.intermediates[0]) {
                         '?' => if (@hasDecl(T, "saveMode")) {
                             for (action.params) |mode_int| {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1397,6 +1397,10 @@ const StreamHandler = struct {
         self.terminal.setTopAndBottomMargin(top, bot);
     }
 
+    pub fn setLeftAndRightMargin(self: *StreamHandler, left: u16, right: u16) !void {
+        self.terminal.setLeftAndRightMargin(left, right);
+    }
+
     pub fn setModifyKeyFormat(self: *StreamHandler, format: terminal.ModifyKeyFormat) !void {
         self.terminal.flags.modify_other_keys_2 = false;
         switch (format) {
@@ -1459,6 +1463,13 @@ const StreamHandler = struct {
 
             // Origin resets cursor pos
             .origin => self.terminal.setCursorPos(1, 1),
+
+            .enable_left_and_right_margin => if (!enabled) {
+                // When we disable left/right margin mode we need to
+                // reset the left/right margins.
+                self.terminal.scrolling_region.left = 0;
+                self.terminal.scrolling_region.right = self.terminal.cols - 1;
+            },
 
             .alt_screen_save_cursor_clear_enter => {
                 const opts: terminal.Terminal.AlternateScreenOptions = .{

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1394,7 +1394,7 @@ const StreamHandler = struct {
     }
 
     pub fn setTopAndBottomMargin(self: *StreamHandler, top: u16, bot: u16) !void {
-        self.terminal.setScrollingRegion(top, bot);
+        self.terminal.setTopAndBottomMargin(top, bot);
     }
 
     pub fn setModifyKeyFormat(self: *StreamHandler, format: terminal.ModifyKeyFormat) !void {

--- a/website/app/vt/decaln/page.mdx
+++ b/website/app/vt/decaln/page.mdx
@@ -1,0 +1,45 @@
+import VTSequence from "@/components/VTSequence";
+
+# Screen Alignment Test (DECALN)
+
+<VTSequence sequence={["ESC", "#", "8"]} />
+
+Reset margins, move cursor to the top left, and fill the screen with `E`.
+
+Reset the top, bottom, left, and right margins and unset [origin mode](#TODO).
+The cursor is moved to the top-left corner of the screen.
+
+All stylistic SGR attributes are unset, such as bold, blink, etc.
+SGR foreground and background colors are preserved.
+The [protected attribute](#TODO) is not unset.
+
+The entire screen is filled with the character `E`. The letter `E` ignores
+the current SGR settings and is written with no styling.
+
+## Validation
+
+### DECALN V-1: Simple Usage
+
+```bash
+printf "\033#8"
+```
+
+```
+|EEEEEEEE|
+|EEEEEEEE|
+|EEEEEEEE|
+```
+
+### DECALN V-2: Reset Margins
+
+```bash
+printf "\033[2;3r" # scroll region top/bottom
+printf "\033#8"
+printf "\033[T"
+```
+
+```
+|c_______|
+|EEEEEEEE|
+|EEEEEEEE|
+```

--- a/website/app/vt/decslrm/page.mdx
+++ b/website/app/vt/decslrm/page.mdx
@@ -1,0 +1,120 @@
+import VTSequence from "@/components/VTSequence";
+
+# Set Left and Right Margins (DECSLRM)
+
+<VTSequence sequence={["CSI", "Pl", ";", "Pr", "s"]} />
+
+Sets the left and right margins, otherwise known as the scroll region.
+To learn more about scroll regions in general, see
+[Set Top and Bottom Margins](/vt/decstbm).
+
+Parameters `l` and `r` are integer values. If either value is zero the
+value will be reset to default values. The default value for `l` is `1`
+and the default value of `r` is the number of columns in the screen.
+
+Values `l` and `r` can be omitted. If either value is omitted, their
+default values will be used. Note that it is impossible to omit `l`
+and not omit `r`.
+
+This sequence requires [enable left and right margin (mode 69)](#TODO)
+to be set. If mode 69 is not set, this sequence does nothing and left
+and right margins will not be set.
+
+This sequence conflicts with [save cursor (`CSI s`)](#TODO). If
+mode 69 is disabled, save cursor will be invoked. If mode 69 is enabled,
+the `CSI s` save cursor sequence will be disabled, but save cursor is always
+also available as `ESC 7`.
+
+If left is larger or equal to right, this sequence does nothing. A
+scroll region must be at least two columns (`r` must be greater than `l`).
+The rest of this sequence description assumes valid values for `l` and `r`.
+
+This sequence unsets the pending wrap state and moves the cursor to
+the top-left of the screen. If [origin mode](#TODO) is set, the cursor is
+moved to the top-left of the scroll region.
+
+To reset the left and right margins, call this sequence with both values set to
+"0". This will force the default values for both `l` and `r` which is
+the full screen. Unsetting mode 69 will also reset the left and right margins.
+
+## Validation
+
+### DECSLRM V-1: Full Screen
+
+```bash
+printf "\033[1;1H" # move to top-left
+printf "\033[0J" # clear screen
+printf "ABC\n"
+printf "DEF\n"
+printf "GHI\n"
+printf "\033[?69h" # enable left/right margins
+printf "\033[s" # scroll region left/right
+printf "\033[X"
+```
+
+```
+|cBC_____|
+|DEF_____|
+|GHI_____|
+```
+
+### DECSLRM V-2: Left Only
+
+```bash
+printf "\033[1;1H" # move to top-left
+printf "\033[0J" # clear screen
+printf "ABC\n"
+printf "DEF\n"
+printf "GHI\n"
+printf "\033[?69h" # enable left/right margins
+printf "\033[2s" # scroll region left/right
+printf "\033[2G" # move cursor to column 2
+printf "\033[L"
+```
+
+```
+|Ac______|
+|DBC_____|
+|GEF_____|
+| HI_____|
+```
+
+### DECSLRM V-3: Left And Right
+
+```bash
+printf "\033[1;1H" # move to top-left
+printf "\033[0J" # clear screen
+printf "ABC\n"
+printf "DEF\n"
+printf "GHI\n"
+printf "\033[?69h" # enable left/right margins
+printf "\033[1;2s" # scroll region left/right
+printf "\033[2G" # move cursor to column 2
+printf "\033[L"
+```
+
+```
+|_cC_____|
+|ABF_____|
+|DEI_____|
+|GH______|
+```
+
+### DECSLRM V-4: Left Equal to Right
+
+```bash
+printf "\033[1;1H" # move to top-left
+printf "\033[0J" # clear screen
+printf "ABC\n"
+printf "DEF\n"
+printf "GHI\n"
+printf "\033[?69h" # enable left/right margins
+printf "\033[2;2s" # scroll region left/right
+printf "\033[X"
+```
+
+```
+|cBC_____|
+|DEF_____|
+|GHI_____|
+```

--- a/website/app/vt/decstbm/page.mdx
+++ b/website/app/vt/decstbm/page.mdx
@@ -1,0 +1,111 @@
+import VTSequence from "@/components/VTSequence";
+
+# Set Top and Bottom Margins (DECSTBM)
+
+<VTSequence sequence={["CSI", "Pt", ";", "Pb", "r"]} />
+
+Sets the top and bottom margins, otherwise known as the scroll region.
+
+Parameters `t` and `b` are integer values. If either value is zero the
+value will be reset to default values. The default value for `t` is `1`
+and the default value of `b` is the number of rows in the screen.
+
+Values `t` and `b` can be omitted. If either value is omitted, their
+default values will be used. Note that it is impossible to omit `t`
+and not omit `b`. The only valid sequences are `CSI t ; b r`,
+`CSI t r` and `CSI r`.
+
+If top is larger or equal to bottom, this sequence does nothing. A
+scroll region must be at least two rows (`b` must be greater than `t`).
+The rest of this sequence description assumes valid values for `t` and `b`.
+
+This sequence unsets the pending wrap state and moves the cursor to
+the top-left of the screen. If [origin mode](#TODO) is set, the cursor is
+moved to the top-left of the scroll region.
+
+To reset the scroll region, call this sequence with both values set to
+"0". This will force the default values for both `t` and `b` which is
+the full screen.
+
+The top and bottom margin constitute what is known as the _scroll region_.
+The scroll region impacts the operation of many sequences such as
+[insert line](/vt/il), [cursor down](/vt/cud), etc. Scroll regions are
+an effective and efficient way to constraint terminal modifications to a
+rectangular region of the screen.
+
+## Validation
+
+### DECSTBM V-1: Full Screen
+
+```bash
+printf "\033[1;1H" # move to top-left
+printf "\033[0J" # clear screen
+printf "ABC\n"
+printf "DEF\n"
+printf "GHI\n"
+printf "\033[r" # scroll region top/bottom
+printf "\033[T"
+```
+
+```
+|c_______|
+|ABC_____|
+|DEF_____|
+|GHI_____|
+```
+
+### DECSTBM V-2: Top Only
+
+```bash
+printf "\033[1;1H" # move to top-left
+printf "\033[0J" # clear screen
+printf "ABC\n"
+printf "DEF\n"
+printf "GHI\n"
+printf "\033[2r" # scroll region top/bottom
+printf "\033[T"
+```
+
+```
+|ABC_____|
+|________|
+|DEF_____|
+|GHI_____|
+```
+
+### DECSTBM V-3: Top and Bottom
+
+```bash
+printf "\033[1;1H" # move to top-left
+printf "\033[0J" # clear screen
+printf "ABC\n"
+printf "DEF\n"
+printf "GHI\n"
+printf "\033[1;2r" # scroll region top/bottom
+printf "\033[T"
+```
+
+```
+|________|
+|ABC_____|
+|GHI_____|
+```
+
+### DECSTBM V-4: Top Equal to Bottom
+
+```bash
+printf "\033[1;1H" # move to top-left
+printf "\033[0J" # clear screen
+printf "ABC\n"
+printf "DEF\n"
+printf "GHI\n"
+printf "\033[2;2r" # scroll region top/bottom
+printf "\033[T"
+```
+
+```
+|________|
+|ABC_____|
+|DEF_____|
+|GHI_____|
+```


### PR DESCRIPTION
- Tests for set top/bottom margins 
- Fix issue where set top/bottom margins should do NOTHING if `top >= bot`
- DECALN should reset margins
- DECALN should reset origin mode
- Implement mode 69 (enable left/right margins)
- Implement DECSLRM (set left and right margins)

**NOTE:** Ghostty will responds as if it doesn't know what mode 69 is, so it is still impossible for running applications to actually set left/right margins. The core plumbing is there however and we just need to flip a bit to turn it on. I am waiting to turn it on until I finish auditing more sequences to ensure left/right margins work properly.