### PR TITLE
fix(terminal/stream): add SPA and EPA handlers

### DIFF
--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -1465,6 +1465,16 @@ pub fn Stream(comptime Handler: type) type {
                     },
                 } else log.warn("unimplemented invokeCharset: {}", .{action}),
 
+                // SPA - Start of Guarded Area
+                'V' => if (@hasDecl(T, "setProtectedMode")) {
+                    try self.handler.setProtectedMode(ansi.ProtectedMode.iso);
+                } else log.warn("unimplemented ESC callback: {}", .{action}),
+
+                // EPA - End of Guarded Area
+                'W' => if (@hasDecl(T, "setProtectedMode")) {
+                    try self.handler.setProtectedMode(ansi.ProtectedMode.off);
+                } else log.warn("unimplemented ESC callback: {}", .{action}),
+
                 // DECID
                 'Z' => if (@hasDecl(T, "deviceAttributes")) {
                     try self.handler.deviceAttributes(.primary, &.{});


### PR DESCRIPTION
This allows protected characters to function like in xterm - allowing you to set the protected mode with DECSCA (`CSI 1 " q` ... `CSI 0/2 " q`) but have non-selective erase operations still respect the protected cells by using `ESC V` `ESC W` afterwards so that the most recently enabled protection mode is no longer DECSCA. (If you're curious why this abomination of a behavior exists, [this comment](https://github.com/xterm-x11/xterm-snapshots/blob/d403be1046f8f0e9dfcdc9d64c363b0a4b9f3a9b/ptyx.h#L3647-L3657) in the xterm source casts some light on the situation.)

This also of course lets you just use `ESC V` ... `ESC W` to protect cells in the first place instead of relying on DECSCA.