### PR TITLE
custom shader animation can be set to "always" to always remain active

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -10,6 +10,7 @@ pub const url = @import("config/url.zig");
 pub const CopyOnSelect = Config.CopyOnSelect;
 pub const Keybinds = Config.Keybinds;
 pub const MouseShiftCapture = Config.MouseShiftCapture;
+pub const CustomShaderAnimation = Config.CustomShaderAnimation;
 pub const NonNativeFullscreen = Config.NonNativeFullscreen;
 pub const OptionAsAlt = Config.OptionAsAlt;
 pub const ShellIntegrationFeatures = Config.ShellIntegrationFeatures;

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -815,15 +815,21 @@ keybind: Keybinds = .{},
 /// If true (default), the focused terminal surface will run an animation
 /// loop when custom shaders are used. This uses slightly more CPU (generally
 /// less than 10%) but allows the shader to animate. This only runs if there
-/// are custom shaders.
+/// are custom shaders and the terminal is focused.
 ///
 /// If this is set to false, the terminal and custom shader will only render
 /// when the terminal is updated. This is more efficient but the shader will
 /// not animate.
 ///
+/// This can also be set to "always", which will always run the animation
+/// loop regardless of whether the terminal is focused or not. The animation
+/// loop will still only run when custom shaders are used. Note that this
+/// will use more CPU per terminal surface and can become quite expensive
+/// depending on the shader and your terminal usage.
+///
 /// This value can be changed at runtime and will affect all currently
 /// open terminals.
-@"custom-shader-animation": bool = true,
+@"custom-shader-animation": CustomShaderAnimation = .true,
 
 /// If anything other than false, fullscreen mode on macOS will not use the
 /// native fullscreen, but make the window fullscreen without animations and
@@ -2078,6 +2084,15 @@ fn equalField(comptime T: type, old: T, new: T) bool {
         },
     }
 }
+
+/// Valid values for custom-shader-animation
+/// c_int because it needs to be extern compatible
+/// If this is changed, you must also update ghostty.h
+pub const CustomShaderAnimation = enum(c_int) {
+    false,
+    true,
+    always,
+};
 
 /// Valid values for macos-non-native-fullscreen
 /// c_int because it needs to be extern compatible

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -155,7 +155,6 @@ pub const DerivedConfig = struct {
     invert_selection_fg_bg: bool,
     min_contrast: f32,
     custom_shaders: std.ArrayListUnmanaged([:0]const u8),
-    custom_shader_animation: bool,
     links: link.Set,
 
     pub fn init(
@@ -218,7 +217,6 @@ pub const DerivedConfig = struct {
                 null,
 
             .custom_shaders = custom_shaders,
-            .custom_shader_animation = config.@"custom-shader-animation",
             .links = links,
 
             .arena = arena,
@@ -488,8 +486,7 @@ pub fn threadExit(self: *const Metal) void {
 /// True if our renderer has animations so that a higher frequency
 /// timer is used.
 pub fn hasAnimations(self: *const Metal) bool {
-    return self.custom_shader_state != null and
-        self.config.custom_shader_animation;
+    return self.custom_shader_state != null;
 }
 
 /// Returns the grid size for a given screen size. This is safe to call

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -252,7 +252,6 @@ pub const DerivedConfig = struct {
     invert_selection_fg_bg: bool,
     min_contrast: f32,
     custom_shaders: std.ArrayListUnmanaged([:0]const u8),
-    custom_shader_animation: bool,
     links: link.Set,
 
     pub fn init(
@@ -315,7 +314,6 @@ pub const DerivedConfig = struct {
                 null,
 
             .custom_shaders = custom_shaders,
-            .custom_shader_animation = config.@"custom-shader-animation",
             .links = links,
 
             .arena = arena,
@@ -558,7 +556,7 @@ pub fn threadExit(self: *const OpenGL) void {
 /// timer is used.
 pub fn hasAnimations(self: *const OpenGL) bool {
     const state = self.gl_state orelse return false;
-    return state.custom != null and self.config.custom_shader_animation;
+    return state.custom != null;
 }
 
 /// Callback when the focus changes for the terminal this is rendering.

--- a/src/renderer/message.zig
+++ b/src/renderer/message.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
+const configpkg = @import("../config.zig");
 const font = @import("../font/main.zig");
 const renderer = @import("../renderer.zig");
 const terminal = @import("../terminal/main.zig");
@@ -45,9 +46,42 @@ pub const Message = union(enum) {
     /// The derived configuration to update the renderer with.
     change_config: struct {
         alloc: Allocator,
-        ptr: *renderer.Renderer.DerivedConfig,
+        thread: *renderer.Thread.DerivedConfig,
+        impl: *renderer.Renderer.DerivedConfig,
     },
 
     /// Activate or deactivate the inspector.
     inspector: bool,
+
+    /// Initialize a change_config message.
+    pub fn initChangeConfig(alloc: Allocator, config: *const configpkg.Config) !Message {
+        const thread_ptr = try alloc.create(renderer.Thread.DerivedConfig);
+        errdefer alloc.destroy(thread_ptr);
+        const config_ptr = try alloc.create(renderer.Renderer.DerivedConfig);
+        errdefer alloc.destroy(config_ptr);
+
+        thread_ptr.* = renderer.Thread.DerivedConfig.init(config);
+        config_ptr.* = try renderer.Renderer.DerivedConfig.init(alloc, config);
+        errdefer config_ptr.deinit();
+
+        return .{
+            .change_config = .{
+                .alloc = alloc,
+                .thread = thread_ptr,
+                .impl = config_ptr,
+            },
+        };
+    }
+
+    pub fn deinit(self: *const Message) void {
+        switch (self.*) {
+            .change_config => |v| {
+                v.impl.deinit();
+                v.alloc.destroy(v.impl);
+                v.alloc.destroy(v.thread);
+            },
+
+            else => {},
+        }
+    }
 };


### PR DESCRIPTION
Fixes #1225

The `custom-shader-animation` configuration can now be set to "always" which keeps animation active even if the terminal is unfocused.