### PR TITLE
terminfo: fix `xr` and `rv`

### DIFF
--- a/src/terminfo/ghostty.zig
+++ b/src/terminfo/ghostty.zig
@@ -135,11 +135,11 @@ pub const ghostty: Source = .{
 
         // Secondary device attributes request / response
         .{ .name = "RV", .value = .{ .string = "\\E[>c" } },
-        .{ .name = "rv", .value = .{ .string = "\\E\\[[0-9]+;[0-9]+;[0-9]+c" } },
+        .{ .name = "rv", .value = .{ .string = "\\E\\\\[[0-9]+;[0-9]+;[0-9]+c" } },
 
         // XTVERSION
         .{ .name = "XR", .value = .{ .string = "\\E[>0q" } },
-        .{ .name = "xr", .value = .{ .string = "\\EP>\\|[ -~]+a\\E\\\\" } },
+        .{ .name = "xr", .value = .{ .string = "\\EP>\\\\|[ -~]+a\\E\\\\" } },
 
         // DECSLRM (Left/Right Margins)
         .{ .name = "Enmg", .value = .{ .string = "\\E[?69h" } },


### PR DESCRIPTION
Commit 5e473ebd ("terminfo: add additional entries, fix smkx/rmkx")
added entries `xr` and `rv`, but without proper escaping of the
backslashes. This commit adds the extras. Output of `infocmp` now
matches foot, kitty, et al.
