### PR TITLE
font/sprite: improve rendering of dashed lines

### DIFF
--- a/src/fastmem.zig
+++ b/src/fastmem.zig
@@ -26,7 +26,7 @@ pub inline fn copy(comptime T: type, dest: []T, source: []const T) void {
 /// and a tmp var for the single rotated item instead of 3 calls to reverse.
 pub inline fn rotateOnce(comptime T: type, items: []T) void {
     const tmp = items[0];
-    move(T, items[0..items.len - 1], items[1..items.len]);
+    move(T, items[0 .. items.len - 1], items[1..items.len]);
     items[items.len - 1] = tmp;
 }
 

--- a/src/font/sprite/Box.zig
+++ b/src/font/sprite/Box.zig
@@ -2425,7 +2425,7 @@ fn draw_light_arc(
 fn draw_dash_horizontal(
     self: Box,
     canvas: *font.sprite.Canvas,
-    comptime count: u8,
+    count: u8,
     thick_px: u32,
     desired_gap: u32,
 ) void {
@@ -2461,11 +2461,11 @@ fn draw_dash_horizontal(
 
     // We never want the gaps to take up more than 50% of the space,
     // because if they do the dashes are too small and look wrong.
-    const gap_width        = @min(desired_gap, self.width / (2 * count));
-    const total_gap_width  = gap_count * gap_width;
+    const gap_width = @min(desired_gap, self.width / (2 * count));
+    const total_gap_width = gap_count * gap_width;
     const total_dash_width = self.width - total_gap_width;
-    const dash_width       = total_dash_width / count;
-    const remaining        = total_dash_width % count;
+    const dash_width = total_dash_width / count;
+    const remaining = total_dash_width % count;
 
     assert(dash_width * count + gap_width * gap_count + remaining == self.width);
 
@@ -2481,7 +2481,7 @@ fn draw_dash_horizontal(
     // more visually obvious.
     var extra: u32 = remaining;
 
-    inline for (0..count) |_| {
+    for (0..count) |_| {
         var x1 = x + dash_width;
         // We distribute left-over size in to dash widths,
         // since it's less obvious there than in the gaps.
@@ -2540,11 +2540,11 @@ fn draw_dash_vertical(
 
     // We never want the gaps to take up more than 50% of the space,
     // because if they do the dashes are too small and look wrong.
-    const gap_height        = @min(desired_gap, self.height / (2 * count));
-    const total_gap_height  = gap_count * gap_height;
+    const gap_height = @min(desired_gap, self.height / (2 * count));
+    const total_gap_height = gap_count * gap_height;
     const total_dash_height = self.height - total_gap_height;
-    const dash_height       = total_dash_height / count;
-    const remaining         = total_dash_height % count;
+    const dash_height = total_dash_height / count;
+    const remaining = total_dash_height % count;
 
     assert(dash_height * count + gap_height * gap_count + remaining == self.height);
 

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -91,7 +91,7 @@ pub fn main() !MainReturn {
             \\
             \\We don't have proper help output yet, sorry! Please refer to the
             \\source code or Discord community for help for now. We'll fix this in time.
-	    \\
+            \\
         ,
             .{},
         );

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1331,8 +1331,8 @@ fn rowWillBeShifted(
     // spacer head will be either moved or cleared, so we also need
     // to turn the spacer heads in to empty cells in that case.
     if (self.scrolling_region.right == self.cols - 1 or
-        self.scrolling_region.left < 2
-    ) {
+        self.scrolling_region.left < 2)
+    {
         const end_cell: *Cell = &cells[page.size.cols - 1];
         if (end_cell.wide == .spacer_head) {
             end_cell.wide = .narrow;
@@ -6318,7 +6318,7 @@ test "Terminal: deleteLines wide character spacer head left and right scroll mar
     try t.printString("AAAAABBBB\u{1F600}CCC");
 
     t.scrolling_region.right = 3;
-    t.scrolling_region.left  = 2;
+    t.scrolling_region.left = 2;
 
     // Delete the top line
     //    ##   <- scrolling region
@@ -6360,7 +6360,7 @@ test "Terminal: deleteLines wide character spacer head left (< 2) and right scro
     try t.printString("AAAAABBBB\u{1F600}CCC");
 
     t.scrolling_region.right = 3;
-    t.scrolling_region.left  = 1;
+    t.scrolling_region.left = 1;
 
     // Delete the top line
     //   ###   <- scrolling region
@@ -6400,7 +6400,7 @@ test "Terminal: deleteLines wide characters split by left/right scroll region bo
     try t.printString("AAAAA\n\u{1F600}B\u{1F600}");
 
     t.scrolling_region.right = 3;
-    t.scrolling_region.left  = 1;
+    t.scrolling_region.left = 1;
 
     // Delete the top line
     //   ###   <- scrolling region

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -184,7 +184,7 @@ pub const Page = struct {
     pub fn reinit(self: *Page) void {
         // We zero the page memory as u64 instead of u8 because
         // we can and it's empirically quite a bit faster.
-        @memset(@as([*]u64, @ptrCast(self.memory))[0..self.memory.len / 8], 0);
+        @memset(@as([*]u64, @ptrCast(self.memory))[0 .. self.memory.len / 8], 0);
         self.* = initBuf(OffsetBuf.init(self.memory), layout(self.capacity));
     }
 


### PR DESCRIPTION
Previous implementation would draw dashes to the edge of the character cell, which would result in double-wide dashes at the point where they tiled. This fixes that, and also generally implements it in a cleaner way than before.

I made the decision that extra "left-over" length should be distributed in to dashes rather than gaps, since in my opinion it's a *lot* more noticeable when there are un-even gaps than when there are un-even dashes.

CC @vancluever

**Before** (left) and **after** (right):
![image](https://github.com/mitchellh/ghostty/assets/7241851/d6b50b49-3281-46d2-b9c8-eb25396e05c4)