### PR TITLE
renderer: handle error.NotFound for timer cancellation

### DIFF
--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -382,11 +382,13 @@ fn cursorCancelCallback(
     // support different sets of errors, so we just unify it.
     const CancelError = xev.Timer.CancelError || error{
         Canceled,
+        NotFound,
         Unexpected,
     };
 
     _ = r catch |err| switch (@as(CancelError, @errorCast(err))) {
-        error.Canceled => {},
+        error.Canceled => {}, // success
+        error.NotFound => {}, // completed before it could cancel
         else => {
             log.warn("error in cursor cancel callback err={}", .{err});
             unreachable;


### PR DESCRIPTION
Fixes #685

This is expected in very rare scenarios where under heavy load, a timer could complete before a cancellation request is processed, resulting in a "not found".