### PR TITLE
build: use dedicated strings for conformance test keys

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -929,7 +929,7 @@ fn conformanceSteps(
         if (index == 0) continue;
 
         // Name of the conformance app and full path to the entrypoint.
-        const name = entry.name[0..index];
+        const name = try b.allocator.dupe(u8, entry.name[0..index]);
         const path = try fs.path.join(b.allocator, &[_][]const u8{
             c_dir_path,
             entry.name,


### PR DESCRIPTION
This uses separate strings for the keys for the conformance tests versus just deriving them from the sliced path.

This fixed an issue for me where a few of the tests were showing up as `InvalidConformance` (notably the "blocks" test), even though, oddly enough, the key/value entries do appear to be there (e.g. if you iterated over them). I did notice, though, that we currently sliced the key from the file entry of the directory iterator, which is closed at the end of `conformanceSteps`.