### PR TITLE
ci: move to self-hosted x86 runners

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -2,7 +2,7 @@ on: [push, pull_request]
 name: Nix
 jobs:
   check-zig-cache-hash:
-    runs-on: ubuntu-latest
+    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-sm
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -10,7 +10,7 @@ name: Release Tip
 
 jobs:
   tag:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-ghostty-sm
     needs: [build-macos]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-sm"]
+        os: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-md"]
 
         target: [
             aarch64-linux,
@@ -41,7 +41,7 @@ jobs:
         run: nix develop -c zig build -Dstatic=true -Dapp-runtime=glfw -Dtarget=${{ matrix.target }}
 
   build-linux-libghostty:
-    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-sm
+    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-md
     needs: test
     steps:
       - name: Checkout code
@@ -60,7 +60,7 @@ jobs:
         run: nix develop -c zig build -Dapp-runtime=none
 
   build-nix:
-    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-sm
+    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-md
     needs: test
     steps:
       - name: Checkout code
@@ -183,7 +183,7 @@ jobs:
         run: Get-Content -Path ".\build.log"
 
   test:
-    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-sm
+    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-md
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-md"]
 
         target: [
             aarch64-linux,
@@ -41,7 +41,7 @@ jobs:
         run: nix develop -c zig build -Dstatic=true -Dapp-runtime=glfw -Dtarget=${{ matrix.target }}
 
   build-linux-libghostty:
-    runs-on: ubuntu-latest
+    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-md
     needs: test
     steps:
       - name: Checkout code
@@ -60,7 +60,7 @@ jobs:
         run: nix develop -c zig build -Dapp-runtime=none
 
   build-nix:
-    runs-on: ubuntu-latest
+    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-md
     needs: test
     steps:
       - name: Checkout code
@@ -183,7 +183,7 @@ jobs:
         run: Get-Content -Path ".\build.log"
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-md
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -210,7 +210,7 @@ jobs:
         run: nix develop -c zig build -Dstatic=false
 
   prettier:
-    runs-on: ubuntu-latest
+    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-sm
     steps:
       - uses: actions/checkout@v4 # Check out repo so we can lint it
       - uses: cachix/install-nix-action@v24
@@ -224,7 +224,7 @@ jobs:
         run: nix develop -c prettier --check .
 
   alejandra:
-    runs-on: ubuntu-latest
+    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-sm
     steps:
       - uses: actions/checkout@v4 # Check out repo so we can lint it
       - uses: cachix/install-nix-action@v24

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,7 @@ jobs:
         run: nix develop -c zig build -Dstatic=false
 
   prettier:
-    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-sm
+    runs-on: namespace-profile-default
     steps:
       - uses: actions/checkout@v4 # Check out repo so we can lint it
       - uses: cachix/install-nix-action@v24
@@ -224,7 +224,7 @@ jobs:
         run: nix develop -c prettier --check .
 
   alejandra:
-    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-sm
+    runs-on: namespace-profile-default
     steps:
       - uses: actions/checkout@v4 # Check out repo so we can lint it
       - uses: cachix/install-nix-action@v24

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-md"]
+        os: ["namespace-profile-ghostty-md"]
 
         target: [
             aarch64-linux,
@@ -41,7 +41,7 @@ jobs:
         run: nix develop -c zig build -Dstatic=true -Dapp-runtime=glfw -Dtarget=${{ matrix.target }}
 
   build-linux-libghostty:
-    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-md
+    runs-on: namespace-profile-ghostty-md
     needs: test
     steps:
       - name: Checkout code
@@ -60,7 +60,7 @@ jobs:
         run: nix develop -c zig build -Dapp-runtime=none
 
   build-nix:
-    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-md
+    runs-on: namespace-profile-ghostty-md
     needs: test
     steps:
       - name: Checkout code
@@ -183,7 +183,7 @@ jobs:
         run: Get-Content -Path ".\build.log"
 
   test:
-    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-md
+    runs-on: namespace-profile-ghostty-md
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -210,7 +210,7 @@ jobs:
         run: nix develop -c zig build -Dstatic=false
 
   prettier:
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-ghostty-sm
     steps:
       - uses: actions/checkout@v4 # Check out repo so we can lint it
       - uses: cachix/install-nix-action@v24
@@ -224,7 +224,7 @@ jobs:
         run: nix develop -c prettier --check .
 
   alejandra:
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-ghostty-sm
     steps:
       - uses: actions/checkout@v4 # Check out repo so we can lint it
       - uses: cachix/install-nix-action@v24

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-md"]
+        os: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-sm"]
 
         target: [
             aarch64-linux,
@@ -41,7 +41,7 @@ jobs:
         run: nix develop -c zig build -Dstatic=true -Dapp-runtime=glfw -Dtarget=${{ matrix.target }}
 
   build-linux-libghostty:
-    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-md
+    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-sm
     needs: test
     steps:
       - name: Checkout code
@@ -60,7 +60,7 @@ jobs:
         run: nix develop -c zig build -Dapp-runtime=none
 
   build-nix:
-    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-md
+    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-sm
     needs: test
     steps:
       - name: Checkout code
@@ -183,7 +183,7 @@ jobs:
         run: Get-Content -Path ".\build.log"
 
   test:
-    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-md
+    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:22.04-sm
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
They're 2x to 3x faster to complete single jobs and are a fraction of the cost for me.

There is a bit of a queue time currently, but including the queue time they often complete in at worst the same amount of total wall clock time and like I said, cost a fraction for me.