### PR TITLE
cli: handle launching as `xdg-terminal-exec`

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1639,6 +1639,7 @@ pub fn parseManuallyHook(self: *Config, alloc: Allocator, arg: []const u8, iter:
         errdefer command.deinit();
 
         while (iter.next()) |param| {
+            try self._inputs.append(alloc, try alloc.dupe(u8, param));
             try command.appendSlice(param);
             try command.append(' ');
         }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1847,6 +1847,28 @@ test "parse e: command and args" {
     try testing.expectEqualStrings("echo foo bar baz", cfg.command.?);
 }
 
+test "parse xdg-terminal-exec: command and args" {
+    const testing = std.testing;
+    var cfg = try Config.default(testing.allocator);
+    defer cfg.deinit();
+    const alloc = cfg._arena.?.allocator();
+
+    var it: TestIterator = .{ .data = &.{ "echo", "foo", "bar baz" } };
+    try testing.expect(!try cfg.parseManuallyHook(alloc, "xdg-terminal-exec", &it));
+    try testing.expectEqualStrings("echo foo bar baz", cfg.command.?);
+}
+
+test "parse xdg-terminal-exec: command and args with abs path" {
+    const testing = std.testing;
+    var cfg = try Config.default(testing.allocator);
+    defer cfg.deinit();
+    const alloc = cfg._arena.?.allocator();
+
+    var it: TestIterator = .{ .data = &.{ "echo", "foo", "bar baz" } };
+    try testing.expect(!try cfg.parseManuallyHook(alloc, "/home/ghostty/.local/bin/xdg-terminal-exec", &it));
+    try testing.expectEqualStrings("echo foo bar baz", cfg.command.?);
+}
+
 test "clone default" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1630,7 +1630,9 @@ pub fn finalize(self: *Config) !void {
 /// Callback for src/cli/args.zig to allow us to handle special cases
 /// like `--help` or `-e`. Returns "false" if the CLI parsing should halt.
 pub fn parseManuallyHook(self: *Config, alloc: Allocator, arg: []const u8, iter: anytype) !bool {
-    if (std.mem.eql(u8, arg, "-e")) {
+    if (std.mem.eql(u8, arg, "-e") or
+        std.mem.eql(u8, std.fs.path.basename(arg), "xdg-terminal-exec"))
+    {
         // Build up the command. We don't clean this up because we take
         // ownership in our allocator.
         var command = std.ArrayList(u8).init(alloc);
@@ -1645,8 +1647,8 @@ pub fn parseManuallyHook(self: *Config, alloc: Allocator, arg: []const u8, iter:
             try self._errors.add(alloc, .{
                 .message = try std.fmt.allocPrintZ(
                     alloc,
-                    "missing command after -e",
-                    .{},
+                    "missing command after {s}",
+                    .{arg},
                 ),
             });
 


### PR DESCRIPTION
[xdg-terminal-exec](https://github.com/Vladimir-csp/xdg-terminal-exec) is a
proposal to allow users to define a "default" terminal to use when launching
applications which have `Terminal=true` in their desktop file. Users can symlink
their terminal of choice to `xdg-terminal-exec`, which is the first option used
in the GIO launch options, and is gaining traction elsewhere.

When launched as `xdg-terminal-exec`, ghostty must parse any args as the
command. Add a special case using the same logic as the '-e' flag to enable
ghostty to be launched in this manner.

Fixes: https://github.com/mitchellh/ghostty/issues/658
