### PR TITLE
xterm audit: DEC mode 3 (DECCOLM), 4 (DECSCLM), 40 (132COLS)

### DIFF
--- a/src/terminal/modes.zig
+++ b/src/terminal/modes.zig
@@ -69,7 +69,7 @@ pub const ModeState = struct {
         // We have this here so that we explicitly fail when we change the
         // size of modes. The size of modes is NOT particularly important,
         // we just want to be mentally aware when it happens.
-        try std.testing.expectEqual(4, @sizeOf(ModePacked));
+        try std.testing.expectEqual(8, @sizeOf(ModePacked));
     }
 };
 

--- a/src/terminal/modes.zig
+++ b/src/terminal/modes.zig
@@ -185,6 +185,7 @@ const entries: []const ModeEntry = &.{
     // DEC
     .{ .name = "cursor_keys", .value = 1 }, // DECCKM
     .{ .name = "132_column", .value = 3 },
+    .{ .name = "slow_scroll", .value = 4 },
     .{ .name = "reverse_colors", .value = 5 },
     .{ .name = "origin", .value = 6 },
     .{ .name = "wraparound", .value = 7, .default = true },

--- a/website/app/vt/modes/deccolm/page.mdx
+++ b/website/app/vt/modes/deccolm/page.mdx
@@ -1,0 +1,70 @@
+import VTMode from "@/components/VTMode";
+
+# Select 80 or 132 Columns per Page (DECCOLM)
+
+<VTMode value={3} />
+
+Sets the screen to 132 columns if set or 80 columns if unset.
+
+This requires [`132COLS` (DEC mode 40)](/vt/modes/132cols) to be set
+to have any effect. If `132COLS` is not set, then setting or unsetting
+this mode does nothing.
+
+When this mode changes, the screen is resized to the given column amount,
+performing reflow if necessary. If the GUI window is too narrow or too wide,
+it is typically resized to fit the explicit column count or a scrollbar is
+used. If the GUI window is manually resized (i.e. with the mouse), the column
+width of DECCOLM is not enforced.
+
+The scroll margins are reset to their default values given the new screen size.
+The cursor is moved to the top-left. The screen is erased using
+[erase display (ED) with command 2](/vt/ed).
+
+## Validation
+
+### DECCOLM V-1: Disabled
+
+```bash
+printf "ABC\n"
+printf "\033[?40l" # disable mode 3
+printf "\033[?3h"
+printf "X"
+```
+
+```
+|ABC_____|
+|Xc______|
+|________|
+```
+
+The command should be completely ignored.
+
+### DECCOLM V-2: Unset (80 Column)
+
+```bash
+printf "ABC\n"
+printf "\033[?40h" # enable mode 3
+printf "\033[?3l" # unset the mode
+printf "X"
+```
+
+```
+|X_______|
+```
+
+The screen should be 80 columns wide.
+
+### DECCOLM V-3: Set (132 Column)
+
+```bash
+printf "ABC\n"
+printf "\033[?40h" # enable mode 3
+printf "\033[?3h"
+printf "X"
+```
+
+```
+|X_______|
+```
+
+The screen should be 132 columns wide.

--- a/website/app/vt/modes/decsclm/page.mdx
+++ b/website/app/vt/modes/decsclm/page.mdx
@@ -1,0 +1,12 @@
+import VTMode from "@/components/VTMode";
+
+# Slow Scroll (DECSCLM)
+
+<VTMode value={4} />
+
+Enable slow or smooth scrolling.
+
+Typically, slow scrolling will scroll line by line when using scroll
+functions (arrow keys, scrollbar, etc.). With this disabling, scrolling
+jumps by more lines. This is purely up to the terminal to implement how it
+sees fit.

--- a/website/app/vt/modes/decscnm/page.mdx
+++ b/website/app/vt/modes/decscnm/page.mdx
@@ -1,0 +1,11 @@
+import VTMode from "@/components/VTMode";
+
+# Reverse Video (DECSCNM)
+
+<VTMode value={5} />
+
+Swap the foreground/background colors of cells.
+
+This swaps the foreground and background color of cells when displayed.
+This does not physically alter the cell state or cell contents; only the
+rendered state is affected.


### PR DESCRIPTION
Changes:

* `DECCOLM` should not force the column width on manual resize.
* `DECCOLM` with `132COLS` disabled should reset mode 3
* `DECSCLM` is tracked but has no effect

Todo, not strictly required:

* Technically, `DECCOLM` should resize the window or show a scrollbar if it's too small/big. DECCOLM is so rare and not used in practice that I didn't want to introduce the complexity. In any case, it doesn't affect the terminal state correctness.