### PR TITLE
Add "Open with..." capability to GTK runtime.

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,29 @@ on the search path for a lot of software (such as Gnome and KDE) and
 installing into a prefix with `-p` sets up a directory structure to ensure
 all features of Ghostty work.
 
+### Linux D-Bus Debugging Tips
+
+The GTK runtime uses D-Bus behind the scenes for sending signals and other features. Debug and release
+builds use different names and paths on the D-Bus bus so that they can run simultaneously.
+
+| Type of Build | NAME                        | PATH                         |
+| ------------- | --------------------------- | ---------------------------- |
+| Release       | com.mitchellh.ghostty       | /com/mitchellh/ghostty       |
+| Debug         | com.mitchellh.ghostty-debug | /com/mitchellh/ghostty_debug |
+|               |                             |                              |
+
+- Introspect
+
+      gdbus introspect --session --dest ${NAME} --object-path ${PATH}
+
+- Monitor
+
+      gdbus monitor --session --dest ${NAME}
+
+- Send Ghostty an `open` signal.
+
+      gdbus call --session --dest ${NAME} --object-path ${PATH} --method org.gtk.Application.Open "['file:///home/user/ghostty/README.md']" "" "[]"
+
 ### Mac `.app`
 
 To build the official, fully featured macOS application, you must

--- a/build.zig
+++ b/build.zig
@@ -439,6 +439,7 @@ pub fn build(b: *std.Build) !void {
             b.installFile("dist/linux/app-flatpak.desktop", "share/applications/com.mitchellh.ghostty.desktop");
         } else {
             b.installFile("dist/linux/app.desktop", "share/applications/com.mitchellh.ghostty.desktop");
+            b.installFile("dist/linux/app.service", "share/dbus-1/services/com.mitchellh.ghostty.service");
         }
 
         // Various icons that our application can use, including the icon

--- a/dist/linux/app.desktop
+++ b/dist/linux/app.desktop
@@ -11,11 +11,11 @@ Keywords=terminal;tty;pty;
 StartupNotify=true
 StartupWMClass=com.mitchellh.ghostty
 Terminal=false
