### PR TITLE
ECH and EL should reset softwrap state

### DIFF
--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1370,6 +1370,9 @@ pub fn eraseLine(
                 if (cell.attrs.wide_spacer_tail) x -= 1;
             }
 
+            // This resets the soft-wrap of this line
+            row.setWrapped(false);
+
             break :right .{ x, row.lenCells() };
         },
 
@@ -1387,6 +1390,8 @@ pub fn eraseLine(
             break :left .{ 0, x + 1 };
         },
 
+        // Note that it seems like complete should reset the soft-wrap
+        // state of the line but in xterm it does not.
         .complete => .{ 0, row.lenCells() },
 
         else => {
@@ -5193,7 +5198,7 @@ test "Terminal: eraseLine simple erase right" {
     }
 }
 
-test "Terminal: eraseLine resets wrap" {
+test "Terminal: eraseLine resets pending wrap" {
     const alloc = testing.allocator;
     var t = try init(alloc, 5, 5);
     defer t.deinit(alloc);
@@ -5208,6 +5213,33 @@ test "Terminal: eraseLine resets wrap" {
         const str = try t.plainString(testing.allocator);
         defer testing.allocator.free(str);
         try testing.expectEqualStrings("ABCDB", str);
+    }
+}
+
+test "Terminal: eraseLine resets wrap" {
+    const alloc = testing.allocator;
+    var t = try init(alloc, 5, 5);
+    defer t.deinit(alloc);
+
+    for ("ABCDE123") |c| try t.print(c);
+    {
+        const row = t.screen.getRow(.{ .active = 0 });
+        try testing.expect(row.isWrapped());
+    }
+
+    t.setCursorPos(1, 1);
+    t.eraseLine(.right, false);
+
+    {
+        const row = t.screen.getRow(.{ .active = 0 });
+        try testing.expect(!row.isWrapped());
+    }
+    try t.print('X');
+
+    {
+        const str = try t.plainString(testing.allocator);
+        defer testing.allocator.free(str);
+        try testing.expectEqualStrings("X\n123", str);
     }
 }
 

--- a/website/app/vt/ech/page.mdx
+++ b/website/app/vt/ech/page.mdx
@@ -12,7 +12,8 @@ or equal to 0, adjust `n` to be 1. If `n` is omitted, `n` defaults to 1.
 The rightmost column that can be erased is the rightmost column of the screen.
 The [right margin](#) has no effect on this sequence.
 
-This sequence always unsets the pending wrap state.
+This sequence always unsets the pending wrap state. If the row under the cursor
+is soft-wrapped, then the soft-wrap state is also reset.
 
 For `n` cells up to the rightmost column, blank the cell by replacing it
 with an empty character with the background color colored according to the

--- a/website/app/vt/el/page.mdx
+++ b/website/app/vt/el/page.mdx
@@ -27,7 +27,9 @@ first or second cell of the two-cell character, both cells should be erased.
 If `n` is `0`, perform an **erase line right** operation. Erase line right
 is equivalent to [Erase Character (ECH)](/vt/ech) with `n` set to the total
 remaining columns from the cursor to the end of the line (and including
-the cursor).
+the cursor). If the line is softwrapped, only the single row is erased;
+it does not erase through the wrap. Further, the wrap state of the row is
+reset such that the line is no longer considered wrapped.
 
 If `n` is `1`, perform an **erase line left** operation. This replaces
 the `n` cells left of and including the cursor with a blank character and


### PR DESCRIPTION
Related to #1329 

Verified with xterm, these operations (in certain scenarios) should reset whether the line they're affecting is soft-wrapped, even if the contents of the screen do not change.