### PR TITLE
input: never report associated text on key release

### DIFF
--- a/src/input/KeyEncoder.zig
+++ b/src/input/KeyEncoder.zig
@@ -1364,6 +1364,29 @@ test "kitty: report associated" {
     try testing.expectEqualStrings("\x1b[106:74;2;74u", actual);
 }
 
+test "kitty: report associated on release" {
+    var buf: [128]u8 = undefined;
+    var enc: KeyEncoder = .{
+        .event = .{
+            .action = .release,
+            .key = .j,
+            .mods = .{ .shift = true },
+            .utf8 = "J",
+            .unshifted_codepoint = 106,
+        },
+        .kitty_flags = .{
+            .disambiguate = true,
+            .report_all = true,
+            .report_alternates = true,
+            .report_associated = true,
+            .report_events = true,
+        },
+    };
+
+    const actual = try enc.kitty(&buf);
+    try testing.expectEqualStrings("[106:74;2:3u", actual[1..]);
+}
+
 test "kitty: alternates omit control characters" {
     var buf: [128]u8 = undefined;
     var enc: KeyEncoder = .{

--- a/src/input/KeyEncoder.zig
+++ b/src/input/KeyEncoder.zig
@@ -186,7 +186,7 @@ fn kitty(
             }
         }
 
-        if (self.kitty_flags.report_associated) associated: {
+        if (self.kitty_flags.report_associated and seq.event != .release) associated: {
             if (comptime builtin.target.isDarwin()) {
                 // macOS has special logic because alt+key can produce unicode
                 // characters. If we are treating option as alt, then we do NOT


### PR DESCRIPTION
Associated text should only be reported when it was generated from the
key event. To my knowledge, there are no release events which produce
text. This now matches kitty reporting for release events.
