### PR TITLE
Add support for desktop notifications

### DIFF
--- a/dist/linux/app.desktop
+++ b/dist/linux/app.desktop
@@ -9,6 +9,7 @@ Keywords=terminal;tty;pty;
 StartupNotify=true
 Terminal=false
 Actions=new-window;
+X-GNOME-UsesNotifications=true
 
 [Desktop Action new-window]
 Name=New Window

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -362,6 +362,7 @@ typedef void (*ghostty_runtime_toggle_fullscreen_cb)(void *, ghostty_non_native_
 typedef void (*ghostty_runtime_set_initial_window_size_cb)(void *, uint32_t, uint32_t);
 typedef void (*ghostty_runtime_render_inspector_cb)(void *);
 typedef void (*ghostty_runtime_set_cell_size_cb)(void *, uint32_t, uint32_t);
+typedef void (*ghostty_runtime_show_desktop_notification_cb)(void *, const char *, const char *);
 
 typedef struct {
     void *userdata;
@@ -388,6 +389,7 @@ typedef struct {
     ghostty_runtime_set_initial_window_size_cb set_initial_window_size_cb;
     ghostty_runtime_render_inspector_cb render_inspector_cb;
     ghostty_runtime_set_cell_size_cb set_cell_size_cb;
+    ghostty_runtime_show_desktop_notification_cb show_desktop_notification_cb;
 } ghostty_runtime_config_s;
 
 //-------------------------------------------------------------------

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -350,7 +350,7 @@ extension Ghostty {
         // MARK: Ghostty Callbacks
 
         static func newSplit(_ userdata: UnsafeMutableRawPointer?, direction: ghostty_split_direction_e, config: ghostty_surface_config_s) {
-            guard let surface = self.surfaceUserdata(from: userdata) else { return }
+            let surface = self.surfaceUserdata(from: userdata)
             NotificationCenter.default.post(name: Notification.ghosttyNewSplit, object: surface, userInfo: [
                 "direction": direction,
                 Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: config),
@@ -358,14 +358,14 @@ extension Ghostty {
         }
 
         static func closeSurface(_ userdata: UnsafeMutableRawPointer?, processAlive: Bool) {
-            guard let surface = self.surfaceUserdata(from: userdata) else { return }
+            let surface = self.surfaceUserdata(from: userdata)
             NotificationCenter.default.post(name: Notification.ghosttyCloseSurface, object: surface, userInfo: [
                 "process_alive": processAlive,
             ])
         }
 
         static func focusSplit(_ userdata: UnsafeMutableRawPointer?, direction: ghostty_split_focus_direction_e) {
-            guard let surface = self.surfaceUserdata(from: userdata) else { return }
+            let surface = self.surfaceUserdata(from: userdata)
             guard let splitDirection = SplitFocusDirection.from(direction: direction) else { return }
             NotificationCenter.default.post(
                 name: Notification.ghosttyFocusSplit,
@@ -377,7 +377,7 @@ extension Ghostty {
         }
 
         static func resizeSplit(_ userdata: UnsafeMutableRawPointer?, direction: ghostty_split_resize_direction_e, amount: UInt16) {
-            guard let surface = self.surfaceUserdata(from: userdata) else { return }
+            let surface = self.surfaceUserdata(from: userdata)
             guard let resizeDirection = SplitResizeDirection.from(direction: direction) else { return }
             NotificationCenter.default.post(
                 name: Notification.didResizeSplit,
@@ -390,12 +390,12 @@ extension Ghostty {
         }
 
         static func equalizeSplits(_ userdata: UnsafeMutableRawPointer?) {
-            guard let surface = self.surfaceUserdata(from: userdata) else { return }
+            let surface = self.surfaceUserdata(from: userdata)
             NotificationCenter.default.post(name: Notification.didEqualizeSplits, object: surface)
         }
 
         static func toggleSplitZoom(_ userdata: UnsafeMutableRawPointer?) {
-            guard let surface = self.surfaceUserdata(from: userdata) else { return }
+            let surface = self.surfaceUserdata(from: userdata)
 
             NotificationCenter.default.post(
                 name: Notification.didToggleSplitZoom,
@@ -404,7 +404,7 @@ extension Ghostty {
         }
 
         static func gotoTab(_ userdata: UnsafeMutableRawPointer?, n: Int32) {
-            guard let surface = self.surfaceUserdata(from: userdata) else { return }
+            let surface = self.surfaceUserdata(from: userdata)
             NotificationCenter.default.post(
                 name: Notification.ghosttyGotoTab,
                 object: surface,
@@ -417,7 +417,7 @@ extension Ghostty {
         static func readClipboard(_ userdata: UnsafeMutableRawPointer?, location: ghostty_clipboard_e, state: UnsafeMutableRawPointer?) {
             // If we don't even have a surface, something went terrible wrong so we have
             // to leak "state".
-            guard let surfaceView = self.surfaceUserdata(from: userdata) else { return }
+            let surfaceView = self.surfaceUserdata(from: userdata)
             guard let surface = surfaceView.surface else { return }
             
             // We only support the standard clipboard
@@ -436,7 +436,7 @@ extension Ghostty {
             state: UnsafeMutableRawPointer?,
             request: ghostty_clipboard_request_e
         ) {
-            guard let surface = self.surfaceUserdata(from: userdata) else { return }
+            let surface = self.surfaceUserdata(from: userdata)
             guard let valueStr = String(cString: string!, encoding: .utf8) else { return }
             guard let request = Ghostty.ClipboardRequest.from(request: request) else { return }
             NotificationCenter.default.post(
@@ -462,7 +462,7 @@ extension Ghostty {
         }
 
         static func writeClipboard(_ userdata: UnsafeMutableRawPointer?, string: UnsafePointer<CChar>?, location: ghostty_clipboard_e, confirm: Bool) {
-            guard let surface = self.surfaceUserdata(from: userdata) else { return }
+            let surface = self.surfaceUserdata(from: userdata)
 
             // We only support the standard clipboard
             if (location != GHOSTTY_CLIPBOARD_STANDARD) { return }
@@ -515,7 +515,7 @@ extension Ghostty {
         }
         
         static func renderInspector(_ userdata: UnsafeMutableRawPointer?) {
-            guard let surface = self.surfaceUserdata(from: userdata) else { return }
+            let surface = self.surfaceUserdata(from: userdata)
             NotificationCenter.default.post(
                 name: Notification.inspectorNeedsDisplay,
                 object: surface
@@ -523,7 +523,7 @@ extension Ghostty {
         }
 
         static func setTitle(_ userdata: UnsafeMutableRawPointer?, title: UnsafePointer<CChar>?) {
-            let surfaceView = Unmanaged<SurfaceView>.fromOpaque(userdata!).takeUnretainedValue()
+            let surfaceView = self.surfaceUserdata(from: userdata)
             guard let titleStr = String(cString: title!, encoding: .utf8) else { return }
             DispatchQueue.main.async {
                 surfaceView.title = titleStr
@@ -531,17 +531,17 @@ extension Ghostty {
         }
 
         static func setMouseShape(_ userdata: UnsafeMutableRawPointer?, shape: ghostty_mouse_shape_e) {
-            let surfaceView = Unmanaged<SurfaceView>.fromOpaque(userdata!).takeUnretainedValue()
+            let surfaceView = self.surfaceUserdata(from: userdata)
             surfaceView.setCursorShape(shape)
         }
 
         static func setMouseVisibility(_ userdata: UnsafeMutableRawPointer?, visible: Bool) {
-            let surfaceView = Unmanaged<SurfaceView>.fromOpaque(userdata!).takeUnretainedValue()
+            let surfaceView = self.surfaceUserdata(from: userdata)
             surfaceView.setCursorVisibility(visible)
         }
 
         static func toggleFullscreen(_ userdata: UnsafeMutableRawPointer?, nonNativeFullscreen: ghostty_non_native_fullscreen_e) {
-            guard let surface = self.surfaceUserdata(from: userdata) else { return }
+            let surface = self.surfaceUserdata(from: userdata)
             NotificationCenter.default.post(
                 name: Notification.ghosttyToggleFullscreen,
                 object: surface,
@@ -553,18 +553,18 @@ extension Ghostty {
         
         static func setInitialWindowSize(_ userdata: UnsafeMutableRawPointer?, width: UInt32, height: UInt32) {
             // We need a window to set the frame
-            guard let surfaceView = self.surfaceUserdata(from: userdata) else { return }
+            let surfaceView = self.surfaceUserdata(from: userdata)
             surfaceView.initialSize = NSMakeSize(Double(width), Double(height))
         }
 
         static func setCellSize(_ userdata: UnsafeMutableRawPointer?, width: UInt32, height: UInt32) {
-            guard let surfaceView = self.surfaceUserdata(from: userdata) else { return }
+            let surfaceView = self.surfaceUserdata(from: userdata)
             let backingSize = NSSize(width: Double(width), height: Double(height))
             surfaceView.cellSize = surfaceView.convertFromBacking(backingSize)
         }
 
         static func newTab(_ userdata: UnsafeMutableRawPointer?, config: ghostty_surface_config_s) {
-            guard let surface = self.surfaceUserdata(from: userdata) else { return }
+            let surface = self.surfaceUserdata(from: userdata)
             
             guard let appState = self.appState(fromView: surface) else { return }
             guard appState.windowDecorations else {
@@ -587,7 +587,7 @@ extension Ghostty {
         }
 
         static func newWindow(_ userdata: UnsafeMutableRawPointer?, config: ghostty_surface_config_s) {
-            guard let surface = self.surfaceUserdata(from: userdata) else { return }
+            let surface = self.surfaceUserdata(from: userdata)
 
             NotificationCenter.default.post(
                 name: Notification.ghosttyNewWindow,
@@ -599,7 +599,7 @@ extension Ghostty {
         }
         
         static func controlInspector(_ userdata: UnsafeMutableRawPointer?, mode: ghostty_inspector_mode_e) {
-            guard let surface = self.surfaceUserdata(from: userdata) else { return }
+            let surface = self.surfaceUserdata(from: userdata)
             NotificationCenter.default.post(name: Notification.didControlInspector, object: surface, userInfo: [
                 "mode": mode,
             ])
@@ -614,7 +614,7 @@ extension Ghostty {
         }
 
         /// Returns the surface view from the userdata.
-        static private func surfaceUserdata(from userdata: UnsafeMutableRawPointer?) -> SurfaceView? {
+        static private func surfaceUserdata(from userdata: UnsafeMutableRawPointer?) -> SurfaceView {
             return Unmanaged<SurfaceView>.fromOpaque(userdata!).takeUnretainedValue()
         }
     }

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -4,6 +4,12 @@ import GhosttyKit
 struct Ghostty {
     // All the notifications that will be emitted will be put here.
     struct Notification {}
+
+    // The user notification category identifier
+    static let userNotificationCategory = "com.mitchellh.ghostty.userNotification"
+
+    // The user notification "Show" action
+    static let userNotificationActionShow = "com.mitchellh.ghostty.userNotification.Show"
 }
 
 // MARK: Surface Notifications

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -722,18 +722,8 @@ pub fn handleMessage(self: *Surface, msg: Message) !void {
                 return;
             }
 
-            const title: [:0]const u8 = switch (notification.title) {
-                .small => |v| v.data[0..v.len :0],
-                // Stream handler only sends small messages
-                else => unreachable,
-            };
-
-            const body: [:0]const u8 = switch (notification.body) {
-                .small => |v| v.data[0..v.len :0],
-                // Stream handler only sends small messages
-                else => unreachable,
-            };
-
+            const title = std.mem.sliceTo(&notification.title, 0);
+            const body = std.mem.sliceTo(&notification.body, 0);
             try self.showDesktopNotification(title, body);
         },
     }

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -117,6 +117,9 @@ pub const App = struct {
 
         /// Called when the cell size changes.
         set_cell_size: ?*const fn (SurfaceUD, u32, u32) callconv(.C) void = null,
+
+        /// Show a desktop notification to the user.
+        show_desktop_notification: ?*const fn (SurfaceUD, [*:0]const u8, [*:0]const u8) void = null,
     };
 
     /// Special values for the goto_tab callback.
@@ -938,6 +941,20 @@ pub const Surface = struct {
     fn cursorPosToPixels(self: *const Surface, pos: apprt.CursorPos) !apprt.CursorPos {
         const scale = try self.getContentScale();
         return .{ .x = pos.x * scale.x, .y = pos.y * scale.y };
+    }
+
+    /// Show a desktop notification.
+    pub fn showDesktopNotification(
+        self: *const Surface,
+        title: [:0]const u8,
+        body: [:0]const u8,
+    ) !void {
+        const func = self.app.opts.show_desktop_notification orelse {
+            log.info("runtime embedder does not support show_desktop_notification", .{});
+            return;
+        };
+
+        func(self.opts.userdata, title, body);
     }
 };
 

--- a/src/apprt/structs.zig
+++ b/src/apprt/structs.zig
@@ -50,3 +50,13 @@ pub const ClipboardRequest = union(ClipboardRequestType) {
     /// A request to write clipboard contents via OSC 52.
     osc_52_write: Clipboard,
 };
+
+/// A desktop notification.
+pub const DesktopNotification = struct {
+    /// The title of the notification. May be an empty string to not show a
+    /// title.
+    title: []const u8,
+
+    /// The body of a notification. This will always be shown.
+    body: []const u8,
+};

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -45,6 +45,15 @@ pub const Message = union(enum) {
     /// The child process running in the surface has exited. This may trigger
     /// a surface close, it may not.
     child_exited: void,
+
+    /// Show a desktop notification.
+    desktop_notification: struct {
+        /// Desktop notification title.
+        title: WriteReq,
+
+        /// Desktop notification body.
+        body: WriteReq,
+    },
 };
 
 /// A surface mailbox.

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -49,10 +49,10 @@ pub const Message = union(enum) {
     /// Show a desktop notification.
     desktop_notification: struct {
         /// Desktop notification title.
-        title: WriteReq,
+        title: [63:0]u8,
 
         /// Desktop notification body.
-        body: WriteReq,
+        body: [255:0]u8,
     },
 };
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -650,6 +650,10 @@ keybind: Keybinds = .{},
 /// libadwaita support.
 @"gtk-adwaita": bool = true,
 
+/// If true (default), applications running in the terminal can show desktop
+/// notifications using certain escape sequences such as OSC 9 or OSC 777.
+@"desktop-notifications": bool = true,
+
 /// This will be used to set the TERM environment variable.
 /// HACK: We set this with an "xterm" prefix because vim uses that to enable key
 /// protocols (specifically this will enable 'modifyOtherKeys'), among other

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -1067,6 +1067,13 @@ pub fn Stream(comptime Handler: type) type {
                         return;
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
+
+                .show_desktop_notification => |v| {
+                    if (@hasDecl(T, "showDesktopNotification")) {
+                        try self.handler.showDesktopNotification(v.title, v.body);
+                        return;
+                    } else log.warn("unimplemented OSC callback: {}", .{cmd});
+                },
             }
 
             // Fall through for when we don't have a handler.


### PR DESCRIPTION
Fixes: https://github.com/mitchellh/ghostty/issues/612

This PR adds support to core for OSC 9 and OSC 777 for sending desktop notifications from terminal applications. For now, the actual notifications are only implemented for macOS, but all of the core plumbing is there to make it work with GTK (it just needs updates to the apprt surface).
