### PR TITLE
Add "terminfo" and "shell_integration" subpackages to the Nix package

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -125,7 +125,21 @@ in stdenv.mkDerivation (finalAttrs: {
     chmod u+rwX -R $ZIG_GLOBAL_CACHE_DIR
   '';
 
-  outputs = [ "out" ];
+  outputs = [ "out" "terminfo" "shell_integration" ];
+
+  postInstall = ''
+    terminfo_src=${
+      if stdenv.isDarwin
+      then ''"$out/Applications/Ghostty.app/Contents/Resources/terminfo"''
+      else "$out/share/terminfo"
+    }
+
+    mkdir -p $terminfo/share
+    cp -r "$terminfo_src" $terminfo/share/terminfo
+
+    mkdir -p $shell_integration
+    cp -r $out/share/shell-integration $shell_integration/shell-integration
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/mitchellh/ghostty";


### PR DESCRIPTION
Add "terminfo" and "shell_integration" subpackages to the Nix packageso that the Ghostty terminfo and shell integration files can be installed on a headless server without copying all of Ghostty to the server. Implementation liberally cribbed from the Kitty Nix package.