### PR TITLE
nix: update zigCacheHash, mention that building pkg requires src

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,15 @@
       let pkgs = import nixpkgs { inherit overlays system; };
       in rec {
         devShell = pkgs.devShell;
+
+        # NOTE: using packages.ghostty right out of the flake currently
+        # requires a build of LLVM 17 and Zig master from source. This will
+        # take quite a bit of time. Until LLVM 17 and an upcoming Zig 0.12 are
+        # up in nixpkgs, most folks will want to continue to use the devShell
+        # and the instructions found at:
+        #
+        #   https://github.com/mitchellh/ghostty/tree/main#developing-ghostty
+        #
         packages.ghostty = pkgs.ghostty;
         defaultPackage = packages.ghostty;
       }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,3 +1,10 @@
+# NOTE: using this derivation right out of the flake currently requires a build
+# of LLVM 17 and Zig master from source. This will take quite a bit of time.
+# Until LLVM 17 and an upcoming Zig 0.12 are up in nixpkgs, most folks will
+# want to continue to use the devShell and the instructions found at:
+#
+#   https://github.com/mitchellh/ghostty/tree/main#developing-ghostty
+#
 { lib
 , stdenv
 
@@ -50,7 +57,7 @@ let
   # (It's also possible that you might see a hash mismatch - without the
   # network errors - if you don't have a previous instance of the cache
   # derivation in your store already. If so, just update the value as above.)
-  zigCacheHash = "sha256-nfvrGL7CMb8sr9gFhU5GVkN5H+hIxNzMPr2760rV2BM=";
+  zigCacheHash = "sha256-/6XhZq5NYWbHhg0yQ9iT/6oGewsurIpeGNJyNT+E6CQ=";
 
   zigCache = src: stdenv.mkDerivation {
     inherit src;


### PR DESCRIPTION
This updates the `zigCacheHash` and just adds a note mentioning that using the package will require you to rebuild LLVM 17 and Zig, and directs people to use the `devShell` until this is resolved.

This is likely good advice for most people until such time that both are in nixpkgs (or at least LLVM 17 as it's by far the bigger culprit here).