### PR TITLE
Open links with Super+click

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2008,7 +2008,7 @@ pub fn mouseButtonCallback(
     // Handle link clicking. We want to do this before we do mouse
     // reporting or any other mouse handling because a successfully
     // clicked link will swallow the event.
-    if (button == .left and action == .release and mods.super and self.mouse.over_link) {
+    if (button == .left and action == .release and mods.ctrlOrSuper() and self.mouse.over_link) {
         const pos = try self.rt_surface.getCursorPos();
         if (self.processLinks(pos)) |processed| {
             if (processed) return;
@@ -2237,6 +2237,9 @@ fn linkAtPos(
 } {
     // If we have no configured links we can save a lot of work
     if (self.config.links.len == 0) return null;
+
+    // Require super to be held down, so bail early
+    if (!self.mouse.mods.ctrlOrSuper()) return null;
 
     // Convert our cursor position to a screen point.
     const mouse_pt = mouse_pt: {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2008,7 +2008,7 @@ pub fn mouseButtonCallback(
     // Handle link clicking. We want to do this before we do mouse
     // reporting or any other mouse handling because a successfully
     // clicked link will swallow the event.
-    if (button == .left and action == .release and self.mouse.over_link) {
+    if (button == .left and action == .release and mods.super and self.mouse.over_link) {
         const pos = try self.rt_surface.getCursorPos();
         if (self.processLinks(pos)) |processed| {
             if (processed) return;

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2289,7 +2289,7 @@ fn linkAtPos(
     for (self.config.links) |link| {
         switch (link.highlight) {
             .always, .hover => {},
-            .mods => |v| if (!v.equal(self.mouse.mods)) continue,
+            .always_mods, .hover_mods => |v| if (!v.equal(self.mouse.mods)) continue,
         }
 
         var it = strmap.searchIterator(link.regex);

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1437,7 +1437,7 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
     try result.link.links.append(alloc, .{
         .regex = url.regex,
         .action = .{ .open = {} },
-        .highlight = .{ .hover = {} },
+        .highlight = .{ .mods = inputpkg.ctrlOrSuper(.{}) },
     });
 
     return result;

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -432,8 +432,8 @@ command: ?[]const u8 = null,
 /// TODO: This can't currently be set!
 link: RepeatableLink = .{},
 
-/// Enable URL matching. URLs are matched on hover and open using the default
-/// system application for the linked URL.
+/// Enable URL matching. URLs are matched on `super` + hover and open using the
+/// default system application for the linked URL.
 ///
 /// The URL matcher is always lowest priority of any configured links (see
 /// `link`). If you want to customize URL matching, use `link` and disable this.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1437,7 +1437,7 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
     try result.link.links.append(alloc, .{
         .regex = url.regex,
         .action = .{ .open = {} },
-        .highlight = .{ .mods = inputpkg.ctrlOrSuper(.{}) },
+        .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
     });
 
     return result;

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -432,8 +432,9 @@ command: ?[]const u8 = null,
 /// TODO: This can't currently be set!
 link: RepeatableLink = .{},
 
-/// Enable URL matching. URLs are matched on `super` + hover and open using the
-/// default system application for the linked URL.
+/// Enable URL matching. URLs are matched on hover with control (Linux) or
+/// super (macOS) pressed and open using the default system application for
+/// the linked URL.
 ///
 /// The URL matcher is always lowest priority of any configured links (see
 /// `link`). If you want to customize URL matching, use `link` and disable this.

--- a/src/input/Link.zig
+++ b/src/input/Link.zig
@@ -5,6 +5,7 @@
 const Link = @This();
 
 const oni = @import("oniguruma");
+const Mods = @import("key.zig").Mods;
 
 /// The regular expression that will be used to match the link. Ownership
 /// of this memory is up to the caller. The link will never free this memory.
@@ -30,6 +31,10 @@ pub const Highlight = union(enum) {
 
     /// Only highlight the link when the mouse is hovering over it.
     hover: void,
+
+    /// Highlight anytime the given mods are pressed, regardless of
+    /// hover state.
+    mods: Mods,
 };
 
 /// Returns a new oni.Regex that can be used to match the link.

--- a/src/input/Link.zig
+++ b/src/input/Link.zig
@@ -32,9 +32,12 @@ pub const Highlight = union(enum) {
     /// Only highlight the link when the mouse is hovering over it.
     hover: void,
 
-    /// Highlight anytime the given mods are pressed, regardless of
-    /// hover state.
-    mods: Mods,
+    /// Highlight anytime the given mods are pressed, either when
+    /// hovering or always. For always, all links will be highlighted
+    /// when the mods are pressed regardless of if the mouse is hovering
+    /// over them.
+    always_mods: Mods,
+    hover_mods: Mods,
 };
 
 /// Returns a new oni.Regex that can be used to match the link.

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1555,6 +1555,7 @@ fn rebuildCells(
         arena_alloc,
         screen,
         mouse.point orelse .{},
+        mouse.mods,
     );
 
     // Determine our x/y range for preedit. We don't want to render anything

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -991,6 +991,7 @@ pub fn rebuildCells(
         arena_alloc,
         screen,
         mouse.point orelse .{},
+        mouse.mods,
     );
 
     // Determine our x/y range for preedit. We don't want to render anything

--- a/src/renderer/State.zig
+++ b/src/renderer/State.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const Inspector = @import("../inspector/main.zig").Inspector;
 const terminal = @import("../terminal/main.zig");
+const inputpkg = @import("../input.zig");
 const renderer = @import("../renderer.zig");
 
 /// The mutex that must be held while reading any of the data in the
@@ -34,6 +35,11 @@ pub const Mouse = struct {
     /// viewport points to avoid the complexity of mapping the mouse to
     /// the renderer state.
     point: ?terminal.point.Viewport = null,
+
+    /// The mods that are currently active for the last mouse event.
+    /// This could really just be mods in general and we probably will
+    /// move it out of mouse state at some point.
+    mods: inputpkg.Mods = .{},
 };
 
 /// The pre-edit state. See Surface.preeditCallback for more information.

--- a/src/renderer/link.zig
+++ b/src/renderer/link.zig
@@ -286,7 +286,7 @@ test "matchset mods no match" {
         .{
             .regex = "EF",
             .action = .{ .open = {} },
-            .highlight = .{ .mods = .{ .ctrl = true } },
+            .highlight = .{ .always_mods = .{ .ctrl = true } },
         },
     });
     defer set.deinit(alloc);

--- a/src/renderer/link.zig
+++ b/src/renderer/link.zig
@@ -96,8 +96,13 @@ pub const Set = struct {
                 // error if any other conditions are added.
                 switch (link.highlight) {
                     .always => {},
-                    .hover => if (!line.selection().contains(mouse_pt)) continue,
-                    .mods => |v| if (!mouse_mods.equal(v)) continue,
+                    .always_mods => |v| if (!mouse_mods.equal(v)) continue,
+                    inline .hover, .hover_mods => |v, tag| {
+                        if (!line.selection().contains(mouse_pt)) continue;
+                        if (comptime tag == .hover_mods) {
+                            if (!mouse_mods.equal(v)) continue;
+                        }
+                    },
                 }
 
                 var it = strmap.searchIterator(link.regex);

--- a/src/renderer/link.zig
+++ b/src/renderer/link.zig
@@ -65,6 +65,7 @@ pub const Set = struct {
         alloc: Allocator,
         screen: *Screen,
         mouse_vp_pt: point.Viewport,
+        mouse_mods: inputpkg.Mods,
     ) !MatchSet {
         // Convert the viewport point to a screen point.
         const mouse_pt = mouse_vp_pt.toScreen(screen);
@@ -90,10 +91,13 @@ pub const Set = struct {
 
             // Go through each link and see if we have any matches.
             for (self.links) |link| {
-                // If this is a hover link and our mouse point isn't within
-                // this line at all, we can skip it.
-                if (link.highlight == .hover) {
-                    if (!line.selection().contains(mouse_pt)) continue;
+                // Determine if our highlight conditions are met. We use a
+                // switch here instead of an if so that we can get a compile
+                // error if any other conditions are added.
+                switch (link.highlight) {
+                    .always => {},
+                    .hover => if (!line.selection().contains(mouse_pt)) continue,
+                    .mods => |v| if (!mouse_mods.equal(v)) continue,
                 }
 
                 var it = strmap.searchIterator(link.regex);
@@ -186,7 +190,7 @@ test "matchset" {
     defer set.deinit(alloc);
 
     // Get our matches
-    var match = try set.matchSet(alloc, &s, .{});
+    var match = try set.matchSet(alloc, &s, .{}, .{});
     defer match.deinit(alloc);
     try testing.expectEqual(@as(usize, 2), match.matches.len);
 
@@ -227,7 +231,7 @@ test "matchset hover links" {
 
     // Not hovering over the first link
     {
-        var match = try set.matchSet(alloc, &s, .{});
+        var match = try set.matchSet(alloc, &s, .{}, .{});
         defer match.deinit(alloc);
         try testing.expectEqual(@as(usize, 1), match.matches.len);
 
@@ -242,7 +246,7 @@ test "matchset hover links" {
 
     // Hovering over the first link
     {
-        var match = try set.matchSet(alloc, &s, .{ .x = 1, .y = 0 });
+        var match = try set.matchSet(alloc, &s, .{ .x = 1, .y = 0 }, .{});
         defer match.deinit(alloc);
         try testing.expectEqual(@as(usize, 2), match.matches.len);
 
@@ -254,4 +258,44 @@ test "matchset hover links" {
         try testing.expect(match.orderedContains(.{ .x = 1, .y = 1 }));
         try testing.expect(!match.orderedContains(.{ .x = 1, .y = 2 }));
     }
+}
+
+test "matchset mods no match" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // Initialize our screen
+    var s = try Screen.init(alloc, 5, 5, 0);
+    defer s.deinit();
+    const str = "1ABCD2EFGH\n3IJKL";
+    try s.testWriteString(str);
+
+    // Get a set
+    var set = try Set.fromConfig(alloc, &.{
+        .{
+            .regex = "AB",
+            .action = .{ .open = {} },
+            .highlight = .{ .always = {} },
+        },
+
+        .{
+            .regex = "EF",
+            .action = .{ .open = {} },
+            .highlight = .{ .mods = .{ .ctrl = true } },
+        },
+    });
+    defer set.deinit(alloc);
+
+    // Get our matches
+    var match = try set.matchSet(alloc, &s, .{}, .{});
+    defer match.deinit(alloc);
+    try testing.expectEqual(@as(usize, 1), match.matches.len);
+
+    // Test our matches
+    try testing.expect(!match.orderedContains(.{ .x = 0, .y = 0 }));
+    try testing.expect(match.orderedContains(.{ .x = 1, .y = 0 }));
+    try testing.expect(match.orderedContains(.{ .x = 2, .y = 0 }));
+    try testing.expect(!match.orderedContains(.{ .x = 3, .y = 0 }));
+    try testing.expect(!match.orderedContains(.{ .x = 1, .y = 1 }));
+    try testing.expect(!match.orderedContains(.{ .x = 1, .y = 2 }));
 }


### PR DESCRIPTION
A few people, including myself, many times accidentally click links by either clicking around aimlessly or getting focus back to Ghostty that happens to be hovering over a link.

In iTerm2, if you want links enabled, it's always Cmd+Click.