### PR TITLE
Use Alejandra to format Nix modules.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,3 +147,13 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: prettier check
         run: nix develop -c prettier --check .
+
+  alejandra:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4 # Check out repo so we can lint it
+      - uses: cachix/install-nix-action@v24
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: alejandra check
+        run: nix develop -c alejandra --check .

--- a/README.md
+++ b/README.md
@@ -492,6 +492,8 @@ on vastly improving this experience over time.
 
 ### Linting
 
+#### Prettier
+
 Ghostty's docs and resources (not including Zig code) are linted using
 [Prettier](https://prettier.io) with out-of-the-box settings. A Prettier CI
 check will fail builds with improper formatting. Therefore, if you are
@@ -502,7 +504,32 @@ run this from the repo root before you commit:
 prettier --write .
 ```
 
-Make sure your Prettier version matches the version of in [devShell.nix](https://github.com/mitchellh/ghostty/blob/main/nix/devShell.nix).
+Make sure your Prettier version matches the version of Prettier in [devShell.nix](https://github.com/mitchellh/ghostty/blob/main/nix/devShell.nix).
+
+Nix users can use the following command to format with Prettier:
+
+```
+nix develop -c prettier --write .
+```
+
+#### Alejandra
+
+Nix modules are formatted with [Alejandra](https://github.com/kamadorueda/alejandra/). An Alejandra CI check
+will fail builds with improper formatting.
+
+Nix users can use the following command to format with Alejanda:
+
+```
+nix develop -c alejandra .
+```
+
+Non-Nix users should install Alejandra and use the follwing command to format with Alejanda:
+
+```
+alejandra .
+```
+
+Make sure your Alejandra version matches the version of Alejandra in [devShell.nix](https://github.com/mitchellh/ghostty/blob/main/nix/devShell.nix).
 
 ### Nix Package
 

--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ Nix users can use the following command to format with Alejanda:
 nix develop -c alejandra .
 ```
 
-Non-Nix users should install Alejandra and use the follwing command to format with Alejanda:
+Non-Nix users should install Alejandra and use the following command to format with Alejanda:
 
 ```
 alejandra .

--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ Nix users can use the following command to format with Alejanda:
 nix develop -c alejandra .
 ```
 
-Non-Nix users should install Alejandra and use the following command to format with Alejanda:
+Non-Nix users should install Alejandra and use the following command to format with Alejandra:
 
 ```
 alejandra .

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,8 @@
         default = ghostty;
       };
 
+      formatter.${system} = pkgs-stable.alejandra;
+
       # Our supported systems are the same supported systems as the Zig binaries.
     }) (builtins.attrNames zig.packages));
 }

--- a/flake.nix
+++ b/flake.nix
@@ -31,32 +31,33 @@
   };
 
   outputs = {
-    nixpkgs-unstable
-  , nixpkgs-stable
-  , nixpkgs-zig-0-12
-  , zig
-  , zls
-  , ...
-  }: builtins.foldl' nixpkgs-stable.lib.recursiveUpdate {} (builtins.map (system: let
-    pkgs-stable = nixpkgs-stable.legacyPackages.${system};
-    pkgs-unstable = nixpkgs-unstable.legacyPackages.${system};
-    pkgs-zig-0-12 = nixpkgs-zig-0-12.legacyPackages.${system};
-  in {
-    devShell.${system} = pkgs-stable.callPackage ./nix/devShell.nix {
-      inherit (pkgs-unstable) tracy;
-      inherit (zls.packages.${system}) zls;
+    nixpkgs-unstable,
+    nixpkgs-stable,
+    nixpkgs-zig-0-12,
+    zig,
+    zls,
+    ...
+  }:
+    builtins.foldl' nixpkgs-stable.lib.recursiveUpdate {} (builtins.map (system: let
+      pkgs-stable = nixpkgs-stable.legacyPackages.${system};
+      pkgs-unstable = nixpkgs-unstable.legacyPackages.${system};
+      pkgs-zig-0-12 = nixpkgs-zig-0-12.legacyPackages.${system};
+    in {
+      devShell.${system} = pkgs-stable.callPackage ./nix/devShell.nix {
+        inherit (pkgs-unstable) tracy;
+        inherit (zls.packages.${system}) zls;
 
-      zig = zig.packages.${system}.master;
-      wraptest = pkgs-stable.callPackage ./nix/wraptest.nix {};
-    };
-
-    packages.${system} = rec {
-      ghostty = pkgs-stable.callPackage ./nix/package.nix {
-        inherit (pkgs-zig-0-12) zig_0_12;
+        zig = zig.packages.${system}.master;
+        wraptest = pkgs-stable.callPackage ./nix/wraptest.nix {};
       };
-      default = ghostty;
-    };
 
-  # Our supported systems are the same supported systems as the Zig binaries.
-  }) (builtins.attrNames zig.packages));
+      packages.${system} = rec {
+        ghostty = pkgs-stable.callPackage ./nix/package.nix {
+          inherit (pkgs-zig-0-12) zig_0_12;
+        };
+        default = ghostty;
+      };
+
+      # Our supported systems are the same supported systems as the Zig binaries.
+    }) (builtins.attrNames zig.packages));
 }

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -1,139 +1,145 @@
 {
-  mkShell
-, lib
-, stdenv
-
-, bashInteractive
-, gdb
-#, glxinfo # unused
-, ncurses
-, nodejs
-, nodePackages
-, oniguruma
-, parallel
-, pkg-config
-, python3
-, scdoc
-, tracy
-, valgrind
-#, vulkan-loader # unused
-, vttest
-, wabt
-, wasmtime
-, wraptest
-, zig
-, zip
-, zls
-, llvmPackages_latest
-
-, bzip2
-, expat
-, fontconfig
-, freetype
-, glib
-, gtk4
-, libadwaita
-, harfbuzz
-, libpng
-, libGL
-, libX11
-, libXcursor
-, libXext
-, libXi
-, libXinerama
-, libXrandr
-, pixman
-, zlib
-}:
-let
+  mkShell,
+  lib,
+  stdenv,
+  bashInteractive,
+  gdb,
+  #, glxinfo # unused
+  ncurses,
+  nodejs,
+  nodePackages,
+  oniguruma,
+  parallel,
+  pkg-config,
+  python3,
+  scdoc,
+  tracy,
+  valgrind,
+  #, vulkan-loader # unused
+  vttest,
+  wabt,
+  wasmtime,
+  wraptest,
+  zig,
+  zip,
+  zls,
+  llvmPackages_latest,
+  bzip2,
+  expat,
+  fontconfig,
+  freetype,
+  glib,
+  gtk4,
+  libadwaita,
+  harfbuzz,
+  libpng,
+  libGL,
+  libX11,
+  libXcursor,
+  libXext,
+  libXi,
+  libXinerama,
+  libXrandr,
+  pixman,
+  zlib,
+  alejandra,
+}: let
   # See package.nix. Keep in sync.
-  rpathLibs = [
-    libGL
-  ] ++ lib.optionals stdenv.isLinux [
-    bzip2
-    expat
-    fontconfig
-    freetype
-    harfbuzz
-    libpng
-    oniguruma
-    pixman
-    zlib
+  rpathLibs =
+    [
+      libGL
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      bzip2
+      expat
+      fontconfig
+      freetype
+      harfbuzz
+      libpng
+      oniguruma
+      pixman
+      zlib
 
-    libX11
-    libXcursor
-    libXi
-    libXrandr
+      libX11
+      libXcursor
+      libXi
+      libXrandr
 
-    libadwaita
-    gtk4
-    glib
-  ];
-in mkShell {
-  name = "ghostty";
+      libadwaita
+      gtk4
+      glib
+    ];
+in
+  mkShell {
+    name = "ghostty";
 
-  nativeBuildInputs = [
-    # For builds
-    llvmPackages_latest.llvm
-    ncurses
-    pkg-config
-    scdoc
-    zig
-    zip
-    zls
+    nativeBuildInputs =
+      [
+        # For builds
+        llvmPackages_latest.llvm
+        ncurses
+        pkg-config
+        scdoc
+        zig
+        zip
+        zls
 
-    # For web and wasm stuff
-    nodejs
+        # For web and wasm stuff
+        nodejs
 
-    # Linting
-    nodePackages.prettier
+        # Linting
+        nodePackages.prettier
+        alejandra
 
-    # Testing
-    parallel
-    python3
-    tracy
-    vttest
+        # Testing
+        parallel
+        python3
+        tracy
+        vttest
 
-    # wasm
-    wabt
-    wasmtime
-  ] ++ lib.optionals stdenv.isLinux [
-    # My nix shell environment installs the non-interactive version
-    # by default so we have to include this.
-    bashInteractive
+        # wasm
+        wabt
+        wasmtime
+      ]
+      ++ lib.optionals stdenv.isLinux [
+        # My nix shell environment installs the non-interactive version
+        # by default so we have to include this.
+        bashInteractive
 
-    gdb
-    valgrind
-    wraptest
-  ];
+        gdb
+        valgrind
+        wraptest
+      ];
 
-  buildInputs = [
-    # TODO: non-linux
-  ] ++ lib.optionals stdenv.isLinux [
-    bzip2
-    expat
-    fontconfig
-    freetype
-    harfbuzz
-    libpng
-    oniguruma
-    pixman
-    zlib
+    buildInputs =
+      [
+        # TODO: non-linux
+      ]
+      ++ lib.optionals stdenv.isLinux [
+        bzip2
+        expat
+        fontconfig
+        freetype
+        harfbuzz
+        libpng
+        oniguruma
+        pixman
+        zlib
 
-    libX11
-    libXcursor
-    libXext
-    libXi
-    libXinerama
-    libXrandr
+        libX11
+        libXcursor
+        libXext
+        libXi
+        libXinerama
+        libXrandr
 
-    # Only needed for GTK builds
-    libadwaita
-    gtk4
-    glib
-  ];
+        # Only needed for GTK builds
+        libadwaita
+        gtk4
+        glib
+      ];
 
-  # This should be set onto the rpath of the ghostty binary if you want
-  # it to be "portable" across the system.
-  LD_LIBRARY_PATH = lib.makeLibraryPath rpathLibs;
-}
+    # This should be set onto the rpath of the ghostty binary if you want
+    # it to be "portable" across the system.
+    LD_LIBRARY_PATH = lib.makeLibraryPath rpathLibs;
+  }

--- a/nix/wraptest.nix
+++ b/nix/wraptest.nix
@@ -1,9 +1,8 @@
 {
-  stdenv
-, fetchFromGitHub
-, autoPatchelfHook
+  stdenv,
+  fetchFromGitHub,
+  autoPatchelfHook,
 }:
-
 stdenv.mkDerivation rec {
   version = "0.1.0-e7a96089";
   pname = "wraptest";
@@ -39,6 +38,6 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Test of DEC VT terminal line-wrapping semantics";
     homepage = "https://github.com/mattiase/wraptest";
-    platforms = [ "aarch64-linux" "i686-linux" "x86_64-linux" ];
+    platforms = ["aarch64-linux" "i686-linux" "x86_64-linux"];
   };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,12 @@
 (import
-   (
-     let flake-compat = (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.flake-compat; in
-     fetchTarball {
-       url = "https://github.com/edolstra/flake-compat/archive/${flake-compat.locked.rev}.tar.gz";
-       sha256 = flake-compat.locked.narHash;
-     }
-   )
-   { src = ./.; }).shellNix
+  (
+    let
+      flake-compat = (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.flake-compat;
+    in
+      fetchTarball {
+        url = "https://github.com/edolstra/flake-compat/archive/${flake-compat.locked.rev}.tar.gz";
+        sha256 = flake-compat.locked.narHash;
+      }
+  )
+  {src = ./.;})
+.shellNix


### PR DESCRIPTION
Use Alejandra to format Nix modules so that formatting stays consistent between maintainers. Adds documentation for running Alejandra manually and includes a CI check for proper formatting.

Alejandra's [style guide](https://github.com/kamadorueda/alejandra/blob/main/STYLE.md) explains the formatting choices for Nix modules.