### PR TITLE
macos: select split above/below should go to correct split when nested

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.SplitNode.swift
+++ b/macos/Sources/Ghostty/Ghostty.SplitNode.swift
@@ -54,10 +54,10 @@ extension Ghostty {
             
             let node: SplitNode
             switch (direction) {
-            case .previous, .bottom, .left:
+            case .previous, .top, .left:
                 node = container.bottomRight
                 
-            case .next, .top, .right:
+            case .next, .bottom, .right:
                 node = container.topLeft
             }
             


### PR DESCRIPTION
Fixes #1330

I admit this code is a mess to understand, so I'm not 100% certain this fix is correct. It definitely fixes #1330 but I'm not sure if this breaks other split scenarios.

I believe that our logic here was simply wrong, notice that left/right had opposite logic and this brings it all into consistency.

Long term, we should redo all of our directional movement since we've refactored how split state is stored now on the controller with parent references.