### PR TITLE
Mode 2031, DSR 996: Color Scheme (Dark/Light) Query + Notification

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -144,6 +144,11 @@ typedef enum {
     GHOSTTY_TAB_NEXT = -2,
 } ghostty_tab_e;
 
+typedef enum {
+    GHOSTTY_COLOR_SCHEME_LIGHT = 0,
+    GHOSTTY_COLOR_SCHEME_DARK = 1,
+} ghostty_color_scheme_e;
+
 // This is a packed struct (see src/input/mouse.zig) but the C standard
 // afaik doesn't let us reliably define packed structs so we build it up
 // from scratch.
@@ -475,6 +480,7 @@ void ghostty_surface_refresh(ghostty_surface_t);
 void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);
 void ghostty_surface_set_focus(ghostty_surface_t, bool);
 void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t);
+void ghostty_surface_set_color_scheme(ghostty_surface_t, ghostty_color_scheme_e);
 ghostty_input_mods_e ghostty_surface_key_translation_mods(ghostty_surface_t, ghostty_input_mods_e);
 void ghostty_surface_key(ghostty_surface_t, ghostty_input_key_s);
 void ghostty_surface_text(ghostty_surface_t, const char *, uintptr_t);

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2803,7 +2803,7 @@ fn dragLeftClickBefore(
 
 /// Call to notify Ghostty that the color scheme for the terminal has
 /// changed.
-pub fn colorSchemeCallback(self: *Surface, scheme: apprt.ColorScheme) void {
+pub fn colorSchemeCallback(self: *Surface, scheme: apprt.ColorScheme) !void {
     self.color_scheme = scheme;
 }
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -689,6 +689,13 @@ pub const Surface = struct {
         };
     }
 
+    pub fn colorSchemeCallback(self: *Surface, scheme: apprt.ColorScheme) void {
+        self.core_surface.colorSchemeCallback(scheme) catch |err| {
+            log.err("error setting color scheme err={}", .{err});
+            return;
+        };
+    }
+
     pub fn mouseButtonCallback(
         self: *Surface,
         action: input.MouseButtonState,
@@ -1514,6 +1521,19 @@ pub const CAPI = struct {
     /// to the pty and the renderer.
     export fn ghostty_surface_set_size(surface: *Surface, w: u32, h: u32) void {
         surface.updateSize(w, h);
+    }
+
+    /// Update the color scheme of the surface.
+    export fn ghostty_surface_set_color_scheme(surface: *Surface, scheme_raw: c_int) void {
+        const scheme = std.meta.intToEnum(apprt.ColorScheme, scheme_raw) catch {
+            log.warn(
+                "invalid color scheme to ghostty_surface_set_color_scheme value={}",
+                .{scheme_raw},
+            );
+            return;
+        };
+
+        surface.colorSchemeCallback(scheme);
     }
 
     /// Update the content scale of the surface.

--- a/src/apprt/structs.zig
+++ b/src/apprt/structs.zig
@@ -61,3 +61,9 @@ pub const DesktopNotification = struct {
     /// The body of a notification. This will always be shown.
     body: []const u8,
 };
+
+/// The color scheme in use (light vs dark).
+pub const ColorScheme = enum(u2) {
+    light = 0,
+    dark = 1,
+};

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -57,6 +57,9 @@ pub const Message = union(enum) {
 
     /// Health status change for the renderer.
     renderer_health: renderer.Health,
+
+    /// Report the color scheme
+    report_color_scheme: void,
 };
 
 /// A surface mailbox.

--- a/src/terminal/ansi.zig
+++ b/src/terminal/ansi.zig
@@ -55,15 +55,6 @@ pub const DeviceAttributeReq = enum {
     tertiary, // =
 };
 
-/// The device status request type (ESC [ n).
-pub const DeviceStatusReq = enum(u16) {
-    operating_status = 5,
-    cursor_position = 6,
-
-    // Non-exhaustive so that @intToEnum never fails for unsupported modes.
-    _,
-};
-
 /// Possible cursor styles (ESC [ q)
 pub const CursorStyle = enum(u16) {
     default = 0,

--- a/src/terminal/device_status.zig
+++ b/src/terminal/device_status.zig
@@ -63,5 +63,5 @@ const Entry = struct {
 const entries: []const Entry = &.{
     .{ .name = "operating_status", .value = 5 },
     .{ .name = "cursor_position", .value = 6 },
-    .{ .name = "theme", .value = 996, .question = true },
+    .{ .name = "color_scheme", .value = 996, .question = true },
 };

--- a/src/terminal/device_status.zig
+++ b/src/terminal/device_status.zig
@@ -1,0 +1,67 @@
+const std = @import("std");
+
+/// An enum(u16) of the available device status requests.
+pub const Request = dsr_enum: {
+    const EnumField = std.builtin.Type.EnumField;
+    var fields: [entries.len]EnumField = undefined;
+    for (entries, 0..) |entry, i| {
+        fields[i] = .{
+            .name = entry.name,
+            .value = @as(Tag.Backing, @bitCast(Tag{
+                .value = entry.value,
+                .question = entry.question,
+            })),
+        };
+    }
+
+    break :dsr_enum @Type(.{ .Enum = .{
+        .tag_type = Tag.Backing,
+        .fields = &fields,
+        .decls = &.{},
+        .is_exhaustive = true,
+    } });
+};
+
+/// The tag type for our enum is a u16 but we use a packed struct
+/// in order to pack the question bit into the tag. The "u16" size is
+/// chosen somewhat arbitrarily to match the largest expected size
+/// we see as a multiple of 8 bits.
+pub const Tag = packed struct(u16) {
+    pub const Backing = @typeInfo(@This()).Struct.backing_integer.?;
+    value: u15,
+    question: bool = false,
+
+    test "order" {
+        const t: Tag = .{ .value = 1 };
+        const int: Backing = @bitCast(t);
+        try std.testing.expectEqual(@as(Backing, 1), int);
+    }
+};
+
+pub fn reqFromInt(v: u16, question: bool) ?Request {
+    inline for (entries) |entry| {
+        if (entry.value == v and entry.question == question) {
+            const tag: Tag = .{ .question = question, .value = entry.value };
+            const int: Tag.Backing = @bitCast(tag);
+            return @enumFromInt(int);
+        }
+    }
+
+    return null;
+}
+
+/// A single entry of a possible device status request we support. The
+/// "question" field determines if it is valid with or without the "?"
+/// prefix.
+const Entry = struct {
+    name: [:0]const u8,
+    value: comptime_int,
+    question: bool = false, // "?" request
+};
+
+/// The full list of device status request entries.
+const entries: []const Entry = &.{
+    .{ .name = "operating_status", .value = 5 },
+    .{ .name = "cursor_position", .value = 6 },
+    .{ .name = "theme", .value = 996, .question = true },
+};

--- a/src/terminal/main.zig
+++ b/src/terminal/main.zig
@@ -12,6 +12,7 @@ pub const dcs = @import("dcs.zig");
 pub const osc = @import("osc.zig");
 pub const point = @import("point.zig");
 pub const color = @import("color.zig");
+pub const device_status = @import("device_status.zig");
 pub const kitty = @import("kitty.zig");
 pub const modes = @import("modes.zig");
 pub const parse_table = @import("parse_table.zig");

--- a/src/terminal/main.zig
+++ b/src/terminal/main.zig
@@ -33,7 +33,6 @@ pub const Stream = stream.Stream;
 pub const Cursor = Screen.Cursor;
 pub const CursorStyleReq = ansi.CursorStyle;
 pub const DeviceAttributeReq = ansi.DeviceAttributeReq;
-pub const DeviceStatusReq = ansi.DeviceStatusReq;
 pub const Mode = modes.Mode;
 pub const ModifyKeyFormat = ansi.ModifyKeyFormat;
 pub const ProtectedMode = ansi.ProtectedMode;

--- a/src/terminal/modes.zig
+++ b/src/terminal/modes.zig
@@ -215,6 +215,7 @@ const entries: []const ModeEntry = &.{
     .{ .name = "bracketed_paste", .value = 2004 },
     .{ .name = "synchronized_output", .value = 2026 },
     .{ .name = "grapheme_cluster", .value = 2027 },
+    .{ .name = "report_color_scheme", .value = 2031 },
 };
 
 test {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -2375,7 +2375,7 @@ const StreamHandler = struct {
                 self.messageWriter(msg);
             },
 
-            .theme => self.surfaceMessageWriter(.{ .report_color_scheme = {} }),
+            .color_scheme => self.surfaceMessageWriter(.{ .report_color_scheme = {} }),
         }
     }
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -2375,7 +2375,7 @@ const StreamHandler = struct {
                 self.messageWriter(msg);
             },
 
-            .theme => {},
+            .theme => self.surfaceMessageWriter(.{ .report_color_scheme = {} }),
         }
     }
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -2345,7 +2345,7 @@ const StreamHandler = struct {
 
     pub fn deviceStatusReport(
         self: *StreamHandler,
-        req: terminal.DeviceStatusReq,
+        req: terminal.device_status.Request,
     ) !void {
         switch (req) {
             .operating_status => self.messageWriter(.{ .write_stable = "\x1B[0n" }),
@@ -2375,7 +2375,7 @@ const StreamHandler = struct {
                 self.messageWriter(msg);
             },
 
-            else => log.warn("unimplemented device status req: {}", .{req}),
+            .theme => {},
         }
     }
 


### PR DESCRIPTION
This implements [color palette update notifications](https://github.com/contour-terminal/contour/blob/f3c3334aa5c861348c5bbe8ffe572c872eef2e08/docs/vt-extensions/color-palette-update-notifications.md), also known as "mode 2031" although it does a bit more than that. Running programs can use this to query and detect light vs dark mode changes.

**This PR only implements this for macOS.** GTK followup volunteered by @jcollie.

## Demo

```sh
#!/usr/bin/env bash

function csi() {
  printf "\033[%s" "$*"
}

csi "?996n"
csi "?2031h"
read
csi "?2031l"
```

https://github.com/mitchellh/ghostty/assets/1299/a46a82d9-983f-4d01-9c65-6f8c4a313b9b

