### PR TITLE
config: grapheme-width-method, default to "unicode"

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -162,6 +162,32 @@ const c = @cImport({
 @"adjust-strikethrough-position": ?MetricModifier = null,
 @"adjust-strikethrough-thickness": ?MetricModifier = null,
 
+/// The method to use for calculating the cell width of a grapheme cluster.
+/// The default value is "unicode" which uses the Unicode standard to
+/// determine grapheme width. This results in correct grapheme width but
+/// may result in cursor-desync issues with some programs (such as shells)
+/// that may use a legacy method such as "wcswidth".
+///
+/// Valid values are:
+///
+///   - "wcswidth" - Use the wcswidth function to determine grapheme width.
+///     This maximizes compatibility with legacy programs but may result
+///     in incorrect grapheme width for certain graphemes such as skin-tone
+///     emoji, non-English characters, etc.
+///
+///     Note that this "wcswidth" functionality is based on the libc wcswidth,
+///     not any other libraries with that name.
+///
+///   - "unicode" - Use the Unicode standard to determine grapheme width.
+///
+/// If a running program explicitly enables terminal mode 2027, then
+/// "unicode" width will be forced regardless of this configuration. When
+/// mode 2027 is reset, this configuration will be used again.
+///
+/// This configuration can be changed at runtime but will not affect existing
+/// printed cells. Only new cells will use the new configuration.
+@"grapheme-width-method": GraphemeWidthMethod = .unicode,
+
 /// A named theme to use. The available themes are currently hardcoded to
 /// the themes that ship with Ghostty. On macOS, this list is in the
 /// `Ghostty.app/Contents/Resources/themes` directory. On Linux, this
@@ -2780,4 +2806,10 @@ pub const WindowSaveState = enum {
     default,
     never,
     always,
+};
+
+/// See grapheme-width-method
+pub const GraphemeWidthMethod = enum {
+    wcswidth,
+    unicode,
 };


### PR DESCRIPTION
This adds a new configuration `grapheme-width-method` to change the default behavior that Ghostty uses to calculate grapheme width. The default value is `unicode` which is identical to setting mode 2027.

**IMPORTANT:** This changes the default Ghostty behavior to be fully grapheme-aware including ZWJs, VS15, VS16. This may cause issues with some legacy programs and shells.

I've changed my mind that this should become the default because enough people use emojis now that I've found in the beta program there are more issues reported about "incorrect emoji width" than any possibly desync issues. We'll see. There are other terminals that default to this behavior too: Foot, WezTerm, Contour that I'm aware of.

For legacy programs, this can still be set to `grapheme-width-method = wcswidth`.

/cc @rockorager @erf @gpanders 