### PR TITLE
Surface: set crosshair, change event processing logic for mouse tracking

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -881,23 +881,23 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
     // Fonts
     try result.keybind.set.put(
         alloc,
-        .{ .key = .equal, .mods = ctrlOrSuper(.{}) },
+        .{ .key = .equal, .mods = inputpkg.ctrlOrSuper(.{}) },
         .{ .increase_font_size = 1 },
     );
     try result.keybind.set.put(
         alloc,
-        .{ .key = .minus, .mods = ctrlOrSuper(.{}) },
+        .{ .key = .minus, .mods = inputpkg.ctrlOrSuper(.{}) },
         .{ .decrease_font_size = 1 },
     );
     try result.keybind.set.put(
         alloc,
-        .{ .key = .zero, .mods = ctrlOrSuper(.{}) },
+        .{ .key = .zero, .mods = inputpkg.ctrlOrSuper(.{}) },
         .{ .reset_font_size = {} },
     );
 
     try result.keybind.set.put(
         alloc,
-        .{ .key = .j, .mods = ctrlOrSuper(.{ .shift = true }) },
+        .{ .key = .j, .mods = inputpkg.ctrlOrSuper(.{ .shift = true }) },
         .{ .write_scrollback_file = {} },
     );
 
@@ -1098,14 +1098,14 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
     // Toggle fullscreen
     try result.keybind.set.put(
         alloc,
-        .{ .key = .enter, .mods = ctrlOrSuper(.{}) },
+        .{ .key = .enter, .mods = inputpkg.ctrlOrSuper(.{}) },
         .{ .toggle_fullscreen = {} },
     );
 
     // Toggle zoom a split
     try result.keybind.set.put(
         alloc,
-        .{ .key = .enter, .mods = ctrlOrSuper(.{ .shift = true }) },
+        .{ .key = .enter, .mods = inputpkg.ctrlOrSuper(.{ .shift = true }) },
         .{ .toggle_split_zoom = {} },
     );
 
@@ -1287,21 +1287,6 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
     });
 
     return result;
-}
-
-/// This sets either "ctrl" or "super" to true (but not both)
-/// on mods depending on if the build target is Mac or not. On
-/// Mac, we default to super (i.e. super+c for copy) and on
-/// non-Mac we default to ctrl (i.e. ctrl+c for copy).
-fn ctrlOrSuper(mods: inputpkg.Mods) inputpkg.Mods {
-    var copy = mods;
-    if (comptime builtin.target.isDarwin()) {
-        copy.super = true;
-    } else {
-        copy.ctrl = true;
-    }
-
-    return copy;
 }
 
 /// Load configuration from an iterator that yields values that look like

