### PR TITLE
add more word boundary characters

### DIFF
--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1739,7 +1739,26 @@ pub fn selectWordBetween(
 /// this happens is if the point pt is outside of the written screen space.
 pub fn selectWord(self: *Screen, pt: point.ScreenPoint) ?Selection {
     // Boundary characters for selection purposes
-    const boundary = &[_]u32{ 0, ' ', '\t', '\'', '"', '│', '`', '|', ':', ',', '(', ')', '[', ']', '{', '}', '<', '>' };
+    const boundary = &[_]u32{
+        0,
+        ' ',
+        '\t',
+        '\'',
+        '"',
+        '│',
+        '`',
+        '|',
+        ':',
+        ',',
+        '(',
+        ')',
+        '[',
+        ']',
+        '{',
+        '}',
+        '<',
+        '>',
+    };
 
     // Impossible to select anything outside of the area we've written.
     const y_max = self.rowsWritten() - 1;
@@ -4770,9 +4789,6 @@ test "Screen: selectWord with character boundary" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
-    var s = try init(alloc, 10, 20, 0);
-    defer s.deinit();
-
     const cases = [_][]const u8{
         " 'abc' \n123",
         " \"abc\" \n123",
@@ -4783,16 +4799,17 @@ test "Screen: selectWord with character boundary" {
         " ,abc, \n123",
         " (abc( \n123",
         " )abc) \n123",
-        // " [abc[ \n123",
-        // " ]abc] \n123",
-        // " {abc{ \n123",
-        // " }abc} \n123",
-        // " <abc< \n123",
-        // " >abc> \n123",
+        " [abc[ \n123",
+        " ]abc] \n123",
+        " {abc{ \n123",
+        " }abc} \n123",
+        " <abc< \n123",
+        " >abc> \n123",
     };
 
     for (cases) |case| {
-        try s.clear(.history);
+        var s = try init(alloc, 10, 20, 0);
+        defer s.deinit();
         try s.testWriteString(case);
 
         // Inside character forward

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1739,7 +1739,7 @@ pub fn selectWordBetween(
 /// this happens is if the point pt is outside of the written screen space.
 pub fn selectWord(self: *Screen, pt: point.ScreenPoint) ?Selection {
     // Boundary characters for selection purposes
-    const boundary = &[_]u32{ 0, ' ', '\t', '\'', '"' };
+    const boundary = &[_]u32{ 0, ' ', '\t', '\'', '"', '│', '`', '|', ':', ',', '(', ')', '[', ']', '{', '}', '<', '>' };
 
     // Impossible to select anything outside of the area we've written.
     const y_max = self.rowsWritten() - 1;
@@ -4766,50 +4766,72 @@ test "Screen: selectWord whitespace across soft-wrap" {
     }
 }
 
-test "Screen: selectWord with single quote boundary" {
+test "Screen: selectWord with character boundary" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
     var s = try init(alloc, 10, 20, 0);
     defer s.deinit();
-    try s.testWriteString(" 'abc' \n123");
 
-    // Inside quotes forward
-    {
-        const sel = s.selectWord(.{ .x = 2, .y = 0 }).?;
-        try testing.expectEqual(@as(usize, 2), sel.start.x);
-        try testing.expectEqual(@as(usize, 0), sel.start.y);
-        try testing.expectEqual(@as(usize, 4), sel.end.x);
-        try testing.expectEqual(@as(usize, 0), sel.end.y);
-    }
+    const cases = [_][]const u8{
+        " 'abc' \n123",
+        " \"abc\" \n123",
+        " │abc│ \n123",
+        " `abc` \n123",
+        " |abc| \n123",
+        " :abc: \n123",
+        " ,abc, \n123",
+        " (abc( \n123",
+        " )abc) \n123",
+        // " [abc[ \n123",
+        // " ]abc] \n123",
+        // " {abc{ \n123",
+        // " }abc} \n123",
+        // " <abc< \n123",
+        // " >abc> \n123",
+    };
 
-    // Inside quotes backward
-    {
-        const sel = s.selectWord(.{ .x = 4, .y = 0 }).?;
-        try testing.expectEqual(@as(usize, 2), sel.start.x);
-        try testing.expectEqual(@as(usize, 0), sel.start.y);
-        try testing.expectEqual(@as(usize, 4), sel.end.x);
-        try testing.expectEqual(@as(usize, 0), sel.end.y);
-    }
+    for (cases) |case| {
+        try s.clear(.history);
+        try s.testWriteString(case);
 
-    // Inside quotes bidirectional
-    {
-        const sel = s.selectWord(.{ .x = 3, .y = 0 }).?;
-        try testing.expectEqual(@as(usize, 2), sel.start.x);
-        try testing.expectEqual(@as(usize, 0), sel.start.y);
-        try testing.expectEqual(@as(usize, 4), sel.end.x);
-        try testing.expectEqual(@as(usize, 0), sel.end.y);
-    }
+        // Inside character forward
+        {
+            const sel = s.selectWord(.{ .x = 2, .y = 0 }).?;
+            try testing.expectEqual(@as(usize, 2), sel.start.x);
+            try testing.expectEqual(@as(usize, 0), sel.start.y);
+            try testing.expectEqual(@as(usize, 4), sel.end.x);
+            try testing.expectEqual(@as(usize, 0), sel.end.y);
+        }
 
-    // On quote
-    // NOTE: this behavior is not ideal, so we can change this one day,
-    // but I think its also not that important compared to the above.
-    {
-        const sel = s.selectWord(.{ .x = 1, .y = 0 }).?;
-        try testing.expectEqual(@as(usize, 0), sel.start.x);
-        try testing.expectEqual(@as(usize, 0), sel.start.y);
-        try testing.expectEqual(@as(usize, 1), sel.end.x);
-        try testing.expectEqual(@as(usize, 0), sel.end.y);
+        // Inside character backward
+        {
+            const sel = s.selectWord(.{ .x = 4, .y = 0 }).?;
+            try testing.expectEqual(@as(usize, 2), sel.start.x);
+            try testing.expectEqual(@as(usize, 0), sel.start.y);
+            try testing.expectEqual(@as(usize, 4), sel.end.x);
+            try testing.expectEqual(@as(usize, 0), sel.end.y);
+        }
+
+        // Inside character bidirectional
+        {
+            const sel = s.selectWord(.{ .x = 3, .y = 0 }).?;
+            try testing.expectEqual(@as(usize, 2), sel.start.x);
+            try testing.expectEqual(@as(usize, 0), sel.start.y);
+            try testing.expectEqual(@as(usize, 4), sel.end.x);
+            try testing.expectEqual(@as(usize, 0), sel.end.y);
+        }
+
+        // On quote
+        // NOTE: this behavior is not ideal, so we can change this one day,
+        // but I think its also not that important compared to the above.
+        {
+            const sel = s.selectWord(.{ .x = 1, .y = 0 }).?;
+            try testing.expectEqual(@as(usize, 0), sel.start.x);
+            try testing.expectEqual(@as(usize, 0), sel.start.y);
+            try testing.expectEqual(@as(usize, 1), sel.end.x);
+            try testing.expectEqual(@as(usize, 0), sel.end.y);
+        }
     }
 }
 


### PR DESCRIPTION
List of characters chosen from what I'd expect to be a word and using prior art:

- https://github.com/wez/wezterm/blob/22f9f8d288521508bd4cdc924d9f209d78b36483/docs/config/lua/config/selection_word_boundary.md?plain=1#L13
- https://codeberg.org/dnkl/foot/src/commit/aca9af020241a4b7e4c172a009bf8d4fcfc4e16b/config.c#L3029