### PR TITLE
Avoid repainting new tab button for native tab bar

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/TerminalWindow.swift
@@ -16,12 +16,18 @@ class TerminalWindow: NSWindow {
         }
         
         super.becomeKey()
-        updateNewTabButtonOpacity()
+
+        if titlebarTabs {
+            updateNewTabButtonOpacity()
+        }
     }
 
     override func resignKey() {
         super.resignKey()
-        updateNewTabButtonOpacity()
+
+        if titlebarTabs {
+            updateNewTabButtonOpacity()
+        }
     }
 
     // MARK: - Titlebar Tabs
@@ -210,6 +216,8 @@ class TerminalWindow: NSWindow {
 
     override func update() {
         super.update()
+
+        guard titlebarTabs else { return }
 
         // This is called when we open, close, switch, and reorder tabs, at which point we determine if the
         // first tab in the tab bar is selected. If it is, we make the `windowButtonsBackdrop` color the same

--- a/src/build_config.zig
+++ b/src/build_config.zig
@@ -50,8 +50,9 @@ pub const BuildConfig = struct {
         step.addOption(bool, "wasm_shared", self.wasm_shared);
 
         // Our version. We also add the string version so we don't need
-        // to do any allocations at runtime.
-        var buf: [64]u8 = undefined;
+        // to do any allocations at runtime. This has to be long enough to
+        // accomodate realistic large branch names for dev versions.
+        var buf: [1024]u8 = undefined;
         step.addOption(std.SemanticVersion, "app_version", self.version);
         step.addOption([:0]const u8, "app_version_string", try std.fmt.bufPrintZ(
             &buf,


### PR DESCRIPTION
The new tab button was repainted in #1501.

However, it is also repainted when `macos-titlebar-tabs` is not enabled. This means that if, say, your theme's background color is dark but you're not in dark mode, the color of the button will not match the system appearance.

This pull request applies the same fix as in #1490 to avoid repainting.

## Screenshot
![image](https://github.com/mitchellh/ghostty/assets/19824/c114f953-8bed-42ab-9203-6a6d1b1e5d95)