### PR TITLE
macos: use ReleaseLocal build configuration for Profile action

### DIFF
--- a/macos/Ghostty.xcodeproj/xcshareddata/xcschemes/Ghostty.xcscheme
+++ b/macos/Ghostty.xcodeproj/xcshareddata/xcschemes/Ghostty.xcscheme
@@ -58,7 +58,7 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
+      buildConfiguration = "ReleaseLocal"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"


### PR DESCRIPTION
This is a small change to use the "ReleaseLocal" build configuration for the "Profile" build action.

Trying to profile with the default Release configuration fails (see https://github.com/mitchellh/ghostty/pull/1135). Profiling is done as part of the development process so there's no need to require library validation.
