### PR TITLE
Update mach-glfw dependency

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1117,7 +1117,6 @@ fn addDeps(
 
             .glfw => {
                 step.root_module.addImport("glfw", mach_glfw_dep.module("mach-glfw"));
-                @import("mach_glfw").addPaths(step);
             },
 
             .gtk => {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -9,8 +9,8 @@
             .hash = "12203f87e00caa6c07c02a748f234a5c0ee2ca5c334ec464e88810d93e7b5495a56f",
         },
         .mach_glfw = .{
-            .url = "https://github.com/der-teufel-programming/mach-glfw/archive/a9aae000cdc104dabe75d829ff9dab6809e47604.tar.gz",
-            .hash = "122071be402af6a317b66f007411678f8600559d5b2d5b00fc80d388a6ec27a43acc",
+            .url = "https://github.com/der-teufel-programming/mach-glfw/archive/250affff8c52d1eaa0fab2ef1118f691bf1225ec.tar.gz",
+            .hash = "122029f65edf3965d86f7d0741fe141bcc1d68b1f013fa7280bbfda4e87c6affc15f",
         },
         .zig_objc = .{
             .url = "https://github.com/mitchellh/zig-objc/archive/f6ed382b6db296626a9b56dadcf9d7e4fcba71d3.tar.gz",

--- a/nix/zigCacheHash.nix
+++ b/nix/zigCacheHash.nix
@@ -1,3 +1,3 @@
 # This file is auto-generated! check build-support/check-zig-cache-hash.sh for
 # more details.
-"sha256-+wU1PXMpR/THc7fBfh2ND34fteQCIUWDjN9xZTx5+bs="
+"sha256-3qABxwGWy8emiSUtDBF2Dj4YdmdR2L4RNpfnQJie3CI="


### PR DESCRIPTION
Updated `mach-glfw` dependency doesn't require `.addPaths` which @andrewrk mentioned in #1447 