### PR TITLE
Move libadwaita to an app runtime

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,7 +159,10 @@ jobs:
         run: nix develop -c zig build -Dapp-runtime=none test
 
       - name: Test GTK Build
-        run: nix develop -c zig build -Dapp-runtime=gtk -Dgtk-libadwaita=true
+        run: nix develop -c zig build -Dapp-runtime=gtk
+
+      - name: Test libadaita Build
+        run: nix develop -c zig build -Dapp-runtime=libadwaita
 
       - name: Test GLFW Build
         run: nix develop -c zig build -Dapp-runtime=glfw

--- a/build.zig
+++ b/build.zig
@@ -40,7 +40,6 @@ var flatpak: bool = false;
 var app_runtime: apprt.Runtime = .none;
 var renderer_impl: renderer.Impl = .opengl;
 var font_backend: font.Backend = .freetype;
-var libadwaita: bool = false;
 
 pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
@@ -88,12 +87,6 @@ pub fn build(b: *std.Build) !void {
         "app-runtime",
         "The app runtime to use. Not all values supported on all platforms.",
     ) orelse apprt.Runtime.default(target);
-
-    libadwaita = b.option(
-        bool,
-        "gtk-libadwaita",
-        "Enables the use of libadwaita when using the gtk rendering backend.",
-    ) orelse true;
 
     renderer_impl = b.option(
         renderer.Impl,
@@ -211,7 +204,6 @@ pub fn build(b: *std.Build) !void {
     exe_options.addOption(apprt.Runtime, "app_runtime", app_runtime);
     exe_options.addOption(font.Backend, "font_backend", font_backend);
     exe_options.addOption(renderer.Impl, "renderer", renderer_impl);
-    exe_options.addOption(bool, "libadwaita", libadwaita);
 
     // Exe
     if (exe_) |exe| {
@@ -873,7 +865,11 @@ fn addDeps(
 
             .gtk => {
                 step.linkSystemLibrary2("gtk4", dynamic_link_opts);
-                if (libadwaita) step.linkSystemLibrary2("adwaita-1", dynamic_link_opts);
+            },
+
+            .libadwaita => {
+                step.linkSystemLibrary2("gtk4", dynamic_link_opts);
+                step.linkSystemLibrary2("adwaita-1", dynamic_link_opts);
             },
         }
     }

--- a/src/apprt.zig
+++ b/src/apprt.zig
@@ -29,6 +29,7 @@ pub const runtime = switch (build_config.artifact) {
         .none => none,
         .glfw => glfw,
         .gtk => gtk,
+        .libadwaita => gtk,
     },
     .lib => embedded,
     .wasm_module => browser,
@@ -52,6 +53,10 @@ pub const Runtime = enum {
 
     /// GTK-backed. Rich windowed application. GTK is dynamically linked.
     gtk,
+
+    /// libadwaita-backed (GTK). Rich windowed application. GTK and libadwaita
+    /// are dynamically linked.
+    libadwaita,
 
     pub fn default(target: std.zig.CrossTarget) Runtime {
         // The Linux default is GTK because it is full featured.

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -70,7 +70,7 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
     }
 
     // Initialize libadwaita
-    if (build_options.libadwaita and config.@"gtk-adwaita") {
+    if (build_options.app_runtime == .libadwaita) {
         log.debug("initializing libadwaita", .{});
         c.adw_init();
         c.adw_style_manager_set_color_scheme(

--- a/src/apprt/gtk/c.zig
+++ b/src/apprt/gtk/c.zig
@@ -1,6 +1,6 @@
 const c = @cImport({
     @cInclude("gtk/gtk.h");
-    if (@import("build_options").libadwaita) @cInclude("libadwaita-1/adwaita.h");
+    if (@import("build_options").app_runtime == .libadwaita) @cInclude("libadwaita-1/adwaita.h");
 
     // Add in X11-specific GDK backend which we use for specific things (e.g.
     // X11 window class).

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -847,20 +847,6 @@ keybind: Keybinds = .{},
 /// which is the old style.
 @"gtk-wide-tabs": bool = true,
 
-/// If true (default), Ghostty will enable libadwaita theme support. This
-/// will make `window-theme` work properly and will also allow Ghostty to
-/// properly respond to system theme changes, light/dark mode changing, etc.
-/// This requires a GTK4 desktop with a GTK4 theme.
-///
-/// If you are running GTK3 or have a GTK3 theme, you may have to set this
-/// to false to get your theme picked up properly. Having this set to true
-/// with GTK3 should not cause any problems, but it may not work exactly as
-/// expected.
-///
-/// This configuration only has an effect if Ghostty was built with
-/// libadwaita support.
-@"gtk-adwaita": bool = true,
-
 /// If true (default), applications running in the terminal can show desktop
 /// notifications using certain escape sequences such as OSC 9 or OSC 777.
 @"desktop-notifications": bool = true,


### PR DESCRIPTION
libadwaita is a very opinionated library, hence why it was an optional build option before. Previously however, ghostty was only using libadwaita as a way to theme the GTK app runtime. libadwaita is much more than a theme for GTK. It is also library full of widgets. For instance, GtkNotebook is an inferior tab management widget to AdwTabView, which I plan to enable in the future for the libadwaita runtime.

In a further off future, we can also depend on libpanel, a libadwaita-based GTK library for managing panels, in order to provide our splits. The GTK app runtime would have to come up with a different solution, most likely involving GtkGridView or some such.