### PR TITLE
macos: middle click always pastes from clipboard

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2080,7 +2080,11 @@ pub fn mouseButtonCallback(
 
     // Middle-click pastes from our selection clipboard
     if (button == .middle and action == .press) {
-        if (self.config.copy_on_select != .false) {
+        if (comptime builtin.target.isDarwin()) {
+            // Fast-path for MacOS - always paste from clipboard on
+            // middle-click.
+            try self.startClipboardRequest(.standard, .{ .paste = {} });
+        } else if (self.config.copy_on_select != .false) {
             const clipboard: apprt.Clipboard = switch (self.config.copy_on_select) {
                 .true => .selection,
                 .clipboard => .standard,


### PR DESCRIPTION
Following up on #1145, this changes middle-click behavior on MacOS to always paste from the system clipboard. This does not alter any of the selection behavior, i.e. default behavior is to allow paste, but you still need to manually copy. MacOS users still need to enable `copy-on-select = clipboard` for that respective functionality.