### PR TITLE
x11: fix modifier mask for Super key

### DIFF
--- a/src/apprt/gtk/x11.zig
+++ b/src/apprt/gtk/x11.zig
@@ -106,7 +106,7 @@ pub const Xkb = struct {
         if (lookup_mods & c.ShiftMask != 0) mods.shift = true;
         if (lookup_mods & c.ControlMask != 0) mods.ctrl = true;
         if (lookup_mods & c.Mod1Mask != 0) mods.alt = true;
-        if (lookup_mods & c.Mod2Mask != 0) mods.super = true;
+        if (lookup_mods & c.Mod4Mask != 0) mods.super = true;
         if (lookup_mods & c.LockMask != 0) mods.caps_lock = true;
 
         return mods;


### PR DESCRIPTION
Mod4 is "Super" in X11, verified via the `xmodmap` command:

    xmodmap:  up to 4 keys per modifier, (keycodes in parentheses):

    shift       Shift_L (0x32),  Shift_R (0x3e)
    lock        Caps_Lock (0x42)
    control     Control_L (0x25),  Caps_Lock (0x42),  Control_R (0x69)
    mod1        Alt_L (0x85),  Alt_R (0x86),  Alt_L (0xcc),  Meta_L (0xcd)
    mod2        Num_Lock (0x4d)
    mod3        ISO_Level5_Shift (0xcb)
    mod4        Super_L (0x40),  Super_R (0x6c),  Super_L (0xce),  Hyper_L (0xcf)
    mod5        ISO_Level3_Shift (0x5c)
