### PR TITLE
renderer/opengl: acquire lock to prep kitty images

### DIFF
--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -709,6 +709,11 @@ pub fn updateFrame(
         // We only do this if the Kitty image state is dirty meaning only if
         // it changes.
         if (state.terminal.screen.kitty_images.dirty) {
+            // prepKittyGraphics touches self.images which is also used
+            // in drawFrame so if we're drawing on a separate thread we need
+            // to lock this.
+            if (single_threaded_draw) self.draw_mutex.lock();
+            defer if (single_threaded_draw) self.draw_mutex.unlock();
             try self.prepKittyGraphics(state.terminal);
         }
 


### PR DESCRIPTION
Fixes #1101

GTK forces all GLArea drawing to happen on the GUI thread. In this scenario, `updateFrame` and `drawFrame` could be happening in parallel. This commit grabs the lock while updating the Kitty image protocol state since that is used by both functions.

We already have a mutex called "draw_mutex" that we hold while we're modifying data that could be shared by this separate draw thread. We should reuse that here.

On macOS/Metal, all updating _and_ drawing happens in a dedicated render thread, so this is not an issue. Additionally, when using GLFW, we are also able to draw with OpenGL on a separate thread. This is why #1101 only showed up with Linux and GTK.