### PR TITLE
fix(terminal): send SI to execute instead of print

### DIFF
--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -91,7 +91,7 @@ pub fn Stream(comptime Handler: type) type {
             while (self.parser.state == .ground and offset < input.len) {
                 const res = simd.vt.utf8DecodeUntilControlSeq(input[offset..], cp_buf);
                 for (cp_buf[0..res.decoded]) |cp| {
-                    if (cp < 0xF) {
+                    if (cp <= 0xF) {
                         try self.execute(@intCast(cp));
                     } else {
                         try self.print(@intCast(cp));
@@ -131,7 +131,7 @@ pub fn Stream(comptime Handler: type) type {
                     const res = self.utf8decoder.next(c);
                     consumed = res[1];
                     if (res[0]) |codepoint| {
-                        if (codepoint < 0xF) {
+                        if (codepoint <= 0xF) {
                             try self.execute(@intCast(codepoint));
                         } else {
                             try self.print(@intCast(codepoint));


### PR DESCRIPTION
`SI` (Shift In) (`0xF`) should be `execute`d, not `print`ed, changed `< 0xF` to `<= 0xF` to fix that.