### PR TITLE
terminfo: add entries for focus reporting

### DIFF
--- a/src/terminfo/ghostty.zig
+++ b/src/terminfo/ghostty.zig
@@ -151,6 +151,12 @@ pub const ghostty: Source = .{
         .{ .name = "clear", .value = .{ .string = "\\E[H\\E[2J" } },
         .{ .name = "E3", .value = .{ .string = "\\E[3J" } },
 
+        // Focus reporting. Introduced in ncurses 6.4-20231028
+        .{ .name = "fe", .value = .{ .string = "\\E[?1004h" } },
+        .{ .name = "fd", .value = .{ .string = "\\E[?1004l" } },
+        .{ .name = "kxIN", .value = .{ .string = "\\E[I" } },
+        .{ .name = "kxOUT", .value = .{ .string = "\\E[O" } },
+
         // These are all capabilities that should be pretty straightforward
         // and map to input sequences.
         .{ .name = "bel", .value = .{ .string = "^G" } },


### PR DESCRIPTION
These sequences have been used "informally" forever, and until recently
mode 1004 was included in Xterm's XM (enable mouse reporting) sequence.
But as of ncurses [6.4 patch 20231028][1], focus reporting mode is removed
from XM and added to new fe and fd capabilities. Xterm also includes
definitions for the actual focus events ("kxIN" and "kxOUT"), so include
those too.

The discussion in Vim has some context too: https://github.com/vim/vim/pull/13440#issuecomment-1791373672

[1]: https://lists.gnu.org/archive/html/bug-ncurses/2023-10/msg00117.html
