### PR TITLE
Clarify macOS build requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,8 @@ To build Ghostty, you need [Zig](https://ziglang.org/) installed.
 
 On Linux, you may need to install additional dependencies. See
 [Linux Installation Tips](#linux-installation-tips). On macOS, you
-need Xcode installed with the macOS and iOS SDKs enabled.
+need Xcode installed with the macOS and iOS SDKs enabled. See
+[Mac `.app`](#mac-app).
 
 The official development environment is defined by Nix. You do not need
 to use Nix to develop Ghostty, but the Nix environment is the environment
@@ -565,7 +566,22 @@ all features of Ghostty work.
 ### Mac `.app`
 
 To build the official, fully featured macOS application, you must
-build on a macOS machine with XCode installed:
+build on a macOS machine with Xcode installed, and the active developer
+directory pointing to it. If you're not sure that's the case, check the
+output of `xcode-select --print-path`:
+
+```shell-session
+$ xcode-select --print-path
+/Library/Developer/CommandLineTools        # <-- BAD
+$ sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
+$ xcode-select --print-path
+/Applications/Xcode.app/Contents/Developer # <-- GOOD
+```
+
+The above can happen if you install the Xcode Command Line Tools _after_ Xcode
+is installed. With that out of the way, make sure you have both the macOS and
+iOS SDKs installed (from inside Xcode → Settings → Platforms), and let's move
+on to building Ghostty:
 
 ```shell-session
 $ zig build -Doptimize=ReleaseFast


### PR DESCRIPTION
A few macOS users have encountered an issue when trying to build Ghostty, due to a local misconfiguration.
This PR adds instructions on how to identify and solve the problem.

_Potentially_, the provided `--switch` command may have to point to a different folder, if a user has installed Xcode in a non-standard location, or if they're running a beta version. I think it's fair to assume that in both those cases they'll know how to adapt the command, but I may be wrong, of course 🤷🏻 