### PR TITLE
Add help CLI action and generate manual pages.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -197,6 +197,8 @@ pub fn build(b: *std.Build) !void {
         .{version},
     ));
 
+    createHelp(b);
+
     // Exe
     if (exe_) |exe| {
         exe.root_module.addOptions("build_options", exe_options);
@@ -1052,7 +1054,40 @@ fn addDeps(
         }
     }
 
+    addHelp(step);
+
     return static_libs;
+}
+
+var generate_help_step: *std.Build.Step.Run = undefined;
+var help_strings: std.Build.LazyPath = undefined;
+
+/// Generate help files
+fn createHelp(b: *std.Build) void {
+    const generate_help = b.addExecutable(.{
+        .name = "generate_help",
+        .root_source_file = .{ .path = "src/generate_help_strings.zig" },
+        .target = b.host,
+    });
+
+    generate_help_step = b.addRunArtifact(generate_help);
+    generate_help_step.step.dependOn(&generate_help.step);
+
+    help_strings = generate_help_step.addOutputFileArg("help_strings.zig");
+
+    if (builtin.target.isDarwin()) {
+        const generated = b.option([]const u8, "help_strings", "generated help file") orelse "help_strings";
+        const write_file = b.addWriteFiles();
+        help_strings = write_file.addCopyFile(help_strings, generated);
+    }
+}
+
+/// Add the generated help files to the build.
+fn addHelp(step: *std.Build.Step.Compile) void {
+    step.step.dependOn(&generate_help_step.step);
+    step.root_module.addAnonymousImport("help_strings", .{
+        .root_source_file = help_strings,
+    });
 }
 
 fn benchSteps(

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -45,6 +45,7 @@
   pixman,
   zlib,
   alejandra,
+  pandoc,
 }: let
   # See package.nix. Keep in sync.
   rpathLibs =
@@ -80,6 +81,7 @@ in
         # For builds
         llvmPackages_latest.llvm
         ncurses
+        pandoc
         pkg-config
         scdoc
         zig

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -23,6 +23,7 @@
   ncurses,
   pkg-config,
   zig_0_12,
+  pandoc,
   revision ? "dirty",
 }: let
   # The Zig hook has no way to select the release type without actual
