### PR TITLE
remove length limit on preedit text, handle widths larger than screen

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1434,10 +1434,13 @@ fn rebuildCells(
     const preedit_range: ?struct {
         y: usize,
         x: [2]usize,
+        cp_offset: usize,
     } = if (preedit) |preedit_v| preedit: {
+        const range = preedit_v.range(screen.cursor.x, screen.cols - 1);
         break :preedit .{
             .y = screen.cursor.y,
-            .x = preedit_v.range(screen.cursor.x, screen.cols - 1),
+            .x = .{ range.start, range.end },
+            .cp_offset = range.cp_offset,
         };
     } else null;
 
@@ -1583,7 +1586,7 @@ fn rebuildCells(
         if (preedit) |preedit_v| {
             const range = preedit_range.?;
             var x = range.x[0];
-            for (preedit_v.codepoints) |cp| {
+            for (preedit_v.codepoints[range.cp_offset..]) |cp| {
                 self.addPreeditCell(cp, x, range.y) catch |err| {
                     log.warn("error building preedit cell, will be invalid x={} y={}, err={}", .{
                         x,

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -632,6 +632,14 @@ pub fn updateFrame(
             cursor_blink_visible,
         );
 
+        // Get our preedit state
+        const preedit: ?renderer.State.Preedit = preedit: {
+            if (cursor_style == null) break :preedit null;
+            const p = state.preedit orelse break :preedit null;
+            break :preedit try p.clone(self.alloc);
+        };
+        errdefer if (preedit) |p| p.deinit(self.alloc);
+
         // If we have Kitty graphics data, we enter a SLOW SLOW SLOW path.
         // We only do this if the Kitty image state is dirty meaning only if
         // it changes.
@@ -644,11 +652,14 @@ pub fn updateFrame(
             .selection = selection,
             .screen = screen_copy,
             .mouse = state.mouse,
-            .preedit = if (cursor_style != null) state.preedit else null,
+            .preedit = preedit,
             .cursor_style = cursor_style,
         };
     };
-    defer critical.screen.deinit();
+    defer {
+        critical.screen.deinit();
+        if (critical.preedit) |p| p.deinit(self.alloc);
+    }
 
     // Build our GPU cells
     try self.rebuildCells(
@@ -1572,7 +1583,7 @@ fn rebuildCells(
         if (preedit) |preedit_v| {
             const range = preedit_range.?;
             var x = range.x[0];
-            for (preedit_v.codepoints[0..preedit_v.len]) |cp| {
+            for (preedit_v.codepoints) |cp| {
                 self.addPreeditCell(cp, x, range.y) catch |err| {
                     log.warn("error building preedit cell, will be invalid x={} y={}, err={}", .{
                         x,

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -697,6 +697,14 @@ pub fn updateFrame(
             cursor_blink_visible,
         );
 
+        // Get our preedit state
+        const preedit: ?renderer.State.Preedit = preedit: {
+            if (cursor_style == null) break :preedit null;
+            const p = state.preedit orelse break :preedit null;
+            break :preedit try p.clone(self.alloc);
+        };
+        errdefer if (preedit) |p| p.deinit(self.alloc);
+
         // If we have Kitty graphics data, we enter a SLOW SLOW SLOW path.
         // We only do this if the Kitty image state is dirty meaning only if
         // it changes.
@@ -709,11 +717,14 @@ pub fn updateFrame(
             .selection = selection,
             .screen = screen_copy,
             .mouse = state.mouse,
-            .preedit = if (cursor_style != null) state.preedit else null,
+            .preedit = preedit,
             .cursor_style = cursor_style,
         };
     };
-    defer critical.screen.deinit();
+    defer {
+        critical.screen.deinit();
+        if (critical.preedit) |p| p.deinit(self.alloc);
+    }
 
     // Grab our draw mutex if we have it and update our data
     {
@@ -1083,7 +1094,7 @@ pub fn rebuildCells(
         if (preedit) |preedit_v| {
             const range = preedit_range.?;
             var x = range.x[0];
-            for (preedit_v.codepoints[0..preedit_v.len]) |cp| {
+            for (preedit_v.codepoints) |cp| {
                 self.addPreeditCell(cp, x, range.y) catch |err| {
                     log.warn("error building preedit cell, will be invalid x={} y={}, err={}", .{
                         x,

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -954,10 +954,13 @@ pub fn rebuildCells(
     const preedit_range: ?struct {
         y: usize,
         x: [2]usize,
+        cp_offset: usize,
     } = if (preedit) |preedit_v| preedit: {
+        const range = preedit_v.range(screen.cursor.x, screen.cols - 1);
         break :preedit .{
             .y = screen.cursor.y,
-            .x = preedit_v.range(screen.cursor.x, screen.cols - 1),
+            .x = .{ range.start, range.end },
+            .cp_offset = range.cp_offset,
         };
     } else null;
 
@@ -1094,7 +1097,7 @@ pub fn rebuildCells(
         if (preedit) |preedit_v| {
             const range = preedit_range.?;
             var x = range.x[0];
-            for (preedit_v.codepoints) |cp| {
+            for (preedit_v.codepoints[range.cp_offset..]) |cp| {
                 self.addPreeditCell(cp, x, range.y) catch |err| {
                     log.warn("error building preedit cell, will be invalid x={} y={}, err={}", .{
                         x,

--- a/src/renderer/State.zig
+++ b/src/renderer/State.zig
@@ -38,11 +38,8 @@ pub const Mouse = struct {
 
 /// The pre-edit state. See Surface.preeditCallback for more information.
 pub const Preedit = struct {
-    /// The codepoints to render as preedit text. We allow up to 16 codepoints
-    /// as a sort of arbitrary limit. If we experience a realisitic use case
-    /// where we need more please open an issue.
-    codepoints: [16]Codepoint = undefined,
-    len: u8 = 0,
+    /// The codepoints to render as preedit text.
+    codepoints: []Codepoint,
 
     /// A single codepoint to render as preedit text.
     pub const Codepoint = struct {
@@ -50,10 +47,22 @@ pub const Preedit = struct {
         wide: bool = false,
     };
 
+    /// Deinit this preedit that was cre
+    pub fn deinit(self: *const Preedit, alloc: Allocator) void {
+        alloc.free(self.codepoints);
+    }
+
+    /// Allocate a copy of this preedit in the given allocator..
+    pub fn clone(self: *const Preedit, alloc: Allocator) !Preedit {
+        return .{
+            .codepoints = try alloc.dupe(Codepoint, self.codepoints),
+        };
+    }
+
     /// The width in cells of all codepoints in the preedit.
     pub fn width(self: *const Preedit) usize {
         var result: usize = 0;
-        for (self.codepoints[0..self.len]) |cp| {
+        for (self.codepoints) |cp| {
             result += if (cp.wide) 2 else 1;
         }
 

--- a/src/renderer/State.zig
+++ b/src/renderer/State.zig
@@ -39,7 +39,7 @@ pub const Mouse = struct {
 /// The pre-edit state. See Surface.preeditCallback for more information.
 pub const Preedit = struct {
     /// The codepoints to render as preedit text.
-    codepoints: []Codepoint,
+    codepoints: []const Codepoint = &.{},
 
     /// A single codepoint to render as preedit text.
     pub const Codepoint = struct {


### PR DESCRIPTION
Fixes #882, two issues:

 - Allows preedit text longer than 16 characters by heap allocating preedits. Before, when text exceeded this the preedit state was cleared and the text was lost. 
 - Properly handles preedits that are wider than our screen. Before they would be rendered off the edge of the screen and not be visible to the user. Additionally, the preedit completion window would be off the edge of the window.

## Before

https://github.com/mitchellh/ghostty/assets/1299/be323dee-2d22-4076-b573-75edc5d9891b

## After

https://github.com/mitchellh/ghostty/assets/1299/208d7c86-087a-4ffc-8491-c78522e47a3f

