### PR TITLE
Add `wait-after-command` configuration to keep terminal window open after command exits

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -258,7 +258,9 @@ pub const Surface = struct {
         /// The working directory to load into.
         working_directory: [*:0]const u8 = "",
 
-        /// The command to run in the new surface.
+        /// The command to run in the new surface. If this is set then
+        /// the "wait-after-command" option is also automatically set to true,
+        /// since this is used for scripting.
         command: [*:0]const u8 = "",
     };
 
@@ -334,10 +336,10 @@ pub const Surface = struct {
         }
 
         // If we have a command from the options then we set it.
-        const cm = std.mem.sliceTo(opts.command, 0);
-        if (cm.len > 0) {
-            // TODO: Maybe add some validation to this, like the working directory has?
-            config.command = cm;
+        const cmd = std.mem.sliceTo(opts.command, 0);
+        if (cmd.len > 0) {
+            config.command = cmd;
+            config.@"wait-after-command" = true;
         }
 
         // Initialize our surface right away. We're given a view that is

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -400,6 +400,14 @@ palette: Palette = .{},
 /// flag. For example: `ghostty -e fish --with --custom --args`.
 command: ?[]const u8 = null,
 
+/// If true, keep the terminal open after the command exits. Normally,
+/// the terminal window closes when the running command (such as a shell)
+/// exits. With this true, the terminal window will stay open until any
+/// keypress is received.
+///
+/// This is primarily useful for scripts or debugging.
+@"wait-after-command": bool = false,
+
 /// The number of milliseconds of runtime below which we consider a process
 /// exit to be abnormal. This is used to show an error message when the
 /// process exits too quickly.


### PR DESCRIPTION
Fixes #1318

In addition to the subject, this also automatically sets this for the embedded runtime when a command is specified for a new surface.

cc @qwerasd205 

## Demo

This explicitly sets `wait-after-command = true`. Normally the shell wouldn't behave this way by default!

![CleanShot 2024-01-17 at 08 44 58@2x](https://github.com/mitchellh/ghostty/assets/1299/11c2562b-48e5-4c48-a710-556e780d17df)
