### PR TITLE
macos: set surface tree on init in restore

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -46,13 +46,16 @@ class TerminalController: NSWindowController, NSWindowDelegate,
     /// changes in the list.
     private var tabWindowsHash: Int = 0
     
-    init(_ ghostty: Ghostty.AppState, withBaseConfig base: Ghostty.SurfaceConfiguration? = nil) {
+    init(_ ghostty: Ghostty.AppState, 
+         withBaseConfig base: Ghostty.SurfaceConfiguration? = nil,
+         withSurfaceTree tree: Ghostty.SplitNode? = nil
+    ) {
         self.ghostty = ghostty
         super.init(window: nil)
         
         // Initialize our initial surface.
         guard let ghostty_app = ghostty.app else { preconditionFailure("app must be loaded") }
-        self.surfaceTree = .leaf(.init(ghostty_app, baseConfig: base))
+        self.surfaceTree = tree ?? .leaf(.init(ghostty_app, baseConfig: base))
         
         // Setup our notifications for behaviors
         let center = NotificationCenter.default

--- a/macos/Sources/Features/Terminal/TerminalManager.swift
+++ b/macos/Sources/Features/Terminal/TerminalManager.swift
@@ -139,9 +139,10 @@ class TerminalManager {
     }
     
     /// Creates a window controller, adds it to our managed list, and returns it.
-    func createWindow(withBaseConfig base: Ghostty.SurfaceConfiguration?) -> TerminalController {
+    func createWindow(withBaseConfig base: Ghostty.SurfaceConfiguration? = nil,
+                      withSurfaceTree tree: Ghostty.SplitNode? = nil) -> TerminalController {
         // Initialize our controller to load the window
-        let c = TerminalController(ghostty, withBaseConfig: base)
+        let c = TerminalController(ghostty, withBaseConfig: base, withSurfaceTree: tree)
 
         // Create a listener for when the window is closed so we can remove it.
         let pubClose = NotificationCenter.default.publisher(

--- a/macos/Sources/Features/Terminal/TerminalRestorable.swift
+++ b/macos/Sources/Features/Terminal/TerminalRestorable.swift
@@ -81,14 +81,13 @@ class TerminalWindowRestoration: NSObject, NSWindowRestoration {
         // can be found for events from libghostty. This uses the low-level
         // createWindow so that AppKit can place the window wherever it should
         // be.
-        let c = appDelegate.terminalManager.createWindow(withBaseConfig: nil)
+        let c = appDelegate.terminalManager.createWindow(withSurfaceTree: state.surfaceTree)
         guard let window = c.window else {
             completionHandler(nil, TerminalRestoreError.windowDidNotLoad)
             return
         }
         
         // Setup our restored state on the controller
-        c.surfaceTree = state.surfaceTree
         if let focusedStr = state.focusedSurface,
            let focusedUUID = UUID(uuidString: focusedStr),
            let view = c.surfaceTree?.findUUID(uuid: focusedUUID) {


### PR DESCRIPTION
This prevents an unnecessary SurfaceView from being created. Creating a SurfaceView is very expensive because this starts multiple threads, creates the pty, starts the pty process, etc.

Additionally, this was exposing what I believe to be #497 when restoring state: a surface view was created and destroyed very quickly causing hangs on some machines. This still needs to be resolved but the behavior in this commit was still a bug anyways.

/cc @mattrobenolt 