### PR TITLE
termio: delay repeated `waitpid` syscalls when killing children

### DIFF
--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1179,6 +1179,7 @@ const Subprocess = struct {
                         // kill them again.
                         const res = std.os.waitpid(pid, std.c.W.NOHANG);
                         if (res.pid != 0) break;
+                        std.time.sleep(10 * std.time.ns_per_ms);
                     }
                 },
             }


### PR DESCRIPTION
PR #1168 introduced a loop to kill all children. The `waitpid` call is
issued with the NOHANG flag, which means it returns immediately if no
child has exited. This has the effect that we can repeatedly run through
this loop making this syscall, flooding the system with calls and not
getting timely responses. On my system, this caused Ghostty to take ~30
seconds to close. In my attempts to debug, I added logging to the loop
which resolved the issue. To find out why, I added a loop counter and
found the loop would run > 70 million cycles while trying to close. By
adding logging, I introduced just enough delay in the loop cycle to
prevent whatever flooding of syscalls was happening. This reduced the
loop counter to ~2 cycles before closing.

Add a small delay to prevent syscall flooding.
