### PR TITLE
Modify the way the login shell is launched on macOS to reduce nesting

### DIFF
--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -878,9 +878,14 @@ const Subprocess = struct {
                 // "-q" flag to login(1).
                 //
                 // So to get all the behaviors we want, we specify "-l" but
-                // execute "zsh" (which is built-in to macOS). We then use
-                // the zsh builtin "exec" to replace the process with a login
+                // execute "bash" (which is built-in to macOS). We then use
+                // the bash builtin "exec" to replace the process with a login
                 // shell ("-l" on exec) with the command we really want.
+                //
+                // We use "bash" instead of other shells that ship with macOS
+                // because as of macOS Sonoma, we found with a microbenchmark
+                // that bash can `exec` into the desired command ~2x faster
+                // than zsh.
                 //
                 // To figure out a lot of this logic I read the login.c
                 // source code in the OSS distribution Apple provides for
@@ -890,8 +895,15 @@ const Subprocess = struct {
                 try args.append("/usr/bin/login");
                 if (hush) try args.append("-q");
                 try args.append("-flp");
+
+                // We execute bash with "--noprofile --norc" so that it doesn't
+                // load startup files so that (1) our shell integration doesn't
+                // break and (2) user configuration doesn't mess this process
+                // up.
                 try args.append(username);
-                try args.append("/bin/sh");
+                try args.append("/bin/bash");
+                try args.append("--noprofile");
+                try args.append("--norc");
                 try args.append("-c");
                 try args.append(cmd);
                 break :args try args.toOwnedSlice();

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -883,13 +883,8 @@ const Subprocess = struct {
                 // Awesome.
                 try args.append("/usr/bin/login");
                 if (hush) try args.append("-q");
-                try args.append("-flp");
+                try args.append("-fp");
                 try args.append(username);
-
-                // We execute `env` to run the command (aka shell) in a
-                // modified environment and not use another shell interpreter
-                // to launch the shell environment.
-                try args.append("/usr/bin/env");
                 try args.append(opts.full_config.command orelse default_path);
                 break :args try args.toOwnedSlice();
             }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -841,12 +841,6 @@ const Subprocess = struct {
                     break :hush if (dir.access(".hushlogin", .{})) true else |_| false;
                 } else false;
 
-                const cmd = try std.fmt.allocPrint(
-                    alloc,
-                    "exec -l {s}",
-                    .{opts.full_config.command orelse default_path},
-                );
-
                 // The reason for executing login this way is unclear. This
                 // comment will attempt to explain but prepare for a truly
                 // unhinged reality.
@@ -892,15 +886,11 @@ const Subprocess = struct {
                 try args.append("-flp");
                 try args.append(username);
 
-                // We execute zsh with "-d -f" so that it doesn't load any
-                // local zshrc files so that (1) our shell integration doesn't
-                // break and (2) user configuration doesn't mess this process
-                // up.
-                try args.append("/bin/zsh");
-                try args.append("-d");
-                try args.append("-f");
-                try args.append("-c");
-                try args.append(cmd);
+                // We execute `env` to run the command (aka shell) in a
+                // modified environment and not use another shell interpreter
+                // to launch the shell environment.
+                try args.append("/usr/bin/env");
+                try args.append(opts.full_config.command orelse default_path);
                 break :args try args.toOwnedSlice();
             }
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -841,6 +841,12 @@ const Subprocess = struct {
                     break :hush if (dir.access(".hushlogin", .{})) true else |_| false;
                 } else false;
 
+                const cmd = try std.fmt.allocPrint(
+                    alloc,
+                    "exec -l {s}",
+                    .{opts.full_config.command orelse default_path},
+                );
+
                 // The reason for executing login this way is unclear. This
                 // comment will attempt to explain but prepare for a truly
                 // unhinged reality.
@@ -883,9 +889,11 @@ const Subprocess = struct {
                 // Awesome.
                 try args.append("/usr/bin/login");
                 if (hush) try args.append("-q");
-                try args.append("-fp");
+                try args.append("-flp");
                 try args.append(username);
-                try args.append(opts.full_config.command orelse default_path);
+                try args.append("/bin/sh");
+                try args.append("-c");
+                try args.append(cmd);
                 break :args try args.toOwnedSlice();
             }
 


### PR DESCRIPTION
I have modified the way the login shell was being launch on macOS to try an eliminate as much of the nesting of different shell environments to launch the login shell. 