### PR TITLE
gtk: implement equalize_splits

### DIFF
--- a/src/apprt/gtk/Split.zig
+++ b/src/apprt/gtk/Split.zig
@@ -178,27 +178,24 @@ pub fn moveDivider(self: *Split, direction: input.SplitResizeDirection, amount: 
 /// It works recursively by equalizing the children of each split.
 ///
 /// It returns this split's weight.
-pub fn equalize(self: *Split) i16 {
+pub fn equalize(self: *Split) f64 {
     // Calculate weights of top_left/bottom_right
     const top_left_weight = self.top_left.equalize();
     const bottom_right_weight = self.bottom_right.equalize();
     const weight = top_left_weight + bottom_right_weight;
 
     // Ratio of top_left weight to overall weight, which gives the split ratio
-    const ratio = @as(f16, @floatFromInt(top_left_weight)) / @as(f16, @floatFromInt(weight));
+    const ratio = top_left_weight / weight;
 
     // Convert split ratio into new position for divider
-    const max: f16 = @floatFromInt(self.maxPosition());
-    const new: c_int = @intFromFloat(max * ratio);
-
-    c.gtk_paned_set_position(self.paned, new);
+    c.gtk_paned_set_position(self.paned, @intFromFloat(self.maxPosition() * ratio));
 
     return weight;
 }
 
 // maxPosition returns the maximum position of the GtkPaned, which is the
 // "max-position" attribute.
-fn maxPosition(self: *Split) c_int {
+fn maxPosition(self: *Split) f64 {
     var value: c.GValue = std.mem.zeroes(c.GValue);
     defer c.g_value_unset(&value);
 
@@ -209,7 +206,7 @@ fn maxPosition(self: *Split) c_int {
         &value,
     );
 
-    return c.g_value_get_int(&value);
+    return @floatFromInt(c.g_value_get_int(&value));
 }
 
 // This replaces the element at the given pointer with a new element.

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -96,7 +96,7 @@ pub const Container = union(enum) {
             }
         }
 
-        pub fn equalize(self: Elem) i16 {
+        pub fn equalize(self: Elem) f64 {
             return switch (self) {
                 .surface => 1,
                 .split => |s| s.equalize(),

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -96,6 +96,13 @@ pub const Container = union(enum) {
             }
         }
 
+        pub fn equalize(self: Elem) i16 {
+            return switch (self) {
+                .surface => 1,
+                .split => |s| s.equalize(),
+            };
+        }
+
         /// The last surface in this container in the direction specified.
         /// Direction must be "top_left" or "bottom_right".
         pub fn deepestSurface(self: Elem, side: SplitSide) ?*Surface {
@@ -580,6 +587,15 @@ pub fn resizeSplit(self: *const Surface, direction: input.SplitResizeDirection, 
         Split.Orientation.fromResizeDirection(direction),
     ) orelse return;
     s.moveDivider(direction, amount);
+}
+
+pub fn equalizeSplits(self: *const Surface) void {
+    const tab = self.container.tab() orelse return;
+    const top_split = switch (tab.elem) {
+        .split => |s| s,
+        else => return,
+    };
+    _ = top_split.equalize();
 }
 
 pub fn newTab(self: *Surface) !void {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1008,6 +1008,11 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
             .{ .key = .right, .mods = .{ .super = true, .ctrl = true, .shift = true } },
             .{ .resize_split = .{ .right, 10 } },
         );
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .equal, .mods = .{ .super = true, .ctrl = true, .shift = true } },
+            .{ .equalize_splits = {} },
+        );
 
         // Viewport scrolling
         try result.keybind.set.put(


### PR DESCRIPTION
This adds support for the equalize_splits feature that's already implemented for macOS.

It's essentially a port of the Swift implementation, using the same weights-mechanism to equalize split sizes.

I confirmed that the behaviour is the same by comparing various split configurations and their equalized result.

@mitchellh I'm not 100% sure about the `f16` and the conversion to/from int/float. I tried to match existing conventions I could spot in the codebase, but you have better eyes here when it comes to Zig.

### Demo

[equalize_splits_gtk.webm](https://github.com/mitchellh/ghostty/assets/1185253/47b144cb-f9c0-433f-8468-4aed7314407a)
