### PR TITLE
macOS: restore windows, tabs, splits, working directories, etc. on restart

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -460,6 +460,7 @@ void ghostty_surface_split_resize(ghostty_surface_t, ghostty_split_resize_direct
 void ghostty_surface_split_equalize(ghostty_surface_t);
 bool ghostty_surface_binding_action(ghostty_surface_t, const char *, uintptr_t);
 void ghostty_surface_complete_clipboard_request(ghostty_surface_t, const char *, void *, bool);
+uintptr_t ghostty_surface_pwd(ghostty_surface_t, char *, uintptr_t);
 
 ghostty_inspector_t ghostty_surface_inspector(ghostty_surface_t);
 void ghostty_inspector_free(ghostty_surface_t);

--- a/macos/Ghostty.xcodeproj/project.pbxproj
+++ b/macos/Ghostty.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		A5CEAFDC29B8009000646FDA /* SplitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CEAFDB29B8009000646FDA /* SplitView.swift */; };
 		A5CEAFDE29B8058B00646FDA /* SplitView.Divider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CEAFDD29B8058B00646FDA /* SplitView.Divider.swift */; };
 		A5CEAFFF29C2410700646FDA /* Backport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CEAFFE29C2410700646FDA /* Backport.swift */; };
+		A5D0AF3B2B36A1DE00D21823 /* TerminalRestorable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D0AF3A2B36A1DE00D21823 /* TerminalRestorable.swift */; };
 		A5E112932AF73E6E00C6E0C2 /* ClipboardConfirmation.xib in Resources */ = {isa = PBXBuildFile; fileRef = A5E112922AF73E6E00C6E0C2 /* ClipboardConfirmation.xib */; };
 		A5E112952AF73E8A00C6E0C2 /* ClipboardConfirmationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E112942AF73E8A00C6E0C2 /* ClipboardConfirmationController.swift */; };
 		A5E112972AF7401B00C6E0C2 /* ClipboardConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E112962AF7401B00C6E0C2 /* ClipboardConfirmationView.swift */; };
@@ -95,6 +96,7 @@
 		A5CEAFDB29B8009000646FDA /* SplitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitView.swift; sourceTree = "<group>"; };
 		A5CEAFDD29B8058B00646FDA /* SplitView.Divider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitView.Divider.swift; sourceTree = "<group>"; };
 		A5CEAFFE29C2410700646FDA /* Backport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Backport.swift; sourceTree = "<group>"; };
+		A5D0AF3A2B36A1DE00D21823 /* TerminalRestorable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalRestorable.swift; sourceTree = "<group>"; };
 		A5D495A1299BEC7E00DD1313 /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = GhosttyKit.xcframework; sourceTree = "<group>"; };
 		A5E112922AF73E6E00C6E0C2 /* ClipboardConfirmation.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ClipboardConfirmation.xib; sourceTree = "<group>"; };
 		A5E112942AF73E8A00C6E0C2 /* ClipboardConfirmationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardConfirmationController.swift; sourceTree = "<group>"; };
@@ -213,6 +215,7 @@
 				A59630992AEE1C6400D64628 /* Terminal.xib */,
 				A596309F2AEF6AEB00D64628 /* TerminalManager.swift */,
 				A596309B2AEE1C9E00D64628 /* TerminalController.swift */,
+				A5D0AF3A2B36A1DE00D21823 /* TerminalRestorable.swift */,
 				A596309D2AEE1D6C00D64628 /* TerminalView.swift */,
 				A51B78462AF4B58B00F3EDB9 /* TerminalWindow.swift */,
 				A535B9D9299C569B0017E2E4 /* ErrorView.swift */,
