### PR TITLE
terminal: support `58;5` for setting underline color via 256 palette

### DIFF
--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -515,6 +515,11 @@ pub fn setAttribute(self: *Terminal, attr: sgr.Attribute) !void {
             };
         },
 
+        .@"256_underline_color" => |idx| {
+            self.screen.cursor.pen.attrs.underline_color = true;
+            self.screen.cursor.pen.underline_fg = self.color_palette.colors[idx];
+        },
+
         .reset_underline_color => {
             self.screen.cursor.pen.attrs.underline_color = false;
         },

--- a/src/terminal/sgr.zig
+++ b/src/terminal/sgr.zig
@@ -34,6 +34,7 @@ pub const Attribute = union(enum) {
     underline: Underline,
     reset_underline: void,
     underline_color: color.RGB,
+    @"256_underline_color": u8,
     reset_underline_color: void,
 
     /// Blink the text
@@ -253,6 +254,11 @@ pub const Parser = struct {
                         .b = @truncate(rgb[2]),
                     },
                 };
+            } else if (slice.len >= 3 and slice[1] == 5) {
+                self.idx += 2;
+                return Attribute{
+                    .@"256_underline_color" = @truncate(slice[2]),
+                };
             },
 
             59 => return Attribute{ .reset_underline_color = {} },
@@ -462,6 +468,13 @@ test "sgr: 256 color" {
     var p: Parser = .{ .params = &[_]u16{ 38, 5, 161, 48, 5, 236 } };
     try testing.expect(p.next().? == .@"256_fg");
     try testing.expect(p.next().? == .@"256_bg");
+    try testing.expect(p.next() == null);
+}
+
+test "sgr: 256 color underline" {
+    var p: Parser = .{ .params = &[_]u16{ 58, 5, 9 } };
+    try testing.expect(p.next().? == .@"256_underline_color");
+    try testing.expect(p.next() == null);
 }
 
 test "sgr: 24-bit bg color" {

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -577,6 +577,7 @@ pub fn Stream(comptime Handler: type) type {
                 // SGR - Select Graphic Rendition
                 'm' => switch (action.intermediates.len) {
                     0 => if (@hasDecl(T, "setAttribute")) {
+                        // log.info("parse SGR params={any}", .{action.params});
                         var p: sgr.Parser = .{ .params = action.params, .colon = action.sep == .colon };
                         while (p.next()) |attr| {
                             // log.info("SGR attribute: {}", .{attr});


### PR DESCRIPTION
Fixes #1013

## Before

```sh
#!/usr/bin/env bash
printf "\x1b[4:3m"
printf "\x1b[58;5;32m"
printf "hello"
printf "\x1b[59m"
printf "\x1b[0m"
echo
```

![CleanShot 2023-12-07 at 14 59 57@2x](https://github.com/mitchellh/ghostty/assets/1299/20ba4819-853a-4509-8ed7-8aa6d1b95211)


## After

![CleanShot 2023-12-07 at 14 59 15@2x](https://github.com/mitchellh/ghostty/assets/1299/45e98922-5fb3-434a-bf94-897d4e1b9229)
