### PR TITLE
macos: put build numbers back into info.plist, other metadata

### DIFF
--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -39,6 +39,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Important so that build number generation works
+          fetch-depth: 0
 
       # Install Nix and use that to run our tests so our environment matches exactly.
       - uses: cachix/install-nix-action@v24
@@ -57,7 +60,8 @@ jobs:
       # Load Build Number
       - name: Build Number
         run: |
-          echo "GHOSTTY_BUILD=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "GHOSTTY_BUILD=$(git rev-list --count head)" >> $GITHUB_ENV
+          echo "GHOSTTY_COMMIT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       # GhosttyKit is the framework that is built from Zig for our native
       # Mac app to access. Build this in release mode.
@@ -74,8 +78,9 @@ jobs:
       # This will be a monotonically always increasing build number that we use.
       - name: Inject Build Number
         run: |
-          echo "Setting build to $GHOSTTY_BUILD"
+          /usr/libexec/PlistBuddy -c "Set :GhosttyCommit $GHOSTTY_COMMIT" "macos/build/Release/Ghostty.app/Contents/Info.plist"
           /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $GHOSTTY_BUILD" "macos/build/Release/Ghostty.app/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $GHOSTTY_COMMIT" "macos/build/Release/Ghostty.app/Contents/Info.plist"
 
       - name: Zip Unsigned App
         run: nix develop -c sh -c 'cd macos/build/Release && zip -9 -r --symlinks ../../../ghostty-macos-universal-unsigned.zip Ghostty.app'

--- a/macos/Ghostty-Info.plist
+++ b/macos/Ghostty-Info.plist
@@ -91,5 +91,11 @@
 	<string>A program in Ghostty wants to use speech recognition.</string>
 	<key>NSSystemAdministrationUsageDescription</key>
 	<string>A program in Ghostty requires elevated privileges.</string>
+	<key>CFBundleVersion</key>
+	<string></string>
+	<key>CFBundleShortVersionString</key>
+	<string></string>
+	<key>GhosttyCommit</key>
+	<string></string>
 </dict>
 </plist>

--- a/macos/Sources/Features/About/AboutView.swift
+++ b/macos/Sources/Features/About/AboutView.swift
@@ -2,14 +2,9 @@ import SwiftUI
 
 struct AboutView: View {
     /// Read the commit from the bundle.
-    var commit: String {
-        guard let valueAny = Bundle.main.infoDictionary?["CFBundleVersion"],
-              let version = valueAny as? String else {
-            return "unknown"
-        }
-        
-        return version
-    }
+    var build: String? { Bundle.main.infoDictionary?["CFBundleVersion"] as? String }
+    var commit: String? { Bundle.main.infoDictionary?["GhosttyCommit"] as? String }
+    var version: String? { Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String }
     
     var body: some View {
         VStack(alignment: .center) {
@@ -21,8 +16,10 @@ struct AboutView: View {
             Text("Ghostty")
                 .font(.title3)
             
-            Text("Commit: \(commit)")
-                .font(.body)
+            if let version = self.version {
+                Text("Version: \(version)")
+                    .font(.body)
+            }
         }
         .frame(minWidth: 300)
         .padding()


### PR DESCRIPTION
This adds more metadata back into the Info.plist for a build. This metadata is used with the About window. The reason I want the build number back is so that we have a monotonically increasing number to do self-updating with (i.e. Sparkle).

The build number itself is never publicly shown. For the about window we use `CFBundleShortVersionString` which is currently set to the commit but in the future can be anything human-friendly we think of. The commit is always available as `GhosttyCommit` and the build number is always `CFBundleVersion`.