### PR TITLE
terminal: index (LF) that scrolls scroll region preserves SGR

### DIFF
--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -967,7 +967,7 @@ pub fn clearPrompt(self: *Screen) void {
 
 /// Returns the blank cell to use when doing terminal operations that
 /// require preserving the bg color.
-fn blankCell(self: *const Screen) Cell {
+pub fn blankCell(self: *const Screen) Cell {
     if (self.cursor.style_id == style.default_id) return .{};
     return self.cursor.style.bgCell() orelse .{};
 }

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -1138,6 +1138,10 @@ pub const Cell = packed struct(u64) {
         };
     }
 
+    pub fn isZero(self: Cell) bool {
+        return @as(u64, @bitCast(self)) == 0;
+    }
+
     pub fn hasText(self: Cell) bool {
         return switch (self.content_tag) {
             .codepoint,
@@ -1230,6 +1234,12 @@ pub const Cell = packed struct(u64) {
 //     try testing.expectEqual(@as(usize, 524_288), total_size); // 512 KiB
 //     //const pages = total_size / std.mem.page_size;
 // }
+
+test "Cell is zero by default" {
+    const cell: Cell = .{};
+    const cell_int: u64 = @bitCast(cell);
+    try std.testing.expectEqual(@as(u64, 0), cell_int);
+}
 
 test "Page capacity adjust cols down" {
     const original = std_capacity;

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -316,7 +316,9 @@ pub fn Stream(comptime Handler: type) type {
         }
 
         pub fn execute(self: *Self, c: u8) !void {
-            switch (@as(ansi.C0, @enumFromInt(c))) {
+            const c0: ansi.C0 = @enumFromInt(c);
+            // log.info("execute: {}", .{c0});
+            switch (c0) {
                 // We ignore SOH/STX: https://github.com/microsoft/terminal/issues/10786
                 .NUL, .SOH, .STX => {},
 


### PR DESCRIPTION
Fixes #1676

The comment in the diff explains. This is a regression that was not unit tested properly in the old implementation prior to the paged-terminal merge.