### PR TITLE
Fix cursor width, underline width with wide chars

### DIFF
--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -515,6 +515,7 @@ pub fn renderGlyph(
             alloc,
             atlas,
             glyph_index,
+            opts,
         ),
     };
 

--- a/src/font/GroupCache.zig
+++ b/src/font/GroupCache.zig
@@ -41,6 +41,7 @@ const CodepointKey = struct {
 const GlyphKey = struct {
     index: Group.FontIndex,
     glyph: u32,
+    opts: font.face.RenderOptions,
 };
 
 /// The GroupCache takes ownership of Group and will free it.
@@ -124,7 +125,7 @@ pub fn renderGlyph(
     glyph_index: u32,
     opts: font.face.RenderOptions,
 ) !Glyph {
-    const key: GlyphKey = .{ .index = index, .glyph = glyph_index };
+    const key: GlyphKey = .{ .index = index, .glyph = glyph_index, .opts = opts };
     const gop = try self.glyphs.getOrPut(alloc, key);
 
     // If it is in the cache, use it.

--- a/src/font/face.zig
+++ b/src/font/face.zig
@@ -76,6 +76,10 @@ pub const RenderOptions = struct {
     /// is typically naive, but ultimately up to the rasterizer.
     max_height: ?u16 = null,
 
+    /// The number of grid cells this glyph will take up. This can be used
+    /// optionally by the rasterizer to better layout the glyph.
+    cell_width: ?u2 = null,
+
     /// Thicken the glyph. This draws the glyph with a thicker stroke width.
     /// This is purely an aesthetic setting.
     ///

--- a/src/font/sprite/Face.zig
+++ b/src/font/sprite/Face.zig
@@ -49,6 +49,7 @@ pub fn renderGlyph(
     alloc: Allocator,
     atlas: *font.Atlas,
     cp: u32,
+    opts: font.face.RenderOptions,
 ) !font.Glyph {
     if (std.debug.runtime_safety) {
         if (!self.hasCodepoint(cp, null)) {
@@ -57,11 +58,17 @@ pub fn renderGlyph(
         }
     }
 
+    // We adjust our sprite width based on the cell width.
+    const width = switch (opts.cell_width orelse 1) {
+        0, 1 => self.width,
+        else => |width| self.width * width,
+    };
+
     // Safe to ".?" because of the above assertion.
     return switch (Kind.init(cp).?) {
         .box => box: {
             const f: Box = .{
-                .width = self.width,
+                .width = width,
                 .height = self.height,
                 .thickness = self.thickness,
             };
@@ -73,7 +80,7 @@ pub fn renderGlyph(
             alloc,
             atlas,
             @enumFromInt(cp),
-            self.width,
+            width,
             self.height,
             self.underline_position,
             self.thickness,

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1364,7 +1364,7 @@ pub fn updateCell(
             self.alloc,
             font.sprite_index,
             @intFromEnum(sprite),
-            .{},
+            .{ .cell_width = if (cell.attrs.wide) 2 else 1 },
         );
 
         const color = if (cell.attrs.underline_color) cell.underline_fg else colors.fg;
@@ -1421,7 +1421,7 @@ fn addCursor(
         self.alloc,
         font.sprite_index,
         @intFromEnum(sprite),
-        .{},
+        .{ .cell_width = if (cell.attrs.wide) 2 else 1 },
     ) catch |err| {
         log.warn("error rendering cursor glyph err={}", .{err});
         return null;

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -872,7 +872,7 @@ fn addCursor(
         self.alloc,
         font.sprite_index,
         @intFromEnum(sprite),
-        .{},
+        .{ .cell_width = if (cell.attrs.wide) 2 else 1 },
     ) catch |err| {
         log.warn("error rendering cursor glyph err={}", .{err});
         return null;
@@ -1136,7 +1136,7 @@ pub fn updateCell(
             self.alloc,
             font.sprite_index,
             @intFromEnum(sprite),
-            .{},
+            .{ .cell_width = if (cell.attrs.wide) 2 else 1 },
         );
 
         const color = if (cell.attrs.underline_color) cell.underline_fg else colors.fg;

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -848,12 +848,26 @@ fn addCursor(
     screen: *terminal.Screen,
     cursor_style: renderer.CursorStyle,
 ) ?*const GPUCell {
-    // Add the cursor
-    const cell = screen.getCell(
-        .active,
-        screen.cursor.y,
-        screen.cursor.x,
-    );
+    // Add the cursor. We render the cursor over the wide character if
+    // we're on the wide characer tail.
+    const cell, const x = cell: {
+        // The cursor goes over the screen cursor position.
+        const cell = screen.getCell(
+            .active,
+            screen.cursor.y,
+            screen.cursor.x,
+        );
+        if (!cell.attrs.wide_spacer_tail or screen.cursor.x == 0)
+            break :cell .{ cell, screen.cursor.x };
+
+        // If we're part of a wide character, we move the cursor back to
+        // the actual character.
+        break :cell .{ screen.getCell(
+            .active,
+            screen.cursor.y,
+            screen.cursor.x - 1,
+        ), screen.cursor.x - 1 };
+    };
 
     const color = self.config.cursor_color orelse terminal.color.RGB{
         .r = 0xFF,
@@ -880,7 +894,7 @@ fn addCursor(
 
     self.cells.appendAssumeCapacity(.{
         .mode = .fg,
-        .grid_col = @intCast(screen.cursor.x),
+        .grid_col = @intCast(x),
         .grid_row = @intCast(screen.cursor.y),
         .grid_width = if (cell.attrs.wide) 2 else 1,
         .fg_r = color.r,


### PR DESCRIPTION
Fixes #666 

This fixes a couple issues, verified with xterm:

  - The cursor over a wide character should itself be wide (prev: only covered one cell)
  - The underline under a wide character should be wide (prev: only covered one cell)
  - When writing over the 2nd cell of a wide char, also clear the wide char