### PR TITLE
Text action: input any text you want

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2254,6 +2254,39 @@ fn showMouse(self: *Surface) void {
     self.rt_surface.setMouseVisibility(true);
 }
 
+pub fn parseStringLiteral(out: []u8, bytes: []const u8) []u8 {
+    var offset: usize = 0;
+    var index: usize = 0;
+    while (true) {
+        if (index >= bytes.len or offset >= out.len) break;
+        const b = bytes[index];
+        switch (b) {
+            '\\' => {
+                const escape_char_index = index + 1;
+                const result = std.zig.string_literal.parseEscapeSequence(bytes, &index);
+                switch (result) {
+                    .success => |codepoint| {
+                        if (bytes[escape_char_index] == 'u') {
+                            const len = std.unicode.utf8Encode(codepoint, out[offset..]) catch break;
+                            offset += len;
+                        } else {
+                            out[offset] = @as(u8, @intCast(codepoint));
+                            offset += 1;
+                        }
+                    },
+                    .failure => break,
+                }
+            },
+            else => {
+                out[offset] = b;
+                offset += 1;
+                index += 1;
+            },
+        }
+    }
+    return out[0..offset];
+}
+
 /// Perform a binding action. A binding is a keybinding. This function
 /// must be called from the GUI thread.
 ///
