### PR TITLE
Command args, `-e` flag

### DIFF
--- a/src/cli/args.zig
+++ b/src/cli/args.zig
@@ -64,6 +64,11 @@ pub fn parse(comptime T: type, alloc: Allocator, dst: *T, iter: anytype) !void {
     };
 
     while (iter.next()) |arg| {
+        // Do manual parsing if we have a hook for it.
+        if (@hasDecl(T, "parseManuallyHook")) {
+            if (!try dst.parseManuallyHook(arena_alloc, arg, iter)) return;
+        }
+
         if (mem.startsWith(u8, arg, "--")) {
             var key: []const u8 = arg[2..];
             const value: ?[]const u8 = value: {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -268,6 +268,16 @@ palette: Palette = .{},
 ///
 command: ?[]const u8 = null,
 
+/// A single argument to pass to the command. This can be repeated to
+/// pass multiple arguments. This slightly clunky configuration style is
+/// so that Ghostty doesn't have to perform any sort of shell parsing
+/// to find argument boundaries.
+///
+/// This cannot be used to override argv[0]. argv[0] will always be
+/// set by Ghostty to be the command (possibly with a hyphen-prefix to
+/// indicate that it is a login shell, depending on the OS).
+@"command-arg": RepeatableString = .{},
+
 /// The directory to change to after starting the command.
 ///
 /// The default is "inherit" except in special scenarios listed next.


### PR DESCRIPTION
Fixes #744

This adds the `command-arg` repeatable configuration for setting an argument for the `command`. This also adds the CLI-only `-e` flag that is standard across most terminals to execute a command. Everything after the `-e` becomes part of the command to execute so this is the last flag Ghostty processes.