### PR TITLE
empty cli or config args reset the value to the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ foreground= ffffff
 keybind = ctrl+z=close_surface
 keybind = ctrl+d=new_split:right
 
+# Empty values reset the configuration to the default value
+
+font-family =
+
 # Colors can be changed by setting the 16 colors of `palette`, which each color
 # being defined as regular and bold.
 #


### PR DESCRIPTION
Fixes #1367

We previously special-cased optionals but we should do better and have this reset ANY type to the defined default value on the struct.