### PR TITLE
renderer: consider powerline box glyphs whitespace for PUA scaling

### DIFF
--- a/src/renderer/cell.zig
+++ b/src/renderer/cell.zig
@@ -58,8 +58,14 @@ pub fn fgMode(
 
             // If we have a previous cell and it was PUA then we need to
             // also constrain. This is so that multiple PUA glyphs align.
-            if (x > 0) {
+            // As an exception, we ignore powerline glyphs since they are
+            // used for box drawing and we consider them whitespace.
+            if (x > 0) prev: {
                 const prev_cell = screen.getCell(.active, y, x - 1);
+
+                // Powerline is whitespace
+                if (isPowerline(prev_cell.char)) break :prev;
+
                 if (ziglyph.general_category.isPrivateUse(@intCast(prev_cell.char))) {
                     break :text .constrained;
                 }
@@ -68,7 +74,10 @@ pub fn fgMode(
             // If the next cell is empty, then we allow it to use the
             // full glyph size.
             const next_cell = screen.getCell(.active, y, x + 1);
-            if (next_cell.char == 0 or next_cell.char == ' ') {
+            if (next_cell.char == 0 or
+                next_cell.char == ' ' or
+                isPowerline(next_cell.char))
+            {
                 break :text .normal;
             }
 


### PR DESCRIPTION
This adds to the heuristics introduced for #1071. Please read that issue and associated PRs in their entirety to understand this commit.

This extends our concept of "whitespace" to include powerline box glyphs. We don't want to constrain nerd symbols next to powerline box glyphs because box glyphs are often used to style and contain nerd glyphs. For example, its common to see a right-facing semi-circle, then a nerd font glyph, then a left-facing semi-circle to create a pill-shaped label.

This allows those nerd font symbols to be rendered full size. Test script below (copy the bytes):

    printf "󰃰\n"
    printf "󰃰 \n"
    printf "󰃰\n"

## Before

![CleanShot 2024-01-25 at 15 40 36@2x](https://github.com/mitchellh/ghostty/assets/1299/96561263-1137-4e10-a625-800045ea08eb)


## After

![CleanShot 2024-01-25 at 15 40 08@2x](https://github.com/mitchellh/ghostty/assets/1299/d879b23e-b053-4895-ae15-c3108f39e672)
