### PR TITLE
Set background color in title bar tab mode only

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -254,10 +254,10 @@ class TerminalController: NSWindowController, NSWindowDelegate,
         // Center the window to start, we'll move the window frame automatically
         // when cascading.
         window.center()
-        
+
         // Set the background color of the window
         window.backgroundColor = NSColor(ghostty.config.backgroundColor)
-        
+
         // Handle titlebar tabs config option. Something about what we do while setting up the
         // titlebar tabs interferes with the window restore process unless window.tabbingMode
         // is set to .preferred, so we set it, and switch back to automatic as soon as we can.
@@ -269,7 +269,7 @@ class TerminalController: NSWindowController, NSWindowDelegate,
                 window.tabbingMode = .automatic
             }
         }
-        
+
         // Set a custom background on the titlebar - this is required for when
         // titlebar tabs is used in conjunction with a transparent background.
         window.setTitlebarBackground(
@@ -278,7 +278,7 @@ class TerminalController: NSWindowController, NSWindowDelegate,
                 .withAlphaComponent(ghostty.config.backgroundOpacity)
                 .cgColor
         )
-        
+
         // Initialize our content view to the SwiftUI root
         window.contentView = NSHostingView(rootView: TerminalView(
             ghostty: self.ghostty,

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -259,15 +259,15 @@ class TerminalController: NSWindowController, NSWindowDelegate,
         // titlebar tabs interferes with the window restore process unless window.tabbingMode
         // is set to .preferred, so we set it, and switch back to automatic as soon as we can.
         if (ghostty.config.macosTitlebarTabs) {
-            // Set the background color of the window
-            window.backgroundColor = NSColor(ghostty.config.backgroundColor)
-
             window.tabbingMode = .preferred
             window.titlebarTabs = true
             syncAppearance()
             DispatchQueue.main.async {
                 window.tabbingMode = .automatic
             }
+            
+            // Set the background color of the window
+            window.backgroundColor = NSColor(ghostty.config.backgroundColor)
 
             // Set a custom background on the titlebar - this is required for when
             // titlebar tabs are used in conjunction with a transparent background.

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -255,29 +255,29 @@ class TerminalController: NSWindowController, NSWindowDelegate,
         // when cascading.
         window.center()
 
-        // Set the background color of the window
-        window.backgroundColor = NSColor(ghostty.config.backgroundColor)
-
         // Handle titlebar tabs config option. Something about what we do while setting up the
         // titlebar tabs interferes with the window restore process unless window.tabbingMode
         // is set to .preferred, so we set it, and switch back to automatic as soon as we can.
         if (ghostty.config.macosTitlebarTabs) {
+            // Set the background color of the window
+            window.backgroundColor = NSColor(ghostty.config.backgroundColor)
+
             window.tabbingMode = .preferred
             window.titlebarTabs = true
             syncAppearance()
             DispatchQueue.main.async {
                 window.tabbingMode = .automatic
             }
-        }
 
-        // Set a custom background on the titlebar - this is required for when
-        // titlebar tabs are used in conjunction with a transparent background.
-        window.setTitlebarBackground(
-            window
-                .backgroundColor
-                .withAlphaComponent(ghostty.config.backgroundOpacity)
-                .cgColor
-        )
+            // Set a custom background on the titlebar - this is required for when
+            // titlebar tabs are used in conjunction with a transparent background.
+            window.setTitlebarBackground(
+                window
+                    .backgroundColor
+                    .withAlphaComponent(ghostty.config.backgroundOpacity)
+                    .cgColor
+            )
+        }
 
         // Initialize our content view to the SwiftUI root
         window.contentView = NSHostingView(rootView: TerminalView(

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -271,7 +271,7 @@ class TerminalController: NSWindowController, NSWindowDelegate,
         }
 
         // Set a custom background on the titlebar - this is required for when
-        // titlebar tabs is used in conjunction with a transparent background.
+        // titlebar tabs are used in conjunction with a transparent background.
         window.setTitlebarBackground(
             window
                 .backgroundColor


### PR DESCRIPTION
The background color needs to be set for the title bar tab mode (see #1418).

If `macos-titlebar-tabs` is not enabled and you're using a theme with a dark background color, setting the background color will make window's appearance darker - even when `window-theme` is "light" or "system".

This seems undesired so this change sets the background color only when `macos-titlebar-tabs` is enabled. (This makes the appearance similar to other applications.)

## Screenshots

The two screenshots show before and after this change.

![darker light](https://github.com/mitchellh/ghostty/assets/19824/b025f5dd-a277-4838-9359-4f95e9aa89c0)

![default light](https://github.com/mitchellh/ghostty/assets/19824/b81f6ffd-7054-43ea-a0a1-2fe598427839)