### PR TITLE
macos: add menu items to modify font size

### DIFF
--- a/macos/Sources/AppDelegate.swift
+++ b/macos/Sources/AppDelegate.swift
@@ -32,7 +32,11 @@ class AppDelegate: NSObject, ObservableObject, NSApplicationDelegate, GhosttyApp
     @IBOutlet private var menuSelectSplitBelow: NSMenuItem?
     @IBOutlet private var menuSelectSplitLeft: NSMenuItem?
     @IBOutlet private var menuSelectSplitRight: NSMenuItem?
-    
+
+    @IBOutlet private var menuIncreaseFontSize: NSMenuItem?
+    @IBOutlet private var menuDecreaseFontSize: NSMenuItem?
+    @IBOutlet private var menuResetFontSize: NSMenuItem?
+
     /// The dock menu
     private var dockMenu: NSMenu = NSMenu()
     
@@ -204,7 +208,11 @@ class AppDelegate: NSObject, ObservableObject, NSApplicationDelegate, GhosttyApp
         syncMenuShortcut(action: "goto_split:bottom", menuItem: self.menuSelectSplitBelow)
         syncMenuShortcut(action: "goto_split:left", menuItem: self.menuSelectSplitLeft)
         syncMenuShortcut(action: "goto_split:right", menuItem: self.menuSelectSplitRight)
-        
+
+        syncMenuShortcut(action: "increase_font_size:1", menuItem: self.menuIncreaseFontSize)
+        syncMenuShortcut(action: "decrease_font_size:1", menuItem: self.menuDecreaseFontSize)
+        syncMenuShortcut(action: "reset_font_size", menuItem: self.menuResetFontSize)
+
         // Dock menu
         reloadDockMenu()
     }
