### PR TITLE
Add action '+show-config' that will print out either the current or the default config.

### DIFF
--- a/src/cli/action.zig
+++ b/src/cli/action.zig
@@ -6,6 +6,7 @@ const version = @import("version.zig");
 const list_keybinds = @import("list_keybinds.zig");
 const list_themes = @import("list_themes.zig");
 const list_colors = @import("list_colors.zig");
+const show_config = @import("show_config.zig");
 
 /// Special commands that can be invoked via CLI flags. These are all
 /// invoked by using `+<action>` as a CLI flag. The only exception is
@@ -25,6 +26,9 @@ pub const Action = enum {
 
     /// List named RGB colors
     @"list-colors",
+
+    /// Dump the config to stdout
+    @"show-config",
 
     pub const Error = error{
         /// Multiple actions were detected. You can specify at most one
@@ -67,6 +71,7 @@ pub const Action = enum {
             .@"list-keybinds" => try list_keybinds.run(alloc),
             .@"list-themes" => try list_themes.run(alloc),
             .@"list-colors" => try list_colors.run(alloc),
+            .@"show-config" => try show_config.run(alloc),
         };
     }
 };

--- a/src/cli/list_keybinds.zig
+++ b/src/cli/list_keybinds.zig
@@ -39,12 +39,7 @@ pub fn run(alloc: Allocator) !u8 {
     defer config.deinit();
 
     const stdout = std.io.getStdOut().writer();
-    var iter = config.keybind.set.bindings.iterator();
-    while (iter.next()) |next| {
-        const keys = next.key_ptr.*;
-        const value = next.value_ptr.*;
-        try stdout.print("{}={}\n", .{ keys, value });
-    }
+    try config.keybind.formatConfig(stdout, "keybind=");
 
     return 0;
 }

--- a/src/cli/show_config.zig
+++ b/src/cli/show_config.zig
@@ -1,0 +1,46 @@
+const std = @import("std");
+const args = @import("args.zig");
+const Allocator = std.mem.Allocator;
+const Config = @import("../config/Config.zig");
+
+pub const Options = struct {
+    /// If true, print out the default config instead of the user's config.
+    default: bool = false,
+
+    pub fn deinit(self: Options) void {
+        _ = self;
+    }
+};
+
+/// The "show-config" command is used to list all the available configuration
+/// settings for Ghostty.
+///
+/// When executed without any arguments this will list the current settings
+/// loaded by the config file(s). If no config file is found or there aren't
+/// any changes to the settings it will print out the default ones configured
+/// for Ghostty
+///
+/// The "--default" argument will print out all the default settings
+/// configured for Ghostty
+pub fn run(alloc: Allocator) !u8 {
+    var opts: Options = .{};
+    defer opts.deinit();
+
+    {
+        var iter = try std.process.argsWithAllocator(alloc);
+        defer iter.deinit();
+        try args.parse(Options, alloc, &opts, &iter);
+    }
+
+    var config = if (opts.default) try Config.default(alloc) else try Config.load(alloc);
+    defer config.deinit();
+
+    const stdout = std.io.getStdOut().writer();
+
+    const info = @typeInfo(Config);
+    std.debug.assert(info == .Struct);
+
+    try config.formatConfig(stdout);
+
+    return 0;
+}

--- a/src/font/face/Metrics.zig
+++ b/src/font/face/Metrics.zig
@@ -140,6 +140,37 @@ pub const Modifier = union(enum) {
             },
         };
     }
+
+    pub fn formatConfig(self: Modifier, writer: anytype, prefix: ?[]const u8) !void {
+        switch (self) {
+            .percent => |v| {
+                try writer.print("{s}{d}%\n", .{ prefix orelse "", v });
+            },
+            .absolute => |v| {
+                try writer.print("{s}{d}\n", .{ prefix orelse "", v });
+            },
+        }
+    }
+
+    test "formatConfig-percent" {
+        var buffer: [16]u8 = undefined;
+        var fbs = std.io.fixedBufferStream(&buffer);
+        const writer = fbs.writer();
+
+        const value: Modifier = .{ .percent = 50 };
+        try value.formatConfig(writer, "a=");
+        try std.testing.expectEqualSlices(u8, "a=50%\n", fbs.getWritten());
+    }
+
+    test "formatConfig-absolute" {
+        var buffer: [16]u8 = undefined;
+        var fbs = std.io.fixedBufferStream(&buffer);
+        const writer = fbs.writer();
+
+        const value: Modifier = .{ .absolute = 50 };
+        try value.formatConfig(writer, "a=");
+        try std.testing.expectEqualSlices(u8, "a=50\n", fbs.getWritten());
+    }
 };
 
 /// Key is an enum of all the available metrics keys.


### PR DESCRIPTION
As an alternative to #1234, add an action that will print out either the current or the default config. One downside of the current argument parsing code is that you cannot use an action in conjuction with "normal" configuration settings on the CLI.