### PR TITLE
fix window-padding-balance in combination with explicit padding

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1019,7 +1019,7 @@ pub fn setScreenSize(
     // the leftover amounts on the right/bottom that don't fit a full grid cell
     // and we split them equal across all boundaries.
     const padding = self.padding.explicit.add(if (self.padding.balance)
-        renderer.Padding.balanced(dim, grid_size, self.cell_size)
+        renderer.Padding.balanced(dim.subPadding(self.padding.explicit), grid_size, self.cell_size)
     else
         .{});
     const padded_dim = dim.subPadding(padding);

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1018,10 +1018,10 @@ pub fn setScreenSize(
     // Determine if we need to pad the window. For "auto" padding, we take
     // the leftover amounts on the right/bottom that don't fit a full grid cell
     // and we split them equal across all boundaries.
-    const padding = self.padding.explicit.add(if (self.padding.balance)
-        renderer.Padding.balanced(dim.subPadding(self.padding.explicit), grid_size, self.cell_size)
+    const padding = if (self.padding.balance)
+        renderer.Padding.balanced(dim, grid_size, self.cell_size)
     else
-        .{});
+        self.padding.explicit;
     const padded_dim = dim.subPadding(padding);
 
     // Set the size of the drawable surface to the bounds

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -94,10 +94,10 @@ const SetScreenSize = struct {
         const gl_state = r.gl_state orelse return error.OpenGLUninitialized;
 
         // Apply our padding
-        const padding = r.padding.explicit.add(if (r.padding.balance)
-            renderer.Padding.balanced(self.size.subPadding(r.padding.explicit), r.gridSize(self.size), r.cell_size)
+        const padding = if (r.padding.balance)
+            renderer.Padding.balanced(self.size, r.gridSize(self.size), r.cell_size)
         else
-            .{});
+            r.padding.explicit;
         const padded_size = self.size.subPadding(padding);
 
         log.debug("GL api: screen size padded={} screen={} grid={} cell={} padding={}", .{

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -95,7 +95,7 @@ const SetScreenSize = struct {
 
         // Apply our padding
         const padding = r.padding.explicit.add(if (r.padding.balance)
-            renderer.Padding.balanced(self.size, r.gridSize(self.size), r.cell_size)
+            renderer.Padding.balanced(self.size.subPadding(r.padding.explicit), r.gridSize(self.size), r.cell_size)
         else
             .{});
         const padded_size = self.size.subPadding(padding);


### PR DESCRIPTION
Computation of balanced padding was slightly off in combination with explicit paddings, because the "leftover" space was computed from the whole screen and not the padded one.

before:
<img width="616" alt="before" src="https://github.com/mitchellh/ghostty/assets/4776553/33774639-fc2a-4517-9013-1fa66ad8f6f5">

after:
<img width="616" alt="after" src="https://github.com/mitchellh/ghostty/assets/4776553/679f8a81-3384-4517-9847-4573aaff6e92">
