### PR TITLE
Add sudo wrapper as optional shell integration feature

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -774,8 +774,9 @@ keybind: Keybinds = .{},
 /// Available features:
 ///
 ///   - "cursor" - Set the cursor to a blinking bar at the prompt.
+///   - "sudo" - Set sudo wrapper to preserve terminfo.
 ///
-/// Example: "cursor", "no-cursor"
+/// Example: "cursor", "no-cursor", "sudo", "no-sudo"
 @"shell-integration-features": ShellIntegrationFeatures = .{},
 
 /// Sets the reporting format for OSC sequences that request color information.
@@ -2853,6 +2854,7 @@ pub const ShellIntegration = enum {
 /// Shell integration features
 pub const ShellIntegrationFeatures = packed struct {
     cursor: bool = true,
+    sudo: bool = false,
 };
 
 /// OSC 4, 10, 11, and 12 default color reporting format.

--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -218,6 +218,30 @@ _ghostty_deferred_init() {
 	  builtin print -rnu $_ghostty_fd \$'\\e[0 q'"
     fi
 
+    # Sudo
+    if [[ "$GHOSTTY_SHELL_INTEGRATION_NO_SUDO" != "1" ]] && [[ -n "$TERMINFO" ]]; then
+      # Wrap `sudo` command to ensure Ghostty terminfo is preserved
+      sudo() {
+        builtin local sudo_has_sudoedit_flags="no"
+        for arg in "$@"; do
+          # Check if argument is '-e' or '--edit' (sudoedit flags)
+          if [[ "$arg" == "-e" || $arg == "--edit" ]]; then
+            sudo_has_sudoedit_flags="yes"
+            builtin break
+          fi
+          # Check if argument is neither an option nor a key-value pair
+          if [[ "$arg" != -* && "$arg" != *=* ]]; then
+            builtin break
+          fi
+        done
+        if [[ "$sudo_has_sudoedit_flags" == "yes" ]]; then
+          builtin command sudo "$@";
+        else
+          builtin command sudo TERMINFO="$TERMINFO" "$@";
+        fi
+      }
+    fi
+
     # Some zsh users manually run `source ~/.zshrc` in order to apply rc file
     # changes to the current shell. This is a terrible practice that breaks many
     # things, including our shell integration. For example, Oh My Zsh and Prezto

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -49,6 +49,7 @@ pub fn setup(
 
     // Setup our feature env vars
     if (!features.cursor) try env.put("GHOSTTY_SHELL_INTEGRATION_NO_CURSOR", "1");
+    if (!features.sudo) try env.put("GHOSTTY_SHELL_INTEGRATION_NO_SUDO", "1");
 
     return shell;
 }


### PR DESCRIPTION
My attempt of implementing a sudo wrapper as an optional shell integration feature `sudo`, as discussed in https://github.com/mitchellh/ghostty/issues/1291

It's basically following the Kitty implementation, with a slight modifications focused on code readability and syntax consistency. 