### PR TITLE
doc: Update `gtk-titlebar` documentation

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -550,6 +550,9 @@ keybind: Keybinds = .{},
 ///
 /// This option does nothing when window-decoration is false or when running
 /// under MacOS.
+///
+/// Changing this value at runtime and reloading the configuration will only
+/// affect new windows.
 @"gtk-titlebar": bool = true,
 
 /// Whether to allow programs running in the terminal to read/write to


### PR DESCRIPTION
Mention that changes to `gtk-titlebar` only
affects new windows.