### PR TITLE
os: remove UB, tmpDir is returning stack memory on Windows

### DIFF
--- a/src/os/TempDir.zig
+++ b/src/os/TempDir.zig
@@ -31,7 +31,8 @@ pub fn init() !TempDir {
 
     const dir = dir: {
         const cwd = std.fs.cwd();
-        const tmp_dir = internal_os.tmpDir() orelse break :dir cwd;
+        const tmp_dir = internal_os.allocTmpDir(std.heap.page_allocator) orelse break :dir cwd;
+        defer internal_os.freeTmpDir(std.heap.page_allocator, tmp_dir);
         break :dir try cwd.openDir(tmp_dir, .{});
     };
 

--- a/src/terminal/kitty/graphics_image.zig
+++ b/src/terminal/kitty/graphics_image.zig
@@ -192,7 +192,8 @@ pub const LoadingImage = struct {
     fn isPathInTempDir(path: []const u8) bool {
         if (std.mem.startsWith(u8, path, "/tmp")) return true;
         if (std.mem.startsWith(u8, path, "/dev/shm")) return true;
-        if (internal_os.tmpDir()) |dir| {
+        if (internal_os.allocTmpDir(std.heap.page_allocator)) |dir| {
+            defer internal_os.freeTmpDir(std.heap.page_allocator, dir);
             if (std.mem.startsWith(u8, path, dir)) return true;
 
             // The temporary dir is sometimes a symlink. On macOS for


### PR DESCRIPTION
On Windows, the tmpDir function is currently using a buffer on the stack to convert the WTF16-encoded environment variable value "TMP" to utf8 and then returns it as a slice...but that stack buffer is no longer valid when the function returns.  This was causing the "image load...temporary file" test to fail on Windows.

I've updated the function to take an allocator but it only uses the allocator on Windows.  No allocation is needed on other platforms because they return environment variables that are already utf8 (ascii) encoded, and the OS pre-allocates all environment variables in the process. To keep the conditional that determines when allocation is required, I added the `freeTmpDir` function.