### PR TITLE
terminal: cursor back should not reduce by one with pending wrap

### DIFF
--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1564,12 +1564,10 @@ pub fn cursorLeft(self: *Terminal, count_req: usize) void {
         break :wrap_mode .none;
     };
 
-    // If we have a pending wrap state on, we reset it and reduce our count.
+    // Unset the pending wrap state no matter what
+    self.screen.cursor.pending_wrap = false;
+
     var count: usize = @max(count_req, 1);
-    if (self.screen.cursor.pending_wrap) {
-        self.screen.cursor.pending_wrap = false;
-        count -= 1;
-    }
 
     // If we are in no wrap mode, then we move the cursor left and exit
     // since this is the fastest and most typical path.
@@ -6245,7 +6243,7 @@ test "Terminal: cursorLeft unsets pending wrap state" {
     {
         const str = try t.plainString(testing.allocator);
         defer testing.allocator.free(str);
-        try testing.expectEqualStrings("ABCDX", str);
+        try testing.expectEqualStrings("ABCXE", str);
     }
 }
 
@@ -6263,7 +6261,7 @@ test "Terminal: cursorLeft unsets pending wrap state with longer jump" {
     {
         const str = try t.plainString(testing.allocator);
         defer testing.allocator.free(str);
-        try testing.expectEqualStrings("ABXDE", str);
+        try testing.expectEqualStrings("AXCDE", str);
     }
 }
 


### PR DESCRIPTION
Fixes #1183

I'm not sure why the original logic was there. When I translated the original test cases to shell and ran them in xterm, they did NOT match what Ghostty expected. This updates the tests to match xterm and removes this case. We can add back in more tests if/when we figure out under what scenario this original logic was correct (if it ever was).

Test case:

```
#!/usr/bin/env bash

cols=$(tput cols)
printf "\033[${cols}G"
printf "\033[4D"
printf "ABCDE"
printf "\033[D"
printf "X"
```

Expected output (xterm): `ABCXE`