### PR TITLE
nix: use `-Doptimize=ReleaseFast`

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -27,6 +27,17 @@
 }:
 
 let
+  # The Zig hook has no way to select the release type without actual
+  # overriding of the default flags.
+  #
+  # TODO: Once
+  # https://github.com/ziglang/zig/issues/14281#issuecomment-1624220653 is
+  # ultimately acted on and has made its way to a nixpkgs implementation, this
+  # can probably be removed in favor of that.
+  zig012Hook = zig_0_12.hook.overrideAttrs {
+    zig_default_flags = "-Dcpu=baseline -Doptimize=ReleaseFast";
+  };
+
   # This hash is the computation of the zigCache fixed-output derivation. This
   # allows us to use remote package dependencies without breaking the sandbox.
   #
@@ -82,7 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
     git
     ncurses
     pkg-config
-    zig_0_12.hook
+    zig012Hook
   ];
 
   buildInputs = [


### PR DESCRIPTION
I figured out how to override the hook default build flags so that we can set `-Doptimize=ReleaseFast`. :slightly_smiling_face: 

There's a long conversation that's gone on about this in nixpkgs, but it's fairly well summed up here:
https://github.com/ziglang/zig/issues/14281#issuecomment-1624220653

I'd imagine we will want to adopt whatever is eventually done - after this, we can remove the override and rely on more first-class configuration, or logic in `build.zig`.