### PR TITLE
feat(actions): add new `list-keybinds` action

### DIFF
--- a/src/cli/action.zig
+++ b/src/cli/action.zig
@@ -3,6 +3,7 @@ const Allocator = std.mem.Allocator;
 
 const list_fonts = @import("list_fonts.zig");
 const version = @import("version.zig");
+const list_keybinds = @import("list_keybinds.zig");
 
 /// Special commands that can be invoked via CLI flags. These are all
 /// invoked by using `+<action>` as a CLI flag. The only exception is
@@ -13,6 +14,9 @@ pub const Action = enum {
 
     /// List available fonts
     @"list-fonts",
+
+    /// List available keybinds
+    @"list-keybinds",
 
     pub const Error = error{
         /// Multiple actions were detected. You can specify at most one
@@ -52,6 +56,7 @@ pub const Action = enum {
         return switch (self) {
             .version => try version.run(),
             .@"list-fonts" => try list_fonts.run(alloc),
+            .@"list-keybinds" => try list_keybinds.run(alloc),
         };
     }
 };

--- a/src/cli/list_keybinds.zig
+++ b/src/cli/list_keybinds.zig
@@ -63,15 +63,7 @@ fn iterConfig(stdout: anytype, iter: anytype) !u8 {
     while (iter.next()) |next| {
         const keys = next.key_ptr.*;
         const value = next.value_ptr.*;
-        try stdout.print("{s}", .{@tagName(value)});
-        switch (value) {
-            .goto_tab => |val| try stdout.print(" {d}:", .{val}),
-            .jump_to_prompt => |val| try stdout.print(" {d}:", .{val}),
-            .increase_font_size, .decrease_font_size => |val| try stdout.print(" {d}:", .{val}),
-            .goto_split => |val| try stdout.print(" {s}:", .{@tagName(val)}),
-            .inspector => |val| try stdout.print(" {s}:", .{@tagName(val)}),
-            inline else => try stdout.print(":", .{}),
-        }
+        try stdout.print("{}", .{value});
 
         switch (keys.key) {
             .one, .two, .three, .four, .five, .six, .seven, .eight, .nine => try stdout.print(" {d} +", .{(@intFromEnum(keys.key) - start) + 1}),

--- a/src/cli/list_keybinds.zig
+++ b/src/cli/list_keybinds.zig
@@ -6,57 +6,40 @@ const Allocator = std.mem.Allocator;
 const Config = @import("../config/Config.zig");
 
 pub const Options = struct {
-    _arena: ?Arena = null,
+    /// If true, print out the default keybinds instead of the ones
+    /// configured in the config file.
     default: bool = false,
 
-    pub fn deinit(self: *Options) void {
-        if (self._arena) |arena| arena.deinit();
-        self.* = undefined;
+    pub fn deinit(self: Options) void {
+        _ = self;
     }
 };
 
-/// The "list-keybinds" command is used to list all the available keybinds for Ghostty.
+/// The "list-keybinds" command is used to list all the available keybinds
+/// for Ghostty.
 ///
-/// When executed without any arguments this will list the current keybinds loaded by the config file.
-/// If no config file is found or there aren't any changes to the keybinds it will print out the default ones configured for Ghostty
+/// When executed without any arguments this will list the current keybinds
+/// loaded by the config file. If no config file is found or there aren't any
+/// changes to the keybinds it will print out the default ones configured for
+/// Ghostty
 ///
-/// The "--default" argument will print out all the default keybinds configured for Ghostty
+/// The "--default" argument will print out all the default keybinds
+/// configured for Ghostty
 pub fn run(alloc: Allocator) !u8 {
     var opts: Options = .{};
     defer opts.deinit();
 
-    var iter = try std.process.argsWithAllocator(alloc);
-    defer iter.deinit();
-    try args.parse(Options, alloc, &opts, &iter);
-
-    if (opts.default) {
-        return try listDefaultKeybinds(alloc);
+    {
+        var iter = try std.process.argsWithAllocator(alloc);
+        defer iter.deinit();
+        try args.parse(Options, alloc, &opts, &iter);
     }
 
-    return try listKeybinds(alloc);
-}
-
-fn listKeybinds(alloc: Allocator) !u8 {
-    var loaded_config = try Config.load(alloc);
-    defer loaded_config.deinit();
+    var config = if (opts.default) try Config.default(alloc) else try Config.load(alloc);
+    defer config.deinit();
 
     const stdout = std.io.getStdOut().writer();
-    var iter = loaded_config.keybind.set.bindings.iterator();
-
-    return try iterConfig(&stdout, &iter);
-}
-
-fn listDefaultKeybinds(alloc: Allocator) !u8 {
-    var default = try Config.default(alloc);
-    defer default.deinit();
-
-    const stdout = std.io.getStdOut().writer();
-    var iter = default.keybind.set.bindings.iterator();
-
-    return try iterConfig(&stdout, &iter);
-}
-
-fn iterConfig(stdout: anytype, iter: anytype) !u8 {
+    var iter = config.keybind.set.bindings.iterator();
     while (iter.next()) |next| {
         const keys = next.key_ptr.*;
         const value = next.value_ptr.*;

--- a/src/cli/list_keybinds.zig
+++ b/src/cli/list_keybinds.zig
@@ -57,40 +57,10 @@ fn listDefaultKeybinds(alloc: Allocator) !u8 {
 }
 
 fn iterConfig(stdout: anytype, iter: anytype) !u8 {
-    const start = @intFromEnum(inputpkg.Key.one);
-    var amount: u8 = 0;
-
     while (iter.next()) |next| {
         const keys = next.key_ptr.*;
         const value = next.value_ptr.*;
-        try stdout.print("{}", .{value});
-
-        switch (keys.key) {
-            .one, .two, .three, .four, .five, .six, .seven, .eight, .nine => try stdout.print(" {d} +", .{(@intFromEnum(keys.key) - start) + 1}),
-            inline else => try stdout.print(" {s} +", .{@tagName(keys.key)}),
-        }
-        const fields = @typeInfo(@TypeOf(keys.mods)).Struct.fields;
-        inline for (fields) |field| {
-            switch (field.type) {
-                bool => {
-                    if (@field(keys.mods, field.name)) {
-                        if (amount >= 1) {
-                            try stdout.print(" +", .{});
-                        }
-                        try stdout.print(" {s}", .{field.name});
-                        amount += 1;
-                    }
-                },
-                u6 => continue,
-
-                inline else => {
-                    try stdout.print("\n", .{});
-                    continue;
-                },
-            }
-        }
-
-        amount = 0;
+        try stdout.print("{}={}\n", .{ keys, value });
     }
 
     return 0;

--- a/src/cli/list_keybinds.zig
+++ b/src/cli/list_keybinds.zig
@@ -1,0 +1,105 @@
+const std = @import("std");
+const inputpkg = @import("../input.zig");
+const args = @import("args.zig");
+const Arena = std.heap.ArenaAllocator;
+const Allocator = std.mem.Allocator;
+const Config = @import("../config/Config.zig");
+
+pub const Options = struct {
+    _arena: ?Arena = null,
+    default: bool = false,
+
+    pub fn deinit(self: *Options) void {
+        if (self._arena) |arena| arena.deinit();
+        self.* = undefined;
+    }
+};
+
+/// The "list-keybinds" command is used to list all the available keybinds for Ghostty.
+///
+/// When executed without any arguments this will list the current keybinds loaded by the config file.
+/// If no config file is found or there aren't any changes to the keybinds it will print out the default ones configured for Ghostty
+///
+/// The "--default" argument will print out all the default keybinds configured for Ghostty
+pub fn run(alloc: Allocator) !u8 {
+    var opts: Options = .{};
+    defer opts.deinit();
+
+    var iter = try std.process.argsWithAllocator(alloc);
+    defer iter.deinit();
+    try args.parse(Options, alloc, &opts, &iter);
+
+    if (opts.default) {
+        return try listDefaultKeybinds(alloc);
+    }
+
+    return try listKeybinds(alloc);
+}
+
+fn listKeybinds(alloc: Allocator) !u8 {
+    var loaded_config = try Config.load(alloc);
+    defer loaded_config.deinit();
+
+    const stdout = std.io.getStdOut().writer();
+    var iter = loaded_config.keybind.set.bindings.iterator();
+
+    return try iterConfig(&stdout, &iter);
+}
+
+fn listDefaultKeybinds(alloc: Allocator) !u8 {
+    var default = try Config.default(alloc);
+    defer default.deinit();
+
+    const stdout = std.io.getStdOut().writer();
+    var iter = default.keybind.set.bindings.iterator();
+
+    return try iterConfig(&stdout, &iter);
+}
+
+fn iterConfig(stdout: anytype, iter: anytype) !u8 {
+    const start = @intFromEnum(inputpkg.Key.one);
+    var amount: u8 = 0;
+
+    while (iter.next()) |next| {
+        const keys = next.key_ptr.*;
+        const value = next.value_ptr.*;
+        try stdout.print("{s}", .{@tagName(value)});
+        switch (value) {
+            .goto_tab => |val| try stdout.print(" {d}:", .{val}),
+            .jump_to_prompt => |val| try stdout.print(" {d}:", .{val}),
+            .increase_font_size, .decrease_font_size => |val| try stdout.print(" {d}:", .{val}),
+            .goto_split => |val| try stdout.print(" {s}:", .{@tagName(val)}),
+            .inspector => |val| try stdout.print(" {s}:", .{@tagName(val)}),
+            inline else => try stdout.print(":", .{}),
+        }
+
+        switch (keys.key) {
+            .one, .two, .three, .four, .five, .six, .seven, .eight, .nine => try stdout.print(" {d} +", .{(@intFromEnum(keys.key) - start) + 1}),
+            inline else => try stdout.print(" {s} +", .{@tagName(keys.key)}),
+        }
+        const fields = @typeInfo(@TypeOf(keys.mods)).Struct.fields;
+        inline for (fields) |field| {
+            switch (field.type) {
+                bool => {
+                    if (@field(keys.mods, field.name)) {
+                        if (amount >= 1) {
+                            try stdout.print(" +", .{});
+                        }
+                        try stdout.print(" {s}", .{field.name});
+                        amount += 1;
+                    }
+                },
+                u6 => continue,
+
+                inline else => {
+                    try stdout.print("\n", .{});
+                    continue;
+                },
+            }
+        }
+
+        amount = 0;
+    }
+
+    return 0;
+}

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -416,6 +416,27 @@ pub const Trigger = extern struct {
         std.hash.autoHash(&hasher, self.physical);
         return hasher.final();
     }
+
+    /// Format implementation for fmt package.
+    pub fn format(
+        self: Trigger,
+        comptime layout: []const u8,
+        opts: std.fmt.FormatOptions,
+        writer: anytype,
+    ) !void {
+        _ = layout;
+        _ = opts;
+
+        // Modifiers first
+        if (self.mods.super) try writer.writeAll("super+");
+        if (self.mods.ctrl) try writer.writeAll("ctrl+");
+        if (self.mods.alt) try writer.writeAll("alt+");
+        if (self.mods.shift) try writer.writeAll("shift+");
+
+        // Key
+        if (self.physical) try writer.writeAll("physical:");
+        try writer.print("{s}", .{@tagName(self.key)});
+    }
 };
 
 /// A structure that contains a set of bindings and focuses on fast lookup.


### PR DESCRIPTION
This PR aims to add support for a new action called `list-keybinds` with the optional `--default` parameter. 
So that folks can quickly use to see what are the currently set list of keybinds that they have or that are configured by default in Ghostty.

Using `ghostty +list-keybinds`
![image](https://github.com/mitchellh/ghostty/assets/67233402/ea33d9b6-96ff-41e9-a2c3-7276d3cb7339)

Using `ghostty +list-keybinds --default`
![image](https://github.com/mitchellh/ghostty/assets/67233402/563f79a4-fcd0-46fc-9566-b9c8e5d16ff9)