### PR TITLE
font/coretext: discovery scoring should take into account symb. traits

### DIFF
--- a/pkg/macos/text/font.zig
+++ b/pkg/macos/text/font.zig
@@ -47,6 +47,10 @@ pub const Font = opaque {
         return @ptrCast(@constCast(c.CTFontCopyFontDescriptor(@ptrCast(self))));
     }
 
+    pub fn getGlyphCount(self: *Font) usize {
+        return @intCast(c.CTFontGetGlyphCount(@ptrCast(self)));
+    }
+
     pub fn getGlyphsForCharacters(self: *Font, chars: []const u16, glyphs: []graphics.Glyph) bool {
         assert(chars.len == glyphs.len);
         return c.CTFontGetGlyphsForCharacters(


### PR DESCRIPTION
Fixes #707

Our scoring algorithm previously did not take into account symbolic traits, so when `bold = false and italic = false`, regular, bold, italic would all be equally likely to appear first.

This modifies our scoring algorithm to prioritize matching symbolic traits. Further, we have a special case for no symbolic traits to prioritize "Regular" named styles. We can expand this to other styles too but we do not do this here.

We also modified the algorithm to always prefer fonts with more glyphs over fonts with less, hopeful that we can load fewer fonts for other glyphs later.

## Before

![CleanShot 2023-11-03 at 22 04 27@2x](https://github.com/mitchellh/ghostty/assets/1299/6aebd510-0110-470f-90f8-998ba7ab0577)

## After

(One character is still not perfect, that's due to that being a different font face. If anyone can think of further improvements to the scoring algorithm to resolve this I'd be happy to incorporate them. The best solution for a consistent user of these glyphs would be to use `font-codepoint-map` to force a specific font for a codepoint range.)

![CleanShot 2023-11-03 at 22 27 36@2x](https://github.com/mitchellh/ghostty/assets/1299/60c695bc-aecd-4213-881d-1d29bdec542f)
