### PR TITLE
Mouse selection fixes around the initially clicked cell

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,6 @@ zig-out/
 
 # macos is managed by XCode GUI
 macos/
+
+# website dev run
+website/.next

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1853,7 +1853,7 @@ fn dragLeftClickSingle(
         //   - Inverse logic for a point after the start.
         const click_point = self.mouse.left_click_point;
         const start: terminal.point.ScreenPoint = if (screen_point.before(click_point)) start: {
-            if (self.mouse.left_click_xpos > cell_xboundary) {
+            if (cell_start_xpos >= cell_xboundary) {
                 break :start click_point;
             } else {
                 break :start if (click_point.x > 0) terminal.point.ScreenPoint{

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1865,7 +1865,7 @@ fn dragLeftClickSingle(
                 };
             }
         } else start: {
-            if (self.mouse.left_click_xpos < cell_xboundary) {
+            if (cell_start_xpos < cell_xboundary) {
                 break :start click_point;
             } else {
                 break :start if (click_point.x < self.io.terminal.screen.cols - 1) terminal.point.ScreenPoint{


### PR DESCRIPTION
Fixes #645 

We were using the wrong units here (screen `x` position versus cell `x` position). We had the right logic but were comparing with the wrong values. This not currently a unit-testable part of Ghostty unfortunately but there is already a comment in this function with a TODO to figure that out.

This is a hard thing to video, see #645 so the erroneous behavior thats now fixed.