### PR TITLE
terminal: add "scroll and clear" (ESC [ 22 J) and associated logic

### DIFF
--- a/src/circ_buf.zig
+++ b/src/circ_buf.zig
@@ -93,7 +93,7 @@ pub fn CircBuf(comptime T: type, comptime default: T) type {
 
         /// Resize the buffer to the given size (larger or smaller).
         /// If larger, new values will be set to the default value.
-        pub fn resize(self: *Self, alloc: Allocator, size: usize) !void {
+        pub fn resize(self: *Self, alloc: Allocator, size: usize) Allocator.Error!void {
             // Rotate to zero so it is aligned.
             try self.rotateToZero(alloc);
 
@@ -116,7 +116,7 @@ pub fn CircBuf(comptime T: type, comptime default: T) type {
         }
 
         /// Rotate the data so that it is zero-aligned.
-        fn rotateToZero(self: *Self, alloc: Allocator) !void {
+        fn rotateToZero(self: *Self, alloc: Allocator) Allocator.Error!void {
             // TODO: this does this in the worst possible way by allocating.
             // rewrite to not allocate, its possible, I'm just lazy right now.
 

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -6421,34 +6421,6 @@ test "Screen: resize less cols with reflow previously wrapped and scrollback" {
     try testing.expectEqual(@as(usize, 2), s.cursor.y);
 }
 
-// test "Screen: resize less cols with scrollback keeps cursor row" {
-//     const testing = std.testing;
-//     const alloc = testing.allocator;
-//
-//     var s = try init(alloc, 3, 5, 5);
-//     defer s.deinit();
-//     const str = "1A\n2B\n3C\n4D\n5E";
-//     try s.testWriteString(str);
-//
-//     // Put our cursor on the end
-//     s.cursor.x = 1;
-//     s.cursor.y = s.rows - 1;
-//     try testing.expectEqual(@as(u32, 'E'), s.getCell(.active, s.cursor.y, s.cursor.x).char);
-//
-//     try s.resize(3, 3);
-//
-//     {
-//         const contents = try s.testString(alloc, .viewport);
-//         defer alloc.free(contents);
-//         const expected = "3C\n4D\n5E";
-//         try testing.expectEqualStrings(expected, contents);
-//     }
-//
-//     // Cursor should be on the last line
-//     try testing.expectEqual(@as(usize, 1), s.cursor.x);
-//     try testing.expectEqual(@as(usize, 2), s.cursor.y);
-// }
-//
 test "Screen: resize more rows, less cols with reflow with scrollback" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1794,7 +1794,7 @@ pub const Scroll = union(enum) {
 /// "move" the screen. It is up to the caller to determine if they actually
 /// want to do that yet (i.e. are they writing to the end of the screen
 /// or not).
-pub fn scroll(self: *Screen, behavior: Scroll) !void {
+pub fn scroll(self: *Screen, behavior: Scroll) Allocator.Error!void {
     // No matter what, scrolling marks our image state as dirty since
     // it could move placements. If there are no placements or no images
     // this is still a very cheap operation.
@@ -1830,7 +1830,7 @@ fn scrollRow(self: *Screen, idx: RowIndex) void {
     assert(screen_pt.inViewport(self));
 }
 
-fn scrollDelta(self: *Screen, delta: isize, viewport_only: bool) !void {
+fn scrollDelta(self: *Screen, delta: isize, viewport_only: bool) Allocator.Error!void {
     const tracy = trace(@src());
     defer tracy.end();
 

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1788,6 +1788,15 @@ pub const Scroll = union(enum) {
     /// this will change nothing. If the row is outside the viewport, the
     /// viewport will change so that this row is at the top of the viewport.
     row: RowIndex,
+
+    /// Scroll down and move all viewport contents into the scrollback
+    /// so that the screen is clear. This isn't eqiuivalent to "screen" with
+    /// the value set to the viewport size because this will handle the case
+    /// that the viewport is not full.
+    ///
+    /// This will ignore empty trailing rows. An empty row is a row that
+    /// has never been written to at all. A row with spaces is not empty.
+    clear: void,
 };
 
 /// Scroll the screen by the given behavior. Note that this will always
@@ -1815,7 +1824,25 @@ pub fn scroll(self: *Screen, behavior: Scroll) Allocator.Error!void {
 
         // Scroll to a specific row
         .row => |idx| self.scrollRow(idx),
+
+        // Scroll until the viewport is clear by moving the viewport contents
+        // into the scrollback.
+        .clear => try self.scrollClear(),
     }
+}
+
+fn scrollClear(self: *Screen) Allocator.Error!void {
+    // The full amount of rows in the viewport
+    const full_amount = self.rowsWritten() - self.viewport;
+
+    // Find the number of non-empty rows
+    const non_empty = for (0..full_amount) |i| {
+        const rev_i = full_amount - i - 1;
+        const row = self.getRow(.{ .viewport = rev_i });
+        if (!row.isEmpty()) break rev_i + 1;
+    } else full_amount;
+
+    try self.scroll(.{ .screen = @intCast(non_empty) });
 }
 
 fn scrollRow(self: *Screen, idx: RowIndex) void {
@@ -3688,6 +3715,109 @@ test "Screen: scrolling with scrollback available doesn't move selection" {
         const contents = try s.testString(alloc, .viewport);
         defer alloc.free(contents);
         try testing.expectEqualStrings("3IJKL", contents);
+    }
+}
+
+test "Screen: scroll and clear full screen" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, 3, 5, 5);
+    defer s.deinit();
+    try s.testWriteString("1ABCD\n2EFGH\n3IJKL");
+
+    {
+        const contents = try s.testString(alloc, .viewport);
+        defer alloc.free(contents);
+        try testing.expectEqualStrings("1ABCD\n2EFGH\n3IJKL", contents);
+    }
+
+    try s.scroll(.{ .clear = {} });
+    {
+        const contents = try s.testString(alloc, .viewport);
+        defer alloc.free(contents);
+        try testing.expectEqualStrings("", contents);
+    }
+    {
+        const contents = try s.testString(alloc, .screen);
+        defer alloc.free(contents);
+        try testing.expectEqualStrings("1ABCD\n2EFGH\n3IJKL", contents);
+    }
+}
+
+test "Screen: scroll and clear partial screen" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, 3, 5, 5);
+    defer s.deinit();
+    try s.testWriteString("1ABCD\n2EFGH");
+
+    {
+        const contents = try s.testString(alloc, .viewport);
+        defer alloc.free(contents);
+        try testing.expectEqualStrings("1ABCD\n2EFGH", contents);
+    }
+
+    try s.scroll(.{ .clear = {} });
+    {
+        const contents = try s.testString(alloc, .viewport);
+        defer alloc.free(contents);
+        try testing.expectEqualStrings("", contents);
+    }
+    {
+        const contents = try s.testString(alloc, .screen);
+        defer alloc.free(contents);
+        try testing.expectEqualStrings("1ABCD\n2EFGH", contents);
+    }
+}
+
+test "Screen: scroll and clear empty screen" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, 3, 5, 5);
+    defer s.deinit();
+    try s.scroll(.{ .clear = {} });
+    try testing.expectEqual(@as(usize, 0), s.viewport);
+}
+
+test "Screen: scroll and clear ignore blank lines" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, 3, 5, 10);
+    defer s.deinit();
+    try s.testWriteString("1ABCD\n2EFGH");
+    try s.scroll(.{ .clear = {} });
+    {
+        const contents = try s.testString(alloc, .viewport);
+        defer alloc.free(contents);
+        try testing.expectEqualStrings("", contents);
+    }
+
+    // Move back to top-left
+    s.cursor.x = 0;
+    s.cursor.y = 0;
+
+    // Write and clear
+    try s.testWriteString("3ABCD\n");
+    try s.scroll(.{ .clear = {} });
+    {
+        const contents = try s.testString(alloc, .viewport);
+        defer alloc.free(contents);
+        try testing.expectEqualStrings("", contents);
+    }
+
+    // Move back to top-left
+    s.cursor.x = 0;
+    s.cursor.y = 0;
+    try s.testWriteString("X");
+
+    {
+        const contents = try s.testString(alloc, .screen);
+        defer alloc.free(contents);
+        try testing.expectEqualStrings("1ABCD\n2EFGH\n3ABCD\nX", contents);
     }
 }
 

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -6421,6 +6421,34 @@ test "Screen: resize less cols with reflow previously wrapped and scrollback" {
     try testing.expectEqual(@as(usize, 2), s.cursor.y);
 }
 
+// test "Screen: resize less cols with scrollback keeps cursor row" {
+//     const testing = std.testing;
+//     const alloc = testing.allocator;
+//
+//     var s = try init(alloc, 3, 5, 5);
+//     defer s.deinit();
+//     const str = "1A\n2B\n3C\n4D\n5E";
+//     try s.testWriteString(str);
+//
+//     // Put our cursor on the end
+//     s.cursor.x = 1;
+//     s.cursor.y = s.rows - 1;
+//     try testing.expectEqual(@as(u32, 'E'), s.getCell(.active, s.cursor.y, s.cursor.x).char);
+//
+//     try s.resize(3, 3);
+//
+//     {
+//         const contents = try s.testString(alloc, .viewport);
+//         defer alloc.free(contents);
+//         const expected = "3C\n4D\n5E";
+//         try testing.expectEqualStrings(expected, contents);
+//     }
+//
+//     // Cursor should be on the last line
+//     try testing.expectEqual(@as(usize, 1), s.cursor.x);
+//     try testing.expectEqual(@as(usize, 2), s.cursor.y);
+// }
+//
 test "Screen: resize more rows, less cols with reflow with scrollback" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1144,6 +1144,20 @@ pub fn eraseDisplay(
     const protected = self.screen.protected_mode == .iso or protected_req;
 
     switch (mode) {
+        .scroll_complete => {
+            self.screen.scroll(.{ .clear = {} }) catch |err| {
+                log.warn("scroll clear failed, doing a normal clear err={}", .{err});
+                self.eraseDisplay(alloc, .complete, protected_req);
+                return;
+            };
+
+            // Unsets pending wrap state
+            self.screen.cursor.pending_wrap = false;
+
+            // Clear all Kitty graphics state for this screen
+            self.screen.kitty_images.delete(alloc, self, .{ .all = true });
+        },
+
         .complete => {
             var it = self.screen.rowIterator(.active);
             while (it.next()) |row| {
@@ -6015,6 +6029,23 @@ test "Terminal: eraseDisplay protected below" {
 test "Terminal: eraseDisplay protected above" {
     const alloc = testing.allocator;
     var t = try init(alloc, 10, 5);
+    defer t.deinit(alloc);
+
+    try t.print('A');
+    t.carriageReturn();
+    try t.linefeed();
+    t.eraseDisplay(alloc, .scroll_complete, false);
+
+    {
+        const str = try t.plainString(testing.allocator);
+        defer testing.allocator.free(str);
+        try testing.expectEqualStrings("", str);
+    }
+}
+
+test "Terminal: eraseDisplay scroll complete" {
+    const alloc = testing.allocator;
+    var t = try init(alloc, 10, 3);
     defer t.deinit(alloc);
 
     try t.print('A');

--- a/src/terminal/csi.zig
+++ b/src/terminal/csi.zig
@@ -4,6 +4,10 @@ pub const EraseDisplay = enum(u8) {
     above = 1,
     complete = 2,
     scrollback = 3,
+
+    /// This is an extension added by Kitty to move the viewport into the
+    /// scrollback and then erase the display.
+    scroll_complete = 22,
 };
 
 // Modes for the EL CSI command.

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -294,7 +294,10 @@ pub fn Stream(comptime Handler: type) type {
 
                     const mode_: ?csi.EraseDisplay = switch (action.params.len) {
                         0 => .below,
-                        1 => if (action.params[0] <= 3) @enumFromInt(action.params[0]) else null,
+                        1 => if (action.params[0] <= 3)
+                            std.meta.intToEnum(csi.EraseDisplay, action.params[0]) catch null
+                        else
+                            null,
                         else => null,
                     };
 


### PR DESCRIPTION
Fixes #905

For full background on "why?" see #905 which covers the history very well.

This adds the Kitty extension `ESC [ 22 J` to perform a "scroll and clear" operation. This operation is the same as `ESC [ 2 J` but instead of _deleting_ the active screen contents, the active screen contents are moved into the scroll back area. Otherwise, it is semantically the same: pending wrap is unset, cursor position is not moved, Kitty image placements are cleared.

This adds two other behavioral extensions that are not present in any other terminal I'm aware of:

First, the "scroll and clear" operation ignores trailing empty rows. An empty row is a row with no contents and no styling. If a single cell has a style, a space (0x20), etc, is it _not_ considered empty. This makes it so that repeated `^L` doesn't create a huge amount of scrollback.

Second, if we're on the primary screen and the last row of the viewport is a prompt (notified via shell integration), `ESC [ 2 J` behaves as `ESC [ 22 J`. This is a convenience heuristic so that `^L` in all major shells by default performs a "scroll and clear". Normally, I'd say users should just configure their shell to send 22 but enough mainstream terminals do this for _every_ `ESC [ 2 J` that I felt this was a good middle ground. (See #905 for a list of terminals)