### PR TITLE
feat(actions): implement CLI --help (issue #706) using comptime introspection

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1,5 +1,8 @@
 pub const args = @import("cli/args.zig");
-pub const Action = @import("cli/action.zig").Action;
+pub const Action  = cli.Action;
+pub const ActionXtra = cli.ActionXtra;
+pub const welcome_msg = cli.cli_welcome_msg;
+const cli = @import("cli/action.zig");
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/cli/action.zig
+++ b/src/cli/action.zig
@@ -18,6 +18,20 @@ pub const Action = enum {
     /// List available keybinds
     @"list-keybinds",
 
+    /// help flag. Provides overall help as well as help for specific action.
+    /// Can be called as --help or +help
+    help,
+
+    /// comptime type dispatch based on Action enum. Use to simplify switch statements.
+    pub inline fn ToType(comptime self: Action) type {
+        return switch (self) {
+            .version            => version,
+            .@"list-fonts"      => list_fonts,
+            .@"list-keybinds"   => list_keybinds,
+            .help               => Help,
+        };
+    }
+
     pub const Error = error{
         /// Multiple actions were detected. You can specify at most one
         /// action on the CLI otherwise the behavior desired is ambiguous.
@@ -28,37 +42,97 @@ pub const Action = enum {
     };
 
     /// Detect the action from CLI args.
-    pub fn detectCLI(alloc: Allocator) !?Action {
+    pub fn detectCLI(alloc: Allocator) !?ActionXtra {
         var iter = try std.process.argsWithAllocator(alloc);
         defer iter.deinit();
         return try detectIter(&iter);
     }
 
     /// Detect the action from any iterator, used primarily for tests.
-    pub fn detectIter(iter: anytype) Error!?Action {
+    pub fn detectIter(iter: anytype) Error!?ActionXtra {
         var pending: ?Action = null;
+        var oa: ?Action = null;
+        var ox: ?Action = null;
+        var cnt: i32 = 0;
         while (iter.next()) |arg| {
             // Special case, --version always outputs the version no
             // matter what, no matter what other args exist.
-            if (std.mem.eql(u8, arg, "--version")) return .version;
-
-            // Commands must start with "+"
-            if (arg.len == 0 or arg[0] != '+') continue;
-            if (pending != null) return Error.MultipleActions;
-            pending = std.meta.stringToEnum(Action, arg[1..]) orelse return Error.InvalidAction;
+            if (std.mem.eql(u8, arg, "--version")) {
+                pending = .version;
+            } else if (std.mem.eql(u8, arg, "--help")) {
+                pending = .help;
+            } else {
+                // Commands must start with "+"
+                if (arg.len == 0 or arg[0] != '+') continue;
+                pending = std.meta.stringToEnum(Action, arg[1..]) orelse return Error.InvalidAction;
+            }
+            cnt +=1;
+            // keeping track
+            if ((oa != .help) and (pending == .help)) {
+                cnt -= 1;
+                ox = oa;
+                oa = .help;
+            } else if (oa == .help) {
+                ox = pending;
+            } else {
+                oa = pending;
+            }
+            if (cnt > 1) return Error.MultipleActions;
         }
-
-        return pending;
+        return if (oa) |a| .{.action = a, .xtra = ox} else null;
     }
 
     /// Run the action. This returns the exit code to exit with.
     pub fn run(self: Action, alloc: Allocator) !u8 {
         return switch (self) {
-            .version => try version.run(),
+            // .help => |act| act.ToType().help(alloc),
+            inline else => |act| try act.ToType().run(alloc),
+        };
+    }
+
+    pub fn write_help(self: Action, alloc: Allocator, writer: anytype, short: bool) anyerror!u8 {
+        return switch (self) {
+            inline else => |act| try act.ToType().help(alloc, writer, short),
+        };
+    }
+
+    /// Run the action. This returns the exit code to exit with.
+    pub fn run_DISABLED(self: Action, alloc: Allocator) !u8 {
+        return switch (self) {
+            .version => try version.run(alloc),
             .@"list-fonts" => try list_fonts.run(alloc),
             .@"list-keybinds" => try list_keybinds.run(alloc),
         };
     }
+};
+
+/// ActionXtra supports --help for actions
+pub const ActionXtra = struct {
+    action: Action,
+    xtra: ?Action,
+    
+    const Self = @This();
+
+    pub fn run(self: Self, alloc: Allocator) !u8 {
+        switch (self.action) { 
+            inline else => |a| {return try a.ToType().run(alloc);}
+        }
+    }
+
+    pub fn help(self: Self, alloc: Allocator, writer: anytype) !u8 {
+        if (self.action == .help) {
+            if (self.xtra) |x| { // long action help
+                switch (x) { 
+                    inline else => |a| {return try a.ToType().help(alloc, writer, false);}
+                }
+            } else { // general ghostty help screen
+                return try Help.generate_help(alloc, writer, true);
+                }
+        } else {
+            return 127;
+        }
+    }
+
 };
 
 test "parse action none" {
@@ -84,8 +158,8 @@ test "parse action version" {
             "--a=42 --b --b-f=false --version",
         );
         defer iter.deinit();
-        const action = try Action.detectIter(&iter);
-        try testing.expect(action.? == .version);
+        const action_xtra = try Action.detectIter(&iter);
+        try testing.expect(action_xtra.?.action == .version);
     }
 
     {
@@ -95,7 +169,7 @@ test "parse action version" {
         );
         defer iter.deinit();
         const action = try Action.detectIter(&iter);
-        try testing.expect(action.? == .version);
+        try testing.expect(action.?.action == .version);
     }
 
     {
@@ -105,7 +179,7 @@ test "parse action version" {
         );
         defer iter.deinit();
         const action = try Action.detectIter(&iter);
-        try testing.expect(action.? == .version);
+        try testing.expect(action.?.action == .version);
     }
 }
 
@@ -120,7 +194,7 @@ test "parse action plus" {
         );
         defer iter.deinit();
         const action = try Action.detectIter(&iter);
-        try testing.expect(action.? == .version);
+        try testing.expect(action.?.action == .version);
     }
 
     {
@@ -130,7 +204,7 @@ test "parse action plus" {
         );
         defer iter.deinit();
         const action = try Action.detectIter(&iter);
-        try testing.expect(action.? == .version);
+        try testing.expect(action.?.action == .version);
     }
 
     {
@@ -140,6 +214,124 @@ test "parse action plus" {
         );
         defer iter.deinit();
         const action = try Action.detectIter(&iter);
-        try testing.expect(action.? == .version);
+        try testing.expect(action.?.action == .version);
     }
 }
+
+test "parse action help" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(
+            alloc,
+            "--a=42 --b --b-f=false --help",
+        );
+        defer iter.deinit();
+        const action = try Action.detectIter(&iter);
+        try testing.expect(action.?.action == .help);
+        try testing.expect(action.?.xtra == null);
+    }
+
+    {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(
+            alloc,
+            "--a=42 --b --b-f=false --help +version",
+        );
+        defer iter.deinit();
+        const action = try Action.detectIter(&iter);
+        try testing.expect(action.?.action == .help);
+        try testing.expect(action.?.xtra == .version);
+    }
+
+    {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(
+            alloc,
+            "--a=42 --b --b-f=false +version --help",
+        );
+        defer iter.deinit();
+        const action = try Action.detectIter(&iter);
+        try testing.expect(action.?.action == .help);
+        try testing.expect(action.?.xtra == .version);
+    }
+
+    {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(
+            alloc,
+            "--a=42 --b --b-f=false +help",
+        );
+        defer iter.deinit();
+        const action = try Action.detectIter(&iter);
+        try testing.expect(action.?.action == .help);
+        try testing.expect(action.?.xtra == null);
+    }
+
+}
+
+pub const Help = struct {
+
+    pub fn help(
+        alloc: Allocator, // in case of dynamically generated help
+        writer: anytype, // duck-typing, print to any writer including ArrayList
+        short: bool // short one-line (<68 letters, no NL) or long (unlimited size) help
+    ) !u8 {
+        _ = alloc;
+    if (short) {
+        try writer.print("Display help messages.  Use as +help or --help", .{});
+    } else {
+        try writer.print( "{s}\n", .{cli_welcome_msg});
+    }
+
+        return 42;
+    }
+
+    pub fn run(_: anytype) !u8 { return 0; }
+
+    fn generate_help(alloc: Allocator, writer: anytype, short:bool) !u8 {
+        _ = short;
+        var action_max_len: usize = 0;
+        const fields = @typeInfo(Action).Enum.fields;
+        inline for (fields) |fld| {
+            if (fld.name.len > action_max_len) action_max_len = fld.name.len;
+        }
+
+        try writer.print(
+            \\Ghostty helper CLI
+            \\Usage:
+            \\  ghostty +some_action [options...] [arguments...]
+            \\
+            \\where some_action is one of the following:
+            \\
+        , .{});
+
+        inline for (fields) |fld| {
+            const name = fld.name;
+            try writer.print("  {[name]s: <[w]} - ", .{.name=name, .w=action_max_len});
+            _ = try @field(Action, name).write_help(alloc, writer, true);
+            _ = try writer.write("\n");
+        }
+
+
+        try writer.print(
+            \\
+            \\For help about specific action try "ghostty --help +<action>" or "ghostty +<action> --help"
+            \\The +help action can be used in place of the --help option.
+            \\
+        , .{});
+
+        return 0;
+    }
+
+};
+
+pub const cli_welcome_msg = 
+    \\Usage: ghostty +<action> [flags]
+    \\
+    \\This is the Ghostty helper CLI that accompanies the graphical Ghostty app.
+    \\To launch the terminal directly, please launch the graphical app
+    \\(i.e. Ghostty.app on macOS). This CLI can be used to perform various
+    \\actions such as inspecting the version, listing fonts, etc.
+    \\
+    \\Try "ghostty --help" for help on available CLI actions.
+    \\Please refer to the source code or Discord community for further help/information.
+    ;

