### PR TITLE
Surface: fix some rectangle select behaviors

### DIFF
--- a/src/terminal/Selection.zig
+++ b/src/terminal/Selection.zig
@@ -200,7 +200,7 @@ pub fn ordered(self: Selection, desired: Order) Selection {
 ///
 pub const Order = enum { forward, reverse, mirrored_forward, mirrored_reverse };
 
-fn order(self: Selection) Order {
+pub fn order(self: Selection) Order {
     if (self.rectangle) {
         // Reverse (also handles single-column)
         if (self.start.y > self.end.y and self.start.x >= self.end.x) return .reverse;


### PR DESCRIPTION
This fixes a couple of subtle rectangle select behaviors:

* Corrects how selection rolls over when crossing the x-boundary; this was mentioned in #1021, this properly corrects it so both sides of the x-boundary do not share characters.

* Corrects a minor quirk in the selection of initial cells in a selection - this can be more readily observed when selecting a single line with rectangle select. To correct this, we only use the x axis when calculating this instead of both x and y.

## x-boundary stuff

### Before

https://github.com/mitchellh/ghostty/assets/10704423/8be6a896-c0e0-41ac-81cb-426711ec9d32

### After

https://github.com/mitchellh/ghostty/assets/10704423/89fe4a7a-35f5-4e4c-8115-f0266a1b599b

### Kitty

https://github.com/mitchellh/ghostty/assets/10704423/707a14b3-c27b-4607-b521-a0b4a6de1c81

## Selection neighbor stuff

## Before

https://github.com/mitchellh/ghostty/assets/10704423/69cc45a7-3eda-4790-baf0-49c95e5a9e2c

## After

https://github.com/mitchellh/ghostty/assets/10704423/42cf3aee-a042-42ff-a901-2ce5c19e2be6
