### PR TITLE
nix: fix package build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,6 +176,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-zig-0-12": {
+      "locked": {
+        "lastModified": 1700381855,
+        "narHash": "sha256-2iN7PIsz7zcGU+va5eUZwNEmBnDGr+sUgoWhpsT5xtw=",
+        "owner": "vancluever",
+        "repo": "nixpkgs",
+        "rev": "d986dbb50cea7804e544ebd77342a2498e399166",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vancluever",
+        "ref": "vancluever-zig-0-12",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1689088367,
@@ -214,6 +230,7 @@
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
+        "nixpkgs-zig-0-12": "nixpkgs-zig-0-12",
         "zig": "zig",
         "zls-master": "zls-master"
       }


### PR DESCRIPTION
This fixes the Nix *package* build (read: not `devShell`, which is not touched) so that it builds, and also conforms to what is generally seen for a Zig project in nixpkgs.

The highlights:

* We use a Zig 0.12 derivation that I constructed from the Zig 0.11 derivation, in addition to LLVM 17 updates found in NixOS/nixpkgs#258614. This specifically includes the patches that address ziglang/zig#15898, and also allows us to take advantage of the build hooks included in the Zig toolchain there.

* We pre-download the cache using `zig build --fetch` and a fixed-output derivation. This is similar to how the Go builders work in nixpkgs and I could see Zig ultimately going in a similar path, given that the fetcher part of the build system seems to be shaping up to having a Go module system-style DX (mind you, this is a naive opinion right now).

* Finally, cleaned up the derivation so that there's no special fixups happening outside of what is defined in the basic nixpkgs workflow. This is similar to other Zig projects I looked at (notably River) that seem to just include their dependencies in `buildInputs` and call it a day.

One specific change that is worth noting is that this changes the build mode from `ReleaseFast` to `ReleaseSafe` - this is the current default within the Zig build hook in nixpkgs. If we need `ReleaseFast`, we'll have to override this.