### PR TITLE
Include completions on macOS

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -436,6 +436,17 @@ pub fn build(b: *std.Build) !void {
             }),
         };
         b.getInstallStep().dependOn(&install.step);
+
+        if (target.result.os.tag == .macos and exe_ != null) {
+            const mac_install = b.addInstallDirectory(options: {
+                var copy = install.options;
+                copy.install_dir = .{
+                    .custom = "Ghostty.app/Contents/Resources",
+                };
+                break :options copy;
+            });
+            b.getInstallStep().dependOn(&mac_install.step);
+        }
     }
 
     // Vim plugin

--- a/build.zig
+++ b/build.zig
@@ -422,11 +422,20 @@ pub fn build(b: *std.Build) !void {
         const wf = b.addWriteFiles();
         _ = wf.add("ghostty.fish", fish_completions.fish_completions);
 
-        b.installDirectory(.{
-            .source_dir = wf.getDirectory(),
-            .install_dir = .prefix,
-            .install_subdir = "share/fish/vendor_completions.d",
-        });
+        const install = switch (target.result.os.tag) {
+            .macos => b.addInstallDirectory(.{
+                .source_dir = wf.getDirectory(),
+                .install_dir = .{ .custom = "share" },
+                .install_subdir = "ghostty/shell-integration/fish/vendor_completions.d",
+            }),
+
+            else => b.addInstallDirectory(.{
+                .source_dir = wf.getDirectory(),
+                .install_dir = .prefix,
+                .install_subdir = "share/fish/vendor_completions.d",
+            }),
+        };
+        b.getInstallStep().dependOn(&install.step);
     }
 
     // Vim plugin


### PR DESCRIPTION
#1474 generates completions for fish but as far as I can tell, they're not available on macOS by default.

I made two changes:

1. I moved the completions to ghostty/shell-integration/fish/vendor_completions.d so they're included in development builds.
2. I made them part of the resources directory to include them in the distributed build.

I don't know that either of these changes are correct or ideal. I did confirm that running Ghostty automatically loads the completions. Feel free to change it.

This of course depends on having the shell integration enabled. If you don't, it seems reasonable to symlink from the resources directory and into /usr/local/share/fish/vendor_completions.d.