### PR TITLE
workflows: disable nix build job

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -12,19 +12,21 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Check Zig cache hash
         run: nix develop -c ./nix/build-support/check-zig-cache-hash.sh
-  build:
-    needs: check-zig-cache-hash
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Setup Nix
-        uses: cachix/install-nix-action@v23
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
-        with:
-          diagnostic-endpoint: "" # disable telemetry
-      - name: Run build
-        run: nix build .
+#
+# NOTE: Build is disabled until we resolve dependency build speeds.
+#   build:
+#     needs: check-zig-cache-hash
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Checkout code
+#         uses: actions/checkout@v4
+#       - name: Setup Nix
+#         uses: cachix/install-nix-action@v23
+#         with:
+#           nix_path: nixpkgs=channel:nixos-unstable
+#       - name: Setup Nix cache
+#         uses: DeterminateSystems/magic-nix-cache-action@main
+#         with:
+#           diagnostic-endpoint: "" # disable telemetry
+#       - name: Run build
+#         run: nix build .


### PR DESCRIPTION
Unfortunately building LLVM/Zig is much too slow on default GHA, so we will need to keep this off until we don't need to do that.