### PR TITLE
macos: show alert when creating new tab in non-native fs

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -34,7 +34,7 @@ class TerminalController: NSWindowController, NSWindowDelegate,
     }
     
     /// Fullscreen state management.
-    private let fullscreenHandler = FullScreenHandler()
+    let fullscreenHandler = FullScreenHandler()
     
     /// True when an alert is active so we don't overlap multiple.
     private var alert: NSAlert? = nil

--- a/macos/Sources/Features/Terminal/TerminalManager.swift
+++ b/macos/Sources/Features/Terminal/TerminalManager.swift
@@ -105,6 +105,19 @@ class TerminalManager {
     }
     
     private func newTab(to parent: NSWindow, withBaseConfig base: Ghostty.SurfaceConfiguration?) {
+        // If our parent is in non-native fullscreen, then new tabs do not work.
+        // See: https://github.com/mitchellh/ghostty/issues/392
+        if let controller = parent.windowController as? TerminalController,
+           controller.fullscreenHandler.isInNonNativeFullscreen {
+            let alert = NSAlert()
+            alert.messageText = "Cannot Create New Tab"
+            alert.informativeText = "New tabs are unsupported while in non-native fullscreen. Exit fullscreen and try again."
+            alert.addButton(withTitle: "OK")
+            alert.alertStyle = .warning
+            alert.beginSheetModal(for: parent)
+            return
+        }
+        
         // Create a new window and add it to the parent
         let controller = createWindow(withBaseConfig: base)
         let window = controller.window!


### PR DESCRIPTION
Fixes #1683

The root issue is #392 and we can likely find a way to fix it, but for now let's prevent the full program hang by showing an alert.

![CleanShot 2024-04-16 at 09 35 02@2x](https://github.com/mitchellh/ghostty/assets/1299/1c46e566-bd7f-4513-9d18-ae1762cec666)
