### PR TITLE
 Add exit code and runtime to abnormal exit error message, make threshold configurable.

### DIFF
--- a/src/cli/args.zig
+++ b/src/cli/args.zig
@@ -230,6 +230,12 @@ fn parseIntoField(
                     0,
                 ) catch return error.InvalidValue,
 
+                u64 => std.fmt.parseInt(
+                    u64,
+                    value orelse return error.ValueRequired,
+                    0,
+                ) catch return error.InvalidValue,
+
                 f64 => std.fmt.parseFloat(
                     f64,
                     value orelse return error.ValueRequired,

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -387,6 +387,11 @@ palette: Palette = .{},
 /// flag. For example: `ghostty -e fish --with --custom --args`.
 command: ?[]const u8 = null,
 
+/// The number of milliseconds below which we consider a process
+/// exit to be abnormal. This is used to show an error message
+/// when the process exits too quickly.
+@"abnormal-runtime-threshold-ms": u64 = 250,
+
 /// Match a regular expression against the terminal text and associate
 /// clicking it with an action. This can be used to match URLs, file paths,
 /// etc. Actions can be opening using the system opener (i.e. "open" or

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -387,10 +387,14 @@ palette: Palette = .{},
 /// flag. For example: `ghostty -e fish --with --custom --args`.
 command: ?[]const u8 = null,
 
-/// The number of milliseconds below which we consider a process
-/// exit to be abnormal. This is used to show an error message
-/// when the process exits too quickly.
-@"abnormal-runtime-threshold-ms": u64 = 250,
+/// The number of milliseconds of runtime below which we consider a process
+/// exit to be abnormal. This is used to show an error message when the
+/// process exits too quickly.
+///
+/// On Linux, this must be paired with a non-zero exit code. On macOS,
+/// we allow any exit code because of the way shell processes are launched
+/// via the login command.
+@"abnormal-command-exit-runtime": u32 = 250,
 
 /// Match a regular expression against the terminal text and associate
 /// clicking it with an action. This can be used to match URLs, file paths,

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -587,13 +587,12 @@ pub fn childExitedAbnormally(self: *Exec, exit_code: u32, runtime_ms: u64) !void
     // Output our error message
     try t.setAttribute(.{ .@"8_fg" = .bright_red });
     try t.setAttribute(.{ .bold = {} });
-    try t.printString("Ghostty failed to launch the requested command.");
+    try t.printString("Ghostty failed to launch the requested command:");
     try t.setAttribute(.{ .unset = {} });
 
     t.carriageReturn();
     try t.linefeed();
     try t.linefeed();
-    try t.printString("Command: ");
     try t.printString(command);
     try t.setAttribute(.{ .unset = {} });
 
@@ -601,7 +600,7 @@ pub fn childExitedAbnormally(self: *Exec, exit_code: u32, runtime_ms: u64) !void
     try t.linefeed();
     try t.linefeed();
     try t.printString("Runtime: ");
-    try t.setAttribute(.{ .@"8_fg" = .bright_red });
+    try t.setAttribute(.{ .@"8_fg" = .red });
     try t.printString(runtime_str);
     try t.setAttribute(.{ .unset = {} });
 
@@ -612,7 +611,7 @@ pub fn childExitedAbnormally(self: *Exec, exit_code: u32, runtime_ms: u64) !void
         t.carriageReturn();
         try t.linefeed();
         try t.printString("Exit Code: ");
-        try t.setAttribute(.{ .@"8_fg" = .bright_red });
+        try t.setAttribute(.{ .@"8_fg" = .red });
         try t.printString(exit_code_str);
         try t.setAttribute(.{ .unset = {} });
     }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -38,16 +38,16 @@ const c = @cImport({
 /// correct granularity of events.
 const disable_kitty_keyboard_protocol = apprt.runtime == apprt.glfw;
 
-/// The number of milliseconds below which we consider a process
-/// exit to be abnormal. This is used to show an error message
-/// when the process exits too quickly.
-abnormal_runtime_threshold_ms: u32,
-
 /// Allocator
 alloc: Allocator,
 
 /// This is the pty fd created for the subcommand.
 subprocess: Subprocess,
+
+/// The number of milliseconds below which we consider a process
+/// exit to be abnormal. This is used to show an error message
+/// when the process exits too quickly.
+abnormal_runtime_threshold_ms: u32,
 
 /// The terminal emulator internal state. This is the abstract "terminal"
 /// that manages input, grid updating, etc. and is renderer-agnostic. It

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -186,7 +186,7 @@ fn drainMailbox(self: *Thread) !void {
             .jump_to_prompt => |v| try self.impl.jumpToPrompt(v),
             .start_synchronized_output => self.startSynchronizedOutput(),
             .linefeed_mode => |v| self.flags.linefeed_mode = v,
-            .child_exited_abnormally => try self.impl.childExitedAbnormally(),
+            .child_exited_abnormally => |v| try self.impl.childExitedAbnormally(v.exit_code, v.runtime_ms),
             .write_small => |v| try self.impl.queueWrite(v.data[0..v.len], self.flags.linefeed_mode),
             .write_stable => |v| try self.impl.queueWrite(v, self.flags.linefeed_mode),
             .write_alloc => |v| {

--- a/src/termio/message.zig
+++ b/src/termio/message.zig
@@ -67,7 +67,7 @@ pub const Message = union(enum) {
     /// close because termio can use this to update the terminal
     /// with an error message.
     child_exited_abnormally: struct {
-        code: u32,
+        exit_code: u32,
         runtime_ms: u64,
     },
 


### PR DESCRIPTION
Added runtime and exit code to the error message.

![image](https://github.com/mitchellh/ghostty/assets/740022/6b80506e-4b16-4bf9-9c93-1753a9c2b45b)
