### PR TITLE
terminal: clamp cursor left above scroll region with XTREVWRAP2

### DIFF
--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -60,6 +60,8 @@ pub fn Stream(comptime Handler: type) type {
             for (actions) |action_opt| {
                 const action = action_opt orelse continue;
 
+                // log.info("action: {}", .{action});
+
                 // If this handler handles everything manually then we do nothing
                 // if it can be processed.
                 if (@hasDecl(T, "handleManually")) {
@@ -74,11 +76,6 @@ pub fn Stream(comptime Handler: type) type {
 
                     if (processed) continue;
                 }
-
-                // if (action_opt) |action| {
-                //     if (action != .print)
-                //         log.info("action: {}", .{action});
-                // }
 
                 switch (action) {
                     .print => |p| if (@hasDecl(T, "print")) try self.handler.print(p),


### PR DESCRIPTION
Fixes a crash found through fuzzing. This crash is also exhibited in xterm (as of v384). The issue arises when you set the cursor above the top scroll margin, then issue a large cursor left (CSI D) with extended reverse wrap (?1045) set. Extended reverse wrap loops back until it reaches the top scroll then wraps around. But since the cursor is before the top scroll, xterm just arbitrarily moves back into negative row numbers, which reads into bad memory.

We decided to fix this by clamping to (0,0) and exiting because this will mimic the xterm behavior for valid values of cursor left count (prior to crashing).