### PR TITLE
macos: set titlebar tab window button backdrop color based on appearance

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/TerminalWindow.swift
@@ -177,7 +177,6 @@ class TerminalWindow: NSWindow {
         view.topAnchor.constraint(equalTo: toolbarView.topAnchor).isActive = true
         view.heightAnchor.constraint(equalTo: toolbarView.heightAnchor).isActive = true
         view.wantsLayer = true
-        view.layer?.backgroundColor = CGColor(genericGrayGamma2_2Gray: 0.0, alpha: 0.45)
         
         let topBorder = NSView()
         view.addSubview(topBorder)
@@ -187,7 +186,17 @@ class TerminalWindow: NSWindow {
         topBorder.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
         topBorder.bottomAnchor.constraint(equalTo: view.topAnchor, constant: 1).isActive = true
         topBorder.wantsLayer = true
-        topBorder.layer?.backgroundColor = CGColor(genericGrayGamma2_2Gray: 0.0, alpha: 0.85)
+        
+        // This is jank but this makes the background color for light themes on the button
+        // backdrop look MUCH better. I couldn't figure out a perfect color to use that works
+        // for both so we just check the appearance.
+        if effectiveAppearance.name == .aqua {
+            view.layer?.backgroundColor = NSColor.textBackgroundColor.cgColor.copy(alpha: 0.45)
+            topBorder.layer?.backgroundColor = NSColor.textBackgroundColor.cgColor.copy(alpha: 0.85)
+        } else {
+            view.layer?.backgroundColor = CGColor(genericGrayGamma2_2Gray: 0.0, alpha: 0.45)
+            topBorder.layer?.backgroundColor = CGColor(genericGrayGamma2_2Gray: 0.0, alpha: 0.85)
+        }
         
         windowButtonsBackdrop = view
     }


### PR DESCRIPTION
The dark color themes are unaffected.

|Light Before|Light After|
|-|-|
|![CleanShot 2024-02-01 at 21 12 07@2x](https://github.com/mitchellh/ghostty/assets/1299/b3ea8f32-788e-4b46-9a40-48f442661e4e)|![CleanShot 2024-02-01 at 21 14 37@2x](https://github.com/mitchellh/ghostty/assets/1299/9fa106ce-83dc-4e7b-bc50-44997e9ddaa4)|