### PR TITLE
WIP: Update to NixOS 23.11 but keep option to build with 23.05

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,22 +1,24 @@
-on: [push, pull_request]
+---
+on:
+  - push
+  - pull_request
 name: Test
 jobs:
   build:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-
-        target: [
-            aarch64-linux,
-            x86_64-linux,
-            x86-windows-gnu,
-            x86_64-windows-gnu,
+        os:
+          - ubuntu-latest
+        target:
+          - aarch64-linux
+          - x86_64-linux
+          - x86-windows-gnu
+          - x86_64-windows-gnu
             # We don't support cross-compiling to macOS because the macOS build
             # requires xcode due to the swift harness.
-            #aarch64-macos,
-            #x86_64-macos,
-          ]
+            # aarch64-macos,
+            # x86_64-macos,
     runs-on: ${{ matrix.os }}
     needs: test
     env:
@@ -26,39 +28,70 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Install Nix and use that to run our tests so our environment matches exactly.
+        # Install Nix and use that to run our tests so our environment matches exactly.
       - uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v13
         with:
           name: ghostty
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      # Cross-compile the binary. We always use static building for this
-      # because its the only way to access the headers.
+        # Cross-compile the binary. We always use static building for this
+        # because its the only way to access the headers.
       - name: Test Build
         run: nix develop -c zig build -Dstatic=true -Dapp-runtime=glfw -Dtarget=${{ matrix.target }}
-
-  build-nix:
+  build-nix-23-05:
     runs-on: ubuntu-latest
     needs: test
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Install Nix and use that to run our tests so our environment matches exactly.
+        # Install Nix and use that to run our tests so our environment matches exactly.
       - uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v13
         with:
           name: ghostty
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Test package build on NixOS 23.05
+        run: nix build .#ghostty-23-05
+  build-nix-23-11:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-      - name: Test NixOS package build
-        run: nix build .#ghostty
+        # Install Nix and use that to run our tests so our environment matches exactly.
+      - uses: cachix/install-nix-action@v24
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v13
+        with:
+          name: ghostty
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Test package build on NixOS 23.11
+        run: nix build .#ghostty-23-11
+  build-nix-unstable:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
+        # Install Nix and use that to run our tests so our environment matches exactly.
+      - uses: cachix/install-nix-action@v24
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v13
+        with:
+          name: ghostty
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Test package build on NixOS Unstable
+        run: nix build .#ghostty-unstable
   build-macos:
     runs-on: ghcr.io/cirruslabs/macos-ventura-xcode:latest
     needs: test
@@ -69,26 +102,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Install Nix and use that to run our tests so our environment matches exactly.
+        # Install Nix and use that to run our tests so our environment matches exactly.
       - uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v13
         with:
           name: ghostty
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      # GhosttyKit is the framework that is built from Zig for our native
-      # Mac app to access.
+        # GhosttyKit is the framework that is built from Zig for our native
+        # Mac app to access.
       - name: Build GhosttyKit
         run: nix develop -c zig build -Dstatic=true
 
-      # The native app is built with native XCode tooling. This also does
-      # codesigning. IMPORTANT: this must NOT run in a Nix environment.
-      # Nix breaks xcodebuild so this has to be run outside.
+        # The native app is built with native XCode tooling. This also does
+        # codesigning. IMPORTANT: this must NOT run in a Nix environment.
+        # Nix breaks xcodebuild so this has to be run outside.
       - name: Build Ghostty.app
         run: cd macos && xcodebuild
-
   build-windows:
     runs-on: windows-2019
     # this will not stop other jobs from running
@@ -98,10 +130,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # This could be from a script if we wanted to but inlining here for now
-      # in one place.
-      # Using powershell so that we do not need to install WSL components. Also,
-      # WSLv1 is only installed on Github runners.
+        # This could be from a script if we wanted to but inlining here for now
+        # in one place.
+        # Using powershell so that we do not need to install WSL components. Also,
+        # WSLv1 is only installed on Github runners.
       - name: Install zig
         shell: pwsh
         run: |
