### PR TITLE
font/coretext: split typographic leading when calculating cell height/baseline

### DIFF
--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -466,10 +466,15 @@ pub const Face = struct {
         } = metrics: {
             const ascent = @round(ct_font.getAscent());
             const descent = @round(ct_font.getDescent());
-            const leading = @round(ct_font.getLeading());
+
+            // Leading is the value between lines at the TOP of a line.
+            // Because we are rendering a fixed size terminal grid, we
+            // want the leading to be split equally between the top and bottom.
+            const leading = ct_font.getLeading();
+
             break :metrics .{
-                .height = @floatCast(ascent + descent + leading),
-                .ascent = @floatCast(ascent),
+                .height = @floatCast(@round(ascent + descent + leading)),
+                .ascent = @floatCast(@round(ascent + (leading / 2))),
             };
         };
 


### PR DESCRIPTION
This maybe is a robust way to get Monaspace fonts working.

Previously, we used leading as part of the calculation in cell height. I
don't remember why. It appears most popular monospace fonts (Fira Code,
Berkeley Mono, JetBrains Mono, Monaco are the few I tested) have a value
of 0 for leading, so this has no effect. But some fonts like Monaspace
have a non-zero (positive) value, resulting in overly large cell
heights.

The issue is that we simply add leading to the height, without modifying
ascent. Normally this is what you want (normal typesetting) but for
terminals, we're trying to set text centered vertically in equally
spaced grid cells. For this, we want to split the leading between the
top and bottom.

## Before

![CleanShot 2023-11-10 at 21 30 27@2x](https://github.com/mitchellh/ghostty/assets/1299/b251f0da-d194-4b4f-9f51-f8bff6344125)

## After

![CleanShot 2023-11-10 at 21 43 26@2x](https://github.com/mitchellh/ghostty/assets/1299/1b68a11a-e38b-49ca-874e-f7beb238f39d)
