### PR TITLE
macos: implement split resizing

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -50,6 +50,13 @@ typedef enum {
 } ghostty_split_focus_direction_e;
 
 typedef enum {
+    GHOSTTY_SPLIT_RESIZE_UP,
+    GHOSTTY_SPLIT_RESIZE_DOWN,
+    GHOSTTY_SPLIT_RESIZE_LEFT,
+    GHOSTTY_SPLIT_RESIZE_RIGHT,
+} ghostty_split_resize_direction_e;
+
+typedef enum {
     GHOSTTY_INSPECTOR_TOGGLE,
     GHOSTTY_INSPECTOR_SHOW,
     GHOSTTY_INSPECTOR_HIDE,
@@ -333,6 +340,7 @@ typedef void (*ghostty_runtime_new_window_cb)(void *, ghostty_surface_config_s);
 typedef void (*ghostty_runtime_control_inspector_cb)(void *, ghostty_inspector_mode_e);
 typedef void (*ghostty_runtime_close_surface_cb)(void *, bool);
 typedef void (*ghostty_runtime_focus_split_cb)(void *, ghostty_split_focus_direction_e);
+typedef void (*ghostty_runtime_resize_split_cb)(void *, ghostty_split_resize_direction_e, uint16_t);
 typedef void (*ghostty_runtime_toggle_split_zoom_cb)(void *);
 typedef void (*ghostty_runtime_goto_tab_cb)(void *, int32_t);
 typedef void (*ghostty_runtime_toggle_fullscreen_cb)(void *, ghostty_non_native_fullscreen_e);
@@ -357,6 +365,7 @@ typedef struct {
     ghostty_runtime_control_inspector_cb control_inspector_cb;
     ghostty_runtime_close_surface_cb close_surface_cb;
     ghostty_runtime_focus_split_cb focus_split_cb;
+    ghostty_runtime_resize_split_cb resize_split_cb;
     ghostty_runtime_toggle_split_zoom_cb toggle_split_zoom_cb;
     ghostty_runtime_goto_tab_cb goto_tab_cb;
     ghostty_runtime_toggle_fullscreen_cb toggle_fullscreen_cb;
@@ -412,6 +421,7 @@ void ghostty_surface_ime_point(ghostty_surface_t, double *, double *);
 void ghostty_surface_request_close(ghostty_surface_t);
 void ghostty_surface_split(ghostty_surface_t, ghostty_split_direction_e);
 void ghostty_surface_split_focus(ghostty_surface_t, ghostty_split_focus_direction_e);
+void ghostty_surface_split_resize(ghostty_surface_t, ghostty_split_resize_direction_e, uint16_t);
 bool ghostty_surface_binding_action(ghostty_surface_t, const char *, uintptr_t);
 void ghostty_surface_complete_clipboard_request(ghostty_surface_t, const char *, void *, bool);
 

--- a/macos/Sources/AppDelegate.swift
+++ b/macos/Sources/AppDelegate.swift
@@ -38,6 +38,11 @@ class AppDelegate: NSObject, ObservableObject, NSApplicationDelegate, GhosttyApp
     @IBOutlet private var menuResetFontSize: NSMenuItem?
     @IBOutlet private var menuTerminalInspector: NSMenuItem?
 
+    @IBOutlet private var menuMoveSplitDividerUp: NSMenuItem?
+    @IBOutlet private var menuMoveSplitDividerDown: NSMenuItem?
+    @IBOutlet private var menuMoveSplitDividerLeft: NSMenuItem?
+    @IBOutlet private var menuMoveSplitDividerRight: NSMenuItem?
+
     /// The dock menu
     private var dockMenu: NSMenu = NSMenu()
     
@@ -206,6 +211,10 @@ class AppDelegate: NSObject, ObservableObject, NSApplicationDelegate, GhosttyApp
         syncMenuShortcut(action: "goto_split:bottom", menuItem: self.menuSelectSplitBelow)
         syncMenuShortcut(action: "goto_split:left", menuItem: self.menuSelectSplitLeft)
         syncMenuShortcut(action: "goto_split:right", menuItem: self.menuSelectSplitRight)
+        syncMenuShortcut(action: "resize_split:up,10", menuItem: self.menuMoveSplitDividerUp)
+        syncMenuShortcut(action: "resize_split:down,10", menuItem: self.menuMoveSplitDividerDown)
+        syncMenuShortcut(action: "resize_split:right,10", menuItem: self.menuMoveSplitDividerRight)
+        syncMenuShortcut(action: "resize_split:left,10", menuItem: self.menuMoveSplitDividerLeft)
 
         syncMenuShortcut(action: "increase_font_size:1", menuItem: self.menuIncreaseFontSize)
         syncMenuShortcut(action: "decrease_font_size:1", menuItem: self.menuDecreaseFontSize)

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -270,7 +270,27 @@ class TerminalController: NSWindowController, NSWindowDelegate,
     @IBAction func splitMoveFocusRight(_ sender: Any) {
         splitMoveFocus(direction: .right)
     }
-    
+
+    @IBAction func moveSplitDividerUp(_ sender: Any) {
+        guard let surface = focusedSurface?.surface else { return }
+        ghostty.splitResize(surface: surface, direction: .up, amount: 10)
+    }
+
+    @IBAction func moveSplitDividerDown(_ sender: Any) {
+        guard let surface = focusedSurface?.surface else { return }
+        ghostty.splitResize(surface: surface, direction: .down, amount: 10)
+    }
+
+    @IBAction func moveSplitDividerLeft(_ sender: Any) {
+        guard let surface = focusedSurface?.surface else { return }
+        ghostty.splitResize(surface: surface, direction: .left, amount: 10)
+    }
+
+    @IBAction func moveSplitDividerRight(_ sender: Any) {
+        guard let surface = focusedSurface?.surface else { return }
+        ghostty.splitResize(surface: surface, direction: .right, amount: 10)
+    }
+
     private func splitMoveFocus(direction: Ghostty.SplitFocusDirection) {
         guard let surface = focusedSurface?.surface else { return }
         ghostty.splitMoveFocus(surface: surface, direction: direction)

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -40,7 +40,7 @@ class TerminalController: NSWindowController, NSWindowDelegate,
         
         // Initialize our initial surface.
         guard let ghostty_app = ghostty.app else { preconditionFailure("app must be loaded") }
-        self.surfaceTree = .noSplit(.init(ghostty_app, base))
+        self.surfaceTree = .leaf(.init(ghostty_app, base))
         
         // Setup our notifications for behaviors
         let center = NotificationCenter.default

--- a/macos/Sources/Features/Terminal/TerminalView.swift
+++ b/macos/Sources/Features/Terminal/TerminalView.swift
@@ -85,8 +85,6 @@ struct TerminalView<ViewModel: TerminalViewModel>: View {
                 
                 Ghostty.TerminalSplit(node: $viewModel.surfaceTree)
                     .environmentObject(ghostty)
-                    .ghosttyApp(ghostty.app!)
-                    .ghosttyConfig(ghostty.config!)
                     .focused($focused)
                     .onAppear { self.focused = true }
                     .onChange(of: focusedSurface) { newValue in

--- a/macos/Sources/Features/Terminal/TerminalView.swift
+++ b/macos/Sources/Features/Terminal/TerminalView.swift
@@ -84,6 +84,7 @@ struct TerminalView<ViewModel: TerminalViewModel>: View {
                 }
                 
                 Ghostty.TerminalSplit(node: $viewModel.surfaceTree)
+                    .environmentObject(ghostty)
                     .ghosttyApp(ghostty.app!)
                     .ghosttyConfig(ghostty.config!)
                     .focused($focused)

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -149,6 +149,8 @@ extension Ghostty {
                 control_inspector_cb: { userdata, mode in AppState.controlInspector(userdata, mode: mode) },
                 close_surface_cb: { userdata, processAlive in AppState.closeSurface(userdata, processAlive: processAlive) },
                 focus_split_cb: { userdata, direction in AppState.focusSplit(userdata, direction: direction) },
+                resize_split_cb: { userdata, direction, amount in
+                    AppState.resizeSplit(userdata, direction: direction, amount: amount) },
                 toggle_split_zoom_cb: { userdata in AppState.toggleSplitZoom(userdata) },
                 goto_tab_cb: { userdata, n in AppState.gotoTab(userdata, n: n) },
                 toggle_fullscreen_cb: { userdata, nonNativeFullscreen in AppState.toggleFullscreen(userdata, nonNativeFullscreen: nonNativeFullscreen) },
@@ -283,6 +285,10 @@ extension Ghostty {
             ghostty_surface_split_focus(surface, direction.toNative())
         }
 
+        func splitResize(surface: ghostty_surface_t, direction: SplitResizeDirection, amount: UInt16) {
+            ghostty_surface_split_resize(surface, direction.toNative(), amount)
+        }
+
         func splitToggleZoom(surface: ghostty_surface_t) {
             let action = "toggle_split_zoom"
             if (!ghostty_surface_binding_action(surface, action, UInt(action.count))) {
@@ -351,6 +357,19 @@ extension Ghostty {
                 object: surface,
                 userInfo: [
                     Notification.SplitDirectionKey: splitDirection,
+                ]
+            )
+        }
+
+        static func resizeSplit(_ userdata: UnsafeMutableRawPointer?, direction: ghostty_split_resize_direction_e, amount: UInt16) {
+            guard let surface = self.surfaceUserdata(from: userdata) else { return }
+            guard let resizeDirection = SplitResizeDirection.from(direction: direction) else { return }
+            NotificationCenter.default.post(
+                name: Notification.didResizeSplit,
+                object: surface,
+                userInfo: [
+                    Notification.ResizeSplitDirectionKey: resizeDirection,
+                    Notification.ResizeSplitAmountKey: amount,
                 ]
             )
         }

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -582,35 +582,3 @@ extension Ghostty {
         }
     }
 }
-
-// MARK: AppState Environment Keys
-
-private struct GhosttyAppKey: EnvironmentKey {
-    static let defaultValue: ghostty_app_t? = nil
-}
-
-private struct GhosttyConfigKey: EnvironmentKey {
-    static let defaultValue: ghostty_config_t? = nil
-}
-
-extension EnvironmentValues {
-    var ghosttyApp: ghostty_app_t? {
-        get { self[GhosttyAppKey.self] }
-        set { self[GhosttyAppKey.self] = newValue }
-    }
-
-    var ghosttyConfig: ghostty_config_t? {
-        get { self[GhosttyConfigKey.self] }
-        set { self[GhosttyConfigKey.self] = newValue }
-    }
-}
-
-extension View {
-    func ghosttyApp(_ app: ghostty_app_t?) -> some View {
-        environment(\.ghosttyApp, app)
-    }
-
-    func ghosttyConfig(_ config: ghostty_config_t?) -> some View {
-        environment(\.ghosttyConfig, config)
-    }
-}

--- a/macos/Sources/Ghostty/Ghostty.SplitNode.swift
+++ b/macos/Sources/Ghostty/Ghostty.SplitNode.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 import GhosttyKit
 
 extension Ghostty {
@@ -123,6 +124,8 @@ extension Ghostty {
             @Published var topLeft: SplitNode
             @Published var bottomRight: SplitNode
 
+            var resizeEvent: PassthroughSubject<Double, Never> = .init()
+
             weak var parent: SplitNode.Container?
 
             /// A container is always initialized from some prior leaf because a split has to originate
@@ -143,6 +146,30 @@ extension Ghostty {
                 from.parent = self
                 bottomRight.parent = self
             }
+
+            /// Resize the split by moving the split divider in the given
+            /// direction by the given amount. If this container is not split
+            /// in the given direction, navigate up the tree until we find a
+            /// container that is
+            func resize(direction: SplitResizeDirection, amount: UInt16) {
+                 // We send a resize event to our publisher which will be
+                 // received by the SplitView.
+                switch (self.direction) {
+                case .horizontal:
+                    switch (direction) {
+                    case .left: resizeEvent.send(-Double(amount))
+                    case .right: resizeEvent.send(Double(amount))
+                    default: parent?.resize(direction: direction, amount: amount)
+                    }
+                case .vertical:
+                    switch (direction) {
+                    case .up: resizeEvent.send(-Double(amount))
+                    case .down: resizeEvent.send(Double(amount))
+                    default: parent?.resize(direction: direction, amount: amount)
+                    }
+                }
+            }
+
             
             // MARK: - Hashable
             

--- a/macos/Sources/Ghostty/Ghostty.TerminalSplit.swift
+++ b/macos/Sources/Ghostty/Ghostty.TerminalSplit.swift
@@ -61,25 +61,15 @@ extension Ghostty {
                     case nil:
                         Color(.clear)
                         
-                    case .noSplit(let leaf):
+                    case .leaf(let leaf):
                         TerminalSplitLeaf(
                             leaf: leaf,
                             neighbors: .empty,
                             node: $node
                         )
 
-                    case .horizontal(let container):
+                    case .split(let container):
                         TerminalSplitContainer(
-                            direction: .horizontal,
-                            neighbors: .empty,
-                            node: $node,
-                            container: container
-                        )
-                        .onReceive(pubZoom) { onZoom(notification: $0) }
-
-                    case .vertical(let container):
-                        TerminalSplitContainer(
-                            direction: .vertical,
                             neighbors: .empty,
                             node: $node,
                             container: container
@@ -105,7 +95,7 @@ extension Ghostty {
         
         func onZoom(notification: SwiftUI.Notification) {
             // Our node must be split to receive zooms. You can't zoom an unsplit terminal.
-            if case .noSplit = node {
+            if case .leaf = node {
                 preconditionFailure("TerminalSplitRoom must not be zoom-able if no splits exist")
             }
 
@@ -234,16 +224,10 @@ extension Ghostty {
             }
 
             // Setup our new container since we are now split
-            let container = SplitNode.Container(from: leaf, baseConfig: config)
+            let container = SplitNode.Container(from: leaf, direction: splitDirection, baseConfig: config)
 
-            // Depending on the direction, change the parent node. This will trigger
-            // the parent to relayout our views.
-            switch (splitDirection) {
-            case .horizontal:
-                node = .horizontal(container)
-            case .vertical:
-                node = .vertical(container)
-            }
+            // Change the parent node. This will trigger the parent to relayout our views.
+            node = .split(container)
 
             // See moveFocus comment, we have to run this whenever split changes.
             Ghostty.moveFocus(to: container.bottomRight.preferredFocus(), from: node!.preferredFocus())
@@ -263,14 +247,13 @@ extension Ghostty {
     
     /// This represents a split view that is in the horizontal or vertical split state.
     private struct TerminalSplitContainer: View {
-        let direction: SplitViewDirection
         let neighbors: SplitNode.Neighbors
         @Binding var node: SplitNode?
         @StateObject var container: SplitNode.Container
 
         var body: some View {
-            SplitView(direction, left: {
-                let neighborKey: WritableKeyPath<SplitNode.Neighbors, SplitNode?> = direction == .horizontal ? \.right : \.bottom
+            SplitView(container.direction, left: {
+                let neighborKey: WritableKeyPath<SplitNode.Neighbors, SplitNode?> = container.direction == .horizontal ? \.right : \.bottom
 
                 TerminalSplitNested(
                     node: closeableTopLeft(),
@@ -280,8 +263,8 @@ extension Ghostty {
                     ])
                 )
             }, right: {
-                let neighborKey: WritableKeyPath<SplitNode.Neighbors, SplitNode?> = direction == .horizontal ? \.left : \.top
-                
+                let neighborKey: WritableKeyPath<SplitNode.Neighbors, SplitNode?> = container.direction == .horizontal ? \.left : \.top
+
                 TerminalSplitNested(
                     node: closeableBottomRight(),
                     neighbors: neighbors.update([
@@ -304,7 +287,16 @@ extension Ghostty {
                 // Closing
                 container.topLeft.close()
                 node = container.bottomRight
-                
+
+                switch (node) {
+                case .leaf(let l):
+                    l.parent = container.parent
+                case .split(let c):
+                    c.parent = container.parent
+                case .none:
+                    break
+                }
+
                 DispatchQueue.main.async {
                     Ghostty.moveFocus(
                         to: container.bottomRight.preferredFocus(),
@@ -326,7 +318,16 @@ extension Ghostty {
                 // Closing
                 container.bottomRight.close()
                 node = container.topLeft
-                
+
+                switch (node) {
+                case .leaf(let l):
+                    l.parent = container.parent
+                case .split(let c):
+                    c.parent = container.parent
+                case .none:
+                    break
+                }
+
                 DispatchQueue.main.async {
                     Ghostty.moveFocus(
                         to: container.topLeft.preferredFocus(),
@@ -350,24 +351,15 @@ extension Ghostty {
                 case nil:
                     Color(.clear)
 
-                case .noSplit(let leaf):
+                case .leaf(let leaf):
                     TerminalSplitLeaf(
                         leaf: leaf,
                         neighbors: neighbors,
                         node: $node
                     )
 
-                case .horizontal(let container):
+                case .split(let container):
                     TerminalSplitContainer(
-                        direction: .horizontal,
-                        neighbors: neighbors,
-                        node: $node,
-                        container: container
-                    )
-
-                case .vertical(let container):
-                    TerminalSplitContainer(
-                        direction: .vertical,
                         neighbors: neighbors,
                         node: $node,
                         container: container

--- a/macos/Sources/Ghostty/Ghostty.TerminalSplit.swift
+++ b/macos/Sources/Ghostty/Ghostty.TerminalSplit.swift
@@ -277,7 +277,11 @@ extension Ghostty {
         @State private var resizeIncrements: NSSize = .init(width: 1.0, height: 1.0)
 
         var body: some View {
-            SplitView(container.direction, left: {
+            SplitView(
+                container.direction,
+                resizeIncrements: resizeIncrements,
+                resizePublisher: container.resizeEvent,
+                left: {
                 let neighborKey: WritableKeyPath<SplitNode.Neighbors, SplitNode?> = container.direction == .horizontal ? \.right : \.bottom
 
                 TerminalSplitNested(
@@ -303,8 +307,6 @@ extension Ghostty {
                 guard ghostty.windowStepResize else { return }
                 self.resizeIncrements = increments
             }
-            .resizeIncrements(resizeIncrements)
-            .resizePublisher(container.resizeEvent)
         }
         
         private func closeableTopLeft() -> Binding<SplitNode?> {

--- a/macos/Sources/Ghostty/Ghostty.TerminalSplit.swift
+++ b/macos/Sources/Ghostty/Ghostty.TerminalSplit.swift
@@ -267,19 +267,10 @@ extension Ghostty {
         @Binding var node: SplitNode?
         @StateObject var container: SplitNode.Container
 
-        @EnvironmentObject private var ghostty: Ghostty.AppState
-
-        /// The cell size of the currently focused view. We use this to
-        /// (optionally) set the resizeIncrements binding for the SplitView
-        @FocusedValue(\.ghosttySurfaceCellSize) private var focusedCellSize
-
-        /// Resize increments used by the split view
-        @State private var resizeIncrements: NSSize = .init(width: 1.0, height: 1.0)
-
         var body: some View {
             SplitView(
                 container.direction,
-                resizeIncrements: resizeIncrements,
+                resizeIncrements: .init(width: 1, height: 1),
                 resizePublisher: container.resizeEvent,
                 left: {
                 let neighborKey: WritableKeyPath<SplitNode.Neighbors, SplitNode?> = container.direction == .horizontal ? \.right : \.bottom
@@ -302,11 +293,6 @@ extension Ghostty {
                     ])
                 )
             })
-            .onChange(of: focusedCellSize) { newValue in
-                guard let increments = newValue else { return }
-                guard ghostty.windowStepResize else { return }
-                self.resizeIncrements = increments
-            }
         }
         
         private func closeableTopLeft() -> Binding<SplitNode?> {

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -61,6 +61,39 @@ extension Ghostty {
             }
         }
     }
+
+    /// Enum used for resizing splits. This is the direction the split divider will move.
+    enum SplitResizeDirection {
+        case up, down, left, right
+
+        static func from(direction: ghostty_split_resize_direction_e) -> Self? {
+            switch (direction) {
+            case GHOSTTY_SPLIT_RESIZE_UP:
+                return .up;
+            case GHOSTTY_SPLIT_RESIZE_DOWN:
+                return .down;
+            case GHOSTTY_SPLIT_RESIZE_LEFT:
+                return .left;
+            case GHOSTTY_SPLIT_RESIZE_RIGHT:
+                return .right;
+            default:
+                return nil
+            }
+        }
+
+        func toNative() -> ghostty_split_resize_direction_e {
+            switch (self) {
+            case .up:
+                return GHOSTTY_SPLIT_RESIZE_UP;
+            case .down:
+                return GHOSTTY_SPLIT_RESIZE_DOWN;
+            case .left:
+                return GHOSTTY_SPLIT_RESIZE_LEFT;
+            case .right:
+                return GHOSTTY_SPLIT_RESIZE_RIGHT;
+            }
+        }
+    }
 }
 
 extension Ghostty.Notification {
@@ -112,6 +145,11 @@ extension Ghostty.Notification {
     static let confirmUnsafePaste = Notification.Name("com.mitchellh.ghostty.confirmUnsafePaste")
     static let UnsafePasteStrKey = confirmUnsafePaste.rawValue + ".str"
     static let UnsafePasteStateKey = confirmUnsafePaste.rawValue + ".state"
+
+    /// Notification sent to the active split view to resize the split.
+    static let didResizeSplit = Notification.Name("com.mitchellh.ghostty.didResizeSplit")
+    static let ResizeSplitDirectionKey = didResizeSplit.rawValue + ".direction"
+    static let ResizeSplitAmountKey = didResizeSplit.rawValue + ".amount"
 }
 
 // Make the input enum hashable.

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -4,11 +4,11 @@ import GhosttyKit
 extension Ghostty {
     /// Render a terminal for the active app in the environment.
     struct Terminal: View {
-        @Environment(\.ghosttyApp) private var app
+        @EnvironmentObject private var ghostty: Ghostty.AppState
         @FocusedValue(\.ghosttySurfaceTitle) private var surfaceTitle: String?
 
         var body: some View {
-            if let app = self.app {
+            if let app = self.ghostty.app {
                 SurfaceForApp(app) { surfaceView in
                     SurfaceWrapper(surfaceView: surfaceView)
                 }
@@ -48,7 +48,7 @@ extension Ghostty {
         // Maintain whether our window has focus (is key) or not
         @State private var windowFocus: Bool = true
 
-        @Environment(\.ghosttyConfig) private var ghostty_config
+        @EnvironmentObject private var ghostty: Ghostty.AppState
 
         // This is true if the terminal is considered "focused". The terminal is focused if
         // it is both individually focused and the containing window is key.
@@ -58,7 +58,7 @@ extension Ghostty {
         private var unfocusedOpacity: Double {
             var opacity: Double = 0.85
             let key = "unfocused-split-opacity"
-            _ = ghostty_config_get(ghostty_config, &opacity, key, UInt(key.count))
+            _ = ghostty_config_get(ghostty.config, &opacity, key, UInt(key.count))
             return 1 - opacity
         }
 

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -508,7 +508,7 @@ extension Ghostty {
             guard let window = self.window else { return }
             guard let windowControllerRaw = window.windowController else { return }
             guard let windowController = windowControllerRaw as? TerminalController else { return }
-            guard case .noSplit = windowController.surfaceTree else { return }
+            guard case .leaf = windowController.surfaceTree else { return }
             
             // If our window is full screen, we do not set the frame
             guard !window.styleMask.contains(.fullScreen) else { return }

--- a/macos/Sources/MainMenu.xib
+++ b/macos/Sources/MainMenu.xib
@@ -19,6 +19,10 @@
                 <outlet property="menuCopy" destination="Jqf-pv-Zcu" id="bKd-1C-oy9"/>
                 <outlet property="menuDecreaseFontSize" destination="kzb-SZ-dOA" id="Y1B-Vh-6Z2"/>
                 <outlet property="menuIncreaseFontSize" destination="CIH-ey-Z6x" id="hkc-9C-80E"/>
+                <outlet property="menuMoveSplitDividerDown" destination="Zj7-2W-fdF" id="997-LL-nlN"/>
+                <outlet property="menuMoveSplitDividerLeft" destination="wSR-ny-j1a" id="HCZ-CI-2ob"/>
+                <outlet property="menuMoveSplitDividerRight" destination="CcX-ql-QU4" id="rIn-PK-fVM"/>
+                <outlet property="menuMoveSplitDividerUp" destination="h9Y-40-3oo" id="dDi-Vq-I3r"/>
                 <outlet property="menuNewTab" destination="uTG-Vz-hJU" id="eMg-R3-SeS"/>
                 <outlet property="menuNewWindow" destination="Was-JA-tGl" id="lK7-3I-CPG"/>
                 <outlet property="menuNextSplit" destination="bD7-ei-wKU" id="LeT-xw-eh4"/>
@@ -257,6 +261,37 @@
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
                                                 <action selector="splitMoveFocusRight:" target="-1" id="ELo-QZ-O6q"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Resize Split" id="BJO-3W-fkO" userLabel="Resize Split">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Resize Split" id="t7T-Ti-0im">
+                                    <items>
+                                        <menuItem title="Move Divider Up" id="h9Y-40-3oo">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="moveSplitDividerUp:" target="-1" id="NhD-6U-Eq2"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Move Divider Down" id="Zj7-2W-fdF">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="moveSplitDividerDown:" target="-1" id="jeD-bm-wJX"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Move Divider Left" id="wSR-ny-j1a">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="moveSplitDividerLeft:" target="-1" id="mlg-SJ-ZZO"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Move Divider Right" id="CcX-ql-QU4">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="moveSplitDividerRight:" target="-1" id="h3W-wY-PI7"/>
                                             </connections>
                                         </menuItem>
                                     </items>

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2426,6 +2426,14 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             } else log.warn("runtime doesn't implement gotoSplit", .{});
         },
 
+        .resize_split => |param| {
+            if (@hasDecl(apprt.Surface, "resizeSplit")) {
+                const direction = param[0];
+                const amount = param[1];
+                self.rt_surface.resizeSplit(direction, amount);
+            } else log.warn("runtime doesn't implement resizeSplit", .{});
+        },
+
         .toggle_split_zoom => {
             if (@hasDecl(apprt.Surface, "toggleSplitZoom")) {
                 self.rt_surface.toggleSplitZoom();

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -92,6 +92,9 @@ pub const App = struct {
         /// Focus the previous/next split (if any).
         focus_split: ?*const fn (SurfaceUD, input.SplitFocusDirection) callconv(.C) void = null,
 
+        /// Resize the current split.
+        resize_split: ?*const fn (SurfaceUD, input.SplitResizeDirection, u16) callconv(.C) void = null,
+
         /// Zoom the current split.
         toggle_split_zoom: ?*const fn (SurfaceUD) callconv(.C) void = null,
 
@@ -382,6 +385,15 @@ pub const Surface = struct {
         };
 
         func(self.opts.userdata, direction);
+    }
+
+    pub fn resizeSplit(self: *const Surface, direction: input.SplitResizeDirection, amount: u16) void {
+        const func = self.app.opts.resize_split orelse {
+            log.info("runtime embedder does not support resize split", .{});
+            return;
+        };
+
+        func(self.opts.userdata, direction, amount);
     }
 
     pub fn toggleSplitZoom(self: *const Surface) void {
@@ -1372,6 +1384,14 @@ pub const CAPI = struct {
     /// Focus on the next split (if any).
     export fn ghostty_surface_split_focus(ptr: *Surface, direction: input.SplitFocusDirection) void {
         ptr.gotoSplit(direction);
+    }
+
+    /// Resize the current split by moving the split divider in the given
+    /// direction. `direction` specifies which direction the split divider will
+    /// move relative to the focused split. `amount` is a fractional value
+    /// between 0 and 1 that specifies by how much the divider will move.
+    export fn ghostty_surface_split_resize(ptr: *Surface, direction: input.SplitResizeDirection, amount: u16) void {
+        ptr.resizeSplit(direction, amount);
     }
 
     /// Invoke an action on the surface.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -956,6 +956,26 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
             .{ .key = .right, .mods = .{ .super = true, .alt = true } },
             .{ .goto_split = .right },
         );
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .up, .mods = .{ .super = true, .ctrl = true } },
+            .{ .resize_split = .{ .up, 10 } },
+        );
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .down, .mods = .{ .super = true, .ctrl = true } },
+            .{ .resize_split = .{ .down, 10 } },
+        );
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .left, .mods = .{ .super = true, .ctrl = true } },
+            .{ .resize_split = .{ .left, 10 } },
+        );
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .right, .mods = .{ .super = true, .ctrl = true } },
+            .{ .resize_split = .{ .right, 10 } },
+        );
 
         // Inspector, matching Chromium
         try result.keybind.set.put(

--- a/src/input.zig
+++ b/src/input.zig
@@ -11,6 +11,7 @@ pub const KeyEncoder = @import("input/KeyEncoder.zig");
 pub const InspectorMode = Binding.Action.InspectorMode;
 pub const SplitDirection = Binding.Action.SplitDirection;
 pub const SplitFocusDirection = Binding.Action.SplitFocusDirection;
+pub const SplitResizeDirection = Binding.Action.SplitResizeDirection;
 
 // Keymap is only available on macOS right now. We could implement it
 // in theory for XKB too on Linux but we don't need it right now.

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -288,6 +288,9 @@ pub const Action = union(enum) {
                     };
                 }
 
+                // If we have extra parameters it is an error
+                if (it.next() != null) return Error.InvalidFormat;
+
                 break :blk value;
             },
 
@@ -827,6 +830,27 @@ test "parse: action with float" {
         try testing.expect(binding.action == .scroll_page_fractional);
         try testing.expectEqual(@as(f32, 0.5), binding.action.scroll_page_fractional);
     }
+}
+
+test "parse: action with a tuple" {
+    const testing = std.testing;
+
+    // parameter
+    {
+        const binding = try parse("a=resize_split:up,10");
+        try testing.expect(binding.action == .resize_split);
+        try testing.expectEqual(Action.SplitResizeDirection.up, binding.action.resize_split[0]);
+        try testing.expectEqual(@as(u16, 10), binding.action.resize_split[1]);
+    }
+
+    // missing parameter
+    try testing.expectError(Error.InvalidFormat, parse("a=resize_split:up"));
+
+    // too many
+    try testing.expectError(Error.InvalidFormat, parse("a=resize_split:up,10,12"));
+
+    // invalid type
+    try testing.expectError(Error.InvalidFormat, parse("a=resize_split:up,four"));
 }
 
 test "set: maintains reverse mapping" {

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -179,6 +179,10 @@ pub const Action = union(enum) {
     /// zoom/unzoom the current split.
     toggle_split_zoom: void,
 
+    /// Resize the current split by moving the split divider in the given
+    /// direction
+    resize_split: SplitResizeParameter,
+
     /// Show, hide, or toggle the terminal inspector for the currently
     /// focused terminal.
     inspector: InspectorMode,
@@ -225,6 +229,19 @@ pub const Action = union(enum) {
         left,
         bottom,
         right,
+    };
+
+    // Extern because it is used in the embedded runtime ABI.
+    pub const SplitResizeDirection = enum(c_int) {
+        up,
+        down,
+        left,
+        right,
+    };
+
+    pub const SplitResizeParameter = struct {
+        SplitResizeDirection,
+        u16,
     };
 
     // Extern because it is used in the embedded runtime ABI.


### PR DESCRIPTION
Fixes: https://github.com/mitchellh/ghostty/issues/305

The commits are broken out individually with commit messages. Below is more of a brain dump discussing the approach I took.

- macos: refactor SplitNode
- core: add support for bindings with multiple parameters
- core: add resize_split binding with default keys
- macos: support resizing splits
- macos: use Ghostty.AppState as @EnvironmentObject
---

This ended up being a lot more work than I originally anticipated, and I still think there is probably a lot that could be done better here. I'm opening the PR because it's time to get some external feedback and I've been sitting on this for far too long.

First, semantics: how do we describe "resizing a split"? I looked at prior art in iTerm2, kitty, and tmux and while the UI is different in all three, all have the concept of resizing a split by moving the "split divider" either left, right, up, or down relative to the focused split. This is the approach I took as well. This certainly _feels_ intuitive (at least to me) when used interactively with the keybindings, but in the future if Ghostty ever provides a programmatic API, we may also want to provide a way to resize splits in "absoltue" terms (e.g. "increase/decrease width/height", rather than moving the split divider).

Second, implementation: I implemented this by sending a notification to the currently focused `SplitNode.Leaf`. The leaf needs to know whether or not it is part of a split container, so we add a `parent` field to the Leaf so that it has access to its parent container, if any. If the user requests a resize along the same direction of the split (e.g. resizing left/right in a horizontal split or up/down in a vertical split) then we're done: the container resizes appropriately. But if not, we must continue to travel up the tree until we find a container that is split along the same direction as the requested resize.

The biggest challenge was figuring out how to take a resize amount (which is in points) and translate that into a change in the fractional split value that is used in the `SplitView`. The `SplitView` has a `split` field with a value between 0 and 1 which determines how much space is allocated to its top/left view versus the bottom/right view. I could not find a way to get the `SplitView`'s size outside of the view itself, so instead I did this by using a Publisher (`PassthroughSubject`) that is given to the `SplitView` by the `TerminalSplitContainer`. When the `SplitNode.Container` object has its `resize()` method called, we send a message to the Publisher which is received by the `SplitView`, which in turn updates its `split` field.

I am 100% open to better solutions here. I've been going over this for over a week trying to find the best, most idiomatic way to do it, and I'm out of ideas. So I just went with something that worked and am hoping somebody has a better idea.

