### PR TITLE
macos: respect window-new-tab-position config setting when opening new tabs

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalManager.swift
+++ b/macos/Sources/Features/Terminal/TerminalManager.swift
@@ -124,13 +124,20 @@ class TerminalManager {
             tg.removeWindow(window)
         }
         
-        // Our windows start our invisible. We need to make it visible. If we
+        // Our windows start out invisible. We need to make it visible. If we
         // don't do this then various features such as window blur won't work because
         // the macOS APIs only work on a visible window.
         controller.showWindow(self)
         
-        // Add the window to the tab group and show it
-        parent.addTabbedWindow(window, ordered: .above)
+        // Add the window to the tab group and show it. If we already have a tab group
+        // and we want the new tab to open at the end, then we use the last window in
+        // the tab group as the parent.
+        if let last = parent.tabGroup?.windows.last, ghostty.windowNewTabPosition == "end" {
+            last.addTabbedWindow(window, ordered: .above)
+        } else {
+            parent.addTabbedWindow(window, ordered: .above)
+        }
+
         window.makeKeyAndOrderFront(self)
         
         // It takes an event loop cycle until the macOS tabGroup state becomes

--- a/macos/Sources/Features/Terminal/TerminalManager.swift
+++ b/macos/Sources/Features/Terminal/TerminalManager.swift
@@ -129,12 +129,18 @@ class TerminalManager {
         // the macOS APIs only work on a visible window.
         controller.showWindow(self)
         
-        // Add the window to the tab group and show it. If we already have a tab group
-        // and we want the new tab to open at the end, then we use the last window in
-        // the tab group as the parent.
-        if let last = parent.tabGroup?.windows.last, ghostty.windowNewTabPosition == "end" {
-            last.addTabbedWindow(window, ordered: .above)
-        } else {
+        // Add the window to the tab group and show it.
+        switch ghostty.windowNewTabPosition {
+        case "end":
+            // If we already have a tab group and we want the new tab to open at the end,
+            // then we use the last window in the tab group as the parent.
+            if let last = parent.tabGroup?.windows.last {
+                last.addTabbedWindow(window, ordered: .above)
+            } else {
+                fallthrough
+            }
+        case "current": fallthrough
+        default:
             parent.addTabbedWindow(window, ordered: .above)
         }
 

--- a/macos/Sources/Ghostty/AppState.swift
+++ b/macos/Sources/Ghostty/AppState.swift
@@ -84,6 +84,16 @@ extension Ghostty {
             guard let ptr = v else { return "" }
             return String(cString: ptr)
         }
+
+        /// window-new-tab-position
+        var windowNewTabPosition: String {
+            guard let config = self.config else { return "" }
+            var v: UnsafePointer<Int8>? = nil
+            let key = "window-new-tab-position"
+            guard ghostty_config_get(config, &v, key, UInt(key.count)) else { return "" }
+            guard let ptr = v else { return "" }
+            return String(cString: ptr)
+        }
         
         /// True if we need to confirm before quitting.
         var needsConfirmQuit: Bool {


### PR DESCRIPTION
This is the macOS sibling to #1292.

@mitchellh I'm _really_ unsure about the Swift code here, lol. I had a relatively simple `if let` first, then changed it to a switch statement, since we do have an "enum". Then I thought about using a proper Swift enum too, but realised that the other values in `AppState` don't do that and that it's a bit of a pain in the butt to duplicate the exact Zig enum, so I left it out.

### Demo: `window-new-tab-position = end`

https://github.com/mitchellh/ghostty/assets/1185253/745c83f8-fbbc-411c-8dbb-4606f405dcf5

### Demo: `window-new-tab-position = current`

https://github.com/mitchellh/ghostty/assets/1185253/160eb675-3d69-4f27-a8c7-cabf51c9ff00


