### PR TITLE
config/url: exclude trailing single quotes

### DIFF
--- a/src/config/url.zig
+++ b/src/config/url.zig
@@ -26,7 +26,7 @@ const oni = @import("oniguruma");
 /// handling them well requires a non-regex approach.
 pub const regex = "(?:" ++ url_scheme ++ ")(?:[^" ++ url_exclude ++ "]*[^" ++ url_exclude ++ ").]|[^" ++ url_exclude ++ "(]*\\([^" ++ url_exclude ++ ")]*\\))";
 const url_scheme = "ipfs:|ipns:|magnet:|mailto:|gemini://|gopher://|https://|http://|news:|file:|git://|ssh:|ftp://";
-const url_exclude = "\u{0000}-\u{001F}\u{007F}-\u{009F}<>\x22\\s{-}\\^⟨⟩\x60";
+const url_exclude = "\u{0000}-\u{001F}\u{007F}-\u{009F}<>\x22\x27\\s{-}\\^⟨⟩\x60";
 
 test "url regex" {
     const testing = std.testing;
@@ -65,6 +65,14 @@ test "url regex" {
         },
         .{
             .input = "Link period https://example.com. More text.",
+            .expect = "https://example.com",
+        },
+        .{
+            .input = "Link in double quotes \"https://example.com\" and more",
+            .expect = "https://example.com",
+        },
+        .{
+            .input = "Link in single quotes 'https://example.com' and more",
             .expect = "https://example.com",
         },
     };


### PR DESCRIPTION
I noticed that single quotes at the end of a URL would also get matched, this adds the `'` to the set of characters excluded in the URL regex. I cannot say that I've fully grasped the expression, but I noticed that the `"` was already excluded, which seemed appropriate to add.

<img width="514" alt="image" src="https://github.com/mitchellh/ghostty/assets/7118751/45d11eae-b52c-493d-a8eb-804e1bf24e47">
<img width="496" alt="image" src="https://github.com/mitchellh/ghostty/assets/7118751/8a79c3c6-7b4d-414d-b083-560ff44ce833">