@@ -2279,7 +2312,7 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             const full_data = switch (action) {
                 .csi => try std.fmt.bufPrint(&buf, "\x1b[{s}", .{data}),
                 .esc => try std.fmt.bufPrint(&buf, "\x1b{s}", .{data}),
-                .text => data,
+                .text => parseStringLiteral(&buf, data),
                 else => unreachable,
             };
             _ = self.io_thread.mailbox.push(try termio.Message.writeReq(

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2254,39 +2254,6 @@ fn showMouse(self: *Surface) void {
     self.rt_surface.setMouseVisibility(true);
 }
 
-pub fn parseStringLiteral(out: []u8, bytes: []const u8) []u8 {
-    var offset: usize = 0;
-    var index: usize = 0;
-    while (true) {
-        if (index >= bytes.len or offset >= out.len) break;
-        const b = bytes[index];
-        switch (b) {
-            '\\' => {
-                const escape_char_index = index + 1;
-                const result = std.zig.string_literal.parseEscapeSequence(bytes, &index);
-                switch (result) {
-                    .success => |codepoint| {
-                        if (bytes[escape_char_index] == 'u') {
-                            const len = std.unicode.utf8Encode(codepoint, out[offset..]) catch break;
-                            offset += len;
-                        } else {
-                            out[offset] = @as(u8, @intCast(codepoint));
-                            offset += 1;
-                        }
-                    },
-                    .failure => break,
-                }
-            },
-            else => {
-                out[offset] = b;
-                offset += 1;
-                index += 1;
-            },
-        }
-    }
-    return out[0..offset];
-}
-
 /// Perform a binding action. A binding is a keybinding. This function
 /// must be called from the GUI thread.
 ///
@@ -2312,7 +2279,7 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             const full_data = switch (action) {
                 .csi => try std.fmt.bufPrint(&buf, "\x1b[{s}", .{data}),
                 .esc => try std.fmt.bufPrint(&buf, "\x1b{s}", .{data}),
-                .text => parseStringLiteral(&buf, data),
+                .text => data,
                 else => unreachable,
             };
             _ = self.io_thread.mailbox.push(try termio.Message.writeReq(

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2254,39 +2254,6 @@ fn showMouse(self: *Surface) void {
     self.rt_surface.setMouseVisibility(true);
 }
 
-pub fn parseStringLiteral(out: []u8, bytes: []const u8) []u8 {
-    var offset: usize = 0;
-    var index: usize = 0;
-    while (true) {
-        if (index >= bytes.len or offset >= out.len) break;
-        const b = bytes[index];
-        switch (b) {
-            '\\' => {
-                const escape_char_index = index + 1;
-                const result = std.zig.string_literal.parseEscapeSequence(bytes, &index);
-                switch (result) {
-                    .success => |codepoint| {
-                        if (bytes[escape_char_index] == 'u') {
-                            const len = std.unicode.utf8Encode(codepoint, out[offset..]) catch break;
-                            offset += len;
-                        } else {
-                            out[offset] = @as(u8, @intCast(codepoint));
-                            offset += 1;
-                        }
-                    },
-                    .failure => break,
-                }
-            },
-            else => {
-                out[offset] = b;
-                offset += 1;
-                index += 1;
-            },
-        }
-    }
-    return out[0..offset];
-}
-
 /// Perform a binding action. A binding is a keybinding. This function
 /// must be called from the GUI thread.
 ///
@@ -2312,7 +2279,10 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             const full_data = switch (action) {
                 .csi => try std.fmt.bufPrint(&buf, "\x1b[{s}", .{data}),
                 .esc => try std.fmt.bufPrint(&buf, "\x1b{s}", .{data}),
-                .text => parseStringLiteral(&buf, data),
+                .text => configpkg.string.parse(&buf, data) catch |err| {
+                    log.warn("error parsing text binding text={s} err={}", .{ data, err });
+                    return true;
+                },
                 else => unreachable,
             };
             _ = self.io_thread.mailbox.push(try termio.Message.writeReq(

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2271,7 +2271,7 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
 
         .reload_config => try self.app.reloadConfig(self.rt_app),
 
-        .csi, .esc, .text => |data| {
+        .csi, .esc => |data| {
             // We need to send the CSI/ESC sequence as a single write request.
             // If you split it across two then the shell can interpret it
             // as two literals.
@@ -2279,10 +2279,6 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             const full_data = switch (action) {
                 .csi => try std.fmt.bufPrint(&buf, "\x1b[{s}", .{data}),
                 .esc => try std.fmt.bufPrint(&buf, "\x1b{s}", .{data}),
-                .text => configpkg.string.parse(&buf, data) catch |err| {
-                    log.warn("error parsing text binding text={s} err={}", .{ data, err });
-                    return true;
-                },
                 else => unreachable,
             };
             _ = self.io_thread.mailbox.push(try termio.Message.writeReq(
@@ -2292,6 +2288,34 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             try self.io_thread.wakeup.notify();
 
             // CSI/ESC triggers a scroll.
+            {
+                self.renderer_state.mutex.lock();
+                defer self.renderer_state.mutex.unlock();
+                self.scrollToBottom() catch |err| {
+                    log.warn("error scrolling to bottom err={}", .{err});
+                };
+            }
+        },
+
+        .text => |data| {
+            // For text we always allocate just because its easier to
+            // handle all cases that way.
+            var buf = try self.alloc.alloc(u8, data.len);
+            defer self.alloc.free(buf);
+            const text = configpkg.string.parse(buf, data) catch |err| {
+                log.warn(
+                    "error parsing text binding text={s} err={}",
+                    .{ data, err },
+                );
+                return true;
+            };
+            _ = self.io_thread.mailbox.push(try termio.Message.writeReq(
+                self.alloc,
+                text,
+            ), .{ .forever = {} });
+            try self.io_thread.wakeup.notify();
+
+            // Text triggers a scroll.
             {
                 self.renderer_state.mutex.lock();
                 defer self.renderer_state.mutex.unlock();

--- a/src/config.zig
+++ b/src/config.zig
@@ -2,6 +2,7 @@ const builtin = @import("builtin");
 
 pub usingnamespace @import("config/key.zig");
 pub const Config = @import("config/Config.zig");
+pub const string = @import("config/string.zig");
 
 // Field types
 pub const CopyOnSelect = Config.CopyOnSelect;

--- a/src/config/string.zig
+++ b/src/config/string.zig
@@ -1,0 +1,67 @@
+const std = @import("std");
+
+/// Parse a string literal into a byte array. The string can contain
+/// any valid Zig string literal escape sequences.
+///
+/// The output buffer never needs sto be larger than the input buffer.
+/// The buffers may alias.
+pub fn parse(out: []u8, bytes: []const u8) ![]u8 {
+    var dst_i: usize = 0;
+    var src_i: usize = 0;
+    while (src_i < bytes.len) {
+        if (dst_i >= out.len) return error.OutOfMemory;
+
+        // If this byte is not beginning an escape sequence we copy.
+        const b = bytes[src_i];
+        if (b != '\\') {
+            out[dst_i] = b;
+            dst_i += 1;
+            src_i += 1;
+            continue;
+        }
+
+        // Parse the escape sequence
+        switch (std.zig.string_literal.parseEscapeSequence(
+            bytes,
+            &src_i,
+        )) {
+            .failure => return error.InvalidString,
+            .success => |cp| dst_i += try std.unicode.utf8Encode(
+                cp,
+                out[dst_i..],
+            ),
+        }
+    }
+
+    return out[0..dst_i];
+}
+
+test "parse: empty" {
+    const testing = std.testing;
+
+    var buf: [128]u8 = undefined;
+    const result = try parse(&buf, "");
+    try testing.expectEqualStrings("", result);
+}
+
+test "parse: no escapes" {
+    const testing = std.testing;
+
+    var buf: [128]u8 = undefined;
+    const result = try parse(&buf, "hello world");
+    try testing.expectEqualStrings("hello world", result);
+}
+
+test "parse: escapes" {
+    const testing = std.testing;
+
+    var buf: [128]u8 = undefined;
+    {
+        const result = try parse(&buf, "hello\\nworld");
+        try testing.expectEqualStrings("hello\nworld", result);
+    }
+    {
+        const result = try parse(&buf, "hello\\u{1F601}world");
+        try testing.expectEqualStrings("hello\u{1F601}world", result);
+    }
+}

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -134,7 +134,10 @@ pub const Action = union(enum) {
     /// Send an ESC sequence.
     esc: []const u8,
 
-    // Send the given text. Uses Zig string literal syntax.
+    // Send the given text. Uses Zig string literal syntax. The maximum
+    // length of the string is 128 bytes. This is currently not validated.
+    // If the text is invalid (i.e. contains an invalid escape sequence),
+    // the error will currently only show up in logs.
     text: []const u8,
 
     /// Send data to the pty depending on whether cursor key mode is

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -134,10 +134,10 @@ pub const Action = union(enum) {
     /// Send an ESC sequence.
     esc: []const u8,
 
-    // Send the given text. Uses Zig string literal syntax. The maximum
-    // length of the string is 128 bytes. This is currently not validated.
-    // If the text is invalid (i.e. contains an invalid escape sequence),
-    // the error will currently only show up in logs.
+    // Send the given text. Uses Zig string literal syntax. This is
+    // currently not validated. If the text is invalid (i.e. contains
+    // an invalid escape sequence), the error will currently only show
+    // up in logs.
     text: []const u8,
 
     /// Send data to the pty depending on whether cursor key mode is

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -134,6 +134,9 @@ pub const Action = union(enum) {
     /// Send an ESC sequence.
     esc: []const u8,
 
+    // Send the given text. Uses Zig string literal syntax.
+    text: []const u8,
+
     /// Send data to the pty depending on whether cursor key mode is
     /// enabled ("application") or disabled ("normal").
     cursor_key: CursorKey,

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -321,47 +321,6 @@ pub const Action = union(enum) {
         };
     }
 
-    // Use Zig syntax to parse a string literal.
-    // Since the escaping syntax is verbose, we can do the parsing inplace.
-    pub fn parseStringLiteralInPlace(bytes: []const u8) []const u8 {
-        var out: [128]u8 = undefined;
-        var offset: usize = 0;
-        var index: usize = 0;
-        while (true) {
-            assert(offset <= index);
-            if (index >= bytes.len or offset >= out.len) break;
-            const b = bytes[index];
-            switch (b) {
-                '\\' => {
-                    const escape_char_index = index + 1;
-                    const result = std.zig.string_literal.parseEscapeSequence(bytes, &index);
-                    switch (result) {
-                        .success => |codepoint| {
-                            if (bytes[escape_char_index] == 'u') {
-                                const len = std.unicode.utf8Encode(codepoint, out[offset..]) catch break;
-                                offset += len;
-                            } else {
-                                out[offset] = @as(u8, @intCast(codepoint));
-                                offset += 1;
-                            }
-                        },
-                        .failure => break,
-                    }
-                },
-                else => {
-                    out[offset] = b;
-                    offset += 1;
-                    index += 1;
-                },
-            }
-        }
-        // No escaping => no copy needed.
-        if (offset == index and index == bytes.len) return bytes;
-        const mut_bytes: []u8 = @as([*]u8, @ptrFromInt(@intFromPtr(bytes.ptr)))[0..offset];
-        @memcpy(mut_bytes, out[0..offset]);
-        return mut_bytes;
-    }
-
     /// Parse an action in the format of "key=value" where key is the
     /// action name and value is the action parameter. The parameter
     /// is optional depending on the action.
@@ -387,10 +346,7 @@ pub const Action = union(enum) {
 
                     []const u8 => {
                         const idx = colonIdx orelse return Error.InvalidFormat;
-                        const param = if (std.mem.eql(u8, field.name, "text"))
-                            parseStringLiteralInPlace(input[idx + 1 ..])
-                        else
-                            input[idx + 1 ..];
+                        const param = input[idx + 1 ..];
                         return @unionInit(Action, field.name, param);
                     },
 
@@ -895,12 +851,6 @@ test "parse: action with string" {
         const binding = try parse("a=esc:A");
         try testing.expect(binding.action == .esc);
         try testing.expectEqualStrings("A", binding.action.esc);
-    }
-    // parameter
-    {
-        const binding = try parse("a=text:\\x03\\u{26a1}");
-        try testing.expect(binding.action == .text);
-        try testing.expectEqualStrings(binding.action.text, &[_]u8{ 3, 0xe2, 0x9a, 0xa1 });
     }
 }
 


### PR DESCRIPTION
Implementation of #902 
I'm using zig parser code to parse the string, which allows to input any byte to the terminal such as `0x3` aka `ctrl+c`.

The first commit is doing the parsing on every key press,
the second is doing the parsing once when parsing the config. Since the parsing is 0-allocation I had to rewrite the string in place.
If you don't like that I'll drop the commit and stick with the first version.