--- a/src/cli/list_fonts.zig
+++ b/src/cli/list_fonts.zig
@@ -144,3 +144,41 @@ fn runArgs(alloc_gpa: Allocator, argsIter: anytype) !u8 {
 
     return 0;
 }
+
+pub fn help(
+    alloc: Allocator, // in case of dynamically generated help
+    writer: anytype, // duck-typing, print to any writer including ArrayList
+    short: bool // short one-line (<68 letters, no NL) or long (unlimited size) help
+) !u8 {
+    _ = alloc;
+    if (short) {
+        try writer.print("SHORT help for +list-fonts action", .{});
+    } else {
+        try writer.print(
+            \\Usage:
+            \\  ghostty +list-fonts [option ...]
+            \\
+            \\The list-fonts action is used to list all the available fonts for Ghostty.
+            \\This uses the exact same font discovery mechanism Ghostty uses to find
+            \\fonts to use.
+            \\
+            \\When executed with no arguments, this will list all available fonts,
+            \\sorted by family name, then font name. If a family name is given
+            \\with "--family", the sorting will be disabled and the results instead
+            \\will be shown in the same priority order Ghostty would use to pick a
+            \\font.
+            \\
+            \\The "--family" option can be used to filter results to a specific family.
+            \\The family handling is identical to the "font-familiy" set of Ghostty
+            \\configuration values, so this can be used to debug why your desired font
+            \\may not be loading.
+            \\
+            \\The "--bold" and "--italic" options can be used to filter results to
+            \\specific styles. It is not guaranteed that only those styles are returned,
+            \\it will just prioriiize fonts that match those styles.
+            \\
+            , .{});
+    }
+
+    return 22;
+}

