### PR TITLE
display cursor duing clipboard confirmation

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -722,7 +722,7 @@ class TerminalController: NSWindowController, NSWindowDelegate,
             Ghostty.App.completeClipboardRequest(surface, data: "", state: state, confirmed: true)
             return
         }
-        
+
         // Show our paste confirmation
         self.clipboardConfirmation = ClipboardConfirmationController(
             surface: surface,
@@ -732,5 +732,8 @@ class TerminalController: NSWindowController, NSWindowDelegate,
             delegate: self
         )
         window.beginSheet(self.clipboardConfirmation!.window!)
+
+        // Force the cursor to be shown when the sheet opens
+        NSCursor.unhide()
     }
 }

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -136,7 +136,7 @@ extension Ghostty {
         /// An application is attempting to read from the clipboard using OSC 52
         case osc_52_read
 
-        /// An applciation is attempting to write to the clipboard using OSC 52
+        /// An application is attempting to write to the clipboard using OSC 52
         case osc_52_write
 
         /// The text to show in the clipboard confirmation prompt for a given request type
@@ -144,7 +144,7 @@ extension Ghostty {
             switch (self) {
             case .paste:
                 return """
-                Pasting this text to the terminal may be dangerous as it looks like some commands may be executed.
+                Pasting this text into the terminal may be dangerous as it looks like some commands may be executed.
                 """
             case .osc_52_read:
                 return """

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -508,9 +508,9 @@ extension Ghostty {
             // tab is created. In this scenario, we only want to process our
             // callback once since this is stateful and we expect balancing.
             if (mouseEntered) { return }
-            
+
             mouseEntered = true
-            
+
             // Update our cursor when we enter so we fully process our
             // cursorVisible state.
             cursorUpdate(with: NSEvent())
@@ -519,20 +519,15 @@ extension Ghostty {
         override func mouseExited(with event: NSEvent) {
             // See mouseEntered
             if (!mouseEntered) { return }
-            
+
             mouseEntered = false
-            
+
             // If the mouse is currently hidden, we want to show it when we exit
             // this view. We go through the cursorVisible dance so that only
             // cursorUpdate manages cursor state.
             if (cursorVisible == .hidden) {
-                cursorVisible = .pendingVisible
+                self.setCursorVisibility(true)
                 cursorUpdate(with: NSEvent())
-                assert(cursorVisible == .visible)
-                
-                // We set the state to pending hidden again for the next time
-                // we enter.
-                cursorVisible = .pendingHidden
             }
         }
 
@@ -584,16 +579,16 @@ extension Ghostty {
             case .visible, .hidden:
                 // Do nothing, stable state
                 break
-                
+
             case .pendingHidden:
                 NSCursor.hide()
                 cursorVisible = .hidden
-                
+
             case .pendingVisible:
                 NSCursor.unhide()
                 cursorVisible = .visible
             }
-            
+
             cursor.set()
         }
 

--- a/src/apprt/gtk/ClipboardConfirmationWindow.zig
+++ b/src/apprt/gtk/ClipboardConfirmationWindow.zig
@@ -238,7 +238,7 @@ fn promptText(req: apprt.ClipboardRequest) [:0]const u8 {
         \\Pasting this text into the terminal may be dangerous as it looks like some commands may be executed.
         ,
         .osc_52_read =>
-        \\An appliclication is attempting to read from the clipboard.
+        \\An application is attempting to read from the clipboard.
         \\The current clipboard contents are shown below.
         ,
         .osc_52_write =>


### PR DESCRIPTION
fixes #1516

the main changes of note are in `TerminalController`, where the cursor is forced to be shown after the display is rendered. I don't know if this is the most idiomatic approach... the other change is in `SurfaceView_AppKit` where I changed the logic to use `setCursorVisibility`.

regarding the change in `Package.swift`, I noticed the messages were different in the gtk and swift version, I just took the gtk version

everything else is simple typos or white spaces.