### PR TITLE
termio: handle termio thread failure by showing a message in window

### DIFF
--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -706,13 +706,20 @@ pub fn invokeCharset(
     }
 }
 
-/// Print UTF-8 encoded string to the terminal. This string must be
-/// a single line, newlines and carriage returns and other control
-/// characters are not processed.
+/// Print UTF-8 encoded string to the terminal.
 pub fn printString(self: *Terminal, str: []const u8) !void {
     const view = try std.unicode.Utf8View.init(str);
     var it = view.iterator();
-    while (it.nextCodepoint()) |cp| try self.print(cp);
+    while (it.nextCodepoint()) |cp| {
+        switch (cp) {
+            '\n' => {
+                self.carriageReturn();
+                try self.linefeed();
+            },
+
+            else => try self.print(cp),
+        }
+    }
 }
 
 pub fn print(self: *Terminal, c: u21) !void {


### PR DESCRIPTION
Fixes #1301

Previously, if the termio thread failed to start, we'd just render an empty terminal window. The logs _usually_ had information but this is generally not helpful. This PR catches the error and renders it in the terminal.

![CleanShot 2024-01-15 at 20 00 11@2x](https://github.com/mitchellh/ghostty/assets/1299/674c9d52-fcbc-4183-8fdc-ec03b220dc28)
