### PR TITLE
(macOS) Fixed/improved titlebar tabs custom title label handling

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalToolbar.swift
+++ b/macos/Sources/Features/Terminal/TerminalToolbar.swift
@@ -69,9 +69,9 @@ class TerminalToolbar: NSToolbar, NSToolbarDelegate {
 }
 
 /// A label that expands to fit whatever text you put in it and horizontally centers itself in the current window.
-class CenteredDynamicLabel: NSTextField {
+fileprivate class CenteredDynamicLabel: NSTextField {
     override func viewDidMoveToSuperview() {
-        // Truncate the title when it gets too long- cutting it off with an ellipsis.
+        // Truncate the title when it gets too long, cutting it off with an ellipsis.
         cell?.truncatesLastVisibleLine = true
         cell?.lineBreakMode = .byCharWrapping
         

--- a/macos/Sources/Features/Terminal/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/TerminalWindow.swift
@@ -45,19 +45,10 @@ class TerminalWindow: NSWindow {
                 self.toolbar = TerminalToolbar(identifier: "Toolbar")
             }
             
-            // We directly hide the view containing the title text because if we use the
-            // `titleVisibility` property for this it prevents the window from hiding the
-            // tab bar when we get down to a single tab.
-            if let toolbarTitleView = contentView?.superview?.subviews.first(where: {
-                $0.className == "NSTitlebarContainerView"
-            })?.subviews.first(where: {
-                $0.className == "NSTitlebarView"
-            })?.subviews.first(where: {
-                $0.className == "NSToolbarView"
-            })?.subviews.first(where: {
-                $0.className == "NSToolbarTitleView"
-            }) {
-                toolbarTitleView.isHidden = true
+            // We have to wait before setting the titleVisibility or else it prevents
+            // the window from hiding the tab bar when we get down to a single tab.
+            DispatchQueue.main.async {
+                self.titleVisibility = .hidden
             }
         } else {
             // "expanded" places the toolbar below the titlebar, so setting this style and


### PR DESCRIPTION
Fixes #1453

Only way I could figure out to do this that worked requires the use of some deprecated properties. Setting them has some sort of side effect in how the toolbar decides what to hide and when in a way that behaves differently to the constraint-based method.

The change I made to the native title hiding *might* fix #1450 - but I'm not sure since I can't repro the issue myself.