### PR TITLE
Ability to set preferred fallback fonts

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -342,7 +342,7 @@ pub fn init(
             // A buffer we use to store the font names for logging.
             var name_buf: [256]u8 = undefined;
 
-            if (config.@"font-family") |family| {
+            for (config.@"font-family".list.items) |family| {
                 var disco_it = try disco.discover(alloc, .{
                     .family = family,
                     .style = config.@"font-style".nameValue(),
@@ -364,7 +364,7 @@ pub fn init(
             // a user says `font-style = italic` for the bold face for example,
             // no results would be found if we restrict to ALSO searching for
             // italic.
-            if (config.@"font-family-bold") |family| {
+            for (config.@"font-family-bold".list.items) |family| {
                 const style = config.@"font-style-bold".nameValue();
                 var disco_it = try disco.discover(alloc, .{
                     .family = family,
@@ -379,7 +379,7 @@ pub fn init(
                     _ = try group.addFace(.bold, .{ .deferred = face });
                 } else log.warn("font-family-bold not found: {s}", .{family});
             }
-            if (config.@"font-family-italic") |family| {
+            for (config.@"font-family-italic".list.items) |family| {
                 const style = config.@"font-style-italic".nameValue();
                 var disco_it = try disco.discover(alloc, .{
                     .family = family,
@@ -394,7 +394,7 @@ pub fn init(
                     _ = try group.addFace(.italic, .{ .deferred = face });
                 } else log.warn("font-family-italic not found: {s}", .{family});
             }
-            if (config.@"font-family-bold-italic") |family| {
+            for (config.@"font-family-bold-italic".list.items) |family| {
                 const style = config.@"font-style-bold-italic".nameValue();
                 var disco_it = try disco.discover(alloc, .{
                     .family = family,

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2213,6 +2213,13 @@ pub const RepeatableString = struct {
 
     pub fn parseCLI(self: *Self, alloc: Allocator, input: ?[]const u8) !void {
         const value = input orelse return error.ValueRequired;
+
+        // Empty value resets the list
+        if (value.len == 0) {
+            self.list.clearRetainingCapacity();
+            return;
+        }
+
         const copy = try alloc.dupeZ(u8, value);
         try self.list.append(alloc, copy);
     }
@@ -2248,8 +2255,10 @@ pub const RepeatableString = struct {
         var list: Self = .{};
         try list.parseCLI(alloc, "A");
         try list.parseCLI(alloc, "B");
-
         try testing.expectEqual(@as(usize, 2), list.list.items.len);
+
+        try list.parseCLI(alloc, "");
+        try testing.expectEqual(@as(usize, 0), list.list.items.len);
     }
 };
 

--- a/src/config/key.zig
+++ b/src/config/key.zig
@@ -50,6 +50,6 @@ pub fn Value(comptime key: Key) type {
 test "Value" {
     const testing = std.testing;
 
-    try testing.expectEqual(?[:0]const u8, Value(.@"font-family"));
+    try testing.expectEqual(Config.RepeatableString, Value(.@"font-family"));
     try testing.expectEqual(?bool, Value(.@"cursor-style-blink"));
 }

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -142,7 +142,7 @@ pub const DerivedConfig = struct {
     arena: ArenaAllocator,
 
     font_thicken: bool,
-    font_features: std.ArrayListUnmanaged([]const u8),
+    font_features: std.ArrayListUnmanaged([:0]const u8),
     font_styles: font.Group.StyleStatus,
     cursor_color: ?terminal.color.RGB,
     cursor_opacity: f64,
@@ -154,7 +154,7 @@ pub const DerivedConfig = struct {
     selection_foreground: ?terminal.color.RGB,
     invert_selection_fg_bg: bool,
     min_contrast: f32,
-    custom_shaders: std.ArrayListUnmanaged([]const u8),
+    custom_shaders: std.ArrayListUnmanaged([:0]const u8),
     custom_shader_animation: bool,
     links: link.Set,
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -239,7 +239,7 @@ pub const DerivedConfig = struct {
     arena: ArenaAllocator,
 
     font_thicken: bool,
-    font_features: std.ArrayListUnmanaged([]const u8),
+    font_features: std.ArrayListUnmanaged([:0]const u8),
     font_styles: font.Group.StyleStatus,
     cursor_color: ?terminal.color.RGB,
     cursor_text: ?terminal.color.RGB,
@@ -251,7 +251,7 @@ pub const DerivedConfig = struct {
     selection_foreground: ?terminal.color.RGB,
     invert_selection_fg_bg: bool,
     min_contrast: f32,
-    custom_shaders: std.ArrayListUnmanaged([]const u8),
+    custom_shaders: std.ArrayListUnmanaged([:0]const u8),
     custom_shader_animation: bool,
     links: link.Set,
 


### PR DESCRIPTION
Fixes #1196 
Fixes #886 

The `font-family` set of configurations are now repeatable. Repeating the value specifies a font fallback in case a font is not found.

This is a breaking change, since `font-family` would previously _overwrite_ the previous value so it was a way to _change_ the font. This is no longer possible. To facilitate this use case, I've added a special sentinel value that can be used with any `RepeatableString` type: if the value is empty (`""`) then the list will be reset.