### PR TITLE
apple-sdk: use zig's libstd getSdk to get active Apple SDK

### DIFF
--- a/pkg/apple-sdk/build.zig
+++ b/pkg/apple-sdk/build.zig
@@ -11,18 +11,36 @@ pub fn build(b: *std.Build) !void {
 /// The module target is used to determine the SDK to use so it must have
 /// a resolved target.
 pub fn addPaths(b: *std.Build, m: *std.Build.Module) !void {
-    // Get the path to our active SDK installation. If this fails then
-    // the zig build will fail. We store this in a struct variable so its
-    // static and only calculated once per build.
-    const Path = struct {
-        var value: ?[]const u8 = null;
+    // The cache. This always uses b.allocator and never frees memory
+    // (which is idiomatic for a Zig build exe).
+    const Cache = struct {
+        const Key = struct {
+            arch: std.Target.Cpu.Arch,
+            os: std.Target.Os.Tag,
+            abi: std.Target.Abi,
+        };
+
+        var map: std.AutoHashMapUnmanaged(Key, ?[]const u8) = .{};
     };
-    const path = Path.value orelse path: {
-        const path = std.zig.system.darwin.getSdk(b.allocator, m.resolved_target.?.result) orelse "";
-        Path.value = path;
-        break :path path;
-    };
+
+    const target = m.resolved_target.?.result;
+    const gop = try Cache.map.getOrPut(b.allocator, .{
+        .arch = target.cpu.arch,
+        .os = target.os.tag,
+        .abi = target.abi,
+    });
+
+    // This executes `xcrun` to get the SDK path. We don't want to execute
+    // this multiple times so we cache the value.
+    if (!gop.found_existing) {
+        gop.value_ptr.* = std.zig.system.darwin.getSdk(
+            b.allocator,
+            m.resolved_target.?.result,
+        );
+    }
+
     // The active SDK we want to use
+    const path = gop.value_ptr.* orelse return error.AppleSDKNotFound;
     m.addSystemFrameworkPath(.{ .cwd_relative = b.pathJoin(&.{ path, "/System/Library/Frameworks" }) });
     m.addSystemIncludePath(.{ .cwd_relative = b.pathJoin(&.{ path, "/usr/include" }) });
     m.addLibraryPath(.{ .cwd_relative = b.pathJoin(&.{ path, "/usr/lib" }) });

--- a/pkg/apple-sdk/build.zig
+++ b/pkg/apple-sdk/build.zig
@@ -11,46 +11,19 @@ pub fn build(b: *std.Build) !void {
 /// The module target is used to determine the SDK to use so it must have
 /// a resolved target.
 pub fn addPaths(b: *std.Build, m: *std.Build.Module) !void {
-    // The active SDK we want to use
-    const sdk = try SDK.fromTarget(m.resolved_target.?.result);
-
-    // Get the path to our active Xcode installation. If this fails then
+    // Get the path to our active SDK installation. If this fails then
     // the zig build will fail. We store this in a struct variable so its
     // static and only calculated once per build.
     const Path = struct {
         var value: ?[]const u8 = null;
     };
     const path = Path.value orelse path: {
-        const path = std.mem.trim(u8, b.run(&.{ "xcode-select", "--print-path" }), " \r\n");
+        const path = std.zig.system.darwin.getSdk(b.allocator, m.resolved_target.?.result) orelse "";
         Path.value = path;
         break :path path;
     };
-
-    // Base path
-    const base = b.fmt("{s}/Platforms/{s}.platform/Developer/SDKs/{s}{s}.sdk", .{
-        path,
-        sdk.platform,
-        sdk.platform,
-        sdk.version,
-    });
-
-    m.addSystemFrameworkPath(.{ .cwd_relative = b.pathJoin(&.{ base, "/System/Library/Frameworks" }) });
-    m.addSystemIncludePath(.{ .cwd_relative = b.pathJoin(&.{ base, "/usr/include" }) });
-    m.addLibraryPath(.{ .cwd_relative = b.pathJoin(&.{ base, "/usr/lib" }) });
+    // The active SDK we want to use
+    m.addSystemFrameworkPath(.{ .cwd_relative = b.pathJoin(&.{ path, "/System/Library/Frameworks" }) });
+    m.addSystemIncludePath(.{ .cwd_relative = b.pathJoin(&.{ path, "/usr/include" }) });
+    m.addLibraryPath(.{ .cwd_relative = b.pathJoin(&.{ path, "/usr/lib" }) });
 }
-
-const SDK = struct {
-    platform: []const u8,
-    version: []const u8,
-
-    pub fn fromTarget(target: std.Target) !SDK {
-        return switch (target.os.tag) {
-            .ios => .{ .platform = "iPhoneOS", .version = "" },
-            .macos => .{ .platform = "MacOSX", .version = "14" },
-            else => {
-                std.log.err("unsupported os={}", .{target.os.tag});
-                return error.UnsupportedOS;
-            },
-        };
-    }
-};


### PR DESCRIPTION
I might be misunderstanding the intent behind `apple-sdk` package, but hard-coding a requirement of SDK 14 is wrong if run on a x86_64 macOS 13 host with latest Xcode installed - the SDK is actually installed and reported as 13.1. Additionally, is there any reason why `std.zig.system.darwin.getSdk` cannot be used? I took the liberty of drafting a PR that switches to Zig's exposed helper in libstd. If the fix is incorrect, feel free to close the PR! 