--- a/src/main.zig
+++ b/src/main.zig
@@ -313,6 +313,7 @@ test {
     _ = @import("termio.zig");
     _ = @import("input.zig");
     _ = @import("cli.zig");
+    _ = @import("surface_mouse.zig");
 
     // Libraries
     _ = @import("segmented_pool.zig");

--- a/src/surface_mouse.zig
+++ b/src/surface_mouse.zig
@@ -1,0 +1,302 @@
+/// SurfaceMouse represents mouse helper functionality for the core surface.
+///
+/// It's currently small in scope; its purpose is to isolate mouse logic that
+/// has gotten a bit complex (e.g. pointer shape handling for key events), but
+/// the intention is to grow it later so that we can better test said logic).
+const SurfaceMouse = @This();
+
+const std = @import("std");
+const builtin = @import("builtin");
+const input = @import("input.zig");
+const apprt = @import("apprt.zig");
+const terminal = @import("terminal/main.zig");
+const MouseShape = @import("terminal/mouse_shape.zig").MouseShape;
+
+/// For processing key events; the key that was physically pressed on the
+/// keyboard.
+physical_key: input.Key,
+
+/// The mouse event tracking mode, if any.
+mouse_event: terminal.Terminal.MouseEvents,
+
+/// The current terminal's mouse shape.
+mouse_shape: MouseShape,
+
+/// The last mods state when the last mouse button (whatever it was) was
+/// pressed or release.
+mods: input.Mods,
+
+/// True if the mouse position is currently over a link.
+over_link: bool,
+
+/// Translates key state to mouse shape (cursor) state, based on a state
+/// machine.
+///
+/// There are 4 current states:
+///
+/// * text: starting state, displays a text bar.
+/// * default: default state when in a mouse tracking mode. (e.g. vim, etc).
+///   Displays an arrow pointer.
+/// * pointer: default state when over a link. Displays a pointing finger.
+/// * crosshair: any above state can transition to this when the rectangle
+///   select keys are pressed (ctrl/super+alt).
+///
+/// Additionally, default can transition back to text if one of the shift keys
+/// are pressed during mouse tracking mode.
+///
+/// Any secondary state transitions back to its default state when the
+/// appropriate keys are released.
+///
+/// null is returned when the mouse shape does not need changing.
+pub fn keyToMouseShape(self: SurfaceMouse) ?MouseShape {
+    // Filter for appropriate key events
+    if (!eligibleMouseShapeKeyEvent(self.physical_key)) return null;
+
+    // Exception: link hover overrides any other shape processing currently and
+    // does not change state.
+    //
+    // TODO: As we unravel mouse state, we can fix this to be more explicit.
+    if (self.over_link) {
+        return null;
+    }
+
+    // Set our current default state
+    var current_shape_state: MouseShape = undefined;
+    if (self.mouse_event != .none) {
+        // In mouse tracking mode, should be default (arrow pointer)
+        current_shape_state = .default;
+    } else {
+        // Default terminal mode, should be text (text bar)
+        current_shape_state = .text;
+    }
+
+    // Transition table.
+    //
+    // TODO: This could be updated eventually to be a true transition table if
+    // we move to a full stateful mouse surface, e.g. very specific inputs
+    // transitioning state based on previous state, versus flags like "is the
+    // mouse over a link", etc.
+    switch (current_shape_state) {
+        .default => {
+            if (isMouseModeOverrideState(self.mods) and isRectangleSelectState(self.mods)) {
+                // Crosshair (rectangle select), only set if we are also
+                // overriding (e.g. shift+ctrl+alt)
+                return .crosshair;
+            } else if (isMouseModeOverrideState(self.mods)) {
+                // Normal override state
+                return .text;
+            } else {
+                return .default;
+            }
+        },
+
+        .text => {
+            if (isRectangleSelectState(self.mods)) {
+                // Crosshair (rectangle select)
+                return .crosshair;
+            } else {
+                return .text;
+            }
+        },
+
+        // Fall back on default state
+        else => unreachable,
+    }
+}
+
+fn eligibleMouseShapeKeyEvent(physical_key: input.Key) bool {
+    return physical_key.ctrlOrSuper() or
+        physical_key.leftOrRightShift() or
+        physical_key.leftOrRightAlt();
+}
+
+fn isRectangleSelectState(mods: input.Mods) bool {
+    return mods.ctrlOrSuper() and mods.alt;
+}
+
+fn isMouseModeOverrideState(mods: input.Mods) bool {
+    return mods.shift;
+}
+
+test "keyToMouseShape" {
+    const testing = std.testing;
+
+    {
+        // No specific key pressed
+        const m: SurfaceMouse = .{
+            .physical_key = .invalid,
+            .mouse_event = .none,
+            .mouse_shape = .progress,
+            .mods = .{},
+            .over_link = false,
+        };
+
+        const got = m.keyToMouseShape();
+        try testing.expect(got == null);
+    }
+
+    {
+        // Over a link. NOTE: This tests that we don't touch the inbound state,
+        // not necessarily if we're over a link.
+        const m: SurfaceMouse = .{
+            .physical_key = .left_shift,
+            .mouse_event = .none,
+            .mouse_shape = .progress,
+            .mods = .{},
+            .over_link = true,
+        };
+
+        const got = m.keyToMouseShape();
+        try testing.expect(got == null);
+    }
+
+    {
+        // default, no mods (mouse tracking)
+        const m: SurfaceMouse = .{
+            .physical_key = .left_shift,
+            .mouse_event = .x10,
+            .mouse_shape = .default,
+            .mods = .{},
+            .over_link = false,
+        };
+
+        const want: MouseShape = .default;
+        const got = m.keyToMouseShape();
+        try testing.expect(want == got);
+    }
+
+    {
+        // default -> crosshair (mouse tracking)
+        const m: SurfaceMouse = .{
+            .physical_key = .left_alt,
+            .mouse_event = .x10,
+            .mouse_shape = .default,
+            .mods = .{ .ctrl = true, .super = true, .alt = true, .shift = true },
+            .over_link = false,
+        };
+
+        const want: MouseShape = .crosshair;
+        const got = m.keyToMouseShape();
+        try testing.expect(want == got);
+    }
+
+    {
+        // default -> text (mouse tracking)
+        const m: SurfaceMouse = .{
+            .physical_key = .left_shift,
+            .mouse_event = .x10,
+            .mouse_shape = .default,
+            .mods = .{ .shift = true },
+            .over_link = false,
+        };
+
+        const want: MouseShape = .text;
+        const got = m.keyToMouseShape();
+        try testing.expect(want == got);
+    }
+
+    {
+        // crosshair -> text (mouse tracking)
+        const m: SurfaceMouse = .{
+            .physical_key = .left_alt,
+            .mouse_event = .x10,
+            .mouse_shape = .crosshair,
+            .mods = .{ .shift = true },
+            .over_link = false,
+        };
+
+        const want: MouseShape = .text;
+        const got = m.keyToMouseShape();
+        try testing.expect(want == got);
+    }
+
+    {
+        // crosshair -> default (mouse tracking)
+        const m: SurfaceMouse = .{
+            .physical_key = .left_alt,
+            .mouse_event = .x10,
+            .mouse_shape = .crosshair,
+            .mods = .{},
+            .over_link = false,
+        };
+
+        const want: MouseShape = .default;
+        const got = m.keyToMouseShape();
+        try testing.expect(want == got);
+    }
+
+    {
+        // text -> crosshair (mouse tracking)
+        const m: SurfaceMouse = .{
+            .physical_key = .left_alt,
+            .mouse_event = .x10,
+            .mouse_shape = .text,
+            .mods = .{ .ctrl = true, .super = true, .alt = true, .shift = true },
+            .over_link = false,
+        };
+
+        const want: MouseShape = .crosshair;
+        const got = m.keyToMouseShape();
+        try testing.expect(want == got);
+    }
+
+    {
+        // text -> default (mouse tracking)
+        const m: SurfaceMouse = .{
+            .physical_key = .left_shift,
+            .mouse_event = .x10,
+            .mouse_shape = .text,
+            .mods = .{},
+            .over_link = false,
+        };
+
+        const want: MouseShape = .default;
+        const got = m.keyToMouseShape();
+        try testing.expect(want == got);
+    }
+
+    {
+        // text, no mods (no mouse tracking)
+        const m: SurfaceMouse = .{
+            .physical_key = .left_shift,
+            .mouse_event = .none,
+            .mouse_shape = .text,
+            .mods = .{},
+            .over_link = false,
+        };
+
+        const want: MouseShape = .text;
+        const got = m.keyToMouseShape();
+        try testing.expect(want == got);
+    }
+
+    {
+        // text -> crosshair (no mouse tracking)
+        const m: SurfaceMouse = .{
+            .physical_key = .left_alt,
+            .mouse_event = .none,
+            .mouse_shape = .text,
+            .mods = .{ .ctrl = true, .super = true, .alt = true },
+            .over_link = false,
+        };
+
+        const want: MouseShape = .crosshair;
+        const got = m.keyToMouseShape();
+        try testing.expect(want == got);
+    }
+
+    {
+        // crosshair -> text (no mouse tracking)
+        const m: SurfaceMouse = .{
+            .physical_key = .left_alt,
+            .mouse_event = .none,
+            .mouse_shape = .crosshair,
+            .mods = .{},
+            .over_link = false,
+        };
+
+        const want: MouseShape = .text;
+        const got = m.keyToMouseShape();
+        try testing.expect(want == got);
+    }
+}


### PR DESCRIPTION
This work is mainly targeted at adding the crosshair for when ctrl/super+alt is pressed. We also add this for when mouse tracking is enabled so that we show the crosshair when ctrl/super+alt+shift is pressed at the same time.

I've also changed the event processing logic here because the amount of keys we have to process has greatly increased. Instead of processing each individual event, we now process the modifier state.

Additionally, some refactoring has been done geared at starting to re-work the mouse for the core surface into a something stateful. My hope is that we can continue to unravel some of this from the core
surface so that we can process key inputs, motion events, and anything else relevant as inputs to transitions for shape display, click behavior, etc.

This commit now also moves the `ctrlOrSuper` handlers to respective parts in the `Key` hierarchy, while also adding additional helpers for other modifiers.