### PR TITLE
app: call `close` instead of `deinit` in App.destroy

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -68,7 +68,7 @@ pub fn create(
 
 pub fn destroy(self: *App) void {
     // Clean up all our surfaces
-    for (self.surfaces.items) |surface| surface.deinit();
+    for (self.surfaces.items) |surface| surface.close(false);
     self.surfaces.deinit(self.alloc);
 
     if (comptime font.Discover != void) {


### PR DESCRIPTION
NOTE: tested on the win32 and linux-glfw app runtimes

From the code it looks like `deinit` cleans up the Surface internals but doesn't free the memory that `Surface` itself occupies.  This updates `App.destroy` to call close instead to fully cleanup each surface.  This fixed a leak that was detected in the win32 apprt.