### PR TITLE
macOS: only unhide menu in non-native FS if focus lost to Ghostty

### DIFF
--- a/macos/Sources/Helpers/FullScreenHandler.swift
+++ b/macos/Sources/Helpers/FullScreenHandler.swift
@@ -83,7 +83,7 @@ class FullScreenHandler {
                 object: window)
             NotificationCenter.default.addObserver(
                 self,
-                selector: #selector(FullScreenHandler.unHideMenu),
+                selector: #selector(FullScreenHandler.onDidResignMain),
                 name: NSWindow.didResignMainNotification,
                 object: window)
         }
@@ -105,8 +105,16 @@ class FullScreenHandler {
         NSApp.presentationOptions.insert(.autoHideMenuBar)
     }
     
-    @objc func unHideMenu() {
-        NSApp.presentationOptions.remove(.autoHideMenuBar)
+    @objc func onDidResignMain(_ notification: Notification) {
+        guard let resigningWindow = notification.object as? NSWindow else { return }
+        guard let mainWindow = NSApplication.shared.mainWindow else { return }
+        
+        // We're only unhiding the menu bar, if the focus shifted within our application.
+        // In that case, `mainWindow` is the window of our application the focus shifted
+        // to.
+        if !resigningWindow.isEqual(mainWindow) {
+            NSApp.presentationOptions.remove(.autoHideMenuBar)
+        }
     }
     
     @objc func hideDock() {


### PR DESCRIPTION
This fixes https://github.com/mitchellh/ghostty/issues/786 by adding a check to the callback that unhides the menu bar to only unhide the menu bar if focus was lost to another Ghostty window.

That's the desired behaviour: when focus is lost to another app's window, we want the non-native-fullscreen window to stay unchanged in background, but when changing focus to another Ghostty window, we want to unhide the menu bar.

Why did this problem even show up?

It started to show up with the introduction of the Xib-file based approach, in https://github.com/mitchellh/ghostty/commit/301837738904af52b621356a7fea5ed490f8e714.

Before that, in https://github.com/mitchellh/ghostty/commit/27ddc90c1810b0f8bc426f6f78f43cd171436d97, for example, the app would receive the same notifications, but the `.autoHideMenuBar` didn't have an effect on the window. Only after adding the Xib-file did it start to have an effect.

So I figured there's two ways we could fix it:

1. Figure out why the `.autoHideMenuBar` now works with Xib-files and suppress it, or
2. Encode in the code the behaviour that we actually want: we only want to show the menu bar when focus shifts to another one of Ghostty's windows, but we want to leave it untouched when focus is lost to another app's window.

I went with (2) but I think (1) is also valid and happy to close PR if that's what we want to do.

## Video

https://github.com/mitchellh/ghostty/assets/1185253/e0e19cdc-34e4-4380-887c-84d7f537edb0

