### PR TITLE
terminal: initialize active palette with configured palette

### DIFF
--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -145,6 +145,7 @@ pub fn init(alloc: Allocator, opts: termio.Options) !Exec {
     );
     errdefer term.deinit(alloc);
     term.default_palette = opts.config.palette;
+    term.color_palette.colors = opts.config.palette;
 
     // Set the image size limits
     try term.screen.kitty_images.setLimit(alloc, opts.config.image_storage_limit);


### PR DESCRIPTION
PR #850 introduced several color palette OSC setting and querying sequencing. In doing so, an active palette was introduced to enable resetting back to the default (configured) palette. The active palette was not initialized with the configured palette, thus any configured theme by the terminal was not set at launch.

This behavior can be confirmed thanks to PR #852, which resets the active palette on configuration reload. To observe the behavior:

1. Set the configured palette to something other than the default
2. Open ghostty. Observe the color palette
3. Reload the configuration
4. Press enter for a new shell prompt. Note the palette has changed

This patch sets the configured palette as the active palette at initialization.