### PR TITLE
More macOS fixups

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalManager.swift
+++ b/macos/Sources/Features/Terminal/TerminalManager.swift
@@ -87,7 +87,6 @@ class TerminalManager {
         // Create a new window and add it to the parent
         let window = createWindow(withBaseConfig: base).window!
         parent.addTabbedWindow(window, ordered: .above)
-        relabelTabs(parent)
         window.makeKeyAndOrderFront(self)
     }
     
@@ -130,12 +129,6 @@ class TerminalManager {
         // Ensure any publishers we have are cancelled
         w.closePublisher.cancel()
         
-        // Removing the window can change tabs, so we need to relabel all tabs.
-        // At this point, the window is already removed from the tab bar so
-        // I don't know a way to only relabel the active tab bar, so just relabel
-        // all of them.
-        relabelAllTabs()
-        
         // If we remove a window, we reset the cascade point to the key window so that
         // the next window cascade's from that one.
         if let focusedWindow = NSApplication.shared.keyWindow {
@@ -157,32 +150,7 @@ class TerminalManager {
     /// Relabels all the tabs with the proper keyboard shortcut.
     func relabelAllTabs() {
         for w in windows {
-            if let window = w.controller.window {
-                relabelTabs(window)
-            }
-        }
-    }
-    
-    /// Update the accessory view of each tab according to the keyboard
-    /// shortcut that activates it (if any). This is called when the key window
-    /// changes and when a window is closed.
-    private func relabelTabs(_ window: NSWindow) {
-        guard let windows = window.tabbedWindows else { return }
-        guard let cfg = ghostty.config else { return }
-        for (index, window) in windows.enumerated().prefix(9) {
-            let action = "goto_tab:\(index + 1)"
-            let trigger = ghostty_config_trigger(cfg, action, UInt(action.count))
-            guard let equiv = Ghostty.keyEquivalentLabel(key: trigger.key, mods: trigger.mods) else {
-                continue
-            }
-
-            let attributes: [NSAttributedString.Key: Any] = [
-                .font: NSFont.labelFont(ofSize: 0),
-                .foregroundColor: window.isKeyWindow ? NSColor.labelColor : NSColor.secondaryLabelColor,
-            ]
-            let attributedString = NSAttributedString(string: " \(equiv) ", attributes: attributes)
-            let text = NSTextField(labelWithAttributedString: attributedString)
-            window.tab.accessoryView = text
+            w.controller.relabelTabs()
         }
     }
     

--- a/macos/Sources/Features/Terminal/TerminalManager.swift
+++ b/macos/Sources/Features/Terminal/TerminalManager.swift
@@ -95,7 +95,13 @@ class TerminalManager {
     private func createWindow(withBaseConfig base: Ghostty.SurfaceConfiguration?) -> TerminalController {
         // Initialize our controller to load the window
         let c = TerminalController(ghostty, withBaseConfig: base)
-        
+
+        // For new windows, explicitly disallow tabbing with other windows.
+        // This overrides the value of userTabbingPreference. Rationale:
+        // Ghostty provides separate "New Tab" and "New Window" actions so
+        // there's no reason to make "New Window" open in a tab.
+        c.window!.tabbingMode = .disallowed;
+
         // Create a listener for when the window is closed so we can remove it.
         let pubClose = NotificationCenter.default.publisher(
             for: NSWindow.willCloseNotification,


### PR DESCRIPTION
Fixes: https://github.com/mitchellh/ghostty/issues/799
Fixes: https://github.com/mitchellh/ghostty/issues/800

---

@mitchellh I know that in https://github.com/mitchellh/ghostty/pull/772 you moved the tab relabeling out of `TerminalController` and into `TerminalManager`, and this PR moves them back in. I think this is the right approach for a couple reasons:

1. It solves the issue in the comment you left:

   >I don't know a way to only relabel the active tab bar, so just relabel all of them.
   
   We don't need to relabel all windows if we let the WindowDelegate do it when a specific window is closed.
   
2. The `TerminalController` already "owns" its tabs because it handles the `onGotoTab` notification. So I think a distinction where `TerminalController` owns the tabs within a window, and `TerminalManager` owns the windows themselves is clear and makes sense.

Let me know your thoughts!