### PR TITLE
macos: invalid restorable state when surface is closed

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -374,6 +374,10 @@ extension Ghostty {
         }
 
         deinit {
+            // Whenever the surface is removed, we need to note that our restorable
+            // state is invalid to prevent the surface from being restored.
+            invalidateRestorableState()
+            
             trackingAreas.forEach { removeTrackingArea($0) }
             
             // mouseExited is not called by AppKit one last time when the view


### PR DESCRIPTION
Fixes #1177

There are _probably_ more instances that this is required. But let's just go for it as we detect them.