### PR TITLE
gtk: use modifier state from GTK key event on X11

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -600,10 +600,3 @@ test "isValidAppId" {
     try testing.expect(!isValidAppId(""));
     try testing.expect(!isValidAppId("foo" ** 86));
 }
-
-/// Loads keyboard state from Xkb if there is an event pending and Xkb is
-/// loaded (X11 only). Returns null otherwise.
-pub fn modifier_state_from_xkb(self: *App, display_: ?*c.GdkDisplay) ?input.Mods {
-    const x11_xkb = self.x11_xkb orelse return null;
-    return x11_xkb.modifier_state_from_notify(display_);
-}


### PR DESCRIPTION
Fixes: https://github.com/mitchellh/ghostty/issues/1274

On X11 `gdk_device_get_modifier_state` does not correctly return the
modifier state, while the modifier state passed to the key callback
does. On Wayland, the situation is exactly reversed.

Therefore on X11 we use the mods provided by the key callback and on
Wayland we continue to get the modifier state from the device.

`App.modifier_state_from_xkb` is removed since we can lift the
conditional out of the function call (we would need to make a second,
redundant check for the presence of `x11_xkb` otherwise).
