### PR TITLE
fix(macOS): Use better hardcoded colors for light titlebar tabs window button backdrop

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/TerminalWindow.swift
@@ -191,8 +191,8 @@ class TerminalWindow: NSWindow {
         // backdrop look MUCH better. I couldn't figure out a perfect color to use that works
         // for both so we just check the appearance.
         if effectiveAppearance.name == .aqua {
-            view.layer?.backgroundColor = NSColor.textBackgroundColor.cgColor.copy(alpha: 0.45)
-            topBorder.layer?.backgroundColor = NSColor.textBackgroundColor.cgColor.copy(alpha: 0.85)
+            view.layer?.backgroundColor = CGColor(genericGrayGamma2_2Gray: 0.95, alpha: 1)
+            topBorder.layer?.backgroundColor = CGColor(genericGrayGamma2_2Gray: 0.0, alpha: 0.2)
         } else {
             view.layer?.backgroundColor = CGColor(genericGrayGamma2_2Gray: 0.0, alpha: 0.45)
             topBorder.layer?.backgroundColor = CGColor(genericGrayGamma2_2Gray: 0.0, alpha: 0.85)


### PR DESCRIPTION
In light mode, the backdrop for the window buttons when titlebar tabs is enabled should not have any transparency as the inactive tabs and + button do not. This sets the ideal colors, at least for macOS Sonoma.

| Before | After |
| :-: | :-: |
| ![image](https://github.com/mitchellh/ghostty/assets/7241851/eb0a461e-3c48-4cf3-a38f-527dac9ccec5) | ![image](https://github.com/mitchellh/ghostty/assets/7241851/74d35cfd-40ff-4735-8855-3006f5ee29d0) |

(Forgive the eyebleeding background color, I chose a random bright color to test with)
