### PR TITLE
macos: more robust surface focus state detection

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.SplitNode.swift
+++ b/macos/Sources/Ghostty/Ghostty.SplitNode.swift
@@ -11,7 +11,7 @@ extension Ghostty {
     ///   "container" which has a recursive top/left SplitNode and bottom/right SplitNode. These
     ///   values can further be split infinitely.
     ///
-    enum SplitNode: Equatable, Hashable, Codable {
+    enum SplitNode: Equatable, Hashable, Codable, Sequence {
         case leaf(Leaf)
         case split(Container)
         
@@ -133,6 +133,24 @@ extension Ghostty {
             case .split(let container):
                 return container.topLeft.findUUID(uuid: uuid) ??
                     container.bottomRight.findUUID(uuid: uuid)
+            }
+        }
+        
+        // MARK: - Sequence
+        
+        func makeIterator() -> IndexingIterator<[Leaf]> {
+            return leaves().makeIterator()
+        }
+        
+        /// Return all the leaves in this split node. This isn't very efficient but our split trees are never super
+        /// deep so its not an issue.
+        private func leaves() -> [Leaf] {
+            switch (self) {
+            case .leaf(let leaf):
+                return [leaf]
+
+            case .split(let container):
+                return container.topLeft.leaves() + container.bottomRight.leaves()
             }
         }
         

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -51,10 +51,6 @@ extension Ghostty {
 
         @EnvironmentObject private var ghostty: Ghostty.App
 
-        // This is true if the terminal is considered "focused". The terminal is focused if
-        // it is both individually focused and the containing window is key.
-        private var hasFocus: Bool { surfaceFocus && windowFocus }
-
         var body: some View {
             let center = NotificationCenter.default
             
@@ -72,7 +68,7 @@ extension Ghostty {
                     let pubResign = center.publisher(for: NSWindow.didResignKeyNotification)
                     #endif
 
-                    Surface(view: surfaceView, hasFocus: hasFocus, size: geo.size)
+                    Surface(view: surfaceView, size: geo.size)
                         .focused($surfaceFocus)
                         .focusedValue(\.ghosttySurfaceTitle, surfaceView.title)
                         .focusedValue(\.ghosttySurfaceView, surfaceView)
@@ -230,11 +226,6 @@ extension Ghostty {
         /// The view to render for the terminal surface.
         let view: SurfaceView
 
-        /// This should be set to true when the surface has focus. This is up to the parent because
-        /// focus is also defined by window focus. It is important this is set correctly since if it is
-        /// false then the surface will idle at almost 0% CPU.
-        let hasFocus: Bool
-
         /// The size of the frame containing this view. We use this to update the the underlying
         /// surface. This does not actually SET the size of our frame, this only sets the size
         /// of our Metal surface for drawing.
@@ -253,7 +244,6 @@ extension Ghostty {
         }
 
         func updateOSView(_ view: SurfaceView, context: Context) {
-            view.focusDidChange(hasFocus)
             view.sizeDidChange(size)
         }
     }

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -188,6 +188,8 @@ extension Ghostty {
 
         func focusDidChange(_ focused: Bool) {
             guard let surface = self.surface else { return }
+            guard self.focused != focused else { return }
+            self.focused = focused
             ghostty_surface_set_focus(surface, focused)
         }
 
@@ -358,7 +360,7 @@ extension Ghostty {
         
         override func becomeFirstResponder() -> Bool {
             let result = super.becomeFirstResponder()
-            if (result) { focused = true }
+            if (result) { focusDidChange(true) }
             return result
         }
 
@@ -367,10 +369,7 @@ extension Ghostty {
 
             // We sometimes call this manually (see SplitView) as a way to force us to
             // yield our focus state.
-            if (result) {
-                focusDidChange(false)
-                focused = false
-            }
+            if (result) { focusDidChange(false) }
 
             return result
         }


### PR DESCRIPTION
Fixes #1500

This overhauls how we do focus management for surfaces to make it more robust. This DID somehow all work before but was always brittle and was a sketchy play with SwiftUI/AppKit behavior across macOS versions.

The new approach uses our window controller and terminal delegate system to disseminate focus information whenever any surface changes focus. This ensures that only ONE surface ever has focus in libghostty because the controller ensures it is widely distributed.