### PR TITLE
terminal: scroll up full top/bottom region was off by one

### DIFF
--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -469,6 +469,8 @@ pub inline fn queueWrite(self: *Exec, data: []const u8, linefeed: bool) !void {
             break :slice buf[0..buf_i];
         };
 
+        // for (slice) |b| log.warn("write: {x}", .{b});
+
         ev.data_stream.queueWrite(
             ev.loop,
             &ev.write_queue,

--- a/website/app/vt/su/page.mdx
+++ b/website/app/vt/su/page.mdx
@@ -95,3 +95,19 @@ printf "X"
 |________|
 |X_______|
 ```
+
+### SU V-5: Scroll Full Top/Bottom Scroll Region
+
+```bash
+printf "\033[1;1H" # move to top-left
+printf "\033[0J" # clear screen
+printf "top"
+printf "\033[5;1H"
+printf "ABCDEF"
+printf "\033[2;5r" # scroll region top/bottom
+printf "\033[4S"
+```
+
+```
+|top_____|
+```


### PR DESCRIPTION
Fixes #689

See test cases, verified with xterm. This was exposed via 3cc0cbcc9d08b5a7076740867e0a4b80ebbdfa90 but the bug has existed much longer since it has always existed in `DL`. 