### PR TITLE
split: add `auto` as split option

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3195,17 +3195,14 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
 
         .new_split => |direction| {
             if (@hasDecl(apprt.Surface, "newSplit")) {
-                const resolved_direction: input.SplitDirection = switch (direction) {
+                try self.rt_surface.newSplit(switch (direction) {
                     .right => .right,
                     .down => .down,
-                    .auto => auto: {
-                        const size = self.screen_size;
-                        if (size.width > size.height) {
-                            break :auto .right;
-                        } else break :auto .down;
-                    },
-                };
-                try self.rt_surface.newSplit(resolved_direction);
+                    .auto => if (self.screen_size.width > self.screen_size.height)
+                        .right
+                    else
+                        .down,
+                });
             } else log.warn("runtime doesn't implement newSplit", .{});
         },
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3195,7 +3195,17 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
 
         .new_split => |direction| {
             if (@hasDecl(apprt.Surface, "newSplit")) {
-                try self.rt_surface.newSplit(direction);
+                const resolved_direction: input.SplitDirection = switch (direction) {
+                    .right => .right,
+                    .down => .down,
+                    .auto => auto: {
+                        const size = self.screen_size;
+                        if (size.width > size.height) {
+                            break :auto .right;
+                        } else break :auto .down;
+                    },
+                };
+                try self.rt_surface.newSplit(resolved_direction);
             } else log.warn("runtime doesn't implement newSplit", .{});
         },
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -80,7 +80,7 @@ pub const App = struct {
 
         /// Create a new split view. If the embedder doesn't support split
         /// views then this can be null.
-        new_split: ?*const fn (SurfaceUD, input.SplitDirection, apprt.Surface.Options) callconv(.C) void = null,
+        new_split: ?*const fn (SurfaceUD, apprt.SplitDirection, apprt.Surface.Options) callconv(.C) void = null,
 
         /// New tab with options.
         new_tab: ?*const fn (SurfaceUD, apprt.Surface.Options) callconv(.C) void = null,
@@ -460,7 +460,7 @@ pub const Surface = struct {
         func(self.opts.userdata, mode);
     }
 
-    pub fn newSplit(self: *const Surface, direction: input.SplitDirection) !void {
+    pub fn newSplit(self: *const Surface, direction: apprt.SplitDirection) !void {
         const func = self.app.opts.new_split orelse {
             log.info("runtime embedder does not support splits", .{});
             return;
@@ -1640,7 +1640,7 @@ pub const CAPI = struct {
     }
 
     /// Request that the surface split in the given direction.
-    export fn ghostty_surface_split(ptr: *Surface, direction: input.SplitDirection) void {
+    export fn ghostty_surface_split(ptr: *Surface, direction: apprt.SplitDirection) void {
         ptr.newSplit(direction) catch {};
     }
 

--- a/src/apprt/gtk/Split.zig
+++ b/src/apprt/gtk/Split.zig
@@ -5,6 +5,7 @@ const Split = @This();
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const assert = std.debug.assert;
+const apprt = @import("../../apprt.zig");
 const font = @import("../../font/main.zig");
 const input = @import("../../input.zig");
 const CoreSurface = @import("../../Surface.zig");
@@ -20,7 +21,7 @@ pub const Orientation = enum {
     horizontal,
     vertical,
 
-    pub fn fromDirection(direction: input.SplitDirection) Orientation {
+    pub fn fromDirection(direction: apprt.SplitDirection) Orientation {
         return switch (direction) {
             .right => .horizontal,
             .down => .vertical,
@@ -57,7 +58,7 @@ bottom_right: Surface.Container.Elem,
 pub fn create(
     alloc: Allocator,
     sibling: *Surface,
-    direction: input.SplitDirection,
+    direction: apprt.SplitDirection,
 ) !*Split {
     var split = try alloc.create(Split);
     errdefer alloc.destroy(split);
@@ -68,7 +69,7 @@ pub fn create(
 pub fn init(
     self: *Split,
     sibling: *Surface,
-    direction: input.SplitDirection,
+    direction: apprt.SplitDirection,
 ) !void {
     // Create the new child surface for the other direction.
     const alloc = sibling.app.core_app.alloc;

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -570,7 +570,7 @@ pub fn getTitleLabel(self: *Surface) ?*c.GtkWidget {
     }
 }
 
-pub fn newSplit(self: *Surface, direction: input.SplitDirection) !void {
+pub fn newSplit(self: *Surface, direction: apprt.SplitDirection) !void {
     const alloc = self.app.core_app.alloc;
     _ = try Split.create(alloc, self, direction);
 }

--- a/src/apprt/structs.zig
+++ b/src/apprt/structs.zig
@@ -62,6 +62,13 @@ pub const DesktopNotification = struct {
     body: []const u8,
 };
 
+// This is made extern (c_int) to make interop easier with our embedded
+// runtime. The small size cost doesn't make a difference in our union.
+pub const SplitDirection = enum(c_int) {
+    right,
+    down,
+};
+
 /// The color scheme in use (light vs dark).
 pub const ColorScheme = enum(u2) {
     light = 0,

--- a/src/input.zig
+++ b/src/input.zig
@@ -13,13 +13,6 @@ pub const InspectorMode = Binding.Action.InspectorMode;
 pub const SplitFocusDirection = Binding.Action.SplitFocusDirection;
 pub const SplitResizeDirection = Binding.Action.SplitResizeDirection;
 
-// This is made extern (c_int) to make interop easier with our embedded
-// runtime. The small size cost doesn't make a difference in our union.
-pub const SplitDirection = enum(c_int) {
-    right,
-    down,
-};
-
 // Keymap is only available on macOS right now. We could implement it
 // in theory for XKB too on Linux but we don't need it right now.
 pub const Keymap = switch (builtin.os.tag) {

--- a/src/input.zig
+++ b/src/input.zig
@@ -10,9 +10,15 @@ pub const Binding = @import("input/Binding.zig");
 pub const Link = @import("input/Link.zig");
 pub const KeyEncoder = @import("input/KeyEncoder.zig");
 pub const InspectorMode = Binding.Action.InspectorMode;
-pub const SplitDirection = Binding.Action.SplitDirection;
 pub const SplitFocusDirection = Binding.Action.SplitFocusDirection;
 pub const SplitResizeDirection = Binding.Action.SplitResizeDirection;
+
+// This is made extern (c_int) to make interop easier with our embedded
+// runtime. The small size cost doesn't make a difference in our union.
+pub const SplitDirection = enum(c_int) {
+    right,
+    down,
+};
 
 // Keymap is only available on macOS right now. We could implement it
 // in theory for XKB too on Linux but we don't need it right now.

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -256,11 +256,11 @@ pub const Action = union(enum) {
         application: []const u8,
     };
 
-    // This is made extern (c_int) to make interop easier with our embedded
-    // runtime. The small size cost doesn't make a difference in our union.
-    pub const SplitDirection = enum(c_int) {
+    pub const SplitDirection = enum {
         right,
         down,
+        // splits along the larger direction
+        auto,
 
         // Note: we don't support top or left yet
     };

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -259,8 +259,7 @@ pub const Action = union(enum) {
     pub const SplitDirection = enum {
         right,
         down,
-        // splits along the larger direction
-        auto,
+        auto, // splits along the larger direction
 
         // Note: we don't support top or left yet
     };


### PR DESCRIPTION
Add an `auto` split direction which splits along the larger direction.
