### PR TITLE
nix: update nixpkgs-zig-0-12

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -178,11 +178,11 @@
     },
     "nixpkgs-zig-0-12": {
       "locked": {
-        "lastModified": 1701456770,
-        "narHash": "sha256-LsgT/0lG6y8zx8igjK756jF5oG6jMTzu5co/PZ22Af8=",
+        "lastModified": 1701575450,
+        "narHash": "sha256-I3hNRC+3F9RI0YL0YSUpmibCPKr+prCSJ2FWW5cuekA=",
         "owner": "vancluever",
         "repo": "nixpkgs",
-        "rev": "6531bc2e5ae7e409fcb044c609840ffca83737e4",
+        "rev": "fd803506dbed295c45931f4f5938c28e3484dee7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Just updates the input so that we're on the same Zig nightly as zig-overlay (#983).