### PR TITLE
Get `zig build test` working on Windows

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -625,7 +625,6 @@ fn addDeps(
     const fontconfig_dep = b.dependency("fontconfig", .{
         .target = step.target,
         .optimize = step.optimize,
-        .@"enable-iconv-win" = false,
     });
     const freetype_dep = b.dependency("freetype", .{
         .target = step.target,

--- a/build.zig
+++ b/build.zig
@@ -621,9 +621,11 @@ fn addDeps(
     const js_dep = b.dependency("zig_js", .{ .target = step.target, .optimize = step.optimize });
     const libxev_dep = b.dependency("libxev", .{ .target = step.target, .optimize = step.optimize });
     const objc_dep = b.dependency("zig_objc", .{ .target = step.target, .optimize = step.optimize });
+    const iconv_win_enabled = b.option(bool, "enable-iconv-win", "Build libxml2 for fontconfig with iconv on Windows") orelse false;
     const fontconfig_dep = b.dependency("fontconfig", .{
         .target = step.target,
         .optimize = step.optimize,
+        .iconv_win_enabled = iconv_win_enabled,
     });
     const freetype_dep = b.dependency("freetype", .{
         .target = step.target,

--- a/build.zig
+++ b/build.zig
@@ -625,7 +625,7 @@ fn addDeps(
     const fontconfig_dep = b.dependency("fontconfig", .{
         .target = step.target,
         .optimize = step.optimize,
-        .iconv_win_enabled = iconv_win_enabled,
+        .@"enable-iconv-win" = iconv_win_enabled,
     });
     const freetype_dep = b.dependency("freetype", .{
         .target = step.target,

--- a/build.zig
+++ b/build.zig
@@ -621,11 +621,11 @@ fn addDeps(
     const js_dep = b.dependency("zig_js", .{ .target = step.target, .optimize = step.optimize });
     const libxev_dep = b.dependency("libxev", .{ .target = step.target, .optimize = step.optimize });
     const objc_dep = b.dependency("zig_objc", .{ .target = step.target, .optimize = step.optimize });
-    const iconv_win_enabled = b.option(bool, "enable-iconv-win", "Build libxml2 for fontconfig with iconv on Windows") orelse false;
+
     const fontconfig_dep = b.dependency("fontconfig", .{
         .target = step.target,
         .optimize = step.optimize,
-        .@"enable-iconv-win" = iconv_win_enabled,
+        .@"enable-iconv-win" = false,
     });
     const freetype_dep = b.dependency("freetype", .{
         .target = step.target,

--- a/pkg/fontconfig/build.zig
+++ b/pkg/fontconfig/build.zig
@@ -6,6 +6,7 @@ pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
 
     const libxml2_enabled = b.option(bool, "enable-libxml2", "Build libxml2") orelse true;
+    const iconv_win_enabled = b.option(bool, "enable-iconv-win", "Build libxml2 with iconv on Windows") orelse false;
     const freetype_enabled = b.option(bool, "enable-freetype", "Build freetype") orelse true;
 
     _ = b.addModule("fontconfig", .{ .source_file = .{ .path = "main.zig" } });
@@ -25,7 +26,11 @@ pub fn build(b: *std.Build) !void {
         lib.linkLibrary(freetype_dep.artifact("freetype"));
     }
     if (libxml2_enabled) {
-        const libxml2_dep = b.dependency("libxml2", .{ .target = target, .optimize = optimize });
+        const libxml2_dep = b.dependency("libxml2", .{
+            .target = target,
+            .optimize = optimize,
+            .iconv = !(target.getOsTag() == .windows) or iconv_win_enabled,
+        });
         lib.linkLibrary(libxml2_dep.artifact("xml2"));
     }
 

--- a/pkg/fontconfig/build.zig
+++ b/pkg/fontconfig/build.zig
@@ -6,7 +6,11 @@ pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
 
     const libxml2_enabled = b.option(bool, "enable-libxml2", "Build libxml2") orelse true;
-    const iconv_win_enabled = b.option(bool, "enable-iconv-win", "Build libxml2 with iconv on Windows") orelse false;
+    const libxml2_iconv_enabled = b.option(
+        bool,
+        "enable-libxml2-iconv",
+        "Build libxml2 with iconv",
+    ) orelse (target.getOsTag() != .windows);
     const freetype_enabled = b.option(bool, "enable-freetype", "Build freetype") orelse true;
 
     _ = b.addModule("fontconfig", .{ .source_file = .{ .path = "main.zig" } });
@@ -29,7 +33,7 @@ pub fn build(b: *std.Build) !void {
         const libxml2_dep = b.dependency("libxml2", .{
             .target = target,
             .optimize = optimize,
-            .iconv = target.getOsTag() != .windows or iconv_win_enabled,
+            .iconv = libxml2_iconv_enabled,
         });
         lib.linkLibrary(libxml2_dep.artifact("xml2"));
     }

--- a/pkg/fontconfig/build.zig
+++ b/pkg/fontconfig/build.zig
@@ -29,7 +29,7 @@ pub fn build(b: *std.Build) !void {
         const libxml2_dep = b.dependency("libxml2", .{
             .target = target,
             .optimize = optimize,
-            .iconv = !(target.getOsTag() == .windows) or iconv_win_enabled,
+            .iconv = target.getOsTag() != .windows or iconv_win_enabled,
         });
         lib.linkLibrary(libxml2_dep.artifact("xml2"));
     }

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -355,6 +355,7 @@ test "createNullDelimitedEnvMap" {
 }
 
 test "Command: pre exec" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
     var cmd: Command = .{
         .path = "/usr/bin/env",
         .args = &.{ "/usr/bin/env", "-v" },
@@ -375,6 +376,7 @@ test "Command: pre exec" {
 }
 
 test "Command: redirect stdout to file" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
     var td = try TempDir.init();
     defer td.deinit();
     var stdout = try td.dir.createFile("stdout.txt", .{ .read = true });
@@ -400,6 +402,7 @@ test "Command: redirect stdout to file" {
 }
 
 test "Command: custom env vars" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
     var td = try TempDir.init();
     defer td.deinit();
     var stdout = try td.dir.createFile("stdout.txt", .{ .read = true });
@@ -430,6 +433,7 @@ test "Command: custom env vars" {
 }
 
 test "Command: custom working directory" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
     var td = try TempDir.init();
     defer td.deinit();
     var stdout = try td.dir.createFile("stdout.txt", .{ .read = true });

--- a/src/Pty.zig
+++ b/src/Pty.zig
@@ -128,6 +128,7 @@ pub fn childPreExec(self: Pty) !void {
 }
 
 test {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
     var ws: winsize = .{
         .ws_row = 50,
         .ws_col = 80,

--- a/src/os/desktop.zig
+++ b/src/os/desktop.zig
@@ -40,7 +40,8 @@ pub fn launchedFromDesktop() bool {
 
             break :linux gio_pid == pid;
         },
-        //TODO: maybe find a way to check that
+
+        // TODO: This should have some logic to detect this. Perhaps std.builtin.subsystem
         .windows => false,
 
         else => @compileError("unsupported platform"),

--- a/src/os/desktop.zig
+++ b/src/os/desktop.zig
@@ -40,6 +40,7 @@ pub fn launchedFromDesktop() bool {
 
             break :linux gio_pid == pid;
         },
+        //TODO: maybe find a way to check that
         .windows => false,
 
         else => @compileError("unsupported platform"),

--- a/src/os/desktop.zig
+++ b/src/os/desktop.zig
@@ -40,6 +40,7 @@ pub fn launchedFromDesktop() bool {
 
             break :linux gio_pid == pid;
         },
+        .windows => false,
 
         else => @compileError("unsupported platform"),
     };

--- a/src/os/passwd.zig
+++ b/src/os/passwd.zig
@@ -138,6 +138,7 @@ pub fn get(alloc: Allocator) !Entry {
 }
 
 test {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
     const testing = std.testing;
     var arena = ArenaAllocator.init(testing.allocator);
     defer arena.deinit();

--- a/src/os/xdg.zig
+++ b/src/os/xdg.zig
@@ -20,35 +20,31 @@ pub const Options = struct {
 
 /// Get the XDG user config directory. The returned value is allocated.
 pub fn config(alloc: Allocator, opts: Options) ![]u8 {
-    if (builtin.os.tag == .windows) {
-        if (std.process.getEnvVarOwned(alloc, "XDG_CONFIG_HOME")) |env| {
-            // If we have a subdir, then we use the env as-is to avoid a copy.
-            if (opts.subdir) |subdir| {
-                defer alloc.free(env);
-                return try std.fs.path.join(alloc, &[_][]const u8{
-                    env,
-                    subdir,
-                });
+    // First check the env var. On Windows we have to allocate so this tracks
+    // both whether we have the env var and whether we own it.
+    const env_, const owned = switch (builtin.os.tag) {
+        else => .{ std.os.getenv("XDG_CONFIG_HOME"), false },
+        .windows => windows: {
+            if (std.process.getEnvVarOwned(alloc, "XDG_CONFIG_HOME")) |env| {
+                break :windows .{ env, true };
+            } else |err| switch (err) {
+                error.EnvironmentVariableNotFound => break :windows .{ null, false },
+                else => return err,
             }
+        },
+    };
+    defer if (owned) if (env_) |v| alloc.free(v);
 
-            // We don't need to dupe since it's already allocated
-            return env;
-        } else |err| switch (err) {
-            error.EnvironmentVariableNotFound => {},
-            else => return err,
+    if (env_) |env| {
+        // If we have a subdir, then we use the env as-is to avoid a copy.
+        if (opts.subdir) |subdir| {
+            return try std.fs.path.join(alloc, &[_][]const u8{
+                env,
+                subdir,
+            });
         }
-    } else {
-        if (std.os.getenv("XDG_CONFIG_HOME")) |env| {
-            // If we have a subdir, then we use the env as-is to avoid a copy.
-            if (opts.subdir) |subdir| {
-                return try std.fs.path.join(alloc, &[_][]const u8{
-                    env,
-                    subdir,
-                });
-            }
 
-            return try alloc.dupe(u8, env);
-        }
+        return try alloc.dupe(u8, env);
     }
 
     // If we have a cached home dir, use that.


### PR DESCRIPTION
Disable iconv on Windows by default (enabled via cli flag).
Skip various tests not implemented on windows.