@@ -366,6 +369,7 @@
 			files = (
 				A59630A42AF059BB00D64628 /* Ghostty.SplitNode.swift in Sources */,
 				A59FB5CF2AE0DB50009128F3 /* InspectorView.swift in Sources */,
+				A5D0AF3B2B36A1DE00D21823 /* TerminalRestorable.swift in Sources */,
 				A596309C2AEE1C9E00D64628 /* TerminalController.swift in Sources */,
 				A56D58892ACDE6CA00508D2C /* ServiceProvider.swift in Sources */,
 				A51BFC222B2FB6B400E92F16 /* AboutView.swift in Sources */,

--- a/macos/Ghostty.xcodeproj/project.pbxproj
+++ b/macos/Ghostty.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		A5CEAFDE29B8058B00646FDA /* SplitView.Divider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CEAFDD29B8058B00646FDA /* SplitView.Divider.swift */; };
 		A5CEAFFF29C2410700646FDA /* Backport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CEAFFE29C2410700646FDA /* Backport.swift */; };
 		A5D0AF3B2B36A1DE00D21823 /* TerminalRestorable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D0AF3A2B36A1DE00D21823 /* TerminalRestorable.swift */; };
+		A5D0AF3D2B37804400D21823 /* CodableBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D0AF3C2B37804400D21823 /* CodableBridge.swift */; };
 		A5E112932AF73E6E00C6E0C2 /* ClipboardConfirmation.xib in Resources */ = {isa = PBXBuildFile; fileRef = A5E112922AF73E6E00C6E0C2 /* ClipboardConfirmation.xib */; };
 		A5E112952AF73E8A00C6E0C2 /* ClipboardConfirmationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E112942AF73E8A00C6E0C2 /* ClipboardConfirmationController.swift */; };
 		A5E112972AF7401B00C6E0C2 /* ClipboardConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E112962AF7401B00C6E0C2 /* ClipboardConfirmationView.swift */; };
@@ -97,6 +98,7 @@
 		A5CEAFDD29B8058B00646FDA /* SplitView.Divider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitView.Divider.swift; sourceTree = "<group>"; };
 		A5CEAFFE29C2410700646FDA /* Backport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Backport.swift; sourceTree = "<group>"; };
 		A5D0AF3A2B36A1DE00D21823 /* TerminalRestorable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalRestorable.swift; sourceTree = "<group>"; };
+		A5D0AF3C2B37804400D21823 /* CodableBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableBridge.swift; sourceTree = "<group>"; };
 		A5D495A1299BEC7E00DD1313 /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = GhosttyKit.xcframework; sourceTree = "<group>"; };
 		A5E112922AF73E6E00C6E0C2 /* ClipboardConfirmation.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ClipboardConfirmation.xib; sourceTree = "<group>"; };
 		A5E112942AF73E8A00C6E0C2 /* ClipboardConfirmationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardConfirmationController.swift; sourceTree = "<group>"; };
@@ -153,6 +155,7 @@
 			isa = PBXGroup;
 			children = (
 				A5CEAFFE29C2410700646FDA /* Backport.swift */,
+				A5D0AF3C2B37804400D21823 /* CodableBridge.swift */,
 				8503D7C62A549C66006CFF3D /* FullScreenHandler.swift */,
 				A59630962AEE163600D64628 /* HostingWindow.swift */,
 				A59FB5D02AE0DEA7009128F3 /* MetalView.swift */,
@@ -369,6 +372,7 @@
 			files = (
 				A59630A42AF059BB00D64628 /* Ghostty.SplitNode.swift in Sources */,
 				A59FB5CF2AE0DB50009128F3 /* InspectorView.swift in Sources */,
+				A5D0AF3D2B37804400D21823 /* CodableBridge.swift in Sources */,
 				A5D0AF3B2B36A1DE00D21823 /* TerminalRestorable.swift in Sources */,
 				A596309C2AEE1C9E00D64628 /* TerminalController.swift in Sources */,
 				A56D58892ACDE6CA00508D2C /* ServiceProvider.swift in Sources */,

--- a/macos/Sources/AppDelegate.swift
+++ b/macos/Sources/AppDelegate.swift
@@ -58,7 +58,7 @@ class AppDelegate: NSObject,
     private var dockMenu: NSMenu = NSMenu()
     
     /// The ghostty global state. Only one per process.
-    private let ghostty: Ghostty.AppState = Ghostty.AppState()
+    let ghostty: Ghostty.AppState = Ghostty.AppState()
     
     /// Manages our terminal windows.
     let terminalManager: TerminalManager

--- a/macos/Sources/AppDelegate.swift
+++ b/macos/Sources/AppDelegate.swift
@@ -96,6 +96,12 @@ class AppDelegate: NSObject,
             // Disable this so that repeated key events make it through to our terminal views.
             "ApplePressAndHoldEnabled": false,
         ])
