### PR TITLE
macos: titlebar tabs set window appearance based on bg luminance

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/TerminalWindow.swift
@@ -59,11 +59,24 @@ class TerminalWindow: NSWindow {
             }) {
                 toolbarTitleView.isHidden = true
             }
+            
+            // We match the appearance depending on the lightness/darkness of the
+            // background color. We have to do this because our titlebars in tabs inherit
+            // our background color for the focused tab but use the macOS theme for the
+            // rest of the titlebar.
+            if let appDelegate = NSApp.delegate as? AppDelegate {
+                let color = OSColor(appDelegate.ghostty.config.backgroundColor)
+                let appearance = NSAppearance(named: color.isLightColor ? .aqua : .darkAqua)
+                self.appearance = appearance
+            }
         } else {
             // "expanded" places the toolbar below the titlebar, so setting this style and
             // removing the toolbar ensures that the titlebar will be the default height.
             self.toolbarStyle = .expanded
             self.toolbar = nil
+            
+            // Reset the appearance to whatever our app global value is
+            self.appearance = nil
         }
     }
     

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -604,6 +604,11 @@ keybind: Keybinds = .{},
 /// whatever the system theme is will be used. This can also be set to `light`
 /// or `dark` to force a specific theme regardless of the system settings.
 ///
+/// On macOS, if `macos-titlebar-tabs` is set, the window theme will be
+/// automatically set based on the luminosity of the terminal background color.
+/// This only applies to terminal windows. This setting will still apply to
+/// non-terminal windows within Ghostty.
+///
 /// This is currently only supported on macOS and Linux.
 @"window-theme": WindowTheme = .system,
 


### PR DESCRIPTION
Fixes #1427

| Before | After |
| - | - |
|![CleanShot 2024-02-01 at 16 49 12@2x](https://github.com/mitchellh/ghostty/assets/1299/4456264f-0d75-4468-9a83-4f070815da00)|![CleanShot 2024-02-01 at 16 49 36@2x](https://github.com/mitchellh/ghostty/assets/1299/38c60dd0-2067-405a-9d01-68ae7190b24a)|



