### PR TITLE
renderer: constrain emoji to cell width

### DIFF
--- a/src/renderer/shaders/cell.metal
+++ b/src/renderer/shaders/cell.metal
@@ -162,7 +162,9 @@ vertex VertexOut uber_vertex(
     glyph_offset.y = cell_size_scaled.y - glyph_offset.y;
 
     // If we're constrained then we need to scale the glyph.
-    if (input.mode == MODE_FG_CONSTRAINED) {
+    // We also always constrain colored glyphs since we should have
+    // their scaled cell size exactly correct.
+    if (input.mode == MODE_FG_CONSTRAINED || input.mode == MODE_FG_COLOR) {
       if (glyph_size.x > cell_size_scaled.x) {
         float new_y = glyph_size.y * (cell_size_scaled.x / glyph_size.x);
         glyph_offset.y += (glyph_size.y - new_y) / 2;

--- a/src/renderer/shaders/cell.v.glsl
+++ b/src/renderer/shaders/cell.v.glsl
@@ -190,8 +190,10 @@ void main() {
         glyph_offset_calc.y = cell_size_scaled.y - glyph_offset_calc.y;
 
         // If this is a constrained mode, we need to constrain it!
+        // We also always constrain colored glyphs since we should have
+        // their scaled cell size exactly correct.
         vec2 glyph_size_calc = glyph_size;
-        if (mode == MODE_FG_CONSTRAINED) {
+        if (mode == MODE_FG_CONSTRAINED || mode == MODE_FG_COLOR) {
             if (glyph_size.x > cell_size_scaled.x) {
                 float new_y = glyph_size.y * (cell_size_scaled.x / glyph_size.x);
                 glyph_offset_calc.y = glyph_offset_calc.y + ((glyph_size.y - new_y) / 2);


### PR DESCRIPTION
Fixes #1402

We previously assumed that the rasterizer would properly render an emoji within a given cell width metric. But it appears with Noto and Freetype specifically, this is not the case. Let's just simplify this by applying our constraint logic we already have to color glyphs (emoji) as well.

@rockorager Can you please test this?

## Before

![CleanShot 2024-01-28 at 09 09 00@2x](https://github.com/mitchellh/ghostty/assets/1299/99d1cbd5-6a9a-4da4-8323-4f28f367ec76)


## After

![CleanShot 2024-01-28 at 09 08 38@2x](https://github.com/mitchellh/ghostty/assets/1299/c5cc7972-789d-4a13-a848-c7c85f972aaa)
