### PR TITLE
font: auto-italic should only apply to text presentation

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -410,21 +410,6 @@ pub fn init(
                     _ = try group.addFace(.bold_italic, .{ .deferred = face });
                 } else log.warn("font-family-bold-italic not found: {s}", .{family});
             }
-
-            // On macOS, always search for and add the Apple Emoji font
-            // as our preferred emoji font for fallback. We do this in case
-            // people add other emoji fonts to their system, we always want to
-            // prefer the official one. Users can override this by explicitly
-            // specifying a font-family for emoji.
-            if (comptime builtin.os.tag == .macos) {
-                var disco_it = try disco.discover(alloc, .{
-                    .family = "Apple Color Emoji",
-                });
-                defer disco_it.deinit();
-                if (try disco_it.next()) |face| {
-                    _ = try group.addFace(.regular, .{ .fallback_deferred = face });
-                }
-            }
         }
 
         // Our built-in font will be used as a backup
@@ -439,6 +424,22 @@ pub fn init(
 
         // Auto-italicize if we have to.
         try group.italicize();
+
+        // On macOS, always search for and add the Apple Emoji font
+        // as our preferred emoji font for fallback. We do this in case
+        // people add other emoji fonts to their system, we always want to
+        // prefer the official one. Users can override this by explicitly
+        // specifying a font-family for emoji.
+        if (comptime builtin.os.tag == .macos) apple_emoji: {
+            const disco = group.discover orelse break :apple_emoji;
+            var disco_it = try disco.discover(alloc, .{
+                .family = "Apple Color Emoji",
+            });
+            defer disco_it.deinit();
+            if (try disco_it.next()) |face| {
+                _ = try group.addFace(.regular, .{ .fallback_deferred = face });
+            }
+        }
 
         // Emoji fallback. We don't include this on Mac since Mac is expected
         // to always have the Apple Emoji available on the system.

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -265,11 +265,16 @@ pub fn italicize(self: *Group) !void {
         const list = self.faces.get(.regular);
         if (list.items.len == 0) return;
 
-        // The font must be loaded.
-        break :regular try self.faceFromIndex(.{
-            .style = .regular,
-            .idx = 0,
-        });
+        // Find our first font that is text.
+        for (0..list.items.len) |i| {
+            const face = try self.faceFromIndex(.{
+                .style = .regular,
+                .idx = @intCast(i),
+            });
+            if (face.presentation == .text) break :regular face;
+        }
+
+        return;
     };
 
     // Try to italicize it.


### PR DESCRIPTION
Fixes #1256

If a user has a font which doesn't support italics, Ghostty auto-italicizes by applying a slant transformation matrix to rasterization. We always applied this to the first "regular" font. If the regular font is not text presentation (emoji) then we'd try to apply it to that, which is not what we want. 

This PR changes the behavior to italicize the first text presentation font.