### PR TITLE
terminfo: add missing % character after conditional

### DIFF
--- a/src/terminfo/ghostty.zig
+++ b/src/terminfo/ghostty.zig
@@ -120,7 +120,7 @@ pub const ghostty: Source = .{
         .{ .name = "Ms", .value = .{ .string = "\\E]52;%p1%s;%p2%s\\007" } },
 
         // Synchronized output
-        .{ .name = "Sync", .value = .{ .string = "\\E[?2026%?%p1%{1}%-%tl%eh" } },
+        .{ .name = "Sync", .value = .{ .string = "\\E[?2026%?%p1%{1}%-%tl%eh%" } },
 
         // Bracketed paste mode
         .{ .name = "BD", .value = .{ .string = "\\E[?2004l" } },


### PR DESCRIPTION
Not sure this is _strictly_ necessary, but according to terminfo(5) a
conditional (`%?`) should have a closing `%` character after the "else"
part. Adding it just in case some parser somewhere depends on this.
