### PR TITLE
macos: manually show window to handle mission control behavior

### DIFF
--- a/macos/Sources/Features/Terminal/Terminal.xib
+++ b/macos/Sources/Features/Terminal/Terminal.xib
@@ -13,7 +13,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="👻 Ghostty" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g" customClass="TerminalWindow" customModule="Ghostty" customModuleProvider="target">
+        <window title="👻 Ghostty" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="QvC-M9-y7g" customClass="TerminalWindow" customModule="Ghostty" customModuleProvider="target">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="0.0" y="0.0" width="800" height="600"/>


### PR DESCRIPTION
Fixes #1018
Fixes #1020

This disables the "visibleAtLaunch" configuration in the xib and manually shows the window when it loads. This lets us carefully control what happens particularly when a window is full screen (native) and part of Mission Control.

Previously, the behavior depended on the Settings.app "Prefer tabs when opening documents" setting, but we didn't handle every behavior correctly (see #1018 and #1020). I couldn't find a way to robustly handle all cases because there are no published macOS APIs for interacting with Mission Control...

Plus, terminals aren't really "documents" so it did confuse at least one user that Ghostty would follow this configuration. We just incidently did because we use native tabbing.

This PR takes full control into our own hands. Our behavior is now:

  - If a new window is created from a native fullscreen window, the new window is created into native fullscreen.

  - If a new tab is created from a native fullscreen window, the tab is added to the existing window and does not create a new space.

  - If a window or tab is created from a non-fullscreen window, the existing behaviors remain.
