### PR TITLE
Fix crash in underline drawing math

### DIFF
--- a/src/font/sprite/canvas.zig
+++ b/src/font/sprite/canvas.zig
@@ -424,9 +424,6 @@ const PixmanImpl = struct {
     /// Draw and fill a rectangle. This is the main primitive for drawing
     /// lines as well (which are just generally skinny rectangles...)
     pub fn rect(self: *Canvas, v: Rect, color: Color) void {
-        assert(v.x >= 0);
-        assert(v.y >= 0);
-
         const boxes = &[_]pixman.Box32{
             .{
                 .x1 = @intCast(v.x),
@@ -436,6 +433,10 @@ const PixmanImpl = struct {
             },
         };
 
+        assert(boxes[0].x1 >= 0);
+        assert(boxes[0].y1 >= 0);
+        assert(boxes[0].x2 <= @as(i32, @intCast(self.image.getWidth())));
+        assert(boxes[0].y2 <= @as(i32, @intCast(self.image.getHeight())));
         self.image.fillBoxes(.src, color.pixmanColor(), boxes) catch {};
     }
 

--- a/src/font/sprite/canvas.zig
+++ b/src/font/sprite/canvas.zig
@@ -424,6 +424,9 @@ const PixmanImpl = struct {
     /// Draw and fill a rectangle. This is the main primitive for drawing
     /// lines as well (which are just generally skinny rectangles...)
     pub fn rect(self: *Canvas, v: Rect, color: Color) void {
+        assert(v.x >= 0);
+        assert(v.y >= 0);
+
         const boxes = &[_]pixman.Box32{
             .{
                 .x1 = @intCast(v.x),

--- a/src/font/sprite/underline.zig
+++ b/src/font/sprite/underline.zig
@@ -80,7 +80,7 @@ const Draw = struct {
         // Ensure we never overflow out of bounds on the canvas
         const y_max = self.height -| 1;
         const bottom = @min(self.pos + self.thickness, y_max);
-        const y = @as(i32, @intCast(bottom - self.thickness));
+        const y = @as(i32, @intCast(bottom)) - @as(i32, @intCast(self.thickness));
 
         canvas.rect(.{
             .x = 0,

--- a/src/font/sprite/underline.zig
+++ b/src/font/sprite/underline.zig
@@ -80,13 +80,14 @@ const Draw = struct {
         // Ensure we never overflow out of bounds on the canvas
         const y_max = self.height -| 1;
         const bottom = @min(self.pos + self.thickness, y_max);
-        const y = @as(i32, @intCast(bottom -| self.thickness));
+        const y = bottom -| self.thickness;
+        const max_height = self.height - y;
 
         canvas.rect(.{
             .x = 0,
-            .y = y,
+            .y = @intCast(y),
             .width = self.width,
-            .height = self.thickness,
+            .height = @min(self.thickness, max_height),
         }, .on);
     }
 

--- a/src/font/sprite/underline.zig
+++ b/src/font/sprite/underline.zig
@@ -80,7 +80,7 @@ const Draw = struct {
         // Ensure we never overflow out of bounds on the canvas
         const y_max = self.height -| 1;
         const bottom = @min(self.pos + self.thickness, y_max);
-        const y = @as(i32, @intCast(bottom)) - @as(i32, @intCast(self.thickness));
+        const y = @as(i32, @intCast(bottom -| self.thickness));
 
         canvas.rect(.{
             .x = 0,
@@ -221,6 +221,26 @@ test "single" {
         18,
         9,
         2,
+    );
+}
+
+test "single large thickness" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var atlas_greyscale = try font.Atlas.init(alloc, 512, .greyscale);
+    defer atlas_greyscale.deinit(alloc);
+
+    // unrealistic thickness but used to cause a crash
+    // https://github.com/mitchellh/ghostty/pull/1548
+    _ = try renderGlyph(
+        alloc,
+        &atlas_greyscale,
+        .underline,
+        36,
+        18,
+        9,
+        200,
     );
 }
 


### PR DESCRIPTION
I found that ghostty would crash when displaying underlined text if you set a large value for the underline thickness, such as `ghostty --adjust-underline-thickness=200`.  I'm just sending this pull request cause it's a pretty straightforward fix, but it should also be easy to repro with the command above if you want to do something else.