### PR TITLE
ci: cache the Zig cache

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -3,13 +3,18 @@ name: Nix
 jobs:
   check-zig-cache-hash:
     runs-on: namespace-profile-ghostty-sm
+    env:
+      ZIG_LOCAL_CACHE_DIR: /zig/local-cache
+      ZIG_GLOBAL_CACHE_DIR: /zig/global-cache
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Setup Nix Cache
+      - name: Setup Cache
         uses: namespacelabs/nscloud-cache-action@v1.1.2
         with:
-          path: /nix
+          path: |
+            /nix
+            /zig
       - name: Setup Nix
         uses: cachix/install-nix-action@v24
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,17 +20,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: test
     env:
-      # Needed for macos SDK
-      AGREE: "true"
+      ZIG_LOCAL_CACHE_DIR: /zig/local-cache
+      ZIG_GLOBAL_CACHE_DIR: /zig/global-cache
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Install Nix and use that to run our tests so our environment matches exactly.
-      - name: Setup Nix Cache
+      - name: Setup Cache
         uses: namespacelabs/nscloud-cache-action@v1.1.2
         with:
-          path: /nix
+          path: |
+            /nix
+            /zig
+
+      # Install Nix and use that to run our tests so our environment matches exactly.
       - uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -48,15 +51,21 @@ jobs:
     # We build benchmarks on large because it uses ReleaseFast
     runs-on: namespace-profile-ghostty-lg
     needs: test
+    env:
+      ZIG_LOCAL_CACHE_DIR: /zig/local-cache
+      ZIG_GLOBAL_CACHE_DIR: /zig/global-cache
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Install Nix and use that to run our tests so our environment matches exactly.
-      - name: Setup Nix Cache
+      - name: Setup Cache
         uses: namespacelabs/nscloud-cache-action@v1.1.2
         with:
-          path: /nix
+          path: |
+            /nix
+            /zig
+
+      # Install Nix and use that to run our tests so our environment matches exactly.
       - uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -71,15 +80,21 @@ jobs:
   build-linux-libghostty:
     runs-on: namespace-profile-ghostty-md
     needs: test
+    env:
+      ZIG_LOCAL_CACHE_DIR: /zig/local-cache
+      ZIG_GLOBAL_CACHE_DIR: /zig/global-cache
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Install Nix and use that to run our tests so our environment matches exactly.
-      - name: Setup Nix Cache
+      - name: Setup Cache
         uses: namespacelabs/nscloud-cache-action@v1.1.2
         with:
-          path: /nix
+          path: |
+            /nix
+            /zig
+
+      # Install Nix and use that to run our tests so our environment matches exactly.
       - uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -98,15 +113,21 @@ jobs:
         os: [namespace-profile-ghostty-md, namespace-profile-ghostty-md-arm64]
     runs-on: ${{ matrix.os }}
     needs: test
+    env:
+      ZIG_LOCAL_CACHE_DIR: /zig/local-cache
+      ZIG_GLOBAL_CACHE_DIR: /zig/global-cache
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Install Nix and use that to run our tests so our environment matches exactly.
-      - name: Setup Nix Cache
+      - name: Setup Cache
         uses: namespacelabs/nscloud-cache-action@v1.1.2
         with:
-          path: /nix
+          path: |
+            /nix
+            /zig
+
+      # Install Nix and use that to run our tests so our environment matches exactly.
       - uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -121,9 +142,6 @@ jobs:
   build-macos:
     runs-on: namespace-profile-ghostty-macos
     needs: test
-    env:
-      # Needed for macos SDK
-      AGREE: "true"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -224,15 +242,21 @@ jobs:
 
   test:
     runs-on: namespace-profile-ghostty-md
+    env:
+      ZIG_LOCAL_CACHE_DIR: /zig/local-cache
+      ZIG_GLOBAL_CACHE_DIR: /zig/global-cache
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Install Nix and use that to run our tests so our environment matches exactly.
-      - name: Setup Nix Cache
+      - name: Setup Cache
         uses: namespacelabs/nscloud-cache-action@v1.1.2
         with:
-          path: /nix
+          path: |
+            /nix
+            /zig
+
+      # Install Nix and use that to run our tests so our environment matches exactly.
       - uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -256,12 +280,17 @@ jobs:
   prettier:
     runs-on: namespace-profile-ghostty-sm
     timeout-minutes: 60
+    env:
+      ZIG_LOCAL_CACHE_DIR: /zig/local-cache
+      ZIG_GLOBAL_CACHE_DIR: /zig/global-cache
     steps:
       - uses: actions/checkout@v4 # Check out repo so we can lint it
-      - name: Setup Nix Cache
+      - name: Setup Cache
         uses: namespacelabs/nscloud-cache-action@v1.1.2
         with:
-          path: /nix
+          path: |
+            /nix
+            /zig
       - uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -277,12 +306,17 @@ jobs:
   alejandra:
     runs-on: namespace-profile-ghostty-sm
     timeout-minutes: 60
+    env:
+      ZIG_LOCAL_CACHE_DIR: /zig/local-cache
+      ZIG_GLOBAL_CACHE_DIR: /zig/global-cache
     steps:
       - uses: actions/checkout@v4 # Check out repo so we can lint it
-      - name: Setup Nix Cache
+      - name: Setup Cache
         uses: namespacelabs/nscloud-cache-action@v1.1.2
         with:
-          path: /nix
+          path: |
+            /nix
+            /zig
       - uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable


### PR DESCRIPTION
This results in some builds running 2x faster, but in general increases build speeds across the board.

This will also make our CI runs way more resilient to sporadic network failures since for most builds (except macOS/Win) we'll have all our dependencies cached unless they're being updated.

cc @hugosantos 