### PR TITLE
font: faces use primary grid metrics to better line up glyphs

### DIFF
--- a/src/font/face.zig
+++ b/src/font/face.zig
@@ -71,10 +71,11 @@ pub const Variation = struct {
 
 /// Additional options for rendering glyphs.
 pub const RenderOptions = struct {
-    /// The maximum height of the glyph. If this is set, then any glyph
-    /// larger than this height will be shrunk to this height. The scaling
-    /// is typically naive, but ultimately up to the rasterizer.
-    max_height: ?u16 = null,
+    /// The metrics that are defining the grid layout. These are usually
+    /// the metrics of the primary font face. The grid metrics are used
+    /// by the font face to better layout the glyph in situations where
+    /// the font is not exactly the same size as the grid.
+    grid_metrics: ?Metrics = null,
 
     /// The number of grid cells this glyph will take up. This can be used
     /// optionally by the rasterizer to better layout the glyph.

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -386,7 +386,9 @@ pub const Face = struct {
         const offset_y: i32 = offset_y: {
             // Our Y coordinate in 3D is (0, 0) bottom left, +y is UP.
             // We need to calculate our baseline from the bottom of a cell.
-            const baseline_from_bottom: f64 = @floatFromInt(self.metrics.cell_baseline);
+            //const baseline_from_bottom: f64 = @floatFromInt(self.metrics.cell_baseline);
+            const metrics = opts.grid_metrics orelse self.metrics;
+            const baseline_from_bottom: f64 = @floatFromInt(metrics.cell_baseline);
 
             // Next we offset our baseline by the bearing in the font. We
             // ADD here because CoreText y is UP.


### PR DESCRIPTION
Fixes #895

Every loaded font face calculates metrics for itself. One of the important metrics is the baseline to "sit" the glyph on top of. Prior to this commit, each rasterized glyph would sit on its own calculated baseline. However, this leads to off-center rendering when the font being rasterized isn't the font that defines the terminal grid.

This commit passes in the font metrics for the font defining the terminal grid to all font rasterization requests. This can then be used by non-primary fonts to sit the glyph according to the primary grid.

## Before

Notice the Chinese characters.

<img width="815" alt="image" src="https://github.com/mitchellh/ghostty/assets/1299/5771105b-90a6-4005-b76d-499aea116bbe">

## After

<img width="914" alt="image" src="https://github.com/mitchellh/ghostty/assets/1299/b90a8635-cd4c-47c6-8a9f-694982f7194b">
