### PR TITLE
Prefer Apple Emoji on macOS, don't crash on unknown Freetype error

### DIFF
--- a/pkg/freetype/errors.zig
+++ b/pkg/freetype/errors.zig
@@ -94,6 +94,7 @@ pub const Error = error{
     BbxTooBig,
     CorruptedFontHeader,
     CorruptedFontGlyphs,
+    UnknownFreetypeError,
 };
 
 pub fn intToError(err: c_int) Error!void {
@@ -188,7 +189,7 @@ pub fn intToError(err: c_int) Error!void {
         c.FT_Err_Bbx_Too_Big => Error.BbxTooBig,
         c.FT_Err_Corrupted_Font_Header => Error.CorruptedFontHeader,
         c.FT_Err_Corrupted_Font_Glyphs => Error.CorruptedFontGlyphs,
-        else => unreachable,
+        else => Error.UnknownFreetypeError,
     };
 }
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -410,6 +410,21 @@ pub fn init(
                     _ = try group.addFace(.bold_italic, .{ .deferred = face });
                 } else log.warn("font-family-bold-italic not found: {s}", .{family});
             }
+
+            // On macOS, always search for and add the Apple Emoji font
+            // as our preferred emoji font for fallback. We do this in case
+            // people add other emoji fonts to their system, we always want to
+            // prefer the official one. Users can override this by explicitly
+            // specifying a font-family for emoji.
+            if (comptime builtin.os.tag == .macos) {
+                var disco_it = try disco.discover(alloc, .{
+                    .family = "Apple Color Emoji",
+                });
+                defer disco_it.deinit();
+                if (try disco_it.next()) |face| {
+                    _ = try group.addFace(.regular, .{ .fallback_deferred = face });
+                }
+            }
         }
 
         // Our built-in font will be used as a backup


### PR DESCRIPTION
This makes it so that on macOS, Apple Color Emoji is preferred even if another emoji font is installed. This is related to #1229. This is added as a fallback font so any user-defined fonts take priority.