### PR TITLE
Include the git commit hash in the Nix package.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
   };
 
   outputs = {
+    self,
     nixpkgs-unstable,
     nixpkgs-stable,
     nixpkgs-zig-0-12,
@@ -54,6 +55,7 @@
       packages.${system} = rec {
         ghostty = pkgs-stable.callPackage ./nix/package.nix {
           inherit (pkgs-zig-0-12) zig_0_12;
+          revision = self.shortRev or self.dirtyShortRev or "dirty";
         };
         default = ghostty;
       };

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -123,7 +123,7 @@ in
 
     dontConfigure = true;
 
-    zigBuildFlags = "-Dversion-string=${finalAttrs.version}-${revision}";
+    zigBuildFlags = "-Dversion-string=${finalAttrs.version}-${revision}-nix";
 
     preBuild = ''
       rm -rf $ZIG_GLOBAL_CACHE_DIR

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,4 +1,5 @@
 {
+  self,
   lib,
   stdenv,
   bzip2,
@@ -23,6 +24,7 @@
   ncurses,
   pkg-config,
   zig_0_12,
+  revision ? "dirty",
 }: let
   # The Zig hook has no way to select the release type without actual
   # overriding of the default flags.
@@ -121,7 +123,7 @@ in
 
     dontConfigure = true;
 
-    zigBuildFlags = "-Dversion-string=${finalAttrs.version}";
+    zigBuildFlags = "-Dversion-string=${finalAttrs.version}-${revision}";
 
     preBuild = ''
       rm -rf $ZIG_GLOBAL_CACHE_DIR


### PR DESCRIPTION
Overriding the version in the Nix package makes it harder to determine what git commit Ghostty was built with on Nix.