### PR TITLE
terminal: preserve multi-point grapheme clusters on scrollback deletion

### DIFF
--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -2174,7 +2174,7 @@ fn scrollDelta(self: *Screen, delta: isize, viewport_only: bool) Allocator.Error
         if (self.graphemes.count() > 0) {
             var y: usize = 0;
             while (y < rows_to_delete) : (y += 1) {
-                const row = self.getRow(.{ .active = y });
+                const row = self.getRow(.{ .screen = y });
                 if (row.storage[0].header.flags.grapheme) row.clear(.{});
             }
         }
@@ -4306,6 +4306,7 @@ test "Screen: history region with scrollback" {
         try testing.expectEqualStrings(expected, contents);
     }
 }
+
 test "Screen: row copy" {
     const testing = std.testing;
     const alloc = testing.allocator;


### PR DESCRIPTION
This codepath was not previously tested (an accident). Upon testing this codepath its clear to see the logic was incorrect. When we have to remove rows from our scrollback to fit new rows in the circular buffer, we have to delete graphemes, but we were deleting them from the wrong row offset.

For the row offset, we previously used the _active_ screen but the proper offset is the _full_ screen. Tests verify.