### PR TITLE
docs: correct MacOS location for themes on config docs

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -213,8 +213,8 @@ const c = @cImport({
 
 /// A named theme to use. The available themes are currently hardcoded to the
 /// themes that ship with Ghostty. On macOS, this list is in the `Ghostty.app/
-/// Contents/Resources/themes` directory. On Linux, this list is in the `share/
-/// ghostty/themes` directory (wherever you installed the Ghostty "share"
+/// Contents/Resources/ghostty/themes` directory. On Linux, this list is in the 
+/// `share/ghostty/themes` directory (wherever you installed the Ghostty "share"
 /// directory.
 ///
 /// To see a list of available themes, run `ghostty +list-themes`.


### PR DESCRIPTION
Not sure if this changed after the initial document was created, but I found the themes in this themes in my installation.