### PR TITLE
apprt/gtk: only reset IME state if key consuming while IME composing

### DIFF
--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1482,10 +1482,15 @@ fn keyEvent(
         .closed => return true,
         .ignored => {},
         .consumed => if (action == .press or action == .repeat) {
-            // If we consume the key then we want to reset the dead key
-            // state.
-            c.gtk_im_context_reset(self.im_context);
-            self.core_surface.preeditCallback(null) catch {};
+            // If we were in the composing state then we reset our context.
+            // We do NOT want to reset if we're not in the composing state
+            // because there is other IME state that we want to preserve,
+            // such as quotation mark ordering for Chinese input.
+            if (self.im_composing) {
+                c.gtk_im_context_reset(self.im_context);
+                self.core_surface.preeditCallback(null) catch {};
+            }
+
             return true;
         },
     }


### PR DESCRIPTION
Fixes #1047

This resets the IME state only if we were previously in a composing state. I did not realize that IME state also included non-composing state that we want to preserve, such as the next quotation direction in the case of chinese. i.e. `“` vs `”`.

I'm not fully sure that this is the right logic, but previous pre-edit states such as in Japanese appear to still work and this fixes Chinese quotation marks.

## After


https://github.com/mitchellh/ghostty/assets/1299/d2c23e44-7f9a-46e5-8e98-09e4fb71535f

