### PR TITLE
terminal: only apply VS15/16 to emoji

### DIFF
--- a/src/unicode/main.zig
+++ b/src/unicode/main.zig
@@ -4,6 +4,7 @@ const grapheme = @import("grapheme.zig");
 const props = @import("props.zig");
 pub const table = props.table;
 pub const Properties = props.Properties;
+pub const getProperties = props.get;
 pub const graphemeBreak = grapheme.graphemeBreak;
 pub const GraphemeBreakState = grapheme.BreakState;
 


### PR DESCRIPTION
Fixes #1482

## Benchmarks to verify no change

The slight speedup is I think just environmental...

### Before

```
Benchmark 1: memcpy
  Time (mean ± σ):       9.5 ms ±   1.1 ms    [User: 2.6 ms, System: 6.2 ms]
  Range (min … max):     7.8 ms …  13.4 ms    201 runs

Benchmark 2: scalar
  Time (mean ± σ):     463.4 ms ±   4.3 ms    [User: 449.2 ms, System: 11.5 ms]
  Range (min … max):   460.2 ms … 474.8 ms    10 runs

Benchmark 3: simd
  Time (mean ± σ):     368.7 ms ±   1.5 ms    [User: 355.3 ms, System: 11.3 ms]
  Range (min … max):   366.9 ms … 372.5 ms    10 runs

Summary
  'memcpy' ran
   38.65 ± 4.53 times faster than 'simd'
   48.58 ± 5.71 times faster than 'scalar'
```

### After

```
Benchmark 1: memcpy
  Time (mean ± σ):       8.8 ms ±   1.1 ms    [User: 2.3 ms, System: 5.9 ms]
  Range (min … max):     7.4 ms …  12.7 ms    231 runs

Benchmark 2: scalar
  Time (mean ± σ):     462.5 ms ±   4.2 ms    [User: 448.9 ms, System: 11.4 ms]
  Range (min … max):   457.9 ms … 472.4 ms    10 runs

Benchmark 3: simd
  Time (mean ± σ):     365.9 ms ±   1.3 ms    [User: 352.6 ms, System: 11.2 ms]
  Range (min … max):   364.2 ms … 367.9 ms    10 runs

Summary
  'memcpy' ran
   41.36 ± 5.22 times faster than 'simd'
   52.26 ± 6.61 times faster than 'scalar'
```