### PR TITLE
add increase_font_size keybind with plus

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1029,6 +1029,12 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
         .{ .key = .equal, .mods = inputpkg.ctrlOrSuper(.{}) },
         .{ .increase_font_size = 1 },
     );
+    // Increase font size mapping for keyboards with dedicated plus keys (like german)
+    try result.keybind.set.put(
+        alloc,
+        .{ .key = .plus, .mods = inputpkg.ctrlOrSuper(.{}) },
+        .{ .increase_font_size = 1 },
+    );
     try result.keybind.set.put(
         alloc,
         .{ .key = .minus, .mods = inputpkg.ctrlOrSuper(.{}) },


### PR DESCRIPTION
This adds a default keybind `ctrl+plus` mapping to `increase_font_size:1` for keyboards with a plus key, such as ones using a german layout.

This has been discussed in #451
