### PR TITLE
macos: handle preedit in AppKit, enables Korean input

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -293,6 +293,14 @@ typedef enum {
 } ghostty_input_key_e;
 
 typedef struct {
+    ghostty_input_action_e action;
+    ghostty_input_mods_e mods;
+    uint32_t keycode;
+    const char *text;
+    bool composing;
+} ghostty_input_key_s;
+
+typedef struct {
     ghostty_input_key_e key;
     ghostty_input_mods_e mods;
     bool physical;
@@ -414,7 +422,7 @@ void ghostty_surface_refresh(ghostty_surface_t);
 void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);
 void ghostty_surface_set_focus(ghostty_surface_t, bool);
 void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t);
-void ghostty_surface_key(ghostty_surface_t, ghostty_input_action_e, uint32_t, ghostty_input_mods_e);
+void ghostty_surface_key(ghostty_surface_t, ghostty_input_key_s);
 void ghostty_surface_text(ghostty_surface_t, const char *, uintptr_t);
 void ghostty_surface_mouse_button(ghostty_surface_t, ghostty_input_mouse_state_e, ghostty_input_mouse_button_e, ghostty_input_mods_e);
 void ghostty_surface_mouse_pos(ghostty_surface_t, double, double);


### PR DESCRIPTION
Fixes #766 

## Before

![CleanShot 2023-11-10 at 09 57 02@2x](https://github.com/mitchellh/ghostty/assets/1299/454909a9-ffd9-452d-a31d-d254b91f6165)


## After

![CleanShot 2023-11-10 at 09 56 24@2x](https://github.com/mitchellh/ghostty/assets/1299/7b5335a4-20d6-48b1-a694-acb6f5bb79a7)
