### PR TITLE
gtk: add support for resizing splits via keybinds

### DIFF
--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -153,7 +153,10 @@ pub const Container = union(enum) {
 
     /// Returns the first split with the given orientation, walking upwards in
     /// the tree.
-    pub fn firstSplitWithOrientation(self: Container, orientation: Split.Orientation) ?*Split {
+    pub fn firstSplitWithOrientation(
+        self: Container,
+        orientation: Split.Orientation,
+    ) ?*Split {
         return switch (self) {
             .none, .tab_ => null,
             .split_tl, .split_br => split: {
@@ -573,10 +576,9 @@ pub fn gotoSplit(self: *const Surface, direction: input.SplitFocusDirection) voi
 }
 
 pub fn resizeSplit(self: *const Surface, direction: input.SplitResizeDirection, amount: u16) void {
-    const s = self.container.firstSplitWithOrientation(switch (direction) {
-        .up, .down => .vertical,
-        .left, .right => .horizontal,
-    }) orelse return;
+    const s = self.container.firstSplitWithOrientation(
+        Split.Orientation.fromResizeDirection(direction),
+    ) orelse return;
     s.moveDivider(direction, amount);
 }
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -977,6 +977,28 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
             .{ .goto_split = .right },
         );
 
+        // Resizing splits
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .up, .mods = .{ .super = true, .ctrl = true, .shift = true } },
+            .{ .resize_split = .{ .up, 10 } },
+        );
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .down, .mods = .{ .super = true, .ctrl = true, .shift = true } },
+            .{ .resize_split = .{ .down, 10 } },
+        );
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .left, .mods = .{ .super = true, .ctrl = true, .shift = true } },
+            .{ .resize_split = .{ .left, 10 } },
+        );
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .right, .mods = .{ .super = true, .ctrl = true, .shift = true } },
+            .{ .resize_split = .{ .right, 10 } },
+        );
+
         // Viewport scrolling
         try result.keybind.set.put(
             alloc,


### PR DESCRIPTION
This adds support for resizing splits via keybinds to the GTK runtime.

Code is straightforward. I couldn't see a way to do it without keeping track of the orientation of the splits, but I think that's fine.

## Demo


https://github.com/mitchellh/ghostty/assets/1185253/a5129229-9dad-4e12-959a-9cc30c5a8c1e

