### PR TITLE
macos: allow first click when non-focused to shift focus

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -690,6 +690,14 @@ extension Ghostty {
             guard let surface = self.surface else { return }
             ghostty_surface_refresh(surface);
         }
+        
+        override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+            // "Override this method in a subclass to allow instances to respond to
+            // click-through. This allows the user to click on a view in an inactive
+            // window, activating the view with one click, instead of clicking first 
+            // to make the window active and then clicking the view."
+            return true
+        }
 
         override func mouseDown(with event: NSEvent) {
             guard let surface = self.surface else { return }


### PR DESCRIPTION
This allows for example clicking on a split when focused on a different app and having focus immediately jump to that split. Before this, you'd have to click to focus the window, then second click to focus on the split.