### PR TITLE
termio: wake up writer thread if the writer mailbox is full

### DIFF
--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -60,7 +60,9 @@ pub fn Stream(comptime Handler: type) type {
             for (actions) |action_opt| {
                 const action = action_opt orelse continue;
 
-                // log.info("action: {}", .{action});
+                // if (action != .print) {
+                //     log.info("action: {}", .{action});
+                // }
 
                 // If this handler handles everything manually then we do nothing
                 // if it can be processed.


### PR DESCRIPTION
Normally, we queue all the writes we need from a single `read()` syscall and only wake up the writer thread at the end of processing that batch of data.

But under very heavy load or large batches of data, it is possible for the terminal sequences to generate enough writes to the pty to fill the writer thread queue while we're still processing the data from `read()`.

This modifies our queuer to attempt to queue, but if the queue is full we wake up the writer thread immediately then queue again (which should succeed in every case -- eventually).