### PR TITLE
macos: complete clipboard request even when clipboard is empty

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -480,12 +480,6 @@ pub const Surface = struct {
     ) void {
         const alloc = self.app.core_app.alloc;
 
-        // If there is no string, then we don't do anything and complete.
-        if (str.len == 0) {
-            alloc.destroy(state);
-            return;
-        }
-
         // Attempt to complete the request, but if its unsafe we may request
         // confirmation.
         self.core_surface.completeClipboardRequest(


### PR DESCRIPTION
Fixes: https://github.com/mitchellh/ghostty/issues/825
