### PR TITLE
terminal: implement OSC 1 (change icon) and ignore it

### DIFF
--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -993,6 +993,10 @@ pub fn Stream(comptime Handler: type) type {
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
 
+                .change_window_icon => |icon| {
+                    log.info("OSC 1 (change icon) received and ignored icon={s}", .{icon});
+                },
+
                 .clipboard_contents => |clip| {
                     if (@hasDecl(T, "clipboardContents")) {
                         try self.handler.clipboardContents(clip.kind, clip.data);


### PR DESCRIPTION
Fixes #948

We want to parse it so we can log at a lower level than warn but we don't want to support this because it isn't very well defined.