### PR TITLE
terminal: set PageList viewport to active area when cloned

### DIFF
--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -306,7 +306,7 @@ pub const Clone = struct {
 
 /// Clone this pagelist from the top to bottom (inclusive).
 ///
-/// The viewport is always moved to the top-left.
+/// The viewport is always moved to the active area.
 ///
 /// The cloned pagelist must contain at least enough rows for the active
 /// area. If the region specified has less rows than the active area then
@@ -478,7 +478,7 @@ pub fn clone(
         .cols = self.cols,
         .rows = self.rows,
         .tracked_pins = tracked_pins,
-        .viewport = .{ .top = {} },
+        .viewport = .{ .active = {} },
         .viewport_pin = viewport_pin,
     };
 


### PR DESCRIPTION
As an optimization, the renderer does not attempt to find the cell under
the cursor if the viewport is in the scrollback (i.e. not the active
area). When the renderer clones the screen state it also clones the
PageList, and the cloned PageList has its viewport set to the top of the
scrollback.

This caused the renderer to never attempt to find the cell under the
cursor, which in turn caused cells under the cursor to be improperly
highlighted. Instead, when the PageList is cloned initialize its
viewport to the active area.

Fixes: https://github.com/mitchellh/ghostty/pull/1584#issuecomment-2004774953