### PR TITLE
termio/exec: detect exec failure and show an error message

### DIFF
--- a/src/Command.zig
+++ b/src/Command.zig
@@ -155,6 +155,11 @@ fn startPosix(self: *Command, arena: Allocator) !void {
 
     // Finally, replace our process.
     _ = std.os.execveZ(pathZ, argsZ, envp) catch null;
+
+    // If we are executing this code, the exec failed. In that scenario,
+    // we return a very specific error that can be detected to determine
+    // we're in the child.
+    return error.ExecFailedInChild;
 }
 
 fn startWindows(self: *Command, arena: Allocator) !void {


### PR DESCRIPTION
This handles the scenario that the `exec` fails by gracefully showing an error. This **does not handle `command` misconfigurations**. Since we wrap all execs in either `login` (macOS) or `/bin/sh` (Linux), this only handles the scenario that those commands fail to exec which is highly unlikely. 

However, prior to this, if those did fail to execute, some really strange behavior would happen because the forked process would continue to run as if it was the parent.