### PR TITLE
nix: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,30 @@
+on: [push, pull_request]
+name: Nix
+jobs:
+  check-zig-cache-hash:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Nix
+        uses: cachix/install-nix-action@v23
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: Check Zig cache hash
+        run: nix develop -c ./nix/build-support/check-zig-cache-hash.sh
+  build:
+    needs: check-zig-cache-hash
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Nix
+        uses: cachix/install-nix-action@v23
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: Setup Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          diagnostic-endpoint: "" # disable telemetry
+      - name: Run build
+        run: nix build .

--- a/nix/build-support/check-zig-cache-hash.sh
+++ b/nix/build-support/check-zig-cache-hash.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Nothing in this script should fail.
+set -e
+
+CACHE_HASH_FILE="$(realpath "$(dirname "$0")/../zig_cache_hash.nix")"
+
+help() {
+  echo ""
+  echo "To fix, please (manually) re-run the script from the repository root,"
+  echo "commit, and push the update:"
+  echo ""
+  echo "    ./nix/build-support/check-zig-cache-hash.sh --update"
+  echo "    git add nix/zig_cache_hash.nix"
+  echo "    git commit -m \"nix: update Zig cache hash\""
+  echo "    git push"
+  echo ""
+}
+
+if [ -f "${CACHE_HASH_FILE}" ]; then
+  OLD_CACHE_HASH="$(nix eval --raw --file "${CACHE_HASH_FILE}")"
+elif [ "$1" != "--update" ]; then
+  echo -e "\nERROR: Zig cache hash file missing."
+  help
+  exit 1
+fi
+
+TMP_CACHE_DIR="$(mktemp --directory --suffix nix-zig-cache)"
+# This is not 100% necessary in CI but is helpful when running locally to keep
+# a local workstation clean.
+trap 'rm -rf "${TMP_CACHE_DIR}"' EXIT
+
+# Run Zig and download the cache to the temporary directory.
+zig build --fetch --global-cache-dir "${TMP_CACHE_DIR}"
+
+# Now, calculate the hash.
+ZIG_CACHE_HASH="sha256-$(nix-hash --type sha256 --to-base64 "$(nix-hash --type sha256 "${TMP_CACHE_DIR}")")"
+
+if [ "${OLD_CACHE_HASH}" == "${ZIG_CACHE_HASH}" ]; then
+  echo -e "\nOK: Zig cache store hash unchanged."
+  exit 0
+elif [ "$1" != "--update" ]; then
+  echo -e "\nERROR: The Zig cache store hash has updated."
+  echo ""
+  echo "    * Old hash: ${OLD_CACHE_HASH}"
+  echo "    * New hash: ${ZIG_CACHE_HASH}"
+  help
+  exit 1
+else
+  echo -e "\nNew Zig cache store hash: ${ZIG_CACHE_HASH}"
+fi
+
+# Write out the cache file
+cat > "${CACHE_HASH_FILE}" <<EOS
+# This file is auto-generated! check build-support/check-zig-cache-hash.sh for
+# more details.
+"${ZIG_CACHE_HASH}"
+EOS
+
+echo -e "\nOK: Wrote new hash to file: ${CACHE_HASH_FILE}"

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -57,7 +57,7 @@ let
   # (It's also possible that you might see a hash mismatch - without the
   # network errors - if you don't have a previous instance of the cache
   # derivation in your store already. If so, just update the value as above.)
-  zigCacheHash = "sha256-/6XhZq5NYWbHhg0yQ9iT/6oGewsurIpeGNJyNT+E6CQ=";
+  zigCacheHash = import ./zig_cache_hash.nix;
 
   zigCache = src: stdenv.mkDerivation {
     inherit src;

--- a/nix/zig_cache_hash.nix
+++ b/nix/zig_cache_hash.nix
@@ -1,0 +1,3 @@
+# This file is auto-generated! check build-support/write-zig-cache-hash.sh for
+# more details.
+"sha256-/6XhZq5NYWbHhg0yQ9iT/6oGewsurIpeGNJyNT+E6CQ="


### PR DESCRIPTION
This adds a nix workflow that does the following:

* Checks to see if the Zig cache fixed derivation needs its hash updated. It does this by downloading a new cache, calculating the hash, and comparing it against what has already been set. If the hash is updated, the new hash is committed.
* Runs a Nix build. This runs off of a hash from the last job to ensure it accounts for any updates to the hash during this workflow.

Note that this is currently set to run off of master as repository state can vary in GHA between pull requests from mainline branches and forks. Specifically, in the latter, GHA always seems to checkout as a detached HEAD, which prevent pushes from happening.

The cache workflow we use in the build job comes from:
  https://github.com/DeterminateSystems/magic-nix-cache-action/

Fixes #937.