### PR TITLE
Expand paths after loading theme

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1662,10 +1662,13 @@ fn loadTheme(self: *Config, theme: []const u8) !void {
     var iter = cli.args.lineIterator(buf_reader.reader());
     try new_config.loadIter(alloc_gpa, &iter);
 
+    const config_path = try internal_os.xdg.config(alloc, .{ .subdir = "ghostty/config" });
+
     // Replay our previous inputs so that we can override values
     // from the theme.
     var slice_it = cli.args.sliceIterator(self._inputs.items[0..input_len]);
     try new_config.loadIter(alloc_gpa, &slice_it);
+    try new_config.expandPaths(std.fs.path.dirname(config_path).?);
 
     // Success, swap our new config in and free the old.
     self.deinit();


### PR DESCRIPTION
If you're using a theme, a `custom-shader` configuration will not work unless you reference an absolute path.

[`loadDefaultFiles`](https://github.com/mitchellh/ghostty/blob/8182b69ae3f1c2352c6204410e424c991a16ad7e/src/config/Config.zig#L1452-L1478) calls [`expandPaths`](https://github.com/mitchellh/ghostty/blob/8182b69ae3f1c2352c6204410e424c991a16ad7e/src/config/Config.zig#L1586-L1599). When the configuration is reloaded in [`loadTheme`](https://github.com/mitchellh/ghostty/blob/8182b69ae3f1c2352c6204410e424c991a16ad7e/src/config/Config.zig#L1601-L1673), there is no such call which causes the following error:

    ghostty: [com.mitchellh.ghostty:metal] error loading custom shaders err=error.FileNotFound