### PR TITLE
shell-integration: implement no-title option

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -839,7 +839,9 @@ keybind: Keybinds = .{},
 ///
 ///   * `sudo` - Set sudo wrapper to preserve terminfo.
 ///
-/// Example: `cursor`, `no-cursor`, `sudo`, `no-sudo`
+///   * `title` - Set the window title via shell integration.
+///
+/// Example: `cursor`, `no-cursor`, `sudo`, `no-sudo`, `title`, `no-title`
 @"shell-integration-features": ShellIntegrationFeatures = .{},
 
 /// Sets the reporting format for OSC sequences that request color information.
@@ -3378,6 +3380,7 @@ pub const ShellIntegration = enum {
 pub const ShellIntegrationFeatures = packed struct {
     cursor: bool = true,
     sudo: bool = false,
+    title: bool = true,
 };
 
 /// OSC 4, 10, 11, and 12 default color reporting format.

--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -70,9 +70,11 @@ function __ghostty_precmd() {
         }
       fi
 
-      # Command
-      PS0=$PS0'$(__ghostty_get_current_command)'
-      PS1=$PS1'\[\e]2;$PWD\a\]'
+      if [[ "$GHOSTTY_SHELL_INTEGRATION_NO_TITLE" != 1 ]]; then
+        # Command
+        PS0=$PS0'$(__ghostty_get_current_command)'
+        PS1=$PS1'\[\e]2;$PWD\a\]'
+      fi
     fi
 
     if test "$_ghostty_executing" != "0"; then

--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -194,11 +194,13 @@ _ghostty_deferred_init() {
         _ghostty_report_pwd"
     _ghostty_report_pwd
 
-    # Enable terminal title changes.
-    functions[_ghostty_precmd]+="
-        builtin print -rnu $_ghostty_fd \$'\\e]2;'\"\${(%):-%(4~|…/%3~|%~)}\"\$'\\a'"
-    functions[_ghostty_preexec]+="
-        builtin print -rnu $_ghostty_fd \$'\\e]2;'\"\${(V)1}\"\$'\\a'"
+    if [[ "$GHOSTTY_SHELL_INTEGRATION_NO_TITLE" != 1 ]]; then
+      # Enable terminal title changes.
+      functions[_ghostty_precmd]+="
+          builtin print -rnu $_ghostty_fd \$'\\e]2;'\"\${(%):-%(4~|…/%3~|%~)}\"\$'\\a'"
+      functions[_ghostty_preexec]+="
+          builtin print -rnu $_ghostty_fd \$'\\e]2;'\"\${(V)1}\"\$'\\a'"
+    fi
 
     if [[ "$GHOSTTY_SHELL_INTEGRATION_NO_CURSOR" != 1 ]]; then
       # Enable cursor shape changes depending on the current keymap.

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -50,6 +50,7 @@ pub fn setup(
     // Setup our feature env vars
     if (!features.cursor) try env.put("GHOSTTY_SHELL_INTEGRATION_NO_CURSOR", "1");
     if (!features.sudo) try env.put("GHOSTTY_SHELL_INTEGRATION_NO_SUDO", "1");
+    if (!features.title) try env.put("GHOSTTY_SHELL_INTEGRATION_NO_TITLE", "1");
 
     return shell;
 }


### PR DESCRIPTION
Thanks for this awesome terminal and all your work!

As discussed in discord, it would be great to be able to opt-out of automatically updating the window title via the shell integration. 

In my case I want to set custom titles, while still preserving all other shell-integration features.

This adds a new option to the shell integration feature set, `no-title`. If this option is set, the shell integration will not automatically update the window title.

Please let me know if something should be adapted, thanks for your help!