### PR TITLE
key-encode: only set associated text when there is printable text

### DIFF
--- a/src/input/KeyEncoder.zig
+++ b/src/input/KeyEncoder.zig
@@ -607,17 +607,16 @@ const KittyMods = packed struct(u8) {
         };
     }
 
-    /// Returns true if the modifiers prevent printable text
+    /// Returns true if the modifiers prevent printable text.
+    ///
+    /// Note on macOS: this logic alone is not enough, since you must
+    /// consider macos_option_as_alt. See the Kitty encoder for more details.
     pub fn preventsText(self: KittyMods) bool {
-        if (self.alt or
+        return self.alt or
             self.ctrl or
             self.super or
             self.hyper or
-            self.meta)
-        {
-            return true;
-        }
-        return false;
+            self.meta;
     }
 
     /// Returns the raw int value of this packed struct.


### PR DESCRIPTION
Associated text should only be sent to the terminal when printable text
is generated from the keypress. Prevent sending associated text when any
modifier is pressed, except for Shift, NumLock, and Capslock

This brings Ghostty inline with the output of Kitty.
