### PR TITLE
macos: associate SurfaceViews with UUIDs

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -39,8 +39,7 @@ class TerminalController: NSWindowController, NSWindowDelegate,
         super.init(window: nil)
         
         // Initialize our initial surface.
-        guard let ghostty_app = ghostty.app else { preconditionFailure("app must be loaded") }
-        self.surfaceTree = .leaf(.init(ghostty_app, base))
+        self.surfaceTree = .leaf(.init(ghostty, base))
         
         // Setup our notifications for behaviors
         let center = NotificationCenter.default

--- a/macos/Sources/Ghostty/Ghostty.SplitNode.swift
+++ b/macos/Sources/Ghostty/Ghostty.SplitNode.swift
@@ -92,13 +92,17 @@ extension Ghostty {
         }
 
         class Leaf: ObservableObject, Equatable, Hashable {
-            let app: ghostty_app_t
+            /// Reference to the global app state
+            let app: Ghostty.AppState
+
+            /// The surface view associated with this leaf node
             @Published var surface: SurfaceView
 
+            /// The parent container of this node. Nil if this is the root node
             weak var parent: SplitNode.Container?
 
             /// Initialize a new leaf which creates a new terminal surface.
-            init(_ app: ghostty_app_t, _ baseConfig: SurfaceConfiguration?) {
+            init(_ app: Ghostty.AppState, _ baseConfig: SurfaceConfiguration?) {
                 self.app = app
                 self.surface = SurfaceView(app, baseConfig)
             }
@@ -106,19 +110,19 @@ extension Ghostty {
             // MARK: - Hashable
             
             func hash(into hasher: inout Hasher) {
-                hasher.combine(app)
                 hasher.combine(surface)
             }
             
             // MARK: - Equatable
             
             static func == (lhs: Leaf, rhs: Leaf) -> Bool {
-                return lhs.app == rhs.app && lhs.surface === rhs.surface
+                return lhs.surface === rhs.surface
             }
         }
 
         class Container: ObservableObject, Equatable, Hashable {
-            let app: ghostty_app_t
+            /// Reference to the global app state
+            let app: Ghostty.AppState
             let direction: SplitViewDirection
 
             @Published var topLeft: SplitNode
@@ -127,6 +131,7 @@ extension Ghostty {
 
             var resizeEvent: PassthroughSubject<Double, Never> = .init()
 
+            /// The parent container of this node. Nil if this is the root node
             weak var parent: SplitNode.Container?
 
             /// A container is always initialized from some prior leaf because a split has to originate
@@ -199,7 +204,6 @@ extension Ghostty {
             // MARK: - Hashable
             
             func hash(into hasher: inout Hasher) {
-                hasher.combine(app)
                 hasher.combine(direction)
                 hasher.combine(topLeft)
                 hasher.combine(bottomRight)
@@ -208,8 +212,7 @@ extension Ghostty {
             // MARK: - Equatable
             
             static func == (lhs: Container, rhs: Container) -> Bool {
-                return lhs.app == rhs.app &&
-                    lhs.direction == rhs.direction &&
+                return lhs.direction == rhs.direction &&
                     lhs.topLeft == rhs.topLeft &&
                     lhs.bottomRight == rhs.bottomRight
             }


### PR DESCRIPTION
Add a unique ID (UUID) to each surface view and use it to associate
SurfaceViews with notifications. This is safer than using the address of
the surface view as the identifier, as there is no risk of addressing
invalid memory in the case where the view is freed while the
notification is still active.

---

This also fixes https://github.com/mitchellh/ghostty/issues/907, though is not mutually exclusive with https://github.com/mitchellh/ghostty/pull/908 as both are improvements.
