### PR TITLE
fix: remove deprecated to-pixdata gresource preprocessor

### DIFF
--- a/src/apprt/gtk/gresource.zig
+++ b/src/apprt/gtk/gresource.zig
@@ -93,7 +93,7 @@ fn writeGResourceXML(libadwaita: bool, writer: anytype) !void {
     );
     for (icons) |icon| {
         try writer.print(
-            "    <file preprocess=\"to-pixdata\" alias=\"{s}/apps/com.mitchellh.ghostty.png\">images/icons/icon_{s}.png</file>\n",
+            "    <file alias=\"{s}/apps/com.mitchellh.ghostty.png\">images/icons/icon_{s}.png</file>\n",
             .{ icon.alias, icon.source },
         );
     }


### PR DESCRIPTION
It was deprecated in gdk-pixbuf 2.32.

Link: https://docs.gtk.org/gio/struct.Resource.html