--- a/src/cli/list_keybinds.zig
+++ b/src/cli/list_keybinds.zig
@@ -48,3 +48,33 @@ pub fn run(alloc: Allocator) !u8 {
 
     return 0;
 }
+
+pub fn help(
+    alloc: Allocator, // in case of dynamically generated help
+    writer: anytype, // duck-typing, print to any writer including ArrayList
+    short: bool // short one-line (<68 letters, no NL) or long (unlimited size) help
+) !u8 {
+    _ = alloc;
+    if (short) {
+        try writer.print("SHORT help for +list-keybinds action", .{});
+    } else {
+        try writer.print(
+            \\Usage:
+            \\  ghostty +list-keybinds [option]
+            \\
+            \\The "list-keybinds" command is used to list all the available keybinds
+            \\for Ghostty.
+            \\
+            \\When executed without any arguments this will list the current keybinds
+            \\loaded by the config file. If no config file is found or there aren't any
+            \\changes to the keybinds it will print out the default ones configured for
+            \\Ghostty
+            \\
+            \\The "--default" option will print out all the default keybinds
+            \\configured for Ghostty.
+            \\
+            , .{});
+    }
+
+    return 33;
+}

--- a/src/cli/version.zig
+++ b/src/cli/version.zig
@@ -3,8 +3,10 @@ const builtin = @import("builtin");
 const build_config = @import("../build_config.zig");
 const xev = @import("xev");
 const renderer = @import("../renderer.zig");
+const Allocator = std.mem.Allocator;
 
-pub fn run() !u8 {
+/// ignored argument is needed to conform to duck-typing at the call sites
+pub fn run(_: anytype) !u8 {
     const stdout = std.io.getStdOut().writer();
     try stdout.print("Ghostty {s}\n\n", .{build_config.version_string});
     try stdout.print("Build Config\n", .{});
@@ -14,4 +16,27 @@ pub fn run() !u8 {
     try stdout.print("  - renderer   : {}\n", .{renderer.Renderer});
     try stdout.print("  - libxev     : {}\n", .{xev.backend});
     return 0;
+}
+
+
+pub fn help(
+    alloc: Allocator, // in case of dynamically generated help
+    writer: anytype, // duck-typing, print to any writer including ArrayList
+    short: bool // short one-line (<68 letters, no NL) or long (unlimited size) help
+) !u8 {
+    _ = alloc;
+    if (short) {
+        try writer.print("print version information. Also available as --version option", .{});
+    } else {
+        try writer.print(
+            \\Usage:
+            \\  ghostty --version
+            \\
+            \\Print Ghostty version information including build config, run-time, font engine, etc.
+            \\ Can use +version (action syntax) in place of --version (option syntax).
+            \\
+            , .{});
+    }
+
+    return 11;
 }


### PR DESCRIPTION
Closes #706

This commit implements ghostty CLI --help according to the specifications in the issue #706. It uses comptime introspection to automatically obtain all the actions from `Action` enum. It comptime dispatches help to the appropriate action-specific help function. Help functions can write to any writer including ArrayList in case one wants to display some of this help in the Ghostty GUI app in addition to CLI.

`ghostty --help` lists all available actions with short descriptions. `ghostty --help +<action>` or `ghostty +<action> --help` show long help text for the `<action>`.

`+help` is equivalent to `--help`, therefore `ghostty +help` is the same as `ghosty --help`.

Added corresponding tests for parsing help option.