+
+        // TODO: make this configurable via ghostty
+        // reset to system defaults
+        //UserDefaults.standard.removeObject(forKey: "NSQuitAlwaysKeepsWindows")
+        // force state save
+        UserDefaults.standard.setValue(true, forKey: "NSQuitAlwaysKeepsWindows")
         
         // Hook up updater menu
         menuCheckForUpdates?.target = updaterController
@@ -292,6 +298,21 @@ class AppDelegate: NSObject,
     
     private func focusedSurface() -> ghostty_surface_t? {
         return terminalManager.focusedSurface?.surface
+    }
+    
+    //MARK: - Restorable State
+    
+    /// We support NSSecureCoding for restorable state. Required as of macOS Sonoma (14) but a good idea anyways.
+    func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
+        return true
+    }
+
+    func application(_ app: NSApplication, willEncodeRestorableState coder: NSCoder) {
+        Self.logger.debug("application will save window state")
+    }
+    
+    func application(_ app: NSApplication, didDecodeRestorableState coder: NSCoder) {
+        Self.logger.debug("application will restore window state")
     }
 
     //MARK: - UNUserNotificationCenterDelegate

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -148,6 +148,11 @@ class TerminalController: NSWindowController, NSWindowDelegate,
     override func windowDidLoad() {
         guard let window = window else { return }
         
+        // Setting all three of these is required for restoration to work.
+        window.isRestorable = true
+        window.restorationClass = TerminalWindowRestoration.self
+        window.identifier = .init(String(describing: TerminalWindowRestoration.self))
+        
         // If window decorations are disabled, remove our title
         if (!ghostty.windowDecorations) { window.styleMask.remove(.titled) }
         
@@ -248,6 +253,16 @@ class TerminalController: NSWindowController, NSWindowDelegate,
     
     func windowDidBecomeKey(_ notification: Notification) {
         self.relabelTabs()
+    }
+    
+    func window(_ window: NSWindow, willEncodeRestorableState state: NSCoder) {
+        let data = TerminalRestorableState()
+        data.encode(with: state)
+        AppDelegate.logger.warning("state window del encode")
+    }
+    
+    func window(_ window: NSWindow, didDecodeRestorableState state: NSCoder) {
+        AppDelegate.logger.warning("state window del restore")
     }
     
     //MARK: - First Responder

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -255,14 +255,11 @@ class TerminalController: NSWindowController, NSWindowDelegate,
         self.relabelTabs()
     }
     
+    // Called when the window will be encoded. We handle the data encoding here in the
+    // window controller.
     func window(_ window: NSWindow, willEncodeRestorableState state: NSCoder) {
-        let data = TerminalRestorableState()
+        let data = TerminalRestorableState(from: self)
         data.encode(with: state)
-        AppDelegate.logger.warning("state window del encode")
-    }
-    
-    func window(_ window: NSWindow, didDecodeRestorableState state: NSCoder) {
-        AppDelegate.logger.warning("state window del restore")
     }
     
     //MARK: - First Responder

--- a/macos/Sources/Features/Terminal/TerminalManager.swift
+++ b/macos/Sources/Features/Terminal/TerminalManager.swift
@@ -139,7 +139,7 @@ class TerminalManager {
     }
     
     /// Creates a window controller, adds it to our managed list, and returns it.
