### PR TITLE
Click to move cursor at prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ The currently supported shell integration features in Ghostty:
 - The cursor at the prompt is turned into a bar.
 - The `jump_to_prompt` keybinding can be used to scroll the terminal window
   forward and back through prompts.
+- Alt+click (option+click on macOS) to move the cursor at the prompt.
 
 #### Shell Integration Installation and Verification
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -182,6 +182,7 @@ const DerivedConfig = struct {
     clipboard_paste_bracketed_safe: bool,
     copy_on_select: configpkg.CopyOnSelect,
     confirm_close_surface: bool,
+    cursor_click_to_move: bool,
     desktop_notifications: bool,
     mouse_interval: u64,
     mouse_hide_while_typing: bool,
@@ -235,6 +236,7 @@ const DerivedConfig = struct {
             .clipboard_paste_bracketed_safe = config.@"clipboard-paste-bracketed-safe",
             .copy_on_select = config.@"copy-on-select",
             .confirm_close_surface = config.@"confirm-close-surface",
+            .cursor_click_to_move = config.@"cursor-click-to-move",
             .desktop_notifications = config.@"desktop-notifications",
             .mouse_interval = config.@"click-repeat-interval" * 1_000_000, // 500ms
             .mouse_hide_while_typing = config.@"mouse-hide-while-typing",
@@ -2094,6 +2096,9 @@ pub fn mouseButtonCallback(
 /// screen point if possible. This works by converting the path to the
 /// given point into a series of arrow key inputs.
 fn clickMoveCursor(self: *Surface, to: terminal.point.ScreenPoint) !void {
+    // If click-to-move is disabled then we're done.
+    if (!self.config.cursor_click_to_move) return;
+
     const t = &self.io.terminal;
 
     // Click to move cursor only works on the primary screen where prompts

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2097,6 +2097,11 @@ fn clickMoveCursor(self: *Surface, to: terminal.point.ScreenPoint) !void {
     // support this feature. It is just too messy.
     if (t.active_screen != .primary) return;
 
+    // This flag is only set if we've seen at least one semantic prompt
+    // OSC sequence. If we've never seen that sequence, we can't possibly
+    // move the cursor so we can fast path out of here.
+    if (!t.flags.shell_redraws_prompt) return;
+
     // Get our path
     const from = (terminal.point.Viewport{
         .x = t.screen.cursor.x,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1989,6 +1989,7 @@ pub fn mouseButtonCallback(
         self.renderer_state.mutex.lock();
         defer self.renderer_state.mutex.unlock();
         try self.clickMoveCursor(self.mouse.left_click_point);
+        return;
     }
 
     // For left button clicks we always record some information for
@@ -2089,6 +2090,9 @@ pub fn mouseButtonCallback(
     }
 }
 
+/// Performs the "click-to-move" logic to move the cursor to the given
+/// screen point if possible. This works by converting the path to the
+/// given point into a series of arrow key inputs.
 fn clickMoveCursor(self: *Surface, to: terminal.point.ScreenPoint) !void {
     const t = &self.io.terminal;
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -264,6 +264,21 @@ palette: Palette = .{},
 /// will be chosen.
 @"cursor-text": ?Color = null,
 
+/// Enables the ability to move the cursor at prompts by using alt+click
+/// on Linux and option+click on macOS.
+///
+/// This feature requires shell integration (specifically prompt marking
+/// via OSC 133) and only works in primary screen mode. Alternate screen
+/// applications like vim usually have their own version of this feature
+/// but this configuration doesn't control that.
+///
+/// It should be noted that this feature works by translating your desired
+/// position into a series of synthetic arrow key movements, so some weird
+/// behavior around edge cases are to be expected. This is unfortunately
+/// how this feature is implemented across terminals because there isn't
+/// any other way to implement it.
+@"cursor-click-to-move": bool = true,
+
 /// Hide the mouse immediately when typing. The mouse becomes visible
 /// again when the mouse is used. The mouse is only hidden if the mouse
 /// cursor is over the active terminal surface.

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1922,6 +1922,39 @@ pub fn selectPrompt(self: *Screen, pt: point.ScreenPoint) ?Selection {
     };
 }
 
+/// Returns the change in x/y that is needed to reach "to" from "from"
+/// within a prompt. If "to" is before or after the prompt bounds then
+/// the result will be bounded to the prompt.
+///
+/// This feature requires shell integration. If shell integration is not
+/// enabled, this will always return zero for both x and y (no path).
+pub fn promptPath(
+    self: *Screen,
+    from: point.ScreenPoint,
+    to: point.ScreenPoint,
+) struct {
+    x: isize,
+    y: isize,
+} {
+    // Get our prompt bounds assuming "from" is at a prompt.
+    const bounds = self.selectPrompt(from) orelse return .{ .x = 0, .y = 0 };
+
+    // Get our actual "to" point clamped to the bounds of the prompt.
+    const to_clamped = if (bounds.contains(to))
+        to
+    else if (to.before(bounds.start))
+        bounds.start
+    else
+        bounds.end;
+
+    // Basic math to calculate our path.
+    const from_x: isize = @intCast(from.x);
+    const from_y: isize = @intCast(from.y);
+    const to_x: isize = @intCast(to_clamped.x);
+    const to_y: isize = @intCast(to_clamped.y);
+    return .{ .x = to_x - from_x, .y = to_y - from_y };
+}
+
 /// Scroll behaviors for the scroll function.
 pub const Scroll = union(enum) {
     /// Scroll to the top of the scroll buffer. The first line of the
@@ -4722,6 +4755,7 @@ test "Screen: selectOutput" {
         try s.testWriteString("output3\n");         // 8
         try s.testWriteString("output3");           // 9
     }
+    // zig fmt: on
 
     var row = s.getRow(.{ .screen = 2 });
     row.setSemanticPrompt(.prompt);
@@ -4794,6 +4828,7 @@ test "Screen: selectPrompt basics" {
         try s.testWriteString("output3\n");         // 8
         try s.testWriteString("output3");           // 9
     }
+    // zig fmt: on
 
     var row = s.getRow(.{ .screen = 2 });
     row.setSemanticPrompt(.prompt);
@@ -4850,6 +4885,7 @@ test "Screen: selectPrompt prompt at start" {
         try s.testWriteString("output2\n");         // 2
         try s.testWriteString("output2\n");         // 3
     }
+    // zig fmt: on
 
     var row = s.getRow(.{ .screen = 0 });
     row.setSemanticPrompt(.prompt);
@@ -4887,6 +4923,7 @@ test "Screen: selectPrompt prompt at end" {
         try s.testWriteString("prompt1\n");         // 2
         try s.testWriteString("input1\n");          // 3
     }
+    // zig fmt: on
 
     var row = s.getRow(.{ .screen = 2 });
     row.setSemanticPrompt(.prompt);
@@ -4906,6 +4943,91 @@ test "Screen: selectPrompt prompt at end" {
             .start = .{ .x = 0, .y = 2 },
             .end = .{ .x = 9, .y = 3 },
         }, sel);
+    }
+}
+
+test "Screen: promtpPath" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, 15, 10, 0);
+    defer s.deinit();
+
+    // zig fmt: off
+    {
+                                                    // line number:
+        try s.testWriteString("output1\n");         // 0
+        try s.testWriteString("output1\n");         // 1
+        try s.testWriteString("prompt2\n");         // 2
+        try s.testWriteString("input2\n");          // 3
+        try s.testWriteString("output2\n");         // 4
+        try s.testWriteString("output2\n");         // 5
+        try s.testWriteString("prompt3$ input3\n"); // 6
+        try s.testWriteString("output3\n");         // 7
+        try s.testWriteString("output3\n");         // 8
+        try s.testWriteString("output3");           // 9
+    }
+    // zig fmt: on
+
+    var row = s.getRow(.{ .screen = 2 });
+    row.setSemanticPrompt(.prompt);
+    row = s.getRow(.{ .screen = 3 });
+    row.setSemanticPrompt(.input);
+    row = s.getRow(.{ .screen = 4 });
+    row.setSemanticPrompt(.command);
+    row = s.getRow(.{ .screen = 6 });
+    row.setSemanticPrompt(.input);
+    row = s.getRow(.{ .screen = 7 });
+    row.setSemanticPrompt(.command);
+
+    // From is not in the prompt
+    {
+        const path = s.promptPath(
+            .{ .x = 0, .y = 1 },
+            .{ .x = 0, .y = 2 },
+        );
+        try testing.expectEqual(@as(isize, 0), path.x);
+        try testing.expectEqual(@as(isize, 0), path.y);
+    }
+
+    // Same line
+    {
+        const path = s.promptPath(
+            .{ .x = 6, .y = 2 },
+            .{ .x = 3, .y = 2 },
+        );
+        try testing.expectEqual(@as(isize, -3), path.x);
+        try testing.expectEqual(@as(isize, 0), path.y);
+    }
+
+    // Different lines
+    {
+        const path = s.promptPath(
+            .{ .x = 6, .y = 2 },
+            .{ .x = 3, .y = 3 },
+        );
+        try testing.expectEqual(@as(isize, -3), path.x);
+        try testing.expectEqual(@as(isize, 1), path.y);
+    }
+
+    // To is out of bounds before
+    {
+        const path = s.promptPath(
+            .{ .x = 6, .y = 2 },
+            .{ .x = 3, .y = 1 },
+        );
+        try testing.expectEqual(@as(isize, -6), path.x);
+        try testing.expectEqual(@as(isize, 0), path.y);
+    }
+
+    // To is out of bounds after
+    {
+        const path = s.promptPath(
+            .{ .x = 6, .y = 2 },
+            .{ .x = 3, .y = 9 },
+        );
+        try testing.expectEqual(@as(isize, 3), path.x);
+        try testing.expectEqual(@as(isize, 1), path.y);
     }
 }
 
@@ -5646,7 +5768,6 @@ test "Screen: selectionString, rectangle, more complex w/breaks" {
     defer alloc.free(contents);
     try testing.expectEqualStrings(expected, contents);
 }
-
 
 test "Screen: dirty with getCellPtr" {
     const testing = std.testing;

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -2115,7 +2115,7 @@ pub fn setLeftAndRightMargin(self: *Terminal, left_req: usize, right_req: usize)
 /// (OSC 133) only allow setting this for wherever the current active cursor
 /// is located.
 pub fn markSemanticPrompt(self: *Terminal, p: SemanticPrompt) void {
-    //log.warn("semantic_prompt y={} p={}", .{ self.screen.cursor.y, p });
+    //log.debug("semantic_prompt y={} p={}", .{ self.screen.cursor.y, p });
     const row = self.screen.getRow(.{ .active = self.screen.cursor.y });
     row.setSemanticPrompt(switch (p) {
         .prompt => .prompt,


### PR DESCRIPTION
Fixes #891 

This mimics iTerm2 and Terminal.app and allows the user to move their cursor at a terminal prompt by using **alt+click** (alt is option on macOS). This works by converting the desired location into a series of synthetic arrow key inputs. That's pretty jank, but that's also how it works with iTerm and Terminal.app since there is no sequence to let the running program know about this behavior.

**This feature requires shell integration.** This uses the [semantic prompts (OSC 133)](https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md) sequences. This feature only works on the primary screen. Therefore, this feature does not work in programs such as `tmux`. Since Ghostty can't possibly know the boundaries of the splits or what line where is a prompt, it just can't work in its current form. 

This feature can be configured with `cursor-click-to-move` (default true).

## Demo

Note some of the weird behaviors around multi-line inputs. That is a limitation of translating to arrow keys and similar behavior exists in iTerm and Terminal under the same circumstance. Terminal.app behaves the worst because it'll send arrow up keys if you click out of the prompt area which starts to scroll through your command history 😬 

https://github.com/mitchellh/ghostty/assets/1299/d61e478e-dab6-4abd-a2a1-48e8b952c78d