@@ -118,7 +150,6 @@ jobs:
           Rename-Item -Path ".\$version" -NewName ".\zig"
           Write-Host "Zig installed."
           ./zig/zig.exe version
-
       - name: Generate build testing script
         shell: pwsh
         run: |
@@ -131,42 +162,34 @@ jobs:
           # Write the script content to a file
           $scriptContent | Set-Content -Path $scriptPath
           Write-Host "Script generated at: $scriptPath"
-
       - name: Test Windows
         shell: pwsh
         run: .\zigbuild.ps1 -ErrorAction SiltentlyContinue
-
       - name: Dump logs
         shell: pwsh
         run: Get-Content -Path ".\build.log"
-
   test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Install Nix and use that to run our tests so our environment matches exactly.
+        # Install Nix and use that to run our tests so our environment matches exactly.
       - uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v13
         with:
           name: ghostty
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: test
         run: nix develop -c zig build -Dapp-runtime=none test
-
       - name: Test GTK Build
         run: nix develop -c zig build -Dapp-runtime=gtk -Dgtk-libadwaita=true
-
       - name: Test GLFW Build
         run: nix develop -c zig build -Dapp-runtime=glfw
-
       - name: Test Dynamic Build
         run: nix develop -c zig build -Dstatic=false
-
   prettier:
     runs-on: ubuntu-latest
     steps:
@@ -177,10 +200,9 @@ jobs:
       - uses: cachix/cachix-action@v13
         with:
           name: ghostty
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: prettier check
         run: nix develop -c prettier --check .
-
   alejandra:
     runs-on: ubuntu-latest
     steps:
@@ -191,6 +213,6 @@ jobs:
       - uses: cachix/cachix-action@v13
         with:
           name: ghostty
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: alejandra check
         run: nix develop -c alejandra --check .

--- a/example/app.ts
+++ b/example/app.ts
@@ -102,12 +102,12 @@ fetch(url.href)
     group_add_face(
       group,
       0 /* regular */,
-      deferred_face_new(font_name.ptr, font_name.len, 0 /* text */)
+      deferred_face_new(font_name.ptr, font_name.len, 0 /* text */),
     );
     group_add_face(
       group,
       0 /* regular */,
-      deferred_face_new(font_name.ptr, font_name.len, 1 /* emoji */)
+      deferred_face_new(font_name.ptr, font_name.len, 1 /* emoji */),
     );
 
     // Initialize our sprite font, without this we just use the browser.
@@ -168,7 +168,7 @@ fetch(url.href)
       group_cache,
       cp,
       0,
-      -1 /* best choice */
+      -1 /* best choice */,
     );
     group_cache_render_glyph(group_cache, font_idx, cp, -1);
 

--- a/flake.lock
+++ b/flake.lock
@@ -16,22 +16,6 @@
         "type": "github"
       }
     },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "locked": {
         "lastModified": 1659877975,
@@ -52,26 +36,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
-      "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -88,11 +57,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694102001,
-        "narHash": "sha256-vky6VPK1n1od6vXbqzOXnekrQpTL4hbPAwUhT5J9c9E=",
+        "lastModified": 1703887061,
+        "narHash": "sha256-gGPa9qWNc6eCXT/+Z5/zMkyYOuRZqeFZBDbopNZQkuY=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "9e21c80adf67ebcb077d75bd5e7d724d21eeafd6",
+        "rev": "43e1aa1308018f37118e34d3a9cb4f5e75dc11d5",
         "type": "github"
       },
       "original": {
@@ -113,13 +82,13 @@
         "url": "https://raw.githubusercontent.com/ziglang/zig/63bd2bff12992aef0ce23ae4b344e9cb5d65f05d/doc/langref.html.in"
       }
     },
