### PR TITLE
input: manage application keypad state with mode 1035 

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1322,6 +1322,7 @@ pub fn keyCallback(
             .alt_esc_prefix = t.modes.get(.alt_esc_prefix),
             .cursor_key_application = t.modes.get(.cursor_keys),
             .keypad_key_application = t.modes.get(.keypad_keys),
+            .ignore_keypad_with_numlock = t.modes.get(.ignore_keypad_with_numlock),
             .modify_other_keys_state_2 = t.flags.modify_other_keys_2,
             .kitty_flags = t.screen.kitty_keyboard.current(),
         };

--- a/src/input/function_keys.zig
+++ b/src/input/function_keys.zig
@@ -121,6 +121,7 @@ pub const keys = keys: {
     result.set(.kp_down, pcStyle("\x1b[1;{}B") ++ cursorKey("\x1b[B", "\x1bOB"));
     result.set(.kp_right, pcStyle("\x1b[1;{}C") ++ cursorKey("\x1b[C", "\x1bOC"));
     result.set(.kp_left, pcStyle("\x1b[1;{}D") ++ cursorKey("\x1b[D", "\x1bOD"));
+    result.set(.kp_begin, pcStyle("\x1b[1;{}E") ++ cursorKey("\x1b[E", "\x1bOE"));
     result.set(.kp_home, pcStyle("\x1b[1;{}H") ++ cursorKey("\x1b[H", "\x1bOH"));
     result.set(.kp_end, pcStyle("\x1b[1;{}F") ++ cursorKey("\x1b[F", "\x1bOF"));
     result.set(.kp_insert, pcStyle("\x1b[2;{}~") ++ .{.{ .sequence = "\x1B[2~" }});

--- a/src/terminal/modes.zig
+++ b/src/terminal/modes.zig
@@ -206,6 +206,7 @@ const entries: []const ModeEntry = &.{
     .{ .name = "mouse_alternate_scroll", .value = 1007, .default = true },
     .{ .name = "mouse_format_urxvt", .value = 1015 },
     .{ .name = "mouse_format_sgr_pixels", .value = 1016 },
+    .{ .name = "ignore_keypad_with_numlock", .value = 1035, .default = true },
     .{ .name = "alt_esc_prefix", .value = 1036, .default = true },
     .{ .name = "alt_sends_escape", .value = 1039 },
     .{ .name = "reverse_wrap_extended", .value = 1045 },


### PR DESCRIPTION
Fixes https://github.com/mitchellh/ghostty/issues/1099

We previously applied application keypad mode logic (`ESC=` or mode 66)
whenever it was active. However, from looking at the behavior of other
terminals (xterm and foot) it appears this isn't correct.

For xterm, application keypad mode only applies unconditionally if the
keyboard mode is VT220 (`-kt vt220`). For modern terminals, application
keypad mode is only applied if mode 1035 is disabled.

Mode 1035 is the "ignore numpad state with keypad mode" mode. It
defaults to true on terminal startup. If this is true, keypads are
always encoded in numerical mode. If this is false, the numlock state
will be respected along with the desired keypad mode.