### PR TITLE
renderer: handle Kitty images where z < 0 for all placements

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1214,6 +1214,9 @@ fn prepKittyGraphics(
             self.image_text_end = @intCast(i);
         }
     }
+    if (self.image_text_end == 0) {
+        self.image_text_end = @intCast(self.image_placements.items.len);
+    }
 }
 
 /// Update the configuration.

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -839,6 +839,9 @@ fn prepKittyGraphics(
             self.image_text_end = @intCast(i);
         }
     }
+    if (self.image_text_end == 0) {
+        self.image_text_end = @intCast(self.image_placements.items.len);
+    }
 }
 
 /// rebuildCells rebuilds all the GPU cells from our CPU state. This is a


### PR DESCRIPTION
If no placements have `z >= 0` then we were rendering all images as if they were positive.

## Before

![CleanShot 2023-11-20 at 21 35 58@2x](https://github.com/mitchellh/ghostty/assets/1299/b0c93d1b-fb7d-443d-8597-75adf6e899ca)


## After

![CleanShot 2023-11-20 at 21 35 30@2x](https://github.com/mitchellh/ghostty/assets/1299/11ee5769-ca43-477d-981c-a3293a29b3ea)
