### PR TITLE
Add final newline to CLI output

### DIFF
--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -91,6 +91,7 @@ pub fn main() !MainReturn {
             \\
             \\We don't have proper help output yet, sorry! Please refer to the
             \\source code or Discord community for help for now. We'll fix this in time.
+	    \\
         ,
             .{},
         );


### PR DESCRIPTION
This ensures the terminal prompt starts on a newline after the output.