### PR TITLE
ci: swap magic-nix-cache with cachix

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -10,28 +10,9 @@ jobs:
         uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      # Use cache to minimize build times.
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: cachix/cachix-action@v12
         with:
-          diagnostic-endpoint: "" # disable telemetry
+          name: ghostty
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Check Zig cache hash
         run: nix develop -c ./nix/build-support/check-zig-cache-hash.sh
-#
-# NOTE: Build is disabled until we resolve dependency build speeds.
-#   build:
-#     needs: check-zig-cache-hash
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Checkout code
-#         uses: actions/checkout@v4
-#       - name: Setup Nix
-#         uses: cachix/install-nix-action@v24
-#         with:
-#           nix_path: nixpkgs=channel:nixos-unstable
-#       - name: Setup Nix cache
-#         uses: DeterminateSystems/magic-nix-cache-action@main
-#         with:
-#           diagnostic-endpoint: "" # disable telemetry
-#       - name: Run build
-#         run: nix build .

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: cachix/cachix-action@v12
         with:
           name: ghostty
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Check Zig cache hash
         run: nix develop -c ./nix/build-support/check-zig-cache-hash.sh

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: cachix/cachix-action@v12
         with:
           name: ghostty
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       # Setup Sparkle
       - name: Setup Sparkle

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -47,12 +47,10 @@ jobs:
       - uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-
-      # Use cache to minimize build times.
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: cachix/cachix-action@v12
         with:
-          diagnostic-endpoint: "" # disable telemetry
+          name: ghostty
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       # Setup Sparkle
       - name: Setup Sparkle

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: cachix/cachix-action@v12
         with:
           name: ghostty
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       # Cross-compile the binary. We always use static building for this
       # because its the only way to access the headers.
@@ -57,7 +57,7 @@ jobs:
       - uses: cachix/cachix-action@v12
         with:
           name: ghostty
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Test NixOS package build
         run: nix build .#ghostty
@@ -79,7 +79,7 @@ jobs:
       - uses: cachix/cachix-action@v12
         with:
           name: ghostty
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       # GhosttyKit is the framework that is built from Zig for our native
       # Mac app to access.
@@ -159,7 +159,7 @@ jobs:
       - uses: cachix/cachix-action@v12
         with:
           name: ghostty
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: test
         run: nix develop -c zig build -Dapp-runtime=none test
@@ -183,7 +183,7 @@ jobs:
       - uses: cachix/cachix-action@v12
         with:
           name: ghostty
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: prettier check
         run: nix develop -c prettier --check .
 
@@ -197,6 +197,6 @@ jobs:
       - uses: cachix/cachix-action@v12
         with:
           name: ghostty
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: alejandra check
         run: nix develop -c alejandra --check .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,10 +41,7 @@ jobs:
         run: nix develop -c zig build -Dstatic=true -Dapp-runtime=glfw -Dtarget=${{ matrix.target }}
 
   build-nix:
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     needs: test
     steps:
       - name: Checkout code
@@ -144,10 +141,7 @@ jobs:
         run: Get-Content -Path ".\build.log"
 
   test:
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,12 +30,10 @@ jobs:
       - uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-
-      # Use cache to minimize build times.
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: cachix/cachix-action@v12
         with:
-          diagnostic-endpoint: "" # disable telemetry
+          name: ghostty
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       # Cross-compile the binary. We always use static building for this
       # because its the only way to access the headers.
@@ -56,12 +54,10 @@ jobs:
       - uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-
-      # Use cache to minimize build times.
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: cachix/cachix-action@v12
         with:
-          diagnostic-endpoint: "" # disable telemetry
+          name: ghostty
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Test NixOS package build
         run: nix build .#ghostty
@@ -80,12 +76,10 @@ jobs:
       - uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-
-      # Use cache to minimize build times.
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: cachix/cachix-action@v12
         with:
-          diagnostic-endpoint: "" # disable telemetry
+          name: ghostty
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       # GhosttyKit is the framework that is built from Zig for our native
       # Mac app to access.
@@ -162,12 +156,10 @@ jobs:
       - uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-
-      # Use cache to minimize build times.
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: cachix/cachix-action@v12
         with:
-          diagnostic-endpoint: "" # disable telemetry
+          name: ghostty
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: test
         run: nix develop -c zig build -Dapp-runtime=none test
@@ -188,11 +180,10 @@ jobs:
       - uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      # Use cache to minimize build times.
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: cachix/cachix-action@v12
         with:
-          diagnostic-endpoint: "" # disable telemetry
+          name: ghostty
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: prettier check
         run: nix develop -c prettier --check .
 
@@ -203,10 +194,9 @@ jobs:
       - uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      # Use cache to minimize build times.
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: cachix/cachix-action@v12
         with:
-          diagnostic-endpoint: "" # disable telemetry
+          name: ghostty
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: alejandra check
         run: nix develop -c alejandra --check .


### PR DESCRIPTION
Cachix doesn't have rate limit issues like GitHub Actions does and I'd love to support the Nix community. Plus, I have experience with Cachix before and they've been so great. I expect the first build will take about an hour but after that it should drop to our standard ~7 minutes for a release build on GHA.

/cc @jcollie @vancluever 