### PR TITLE
Tint split view divider based on theme background

### DIFF
--- a/macos/Ghostty.xcodeproj/project.pbxproj
+++ b/macos/Ghostty.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		A5E112952AF73E8A00C6E0C2 /* ClipboardConfirmationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E112942AF73E8A00C6E0C2 /* ClipboardConfirmationController.swift */; };
 		A5E112972AF7401B00C6E0C2 /* ClipboardConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E112962AF7401B00C6E0C2 /* ClipboardConfirmationView.swift */; };
 		A5FEB3002ABB69450068369E /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FEB2FF2ABB69450068369E /* main.swift */; };
+		C159E81D2B66A06B00FDFE9C /* NSColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C159E81C2B66A06B00FDFE9C /* NSColor+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -123,6 +124,7 @@
 		A5E112942AF73E8A00C6E0C2 /* ClipboardConfirmationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardConfirmationController.swift; sourceTree = "<group>"; };
 		A5E112962AF7401B00C6E0C2 /* ClipboardConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardConfirmationView.swift; sourceTree = "<group>"; };
 		A5FEB2FF2ABB69450068369E /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		C159E81C2B66A06B00FDFE9C /* NSColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSColor+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -187,6 +189,7 @@
 				8503D7C62A549C66006CFF3D /* FullScreenHandler.swift */,
 				A59630962AEE163600D64628 /* HostingWindow.swift */,
 				A59FB5D02AE0DEA7009128F3 /* MetalView.swift */,
+				C159E81C2B66A06B00FDFE9C /* NSColor+Extension.swift */,
 				A5CEAFDA29B8005900646FDA /* SplitView */,
 			);
 			path = Helpers;
@@ -489,6 +492,7 @@
 				A5E112952AF73E8A00C6E0C2 /* ClipboardConfirmationController.swift in Sources */,
 				8503D7C72A549C66006CFF3D /* FullScreenHandler.swift in Sources */,
 				A596309E2AEE1D6C00D64628 /* TerminalView.swift in Sources */,
+				C159E81D2B66A06B00FDFE9C /* NSColor+Extension.swift in Sources */,
 				A5CEAFDE29B8058B00646FDA /* SplitView.Divider.swift in Sources */,
 				A5E112972AF7401B00C6E0C2 /* ClipboardConfirmationView.swift in Sources */,
 				A514C8D82B54DC6800493A16 /* Ghostty.App.swift in Sources */,

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -30,7 +30,7 @@ extension Ghostty {
         /// The global app configuration. This defines the app level configuration plus any behavior
         /// for new windows, tabs, etc. Note that when creating a new window, it may inherit some
         /// configuration (i.e. font size) from the previously focused window. This would override this.
-        private(set) var config: Config
+        @Published private(set) var config: Config
         
         /// The ghostty app instance. We only have one of these for the entire app, although I guess
         /// in theory you can have multiple... I don't know why you would...

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -258,5 +258,14 @@ extension Ghostty {
                 blue: blue / 255
             )
         }
+        
+        // This isn't actually a configurable value currently but it could be done day.
+        // We put it here because it is a color that changes depending on the configuration.
+        var splitDividerColor: Color {
+            let backgroundColor = NSColor(backgroundColor)
+            let isLightBackground = backgroundColor.isLightColor
+            let newColor = isLightBackground ? backgroundColor.shadow(withLevel: 0.1) : backgroundColor.shadow(withLevel: 0.4)
+            return Color(nsColor: newColor ?? .gray.withAlphaComponent(0.5))
+        }
     }
 }

