### PR TITLE
fix(macOS): Prevent squash/stretch during resize

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -118,6 +118,9 @@ extension Ghostty {
                             }
                         }
                         .onAppear() {
+                            // Prevent macOS from stretching rendered frames when the view is resized.
+                            surfaceView.layerContentsPlacement = .topLeft
+                            
                             // Welcome to the SwiftUI bug house of horrors. On macOS 12 (at least
                             // 12.5.1, didn't test other versions), the order in which the view
                             // is added to the window hierarchy is such that $surfaceFocus is

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -118,9 +118,6 @@ extension Ghostty {
                             }
                         }
                         .onAppear() {
-                            // Prevent macOS from stretching rendered frames when the view is resized.
-                            surfaceView.layerContentsPlacement = .topLeft
-                            
                             // Welcome to the SwiftUI bug house of horrors. On macOS 12 (at least
                             // 12.5.1, didn't test other versions), the order in which the view
                             // is added to the window hierarchy is such that $surfaceFocus is

--- a/pkg/macos/animation.zig
+++ b/pkg/macos/animation.zig
@@ -1,0 +1,6 @@
+pub const c = @import("animation/c.zig");
+pub usingnamespace @import("animation/layer.zig");
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/pkg/macos/animation/c.zig
+++ b/pkg/macos/animation/c.zig
@@ -1,0 +1,3 @@
+pub usingnamespace @cImport({
+    @cInclude("QuartzCore/CALayer.h");
+});

--- a/pkg/macos/animation/layer.zig
+++ b/pkg/macos/animation/layer.zig
@@ -1,0 +1,2 @@
+/// https://developer.apple.com/documentation/quartzcore/calayer/contents_gravity_values?language=objc
+pub extern "c" const kCAGravityTopLeft: *anyopaque;

--- a/pkg/macos/build.zig
+++ b/pkg/macos/build.zig
@@ -32,6 +32,7 @@ pub fn build(b: *std.Build) !void {
     lib.linkFramework("CoreGraphics");
     lib.linkFramework("CoreText");
     lib.linkFramework("CoreVideo");
+    lib.linkFramework("QuartzCore");
     if (target.result.os.tag == .macos) {
         lib.linkFramework("Carbon");
         module.linkFramework("Carbon", .{});
@@ -42,6 +43,7 @@ pub fn build(b: *std.Build) !void {
         module.linkFramework("CoreGraphics", .{});
         module.linkFramework("CoreText", .{});
         module.linkFramework("CoreVideo", .{});
+        module.linkFramework("QuartzCore", .{});
 
         if (!target.query.isNative()) {
             try apple_sdk.addPaths(b, &lib.root_module);

--- a/pkg/macos/main.zig
+++ b/pkg/macos/main.zig
@@ -1,4 +1,5 @@
 pub const foundation = @import("foundation.zig");
+pub const animation = @import("animation.zig");
 pub const graphics = @import("graphics.zig");
 pub const os = @import("os.zig");
 pub const text = @import("text.zig");

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -327,6 +327,10 @@ pub fn init(alloc: Allocator, options: renderer.Options) !Metal {
     if (comptime builtin.os.tag == .macos) {
         info.view.setProperty("layer", layer.value);
         info.view.setProperty("wantsLayer", true);
+
+        // The layer gravity is set to top-left so that when we resize
+        // the view, the contents aren't stretched before a redraw.
+        layer.setProperty("contentsGravity", macos.animation.kCAGravityTopLeft);
     }
 
     // Ensure that our metal layer has a content scale set to match the


### PR DESCRIPTION
Fixes #42

To understand what's going on here see the docs for [`NSView.layerContentsPlacement`](https://developer.apple.com/documentation/appkit/nsview/1483375-layercontentsplacement).

There might be a better place to set this property, I just picked the first place I could think of that works. (TBH, this could be done in `libghostty` even, if we really wanted.) Also the choice of which placement to use is fairly arbitrary as long as it's not `scaleAxesIndependently`, perhaps `center` or one of the `scaleProportionally` options might be preferred? I chose top left because it feels the most generic 🤷

EDIT: Actually, the `scaleProportionally` options are undesirable because they give no advantage, the content scale does *not* change when the window is resized, so interpolating it as if it will is no good.  And I think `center` would cause weird bouncing. I think `topLeft` is probably the most sane option when consider left-to-right top-to-bottom text/interfaces.