### PR TITLE
termio: cursor-style-blink being set disables DEC mode 12

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -195,8 +195,19 @@ palette: Palette = .{},
 /// https://sw.kovidgoyal.net/kitty/conf/#opt-kitty.shell_integration
 @"cursor-style": terminal.Cursor.Style = .block,
 
-/// Whether the cursor shall blink
-@"cursor-style-blink": bool = true,
+/// Sets the default blinking state of the cursor. This is just the
+/// default state; running programs may override the cursor style
+/// using DECSCUSR (CSI q).
+///
+/// If this is not set, the cursor blinks by default. Note that
+/// this is not the same as a "true" value, as noted below.
+///
+/// If this is not set at all (null), then Ghostty will respect
+/// DEC Mode 12 (AT&T cursor blink) as an alternate approach to
+/// turning blinking on/off. If this is set to any value other
+/// than null, DEC mode 12 will be ignored but DECSCUSR will still
+/// be respected.
+@"cursor-style-blink": ?bool = null,
 
 /// The color of the text under the cursor. If this is not set, a default
 /// will be chosen.

--- a/src/config/key.zig
+++ b/src/config/key.zig
@@ -51,5 +51,5 @@ test "Value" {
     const testing = std.testing;
 
     try testing.expectEqual(?[:0]const u8, Value(.@"font-family"));
-    try testing.expectEqual(bool, Value(.@"cursor-style-blink"));
+    try testing.expectEqual(?bool, Value(.@"cursor-style-blink"));
 }


### PR DESCRIPTION
Fixes #820

See the very long comment in termio/Exec.zig.


https://github.com/mitchellh/ghostty/assets/1299/ca7a82ab-6bf5-4d25-809c-9084452b69e8

