### PR TITLE
Minimum Contrast Configuration

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -199,6 +199,13 @@ foreground: Color = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF },
 /// colors. The contrast ratio is a value between 1 and 21. A value of
 /// 1 allows for no contrast (i.e. black on black). This value is
 /// the contrast ratio as defined by the WCAG 2.0 specification.
+///
+/// If you want to avoid invisible text (same color as background),
+/// a value of 1.1 is a good value. If you want to avoid text that is
+/// difficult to read, a value of 3 or higher is a good value. The higher
+/// the value, the more likely that text will become black or white.
+///
+/// This value does not apply to Emoji or images.
 @"minimum-contrast": f64 = 1,
 
 /// Color palette for the 256 color form that many terminal applications

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -195,6 +195,12 @@ foreground: Color = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF },
 /// the selection color will vary across the selection.
 @"selection-invert-fg-bg": bool = false,
 
+/// The minimum contrast ratio between the foreground and background
+/// colors. The contrast ratio is a value between 1 and 21. A value of
+/// 1 allows for no contrast (i.e. black on black). This value is
+/// the contrast ratio as defined by the WCAG 2.0 specification.
+@"minimum-contrast": f64 = 1,
+
 /// Color palette for the 256 color form that many terminal applications
 /// use. The syntax of this configuration is "N=HEXCODE" where "n"
 /// is 0 to 255 (for the 256 colors) and HEXCODE is a typical RGB
