### PR TITLE
xterm audit: save cursor, restore cursor

### DIFF
--- a/src/terminal/modes.zig
+++ b/src/terminal/modes.zig
@@ -162,7 +162,13 @@ const ModeEntry = struct {
     name: []const u8,
     value: comptime_int,
     default: bool = false,
+
+    /// True if this is an ANSI mode, false if its a DEC mode (?-prefixed).
     ansi: bool = false,
+
+    /// If true, this mode is disabled and Ghostty will not allow it to be
+    /// set or queried. The mode enum still has it, allowing Ghostty developers
+    /// to develop a mode without exposing it to real users.
     disabled: bool = false,
 };
 

--- a/website/app/vt/decrc/page.mdx
+++ b/website/app/vt/decrc/page.mdx
@@ -1,0 +1,14 @@
+import VTSequence from "@/components/VTSequence";
+
+# Restore Cursor (DECRC)
+
+<VTSequence sequence={["ESC", "8"]} />
+
+Restore the cursor-related state saved via [Save Cursor (DECSC)](/vt/decsc).
+
+If a cursor was never previously saved, this sets all the typically saved
+values to their default values.
+
+## Validation
+
+Validation is shared with [Save Cursor (DECSC)](/vt/decsc).

--- a/website/app/vt/decsc/page.mdx
+++ b/website/app/vt/decsc/page.mdx
@@ -1,0 +1,83 @@
+import VTSequence from "@/components/VTSequence";
+
+# Save Cursor (DECSC)
+
+<VTSequence sequence={["ESC", "7"]} />
+
+Save various cursor-related state that can be restored with
+[Restore Cursor (DECRC)](/vt/decrc).
+
+The following attributes are saved:
+
+- Cursor row and column in absolute screen coordinates
+- Character sets
+- Pending wrap state
+- SGR attributes
+- [Origin mode (DEC Mode 6)](/vt/modes/origin)
+
+Only one cursor can be saved at any time. If save cursor is repeated, the
+previously save cursor is overwritten.
+
+Primary and alternate screens have separate saved cursor state. A cursor
+saved on the primary screen is inaccessible from the alternate screen
+and vice versa.
+
+## Validation
+
+### SC V-1: Cursor Position
+
+```bash
+printf "\033[1;1H" # move to top-left
+printf "\033[0J" # clear screen
+printf "\033[1;5H"
+printf "A"
+printf "\0337" # Save Cursor
+printf "\033[1;1H"
+printf "B"
+printf "\0338" # Restore Cursor
+printf "X"
+```
+
+```
+|B___AX____|
+```
+
+### SC V-2: Pending Wrap State
+
+```bash
+cols=$(tput cols)
+printf "\033[1;1H" # move to top-left
+printf "\033[0J" # clear screen
+printf "\033[${cols}G"
+printf "A"
+printf "\0337" # Save Cursor
+printf "\033[1;1H"
+printf "B"
+printf "\0338" # Restore Cursor
+printf "X"
+```
+
+```
+|B________A|
+|X_________|
+```
+
+### SC V-3: SGR Attributes
+
+```bash
+printf "\033[1;1H" # move to top-left
+printf "\033[0J" # clear screen
+printf "\033[1;4;33;44m"
+printf "A"
+printf "\0337" # Save Cursor
+printf "\033[0m"
+printf "B"
+printf "\0338" # Restore Cursor
+printf "X"
+```
+
+```
+|AX________|
+```
+
+The "A" and "X" should have identical styling.


### PR DESCRIPTION
I don't think I found any actual bugs here, but changed some data layout and added additional tests (to the existing set). All pass.