### PR TITLE
Update usage of std.os.O

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
     },
     "nixpkgs-zig-0-12": {
       "locked": {
-        "lastModified": 1707614255,
-        "narHash": "sha256-26jDBuCgewZb+ifR3Ow6cZS/6Mz09pwC4ukKWtOjFZk=",
+        "lastModified": 1707846486,
+        "narHash": "sha256-ek2NESo8WPqUIuUPVs3L2rliCFofvjhR/i3ptaxfaJ4=",
         "owner": "vancluever",
         "repo": "nixpkgs",
-        "rev": "85b992eb1a8d3a3742ddb21eba7f79b0e4f2e78b",
+        "rev": "31119ca40f326e3a6552883fa62f2df56c17a7bf",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707611073,
-        "narHash": "sha256-sMsxVKXP5TLcaVMNlRZ7KlDsYGwDdJAMtY0DKmb+7fQ=",
+        "lastModified": 1707783766,
+        "narHash": "sha256-kD90pK+KAzr3UrohYRqE7fWUaEg4Mv3rk1IhubiHFUM=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "aa4edff6f53e64443ca77e8d9ffe866f29e5b3d4",
+        "rev": "06f4507d05f90a54409a5206fcfba5966eea0c03",
         "type": "github"
       },
       "original": {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1470,7 +1470,11 @@ const ReadThread = struct {
         // so that we can try to read from the fd in a tight loop and only
         // check the quit fd occasionally.
         if (std.os.fcntl(fd, std.os.F.GETFL, 0)) |flags| {
-            _ = std.os.fcntl(fd, std.os.F.SETFL, flags | std.os.O.NONBLOCK) catch |err| {
+            _ = std.os.fcntl(
+                fd,
+                std.os.F.SETFL,
+                flags | @as(u32, @bitCast(std.os.O{ .NONBLOCK = true })),
+            ) catch |err| {
                 log.warn("read thread failed to set flags err={}", .{err});
                 log.warn("this isn't a fatal error, but may cause performance issues", .{});
             };


### PR DESCRIPTION
Requires Zig version at least `0.12.0-dev.2711+f995c1b08`