-Actions=new-window;
+Actions=new_window;
 X-GNOME-UsesNotifications=true
 DBusActivatable=true
 MimeType=text/*;application/x-sh;application/x-shellscript;
 
-[Desktop Action new-window]
+[Desktop Action new_window]
 Name=New Window
 Exec=ghostty

--- a/dist/linux/app.desktop
+++ b/dist/linux/app.desktop
@@ -1,15 +1,20 @@
 [Desktop Entry]
+Version=1.0
 Name=Ghostty
 Type=Application
 Comment=A terminal emulator
-Exec=ghostty
+TryExec=ghostty
+Exec=ghostty %F
 Icon=com.mitchellh.ghostty
 Categories=System;TerminalEmulator;
 Keywords=terminal;tty;pty;
 StartupNotify=true
+StartupWMClass=com.mitchellh.ghostty
 Terminal=false
 Actions=new-window;
 X-GNOME-UsesNotifications=true
+DBusActivatable=true
+MimeType=text/*;application/x-sh;application/x-shellscript;
 
 [Desktop Action new-window]
 Name=New Window

--- a/dist/linux/app.service
+++ b/dist/linux/app.service
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=com.mitchellh.ghostty
+Exec=ghostty

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -141,6 +141,10 @@ in
         else "$out/share/terminfo"
       }
 
+      sed -ie "s@^Exec=.*ghostty@Exec=$out/bin/ghostty@" $out/share/applications/*.desktop
+      sed -ie "s@^TryExec=.*ghostty@TryExec=$out/bin/ghostty@" $out/share/applications/*.desktop
+      sed -ie "s@^Exec=.*ghostty@Exec=$out/bin/ghostty@" $out/share/dbus-1/services/*.service
+
       mkdir -p "$out/nix-support"
 
       mkdir -p "$terminfo/share"

--- a/src/App.zig
+++ b/src/App.zig
@@ -245,7 +245,12 @@ pub fn newWindow(self: *App, rt_app: *apprt.App, msg: Message.NewWindow) !void {
             null;
     } else null;
 
-    try rt_app.newWindow(parent);
+    try rt_app.newWindow(.{ .parent = parent, .config = msg.config });
+
+    if (msg.config) |config| {
+        config.deinit();
+        self.alloc.destroy(config);
+    }
 }
 
 /// Start quitting
@@ -311,8 +316,11 @@ pub const Message = union(enum) {
     redraw_inspector: *apprt.Surface,
 
     const NewWindow = struct {
-        /// The parent surface
+        /// The parent surface.
         parent: ?*Surface = null,
+        /// Configuration to use for the new window. Will be deinitialized and
+        /// deallocated once the new window has been intialized.
+        config: ?*Config = null,
     };
 };
 

--- a/src/App.zig
+++ b/src/App.zig
@@ -266,7 +266,10 @@ pub fn openFiles(self: *App, rt_app: *apprt.App, msg: Message.OpenFiles) !void {
     // clone the config so that we can add our custom command
     const config = try self.alloc.create(Config);
     defer self.alloc.destroy(config);
-    config.* = try apprt.surface.newConfig(self, &rt_app.config);
+    if (@typeInfo(@TypeOf(rt_app.config)) == .Pointer)
+        config.* = try apprt.surface.newConfig(self, rt_app.config)
+    else
+        config.* = try apprt.surface.newConfig(self, &rt_app.config);
     defer config.deinit();
 
     // use the arena in the cloned config to make sure that everything is

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -219,13 +219,15 @@ pub const App = struct {
         surface.queueInspectorRender();
     }
 
-    pub fn newWindow(self: *App, parent: ?*CoreSurface) !void {
+    pub fn newWindow(self: *App, opts: struct { parent: ?*CoreSurface = null, config: ?*Config = null }) !void {
         _ = self;
+
+        if (opts.config != null) log.warn("embdded library does not support creating a new window with a custom config", .{});
 
         // Right now we only support creating a new window with a parent
         // through this code.
         // The other case is handled by the embedding runtime.
-        if (parent) |surface| {
+        if (opts.parent) |surface| {
             try surface.rt_surface.newWindow();
         }
     }

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -196,8 +196,9 @@ pub const App = struct {
     }
 
     /// Create a new window for the app.
-    pub fn newWindow(self: *App, parent_: ?*CoreSurface) !void {
-        _ = try self.newSurface(parent_);
+    pub fn newWindow(self: *App, opts: struct { parent: ?*CoreSurface = null, config: ?*Config = null }) !void {
+        if (opts.config != null) log.warn("glfw runtime does not support custom per-surface configs", .{});
+        _ = try self.newSurface(opts.parent);
     }
 
     /// Create a new tab in the parent surface.

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -365,7 +365,10 @@ pub fn redrawInspector(self: *App, surface: *Surface) void {
 }
 
 /// Called by CoreApp to create a new window with a new surface.
-pub fn newWindow(self: *App, parent_: ?*CoreSurface) !void {
+pub fn newWindow(self: *App, opts: struct {
+    parent: ?*CoreSurface = null,
+    config: ?*configpkg.Config = null,
+}) !void {
     const alloc = self.core_app.alloc;
 
     // Allocate a fixed pointer for our window. We try to minimize
@@ -378,7 +381,7 @@ pub fn newWindow(self: *App, parent_: ?*CoreSurface) !void {
     var window = try Window.create(alloc, self);
 
     // Add our initial tab
-    try window.newTab(parent_);
+    try window.newTab(.{ .parent = opts.parent, .config = opts.config });
 }
 
 fn quit(self: *App) void {

--- a/src/apprt/gtk/Tab.zig
+++ b/src/apprt/gtk/Tab.zig
@@ -9,6 +9,7 @@ const assert = std.debug.assert;
 const font = @import("../../font/main.zig");
 const input = @import("../../input.zig");
 const CoreSurface = @import("../../Surface.zig");
+const Config = @import("../../config/Config.zig");
 
 const Surface = @import("Surface.zig");
 const Window = @import("Window.zig");
@@ -37,16 +38,21 @@ elem: Surface.Container.Elem,
 // can easily re-focus that terminal.
 focus_child: *Surface,
 
-pub fn create(alloc: Allocator, window: *Window, parent_: ?*CoreSurface) !*Tab {
+const Options = struct {
+    parent: ?*CoreSurface = null,
+    config: ?*Config = null,
+};
+
+pub fn create(alloc: Allocator, window: *Window, opts: Options) !*Tab {
     var tab = try alloc.create(Tab);
     errdefer alloc.destroy(tab);
-    try tab.init(window, parent_);
+    try tab.init(window, opts);
     return tab;
 }
 
 /// Initialize the tab, create a surface, and add it to the window. "self"
 /// needs to be a stable pointer, since it is used for GTK events.
-pub fn init(self: *Tab, window: *Window, parent_: ?*CoreSurface) !void {
+pub fn init(self: *Tab, window: *Window, opts: Options) !void {
     self.* = .{
         .window = window,
         .label_text = undefined,
@@ -97,7 +103,8 @@ pub fn init(self: *Tab, window: *Window, parent_: ?*CoreSurface) !void {
 
     // Create the initial surface since all tabs start as a single non-split
     var surface = try Surface.create(window.app.core_app.alloc, window.app, .{
-        .parent = parent_,
+        .parent = opts.parent,
+        .config = opts.config,
     });
     errdefer surface.unref();
     surface.container = .{ .tab_ = self };

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -188,9 +188,22 @@ pub fn deinit(self: *Window) void {
 }
 
 /// Add a new tab to this window.
-pub fn newTab(self: *Window, parent: ?*CoreSurface) !void {
+pub fn newTab(
+    self: *Window,
+    opts: struct {
+        parent: ?*CoreSurface = null,
+        config: ?*configpkg.Config = null,
+    },
+) !void {
     const alloc = self.app.core_app.alloc;
-    _ = try Tab.create(alloc, self, parent);
+    _ = try Tab.create(
+        alloc,
+        self,
+        .{
+            .parent = opts.parent,
+            .config = opts.config,
+        },
+    );
 
     // TODO: When this is triggered through a GTK action, the new surface
     // redraws correctly. When it's triggered through keyboard shortcuts, it

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -989,8 +989,6 @@ _replay_steps: std.ArrayListUnmanaged(Replay.Step) = .{},
 pub fn deinit(self: *Config) void {
     if (self._arena) |arena| arena.deinit();
     self.* = undefined;
-    // set _arena to null so we don't deinit it again
-    self._arena = null;
 }
 
 /// Load the configuration according to the default rules:

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -969,6 +969,8 @@ _replay_steps: std.ArrayListUnmanaged(Replay.Step) = .{},
 pub fn deinit(self: *Config) void {
     if (self._arena) |arena| arena.deinit();
     self.* = undefined;
+    // set _arena to null so we don't deinit it again
+    self._arena = null;
 }
 
 /// Load the configuration according to the default rules:

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -410,6 +410,25 @@ palette: Palette = .{},
 /// fish --with --custom --args`.
 command: ?[]const u8 = null,
 
+/// A command to use to open/edit text files in a terminal window (using
+/// something like Helix, Vim, NeoVim, Emacs, or Nano). If this is not set,
+/// Ghostty will check the `EDITOR` environment variable for the command. If
+/// the `EDITOR` environment variable is not set, Ghostty will fall back to `vi`
+/// (similar to how many Linux/Unix systems operate).
+///
+/// This command will be used to open/edit files when Ghostty receives a signal
+/// from the operating system to open a file. Currently implemented on the GTK
+/// runtime only.
+///
+/// The command may contain additional arguments besides the path to the
+/// editor's binary. The files that are to be opened will be added to the end of
+/// the command. For example, if `editor` was set to `emacs -nx` and you tried
+/// to open `README` and `hello.c` in your home directory, the final command
+/// would look like
+///
+///     emacs -nx /home/user/README /home/user/hello.c
+editor: ?[]const u8 = null,
+
 /// If true, keep the terminal open after the command exits. Normally, the
 /// terminal window closes when the running command (such as a shell) exits.
 /// With this true, the terminal window will stay open until any keypress is
@@ -903,19 +922,20 @@ keybind: Keybinds = .{},
 /// This does not work with GLFW builds.
 @"macos-option-as-alt": OptionAsAlt = .false,
 
-/// If true, the Ghostty GTK application will run in single-instance mode:
-/// each new `ghostty` process launched will result in a new window if there
-/// is already a running process.
+/// If `true`, the Ghostty GTK application will run in single-instance mode:
+/// each new `ghostty` process launched will result in a new window if there is
+/// already a running process.
 ///
-/// If false, each new ghostty process will launch a separate application.
+/// If `false`, each new ghostty process will launch a separate application.
 ///
-/// The default value is `desktop` which will default to `true` if Ghostty
-/// detects it was launched from the `.desktop` file such as an app launcher.
-/// If Ghostty is launched from the command line, it will default to `false`.
+/// The default value is `detect` which will default to `true` if Ghostty
+/// detects that it was launched from the `.desktop` file such as an app
+/// launcher (like Gnome Shell)  or by D-Bus activation. If Ghostty is launched
+/// from the command line, it will default to `false`.
 ///
 /// Note that debug builds of Ghostty have a separate single-instance ID
 /// so you can test single instance without conflicting with release builds.
-@"gtk-single-instance": GtkSingleInstance = .desktop,
+@"gtk-single-instance": GtkSingleInstance = .detect,
 
 /// If `true` (default), then the Ghostty GTK tabs will be "wide." Wide tabs
 /// are the new typical Gnome style where tabs fill their available space.
@@ -3335,7 +3355,7 @@ pub const WindowColorspace = enum {
 
 /// See gtk-single-instance
 pub const GtkSingleInstance = enum {
-    desktop,
+    detect,
     false,
     true,
 };

--- a/src/main.zig
+++ b/src/main.zig
@@ -98,7 +98,6 @@ pub fn main() !MainReturn {
 
     // Create our runtime app
     var app_runtime = try apprt.App.init(app, .{});
-    defer if (@typeInfo(@TypeOf(app_runtime)) == .Pointer) alloc.destroy(app_runtime);
     defer app_runtime.terminate();
 
     // Run the GUI event loop

--- a/src/main.zig
+++ b/src/main.zig
@@ -98,6 +98,7 @@ pub fn main() !MainReturn {
 
     // Create our runtime app
     var app_runtime = try apprt.App.init(app, .{});
+    defer if (@typeInfo(@TypeOf(app_runtime)) == .Pointer) alloc.destroy(app_runtime);
     defer app_runtime.terminate();
 
     // Run the GUI event loop

--- a/src/os/dbus.zig
+++ b/src/os/dbus.zig
@@ -1,0 +1,30 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const build_config = @import("../build_config.zig");
+
+const c = @cImport({
+    @cInclude("unistd.h");
+});
+
+/// Returns true if the program was launched by D-Bus activation.
+///
+/// On Linux GTK, this returns true if the program was launched using D-Bus
+/// activation. It will return false if Ghostty was launched any other way.
+///
+/// For other platforms and app runtimes, this returns false.
+pub fn launchedByDBusActivation() bool {
+    return switch (builtin.os.tag) {
+
+        // On Linux, D-Bus activation sets `DBUS_STARTER_ADDRESS` and
+        // `DBUS_STARTER_BUS_TYPE`. If these environment variables are present
+        // (no matter the value) we were launched by D-Bus activation.
+        .linux => linux: {
+            _ = std.os.getenv("DBUS_STARTER_ADDRESS") orelse break :linux false;
+            _ = std.os.getenv("DBUS_STARTER_BUS_TYPE") orelse break :linux false;
+            break :linux true;
+        },
+
+        // No other system supports D-Bus so always return false.
+        else => false,
+    };
+}

--- a/src/os/dbus.zig
+++ b/src/os/dbus.zig
@@ -1,10 +1,5 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const build_config = @import("../build_config.zig");
-
-const c = @cImport({
-    @cInclude("unistd.h");
-});
 
 /// Returns true if the program was launched by D-Bus activation.
 ///
@@ -18,11 +13,7 @@ pub fn launchedByDBusActivation() bool {
         // On Linux, D-Bus activation sets `DBUS_STARTER_ADDRESS` and
         // `DBUS_STARTER_BUS_TYPE`. If these environment variables are present
         // (no matter the value) we were launched by D-Bus activation.
-        .linux => linux: {
-            _ = std.os.getenv("DBUS_STARTER_ADDRESS") orelse break :linux false;
-            _ = std.os.getenv("DBUS_STARTER_BUS_TYPE") orelse break :linux false;
-            break :linux true;
-        },
+        .linux => std.os.getenv("DBUS_STARTER_ADDRESS") != null and std.os.getenv("DBUS_STARTER_BUS_TYPE") != null,
 
         // No other system supports D-Bus so always return false.
         else => false,

--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -2,6 +2,7 @@
 //! system.
 
 pub usingnamespace @import("env.zig");
+pub usingnamespace @import("dbus.zig");
 pub usingnamespace @import("desktop.zig");
 pub usingnamespace @import("file.zig");
 pub usingnamespace @import("flatpak.zig");

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -969,6 +969,15 @@ const Subprocess = struct {
             env.remove("GHOSTTY_MAC_APP");
         }
 
+        // On Linux, remove some environment variables that are set when Ghostty
+        // is launched from a `.desktop` file or by D-Bus activation.
+        if (comptime builtin.os.tag == .linux) {
+            env.remove("GIO_LAUNCHED_DESKTOP_FILE");
+            env.remove("GIO_LAUNCHED_DESKTOP_FILE_PID");
+            env.remove("DBUS_STARTER_ADDRESS");
+            env.remove("DBUS_STARTER_BUS_TYPE");
+        }
+
         // Build our args list
         const args = args: {
             const cap = 9; // the most we'll ever use

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -88,6 +88,7 @@ pub const DerivedConfig = struct {
     abnormal_runtime_threshold_ms: u32,
     wait_after_command: bool,
     enquiry_response: []const u8,
+    command: ?[]const u8 = null,
 
     pub fn init(
         alloc_gpa: Allocator,
@@ -111,6 +112,7 @@ pub const DerivedConfig = struct {
             .abnormal_runtime_threshold_ms = config.@"abnormal-command-exit-runtime",
             .wait_after_command = config.@"wait-after-command",
             .enquiry_response = try alloc.dupe(u8, config.@"enquiry-response"),
+            .command = if (config.command) |command| try alloc.dupe(u8, command) else null,
 
             // This has to be last so that we copy AFTER the arena allocations
             // above happen (Zig assigns in order).
@@ -1003,7 +1005,7 @@ const Subprocess = struct {
                 const cmd = try std.fmt.allocPrint(
                     alloc,
                     "exec -l {s}",
-                    .{opts.full_config.command orelse default_path},
+                    .{opts.config.command orelse default_path},
                 );
 
                 // The reason for executing login this way is unclear. This
@@ -1094,7 +1096,7 @@ const Subprocess = struct {
                 try args.append("-c");
             }
 
-            try args.append(opts.full_config.command orelse default_path);
+            try args.append(opts.config.command orelse default_path);
             break :args try args.toOwnedSlice();
         };
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -88,7 +88,6 @@ pub const DerivedConfig = struct {
     abnormal_runtime_threshold_ms: u32,
     wait_after_command: bool,
     enquiry_response: []const u8,
-    command: ?[]const u8 = null,
 
     pub fn init(
         alloc_gpa: Allocator,
@@ -112,7 +111,6 @@ pub const DerivedConfig = struct {
             .abnormal_runtime_threshold_ms = config.@"abnormal-command-exit-runtime",
             .wait_after_command = config.@"wait-after-command",
             .enquiry_response = try alloc.dupe(u8, config.@"enquiry-response"),
-            .command = if (config.command) |command| try alloc.dupe(u8, command) else null,
 
             // This has to be last so that we copy AFTER the arena allocations
             // above happen (Zig assigns in order).
@@ -1014,7 +1012,7 @@ const Subprocess = struct {
                 const cmd = try std.fmt.allocPrint(
                     alloc,
                     "exec -l {s}",
-                    .{opts.config.command orelse default_path},
+                    .{opts.full_config.command orelse default_path},
                 );
 
                 // The reason for executing login this way is unclear. This
@@ -1105,7 +1103,7 @@ const Subprocess = struct {
                 try args.append("-c");
             }
 
-            try args.append(opts.config.command orelse default_path);
+            try args.append(opts.full_config.command orelse default_path);
             break :args try args.toOwnedSlice();
         };
 


### PR DESCRIPTION
This PR adds all of the necessary plumbing to use "Open with..." from Nautilus (and other Gnome/GTK apps). This will open any files in an editor in a new Ghostty window. The editor chosen can be configured either with the `EDITOR` environment variable or can be configured in the Ghostty config. If neither options are available it will fall back to `vi`.

![image](https://github.com/mitchellh/ghostty/assets/740022/4b9d07cc-6c17-4ee5-9c23-0156d477ab59)
[Screencast from 2024-01-31 15-05-48.webm](https://github.com/mitchellh/ghostty/assets/740022/0ce71ee6-1144-4ffb-83a1-ccba87425765)
