### PR TITLE
renderer: constrain dingbats unicode block to cell size

### DIFF
--- a/src/renderer/cell.zig
+++ b/src/renderer/cell.zig
@@ -41,7 +41,9 @@ pub fn fgMode(
         // the subsequent character is empty, then we allow it to use
         // the full glyph size. See #1071.
         .text => text: {
-            if (!ziglyph.general_category.isPrivateUse(@intCast(cell.char))) {
+            if (!ziglyph.general_category.isPrivateUse(@intCast(cell.char)) and
+                !ziglyph.blocks.isDingbats(@intCast(cell.char)))
+            {
                 break :text .normal;
             }
 

--- a/src/renderer/shaders/cell.metal
+++ b/src/renderer/shaders/cell.metal
@@ -165,7 +165,7 @@ vertex VertexOut uber_vertex(
     if (input.mode == MODE_FG_CONSTRAINED) {
       if (glyph_size.x > cell_size_scaled.x) {
         float new_y = glyph_size.y * (cell_size_scaled.x / glyph_size.x);
-        glyph_offset.y += glyph_size.y - new_y;
+        glyph_offset.y += (glyph_size.y - new_y) / 2;
         glyph_size.y = new_y;
         glyph_size.x = cell_size_scaled.x;
       }

--- a/src/renderer/shaders/cell.v.glsl
+++ b/src/renderer/shaders/cell.v.glsl
@@ -194,7 +194,7 @@ void main() {
         if (mode == MODE_FG_CONSTRAINED) {
             if (glyph_size.x > cell_size_scaled.x) {
                 float new_y = glyph_size.y * (cell_size_scaled.x / glyph_size.x);
-                glyph_offset_calc.y = glyph_offset_calc.y + (glyph_size.y - new_y);
+                glyph_offset_calc.y = glyph_offset_calc.y + ((glyph_size.y - new_y) / 2);
                 glyph_size_calc.y = new_y;
                 glyph_size_calc.x = cell_size_scaled.x;
             }


### PR DESCRIPTION
Dingbats are generally symbolic glyphs that frequently overflow the cell. Their defined codepoint width is "1" so they take one cell but very often overflow to the next.

This extends the previously created logic for Nerd Font symbols such that when a dingbat is next to whitespace, we allow it to use the full size, but when a dingbat is next to an occupied cell we constrain it to the cell size.

## Before

![CleanShot 2024-01-07 at 14 56 13@2x](https://github.com/mitchellh/ghostty/assets/1299/97dc0c25-ec83-4887-bf3b-eecc2e3451d6)


## After

![CleanShot 2024-01-07 at 15 03 33@2x](https://github.com/mitchellh/ghostty/assets/1299/72af4d20-2f28-480c-8c70-2b1a9ccde380)

