### PR TITLE
Windows Fixes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -251,6 +251,10 @@ pub fn build(b: *std.Build) !void {
             );
         }
 
+        // Building with LTO on Windows is broken.
+        // https://github.com/ziglang/zig/issues/15958
+        if (target.isWindows()) exe.want_lto = false;
+
         // If we're installing, we get the install step so we can add
         // additional dependencies to it.
         const install_step = if (app_runtime != .none) step: {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1090,14 +1090,21 @@ const Subprocess = struct {
                 break :args try args.toOwnedSlice();
             }
 
-            // We run our shell wrapped in `/bin/sh` so that we don't have
-            // to parse the commadnd line ourselves if it has arguments.
-            // Additionally, some environments (NixOS, I found) use /bin/sh
-            // to setup some environment variables that are important to
-            // have set.
-            try args.append("/bin/sh");
-            if (internal_os.isFlatpak()) try args.append("-l");
-            try args.append("-c");
+            if (builtin.os.tag == .windows) {
+                // We run our shell wrapped in `cmd.exe` so that we don't have
+                // to parse the command line ourselves if it has arguments.
+                try args.append("C:\\Windows\\System32\\cmd.exe");
+                try args.append("/C");
+            } else {
+                // We run our shell wrapped in `/bin/sh` so that we don't have
+                // to parse the command line ourselves if it has arguments.
+                // Additionally, some environments (NixOS, I found) use /bin/sh
+                // to setup some environment variables that are important to
+                // have set.
+                try args.append("/bin/sh");
+                if (internal_os.isFlatpak()) try args.append("-l");
+                try args.append("-c");
+            }
             try args.append(opts.full_config.command orelse default_path);
             break :args try args.toOwnedSlice();
         };

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1090,7 +1090,7 @@ const Subprocess = struct {
                 break :args try args.toOwnedSlice();
             }
 
-            if (builtin.os.tag == .windows) {
+            if (comptime builtin.os.tag == .windows) {
                 // We run our shell wrapped in `cmd.exe` so that we don't have
                 // to parse the command line ourselves if it has arguments.
                 try args.append("C:\\Windows\\System32\\cmd.exe");
@@ -1105,6 +1105,7 @@ const Subprocess = struct {
                 if (internal_os.isFlatpak()) try args.append("-l");
                 try args.append("-c");
             }
+
             try args.append(opts.full_config.command orelse default_path);
             break :args try args.toOwnedSlice();
         };


### PR DESCRIPTION
I just got into the beta and ran into two small problems with ghostty on Windows. Firstly, when doing a release build, LTO is enabled by default which causes problems on Windows. Secondly, ghostty tries to use `sh` to parse the shell command, which it doesn't find on Windows. I got it working locally with these changes disabling `want_lto` for Windows in `build.zig` and using `cmd.exe` instead of `sh` to run the shell command.