### PR TITLE
macos: Address window spawning and ordering issues from service.

### DIFF
--- a/macos/Sources/AppDelegate.swift
+++ b/macos/Sources/AppDelegate.swift
@@ -104,12 +104,6 @@ class AppDelegate: NSObject,
         // Initial config loading
         configDidReload(ghostty)
         
-        // Let's launch our first window. We only do this if we have no other windows. It
-        // is possible to have other windows if we're opening a URL since `application(_:openFile:)`
-        // is called before this.
-        if (terminalManager.windows.count == 0) {
-            terminalManager.newWindow()
-        }
         
         // Register our service provider. This must happen after everything
         // else is initialized.
@@ -130,6 +124,18 @@ class AppDelegate: NSObject,
             )
         ])
         center.delegate = self
+    }
+
+    func applicationDidBecomeActive(_ notification: Notification) {
+        // Let's launch our first window. We only do this if we have no other windows. It
+        // is possible to have other windows if we're opening a URL since `application(_:openFile:)`
+        // is called before this.
+        if (ghostty.firstLaunch) {
+            if terminalManager.windows.count == 0 {
+                terminalManager.newWindow()
+            }
+            ghostty.firstLaunch = false
+        }
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {

--- a/macos/Sources/AppDelegate.swift
+++ b/macos/Sources/AppDelegate.swift
@@ -57,6 +57,9 @@ class AppDelegate: NSObject,
     /// The dock menu
     private var dockMenu: NSMenu = NSMenu()
     
+    /// This is only true before application has become active.
+    private var applicationHasBecomeActive: Bool = false
+    
     /// The ghostty global state. Only one per process.
     let ghostty: Ghostty.AppState = Ghostty.AppState()
     
@@ -104,7 +107,6 @@ class AppDelegate: NSObject,
         // Initial config loading
         configDidReload(ghostty)
         
-        
         // Register our service provider. This must happen after everything
         // else is initialized.
         NSApp.servicesProvider = ServiceProvider()
@@ -127,14 +129,15 @@ class AppDelegate: NSObject,
     }
 
     func applicationDidBecomeActive(_ notification: Notification) {
+        guard !applicationHasBecomeActive else { return }
+        applicationHasBecomeActive = true
+        
         // Let's launch our first window. We only do this if we have no other windows. It
-        // is possible to have other windows if we're opening a URL since `application(_:openFile:)`
-        // is called before this.
-        if (ghostty.firstLaunch) {
-            if terminalManager.windows.count == 0 {
-                terminalManager.newWindow()
-            }
-            ghostty.firstLaunch = false
+        // is possible to have other windows in a few scenarios:
+        //   - if we're opening a URL since `application(_:openFile:)` is called before this.
+        //   - if we're restoring from persisted state
+        if terminalManager.windows.count == 0 {
+            terminalManager.newWindow()
         }
     }
 

--- a/macos/Sources/Features/Terminal/TerminalManager.swift
+++ b/macos/Sources/Features/Terminal/TerminalManager.swift
@@ -33,8 +33,8 @@ class TerminalManager {
             }
         }
         
-        // If we have no main window, just use the first window.
-        return windows.first
+        // If we have no main window, just use the last window.
+        return windows.last
     }
     
     init(_ ghostty: Ghostty.AppState) {

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -36,6 +36,9 @@ extension Ghostty {
         /// Optional delegate
         weak var delegate: GhosttyAppStateDelegate?
 
+        /// True when application is first launched. Immidiately set to false after first window is shown.
+        var firstLaunch: Bool = true
+
         /// The ghostty global configuration. This should only be changed when it is definitely
         /// safe to change. It is definite safe to change only when the embedded app runtime
         /// in Ghostty says so (usually, only in a reload configuration callback).

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -36,9 +36,6 @@ extension Ghostty {
         /// Optional delegate
         weak var delegate: GhosttyAppStateDelegate?
 
-        /// True when application is first launched. Immidiately set to false after first window is shown.
-        var firstLaunch: Bool = true
-
         /// The ghostty global configuration. This should only be changed when it is definitely
         /// safe to change. It is definite safe to change only when the embedded app runtime
         /// in Ghostty says so (usually, only in a reload configuration callback).


### PR DESCRIPTION
An attempt to fix the three issues mentioned in https://github.com/mitchellh/ghostty/issues/1041#issuecomment-1878820364

The first two issues (when Ghostty is closed) is cause by: when the service is triggered it first calls the `applicationDidFinishLaunching` which is creating the first tab/window in the home directory. To fix this, had move the window creation to `applicationDidBecomeActive` instead of `applicationDidFinishLaunching`. Had to add a state for `firstLaunch` as window count is not reliable in `applicationDidBecomeActive` - imagine launching Ghostty, closing all the windows, Alt-tabbing to another application and Alt-tabbing back to Ghostty will call `applicationDidBecomeActive` and we do not want to spawn a new window in this case.

The third issue (when Ghostty is open) is not a bug but probably the desired behavior is different. It is cause by: `window.isMainWindow` is false for all tabs when Ghostty is no longer the focused application and in this case we were just selecting `windows.first` but this PR changes it to `windows.last` instead. The reason I say it is not a bug is because if you launch Ghostty and open some tabs then without losing focus from ghostty right click in finder and launch a new tab then the tab is opened just after the focused tab as the focused tab has `window.isMainWindow` set to true. I don't know if I explained it clearly enough. Let me know if there is some confusion.