### PR TITLE
website: fix `cub` test script

### DIFF
--- a/website/app/vt/cub/page.mdx
+++ b/website/app/vt/cub/page.mdx
@@ -66,7 +66,6 @@ printf "\033[${cols}G" # move to last column
 printf "A" # set pending wrap state
 printf "\033[D" # move back one
 printf "XYZ"
-echo
 ```
 
 ```


### PR DESCRIPTION
The `CUB` V2 test script has a trailing echo which pushes the cursor
down one line, making the expected output incorrect. Remove the `echo`
command so the cursor position is as shown.