-    "nixpkgs-stable": {
+    "nixpkgs-23-05": {
       "locked": {
-        "lastModified": 1702049175,
-        "narHash": "sha256-c/q2+tGHbmLgzT3sXyUKVJR98h1CTks2+nkVaoZPRM0=",
+        "lastModified": 1704290814,
+        "narHash": "sha256-LWvKHp7kGxk/GEtlrGYV68qIvPHkU9iToomNFGagixU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b15508bd65870620f1df5864e8e861dffbc4e428",
+        "rev": "70bdadeb94ffc8806c0570eb5c2695ad29f0e421",
         "type": "github"
       },
       "original": {
@@ -129,13 +98,29 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
+    "nixpkgs-23-11": {
       "locked": {
-        "lastModified": 1688221086,
-        "narHash": "sha256-cdW6qUL71cNWhHCpMPOJjlw0wzSRP0pVlRn2vqX/VVg=",
+        "lastModified": 1704739135,
+        "narHash": "sha256-53ki2t/gtOGk5u0KWN7+ofOhT3v5EnAkti+rHfBQbO4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cd99c2b3c9f160cd004318e0697f90bbd5960825",
+        "rev": "78054cd6861e524296bb267b6cd528c1e9d283ec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1704161960,
+        "narHash": "sha256-QGua89Pmq+FBAro8NriTuoO/wNaUtugt29/qqA8zeeM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "63143ac2c9186be6d9da6035fa22620018c85932",
         "type": "github"
       },
       "original": {
@@ -163,7 +148,8 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs-stable": "nixpkgs-stable",
+        "nixpkgs-23-05": "nixpkgs-23-05",
+        "nixpkgs-23-11": "nixpkgs-23-11",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "nixpkgs-zig-0-12": "nixpkgs-zig-0-12",
         "zig": "zig",
@@ -190,38 +176,15 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": [
-          "nixpkgs-stable"
+          "nixpkgs-23-11"
         ]
       },
       "locked": {
-        "lastModified": 1704542888,
-        "narHash": "sha256-Fb8tc4cXUkWw+Fva6JKbjkFFpZwu4c+ictSAQGEYjIM=",
+        "lastModified": 1704673465,
+        "narHash": "sha256-zyyXoMvXs2/OeaafyEtw0DbrJSPwx890+qX+EZQzGM4=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "112cfb72e47cb85d17fc8075a4d70ab56964453d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "mitchellh",
-        "repo": "zig-overlay",
-        "type": "github"
-      }
-    },
-    "zig-overlay": {
-      "inputs": {
-        "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_3",
-        "nixpkgs": [
-          "zls",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1701390337,
-        "narHash": "sha256-C+Lyio+GPl3B2IAZ6Nk5hAAE2g6a8bO9vMACUfOLC/g=",
-        "owner": "mitchellh",
-        "repo": "zig-overlay",
-        "rev": "1815ef2d0451b1121a6a91051da84906fcb06f99",
+        "rev": "5cf2374c87cbe48139d1571360dcd7dd4807ef1c",
         "type": "github"
       },
       "original": {
@@ -236,16 +199,18 @@
         "gitignore": "gitignore",
         "langref": "langref",
         "nixpkgs": [
-          "nixpkgs-stable"
+          "nixpkgs-23-11"
         ],
-        "zig-overlay": "zig-overlay"
+        "zig-overlay": [
+          "zig"
+        ]
       },
       "locked": {
-        "lastModified": 1703036566,
-        "narHash": "sha256-GKw+ON8FcUVHxDzA35piev/W/YUvXv5aZ4hmIzNFWuc=",
+        "lastModified": 1704507479,
+        "narHash": "sha256-JmZjIkVDQv0L7FZE8F3DXb7QcEp7JKthE+WYn7YlmRU=",
         "owner": "zigtools",
         "repo": "zls",
-        "rev": "adaeabbe1ba888d74309d0a837d4abddc24cf638",
+        "rev": "3471da593bc9d979c73b35c516e902c06781310b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,8 @@
     # We want to stay as up to date as possible but need to be careful that the
     # glibc versions used by our dependencies from Nix are compatible with the
     # system glibc that the user is building for.
-    nixpkgs-stable.url = "github:nixos/nixpkgs/release-23.05";
+    nixpkgs-23-05.url = "github:nixos/nixpkgs/release-23.05";
+    nixpkgs-23-11.url = "github:nixos/nixpkgs/release-23.11";
 
     # This is a nixpkgs mirror (based off of master) that contains
     # patches for Zig 0.12 (master/nightly).
@@ -21,46 +22,58 @@
 
     zig = {
       url = "github:mitchellh/zig-overlay";
-      inputs.nixpkgs.follows = "nixpkgs-stable";
+      inputs.nixpkgs.follows = "nixpkgs-23-11";
     };
 
     zls = {
       url = "github:zigtools/zls/master";
-      inputs.nixpkgs.follows = "nixpkgs-stable";
+      inputs.nixpkgs.follows = "nixpkgs-23-11";
+      inputs.zig-overlay.follows = "zig";
     };
   };
 
   outputs = {
     self,
+    nixpkgs-23-05,
+    nixpkgs-23-11,
     nixpkgs-unstable,
-    nixpkgs-stable,
     nixpkgs-zig-0-12,
     zig,
     zls,
     ...
   }:
-    builtins.foldl' nixpkgs-stable.lib.recursiveUpdate {} (builtins.map (system: let
-      pkgs-stable = nixpkgs-stable.legacyPackages.${system};
+    builtins.foldl' nixpkgs-23-11.lib.recursiveUpdate {} (builtins.map (system: let
+      pkgs-23-05 = nixpkgs-23-05.legacyPackages.${system};
+      pkgs-23-11 = nixpkgs-23-11.legacyPackages.${system};
       pkgs-unstable = nixpkgs-unstable.legacyPackages.${system};
       pkgs-zig-0-12 = nixpkgs-zig-0-12.legacyPackages.${system};
     in {
-      devShell.${system} = pkgs-stable.callPackage ./nix/devShell.nix {
+      devShell.${system} = pkgs-23-11.callPackage ./nix/devShell.nix {
         inherit (pkgs-unstable) tracy;
         inherit (zls.packages.${system}) zls;
 
-        zig = zig.packages.${system}.master;
-        wraptest = pkgs-stable.callPackage ./nix/wraptest.nix {};
+        zig = zig.packages.${system}.master-2024-01-06;
+        wraptest = pkgs-23-11.callPackage ./nix/wraptest.nix {};
       };
 
       packages.${system} = rec {
-        ghostty = pkgs-stable.callPackage ./nix/package.nix {
+        ghostty-23-05 = pkgs-23-05.callPackage ./nix/package.nix {
           inherit (pkgs-zig-0-12) zig_0_12;
           revision = self.shortRev or self.dirtyShortRev or "dirty";
         };
+        ghostty-23-11 = pkgs-23-11.callPackage ./nix/package.nix {
+          inherit (pkgs-zig-0-12) zig_0_12;
+          revision = self.shortRev or self.dirtyShortRev or "dirty";
+        };
+        ghostty-unstable = pkgs-unstable.callPackage ./nix/package.nix {
+          inherit (pkgs-zig-0-12) zig_0_12;
+          revision = self.shortRev or self.dirtyShortRev or "dirty";
+        };
+        ghostty = ghostty-23-11;
         default = ghostty;
       };
 
-      formatter.${system} = pkgs-stable.alejandra;
+      formatter.${system} = pkgs-23-11.alejandra;
 
       # Our supported systems are the same supported systems as the Zig binaries.
     }) (builtins.attrNames zig.packages));


### PR DESCRIPTION
NixOS 23.05 has been deprecated by NixOS. Switch to building by default with NixOS 23.11, which bring in GTK 4.12.x (NixOS 23.05 has GTK 4.10.x). Still test building with NixOS 23.05 but also test building with NixOS unstable.

Also, make sure that the Zig version is pinned at 0.12.0-dev.2059+42389cb9c  regardless of the flake.lock state.

This needs testing by running it through CI and having a few people test it manually on their systems.