### PR TITLE
terminal: handle SCOSC/SCORC

### DIFF
--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -2044,6 +2044,14 @@ const StreamHandler = struct {
         self.terminal.setTopAndBottomMargin(top, bot);
     }
 
+    pub fn setLeftAndRightMarginAmbiguous(self: *StreamHandler) !void {
+        if (self.terminal.modes.get(.enable_left_and_right_margin)) {
+            try self.setLeftAndRightMargin(0, 0);
+        } else {
+            try self.saveCursor();
+        }
+    }
+
     pub fn setLeftAndRightMargin(self: *StreamHandler, left: u16, right: u16) !void {
         self.terminal.setLeftAndRightMargin(left, right);
     }


### PR DESCRIPTION
Fixes #1401

SCOSC is ambiguous with regards to DECSLRM. This commit copies the logic of xterm: if left/right mode is enabled, then CSI S is always DECSLRM. But if left/right mode is disabled then CSI S empty always uses SCOSC.

SCORC always works.