### PR TITLE
font/sprite: manually determine which box codepoints are unadjusted

### DIFF
--- a/src/font/sprite/Box.zig
+++ b/src/font/sprite/Box.zig
@@ -79,6 +79,19 @@ pub fn renderGlyph(
     };
 }
 
+/// Returns true if this codepoint should be rendered with the
+/// width/height set to unadjusted values.
+pub fn unadjustedCodepoint(cp: u32) bool {
+    return switch (cp) {
+        @intFromEnum(Sprite.cursor_rect),
+        @intFromEnum(Sprite.cursor_hollow_rect),
+        @intFromEnum(Sprite.cursor_bar),
+        => true,
+
+        else => false,
+    };
+}
+
 fn draw(self: Box, alloc: Allocator, canvas: *font.sprite.Canvas, cp: u32) !void {
     switch (cp) {
         0x2500 => self.draw_light_horizontal(canvas),


### PR DESCRIPTION
Some box codepoints (the cursor) want to use the original font metrics height but others (corners) want to use the full grid height. I can't see a better way to do this than manually maintaining a switch here. We can add codepoints as needed.

cc @vancluever There's a ton of points missing here, but this should give us a framework to fix those over time. If you're more familiar with the box codepoints now I'd really love any help here but no pressure if you don't want to. 

Also if we find the logic is easier to just invert (i.e. allowlist vs blocklist) then we can do that too. 