### PR TITLE
A couple Kitty keyboard fixes

### DIFF
--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1444,8 +1444,13 @@ fn keyEvent(
     // a text value. We have to do this because GTK will not process
     // "Ctrl+Shift+1" (on US keyboards) as "Ctrl+!" but instead as "".
     // But the keyval is set correctly so we can at least extract that.
-    if (self.im_len == 0 and keyval_unicode > 0) {
+    if (self.im_len == 0 and keyval_unicode > 0) im: {
         if (std.math.cast(u21, keyval_unicode)) |cp| {
+            // We don't want to send control characters as IM
+            // text. Control characters are handled already by
+            // the encoder directly.
+            if (cp < 0x20) break :im;
+
             if (std.unicode.utf8Encode(cp, &self.im_buf)) |len| {
                 self.im_len = len;
             } else |_| {}


### PR DESCRIPTION
Fixes #1078

* On GTK, control characters shouldn't be encoded into the `utf8` field. This causes invalid encoding and it's not what we expect. This fixes #1078.
* When the key event is press with no mods, we previously sent `<keycode>;1:1u`. This isn't _technically_ incorrect because `<keycode>u` is identical (event and mods default to "1" if not set). But Kitty doesn't send them explicitly so we probably shouldn't either.

## After

(Before: no event)

![CleanShot 2023-12-13 at 11 00 08@2x](https://github.com/mitchellh/ghostty/assets/1299/95f8be8f-93d4-456c-a197-1a19d0ff2fed)
