### PR TITLE
config: improve link matching for URLs ending in . or )

### DIFF
--- a/src/config/url.zig
+++ b/src/config/url.zig
@@ -5,22 +5,75 @@ const oni = @import("oniguruma");
 /// This is here in the config package because one day the matchers will be
 /// configurable and this will be a default.
 ///
-/// This is taken from the Alacritty project.
-pub const regex = "(ipfs:|ipns:|magnet:|mailto:|gemini://|gopher://|https://|http://|news:|file:|git://|ssh:|ftp://)[^\u{0000}-\u{001F}\u{007F}-\u{009F}<>\x22\\s{-}\\^⟨⟩\x60]+";
+/// This is adapted from a regex used in the Alacritty project.
+///
+/// This regex is liberal in what it accepts after the scheme, with exceptions
+/// for URLs ending with . or ). Although such URLs are perfectly valid, it is
+/// common for text to contain URLs surrounded by parentheses (such as in
+/// Markdown links) or at the end of sentences. Therefore, this regex excludes
+/// them as follows:
+///
+/// 1. Do not match regexes ending with .
+/// 2. Do not match regexes ending with ), except for ones which contain a (
+///    without a subsequent )
+///
+/// Rule 2 means that that we handle the following two cases:
+///
+///   "https://en.wikipedia.org/wiki/Rust_(video_game)" (include parens)
+///   "(https://example.com)" (do not include the parens)
+///
+/// There are many complicated cases where these heuristics break down, but
+/// handling them well requires a non-regex approach.
+pub const regex = "(?:" ++ url_scheme ++ ")(?:[^" ++ url_exclude ++ "]*[^" ++ url_exclude ++ ").]|[^" ++ url_exclude ++ "(]*\\([^" ++ url_exclude ++ ")]*\\))";
+const url_scheme = "ipfs:|ipns:|magnet:|mailto:|gemini://|gopher://|https://|http://|news:|file:|git://|ssh:|ftp://";
+const url_exclude = "\u{0000}-\u{001F}\u{007F}-\u{009F}<>\x22\\s{-}\\^⟨⟩\x60";
 
 test "url regex" {
+    const testing = std.testing;
+
     try oni.testing.ensureInit();
-    var re = try oni.Regex.init(regex, .{}, oni.Encoding.utf8, oni.Syntax.default, null);
+    var re = try oni.Regex.init(
+        regex,
+        .{ .find_longest = true },
+        oni.Encoding.utf8,
+        oni.Syntax.default,
+        null,
+    );
     defer re.deinit();
 
-    // The URL cases to test that our regex matches. Feel free to add to this
+    // The URL cases to test what our regex matches. Feel free to add to this
     // as we find bugs or just want more coverage.
-    const cases: []const []const u8 = &.{
-        "https://example.com",
+    const cases = [_]struct {
+        input: []const u8,
+        expect: []const u8,
+    }{
+        .{
+            .input = "hello https://example.com world",
+            .expect = "https://example.com",
+        },
+        .{
+            .input = "https://example.com/foo(bar) more",
+            .expect = "https://example.com/foo(bar)",
+        },
+        .{
+            .input = "https://example.com/foo(bar)baz more",
+            .expect = "https://example.com/foo(bar)baz",
+        },
+        .{
+            .input = "Link inside (https://example.com) parens",
+            .expect = "https://example.com",
+        },
+        .{
+            .input = "Link period https://example.com. More text.",
+            .expect = "https://example.com",
+        },
     };
 
     for (cases) |case| {
-        var reg = try re.search(case, .{});
+        var reg = try re.search(case.input, .{});
         defer reg.deinit();
+        try testing.expectEqual(@as(usize, 1), reg.count());
+        const match = case.input[@intCast(reg.starts()[0])..@intCast(reg.ends()[0])];
+        try testing.expectEqualStrings(case.expect, match);
     }
 }

--- a/src/input/Link.zig
+++ b/src/input/Link.zig
@@ -36,7 +36,7 @@ pub const Highlight = union(enum) {
 pub fn oniRegex(self: *const Link) !oni.Regex {
     return try oni.Regex.init(
         self.regex,
-        .{},
+        .{ .find_longest = true },
         oni.Encoding.utf8,
         oni.Syntax.default,
         null,


### PR DESCRIPTION
For #1098.

This improves the link URL-matching heuristics in some cases. It addresses two issues:

* Links followed by `.` (for example, a link at the end of a sentence) are much more common than URLs ending with `.`. So we should not include a trailing `.` in a URL match.
* Links often appear in text surrounded by parentheses (such as in Markdown: `[link](https://example.com)`). But links containing parentheses, while perhaps rarer than links surrounded by parentheses, are not that rare.

As described in #1098, other editors (I looked at Alacritty) go beyond regexes to locate links within text. This enables them to handle nested parentheses and other situations.

This PR expands the regex to handle more of the common cases. While not as robust as something like Alacritty's approach, it pushes the regex about as far as is reasonable (arguably, beyond that :) )

In order to handle trailing `.`, simply do not match an ending `.` in a URL.

In order to handle trailing `)`, only match an ending `)` if there was a `(` earlier in the URL.

---

Here is test text I used to examine how various terminals handle these situations:

```
1. Simple http://example.com blah
2. URL containing paren https://example.com/foo(bar)baz blah.
3. URL ending with paren https://en.wikipedia.org/wiki/Rust_(video_game) blah.
4. Here's a markdown link [link](https://google.com) to a site.
5. URL followed by a period: https://example.com. More after.
6. URL inside (https://example.com) parens.
7. Harder case [here](https://example.com/foo_(bar)).
8. And another hard one (https://example.com/foo_(bar)) here.
9. Even harder https://example.com/(what(a_weird)url_)_this(is)
10. Harder! ((https://example.com/foo_((bar)))).
```

(In each of these cases, I hope it is obvious what the "correct" answer is, though of course this is all best-effort and there are no objectively 100% right answers.)

* Currently, ghostty gets 1-3 and 9 correct.
* After this PR, ghostty gets 1-8 correct.
* Gnome terminal gets all 10 correct.
* Alacritty gets all 10 correct.
* Kitty gets 1-6 and 9 correct.

---

This is my first encounter with Zig code so it may have some beginner mistakes or style issues.