### PR TITLE
font: if a codepoint is emoji presentation, prefer that for shaping

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -669,6 +669,10 @@ fn addDeps(
         .@"enable-freetype" = true,
         .@"enable-coretext" = font_backend.hasCoretext(),
     });
+    const ziglyph_dep = b.dependency("ziglyph", .{
+        .target = step.target,
+        .optimize = step.optimize,
+    });
 
     // Wasm we do manually since it is such a different build.
     if (step.target.getCpuArch() == .wasm32) {
@@ -716,6 +720,7 @@ fn addDeps(
     step.addModule("xev", libxev_dep.module("xev"));
     step.addModule("pixman", pixman_dep.module("pixman"));
     step.addModule("utf8proc", utf8proc_dep.module("utf8proc"));
+    step.addModule("ziglyph", ziglyph_dep.module("ziglyph"));
 
     // Mac Stuff
     if (step.target.isDarwin()) {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,6 +4,10 @@
     .paths = .{""},
     .dependencies = .{
         // Zig libs
+        .glfw = .{
+            .url = "https://pkg.machengine.org/glfw/14181bd28aa65915262ac3b4549bbd2dc70bbaa5.tar.gz",
+            .hash = "1220c6bb317ae3948b95161b9706777dde0509e72e8b35b62b92898aef801897d904",
+        },
         .libxev = .{
             .url = "https://github.com/mitchellh/libxev/archive/5ecbc871f3bfa80fb7bf0fa853866cb93b99bc18.tar.gz",
             .hash = "1220416854e424601ecc9814afb461a5dc9cf95db5917d82f794594a58ffc723b82c",
@@ -20,10 +24,9 @@
             .url = "https://github.com/mitchellh/zig-js/archive/60ac42ab137461cdba2b38cc6c5e16376470aae6.tar.gz",
             .hash = "1220319b42fbc0116f3f198343256018e9f1da9483cef259201afe4ebab0ce0d8f6a",
         },
-
-        .glfw = .{
-            .url = "https://pkg.machengine.org/glfw/14181bd28aa65915262ac3b4549bbd2dc70bbaa5.tar.gz",
-            .hash = "1220c6bb317ae3948b95161b9706777dde0509e72e8b35b62b92898aef801897d904",
+        .ziglyph = .{
+            .url = "https://codeberg.org/dude_the_builder/ziglyph/archive/v0.11.1.tar.gz",
+            .hash = "1220dee955839b7f267c1bb21e0ee60888c08f408c30f0722b243cabcc8cce8b7508",
         },
 
         // C libs


### PR DESCRIPTION
Fixes #787

We should replace `utf8proc` completely with `ziglyph`, but we need to replace `graphemeBreakStateful`.