### PR TITLE
config: add quit-after-last-window-closed

### DIFF
--- a/macos/Sources/AppDelegate.swift
+++ b/macos/Sources/AppDelegate.swift
@@ -81,7 +81,11 @@ class AppDelegate: NSObject, ObservableObject, NSApplicationDelegate, GhosttyApp
         // else is initialized.
         NSApp.servicesProvider = ServiceProvider()
     }
-    
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        return ghostty.shouldQuitAfterLastWindowClosed
+    }
+
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         let windows = NSApplication.shared.windows
         if (windows.isEmpty) { return .terminateNow }

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -51,6 +51,15 @@ extension Ghostty {
             }
         }
 
+        /// True if we should quit when the last window is closed.
+        var shouldQuitAfterLastWindowClosed: Bool {
+            guard let config = self.config else { return true }
+            var v = false;
+            let key = "quit-after-last-window-closed"
+            _ = ghostty_config_get(config, &v, key, UInt(key.count))
+            return v;
+        }
+
         /// True if we need to confirm before quitting.
         var needsConfirmQuit: Bool {
             guard let app = app else { return false }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -430,6 +430,10 @@ keybind: Keybinds = .{},
 /// to true. If set to false, surfaces will close without any confirmation.
 @"confirm-close-surface": bool = true,
 
+/// Whether or not to quit after the last window is closed. This defaults
+/// to false. Currently only supported on macOS.
+@"quit-after-last-window-closed": bool = false,
+
 /// Whether to enable shell integration auto-injection or not. Shell
 /// integration greatly enhances the terminal experience by enabling
 /// a number of features:

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -431,7 +431,8 @@ keybind: Keybinds = .{},
 @"confirm-close-surface": bool = true,
 
 /// Whether or not to quit after the last window is closed. This defaults
-/// to false. Currently only supported on macOS.
+/// to false. Currently only supported on macOS. On Linux, the process always
+/// exits after the last window is closed.
 @"quit-after-last-window-closed": bool = false,
 
 /// Whether to enable shell integration auto-injection or not. Shell


### PR DESCRIPTION
Whether or not to quit after the last window is closed. This defaults
to false (for backwards compatibility).

Currently only supported on macOS.