### PR TITLE
fix: adjust for window padding when calculating whether selection has started

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.vscode
 .direnv/
 .flatpak-builder/
 zig-cache/

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1871,20 +1871,20 @@ fn dragLeftClickSingle(
     //
 
     // the boundary point at which we consider selection or non-selection
-    const cell_xboundary = @as(f32, @floatFromInt(self.cell_size.width)) * 0.6;
+    const cell_width_f64: f64 = @floatFromInt(self.cell_size.width);
+    const cell_xboundary = cell_width_f64 * 0.6;
 
-    // first xpos of the clicked cell
-    const cell_xstart = @as(
-        f32,
-        @floatFromInt(self.mouse.left_click_point.x),
-    ) * @as(f32, @floatFromInt(self.cell_size.width));
-    const cell_start_xpos = self.mouse.left_click_xpos - cell_xstart;
+    // first xpos of the clicked cell adjusted for padding
+    const left_padding_f64: f64 = @as(f64, @floatFromInt(self.padding.left));
+    const cell_xstart = @as(f64, @floatFromInt(self.mouse.left_click_point.x)) * cell_width_f64;
+    const cell_start_xpos = self.mouse.left_click_xpos - cell_xstart - left_padding_f64;
 
     // If this is the same cell, then we only start the selection if weve
     // moved past the boundary point the opposite direction from where we
     // started.
     if (std.meta.eql(screen_point, self.mouse.left_click_point)) {
-        const cell_xpos = xpos - cell_xstart;
+        // Ensuring to adjusting the cursor position for padding
+        const cell_xpos = xpos - cell_xstart - left_padding_f64;
         const selected: bool = if (cell_start_xpos < cell_xboundary)
             cell_xpos >= cell_xboundary
         else


### PR DESCRIPTION
When calculating whether the selection has started the cursor position was not adjusting for any window padding configured.  For example if you used the following configuration, then the character the cursor is over would not be selected, even if you were past the threshold point.

```
font-size = 14
font-thicken = true
font-family = MesloLGM Nerd Font Mono

window-padding-x = 8
window-padding-y = 8
```

Logic is modified to adjust the cursor position for padding.   The threshold has been modified to 50% as this works without the need for modification when dealing with left to right and right to left selection.  This also seemed more accurate during my own testing on macOS.