### PR TITLE
apprt/gtk: let GTK titlebar be toggleable

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -79,20 +79,24 @@ pub fn init(self: *Window, app: *App) !void {
     // Use the new GTK4 header bar. We only create a header bar if we have
     // window decorations.
     if (app.config.@"window-decoration") {
-        const header = c.gtk_header_bar_new();
-        c.gtk_window_set_titlebar(gtk_window, header);
-        {
-            const btn = c.gtk_menu_button_new();
-            c.gtk_widget_set_tooltip_text(btn, "Main Menu");
-            c.gtk_menu_button_set_icon_name(@ptrCast(btn), "open-menu-symbolic");
-            c.gtk_menu_button_set_menu_model(@ptrCast(btn), @ptrCast(@alignCast(app.menu)));
-            c.gtk_header_bar_pack_end(@ptrCast(header), btn);
-        }
-        {
-            const btn = c.gtk_button_new_from_icon_name("tab-new-symbolic");
-            c.gtk_widget_set_tooltip_text(btn, "New Tab");
-            c.gtk_header_bar_pack_end(@ptrCast(header), btn);
-            _ = c.g_signal_connect_data(btn, "clicked", c.G_CALLBACK(&gtkTabNewClick), self, null, c.G_CONNECT_DEFAULT);
+        // gtk-titlebar can also be used to disable the header bar (but keep
+        // the window manager's decorations).
+        if (app.config.@"gtk-titlebar") {
+            const header = c.gtk_header_bar_new();
+            c.gtk_window_set_titlebar(gtk_window, header);
+            {
+                const btn = c.gtk_menu_button_new();
+                c.gtk_widget_set_tooltip_text(btn, "Main Menu");
+                c.gtk_menu_button_set_icon_name(@ptrCast(btn), "open-menu-symbolic");
+                c.gtk_menu_button_set_menu_model(@ptrCast(btn), @ptrCast(@alignCast(app.menu)));
+                c.gtk_header_bar_pack_end(@ptrCast(header), btn);
+            }
+            {
+                const btn = c.gtk_button_new_from_icon_name("tab-new-symbolic");
+                c.gtk_widget_set_tooltip_text(btn, "New Tab");
+                c.gtk_header_bar_pack_end(@ptrCast(header), btn);
+                _ = c.g_signal_connect_data(btn, "clicked", c.G_CALLBACK(&gtkTabNewClick), self, null, c.G_CONNECT_DEFAULT);
+            }
         }
     } else {
         // Hide window decoration if configured. This has to happen before

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -472,6 +472,14 @@ keybind: Keybinds = .{},
 /// Currently only supported on macOS.
 @"window-step-resize": bool = false,
 
+/// When enabled, the full GTK titlebar is displayed instead of your window
+/// manager's simple titlebar. The behavior of this option will vary with your
+/// window manager.
+///
+/// This option does nothing when window-decoration is false or when running
+/// under MacOS.
+@"gtk-titlebar": bool = true,
+
 /// Whether to allow programs running in the terminal to read/write to
 /// the system clipboard (OSC 52, for googling). The default is to
 /// allow clipboard reading after prompting the user and allow writing


### PR DESCRIPTION
This adds the `gtk-titlebar` option, which allows you to toggle the GTK titlebar on (default) and off.

Under some circumstances (e.g. tiling WMs with titlebars enabled), one may wish to disable the GTK titlebar/CSD for aesthetic reasons. This allows you to do that.

## Default (on)

![image](https://github.com/mitchellh/ghostty/assets/10704423/961841d3-c087-4582-bcb6-78ab2c9fede8)

## `--gtk-titlebar=false` (off)

![image](https://github.com/mitchellh/ghostty/assets/10704423/4290e59d-0db6-4fef-a682-61125e2d56b4)

Fixes #920.