### PR TITLE
log more information about the build

### DIFF
--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -251,6 +251,22 @@ pub const GlobalState = struct {
 
         // Output some debug information right away
         std.log.info("ghostty version={s}", .{build_config.version_string});
+        const mode = mode: {
+            const m = @tagName(builtin.mode);
+            if (std.mem.lastIndexOfScalar(u8, m, '.')) |i| break :mode m[i..];
+            break :mode m;
+        };
+        const baseline = baseline: {
+            const baseline = std.Target.Cpu.baseline(builtin.target.cpu.arch);
+            if (std.Target.Cpu.Feature.Set.eql(baseline.features, builtin.target.cpu.features)) break :baseline " -Dcpu=baseline";
+            break :baseline "";
+        };
+        std.log.info("ghostty built with{s} -Doptimize={s}", .{ baseline, mode });
+        {
+            const target = try builtin.target.zigTriple(self.alloc);
+            defer self.alloc.free(target);
+            std.log.info("zig triple: {s}", .{target});
+        }
         std.log.info("runtime={}", .{build_config.app_runtime});
         std.log.info("font_backend={}", .{build_config.font_backend});
         std.log.info("dependency harfbuzz={s}", .{harfbuzz.versionString()});


### PR DESCRIPTION

Logs a couple of additional lines with information about the Zig build. Not sure if this should be against the `main` branch or the `paged-terminal` branch but it should apply cleanly to both.

> → ./result/bin/ghostty                                                                                                     at 12:17:20
> info: ghostty version=0.1.0-0381694-nix
> **info: ghostty built with -Dcpu=baseline -Doptimize=ReleaseSafe
> info: zig triple: x86_64-linux.6.8...6.8-gnu.2.38**
> info: runtime=apprt.Runtime.gtk
> info: font_backend=font.main.Backend.fontconfig_freetype
> info: dependency harfbuzz=8.2.2
> info: dependency fontconfig=21402
> info: renderer=renderer.OpenGL
> info: libxev backend=main.Backend.io_uring
> 