### PR TITLE
build: use Xcode to find macOS SDK

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -444,8 +444,8 @@ pub fn build(b: *std.Build) !void {
         b.installFile("images/icons/icon_256x256@2x@2x.png", "share/icons/hicolor/256x256@2/apps/com.mitchellh.ghostty.png");
     }
 
-    // On Mac we can build the embedding library.
-    if (builtin.target.isDarwin() and target.result.isDarwin()) {
+    // On Mac we can build the embedding library. This only handles the macOS lib.
+    if (builtin.target.isDarwin() and target.result.os.tag == .macos) {
         const static_lib_aarch64 = lib: {
             const lib = b.addStaticLibrary(.{
                 .name = "ghostty",

--- a/build.zig
+++ b/build.zig
@@ -792,7 +792,7 @@ fn addDeps(
     // We always require the system SDK so that our system headers are available.
     // This makes things like `os/log.h` available for cross-compiling.
     if (step.rootModuleTarget().isDarwin()) {
-        try @import("apple_sdk").addPaths(b, step);
+        try @import("apple_sdk").addPaths(b, &step.root_module);
     }
 
     // We always need the Zig packages

--- a/nix/zigCacheHash.nix
+++ b/nix/zigCacheHash.nix
@@ -1,3 +1,3 @@
 # This file is auto-generated! check build-support/check-zig-cache-hash.sh for
 # more details.
-"sha256-iRXzPgzOkt+TTcqPCRQubP3dN6lS+Wvn17l+0I/pDGg="
+"sha256-1qlnSOyr2C9DtUdf+4QRNrBr4vUM1nVnv/mVUXxE5fA="

--- a/pkg/apple-sdk/build.zig
+++ b/pkg/apple-sdk/build.zig
@@ -15,12 +15,16 @@ pub fn addPaths(b: *std.Build, m: *std.Build.Module) !void {
     const sdk = try SDK.fromTarget(m.resolved_target.?.result);
 
     // Get the path to our active Xcode installation. If this fails then
-    // the zig build will fail.
-    const path = std.mem.trim(
-        u8,
-        b.run(&.{ "xcode-select", "--print-path" }),
-        " \r\n",
-    );
+    // the zig build will fail. We store this in a struct variable so its
+    // static and only calculated once per build.
+    const Path = struct {
+        var value: ?[]const u8 = null;
+    };
+    const path = Path.value orelse path: {
+        const path = std.mem.trim(u8, b.run(&.{ "xcode-select", "--print-path" }), " \r\n");
+        Path.value = path;
+        break :path path;
+    };
 
     // Base path
     const base = b.fmt("{s}/Platforms/{s}.platform/Developer/SDKs/{s}{s}.sdk", .{

--- a/pkg/apple-sdk/build.zig
+++ b/pkg/apple-sdk/build.zig
@@ -7,6 +7,9 @@ pub fn build(b: *std.Build) !void {
     _ = optimize;
 }
 
+/// Add the SDK framework, include, and library paths to the given module.
+/// The module target is used to determine the SDK to use so it must have
+/// a resolved target.
 pub fn addPaths(b: *std.Build, m: *std.Build.Module) !void {
     // The active SDK we want to use
     const sdk = try SDK.fromTarget(m.resolved_target.?.result);

--- a/pkg/apple-sdk/build.zig
+++ b/pkg/apple-sdk/build.zig
@@ -7,7 +7,7 @@ pub fn build(b: *std.Build) !void {
     _ = optimize;
 }
 
-pub fn addPaths(b: *std.Build, step: anytype) !void {
+pub fn addPaths(b: *std.Build, m: *std.Build.Module) !void {
     // The active SDK we want to use
     const sdk = "MacOSX14.sdk";
 
@@ -19,19 +19,19 @@ pub fn addPaths(b: *std.Build, step: anytype) !void {
         " \r\n",
     );
 
-    step.addSystemFrameworkPath(.{
+    m.addSystemFrameworkPath(.{
         .cwd_relative = b.pathJoin(&.{
             path,
             "Platforms/MacOSX.platform/Developer/SDKs/" ++ sdk ++ "/System/Library/Frameworks",
         }),
     });
-    step.addSystemIncludePath(.{
+    m.addSystemIncludePath(.{
         .cwd_relative = b.pathJoin(&.{
             path,
             "Platforms/MacOSX.platform/Developer/SDKs/" ++ sdk ++ "/usr/include",
         }),
     });
-    step.addLibraryPath(.{
+    m.addLibraryPath(.{
         .cwd_relative = b.pathJoin(&.{
             path,
             "Platforms/MacOSX.platform/Developer/SDKs/" ++ sdk ++ "/usr/lib",

--- a/pkg/apple-sdk/build.zig
+++ b/pkg/apple-sdk/build.zig
@@ -41,7 +41,7 @@ const SDK = struct {
 
     pub fn fromTarget(target: std.Target) !SDK {
         return switch (target.os.tag) {
-            .macos => .{ .platform = "MacOSX", .version = "14.2" },
+            .macos => .{ .platform = "MacOSX", .version = "14" },
             else => {
                 std.log.err("unsupported os={}", .{target.os.tag});
                 return error.UnsupportedOS;

--- a/pkg/apple-sdk/build.zig
+++ b/pkg/apple-sdk/build.zig
@@ -7,12 +7,34 @@ pub fn build(b: *std.Build) !void {
     _ = optimize;
 }
 
-pub fn addPaths(b: *std.Build, step: *std.Build.Step.Compile) !void {
-    _ = b;
-    @import("macos_sdk").addPaths(step);
-}
+pub fn addPaths(b: *std.Build, step: anytype) !void {
+    // The active SDK we want to use
+    const sdk = "MacOSX14.sdk";
 
-pub fn addPathsModule(b: *std.Build, m: *std.Build.Module) !void {
-    _ = b;
-    @import("macos_sdk").addPathsModule(m);
+    // Get the path to our active Xcode installation. If this fails then
+    // the zig build will fail.
+    const path = std.mem.trim(
+        u8,
+        b.run(&.{ "xcode-select", "--print-path" }),
+        " \r\n",
+    );
+
+    step.addSystemFrameworkPath(.{
+        .cwd_relative = b.pathJoin(&.{
+            path,
+            "Platforms/MacOSX.platform/Developer/SDKs/" ++ sdk ++ "/System/Library/Frameworks",
+        }),
+    });
+    step.addSystemIncludePath(.{
+        .cwd_relative = b.pathJoin(&.{
+            path,
+            "Platforms/MacOSX.platform/Developer/SDKs/" ++ sdk ++ "/usr/include",
+        }),
+    });
+    step.addLibraryPath(.{
+        .cwd_relative = b.pathJoin(&.{
+            path,
+            "Platforms/MacOSX.platform/Developer/SDKs/" ++ sdk ++ "/usr/lib",
+        }),
+    });
 }

--- a/pkg/apple-sdk/build.zig.zon
+++ b/pkg/apple-sdk/build.zig.zon
@@ -1,10 +1,5 @@
 .{
     .name = "apple-sdk",
     .version = "0.1.0",
-    .dependencies = .{
-        .macos_sdk = .{
-            .url = "https://github.com/mitchellh/zig-build-macos-sdk/archive/ee70f27c08680307fa35ada92e6b2c36e0ff84c6.tar.gz",
-            .hash = "1220b415f529f1c04ed876c2b481e9f8119d353d4e3d4d7c8607ee302d2142e13eca",
-        },
-    },
+    .dependencies = .{},
 }

--- a/pkg/cimgui/build.zig
+++ b/pkg/cimgui/build.zig
@@ -60,7 +60,7 @@ pub fn build(b: *std.Build) !void {
 
     if (target.result.isDarwin()) {
         if (!target.query.isNative()) {
-            try @import("apple_sdk").addPaths(b, lib);
+            try @import("apple_sdk").addPaths(b, &lib.root_module);
             try @import("apple_sdk").addPaths(b, module);
         }
         lib.addCSourceFile(.{

--- a/pkg/cimgui/build.zig
+++ b/pkg/cimgui/build.zig
@@ -61,7 +61,7 @@ pub fn build(b: *std.Build) !void {
     if (target.result.isDarwin()) {
         if (!target.query.isNative()) {
             try @import("apple_sdk").addPaths(b, lib);
-            try @import("apple_sdk").addPathsModule(b, module);
+            try @import("apple_sdk").addPaths(b, module);
         }
         lib.addCSourceFile(.{
             .file = imgui.path("backends/imgui_impl_metal.mm"),

--- a/pkg/cimgui/build.zig
+++ b/pkg/cimgui/build.zig
@@ -5,7 +5,11 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const module = b.addModule("cimgui", .{ .root_source_file = .{ .path = "main.zig" } });
+    const module = b.addModule("cimgui", .{
+        .root_source_file = .{ .path = "main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
 
     const imgui = b.dependency("imgui", .{});
     const freetype = b.dependency("freetype", .{

--- a/pkg/harfbuzz/build.zig
+++ b/pkg/harfbuzz/build.zig
@@ -18,6 +18,8 @@ pub fn build(b: *std.Build) !void {
 
     const module = b.addModule("harfbuzz", .{
         .root_source_file = .{ .path = "main.zig" },
+        .target = target,
+        .optimize = optimize,
         .imports = &.{
             .{ .name = "freetype", .module = freetype.module("freetype") },
             .{ .name = "macos", .module = macos.module("macos") },
@@ -59,7 +61,7 @@ pub fn build(b: *std.Build) !void {
         "-DHAVE_FT_DONE_MM_VAR=1",
         "-DHAVE_FT_GET_TRANSFORM=1",
     });
-    if (coretext_enabled) {
+    if (coretext_enabled and target.result.isDarwin()) {
         try flags.appendSlice(&.{"-DHAVE_CORETEXT=1"});
         try apple_sdk.addPaths(b, &lib.root_module);
         try apple_sdk.addPaths(b, module);

--- a/pkg/harfbuzz/build.zig
+++ b/pkg/harfbuzz/build.zig
@@ -62,7 +62,7 @@ pub fn build(b: *std.Build) !void {
     if (coretext_enabled) {
         try flags.appendSlice(&.{"-DHAVE_CORETEXT=1"});
         try apple_sdk.addPaths(b, lib);
-        try apple_sdk.addPathsModule(b, module);
+        try apple_sdk.addPaths(b, module);
         lib.linkFramework("ApplicationServices");
         module.linkFramework("ApplicationServices", .{});
     }

--- a/pkg/harfbuzz/build.zig
+++ b/pkg/harfbuzz/build.zig
@@ -61,7 +61,7 @@ pub fn build(b: *std.Build) !void {
     });
     if (coretext_enabled) {
         try flags.appendSlice(&.{"-DHAVE_CORETEXT=1"});
-        try apple_sdk.addPaths(b, lib);
+        try apple_sdk.addPaths(b, &lib.root_module);
         try apple_sdk.addPaths(b, module);
         lib.linkFramework("ApplicationServices");
         module.linkFramework("ApplicationServices", .{});

--- a/pkg/macos/build.zig
+++ b/pkg/macos/build.zig
@@ -40,7 +40,7 @@ pub fn build(b: *std.Build) !void {
 
     if (!target.query.isNative()) {
         try apple_sdk.addPaths(b, lib);
-        try apple_sdk.addPathsModule(b, module);
+        try apple_sdk.addPaths(b, module);
     }
     b.installArtifact(lib);
 

--- a/pkg/macos/build.zig
+++ b/pkg/macos/build.zig
@@ -38,7 +38,7 @@ pub fn build(b: *std.Build) !void {
         module.linkFramework("CoreVideo", .{});
 
         if (!target.query.isNative()) {
-            try apple_sdk.addPaths(b, lib);
+            try apple_sdk.addPaths(b, &lib.root_module);
             try apple_sdk.addPaths(b, module);
         }
     }

--- a/pkg/macos/build.zig
+++ b/pkg/macos/build.zig
@@ -6,7 +6,11 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const module = b.addModule("macos", .{ .root_source_file = .{ .path = "main.zig" } });
+    const module = b.addModule("macos", .{
+        .root_source_file = .{ .path = "main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
 
     const lib = b.addStaticLibrary(.{
         .name = "macos",

--- a/pkg/macos/build.zig
+++ b/pkg/macos/build.zig
@@ -36,11 +36,11 @@ pub fn build(b: *std.Build) !void {
         module.linkFramework("CoreGraphics", .{});
         module.linkFramework("CoreText", .{});
         module.linkFramework("CoreVideo", .{});
-    }
 
-    if (!target.query.isNative()) {
-        try apple_sdk.addPaths(b, lib);
-        try apple_sdk.addPaths(b, module);
+        if (!target.query.isNative()) {
+            try apple_sdk.addPaths(b, lib);
+            try apple_sdk.addPaths(b, module);
+        }
     }
     b.installArtifact(lib);
 


### PR DESCRIPTION
Instead of depending on a manually updated [Zig macOS SDK package](https://github.com/mitchellh/zig-build-macos-sdk), just depend on Xcode itself since we _already_ depend on Xcode to build the macOS app. I previously used the Zig package when we supported cross compiling -- over a year ago -- before we made the Mac experience more native.

