### PR TITLE
macos-option-as-alt works again

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1162,6 +1162,7 @@ pub fn keyCallback(
         const t = &self.io.terminal;
         break :enc .{
             .event = event,
+            .macos_option_as_alt = self.config.macos_option_as_alt,
             .alt_esc_prefix = t.modes.get(.alt_esc_prefix),
             .cursor_key_application = t.modes.get(.cursor_keys),
             .keypad_key_application = t.modes.get(.keypad_keys),


### PR DESCRIPTION
This regressed sometime -- I can't find the exact commit -- but in any case I've moved this handling directly into the KeyEncoder so we can unit test it and prevent future regressions.