### PR TITLE
input: fix bs emitting sequence when it should not

### DIFF
--- a/src/input/KeyEncoder.zig
+++ b/src/input/KeyEncoder.zig
@@ -266,10 +266,8 @@ fn legacy(
         if (self.event.utf8.len > 0) {
             switch (self.event.key) {
                 else => {},
-                .enter,
-                .escape,
-                .backspace,
-                => break :pc_style,
+                .backspace => return "",
+                .enter, .escape => break :pc_style,
             }
         }
 
@@ -1658,7 +1656,7 @@ test "legacy: backspace with utf8 (dead key state)" {
     };
 
     const actual = try enc.legacy(&buf);
-    try testing.expectEqualStrings("A", actual);
+    try testing.expectEqualStrings("", actual);
 }
 
 test "legacy: enter with utf8 (dead key state)" {


### PR DESCRIPTION
In korean input method on macos, it should simply return empty string. Issue was created after https://github.com/mitchellh/ghostty/pull/1659.

```
gksr<BS> # 한ㄱ<BS>
```

'ㄱ' at the end should be removed with single <BS>, but for now it requires two <bs> to remove 'ㄱ'.