### PR TITLE
fix(inspector): cell picker in scrollback

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2146,7 +2146,7 @@ pub fn mouseButtonCallback(
             const pos = try self.rt_surface.getCursorPos();
             const point = self.posToViewport(pos.x, pos.y);
             const screen = &self.renderer_state.terminal.screen;
-            const p = screen.pages.pin(.{ .active = point }) orelse {
+            const p = screen.pages.pin(.{ .viewport = point }) orelse {
                 log.warn("failed to get pin for clicked point", .{});
                 return;
             };


### PR DESCRIPTION
Previously cell picking only worked correctly in the active area, not when scrolled in to scrollback.

fixes #1644 