### PR TITLE
renderer/opengl: set texture size for constrained glyphs

### DIFF
--- a/src/renderer/shaders/cell.v.glsl
+++ b/src/renderer/shaders/cell.v.glsl
@@ -208,6 +208,7 @@ void main() {
         // device coordinates (0 to 1.0) by dividing by the size of the texture.
         ivec2 text_size;
         switch(mode) {
+        case MODE_FG_CONSTRAINED:
         case MODE_FG:
             text_size = textureSize(text, 0);
             break;


### PR DESCRIPTION
This wasn't setting the texture size so the glyphs would show up blank (zero texture size).

## Before

![CleanShot 2024-01-15 at 15 05 40@2x](https://github.com/mitchellh/ghostty/assets/1299/92cc41b3-65a4-43b4-9d9e-a3aee68897c4)

## After

![CleanShot 2024-01-15 at 15 05 12@2x](https://github.com/mitchellh/ghostty/assets/1299/50491d20-f281-4444-a59b-30dc2fa32cd3)