-    private func createWindow(withBaseConfig base: Ghostty.SurfaceConfiguration?) -> TerminalController {
+    func createWindow(withBaseConfig base: Ghostty.SurfaceConfiguration?) -> TerminalController {
         // Initialize our controller to load the window
         let c = TerminalController(ghostty, withBaseConfig: base)
 
@@ -162,7 +162,7 @@ class TerminalManager {
         return c
     }
     
-    private func removeWindow(_ controller: TerminalController) {
+    func removeWindow(_ controller: TerminalController) {
         // Remove it from our managed set
         guard let idx = self.windows.firstIndex(where: { $0.controller == controller }) else { return }
         let w = self.windows[idx]

--- a/macos/Sources/Features/Terminal/TerminalRestorable.swift
+++ b/macos/Sources/Features/Terminal/TerminalRestorable.swift
@@ -1,0 +1,77 @@
+import Cocoa
+
+/// The state stored for terminal window restoration.
+class TerminalRestorableState: NSObject, NSSecureCoding {
+    public static var supportsSecureCoding = true
+    
+    static let coderKey = "state"
+    static let versionKey = "version"
+    static let version: Int = 1
+    
+    override init() {
+        super.init()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        // If the version doesn't match then we can't decode. In the future we can perform
+        // version upgrading or something but for now we only have one version so we
+        // don't bother.
+        guard aDecoder.decodeInteger(forKey: Self.versionKey) == Self.version else {
+            return nil
+        }
+    }
+    
+    func encode(with coder: NSCoder) {
+        coder.encode(Self.version, forKey: Self.versionKey)
+        coder.encode(self, forKey: Self.coderKey)
+    }
+}
+
+/// The NSWindowRestoration implementation that is called when a terminal window needs to be restored.
+/// The encoding of a terminal window is handled elsewhere (usually NSWindowDelegate).
+class TerminalWindowRestoration: NSObject, NSWindowRestoration {
+    enum RestoreError: Error {
+        case delegateInvalid
+        case identifierUnknown
+        case stateDecodeFailed
+        case windowDidNotLoad
+    }
+    
+    static func restoreWindow(
+        withIdentifier identifier: NSUserInterfaceItemIdentifier,
+        state: NSCoder,
+        completionHandler: @escaping (NSWindow?, Error?) -> Void
+    ) {
+        // Verify the identifier is what we expect
+        guard identifier == .init(String(describing: Self.self)) else {
+            completionHandler(nil, RestoreError.identifierUnknown)
+            return
+        }
+        
+        // Decode the state. If we can't decode the state, then we can't restore.
+        guard let state = TerminalRestorableState(coder: state) else {
+            completionHandler(nil, RestoreError.stateDecodeFailed)
+            return
+        }
+        
+        // The app delegate is definitely setup by now. If it isn't our AppDelegate
+        // then something is royally fucked up but protect against it anyhow.
+        guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else {
+            completionHandler(nil, RestoreError.delegateInvalid)
+            return
+        }
+        
+        // The window creation has to go through our terminalManager so that it
+        // can be found for events from libghostty. This uses the low-level
+        // createWindow so that AppKit can place the window wherever it should
+        // be.
+        let c = appDelegate.terminalManager.createWindow(withBaseConfig: nil)
+        guard let window = c.window else {
+            completionHandler(nil, RestoreError.windowDidNotLoad)
+            return
+        }
+        
+        completionHandler(window, nil)
+        AppDelegate.logger.warning("state RESTORE")
+    }
+}

--- a/macos/Sources/Features/Terminal/TerminalRestorable.swift
+++ b/macos/Sources/Features/Terminal/TerminalRestorable.swift
@@ -4,7 +4,7 @@ import Cocoa
 class TerminalRestorableState: Codable {
     static let selfKey = "state"
     static let versionKey = "version"
-    static let version: Int = 3
+    static let version: Int = 1
     
     let surfaceTree: Ghostty.SplitNode?
     

--- a/macos/Sources/Features/Terminal/TerminalRestorable.swift
+++ b/macos/Sources/Features/Terminal/TerminalRestorable.swift
@@ -48,16 +48,23 @@ class TerminalWindowRestoration: NSObject, NSWindowRestoration {
             return
         }
         
-        // Decode the state. If we can't decode the state, then we can't restore.
-        guard let state = TerminalRestorableState(coder: state) else {
-            completionHandler(nil, RestoreError.stateDecodeFailed)
-            return
-        }
-        
         // The app delegate is definitely setup by now. If it isn't our AppDelegate
         // then something is royally fucked up but protect against it anyhow.
         guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else {
             completionHandler(nil, RestoreError.delegateInvalid)
+            return
+        }
+        
+        // If our configuration is "never" then we never restore the state
+        // no matter what.
+        if (appDelegate.terminalManager.ghostty.windowSaveState == "never") {
+            completionHandler(nil, nil)
+            return
+        }
+        
+        // Decode the state. If we can't decode the state, then we can't restore.
+        guard let state = TerminalRestorableState(coder: state) else {
+            completionHandler(nil, RestoreError.stateDecodeFailed)
             return
         }
         

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -58,9 +58,19 @@ extension Ghostty {
             var v = false;
             let key = "quit-after-last-window-closed"
             _ = ghostty_config_get(config, &v, key, UInt(key.count))
-            return v;
+            return v
         }
-
+        
+        /// window-save-state
+        var windowSaveState: String {
+            guard let config = self.config else { return "" }
+            var v: UnsafePointer<Int8>? = nil
+            let key = "window-save-state"
+            guard ghostty_config_get(config, &v, key, UInt(key.count)) else { return "" }
+            guard let ptr = v else { return "" }
+            return String(cString: ptr)
+        }
+        
         /// True if we need to confirm before quitting.
         var needsConfirmQuit: Bool {
             guard let app = app else { return false }

--- a/macos/Sources/Ghostty/Ghostty.SplitNode.swift
+++ b/macos/Sources/Ghostty/Ghostty.SplitNode.swift
@@ -141,6 +141,10 @@ extension Ghostty {
             
             // MARK: - Codable
             
+            enum CodingKeys: String, CodingKey {
+                case pwd
+            }
+            
             required convenience init(from decoder: Decoder) throws {
                 // Decoding uses the global Ghostty app
                 guard let del = NSApplication.shared.delegate,
@@ -149,12 +153,16 @@ extension Ghostty {
                     throw TerminalRestoreError.delegateInvalid
                 }
                 
-                self.init(app, nil)
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                var config = SurfaceConfiguration()
+                config.workingDirectory = try container.decode(String?.self, forKey: .pwd)
+                
+                self.init(app, config)
             }
             
             func encode(to encoder: Encoder) throws {
-                // We don't currently encode anything, but in the future we will
-                // want to encode pwd, etc...
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(surface.pwd, forKey: .pwd)
             }
         }
 

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -283,6 +283,17 @@ extension Ghostty {
             return ghostty_surface_needs_confirm_quit(surface)
         }
         
+        /// Returns the pwd of the surface if it has one.
+        var pwd: String? {
+            guard let surface = self.surface else { return nil }
+            let v = String(unsafeUninitializedCapacity: 1024) {
+                Int(ghostty_surface_pwd(surface, $0.baseAddress, UInt($0.count)))
+            }
+            
+            if (v.count == 0) { return nil }
+            return v
+        }
+        
         // Returns the inspector instance for this surface, or nil if the
         // surface has been closed.
         var inspector: ghostty_inspector_t? {

--- a/macos/Sources/Helpers/CodableBridge.swift
+++ b/macos/Sources/Helpers/CodableBridge.swift
@@ -8,10 +8,7 @@ class CodableBridge<Wrapped: Codable>: NSObject, NSSecureCoding {
     static var supportsSecureCoding: Bool { return true }
     
     required init?(coder aDecoder: NSCoder) {
-        // TODO: This outputs a warning with deprecation on decode. I don't know how to
-        // fix that yet but there must be something we can change with the encode/decode here
-        // to resolve it.
-        guard let data = aDecoder.decodeData() else { return nil }
+        guard let data = aDecoder.decodeObject(of: NSData.self, forKey: "data") as? Data else { return nil }
         guard let archiver = try? NSKeyedUnarchiver(forReadingFrom: data) else { return nil }
         guard let value = archiver.decodeDecodable(Wrapped.self, forKey: "value") else { return nil }
         self.value = value
@@ -20,6 +17,6 @@ class CodableBridge<Wrapped: Codable>: NSObject, NSSecureCoding {
     func encode(with aCoder: NSCoder) {
         let archiver = NSKeyedArchiver(requiringSecureCoding: true)
         try? archiver.encodeEncodable(value, forKey: "value")
-        aCoder.encode(archiver.encodedData)
+        aCoder.encode(archiver.encodedData, forKey: "data")
     }
 }

--- a/macos/Sources/Helpers/CodableBridge.swift
+++ b/macos/Sources/Helpers/CodableBridge.swift
@@ -1,0 +1,25 @@
+import Cocoa
+
+/// A wrapper that allows a Swift Codable to implement NSSecureCoding.
+class CodableBridge<Wrapped: Codable>: NSObject, NSSecureCoding {
+    let value: Wrapped
+    init(_ value: Wrapped) { self.value = value }
+    
+    static var supportsSecureCoding: Bool { return true }
+    
+    required init?(coder aDecoder: NSCoder) {
+        // TODO: This outputs a warning with deprecation on decode. I don't know how to
+        // fix that yet but there must be something we can change with the encode/decode here
+        // to resolve it.
+        guard let data = aDecoder.decodeData() else { return nil }
+        guard let archiver = try? NSKeyedUnarchiver(forReadingFrom: data) else { return nil }
+        guard let value = archiver.decodeDecodable(Wrapped.self, forKey: "value") else { return nil }
+        self.value = value
+    }
+    
+    func encode(with aCoder: NSCoder) {
+        let archiver = NSKeyedArchiver(requiringSecureCoding: true)
+        try? archiver.encodeEncodable(value, forKey: "value")
+        aCoder.encode(archiver.encodedData)
+    }
+}

--- a/macos/Sources/Helpers/SplitView/SplitView.swift
+++ b/macos/Sources/Helpers/SplitView/SplitView.swift
@@ -163,6 +163,6 @@ struct SplitView<L: View, R: View>: View {
     }
 }
 
-enum SplitViewDirection {
+enum SplitViewDirection: Codable {
     case horizontal, vertical
 }

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1355,6 +1355,25 @@ pub const CAPI = struct {
         return surface.core_surface.needsConfirmQuit();
     }
 
+    /// Copies the surface working directory into the provided buffer and
+    /// returns the copied size. If the buffer is too small, there is no pwd,
+    /// or there is an error, then 0 is returned.
+    export fn ghostty_surface_pwd(surface: *Surface, buf: [*]u8, cap: usize) usize {
+        const pwd_ = surface.core_surface.pwd(global.alloc) catch |err| {
+            log.warn("error getting pwd err={}", .{err});
+            return 0;
+        };
+        const pwd = pwd_ orelse return 0;
+        defer global.alloc.free(pwd);
+
+        // If the buffer is too small, return no pwd.
+        if (pwd.len > cap) return 0;
+
+        // Copy into the buffer and return the length
+        @memcpy(buf[0..pwd.len], pwd);
+        return pwd.len;
+    }
+
     /// Tell the surface that it needs to schedule a render
     export fn ghostty_surface_refresh(surface: *Surface) void {
         surface.refresh();

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -575,9 +575,14 @@ keybind: Keybinds = .{},
 ///   - "never" will never save window state.
 ///   - "always" will always save window state whenever Ghostty is exited.
 ///
-/// If you change this value so that window state is NOT saved while
-/// window state is already saved, the next Ghostty launch will NOT restore
-/// the window state.
+/// If you change this value to "never" while Ghostty is not running,
+/// the next Ghostty launch will NOT restore the window state.
+///
+/// If you change this value to "default" while Ghostty is not running
+/// and the previous exit saved state, the next Ghostty launch will
+/// still restore the window state. This is because Ghostty cannot know
+/// if the previous exit was due to a forced save or not (macOS doesn't
+/// provide this information).
 ///
 /// If you change this value so that window state is saved while Ghostty
 /// is not running, the previous window state will not be restored because

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -591,7 +591,7 @@ keybind: Keybinds = .{},
 /// The default value is "default".
 ///
 /// This is currently only supported on macOS. This has no effect on Linux.
-@"window-save-state": WindowSaveState = .always, // TODO: change before PR
+@"window-save-state": WindowSaveState = .default,
 
 /// Resize the window in discrete increments of the focused surface's
 /// cell size. If this is disabled, surfaces are resized in pixel increments.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -563,6 +563,31 @@ keybind: Keybinds = .{},
 @"window-height": u32 = 0,
 @"window-width": u32 = 0,
 
+/// Whether to enable saving and restoring window state. Window state
+/// includes their position, size, tabs, splits, etc. Some window state
+/// requires shell integration, such as preserving working directories.
+/// See shell-integration for more information.
+///
+/// There are three valid values for this configuration:
+///   - "default" will use the default system behavior. On macOS, this
+///     will only save state if the application is forcibly terminated
+///     or if it is configured systemwide via Settings.app.
+///   - "never" will never save window state.
+///   - "always" will always save window state whenever Ghostty is exited.
+///
+/// If you change this value so that window state is NOT saved while
+/// window state is already saved, the next Ghostty launch will NOT restore
+/// the window state.
+///
+/// If you change this value so that window state is saved while Ghostty
+/// is not running, the previous window state will not be restored because
+/// Ghostty only saves state on exit if this is enabled.
+///
+/// The default value is "default".
+///
+/// This is currently only supported on macOS. This has no effect on Linux.
+@"window-save-state": WindowSaveState = .always, // TODO: change before PR
+
 /// Resize the window in discrete increments of the focused surface's
 /// cell size. If this is disabled, surfaces are resized in pixel increments.
 /// Currently only supported on macOS.
@@ -2743,4 +2768,11 @@ pub const ClipboardAccess = enum {
     allow,
     deny,
     ask,
+};
+
+/// See window-save-state
+pub const WindowSaveState = enum {
+    default,
+    never,
+    always,
 };


### PR DESCRIPTION
Fixes #572 

This implements macOS app state save/restore so that the state of the application is restored on restart. This is configurable using the `window-save-state` configuration which defaults to `default` which means that it is up to the OS or GUI toolkit to determine if the app should save/restore. This configuration can also be set to `never` or `always` which does what you'd expect.

On macOS, the default behavior is to only save/restore when an application is forcibly terminated i.e. during a system update. This can be configured to always happen in the system settings application or by setting `window-save-state` for Ghostty specifically.

The following are saved:

  - window position
  - window size
  - tabs
  - focused window and tab
  - splits including split amount
  - terminal working directories (with shell integration)

The following is not saved:

  - the currently focused split, but the tab/window containing that split will be focused. This will be solved later.
  - scrollback. This _may_ be done later, but is currently unplanned. 

## Demo

This demo has `window-save-state = always` so that the save state definitely happens.


https://github.com/mitchellh/ghostty/assets/1299/219cb840-7795-4ab1-86f9-5446feff3ae9

