### PR TITLE
make mach_glfw a lazy dependency

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -925,10 +925,6 @@ fn addDeps(
         .target = target,
         .optimize = optimize,
     });
-    const mach_glfw_dep = b.dependency("mach_glfw", .{
-        .target = target,
-        .optimize = optimize,
-    });
     const libpng_dep = b.dependency("libpng", .{
         .target = target,
         .optimize = optimize,
@@ -1096,7 +1092,11 @@ fn addDeps(
         switch (config.app_runtime) {
             .none => {},
 
-            .glfw => {
+            .glfw => glfw: {
+                const mach_glfw_dep = b.lazyDependency("mach_glfw", .{
+                    .target = target,
+                    .optimize = optimize,
+                }) orelse break :glfw;
                 step.root_module.addImport("glfw", mach_glfw_dep.module("mach-glfw"));
             },
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -11,6 +11,7 @@
         .mach_glfw = .{
             .url = "https://github.com/der-teufel-programming/mach-glfw/archive/250affff8c52d1eaa0fab2ef1118f691bf1225ec.tar.gz",
             .hash = "122029f65edf3965d86f7d0741fe141bcc1d68b1f013fa7280bbfda4e87c6affc15f",
+            .lazy = true,
         },
         .zig_objc = .{
             .url = "https://github.com/mitchellh/zig-objc/archive/f6ed382b6db296626a9b56dadcf9d7e4fcba71d3.tar.gz",

--- a/nix/zigCacheHash.nix
+++ b/nix/zigCacheHash.nix
@@ -1,3 +1,3 @@
 # This file is auto-generated! check build-support/check-zig-cache-hash.sh for
 # more details.
-"sha256-3qABxwGWy8emiSUtDBF2Dj4YdmdR2L4RNpfnQJie3CI="
+"sha256-YXSgZynCPCwahbV4cQx05IrtzOaUxG75715dc+j+8/c="


### PR DESCRIPTION
I wanted to see how https://github.com/ziglang/zig/pull/18778 would fare on a real world project, so I tried out these changes on ghostty with nice results. Since the results are nice, I thought I would share them here.

I'm not sure exactly what that `@import("mach_glfw").addPaths(step);` was doing. I suspect it is a relic of pre- https://github.com/ziglang/zig/pull/18160 times.

Anyway, with these changes, I verified the following steps:
1. cleared my global zig cache
2. built ghostty on linux with `zig build` (defaults to gtk build)
3. inspected global zig cache, and noted that mach_glfw was *not* present
4. built ghostty with `zig build -Dapp-runtime=glfw`
5. inspected global zig cache, noted that mach_glfw is now present