### PR TITLE
Use Namespace cache volumes to cache /nix.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
 
       # Install Nix and use that to run our tests so our environment matches exactly.
       - name: Setup Nix Cache
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@v1.1.0
         with:
           path: /nix
       - uses: cachix/install-nix-action@v24
@@ -54,7 +54,7 @@ jobs:
 
       # Install Nix and use that to run our tests so our environment matches exactly.
       - name: Setup Nix Cache
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@v1.1.0
         with:
           path: /nix
       - uses: cachix/install-nix-action@v24
@@ -77,7 +77,7 @@ jobs:
 
       # Install Nix and use that to run our tests so our environment matches exactly.
       - name: Setup Nix Cache
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@v1.1.0
         with:
           path: /nix
       - uses: cachix/install-nix-action@v24
@@ -222,7 +222,7 @@ jobs:
 
       # Install Nix and use that to run our tests so our environment matches exactly.
       - name: Setup Nix Cache
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@v1.1.0
         with:
           path: /nix
       - uses: cachix/install-nix-action@v24
@@ -251,7 +251,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4 # Check out repo so we can lint it
       - name: Setup Nix Cache
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@v1.1.0
         with:
           path: /nix
       - uses: cachix/install-nix-action@v24
@@ -272,7 +272,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4 # Check out repo so we can lint it
       - name: Setup Nix Cache
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@v1.1.0
         with:
           path: /nix
       - uses: cachix/install-nix-action@v24

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,10 @@ jobs:
         uses: actions/checkout@v4
 
       # Install Nix and use that to run our tests so our environment matches exactly.
+      - name: Setup Nix Cache
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          path: /nix
       - uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -49,6 +53,10 @@ jobs:
         uses: actions/checkout@v4
 
       # Install Nix and use that to run our tests so our environment matches exactly.
+      - name: Setup Nix Cache
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          path: /nix
       - uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -68,6 +76,10 @@ jobs:
         uses: actions/checkout@v4
 
       # Install Nix and use that to run our tests so our environment matches exactly.
+      - name: Setup Nix Cache
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          path: /nix
       - uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -209,6 +221,10 @@ jobs:
         uses: actions/checkout@v4
 
       # Install Nix and use that to run our tests so our environment matches exactly.
+      - name: Setup Nix Cache
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          path: /nix
       - uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -234,6 +250,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4 # Check out repo so we can lint it
+      - name: Setup Nix Cache
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          path: /nix
       - uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -251,6 +271,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4 # Check out repo so we can lint it
+      - name: Setup Nix Cache
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          path: /nix
       - uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable


### PR DESCRIPTION
Leads to an overall improvement of 25% in total runtime.

Before --> After
![Screenshot 2024-02-12 at 16 03 44](https://github.com/mitchellh/ghostty/assets/175449/b671d3ef-436d-43d2-805e-a10ffb43cceb)
![Screenshot 2024-02-12 at 16 04 19](https://github.com/mitchellh/ghostty/assets/175449/4baf3493-6e6f-4fc7-a51d-a4a370dfb446)
