### PR TITLE
font: fallback search should search full discovery chain

### DIFF
--- a/pkg/macos/text/font.zig
+++ b/pkg/macos/text/font.zig
@@ -7,7 +7,7 @@ const text = @import("../text.zig");
 const c = @import("c.zig");
 
 pub const Font = opaque {
-    pub fn createWithFontDescriptor(desc: *text.FontDescriptor, size: f32) Allocator.Error!*Font {
+    pub fn createWithFontDescriptor(desc: *const text.FontDescriptor, size: f32) Allocator.Error!*Font {
         return @as(
             ?*Font,
             @ptrFromInt(@intFromPtr(c.CTFontCreateWithFontDescriptor(


### PR DESCRIPTION
Fixes #668

We were previously only checking the first font result in the search. This also fixes our CoreText scoring algorithm to prioritize faces that have the codepoint we're searching for.