### PR TITLE
nix: update nixpkgs-zig-0-12

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
     },
     "nixpkgs-zig-0-12": {
       "locked": {
-        "lastModified": 1704769352,
-        "narHash": "sha256-qgRtwLlB1QePcFVrzGWVcL51NoYjVTsMlhG9JZTJVyU=",
+        "lastModified": 1706247802,
+        "narHash": "sha256-wcEYxplhiIQNRAjgDhuinZTfMqTXCyVqXpbLRRSofRo=",
         "owner": "vancluever",
         "repo": "nixpkgs",
-        "rev": "2e0fee0ad691025495254bf35a4fbe87dd8f2b92",
+        "rev": "73426540157eea901755d4ac2b6f9b9d83540f54",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This updates the nixpkgs-zig-0-12 to be in line with the current overlay Zig (0.12.0-dev.2334+aef1da163).