### PR TITLE
Shift+<arrows, home, end, page up/down> with selection should expand selection

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1281,7 +1281,7 @@ pub fn keyCallback(
         const viewport_end = screen.viewport + terminal.Screen.RowIndexTag.viewport.maxLen(&screen) - 1;
         const screen_end = terminal.Screen.RowIndexTag.screen.maxLen(&screen) - 1;
 
-        switch (event.physical_key) {
+        switch (event.key) {
             .left => {
                 var iterator = sel.end.iterator(&screen, .left_up);
                 // This iterator emits the start point first, throw it out.
@@ -1322,10 +1322,43 @@ pub fn keyCallback(
                 }
             },
             .up => {
-                if (sel.end.y > 0) sel.end.y -= 1;
+                if (sel.end.y == 0) {
+                    sel.end.x = 0;
+                } else {
+                    sel.end.y -= 1;
+                }
             },
             .down => {
-                if (sel.end.y < screen_end) sel.end.y += 1;
+                if (sel.end.y >= screen_end) {
+                    sel.end.y = screen_end;
+                    sel.end.x = screen.cols - 1;
+                } else {
+                    sel.end.y += 1;
+                }
+            },
+            .page_up => {
+                if (screen.rows > sel.end.y) {
+                    sel.end.y = 0;
+                    sel.end.x = 0;
+                } else {
+                    sel.end.y -= screen.rows;
+                }
+            },
+            .page_down => {
+                if (screen.rows > screen_end - sel.end.y) {
+                    sel.end.y = screen_end;
+                    sel.end.x = screen.cols - 1;
+                } else {
+                    sel.end.y += screen.rows;
+                }
+            },
+            .home => {
+                sel.end.y = 0;
+                sel.end.x = 0;
+            },
+            .end => {
+                sel.end.y = screen_end;
+                sel.end.x = screen.cols - 1;
             },
             else => { break :adjust_selection; },
         }

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1273,9 +1273,6 @@ pub fn keyCallback(
 
         if (selection == null) break :adjust_selection;
 
-        // Silently consume key releases.
-        if (event.action != .press and event.action != .repeat) return .consumed;
-
         var sel = selection.?;
 
         const viewport_end = screen.viewport + terminal.Screen.RowIndexTag.viewport.maxLen(&screen) - 1;
@@ -1362,6 +1359,10 @@ pub fn keyCallback(
             },
             else => { break :adjust_selection; },
         }
+
+        // Silently consume key releases.
+        if (event.action != .press and event.action != .repeat) return .consumed;
+
         // If the selection endpoint is outside of the current viewpoint, scroll it in to view.
         if (sel.end.y < screen.viewport) {
             try self.io.terminal.scrollViewport(.{

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1264,6 +1264,86 @@ pub fn keyCallback(
         }
     }
 
+    // Expand selection if one exists and event is shift + <arrows, home, end, pg up/down>
+    if (event.mods.shift) adjust_selection: {
+        self.renderer_state.mutex.lock();
+        defer self.renderer_state.mutex.unlock();
+        var screen = self.io.terminal.screen;
+        const selection = screen.selection;
+
+        if (selection == null) break :adjust_selection;
+
+        // Silently consume key releases.
+        if (event.action != .press and event.action != .repeat) return .consumed;
+
+        var sel = selection.?;
+
+        const viewport_end = screen.viewport + terminal.Screen.RowIndexTag.viewport.maxLen(&screen) - 1;
+        const screen_end = terminal.Screen.RowIndexTag.screen.maxLen(&screen) - 1;
+
+        switch (event.physical_key) {
+            .left => {
+                var iterator = sel.end.iterator(&screen, .left_up);
+                // This iterator emits the start point first, throw it out.
+                _ = iterator.next();
+                var next = iterator.next();
+                // Step left, wrapping to the next row up at the start of each new line,
+                // until we find a non-empty cell.
+                while (
+                    next != null and
+                    screen.getCell(.screen, next.?.y, next.?.x).char == 0
+                ) {
+                    next = iterator.next();
+                }
+                if (next != null) {
+                    sel.end = next.?;
+                }
+            },
+            .right => {
+                var iterator = sel.end.iterator(&screen, .right_down);
+                // This iterator emits the start point first, throw it out.
+                _ = iterator.next();
+                var next = iterator.next();
+                // Step right, wrapping to the next row down at the start of each new line,
+                // until we find a non-empty cell.
+                while (
+                    next != null and
+                    next.?.y <= screen_end and
+                    screen.getCell(.screen, next.?.y, next.?.x).char == 0
+                ) {
+                    next = iterator.next();
+                }
+                if (next != null) {
+                    if (next.?.y > screen_end) {
+                        sel.end.y = screen_end;
+                    } else {
+                        sel.end = next.?;
+                    }
+                }
+            },
+            .up => {
+                if (sel.end.y > 0) sel.end.y -= 1;
+            },
+            .down => {
+                if (sel.end.y < screen_end) sel.end.y += 1;
+            },
+            else => { break :adjust_selection; },
+        }
+        // If the selection endpoint is outside of the current viewpoint, scroll it in to view.
+        if (sel.end.y < screen.viewport) {
+            try self.io.terminal.scrollViewport(.{
+                .delta = @as(isize, @intCast(sel.end.y)) - @as(isize, @intCast(screen.viewport))
+            });
+        } else if (sel.end.y > viewport_end) {
+            try self.io.terminal.scrollViewport(.{
+                .delta = @as(isize, @intCast(sel.end.y)) - @as(isize, @intCast(viewport_end))
+            });
+        }
+        self.setSelection(sel);
+        try self.queueRender();
+        return .consumed;
+    }
+
     // If we allow KAM and KAM is enabled then we do nothing.
     if (self.config.vt_kam_allowed) {
         self.renderer_state.mutex.lock();


### PR DESCRIPTION
This PR implements the enhancement requested by #1210 

### NOTE:
It might be desirable to add a config option to toggle this behavior, since I can imagine someone who has shift+arrows bound to something in some TUI app and also uses selections a lot to where this would conflict.

### Demo (shows use of `up`/`down`, `left`/`right`, `page up`/`page down`, `home`, and `end`):
![demo](https://github.com/mitchellh/ghostty/assets/7241851/b8159690-96b5-4e1f-8fe3-5a1919955e40)