### PR TITLE
config: update font-thicken docs

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -148,8 +148,7 @@ const c = @cImport({
 /// i.e. new windows, tabs, etc.
 @"font-codepoint-map": RepeatableCodepointMap = .{},
 
-/// Draw fonts with a thicker stroke, if supported. This is only supported
-/// currently on MacOS.
+/// Draw fonts with a thicker stroke, if supported.
 @"font-thicken": bool = false,
 
 /// All of the configurations behavior adjust various metrics determined by the


### PR DESCRIPTION
As far as I can tell, `font-thicken` is supported in both the metal and opengl renderers as of #193 , commit [1331547](https://github.com/mitchellh/ghostty/commit/13315471d76b110134e18e43e7f48749ec0407da).