### PR TITLE
Abnormal command exit detection

### DIFF
--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -425,7 +425,7 @@ fn clearPromptForResize(self: *Terminal) void {
 /// encoded as "\n". This omits any formatting such as fg/bg.
 ///
 /// The caller must free the string.
-fn plainString(self: *Terminal, alloc: Allocator) ![]const u8 {
+pub fn plainString(self: *Terminal, alloc: Allocator) ![]const u8 {
     return try self.screen.testString(alloc, .viewport);
 }
 
@@ -715,9 +715,7 @@ pub fn invokeCharset(
 /// Print UTF-8 encoded string to the terminal. This string must be
 /// a single line, newlines and carriage returns and other control
 /// characters are not processed.
-///
-/// This is not public because it is only used for tests rigt now.
-fn printString(self: *Terminal, str: []const u8) !void {
+pub fn printString(self: *Terminal, str: []const u8) !void {
     const view = try std.unicode.Utf8View.init(str);
     var it = view.iterator();
     while (it.nextCodepoint()) |cp| try self.print(cp);

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -816,7 +816,10 @@ fn processExit(
         // Notify our main writer thread which has access to more
         // information so it can show a better error message.
         _ = ev.writer_mailbox.push(.{
-            .child_exited_abnormally = {},
+            .child_exited_abnormally = .{
+                .code = code,
+                .runtime_ms = runtime,
+            },
         }, .{ .forever = {} });
         ev.writer_wakeup.notify() catch break :runtime;
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -741,6 +741,14 @@ fn processExit(
     // If our runtime was below some threshold then we assume that this
     // was an abnormal exit and we show an error message.
     if (runtime_ms) |runtime| runtime: {
+        // On macOS, our exit code detection doesn't work, possibly
+        // because of our `login` wrapper. More investigation required.
+        if (comptime !builtin.target.isDarwin()) {
+            // If our exit code is zero, then the command was successful
+            // and we don't ever consider it abnormal.
+            if (code == 0) break :runtime;
+        }
+
         if (runtime > abnormal_runtime_threshold_ms) break :runtime;
         log.warn("abnormal process exit detected, showing error message", .{});
 

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -186,6 +186,7 @@ fn drainMailbox(self: *Thread) !void {
             .jump_to_prompt => |v| try self.impl.jumpToPrompt(v),
             .start_synchronized_output => self.startSynchronizedOutput(),
             .linefeed_mode => |v| self.flags.linefeed_mode = v,
+            .child_exited_abnormally => try self.impl.childExitedAbnormally(),
             .write_small => |v| try self.impl.queueWrite(v.data[0..v.len], self.flags.linefeed_mode),
             .write_stable => |v| try self.impl.queueWrite(v, self.flags.linefeed_mode),
             .write_alloc => |v| {

--- a/src/termio/message.zig
+++ b/src/termio/message.zig
@@ -62,6 +62,12 @@ pub const Message = union(enum) {
     /// Enable or disable linefeed mode (mode 20).
     linefeed_mode: bool,
 
+    /// The child exited abnormally. The termio state is marked
+    /// as process exited but the surface hasn't been notified to
+    /// close because termio can use this to update the terminal
+    /// with an error message.
+    child_exited_abnormally: void,
+
     /// Write where the data fits in the union.
     write_small: WriteReq.Small,
 

--- a/src/termio/message.zig
+++ b/src/termio/message.zig
@@ -66,7 +66,10 @@ pub const Message = union(enum) {
     /// as process exited but the surface hasn't been notified to
     /// close because termio can use this to update the terminal
     /// with an error message.
-    child_exited_abnormally: void,
+    child_exited_abnormally: struct {
+        code: u32,
+        runtime_ms: u64,
+    },
 
     /// Write where the data fits in the union.
     write_small: WriteReq.Small,


### PR DESCRIPTION
This replaces #1182. 

This attempts to detect "abnormal" exit conditions and show a message in the terminal. For the purpose of this PR, an abnormal exit condition is defined as any terminal session that is only alive for less than 250ms. On Linux, the exit code must also be non-zero. 

We can't use exit code detection on macOS because of our shell nesting (via login on macOS) which always returns exit code zero even if the process it executes fails. I'm still investigating this.

I'd love to add more information to the error message but the point this error is detected no longer has access to the configuration so we [currently] can't access the command. This could probably be plumbed through but I want to make sure I do it in a way that isn't wasteful.

cc @jcollie 

## Demo

![CleanShot 2023-12-30 at 15 43 34@2x](https://github.com/mitchellh/ghostty/assets/1299/69ede89a-e5ca-4068-9c98-afbc6f4f4267)
