### PR TITLE
`adjust-cell-height` adjustments

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -147,6 +147,13 @@ const c = @cImport({
 /// position is clamped to the height of a cell. If you set the underline
 /// position so high that it extends beyond the bottom of the cell size,
 /// it will be clamped to the bottom of the cell.
+///
+/// "adjust-cell-height" has some additional behaviors to describe:
+/// - The font will be centered vertically in the cell.
+/// - The cursor will remain the same size as the font.
+/// - Powerline glyphs will be adjusted along with the cell height so
+///   that things like status lines continue to look aligned.
+///
 @"adjust-cell-width": ?MetricModifier = null,
 @"adjust-cell-height": ?MetricModifier = null,
 @"adjust-font-baseline": ?MetricModifier = null,

--- a/src/font/face/Metrics.zig
+++ b/src/font/face/Metrics.zig
@@ -21,6 +21,11 @@ underline_thickness: u32,
 strikethrough_position: u32,
 strikethrough_thickness: u32,
 
+/// Original cell width and height. These are used to render the cursor
+/// in the original cell size after modification.
+original_cell_width: ?u32 = null,
+original_cell_height: ?u32 = null,
+
 /// Apply a set of modifiers.
 pub fn apply(self: *Metrics, mods: ModifierSet) void {
     var it = mods.iterator();
@@ -31,8 +36,18 @@ pub fn apply(self: *Metrics, mods: ModifierSet) void {
             inline .cell_width,
             .cell_height,
             => |tag| {
+                // Compute the new value. If it is the same avoid the work.
                 const original = @field(self, @tagName(tag));
                 const new = @max(entry.value_ptr.apply(original), 1);
+                if (new == original) continue;
+
+                // Preserve the original cell width and height if not set.
+                if (self.original_cell_width == null) {
+                    self.original_cell_width = self.cell_width;
+                    self.original_cell_height = self.cell_height;
+                }
+
+                // Set the new value
                 @field(self, @tagName(tag)) = new;
 
                 // For cell height, we have to also modify some positions
@@ -42,10 +57,17 @@ pub fn apply(self: *Metrics, mods: ModifierSet) void {
                 if (comptime tag == .cell_height) {
                     // We split the difference in half because we want to
                     // center the baseline in the cell.
-                    const diff = (new - original) / 2;
-                    self.cell_baseline += diff;
-                    self.underline_position += diff;
-                    self.strikethrough_position += diff;
+                    if (new > original) {
+                        const diff = (new - original) / 2;
+                        self.cell_baseline +|= diff;
+                        self.underline_position +|= diff;
+                        self.strikethrough_position +|= diff;
+                    } else {
+                        const diff = (original - new) / 2;
+                        self.cell_baseline -|= diff;
+                        self.underline_position -|= diff;
+                        self.strikethrough_position -|= diff;
+                    }
                 }
             },
 
@@ -124,18 +146,18 @@ pub const Modifier = union(enum) {
 pub const Key = key: {
     const field_infos = std.meta.fields(Metrics);
     var enumFields: [field_infos.len]std.builtin.Type.EnumField = undefined;
+    var count: usize = 0;
     for (field_infos, 0..) |field, i| {
-        enumFields[i] = .{
-            .name = field.name,
-            .value = i,
-        };
+        if (field.type != u32) continue;
+        enumFields[i] = .{ .name = field.name, .value = i };
+        count += 1;
     }
 
     var decls = [_]std.builtin.Type.Declaration{};
     break :key @Type(.{
         .Enum = .{
-            .tag_type = std.math.IntFittingRange(0, field_infos.len - 1),
-            .fields = &enumFields,
+            .tag_type = std.math.IntFittingRange(0, count - 1),
+            .fields = enumFields[0..count],
             .decls = &decls,
             .is_exhaustive = true,
         },
@@ -168,6 +190,48 @@ test "Metrics: apply modifiers" {
     m.cell_width = 100;
     m.apply(set);
     try testing.expectEqual(@as(u32, 120), m.cell_width);
+}
+
+test "Metrics: adjust cell height smaller" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var set: ModifierSet = .{};
+    defer set.deinit(alloc);
+    try set.put(alloc, .cell_height, .{ .percent = 0.5 });
+
+    var m: Metrics = init();
+    m.cell_baseline = 50;
+    m.underline_position = 55;
+    m.strikethrough_position = 30;
+    m.cell_height = 100;
+    m.apply(set);
+    try testing.expectEqual(@as(u32, 50), m.cell_height);
+    try testing.expectEqual(@as(u32, 25), m.cell_baseline);
+    try testing.expectEqual(@as(u32, 30), m.underline_position);
+    try testing.expectEqual(@as(u32, 5), m.strikethrough_position);
+    try testing.expectEqual(@as(u32, 100), m.original_cell_height.?);
+}
+
+test "Metrics: adjust cell height larger" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var set: ModifierSet = .{};
+    defer set.deinit(alloc);
+    try set.put(alloc, .cell_height, .{ .percent = 2 });
+
+    var m: Metrics = init();
+    m.cell_baseline = 50;
+    m.underline_position = 55;
+    m.strikethrough_position = 30;
+    m.cell_height = 100;
+    m.apply(set);
+    try testing.expectEqual(@as(u32, 200), m.cell_height);
+    try testing.expectEqual(@as(u32, 100), m.cell_baseline);
+    try testing.expectEqual(@as(u32, 105), m.underline_position);
+    try testing.expectEqual(@as(u32, 80), m.strikethrough_position);
+    try testing.expectEqual(@as(u32, 100), m.original_cell_height.?);
 }
 
 test "Modifier: parse absolute" {

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -468,17 +468,20 @@ pub const Face = struct {
             height: f32,
             ascent: f32,
         } = metrics: {
-            const ascent = @round(ct_font.getAscent());
-            const descent = @round(ct_font.getDescent());
+            const ascent = ct_font.getAscent();
+            const descent = ct_font.getDescent();
 
             // Leading is the value between lines at the TOP of a line.
             // Because we are rendering a fixed size terminal grid, we
             // want the leading to be split equally between the top and bottom.
             const leading = ct_font.getLeading();
 
+            // We ceil the metrics below because we don't want to cut off any
+            // potential used pixels. This tends to only make a one pixel
+            // difference but at small font sizes this can be noticeable.
             break :metrics .{
-                .height = @floatCast(@round(ascent + descent + leading)),
-                .ascent = @floatCast(@round(ascent + (leading / 2))),
+                .height = @floatCast(@ceil(ascent + descent + leading)),
+                .ascent = @floatCast(@ceil(ascent + (leading / 2))),
             };
         };
 


### PR DESCRIPTION
Fixes #1068 
Fixes #1067 
Fixes #1066 
Fixes #1064 

This makes multiple changes to `adjust-cell-height` behaviors:

  * Font rendering is centered vertically in adjusted cell. Previously, a cell adjusted larger would cause text to hug the bottom and a cell adjusted smaller would hug the top.
  * Adjust the underline and strikethrough positions so they render in the correct position.
  * Adjust the cell height calculation for CoreText to always round up. We were seeing 1 or 2 pixels differences from iTerm and this appears to be part of the source. Regardless of comparison, it fundamentally makes sense: if a font says that an ascent is `7.2`, that means _something_ takes up that `0.2`, so we should set the height to `8` (plus the descent). 
  * Render the cursor height the same height as the original cell, not the adjusted cell.
  * Powerline glyphs are rendered the _adjusted height_! This is a strange but important detail: although `adjust-cell-height` doesn't change font size, I believe the expected behavior is that powerline glyphs _do_ change size because they're often used as boundaries on background-colored cells (i.e. half circles, arrows) and it looks very weird if they don't take up the full cell size.

## Before

All adjustments exaggerated. This is `adjust-cell-height = 100%` (double).

![CleanShot 2023-12-12 at 20 49 23@2x](https://github.com/mitchellh/ghostty/assets/1299/8003fb63-b454-4d1e-bd9c-07934c8d86c7)

## After

![CleanShot 2023-12-12 at 20 50 08@2x](https://github.com/mitchellh/ghostty/assets/1299/8b6d5827-c411-4ff0-803e-4ad6c8a84b00)

## iTerm2

Notice the Powerline glyphs are funky. Note: if you tell iTerm2 to use built-in power line glyphs (default is off) then it fixes this. But, I'm sure a lot more terminals also look funky.

![CleanShot 2023-12-12 at 20 50 47@2x](https://github.com/mitchellh/ghostty/assets/1299/820f52db-c5a2-40db-9bad-f96aaafdd2ae)
