### PR TITLE
macos: allow submitting clipboard confirmation with return

### DIFF
--- a/macos/Sources/Features/ClipboardConfirmation/ClipboardConfirmationView.swift
+++ b/macos/Sources/Features/ClipboardConfirmation/ClipboardConfirmationView.swift
@@ -48,10 +48,12 @@ struct ClipboardConfirmationView: View {
                     .padding()
             }
 
-            TextEditor(text: .constant(contents))
-                .textSelection(.enabled)
-                .font(.system(.body, design: .monospaced))
-                .padding(.all, 4)
+            ScrollView {
+                Text(contents)
+                    .textSelection(.enabled)
+                    .font(.system(.body, design: .monospaced))
+                    .padding(.all, 4)
+            }
 
             HStack {
                 Spacer()


### PR DESCRIPTION
Before this change I couldn't submit the dialog with return. Or cmd+return.

From what I understand the problem was that the `TextEditor` always steals the default focus. I tried a bunch of workarounds I found to set the default focus on the button, but none of them worked.

Then I thought: do we even need a full-on Text*Editor*? So I switched `TextEditor` to `Text` with a `ScrollView`: things look the same, text is selectable and scrollable, but I can hit return to submit the dialog.

### Demo Video

https://github.com/mitchellh/ghostty/assets/1185253/a38203d4-0f96-456c-b6a2-f267f926cfb6

