### PR TITLE
font sizes are limited to u8 (max size = 255 points)

### DIFF
--- a/src/font/face.zig
+++ b/src/font/face.zig
@@ -40,7 +40,8 @@ pub const DesiredSize = struct {
     // Converts points to pixels
     pub fn pixels(self: DesiredSize) u16 {
         // 1 point = 1/72 inch
-        return (self.points * self.ydpi) / 72;
+        const points_u16: u16 = @intCast(self.points);
+        return (points_u16 * self.ydpi) / 72;
     }
 };
 

--- a/src/font/face.zig
+++ b/src/font/face.zig
@@ -31,7 +31,7 @@ pub const Options = struct {
 /// The desired size for loading a font.
 pub const DesiredSize = struct {
     // Desired size in points
-    points: u16,
+    points: u8,
 
     // The DPI of the screen so we can convert points to pixels.
     xdpi: u16 = default_dpi,

--- a/src/font/face/freetype.zig
+++ b/src/font/face/freetype.zig
@@ -137,7 +137,7 @@ pub const Face = struct {
         // to what the user requested. Otherwise, we can choose an arbitrary
         // pixel size.
         if (face.isScalable()) {
-            const size_26dot6 = @as(i32, @intCast(size.points << 6)); // mult by 64
+            const size_26dot6 = @as(i32, @intCast(size.points)) << 6; // mult by 64
             try face.setCharSize(0, size_26dot6, size.xdpi, size.ydpi);
         } else try selectSizeNearest(face, size.pixels());
     }

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -158,8 +158,8 @@ pub const Action = union(enum) {
     paste_from_selection: void,
 
     /// Increase/decrease the font size by a certain amount.
-    increase_font_size: u16,
-    decrease_font_size: u16,
+    increase_font_size: u8,
+    decrease_font_size: u8,
 
     /// Reset the font size to the original configured size.
     reset_font_size: void,


### PR DESCRIPTION
Fixes #1618

Font sizes in configuration were always a u8, but the keybinding and internal state was a u16 so it allowed for an ever-growing font size. At a certain point, there is an integer overflow which causes it to wrap around. This is all silly, 255 should be large enough for anyone[1]

We've always done saturating add/sub for inc/dec so this will not overflow anymore.

[1]: Ready to be super wrong about this