### PR TITLE
Add consistent themeing support for gtk backend

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -814,6 +814,7 @@ fn addDeps(
 
             .gtk => {
                 step.linkSystemLibrary2("gtk4", dynamic_link_opts);
+                step.linkSystemLibrary2("adwaita-1", dynamic_link_opts);
             },
         }
     }

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -120,6 +120,7 @@ in mkShell rec {
     libXrandr
 
     # Only needed for GTK builds
+    libadwaita
     gtk4
     glib
   ];

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -28,6 +28,7 @@
 , freetype
 , glib
 , gtk4
+, libadwaita
 , harfbuzz
 , libpng
 , libGL
@@ -59,6 +60,7 @@ let
     libXi
     libXrandr
 
+    libadwaita
     gtk4
     glib
   ];

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -52,9 +52,22 @@ running: bool = true,
 pub fn init(core_app: *CoreApp, opts: Options) !App {
     _ = opts;
 
+    // Initialize libadwaita
+    c.adw_init();
+
     // Load our configuration
     var config = try Config.load(core_app.alloc);
     errdefer config.deinit();
+
+    // Retrieve the style manager
+    var style_manager = c.adw_style_manager_get_default();
+
+    // Set the style based on our configuration file
+    c.adw_style_manager_set_color_scheme(style_manager, switch (config.@"window-theme") {
+        .system => c.ADW_COLOR_SCHEME_PREFER_LIGHT,
+        .dark => c.ADW_COLOR_SCHEME_FORCE_DARK,
+        .light => c.ADW_COLOR_SCHEME_FORCE_LIGHT,
+    });
 
     // If we had configuration errors, then log them.
     if (!config._errors.empty()) {

--- a/src/apprt/gtk/c.zig
+++ b/src/apprt/gtk/c.zig
@@ -1,5 +1,6 @@
 const c = @cImport({
     @cInclude("gtk/gtk.h");
+    @cInclude("libadwaita-1/adwaita.h");
 });
 
 pub usingnamespace c;

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -378,7 +378,7 @@ keybind: Keybinds = .{},
 /// also be set to "light" or "dark" to force a specific theme regardless
 /// of the system settings.
 ///
-/// This is currently only supported on macOS.
+/// This is currently only supported on macOS and linux.
 @"window-theme": WindowTheme = .system,
 
 /// The initial window size. This size is in terminal grid cells by default.


### PR DESCRIPTION
With the current status quo the gtk backend for Ghostty does not respect Gnome's theme setting. This change will add consistent theme support to Ghostty by utilizing libadwaita's [StyleManager](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.StyleManager.html) APIs. This is done by initializing libadwaita before creating the base GTK application with `adw_init()`, and later getting the current default style manager, and setting the theme based on the `window-theme` option in the config, which previously only supported macOS.

```zig
    // Initialize libadwaita
    c.adw_init();

    // Load our configuration
    var config = try Config.load(core_app.alloc);
    errdefer config.deinit();

    // Retrieve the style manager
    var style_manager = c.adw_style_manager_get_default();

    // Set the style based on our configuration file
    c.adw_style_manager_set_color_scheme(style_manager, switch (config.@"window-theme") {
        .system => c.ADW_COLOR_SCHEME_PREFER_LIGHT,
        .dark => c.ADW_COLOR_SCHEME_FORCE_DARK,
        .light => c.ADW_COLOR_SCHEME_FORCE_LIGHT,
    });
```
Unfortunately this also adds `libadwaita` as a dependency for anyone using the `gtk` backend. As far as I am aware the only other things that need to be updated are the Nix flake(s) and CI workflows so that they are able to link libadwaita.