### PR TITLE
renderer/opengl: Kitty Images

### DIFF
--- a/pkg/opengl/Texture.zig
+++ b/pkg/opengl/Texture.zig
@@ -78,6 +78,7 @@ pub const InternalFormat = enum(c_int) {
 pub const Format = enum(c_uint) {
     red = c.GL_RED,
     rgb = c.GL_RGB,
+    rgba = c.GL_RGBA,
     bgra = c.GL_BGRA,
 
     // There are so many more that I haven't filled in.

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -755,7 +755,7 @@ pub fn drawFrame(self: *Metal, surface: *apprt.Surface) !void {
         try self.drawCells(encoder, &self.buf_cells_bg, self.cells_bg);
 
         // Then draw images under text
-        try self.drawImagePlacements(encoder, self.image_placements.items[0..self.image_text_end]);
+        try self.drawImagePlacements(encoder, self.image_placements.items[self.image_bg_end..self.image_text_end]);
 
         // Then draw fg cells
         try self.drawCells(encoder, &self.buf_cells, self.cells);

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -22,7 +22,11 @@ const math = @import("../math.zig");
 const Surface = @import("../Surface.zig");
 
 const CellProgram = @import("opengl/CellProgram.zig");
+const gl_image = @import("opengl/image.zig");
 const custom = @import("opengl/custom.zig");
+const Image = gl_image.Image;
+const ImageMap = gl_image.ImageMap;
+const ImagePlacementList = std.ArrayListUnmanaged(gl_image.Placement);
 
 const log = std.log.scoped(.grid);
 
@@ -102,6 +106,12 @@ draw_mutex: DrawMutex = drawMutexZero,
 /// Current background to draw. This may not match self.background if the
 /// terminal is in reversed mode.
 draw_background: terminal.color.RGB,
+
+/// The images that we may render.
+images: ImageMap = .{},
+image_placements: ImagePlacementList = .{},
+image_bg_end: u32 = 0,
+image_text_end: u32 = 0,
 
 /// Defererred OpenGL operation to update the screen size.
 const SetScreenSize = struct {
@@ -306,6 +316,13 @@ pub fn init(alloc: Allocator, options: renderer.Options) !OpenGL {
 
 pub fn deinit(self: *OpenGL) void {
     self.font_shaper.deinit();
+
+    {
+        var it = self.images.iterator();
+        while (it.next()) |kv| kv.value_ptr.deinit(self.alloc);
+        self.images.deinit(self.alloc);
+    }
+    self.image_placements.deinit(self.alloc);
 
     if (self.gl_state) |*v| v.deinit(self.alloc);
 
@@ -623,6 +640,13 @@ pub fn updateFrame(
             cursor_blink_visible,
         );
 
+        // If we have Kitty graphics data, we enter a SLOW SLOW SLOW path.
+        // We only do this if the Kitty image state is dirty meaning only if
+        // it changes.
+        if (state.terminal.screen.kitty_images.dirty) {
+            try self.prepKittyGraphics(state.terminal);
+        }
+
         break :critical .{
             .gl_bg = self.background_color,
             .selection = selection,
@@ -648,6 +672,158 @@ pub fn updateFrame(
             critical.preedit,
             critical.cursor_style,
         );
+    }
+}
+
+/// This goes through the Kitty graphic placements and accumulates the
+/// placements we need to render on our viewport. It also ensures that
+/// the visible images are loaded on the GPU.
+fn prepKittyGraphics(
+    self: *OpenGL,
+    t: *terminal.Terminal,
+) !void {
+    const storage = &t.screen.kitty_images;
+    defer storage.dirty = false;
+
+    // We always clear our previous placements no matter what because
+    // we rebuild them from scratch.
+    self.image_placements.clearRetainingCapacity();
+
+    // Go through our known images and if there are any that are no longer
+    // in use then mark them to be freed.
+    //
+    // This never conflicts with the below because a placement can't
+    // reference an image that doesn't exist.
+    {
+        var it = self.images.iterator();
+        while (it.next()) |kv| {
+            if (storage.imageById(kv.key_ptr.*) == null) {
+                kv.value_ptr.markForUnload();
+            }
+        }
+    }
+
+    // The top-left and bottom-right corners of our viewport in screen
+    // points. This lets us determine offsets and containment of placements.
+    const top = (terminal.point.Viewport{}).toScreen(&t.screen);
+    const bot = (terminal.point.Viewport{
+        .x = t.screen.cols - 1,
+        .y = t.screen.rows - 1,
+    }).toScreen(&t.screen);
+
+    // Go through the placements and ensure the image is loaded on the GPU.
+    var it = storage.placements.iterator();
+    while (it.next()) |kv| {
+        // Find the image in storage
+        const p = kv.value_ptr;
+        const image = storage.imageById(kv.key_ptr.image_id) orelse {
+            log.warn(
+                "missing image for placement, ignoring image_id={}",
+                .{kv.key_ptr.image_id},
+            );
+            continue;
+        };
+
+        // If the selection isn't within our viewport then skip it.
+        const rect = p.rect(image, t);
+        if (rect.top_left.y > bot.y) continue;
+        if (rect.bottom_right.y < top.y) continue;
+
+        // If the top left is outside the viewport we need to calc an offset
+        // so that we render (0, 0) with some offset for the texture.
+        const offset_y: u32 = if (rect.top_left.y < t.screen.viewport) offset_y: {
+            const offset_cells = t.screen.viewport - rect.top_left.y;
+            const offset_pixels = offset_cells * self.cell_size.height;
+            break :offset_y @intCast(offset_pixels);
+        } else 0;
+
+        // If we already know about this image then do nothing
+        const gop = try self.images.getOrPut(self.alloc, kv.key_ptr.image_id);
+        if (!gop.found_existing) {
+            // Copy the data into the pending state.
+            const data = try self.alloc.dupe(u8, image.data);
+            errdefer self.alloc.free(data);
+
+            // Store it in the map
+            const pending: Image.Pending = .{
+                .width = image.width,
+                .height = image.height,
+                .data = data.ptr,
+            };
+
+            gop.value_ptr.* = switch (image.format) {
+                .rgb => .{ .pending_rgb = pending },
+                .rgba => .{ .pending_rgba = pending },
+                .png => unreachable, // should be decoded by now
+            };
+        }
+
+        // Convert our screen point to a viewport point
+        const viewport = p.point.toViewport(&t.screen);
+
+        // Calculate the source rectangle
+        const source_x = @min(image.width, p.source_x);
+        const source_y = @min(image.height, p.source_y + offset_y);
+        const source_width = if (p.source_width > 0)
+            @min(image.width - source_x, p.source_width)
+        else
+            image.width;
+        const source_height = if (p.source_height > 0)
+            @min(image.height, p.source_height)
+        else
+            image.height -| offset_y;
+
+        // Calculate the width/height of our image.
+        const dest_width = if (p.columns > 0) p.columns * self.cell_size.width else source_width;
+        const dest_height = if (p.rows > 0) p.rows * self.cell_size.height else source_height;
+
+        // Accumulate the placement
+        if (image.width > 0 and image.height > 0) {
+            try self.image_placements.append(self.alloc, .{
+                .image_id = kv.key_ptr.image_id,
+                .x = @intCast(p.point.x),
+                .y = @intCast(viewport.y),
+                .z = p.z,
+                .width = dest_width,
+                .height = dest_height,
+                .cell_offset_x = p.x_offset,
+                .cell_offset_y = p.y_offset,
+                .source_x = source_x,
+                .source_y = source_y,
+                .source_width = source_width,
+                .source_height = source_height,
+            });
+        }
+    }
+
+    // Sort the placements by their Z value.
+    std.mem.sortUnstable(
+        gl_image.Placement,
+        self.image_placements.items,
+        {},
+        struct {
+            fn lessThan(
+                ctx: void,
+                lhs: gl_image.Placement,
+                rhs: gl_image.Placement,
+            ) bool {
+                _ = ctx;
+                return lhs.z < rhs.z or (lhs.z == rhs.z and lhs.image_id < rhs.image_id);
+            }
+        }.lessThan,
+    );
+
+    // Find our indices
+    self.image_bg_end = 0;
+    self.image_text_end = 0;
+    const bg_limit = std.math.minInt(i32) / 2;
+    for (self.image_placements.items, 0..) |p, i| {
+        if (self.image_bg_end == 0 and p.z >= bg_limit) {
+            self.image_bg_end = @intCast(i);
+        }
+        if (self.image_text_end == 0 and p.z >= 0) {
+            self.image_text_end = @intCast(i);
+        }
     }
 }
 
@@ -1395,6 +1571,27 @@ pub fn drawFrame(self: *OpenGL, surface: *apprt.Surface) !void {
     if (single_threaded_draw) self.draw_mutex.lock();
     defer if (single_threaded_draw) self.draw_mutex.unlock();
     const gl_state: *GLState = if (self.gl_state) |*v| v else return;
+
+    // Go through our images and see if we need to setup any textures.
+    {
+        var image_it = self.images.iterator();
+        while (image_it.next()) |kv| {
+            switch (kv.value_ptr.*) {
+                .ready => {},
+
+                .pending_rgb,
+                .pending_rgba,
+                => try kv.value_ptr.upload(self.alloc),
+
+                .unload_pending,
+                .unload_ready,
+                => {
+                    kv.value_ptr.deinit(self.alloc);
+                    self.images.removeByPtr(kv.key_ptr);
+                },
+            }
+        }
+    }
 
     // Draw our terminal cells
     try self.drawCellProgram(gl_state);

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -1683,19 +1683,28 @@ fn drawCellProgram(
     }
 
     // Draw background images first
-    try self.drawImages(gl_state, self.image_placements.items[0..self.image_bg_end]);
+    try self.drawImages(
+        gl_state,
+        self.image_placements.items[0..self.image_bg_end],
+    );
 
     // Draw our background
     try self.drawCells(gl_state, self.cells_bg);
 
     // Then draw images under text
-    try self.drawImages(gl_state, self.image_placements.items[self.image_bg_end..self.image_text_end]);
+    try self.drawImages(
+        gl_state,
+        self.image_placements.items[self.image_bg_end..self.image_text_end],
+    );
 
     // Drag foreground
     try self.drawCells(gl_state, self.cells);
 
     // Draw remaining images
-    try self.drawImages(gl_state, self.image_placements.items[self.image_text_end..]);
+    try self.drawImages(
+        gl_state,
+        self.image_placements.items[self.image_text_end..],
+    );
 }
 
 /// Runs the image program to draw images.

--- a/src/renderer/opengl/ImageProgram.zig
+++ b/src/renderer/opengl/ImageProgram.zig
@@ -1,0 +1,134 @@
+/// The OpenGL program for rendering terminal cells.
+const ImageProgram = @This();
+
+const std = @import("std");
+const gl = @import("opengl");
+
+program: gl.Program,
+vao: gl.VertexArray,
+ebo: gl.Buffer,
+vbo: gl.Buffer,
+
+pub const Input = extern struct {
+    /// vec2 grid_coord
+    grid_col: u16,
+    grid_row: u16,
+
+    /// vec2 cell_offset
+    cell_offset_x: u32 = 0,
+    cell_offset_y: u32 = 0,
+
+    /// vec4 source_rect
+    source_x: u32 = 0,
+    source_y: u32 = 0,
+    source_width: u32 = 0,
+    source_height: u32 = 0,
+
+    /// vec2 dest_size
+    dest_width: u32 = 0,
+    dest_height: u32 = 0,
+};
+
+pub fn init() !ImageProgram {
+    // Load and compile our shaders.
+    const program = try gl.Program.createVF(
+        @embedFile("../shaders/image.v.glsl"),
+        @embedFile("../shaders/image.f.glsl"),
+    );
+    errdefer program.destroy();
+
+    // Set our program uniforms
+    const pbind = try program.use();
+    defer pbind.unbind();
+
+    // Set all of our texture indexes
+    try program.setUniform("image", 0);
+
+    // Setup our VAO
+    const vao = try gl.VertexArray.create();
+    errdefer vao.destroy();
+    const vaobind = try vao.bind();
+    defer vaobind.unbind();
+
+    // Element buffer (EBO)
+    const ebo = try gl.Buffer.create();
+    errdefer ebo.destroy();
+    var ebobind = try ebo.bind(.element_array);
+    defer ebobind.unbind();
+    try ebobind.setData([6]u8{
+        0, 1, 3, // Top-left triangle
+        1, 2, 3, // Bottom-right triangle
+    }, .static_draw);
+
+    // Vertex buffer (VBO)
+    const vbo = try gl.Buffer.create();
+    errdefer vbo.destroy();
+    var vbobind = try vbo.bind(.array);
+    defer vbobind.unbind();
+    var offset: usize = 0;
+    try vbobind.attributeAdvanced(0, 2, gl.c.GL_UNSIGNED_SHORT, false, @sizeOf(Input), offset);
+    offset += 2 * @sizeOf(u16);
+    try vbobind.attributeAdvanced(1, 2, gl.c.GL_UNSIGNED_INT, false, @sizeOf(Input), offset);
+    offset += 2 * @sizeOf(u32);
+    try vbobind.attributeAdvanced(2, 4, gl.c.GL_UNSIGNED_INT, false, @sizeOf(Input), offset);
+    offset += 4 * @sizeOf(u32);
+    try vbobind.attributeAdvanced(3, 2, gl.c.GL_UNSIGNED_INT, false, @sizeOf(Input), offset);
+    offset += 2 * @sizeOf(u32);
+    try vbobind.enableAttribArray(0);
+    try vbobind.enableAttribArray(1);
+    try vbobind.enableAttribArray(2);
+    try vbobind.enableAttribArray(3);
+    try vbobind.attributeDivisor(0, 1);
+    try vbobind.attributeDivisor(1, 1);
+    try vbobind.attributeDivisor(2, 1);
+    try vbobind.attributeDivisor(3, 1);
+
+    return .{
+        .program = program,
+        .vao = vao,
+        .ebo = ebo,
+        .vbo = vbo,
+    };
+}
+
+pub fn bind(self: ImageProgram) !Binding {
+    const program = try self.program.use();
+    errdefer program.unbind();
+
+    const vao = try self.vao.bind();
+    errdefer vao.unbind();
+
+    const ebo = try self.ebo.bind(.element_array);
+    errdefer ebo.unbind();
+
+    const vbo = try self.vbo.bind(.array);
+    errdefer vbo.unbind();
+
+    return .{
+        .program = program,
+        .vao = vao,
+        .ebo = ebo,
+        .vbo = vbo,
+    };
+}
+
+pub fn deinit(self: ImageProgram) void {
+    self.vbo.destroy();
+    self.ebo.destroy();
+    self.vao.destroy();
+    self.program.destroy();
+}
+
+pub const Binding = struct {
+    program: gl.Program.Binding,
+    vao: gl.VertexArray.Binding,
+    ebo: gl.Buffer.Binding,
+    vbo: gl.Buffer.Binding,
+
+    pub fn unbind(self: Binding) void {
+        self.vbo.unbind();
+        self.ebo.unbind();
+        self.vao.unbind();
+        self.program.unbind();
+    }
+};

--- a/src/renderer/opengl/image.zig
+++ b/src/renderer/opengl/image.zig
@@ -1,0 +1,220 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const assert = std.debug.assert;
+const gl = @import("opengl");
+
+/// Represents a single image placement on the grid. A placement is a
+/// request to render an instance of an image.
+pub const Placement = struct {
+    /// The image being rendered. This MUST be in the image map.
+    image_id: u32,
+
+    /// The grid x/y where this placement is located.
+    x: u32,
+    y: u32,
+    z: i32,
+
+    /// The width/height of the placed image.
+    width: u32,
+    height: u32,
+
+    /// The offset in pixels from the top left of the cell. This is
+    /// clamped to the size of a cell.
+    cell_offset_x: u32,
+    cell_offset_y: u32,
+
+    /// The source rectangle of the placement.
+    source_x: u32,
+    source_y: u32,
+    source_width: u32,
+    source_height: u32,
+};
+
+/// The map used for storing images.
+pub const ImageMap = std.AutoHashMapUnmanaged(u32, Image);
+
+/// The state for a single image that is to be rendered. The image can be
+/// pending upload or ready to use with a texture.
+pub const Image = union(enum) {
+    /// The image is pending upload to the GPU. The different keys are
+    /// different formats since some formats aren't accepted by the GPU
+    /// and require conversion.
+    ///
+    /// This data is owned by this union so it must be freed once the
+    /// image is uploaded.
+    pending_rgb: Pending,
+    pending_rgba: Pending,
+
+    /// The image is uploaded and ready to be used.
+    ready: gl.Texture,
+
+    /// The image is uploaded but is scheduled to be unloaded.
+    unload_pending: []u8,
+    unload_ready: gl.Texture,
+
+    /// Pending image data that needs to be uploaded to the GPU.
+    pub const Pending = struct {
+        height: u32,
+        width: u32,
+
+        /// Data is always expected to be (width * height * depth). Depth
+        /// is based on the union key.
+        data: [*]u8,
+
+        pub fn dataSlice(self: Pending, d: u32) []u8 {
+            return self.data[0..self.len(d)];
+        }
+
+        pub fn len(self: Pending, d: u32) u32 {
+            return self.width * self.height * d;
+        }
+    };
+
+    pub fn deinit(self: Image, alloc: Allocator) void {
+        switch (self) {
+            .pending_rgb => |p| alloc.free(p.dataSlice(3)),
+            .pending_rgba => |p| alloc.free(p.dataSlice(4)),
+            .unload_pending => |data| alloc.free(data),
+
+            .ready,
+            .unload_ready,
+            => |tex| tex.destroy(),
+        }
+    }
+
+    /// Mark this image for unload whatever state it is in.
+    pub fn markForUnload(self: *Image) void {
+        self.* = switch (self.*) {
+            .unload_pending,
+            .unload_ready,
+            => return,
+
+            .ready => |obj| .{ .unload_ready = obj },
+            .pending_rgb => |p| .{ .unload_pending = p.dataSlice(3) },
+            .pending_rgba => |p| .{ .unload_pending = p.dataSlice(4) },
+        };
+    }
+
+    /// Returns true if this image is pending upload.
+    pub fn isPending(self: Image) bool {
+        return self.pending() != null;
+    }
+
+    /// Returns true if this image is pending an unload.
+    pub fn isUnloading(self: Image) bool {
+        return switch (self) {
+            .unload_pending,
+            .unload_ready,
+            => true,
+
+            .ready,
+            .pending_rgb,
+            .pending_rgba,
+            => false,
+        };
+    }
+
+    /// Converts the image data to a format that can be uploaded to the GPU.
+    /// If the data is already in a format that can be uploaded, this is a
+    /// no-op.
+    pub fn convert(self: *Image, alloc: Allocator) !void {
+        switch (self.*) {
+            .ready,
+            .unload_pending,
+            .unload_ready,
+            => unreachable, // invalid
+
+            .pending_rgba => {}, // ready
+
+            // RGB needs to be converted to RGBA because Metal textures
+            // don't support RGB.
+            .pending_rgb => |*p| {
+                // Note: this is the slowest possible way to do this...
+                const data = p.dataSlice(3);
+                const pixels = data.len / 3;
+                var rgba = try alloc.alloc(u8, pixels * 4);
+                errdefer alloc.free(rgba);
+                var i: usize = 0;
+                while (i < pixels) : (i += 1) {
+                    const data_i = i * 3;
+                    const rgba_i = i * 4;
+                    rgba[rgba_i] = data[data_i];
+                    rgba[rgba_i + 1] = data[data_i + 1];
+                    rgba[rgba_i + 2] = data[data_i + 2];
+                    rgba[rgba_i + 3] = 255;
+                }
+
+                alloc.free(data);
+                p.data = rgba.ptr;
+                self.* = .{ .pending_rgba = p.* };
+            },
+        }
+    }
+
+    /// Upload the pending image to the GPU and change the state of this
+    /// image to ready.
+    pub fn upload(
+        self: *Image,
+        alloc: Allocator,
+    ) !void {
+        // Convert our data if we have to
+        try self.convert(alloc);
+
+        // Get our pending info
+        const p = self.pending().?;
+
+        // Get our format
+        const formats: struct {
+            internal: gl.Texture.InternalFormat,
+            format: gl.Texture.Format,
+        } = switch (self.*) {
+            .pending_rgb => .{ .internal = .rgb, .format = .rgb },
+            .pending_rgba => .{ .internal = .rgba, .format = .rgba },
+            else => unreachable,
+        };
+
+        // Create our texture
+        const tex = try gl.Texture.create();
+        errdefer tex.destroy();
+
+        const texbind = try tex.bind(.@"2D");
+        try texbind.parameter(.WrapS, gl.c.GL_CLAMP_TO_EDGE);
+        try texbind.parameter(.WrapT, gl.c.GL_CLAMP_TO_EDGE);
+        try texbind.parameter(.MinFilter, gl.c.GL_LINEAR);
+        try texbind.parameter(.MagFilter, gl.c.GL_LINEAR);
+        try texbind.image2D(
+            0,
+            formats.internal,
+            @intCast(p.width),
+            @intCast(p.height),
+            0,
+            formats.format,
+            .UnsignedByte,
+            p.data,
+        );
+
+        // Uploaded. We can now clear our data and change our state.
+        self.deinit(alloc);
+        self.* = .{ .ready = tex };
+    }
+
+    /// Our pixel depth
+    fn depth(self: Image) u32 {
+        return switch (self) {
+            .pending_rgb => 3,
+            .pending_rgba => 4,
+            else => unreachable,
+        };
+    }
+
+    /// Returns true if this image is in a pending state and requires upload.
+    fn pending(self: Image) ?Pending {
+        return switch (self) {
+            .pending_rgb,
+            .pending_rgba,
+            => |p| p,
+
+            else => null,
+        };
+    }
+};

--- a/src/renderer/opengl/image.zig
+++ b/src/renderer/opengl/image.zig
@@ -114,52 +114,12 @@ pub const Image = union(enum) {
         };
     }
 
-    /// Converts the image data to a format that can be uploaded to the GPU.
-    /// If the data is already in a format that can be uploaded, this is a
-    /// no-op.
-    pub fn convert(self: *Image, alloc: Allocator) !void {
-        switch (self.*) {
-            .ready,
-            .unload_pending,
-            .unload_ready,
-            => unreachable, // invalid
-
-            .pending_rgba => {}, // ready
-
-            // RGB needs to be converted to RGBA because Metal textures
-            // don't support RGB.
-            .pending_rgb => |*p| {
-                // Note: this is the slowest possible way to do this...
-                const data = p.dataSlice(3);
-                const pixels = data.len / 3;
-                var rgba = try alloc.alloc(u8, pixels * 4);
-                errdefer alloc.free(rgba);
-                var i: usize = 0;
-                while (i < pixels) : (i += 1) {
-                    const data_i = i * 3;
-                    const rgba_i = i * 4;
-                    rgba[rgba_i] = data[data_i];
-                    rgba[rgba_i + 1] = data[data_i + 1];
-                    rgba[rgba_i + 2] = data[data_i + 2];
-                    rgba[rgba_i + 3] = 255;
-                }
-
-                alloc.free(data);
-                p.data = rgba.ptr;
-                self.* = .{ .pending_rgba = p.* };
-            },
-        }
-    }
-
     /// Upload the pending image to the GPU and change the state of this
     /// image to ready.
     pub fn upload(
         self: *Image,
         alloc: Allocator,
     ) !void {
-        // Convert our data if we have to
-        try self.convert(alloc);
-
         // Get our pending info
         const p = self.pending().?;
 

--- a/src/renderer/shaders/image.f.glsl
+++ b/src/renderer/shaders/image.f.glsl
@@ -1,11 +1,11 @@
 #version 330 core
 
-in vec2 tex_coords;
+in vec2 tex_coord;
 
 layout(location = 0) out vec4 out_FragColor;
 
 uniform sampler2D image;
 
 void main() {
-    out_FragColor = texture(image, tex_coords);
+    out_FragColor = texture(image, tex_coord);
 }

--- a/src/renderer/shaders/image.f.glsl
+++ b/src/renderer/shaders/image.f.glsl
@@ -1,0 +1,11 @@
+#version 330 core
+
+in vec2 tex_coords;
+
+layout(location = 0) out vec4 out_FragColor;
+
+uniform sampler2D image;
+
+void main() {
+    out_FragColor = texture(image, tex_coords);
+}

--- a/src/renderer/shaders/image.v.glsl
+++ b/src/renderer/shaders/image.v.glsl
@@ -1,0 +1,44 @@
+#version 330 core
+
+layout (location = 0) in vec2 grid_pos;
+layout (location = 1) in vec2 cell_offset;
+layout (location = 2) in vec4 source_rect;
+layout (location = 3) in vec2 dest_size;
+
+out vec2 tex_coord;
+
+uniform sampler2D image;
+uniform vec2 cell_size;
+uniform mat4 projection;
+
+void main() {
+    // The size of the image in pixels
+    vec2 image_size = textureSize(image, 0);
+
+    // Turn the cell position into a vertex point depending on the
+    // gl_VertexID. Since we use instanced drawing, we have 4 vertices
+    // for each corner of the cell. We can use gl_VertexID to determine
+    // which one we're looking at. Using this, we can use 1 or 0 to keep
+    // or discard the value for the vertex.
+    //
+    // 0 = top-right
+    // 1 = bot-right
+    // 2 = bot-left
+    // 3 = top-left
+    vec2 position;
+    position.x = (gl_VertexID == 0 || gl_VertexID == 1) ? 1. : 0.;
+    position.y = (gl_VertexID == 0 || gl_VertexID == 3) ? 0. : 1.;
+
+    // The texture coordinates start at our source x/y, then add the width/height
+    // as enabled by our instance id, then normalize to [0, 1]
+    tex_coord = source_rect.xy;
+    tex_coord += source_rect.zw * position;
+    tex_coord /= image_size;
+
+    // The position of our image starts at the top-left of the grid cell and
+    // adds the source rect width/height components.
+    vec2 image_pos = (cell_size * grid_pos) + cell_offset;
+    image_pos += dest_size * position;
+
+    gl_Position = projection * vec4(image_pos.xy, 0, 1.0);
+}

--- a/src/terminal/kitty/graphics_exec.zig
+++ b/src/terminal/kitty/graphics_exec.zig
@@ -35,12 +35,6 @@ pub fn execute(
         return null;
     }
 
-    // Only Metal supports rendering the images, right now.
-    if (comptime renderer.Renderer != renderer.Metal) {
-        log.warn("kitty graphics not supported on this renderer", .{});
-        return null;
-    }
-
     log.debug("executing kitty graphics command: quiet={} control={}", .{
         cmd.quiet,
         cmd.control,


### PR DESCRIPTION
This brings Kitty image protocol to OpenGL-based builds. Ghostty has supported Kitty image protocol for a long time (since #317) but I never completed the OpenGL renderer, only the Metal one. This completes that work. 

Not specifically related to this PR but I'll mention it here: I'm noticing a lot of places in the OpenGL renderer for improvement. The OpenGL renderer is _very old_ (some of the first code in Ghostty) and my inexperience with GPUs and Zig show. Since then, I've learned quite a lot more and I'm seeing lots of low hanging fruit. I'll try to do some of it but just noting this as something we can do...

![CleanShot 2023-11-19 at 22 52 29@2x](https://github.com/mitchellh/ghostty/assets/1299/b352ccc5-1496-41c6-94db-6f5747be6f21)
