### PR TITLE
xterm audit: cursor position report (CPR)

### DIFF
--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1611,8 +1611,7 @@ const StreamHandler = struct {
                     x: usize,
                     y: usize,
                 } = if (self.terminal.modes.get(.origin)) .{
-                    // TODO: what do we do if cursor is outside scrolling region?
-                    .x = self.terminal.screen.cursor.x,
+                    .x = self.terminal.screen.cursor.x -| self.terminal.scrolling_region.left,
                     .y = self.terminal.screen.cursor.y -| self.terminal.scrolling_region.top,
                 } else .{
                     .x = self.terminal.screen.cursor.x,

--- a/website/app/vt/dsr/page.mdx
+++ b/website/app/vt/dsr/page.mdx
@@ -1,0 +1,46 @@
+import VTSequence from "@/components/VTSequence";
+
+# Device Status Report (DSR)
+
+<VTSequence sequence={["CSI", "Pn", "n"]} />
+
+Request information from the terminal depending on the value of `n`.
+
+The possible valid values of `n` are described in the paragraphs below. If
+any other value of `n` is provided, this sequence does nothing.
+
+If `n = 5`, the _operating status_ is requested. The terminal responds
+to the program with `ESC [ 0 n` to indicate no malfunctions.
+
+If `n = 6`, the _cursor position_ is requested. The terminal responds to
+the program in the format `ESC [ y ; x R` where `y` is the row and `x`
+is the column, both one-indexed. If [origin mode (DEC Mode 6)](/vt/modes/origin)
+is enabled, the reported cursor position is relative to the top-left of the
+scroll region.
+
+## Validation
+
+### DSR V-1: Operating Status
+
+```bash
+printf "\033[1;1H" # move to top-left
+printf "\033[0J" # clear screen
+printf "\033[5n"
+```
+
+```
+|^[[0n_____|
+```
+
+### DSR V-2: Cursor Position
+
+```bash
+printf "\033[1;1H" # move to top-left
+printf "\033[0J" # clear screen
+printf "\033[2;4H" # move to top-left
+printf "\033[6n"
+```
+
+```
+^[[2;4R
+```


### PR DESCRIPTION
One bug fix: origin mode respects left margin in report.