### PR TITLE
fix(macos): ReleaseLocal build configuration with "Library Validation" disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ build on a macOS machine with XCode installed:
 
 ```shell-session
 $ zig build -Doptimize=ReleaseFast
-$ cd macos && xcodebuild -configuration ReleaseLocal
+$ cd macos && xcodebuild
 ```
 
 This will output the app to `macos/build/ReleaseLocal/Ghostty.app`.

--- a/README.md
+++ b/README.md
@@ -504,9 +504,7 @@ $ zig build -Doptimize=ReleaseFast
 $ cd macos && xcodebuild -configuration ReleaseLocal
 ```
 
-We currently don't support any way to do this from
-the command line so you'll have to open Xcode graphically. If you want a release
-build, I highly recommend you use
+If you want a release build, I highly recommend you use
 [the official continuous builds](https://github.com/mitchellh/ghostty/releases/tag/tip).
 
 If Ghostty is crashing on launch with an error about codesigning, you've

--- a/README.md
+++ b/README.md
@@ -485,31 +485,20 @@ build on a macOS machine with XCode installed:
 
 ```shell-session
 $ zig build -Doptimize=ReleaseFast
-$ cd macos && xcodebuild -configuration Debug
+$ cd macos && xcodebuild -configuration ReleaseLocal
 ```
 
-This will output the app to `macos/build/Debug/Ghostty.app`.
+This will output the app to `macos/build/ReleaseLocal/Ghostty.app`.
 This app will be not be signed or notarized.
 [Official continuous builds are available](https://github.com/mitchellh/ghostty/releases/tag/tip)
 that are both signed and notarized.
 
-Note that this is a debug build. If you build a release build, you'll have
-to either manually disable "Library Validation" for the release target or
-you'll have to manually configure the Xcode project to use a valid macOS
-developer signing key. `ReleaseLocal` build configuration provides Release
-build settings with "Library Validation" disabled.
-
-```shell-session
-$ zig build -Doptimize=ReleaseFast
-$ cd macos && xcodebuild -configuration ReleaseLocal
-```
-
-If you want a release build, I highly recommend you use
+The "ReleaseLocal" build configuration is specifically for local release
+builds and disables some security features (such as "Library Validation")
+to make it easier to run without having to have a code signing identity
+and so on. These builds aren't meant for distribution. If you want a release
+build with all security features, I highly recommend you use
 [the official continuous builds](https://github.com/mitchellh/ghostty/releases/tag/tip).
-
-If Ghostty is crashing on launch with an error about codesigning, you've
-probably built a release build without applying the requirements in the previous
-paragraph.
 
 When running the app, logs are available via macOS unified logging such
 as `Console.app`. The easiest way I've found to view these is to just use the CLI:

--- a/README.md
+++ b/README.md
@@ -496,7 +496,15 @@ that are both signed and notarized.
 Note that this is a debug build. If you build a release build, you'll have
 to either manually disable "Library Validation" for the release target or
 you'll have to manually configure the Xcode project to use a valid macOS
-developer signing key. We currently don't support any way to do this from
+developer signing key. `ReleaseLocal` build configuration provides Release
+build settings with "Library Validation" disabled.
+
+```shell-session
+$ zig build -Doptimize=ReleaseFast
+$ cd macos && xcodebuild -configuration ReleaseLocal
+```
+
+We currently don't support any way to do this from
 the command line so you'll have to open Xcode graphically. If you want a release
 build, I highly recommend you use
 [the official continuous builds](https://github.com/mitchellh/ghostty/releases/tag/tip).

--- a/macos/Ghostty.xcodeproj/project.pbxproj
+++ b/macos/Ghostty.xcodeproj/project.pbxproj
@@ -232,12 +232,12 @@
 		A5B30528299BEAAA0047F10C = {
 			isa = PBXGroup;
 			children = (
-				3B39CAA42B33949B00DABEB8 /* GhosttyReleaseLocal.entitlements */,
 				A5CB04372B0F1C1C009ED217 /* themes */,
 				A571AB1C2A206FC600248498 /* Ghostty-Info.plist */,
 				A5B30538299BEAAB0047F10C /* Assets.xcassets */,
 				A5B3053D299BEAAB0047F10C /* Ghostty.entitlements */,
 				A51BFC282B30F26D00E92F16 /* GhosttyDebug.entitlements */,
+				3B39CAA42B33949B00DABEB8 /* GhosttyReleaseLocal.entitlements */,
 				A54CD6ED299BEB14008C95BB /* Sources */,
 				A5D495A3299BECBA00DD1313 /* Frameworks */,
 				A5A1F8862A489D7400D1E8BC /* Resources */,
@@ -685,7 +685,7 @@
 				3B39CAA22B33946300DABEB8 /* ReleaseLocal */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = ReleaseLocal;
 		};
 		A5B30540299BEAAB0047F10C /* Build configuration list for PBXNativeTarget "Ghostty" */ = {
 			isa = XCConfigurationList;
@@ -695,7 +695,7 @@
 				3B39CAA32B33946300DABEB8 /* ReleaseLocal */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = ReleaseLocal;
 		};
 /* End XCConfigurationList section */
 

--- a/macos/Ghostty.xcodeproj/project.pbxproj
+++ b/macos/Ghostty.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3B39CAA42B33949B00DABEB8 /* GhosttyReleaseLocal.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = GhosttyReleaseLocal.entitlements; sourceTree = "<group>"; };
 		8503D7C62A549C66006CFF3D /* FullScreenHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenHandler.swift; sourceTree = "<group>"; };
 		857F63802A5E64F200CA4815 /* MainMenu.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MainMenu.xib; sourceTree = "<group>"; };
 		A51B78462AF4B58B00F3EDB9 /* TerminalWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalWindow.swift; sourceTree = "<group>"; };
@@ -231,6 +232,7 @@
 		A5B30528299BEAAA0047F10C = {
 			isa = PBXGroup;
 			children = (
+				3B39CAA42B33949B00DABEB8 /* GhosttyReleaseLocal.entitlements */,
 				A5CB04372B0F1C1C009ED217 /* themes */,
 				A571AB1C2A206FC600248498 /* Ghostty-Info.plist */,
 				A5B30538299BEAAB0047F10C /* Assets.xcassets */,
@@ -399,6 +401,95 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
+		3B39CAA22B33946300DABEB8 /* ReleaseLocal */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = ReleaseLocal;
+		};
+		3B39CAA32B33946300DABEB8 /* ReleaseLocal */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
+				CODE_SIGN_ENTITLEMENTS = GhosttyReleaseLocal.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				EXECUTABLE_NAME = ghostty;
+				GCC_OPTIMIZATION_LEVEL = fast;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Ghostty-Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = Ghostty;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSMainNibFile = MainMenu;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = 0.1;
+				"OTHER_LDFLAGS[arch=*]" = "-lstdc++";
+				PRODUCT_BUNDLE_IDENTIFIER = com.mitchellh.ghostty;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = ReleaseLocal;
+		};
 		A5B3053E299BEAAB0047F10C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -591,6 +682,7 @@
 			buildConfigurations = (
 				A5B3053E299BEAAB0047F10C /* Debug */,
 				A5B3053F299BEAAB0047F10C /* Release */,
+				3B39CAA22B33946300DABEB8 /* ReleaseLocal */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -600,6 +692,7 @@
 			buildConfigurations = (
 				A5B30541299BEAAB0047F10C /* Debug */,
 				A5B30542299BEAAB0047F10C /* Release */,
+				3B39CAA32B33946300DABEB8 /* ReleaseLocal */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/macos/GhosttyReleaseLocal.entitlements
+++ b/macos/GhosttyReleaseLocal.entitlements
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+	<key>com.apple.security.personal-information.addressbook</key>
+	<true/>
+	<key>com.apple.security.personal-information.calendars</key>
+	<true/>
+	<key>com.apple.security.personal-information.location</key>
+	<true/>
+	<key>com.apple.security.personal-information.photos-library</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Fixes #1133

MacOS: If ghostty build succeeds but it crashes at startup due to a library or framework failing to load, build it with `xcodebuild -configuration ReleaseLocal`
