### PR TITLE
README.md: Fix broken link to devShell.nix file

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,7 +502,7 @@ run this from the repo root before you commit:
 prettier --write .
 ```
 
-Make sure your Prettier version matches the version of in [devshell.nix](https://github.com/mitchellh/ghostty/blob/main/nix/devshell.nix).
+Make sure your Prettier version matches the version of in [devShell.nix](https://github.com/mitchellh/ghostty/blob/main/nix/devShell.nix).
 
 ### Nix Package
 


### PR DESCRIPTION
GitHub is apparently case-sensitive for this kind of path. Fixes a 404 upon clicking the link in the readme.