### PR TITLE
macos: ensure tab labels are always visible

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -90,6 +90,7 @@ class TerminalController: NSWindowController, NSWindowDelegate,
             ]
             let attributedString = NSAttributedString(string: " \(equiv) ", attributes: attributes)
             let text = NSTextField(labelWithAttributedString: attributedString)
+            text.setContentCompressionResistancePriority(.windowSizeStayPut, for: .horizontal)
             window.tab.accessoryView = text
         }
     }


### PR DESCRIPTION
This tells AppKit to give the tab labels higher priority than the tab
titles. When the tabs become small, this causes the tab title text to be
truncated instead of dropping the tab label.

Fixes: https://github.com/mitchellh/ghostty/issues/843

**Before:**
<img width="876" alt="Untitled" src="https://github.com/mitchellh/ghostty/assets/8965202/94a5d639-8c1d-4a20-87bd-f0858105d487">

**After:**
<img width="931" alt="Untitled 2" src="https://github.com/mitchellh/ghostty/assets/8965202/7b820148-d140-4f9b-9c39-b487d66833ab">

