### PR TITLE
font: position combining character correctly on x-axis

### DIFF
--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -397,6 +397,10 @@ pub const Face = struct {
             break :offset_y @intFromFloat(@ceil(baseline_with_offset));
         };
 
+        // Get our advance
+        var advances: [glyphs.len]macos.graphics.Size = undefined;
+        _ = self.font.getAdvancesForGlyphs(.horizontal, &glyphs, &advances);
+
         // std.log.warn("renderGlyph rect={} width={} height={} render_x={} render_y={} offset_y={} ascent={} cell_height={} cell_baseline={}", .{
         //     rect,
         //     width,
@@ -416,10 +420,7 @@ pub const Face = struct {
             .offset_y = offset_y,
             .atlas_x = region.x,
             .atlas_y = region.y,
-
-            // This is not used, so we don't bother calculating it. If we
-            // ever need it, we can calculate it using getAdvancesForGlyph.
-            .advance_x = 0,
+            .advance_x = @floatCast(advances[0].width),
         };
     }
 

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1787,6 +1787,15 @@ pub fn updateCell(
             .emoji => .fg_color,
         };
 
+        // If this glyph doesn't have an advance, then we assume it is
+        // connected to the previous glyph (perhaps an unsafe assumption...)
+        // and offset by the cell width.
+        // Related: https://github.com/mitchellh/ghostty/issues/1046
+        const extra_offset: i32 = if (glyph.advance_x == 0)
+            @intCast(self.grid_metrics.cell_width)
+        else
+            0;
+
         self.cells.appendAssumeCapacity(.{
             .mode = mode,
             .grid_pos = .{ @as(f32, @floatFromInt(x)), @as(f32, @floatFromInt(y)) },
@@ -1795,7 +1804,7 @@ pub fn updateCell(
             .bg_color = bg,
             .glyph_pos = .{ glyph.atlas_x, glyph.atlas_y },
             .glyph_size = .{ glyph.width, glyph.height },
-            .glyph_offset = .{ glyph.offset_x, glyph.offset_y },
+            .glyph_offset = .{ glyph.offset_x + extra_offset, glyph.offset_y },
         });
     }
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -1490,6 +1490,15 @@ pub fn updateCell(
             .emoji => .fg_color,
         };
 
+        // If this glyph doesn't have an advance, then we assume it is
+        // connected to the previous glyph (perhaps an unsafe assumption...)
+        // and offset by the cell width.
+        // Related: https://github.com/mitchellh/ghostty/issues/1046
+        const extra_offset: i32 = if (glyph.advance_x == 0)
+            @intCast(self.grid_metrics.cell_width)
+        else
+            0;
+
         self.cells.appendAssumeCapacity(.{
             .mode = mode,
             .grid_col = @intCast(x),
@@ -1499,7 +1508,7 @@ pub fn updateCell(
             .glyph_y = glyph.atlas_y,
             .glyph_width = glyph.width,
             .glyph_height = glyph.height,
-            .glyph_offset_x = glyph.offset_x,
+            .glyph_offset_x = glyph.offset_x + extra_offset,
             .glyph_offset_y = glyph.offset_y,
             .r = colors.fg.r,
             .g = colors.fg.g,


### PR DESCRIPTION
Fixes #1046 

This positions combining characters correctly on the x-axis. The y offset is still not quite right but I see a couple other terminals exhibit this as well. Looking at the font metrics I'm unable to see how you get the hat higher on theta... if someone figures this out please let me know.

For now, I want to at least merge this because it gets it much closer to correct.

Comparing to other terminals... terminals that do not do any font shaping (i.e. Alacrity) render this incorrectly. WezTerm appears identical to Ghostty after this PR. Kitty and iTerm appear to render this perfectly and I'm unsure how... yet.

## Before

![CleanShot 2023-12-10 at 20 11 00@2x](https://github.com/mitchellh/ghostty/assets/1299/69ebbcff-dfce-4863-ab07-4d41faf3eeca)


## After

(Notice the combining chars are "inside" the top of the char. This is still a bug I'm looking into).

![CleanShot 2023-12-10 at 20 10 40@2x](https://github.com/mitchellh/ghostty/assets/1299/234bf404-07a7-472e-ac44-09d9e47e9c0f)
