### PR TITLE
renderers: clear GPU cell buffers when resizing

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1047,6 +1047,12 @@ pub fn setScreenSize(
         .strikethrough_thickness = old.strikethrough_thickness,
     };
 
+    // Reset our buffer sizes so that we free memory when the screen shrinks.
+    // This could be made more clever by only doing this when the screen
+    // shrinks but the performance cost really isn't that much.
+    self.cells.clearAndFree(self.alloc);
+    self.cells_bg.clearAndFree(self.alloc);
+
     log.debug("screen size screen={} grid={}, cell={}", .{ dim, grid_size, self.cell_size });
 }
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -1259,6 +1259,12 @@ pub fn setScreenSize(
     if (single_threaded_draw) self.draw_mutex.lock();
     defer if (single_threaded_draw) self.draw_mutex.unlock();
 
+    // Reset our buffer sizes so that we free memory when the screen shrinks.
+    // This could be made more clever by only doing this when the screen
+    // shrinks but the performance cost really isn't that much.
+    self.cells.clearAndFree(self.alloc);
+    self.cells_bg.clearAndFree(self.alloc);
+
     // Store our screen size
     self.screen_size = dim;
     self.padding.explicit = pad;


### PR DESCRIPTION
This leads to very small per-surface memory improvements when resizing from large to small. Going from full screen to the smallest window on Mac and Linux leads to about a 5MB per surface savings. Nothing huge but we might as well do it.

Related to #254 