### PR TITLE
renderer/metal,opengl: premult alpha for fragment shaders for images

### DIFF
--- a/src/renderer/shaders/cell.metal
+++ b/src/renderer/shaders/cell.metal
@@ -328,7 +328,12 @@ fragment float4 image_fragment(
   // BGRA8Unorm. So we need to convert it. We should really be converting
   // our texture to BGRA8Unorm.
   uint4 rgba = image.sample(textureSampler, in.tex_coord);
-  return float4(rgba) / 255.0f;
+
+  // Convert to float4 and premultiply the alpha. We should also probably
+  // premultiply the alpha in the texture.
+  float4 result = float4(rgba) / 255.0f;
+  result.rgb *= result.a;
+  return result;
 }
 
 //-------------------------------------------------------------------

--- a/src/renderer/shaders/image.f.glsl
+++ b/src/renderer/shaders/image.f.glsl
@@ -7,5 +7,6 @@ layout(location = 0) out vec4 out_FragColor;
 uniform sampler2D image;
 
 void main() {
-    out_FragColor = texture(image, tex_coord);
+    vec4 color = texture(image, tex_coord);
+    out_FragColor = vec4(color.rgb * color.a, color.a);
 }


### PR DESCRIPTION
Fixes #1346

## Before

![298399840-6a2442f7-6dd6-4aae-8813-c0c1f495a0aa-2](https://github.com/mitchellh/ghostty/assets/1299/2b928128-4df3-480a-9ac8-3c218924889c)

## After

![CleanShot 2024-01-21 at 14 08 32@2x](https://github.com/mitchellh/ghostty/assets/1299/40647ef4-b103-4df5-a6cf-9a36a1d14440)
