### PR TITLE
feat(nix): add cachix binary cache to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -62,4 +62,9 @@
 
       # Our supported systems are the same supported systems as the Zig binaries.
     }) (builtins.attrNames zig.packages));
+
+  nixConfig = {
+    extra-substituters = ["https://ghostty.cachix.org"];
+    extra-trusted-public-keys = ["ghostty.cachix.org-1:QB389yTa6gTyneehvqG58y0WnHjQOqgnA+wBnpWWxns="];
+  };
 }


### PR DESCRIPTION
Nix flake [schema] allows for a top level attribute called `nixConfig`. This allows a flake to extend a users nix for the specific flake.
This lets us add ghostty's binary cache automatically when using the repo (nix develop, nix build, ...).

[schema]: https://nixos.wiki/wiki/Flakes#Flake_schema