### PR TITLE
macOS: detect changed shell (via `chsh`) immediately without requiring system restart

### DIFF
--- a/src/os/desktop.zig
+++ b/src/os/desktop.zig
@@ -19,7 +19,15 @@ pub fn launchedFromDesktop() bool {
     return switch (builtin.os.tag) {
         // macOS apps launched from finder or `open` always have the init
         // process as their parent.
-        .macos => c.getppid() == 1,
+        .macos => macos: {
+            // This special case is so that if we launch the app via the
+            // app bundle (i.e. via open) then we still treat it as if it
+            // was launched from the desktop.
+            if (build_config.artifact == .lib and
+                std.os.getenv("GHOSTTY_MAC_APP") != null) break :macos true;
+
+            break :macos c.getppid() == 1;
+        },
 
         // On Linux, GTK sets GIO_LAUNCHED_DESKTOP_FILE and
         // GIO_LAUNCHED_DESKTOP_FILE_PID. We only check the latter to see if


### PR DESCRIPTION
Fixes #139 

From the issue:

> Looking into this now, I think I figured out the broken logic. When launching from open, the parent process of Ghostty is launchd which appears to set your SHELL env var to your configured shell when logging in. That's why a restart fixes it. However, I believe directory services (the macOS equivalent to /etc/passwd) is updated in real time.
> 
> Ghostty does read directory services but at a lower priority than SHELL. This logic makes sense for CLI-launched terminals but not desktop-launched. From a CLI you want the terminal you're launching to probably inherit the shell from the CLI you launched it from. (Note that using open explicitly forces a launchd-style launch so it quacks as if it was double-clicked on the desktop).
> 
> In conclusion, I believe the correct logic is to invert the priority on SHELL vs directory services when Ghostty detects it was launched from launchd. We already have this detection logic in Ghostty because we use it for a number of other things as well, so this should be easy to fix. I'll work on it later today.