### PR TITLE
input: do not emit sequence on <BS> when their's UTF-8 text

### DIFF
--- a/src/input/KeyEncoder.zig
+++ b/src/input/KeyEncoder.zig
@@ -245,6 +245,10 @@ fn legacy(
     // If we're in a dead key state then we never emit a sequence.
     if (self.event.composing) return "";
 
+    // When pressed backspace and have UTF-8 text, do not emit sequence.
+    // This prevents backspace emitted twice on macOS with korean input method.
+    if (self.event.key == .backspace and self.event.utf8.len > 0) return "";
+
     // If we match a PC style function key then that is our result.
     if (pcStyleFunctionKey(
         self.event.key,


### PR DESCRIPTION
This prevents backspace sequence emitted twice on macOS with korean input method.

```
gksr<bs> // 한ㄱ<bs>
```
It should remove 'ㄱ', right now it removes two characters '한ㄱ'.
This happens on macOS with korean input method because when backspace is entered 2 key event is triggered. 1 for 'ㄱ' and 1 for backspace and both event emits backspace sequence.

fixes #1638 