### PR TITLE
macOS: filter option-as-alt properly at AppKit layer

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -428,6 +428,7 @@ void ghostty_surface_refresh(ghostty_surface_t);
 void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);
 void ghostty_surface_set_focus(ghostty_surface_t, bool);
 void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t);
+ghostty_input_mods_e ghostty_surface_key_translation_mods(ghostty_surface_t, ghostty_input_mods_e);
 void ghostty_surface_key(ghostty_surface_t, ghostty_input_key_s);
 void ghostty_surface_text(ghostty_surface_t, const char *, uintptr_t);
 void ghostty_surface_mouse_button(ghostty_surface_t, ghostty_input_mouse_state_e, ghostty_input_mouse_button_e, ghostty_input_mods_e);

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1026,6 +1026,8 @@ fn resize(self: *Surface, size: renderer.ScreenSize) !void {
 /// keyCallback and we rely completely on the apprt implementation to track
 /// the preedit state correctly.
 pub fn preeditCallback(self: *Surface, preedit_: ?u21) !void {
+    // log.debug("preedit cp={any}", .{preedit_});
+
     const preedit: ?renderer.State.Preedit = if (preedit_) |cp| preedit: {
         const width = ziglyph.display_width.codePointWidth(cp, .half);
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1348,6 +1348,24 @@ pub const CAPI = struct {
         surface.focusCallback(focused);
     }
 
+    /// Filter the mods if necessary. This handles settings such as
+    /// `macos-option-as-alt`. The filtered mods should be used for
+    /// key translation but should NOT be sent back via the `_key`
+    /// function -- the original mods should be used for that.
+    export fn ghostty_surface_key_translation_mods(
+        surface: *Surface,
+        mods_raw: c_int,
+    ) c_int {
+        const mods: input.Mods = @bitCast(@as(
+            input.Mods.Backing,
+            @truncate(@as(c_uint, @bitCast(mods_raw))),
+        ));
+        const result = mods.translation(
+            surface.core_surface.config.macos_option_as_alt,
+        );
+        return @intCast(@as(input.Mods.Backing, @bitCast(result)));
+    }
+
     /// Send this for raw keypresses (i.e. the keyDown event on macOS).
     /// This will handle the keymap translation and send the appropriate
     /// key and char events.

--- a/src/input/KeyEncoder.zig
+++ b/src/input/KeyEncoder.zig
@@ -344,6 +344,16 @@ fn legacyAltPrefix(
         }
     }
 
+    // If UTF8 isn't set, we will allow unshifted codepoints through.
+    if (self.event.unshifted_codepoint > 0) {
+        if (std.math.cast(
+            u8,
+            self.event.unshifted_codepoint,
+        )) |byte| {
+            return byte;
+        }
+    }
+
     // Else, we can't figure out the byte to alt-prefix so we
     // exit this handling.
     return null;

--- a/src/input/key.zig
+++ b/src/input/key.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const cimgui = @import("cimgui");
+const config = @import("../config.zig");
 
 /// A generic key input event. This is the information that is necessary
 /// regardless of apprt in order to generate the proper terminal
@@ -121,6 +123,37 @@ pub const Mods = packed struct(Mods.Backing) {
         return copy;
     }
 
+    /// Return the mods to use for key translation. This handles settings
+    /// like macos-option-as-alt. The translation mods should be used for
+    /// translation but never sent back in for the key callback.
+    pub fn translation(self: Mods, option_as_alt: config.OptionAsAlt) Mods {
+        // We currently only process macos-option-as-alt so other
+        // platforms don't need to do anything.
+        if (comptime !builtin.target.isDarwin()) return self;
+
+        // We care if only alt is set.
+        const alt_only: bool = alt_only: {
+            const alt_mods: Mods = .{ .alt = true };
+            var compare = self;
+            compare.sides = .{};
+            break :alt_only alt_mods.equal(compare);
+        };
+        if (!alt_only) return self;
+
+        // Alt has to be set only on the correct side
+        switch (option_as_alt) {
+            .false => return self,
+            .true => {},
+            .left => if (self.sides.alt == .right) return self,
+            .right => if (self.sides.alt == .left) return self,
+        }
+
+        // Unset alt
+        var result = self;
+        result.alt = false;
+        return result;
+    }
+
     // For our own understanding
     test {
         const testing = std.testing;
@@ -129,6 +162,45 @@ pub const Mods = packed struct(Mods.Backing) {
             @as(Backing, @bitCast(Mods{ .shift = true })),
             @as(Backing, 0b0000_0001),
         );
+    }
+
+    test "translation macos-option-as-alt" {
+        if (comptime !builtin.target.isDarwin()) return error.SkipZigTest;
+
+        const testing = std.testing;
+
+        // Unset
+        {
+            const mods: Mods = .{};
+            const result = mods.translation(.true);
+            try testing.expectEqual(result, mods);
+        }
+
+        // Set
+        {
+            const mods: Mods = .{ .alt = true };
+            const result = mods.translation(.true);
+            try testing.expectEqual(Mods{}, result);
+        }
+
+        // Set but disabled
+        {
+            const mods: Mods = .{ .alt = true };
+            const result = mods.translation(.false);
+            try testing.expectEqual(result, mods);
+        }
+
+        // Set wrong side
+        {
+            const mods: Mods = .{ .alt = true, .sides = .{ .alt = .right } };
+            const result = mods.translation(.left);
+            try testing.expectEqual(result, mods);
+        }
+        {
+            const mods: Mods = .{ .alt = true, .sides = .{ .alt = .left } };
+            const result = mods.translation(.right);
+            try testing.expectEqual(result, mods);
+        }
     }
 };
 


### PR DESCRIPTION
Fixes https://github.com/mitchellh/ghostty/issues/872

In https://github.com/mitchellh/ghostty/pull/867 we fixed macos-option-as-alt, but unfortunately AppKit ALSO does
some translation so some behaviors were not working correctly.
Specifically, when you had macos-option-as-alt set, option+e would
properly send `esc+e` to the pty but it would ALSO set the dead key
state for "`" since AppKit was still translating the option key.

This commit introduces a function to strip alt when necessary from the
translation modifiers used at the AppKit layer, preventing this
behavior.