### PR TITLE
macos: use commit hash in version info instead of build number

### DIFF
--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -49,7 +49,7 @@ jobs:
       # Load Build Number
       - name: Build Number
         run: |
-          echo "GHOSTTY_BUILD=$(git rev-list --count head)" >> $GITHUB_ENV
+          echo "GHOSTTY_BUILD=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       # GhosttyKit is the framework that is built from Zig for our native
       # Mac app to access. Build this in release mode.


### PR DESCRIPTION
Using the "build number" (i.e. the commit number) did not seem to work
correctly anyway (it always showed '1' for releases built in CI).
Presumably this is because GitHub performs a shallow clone so it does
not have full access to the Git history.

Instead of the build number, use the Git commit hash of HEAD, which
works even for shallow clones and is more useful for debugging.

Fixes: https://github.com/mitchellh/ghostty/issues/717