### PR TITLE
kitty graphics: assign automatic placement ID if p==0

### DIFF
--- a/src/terminal/kitty/graphics_exec.zig
+++ b/src/terminal/kitty/graphics_exec.zig
@@ -170,6 +170,16 @@ fn display(
         .placement_id = d.placement_id,
     };
 
+    // If the placement has no ID, we assign one. This is not in the spec
+    // but Kitty appears to support the behavior where specifying multiple
+    // placements with ID 0 creates new placements rather than replacing
+    // the existing placement.
+    if (result.placement_id == 0) {
+        const storage = &terminal.screen.kitty_images;
+        result.placement_id = storage.next_id;
+        storage.next_id +%= 1;
+    }
+
     // Verify the requested image exists if we have an ID
     const storage = &terminal.screen.kitty_images;
     const img_: ?Image = if (d.image_id != 0)
@@ -203,7 +213,12 @@ fn display(
         .rows = d.rows,
         .z = d.z,
     };
-    storage.addPlacement(alloc, img.id, d.placement_id, p) catch |err| {
+    storage.addPlacement(
+        alloc,
+        img.id,
+        result.placement_id,
+        p,
+    ) catch |err| {
         encodeError(&result, err);
         return result;
     };


### PR DESCRIPTION
Fixes #1356

As stated in the code, the specification itself doesn't explicitly specify this behavior (as far as I can tell), but testing in Kitty results in this working and I believe this is how they do it.