### PR TITLE
macos: fall back to the system titlebar font

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/TerminalWindow.swift
@@ -52,11 +52,13 @@ class TerminalWindow: NSWindow {
     // Used to set the titlebar font.
     var titlebarFont: NSFont? {
         didSet {
-            titlebarTextField?.font = titlebarFont
+            let font = titlebarFont ?? NSFont.titleBarFont(ofSize: NSFont.systemFontSize)
+
+            titlebarTextField?.font = font
             tab.attributedTitle = attributedTitle
 
             if let toolbar = toolbar as? TerminalToolbar {
-                toolbar.titleFont = titlebarFont
+                toolbar.titleFont = font
             }
         }
     }


### PR DESCRIPTION
We allow titlebarFont to be nil to differentiate between "system" (nil) and "custom" (non-nil) behavior. For the "system" case, we need to use the system _titlebar_ font (rather than just the default system font), to match the system's conventions.