### PR TITLE
font/sprite: Fix U+255D

### DIFF
--- a/src/font/sprite/Box.zig
+++ b/src/font/sprite/Box.zig
@@ -928,7 +928,7 @@ fn draw_double_up_and_left(self: Box, canvas: *font.sprite.Canvas) void {
     self.vline(canvas, 0, hmid + 0 * thick_px + thick_px, vmid, thick_px);
     self.vline(canvas, 0, hmid + 2 * thick_px + thick_px, vmid + 2 * thick_px, thick_px);
     self.hline(canvas, 0, vmid, hmid, thick_px);
-    self.hline(canvas, 0, vmid, hmid + 2 * thick_px, thick_px);
+    self.hline(canvas, 0, vmid + 2 * thick_px, hmid + 2 * thick_px, thick_px);
 }
 
 fn draw_vertical_single_and_right_double(self: Box, canvas: *font.sprite.Canvas) void {


### PR DESCRIPTION
Double Up and Left '╝' previously had a hole in the bottom, extend line to fill gap.

Before / After:
<img width="48" alt="image" src="https://github.com/mitchellh/ghostty/assets/7241851/a3d56104-ee98-47a4-beb8-f444e4939692"><img width="48" alt="image" src="https://github.com/mitchellh/ghostty/assets/7241851/9e16aca0-35e3-4b5b-8a86-1f85af727fe0">
