### PR TITLE
Fix copy

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694102001,
-        "narHash": "sha256-vky6VPK1n1od6vXbqzOXnekrQpTL4hbPAwUhT5J9c9E=",
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "9e21c80adf67ebcb077d75bd5e7d724d21eeafd6",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
         "type": "github"
       },
       "original": {
@@ -104,13 +104,13 @@
     "langref": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-mYdDCBdNEIeMbavdhSo8qXqW+3fqPC8BAich7W3umrI=",
+        "narHash": "sha256-94broSBethRhPJr0G9no4TPyB8ee6BQ/hHK1QnLPln0=",
         "type": "file",
-        "url": "https://raw.githubusercontent.com/ziglang/zig/63bd2bff12992aef0ce23ae4b344e9cb5d65f05d/doc/langref.html.in"
+        "url": "https://raw.githubusercontent.com/ziglang/zig/54bbc73f8502fe073d385361ddb34a43d12eec39/doc/langref.html.in"
       },
       "original": {
         "type": "file",
-        "url": "https://raw.githubusercontent.com/ziglang/zig/63bd2bff12992aef0ce23ae4b344e9cb5d65f05d/doc/langref.html.in"
+        "url": "https://raw.githubusercontent.com/ziglang/zig/54bbc73f8502fe073d385361ddb34a43d12eec39/doc/langref.html.in"
       }
     },
     "nixpkgs-stable": {
@@ -217,11 +217,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701390337,
-        "narHash": "sha256-C+Lyio+GPl3B2IAZ6Nk5hAAE2g6a8bO9vMACUfOLC/g=",
+        "lastModified": 1711627798,
+        "narHash": "sha256-4BUZmgUFrrD5dRZbOUYRRQEDwLX/r7/ErLi+vHfB/+8=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "1815ef2d0451b1121a6a91051da84906fcb06f99",
+        "rev": "b01e0b81d1fa489e54362ea0a74f182eaa9a35bb",
         "type": "github"
       },
       "original": {
@@ -241,11 +241,11 @@
         "zig-overlay": "zig-overlay"
       },
       "locked": {
-        "lastModified": 1703036566,
-        "narHash": "sha256-GKw+ON8FcUVHxDzA35piev/W/YUvXv5aZ4hmIzNFWuc=",
+        "lastModified": 1711925513,
+        "narHash": "sha256-DFgsGlEGsxLgtRrh7J+v8x4w+/cJatTCkrZP3/0Gb/o=",
         "owner": "zigtools",
         "repo": "zls",
-        "rev": "adaeabbe1ba888d74309d0a837d4abddc24cf638",
+        "rev": "4e01c08f558ea07462aaa7b71d2a24f86f47a855",
         "type": "github"
       },
       "original": {

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -7079,29 +7079,30 @@ test "Screen: selectionString multi-page" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
-    var s = try init(alloc, 130, 40, 512);
+    var s = try init(alloc, 1, 3, 2048);
     defer s.deinit();
-    // 512 * "y\n"
-    var str: [1024]u8 = undefined;
-    var i: usize = 0;
-    while (i < str.len) : (i += 2) {
-        str[i] = 'y';
-        str[i + 1] = '\n';
+
+    const first_page_size = s.pages.pages.first.?.data.capacity.rows;
+
+    // Lazy way to seek to the first page boundary.
+    for (0..first_page_size - 1) |_| {
+        try s.testWriteString("\n");
     }
-    try s.testWriteString(&str);
+
+    try s.testWriteString("y\ny\ny");
 
     {
         const sel = Selection.init(
-            s.pages.pin(.{ .screen = .{ .x = 0, .y = 0 } }).?,
-            s.pages.pin(.{ .active = .{ .x = 1, .y = 39 } }).?,
+            s.pages.pin(.{ .active = .{ .x = 0, .y = 0 } }).?,
+            s.pages.pin(.{ .active = .{ .x = 0, .y = 2 } }).?,
             false,
         );
         const contents = try s.selectionString(alloc, .{
             .sel = sel,
-            .trim = true,
+            .trim = false,
         });
         defer alloc.free(contents);
-        const expected = str[0..1023];
+        const expected = "y\ny\ny";
         try testing.expectEqualStrings(expected, contents);
     }
 }

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1433,7 +1433,7 @@ pub fn selectionString(self: *Screen, alloc: Allocator, opts: SelectionString) !
                 }
             }
 
-            const is_final_row = sel_end.page == chunk.page and sel_end.y == chunk.start + row_count;
+            const is_final_row = chunk.page == sel_end.page and y == sel_end.y;
 
             if (!is_final_row and
                 (!row.wrap or sel_ordered.rectangle))


### PR DESCRIPTION
Changes the multi-page `selectionString` test to be a bit nicer when it fails, and also cover more edge cases (non full-page, and not trimmed).

Fixes a remaining bug with copying. The problem was that I was calculating `is_final_row` incorrectly before. That is resolved.

I built this on top of #1654 so that should be merged first probably cause that commit probably shouldn't be part of this PR :p