### PR TITLE
feat: update undercurl with antialiasing

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -714,7 +714,6 @@ fn addDeps(
     step.addModule("freetype", freetype_dep.module("freetype"));
     step.addModule("harfbuzz", harfbuzz_dep.module("harfbuzz"));
     step.addModule("xev", libxev_dep.module("xev"));
-    step.addModule("zig-js", js_dep.module("zig-js"));
     step.addModule("pixman", pixman_dep.module("pixman"));
     step.addModule("utf8proc", utf8proc_dep.module("utf8proc"));
 

--- a/build.zig
+++ b/build.zig
@@ -714,6 +714,7 @@ fn addDeps(
     step.addModule("freetype", freetype_dep.module("freetype"));
     step.addModule("harfbuzz", harfbuzz_dep.module("harfbuzz"));
     step.addModule("xev", libxev_dep.module("xev"));
+    step.addModule("zig-js", js_dep.module("zig-js"));
     step.addModule("pixman", pixman_dep.module("pixman"));
     step.addModule("utf8proc", utf8proc_dep.module("utf8proc"));
 

--- a/src/font/sprite/canvas.zig
+++ b/src/font/sprite/canvas.zig
@@ -140,6 +140,12 @@ const WebCanvasImpl = struct {
         self.* = undefined;
     }
 
+    pub fn pixel(self: *WebCanvasImpl, x: u32, y: u32, color: Color) void {
+        const ctx = self.context(color) catch return;
+        defer ctx.deinit();
+        ctx.call(void, "fillRect", .{ x, y, 1, 1 }) catch return;
+    }
+
     pub fn rect(self: *WebCanvasImpl, v: Rect, color: Color) void {
         const ctx = self.context(color) catch return;
         defer ctx.deinit();
@@ -399,6 +405,20 @@ const PixmanImpl = struct {
         }
 
         return region;
+    }
+
+    /// Draw and fill a single pixel
+    pub fn pixel(self: *Canvas, x: u32, y: u32, color: Color) void {
+        const boxes = &[_]pixman.Box32{
+            .{
+                .x1 = @intCast(x),
+                .y1 = @intCast(y),
+                .x2 = @intCast(x + 1),
+                .y2 = @intCast(y + 1),
+            },
+        };
+
+        self.image.fillBoxes(.src, color.pixmanColor(), boxes) catch {};
     }
 
     /// Draw and fill a rectangle. This is the main primitive for drawing

--- a/src/font/sprite/underline.zig
+++ b/src/font/sprite/underline.zig
@@ -165,6 +165,10 @@ const Draw = struct {
     fn drawCurly(self: Draw, canvas: *font.sprite.Canvas) void {
         // This is the lowest that the curl can go.
         const y_max = self.height - 1;
+
+        // Determines the density of the waves.
+        //   `2 * pi...` = 1 peak per character
+        //   `4 * pi...` = 2 peaks per character
         const x_factor = 2 * std.math.pi / @as(f64, @floatFromInt(self.width - 1));
 
         // Some fonts put the underline too close to the bottom of the
@@ -181,7 +185,6 @@ const Draw = struct {
         // underline position. We also calculate our starting y which is
         // slightly below our descender since our wave will move about that.
         const wave_height = @as(f64, @floatFromInt(y_max - pos));
-        //const wave_height = @as(f64, @floatFromInt(y_max - (pos - self.thickness / 2)));
         const half_height = @max(1, wave_height / 4);
         const y_pos = @as(i32, @intCast(pos)) + @as(i32, @intFromFloat(2 * half_height));
 

--- a/src/font/sprite/underline.zig
+++ b/src/font/sprite/underline.zig
@@ -174,18 +174,18 @@ const Draw = struct {
         // Some fonts put the underline too close to the bottom of the
         // cell height and this doesn't allow us to make a high enough
         // wave. This constant is arbitrary, change it for aesthetics.
-        const pos = pos: {
+        const pos: u32 = pos: {
             const MIN_HEIGHT = 5;
             const clamped_pos = @min(y_max, self.pos);
             const height = y_max - clamped_pos;
             break :pos if (height < MIN_HEIGHT) clamped_pos -| MIN_HEIGHT else clamped_pos;
         };
 
-        // The full heightof the wave can be from the bottom to the
+        // The full height of the wave can be from the bottom to the
         // underline position. We also calculate our starting y which is
         // slightly below our descender since our wave will move about that.
-        const wave_height = @as(f64, @floatFromInt(y_max - pos));
-        const half_height = @max(1, wave_height / 4);
+        const wave_height: f64 = @floatFromInt(y_max - pos);
+        const half_height: f64 = @max(1, wave_height / 4);
         const y_pos = @as(i32, @intCast(pos)) + @as(i32, @intFromFloat(2 * half_height));
 
         // follow Xiaolin Wu's antialias algorithm to draw the curve
@@ -194,7 +194,7 @@ const Draw = struct {
             const y0 = half_height * @cos(@as(f64, @floatFromInt(x)) * x_factor);
             const y1 = y_pos + @as(i32, @intFromFloat(@floor(y0)));
             const y3 = y1 - 1 + @as(i32, @intCast(self.thickness));
-            const alpha = @as(u8, @intFromFloat(255 * @abs(y0 - @floor(y0))));
+            const alpha: u8 = @intFromFloat(255 * @abs(y0 - @floor(y0)));
 
             // upper and lower bounds
             canvas.pixel(x, @min(@as(u32, @intCast(y1)), y_max), @enumFromInt(255 - alpha));

--- a/src/font/sprite/underline.zig
+++ b/src/font/sprite/underline.zig
@@ -182,28 +182,27 @@ const Draw = struct {
         };
 
         // The full height of the wave can be from the bottom to the
-        // underline position. We also calculate our starting y which is
-        // slightly below our descender since our wave will move about that.
+        // underline position. We also calculate our mid y point of the wave
         const wave_height: f64 = @floatFromInt(y_max - pos);
         const half_height: f64 = @max(1, wave_height / 4);
-        const y_pos = @as(i32, @intCast(pos)) + @as(i32, @intFromFloat(2 * half_height));
+        const y_mid: u32 = pos + @as(u32, @intFromFloat(2 * half_height));
 
         // follow Xiaolin Wu's antialias algorithm to draw the curve
         var x: u32 = 0;
         while (x < self.width) : (x += 1) {
-            const y0 = half_height * @cos(@as(f64, @floatFromInt(x)) * x_factor);
-            const y1 = y_pos + @as(i32, @intFromFloat(@floor(y0)));
-            const y3 = y1 - 1 + @as(i32, @intCast(self.thickness));
-            const alpha: u8 = @intFromFloat(255 * @abs(y0 - @floor(y0)));
+            const y: f64 = @as(f64, @floatFromInt(y_mid)) + (half_height * @cos(@as(f64, @floatFromInt(x)) * x_factor));
+            const y_upper: u32 = @intFromFloat(@floor(y));
+            const y_lower: u32 = y_upper - 1 + self.thickness;
+            const alpha: u8 = @intFromFloat(255 * @abs(y - @floor(y)));
 
             // upper and lower bounds
-            canvas.pixel(x, @min(@as(u32, @intCast(y1)), y_max), @enumFromInt(255 - alpha));
-            canvas.pixel(x, @min(@as(u32, @intCast(y3)), y_max), @enumFromInt(alpha));
+            canvas.pixel(x, @min(y_upper, y_max), @enumFromInt(255 - alpha));
+            canvas.pixel(x, @min(y_lower, y_max), @enumFromInt(alpha));
 
             // fill between upper and lower bound
-            var y2: u32 = @as(u32, @intCast(y1)) + 1;
-            while (y2 < y3) : (y2 += 1) {
-                canvas.pixel(x, @min(y2, y_max), .on);
+            var y_fill: u32 = y_upper + 1;
+            while (y_fill < y_lower) : (y_fill += 1) {
+                canvas.pixel(x, @min(y_fill, y_max), .on);
             }
         }
     }


### PR DESCRIPTION
Updated the `undercurl` to be antialised to give the representation of a smooth curl.

The `undercurl` now starts at the midpoint of the wave which means the peak is always in the middle of the character.

The below screenshot compares a number of different options side by side with the 4 options that Kitty provides.

What has been committed as part of this pull request is Option 3.

![image](https://github.com/mitchellh/ghostty/assets/33818/c1f2b5e2-f8bf-4b39-8da2-ce2992af23bd)
