### PR TITLE
Add note about GTK 4.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,11 @@ on the search path for a lot of software (such as Gnome and KDE) and
 installing into a prefix with `-p` sets up a directory structure to ensure
 all features of Ghostty work.
 
+#### GTK 4.14 on Wayland's GL
+
+After upgrading to 4.14, many users got crashed. There is [open issue](https://gitlab.gnome.org/GNOME/gtk/-/issues/6589/note_2072039).
+Workaround is running ghostty with `GDK_DEBUG=gl-disable-gles ghostty`
+
 ### Mac `.app`
 
 To build the official, fully featured macOS application, you must

--- a/README.md
+++ b/README.md
@@ -529,6 +529,13 @@ $ sudo apt install libgtk-4-dev libadwaita-1-dev git
 > Ubuntu 23.10 is 6.5.0 which has a bug which
 > [causes zig to fail its hash check for packages](https://github.com/ziglang/zig/issues/17282).
 
+> [!WARNING]
+>
+> GTK 4.14 on Wayland has a bug which may cause an immediate crash.
+> There is an [open issue](https://gitlab.gnome.org/GNOME/gtk/-/issues/6589/note_2072039)
+> to track this GTK bug. You can workaround this issue by running ghostty with
+> `GDK_DEBUG=gl-disable-gles ghostty`
+
 On Arch Linux, use
 
 ```
@@ -562,11 +569,6 @@ This _isn't required_, but `~/.local` is a directory that happens to be
 on the search path for a lot of software (such as Gnome and KDE) and
 installing into a prefix with `-p` sets up a directory structure to ensure
 all features of Ghostty work.
-
-#### GTK 4.14 on Wayland's GL
-
-After upgrading to 4.14, many users got crashed. There is [open issue](https://gitlab.gnome.org/GNOME/gtk/-/issues/6589/note_2072039).
-Workaround is running ghostty with `GDK_DEBUG=gl-disable-gles ghostty`
 
 ### Mac `.app`
 


### PR DESCRIPTION
After upgrading GTK 4.14, we got crashed because GDK was initialized with GLES. I reported to GTK's team and they're investigating. 
We update README with workaround.