### PR TITLE
feat: keybind escape sequence action "esc:text" similar to "csi:text"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
+*~
+.*.swp
+.swp
+*.log
 .DS_Store
-.vscode
+.vscode/
 .direnv/
 .flatpak-builder/
 zig-cache/

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -321,6 +321,8 @@ command: ?[]const u8 = null,
 ///     is removed, and the key will be sent through to the child command
 ///     if it is printable.
 ///   - "csi:text" - Send a CSI sequence. i.e. "csi:A" sends "cursor up".
+///   - "esc:text" - Send an Escape sequence. i.e. "esc:d" deletes to the
+///     end of the word to the right.
 ///
 /// Some notes for the action:
 ///

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -117,6 +117,9 @@ pub const Action = union(enum) {
     /// without the CSI header ("ESC ]" or "\x1b]").
     csi: []const u8,
 
+    /// Send an ESC sequence.
+    esc: []const u8,
+
     /// Send data to the pty depending on whether cursor key mode is
     /// enabled ("application") or disabled ("normal").
     cursor_key: CursorKey,
@@ -664,6 +667,12 @@ test "parse: action with string" {
         const binding = try parse("a=csi:A");
         try testing.expect(binding.action == .csi);
         try testing.expectEqualStrings("A", binding.action.csi);
+    }
+    // parameter
+    {
+        const binding = try parse("a=esc:A");
+        try testing.expect(binding.action == .esc);
+        try testing.expectEqualStrings("A", binding.action.esc);
     }
 }
 


### PR DESCRIPTION
Following discussion on discord implemented Escape sequence keybind action `esc:text` similar in nature to `csi:text`.
