### PR TITLE
Add packages.default property

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,7 @@
         #   https://github.com/mitchellh/ghostty/tree/main#developing-ghostty
         #
         packages.ghostty = pkgs.ghostty;
+        packages.default = packages.ghostty;
         defaultPackage = packages.ghostty;
       }
     );


### PR DESCRIPTION
This is useful for doing `nix run $flakeref` and other nix tools (it will use #default if you don't specify the package/app/etc)