### PR TITLE
macos: do not load zsh config on the outer zsh launch

### DIFF
--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -881,7 +881,14 @@ const Subprocess = struct {
                 if (hush) try args.append("-q");
                 try args.append("-flp");
                 try args.append(username);
+
+                // We execute zsh with "-d -f" so that it doesn't load any
+                // local zshrc files so that (1) our shell integration doesn't
+                // break and (2) user configuration doesn't mess this process
+                // up.
                 try args.append("/bin/zsh");
+                try args.append("-d");
+                try args.append("-f");
                 try args.append("-c");
                 try args.append(cmd);
                 break :args try args.toOwnedSlice();


### PR DESCRIPTION
Related to #1102, #1074

Because we are now using the built-in zsh on macOS to launch the real shell the user wants to use (see #1102 for why), this "outer zsh" process was consuming our shell integration setup.

This commit adds flags so that this zsh instance doesn't load local zshrc files and therefore doesn't consume our shell integration setup.