### PR TITLE
font/coretext: use `CTFontCopyFamilyName`

### DIFF
--- a/pkg/macos/text/font.zig
+++ b/pkg/macos/text/font.zig
@@ -120,6 +120,10 @@ pub const Font = opaque {
         )));
     }
 
+    pub fn copyFamilyName(self: *Font) *foundation.String {
+        return @ptrFromInt(@intFromPtr(c.CTFontCopyFamilyName(@ptrCast(self))));
+    }
+
     pub fn copyDisplayName(self: *Font) *foundation.String {
         return @ptrFromInt(@intFromPtr(c.CTFontCopyDisplayName(@ptrCast(self))));
     }


### PR DESCRIPTION
We could've also went with using `std.mem.startsWith` in `quirks.zig` but this approach seems better to match the behavior of `name` function of freetype backend.

Before & after:

![before-and-after](https://github.com/mitchellh/ghostty/assets/153218822/7e322c68-6440-40a6-9ada-a5c4dc0d82ba)
