### PR TITLE
Preserve cursor shape when over a link

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1252,7 +1252,11 @@ pub fn keyCallback(
         event.physical_key == .right_shift)
     {
         switch (event.action) {
-            .press => try self.rt_surface.setMouseShape(.text),
+            .press => if (!self.mouse.over_link) {
+                // If the cursor is over a link then the pointer shape takes
+                // priority
+                try self.rt_surface.setMouseShape(.text);
+            },
             .release => try self.rt_surface.setMouseShape(self.io.terminal.mouse_shape),
             .repeat => {},
         }


### PR DESCRIPTION
Fixes: https://github.com/mitchellh/ghostty/issues/974

If mouse events are active and the cursor is hovered over a link, pressing Shift does not change the cursor to a pointer, but to the text selection shape, until the cursor is moved again. The pointer shape should have higher priority over the text selection shape when the cursor is hovered over a pointer.
