### PR TITLE
gtk: use symbolic icon for tab close

### DIFF
--- a/src/apprt/gtk/Tab.zig
+++ b/src/apprt/gtk/Tab.zig
@@ -64,7 +64,7 @@ pub fn init(self: *Tab, window: *Window, parent_: ?*CoreSurface) !void {
     self.label_text = label_text;
 
     // Build the close button for the tab
-    const label_close_widget = c.gtk_button_new_from_icon_name("window-close");
+    const label_close_widget = c.gtk_button_new_from_icon_name("window-close-symbolic");
     const label_close: *c.GtkButton = @ptrCast(label_close_widget);
     c.gtk_button_set_has_frame(label_close, 0);
     c.gtk_box_append(label_box, label_close_widget);


### PR DESCRIPTION
On my system (xorg Ubuntu 24.04, Adwaita:dark theme) tab close icon was red while in all other applications was more discrete. With adding `-symbolic` to the icon name now looks like other applications.

Before: 
![Screenshot from 2024-03-27 19-27-44](https://github.com/mitchellh/ghostty/assets/35909/e0446bee-f5af-465f-bac0-a6ca89f7459a)

After:
![Screenshot from 2024-03-27 19-51-22](https://github.com/mitchellh/ghostty/assets/35909/feb7baac-9e28-41de-a05c-5e27c93942e3)


like gnome terminal:
![Screenshot from 2024-03-27 19-52-18](https://github.com/mitchellh/ghostty/assets/35909/bb8aad1e-e4c8-4ecc-b6d1-aecd1123aa76)
