### PR TITLE
linux: consider Xft.dpi to scale the content

### DIFF
--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -664,30 +664,25 @@ pub fn getContentScale(self: *const Surface) !apprt.ContentScale {
     const gtk_scale: f32 = @floatFromInt(c.gtk_widget_get_scale_factor(@ptrCast(self.gl_area)));
 
     // If we are on X11, we also have to scale using Xft.dpi
-    const xft_dpi_scale = if (x11.is_current_display_server()) getXftDpiScale() else 1.0;
+    const xft_dpi_scale = if (!x11.is_current_display_server()) 1.0 else xft_scale: {
+        // Here we use GTK to retrieve gtk-xft-dpi, which is Xft.dpi multiplied
+        // by 1024. See https://docs.gtk.org/gtk4/property.Settings.gtk-xft-dpi.html
+        const settings = c.gtk_settings_get_default();
+
+        var value: c.GValue = std.mem.zeroes(c.GValue);
+        defer c.g_value_unset(&value);
+        _ = c.g_value_init(&value, c.G_TYPE_INT);
+        c.g_object_get_property(@ptrCast(@alignCast(settings)), "gtk-xft-dpi", &value);
+        const gtk_xft_dpi = c.g_value_get_int(&value);
+
+        // As noted above Xft.dpi is multiplied by 1024, so we divide by 1024,
+        // then divide by the default value of Xft.dpi (96) to derive a scale
+        const xft_dpi: f32 = @floatFromInt(@divExact(gtk_xft_dpi, 1024));
+        break :xft_scale xft_dpi / 96;
+    };
 
     const scale = gtk_scale * xft_dpi_scale;
-
     return .{ .x = scale, .y = scale };
-}
-
-fn getXftDpiScale() f32 {
-    // Here we use GTK to retrieve gtk-xft-dpi, which is Xft.dpi multiplied by 1024
-    // See https://docs.gtk.org/gtk4/property.Settings.gtk-xft-dpi.html
-    const settings = c.gtk_settings_get_default();
-
-    var value: c.GValue = std.mem.zeroes(c.GValue);
-    defer c.g_value_unset(&value);
-    _ = c.g_value_init(&value, c.G_TYPE_INT);
-
-    c.g_object_get_property(@ptrCast(@alignCast(settings)), "gtk-xft-dpi", &value);
-    const gtk_xft_dpi = c.g_value_get_int(&value);
-
-    // Scale the value back to obtain Xft.dpi
-    const xft_dpi = @divExact(gtk_xft_dpi, 1024);
-
-    // Divide by the default value of Xft.dpi (96) to derive a scale
-    return @as(f32, @floatFromInt(xft_dpi)) / 96.0;
 }
 
 pub fn getSize(self: *const Surface) !apprt.SurfaceSize {

--- a/src/apprt/gtk/x11.zig
+++ b/src/apprt/gtk/x11.zig
@@ -13,6 +13,12 @@ pub fn is_display(display: ?*c.GdkDisplay) bool {
     ) != 0;
 }
 
+/// Returns true if the app is running on X11
+pub fn is_current_display_server() bool {
+    const display = c.gdk_display_get_default();
+    return is_display(display);
+}
+
 pub const Xkb = struct {
     base_event_code: c_int,
     funcs: Funcs,


### PR DESCRIPTION
Many applications use Xft.dpi to scale their contents (e.g. Chromium, kitty, alacritty...). This value also gets set by DE setting managers and can be manually set in ~/.Xresources if using, e.g., i3 (see discussion on #1243).

This should make HiDPI on Linux more consistent even when not using GTK-specific methods (e.g. GDK_SCALE=2).

Note that we still consider GTK scaling, so it's possible to use the two independently.