### PR TITLE
macos: pass split as a binding to SplitView

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.SplitNode.swift
+++ b/macos/Sources/Ghostty/Ghostty.SplitNode.swift
@@ -123,6 +123,7 @@ extension Ghostty {
 
             @Published var topLeft: SplitNode
             @Published var bottomRight: SplitNode
+            @Published var split: CGFloat = 0.5
 
             var resizeEvent: PassthroughSubject<Double, Never> = .init()
 

--- a/macos/Sources/Ghostty/Ghostty.TerminalSplit.swift
+++ b/macos/Sources/Ghostty/Ghostty.TerminalSplit.swift
@@ -270,6 +270,7 @@ extension Ghostty {
         var body: some View {
             SplitView(
                 container.direction,
+                $container.split,
                 resizeIncrements: .init(width: 1, height: 1),
                 resizePublisher: container.resizeEvent,
                 left: {

--- a/macos/Sources/Ghostty/InspectorView.swift
+++ b/macos/Sources/Ghostty/InspectorView.swift
@@ -12,7 +12,10 @@ extension Ghostty {
         
         // Maintain whether our view has focus or not
         @FocusState private var inspectorFocus: Bool
-        
+
+        // The fractional area of the surface view vs. the inspector (0.5 means a 50/50 split)
+        @State private var split: CGFloat = 0.5
+
         var body: some View {
             let center = NotificationCenter.default
             let pubInspector = center.publisher(for: Notification.didControlInspector, object: surfaceView)
@@ -21,7 +24,7 @@ extension Ghostty {
                 if (!surfaceView.inspectorVisible) {
                     SurfaceWrapper(surfaceView: surfaceView, isSplit: isSplit)
                 } else {
-                    SplitView(.vertical, left: {
+                    SplitView(.vertical, $split, left: {
                         SurfaceWrapper(surfaceView: surfaceView, isSplit: isSplit)
                     }, right: {
                         InspectorViewRepresentable(surfaceView: surfaceView)

--- a/macos/Sources/Helpers/SplitView/SplitView.swift
+++ b/macos/Sources/Helpers/SplitView/SplitView.swift
@@ -22,7 +22,7 @@ struct SplitView<L: View, R: View>: View {
     let right: R
     
     /// The current fractional width of the split view. 0.5 means L/R are equally sized, for example.
-    @State var split: CGFloat = 0.5
+    @Binding var split: CGFloat
 
     /// The visible size of the splitter, in points. The invisible size is a transparent hitbox that can still
     /// be used for getting a resize handle. The total width/height of the splitter is the sum of both.
@@ -54,9 +54,10 @@ struct SplitView<L: View, R: View>: View {
     
     /// Initialize a split view. This view isn't programmatically resizable; it can only be resized
     /// by manually dragging the divider.
-    init(_ direction: SplitViewDirection, @ViewBuilder left: (() -> L), @ViewBuilder right: (() -> R)) {
+    init(_ direction: SplitViewDirection, _ split: Binding<CGFloat>, @ViewBuilder left: (() -> L), @ViewBuilder right: (() -> R)) {
         self.init(
             direction,
+            split,
             resizeIncrements: .init(width: 1, height: 1),
             resizePublisher: .init(),
             left: left,
@@ -67,12 +68,14 @@ struct SplitView<L: View, R: View>: View {
     /// Initialize a split view that supports programmatic resizing.
     init(
         _ direction: SplitViewDirection,
+        _ split: Binding<CGFloat>,
         resizeIncrements: NSSize,
         resizePublisher: PassthroughSubject<Double, Never>,
         @ViewBuilder left: (() -> L),
         @ViewBuilder right: (() -> R)
     ) {
         self.direction = direction
+        self._split = split
         self.resizeIncrements = resizeIncrements
         self.resizePublisher = resizePublisher
         self.left = left()


### PR DESCRIPTION
Fixes: https://github.com/mitchellh/ghostty/issues/833
