### PR TITLE
core: fallback to heap allocation for long preedit inputs

### DIFF
--- a/src/termio/message.zig
+++ b/src/termio/message.zig
@@ -162,6 +162,22 @@ pub fn MessageData(comptime Elem: type, comptime small_size: comptime_int) type 
                 else => unreachable,
             }
         }
+
+        pub fn deinit(self: Self) void {
+            switch (self) {
+                .small, .stable => {},
+                .alloc => |v| v.alloc.free(v.alloc.data),
+            }
+        }
+
+        /// Returns a const slice of the data pointed to by this request.
+        pub fn slice(self: Self) []const Elem {
+            return switch (self) {
+                .small => |v| v.data[0..v.len],
+                .stable => |v| v,
+                .alloc => |v| v.data,
+            };
+        }
     };
 }
 


### PR DESCRIPTION
Fixes #1514

We previously required all preedit inputs to fit into the small copied message size. That's true for 99% of all inputs, but if a long pre-edit input comes in, this may not be true. We should try the small array fast-path but fall back to heap allocation if we must.