### PR TITLE
terminal: switching alt/primary screen invalidates Kitty image state

### DIFF
--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -238,6 +238,9 @@ pub fn alternateScreen(
     // Clear our selection
     self.screen.selection = null;
 
+    // Mark kitty images as dirty so they redraw
+    self.screen.kitty_images.dirty = true;
+
     if (options.clear_on_enter) {
         self.eraseDisplay(alloc, .complete, false);
     }
@@ -268,6 +271,9 @@ pub fn primaryScreen(
 
     // Clear our selection
     self.screen.selection = null;
+
+    // Mark kitty images as dirty so they redraw
+    self.screen.kitty_images.dirty = true;
 
     // Restore the cursor from the primary screen
     if (options.cursor_save) self.restoreCursor();


### PR DESCRIPTION
## Before


https://github.com/mitchellh/ghostty/assets/1299/d050fc2a-4338-4c22-995e-10632ad20b0f



## After

https://github.com/mitchellh/ghostty/assets/1299/f6567101-86b6-4eb7-9dea-9c36eb0fc0a1

