### PR TITLE
fontconfig: comment out flags that aren't common for windows and other targets

### DIFF
--- a/pkg/fontconfig/build.zig
+++ b/pkg/fontconfig/build.zig
@@ -25,7 +25,11 @@ pub fn build(b: *std.Build) !void {
         lib.linkLibrary(freetype_dep.artifact("freetype"));
     }
     if (libxml2_enabled) {
-        const libxml2_dep = b.dependency("libxml2", .{ .target = target, .optimize = optimize });
+        const libxml2_dep = b.dependency("libxml2", .{
+            .target = target,
+            .optimize = optimize,
+            .iconv = !target.isWindows(),
+        });
         lib.linkLibrary(libxml2_dep.artifact("xml2"));
     }
 
@@ -40,13 +44,13 @@ pub fn build(b: *std.Build) !void {
         "-DHAVE_STDLIB_H",
         "-DHAVE_STRING_H",
         "-DHAVE_UNISTD_H",
-        "-DHAVE_SYS_STATVFS_H",
+        // "-DHAVE_SYS_STATVFS_H",
         "-DHAVE_SYS_PARAM_H",
-        "-DHAVE_SYS_MOUNT_H",
+        // "-DHAVE_SYS_MOUNT_H",
 
-        "-DHAVE_LINK",
+        // "-DHAVE_LINK",
         "-DHAVE_MKSTEMP",
-        "-DHAVE_MKOSTEMP",
+        // "-DHAVE_MKOSTEMP",
         "-DHAVE__MKTEMP_S",
         "-DHAVE_MKDTEMP",
         "-DHAVE_GETOPT",
@@ -54,15 +58,15 @@ pub fn build(b: *std.Build) !void {
         //"-DHAVE_GETPROGNAME",
         //"-DHAVE_GETEXECNAME",
         "-DHAVE_RAND",
-        "-DHAVE_RANDOM",
-        "-DHAVE_LRAND48",
+        // "-DHAVE_RANDOM",
+        // "-DHAVE_LRAND48",
         //"-DHAVE_RANDOM_R",
-        "-DHAVE_RAND_R",
-        "-DHAVE_READLINK",
-        "-DHAVE_FSTATVFS",
+        // "-DHAVE_RAND_R",
+        // "-DHAVE_READLINK",
+        // "-DHAVE_FSTATVFS",
         "-DHAVE_FSTATFS",
-        "-DHAVE_LSTAT",
-        "-DHAVE_MMAP",
+        // "-DHAVE_LSTAT",
+        // "-DHAVE_MMAP",
         "-DHAVE_VPRINTF",
 
         "-DHAVE_FT_GET_BDF_PROPERTY",

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -355,6 +355,7 @@ test "createNullDelimitedEnvMap" {
 }
 
 test "Command: pre exec" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
     var cmd: Command = .{
         .path = "/usr/bin/env",
         .args = &.{ "/usr/bin/env", "-v" },
@@ -375,6 +376,7 @@ test "Command: pre exec" {
 }
 
 test "Command: redirect stdout to file" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
     var td = try TempDir.init();
     defer td.deinit();
     var stdout = try td.dir.createFile("stdout.txt", .{ .read = true });
@@ -400,6 +402,7 @@ test "Command: redirect stdout to file" {
 }
 
 test "Command: custom env vars" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
     var td = try TempDir.init();
     defer td.deinit();
     var stdout = try td.dir.createFile("stdout.txt", .{ .read = true });
@@ -430,6 +433,7 @@ test "Command: custom env vars" {
 }
 
 test "Command: custom working directory" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
     var td = try TempDir.init();
     defer td.deinit();
     var stdout = try td.dir.createFile("stdout.txt", .{ .read = true });

--- a/src/os/passwd.zig
+++ b/src/os/passwd.zig
@@ -138,6 +138,7 @@ pub fn get(alloc: Allocator) !Entry {
 }
 
 test {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
     const testing = std.testing;
     var arena = ArenaAllocator.init(testing.allocator);
     defer arena.deinit();


### PR DESCRIPTION
don't build with iconv support on windows for now

Command: Skip tests on windows
os.passwd: Skip tests on windows