### PR TITLE
apprt/gtk: ensure modifier state matches current keypress under X11

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -28,6 +28,7 @@ const ClipboardConfirmationWindow = @import("ClipboardConfirmationWindow.zig");
 const c = @import("c.zig");
 const inspector = @import("inspector.zig");
 const key = @import("key.zig");
+const x11 = @import("x11.zig");
 const testing = std.testing;
 
 const log = std.log.scoped(.gtk);
@@ -170,7 +171,7 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
     }
 
     const display = c.gdk_display_get_default();
-    if (c.g_type_check_instance_is_a(@ptrCast(@alignCast(display)), c.gdk_x11_display_get_type()) != 0) {
+    if (x11.x11_is_display(display)) {
         // Set the X11 window class property (WM_CLASS) if are are on an X11
         // display.
         //

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1333,22 +1333,15 @@ fn keyEvent(
     // was presssed (i.e. left control)
     const mods = mods: {
         _ = gtk_mods;
-
         const device = c.gdk_event_get_device(event);
-        var mods = init_mods: {
-            // Add any modifier state events from Xkb if we have them (X11 only).
-            if (self.app.modifier_state_from_xkb(display)) |xkb_mods| {
-                break :init_mods xkb_mods;
-            }
 
-            // Null back from the Xkb call means there was no modifier
-            // event to read. This likely means that the key event did not
-            // result in a modifier change and we can safely rely on the
-            // GDK state.
-
-            break :init_mods translateMods(c.gdk_device_get_modifier_state(device));
-        };
-
+        // Add any modifier state events from Xkb if we have them (X11 only).
+        // Null back from the Xkb call means there was no modifier
+        // event to read. This likely means that the key event did not
+        // result in a modifier change and we can safely rely on the
+        // GDK state.
+        var mods = self.app.modifier_state_from_xkb(display) orelse
+            translateMods(c.gdk_device_get_modifier_state(device));
         mods.num_lock = c.gdk_device_get_num_lock_state(device) == 1;
 
         switch (physical_key) {

--- a/src/apprt/gtk/c.zig
+++ b/src/apprt/gtk/c.zig
@@ -5,6 +5,8 @@ const c = @cImport({
     // Add in X11-specific GDK backend which we use for specific things (e.g.
     // X11 window class).
     @cInclude("gdk/x11/gdkx.h");
+    // Xkb for X11 state handling
+    @cInclude("X11/XKBlib.h");
 });
 
 pub usingnamespace c;

--- a/src/apprt/gtk/x11.zig
+++ b/src/apprt/gtk/x11.zig
@@ -6,7 +6,7 @@ const input = @import("../../input.zig");
 const log = std.log.scoped(.gtk_x11);
 
 /// Returns true if the passed in display is an X11 display.
-pub fn x11_is_display(display: ?*c.GdkDisplay) bool {
+pub fn is_display(display: ?*c.GdkDisplay) bool {
     return c.g_type_check_instance_is_a(
         @ptrCast(@alignCast(display orelse return false)),
         c.gdk_x11_display_get_type(),
@@ -14,9 +14,7 @@ pub fn x11_is_display(display: ?*c.GdkDisplay) bool {
 }
 
 pub const X11Xkb = struct {
-    opcode: c_int,
     base_event_code: c_int,
-    base_error_code: c_int,
     funcs: Funcs,
 
     /// Initialize an X11Xkb struct, for the given GDK display. If the display
@@ -27,25 +25,25 @@ pub const X11Xkb = struct {
         const display = display_ orelse return null;
 
         // If the display isn't X11, then we don't need to do anything.
-        if (!x11_is_display(display)) return null;
+        if (!is_display(display)) return null;
 
         log.debug("X11Xkb.init: initializing Xkb", .{});
         const xdisplay = c.gdk_x11_display_get_xdisplay(display);
         var result: X11Xkb = .{
-            .opcode = 0,
             .base_event_code = 0,
-            .base_error_code = 0,
             .funcs = try Funcs.init(),
         };
 
         log.debug("X11Xkb.init: running XkbQueryExtension", .{});
+        var opcode: c_int = 0;
+        var base_error_code: c_int = 0;
         var major = c.XkbMajorVersion;
         var minor = c.XkbMinorVersion;
         if (result.funcs.XkbQueryExtension(
             xdisplay,
-            &result.opcode,
+            &opcode,
             &result.base_event_code,
-            &result.base_error_code,
+            &base_error_code,
             &major,
             &minor,
         ) == 0) {

--- a/src/apprt/gtk/x11.zig
+++ b/src/apprt/gtk/x11.zig
@@ -1,0 +1,120 @@
+/// Utility functions for X11 handling.
+const std = @import("std");
+const c = @import("c.zig");
+const input = @import("../../input.zig");
+
+const log = std.log.scoped(.gtk);
+
+// X11 Function types. We load these dynamically at runtime to avoid having to
+// link against X11.
+const XkbQueryExtensionType = *const fn (?*c.struct__XDisplay, [*c]c_int, [*c]c_int, [*c]c_int, [*c]c_int, [*c]c_int) callconv(.C) c_int;
+const XkbSelectEventDetailsType = *const fn (?*c.struct__XDisplay, c_uint, c_uint, c_ulong, c_ulong) callconv(.C) c_int;
+const XEventsQueuedType = *const fn (?*c.struct__XDisplay, c_int) callconv(.C) c_int;
+const XPeekEventType = *const fn (?*c.struct__XDisplay, [*c]c.union__XEvent) callconv(.C) c_int;
+
+/// Returns true if the passed in display is an X11 display.
+pub fn x11_is_display(display_: ?*c.GdkDisplay) bool {
+    const display = display_ orelse return false;
+    return (c.g_type_check_instance_is_a(@ptrCast(@alignCast(display)), c.gdk_x11_display_get_type()) != 0);
+}
+
+pub const X11Xkb = struct {
+    opcode: c_int,
+    base_event_code: c_int,
+    base_error_code: c_int,
+
+    // Dynamic functions
+    XkbQueryExtension: XkbQueryExtensionType = undefined,
+    XkbSelectEventDetails: XkbSelectEventDetailsType = undefined,
+    XEventsQueued: XEventsQueuedType = undefined,
+    XPeekEvent: XPeekEventType = undefined,
+
+    pub fn init(display_: ?*c.GdkDisplay) !X11Xkb {
+        log.debug("X11: X11Xkb.init: initializing Xkb", .{});
+        const display = display_ orelse {
+            log.err("Fatal: error initializing Xkb extension: display is null", .{});
+            return error.XkbInitializationError;
+        };
+
+        const xdisplay = c.gdk_x11_display_get_xdisplay(display);
+        var result: X11Xkb = .{ .opcode = 0, .base_event_code = 0, .base_error_code = 0 };
+
+        // Load in the X11 calls we need.
+        log.debug("X11: X11Xkb.init: loading libX11.so dynamically", .{});
+        var libX11 = try std.DynLib.open("libX11.so");
+        defer libX11.close();
+        result.XkbQueryExtension = libX11.lookup(XkbQueryExtensionType, "XkbQueryExtension") orelse {
+            log.err("Fatal: error dynamic loading libX11: missing symbol XkbQueryExtension", .{});
+            return error.XkbInitializationError;
+        };
+        result.XkbSelectEventDetails = libX11.lookup(XkbSelectEventDetailsType, "XkbSelectEventDetails") orelse {
+            log.err("Fatal: error dynamic loading libX11: missing symbol XkbSelectEventDetails", .{});
+            return error.XkbInitializationError;
+        };
+        result.XEventsQueued = libX11.lookup(XEventsQueuedType, "XEventsQueued") orelse {
+            log.err("Fatal: error dynamic loading libX11: missing symbol XEventsQueued", .{});
+            return error.XkbInitializationError;
+        };
+        result.XPeekEvent = libX11.lookup(XPeekEventType, "XPeekEvent") orelse {
+            log.err("Fatal: error dynamic loading libX11: missing symbol XPeekEvent", .{});
+            return error.XkbInitializationError;
+        };
+
+        log.debug("X11: X11Xkb.init: running XkbQueryExtension", .{});
+        var major = c.XkbMajorVersion;
+        var minor = c.XkbMinorVersion;
+        if (result.XkbQueryExtension(xdisplay, &result.opcode, &result.base_event_code, &result.base_error_code, &major, &minor) == 0) {
+            log.err("Fatal: error initializing Xkb extension: error executing XkbQueryExtension", .{});
+            return error.XkbInitializationError;
+        }
+
+        log.debug("X11: X11Xkb.init: running XkbSelectEventDetails", .{});
+        if (result.XkbSelectEventDetails(xdisplay, c.XkbUseCoreKbd, c.XkbStateNotify, c.XkbModifierStateMask, c.XkbModifierStateMask) == 0) {
+            log.err("Fatal: error initializing Xkb extension: error executing XkbSelectEventDetails", .{});
+            return error.XkbInitializationError;
+        }
+
+        return result;
+    }
+
+    /// Checks for an immediate pending XKB state update event, and returns the
+    /// keyboard state based on if it finds any. This is necessary as the
+    /// standard GTK X11 API (and X11 in general) does not include the current
+    /// key pressed in any modifier state snapshot for that event (e.g. if the
+    /// pressed key is a modifier, that is not necessarily reflected in the
+    /// modifiers).
+    ///
+    /// Returns null if there is no event. In this case, the caller should fall
+    /// back to the standard GDK modifier state (this likely means the key
+    /// event did not result in a modifier change).
+    pub fn modifier_state_from_notify(self: X11Xkb, display_: ?*c.GdkDisplay) ?input.Mods {
+        const display = display_ orelse return null;
+        // Shoutout to Mozilla for figuring out a clean way to do this, this is
+        // paraphrased from Firefox/Gecko in widget/gtk/nsGtkKeyUtils.cpp.
+        const xdisplay = c.gdk_x11_display_get_xdisplay(display);
+        if (self.XEventsQueued(xdisplay, c.QueuedAfterReading) != 0) {
+            var nextEvent: c.XEvent = undefined;
+            _ = self.XPeekEvent(xdisplay, &nextEvent);
+            if (nextEvent.type == self.base_event_code) {
+                const xkb_event: *c.XkbEvent = @ptrCast(&nextEvent);
+                if (xkb_event.any.xkb_type == c.XkbStateNotify) {
+                    const xkb_state_notify_event: *c.XkbStateNotifyEvent = @ptrCast(xkb_event);
+                    // Check the state according to XKB masks.
+                    const lookup_mods = xkb_state_notify_event.lookup_mods;
+                    var mods: input.Mods = .{};
+
+                    log.debug("X11: found extra XkbStateNotify event w/lookup_mods: {b}", .{lookup_mods});
+                    if (lookup_mods & c.ShiftMask != 0) mods.shift = true;
+                    if (lookup_mods & c.ControlMask != 0) mods.ctrl = true;
+                    if (lookup_mods & c.Mod1Mask != 0) mods.alt = true;
+                    if (lookup_mods & c.Mod2Mask != 0) mods.super = true;
+                    if (lookup_mods & c.LockMask != 0) mods.caps_lock = true;
+
+                    return mods;
+                }
+            }
+        }
+
+        return null;
+    }
+};


### PR DESCRIPTION
This fixes an issue in that when running under X11, when a modifier key is pressed, the modifier state will "lag" behind what should be current. This is due to how X11 sends modifiers in events, i.e. it sends the state from right before the key press, and does not include the effects of the key press itself.

This is corrected by checking the X event queue directly for a pending XkbStateNotify event (we mask this on modifiers), and setting the modifiers off of that if we find one. If not, we fall back to the GDK call.