### PR TITLE
macos: support Display P3 colorspace through configuration

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -162,7 +162,15 @@ class TerminalController: NSWindowController, NSWindowDelegate,
         // Terminals typically operate in sRGB color space and macOS defaults
         // to "native" which is typically P3. There is a lot more resources
         // covered in thie GitHub issue: https://github.com/mitchellh/ghostty/pull/376
-        window.colorSpace = NSColorSpace.sRGB
+        // Ghostty defaults to sRGB but this can be overridden.
+        switch (ghostty.windowColorspace) {
+        case "display-p3":
+            window.colorSpace = .displayP3
+        case "srgb":
+            fallthrough
+        default:
+            window.colorSpace = .sRGB
+        }
         
         // If we have only a single surface (no splits) and that surface requested
         // an initial size then we set it here now.

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -65,6 +65,16 @@ extension Ghostty {
             return v
         }
         
+        /// window-colorspace
+        var windowColorspace: String {
+            guard let config = self.config else { return "" }
+            var v: UnsafePointer<Int8>? = nil
+            let key = "window-colorspace"
+            guard ghostty_config_get(config, &v, key, UInt(key.count)) else { return "" }
+            guard let ptr = v else { return "" }
+            return String(cString: ptr)
+        }
+        
         /// window-save-state
         var windowSaveState: String {
             guard let config = self.config else { return "" }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -587,6 +587,15 @@ keybind: Keybinds = .{},
 /// This is currently only supported on macOS and linux.
 @"window-theme": WindowTheme = .system,
 
+/// The colorspace to use for the terminal window. The default is "srgb"
+/// but this can also be set to "display-p3" to use the Display P3
+/// colorspace.
+///
+/// Changing this value at runtime will only affect new windows.
+///
+/// This setting is only supported on macOS.
+@"window-colorspace": WindowColorspace = .srgb,
+
 /// The initial window size. This size is in terminal grid cells by default.
 ///
 /// We don't currently support specifying a size in pixels but a future
@@ -2833,6 +2842,12 @@ pub const WindowTheme = enum {
     system,
     light,
     dark,
+};
+
+/// See window-colorspace
+pub const WindowColorspace = enum {
+    srgb,
+    @"display-p3",
 };
 
 /// See gtk-single-instance


### PR DESCRIPTION
Fixes #1214

This introduces the `window-colorspace` configuration which allows configuring the colorspace to use for windows on macOS. The default is sRGB (same as before) but this can also be set to `display-p3`.