### PR TITLE
nix: use wrapGAppsHook to package ghostty

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,6 @@
 # If we are a computer with nix-shell available, then use that to setup
 # the build environment with exactly what we need.
 if has nix; then
+  watch_file nix/{devShell,package,wraptest}.nix
   use flake
 fi

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -145,7 +145,9 @@ in
     # it to be "portable" across the system.
     LD_LIBRARY_PATH = lib.makeLibraryPath rpathLibs;
 
-    shellHook = ''
+    # On Linux we need to setup the environment so that all GTK data
+    # is available (namely icons).
+    shellHook = lib.optionalString stdenv.isLinux ''
       # Minimal subset of env set by wrapGAppsHook4 for icons and global settings
       export XDG_DATA_DIRS=$XDG_DATA_DIRS:${hicolor-icon-theme}/share:${gnome.adwaita-icon-theme}/share
       export XDG_DATA_DIRS=$XDG_DATA_DIRS:$GSETTINGS_SCHEMAS_PATH # from glib setup hook

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -31,6 +31,8 @@
   glib,
   gtk4,
   libadwaita,
+  gnome,
+  hicolor-icon-theme,
   harfbuzz,
   libpng,
   libGL,
@@ -142,4 +144,10 @@ in
     # This should be set onto the rpath of the ghostty binary if you want
     # it to be "portable" across the system.
     LD_LIBRARY_PATH = lib.makeLibraryPath rpathLibs;
+
+    shellHook = ''
+      # Minimal subset of env set by wrapGAppsHook4 for icons and global settings
+      export XDG_DATA_DIRS=$XDG_DATA_DIRS:${hicolor-icon-theme}/share:${gnome.adwaita-icon-theme}/share
+      export XDG_DATA_DIRS=$XDG_DATA_DIRS:$GSETTINGS_SCHEMAS_PATH # from glib setup hook
+    '';
   }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -17,6 +17,8 @@
   glib,
   gtk4,
   libadwaita,
+  wrapGAppsHook4,
+  gsettings-desktop-schemas,
   git,
   ncurses,
   pkg-config,
@@ -89,6 +91,7 @@ in
       ncurses
       pkg-config
       zig012Hook
+      wrapGAppsHook4
     ];
 
     buildInputs =
@@ -113,6 +116,7 @@ in
         libadwaita
         gtk4
         glib
+        gsettings-desktop-schemas
       ];
 
     dontConfigure = true;


### PR DESCRIPTION
`wrapGAppsHook` is [recommended by nixpkgs](https://nixos.org/manual/nixpkgs/stable/#ssec-gnome-hooks) for packaging Gnome applications. It ensures `XDG_DATA_DIRS` includes the nescessary icons and gsettings schemas.

[gnome-terminal](https://github.com/NixOS/nixpkgs/blob/203ecda835bcf69633df7183459283543dd4a874/pkgs/desktops/gnome/core/gnome-terminal/default.nix) is packaged this way.

For ghostty, we also need to configure the shell so a debug build built using `zig build` has the correct environment available.

Fixes #1053, see screenshot for proof of working icons. Background ghostty is started outside the `nix develop` environment, foreground is inside:
![image](https://github.com/mitchellh/ghostty/assets/191622/604144c2-dc5a-4cb2-bf02-de11c1f20970)
