### PR TITLE
GTK Feature: Clipboard Safety

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1165,7 +1165,7 @@ pub fn keyCallback(
 /// if bracketed mode is on this will do a bracketed paste. Otherwise,
 /// this will filter newlines to '\r'.
 pub fn textCallback(self: *Surface, text: []const u8) !void {
-    try self.completeClipboardPaste(text);
+    try self.completeClipboardPaste(text, false);
 }
 
 pub fn focusCallback(self: *Surface, focused: bool) !void {
@@ -2463,6 +2463,7 @@ pub fn completeClipboardRequest(
 ) !void {
     switch (req) {
         .paste => try self.completeClipboardPaste(data, force),
+        // TODO: Support sanaization for OSC 52
         .osc_52 => |kind| try self.completeClipboardReadOSC52(data, kind),
     }
 }

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1165,7 +1165,7 @@ pub fn keyCallback(
 /// if bracketed mode is on this will do a bracketed paste. Otherwise,
 /// this will filter newlines to '\r'.
 pub fn textCallback(self: *Surface, text: []const u8) !void {
-    try self.completeClipboardPaste(text, false);
+    try self.completeClipboardPaste(text, true);
 }
 
 pub fn focusCallback(self: *Surface, focused: bool) !void {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -142,6 +142,7 @@ const DerivedConfig = struct {
     clipboard_read: bool,
     clipboard_write: bool,
     clipboard_trim_trailing_spaces: bool,
+    clipboard_paste_protection: bool,
     copy_on_select: configpkg.CopyOnSelect,
     confirm_close_surface: bool,
     mouse_interval: u64,
@@ -165,6 +166,7 @@ const DerivedConfig = struct {
             .clipboard_read = config.@"clipboard-read",
             .clipboard_write = config.@"clipboard-write",
             .clipboard_trim_trailing_spaces = config.@"clipboard-trim-trailing-spaces",
+            .clipboard_paste_protection = config.@"clipboard-paste-protection",
             .copy_on_select = config.@"copy-on-select",
             .confirm_close_surface = config.@"confirm-close-surface",
             .mouse_interval = config.@"click-repeat-interval" * 1_000_000, // 500ms
@@ -2500,7 +2502,7 @@ fn sanatizeClipboardPaste(data: []const u8) !void {
 fn completeClipboardPaste(self: *Surface, data: []const u8, force: bool) !void {
     if (data.len == 0) return;
 
-    if (!force) {
+    if (!force and self.config.clipboard_paste_protection) {
         try sanatizeClipboardPaste(data);
     }
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1360,7 +1360,8 @@ pub const CAPI = struct {
 
         if (str_len == 0) return;
         const str = str_ptr[0..str_len];
-        ptr.core_surface.completeClipboardRequest(state.*, str, false) catch |err| {
+        // TODO: Support sanaization for MacOS (force: false)
+        ptr.core_surface.completeClipboardRequest(state.*, str, true) catch |err| {
             log.err("error completing clipboard request err={}", .{err});
             return;
         };

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1360,7 +1360,7 @@ pub const CAPI = struct {
 
         if (str_len == 0) return;
         const str = str_ptr[0..str_len];
-        ptr.core_surface.completeClipboardRequest(state.*, str) catch |err| {
+        ptr.core_surface.completeClipboardRequest(state.*, str, false) catch |err| {
             log.err("error completing clipboard request err={}", .{err});
             return;
         };

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -589,7 +589,8 @@ pub const Surface = struct {
         };
 
         // Complete our request
-        try self.core_surface.completeClipboardRequest(state, str, false);
+        // TODO: Support sanaization for GLFW (force: false)
+        try self.core_surface.completeClipboardRequest(state, str, true);
     }
 
     /// Set the clipboard.

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -589,7 +589,7 @@ pub const Surface = struct {
         };
 
         // Complete our request
-        try self.core_surface.completeClipboardRequest(state, str);
+        try self.core_surface.completeClipboardRequest(state, str, false);
     }
 
     /// Set the clipboard.

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -588,8 +588,8 @@ pub const Surface = struct {
             },
         };
 
-        // Complete our request
-        // TODO: Support sanaization for GLFW (force: false)
+        // Complete our request. We always allow unsafe because we don't
+        // want to deal with user confirmation in this runtime.
         try self.core_surface.completeClipboardRequest(state, str, true);
     }
 

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -24,6 +24,7 @@ const build_options = @import("build_options");
 const Surface = @import("Surface.zig");
 const Window = @import("Window.zig");
 const ConfigErrorsWindow = @import("ConfigErrorsWindow.zig");
+const UnsafePasteWindow = @import("UnsafePasteWindow.zig");
 const c = @import("c.zig");
 const inspector = @import("inspector.zig");
 const key = @import("key.zig");
@@ -46,6 +47,9 @@ menu: ?*c.GMenu = null,
 
 /// The configuration errors window, if it is currently open.
 config_errors_window: ?*ConfigErrorsWindow = null,
+
+/// The unsafe paste window, if it is currently open.
+unsafe_paste_window: ?*UnsafePasteWindow = null,
 
 /// This is set to false when the main loop should exit.
 running: bool = true,

--- a/src/apprt/gtk/UnsafePasteWindow.zig
+++ b/src/apprt/gtk/UnsafePasteWindow.zig
@@ -1,0 +1,216 @@
+/// Configuration errors window.
+const UnsafePaste = @This();
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const CoreSurface = @import("../../Surface.zig");
+const ClipboardRequest = @import("../structs.zig").ClipboardRequest;
+const App = @import("App.zig");
+const View = @import("View.zig");
+const c = @import("c.zig");
+
+const log = std.log.scoped(.gtk);
+
+app: *App,
+window: *c.GtkWindow,
+view: PrimaryView,
+
+data: []u8,
+core_surface: CoreSurface,
+pending_req: ClipboardRequest,
+
+pub fn create(
+    app: *App,
+    data: []const u8,
+    core_surface: CoreSurface,
+    request: ClipboardRequest,
+) !void {
+    if (app.unsafe_paste_window != null) return error.WindowAlreadyExists;
+
+    const alloc = app.core_app.alloc;
+    const self = try alloc.create(UnsafePaste);
+    errdefer alloc.destroy(self);
+    try self.init(
+        app,
+        data,
+        core_surface,
+        request,
+    );
+
+    app.unsafe_paste_window = self;
+}
+
+/// Not public because this should be called by the GTK lifecycle.
+fn destroy(self: *UnsafePaste) void {
+    const alloc = self.app.core_app.alloc;
+    self.app.config_errors_window = null;
+    alloc.destroy(self);
+}
+
+fn init(
+    self: *UnsafePaste,
+    app: *App,
+    data: []const u8,
+    core_surface: CoreSurface,
+    request: ClipboardRequest,
+) !void {
+    // Create the window
+    const window = c.gtk_window_new();
+    const gtk_window: *c.GtkWindow = @ptrCast(window);
+    errdefer c.gtk_window_destroy(gtk_window);
+    c.gtk_window_set_title(gtk_window, "Unsafe Paste!");
+    c.gtk_window_set_default_size(gtk_window, 600, 400);
+    c.gtk_window_set_resizable(gtk_window, 0);
+    _ = c.g_signal_connect_data(
+        window,
+        "destroy",
+        c.G_CALLBACK(&gtkDestroy),
+        self,
+        null,
+        c.G_CONNECT_DEFAULT,
+    );
+
+    // Set some state
+    self.* = .{
+        .app = app,
+        .window = gtk_window,
+        .view = undefined,
+        .data = try app.core_app.alloc.dupe(u8, data),
+        .core_surface = core_surface,
+        .pending_req = request,
+    };
+
+    // Show the window
+    const view = try PrimaryView.init(self, data);
+    self.view = view;
+    c.gtk_window_set_child(@ptrCast(window), view.root);
+    c.gtk_widget_show(window);
+}
+
+fn gtkDestroy(_: *c.GtkWidget, ud: ?*anyopaque) callconv(.C) void {
+    const self = userdataSelf(ud.?);
+    self.destroy();
+}
+
+fn userdataSelf(ud: *anyopaque) *UnsafePaste {
+    return @ptrCast(@alignCast(ud));
+}
+
+const PrimaryView = struct {
+    root: *c.GtkWidget,
+    text: *c.GtkTextView,
+
+    pub fn init(root: *UnsafePaste, data: []const u8) !PrimaryView {
+        // All our widgets
+        const label = c.gtk_label_new(
+            \\ Pasting this text into the terminal may be dangerous as 
+            \\ unintended commands may be be executed.
+        );
+        const buf = unsafeBuffer(data);
+        defer c.g_object_unref(buf);
+        const buttons = try ButtonsView.init(root);
+        const text_scroll = c.gtk_scrolled_window_new();
+        errdefer c.g_object_unref(text_scroll);
+        const text = c.gtk_text_view_new_with_buffer(buf);
+        errdefer c.g_object_unref(text);
+        c.gtk_scrolled_window_set_child(@ptrCast(text_scroll), text);
+
+        // Create our view
+        const view = try View.init(&.{
+            .{ .name = "label", .widget = label },
+            .{ .name = "text", .widget = text_scroll },
+            .{ .name = "buttons", .widget = buttons.root },
+        }, &vfl);
+        errdefer view.deinit();
+
+        // We can do additional settings once the layout is setup
+        c.gtk_label_set_wrap(@ptrCast(label), 1);
+        c.gtk_text_view_set_editable(@ptrCast(text), 0);
+        c.gtk_text_view_set_cursor_visible(@ptrCast(text), 0);
+        c.gtk_text_view_set_top_margin(@ptrCast(text), 8);
+        c.gtk_text_view_set_bottom_margin(@ptrCast(text), 8);
+        c.gtk_text_view_set_left_margin(@ptrCast(text), 8);
+        c.gtk_text_view_set_right_margin(@ptrCast(text), 8);
+
+        return .{ .root = view.root, .text = @ptrCast(text) };
+    }
+
+    /// Returns the GtkTextBuffer for the data that was unsafe.
+    fn unsafeBuffer(data: []const u8) *c.GtkTextBuffer {
+        const buf = c.gtk_text_buffer_new(null);
+        errdefer c.g_object_unref(buf);
+
+        c.gtk_text_buffer_insert_at_cursor(buf, data.ptr, @intCast(data.len));
+
+        return buf;
+    }
+
+    const vfl = [_][*:0]const u8{
+        "H:|-8-[label]-8-|",
+        "H:|[text]|",
+        "H:|[buttons]|",
+        "V:|[label(<=80)][text(>=100)]-[buttons]-|",
+    };
+};
+
+const ButtonsView = struct {
+    root: *c.GtkWidget,
+
+    pub fn init(root: *UnsafePaste) !ButtonsView {
+        const cancel_button = c.gtk_button_new_with_label("Cancel");
+        errdefer c.g_object_unref(cancel_button);
+
+        const paste_button = c.gtk_button_new_with_label("Paste");
+        errdefer c.g_object_unref(paste_button);
+
+        // Create our view
+        const view = try View.init(&.{
+            .{ .name = "cancel", .widget = cancel_button },
+            .{ .name = "paste", .widget = paste_button },
+        }, &vfl);
+
+        // Signals
+        _ = c.g_signal_connect_data(
+            cancel_button,
+            "clicked",
+            c.G_CALLBACK(&gtkCancelClick),
+            root,
+            null,
+            c.G_CONNECT_DEFAULT,
+        );
+        _ = c.g_signal_connect_data(
+            paste_button,
+            "clicked",
+            c.G_CALLBACK(&gtkPasteClick),
+            root,
+            null,
+            c.G_CONNECT_DEFAULT,
+        );
+
+        return .{ .root = view.root };
+    }
+
+    fn gtkCancelClick(_: *c.GtkWidget, ud: ?*anyopaque) callconv(.C) void {
+        const self: *UnsafePaste = @ptrCast(@alignCast(ud));
+        c.gtk_window_destroy(@ptrCast(self.window));
+
+        self.app.unsafe_paste_window = null;
+    }
+
+    fn gtkPasteClick(_: *c.GtkWidget, ud: ?*anyopaque) callconv(.C) void {
+        const self: *UnsafePaste = @ptrCast(@alignCast(ud));
+
+        // Requeue the paste, this time forcing it.
+        self.core_surface.completeClipboardRequest(self.pending_req, self.data, true) catch |err| {
+            std.log.err("Failed to requeue clipboard request: {}", .{err});
+        };
+
+        c.gtk_window_destroy(@ptrCast(self.window));
+        self.app.unsafe_paste_window = null;
+    }
+
+    const vfl = [_][*:0]const u8{
+        "H:[cancel]-8-[paste]-8-|",
+    };
+};

--- a/src/apprt/gtk/UnsafePasteWindow.zig
+++ b/src/apprt/gtk/UnsafePasteWindow.zig
@@ -60,7 +60,7 @@ fn init(
     const gtk_window: *c.GtkWindow = @ptrCast(window);
     errdefer c.gtk_window_destroy(gtk_window);
     c.gtk_window_set_title(gtk_window, "Warning: Potentially Unsafe Paste");
-    c.gtk_window_set_default_size(gtk_window, 600, 275);
+    c.gtk_window_set_default_size(gtk_window, 550, 275);
     c.gtk_window_set_resizable(gtk_window, 0);
     _ = c.g_signal_connect_data(
         window,
@@ -104,8 +104,8 @@ const PrimaryView = struct {
     pub fn init(root: *UnsafePaste, data: []const u8) !PrimaryView {
         // All our widgets
         const label = c.gtk_label_new(
-            \\ Pasting this text into the terminal may be dangerous as
-            \\ it looks like some commands may be executed.
+            "Pasting this text into the terminal may be dangerous as " ++
+                "it looks like some commands may be executed.",
         );
         const buf = unsafeBuffer(data);
         defer c.g_object_unref(buf);

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -423,6 +423,10 @@ keybind: Keybinds = .{},
 /// This does not affect data sent to the clipboard via "clipboard-write".
 @"clipboard-trim-trailing-spaces": bool = true,
 
+/// Creates a pop-up window when active, warning the user that they are pasting
+/// contents that contains more than one line. This could be a "copy paste attack"
+@"clipboard-paste-protection": bool = true,
+
 /// The total amount of bytes that can be used for image data (i.e.
 /// the Kitty image protocol) per terminal scren. The maximum value
 /// is 4,294,967,295 (4GB). The default is 320MB. If this is set to zero,

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -423,8 +423,11 @@ keybind: Keybinds = .{},
 /// This does not affect data sent to the clipboard via "clipboard-write".
 @"clipboard-trim-trailing-spaces": bool = true,
 
-/// Creates a pop-up window when active, warning the user that they are pasting
-/// contents that contains more than one line. This could be a "copy paste attack"
+/// Require confirmation before pasting text that appears unsafe. This helps
+/// prevent a "copy/paste attack" where a user may accidentally execute unsafe
+/// commands by pasting text with newlines.
+///
+/// This currently only works on Linux (GTK).
 @"clipboard-paste-protection": bool = true,
 
 /// The total amount of bytes that can be used for image data (i.e.

--- a/src/terminal/main.zig
+++ b/src/terminal/main.zig
@@ -1,5 +1,7 @@
 const builtin = @import("builtin");
 
+pub usingnamespace @import("sanitize.zig");
+
 const charsets = @import("charsets.zig");
 const stream = @import("stream.zig");
 const ansi = @import("ansi.zig");

--- a/src/terminal/sanitize.zig
+++ b/src/terminal/sanitize.zig
@@ -1,0 +1,13 @@
+const std = @import("std");
+
+/// Returns true if the data looks safe to paste.
+pub fn isSafePaste(data: []const u8) bool {
+    return std.mem.indexOf(u8, data, "\n") == null;
+}
+
+test isSafePaste {
+    const testing = std.testing;
+    try testing.expect(isSafePaste("hello"));
+    try testing.expect(!isSafePaste("hello\n"));
+    try testing.expect(!isSafePaste("hello\nworld"));
+}


### PR DESCRIPTION
This PR would add a new popup that would warn users that they are pasting a clipboard that contains newlines. Would bring #469 closer to resolution, however I/someone still needs to impliment MacOS and GLFW side of this.

This can be turned off wit `clipboard-paste-protection = false`

I would still really want to implement auto-focusing feature, but GTK really doesn't want to comply.

It looks like this when in action:
This example is meant to show the pop-up, and show the scrolling, when the arg is very "tall".
![image](https://github.com/mitchellh/ghostty/assets/87927264/0f7f05d8-3648-4236-b5ee-6c176280b10c)



