### PR TITLE
macos: set initial window size in controller window init

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -164,6 +164,23 @@ class TerminalController: NSWindowController, NSWindowDelegate,
         // covered in thie GitHub issue: https://github.com/mitchellh/ghostty/pull/376
         window.colorSpace = NSColorSpace.sRGB
         
+        // If we have only a single surface (no splits) and that surface requested
+        // an initial size then we set it here now.
+        if case let .leaf(leaf) = surfaceTree {
+            if let initialSize = leaf.surface.initialSize {
+                // Setup our frame. We need to first subtract the views frame so that we can
+                // just get the chrome frame so that we only affect the surface view size.
+                var frame = window.frame
+                frame.size.width -= leaf.surface.frame.size.width
+                frame.size.height -= leaf.surface.frame.size.height
+                frame.size.width += initialSize.width
+                frame.size.height += initialSize.height
+                
+                // We have no tabs and we are not a split, so set the initial size of the window.
+                window.setFrame(frame, display: true)
+            }
+        }
+        
         // Center the window to start, we'll move the window frame automatically
         // when cascading.
         window.center()

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -534,9 +534,6 @@ extension Ghostty {
         override func viewDidMoveToWindow() {
             // Set our background blur if requested
             setWindowBackgroundBlur(window)
-            
-            // Try to set the initial window size if we have one
-            setInitialWindowSize()
         }
         
         /// This function sets the window background to blur if it is configured on the surface.
@@ -566,37 +563,6 @@ extension Ghostty {
 
             // If we have a blur, set the blur
             ghostty_set_window_background_blur(surface, Unmanaged.passUnretained(window).toOpaque())
-        }
-       
-        /// Sets the initial window size requested by the Ghostty config.
-        ///
-        /// This only works under certain conditions:
-        ///   - The window must be "uninitialized"
-        ///   - The window must have no tabs
-        ///   - Ghostty must have requested an initial size
-        ///   
-        private func setInitialWindowSize() {
-            guard let initialSize = initialSize else { return }
-            
-            // If we have tabs, then do not change the window size
-            guard let window = self.window else { return }
-            guard let windowControllerRaw = window.windowController else { return }
-            guard let windowController = windowControllerRaw as? TerminalController else { return }
-            guard case .leaf = windowController.surfaceTree else { return }
-            
-            // If our window is full screen, we do not set the frame
-            guard !window.styleMask.contains(.fullScreen) else { return }
-            
-            // Setup our frame. We need to first subtract the views frame so that we can
-            // just get the chrome frame so that we only affect the surface view size.
-            var frame = window.frame
-            frame.size.width -= self.frame.size.width
-            frame.size.height -= self.frame.size.height
-            frame.size.width += initialSize.width
-            frame.size.height += initialSize.height
-            
-            // We have no tabs and we are not a split, so set the initial size of the window.
-            window.setFrame(frame, display: true)
         }
         
         override func becomeFirstResponder() -> Bool {


### PR DESCRIPTION
Fixes #1227
Fixes #1206

This moves the logic that respects `window-width` and `window-height` to the controller window initialization. This is where it should've been all the time but we previously didn't use a controller architecture so we did our best to use heuristics in the view to do this.

This location now ensures that this only happens on window initialization and only if we have one surface.

## Before

```
window-width = 125
window-height = 45
```

https://github.com/mitchellh/ghostty/assets/1299/e7983cef-11b8-4550-9479-28ab621a5507

## After


https://github.com/mitchellh/ghostty/assets/1299/b40f33f0-7f0b-4510-91ac-ddc5520d1cdd

