### PR TITLE
Add 'Open Config' menu to the GTK runtime and synchronize config-related keybindings across platforms.

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -293,6 +293,7 @@ fn updateConfigErrors(self: *App) !void {
 
 fn syncActionAccelerators(self: *App) !void {
     try self.syncActionAccelerator("app.quit", .{ .quit = {} });
+    try self.syncActionAccelerator("app.open_config", .{ .open_config = {} });
     try self.syncActionAccelerator("app.reload_config", .{ .reload_config = {} });
     try self.syncActionAccelerator("app.toggle_inspector", .{ .inspector = .toggle });
     try self.syncActionAccelerator("win.close", .{ .close_surface = {} });
@@ -479,6 +480,17 @@ fn gtkActivate(app: *c.GtkApplication, ud: ?*anyopaque) callconv(.C) void {
     }, .{ .forever = {} });
 }
 
+fn gtkActionOpenConfig(
+    _: *c.GSimpleAction,
+    _: *c.GVariant,
+    ud: ?*anyopaque,
+) callconv(.C) void {
+    const self: *App = @ptrCast(@alignCast(ud orelse return));
+    _ = self.core_app.mailbox.push(.{
+        .open_config = {},
+    }, .{ .forever = {} });
+}
+
 fn gtkActionReloadConfig(
     _: *c.GSimpleAction,
     _: *c.GVariant,
@@ -507,6 +519,7 @@ fn gtkActionQuit(
 fn initActions(self: *App) void {
     const actions = .{
         .{ "quit", &gtkActionQuit },
+        .{ "open_config", &gtkActionOpenConfig },
         .{ "reload_config", &gtkActionReloadConfig },
     };
 
@@ -545,6 +558,7 @@ fn initMenu(self: *App) void {
         defer c.g_object_unref(section);
         c.g_menu_append_section(menu, null, @ptrCast(@alignCast(section)));
         c.g_menu_append(section, "Terminal Inspector", "win.toggle_inspector");
+        c.g_menu_append(section, "Open Configuration", "app.open_config");
         c.g_menu_append(section, "Reload Configuration", "app.reload_config");
         c.g_menu_append(section, "About Ghostty", "win.about");
     }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -946,10 +946,17 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
     const alloc = result._arena.?.allocator();
 
     // Add our default keybindings
+
+    // keybinds for opening and reloading config
     try result.keybind.set.put(
         alloc,
-        .{ .key = .space, .mods = .{ .super = true, .alt = true, .ctrl = true } },
+        .{ .key = .comma, .mods = inputpkg.ctrlOrSuper(.{ .shift = true }) },
         .{ .reload_config = {} },
+    );
+    try result.keybind.set.put(
+        alloc,
+        .{ .key = .comma, .mods = inputpkg.ctrlOrSuper(.{}) },
+        .{ .open_config = {} },
     );
 
     {
@@ -1209,16 +1216,6 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
             alloc,
             .{ .key = .q, .mods = .{ .super = true } },
             .{ .quit = {} },
-        );
-        try result.keybind.set.put(
-            alloc,
-            .{ .key = .comma, .mods = .{ .super = true, .shift = true } },
-            .{ .reload_config = {} },
-        );
-        try result.keybind.set.put(
-            alloc,
-            .{ .key = .comma, .mods = .{ .super = true } },
-            .{ .open_config = {} },
         );
         try result.keybind.set.put(
             alloc,


### PR DESCRIPTION
![Screenshot from 2024-01-04 23-04-17](https://github.com/mitchellh/ghostty/assets/740022/de8baa46-b0e8-442b-a134-e96caa505f82)
