### PR TITLE
terminal: implement mode 1047 (alternate screen)

### DIFF
--- a/src/terminal/modes.zig
+++ b/src/terminal/modes.zig
@@ -209,6 +209,7 @@ const entries: []const ModeEntry = &.{
     .{ .name = "alt_esc_prefix", .value = 1036, .default = true },
     .{ .name = "alt_sends_escape", .value = 1039 },
     .{ .name = "reverse_wrap_extended", .value = 1045 },
+    .{ .name = "alt_screen", .value = 1047 },
     .{ .name = "alt_screen_save_cursor_clear_enter", .value = 1049 },
     .{ .name = "bracketed_paste", .value = 2004 },
     .{ .name = "synchronized_output", .value = 2026 },

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1772,6 +1772,21 @@ const StreamHandler = struct {
                 self.terminal.scrolling_region.right = self.terminal.cols - 1;
             },
 
+            .alt_screen => {
+                const opts: terminal.Terminal.AlternateScreenOptions = .{
+                    .cursor_save = false,
+                    .clear_on_enter = false,
+                };
+
+                if (enabled)
+                    self.terminal.alternateScreen(self.alloc, opts)
+                else
+                    self.terminal.primaryScreen(self.alloc, opts);
+
+                // Schedule a render since we changed screens
+                try self.queueRender();
+            },
+
             .alt_screen_save_cursor_clear_enter => {
                 const opts: terminal.Terminal.AlternateScreenOptions = .{
                     .cursor_save = true,


### PR DESCRIPTION
Implement handling of mode 1047, which enters the alternate screen. This
is not used often, typically applications will favor 1049 (enter alt
screen, save cursor, clear alt screen).
