### PR TITLE
Automatically inject ghostty cli to end of $PATH

### DIFF
--- a/src/os/env.zig
+++ b/src/os/env.zig
@@ -2,6 +2,12 @@ const std = @import("std");
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 
+/// The separator used in environment variables such as PATH.
+pub const PATH_SEP = switch (builtin.os.tag) {
+    .windows => ";",
+    else => ":",
+};
+
 /// Append a value to an environment variable such as PATH.
 /// The returned value is always allocated so it must be freed.
 pub fn appendEnv(
@@ -13,14 +19,9 @@ pub fn appendEnv(
     if (current.len == 0) return try alloc.dupe(u8, value);
 
     // Otherwise we must prefix.
-    const sep = switch (builtin.os.tag) {
-        .windows => ";",
-        else => ":",
-    };
-
     return try std.fmt.allocPrint(alloc, "{s}{s}{s}", .{
         current,
-        sep,
+        PATH_SEP,
         value,
     });
 }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1145,6 +1145,20 @@ const Subprocess = struct {
         // Our screen size should be our padded size
         const padded_size = opts.screen_size.subPadding(opts.padding);
 
+
+        var exe_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+        const ghostty_bin_dir = ghostty: {
+            const exe: ?[]const u8 = std.fs.selfExePath(&exe_buf) catch break: ghostty null;
+            const exe_bin_path = exe orelse break :ghostty null;
+            break :ghostty std.fs.path.dirname(exe_bin_path);
+        };
+        if (ghostty_bin_dir) |dir| {
+            if (env.get("PATH")) |path| {
+                try env.put("PATH", try internal_os.appendEnv(alloc, path, dir));
+                log.info("shell appending ghostty bin to path ghostty_dir={s}", .{dir});
+            }
+        }
+
         return .{
             .arena = arena,
             .env = env,


### PR DESCRIPTION
fixes https://github.com/mitchellh/ghostty/issues/1372

Automatically injects `ghostty` into the shell's $PATH making it available without an additional linking step. Pretty much any other directory in the users $PATH takes precedence over this so users with existing links will continue using that unless they remove it.

## Testing
- Verified hard links to earlier path entries prefer those (`/usr/local/bin` etc)
- `ghostty_bin_dir` is available on MacOS builds through xcode
- `ghostty_bin_dir` is available when invoked directly through the cli

I don't have the ability to test this on Windows but since I'm reusing the existing `appendEnv` I don't anticipate any issues but maybe someone with windows can verify this.
