### PR TITLE
macos: notifications use surface UUID for lookups

### DIFF
--- a/macos/Sources/AppDelegate.swift
+++ b/macos/Sources/AppDelegate.swift
@@ -332,6 +332,16 @@ class AppDelegate: NSObject,
 
     //MARK: - GhosttyAppStateDelegate
     
+    func findSurface(forUUID uuid: UUID) -> Ghostty.SurfaceView? {
+        for c in terminalManager.windows {
+            if let v = c.controller.surfaceTree?.findUUID(uuid: uuid) {
+                return v
+            }
+        }
+        
+        return nil
+    }
+    
     func configDidReload(_ state: Ghostty.AppState) {
         // Depending on the "window-save-state" setting we have to set the NSQuitAlwaysKeepsWindows
         // configuration. This is the only way to carefully control whether macOS invokes the

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -1145,16 +1145,7 @@ extension Ghostty {
             content.body = body
             content.sound = UNNotificationSound.default
             content.categoryIdentifier = Ghostty.userNotificationCategory
-
-            // The userInfo must conform to NSSecureCoding, which SurfaceView
-            // does not. So instead we pass an integer representation of the
-            // SurfaceView's address, which is reconstructed back into a
-            // SurfaceView if the notification is clicked. This is safe to do
-            // so long as the SurfaceView removes all of its notifications when
-            // it closes so that there are no dangling pointers.
-            content.userInfo = [
-                "address": Int(bitPattern: Unmanaged.passUnretained(self).toOpaque()),
-            ]
+            content.userInfo = ["surface": self.uuid.uuidString]
 
             let uuid = UUID().uuidString
             let request = UNNotificationRequest(


### PR DESCRIPTION
Fixes #1162

/cc @tt @gpanders could one of you please verify this? I was never able to reproduce the crash exactly.