### PR TITLE
Realpath with nulls and malformed OSC 4 causing panics

### DIFF
--- a/src/terminal/kitty/graphics_image.zig
+++ b/src/terminal/kitty/graphics_image.zig
@@ -76,11 +76,15 @@ pub const LoadingImage = struct {
             return error.InvalidData;
         };
 
-        if (builtin.os != .windows and std.mem.indexOfScalar(u8, buf[0..size], 0) == null) {
-            // std.os.realpath *asserts* that the path does not have internal nulls instead of erroring.
-            log.warn("failed to get absolute path: BadPathName", .{});
-            return error.InvalidData;
+        if (comptime builtin.os != .windows) {
+            if (std.mem.indexOfScalar(u8, buf[0..size], 0) == null) {
+                // std.os.realpath *asserts* that the path does not have
+                // internal nulls instead of erroring.
+                log.warn("failed to get absolute path: BadPathName", .{});
+                return error.InvalidData;
+            }
         }
+
         var abs_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
         const path = std.os.realpath(buf[0..size], &abs_buf) catch |err| {
             log.warn("failed to get absolute path: {}", .{err});

--- a/src/terminal/kitty/graphics_image.zig
+++ b/src/terminal/kitty/graphics_image.zig
@@ -75,6 +75,12 @@ pub const LoadingImage = struct {
             log.warn("failed to decode base64 data: {}", .{err});
             return error.InvalidData;
         };
+
+        if (builtin.os != .windows and std.mem.indexOfScalar(u8, buf[0..size], 0) == null) {
+            // std.os.realpath *asserts* that the path does not have internal nulls instead of erroring.
+            log.warn("failed to get absolute path: BadPathName", .{});
+            return error.InvalidData;
+        }
         var abs_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
         const path = std.os.realpath(buf[0..size], &abs_buf) catch |err| {
             log.warn("failed to get absolute path: {}", .{err});


### PR DESCRIPTION
Both of these were relatively low hanging fruit in the latest batch of fuzzing src/terminal.

`std.os.realpath` asserts that the path it is provided contains no nulls; this causes a panic when debug safety is enabled (which im aware is uncommon for ghostty).

a malformed OSC 4, namely `OSC 4 ; ;` passes an empty string to `std.fmt.parseUnsigned`, which returns `error.InvalidCharacter`, which is marked unreachable. This handles the edge case explicitly, because the OSC parser otherwise guarantees that InvalidCharacter is impossible.