### PR TITLE
ci: use Cirrus macOS VMs

### DIFF
--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -31,7 +31,7 @@ jobs:
         )
       }}
 
-    runs-on: macos-12
+    runs-on: ghcr.io/cirruslabs/macos-sonoma-xcode:latest
     timeout-minutes: 90
     env:
       # Needed for macos SDK

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -31,7 +31,7 @@ jobs:
         )
       }}
 
-    runs-on: ghcr.io/cirruslabs/macos-sonoma-xcode:latest
+    runs-on: ghcr.io/cirruslabs/macos-ventura-xcode:latest
     timeout-minutes: 90
     env:
       # Needed for macos SDK

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         run: nix develop -c zig build -Dstatic=true -Dapp-runtime=glfw -Dtarget=${{ matrix.target }}
 
   build-macos:
-    runs-on: macos-12
+    runs-on: ghcr.io/cirruslabs/macos-sonoma-xcode:latest
     needs: test
     env:
       # Needed for macos SDK

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         run: nix develop -c zig build -Dstatic=true -Dapp-runtime=glfw -Dtarget=${{ matrix.target }}
 
   build-macos:
-    runs-on: ghcr.io/cirruslabs/macos-sonoma-xcode:latest
+    runs-on: ghcr.io/cirruslabs/macos-ventura-xcode:latest
     needs: test
     env:
       # Needed for macos SDK


### PR DESCRIPTION
Switches our macOS machines from GitHub hosted to [Cirrus](https://cirrus-ci.org) (but using their GHA compatible product). These are available at a flat rate per concurrent run per month rather than per minute and are also more than twice as fast it appears. I recently started going over my quota for GHA (well past the free tier, I set a billing quota) so I wanted to look into alternatives.