### PR TITLE
nix: add libX11 to RUNPATH

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -151,6 +151,10 @@ in
       echo "$shell_integration" >> "$out/nix-support/propagated-user-env-packages"
     '';
 
+    postFixup = ''
+      patchelf --add-rpath "${lib.makeLibraryPath [libX11]}" "$out/bin/.ghostty-wrapped"
+    '';
+
     meta = with lib; {
       homepage = "https://github.com/mitchellh/ghostty";
       license = licenses.mit;


### PR DESCRIPTION
This adds libX11 to the (wrapped) binary `RUNPATH` in the Nix package `fixupPhase`, to ensure that the `dlopen` we are doing of it now in #1193 functions correctly.

Note that we patch `.ghostty-wrapped` here, as this is now the main binary after #1104.