### PR TITLE
build: no more resolved target hack for macOS

### DIFF
--- a/pkg/glslang/build.zig
+++ b/pkg/glslang/build.zig
@@ -4,7 +4,11 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const module = b.addModule("glslang", .{ .root_source_file = .{ .path = "main.zig" } });
+    const module = b.addModule("glslang", .{
+        .root_source_file = .{ .path = "main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
 
     const upstream = b.dependency("glslang", .{});
     const lib = try buildGlslang(b, upstream, target, optimize);
@@ -13,9 +17,6 @@ pub fn build(b: *std.Build) !void {
     module.addIncludePath(upstream.path(""));
     module.addIncludePath(.{ .path = "override" });
     if (target.result.isDarwin()) {
-        // See pkg/harfbuzz/build.zig
-        module.resolved_target = target;
-        defer module.resolved_target = null;
         const apple_sdk = @import("apple_sdk");
         try apple_sdk.addPaths(b, module);
     }

--- a/pkg/harfbuzz/build.zig
+++ b/pkg/harfbuzz/build.zig
@@ -18,6 +18,8 @@ pub fn build(b: *std.Build) !void {
 
     const module = b.addModule("harfbuzz", .{
         .root_source_file = .{ .path = "main.zig" },
+        .target = target,
+        .optimize = optimize,
         .imports = &.{
             .{ .name = "freetype", .module = freetype.module("freetype") },
             .{ .name = "macos", .module = macos.module("macos") },
@@ -35,13 +37,6 @@ pub fn build(b: *std.Build) !void {
     module.addIncludePath(upstream.path("src"));
 
     if (target.result.isDarwin()) {
-        // This is definitely super sketchy and not right but without this
-        // zig build test breaks on macOS. We have to look into what exactly
-        // is going on here but this getting comitted in the interest of
-        // unblocking zig build test.
-        module.resolved_target = target;
-        defer module.resolved_target = null;
-
         try apple_sdk.addPaths(b, &lib.root_module);
         try apple_sdk.addPaths(b, module);
     }


### PR DESCRIPTION
This was necessary to fix `zig build test` but since #1305 this is not necessary anymore.