@@ -366,5 +374,20 @@ class AppDelegate: NSObject, ObservableObject, NSApplicationDelegate, GhosttyApp
     @IBAction func toggleFullScreen(_ sender: Any) {
         guard let surface = focusedSurface() else { return }
         ghostty.toggleFullscreen(surface: surface)
+    }
+
+    @IBAction func increaseFontSize(_ sender: Any) {
+        guard let surface = focusedSurface() else { return }
+        ghostty.changeFontSize(surface: surface, .increase(1))
+    }
+
+    @IBAction func decreaseFontSize(_ sender: Any) {
+        guard let surface = focusedSurface() else { return }
+        ghostty.changeFontSize(surface: surface, .decrease(1))
+    }
+
+    @IBAction func resetFontSize(_ sender: Any) {
+        guard let surface = focusedSurface() else { return }
+        ghostty.changeFontSize(surface: surface, .reset)
     }
 }

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -276,13 +276,14 @@ extension Ghostty {
         }
 
         func changeFontSize(surface: ghostty_surface_t, _ change: FontSizeModification) {
-            let action = switch change {
+            let action: String
+            switch change {
             case .increase(let amount):
-                "increase_font_size:\(amount)"
+                action = "increase_font_size:\(amount)"
             case .decrease(let amount):
-                "decrease_font_size:\(amount)"
+                action = "decrease_font_size:\(amount)"
             case .reset:
-                "reset_font_size"
+                action = "reset_font_size"
             }
             if (!ghostty_surface_binding_action(surface, action, UInt(action.count))) {
                 AppDelegate.logger.warning("action failed action=\(action)")

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -11,6 +11,12 @@ extension Ghostty {
         case loading, error, ready
     }
 
+    enum FontSizeModification {
+        case increase(Int)
+        case decrease(Int)
+        case reset
+    }
+
     struct Info {
         var mode: ghostty_build_mode_e
         var version: String
@@ -264,6 +270,20 @@ extension Ghostty {
         
         func toggleFullscreen(surface: ghostty_surface_t) {
             let action = "toggle_fullscreen"
+            if (!ghostty_surface_binding_action(surface, action, UInt(action.count))) {
+                AppDelegate.logger.warning("action failed action=\(action)")
+            }
+        }
+
+        func changeFontSize(surface: ghostty_surface_t, _ change: FontSizeModification) {
+            let action = switch change {
+            case .increase(let amount):
+                "increase_font_size:\(amount)"
+            case .decrease(let amount):
+                "decrease_font_size:\(amount)"
+            case .reset:
+                "reset_font_size"
+            }
             if (!ghostty_surface_binding_action(surface, action, UInt(action.count))) {
                 AppDelegate.logger.warning("action failed action=\(action)")
             }

--- a/macos/Sources/MainMenu.xib
+++ b/macos/Sources/MainMenu.xib
@@ -17,6 +17,8 @@
                 <outlet property="menuClose" destination="DVo-aG-piG" id="R3t-0C-aSU"/>
                 <outlet property="menuCloseWindow" destination="W5w-UZ-crk" id="6ff-BT-ENV"/>
                 <outlet property="menuCopy" destination="Jqf-pv-Zcu" id="bKd-1C-oy9"/>
+                <outlet property="menuDecreaseFontSize" destination="kzb-SZ-dOA" id="Y1B-Vh-6Z2"/>
+                <outlet property="menuIncreaseFontSize" destination="CIH-ey-Z6x" id="hkc-9C-80E"/>
                 <outlet property="menuNewTab" destination="uTG-Vz-hJU" id="eMg-R3-SeS"/>
                 <outlet property="menuNewWindow" destination="Was-JA-tGl" id="lK7-3I-CPG"/>
                 <outlet property="menuNextSplit" destination="bD7-ei-wKU" id="LeT-xw-eh4"/>
@@ -24,6 +26,7 @@
                 <outlet property="menuPreviousSplit" destination="Lic-px-1wg" id="Rto-CG-yRe"/>
                 <outlet property="menuQuit" destination="4sb-4s-VLi" id="qYN-S1-6UW"/>
                 <outlet property="menuReloadConfig" destination="KKH-XX-5py" id="Wvp-7J-wqX"/>
+                <outlet property="menuResetFontSize" destination="Jah-MY-aLX" id="ger-qM-wrm"/>
                 <outlet property="menuSelectSplitAbove" destination="0yU-hC-8xF" id="aPc-lS-own"/>
                 <outlet property="menuSelectSplitBelow" destination="QDz-d9-CBr" id="FsH-Dq-jij"/>
                 <outlet property="menuSelectSplitLeft" destination="cTK-oy-KuV" id="Jpr-5q-dqz"/>
@@ -123,6 +126,31 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="closeWindow:" target="bbz-4X-AYv" id="j4w-Nd-9bO"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+                <menuItem title="View" id="3L3-2p-Joi" userLabel="View">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="View" id="m6z-2H-VW7">
+                        <items>
+                            <menuItem title="Increase Font Size" id="CIH-ey-Z6x" userLabel="Increase Font Size">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="increaseFontSize:" target="bbz-4X-AYv" id="qbI-YJ-xuW"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Reset Font Size" id="Jah-MY-aLX">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="resetFontSize:" target="bbz-4X-AYv" id="2qT-E9-Qt1"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Decrease Font Size" id="kzb-SZ-dOA">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="decreaseFontSize:" target="bbz-4X-AYv" id="rlw-0o-kA2"/>
                                 </connections>
                             </menuItem>
                         </items>


### PR DESCRIPTION
Add a new "View" menu to the menu bar with items to increase, decrease, or reset the font size.

---

We also get the "Show Tab Bar" (to show the tab bar even when there is only one tab) and the "Show All Tabs" menu items for free.

Some screenshots:

<img width="429" alt="Screenshot 2023-10-16 at 8 15 53 PM" src="https://github.com/mitchellh/ghostty/assets/8965202/808d80a9-68b8-4f04-babe-ad59cd1b7898">

<img width="695" alt="Screenshot 2023-10-16 at 8 16 02 PM" src="https://github.com/mitchellh/ghostty/assets/8965202/84ad1414-e048-48af-861c-709c828ec05c">


