### PR TITLE
apprt/gtk: set default cursor to be "text" (ibeam)

### DIFF
--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -97,7 +97,6 @@ im_len: u7 = 0,
 
 pub fn init(self: *Surface, app: *App, opts: Options) !void {
     const widget = @as(*c.GtkWidget, @ptrCast(opts.gl_area));
-    c.gtk_widget_set_cursor_from_name(@ptrCast(opts.gl_area), "text");
     c.gtk_gl_area_set_required_version(opts.gl_area, 3, 3);
     c.gtk_gl_area_set_has_stencil_buffer(opts.gl_area, 0);
     c.gtk_gl_area_set_has_depth_buffer(opts.gl_area, 0);
@@ -167,6 +166,9 @@ pub fn init(self: *Surface, app: *App, opts: Options) !void {
         .im_context = im_context,
     };
     errdefer self.* = undefined;
+
+    // Set our default mouse shape
+    try self.setMouseShape(.text);
 
     // GL events
     _ = c.g_signal_connect_data(opts.gl_area, "realize", c.G_CALLBACK(&gtkRealize), self, null, c.G_CONNECT_DEFAULT);


### PR DESCRIPTION
Fixes #933

On startup, we'd set the cursor to "text" but we wouldn't store that as our cursor so when the mouse was unhidden, we'd go back to "default". This PR changes it so that on surface startup we set and store the "text" cursor so as the cursor hides/shows it reverts to the proper value.

## Video


https://github.com/mitchellh/ghostty/assets/1299/105c83e5-99ac-4222-aff4-74fe5f022553

