### PR TITLE
core: Fix various double-click word selection bugs

### DIFF
--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1494,6 +1494,30 @@ pub fn selectLine(self: *Screen, pt: point.ScreenPoint) ?Selection {
     };
 }
 
+/// Select the nearest word to start point that is between start_pt and
+/// end_pt (inclusive). Because it selects "nearest" to start point, start
+/// point can be before or after end point.
+pub fn selectWordBetween(
+    self: *Screen,
+    start_pt: point.ScreenPoint,
+    end_pt: point.ScreenPoint,
+) ?Selection {
+    const dir: point.Direction = if (start_pt.before(end_pt)) .right_down else .left_up;
+    var it = start_pt.iterator(self, dir);
+    while (it.next()) |pt| {
+        // Boundary conditions
+        switch (dir) {
+            .right_down => if (end_pt.before(pt)) return null,
+            .left_up => if (pt.before(end_pt)) return null,
+        }
+
+        // If we found a word, then return it
+        if (self.selectWord(pt)) |sel| return sel;
+    }
+
+    return null;
+}
+
 /// Select the word under the given point. A word is any consecutive series
 /// of characters that are exclusively whitespace or exclusively non-whitespace.
 /// A selection can span multiple physical lines if they are soft-wrapped.


### PR DESCRIPTION
Fixes #741

This completely reimplements double-click-and-drag logic for selecting by word. The previous implementation was horribly broken. See #741 for all the details.

The implemented logic now is:

* A double-click initiates a select-by-word selection mechanism.
  - A double-click may start on a word or whitespace
  - If the initial double-click is on a word, that word is immediately selected.
  - If the initial double-click is on whitespace, the whitespace is not selected.
* A "word" is determined by a non-boundary character meeting a boundary character.
  - A boundary character is `NUL` ` ` (space) `\t` `'` `"`
  - This list is somewhat arbitrary to make the terminal "feel" good.
  - Cell SGR states (fg/bg, bold, italic, etc.) have no effect on boundary determination or selection logic.
* As the user drags _on the same line_:
  - No selection change occurs until the cursor is over a new word. Whitespace change does nothing.
  - When selection is over a new word, that entire word added to the selection.
* When the user drags _up_ one or more lines:
  - If the cursor is over whitespace, all lines from the selection point up to but not including the cursor line are selected. * This selection is done in accordance to the previous rules.
  - If the cursor is over a word, the word becomes the beginning of the selection.
  - The end of the selection in all cases is the first word at or before the initial double-click point.
* When the user drags _down_ one or more lines:
  - The same logic as _up_ but swap the "beginning" and "end" of selection terminology.
* With this logic, the behavior of Ghostty has the following invariants:
  - Whitespace is never selected unless it is between two selected words
  - Selection implies at least one word is highlighted
  - The initial double-click point marks the beginning or end of a selection, never the middle.