### PR TITLE
fix(macOS): Prevent incorrect scaling of the Metal layer after DPI change

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -417,7 +417,13 @@ extension Ghostty {
             // Ref: High Resolution Guidelines for OS X
             // https://developer.apple.com/library/archive/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/CapturingScreenContents/CapturingScreenContents.html#//apple_ref/doc/uid/TP40012302-CH10-SW27
             if let window = window {
+                CATransaction.begin()
+                // Disable the implicit transition animation that Core Animation applies to
+                // property changes. Otherwise it will apply a scale animation to the layer
+                // contents which looks pretty janky.
+                CATransaction.setDisableActions(true)
                 layer?.contentsScale = window.backingScaleFactor
+                CATransaction.commit()
             }
             
             guard let surface = self.surface else { return }

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -403,6 +403,22 @@ extension Ghostty {
         }
 
         override func viewDidChangeBackingProperties() {
+            super.viewDidChangeBackingProperties()
+            
+            // The Core Animation compositing engine uses the layer's contentsScale property
+            // to determine whether to scale its contents during compositing. When the window
+            // moves between a high DPI display and a low DPI display, or the user modifies
+            // the DPI scaling for a display in the system settings, this can result in the
+            // layer being scaled inappropriately. Since we handle the adjustment of scale
+            // and resolution ourselves below, we update the layer's contentsScale property
+            // to match the window's backingScaleFactor, so as to ensure it is not scaled by
+            // the compositor.
+            //
+            // Ref: High Resolution Guidelines for OS X
+            if let window = window {
+                layer?.contentsScale = window.backingScaleFactor
+            }
+            
             guard let surface = self.surface else { return }
 
             // Detect our X/Y scale factor so we can update our surface

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -415,6 +415,7 @@ extension Ghostty {
             // the compositor.
             //
             // Ref: High Resolution Guidelines for OS X
+            // https://developer.apple.com/library/archive/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/CapturingScreenContents/CapturingScreenContents.html#//apple_ref/doc/uid/TP40012302-CH10-SW27
             if let window = window {
                 layer?.contentsScale = window.backingScaleFactor
             }


### PR DESCRIPTION
Fixes #1445

This is explained fairly well in the [High Resolution Guidelines for OS X](https://developer.apple.com/library/archive/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/CapturingScreenContents/CapturingScreenContents.html#//apple_ref/doc/uid/TP40012302-CH10-SW27) document available in the Apple documentation archive. The compositor is fighting with our own scaling because it assumes we aren't handling the transition between "low resolution" and "high resolution" displays; setting the `contentsScale` on the layer basically lets it know that we know that things have changed and we're generating content with the appropriate resolution for the window, so it shouldn't try to magnify or shrink it.

NOTE:
This fixed the issue *in the way I reproduce it* by changing the DPI scaling in the system settings, but I don't currently have a secondary monitor to test dragging between displays with different DPI scales. It may be a good idea for someone who can reproduce that manifestation of the issue to check that this fix works appropriately before it's merged.