### PR TITLE
(macOS) Fix a couple transparent window + titlebar tabs bugs

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -140,6 +140,18 @@ class TerminalController: NSWindowController, NSWindowDelegate,
         }
     }
     
+    func fixTabBar() {
+        // We do this to make sure that the tab bar will always re-composite. If we don't,
+        // then the it will "drag" pieces of the background with it when a transparent
+        // window is moved around.
+        //
+        // There might be a better way to make the tab bar "un-lazy", but I can't find it.
+        if let window = window, !window.isOpaque {
+            window.isOpaque = true
+            window.isOpaque = false
+        }
+    }
+    
     @objc private func onFrameDidChange(_ notification: NSNotification) {
         // This is a huge hack to set the proper shortcut for tab selection
         // on tab reordering using the mouse. There is no event, delegate, etc.
@@ -335,6 +347,11 @@ class TerminalController: NSWindowController, NSWindowDelegate,
     
     func windowDidBecomeKey(_ notification: Notification) {
         self.relabelTabs()
+        self.fixTabBar()
+    }
+    
+    func windowDidMove(_ notification: Notification) {
+        self.fixTabBar()
     }
     
     // Called when the window will be encoded. We handle the data encoding here in the

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -140,7 +140,7 @@ class TerminalController: NSWindowController, NSWindowDelegate,
         }
     }
     
-    func fixTabBar() {
+    private func fixTabBar() {
         // We do this to make sure that the tab bar will always re-composite. If we don't,
         // then the it will "drag" pieces of the background with it when a transparent
         // window is moved around.

--- a/macos/Sources/Features/Terminal/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/TerminalWindow.swift
@@ -45,6 +45,10 @@ class TerminalWindow: NSWindow {
                 self.toolbar = TerminalToolbar(identifier: "Toolbar")
             }
             
+            // Set a custom background on the titlebar - this is required for when
+            // titlebar tabs is used in conjunction with a transparent background.
+            self.restoreTitlebarBackground()
+            
             // We have to wait before setting the titleVisibility or else it prevents
             // the window from hiding the tab bar when we get down to a single tab.
             DispatchQueue.main.async {
@@ -61,14 +65,25 @@ class TerminalWindow: NSWindow {
         }
     }
     
+    private var storedTitlebarBackgroundColor: CGColor? = nil
+    
     // Assign a background color to the titlebar area.
     func setTitlebarBackground(_ color: CGColor) {
+        storedTitlebarBackgroundColor = color
+        
         guard let titlebarContainer = contentView?.superview?.subviews.first(where: {
             $0.className == "NSTitlebarContainerView"
         }) else { return }
         
         titlebarContainer.wantsLayer = true
         titlebarContainer.layer?.backgroundColor = color
+    }
+    
+    // Make sure the titlebar has the assigned background color.
+    func restoreTitlebarBackground() {
+        guard let color = storedTitlebarBackgroundColor else { return }
+        
+        setTitlebarBackground(color)
     }
     
     // This is called by macOS for native tabbing in order to add the tab bar. We hook into

--- a/macos/Sources/Features/Terminal/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/TerminalWindow.swift
@@ -29,6 +29,7 @@ class TerminalWindow: NSWindow {
     
     private var windowButtonsBackdrop: NSView? = nil
     private var windowDragHandle: WindowDragView? = nil
+    private var storedTitlebarBackgroundColor: CGColor? = nil
     
     // The tab bar controller ID from macOS
     static private let TabBarController = NSUserInterfaceItemIdentifier("_tabBarController")
@@ -65,8 +66,6 @@ class TerminalWindow: NSWindow {
         }
     }
     
-    private var storedTitlebarBackgroundColor: CGColor? = nil
-    
     // Assign a background color to the titlebar area.
     func setTitlebarBackground(_ color: CGColor) {
         storedTitlebarBackgroundColor = color
@@ -80,9 +79,8 @@ class TerminalWindow: NSWindow {
     }
     
     // Make sure the titlebar has the assigned background color.
-    func restoreTitlebarBackground() {
+    private func restoreTitlebarBackground() {
         guard let color = storedTitlebarBackgroundColor else { return }
-        
         setTitlebarBackground(color)
     }
     


### PR DESCRIPTION
Fixes #1468 
Pretty straight forward, restores the custom backing color on the titlebar in the titlebar tabs handler which is triggered when exiting non native fullscreen.

Fixes #1465
*Not a great fix*, but much better than how it was before. I'd really prefer a proper fix to be found, but I gave up looking for one after ~30-40 minutes of finding nothing even promising. This fix results in slightly choppy slightly delayed updating of the tab backgrounds during window moves, as opposed to none at all.