### PR TITLE
Selection: fix bottom-right/top-left rectangle selections

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2300,13 +2300,11 @@ fn dragLeftClickDouble(
         self.setSelection(.{
             .start = word_current.start,
             .end = word_start.end,
-            .rectangle = ctrlOrSuper(self.mouse.mods) and self.mouse.mods.alt,
         });
     } else {
         self.setSelection(.{
             .start = word_start.start,
             .end = word_current.end,
-            .rectangle = ctrlOrSuper(self.mouse.mods) and self.mouse.mods.alt,
         });
     }
 }
@@ -2409,7 +2407,7 @@ fn dragLeftClickSingle(
         //   - Inverse logic for a point after the start.
         const click_point = self.mouse.left_click_point;
         const start: terminal.point.ScreenPoint = if (screen_point.before(click_point)) start: {
-            if (cell_start_xpos >= cell_xboundary) {
+            if ((ctrlOrSuper(self.mouse.mods) and self.mouse.mods.alt) or cell_start_xpos >= cell_xboundary) {
                 break :start click_point;
             } else {
                 break :start if (click_point.x > 0) terminal.point.ScreenPoint{
@@ -2421,7 +2419,7 @@ fn dragLeftClickSingle(
                 };
             }
         } else start: {
-            if (cell_start_xpos < cell_xboundary) {
+            if ((ctrlOrSuper(self.mouse.mods) and self.mouse.mods.alt) or cell_start_xpos < cell_xboundary) {
                 break :start click_point;
             } else {
                 break :start if (click_point.x < self.io.terminal.screen.cols - 1) terminal.point.ScreenPoint{


### PR DESCRIPTION
This fixes an issue where selections from the bottom-right to the top-left (or top-left to bottom-right), in addition to some single-line rectangle selections, were not working.

This works by handling situations where only one of the x or y axes in the start or end points may need to be flipped to get the correct top-left or bottom-right of a selection. We call these kinds of orientations "mirrored", like you were looking in a mirror.

This also adds a small bit of logic that keeps these kinds of motions in rectangle selection from selecting the character before (or after) it. This has the current side-effect of anchoring a rectangle selection to the original characters if you change directions during the selection, something I will look at in a later commit.

Finally, this also removes rectangle select on double-click. I thought this might be a good idea, but word select in rectangle mode really does not work (the effect seems pretty erratic), and it's not implemented in Kitty either.

Fixes #1008.


https://github.com/mitchellh/ghostty/assets/10704423/bd1e1259-d46a-4e3a-93e0-f6248dbc4fc4

