### PR TITLE
macos: stop windows glitching when cascading

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalManager.swift
+++ b/macos/Sources/Features/Terminal/TerminalManager.swift
@@ -78,14 +78,13 @@ class TerminalManager {
             window.toggleFullScreen(nil)
         }
         
-        c.showWindow(self)
-        
-        // Only cascade if we aren't fullscreen. This has to be dispatched async
-        // because it takes one event loop tick for showWindow to work.
-        if (!window.styleMask.contains(.fullScreen)) {
-            DispatchQueue.main.async {
+        // We're dispatching this async because otherwise the last-cascade-point won't work.
+        DispatchQueue.main.async {
+            // Only cascade if we aren't fullscreen.
+            if (!window.styleMask.contains(.fullScreen)) {
                 Self.lastCascadePoint = window.cascadeTopLeft(from: Self.lastCascadePoint)
             }
+            c.showWindow(self)
         }
     }
     

--- a/macos/Sources/Features/Terminal/TerminalManager.swift
+++ b/macos/Sources/Features/Terminal/TerminalManager.swift
@@ -78,12 +78,15 @@ class TerminalManager {
             window.toggleFullScreen(nil)
         }
         
-        // We're dispatching this async because otherwise the last-cascade-point won't work.
+        // We're dispatching this async because otherwise the lastCascadePoint doesn't
+        // take effect. Our best theory is there is some next-event-loop-tick logic
+        // that Cocoa is doing that we need to be after.
         DispatchQueue.main.async {
             // Only cascade if we aren't fullscreen.
             if (!window.styleMask.contains(.fullScreen)) {
                 Self.lastCascadePoint = window.cascadeTopLeft(from: Self.lastCascadePoint)
             }
+            
             c.showWindow(self)
         }
     }


### PR DESCRIPTION
Noticed that windows glitch when cascading: they show up in center of screen, then quickly move to the correct position at last-cascade point.

This fixes the issue, by moving the `showWindow` call to _after_ the setting of the last cascade point.

Now if you look at the code and think: "shouldn't this work without the async-dispatch, like this?"

```swift
if (!window.styleMask.contains(.fullScreen)) {
    Self.lastCascadePoint = window.cascadeTopLeft(from: Self.lastCascadePoint)
}
c.showWindow(self)
```

Then, yes, I had the same thought, but it doesn't. And as discussed on Discord, we probably don't know what's going on behind the scenes.

So this is the simplified code of the version we have to live with: async dispatching the cascade and non-cascade versions both.

### Before

https://github.com/mitchellh/ghostty/assets/1185253/dd067b33-0699-41e6-b1fd-870bf92bb8d1

### After

https://github.com/mitchellh/ghostty/assets/1185253/e241fbdd-0ba5-4ea1-b7e3-3394ab9c1b96