@@ -1568,6 +1574,9 @@ pub fn finalize(self: *Config) !void {
 
     // Clamp our split opacity
     self.@"unfocused-split-opacity" = @min(1.0, @max(0.15, self.@"unfocused-split-opacity"));
+
+    // Clamp our contrast
+    self.@"minimum-contrast" = @min(21, @max(1, self.@"minimum-contrast"));
 
     // Minimmum window size
     if (self.@"window-width" > 0) self.@"window-width" = @max(10, self.@"window-width");

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1667,7 +1667,7 @@ pub fn updateCell(
     const alpha: u8 = if (cell.attrs.faint) 175 else 255;
 
     // If the cell has a background, we always draw it.
-    if (colors.bg) |rgb| {
+    const bg: [4]u8 = if (colors.bg) |rgb| bg: {
         // Determine our background alpha. If we have transparency configured
         // then this is dynamic depending on some situations. This is all
         // in an attempt to make transparency look the best for various
@@ -1701,8 +1701,11 @@ pub fn updateCell(
             .grid_pos = .{ @as(f32, @floatFromInt(x)), @as(f32, @floatFromInt(y)) },
             .cell_width = cell.widthLegacy(),
             .color = .{ rgb.r, rgb.g, rgb.b, bg_alpha },
+            .bg_color = .{ 0, 0, 0, 0 },
         });
-    }
+
+        break :bg .{ rgb.r, rgb.g, rgb.b, bg_alpha };
+    } else .{ 0, 0, 0, 0 };
 
     // If the cell has a character, draw it
     if (cell.char > 0) {
@@ -1729,6 +1732,7 @@ pub fn updateCell(
             .grid_pos = .{ @as(f32, @floatFromInt(x)), @as(f32, @floatFromInt(y)) },
             .cell_width = cell.widthLegacy(),
             .color = .{ colors.fg.r, colors.fg.g, colors.fg.b, alpha },
+            .bg_color = bg,
             .glyph_pos = .{ glyph.atlas_x, glyph.atlas_y },
             .glyph_size = .{ glyph.width, glyph.height },
             .glyph_offset = .{ glyph.offset_x, glyph.offset_y },
@@ -1759,6 +1763,7 @@ pub fn updateCell(
             .grid_pos = .{ @as(f32, @floatFromInt(x)), @as(f32, @floatFromInt(y)) },
             .cell_width = cell.widthLegacy(),
             .color = .{ color.r, color.g, color.b, alpha },
+            .bg_color = bg,
             .glyph_pos = .{ glyph.atlas_x, glyph.atlas_y },
             .glyph_size = .{ glyph.width, glyph.height },
             .glyph_offset = .{ glyph.offset_x, glyph.offset_y },
@@ -1771,6 +1776,7 @@ pub fn updateCell(
             .grid_pos = .{ @as(f32, @floatFromInt(x)), @as(f32, @floatFromInt(y)) },
             .cell_width = cell.widthLegacy(),
             .color = .{ colors.fg.r, colors.fg.g, colors.fg.b, alpha },
+            .bg_color = bg,
         });
     }
 
@@ -1834,6 +1840,7 @@ fn addCursor(
         },
         .cell_width = if (wide) 2 else 1,
         .color = .{ color.r, color.g, color.b, alpha },
+        .bg_color = .{ 0, 0, 0, 0 },
         .glyph_pos = .{ glyph.atlas_x, glyph.atlas_y },
         .glyph_size = .{ glyph.width, glyph.height },
         .glyph_offset = .{ glyph.offset_x, glyph.offset_y },
@@ -1886,6 +1893,7 @@ fn addPreeditCell(
         .grid_pos = .{ @as(f32, @floatFromInt(x)), @as(f32, @floatFromInt(y)) },
         .cell_width = if (cp.wide) 2 else 1,
         .color = .{ bg.r, bg.g, bg.b, 255 },
+        .bg_color = .{ bg.r, bg.g, bg.b, 255 },
     });
 
     // Add our text
@@ -1894,6 +1902,7 @@ fn addPreeditCell(
         .grid_pos = .{ @as(f32, @floatFromInt(x)), @as(f32, @floatFromInt(y)) },
         .cell_width = if (cp.wide) 2 else 1,
         .color = .{ fg.r, fg.g, fg.b, 255 },
+        .bg_color = .{ bg.r, bg.g, bg.b, 255 },
         .glyph_pos = .{ glyph.atlas_x, glyph.atlas_y },
         .glyph_size = .{ glyph.width, glyph.height },
         .glyph_offset = .{ glyph.offset_x, glyph.offset_y },

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -95,6 +95,7 @@ pub const Cell = extern struct {
     glyph_size: [2]u32 = .{ 0, 0 },
     glyph_offset: [2]i32 = .{ 0, 0 },
     color: [4]u8,
+    bg_color: [4]u8,
     cell_width: u8,
 
     pub const Mode = enum(u8) {
@@ -399,6 +400,17 @@ fn initCellPipeline(device: objc.Object, library: objc.Object) !objc.Object {
 
             attr.setProperty("format", @intFromEnum(mtl.MTLVertexFormat.uchar4));
             attr.setProperty("offset", @as(c_ulong, @offsetOf(Cell, "color")));
+            attr.setProperty("bufferIndex", @as(c_ulong, 0));
+        }
+        {
+            const attr = attrs.msgSend(
+                objc.Object,
+                objc.sel("objectAtIndexedSubscript:"),
+                .{@as(c_ulong, 7)},
+            );
+
+            attr.setProperty("format", @intFromEnum(mtl.MTLVertexFormat.uchar4));
+            attr.setProperty("offset", @as(c_ulong, @offsetOf(Cell, "bg_color")));
             attr.setProperty("bufferIndex", @as(c_ulong, 0));
         }
         {

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -126,6 +126,10 @@ pub const Uniforms = extern struct {
     /// Metrics for underline/strikethrough
     strikethrough_position: f32,
     strikethrough_thickness: f32,
+
+    /// The minimum contrast ratio for text. The contrast ratio is calculated
+    /// according to the WCAG 2.0 spec.
+    min_contrast: f32,
 };
 
 /// The uniforms used for custom postprocess shaders.

--- a/src/renderer/opengl/CellProgram.zig
+++ b/src/renderer/opengl/CellProgram.zig
@@ -29,11 +29,17 @@ pub const Cell = extern struct {
     glyph_offset_x: i32 = 0,
     glyph_offset_y: i32 = 0,
 
-    /// vec4 fg_color_in
+    /// vec4 color_in
     r: u8,
     g: u8,
     b: u8,
     a: u8,
+
+    /// vec4 bg_color_in
+    bg_r: u8,
+    bg_g: u8,
+    bg_b: u8,
+    bg_a: u8,
 
     /// uint mode
     mode: CellMode,
@@ -105,9 +111,11 @@ pub fn init() !CellProgram {
     offset += 2 * @sizeOf(i32);
     try vbobind.attributeAdvanced(4, 4, gl.c.GL_UNSIGNED_BYTE, false, @sizeOf(Cell), offset);
     offset += 4 * @sizeOf(u8);
-    try vbobind.attributeIAdvanced(5, 1, gl.c.GL_UNSIGNED_BYTE, @sizeOf(Cell), offset);
-    offset += 1 * @sizeOf(u8);
+    try vbobind.attributeAdvanced(5, 4, gl.c.GL_UNSIGNED_BYTE, false, @sizeOf(Cell), offset);
+    offset += 4 * @sizeOf(u8);
     try vbobind.attributeIAdvanced(6, 1, gl.c.GL_UNSIGNED_BYTE, @sizeOf(Cell), offset);
+    offset += 1 * @sizeOf(u8);
+    try vbobind.attributeIAdvanced(7, 1, gl.c.GL_UNSIGNED_BYTE, @sizeOf(Cell), offset);
     try vbobind.enableAttribArray(0);
     try vbobind.enableAttribArray(1);
     try vbobind.enableAttribArray(2);
@@ -115,6 +123,7 @@ pub fn init() !CellProgram {
     try vbobind.enableAttribArray(4);
     try vbobind.enableAttribArray(5);
     try vbobind.enableAttribArray(6);
+    try vbobind.enableAttribArray(7);
     try vbobind.attributeDivisor(0, 1);
     try vbobind.attributeDivisor(1, 1);
     try vbobind.attributeDivisor(2, 1);
@@ -122,6 +131,7 @@ pub fn init() !CellProgram {
     try vbobind.attributeDivisor(4, 1);
     try vbobind.attributeDivisor(5, 1);
     try vbobind.attributeDivisor(6, 1);
+    try vbobind.attributeDivisor(7, 1);
 
     return .{
         .program = program,

--- a/src/renderer/shaders/cell.metal
+++ b/src/renderer/shaders/cell.metal
@@ -168,7 +168,14 @@ vertex VertexOut uber_vertex(
     // (between 0.0 and 1.0) and must be done in the fragment shader.
     out.tex_coord = float2(input.glyph_pos) + float2(input.glyph_size) * position;
 
-    out.color = contrasted_color(uniforms.min_contrast, out.color, float4(input.bg_color) / 255.0f);
+    // If we have a minimum contrast, we need to check if we need to
+    // change the color of the text to ensure it has enough contrast
+    // with the background.
+    if (uniforms.min_contrast > 1.0f && input.mode == MODE_FG) {
+      float4 bg_color = float4(input.bg_color) / 255.0f;
+      out.color = contrasted_color(uniforms.min_contrast, out.color, bg_color);
+    }
+
     break;
   }
 

--- a/src/renderer/shaders/cell.metal
+++ b/src/renderer/shaders/cell.metal
@@ -13,6 +13,7 @@ struct Uniforms {
   float2 cell_size;
   float strikethrough_position;
   float strikethrough_thickness;
+  float min_contrast;
 };
 
 struct VertexIn {
@@ -29,7 +30,11 @@ struct VertexIn {
   // the text color. For styles, this is the color of the style.
   uchar4 color [[ attribute(5) ]];
 
-  // The fields below are present only when rendering text.
+  // The fields below are present only when rendering text (fg mode)
+
+  // The background color of the cell. This is used to determine if
+  // we need to render the text with a different color to ensure
+  // contrast.
   uchar4 bg_color [[ attribute(7) ]];
 
   // The position of the glyph in the texture (x,y)
@@ -79,13 +84,17 @@ float contrast_ratio(float3 color1, float3 color2) {
   return (max(l1, l2) + 0.05f) / (min(l1, l2) + 0.05f);
 }
 
-float4 contrasted_color(float4 fg, float4 bg) {
+// Return the fg if the contrast ratio is greater than min, otherwise
+// return a color that satisfies the contrast ratio. Currently, the color
+// is always white or black, whichever has the highest contrast ratio.
+float4 contrasted_color(float min, float4 fg, float4 bg) {
     float3 fg_premult = fg.rgb * fg.a;
     float3 bg_premult = bg.rgb * bg.a;
     float ratio = contrast_ratio(fg_premult, bg_premult);
-    if (ratio <= 3.0f) {
-        float ratio = contrast_ratio(float3(1.0f), bg_premult);
-        if (ratio > 3.0f) {
+    if (ratio < min) {
+        float white_ratio = contrast_ratio(float3(1.0f), bg_premult);
+        float black_ratio = contrast_ratio(float3(0.0f), bg_premult);
+        if (white_ratio > black_ratio) {
             return float4(1.0f);
         } else {
             return float4(0.0f, 0.0f, 0.0f, 1.0f);
@@ -159,7 +168,7 @@ vertex VertexOut uber_vertex(
     // (between 0.0 and 1.0) and must be done in the fragment shader.
     out.tex_coord = float2(input.glyph_pos) + float2(input.glyph_size) * position;
 
-    out.color = contrasted_color(out.color, float4(input.bg_color) / 255.0f);
+    out.color = contrasted_color(uniforms.min_contrast, out.color, float4(input.bg_color) / 255.0f);
     break;
   }
 


### PR DESCRIPTION
Fixes #354 

This adds a new configuration `minimum-contrast` that takes a [WCAG contrast ratio](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast) value. Any cells that have a fg/bg less than this ratio will be adjusted. 

For those unfamiliar, the WCAG contrast ratio is a value between 1 and 21. The value of "1" disables any minimum contrast. Any values above 5 or 6 really force most colors to change. A reasonable value is really more like 2 or 3. Floating point value are accepted too, so if you just want to avoid matching colors, a value of 1.1 will work.

In this PR, the adjusted color is always white or black, whichever provides more contrast. This is because calculating a more optimal color is harder and I couldn't find a straightforward, guaranteed fast algorithm to do it. There probably is one, I'm not an expert at this. I noticed that Kitty also simply uses white or black, too.

The contrast calculations are all done in shaders on the GPU. I didn't heavily benchmark this but my assumption (hopefully not totally wrong) is that these sorts of calculations are easy for a GPU, and this allows every cell to calculate their contrast ratios and colors in parallel (up to shader core counts at least).

## Demo 1: Red on Red

This text would typically be invisible, but with `minimum-contrast = 1.1`:

![CleanShot 2023-12-01 at 22 02 10@2x](https://github.com/mitchellh/ghostty/assets/1299/f432aede-5b5b-4a18-8afa-a77667b41f1d)

## Demo 2: Extreme Contrast

`htop` with `minimum-contrast = 20` basically forces all text to be white or black:

![CleanShot 2023-12-01 at 22 02 46@2x](https://github.com/mitchellh/ghostty/assets/1299/834f78c6-3d9a-4319-a911-58a3098c3165)
