### PR TITLE
Fix shader time uniforms

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -768,7 +768,7 @@ pub fn drawFrame(self: *Metal, surface: *apprt.Surface) !void {
         const delta_ns: f32 = @floatFromInt(now.since(state.last_frame_time));
         state.uniforms.time = since_ns / std.time.ns_per_s;
         state.uniforms.time_delta = delta_ns / std.time.ns_per_s;
-        self.last_frame_time = now;
+        state.last_frame_time = now;
     }
 
     // @autoreleasepool {}

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -137,6 +137,11 @@ pub const CustomShaderState = struct {
     screen_texture: objc.Object, // MTLTexture
     sampler: mtl_sampler.Sampler,
     uniforms: mtl_shaders.PostUniforms,
+    /// The first time a frame was drawn. This is used to update the time
+    /// uniform.
+    first_frame_time: std.time.Instant,
+    /// The last time a frame was drawn. This is used to update the time
+    /// uniform.
     last_frame_time: std.time.Instant,
 
     pub fn deinit(self: *CustomShaderState) void {
@@ -412,6 +417,7 @@ pub fn init(alloc: Allocator, options: renderer.Options) !Metal {
                 .sample_rate = 1,
             },
 
+            .first_frame_time = try std.time.Instant.now(),
             .last_frame_time = try std.time.Instant.now(),
         };
     };
@@ -757,10 +763,12 @@ pub fn drawFrame(self: *Metal, surface: *apprt.Surface) !void {
 
     // If we have custom shaders, update the animation time.
     if (self.custom_shader_state) |*state| {
-        const now = std.time.Instant.now() catch state.last_frame_time;
-        const since_ns: f32 = @floatFromInt(now.since(state.last_frame_time));
+        const now = std.time.Instant.now() catch state.first_frame_time;
+        const since_ns: f32 = @floatFromInt(now.since(state.first_frame_time));
+        const delta_ns: f32 = @floatFromInt(now.since(state.last_frame_time));
         state.uniforms.time = since_ns / std.time.ns_per_s;
-        state.uniforms.time_delta = since_ns / std.time.ns_per_s;
+        state.uniforms.time_delta = delta_ns / std.time.ns_per_s;
+        self.last_frame_time = now;
     }
 
     // @autoreleasepool {}

--- a/src/renderer/opengl/custom.zig
+++ b/src/renderer/opengl/custom.zig
@@ -45,9 +45,13 @@ pub const State = struct {
     /// The set of programs for the custom shaders.
     programs: []const Program,
 
-    /// The last time the frame was drawn. This is used to update
+    /// The first time a frame was drawn. This is used to update
     /// the time uniform.
     first_frame_time: std.time.Instant,
+
+    /// The last time a frame was drawn. This is used to update
+    /// the time uniform.
+    last_frame_time: std.time.Instant,
 
     pub fn init(
         alloc: Allocator,
@@ -136,6 +140,7 @@ pub const State = struct {
             .ebo = ebo,
             .fb_texture = fb_tex,
             .first_frame_time = try std.time.Instant.now(),
+            .last_frame_time = try std.time.Instant.now(),
         };
     }
 
@@ -180,8 +185,10 @@ pub const State = struct {
         // Update our frame time
         const now = std.time.Instant.now() catch self.first_frame_time;
         const since_ns: f32 = @floatFromInt(now.since(self.first_frame_time));
+        const delta_ns: f32 = @floatFromInt(now.since(self.last_frame_time));
         self.uniforms.time = since_ns / std.time.ns_per_s;
-        self.uniforms.time_delta = since_ns / std.time.ns_per_s;
+        self.uniforms.time_delta = delta_ns / std.time.ns_per_s;
+        self.last_frame_time = now;
 
         // Sync our uniform changes
         try self.syncUniforms();


### PR DESCRIPTION
@qwerasd205 pointed out on Discord that the time_delta that is passed to custom shaders was not computed correctly. Instead of being the number of seconds since the last frame, it was the number of seconds since the shader started (duplicating the time). I updated the time_delta so that it properly reflects the time since the last frame in both the OpenGL and the Metal renderers. I don't have access to a macOS system so I can't test the Metal changes so the chances of something being borked are high.