### PR TITLE
terminfo: fixup Sync terminfo string

### DIFF
--- a/src/terminfo/ghostty.zig
+++ b/src/terminfo/ghostty.zig
@@ -120,7 +120,7 @@ pub const ghostty: Source = .{
         .{ .name = "Ms", .value = .{ .string = "\\E]52;%p1%s;%p2%s\\007" } },
 
         // Synchronized output
-        .{ .name = "Sync", .value = .{ .string = "\\E[?2026%?%p1%{1}%-%tl%eh%" } },
+        .{ .name = "Sync", .value = .{ .string = "\\E[?2026%?%p1%{1}%-%tl%eh%;" } },
 
         // Bracketed paste mode
         .{ .name = "BD", .value = .{ .string = "\\E[?2004l" } },


### PR DESCRIPTION
The closing string on a conditional is `%;`, not `%`.

This is my mistake: in https://github.com/mitchellh/ghostty/pull/802 I added the final `%` but it should have been `%;` (note the semicolon).

I tested this directly to be extra sure. Without the semicolon, `%` characters were appearing when synchronized output was enabled, which is bad. For reference, here is the exact text from the [terminfo man page][1]:

       %? expr %t thenpart %e elsepart %;
            This forms an if-then-else.  The %e elsepart is optional.
            Usually the %? expr part pushes a value onto the stack, and
            %t pops it from the stack, testing if it is nonzero (true).
            If it is zero (false), control passes to the %e (else) part.

            It is possible to form else-if's a la Algol 68:
            %? c1 %t b1 %e c2 %t b2 %e c3 %t b3 %e c4 %t b4 %e %;

            where ci are conditions, bi are bodies.

            Use the -f option of @TIC@ or @INFOCMP@ to see the structure
            of if-then-else's.  Some strings, e.g., sgr can be very
            complicated when written on one line.  The -f option splits
            the string into lines with the parts indented.


[1]: https://man7.org/linux/man-pages/man5/terminfo.5.html
