### PR TITLE
Add option to enable or disable libadwaita

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,7 +132,7 @@ jobs:
         run: nix develop -c zig build -Dapp-runtime=none test
 
       - name: Test GTK Build
-        run: nix develop -c zig build -Dapp-runtime=gtk
+        run: nix develop -c zig build -Dapp-runtime=gtk -Dlibadwaita=true
 
       - name: Test GLFW Build
         run: nix develop -c zig build -Dapp-runtime=glfw

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,7 +132,7 @@ jobs:
         run: nix develop -c zig build -Dapp-runtime=none test
 
       - name: Test GTK Build
-        run: nix develop -c zig build -Dapp-runtime=gtk -Dlibadwaita=true
+        run: nix develop -c zig build -Dapp-runtime=gtk -Dgtk-libadwaita=true
 
       - name: Test GLFW Build
         run: nix develop -c zig build -Dapp-runtime=glfw

--- a/build.zig
+++ b/build.zig
@@ -39,6 +39,7 @@ var flatpak: bool = false;
 var app_runtime: apprt.Runtime = .none;
 var renderer_impl: renderer.Impl = .opengl;
 var font_backend: font.Backend = .freetype;
+var libadwaita: bool = false;
 
 pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
@@ -86,6 +87,12 @@ pub fn build(b: *std.Build) !void {
         "app-runtime",
         "The app runtime to use. Not all values supported on all platforms.",
     ) orelse apprt.Runtime.default(target);
+
+    libadwaita = b.option(
+        bool,
+        "libadwaita",
+        "Enables the use of libadwaita when using the gtk rendering backend.",
+    ) orelse false;
 
     renderer_impl = b.option(
         renderer.Impl,
@@ -203,6 +210,7 @@ pub fn build(b: *std.Build) !void {
     exe_options.addOption(apprt.Runtime, "app_runtime", app_runtime);
     exe_options.addOption(font.Backend, "font_backend", font_backend);
     exe_options.addOption(renderer.Impl, "renderer", renderer_impl);
+    exe_options.addOption(bool, "libadwaita", libadwaita);
 
     // Exe
     if (exe_) |exe| {
@@ -814,7 +822,7 @@ fn addDeps(
 
             .gtk => {
                 step.linkSystemLibrary2("gtk4", dynamic_link_opts);
-                step.linkSystemLibrary2("adwaita-1", dynamic_link_opts);
+                if (libadwaita) step.linkSystemLibrary2("adwaita-1", dynamic_link_opts);
             },
         }
     }

--- a/build.zig
+++ b/build.zig
@@ -90,9 +90,9 @@ pub fn build(b: *std.Build) !void {
 
     libadwaita = b.option(
         bool,
-        "libadwaita",
+        "gtk-libadwaita",
         "Enables the use of libadwaita when using the gtk rendering backend.",
-    ) orelse false;
+    ) orelse true;
 
     renderer_impl = b.option(
         renderer.Impl,

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -19,6 +19,7 @@ const internal_os = @import("../../os/main.zig");
 const Config = configpkg.Config;
 const CoreApp = @import("../../App.zig");
 const CoreSurface = @import("../../Surface.zig");
+const build_options = @import("build_options");
 
 const Surface = @import("Surface.zig");
 const Window = @import("Window.zig");
@@ -53,7 +54,7 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
     _ = opts;
 
     // Initialize libadwaita
-    c.adw_init();
+    if (build_options.libadwaita) c.adw_init();
 
     // Load our configuration
     var config = try Config.load(core_app.alloc);
@@ -67,14 +68,16 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
     }
 
     // Set the style based on our configuration file
-    c.adw_style_manager_set_color_scheme(
-        c.adw_style_manager_get_default(),
-        switch (config.@"window-theme") {
-            .system => c.ADW_COLOR_SCHEME_PREFER_LIGHT,
-            .dark => c.ADW_COLOR_SCHEME_FORCE_DARK,
-            .light => c.ADW_COLOR_SCHEME_FORCE_LIGHT,
-        },
-    );
+    if (build_options.libadwaita) {
+        c.adw_style_manager_set_color_scheme(
+            c.adw_style_manager_get_default(),
+            switch (config.@"window-theme") {
+                .system => c.ADW_COLOR_SCHEME_PREFER_LIGHT,
+                .dark => c.ADW_COLOR_SCHEME_FORCE_DARK,
+                .light => c.ADW_COLOR_SCHEME_FORCE_LIGHT,
+            },
+        );
+    }
 
     // The "none" cursor is used for hiding the cursor
     const cursor_none = c.gdk_cursor_new_from_name("none", null);


### PR DESCRIPTION
Another pull request to add onto #792, this simply adds a `-Dlibadwaita` build flag which will enable libadwaita. By default libadwaita is not linked or enabled so that people who don't wish to take advantage of libadwaita's style manager can still build it without the dependency.