### PR TITLE
website(el): clarify cursor position in test script

### DIFF
--- a/website/app/vt/el/page.mdx
+++ b/website/app/vt/el/page.mdx
@@ -63,8 +63,10 @@ printf "X"
 ```
 
 ```
-|_______Xc
+|_______X|
 ```
+
+The cursor should be on the 'X'
 
 ### EL V-3: Erase Right SGR State
 


### PR DESCRIPTION
The test script for `el` shows the cursor being on the right side of
`X`, however in xterm and ghostty the cursor is _on_ the `X`. Delete the
cursor position and add a comment on where the cursor should be.
