### PR TITLE
terminal: track palette color in cell state

### DIFF
--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -260,8 +260,7 @@ test "run iterator: empty cells with background set" {
         // Make a screen with some data
         var screen = try terminal.Screen.init(alloc, 3, 5, 0);
         defer screen.deinit();
-        screen.cursor.pen.bg = try terminal.color.Name.cyan.default();
-        screen.cursor.pen.attrs.has_bg = true;
+        screen.cursor.pen.bg = .{ .rgb = try terminal.color.Name.cyan.default() };
         try screen.testWriteString("A");
 
         // Get our first row
@@ -836,10 +835,9 @@ test "shape cell attribute change" {
     {
         var screen = try terminal.Screen.init(alloc, 3, 10, 0);
         defer screen.deinit();
-        screen.cursor.pen.attrs.has_fg = true;
-        screen.cursor.pen.fg = .{ .r = 1, .g = 2, .b = 3 };
+        screen.cursor.pen.fg = .{ .rgb = .{ .r = 1, .g = 2, .b = 3 } };
         try screen.testWriteString(">");
-        screen.cursor.pen.fg = .{ .r = 3, .g = 2, .b = 1 };
+        screen.cursor.pen.fg = .{ .rgb = .{ .r = 3, .g = 2, .b = 1 } };
         try screen.testWriteString("=");
 
         var shaper = &testdata.shaper;
@@ -856,10 +854,9 @@ test "shape cell attribute change" {
     {
         var screen = try terminal.Screen.init(alloc, 3, 10, 0);
         defer screen.deinit();
-        screen.cursor.pen.attrs.has_bg = true;
-        screen.cursor.pen.bg = .{ .r = 1, .g = 2, .b = 3 };
+        screen.cursor.pen.bg = .{ .rgb = .{ .r = 1, .g = 2, .b = 3 } };
         try screen.testWriteString(">");
-        screen.cursor.pen.bg = .{ .r = 3, .g = 2, .b = 1 };
+        screen.cursor.pen.bg = .{ .rgb = .{ .r = 3, .g = 2, .b = 1 } };
         try screen.testWriteString("=");
 
         var shaper = &testdata.shaper;
@@ -876,8 +873,7 @@ test "shape cell attribute change" {
     {
         var screen = try terminal.Screen.init(alloc, 3, 10, 0);
         defer screen.deinit();
-        screen.cursor.pen.attrs.has_bg = true;
-        screen.cursor.pen.bg = .{ .r = 1, .g = 2, .b = 3 };
+        screen.cursor.pen.bg = .{ .rgb = .{ .r = 1, .g = 2, .b = 3 } };
         try screen.testWriteString(">");
         try screen.testWriteString("=");
 

--- a/src/font/shaper/run.zig
+++ b/src/font/shaper/run.zig
@@ -87,8 +87,8 @@ pub const RunIterator = struct {
                 const prev_attrs: Int = @bitCast(prev_cell.attrs.styleAttrs());
                 const attrs: Int = @bitCast(cell.attrs.styleAttrs());
                 if (prev_attrs != attrs) break;
-                if (cell.attrs.has_bg and !cell.bg.eql(prev_cell.bg)) break;
-                if (cell.attrs.has_fg and !cell.fg.eql(prev_cell.fg)) break;
+                if (!cell.bg.eql(prev_cell.bg)) break;
+                if (!cell.fg.eql(prev_cell.fg)) break;
             }
 
             // Text runs break when font styles change so we need to get

--- a/src/inspector/cursor.zig
+++ b/src/inspector/cursor.zig
@@ -3,7 +3,10 @@ const cimgui = @import("cimgui");
 const terminal = @import("../terminal/main.zig");
 
 /// Render cursor information with a table already open.
-pub fn renderInTable(cursor: *const terminal.Screen.Cursor) void {
+pub fn renderInTable(
+    cursor: *const terminal.Screen.Cursor,
+    palette: *const terminal.color.Palette,
+) void {
     {
         cimgui.c.igTableNextRow(cimgui.c.ImGuiTableRowFlags_None, 0);
         {
@@ -41,49 +44,66 @@ pub fn renderInTable(cursor: *const terminal.Screen.Cursor) void {
     }
 
     // If we have a color then we show the color
-    if (cursor.pen.attrs.has_fg) color: {
-        cimgui.c.igTableNextRow(cimgui.c.ImGuiTableRowFlags_None, 0);
-        _ = cimgui.c.igTableSetColumnIndex(0);
-        cimgui.c.igText("Foreground Color");
-        _ = cimgui.c.igTableSetColumnIndex(1);
-        if (!cursor.pen.attrs.has_fg) {
-            cimgui.c.igText("default");
-            break :color;
-        }
+    cimgui.c.igTableNextRow(cimgui.c.ImGuiTableRowFlags_None, 0);
+    _ = cimgui.c.igTableSetColumnIndex(0);
+    cimgui.c.igText("Foreground Color");
+    _ = cimgui.c.igTableSetColumnIndex(1);
+    switch (cursor.pen.fg) {
+        .none => cimgui.c.igText("default"),
+        else => {
+            const rgb = switch (cursor.pen.fg) {
+                .none => unreachable,
+                .indexed => |idx| palette[idx],
+                .rgb => |rgb| rgb,
+            };
 
-        var color: [3]f32 = .{
-            @as(f32, @floatFromInt(cursor.pen.fg.r)) / 255,
-            @as(f32, @floatFromInt(cursor.pen.fg.g)) / 255,
-            @as(f32, @floatFromInt(cursor.pen.fg.b)) / 255,
-        };
-        _ = cimgui.c.igColorEdit3(
-            "color_fg",
-            &color,
-            cimgui.c.ImGuiColorEditFlags_NoPicker |
-                cimgui.c.ImGuiColorEditFlags_NoLabel,
-        );
+            if (cursor.pen.fg == .indexed) {
+                cimgui.c.igValue_Int("Palette", cursor.pen.fg.indexed);
+            }
+
+            var color: [3]f32 = .{
+                @as(f32, @floatFromInt(rgb.r)) / 255,
+                @as(f32, @floatFromInt(rgb.g)) / 255,
+                @as(f32, @floatFromInt(rgb.b)) / 255,
+            };
+            _ = cimgui.c.igColorEdit3(
+                "color_fg",
+                &color,
+                cimgui.c.ImGuiColorEditFlags_NoPicker |
+                    cimgui.c.ImGuiColorEditFlags_NoLabel,
+            );
+        },
     }
-    if (cursor.pen.attrs.has_bg) color: {
-        cimgui.c.igTableNextRow(cimgui.c.ImGuiTableRowFlags_None, 0);
-        _ = cimgui.c.igTableSetColumnIndex(0);
-        cimgui.c.igText("Background Color");
-        _ = cimgui.c.igTableSetColumnIndex(1);
-        if (!cursor.pen.attrs.has_bg) {
-            cimgui.c.igText("default");
-            break :color;
-        }
 
-        var color: [3]f32 = .{
-            @as(f32, @floatFromInt(cursor.pen.bg.r)) / 255,
-            @as(f32, @floatFromInt(cursor.pen.bg.g)) / 255,
-            @as(f32, @floatFromInt(cursor.pen.bg.b)) / 255,
-        };
-        _ = cimgui.c.igColorEdit3(
-            "color_bg",
-            &color,
-            cimgui.c.ImGuiColorEditFlags_NoPicker |
-                cimgui.c.ImGuiColorEditFlags_NoLabel,
-        );
+    cimgui.c.igTableNextRow(cimgui.c.ImGuiTableRowFlags_None, 0);
+    _ = cimgui.c.igTableSetColumnIndex(0);
+    cimgui.c.igText("Background Color");
+    _ = cimgui.c.igTableSetColumnIndex(1);
+    switch (cursor.pen.bg) {
+        .none => cimgui.c.igText("default"),
+        else => {
+            const rgb = switch (cursor.pen.bg) {
+                .none => unreachable,
+                .indexed => |idx| palette[idx],
+                .rgb => |rgb| rgb,
+            };
+
+            if (cursor.pen.bg == .indexed) {
+                cimgui.c.igValue_Int("Palette", cursor.pen.bg.indexed);
+            }
+
+            var color: [3]f32 = .{
+                @as(f32, @floatFromInt(rgb.r)) / 255,
+                @as(f32, @floatFromInt(rgb.g)) / 255,
+                @as(f32, @floatFromInt(rgb.b)) / 255,
+            };
+            _ = cimgui.c.igColorEdit3(
+                "color_bg",
+                &color,
+                cimgui.c.ImGuiColorEditFlags_NoPicker |
+                    cimgui.c.ImGuiColorEditFlags_NoLabel,
+            );
+        },
     }
 
     // Boolean styles

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -649,6 +649,7 @@ pub fn updateFrame(
         mouse: renderer.State.Mouse,
         preedit: ?renderer.State.Preedit,
         cursor_style: ?renderer.CursorStyle,
+        color_palette: terminal.color.Palette,
     };
 
     // Update all our data as tightly as possible within the mutex.
@@ -730,6 +731,7 @@ pub fn updateFrame(
             .mouse = state.mouse,
             .preedit = preedit,
             .cursor_style = cursor_style,
+            .color_palette = state.terminal.color_palette.colors,
         };
     };
     defer {
@@ -752,6 +754,7 @@ pub fn updateFrame(
             critical.mouse,
             critical.preedit,
             critical.cursor_style,
+            &critical.color_palette,
         );
     }
 }
@@ -943,6 +946,7 @@ pub fn rebuildCells(
     mouse: renderer.State.Mouse,
     preedit: ?renderer.State.Preedit,
     cursor_style_: ?renderer.CursorStyle,
+    color_palette: *const terminal.color.Palette,
 ) !void {
     const t = trace(@src());
     defer t.end();
@@ -1097,6 +1101,7 @@ pub fn rebuildCells(
                     term_selection,
                     screen,
                     cell,
+                    color_palette,
                     shaper_cell,
                     run,
                     shaper_cell.x,
@@ -1330,11 +1335,12 @@ fn addCursor(
 /// Update a single cell. The bool returns whether the cell was updated
 /// or not. If the cell wasn't updated, a full refreshCells call is
 /// needed.
-pub fn updateCell(
+fn updateCell(
     self: *OpenGL,
     selection: ?terminal.Selection,
     screen: *terminal.Screen,
     cell: terminal.Screen.Cell,
+    palette: *const terminal.color.Palette,
     shaper_cell: font.shape.Cell,
     shaper_run: font.shape.TextRun,
     x: usize,
@@ -1373,14 +1379,30 @@ pub fn updateCell(
         const cell_res: BgFg = if (!cell.attrs.inverse) .{
             // In normal mode, background and fg match the cell. We
             // un-optionalize the fg by defaulting to our fg color.
-            .bg = if (cell.attrs.has_bg) cell.bg else null,
-            .fg = if (cell.attrs.has_fg) cell.fg else self.foreground_color,
+            .bg = switch (cell.bg) {
+                .none => null,
+                .indexed => |i| palette[i],
+                .rgb => |rgb| rgb,
+            },
+            .fg = switch (cell.fg) {
+                .none => self.foreground_color,
+                .indexed => |i| palette[i],
+                .rgb => |rgb| rgb,
+            },
         } else .{
             // In inverted mode, the background MUST be set to something
             // (is never null) so it is either the fg or default fg. The
             // fg is either the bg or default background.
-            .bg = if (cell.attrs.has_fg) cell.fg else self.foreground_color,
-            .fg = if (cell.attrs.has_bg) cell.bg else self.background_color,
+            .bg = switch (cell.fg) {
+                .none => self.foreground_color,
+                .indexed => |i| palette[i],
+                .rgb => |rgb| rgb,
+            },
+            .fg = switch (cell.bg) {
+                .none => self.background_color,
+                .indexed => |i| palette[i],
+                .rgb => |rgb| rgb,
+            },
         };
 
         // If we are selected, we our colors are just inverted fg/bg
@@ -1441,7 +1463,7 @@ pub fn updateCell(
 
             // If we have a background and its not the default background
             // then we apply background opacity
-            if (cell.attrs.has_bg and !std.meta.eql(rgb, self.background_color)) {
+            if (cell.bg != .none and !rgb.eql(self.background_color)) {
                 break :bg_alpha default;
             }
 


### PR DESCRIPTION
Rather than immediately converting a color palette index into an RGB value for a cell color, when a palette color is used track the palette color directly in the cell state and convert to an RGB value in the renderer.

This causes palette color changes to take effect immediately instead of only for newly drawn cells.

---

This does not change the size of the `Cell` struct (it is 20 bytes before and after this change), and we get 2 bits of the `attrs` bitfield back.

The only other potential performance impact I can think of is having to copy the terminal's color palette on each render. The palette is 256 * 3 = 768 bytes. Not a _huge_ amount, but not trivial either. Profiling on macOS doesn't indicate any performance regressions, but if this is a concern we might be able to figure out a more clever way to do this.

This change makes `notcurses-demo j` work as expected.