### PR TITLE
add 'gtk-tabs-location'

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -112,7 +112,13 @@ pub fn init(self: *Window, app: *App) !void {
     const notebook_widget = c.gtk_notebook_new();
     const notebook: *c.GtkNotebook = @ptrCast(notebook_widget);
     self.notebook = notebook;
-    c.gtk_notebook_set_tab_pos(notebook, c.GTK_POS_TOP);
+    const notebook_tab_pos: c_uint = switch (app.config.@"gtk-tabs-location") {
+        .top => c.GTK_POS_TOP,
+        .bottom => c.GTK_POS_BOTTOM,
+        .left => c.GTK_POS_LEFT,
+        .right => c.GTK_POS_RIGHT,
+    };
+    c.gtk_notebook_set_tab_pos(notebook, notebook_tab_pos);
     c.gtk_notebook_set_scrollable(notebook, 1);
     c.gtk_notebook_set_show_tabs(notebook, 0);
     c.gtk_notebook_set_show_border(notebook, 0);

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -949,6 +949,10 @@ keybind: Keybinds = .{},
 /// so you can test single instance without conflicting with release builds.
 @"gtk-single-instance": GtkSingleInstance = .desktop,
 
+/// Determines the side of the screen that the GTK tab bar will stick to.
+/// Top, bottom, left, and right are supported. The default is top.
+@"gtk-tabs-location": GtkTabsLocation = .top,
+
 /// If `true` (default), then the Ghostty GTK tabs will be "wide." Wide tabs
 /// are the new typical Gnome style where tabs fill their available space.
 /// If you set this to `false` then tabs will only take up space they need,
@@ -3376,6 +3380,14 @@ pub const GtkSingleInstance = enum {
     desktop,
     false,
     true,
+};
+
+/// See gtk-tabs-location
+pub const GtkTabsLocation = enum {
+    top,
+    bottom,
+    left,
+    right,
 };
 
 /// See mouse-shift-capture


### PR DESCRIPTION
Exactly what it says. I have no idea if MacOS supports this as well, so I just went with gtk specific naming. Left and right positioning are a little ridiculous, but hey, why not? Preview of bottom tabs (which personally I kinda like) and then left tabs: 


![image](https://github.com/mitchellh/ghostty/assets/69218859/8be7a0ed-3231-4879-9db7-c3c0e844c6ae)
![image](https://github.com/mitchellh/ghostty/assets/69218859/048b4d9f-aec1-4107-984a-b3368309f958)
