### PR TITLE
Default to background colour for cursor-text

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1738,7 +1738,7 @@ fn rebuildCells(
                 cell.color = if (self.config.cursor_text) |txt|
                     .{ txt.r, txt.g, txt.b, 255 }
                 else
-                    .{ 0, 0, 0, 255 };
+                    .{ self.background_color.r, self.background_color.g, self.background_color.b, 255 };
             }
 
             self.cells.appendAssumeCapacity(cell.*);

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -1168,9 +1168,9 @@ pub fn rebuildCells(
                     cell.b = txt.b;
                     cell.a = 255;
                 } else {
-                    cell.r = 0;
-                    cell.g = 0;
-                    cell.b = 0;
+                    cell.r = self.background_color.r;
+                    cell.g = self.background_color.g;
+                    cell.b = self.background_color.b;
                     cell.a = 255;
                 }
             }


### PR DESCRIPTION
I switch themes dynamically between dark & light using OSC 4/10/11/12 but, I don't think, there is an OSC for the cursor text colour.

The current default for cursor-text is black, and that doesn't work if the cursor block is a dark colour, so this PR changes the default to be the background colour which will usually contrast well with the cursor block colour.

I did look into making a 'proper' inverse cursor option but it was a larger change, and I'm not sure how to integrate that with cursor shapes other than block, as I guess inverse cursor only really makes sense for block shape.

This simpler change works well for me, so maybe it is a better default?

I've tested on macOS with Metal. I tried the GLFW build to test the OpenGL change but that build doesn't appear to support OSC 4/10/etc?