### PR TITLE
termio: implement DECRQSS

### DIFF
--- a/src/terminal/dcs.zig
+++ b/src/terminal/dcs.zig
@@ -209,7 +209,7 @@ const State = union(enum) {
     /// DECRQSS
     decrqss: struct {
         data: [2]u8 = undefined,
-        len: usize = 0,
+        len: u2 = 0,
     },
 };
 


### PR DESCRIPTION
Only SGR, DECSCUSR, DECSTBM, and DECSLRM are handled, as these are the only ones that Ghostty supports (as far as I can tell) and are the only ones that seem actually useful.
