### PR TITLE
gtk: append new tabs at the end if config is set

### DIFF
--- a/src/apprt/gtk/Tab.zig
+++ b/src/apprt/gtk/Tab.zig
@@ -108,13 +108,9 @@ pub fn init(self: *Tab, window: *Window, parent_: ?*CoreSurface) !void {
     c.gtk_box_append(self.box, gl_area_widget);
 
     // Add the notebook page (create tab).
-    const parent_page_idx = parent_page_idx: {
-        // If this option is enabled we append the new tab to the end of the notebook.
-        if (window.app.config.@"window-append-new-tabs") {
-            break :parent_page_idx c.gtk_notebook_get_n_pages(window.notebook);
-        }
-        // Otherwise we add it after the current tab.
-        break :parent_page_idx c.gtk_notebook_get_current_page(window.notebook) + 1;
+    const parent_page_idx = switch (window.app.config.@"window-new-tab-position") {
+        .current => c.gtk_notebook_get_current_page(window.notebook) + 1,
+        .end => c.gtk_notebook_get_n_pages(window.notebook),
     };
 
     const page_idx = c.gtk_notebook_insert_page(

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -656,9 +656,14 @@ keybind: Keybinds = .{},
 /// Currently only supported on macOS.
 @"window-step-resize": bool = false,
 
-/// Append new tabs to the end of the tab list instead of right after the
-/// current tab.
-@"window-append-new-tabs": bool = false,
+/// The position where new tabs are created. Valid values:
+///
+///   - "current" - Insert the new tab after the currently focused tab,
+///     or at the end if there are no focused tabs.
+///   - "end" - Insert the new tab at the end of the tab list.
+///
+/// This configuration currently only works with GTK.
+@"window-new-tab-position": WindowNewTabPosition = .current,
 
 /// When enabled, the full GTK titlebar is displayed instead of your window
 /// manager's simple titlebar. The behavior of this option will vary with your
@@ -2897,6 +2902,12 @@ pub const WindowSaveState = enum {
     default,
     never,
     always,
+};
+
+/// See window-new-tab-position
+pub const WindowNewTabPosition = enum {
+    current,
+    end,
 };
 
 /// See grapheme-width-method

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -656,6 +656,10 @@ keybind: Keybinds = .{},
 /// Currently only supported on macOS.
 @"window-step-resize": bool = false,
 
+/// Append new tabs to the end of the tab list instead of right after the
+/// current tab.
+@"window-append-new-tabs": bool = false,
+
 /// When enabled, the full GTK titlebar is displayed instead of your window
 /// manager's simple titlebar. The behavior of this option will vary with your
 /// window manager.


### PR DESCRIPTION
This adds a new config option: `window-append-new-tabs` (please: if you have a better name, let me know). If this is set to true, then new GTK tabs aren't added after the current tab, but after at the end.

### Demo: `window-append-new-tabs: false` (default, state before this PR)

[default-mode.webm](https://github.com/mitchellh/ghostty/assets/1185253/d9588479-4f33-4777-8a69-0345567315c5)

### Demo: `window-append-new-tabs: true` (new!)

[Screencast from 2024-01-12 17-33-52.webm](https://github.com/mitchellh/ghostty/assets/1185253/3138a88e-6a26-45fc-bfce-6d6e3a1e3294)
