### PR TITLE
Add 'adjust-cursor-thickness' config option

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -148,9 +148,13 @@ const c = @cImport({
 /// i.e. new windows, tabs, etc.
 @"font-codepoint-map": RepeatableCodepointMap = .{},
 
-/// Draw fonts with a thicker stroke, if supported. This is only supported
-/// currently on MacOS.
+/// Draw fonts with a thicker stroke, if supported. Currently this only
+/// affects fonts on MacOS as well as supported sprites (cursors, underlines,
+/// etc.).
 @"font-thicken": bool = false,
+
+/// Adjust the line thickness of cursor sprites only. This is in pixels.
+@"adjust-cursor-thickness": u32 = 0,
 
 /// All of the configurations behavior adjust various metrics determined by the
 /// font. The values can be integers (1, -1, etc.) or a percentage (20%, -15%,

--- a/src/font/Group.zig
+++ b/src/font/Group.zig
@@ -705,6 +705,7 @@ pub const Wasm = struct {
             .width = metrics.cell_width,
             .height = metrics.cell_height,
             .thickness = 2,
+            .cursor_thickness_adjustment = 0,
             .underline_position = metrics.underline_position,
         };
     }
@@ -929,7 +930,12 @@ test "box glyph" {
     defer group.deinit();
 
     // Set box font
-    group.sprite = font.sprite.Face{ .width = 18, .height = 36, .thickness = 2 };
+    group.sprite = font.sprite.Face{
+        .width = 18,
+        .height = 36,
+        .thickness = 2,
+        .cursor_thickness_adjustment = 0,
+    };
 
     // Should find a box glyph
     const idx = group.indexForCodepoint(0x2500, .regular, null).?;

--- a/src/font/face.zig
+++ b/src/font/face.zig
@@ -84,7 +84,8 @@ pub const RenderOptions = struct {
     /// Thicken the glyph. This draws the glyph with a thicker stroke width.
     /// This is purely an aesthetic setting.
     ///
-    /// This only works with CoreText currently.
+    /// This currently only works with CoreText and supported sprites (cursors,
+    /// underlines, etc.).
     thicken: bool = false,
 };
 

--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -614,6 +614,7 @@ test "shape box glyphs" {
         .width = 18,
         .height = 36,
         .thickness = 2,
+        .cursor_thickness_adjustment = 0,
     };
 
     var buf: [32]u8 = undefined;

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -626,6 +626,7 @@ test "shape box glyphs" {
         .width = 18,
         .height = 36,
         .thickness = 2,
+        .cursor_thickness_adjustment = 0,
     };
 
     var buf: [32]u8 = undefined;

--- a/src/font/sprite/Face.zig
+++ b/src/font/sprite/Face.zig
@@ -32,6 +32,10 @@ height: u32,
 /// want to do any DPI scaling, it is expected to be done earlier.
 thickness: u32,
 
+/// Adjustment value for the thickness of lines in cursor sprites only.
+/// This is in pixels.
+cursor_thickness_adjustment: u32,
+
 /// The position of the underline.
 underline_position: u32 = 0,
 
@@ -73,7 +77,13 @@ pub fn renderGlyph(
                 var f: Box = .{
                     .width = width,
                     .height = self.height,
-                    .thickness = self.thickness,
+                    .thickness = switch (cp) {
+                        @intFromEnum(Sprite.cursor_rect),
+                        @intFromEnum(Sprite.cursor_hollow_rect),
+                        @intFromEnum(Sprite.cursor_bar),
+                        => self.thickness + self.cursor_thickness_adjustment,
+                        else => self.thickness,
+                    },
                 };
 
                 // If the codepoint is unadjusted then we want to adjust

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -159,6 +159,7 @@ pub const DerivedConfig = struct {
     font_thicken: bool,
     font_features: std.ArrayListUnmanaged([:0]const u8),
     font_styles: font.Group.StyleStatus,
+    adjust_cursor_thickness: u32,
     cursor_color: ?terminal.color.RGB,
     cursor_opacity: f64,
     cursor_text: ?terminal.color.RGB,
@@ -215,6 +216,8 @@ pub const DerivedConfig = struct {
                 null,
 
             .cursor_opacity = @max(0, @min(1, config.@"cursor-opacity")),
+
+            .adjust_cursor_thickness = config.@"adjust-cursor-thickness",
 
             .background = config.background.toTerminalRGB(),
             .foreground = config.foreground.toTerminalRGB(),
@@ -360,6 +363,7 @@ pub fn init(alloc: Allocator, options: renderer.Options) !Metal {
         .thickness = metrics.underline_thickness *
             @as(u32, if (options.config.font_thicken) 2 else 1),
         .underline_position = metrics.underline_position,
+        .cursor_thickness_adjustment = options.config.adjust_cursor_thickness,
     };
 
     // Create the font shaper. We initially create a shaper that can support
@@ -600,6 +604,7 @@ pub fn setFontSize(self: *Metal, size: font.face.DesiredSize) !void {
         .height = metrics.cell_height,
         .thickness = metrics.underline_thickness * @as(u32, if (self.config.font_thicken) 2 else 1),
         .underline_position = metrics.underline_position,
+        .cursor_thickness_adjustment = self.config.adjust_cursor_thickness,
     };
 
     // Notify the window that the cell size changed.

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -240,6 +240,7 @@ pub const DerivedConfig = struct {
     font_thicken: bool,
     font_features: std.ArrayListUnmanaged([:0]const u8),
     font_styles: font.Group.StyleStatus,
+    adjust_cursor_thickness: u32,
     cursor_color: ?terminal.color.RGB,
     cursor_text: ?terminal.color.RGB,
     cursor_opacity: f64,
@@ -297,6 +298,8 @@ pub const DerivedConfig = struct {
 
             .cursor_opacity = @max(0, @min(1, config.@"cursor-opacity")),
 
+            .adjust_cursor_thickness = config.@"adjust-cursor-thickness",
+
             .background = config.background.toTerminalRGB(),
             .foreground = config.foreground.toTerminalRGB(),
             .invert_selection_fg_bg = config.@"selection-invert-fg-bg",
@@ -338,6 +341,7 @@ pub fn init(alloc: Allocator, options: renderer.Options) !OpenGL {
         alloc,
         options.font_group,
         options.config.font_thicken,
+        options.config.adjust_cursor_thickness,
     );
 
     var gl_state = try GLState.init(alloc, options.config, options.font_group);
@@ -475,6 +479,7 @@ pub fn displayRealize(self: *OpenGL) !void {
         self.alloc,
         self.font_group,
         self.config.font_thicken,
+        self.config.adjust_cursor_thickness,
     );
 
     // Make our new state
@@ -598,6 +603,7 @@ pub fn setFontSize(self: *OpenGL, size: font.face.DesiredSize) !void {
         self.alloc,
         self.font_group,
         self.config.font_thicken,
+        self.config.adjust_cursor_thickness,
     );
 
     // Defer our GPU updates
@@ -623,6 +629,7 @@ fn resetFontMetrics(
     alloc: Allocator,
     font_group: *font.GroupCache,
     font_thicken: bool,
+    cursor_thickness_adjustment: u32,
 ) !font.face.Metrics {
     // Get our cell metrics based on a regular font ascii 'M'. Why 'M'?
     // Doesn't matter, any normal ASCII will do we're just trying to make
@@ -639,6 +646,7 @@ fn resetFontMetrics(
         .width = metrics.cell_width,
         .height = metrics.cell_height,
         .thickness = metrics.underline_thickness * @as(u32, if (font_thicken) 2 else 1),
+        .cursor_thickness_adjustment = cursor_thickness_adjustment,
         .underline_position = metrics.underline_position,
     };
 


### PR DESCRIPTION
This is a follow up to #1546 and the recent conversation there about font-thicken and support for custom cursor widths.

Currently, `font-thicken` affects CoreText as well as supported Box sprites (double thickness for underlines, certain box characters, and cursors).
This adds a new option, `adjust-cursor-thickness`, that doesn't change the functionality of `font-thicken` (it still applies to CoreText *and* sprites) but allows the user to configure cursor widths without "relying" on `font-thicken` for it (or just to have thick cursors but not thick underlines for example). I think it stays as close to what Mitchel suggested [here](https://github.com/mitchellh/ghostty/pull/1546#issuecomment-1961895731) as possible, but I don't know if it's necessarily the right way to go. The downside is that now there are two separate config options that both affect the thickness of cursors. I wasn't sure if you'd want to keep it that way or change it up a bit more, so I just went with your suggestion earlier.

I also would like to note that I'm not at all confident in *how* I implemented it; it feels weird to me that the `Renderer`s all have to know about specifically the cursor thickness, but I couldn't figure out a better way to get the adjustment configuration through to the sprite face (which is created in the renderers). Cursor thickness to me also didn't feel worthy of "a metric determined by the font," so I avoided using `MetricModier`; but maybe that would be better. So feel free to dismiss/replace/correct whatever you don't see fit (Im doing this mostly to practice my very adolescent programming skills anyways, having fun regardless :).