### PR TITLE
input: escape can be used to clear dead key state

### DIFF
--- a/src/input/KeyEncoder.zig
+++ b/src/input/KeyEncoder.zig
@@ -254,10 +254,10 @@ fn legacy(
         self.ignore_keypad_with_numlock,
         self.modify_other_keys_state_2,
     )) |sequence| pc_style: {
-        // If we're pressing enter and have UTF-8 text, we probably are
+        // If we're pressing enter or escape and have UTF-8 text, we probably are
         // clearing a dead key state. This happens specifically on macOS.
         // We have a unit test for this.
-        if (self.event.key == .enter and self.event.utf8.len > 0) {
+        if (self.event.key == .enter or self.event.key == .escape and self.event.utf8.len > 0) {
             break :pc_style;
         }
 

--- a/src/input/KeyEncoder.zig
+++ b/src/input/KeyEncoder.zig
@@ -254,10 +254,19 @@ fn legacy(
         self.ignore_keypad_with_numlock,
         self.modify_other_keys_state_2,
     )) |sequence| pc_style: {
-        // If we're pressing enter or escape and have UTF-8 text, we probably are
-        // clearing a dead key state. This happens specifically on macOS.
+        // If we're pressing enter or escape and have UTF-8 text, we probably
+        // are clearing a dead key state. This happens specifically on macOS.
+        // "Clearing" a dead key state may or may not commit the dead key
+        // state; this differs by language:
+        //
+        //   - Japanese clears and does not write the characters.
+        //   - Korean clears and writes the characters.
+        //
         // We have a unit test for this.
-        if (self.event.key == .enter or self.event.key == .escape and self.event.utf8.len > 0) {
+        if ((self.event.key == .enter or
+            self.event.key == .escape) and
+            self.event.utf8.len > 0)
+        {
             break :pc_style;
         }
 
@@ -1640,6 +1649,20 @@ test "legacy: enter with utf8 (dead key state)" {
     var enc: KeyEncoder = .{
         .event = .{
             .key = .enter,
+            .utf8 = "A",
+            .unshifted_codepoint = 0x0D,
+        },
+    };
+
+    const actual = try enc.legacy(&buf);
+    try testing.expectEqualStrings("A", actual);
+}
+
+test "legacy: esc with utf8 (dead key state)" {
+    var buf: [128]u8 = undefined;
+    var enc: KeyEncoder = .{
+        .event = .{
+            .key = .escape,
             .utf8 = "A",
             .unshifted_codepoint = 0x0D,
         },


### PR DESCRIPTION
This fixes korean input method issue on mac. When typing korean and press escape in vim, composing korean character should remain. Fixes issue 1 on #1638.

Right now, korean character gets deleted when pressed 'esc' which makes korean input method unusable in vim.
```
gk<esc> // 하<esc>, '하' gets removed
```