### PR TITLE
config: rename "wcswidth" to "legacy" for "grapheme-width-method"

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -193,13 +193,14 @@ const c = @cImport({
 ///
 /// Valid values are:
 ///
-///   * `wcswidth` - Use the wcswidth function to determine grapheme width.
-///     This maximizes compatibility with legacy programs but may result
+///   * `legacy` - Use a legacy method to determine grapheme width, such as
+///     wcswidth This maximizes compatibility with legacy programs but may result
 ///     in incorrect grapheme width for certain graphemes such as skin-tone
 ///     emoji, non-English characters, etc.
 ///
-///     Note that this `wcswidth` functionality is based on the libc wcswidth,
-///     not any other libraries with that name.
+///     This is called "legacy" and not something more specific because the
+///     behavior is undefined and we want to retain the ability to modify it.
+///     For example, we may or may not use libc `wcswidth` now or in the future.
 ///
 ///   * `unicode` - Use the Unicode standard to determine grapheme width.
 ///
@@ -3464,6 +3465,6 @@ pub const WindowNewTabPosition = enum {
 
 /// See grapheme-width-method
 pub const GraphemeWidthMethod = enum {
-    wcswidth,
+    legacy,
     unicode,
 };

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -141,7 +141,7 @@ pub fn init(alloc: Allocator, opts: termio.Options) !Exec {
     // switch to ensure we get a compiler error if more cases are added.
     switch (opts.config.grapheme_width_method) {
         .unicode => term.modes.set(.grapheme_cluster, true),
-        .wcswidth => {},
+        .legacy => {},
     }
 
     // Set the image size limits


### PR DESCRIPTION
We don't actually use libc wcswidth to determine width and even if we did some terminals use wcwidth (which behaves differently), some use the Python wcswidth library (which behaves differently), etc. The reality is there is no real consistency on "legacy" behavior so by naming it "legacy" we show that we're doing our best but also gives us wiggle room to change our behavior in the future if we feel certain behaviors work better than others.

We could in the future add back "wcswidth" or others to _force_ a very specific style of width calculation, but I don't see the benefit of doing that now or ever, and would need justification.

Functionally nothing changes with this commit.

cc @gpanders @rockorager @qwerasd205 