### PR TITLE
macOS: detect Metal renderer failures (i.e. GPU memory exhaustion) and show an error message

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,8 +13,8 @@
             .hash = "122071be402af6a317b66f007411678f8600559d5b2d5b00fc80d388a6ec27a43acc",
         },
         .zig_objc = .{
-            .url = "https://github.com/mitchellh/zig-objc/archive/294e0f3765a96613b45ff7dd594bf99e22409e96.tar.gz",
-            .hash = "1220ae28cc6af7600c6f23db1573b33ca3b8accd15e60a1fe1a2c979c20868f151fa",
+            .url = "https://github.com/mitchellh/zig-objc/archive/f6ed382b6db296626a9b56dadcf9d7e4fcba71d3.tar.gz",
+            .hash = "1220c94dbcdf5a799ce2b1571978ff3c97bab1341fe329084fcc3c06e5d6375469b9",
         },
         .zig_js = .{
             .url = "https://github.com/mitchellh/zig-js/archive/d4edb682733aef8dc3933683272bdf7c8b9fe658.tar.gz",

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -331,6 +331,11 @@ typedef enum {
     GHOSTTY_BUILD_MODE_RELEASE_SMALL,
 } ghostty_build_mode_e;
 
+typedef enum {
+    GHOSTTY_RENDERER_HEALTH_OK,
+    GHOSTTY_RENDERER_HEALTH_UNHEALTHY,
+} ghostty_renderer_health_e;
+
 // Fully defined types. This MUST be kept in sync with equivalent Zig
 // structs. To find the Zig struct, grep for this type name. The documentation
 // for all of these types is available in the Zig source.
@@ -376,6 +381,7 @@ typedef void (*ghostty_runtime_set_initial_window_size_cb)(void *, uint32_t, uin
 typedef void (*ghostty_runtime_render_inspector_cb)(void *);
 typedef void (*ghostty_runtime_set_cell_size_cb)(void *, uint32_t, uint32_t);
 typedef void (*ghostty_runtime_show_desktop_notification_cb)(void *, const char *, const char *);
+typedef void (*ghostty_runtime_update_renderer_health)(void *, ghostty_renderer_health_e);
 
 typedef struct {
     void *userdata;
@@ -404,6 +410,7 @@ typedef struct {
     ghostty_runtime_render_inspector_cb render_inspector_cb;
     ghostty_runtime_set_cell_size_cb set_cell_size_cb;
     ghostty_runtime_show_desktop_notification_cb show_desktop_notification_cb;
+    ghostty_runtime_update_renderer_health update_renderer_health_cb;
 } ghostty_runtime_config_s;
 
 //-------------------------------------------------------------------

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -92,8 +92,8 @@ extension Ghostty {
                 render_inspector_cb: { userdata in App.renderInspector(userdata) },
                 set_cell_size_cb: { userdata, width, height in App.setCellSize(userdata, width: width, height: height) },
                 show_desktop_notification_cb: { userdata, title, body in
-                    App.showUserNotification(userdata, title: title, body: body)
-                }
+                    App.showUserNotification(userdata, title: title, body: body) },
+                update_renderer_health_cb: { userdata, health in App.updateRendererHealth(userdata, health: health) }
             )
             
             // Create the ghostty app.
@@ -289,6 +289,7 @@ extension Ghostty {
         static func renderInspector(_ userdata: UnsafeMutableRawPointer?) {}
         static func setCellSize(_ userdata: UnsafeMutableRawPointer?, width: UInt32, height: UInt32) {}
         static func showUserNotification(_ userdata: UnsafeMutableRawPointer?, title: UnsafePointer<CChar>?, body: UnsafePointer<CChar>?) {}
+        static func updateRendererHealth(_ userdata: UnsafeMutableRawPointer?, health: ghostty_renderer_health_e) {}
         #endif
         
         #if os(macOS)
@@ -610,6 +611,17 @@ extension Ghostty {
             NotificationCenter.default.post(name: Notification.didControlInspector, object: surface, userInfo: [
                 "mode": mode,
             ])
+        }
+        
+        static func updateRendererHealth(_ userdata: UnsafeMutableRawPointer?, health: ghostty_renderer_health_e) {
+            let surface = self.surfaceUserdata(from: userdata)
+            NotificationCenter.default.post(
+                name: Notification.didUpdateRendererHealth, 
+                object: surface,
+                userInfo: [
+                    "health": health,
+                ]
+            )
         }
 
         /// Returns the GhosttyState from the given userdata value.

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -202,7 +202,13 @@ extension Ghostty {
             var rgb: UInt32 = 0
             let bg_key = "background"
             if (!ghostty_config_get(config, &rgb, bg_key, UInt(bg_key.count))) {
+                #if os(macOS)
                 return Color(NSColor.windowBackgroundColor)
+                #elseif os(iOS)
+                return Color(UIColor.systemBackground)
+                #else
+                #error("unsupported")
+                #endif
             }
             
             let red = Double(rgb & 0xff)

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -197,6 +197,24 @@ extension Ghostty {
             _ = ghostty_config_get(config, &v, key, UInt(key.count))
             return v
         }
+        
+        var backgroundColor: Color {
+            var rgb: UInt32 = 0
+            let bg_key = "background"
+            if (!ghostty_config_get(config, &rgb, bg_key, UInt(bg_key.count))) {
+                return Color(NSColor.windowBackgroundColor)
+            }
+            
+            let red = Double(rgb & 0xff)
+            let green = Double((rgb >> 8) & 0xff)
+            let blue = Double((rgb >> 16) & 0xff)
+
+            return Color(
+                red: red / 255,
+                green: green / 255,
+                blue: blue / 255
+            )
+        }
 
         var backgroundOpacity: Double {
             guard let config = self.config else { return 1 }

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -232,6 +232,9 @@ extension Ghostty.Notification {
 
     /// Notification sent to the split root to equalize split sizes
     static let didEqualizeSplits = Notification.Name("com.mitchellh.ghostty.didEqualizeSplits")
+    
+    /// Notification that renderer health changed
+    static let didUpdateRendererHealth = Notification.Name("com.mitchellh.ghostty.didUpdateRendererHealth")
 }
 
 // Make the input enum hashable.

--- a/nix/zigCacheHash.nix
+++ b/nix/zigCacheHash.nix
@@ -1,3 +1,3 @@
 # This file is auto-generated! check build-support/check-zig-cache-hash.sh for
 # more details.
-"sha256-to0V9rCefIs8KcWsx+nopgQO4i7O3gb06LGNc6NXN2M="
+"sha256-+wU1PXMpR/THc7fBfh2ND34fteQCIUWDjN9xZTx5+bs="

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -808,7 +808,16 @@ pub fn handleMessage(self: *Surface, msg: Message) !void {
             const body = std.mem.sliceTo(&notification.body, 0);
             try self.showDesktopNotification(title, body);
         },
+
+        .renderer_health => |health| self.updateRendererHealth(health),
     }
+}
+
+/// Called when our renderer health state changes.
+fn updateRendererHealth(self: *Surface, health: renderer.Health) void {
+    log.warn("renderer health status change status={}", .{health});
+    if (!@hasDecl(apprt.runtime.Surface, "updateRendererHealth")) return;
+    self.rt_surface.updateRendererHealth(health);
 }
 
 /// Update our configuration at runtime.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -11,6 +11,7 @@ const Allocator = std.mem.Allocator;
 const objc = @import("objc");
 const apprt = @import("../apprt.zig");
 const input = @import("../input.zig");
+const renderer = @import("../renderer.zig");
 const terminal = @import("../terminal/main.zig");
 const CoreApp = @import("../App.zig");
 const CoreInspector = @import("../inspector/main.zig").Inspector;
@@ -123,6 +124,9 @@ pub const App = struct {
 
         /// Show a desktop notification to the user.
         show_desktop_notification: ?*const fn (SurfaceUD, [*:0]const u8, [*:0]const u8) void = null,
+
+        /// Called when the health of the renderer changes.
+        update_renderer_health: ?*const fn (SurfaceUD, renderer.Health) void = null,
     };
 
     /// Special values for the goto_tab callback.
@@ -959,6 +963,16 @@ pub const Surface = struct {
         };
 
         func(self.opts.userdata, title, body);
+    }
+
+    /// Update the health of the renderer.
+    pub fn updateRendererHealth(self: *const Surface, health: renderer.Health) void {
+        const func = self.app.opts.update_renderer_health orelse {
+            log.info("runtime embedder does not support update_renderer_health", .{});
+            return;
+        };
+
+        func(self.opts.userdata, health);
     }
 };
 

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -54,6 +54,9 @@ pub const Message = union(enum) {
         /// Desktop notification body.
         body: [255:0]u8,
     },
+
+    /// Health status change for the renderer.
+    renderer_health: renderer.Health,
 };
 
 /// A surface mailbox.

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -52,6 +52,14 @@ pub const Renderer = switch (build_config.renderer) {
     .webgl => WebGL,
 };
 
