### PR TITLE
input: kitty keyboard modifier event changes from Kitty 0.32

### DIFF
--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1328,56 +1328,25 @@ fn keyEvent(
         if (entry.native == keycode) break :keycode entry.key;
     } else .invalid;
 
-    // Get our modifiers. We have to translate modifier-only presses here
-    // to state in the mods manually because GTK only does it AFTER the press
-    // event.
+    // Get our modifiers. We have to use the GDK device because the mods
+    // sent to this event do not have the modifier key applied it if it
+    // was presssed (i.e. left control)
     const mods = mods: {
-        var mods = translateMods(gtk_mods);
+        _ = gtk_mods;
 
         const device = c.gdk_event_get_device(event);
+        var mods = translateMods(c.gdk_device_get_modifier_state(device));
         mods.num_lock = c.gdk_device_get_num_lock_state(device) == 1;
 
         switch (physical_key) {
-            .left_shift => {
-                mods.shift = action == .press;
-                if (mods.shift) mods.sides.shift = .left;
-            },
-
-            .right_shift => {
-                mods.shift = action == .press;
-                if (mods.shift) mods.sides.shift = .right;
-            },
-
-            .left_control => {
-                mods.ctrl = action == .press;
-                if (mods.ctrl) mods.sides.ctrl = .left;
-            },
-
-            .right_control => {
-                mods.ctrl = action == .press;
-                if (mods.ctrl) mods.sides.ctrl = .right;
-            },
-
-            .left_alt => {
-                mods.alt = action == .press;
-                if (mods.alt) mods.sides.alt = .left;
-            },
-
-            .right_alt => {
-                mods.alt = action == .press;
-                if (mods.alt) mods.sides.alt = .right;
-            },
-
-            .left_super => {
-                mods.super = action == .press;
-                if (mods.super) mods.sides.super = .left;
-            },
-
-            .right_super => {
-                mods.super = action == .press;
-                if (mods.super) mods.sides.super = .right;
-            },
-
+            .left_shift => mods.sides.shift = .left,
+            .right_shift => mods.sides.shift = .right,
+            .left_control => mods.sides.ctrl = .left,
+            .right_control => mods.sides.ctrl = .right,
+            .left_alt => mods.sides.alt = .left,
+            .right_alt => mods.sides.alt = .right,
+            .left_super => mods.sides.super = .left,
+            .right_super => mods.sides.super = .right,
             else => {},
         }
 

--- a/src/input/KeyEncoder.zig
+++ b/src/input/KeyEncoder.zig
@@ -612,22 +612,13 @@ const KittyMods = packed struct(u8) {
         k: key.Key,
         mods: key.Mods,
     ) KittyMods {
-        // Annoying boolean logic, but according to the Kitty spec:
-        // "When both left and right control keys are pressed and one is
-        // released, the release event must again have the modifier bit reset"
-        // In other words, we allow a modifier if it is set AND the action
-        // is NOT a release. Or if the action is a release, then the key being
-        // released must not be the associated modifier key.
-        const shift = mods.shift and (action != .release or (k != .left_shift and k != .right_shift));
-        const alt = mods.alt and (action != .release or (k != .left_alt and k != .right_alt));
-        const ctrl = mods.ctrl and (action != .release or (k != .left_control and k != .right_control));
-        const super = mods.super and (action != .release or (k != .left_super and k != .right_super));
-
+        _ = action;
+        _ = k;
         return .{
-            .shift = shift,
-            .alt = alt,
-            .ctrl = ctrl,
-            .super = super,
+            .shift = mods.shift,
+            .alt = mods.alt,
+            .ctrl = mods.ctrl,
+            .super = mods.super,
             .caps_lock = mods.caps_lock,
             .num_lock = mods.num_lock,
         };
@@ -1026,7 +1017,7 @@ test "kitty: ctrl release with ctrl mod set" {
         },
     };
     const actual = try enc.kitty(&buf);
-    try testing.expectEqualStrings("[57442;1:3u", actual[1..]);
+    try testing.expectEqualStrings("[57442;5:3u", actual[1..]);
 }
 
 test "kitty: delete" {


### PR DESCRIPTION
> When the key event is related to an actual modifier key, the corresponding
> modifier's bit must be set to the modifier state including the effect for the
> current event. For example, when pressing the :kbd:`LEFT_CONTROL` key, the
> ``ctrl`` bit must be set and when releasing it, it must be reset. When both
> left and right control keys are pressed and one is released, the release event
> must have the ``ctrl`` bit set. See :iss:`6913` for discussion of this design.

Related Kitty commit: https://github.com/kovidgoyal/kitty/commit/91cdf4af00d9b7ee7752b3ab8f3792febc3574ec