### PR TITLE
Update minimum Zig version in build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -24,7 +24,7 @@ const Command = @import("src/Command.zig");
 // but we liberally update it. In the future, we'll be more careful about
 // using released versions so that package managers can integrate better.
 comptime {
-    const required_zig = "0.12.0-dev.2701+d18f52197";
+    const required_zig = "0.12.0-dev.2711+f995c1b08";
     const current_zig = builtin.zig_version;
     const min_zig = std.SemanticVersion.parse(required_zig) catch unreachable;
     if (current_zig.order(min_zig) == .lt) {


### PR DESCRIPTION
This is the version required to use the new std.os.O struct format from
https://github.com/mitchellh/ghostty/pull/1509.