### PR TITLE
macos: handle middle click

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -635,6 +635,21 @@ extension Ghostty {
             ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, mods)
         }
 
+        override func otherMouseDown(with event: NSEvent) {
+            guard let surface = self.surface else { return }
+            guard event.buttonNumber == 2 else { return }
+            let mods = Ghostty.ghosttyMods(event.modifierFlags)
+            ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_MIDDLE, mods)
+        }
+
+        override func otherMouseUp(with event: NSEvent) {
+            guard let surface = self.surface else { return }
+            guard event.buttonNumber == 2 else { return }
+            let mods = Ghostty.ghosttyMods(event.modifierFlags)
+            ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_MIDDLE, mods)
+        }
+
+
         override func rightMouseDown(with event: NSEvent) {
             guard let surface = self.surface else { return }
             let mods = Ghostty.ghosttyMods(event.modifierFlags)


### PR DESCRIPTION
This adds middle-click support to MacOS.

Very simple update, since everything else is in place to handle mouse clicks in the embedded runtime already, we just needed to add the event handlers in the UI.