@@ -90,6 +91,7 @@ in
     nativeBuildInputs = [
       git
       ncurses
+      pandoc
       pkg-config
       zig012Hook
       wrapGAppsHook4

--- a/src/cli/action.zig
+++ b/src/cli/action.zig
@@ -6,6 +6,7 @@ const version = @import("version.zig");
 const list_keybinds = @import("list_keybinds.zig");
 const list_themes = @import("list_themes.zig");
 const list_colors = @import("list_colors.zig");
+const help = @import("help.zig");
 
 /// Special commands that can be invoked via CLI flags. These are all
 /// invoked by using `+<action>` as a CLI flag. The only exception is
@@ -13,6 +14,9 @@ const list_colors = @import("list_colors.zig");
 pub const Action = enum {
     /// Output the version and exit
     version,
+
+    /// List general or config/actions help information
+    help,
 
     /// List available fonts
     @"list-fonts",
@@ -49,6 +53,9 @@ pub const Action = enum {
             // Special case, --version always outputs the version no
             // matter what, no matter what other args exist.
             if (std.mem.eql(u8, arg, "--version")) return .version;
+            if (std.mem.eql(u8, arg, "--help")) {
+                if (pending == null) return .help;
+            }
 
             // Commands must start with "+"
             if (arg.len == 0 or arg[0] != '+') continue;
@@ -62,7 +69,8 @@ pub const Action = enum {
     /// Run the action. This returns the exit code to exit with.
     pub fn run(self: Action, alloc: Allocator) !u8 {
         return switch (self) {
-            .version => try version.run(),
+            .version => try version.run(alloc),
+            .help => try help.run(alloc),
             .@"list-fonts" => try list_fonts.run(alloc),
             .@"list-keybinds" => try list_keybinds.run(alloc),
             .@"list-themes" => try list_themes.run(alloc),

--- a/src/cli/args.zig
+++ b/src/cli/args.zig
@@ -19,6 +19,7 @@ pub const Error = error{
     ValueRequired,
     InvalidField,
     InvalidValue,
+    OutOfMemory,
 };
 
 /// Parse the command line arguments from iter into dst.
@@ -94,7 +95,7 @@ pub fn parse(comptime T: type, alloc: Allocator, dst: *T, iter: anytype) !void {
 
                 // The error set is dependent on comptime T, so we always add
                 // an extra error so we can have the "else" below.
-                const ErrSet = @TypeOf(err) || error{Unknown};
+                const ErrSet = @TypeOf(err) || Error || error{Unknown};
                 switch (@as(ErrSet, @errorCast(err))) {
                     // OOM is not recoverable since we need to allocate to
                     // track more error messages.

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -1,0 +1,72 @@
+const std = @import("std");
+const help_strings = @import("help_strings"){};
+const Action = @import("../cli/action.zig").Action;
+const Config = @import("../config/Config.zig");
+
+/// Print help text about the options or actions specified on the command line.
+pub fn run(alloc: std.mem.Allocator) !u8 {
+    const stdout = std.io.getStdOut().writer();
+    const args = try std.process.argsAlloc(alloc);
+    defer std.process.argsFree(alloc, args);
+
+    if (args.len == 2) try stdout.print(
+        \\To list help for config options use:
+        \\ghostty [--config_options] --help
+        \\ghostty --help [--config_options]
+        \\
+        \\To list help for actions use:
+        \\ghostty [+action] --help (This will only print the help for the specific action)
+        \\ghostty --help [+action] (With this you can use it for multiple actions)
+        \\
+        \\You can also list help for both options and actions by using one of following
+        \\ghostty --help [--config_options] [+action]
+        \\ghostty --help [+action] [--config_options]
+    , .{});
+
+    for (args) |arg| {
+        if (std.mem.eql(u8, arg, "--help")) continue;
+        const key = parseArgKey(arg);
+
+        if (key.len == 0) continue;
+
+        var found = false;
+
+        inline for (@typeInfo(@TypeOf(help_strings)).Struct.fields) |field| {
+            if (std.mem.eql(u8, field.name, key)) {
+                found = true;
+                try stdout.print("{s}:\n", .{arg});
+                var iter = std.mem.splitScalar(u8, @field(help_strings, field.name), '\n');
+                while (iter.next()) |line| {
+                    try stdout.print("  {s}\n", .{line});
+                }
+            }
+        }
+
+        if (!found) {
+            try stdout.print("{s}: no help found!\n", .{arg});
+        }
+    }
+
+    return 0;
+}
+
+fn parseArgKey(arg: []const u8) []const u8 {
+    if (std.mem.startsWith(u8, arg, "--")) {
+        var key = arg[2..];
+        if (std.mem.indexOf(u8, key, "=")) |idx| {
+            key = key[0..idx];
+        }
+
+        return key;
+    }
+
+    if (std.mem.startsWith(u8, arg, "+")) {
+        return arg;
+    }
+
+    if (std.mem.eql(u8, arg, "-e")) {
+        return "command";
+    }
+
+    return "";
+}

--- a/src/cli/list_colors.zig
+++ b/src/cli/list_colors.zig
@@ -8,7 +8,7 @@ pub const Options = struct {
     }
 };
 
-/// The "list-colors" command is used to list all the named RGB colors in
+/// The `list-colors` command is used to list all the named RGB colors in
 /// Ghostty.
 pub fn run(alloc: std.mem.Allocator) !u8 {
     var opts: Options = .{};

--- a/src/cli/list_keybinds.zig
+++ b/src/cli/list_keybinds.zig
@@ -4,18 +4,20 @@ const args = @import("args.zig");
 const Arena = std.heap.ArenaAllocator;
 const Allocator = std.mem.Allocator;
 const Config = @import("../config/Config.zig");
+const help_strings = @import("help_strings"){};
 
 pub const Options = struct {
     /// If true, print out the default keybinds instead of the ones
     /// configured in the config file.
     default: bool = false,
+    help: bool = false,
 
     pub fn deinit(self: Options) void {
         _ = self;
     }
 };
 
-/// The "list-keybinds" command is used to list all the available keybinds
+/// The `list-keybinds` command is used to list all the available keybinds
 /// for Ghostty.
 ///
 /// When executed without any arguments this will list the current keybinds
@@ -23,7 +25,7 @@ pub const Options = struct {
 /// changes to the keybinds it will print out the default ones configured for
 /// Ghostty
 ///
-/// The "--default" argument will print out all the default keybinds
+/// The `--default` argument will print out all the default keybinds
 /// configured for Ghostty
 pub fn run(alloc: Allocator) !u8 {
     var opts: Options = .{};
@@ -35,10 +37,16 @@ pub fn run(alloc: Allocator) !u8 {
         try args.parse(Options, alloc, &opts, &iter);
     }
 
+    const stdout = std.io.getStdOut().writer();
+
+    if (opts.help) {
+        try stdout.print("{s}", .{help_strings.@"+list-keybinds"});
+        return 0;
+    }
+
     var config = if (opts.default) try Config.default(alloc) else try Config.load(alloc);
     defer config.deinit();
 
-    const stdout = std.io.getStdOut().writer();
     var iter = config.keybind.set.bindings.iterator();
     while (iter.next()) |next| {
         const keys = next.key_ptr.*;

--- a/src/cli/version.zig
+++ b/src/cli/version.zig
@@ -4,6 +4,8 @@ const build_config = @import("../build_config.zig");
 const xev = @import("xev");
 const renderer = @import("../renderer.zig");
 
+/// The `version` command is used to display information
+/// about Ghostty.
 pub fn run() !u8 {
     const stdout = std.io.getStdOut().writer();
     try stdout.print("Ghostty {s}\n\n", .{build_config.version_string});

--- a/src/cli/version.zig
+++ b/src/cli/version.zig
@@ -3,13 +3,33 @@ const builtin = @import("builtin");
 const build_config = @import("../build_config.zig");
 const xev = @import("xev");
 const renderer = @import("../renderer.zig");
+const args = @import("args.zig");
+const Allocator = std.mem.Allocator;
+const help_strings = @import("help_strings"){};
+
+pub const Options = struct { help: bool = false, version: bool = false };
 
 /// The `version` command is used to display information
 /// about Ghostty.
-pub fn run() !u8 {
+pub fn run(alloc: Allocator) !u8 {
+    var opts: Options = .{};
+
+    {
+        var iter = try std.process.argsWithAllocator(alloc);
+        defer iter.deinit();
+        try args.parse(Options, alloc, &opts, &iter);
+    }
+
     const stdout = std.io.getStdOut().writer();
+
+    if (opts.help) {
+        try stdout.print("{s}", .{help_strings.@"+version"});
+        return 0;
+    }
+
     try stdout.print("Ghostty {s}\n\n", .{build_config.version_string});
     try stdout.print("Build Config\n", .{});
+    try stdout.print("  - Zig        : {}\n", .{builtin.zig_version});
     try stdout.print("  - build mode : {}\n", .{builtin.mode});
     try stdout.print("  - app runtime: {}\n", .{build_config.app_runtime});
     try stdout.print("  - font engine: {}\n", .{build_config.font_backend});

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1,5 +1,13 @@
 /// Config is the main config struct. These fields map directly to the
 /// CLI flag names hence we use a lot of `@""` syntax to support hyphens.
+
+// Pandoc is used to automatically generate manual pages and other forms
+// of documentation, so documentation comments on fields in the Config
+// struct should use Pandoc's flavor of Markdown.
+//
+// For a reference to Pandoc's Markdown see their online manual:
+// https://pandoc.org/MANUAL.html#pandocs-markdown
+
 const Config = @This();
 
 const std = @import("std");
@@ -31,7 +39,8 @@ const c = @cImport({
 /// The font families to use.
 ///
 /// You can generate the list of valid values using the CLI:
-///   path/to/ghostty/cli +list-fonts
+///
+///     ghostty +list-fonts
 ///
 /// This configuration can be repeated multiple times to specify
 /// preferred fallback fonts when the requested codepoint is not
@@ -39,7 +48,7 @@ const c = @cImport({
 /// multiple languages, symbolic fonts, etc.
 ///
 /// If you want to overwrite a previous set value rather than append
-/// a fallback, specify the value as "" (empty string) to reset the list
+/// a fallback, specify the value as `""` (empty string) to reset the list
 /// and then set the new values. For example:
 ///
 ///     font-family = ""
@@ -57,7 +66,7 @@ const c = @cImport({
 /// by the font itself. For example, "Iosevka Heavy" has a style of "Heavy".
 ///
 /// You can also use these fields to completely disable a font style. If
-/// you set the value of the configuration below to literal "false" then
+/// you set the value of the configuration below to literal `false` then
 /// that font style will be disabled. If the running program in the terminal
 /// requests a disabled font style, the regular font style will be used
 /// instead.
@@ -78,20 +87,20 @@ const c = @cImport({
 /// future enhancement will allow targeting specific faces.
 ///
 /// A valid value is the name of a feature. Prefix the feature with a
-/// "-" to explicitly disable it. Example: "ss20" or "-ss20".
+/// `-` to explicitly disable it. Example: `ss20` or `-ss20`.
 ///
-/// To disable programming ligatures, use "-calt" since this is the typical
+/// To disable programming ligatures, use `-calt` since this is the typical
 /// feature name for programming ligatures. To look into what font features
 /// your font has and what they do, use a font inspection tool such as
-/// fontdrop.info.
+/// [fontdrop.info](https://fontdrop.info).
 ///
-/// To generally disable most ligatures, use "-calt", "-liga", and "-dlig"
+/// To generally disable most ligatures, use `-calt`, `-liga`, and `-dlig`
 /// (as separate repetitive entries in your config).
 @"font-feature": RepeatableString = .{},
 
 /// Font size in points
 @"font-size": u8 = switch (builtin.os.tag) {
-    // On Mac we default a little bigger since this tends to look better.
+    // On macOS we default a little bigger since this tends to look better.
     // This is purely subjective but this is easy to modify.
     .macos => 13,
     else => 12,
@@ -99,23 +108,23 @@ const c = @cImport({
 
 /// A repeatable configuration to set one or more font variations values
 /// for a variable font. A variable font is a single font, usually
-/// with a filename ending in "-VF.ttf" or "-VF.otf" that contains
+/// with a filename ending in `-VF.ttf` or `-VF.otf` that contains
 /// one or more configurable axes for things such as weight, slant,
 /// etc. Not all fonts support variations; only fonts that explicitly
 /// state they are variable fonts will work.
 ///
-/// The format of this is "id=value" where "id" is the axis identifier.
-/// An axis identifier is always a 4 character string, such as "wght".
+/// The format of this is `id=value` where `id` is the axis identifier.
+/// An axis identifier is always a 4 character string, such as `wght`.
 /// To get the list of supported axes, look at your font documentation
 /// or use a font inspection tool.
 ///
 /// Invalid ids and values are usually ignored. For example, if a font
-/// only supports weights from 100 to 700, setting "wght=800" will
+/// only supports weights from 100 to 700, setting `wght=800` will
 /// do nothing (it will not be clamped to 700). You must consult your
 /// font's documentation to see what values are supported.
 ///
-/// Common axes are: "wght" (weight), "slnt" (slant), "ital" (italic),
-/// "opsz" (optical size), "wdth" (width), "GRAD" (gradient), etc.
+/// Common axes are: `wght` (weight), `slnt` (slant), `ital` (italic),
+/// `opsz` (optical size), `wdth` (width), `GRAD` (gradient), etc.
 @"font-variation": RepeatableFontVariation = .{},
 @"font-variation-bold": RepeatableFontVariation = .{},
 @"font-variation-italic": RepeatableFontVariation = .{},
@@ -125,12 +134,12 @@ const c = @cImport({
 /// font. This is useful if you want to support special symbols or if you
 /// want to use specific glyphs that render better for your specific font.
 ///
-/// The syntax is "codepoint=fontname" where "codepoint" is either a
+/// The syntax is `codepoint=fontname` where `codepoint` is either a
 /// single codepoint or a range. Codepoints must be specified as full
-/// Unicode hex values, such as "U+ABCD". Codepoints ranges are specified
-/// as "U+ABCD-U+DEFG". You can specify multiple ranges for the same font
-/// separated by commas, such as "U+ABCD-U+DEFG,U+1234-U+5678=fontname".
-/// The font name is the same value as you would use for "font-family".
+/// Unicode hex values, such as `U+ABCD`. Codepoints ranges are specified
+/// as `U+ABCD-U+DEFG`. You can specify multiple ranges for the same font
+/// separated by commas, such as `U+ABCD-U+DEFG,U+1234-U+5678=fontname`.
+/// The font name is the same value as you would use for `font-family`.
 ///
 /// This configuration can be repeated multiple times to specify multiple
 /// codepoint mappings.
@@ -140,7 +149,7 @@ const c = @cImport({
 @"font-codepoint-map": RepeatableCodepointMap = .{},
 
 /// Draw fonts with a thicker stroke, if supported. This is only supported
-/// currently on macOS.
+/// currently on MacOS.
 @"font-thicken": bool = false,
 
 /// All of the configurations behavior adjust various metrics determined
@@ -148,12 +157,12 @@ const c = @cImport({
 /// (20%, -15%, etc.). In each case, the values represent the amount to
 /// change the original value.
 ///
-/// For example, a value of "1" increases the value by 1; it does not set
-/// it to literally 1. A value of "20%" increases the value by 20%. And so
+/// For example, a value of `1` increases the value by 1; it does not set
+/// it to literally 1. A value of `20%` increases the value by 20%. And so
 /// on.
 ///
 /// There is little to no validation on these values so the wrong values
-/// (i.e. "-100%") can cause the terminal to be unusable. Use with caution
+/// (i.e. `-100%`) can cause the terminal to be unusable. Use with caution
 /// and reason.
 ///
 /// Some values are clamped to minimum or maximum values. This can make it
@@ -162,12 +171,14 @@ const c = @cImport({
 /// position so high that it extends beyond the bottom of the cell size,
 /// it will be clamped to the bottom of the cell.
 ///
-/// "adjust-cell-height" has some additional behaviors to describe:
-/// - The font will be centered vertically in the cell.
-/// - The cursor will remain the same size as the font.
-/// - Powerline glyphs will be adjusted along with the cell height so
-///   that things like status lines continue to look aligned.
+/// `adjust-cell-height` has some additional behaviors to describe:
 ///
+///   * The font will be centered vertically in the cell.
+///
+///   * The cursor will remain the same size as the font.
+///
+///   * Powerline glyphs will be adjusted along with the cell height so
+///     that things like status lines continue to look aligned.
 @"adjust-cell-width": ?MetricModifier = null,
 @"adjust-cell-height": ?MetricModifier = null,
 @"adjust-font-baseline": ?MetricModifier = null,
@@ -177,25 +188,25 @@ const c = @cImport({
 @"adjust-strikethrough-thickness": ?MetricModifier = null,
 
 /// The method to use for calculating the cell width of a grapheme cluster.
-/// The default value is "unicode" which uses the Unicode standard to
+/// The default value is `unicode` which uses the Unicode standard to
 /// determine grapheme width. This results in correct grapheme width but
 /// may result in cursor-desync issues with some programs (such as shells)
-/// that may use a legacy method such as "wcswidth".
+/// that may use a legacy method such as `wcswidth`.
 ///
 /// Valid values are:
 ///
-///   - "wcswidth" - Use the wcswidth function to determine grapheme width.
+///   * `wcswidth` - Use the wcswidth function to determine grapheme width.
 ///     This maximizes compatibility with legacy programs but may result
 ///     in incorrect grapheme width for certain graphemes such as skin-tone
 ///     emoji, non-English characters, etc.
 ///
-///     Note that this "wcswidth" functionality is based on the libc wcswidth,
+///     Note that this `wcswidth` functionality is based on the libc wcswidth,
 ///     not any other libraries with that name.
 ///
-///   - "unicode" - Use the Unicode standard to determine grapheme width.
+///   * `unicode` - Use the Unicode standard to determine grapheme width.
 ///
 /// If a running program explicitly enables terminal mode 2027, then
-/// "unicode" width will be forced regardless of this configuration. When
+/// `unicode` width will be forced regardless of this configuration. When
 /// mode 2027 is reset, this configuration will be used again.
 ///
 /// This configuration can be changed at runtime but will not affect existing
@@ -235,7 +246,7 @@ foreground: Color = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF },
 @"selection-background": ?Color = null,
 
 /// Swap the foreground and background colors of cells for selection.
-/// This option overrides the "selection-foreground" and "selection-background"
+/// This option overrides the `selection-foreground` and `selection-background`
 /// options.
 ///
 /// If you select across cells with differing foregrounds and backgrounds,
@@ -245,7 +256,7 @@ foreground: Color = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF },
 /// The minimum contrast ratio between the foreground and background
 /// colors. The contrast ratio is a value between 1 and 21. A value of
 /// 1 allows for no contrast (i.e. black on black). This value is
-/// the contrast ratio as defined by the WCAG 2.0 specification.
+/// the contrast ratio as defined by the [WCAG 2.0 specification](https://www.w3.org/TR/WCAG20/).
 ///
 /// If you want to avoid invisible text (same color as background),
 /// a value of 1.1 is a good value. If you want to avoid text that is
@@ -255,14 +266,12 @@ foreground: Color = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF },
 /// This value does not apply to Emoji or images.
 @"minimum-contrast": f64 = 1,
 
-/// Color palette for the 256 color form that many terminal applications
-/// use. The syntax of this configuration is "N=HEXCODE" where "n"
-/// is 0 to 255 (for the 256 colors) and HEXCODE is a typical RGB
-/// color code such as "#AABBCC". The 0 to 255 correspond to the
-/// terminal color table.
+/// Color palette for the 256 color form that many terminal applications use.
+/// The syntax of this configuration is `N=HEXCODE` where `N` is 0 to 255 (for
+/// the 256 colors in the terminal color table) and `HEXCODE` is a typical RGB
+/// color code such as `#AABBCC`.
 ///
-/// For definitions on all the codes:
-/// https://www.ditig.com/256-colors-cheat-sheet
+/// For definitions on all the codes [see this cheat sheet](https://www.ditig.com/256-colors-cheat-sheet).
 palette: Palette = .{},
 
 /// The color of the cursor. If this is not set, a default will be chosen.
@@ -277,7 +286,7 @@ palette: Palette = .{},
 
 /// The style of the cursor. This sets the default style. A running
 /// programn can still request an explicit cursor style using escape
-/// sequences (such as CSI q). Shell configurations will often request
+/// sequences (such as `CSI q`). Shell configurations will often request
 /// specific cursor styles.
 ///
 /// Note that shell integration will automatically set the cursor to a bar
@@ -288,15 +297,15 @@ palette: Palette = .{},
 
 /// Sets the default blinking state of the cursor. This is just the
 /// default state; running programs may override the cursor style
-/// using DECSCUSR (CSI q).
+/// using `DECSCUSR` (`CSI q`).
 ///
 /// If this is not set, the cursor blinks by default. Note that
 /// this is not the same as a "true" value, as noted below.
 ///
-/// If this is not set at all (null), then Ghostty will respect
+/// If this is not set at all (`null`), then Ghostty will respect
 /// DEC Mode 12 (AT&T cursor blink) as an alternate approach to
 /// turning blinking on/off. If this is set to any value other
-/// than null, DEC mode 12 will be ignored but DECSCUSR will still
+/// than null, DEC mode 12 will be ignored but `DECSCUSR` will still
 /// be respected.
 @"cursor-style-blink": ?bool = null,
 
@@ -304,11 +313,11 @@ palette: Palette = .{},
 /// will be chosen.
 @"cursor-text": ?Color = null,
 
-/// Enables the ability to move the cursor at prompts by using alt+click
-/// on Linux and option+click on macOS.
+/// Enables the ability to move the cursor at prompts by using `alt+click`
+/// on Linux and `option+click` on macOS.
 ///
 /// This feature requires shell integration (specifically prompt marking
-/// via OSC 133) and only works in primary screen mode. Alternate screen
+/// via `OSC 133`) and only works in primary screen mode. Alternate screen
 /// applications like vim usually have their own version of this feature
 /// but this configuration doesn't control that.
 ///
@@ -328,22 +337,22 @@ palette: Palette = .{},
 /// with a mouse click. Typically, the shift key is used to extend mouse
 /// selection.
 ///
-/// The default value of "false" means that the shift key is not sent
+/// The default value of `false` means that the shift key is not sent
 /// with the mouse protocol and will extend the selection. This value
 /// can be conditionally overridden by the running program with the
-/// XTSHIFTESCAPE sequence.
+/// `XTSHIFTESCAPE` sequence.
 ///
-/// The value "true" means that the shift key is sent with the mouse
+/// The value `true` means that the shift key is sent with the mouse
 /// protocol but the running program can override this behavior with
-/// XTSHIFTESCAPE.
+/// `XTSHIFTESCAPE`.
 ///
-/// The value "never" is the same as "false" but the running program
-/// cannot override this behavior with XTSHIFTESCAPE. The value "always"
-/// is the same as "true" but the running program cannot override this
-/// behavior with XTSHIFTESCAPE.
+/// The value `never` is the same as `false` but the running program
+/// cannot override this behavior with `XTSHIFTESCAPE`. The value `always`
+/// is the same as `true` but the running program cannot override this
+/// behavior with `XTSHIFTESCAPE`.
 ///
 /// If you always want shift to extend mouse selection even if the
-/// program requests otherwise, set this to "never".
+/// program requests otherwise, set this to `never`.
 @"mouse-shift-capture": MouseShiftCapture = .false,
 
 /// The opacity level (opposite of transparency) of the background.
@@ -385,15 +394,16 @@ palette: Palette = .{},
 @"unfocused-split-fill": ?Color = null,
 
 /// The command to run, usually a shell. If this is not an absolute path,
-/// it'll be looked up in the PATH. If this is not set, a default will
+/// it'll be looked up in the `PATH`. If this is not set, a default will
 /// be looked up from your system. The rules for the default lookup are:
 ///
-///   - SHELL environment variable
-///   - passwd entry (user information)
+///   * `SHELL` environment variable
+///
+///   * `passwd` entry (user information)
 ///
 /// This can contain additional arguments to run the command with.
 /// If additional arguments are provided, the command will be executed
-/// using "/bin/sh -c". Ghostty does not do any shell command parsing.
+/// using `/bin/sh -c`. Ghostty does not do any shell command parsing.
 ///
 /// If you're using the `ghostty` CLI there is also a shortcut
 /// to run a command with argumens directly: you can use the `-e`
@@ -411,14 +421,14 @@ command: ?[]const u8 = null,
 
 /// Match a regular expression against the terminal text and associate
 /// clicking it with an action. This can be used to match URLs, file paths,
-/// etc. Actions can be opening using the system opener (i.e. "open" or
-/// "xdg-open") or executing any arbitrary binding action.
+/// etc. Actions can be opening using the system opener (i.e. `open` or
+/// `xdg-open`) or executing any arbitrary binding action.
 ///
 /// Links that are configured earlier take precedence over links that
 /// are configured later.
 ///
 /// A default link that matches a URL and opens it in the system opener
-/// always exists. This can be disabled using "link-url".
+/// always exists. This can be disabled using `link-url`.
 ///
 /// TODO: This can't currently be set!
 link: RepeatableLink = .{},
@@ -427,7 +437,7 @@ link: RepeatableLink = .{},
 /// default system application for the linked URL.
 ///
 /// The URL matcher is always lowest priority of any configured links
-/// (see "link"). If you want to customize URL matching, use "link"
+/// (see `link`). If you want to customize URL matching, use `link`
 /// and disable this.
 @"link-url": bool = true,
 
@@ -447,99 +457,103 @@ title: ?[:0]const u8 = null,
 
 /// The setting that will change the application class value.
 ///
-/// This controls the class field of the WM_CLASS X11 property (when running
+/// This controls the class field of the `WM_CLASS` X11 property (when running
 /// under X11), and the Wayland application ID (when running under Wayland).
 ///
 /// Note that changing this value between invocations will create new, separate
-/// instances, of Ghostty when running with --gtk-single-instance=true. See
+/// instances, of Ghostty when running with `gtk-single-instance=true`. See
 /// that option for more details.
 ///
-/// The class name must follow the GTK requirements defined here:
-/// https://docs.gtk.org/gio/type_func.Application.id_is_valid.html
+/// The class name must follow the requirements defined [in the GTK
+/// documentation](https://docs.gtk.org/gio/type_func.Application.id_is_valid.html).
 ///
-/// The default is "com.mitchellh.ghostty".
+/// The default is `com.mitchellh.ghostty`.
 ///
 /// This only affects GTK builds.
 class: ?[:0]const u8 = null,
 
-/// This controls the instance name field of the WM_CLASS X11 property when
+/// This controls the instance name field of the `WM_CLASS` X11 property when
 /// running under X11. It has no effect otherwise.
 ///
-/// The default is "ghostty".
+/// The default is `ghostty`.
 ///
 /// This only affects GTK builds.
 @"x11-instance-name": ?[:0]const u8 = null,
 
 /// The directory to change to after starting the command.
 ///
-/// This setting is secondary to the "window-inherit-working-directory"
+/// This setting is secondary to the `window-inherit-working-directory`
 /// setting. If a previous Ghostty terminal exists in the same process,
-/// "window-inherit-working-directory" will take precedence. Otherwise,
+/// `window-inherit-working-directory` will take precedence. Otherwise,
 /// this setting will be used. Typically, this setting is used only
 /// for the first window.
 ///
-/// The default is "inherit" except in special scenarios listed next.
+/// The default is `inherit` except in special scenarios listed next.
 /// On macOS, if Ghostty can detect it is launched from launchd
-/// (double-clicked) or `open`, then it defaults to "home".
+/// (double-clicked) or `open`, then it defaults to `home`.
 /// On Linux with GTK, if Ghostty can detect it was launched from
-/// a desktop launcher, then it defaults to "home".
+/// a desktop launcher, then it defaults to `home`.
 ///
 /// The value of this must be an absolute value or one of the special
 /// values below:
 ///
-///   - "home" - The home directory of the executing user.
-///   - "inherit" - The working directory of the launching process.
+///   * `home` - The home directory of the executing user.
 ///
+///   * `inherit` - The working directory of the launching process.
 @"working-directory": ?[]const u8 = null,
 
-/// Key bindings. The format is "trigger=action". Duplicate triggers
+/// Key bindings. The format is `trigger=action`. Duplicate triggers
 /// will overwrite previously set values.
 ///
-/// Trigger: "+"-separated list of keys and modifiers. Example:
-/// "ctrl+a", "ctrl+shift+b", "up". Some notes:
+/// Trigger: `+`-separated list of keys and modifiers. Example:
+/// `ctrl+a`, `ctrl+shift+b`, `up`. Some notes:
 ///
-///   - modifiers cannot repeat, "ctrl+ctrl+a" is invalid.
-///   - modifiers and keys can be in any order, "shift+a+ctrl" is weird,
+///   * modifiers cannot repeat, `ctrl+ctrl+a` is invalid.
+///
+///   * modifiers and keys can be in any order, `shift+a+ctrl` is *weird*,
 ///     but valid.
-///   - only a single key input is allowed, "ctrl+a+b" is invalid.
 ///
-/// Valid modifiers are "shift", "ctrl" (alias: "control"),
-/// "alt" (alias: "opt", "option"), and "super" (alias: "cmd", "command").
+///   * only a single key input is allowed, `ctrl+a+b` is invalid.
+///
+/// Valid modifiers are `shift`, `ctrl` (alias: `control`),
+/// `alt` (alias: `opt`, `option`), and `super` (alias: `cmd`, `command`).
 /// You may use the modifier or the alias. When debugging keybinds,
 /// the non-aliased modifier will always be used in output.
 ///
 /// Action is the action to take when the trigger is satisfied. It takes
-/// the format "action" or "action:param". The latter form is only valid
+/// the format `action` or `action:param`. The latter form is only valid
 /// if the action requires a parameter.
 ///
-///   - "ignore" - Do nothing, ignore the key input. This can be used to
+///   * `ignore` - Do nothing, ignore the key input. This can be used to
 ///     black hole certain inputs to have no effect.
-///   - "unbind" - Remove the binding. This makes it so the previous action
+///
+///   * `unbind` - Remove the binding. This makes it so the previous action
 ///     is removed, and the key will be sent through to the child command
 ///     if it is printable.
-///   - "csi:text" - Send a CSI sequence. i.e. "csi:A" sends "cursor up".
-///   - "esc:text" - Send an Escape sequence. i.e. "esc:d" deletes to the
+///
+///   * `csi:text` - Send a CSI sequence. i.e. `csi:A` sends "cursor up".
+///
+///   * `esc:text` - Send an escape sequence. i.e. `esc:d` deletes to the
 ///     end of the word to the right.
 ///
 /// Some notes for the action:
 ///
-///   - The parameter is taken as-is after the ":". Double quotes or
+///   * The parameter is taken as-is after the `:`. Double quotes or
 ///     other mechanisms are included and NOT parsed. If you want to
 ///     send a string value that includes spaces, wrap the entire
-///     trigger/action in double quotes. Example: --keybind="up=csi:A B"
+///     trigger/action in double quotes. Example: `--keybind="up=csi:A B"`
 ///
 /// There are some additional special values that can be specified for
 /// keybind:
 ///
-///   - `keybind = clear` will clear all set keybindings. Warning: this
+///   * `keybind=clear` will clear all set keybindings. Warning: this
 ///     removes ALL keybindings up to this point, including the default
 ///     keybindings.
-///
 keybind: Keybinds = .{},
 
 /// Window padding. This applies padding between the terminal cells and
-/// the window border. The "x" option applies to the left and right
-/// padding and the "y" option is top and bottom. The value is in points,
+/// the window border. The `x` option applies to the left and right
+/// padding and the `y` option is top and bottom. The value is in points,
 /// meaning that it will be scaled appropriately for screen DPI.
 ///
 /// If this value is set too large, the screen will render nothing, because
@@ -555,9 +569,9 @@ keybind: Keybinds = .{},
 /// then this extra padding is automatically balanced between all four
 /// edges to minimize imbalance on one side. If this is false, the top
 /// left grid cell will always hug the edge with zero padding other than
-/// what may be specified with the other "window-padding" options.
+/// what may be specified with the other `window-padding` options.
 ///
-/// If other "window-padding" fields are set and this is true, this will
+/// If other `window-padding` fields are set and this is true, this will
 /// still apply. The other padding is applied first and may affect how
 /// many grid cells actually exist, and this is applied last in order
 /// to balance the padding given a certain viewport size and grid cell size.
@@ -565,30 +579,30 @@ keybind: Keybinds = .{},
 
 /// If true, new windows and tabs will inherit the working directory of
 /// the previously focused window. If no window was previously focused,
-/// the default working directory will be used (the "working-directory"
+/// the default working directory will be used (the `working-directory`
 /// option).
 @"window-inherit-working-directory": bool = true,
 
 /// If true, new windows and tabs will inherit the font size of the previously
 /// focused window. If no window was previously focused, the default
 /// font size will be used. If this is false, the default font size
-/// specified in the configuration "font-size" will be used.
+/// specified in the configuration `font-size` will be used.
 @"window-inherit-font-size": bool = true,
 
 /// If false, windows won't have native decorations, i.e. titlebar and
 /// borders.
 @"window-decoration": bool = true,
 
-/// The theme to use for the windows. The default is "system" which
+/// The theme to use for the windows. The default is `system` which
 /// means that whatever the system theme is will be used. This can
-/// also be set to "light" or "dark" to force a specific theme regardless
+/// also be set to `light` or `dark` to force a specific theme regardless
 /// of the system settings.
 ///
-/// This is currently only supported on macOS and linux.
+/// This is currently only supported on macOS and Linux.
 @"window-theme": WindowTheme = .system,
 
-/// The colorspace to use for the terminal window. The default is "srgb"
-/// but this can also be set to "display-p3" to use the Display P3
+/// The colorspace to use for the terminal window. The default is `srgb`
+/// but this can also be set to `display-p3` to use the Display P3
 /// colorspace.
 ///
 /// Changing this value at runtime will only affect new windows.
@@ -624,19 +638,22 @@ keybind: Keybinds = .{},
 /// Whether to enable saving and restoring window state. Window state
 /// includes their position, size, tabs, splits, etc. Some window state
 /// requires shell integration, such as preserving working directories.
-/// See shell-integration for more information.
+/// See `shell-integration` for more information.
 ///
 /// There are three valid values for this configuration:
-///   - "default" will use the default system behavior. On macOS, this
+///
+///   * `default` will use the default system behavior. On macOS, this
 ///     will only save state if the application is forcibly terminated
 ///     or if it is configured systemwide via Settings.app.
-///   - "never" will never save window state.
-///   - "always" will always save window state whenever Ghostty is exited.
 ///
-/// If you change this value to "never" while Ghostty is not running,
+///   * `never` will never save window state.
+///
+///   * `always` will always save window state whenever Ghostty is exited.
+///
+/// If you change this value to `never` while Ghostty is not running,
 /// the next Ghostty launch will NOT restore the window state.
 ///
-/// If you change this value to "default" while Ghostty is not running
+/// If you change this value to `default` while Ghostty is not running
 /// and the previous exit saved state, the next Ghostty launch will
 /// still restore the window state. This is because Ghostty cannot know
 /// if the previous exit was due to a forced save or not (macOS doesn't
@@ -646,7 +663,7 @@ keybind: Keybinds = .{},
 /// is not running, the previous window state will not be restored because
 /// Ghostty only saves state on exit if this is enabled.
 ///
-/// The default value is "default".
+/// The default value is `default`.
 ///
 /// This is currently only supported on macOS. This has no effect on Linux.
 @"window-save-state": WindowSaveState = .default,
@@ -669,8 +686,8 @@ keybind: Keybinds = .{},
 /// manager's simple titlebar. The behavior of this option will vary with your
 /// window manager.
 ///
-/// This option does nothing when window-decoration is false or when running
-/// under MacOS.
+/// This option does nothing when `window-decoration` is false or when running
+/// under macOS.
 ///
 /// Changing this value at runtime and reloading the configuration will only
 /// affect new windows.
@@ -684,7 +701,7 @@ keybind: Keybinds = .{},
 @"clipboard-write": ClipboardAccess = .allow,
 
 /// Trims trailing whitespace on data that is copied to the clipboard.
-/// This does not affect data sent to the clipboard via "clipboard-write".
+/// This does not affect data sent to the clipboard via `clipboard-write`.
 @"clipboard-trim-trailing-spaces": bool = true,
 
 /// Require confirmation before pasting text that appears unsafe. This helps
@@ -707,10 +724,10 @@ keybind: Keybinds = .{},
 /// effective limit per surface is double.
 @"image-storage-limit": u32 = 320 * 1000 * 1000,
 
-/// Whether to automatically copy selected text to the clipboard. "true"
+/// Whether to automatically copy selected text to the clipboard. `true`
 /// will only copy on systems that support a selection clipboard.
 ///
-/// The value "clipboard" will copy to the system clipboard, making this
+/// The value `clipboard` will copy to the system clipboard, making this
 /// work on macOS. Note that middle-click will also paste from the system
 /// clipboard in this case.
 ///
@@ -749,34 +766,40 @@ keybind: Keybinds = .{},
 ///
 ///   * Working directory reporting so new tabs, splits inherit the
 ///     previous terminal's working directory.
+///
 ///   * Prompt marking that enables the "jump_to_prompt" keybinding.
+///
 ///   * If you're sitting at a prompt, closing a terminal will not ask
 ///     for confirmation.
+///
 ///   * Resizing the window with a complex prompt usually paints much
 ///     better.
 ///
 /// Allowable values are:
 ///
-///   * "none" - Do not do any automatic injection. You can still manually
+///   * `none` - Do not do any automatic injection. You can still manually
 ///     configure your shell to enable the integration.
-///   * "detect" - Detect the shell based on the filename.
-///   * "fish", "zsh" - Use this specific shell injection scheme.
 ///
-/// The default value is "detect".
+///   * `detect` - Detect the shell based on the filename.
+///
+///   * `fish`, `zsh` - Use this specific shell injection scheme.
+///
+/// The default value is `detect`.
 @"shell-integration": ShellIntegration = .detect,
 
 /// Shell integration features to enable if shell integration itself is enabled.
 /// The format of this is a list of features to enable separated by commas.
-/// If you prefix a feature with "no-" then it is disabled. If you omit
+/// If you prefix a feature with `no-` then it is disabled. If you omit
 /// a feature, its default value is used, so you must explicitly disable
 /// features you don't want.
 ///
 /// Available features:
 ///
-///   - "cursor" - Set the cursor to a blinking bar at the prompt.
-///   - "sudo" - Set sudo wrapper to preserve terminfo.
+///   * `cursor` - Set the cursor to a blinking bar at the prompt.
 ///
-/// Example: "cursor", "no-cursor", "sudo", "no-sudo"
+///   * `sudo` - Set sudo wrapper to preserve terminfo.
+///
+/// Example: `cursor`, `no-cursor`, `sudo`, `no-sudo`
 @"shell-integration-features": ShellIntegrationFeatures = .{},
 
 /// Sets the reporting format for OSC sequences that request color information.
@@ -789,11 +812,13 @@ keybind: Keybinds = .{},
 ///
 /// Allowable values are:
 ///
-///   * "none" - OSC 4/10/11 queries receive no reply
-///   * "8-bit" - Color components are return unscaled, i.e. rr/gg/bb
-///   * "16-bit" - Color components are returned scaled, e.g. rrrr/gggg/bbbb
+///   * `none` - OSC 4/10/11 queries receive no reply
 ///
-/// The default value is "16-bit".
+///   * `8-bit` - Color components are return unscaled, i.e. `rr/gg/bb`
+///
+///   * `16-bit` - Color components are returned scaled, e.g. `rrrr/gggg/bbbb`
+///
+/// The default value is `16-bit`.
 @"osc-color-report-format": OSCColorReportFormat = .@"16-bit",
 
 /// If true, allows the "KAM" mode (ANSI mode 2) to be used within
@@ -822,7 +847,7 @@ keybind: Keybinds = .{},
 /// related to shader compilation will not show up as configuration errors
 /// and only show up in the log, since shader compilation happens after
 /// configuration loading on the dedicated render thread.  For interactive
-/// development, use Shadertoy.com.
+/// development, use [shadertoy.com](https://shadertoy.com).
 ///
 /// This can be repeated multiple times to load multiple shaders. The shaders
 /// will be run in the order they are specified.
@@ -831,16 +856,16 @@ keybind: Keybinds = .{},
 /// affect new windows, tabs, and splits.
 @"custom-shader": RepeatablePath = .{},
 
-/// If true (default), the focused terminal surface will run an animation
+/// If `true` (default), the focused terminal surface will run an animation
 /// loop when custom shaders are used. This uses slightly more CPU (generally
 /// less than 10%) but allows the shader to animate. This only runs if there
 /// are custom shaders and the terminal is focused.
 ///
-/// If this is set to false, the terminal and custom shader will only render
+/// If this is set to `false`, the terminal and custom shader will only render
 /// when the terminal is updated. This is more efficient but the shader will
 /// not animate.
 ///
-/// This can also be set to "always", which will always run the animation
+/// This can also be set to `always`, which will always run the animation
 /// loop regardless of whether the terminal is focused or not. The animation
 /// loop will still only run when custom shaders are used. Note that this
 /// will use more CPU per terminal surface and can become quite expensive
@@ -857,20 +882,22 @@ keybind: Keybinds = .{},
 ///
 /// Allowable values are:
 ///
-///   * "visible-menu" - Use non-native macOS fullscreen, keep the menu bar visible
-///   * "true" - Use non-native macOS fullscreen, hide the menu bar
-///   * "false" - Use native macOS fullscreeen
+///   * `visible-menu` - Use non-native macOS fullscreen, keep the menu bar visible
+///
+///   * `true` - Use non-native macOS fullscreen, hide the menu bar
+///
+///   * `false` - Use native macOS fullscreeen
 @"macos-non-native-fullscreen": NonNativeFullscreen = .false,
 
-/// If true, the Option key will be treated as Alt. This makes terminal
+/// If `true`, the Option key will be treated as Alt. This makes terminal
 /// sequences expecting Alt to work properly, but will break Unicode
-/// input sequences on macOS if you use them via the alt key. You may
-/// set this to false to restore the macOS alt-key unicode sequences
+/// input sequences on macOS if you use them via the Alt key. You may
+/// set this to `false` to restore the macOS Alt key unicode sequences
 /// but this will break terminal sequences expecting Alt to work.
 ///
 /// Note that if an Option-sequence doesn't produce a printable
 /// character, it will be treated as Alt regardless of this setting.
-/// (i.e. alt+ctrl+a).
+/// (i.e. `alt+ctrl+a`).
 ///
 /// This does not work with GLFW builds.
 @"macos-option-as-alt": OptionAsAlt = .false,
@@ -881,21 +908,21 @@ keybind: Keybinds = .{},
 ///
 /// If false, each new ghostty process will launch a separate application.
 ///
-/// The default value is "desktop" which will default to "true" if Ghostty
-/// detects it was launched from the .desktop file such as an app launcher.
-/// If Ghostty is launched from the command line, it will default to "false".
+/// The default value is `desktop` which will default to `true` if Ghostty
+/// detects it was launched from the `.desktop` file such as an app launcher.
+/// If Ghostty is launched from the command line, it will default to `false`.
 ///
 /// Note that debug builds of Ghostty have a separate single-instance ID
 /// so you can test single instance without conflicting with release builds.
 @"gtk-single-instance": GtkSingleInstance = .desktop,
 
-/// If true (default), then the Ghostty GTK tabs will be "wide." Wide tabs
+/// If `true` (default), then the Ghostty GTK tabs will be "wide." Wide tabs
 /// are the new typical Gnome style where tabs fill their available space.
-/// If you set this to false then tabs will only take up space they need,
+/// If you set this to `false` then tabs will only take up space they need,
 /// which is the old style.
 @"gtk-wide-tabs": bool = true,
 
-/// If true (default), Ghostty will enable libadwaita theme support. This
+/// If `true` (default), Ghostty will enable libadwaita theme support. This
 /// will make `window-theme` work properly and will also allow Ghostty to
 /// properly respond to system theme changes, light/dark mode changing, etc.
 /// This requires a GTK4 desktop with a GTK4 theme.
@@ -909,12 +936,12 @@ keybind: Keybinds = .{},
 /// libadwaita support.
 @"gtk-adwaita": bool = true,
 
-/// If true (default), applications running in the terminal can show desktop
+/// If `true` (default), applications running in the terminal can show desktop
 /// notifications using certain escape sequences such as OSC 9 or OSC 777.
 @"desktop-notifications": bool = true,
 
 /// This will be used to set the TERM environment variable.
-/// HACK: We set this with an "xterm" prefix because vim uses that to enable key
+/// HACK: We set this with an `xterm` prefix because vim uses that to enable key
 /// protocols (specifically this will enable 'modifyOtherKeys'), among other
 /// features. An option exists in vim to modify this: `:set
 /// keyprotocol=ghostty:kitty`, however a bug in the implementation prevents it
@@ -922,7 +949,7 @@ keybind: Keybinds = .{},
 term: []const u8 = "xterm-ghostty",
 
 /// String to send when we receive ENQ (0x05) from the command that we are
-/// running. Defaults to "" if not set.
+/// running. Defaults to an empty string if not set.
 @"enquiry-response": []const u8 = "",
 
 /// This is set by the CLI parser for deinit.

--- a/src/doc/ghostty_1_footer.md
+++ b/src/doc/ghostty_1_footer.md
@@ -1,0 +1,40 @@
+# FILES
+
+_\$XDG_CONFIG_HOME/ghostty/config_
+
+: Location of the default configuration file.
+
+_\$LOCALAPPDATA/ghostty/config_
+
+: **On Windows**, if _\$XDG_CONFIG_HOME_ is not set, _\$LOCALAPPDATA_ will be searched
+for configuration files.
+
+# ENVIRONMENT
+
+**TERM**
+
+: Defaults to `xterm-ghostty`. Can be configured with the `term` configuration option.
+
+**GHOSTTY_RESOURCES_DIR**
+
+: Where the Ghostty resources can be found.
+
+**XDG_CONFIG_HOME**
+
+: Default location for configuration files.
+
+**LOCALAPPDATA**
+
+: **WINDOWS ONLY:** alternate location to search for configuration files.
+
+# BUGS
+
+See GitHub issues: <https://github.com/mitchellh/ghostty/issues>
+
+# AUTHOR
+
+Mitchell Hashimoto <m@mitchellh.com>
+
+# SEE ALSO
+
+**ghostty(5)**

--- a/src/doc/ghostty_1_header.md
+++ b/src/doc/ghostty_1_header.md
@@ -1,0 +1,7 @@
+% GHOSTTY(1) Version @@VERSION@@ | Ghostty terminal emulator
+
+# NAME
+
+**ghostty** - Ghostty terminal emulator
+
+# DESCRIPTION

--- a/src/doc/ghostty_5_footer.md
+++ b/src/doc/ghostty_5_footer.md
@@ -1,0 +1,32 @@
+# FILES
+
+_\$XDG_CONFIG_HOME/ghostty/config_
+
+: Location of the default configuration file.
+
+_\$LOCALAPPDATA/ghostty/config_
+
+: **On Windows**, if _\$XDG_CONFIG_HOME_ is not set, _\$LOCALAPPDATA_ will be searched
+for configuration files.
+
+# ENVIRONMENT
+
+**XDG_CONFIG_HOME**
+
+: Default location for configuration files.
+
+**LOCALAPPDATA**
+
+: **WINDOWS ONLY:** alternate location to search for configuration files.
+
+# BUGS
+
+See GitHub issues: <https://github.com/mitchellh/ghostty/issues>
+
+# AUTHOR
+
+Mitchell Hashimoto <m@mitchellh.com>
+
+# SEE ALSO
+
+**ghostty(1)**

--- a/src/doc/ghostty_5_header.md
+++ b/src/doc/ghostty_5_header.md
@@ -1,0 +1,9 @@
+% GHOSTTY(5) Version @@VERSION@@ | Ghostty terminal emulator configuration file
+
+# NAME
+
+**ghostty** - Ghostty terminal emulator configuration file
+
+# DESCRIPTION
+
+# OPTIONS

--- a/src/generate_ghostty_1_markdown.zig
+++ b/src/generate_ghostty_1_markdown.zig
@@ -1,0 +1,105 @@
+const std = @import("std");
+const Config = @import("config/Config.zig");
+const Action = @import("cli/action.zig").Action;
+
+const help_strings = @import("help_strings"){};
+const build_options = @import("build_options");
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var arena_alloc = std.heap.ArenaAllocator.init(gpa.allocator());
+    defer arena_alloc.deinit();
+    const alloc = arena_alloc.allocator();
+
+    const args = try std.process.argsAlloc(alloc);
+    defer std.process.argsFree(alloc, args);
+
+    if (args.len != 2) {
+        std.debug.print("invalid number of arguments provided!", .{});
+        std.process.exit(1);
+    }
+
+    const path = args[1];
+
+    var output = try std.fs.cwd().createFile(path, .{});
+    defer output.close();
+
+    const version_string = try std.fmt.allocPrint(alloc, "{}", .{build_options.version});
+
+    const header_raw = @embedFile("doc/ghostty_1_header.md");
+    const header = try alloc.alloc(u8, std.mem.replacementSize(u8, header_raw, "@@VERSION@@", version_string));
+    _ = std.mem.replace(u8, header_raw, "@@VERSION@@", version_string, header);
+    try output.writeAll(header);
+
+    {
+        try output.writeAll(
+            \\# OPTIONS
+            \\
+            \\
+        );
+        const info = @typeInfo(Config);
+        std.debug.assert(info == .Struct);
+
+        inline for (info.Struct.fields) |field| {
+            if (field.name[0] == '_') continue;
+
+            try output.writeAll("`--");
+            try output.writeAll(field.name);
+            try output.writeAll("`\n\n");
+            if (@hasField(@TypeOf(help_strings), field.name)) {
+                var iter = std.mem.splitScalar(u8, @field(help_strings, field.name), '\n');
+                var first = true;
+                while (iter.next()) |s| {
+                    try output.writeAll(if (first) ":   " else "    ");
+                    try output.writeAll(s);
+                    try output.writeAll("\n");
+                    first = false;
+                }
+                try output.writeAll("\n\n");
+            }
+        }
+    }
+
+    {
+        try output.writeAll(
+            \\# ACTIONS
+            \\
+            \\
+        );
+        const info = @typeInfo(Action);
+        std.debug.assert(info == .Enum);
+
+        inline for (info.Enum.fields) |field| {
+            if (field.name[0] == '_') continue;
+
+            const action = std.meta.stringToEnum(Action, field.name).?;
+
+            switch (action) {
+                .help => try output.writeAll("`--help`\n\n"),
+                .version => try output.writeAll("`--version`\n\n"),
+                else => {
+                    try output.writeAll("`+");
+                    try output.writeAll(field.name);
+                    try output.writeAll("`\n\n");
+                },
+            }
+
+            if (@hasField(@TypeOf(help_strings), "+" ++ field.name)) {
+                var iter = std.mem.splitScalar(u8, @field(help_strings, "+" ++ field.name), '\n');
+                var first = true;
+                while (iter.next()) |s| {
+                    try output.writeAll(if (first) ":   " else "    ");
+                    try output.writeAll(s);
+                    try output.writeAll("\n");
+                    first = false;
+                }
+                try output.writeAll("\n\n");
+            }
+        }
+    }
+
+    const footer_raw = @embedFile("doc/ghostty_1_footer.md");
+    const footer = try alloc.alloc(u8, std.mem.replacementSize(u8, footer_raw, "@@VERSION@@", version_string));
+    _ = std.mem.replace(u8, footer_raw, "@@VERSION@@", version_string, footer);
+    try output.writeAll(footer);
+}

--- a/src/generate_ghostty_5_markdown.zig
+++ b/src/generate_ghostty_5_markdown.zig
@@ -1,0 +1,60 @@
+const std = @import("std");
+const Config = @import("config/Config.zig");
+const help_strings = @import("help_strings"){};
+const build_options = @import("build_options");
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var arena_alloc = std.heap.ArenaAllocator.init(gpa.allocator());
+    defer arena_alloc.deinit();
+    const alloc = arena_alloc.allocator();
+
+    // const gen: help_strings = .{};
+
+    const args = try std.process.argsAlloc(alloc);
+    defer std.process.argsFree(alloc, args);
+
+    if (args.len != 2) {
+        std.debug.print("invalid number of arguments provided!", .{});
+        std.process.exit(1);
+    }
+
+    const path = args[1];
+
+    var output = try std.fs.cwd().createFile(path, .{});
+    defer output.close();
+
+    const version_string = try std.fmt.allocPrint(alloc, "{}", .{build_options.version});
+
+    const header = @embedFile("doc/ghostty_5_header.md");
+    const headerx = try alloc.alloc(u8, std.mem.replacementSize(u8, header, "@@VERSION@@", version_string));
+    _ = std.mem.replace(u8, header, "@@VERSION@@", version_string, headerx);
+    try output.writeAll(headerx);
+
+    const info = @typeInfo(Config);
+    std.debug.assert(info == .Struct);
+
+    inline for (info.Struct.fields) |field| {
+        if (field.name[0] == '_') continue;
+
+        try output.writeAll("`");
+        try output.writeAll(field.name);
+        try output.writeAll("`\n\n");
+        if (@hasField(@TypeOf(help_strings), field.name)) {
+            var iter = std.mem.splitScalar(u8, @field(help_strings, field.name), '\n');
+            var first = true;
+            while (iter.next()) |s| {
+                try output.writeAll(if (first) ":   " else "    ");
+                try output.writeAll(s);
+                try output.writeAll("\n");
+                first = false;
+            }
+            try output.writeAll("\n\n");
+        }
+    }
+
+    const footer = @embedFile("doc/ghostty_5_footer.md");
+    const footerx = try alloc.alloc(u8, std.mem.replacementSize(u8, footer, "@@VERSION@@", version_string));
+    _ = std.mem.replace(u8, footer, "@@VERSION@@", version_string, footerx);
+    try output.writeAll(footerx);
+}

--- a/src/generate_help_strings.zig
+++ b/src/generate_help_strings.zig
@@ -1,0 +1,165 @@
+const std = @import("std");
+const ziglyph = @import("ziglyph");
+const Action = @import("cli/action.zig").Action;
+const Config = @import("config/Config.zig");
+
+pub fn searchConfigAst(alloc: std.mem.Allocator, output: std.fs.File) !void {
+    var ast = try std.zig.Ast.parse(alloc, @embedFile("config/Config.zig"), .zig);
+    defer ast.deinit(alloc);
+
+    const config: Config = .{};
+
+    const tokens = ast.tokens.items(.tag);
+
+    var set = std.StringHashMap(bool).init(alloc);
+    defer set.deinit();
+
+    try output.writeAll(
+        \\//THIS FILE IS AUTO GENERATED
+        \\//DO NOT MAKE ANY CHANGES TO THIS FILE!
+    );
+
+    try output.writeAll("\n\n");
+
+    inline for (@typeInfo(@TypeOf(config)).Struct.fields) |field| {
+        if (field.name[0] != '_') try set.put(field.name, false);
+    }
+
+    var index: u32 = 0;
+    while (true) : (index += 1) {
+        if (index >= tokens.len) break;
+        const token = tokens[index];
+
+        if (token == .identifier) {
+            const slice = ast.tokenSlice(index);
+            // We need this check because the ast grabs the identifier with @"" in case it's used.
+            const key = if (slice[0] == '@') slice[2 .. slice.len - 1] else slice;
+
+            if (key[0] == '_') continue;
+
+            if (set.get(key)) |value| {
+                if (value) continue;
+                if (tokens[index - 1] != .doc_comment) continue;
+
+                const comment = try consumeDocComments(alloc, ast, index - 1, &tokens);
+                const prop_type = ": " ++ "[:0]const u8 " ++ "= " ++ "\n";
+
+                try output.writeAll(slice);
+                try output.writeAll(prop_type);
+                // const concat = try std.mem.concat(self.alloc, u8, &.{ slice, prop_type });
+                // try output.writeAll(concat);
+                try output.writeAll(comment);
+                try output.writeAll("\n\n");
+
+                try set.put(key, true);
+            }
+        }
+        if (token == .eof) break;
+    }
+}
+
+fn actionPath(comptime action: Action) []const u8 {
+    return switch (action) {
+        .version => "cli/version.zig",
+        .@"list-fonts" => "cli/list_fonts.zig",
+        .@"list-keybinds" => "cli/list_keybinds.zig",
+        .@"list-themes" => "cli/list_themes.zig",
+        .@"list-colors" => "cli/list_colors.zig",
+    };
+}
+
+pub fn searchActionsAst(alloc: std.mem.Allocator, output: std.fs.File) !void {
+    inline for (@typeInfo(Action).Enum.fields) |field| {
+        const action = comptime std.meta.stringToEnum(Action, field.name).?;
+
+        var ast = try std.zig.Ast.parse(alloc, @embedFile(comptime actionPath(action)), .zig);
+        const tokens = ast.tokens.items(.tag);
+
+        var index: u32 = 0;
+        while (true) : (index += 1) {
+            if (tokens[index] == .keyword_fn) {
+                if (std.mem.eql(u8, ast.tokenSlice(index + 1), "run")) {
+                    if (tokens[index - 2] != .doc_comment) {
+                        std.debug.print("doc comment must be present on run function of the {s} action!", .{field.name});
+                        std.process.exit(1);
+                    }
+                    const comment = try consumeDocComments(alloc, ast, index - 2, &tokens);
+                    const prop_type = "@\"+" ++ field.name ++ "\"" ++ ": " ++ "[:0]const u8 " ++ "= " ++ "\n";
+
+                    try output.writeAll(prop_type);
+                    try output.writeAll(comment);
+                    try output.writeAll("\n\n");
+                    break;
+                }
+            }
+        }
+    }
+}
+
+fn consumeDocComments(alloc: std.mem.Allocator, ast: std.zig.Ast, index: std.zig.Ast.TokenIndex, toks: anytype) ![]const u8 {
+    var lines = std.ArrayList([]const u8).init(alloc);
+    defer lines.deinit();
+
+    const tokens = toks.*;
+    var current_idx = index;
+
+    // We iterate backwards because the doc_comment tokens should be on top of each other in case there are any.
+    while (true) : (current_idx -= 1) {
+        const token = tokens[current_idx];
+
+        if (token != .doc_comment) break;
+        // Insert at 0 so that we don't have the text in reverse.
+        try lines.insert(0, ast.tokenSlice(current_idx)[3..]);
+    }
+
+    const prefix = findCommonPrefix(lines);
+
+    var buffer = std.ArrayList(u8).init(alloc);
+    const writer = buffer.writer();
+
+    for (lines.items) |line| {
+        try writer.writeAll("    \\\\");
+        try writer.writeAll(line[@min(prefix, line.len)..]);
+        try writer.writeAll("\n");
+    }
+    try writer.writeAll(",\n");
+
+    return buffer.toOwnedSlice();
+}
+
+fn findCommonPrefix(lines: std.ArrayList([]const u8)) usize {
+    var m: usize = std.math.maxInt(usize);
+    for (lines.items) |line| {
+        var n: usize = std.math.maxInt(usize);
+        for (line, 0..) |c, i| {
+            if (c != ' ') {
+                n = i;
+                break;
+            }
+        }
+        m = @min(m, n);
+    }
+    return m;
+}
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var arena = std.heap.ArenaAllocator.init(gpa.allocator());
+    const alloc = arena.allocator();
+
+    const args = try std.process.argsAlloc(alloc);
+    defer std.process.argsFree(alloc, args);
+
+    if (args.len != 2) {
+        std.debug.print("invalid number of arguments provided!", .{});
+        std.process.exit(1);
+    }
+
+    const path = args[1];
+
+    var output = try std.fs.cwd().createFile(path, .{});
+    defer output.close();
+
+    try searchConfigAst(alloc, output);
+    try searchActionsAst(alloc, output);
+}

--- a/src/generate_help_strings.zig
+++ b/src/generate_help_strings.zig
@@ -60,6 +60,7 @@ pub fn searchConfigAst(alloc: std.mem.Allocator, output: std.fs.File) !void {
 
 fn actionPath(comptime action: Action) []const u8 {
     return switch (action) {
+        .help => "cli/help.zig",
         .version => "cli/version.zig",
         .@"list-fonts" => "cli/list_fonts.zig",
         .@"list-keybinds" => "cli/list_keybinds.zig",


### PR DESCRIPTION
This builds on #853. 

- Generate Zig code so that Config and Action doc comments can be accessed at runtime.
- Add a --help action and enhance existing actions to support --help
- Generate manual pages using the generated help strings. Formats are roff (for the man command), Markdown and HTML.