### PR TITLE
renderer: characters in the Unicode PUA (private use area) are scaled if not followed by whitespace

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -11,7 +11,6 @@ const objc = @import("objc");
 const macos = @import("macos");
 const imgui = @import("imgui");
 const glslang = @import("glslang");
-const ziglyph = @import("ziglyph");
 const apprt = @import("../apprt.zig");
 const configpkg = @import("../config.zig");
 const font = @import("../font/main.zig");

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -11,6 +11,7 @@ const objc = @import("objc");
 const macos = @import("macos");
 const imgui = @import("imgui");
 const glslang = @import("glslang");
+const ziglyph = @import("ziglyph");
 const apprt = @import("../apprt.zig");
 const configpkg = @import("../config.zig");
 const font = @import("../font/main.zig");
@@ -19,6 +20,7 @@ const renderer = @import("../renderer.zig");
 const math = @import("../math.zig");
 const Surface = @import("../Surface.zig");
 const link = @import("link.zig");
+const fgMode = @import("cell.zig").fgMode;
 const shadertoy = @import("shadertoy.zig");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
@@ -1780,11 +1782,17 @@ pub fn updateCell(
             },
         );
 
-        // If we're rendering a color font, we use the color atlas
-        const presentation = try self.font_group.group.presentationFromIndex(shaper_run.font_index);
-        const mode: mtl_shaders.Cell.Mode = switch (presentation) {
-            .text => .fg,
-            .emoji => .fg_color,
+        const mode: mtl_shaders.Cell.Mode = switch (try fgMode(
+            &self.font_group.group,
+            screen,
+            cell,
+            shaper_run,
+            x,
+            y,
+        )) {
+            .normal => .fg,
+            .color => .fg_color,
+            .constrained => .fg_constrained,
         };
 
         self.cells.appendAssumeCapacity(.{

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -9,6 +9,7 @@ const testing = std.testing;
 const Allocator = std.mem.Allocator;
 const ArenaAllocator = std.heap.ArenaAllocator;
 const link = @import("link.zig");
+const fgMode = @import("cell.zig").fgMode;
 const shadertoy = @import("shadertoy.zig");
 const apprt = @import("../apprt.zig");
 const configpkg = @import("../config.zig");
@@ -1489,10 +1490,17 @@ pub fn updateCell(
         );
 
         // If we're rendering a color font, we use the color atlas
-        const presentation = try self.font_group.group.presentationFromIndex(shaper_run.font_index);
-        const mode: CellProgram.CellMode = switch (presentation) {
-            .text => .fg,
-            .emoji => .fg_color,
+        const mode: CellProgram.CellMode = switch (try fgMode(
+            &self.font_group.group,
+            screen,
+            cell,
+            shaper_run,
+            x,
+            y,
+        )) {
+            .normal => .fg,
+            .color => .fg_color,
+            .constrained => .fg_constrained,
         };
 
         self.cells.appendAssumeCapacity(.{

--- a/src/renderer/cell.zig
+++ b/src/renderer/cell.zig
@@ -45,13 +45,23 @@ pub fn fgMode(
                 break :text .normal;
             }
 
+            // If we are at the end of the screen its definitely constrained
+            if (x == screen.cols - 1) break :text .constrained;
+
+            // If we have a previous cell and it was PUA then we need to
+            // also constrain. This is so that multiple PUA glyphs align.
+            if (x > 0) {
+                const prev_cell = screen.getCell(.active, y, x - 1);
+                if (ziglyph.general_category.isPrivateUse(@intCast(prev_cell.char))) {
+                    break :text .constrained;
+                }
+            }
+
             // If the next cell is empty, then we allow it to use the
             // full glyph size.
-            if (x < screen.cols - 1) {
-                const next_cell = screen.getCell(.active, y, x + 1);
-                if (next_cell.char == 0 or next_cell.char == ' ') {
-                    break :text .normal;
-                }
+            const next_cell = screen.getCell(.active, y, x + 1);
+            if (next_cell.char == 0 or next_cell.char == ' ') {
+                break :text .normal;
             }
 
             // Must be constrained

--- a/src/renderer/cell.zig
+++ b/src/renderer/cell.zig
@@ -1,0 +1,61 @@
+const ziglyph = @import("ziglyph");
+const font = @import("../font/main.zig");
+const terminal = @import("../terminal/main.zig");
+
+pub const FgMode = enum {
+    /// Normal non-colored text rendering. The text can leave the cell
+    /// size if it is larger than the cell to allow for ligatures.
+    normal,
+
+    /// Colored text rendering, specifically Emoji.
+    color,
+
+    /// Similar to normal but the text must be constrained to the cell
+    /// size. If a glyph is larger than the cell then it must be resized
+    /// to fit.
+    constrained,
+};
+
+/// Returns the appropriate foreground mode for the given cell. This is
+/// meant to be called from the typical updateCell function within a
+/// renderer.
+pub fn fgMode(
+    group: *font.Group,
+    screen: *terminal.Screen,
+    cell: terminal.Screen.Cell,
+    shaper_run: font.shape.TextRun,
+    x: usize,
+    y: usize,
+) !FgMode {
+    const presentation = try group.presentationFromIndex(shaper_run.font_index);
+    return switch (presentation) {
+        // Emoji is always full size and color.
+        .emoji => .color,
+
+        // If it is text it is slightly more complex. If we are a codepoint
+        // in the private use area and we are at the end or the next cell
+        // is not empty, we need to constrain rendering.
+        //
+        // We do this specifically so that Nerd Fonts can render their
+        // icons without overlapping with subsequent characters. But if
+        // the subsequent character is empty, then we allow it to use
+        // the full glyph size. See #1071.
+        .text => text: {
+            if (!ziglyph.general_category.isPrivateUse(@intCast(cell.char))) {
+                break :text .normal;
+            }
+
+            // If the next cell is empty, then we allow it to use the
+            // full glyph size.
+            if (x < screen.cols - 1) {
+                const next_cell = screen.getCell(.active, y, x + 1);
+                if (next_cell.char == 0 or next_cell.char == ' ') {
+                    break :text .normal;
+                }
+            }
+
+            // Must be constrained
+            break :text .constrained;
+        },
+    };
+}

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -101,6 +101,7 @@ pub const Cell = extern struct {
     pub const Mode = enum(u8) {
         bg = 1,
         fg = 2,
+        fg_constrained = 3,
         fg_color = 7,
         strikethrough = 8,
     };

--- a/src/renderer/opengl/CellProgram.zig
+++ b/src/renderer/opengl/CellProgram.zig
@@ -51,6 +51,7 @@ pub const Cell = extern struct {
 pub const CellMode = enum(u8) {
     bg = 1,
     fg = 2,
+    fg_constrained = 3,
     fg_color = 7,
     strikethrough = 8,
 

--- a/src/renderer/shaders/cell.f.glsl
+++ b/src/renderer/shaders/cell.f.glsl
@@ -26,6 +26,7 @@ uniform vec2 cell_size;
 // See vertex shader
 const uint MODE_BG = 1u;
 const uint MODE_FG = 2u;
+const uint MODE_FG_CONSTRAINED = 3u;
 const uint MODE_FG_COLOR = 7u;
 const uint MODE_STRIKETHROUGH = 8u;
 
@@ -38,6 +39,7 @@ void main() {
         break;
 
     case MODE_FG:
+    case MODE_FG_CONSTRAINED:
         a = texture(text, glyph_tex_coords).r;
         vec3 premult = color.rgb * color.a;
         out_FragColor = vec4(premult.rgb*a, a);


### PR DESCRIPTION
Fixes #1071

This is a special scenario specifically so that Nerd Font symbols look nice when followed by additional text. Nerd Font symbols tend to be double-width but PUA (private use area) codepoints are single-width according to the Unicode standard. Therefore, if you print a symbol immediately follow by a character, it'll overlap and look bad. 

Well-written programs should always emit a Nerd Font symbol followed by a space. This allows the full sized glyph to be used and generally looks nice. Unfortunately, not all programs are well-written and you end up getting overlapping glyphs (see before below). Most terminals don't do anything about this but Kitty detects this and decides to scale the glyph if it is not followed by whitespace. This PR follows that behavior.

Additionally, if a PUA char is _preceded_ by another PUA char, we still scale the glyph even if it is followed by whitespace. This allows chained glyphs to align correctly (see the second example below).

This logic follows for all PUA codepoints. In theory we could constrain to just the advertised ranges for Nerd Fonts, but the ranges may change. This logic only has a real affect if the glyph actually _does_ exceed the width of the cell, and in that case I think this logic makes sense for _any_ potential glyph.

## Before

![CleanShot 2023-12-16 at 20 22 57@2x](https://github.com/mitchellh/ghostty/assets/1299/55862dec-3f83-4f73-9b48-d7f91c0cd861)

## After

![CleanShot 2023-12-16 at 20 22 32@2x](https://github.com/mitchellh/ghostty/assets/1299/3c87e417-4955-4820-8516-1e96c2bb2b3b)
