### PR TITLE
core: quit-after-last-window-closed works properly with "exit"

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -103,8 +103,8 @@ pub fn tick(self: *App, rt_app: *apprt.App) !bool {
     // doesn't want to quit, then we can't force it to.
     defer self.quit = false;
 
-    // We quit if our quit flag is on or if we have closed all surfaces.
-    return self.quit or self.surfaces.items.len == 0;
+    // We quit if our quit flag is on
+    return self.quit;
 }
 
 /// Update the configuration associated with the app. This can only be

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -111,7 +111,7 @@ pub const App = struct {
 
             // Tick the terminal app
             const should_quit = try self.app.tick(self);
-            if (should_quit) {
+            if (should_quit or self.app.surfaces.items.len == 0) {
                 for (self.app.surfaces.items) |surface| {
                     surface.close(false);
                 }

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -316,7 +316,7 @@ pub fn run(self: *App) !void {
 
         // Tick the terminal app
         const should_quit = try self.core_app.tick(self);
-        if (should_quit) self.quit();
+        if (should_quit or self.core_app.surfaces.items.len == 0) self.quit();
     }
 }
 


### PR DESCRIPTION
Fixes #1085

This moves the logic of exiting when there are no surfaces left fully to apprt and away from the core.