### PR TITLE
Keep shadows for native tab bar

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/TerminalWindow.swift
@@ -40,6 +40,8 @@ class TerminalWindow: NSWindow {
     override func updateConstraintsIfNeeded() {
         super.updateConstraintsIfNeeded()
 
+        guard titlebarTabs else { return }
+
         guard let titlebarContainer = contentView?.superview?.subviews.first(where: {
             $0.className == "NSTitlebarContainerView"
         }) else { return }

--- a/macos/Sources/Features/Terminal/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/TerminalWindow.swift
@@ -40,6 +40,8 @@ class TerminalWindow: NSWindow {
     override func updateConstraintsIfNeeded() {
         super.updateConstraintsIfNeeded()
 
+        // For titlebar tabs, we want to hide the separator view so that we get rid
+        // of an aesthetically unpleasing shadow.
         guard titlebarTabs else { return }
 
         guard let titlebarContainer = contentView?.superview?.subviews.first(where: {


### PR DESCRIPTION
#1479 removed tab shadows.

I think it was intended to only do so when `macos-titlebar-tabs` is enabled. However, it also applied to the native tab bar which makes Ghostty appear different from apps like Safari or Terminal.app.

I guess it's a preference if the shadows should be removed from both modes. I personally like when it looks like other apps.

## Screenshots

The two screenshots show before and after this change. The first tab is active and the last is hovered.

![Tab bar without shadows](https://github.com/mitchellh/ghostty/assets/19824/7691cb7d-b680-40ac-92e0-b494ae768407)

![Tab bar with shadows](https://github.com/mitchellh/ghostty/assets/19824/a05594c4-d889-490c-a417-d5a762030df5)
