### PR TITLE
fix(renderer): allocate enough room for fg cells

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1552,9 +1552,9 @@ fn rebuildCells(
     try self.cells.ensureTotalCapacity(
         self.alloc,
 
-        // * 3 for background modes and cursor and underlines
+        // * 3 for glyph + underline + strikethrough for each cell
         // + 1 for cursor
-        (screen.rows * screen.cols * 2) + 1,
+        (screen.rows * screen.cols * 3) + 1,
     );
 
     // Create an arena for all our temporary allocations while rebuilding

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -973,9 +973,9 @@ pub fn rebuildCells(
     try self.cells.ensureTotalCapacity(
         self.alloc,
 
-        // * 3 for background modes and cursor and underlines
+        // * 3 for glyph + underline + strikethrough for each cell
         // + 1 for cursor
-        (screen.rows * screen.cols * 2) + 1,
+        (screen.rows * screen.cols * 3) + 1,
     );
 
     // Create an arena for all our temporary allocations while rebuilding


### PR DESCRIPTION
Previously encountered OOB when screen filled with cells with glyphs, underlines, and strikethroughs. Also clarified comment slightly.