### PR TITLE
self-host freedesktop build dependencies

### DIFF
--- a/pkg/fontconfig/build.zig.zon
+++ b/pkg/fontconfig/build.zig.zon
@@ -3,7 +3,7 @@
     .version = "2.14.2",
     .dependencies = .{
         .fontconfig = .{
-            .url = "https://www.freedesktop.org/software/fontconfig/release/fontconfig-2.14.2.tar.gz",
+            .url = "https://deps.files.ghostty.dev/fontconfig-2.14.2.tar.gz",
             .hash = "12201149afb3326c56c05bb0a577f54f76ac20deece63aa2f5cd6ff31a4fa4fcb3b7",
         },
 

--- a/pkg/pixman/build.zig.zon
+++ b/pkg/pixman/build.zig.zon
@@ -3,7 +3,7 @@
     .version = "0.42.2",
     .dependencies = .{
         .pixman = .{
-            .url = "https://gitlab.freedesktop.org/pixman/pixman/-/archive/pixman-0.42.2/pixman-pixman-0.42.2.tar.gz",
+            .url = "https://deps.files.ghostty.dev/pixman-pixman-0.42.2.tar.gz",
             .hash = "12209b9206f9a5d31ccd9a2312cc72cb9dfc3e034aee1883c549dc1d753fae457230",
         },
     },


### PR DESCRIPTION
These are unmodified, so users can still verify the checksum with the official downloads if they feel unsafe.

These are manually uploaded for now. It'd be cool if we had tooling to do this automatically but we very rarely update our dependencies and its very easy to upload here so I'll just do it manually for now.