### PR TITLE
nix: Update nixpkgs-zig-0-12 source

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
     },
     "nixpkgs-zig-0-12": {
       "locked": {
-        "lastModified": 1701575450,
-        "narHash": "sha256-I3hNRC+3F9RI0YL0YSUpmibCPKr+prCSJ2FWW5cuekA=",
+        "lastModified": 1702064370,
+        "narHash": "sha256-iwET6dhyYTVQsoPD8FNDjrXC00S3scCMPfopQ09SI+o=",
         "owner": "vancluever",
         "repo": "nixpkgs",
-        "rev": "fd803506dbed295c45931f4f5938c28e3484dee7",
+        "rev": "f474ae77d1f841a198ab505599a61e837ad82741",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,8 +9,8 @@
     # system glibc that the user is building for.
     nixpkgs-stable.url = "github:nixos/nixpkgs/release-23.05";
 
-    # This is a nixpkgs mirror (based off of nixos-unstable) that contains
-    # patches for LLVM 17 and Zig 0.12 (master/nightly).
+    # This is a nixpkgs mirror (based off of master) that contains
+    # patches for Zig 0.12 (master/nightly).
     #
     # This gives an up-to-date Zig that contains the nixpkgs patches,
     # specifically the ones relating to NativeTargetInfo


### PR DESCRIPTION
With the nixpkgs LLVM 17 PR (NixOS/nixpkgs#258614) now merged, we can update this flake input to base off of master so that we can take advantage of the built LLVM derivation when it's ready.

This only leaves Zig 0.12 which should mean a much reduced build time.

Note that of this writing, the derivations are still queued, so until that happens, this update means a rebuild of LLVM 17 for anyone using the ghostty package.