### PR TITLE
Update some deps for non-mutated var

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,8 +13,8 @@
             .hash = "12202da6b8e9024c653f5d67f55a8065b401c42b3c08b69333d95400fe85d6019a59",
         },
         .zig_objc = .{
-            .url = "https://github.com/mitchellh/zig-objc/archive/a38331cb6ee366b3f22d0068297810ef14c0c400.tar.gz",
-            .hash = "1220dcb34ec79a9b02c46372a41a446212f2366e7c69c8eba68e88f0f25b5ddf475d",
+            .url = "https://github.com/mitchellh/zig-objc/archive/10e552bd37c2f61b9f570d5ceb145165c6f1854b.tar.gz",
+            .hash = "122045926c2a90c61ca2ce907cc83a91ede0d49c989209fff2e2db421a88caf88e91",
         },
         .zig_js = .{
             .url = "https://github.com/mitchellh/zig-js/archive/60ac42ab137461cdba2b38cc6c5e16376470aae6.tar.gz",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .dependencies = .{
         // Zig libs
         .libxev = .{
-            .url = "https://github.com/mitchellh/libxev/archive/1b46c2d6f32754a3029d1863275dd0f877163831.tar.gz",
-            .hash = "12208dc0796bffa6ea9edb60193108e34f835f35fc152e853717aca2b13ba17f3be2",
+            .url = "https://github.com/mitchellh/libxev/archive/a5f8b9851c18d93a79a154004fb0393a1ec55c65.tar.gz",
+            .hash = "1220589dfd60060857bfcee53b0ee0e4175f764ae22d54e46054e2f81b63af1f6636",
         },
         .mach_glfw = .{
             .url = "https://github.com/hexops/mach-glfw/archive/16dc95cc7f74ebbbdd848d9a2c3cc4afc5717708.tar.gz",


### PR DESCRIPTION
This updates some of our dependencies to work with the latest Zig version. This does not fix all problems.