### PR TITLE
macos: ensure all surfaces are closed when a window is closed

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -19,9 +19,12 @@ class TerminalController: NSWindowController, NSWindowDelegate,
     /// The surface tree for this window.
     @Published var surfaceTree: Ghostty.SplitNode? = nil {
         didSet {
-            // If our surface tree becomes nil then it means all our surfaces
-            // have closed, so we also close the window.
-            if (surfaceTree == nil) { lastSurfaceDidClose() }
+            // If our surface tree becomes nil then ensure all surfaces
+            // in the old tree have closed and then close the window.
+            if (surfaceTree == nil) {
+                oldValue?.close()
+                lastSurfaceDidClose()
+            }
         }
     }
     


### PR DESCRIPTION
Fixes: https://github.com/mitchellh/ghostty/issues/907

---

We may want to also find another way to associate a surface with a notification besides using its address, which is kind of hacky, but this solves the immediate problem anyway.
