### PR TITLE
renderer/opengl: error if OpenGL version is too old

### DIFF
--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -412,11 +412,16 @@ pub fn surfaceInit(surface: *apprt.Surface) !void {
         apprt.gtk => {
             // GTK uses global OpenGL context so we load from null.
             const version = try gl.glad.load(null);
+            const major = gl.glad.versionMajor(@intCast(version));
+            const minor = gl.glad.versionMinor(@intCast(version));
             errdefer gl.glad.unload();
-            log.info("loaded OpenGL {}.{}", .{
-                gl.glad.versionMajor(@intCast(version)),
-                gl.glad.versionMinor(@intCast(version)),
-            });
+            log.info("loaded OpenGL {}.{}", .{ major, minor });
+
+            // We require at least OpenGL 3.3
+            if (major < 3 or minor < 3) {
+                log.warn("OpenGL version is too old. Ghostty requires OpenGL 3.3", .{});
+                return error.OpenGLOutdated;
+            }
         },
 
         apprt.glfw => try self.threadEnter(surface),


### PR DESCRIPTION
This returns an error from the renderer implementation. This error just crashes Ghostty currently with a stack trace. We can handle the error later but for now it makes it a lot more obvious why certain error scenarios happen.