### PR TITLE
replace deprecated std.mem.tokenize with std.mem.tokenizeScalar

### DIFF
--- a/src/Command.zig
+++ b/src/Command.zig
@@ -371,7 +371,7 @@ pub fn expandPath(alloc: Allocator, cmd: []const u8) !?[]u8 {
     defer if (builtin.os.tag == .windows) alloc.free(PATH);
 
     var path_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
-    var it = std.mem.tokenize(u8, PATH, &[_]u8{std.fs.path.delimiter});
+    var it = std.mem.tokenizeScalar(u8, PATH, std.fs.path.delimiter);
     var seen_eacces = false;
     while (it.next()) |search_path| {
         // We need enough space in our path buffer to store this

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -45,7 +45,7 @@ pub fn parse(raw_input: []const u8) !Binding {
     // the "=", i.e. "ctrl+shift+a" or "a"
     const trigger = trigger: {
         var result: Trigger = .{};
-        var iter = std.mem.tokenize(u8, input[0..eqlIdx], "+");
+        var iter = std.mem.tokenizeScalar(u8, input[0..eqlIdx], '+');
         loop: while (iter.next()) |part| {
             // All parts must be non-empty
             if (part.len == 0) return Error.InvalidFormat;

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -2322,7 +2322,7 @@ pub fn selectionString(
     // doing this in the loop above but this isn't very hot path code and
     // this is simple.
     if (trim) {
-        var it = std.mem.tokenize(u8, strbuilder.items, "\n");
+        var it = std.mem.tokenizeScalar(u8, strbuilder.items, '\n');
 
         // Reset our items. We retain our capacity. Because we're only
         // removing bytes, we know that the trimmed string must be no longer


### PR DESCRIPTION
[```std.mem.tokenize```](https://ziglang.org/documentation/master/std/#A;std:mem.tokenize) is deprecated. Replace with ```std.mem.tokenizeScalar```.