### PR TITLE
Fix scroll region performance regressions

### DIFF
--- a/src/fastmem.zig
+++ b/src/fastmem.zig
@@ -22,5 +22,13 @@ pub inline fn copy(comptime T: type, dest: []T, source: []const T) void {
     }
 }
 
+/// Same as std.mem.rotate(T, items, 1) but more efficient by using memmove
+/// and a tmp var for the single rotated item instead of 3 calls to reverse.
+pub inline fn rotateOnce(comptime T: type, items: []T) void {
+    const tmp = items[0];
+    move(T, items[0..items.len - 1], items[1..items.len]);
+    items[items.len - 1] = tmp;
+}
+
 extern "c" fn memcpy(*anyopaque, *const anyopaque, usize) *anyopaque;
 extern "c" fn memmove(*anyopaque, *const anyopaque, usize) *anyopaque;

--- a/src/fastmem.zig
+++ b/src/fastmem.zig
@@ -12,7 +12,7 @@ pub inline fn move(comptime T: type, dest: []T, source: []const T) void {
     }
 }
 
-/// Same as std.mem.copyForwards but prefers libc memcpy if it is available
+/// Same as @memcpy but prefers libc memcpy if it is available
 /// because it is generally much faster.
 pub inline fn copy(comptime T: type, dest: []T, source: []const T) void {
     if (builtin.link_libc) {

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -2093,21 +2093,18 @@ pub fn eraseRows(
             const old_dst = dst.*;
             dst.* = src.*;
             src.* = old_dst;
-
-            // // Clear the old data in case we reuse these cells.
-            // chunk.page.data.clearCells(src, 0, chunk.page.data.size.cols);
         }
 
-        // // Clear our remaining cells that we didn't shift or swapped
-        // // in case we grow back into them.
-        // for (scroll_amount..chunk.page.data.size.rows) |i| {
-        //     const row: *Row = &rows[i];
-        //     chunk.page.data.clearCells(
-        //         row,
-        //         0,
-        //         chunk.page.data.size.cols,
-        //     );
-        // }
+        // Clear our remaining cells that we didn't shift or swapped
+        // in case we grow back into them.
+        for (scroll_amount..chunk.page.data.size.rows) |i| {
+            const row: *Row = &rows[i];
+            chunk.page.data.clearCells(
+                row,
+                0,
+                chunk.page.data.size.cols,
+            );
+        }
 
         // Update any tracked pins to shift their y. If it was in the erased
         // row then we move it to the top of this page.

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -1988,8 +1988,12 @@ fn destroyPageExt(
 }
 
 /// Fast-path function to erase exactly 1 row. Erasing means that the row
-/// is completely removed, not just cleared. All rows below the removed row
-/// will be moved up by 1 to account for this.
+/// is completely REMOVED, not just cleared. All rows following the removed
+/// row will be shifted up by 1 to fill the empty space.
+///
+/// Unlike eraseRows, eraseRow does not change the size of any pages. The
+/// caller is responsible for adjusting the row count of the final page if
+/// that behavior is required.
 pub fn eraseRow(
     self: *PageList,
     pt: point.Point,
@@ -2029,7 +2033,7 @@ pub fn eraseRow(
         //    1  |      2         2         2
         //    2  |      3         3         3
         //    3 <'      0 <.      4         4
-        //   ---       --- |     ---       ---
+        //   ---       --- |     ---       ---  <- page boundary
         //    4         4 -'      4 -.      5
         //    5         5         5  |      6
         //    6         6         6  |      7
@@ -2057,35 +2061,34 @@ pub fn eraseRow(
         }
     }
 
-    // The final row needs to be cleared in case we re-use it.
+    // Clear the final row which was rotated from the top of the page.
     page.data.clearCells(&rows[page.data.size.rows - 1], 0, page.data.size.cols);
-
-    // We don't trim off the final row if we erased active, since one of
-    // our invariants is that we always have full active space.
-    if (pt != .active) {
-        page.data.size.rows -= 1;
-    }
 }
 
-/// A special-case of eraseRow that shifts only a bounded number of following
+/// A variant of eraseRow that shifts only a bounded number of following
 /// rows up, filling the space they leave behind with blank rows.
 ///
 /// `limit` is exclusive of the erased row. A limit of 1 will erase the target
 /// row and shift the row below in to its position, leaving a blank row below.
-///
-/// This function has a lot of repeated code in it because it is a hot path.
 pub fn eraseRowBounded(
     self: *PageList,
     pt: point.Point,
     limit: usize,
 ) !void {
+    // This function has a lot of repeated code in it because it is a hot path.
+    //
+    // To get a better idea of what's happening, read eraseRow first for more
+    // in-depth explanatory comments. To avoid repetition, the only comments for
+    // this function are for where it differs from eraseRow.
+
     const pn = self.pin(pt).?;
 
     var page = pn.page;
     var rows = page.data.rows.ptr(page.data.memory.ptr);
 
-    // Special case where we'll reach the limit in the same page as the erased
-    // row, so we don't have to handle cloning rows between pages.
+    // If the row limit is less than the remaining rows before the end of the
+    // page, then we clear the row, rotate it to the end of the boundary limit
+    // and update our pins.
     if (page.data.size.rows - pn.y > limit) {
         page.data.clearCells(&rows[pn.y], 0, page.data.size.cols);
         fastmem.rotateOnce(Row, rows[pn.y..][0..limit + 1]);
@@ -2100,14 +2103,14 @@ pub fn eraseRowBounded(
         return;
     }
 
-    var shifted: usize = 0;
-
     fastmem.rotateOnce(Row, rows[pn.y..page.data.size.rows]);
 
-    shifted += page.data.size.rows - pn.y;
+    // We need to keep track of how many rows we've shifted so that we can
+    // determine at what point we need to do a partial shift on subsequent
+    // pages.
+    var shifted: usize = page.data.size.rows - pn.y;
 
-    // We adjust the tracked pins in this page, moving up any that were below
-    // the removed row.
+    // Update tracked pins.
     {
         var pin_it = self.tracked_pins.keyIterator();
         while (pin_it.next()) |p_ptr| {
@@ -2124,6 +2127,11 @@ pub fn eraseRowBounded(
         page = next;
         rows = next_rows;
 
+        // We check to see if this page contains enough rows to satisfy the
+        // specified limit, accounting for rows we've already shifted in prior
+        // pages.
+        //
+        // The logic here is very similar to the one before the loop.
         const shifted_limit = limit - shifted;
         if (page.data.size.rows > shifted_limit) {
             page.data.clearCells(&rows[0], 0, page.data.size.cols);
@@ -2147,11 +2155,10 @@ pub fn eraseRowBounded(
 
         fastmem.rotateOnce(Row, rows[0..page.data.size.rows]);
 
+        // Account for the rows shifted in this page.
         shifted += page.data.size.rows;
 
-        // Our tracked pins for this page need to be updated.
-        // If the pin is in row 0 that means the corresponding row has
-        // been moved to the previous page. Otherwise, move it up by 1.
+        // Update tracked pins.
         var pin_it = self.tracked_pins.keyIterator();
         while (pin_it.next()) |p_ptr| {
             const p = p_ptr.*;

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -6,6 +6,7 @@ const PageList = @This();
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const assert = std.debug.assert;
+const fastmem = @import("../fastmem.zig");
 const point = @import("point.zig");
 const pagepkg = @import("page.zig");
 const stylepkg = @import("style.zig");
@@ -2001,7 +2002,7 @@ pub fn eraseRow(
     // In order to move the following rows up we rotate the rows array by 1.
     // The rotate operation turns e.g. [ 0 1 2 3 ] in to [ 1 2 3 0 ], which
     // works perfectly to move all of our elements where they belong.
-    std.mem.rotate(Row, rows[pn.y..page.data.size.rows], 1);
+    fastmem.rotateOnce(Row, rows[pn.y..page.data.size.rows]);
 
     // We adjust the tracked pins in this page, moving up any that were below
     // the removed row.
@@ -2038,7 +2039,7 @@ pub fn eraseRow(
         page = next;
         rows = next_rows;
 
-        std.mem.rotate(Row, rows[0..page.data.size.rows], 1);
+        fastmem.rotateOnce(Row, rows[0..page.data.size.rows]);
 
         // Our tracked pins for this page need to be updated.
         // If the pin is in row 0 that means the corresponding row has

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -535,9 +535,15 @@ pub fn cursorDownScroll(self: *Screen) !void {
         // If we have a single-row screen, we have no rows to shift
         // so our cursor is in the correct place we just have to clear
         // the cells.
-        if (self.pages.rows > 1) {
-            // Erase rows will shift our rows up
-            self.pages.eraseRows(.{ .active = .{} }, .{ .active = .{} });
+        if (self.pages.rows == 1) {
+            self.clearCells(
+                &self.cursor.page_pin.page.data,
+                self.cursor.page_row,
+                self.cursor.page_pin.page.data.getCells(self.cursor.page_row),
+            );
+        } else {
+            // eraseRow will shift everything below it up.
+            try self.pages.eraseRow(.{ .active = .{} });
 
             // The above may clear our cursor so we need to update that
             // again. If this fails (highly unlikely) we just reset
@@ -561,15 +567,6 @@ pub fn cursorDownScroll(self: *Screen) !void {
             self.cursor.page_row = page_rac.row;
             self.cursor.page_cell = page_rac.cell;
         }
-
-        // Erase rows does NOT clear the cells because in all other cases
-        // we never write those rows again. Active erasing is a bit
-        // different so we manually clear our one row.
-        self.clearCells(
-            &self.cursor.page_pin.page.data,
-            self.cursor.page_row,
-            self.cursor.page_pin.page.data.getCells(self.cursor.page_row),
-        );
     } else {
         const old_pin = self.cursor.page_pin.*;
 

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1094,6 +1094,15 @@ pub fn index(self: *Terminal) !void {
 
             // Otherwise use a fast path function from PageList to efficiently
             // scroll the contents of the scrolling region.
+
+            // eraseRow and eraseRowBounded will end up moving the cursor pin
+            // up by 1, so we save its current position and restore it after.
+            const cursor_x = self.screen.cursor.x;
+            const cursor_y = self.screen.cursor.y;
+            defer {
+                self.screen.cursorAbsolute(cursor_x, cursor_y);
+            }
+
             if (self.scrolling_region.bottom < self.rows) {
                 try self.screen.pages.eraseRowBounded(
                     .{ .active = .{ .y = self.scrolling_region.top } },
@@ -1116,16 +1125,6 @@ pub fn index(self: *Terminal) !void {
                 self.screen.cursor.style = .{};
                 self.screen.manualStyleUpdate() catch unreachable;
             };
-
-            // We scrolled with the cursor on the bottom row of the scrolling
-            // region, so we should move the cursor to the bottom left.
-            self.screen.cursorAbsolute(
-                self.scrolling_region.left,
-                self.scrolling_region.bottom,
-            );
-
-            // Always unset pending wrap
-            self.screen.cursor.pending_wrap = false;
         }
 
         return;

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1085,7 +1085,7 @@ pub fn index(self: *Terminal) !void {
             try self.screen.cursorDownScroll();
         } else {
             // Slow path for left and right scrolling region margins.
-            if (self.scrolling_region.left != 0 and
+            if (self.scrolling_region.left != 0 or
                 self.scrolling_region.right != self.cols - 1)
             {
                 self.scrollUp(1);

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1103,19 +1103,10 @@ pub fn index(self: *Terminal) !void {
                 self.screen.cursorAbsolute(cursor_x, cursor_y);
             }
 
-            if (self.scrolling_region.bottom < self.rows) {
-                try self.screen.pages.eraseRowBounded(
-                    .{ .active = .{ .y = self.scrolling_region.top } },
-                    self.scrolling_region.bottom - self.scrolling_region.top
-                );
-            } else {
-                // If we have no bottom margin we don't need to worry about
-                // potentially damaging rows below the scrolling region,
-                // and eraseRow is cheaper than eraseRowBounded.
-                try self.screen.pages.eraseRow(
-                    .{ .active = .{ .y = self.scrolling_region.top } },
-                );
-            }
+            try self.screen.pages.eraseRowBounded(
+                .{ .active = .{ .y = self.scrolling_region.top } },
+                self.scrolling_region.bottom - self.scrolling_region.top
+            );
 
             // The operations above can prune our cursor style so we need to
             // update. This should never fail because the above can only FREE


### PR DESCRIPTION
This PR significantly improves scrolling region performance, fixing the regressions experienced in the paged-terminal branch after implementing bug fixes, and in fact drastically improving the performance by using fast path functions for scrolling an area by 1 line in PageList (`eraseRow` and `eraseRowBounded`).

Also adds a small micro-optimization to `Page`, specifically the `@memset`s used to zero the page memory in `reinit` and zero a row of cells in `clearCells`. By casting to `[]u64` and `@memset`ing that to `0`, rather than using `[]u8` for the page memory zeroing and setting the cells to `.{}`, we gain a couple ms of performance on the vtebench scrolling region benchmarks.

These changes, all in all, give us better scrolling region performance than Alacritty on all but the `scrolling_top_small_region` benchmark where we're just a little bit behind still.