### PR TITLE
Resolve path relative to base

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2312,7 +2312,7 @@ pub const RepeatablePath = struct {
             // If it isn't absolute, we need to make it absolute relative
             // to the base.
             var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
-            const abs = std.os.realpath(path, &buf) catch |err| {
+            const abs = dir.realpath(path, &buf) catch |err| {
                 try errors.add(alloc, .{
                     .message = try std.fmt.allocPrintZ(
                         alloc,


### PR DESCRIPTION
Upgrading from 50916555582684c4932d6bf686482e97434d636f to f93c41669ebea2102b30838a3a4967c87353cac9 resulted in the following error:

> error resolving config-file <i>&lt;relative path&gt;</i>: error.FileNotFound

The file exists and I haven't changed my configuration in a while.

98237b112f3d3ccafefff112c80f0db06434a3bd seems to have caused the regression: The call to [`std.fs.Dir.realpathAlloc`](https://ziglang.org/documentation/master/std/#A;std:fs.Dir.realpathAlloc) was changed to [`std.os.realpath`](https://ziglang.org/documentation/master/std/#A;std:os.realpath) but should have been [`std.fs.Dir.realpath`](https://ziglang.org/documentation/master/std/#A;std:fs.Dir.realpath).