### PR TITLE
Fix background-opacity for the GTK backend

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -66,9 +66,9 @@ pub fn init(self: *Window, app: *App) !void {
 
     c.gtk_window_set_icon_name(gtk_window, "com.mitchellh.ghostty");
 
-    // Apply background opacity if we have it
+    // Remove the window's background if any of the widgets need to be transparent
     if (app.config.@"background-opacity" < 1) {
-        c.gtk_widget_set_opacity(@ptrCast(window), app.config.@"background-opacity");
+        c.gtk_widget_remove_css_class(@ptrCast(window), "background");
     }
 
     // Use the new GTK4 header bar. We only create a header bar if we have
@@ -119,16 +119,31 @@ pub fn init(self: *Window, app: *App) !void {
     c.gtk_widget_set_vexpand(notebook_widget, 1);
     c.gtk_widget_set_hexpand(notebook_widget, 1);
 
+    // Add the window background to the tab bar so it still has a background
+    // color when we're using a transparent window.
+    const tab_bar = c.gtk_widget_get_first_child(notebook_widget);
+    c.gtk_widget_add_css_class(tab_bar, "background");
+
+    // Remove the background from the stack so it doesn't become opaque
+    // when multiple tabs are open
+    const stack = c.gtk_widget_get_last_child(notebook_widget);
+    c.gtk_widget_add_css_class(stack, "transparent");
+
     // Create our box which will hold our widgets.
     const box = c.gtk_box_new(c.GTK_ORIENTATION_VERTICAL, 0);
 
     // In debug we show a warning. This is a really common issue where
     // people build from source in debug and performance is really bad.
     if (builtin.mode == .Debug) {
+        const warning_box = c.gtk_box_new(c.GTK_ORIENTATION_VERTICAL, 0);
         const warning = c.gtk_label_new("⚠️ You're running a debug build of Ghostty! Performance will be degraded.");
+
         c.gtk_widget_set_margin_top(warning, 10);
         c.gtk_widget_set_margin_bottom(warning, 10);
-        c.gtk_box_append(@ptrCast(box), warning);
+        c.gtk_box_append(@ptrCast(warning_box), warning);
+
+        c.gtk_widget_add_css_class(@ptrCast(warning_box), "background");
+        c.gtk_box_append(@ptrCast(box), warning_box);
     }
     c.gtk_box_append(@ptrCast(box), notebook_widget);
 

--- a/src/apprt/gtk/style-dark.css
+++ b/src/apprt/gtk/style-dark.css
@@ -1,0 +1,3 @@
+.transparent {
+  background-color: transparent;
+}

--- a/src/apprt/gtk/style-hc-dark.css
+++ b/src/apprt/gtk/style-hc-dark.css
@@ -1,0 +1,3 @@
+.transparent {
+  background-color: transparent;
+}

--- a/src/apprt/gtk/style-hc.css
+++ b/src/apprt/gtk/style-hc.css
@@ -1,0 +1,3 @@
+.transparent {
+  background-color: transparent;
+}

--- a/src/apprt/gtk/style.css
+++ b/src/apprt/gtk/style.css
@@ -1,0 +1,3 @@
+.transparent {
+  background-color: transparent;
+}


### PR DESCRIPTION
The `background-opacity` config option previously applied transparency to the entire window, not just to the window's background, making it not very useful. I've made it now apply only to the background.

![image](https://github.com/mitchellh/ghostty/assets/23222857/a61712ad-866c-4b84-9ca4-d1a26152693f)

For the most part, this works by changing which widgets have the `background` CSS class. A small hack was needed to add this class to the tab bar, but it's necessary to be able to keep the theme's background colour.

This PR works as-is, but I've put the necessary CSS inline into the Zig code. Would you prefer it be added to the `style.css`, etc. files?