### PR TITLE
Surface: clear selection on all key input, not just text-generated

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1249,11 +1249,11 @@ pub fn keyCallback(
 
     // If our event is any keypress that isn't a modifier and we generated
     // some data to send to the pty, then we move the viewport down to the
-    // bottom. If we generated literal text, then we also clear the selection.
+    // bottom. Clear the selection as well.
     if (!event.key.modifier()) {
         self.renderer_state.mutex.lock();
         defer self.renderer_state.mutex.unlock();
-        if (event.utf8.len > 0) self.setSelection(null);
+        self.setSelection(null);
         try self.io.terminal.scrollViewport(.{ .bottom = {} });
         try self.queueRender();
     }


### PR DESCRIPTION
This removes the check to see if a keypress generated any UTF8 data before clearing the selection.

This means that *any* keypress that is a non-modifier, sent to the terminal, now clears the selection, which should resolve a number of situations where selection was not being properly cleared (e.g. vim with `set mouse=""`, `less`, and shell history navigation).