### PR TITLE
Added macOS file open handler

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -350,6 +350,7 @@ typedef struct {
     double scale_factor;
     uint16_t font_size;
     const char *working_directory;
+    const char *command;
 } ghostty_surface_config_s;
 
 typedef void (*ghostty_runtime_wakeup_cb)(void *);

--- a/macos/Ghostty-Info.plist
+++ b/macos/Ghostty-Info.plist
@@ -4,6 +4,23 @@
 <dict>
 	<key>CFBundleDocumentTypes</key>
 	<array>
+    <dict>
+      <key>CFBundleTypeExtensions</key>
+      <array>
+        <string>command</string>
+        <string>tool</string>
+        <string>sh</string>
+        <string>zsh</string>
+        <string>csh</string>
+        <string>pl</string>
+      </array>
+      <key>CFBundleTypeIconFile</key>
+      <string>AppIcon.icns</string>
+      <key>CFBundleTypeName</key>
+      <string>Terminal scripts</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+    </dict>
 		<dict>
 			<key>CFBundleTypeName</key>
 			<string>Folders</string>

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -216,22 +216,23 @@ class AppDelegate: NSObject,
         // this way.
         var isDirectory = ObjCBool(true)
         guard FileManager.default.fileExists(atPath: filename, isDirectory: &isDirectory) else { return false }
-        guard isDirectory.boolValue else {
-            let alert = NSAlert()
-            alert.messageText = "Dropped File is Not a Directory"
-            alert.informativeText = "Ghostty can currently only open directory paths."
-            alert.addButton(withTitle: "OK")
-            alert.alertStyle = .warning
-            _ = alert.runModal()
-            return false
-        }
         
-        // Build our config
+        // Initialize the surface config which will be used to create the tab or window for the opened file.
         var config = Ghostty.SurfaceConfiguration()
-        config.workingDirectory = filename
-        
-        // Add a new tab or create a new window
-        terminalManager.newTab(withBaseConfig: config)
+
+        if (isDirectory.boolValue) {
+            // When opening a directory, create a new tab in the main window with that as the working directory.
+            // If no windows exist, a new one will be created.
+            config.workingDirectory = filename
+            terminalManager.newTab(withBaseConfig: config)
+        } else {
+            // When opening a file, open a new window with that file as the command,
+            // and its parent directory as the working directory.
+            config.command = filename
+            config.workingDirectory = (filename as NSString).deletingLastPathComponent
+            terminalManager.newWindow(withBaseConfig: config)
+        }
+
         return true
     }
     

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -206,12 +206,16 @@ extension Ghostty {
         
         /// Explicit working directory to set
         var workingDirectory: String? = nil
+
+        /// Explicit command to set
+        var command: String? = nil
         
         init() {}
         
         init(from config: ghostty_surface_config_s) {
             self.fontSize = config.font_size
             self.workingDirectory = String.init(cString: config.working_directory, encoding: .utf8)
+            self.command = String.init(cString: config.command, encoding: .utf8)
         }
         
         /// Returns the ghostty configuration for this surface configuration struct. The memory
@@ -225,6 +229,9 @@ extension Ghostty {
             if let fontSize = fontSize { config.font_size = fontSize }
             if let workingDirectory = workingDirectory {
                 config.working_directory = (workingDirectory as NSString).utf8String
+            }
+            if let command = command {
+                config.command = (command as NSString).utf8String
             }
             
             return config

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -253,6 +253,9 @@ pub const Surface = struct {
 
         /// The working directory to load into.
         working_directory: [*:0]const u8 = "",
+
+        /// The command to run in the new surface.
+        command: [*:0]const u8 = "",
     };
 
     /// This is the key event sent for ghostty_surface_key.
@@ -324,6 +327,13 @@ pub const Surface = struct {
             }
 
             config.@"working-directory" = wd;
+        }
+
+        // If we have a command from the options then we set it.
+        const cm = std.mem.sliceTo(opts.command, 0);
+        if (cm.len > 0) {
+            // TODO: Maybe add some validation to this, like the working directory has?
+            config.command = cm;
         }
 
         // Initialize our surface right away. We're given a view that is


### PR DESCRIPTION
Resolves #1039 ('macOS: register ".command" file handler to execute scripts')

- Added types `command`, `tool`, `sh`, `zsh`, `csh`, and `pl` to the `info.plist` to match iTerm2.
- Adjusted `openFile` handler in `AppDelegate.swift` to no longer reject non-directories, instead it now launches a window with the provided file as the `command`. In order to be able to do this I added a `command` entry to `ghostty_surface_config_s` in libghostty.

### Notes:
- Currently libghostty does not validate the provided command in any way, unlike with the working directory. Perhaps it should.
- Currently, surfaces created by opening files will get saved per `window-save-state` and when restored will become a shell in the directory of the file that was opened. This isn't ideal, but is somewhat of an edge case.
- Currently, after a command finishes execution, the surface is immediately removed -- it might be good to, in the future, add some sort of `wait-after-command` functionality that can add a simple key prompt to exit after command completion.
- This behavior is not identical (or even substantially similar) to how file opens are handled in other terminals, however I don't personally see this as an area where behavioural compatibility is much of an issue that needs worrying about.

### How other terminals handle file opens:
#### Terminal.app
- Launches your configured shell and feeds `/path/to/file; exit;` to it.
- After command completes, prints `[Process completed]` and requires you to close the window manually.
#### iTerm2
- Launches your configured shell and feeds `/path/to/file; exit;` to it. (Presumably to match Terminal.app's behavior.)
- After command completes, prints `Session Ended` and then, after a few seconds, repeats the process - which feels like a bug to me, I can't imagine why anyone would want this behavior.
#### Kitty
- Runs the provided file with whatever your default working directory is as the working directory.
- After the command completes, launches your configured shell. (<- very weird)

The major consistency between these 3 is that they all run the file in your default working directory (`~` for me) - which seems less useful/intuitive than using the parent directory of the file itself as the working directory, but that's my opinion.

### Demo:

https://github.com/mitchellh/ghostty/assets/7241851/e3a51b2c-3254-4d68-afd8-8e777c195743