+/// The health status of a renderer. These must be shared across all
+/// renderers even if some states aren't reachable so that our API users
+/// can use the same enum for all renderers.
+pub const Health = enum(u8) {
+    healthy = 0,
+    unhealthy = 1,
+};
+
 test {
     @import("std").testing.refAllDecls(@This());
 }

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -55,7 +55,7 @@ pub const Renderer = switch (build_config.renderer) {
 /// The health status of a renderer. These must be shared across all
 /// renderers even if some states aren't reachable so that our API users
 /// can use the same enum for all renderers.
-pub const Health = enum(u8) {
+pub const Health = enum(c_int) {
     healthy = 0,
     unhealthy = 1,
 };

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -896,7 +896,7 @@ fn bufferCompleted(
     const status = buffer.getProperty(mtl.MTLCommandBufferStatus, "status");
     const health: Health = switch (status) {
         .@"error" => .unhealthy,
-        else => .unhealthy,
+        else => .healthy,
     };
 
     // If our health value hasn't changed, then we do nothing. We don't

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -896,7 +896,7 @@ fn bufferCompleted(
     const status = buffer.getProperty(mtl.MTLCommandBufferStatus, "status");
     const health: Health = switch (status) {
         .@"error" => .unhealthy,
-        else => .healthy,
+        else => .unhealthy,
     };
 
     // If our health value hasn't changed, then we do nothing. We don't

--- a/src/renderer/metal/api.zig
+++ b/src/renderer/metal/api.zig
@@ -1,5 +1,16 @@
 //! This file contains the definitions of the Metal API that we use.
 
+/// https://developer.apple.com/documentation/metal/mtlcommandbufferstatus?language=objc
+pub const MTLCommandBufferStatus = enum(c_ulong) {
+    not_enqueued = 0,
+    enqueued = 1,
+    committed = 2,
+    scheduled = 3,
+    completed = 4,
+    @"error" = 5,
+    _,
+};
+
 /// https://developer.apple.com/documentation/metal/mtlloadaction?language=objc
 pub const MTLLoadAction = enum(c_ulong) {
     dont_care = 0,


### PR DESCRIPTION
Fixes #1301

This introduces a new concept of "renderer health" throughout the renderer and apprt system. Only Metal and the embedded runtime implement this end to end currently. This can be used to detect issues with the renderer and allow apprt to fall back to using some other system to draw. 

Note that the error state _is recoverable_. By freeing up some GPU memory (i.e. by closing some windows), existing error state terminals recover without having to be restarted.

This isn't a fully robust system. At a certain point, my memory is so exhausted that even Cocoa is failing to render basic SwiftUI views. I'll consider _that_ scenario an upstream issue. However, as can be seen in the "real world "screenshot at the bottom of this post, the error messages do show up for some time.

## Example

![CleanShot 2024-01-16 at 11 35 34@2x](https://github.com/mitchellh/ghostty/assets/1299/92191010-e5aa-4e1a-b130-11736ba1eb66)

## Real World

![CleanShot 2024-01-16 at 12 02 19@2x](https://github.com/mitchellh/ghostty/assets/1299/d1776e79-3056-4975-8f2a-0cd61d3adac9)
