### PR TITLE
apprt/gtk: handle non-ascii keyvals

### DIFF
--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -14,6 +14,7 @@ const CoreSurface = @import("../../Surface.zig");
 const App = @import("App.zig");
 const Window = @import("Window.zig");
 const inspector = @import("inspector.zig");
+const gtk_key = @import("key.zig");
 const c = @import("c.zig");
 
 const log = std.log.scoped(.gtk);
@@ -903,6 +904,10 @@ fn keyEvent(
             if (input.Key.fromASCII(ascii)) |key| {
                 break :key key;
             }
+        }
+
+        if (gtk_key.keyFromKeyval(keyval)) |key| {
+            break :key key;
         }
 
         break :key physical_key;

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -906,6 +906,8 @@ fn keyEvent(
             }
         }
 
+        // Before using the physical key, try to convert the keyval
+        // directly to a key. This allows the use of key remapping.
         if (gtk_key.keyFromKeyval(keyval)) |key| {
             break :key key;
         }


### PR DESCRIPTION
Not all GTK keyvals are unicode (and not all unicode keyvals can be translated by `Key.fromASCII`), so in a lot of cases  `physical_key` would be used as a fallback. This means that keymaps set by the window manager (or `setxkbmap`),  xkb_options, user layouts, etc. are ignored.

I left the logic for handling the ASCII case in place because that is using comptime so it might be faster. 
`physical_key` is translated using runtime logic as well.