### PR TITLE
apprt/gtk: ensure equal tab width, truncate with ellipses

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -200,6 +200,16 @@ pub fn newTab(self: *Window, parent_: ?*CoreSurface) !void {
         c.gtk_widget_set_halign(label_box_widget, c.GTK_ALIGN_FILL);
         c.gtk_widget_set_hexpand(label_text, 1);
         c.gtk_widget_set_halign(label_text, c.GTK_ALIGN_FILL);
+
+        // This ensures that tabs are always equal width. If they're too
+        // long, they'll be truncated with an ellipsis.
+        c.gtk_label_set_max_width_chars(@ptrCast(label_text), 1);
+        c.gtk_label_set_ellipsize(@ptrCast(label_text), c.PANGO_ELLIPSIZE_END);
+
+        // We need to set a minimum width so that at a certain point
+        // the notebook will have an arrow button rather than shrinking tabs
+        // to an unreadably small size.
+        c.gtk_widget_set_size_request(@ptrCast(label_text), 100, 1);
     }
 
     const label_close_widget = c.gtk_button_new_from_icon_name("window-close");


### PR DESCRIPTION
Fixes #607

## Before

https://github.com/mitchellh/ghostty/assets/1299/3786c016-b278-4a56-b883-b2c4fe02dabe

## After

https://github.com/mitchellh/ghostty/assets/1299/2696e701-7b53-45be-8325-0c8a8cbb29af


