### PR TITLE
input: translate '\t' to Key.tab

### DIFF
--- a/src/input/key.zig
+++ b/src/input/key.zig
@@ -697,6 +697,9 @@ pub const Key = enum(c_int) {
         .{ ']', .right_bracket },
         .{ '\\', .backslash },
 
+        // Control characters
+        .{ '\t', .tab },
+
         // Keypad entries. We just assume keypad with the kp_ prefix
         // so that has some special meaning. These must also always be last.
         .{ '0', .kp_0 },


### PR DESCRIPTION
This allows bindings with `tab` to work properly on Linux. The issue is that in the key translation, we weren't mapping this and thought it was invalid IME input so we were ignoring it. This wasn't an issue on macOS because tab wasn't translated to "\t" by the OS (it was just sent as a non-character-producing input).