### PR TITLE
Fix copying selection across page boundaries

### DIFF
--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1355,14 +1355,14 @@ pub fn selectionString(self: *Screen, alloc: Allocator, opts: SelectionString) !
     defer if (mapbuilder) |*b| b.deinit();
 
     const sel_ordered = opts.sel.ordered(self, .forward);
-    const sel_start = start: {
-        var start = sel_ordered.start();
+    const sel_start: Pin = start: {
+        var start: Pin = sel_ordered.start();
         const cell = start.rowAndCell().cell;
         if (cell.wide == .spacer_tail) start.x -= 1;
         break :start start;
     };
-    const sel_end = end: {
-        var end = sel_ordered.end();
+    const sel_end: Pin = end: {
+        var end: Pin = sel_ordered.end();
         const cell = end.rowAndCell().cell;
         switch (cell.wide) {
             .narrow, .wide => {},
@@ -1433,7 +1433,9 @@ pub fn selectionString(self: *Screen, alloc: Allocator, opts: SelectionString) !
                 }
             }
 
-            if (row_count < rows.len - 1 and
+            const is_final_row = sel_end.page == chunk.page and sel_end.y == chunk.start + row_count;
+
+            if (!is_final_row and
                 (!row.wrap or sel_ordered.rectangle))
             {
                 try strbuilder.append('\n');

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -7073,6 +7073,37 @@ test "Screen: selectionString, rectangle, more complex w/breaks" {
     try testing.expectEqualStrings(expected, contents);
 }
 
+test "Screen: selectionString multi-page" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, 130, 40, 512);
+    defer s.deinit();
+    // 512 * "y\n"
+    var str: [1024]u8 = undefined;
+    var i: usize = 0;
+    while (i < str.len) : (i += 2) {
+        str[i] = 'y';
+        str[i + 1] = '\n';
+    }
+    try s.testWriteString(&str);
+
+    {
+        const sel = Selection.init(
+            s.pages.pin(.{ .screen = .{ .x = 0, .y = 0 } }).?,
+            s.pages.pin(.{ .active = .{ .x = 1, .y = 39 } }).?,
+            false,
+        );
+        const contents = try s.selectionString(alloc, .{
+            .sel = sel,
+            .trim = true,
+        });
+        defer alloc.free(contents);
+        const expected = str[0..1023];
+        try testing.expectEqualStrings(expected, contents);
+    }
+}
+
 test "Screen: lineIterator" {
     const testing = std.testing;
     const alloc = testing.allocator;


### PR DESCRIPTION
`Screen.selectionString` was omitting `\n` at the end of every page. Simple fix, with test.