### PR TITLE
Shared Atlas Texture on Metal

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -2162,6 +2162,7 @@ fn initAtlasTexture(device: objc.Object, atlas: *const font.Atlas) !objc.Object 
     desc.setProperty("pixelFormat", @intFromEnum(pixel_format));
     desc.setProperty("width", @as(c_ulong, @intCast(atlas.size)));
     desc.setProperty("height", @as(c_ulong, @intCast(atlas.size)));
+    desc.setProperty("storageMode", @as(c_ulong, mtl.MTLResourceStorageModeShared));
 
     // Initialize
     const id = device.msgSend(


### PR DESCRIPTION
While checking out #1354, I noticed a warning in the gputrace I captured indicating that the font atlas texture is using managed mode when it should probably be in shared mode.

This eliminates the warning.

[Trace before:](https://github.com/mitchellh/ghostty/files/14017792/ghostty.gputrace.zip):

<img width="1751" alt="Screenshot 2024-01-22 at 7 54 27 PM" src="https://github.com/mitchellh/ghostty/assets/8205547/e1ac0aa6-c971-464f-859e-4819136ffdc5">

[Trace after](https://github.com/mitchellh/ghostty/files/14017794/ghostty2.gputrace.zip):

<img width="1488" alt="Screenshot 2024-01-22 at 10 00 35 PM" src="https://github.com/mitchellh/ghostty/assets/8205547/b7378ded-fc14-483d-bf8e-f99b32ff7850">