### PR TITLE
core: scroll viewport back to bottom on any key input that isn't a mod

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1032,12 +1032,13 @@ pub fn keyCallback(
     }, .{ .forever = {} });
     try self.io_thread.wakeup.notify();
 
-    // If we have printable text to emit then we always want to clear the
-    // selection and scroll to the bottom.
-    if (event.utf8.len > 0) {
+    // If our event is any keypress that isn't a modifier and we generated
+    // some data to send to the pty, then we move the viewport down to the
+    // bottom. If we generated literal text, then we also clear the selection.
+    if (!event.key.modifier()) {
         self.renderer_state.mutex.lock();
         defer self.renderer_state.mutex.unlock();
-        self.setSelection(null);
+        if (event.utf8.len > 0) self.setSelection(null);
         try self.io.terminal.scrollViewport(.{ .bottom = {} });
         try self.queueRender();
     }

--- a/src/input/key.zig
+++ b/src/input/key.zig
@@ -332,6 +332,23 @@ pub const Key = enum(c_int) {
         };
     }
 
+    /// True if this key is a modifier.
+    pub fn modifier(self: Key) bool {
+        return switch (self) {
+            .left_shift,
+            .left_control,
+            .left_alt,
+            .left_super,
+            .right_shift,
+            .right_control,
+            .right_alt,
+            .right_super,
+            => true,
+
+            else => false,
+        };
+    }
+
     /// Returns true if this is a keypad key.
     pub fn keypad(self: Key) bool {
         return switch (self) {


### PR DESCRIPTION
Fixes #619

This changes the behavior from requiring printable text to any input that isn't a modifier and also generates some data we send to the pty. If there is printable text, we also clear the selection.