### PR TITLE
terminfo: remove focus reporting mode from XM entry

### DIFF
--- a/src/terminfo/ghostty.zig
+++ b/src/terminfo/ghostty.zig
@@ -130,7 +130,7 @@ pub const ghostty: Source = .{
         .{ .name = "PE", .value = .{ .string = "\\E[201~" } },
 
         // Mouse
-        .{ .name = "XM", .value = .{ .string = "\\E[?1006;1004;1000%?%p1%{1}%=%th%el%;" } },
+        .{ .name = "XM", .value = .{ .string = "\\E[?1006;1000%?%p1%{1}%=%th%el%;" } },
         .{ .name = "xm", .value = .{ .string = "\\E[<%i%p3%d;%p1%d;%p2%d;%?%p4%tM%em%;" } },
 
         // Secondary device attributes request / response


### PR DESCRIPTION
The XM entry enables mouse reporting events to applications. An
application that supports mouse events may not necessarily support focus
events, so these should not be bundled together.

Vim includes focus reporting mode (1004) in their example XM entry in
their docs [1], but they do not actually use it in the default value XM
value [2].

Ncurses also includes only modes 1000 and (optionally) mode 1006 in
their mouse driver [3]. The ncurses documentation for XM similarly does
not mention focus reporting (mode 1004) anywhere [4].

Including focus reporting causes bugs in some programs that want to use
mouse mode but do not handle focus events (e.g. `htop`).

[1]: https://vimhelp.org/term.txt.html#xterm-terminfo-entries
[2]: https://github.com/vim/vim/blob/87ca5e86fa0ef305f3d39cc4261b622f21417f7f/src/term.c#L477
[3]: https://github.com/mirror/ncurses/blob/87c2c84cbd2332d6d94b12a1dcaf12ad1a51a938/doc/html/man/curs_mouse.3x.html#L339
[4]: https://www.man7.org/linux/man-pages/man5/user_caps.5.html