--- a/macos/Sources/Ghostty/Ghostty.TerminalSplit.swift
+++ b/macos/Sources/Ghostty/Ghostty.TerminalSplit.swift
@@ -280,6 +280,8 @@ extension Ghostty {
     
     /// This represents a split view that is in the horizontal or vertical split state.
     private struct TerminalSplitContainer: View {
+        @EnvironmentObject var ghostty: Ghostty.App
+
         let neighbors: SplitNode.Neighbors
         @Binding var node: SplitNode?
         @StateObject var container: SplitNode.Container
@@ -288,6 +290,7 @@ extension Ghostty {
             SplitView(
                 container.direction,
                 $container.split,
+                dividerColor: ghostty.config.splitDividerColor,
                 resizeIncrements: .init(width: 1, height: 1),
                 resizePublisher: container.resizeEvent,
                 left: {

--- a/macos/Sources/Ghostty/InspectorView.swift
+++ b/macos/Sources/Ghostty/InspectorView.swift
@@ -6,6 +6,8 @@ import GhosttyKit
 extension Ghostty {
     /// InspectableSurface is a type of Surface view that allows an inspector to be attached.
     struct InspectableSurface: View {
+        @EnvironmentObject var ghostty: Ghostty.App
+
         /// Same as SurfaceWrapper, see the doc comments there.
         @ObservedObject var surfaceView: SurfaceView
         var isSplit: Bool = false
@@ -24,7 +26,7 @@ extension Ghostty {
                 if (!surfaceView.inspectorVisible) {
                     SurfaceWrapper(surfaceView: surfaceView, isSplit: isSplit)
                 } else {
-                    SplitView(.vertical, $split, left: {
+                    SplitView(.vertical, $split, dividerColor: ghostty.config.splitDividerColor, left: {
                         SurfaceWrapper(surfaceView: surfaceView, isSplit: isSplit)
                     }, right: {
                         InspectorViewRepresentable(surfaceView: surfaceView)

--- a/macos/Sources/Helpers/NSColor+Extension.swift
+++ b/macos/Sources/Helpers/NSColor+Extension.swift
@@ -1,10 +1,3 @@
-//
-//  NSColor+Extension.swift
-//  Ghostty
-//
-//  Created by Pete Schaffner on 28/01/2024.
-//
-
 import AppKit
 
 extension NSColor {

--- a/macos/Sources/Helpers/NSColor+Extension.swift
+++ b/macos/Sources/Helpers/NSColor+Extension.swift
@@ -1,0 +1,21 @@
+//
+//  NSColor+Extension.swift
+//  Ghostty
+//
+//  Created by Pete Schaffner on 28/01/2024.
+//
+
+import AppKit
+
+extension NSColor {
+    var isLightColor: Bool {
+        var r: CGFloat = 0
+        var g: CGFloat = 0
+        var b: CGFloat = 0
+        var a: CGFloat = 0
+
+        self.getRed(&r, green: &g, blue: &b, alpha: &a)
+        let luminance = (0.299 * r) + (0.587 * g) + (0.114 * b)
+        return luminance > 0.5
+    }
+}

--- a/macos/Sources/Helpers/SplitView/SplitView.Divider.swift
+++ b/macos/Sources/Helpers/SplitView/SplitView.Divider.swift
@@ -3,11 +3,10 @@ import SwiftUI
 extension SplitView {
     /// The split divider that is rendered and can be used to resize a split view.
     struct Divider: View {
-        @EnvironmentObject var ghostty: Ghostty.App
-
         let direction: SplitViewDirection
         let visibleSize: CGFloat
         let invisibleSize: CGFloat
+        let color: Color
         
         private var visibleWidth: CGFloat? {
             switch (direction) {
@@ -43,14 +42,6 @@ extension SplitView {
             case .vertical:
                 return visibleSize + invisibleSize
             }
-        }
-
-        private var color: Color {
-            let backgroundColor = NSColor(ghostty.config.backgroundColor)
-            let isLightBackground = backgroundColor.isLightColor
-            let newColor = isLightBackground ? backgroundColor.shadow(withLevel: 0.1) : backgroundColor.shadow(withLevel: 0.4)
-
-            return Color(nsColor: newColor ?? .gray.withAlphaComponent(0.5))
         }
 
         var body: some View {

--- a/macos/Sources/Helpers/SplitView/SplitView.Divider.swift
+++ b/macos/Sources/Helpers/SplitView/SplitView.Divider.swift
@@ -3,6 +3,8 @@ import SwiftUI
 extension SplitView {
     /// The split divider that is rendered and can be used to resize a split view.
     struct Divider: View {
+        @EnvironmentObject var ghostty: Ghostty.App
+
         let direction: SplitViewDirection
         let visibleSize: CGFloat
         let invisibleSize: CGFloat
@@ -42,13 +44,21 @@ extension SplitView {
                 return visibleSize + invisibleSize
             }
         }
-        
+
+        private var color: Color {
+            let backgroundColor = NSColor(ghostty.config.backgroundColor)
+            let isLightBackground = backgroundColor.isLightColor
+            let newColor = isLightBackground ? backgroundColor.shadow(withLevel: 0.1) : backgroundColor.shadow(withLevel: 0.4)
+
+            return Color(nsColor: newColor ?? .gray.withAlphaComponent(0.5))
+        }
+
         var body: some View {
             ZStack {
                 Color.clear
                     .frame(width: invisibleWidth, height: invisibleHeight)
                 Rectangle()
-                    .fill(Color.gray)
+                    .fill(color)
                     .frame(width: visibleWidth, height: visibleHeight)
             }
             .onHover { isHovered in

--- a/macos/Sources/Helpers/SplitView/SplitView.swift
+++ b/macos/Sources/Helpers/SplitView/SplitView.swift
@@ -10,6 +10,9 @@ struct SplitView<L: View, R: View>: View {
     /// Direction of the split
     let direction: SplitViewDirection
     
+    /// Divider color
+    let dividerColor: Color
+    
     /// If set, the split view supports programmatic resizing via events sent via the publisher.
     /// Minimum increment (in points) that this split can be resized by, in
     /// each direction. Both `height` and `width` should be whole numbers
@@ -45,7 +48,10 @@ struct SplitView<L: View, R: View>: View {
                 right
                     .frame(width: rightRect.size.width, height: rightRect.size.height)
                     .offset(x: rightRect.origin.x, y: rightRect.origin.y)
-                Divider(direction: direction, visibleSize: splitterVisibleSize, invisibleSize: splitterInvisibleSize)
+                Divider(direction: direction, 
+                        visibleSize: splitterVisibleSize,
+                        invisibleSize: splitterInvisibleSize,
+                        color: dividerColor)
                     .position(splitterPoint)
                     .gesture(dragGesture(geo.size, splitterPoint: splitterPoint))
             }
@@ -57,10 +63,15 @@ struct SplitView<L: View, R: View>: View {
     
     /// Initialize a split view. This view isn't programmatically resizable; it can only be resized
     /// by manually dragging the divider.
-    init(_ direction: SplitViewDirection, _ split: Binding<CGFloat>, @ViewBuilder left: (() -> L), @ViewBuilder right: (() -> R)) {
+    init(_ direction: SplitViewDirection, 
+         _ split: Binding<CGFloat>, 
+         dividerColor: Color,
+         @ViewBuilder left: (() -> L),
+         @ViewBuilder right: (() -> R)) {
         self.init(
             direction,
             split,
+            dividerColor: dividerColor,
             resizeIncrements: .init(width: 1, height: 1),
             resizePublisher: .init(),
             left: left,
@@ -72,6 +83,7 @@ struct SplitView<L: View, R: View>: View {
     init(
         _ direction: SplitViewDirection,
         _ split: Binding<CGFloat>,
+        dividerColor: Color,
         resizeIncrements: NSSize,
         resizePublisher: PassthroughSubject<Double, Never>,
         @ViewBuilder left: (() -> L),
@@ -79,6 +91,7 @@ struct SplitView<L: View, R: View>: View {
     ) {
         self.direction = direction
         self._split = split
+        self.dividerColor = dividerColor
         self.resizeIncrements = resizeIncrements
         self.resizePublisher = resizePublisher
         self.left = left()


### PR DESCRIPTION
This creates a more subtle divider that better melds with the background:

<img width="1357" alt="CleanShot 2024-01-29 at 22 33 45@2x" src="https://github.com/mitchellh/ghostty/assets/411395/f4cc3e7c-ac10-4283-901e-4b496058b6b9">

<img width="1357" alt="CleanShot 2024-01-29 at 22 34 32@2x" src="https://github.com/mitchellh/ghostty/assets/411395/69d20fcd-5503-436b-b0e7-86bb5c212617">

<img width="1357" alt="CleanShot 2024-01-29 at 22 35 34@2x" src="https://github.com/mitchellh/ghostty/assets/411395/42e93e3c-30e3-4b6b-852b-9a535e244ab7">

<img width="1357" alt="CleanShot 2024-01-29 at 22 36 18@2x" src="https://github.com/mitchellh/ghostty/assets/411395/110c962d-d625-4f70-a406-a1591adcc330">

<img width="1357" alt="CleanShot 2024-01-29 at 22 36 43@2x" src="https://github.com/mitchellh/ghostty/assets/411395/58dc17be-b6a4-4b4a-b931-59cf24ecd43a">
