### PR TITLE
macOS: expand explicit restorable state invalidation to more cases

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -470,6 +470,12 @@ class TerminalController: NSWindowController, NSWindowDelegate,
         self.window?.close()
     }
     
+    func surfaceTreeDidChange() {
+        // Whenever our surface tree changes in any way (new split, close split, etc.)
+        // we want to invalidate our state.
+        invalidateRestorableState()
+    }
+    
     //MARK: - Clipboard Confirmation
     
     func clipboardConfirmationComplete(_ action: ClipboardConfirmationView.Action, _ request: Ghostty.ClipboardRequest) {

--- a/macos/Sources/Features/Terminal/TerminalManager.swift
+++ b/macos/Sources/Features/Terminal/TerminalManager.swift
@@ -190,6 +190,11 @@ class TerminalManager {
             let frame = focusedWindow.frame
             Self.lastCascadePoint = NSPoint(x: frame.minX, y: frame.maxY)
         }
+        
+        // I don't think we strictly have to do this but if a window is
+        // closed I want to make sure that the app state is invalided so
+        // we don't reopen closed windows.
+        NSApplication.shared.invalidateRestorableState()
     }
     
     /// Close all windows, asking for confirmation if necessary.

--- a/macos/Sources/Features/Terminal/TerminalView.swift
+++ b/macos/Sources/Features/Terminal/TerminalView.swift
@@ -13,6 +13,10 @@ protocol TerminalViewDelegate: AnyObject {
     
     /// The cell size changed.
     func cellSizeDidChange(to: NSSize)
+    
+    /// The surface tree did change in some way, i.e. a split was added, removed, etc. This is
+    /// not called initially.
+    func surfaceTreeDidChange()
 }
 
 // Default all the functions so they're optional
@@ -96,6 +100,12 @@ struct TerminalView<ViewModel: TerminalViewModel>: View {
                     .onChange(of: cellSize) { newValue in
                         guard let size = newValue else { return }
                         self.delegate?.cellSizeDidChange(to: size)
+                    }
+                    .onChange(of: viewModel.surfaceTree?.hashValue) { _ in
+                        // This is funky, but its the best way I could think of to detect
+                        // ANY CHANGE within the deeply nested surface tree -- detecting a change
+                        // in the hash value.
+                        self.delegate?.surfaceTreeDidChange()
                     }
             }
         }


### PR DESCRIPTION
This adds two new scenarios where we explicitly request Cocoa to invalidate restorable state:

1. Whenever a surface tree (the split hierarchy) changes in any way.
2. Whenever a terminal window is closed. 

I don't think 2 is necessary because I think macOS should be doing it whenever a window closes but its entirely unclear from the documentation as far as I can find so we're doing it to be safe.