### PR TITLE
core: handle mouse capture events with link highlighting

### DIFF
--- a/src/input/Link.zig
+++ b/src/input/Link.zig
@@ -36,6 +36,11 @@ pub const Highlight = union(enum) {
     /// hovering or always. For always, all links will be highlighted
     /// when the mods are pressed regardless of if the mouse is hovering
     /// over them.
+    ///
+    /// Note that if "shift" is specified here, this will NEVER match in
+    /// TUI programs that capture mouse events. "Shift" with mouse capture
+    /// escapes the mouse capture but strips the "shift" so it can't be
+    /// detected.
     always_mods: Mods,
     hover_mods: Mods,
 };

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1551,12 +1551,12 @@ fn rebuildCells(
     const arena_alloc = arena.allocator();
 
     // Create our match set for the links.
-    var link_match_set = try self.config.links.matchSet(
+    var link_match_set: link.MatchSet = if (mouse.point) |mouse_pt| try self.config.links.matchSet(
         arena_alloc,
         screen,
-        mouse.point orelse .{},
+        mouse_pt,
         mouse.mods,
-    );
+    ) else .{};
 
     // Determine our x/y range for preedit. We don't want to render anything
     // here because we will render the preedit separately.

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -987,12 +987,12 @@ pub fn rebuildCells(
     self.gl_cells_written = 0;
 
     // Create our match set for the links.
-    var link_match_set = try self.config.links.matchSet(
+    var link_match_set: link.MatchSet = if (mouse.point) |mouse_pt| try self.config.links.matchSet(
         arena_alloc,
         screen,
-        mouse.point orelse .{},
+        mouse_pt,
         mouse.mods,
-    );
+    ) else .{};
 
     // Determine our x/y range for preedit. We don't want to render anything
     // here because we will render the preedit separately.

--- a/src/renderer/link.zig
+++ b/src/renderer/link.zig
@@ -139,7 +139,7 @@ pub const MatchSet = struct {
     /// The matches.
     ///
     /// Important: this must be in left-to-right top-to-bottom order.
-    matches: []const terminal.Selection,
+    matches: []const terminal.Selection = &.{},
     i: usize = 0,
 
     pub fn deinit(self: *MatchSet, alloc: Allocator) void {


### PR DESCRIPTION
Fixes #1416

At a high level, the issue is that when mouse capture is enabled (i.e. in neovim), "shift" escapes the capture. So "cmd+shift" is equal to "cmd" which doesn't get sent to the TUI program and so on. For link highlighting which now requires "cmd" (super) is held, we were sending "cmd+shift" to the renderer so we weren't checking for links.

So the core of this commit is respecting this scenario and stripping the shift modifier.

This commit also found that when the mouse wasn't over a link, we were always checking and highlighting links on line one of the visible screen. This bug is fixed and should also result in a very slight performance improvement on rendering in all cases.