### PR TITLE
termio: Explicitly set SHELL env var

### DIFF
--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -868,6 +868,9 @@ const Subprocess = struct {
         // The execution path
         const final_path = if (internal_os.isFlatpak()) args[0] else path;
 
+        // Set SHELL to match the path
+        try env.put("SHELL", final_path);
+
         // Setup our shell integration, if we can.
         const shell_integrated: ?shell_integration.Shell = shell: {
             const force: ?shell_integration.Shell = switch (opts.full_config.@"shell-integration") {


### PR DESCRIPTION
In my experience, and maybe I'm wrong, the terminal sets SHELL on the process it starts up so the shell is aware of what it is.

That allows predictable use when doing something maybe like: `exec $SHELL` to "reload current shell".

I found this wasn't being set when I override `command` in the config. I would, and have expected, SHELL to be set to match that value.

For example, I set `command = /opt/homebrew/bin/zsh` and expected that to be present as my SHELL.