### PR TITLE
Fix off-by-one errors in eraseRowBounded which could cause scroll region crashes

### DIFF
--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -470,12 +470,6 @@ pub fn cursorAbsolute(self: *Screen, x: size.CellCountInt, y: size.CellCountInt)
     assert(y < self.pages.rows);
     defer self.assertIntegrity();
 
-    const pt: point.Point = self.pages.pointFromPin(
-        .active,
-        self.cursor.page_pin.*,
-    ) orelse unreachable;
-    std.log.warn("pt={} cur_y={} y={}", .{ pt, self.cursor.y, y });
-
     var page_pin = if (y < self.cursor.y)
         self.cursor.page_pin.up(self.cursor.y - y).?
     else if (y > self.cursor.y)


### PR DESCRIPTION
Fixes #1613

Two combining issues:

* `eraseRowBounded` had a few off-by-one errors, now unit tested and fixed
* `Terminal.index` was using `Screen.cursorAbsolute` but that depends on a valid `screen.cursor.y` which we didn't have, leading to another off-by-one. When erasing rows, only `y` is affected so we can manually fix up the `y` and call `cursorDown` which is actually faster.

cc @qwerasd205 