### PR TITLE
Add super+shift+<left, right, up, down> select expansion

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1293,10 +1293,10 @@ pub fn keyCallback(
         const sel = sel: {
             const old_sel = screen.selection orelse break :adjust_selection;
             break :sel old_sel.adjust(&screen, switch (event.key) {
-                .left => .left,
-                .right => .right,
-                .up => .up,
-                .down => .down,
+                .left => if (event.mods.super) .super_left else .left,
+                .right => if (event.mods.super) .super_right else .right,
+                .up => if (event.mods.super) .super_up else .up,
+                .down => if (event.mods.super) .super_down else .down,
                 .page_up => .page_up,
                 .page_down => .page_down,
                 .home => .home,

--- a/src/terminal/Selection.zig
+++ b/src/terminal/Selection.zig
@@ -342,16 +342,16 @@ pub fn adjust(self: Selection, screen: *Screen, adjustment: Adjustment) Selectio
                 break switch (adj) {
                     .left => result.end = next,
                     .super_left => {
+                        // Select only non-whitespace characters.
                         if (std.mem.indexOfAny(u32, whitespace, &[_]u32{cell.char}) != null) continue;
 
                         const next_word = screen.selectWord(next);
                         if (next_word) |nw| {
                             switch (result.order()) {
                                 // If the current selection is in the forward order and we move left,
-                                // the word is "deselected". We need to, therefore, consume the iterator
+                                // the word is "deselected". We need to move the iterator forward
                                 // equal to the length of the deselected word.
                                 // Then set the end of the next word to the end of the selection.
-                                // Otherwise, we can just set the end of the selection to the start of the word.
                                 .forward => {
                                     const word_start = (nw.start.x + nw.start.y) + (screen.cols * nw.start.y);
                                     const word_end = (nw.end.x + nw.end.y) + (screen.cols * nw.end.y);
@@ -397,10 +397,9 @@ pub fn adjust(self: Selection, screen: *Screen, adjustment: Adjustment) Selectio
                         if (next_word) |nw| {
                             switch (result.order()) {
                                 // If the current selection is in the reverse order and we move right,
-                                // the word is "deselected". We need to, therefore, consume the iterator
+                                // the word is "deselected". We need to move the iterator forward
                                 // equal to the length of the deselected word.
                                 // Then set the start of the next word to the end of the selection.
-                                // Otherwise, we can just set the end of the selection to the end of the word.
                                 .reverse => {
                                     const word_start = (nw.start.x + nw.start.y) + (screen.cols * nw.start.y);
                                     const word_end = (nw.end.x + nw.end.y) + (screen.cols * nw.end.y);


### PR DESCRIPTION
## Change Log
- Add Shift+Super+<left, right> to expand selection by word
- Add Shift+Super+<up, down> to expand selection by paragraph

## Demo
[ghostty-super-shift-select-2024-01-27_23.05.17.webm](https://github.com/mitchellh/ghostty/assets/6732096/d8dfce76-5502-4ade-9c8b-cee379f43543)


## Notes
- Although `selectWord` considers both whitespace and non-whitespace words, selection expansion by word ignores whitespace words. This is because I am working with the assumption that a user would likely want to select the next non-whitespace word when using this feature.

Issue: https://github.com/mitchellh/ghostty/issues/1210#issuecomment-1890497607