### PR TITLE
Remove redundant `inline` key

### DIFF
--- a/src/config/key.zig
+++ b/src/config/key.zig
@@ -8,7 +8,7 @@ pub const Key = key: {
     const field_infos = std.meta.fields(Config);
     var enumFields: [field_infos.len]std.builtin.Type.EnumField = undefined;
     var i: usize = 0;
-    inline for (field_infos) |field| {
+    for (field_infos) |field| {
         // Ignore fields starting with "_" since they're internal and
         // not copied ever.
         if (field.name[0] == '_') continue;


### PR DESCRIPTION
This breaks in zig version `0.12.0-dev.1808+69195d0cd` (current head):

```
$ git clone git@github.com:mitchellh/ghostty.git && cd ghostty
$ zig build -Doptimize=ReleaseFast -p ~/.local
/tmp/ghostty/src/config/key.zig:11:5: error: redundant inline keyword in comptime scope
    inline for (field_infos) |field| {
    ^~~~~~
$ zig version
0.12.0-dev.1808+69195d0cd
```