### PR TITLE
clipboard: add Clipboard variant for primary clipboard

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2727,6 +2727,7 @@ fn completeClipboardReadOSC52(
     const kind: u8 = switch (clipboard_type) {
         .standard => 'c',
         .selection => 's',
+        .primary => 'p',
     };
 
     // Wrap our data with the OSC code

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -474,7 +474,7 @@ pub const Surface = struct {
     ) bool {
         return switch (clipboard_type) {
             .standard => true,
-            .selection => self.app.opts.supports_selection_clipboard,
+            .selection, .primary => self.app.opts.supports_selection_clipboard,
         };
     }
 

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -658,7 +658,7 @@ pub const Surface = struct {
         // GLFW can read clipboards immediately so just do that.
         const str: [:0]const u8 = switch (clipboard_type) {
             .standard => glfw.getClipboardString() orelse return glfw.mustGetErrorCode(),
-            .selection => selection: {
+            .selection, .primary => selection: {
                 // Not supported except on Linux
                 if (comptime builtin.os.tag != .linux) break :selection "";
 
@@ -684,7 +684,7 @@ pub const Surface = struct {
         _ = self;
         switch (clipboard_type) {
             .standard => glfw.setClipboardString(val),
-            .selection => {
+            .selection, .primary => {
                 // Not supported except on Linux
                 if (comptime builtin.os.tag != .linux) return;
                 glfwNative.setX11SelectionString(val.ptr);

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -589,7 +589,7 @@ fn gtkClipboardRead(
 fn getClipboard(widget: *c.GtkWidget, clipboard: apprt.Clipboard) ?*c.GdkClipboard {
     return switch (clipboard) {
         .standard => c.gtk_widget_get_clipboard(widget),
-        .selection => c.gtk_widget_get_primary_clipboard(widget),
+        .selection, .primary => c.gtk_widget_get_primary_clipboard(widget),
     };
 }
 pub fn getCursorPos(self: *const Surface) !apprt.CursorPos {

--- a/src/apprt/structs.zig
+++ b/src/apprt/structs.zig
@@ -27,9 +27,10 @@ pub const IMEPos = struct {
 /// The clipboard type.
 ///
 /// If this is changed, you must also update ghostty.h
-pub const Clipboard = enum(u1) {
+pub const Clipboard = enum(u2) {
     standard = 0, // ctrl+c/v
-    selection = 1, // also known as the "primary" clipboard
+    selection = 1,
+    primary = 2,
 };
 
 pub const ClipboardRequestType = enum(u8) {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -2139,6 +2139,7 @@ const StreamHandler = struct {
         const clipboard_type: apprt.Clipboard = switch (kind) {
             'c' => .standard,
             's' => .selection,
+            'p' => .primary,
             else => .standard,
         };
 


### PR DESCRIPTION
In practice, the primary and selection clipboards are treated exactly
the same, but this allows OSC 52 sequences to use either 's' or 'p' as
the clipboard target.

---

An alternative would be to keep just the `.standard` and `.selection` enum variants, but allow either `p` or `s` in the OSC 52 command. The only difficulty with this approach is that we would need to keep track of which clipboard was requested in an OSC 52 query so that we can populate the same clipboard type in the response (or do we?). But having a separate enum variant might be nice _if_ we ever want to handle the primary and selection clipboards differently.
