### PR TITLE
macos: special case handling of some control keys

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -838,16 +838,17 @@ extension Ghostty {
                 return false
             }
 
-            let equivalent: String?
+            let equivalent: String
             switch (event.charactersIgnoringModifiers) {
             case "/":
-                // Treat C-/ as C-_
+                // Treat C-/ as C-_. We do this because C-/ makes macOS make a beep
+                // sound and we don't like the beep sound.
                 equivalent = "_"
+                
             default:
-                equivalent = nil
+                // Ignore other events
+                return false
             }
-
-            guard let equivalent else { return false }
 
             let newEvent = NSEvent.keyEvent(
                 with: .keyDown,

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -783,7 +783,7 @@ extension Ghostty {
             
             let action = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS
             
-            // By setting this to non-nil, we note that we'rein a keyDown event. From here,
+            // By setting this to non-nil, we note that we're in a keyDown event. From here,
             // we call interpretKeyEvents so that we can handle complex input such as Korean
             // language.
             keyTextAccumulator = []
@@ -823,6 +823,47 @@ extension Ghostty {
 
         override func keyUp(with event: NSEvent) {
             keyAction(GHOSTTY_ACTION_RELEASE, event: event)
+        }
+
+        /// Special case handling for some control keys
+        override func performKeyEquivalent(with event: NSEvent) -> Bool {
+            // Only process keys when Control is the only modifier
+            if (!event.modifierFlags.contains(.control) ||
+                !event.modifierFlags.isDisjoint(with: [.shift, .command, .option])) {
+                return false
+            }
+
+            // Only process key down events
+            if (event.type != .keyDown) {
+                return false
+            }
+
+            let equivalent: String?
+            switch (event.charactersIgnoringModifiers) {
+            case "/":
+                // Treat C-/ as C-_
+                equivalent = "_"
+            default:
+                equivalent = nil
+            }
+
+            guard let equivalent else { return false }
+
+            let newEvent = NSEvent.keyEvent(
+                with: .keyDown,
+                location: event.locationInWindow,
+                modifierFlags: .control,
+                timestamp: event.timestamp,
+                windowNumber: event.windowNumber,
+                context: nil,
+                characters: equivalent,
+                charactersIgnoringModifiers: equivalent,
+                isARepeat: event.isARepeat,
+                keyCode: event.keyCode
+            )
+
+            self.keyDown(with: newEvent!)
+            return true
         }
 
         override func flagsChanged(with event: NSEvent) {


### PR DESCRIPTION
Some control key combinations must be handled specially by Ghostty to prevent undesirable behavior at the OS level. For now, this includes only Ctrl-/, which makes a "beep" sound when processed by AppKit. It is unclear why this beep occurs and no answer was found after extensive searching.

This solution is inspired by iTerm2, which also handles certain control key combinations (including C-/) manually before passing them on to Cocoa/AppKit.
