### PR TITLE
url/Link: simplify regex, remove 'find_longest' param and add tests

### DIFF
--- a/src/input/Link.zig
+++ b/src/input/Link.zig
@@ -49,7 +49,7 @@ pub const Highlight = union(enum) {
 pub fn oniRegex(self: *const Link) !oni.Regex {
     return try oni.Regex.init(
         self.regex,
-        .{ .find_longest = true },
+        .{},
         oni.Encoding.utf8,
         oni.Syntax.default,
         null,


### PR DESCRIPTION
fixes #1398

This changes the default URL regex and is a simplified regex that matches with multiple URLs on a single line. 

This removes the need for the regex `{ .find_longest }` parameter. Also added the `tel://` scheme and a `num_matches` to the test case struct.

There are still some missing test for all the URL schemes but i think this might be a good start.