### PR TITLE
renderer: do not downsample oversized glyphs

### DIFF
--- a/src/renderer/shaders/cell.metal
+++ b/src/renderer/shaders/cell.metal
@@ -99,17 +99,6 @@ vertex VertexOut uber_vertex(
     float2 glyph_size = float2(input.glyph_size);
     float2 glyph_offset = float2(input.glyph_offset);
 
-    // If the glyph is larger than our cell, we need to downsample it.
-    // The "+ 3" here is to give some wiggle room for fonts that are
-    // BARELY over it.
-    float2 glyph_size_downsampled = glyph_size;
-    if (glyph_size_downsampled.y > cell_size_scaled.y + 2) {
-      // Magic 0.9 and 1.1 are padding to make emoji look better
-      glyph_size_downsampled.y = cell_size_scaled.y * 0.9;
-      glyph_size_downsampled.x = glyph_size.x * (glyph_size_downsampled.y / glyph_size.y);
-      glyph_offset.y = glyph_offset.y * 1.1 * (glyph_size_downsampled.y / glyph_size.y);
-    }
-
     // The glyph_offset.y is the y bearing, a y value that when added
     // to the baseline is the offset (+y is up). Our grid goes down.
     // So we flip it with `cell_size.y - glyph_offset.y`.
@@ -117,7 +106,7 @@ vertex VertexOut uber_vertex(
 
     // Calculate the final position of the cell which uses our glyph size
     // and glyph offset to create the correct bounding box for the glyph.
-    cell_pos = cell_pos + glyph_size_downsampled * position + glyph_offset;
+    cell_pos = cell_pos + glyph_size * position + glyph_offset;
     out.position = uniforms.projection_matrix * float4(cell_pos.x, cell_pos.y, 0.0f, 1.0f);
 
     // Calculate the texture coordinate in pixels. This is NOT normalized

--- a/src/renderer/shaders/cell.v.glsl
+++ b/src/renderer/shaders/cell.v.glsl
@@ -124,24 +124,13 @@ void main() {
     case MODE_FG_COLOR:
         vec2 glyph_offset_calc = glyph_offset;
 
-        // If the glyph is larger than our cell, we need to downsample it.
-        // The "+ 3" here is to give some wiggle room for fonts that are
-        // BARELY over it.
-        vec2 glyph_size_downsampled = glyph_size;
-        if (glyph_size_downsampled.y > cell_size_scaled.y + 2) {
-            // Magic 0.9 and 1.1 are padding to make emoji look better
-            glyph_size_downsampled.y = cell_size_scaled.y * 0.9;
-            glyph_size_downsampled.x = glyph_size.x * (glyph_size_downsampled.y / glyph_size.y);
-            glyph_offset_calc.y = glyph_offset.y * 1.1 * (glyph_size_downsampled.y / glyph_size.y);
-        }
-
         // The glyph_offset.y is the y bearing, a y value that when added
         // to the baseline is the offset (+y is up). Our grid goes down.
         // So we flip it with `cell_size.y - glyph_offset.y`.
         glyph_offset_calc.y = cell_size_scaled.y - glyph_offset_calc.y;
 
         // Calculate the final position of the cell.
-        cell_pos = cell_pos + (glyph_size_downsampled * position) + glyph_offset_calc;
+        cell_pos = cell_pos + (glyph_size * position) + glyph_offset_calc;
         gl_Position = projection * vec4(cell_pos, cell_z, 1.0);
 
         // We need to convert our texture position and size to normalized


### PR DESCRIPTION
Fixes #696

We should rely on the rasterizer to create glyphs of the proper size, including doing CPU resizing if necessary.

I don't remember _why_ we used to downsample here. It sounds like it was for Emoji fonts. But I think this is a leftover from before we had CPU resizing using `stb_image_resize` built-in to the rasterizer. Now that that is there I don't think we have to do this anymore. 

We'll see... it fixes a known bug and doesn't break anything I can see but I wonder if this breaks some random unicode codepoint.