### PR TITLE
wip - tcp: implement initial framework for running a tcp server with ghostty

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1353,6 +1353,17 @@ keybind: Keybinds = .{},
 /// If `true`, the bold text will use the bright color palette.
 @"bold-is-bright": bool = false,
 
+/// If set, Ghostty will start a TCP server on the specified socket path. Valid
+/// values can include a valid Unix socket path or an IP address and port. For
+/// example, `0.0.0.0:9393` will start a TCP server on all interfaces on port
+/// 9393. A value such as `/tmp/ghostty.sock` will start a socket on that path.
+@"remote-tcp-socket": ?[:0]const u8 = null,
+
+/// The maximum number of connections (default 10) that can be made to the
+/// remote TCP server. If this limit is reached, new connections will be
+/// rejected with a message and the connection will be closed.
+@"remote-max-connections": u8 = 10,
+
 /// This will be used to set the `TERM` environment variable.
 /// HACK: We set this with an `xterm` prefix because vim uses that to enable key
 /// protocols (specifically this will enable `modifyOtherKeys`), among other

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1355,8 +1355,8 @@ keybind: Keybinds = .{},
 
 /// If set, Ghostty will start a TCP server on the specified socket path. Valid
 /// values can include a valid Unix socket path or an IP address and port. For
-/// example, `0.0.0.0:9393` will start a TCP server on all interfaces on port
-/// 9393. A value such as `/tmp/ghostty.sock` will start a socket on that path.
+/// example, `tcp://0.0.0.0:9393` will start a TCP server on all interfaces on
+/// port 9393 while `unix:///tmp/ghostty.sock` will start a Unix socket server.
 @"remote-tcp-socket": ?[:0]const u8 = null,
 
 /// The maximum number of connections (default 10) that can be made to the

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -325,6 +325,7 @@ test {
     _ = @import("termio.zig");
     _ = @import("input.zig");
     _ = @import("cli.zig");
+    _ = @import("tcp.zig");
     _ = @import("surface_mouse.zig");
 
     // Libraries

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -18,6 +18,7 @@ const fontconfig = @import("fontconfig");
 const harfbuzz = @import("harfbuzz");
 const renderer = @import("renderer.zig");
 const apprt = @import("apprt.zig");
+const tcp = @import("tcp.zig");
 
 const App = @import("App.zig");
 const Ghostty = @import("main_c.zig").Ghostty;
@@ -111,6 +112,18 @@ pub fn main() !MainReturn {
     // quit timer may need to be started. The start timer will get cancelled if/
     // when the first surface is created.
     if (@hasDecl(apprt.App, "startQuitTimer")) app_runtime.startQuitTimer();
+
+    // Not sure where this should go tbh
+    var tcp_thread = try tcp.Thread.init(alloc);
+    defer tcp_thread.deinit();
+
+    var tcp_thr = try std.Thread.spawn(
+        .{},
+        tcp.Thread.threadMain,
+        .{&tcp_thread},
+    );
+
+    tcp_thr.setName("tcp") catch {};
 
     // Run the GUI event loop
     try app_runtime.run();

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -114,7 +114,7 @@ pub fn main() !MainReturn {
     if (@hasDecl(apprt.App, "startQuitTimer")) app_runtime.startQuitTimer();
 
     // Not sure where this should go tbh
-    var tcp_thread = try tcp.Thread.init(alloc);
+    var tcp_thread = try tcp.Thread.init(alloc, &app.mailbox);
     defer tcp_thread.deinit();
 
     var tcp_thr = try std.Thread.spawn(

--- a/src/tcp.zig
+++ b/src/tcp.zig
@@ -1,0 +1,9 @@
+//! TCP implementation. The TCP implementation is responsible for
+//! responding to TCP requests and dispatching them to the app's Mailbox.
+pub const Thread = @import("tcp/Thread.zig");
+pub const Server = @import("tcp/Server.zig");
+pub const Command = @import("tcp/Command.zig").Command;
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/tcp.zig
+++ b/src/tcp.zig
@@ -1,8 +1,8 @@
 //! TCP implementation. The TCP implementation is responsible for
 //! responding to TCP requests and dispatching them to the app's Mailbox.
-pub const Thread = @import("tcp/Thread.zig");
-pub const Server = @import("tcp/Server.zig");
 
 test {
     @import("std").testing.refAllDecls(@This());
+    _ = @import("tcp/Command.zig");
+    _ = @import("tcp/Server.zig");
 }

--- a/src/tcp.zig
+++ b/src/tcp.zig
@@ -1,5 +1,6 @@
 //! TCP implementation. The TCP implementation is responsible for
 //! responding to TCP requests and dispatching them to the app's Mailbox.
+pub const Thread = @import("tcp/Thread.zig");
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/tcp.zig
+++ b/src/tcp.zig
@@ -2,7 +2,6 @@
 //! responding to TCP requests and dispatching them to the app's Mailbox.
 pub const Thread = @import("tcp/Thread.zig");
 pub const Server = @import("tcp/Server.zig");
-pub const Command = @import("tcp/Command.zig").Command;
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/tcp/Command.zig
+++ b/src/tcp/Command.zig
@@ -26,7 +26,8 @@ pub const Command = enum {
         const cmdName = iter.next() orelse return error.InvalidInput;
         // TODO: Handle/support arguments
 
-        return std.meta.stringToEnum(Command, cmdName) orelse return error.InvalidCommand;
+        return std.meta.stringToEnum(Command, cmdName) orelse
+            return error.InvalidCommand;
     }
 
     pub fn handle(self: Command) ![]const u8 {

--- a/src/tcp/Command.zig
+++ b/src/tcp/Command.zig
@@ -1,0 +1,50 @@
+const std = @import("std");
+const log = std.log.scoped(.tcp_thread);
+
+pub const Command = enum {
+    ping,
+
+    pub const Error = error{
+        InvalidInput,
+        InvalidCommand,
+    };
+
+    /// Takes the bytes from our TCP handle and parses them into a Command.
+    pub fn parse(raw_read: []const u8) !Command {
+        const trimmed = std.mem.trim(u8, raw_read, "\t\n\r");
+
+        if (trimmed.len == 0) {
+            return error.InvalidInput;
+        }
+
+        var iter = std.mem.splitScalar(u8, trimmed, ' ');
+
+        // Not using .first() because it returns the remainder of the slice
+        // Instead we're doing what's equivalent to popping the first element
+        const cmdName = iter.next() orelse return error.InvalidInput;
+        log.debug("got command name={s}", .{cmdName});
+        // TODO: Handle/support arguments
+
+        return std.meta.stringToEnum(Command, cmdName) orelse return error.InvalidCommand;
+    }
+
+    pub fn handle(self: Command) ![]const u8 {
+        switch (self) {
+            .ping => return ping(),
+        }
+    }
+
+    pub fn handleError(err: Command.Error) ![]const u8 {
+        switch (err) {
+            error.InvalidInput => return "INVALID INPUT\n",
+            error.InvalidCommand => return "INVALID COMMAND\n",
+        }
+    }
+};
+
+// Want to move this to different file, not sure how I want it organized yet
+fn ping() []const u8 {
+    return "PONG\n";
+}
+
+// TODO: These need proper testing.

--- a/src/tcp/Command.zig
+++ b/src/tcp/Command.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const log = std.log.scoped(.tcp_thread);
+const Server = @import("Server.zig");
 
 const ping = @import("commands/ping.zig").ping;
 
@@ -30,7 +31,8 @@ pub const Command = enum {
             return error.InvalidCommand;
     }
 
-    pub fn handle(self: Command) ![]const u8 {
+    pub fn handle(self: Command, server: *Server) ![]const u8 {
+        _ = server; // TODO: Only pass into commands that actually need it
         switch (self) {
             .ping => return ping(),
         }

--- a/src/tcp/Command.zig
+++ b/src/tcp/Command.zig
@@ -44,4 +44,15 @@ pub const Command = enum {
     }
 };
 
-// TODO: These need proper testing.
+test "Command.parse ping" {
+    const input = "ping";
+    const expected = Command.ping;
+    const result = try Command.parse(input);
+    try std.testing.expect(result == expected);
+}
+
+test "Command.parse invalid input" {
+    const input = "";
+    const result = Command.parse(input);
+    try std.testing.expectError(Command.Error.InvalidInput, result);
+}

--- a/src/tcp/Command.zig
+++ b/src/tcp/Command.zig
@@ -24,7 +24,6 @@ pub const Command = enum {
         // Not using .first() because it returns everything if there is no space
         // Instead we're doing what's equivalent to popping the first element
         const cmdName = iter.next() orelse return error.InvalidInput;
-        log.debug("got command name={s}", .{cmdName});
         // TODO: Handle/support arguments
 
         return std.meta.stringToEnum(Command, cmdName) orelse return error.InvalidCommand;

--- a/src/tcp/Command.zig
+++ b/src/tcp/Command.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const log = std.log.scoped(.tcp_thread);
 
+const ping = @import("commands/ping.zig").ping;
+
 pub const Command = enum {
     ping,
 
@@ -19,7 +21,7 @@ pub const Command = enum {
 
         var iter = std.mem.splitScalar(u8, trimmed, ' ');
 
-        // Not using .first() because it returns the remainder of the slice
+        // Not using .first() because it returns everything if there is no space
         // Instead we're doing what's equivalent to popping the first element
         const cmdName = iter.next() orelse return error.InvalidInput;
         log.debug("got command name={s}", .{cmdName});
@@ -41,10 +43,5 @@ pub const Command = enum {
         }
     }
 };
-
-// Want to move this to different file, not sure how I want it organized yet
-fn ping() []const u8 {
-    return "PONG\n";
-}
 
 // TODO: These need proper testing.

--- a/src/tcp/Server.zig
+++ b/src/tcp/Server.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const xev = @import("xev");
-const Config = @import("../Config.zig").Config;
+const Config = @import("../config/Config.zig");
 
 const reject_client = @import("./handlers/reject.zig").reject_client;
 const read_client = @import("./handlers/reader.zig").read_client;
@@ -37,10 +37,6 @@ socket: xev.TCP,
 
 /// Timer for accepting connections
 acceptor: xev.Timer,
-
-/// Array of client sockets
-/// TODO: Merge with `sock_pool`? or make a hashmap
-clients: SocketPool,
 
 /// Number of clients connected
 clients_count: usize,

--- a/src/tcp/Server.zig
+++ b/src/tcp/Server.zig
@@ -1,0 +1,317 @@
+const std = @import("std");
+const xev = @import("xev");
+const tcp = @import("../tcp.zig");
+
+const reject_client = @import("./handlers/reject.zig").reject_client;
+
+const Allocator = std.mem.Allocator;
+const CompletionPool = std.heap.MemoryPool(xev.Completion);
+const SocketPool = std.heap.MemoryPool(xev.TCP);
+const BufferPool = std.heap.MemoryPool([1024]u8);
+const log = std.log.scoped(.tcp_thread);
+
+/// Maximum connections we allow at once
+const MAX_CLIENTS = 2;
+
+/// Acceptor polling rate in milliseconds
+const ACCEPTOR_RATE = 1;
+
+/// A wrapper around the TCP server socket
+pub const Server = @This();
+
+/// Memory pool that stores the completions required by xev
+comp_pool: CompletionPool,
+
+/// Memory pool that stores client sockets
+sock_pool: SocketPool,
+
+/// Memory pool that stores buffers for reading and writing
+buf_pool: BufferPool,
+
+/// Stop flag
+stop: bool,
+
+/// Event loop
+loop: xev.Loop,
+
+/// Server socket
+socket: xev.TCP,
+
+/// Timer for accepting connections
+acceptor: xev.Timer,
+
+/// Array of client sockets
+clients: [MAX_CLIENTS]*xev.TCP,
+
+/// Number of clients connected
+clients_count: usize,
+
+/// Initializes the server with the given allocator and address
+pub fn init(alloc: Allocator, addr: std.net.Address) !Server {
+    const socket = try xev.TCP.init(addr);
+    try socket.bind(addr);
+
+    return Server{
+        .comp_pool = CompletionPool.init(alloc),
+        .sock_pool = SocketPool.init(alloc),
+        .buf_pool = BufferPool.init(alloc),
+        .stop = false,
+        .loop = try xev.Loop.init(.{}),
+        .socket = socket,
+        .acceptor = try xev.Timer.init(),
+        .clients = undefined,
+        .clients_count = 0,
+    };
+}
+
+/// Deinitializes the server
+pub fn deinit(self: *Server) void {
+    self.buf_pool.deinit();
+    self.comp_pool.deinit();
+    self.sock_pool.deinit();
+    self.loop.deinit();
+    self.acceptor.deinit();
+}
+
+/// Starts the timer which tries to accept connections
+pub fn start(self: *Server) !void {
+    try self.socket.listen(MAX_CLIENTS);
+    log.info("bound server to socket={any}", .{self.socket});
+
+    // Each acceptor borrows a completion from the pool
+    // We do this because the completion is passed to the client TCP handlers
+    const c = self.comp_pool.create() catch {
+        log.err("couldn't allocate completion in pool", .{});
+        return error.OutOfMemory;
+    };
+
+    self.acceptor.run(&self.loop, c, ACCEPTOR_RATE, Server, self, acceptor);
+    while (!self.stop) {
+        try self.loop.run(.until_done);
+    }
+}
+
+/// Convenience function to destroy a buffer in our pool
+fn destroyBuffer(self: *Server, buf: []const u8) void {
+    self.buf_pool.destroy(@alignCast(
+        @as(*[1024]u8, @ptrFromInt(@intFromPtr(buf.ptr))),
+    ));
+}
+
+/// This runs on a loop and attempts to accept a connection to pass into the
+/// handlers that manage client communication. It is very important to note
+/// that the xev.Completion is shared between the acceptor and other handlers.
+/// When a client disconnects, only then the completion is freed.
+fn acceptor(
+    self_: ?*Server,
+    loop: *xev.Loop,
+    c: *xev.Completion,
+    e: xev.Timer.RunError!void,
+) xev.CallbackAction {
+    const self = self_.?;
+    e catch {
+        log.err("timer error", .{});
+        return .disarm;
+    };
+
+    self.socket.accept(loop, c, Server, self, acceptHandler);
+
+    // We need to create a new completion for the next acceptor since each
+    // TCP connection will need its own if it successfully accepts.
+    const accept_recomp = self.comp_pool.create() catch {
+        log.err("couldn't allocate completion in pool", .{});
+        return .disarm;
+    };
+
+    // We can't rearm because it'll repeat *this* instance of the acceptor
+    // So if the socket fails to accept it won't actually accept anything new
+    self.acceptor.run(loop, accept_recomp, ACCEPTOR_RATE, Server, self, acceptor);
+    return .disarm;
+}
+
+/// Accepts a new client connection and starts reading from it until EOF.
+fn acceptHandler(
+    self_: ?*Server,
+    l: *xev.Loop,
+    c: *xev.Completion,
+    e: xev.TCP.AcceptError!xev.TCP,
+) xev.CallbackAction {
+    const self = self_.?;
+    const sock = self.sock_pool.create() catch {
+        log.err("couldn't allocate socket in pool", .{});
+        return .disarm;
+    };
+
+    sock.* = e catch {
+        log.err("accept error", .{});
+        self.sock_pool.destroy(sock);
+        return .disarm;
+    };
+
+    const comp_w = self.comp_pool.create() catch {
+        log.err("couldn't allocate completion in pool", .{});
+        return .disarm;
+    };
+
+    const buf_w = self.buf_pool.create() catch {
+        log.err("couldn't allocate buffer in pool", .{});
+        self.sock_pool.destroy(sock);
+        return .disarm;
+    };
+
+    if (self.clients_count == MAX_CLIENTS) {
+        log.warn("max clients reached, rejecting fd={d}", .{sock.fd});
+        reject_client(self, sock) catch return .rearm;
+        return .disarm;
+    }
+
+    log.info("accepted connection fd={d}", .{sock.fd});
+    self.clients[self.clients_count] = sock;
+    self.clients_count += 1;
+
+    const buf_r = self.buf_pool.create() catch {
+        log.err("couldn't allocate buffer in pool", .{});
+        return .disarm;
+    };
+
+    @memcpy(buf_w.ptr, "GHOSTTY\n");
+    sock.write(l, comp_w, .{ .slice = buf_w }, Server, self, writeHandler);
+    sock.read(l, c, .{ .slice = buf_r }, Server, self, readHandler);
+    return .disarm;
+}
+
+fn readHandler(
+    self_: ?*Server,
+    loop: *xev.Loop,
+    comp: *xev.Completion,
+    sock: xev.TCP,
+    buf: xev.ReadBuffer,
+    e: xev.TCP.ReadError!usize,
+) xev.CallbackAction {
+    const self = self_.?;
+    const l = e catch |err| {
+        switch (err) {
+            error.EOF => {
+                log.info("disconnecting client fd={d}", .{sock.fd});
+                destroyBuffer(self, buf.slice);
+                self.clients_count -= 1;
+                sock.close(loop, comp, Server, self, closeHandler);
+                return .disarm;
+            },
+
+            else => {
+                destroyBuffer(self, buf.slice);
+                log.err("read error", .{});
+                return .disarm;
+            },
+        }
+    };
+
+    const comp_w = self.comp_pool.create() catch {
+        log.err("couldn't allocate completion in pool", .{});
+        return .rearm;
+    };
+
+    const buf_w = self.buf_pool.create() catch {
+        log.err("couldn't allocate buffer in pool", .{});
+        return .rearm;
+    };
+
+    // TODO: What should we do with the rest of the buffer?
+    var iter = std.mem.splitScalar(u8, buf.slice[0..l], '\n');
+    while (iter.next()) |item| {
+        if (item.len == 0) {
+            continue;
+        }
+
+        const c = tcp.Command.parse(item) catch |err| {
+            const res = try tcp.Command.handleError(err);
+            @memcpy(buf_w.ptr, res.ptr[0..res.len]);
+            sock.write(loop, comp_w, .{ .slice = buf_w }, Server, self, writeHandler);
+            return .rearm;
+        };
+
+        const res = try tcp.Command.handle(c);
+        @memcpy(buf_w.ptr, res.ptr[0..res.len]);
+    }
+
+    sock.write(loop, comp_w, .{ .slice = buf_w }, Server, self, writeHandler);
+    return .rearm;
+}
+
+fn writeHandler(
+    self_: ?*Server,
+    loop: *xev.Loop,
+    comp: *xev.Completion,
+    sock: xev.TCP,
+    buf: xev.WriteBuffer,
+    e: xev.TCP.WriteError!usize,
+) xev.CallbackAction {
+    _ = sock;
+    _ = comp;
+    _ = loop;
+    const self = self_.?;
+    _ = e catch |err| {
+        destroyBuffer(self, buf.slice);
+        log.err("write error {any}", .{err});
+        return .disarm;
+    };
+
+    return .disarm;
+}
+
+fn rejectHandler(
+    self_: ?*Server,
+    l: *xev.Loop,
+    c: *xev.Completion,
+    sock: xev.TCP,
+    buf: xev.WriteBuffer,
+    e: xev.TCP.WriteError!usize,
+) xev.CallbackAction {
+    const self = self_.?;
+    _ = e catch |err| {
+        destroyBuffer(self, buf.slice);
+        log.err("write error {any}", .{err});
+        return .disarm;
+    };
+
+    sock.close(l, c, Server, self, closeHandler);
+    return .disarm;
+}
+
+fn shutdownHandler(
+    self_: ?*Server,
+    loop: *xev.Loop,
+    comp: *xev.Completion,
+    sock: xev.TCP,
+    e: xev.TCP.ShutdownError!void,
+) xev.CallbackAction {
+    e catch {
+        // Is this even possible?
+        log.err("couldn't shutdown socket", .{});
+    };
+
+    const self = self_.?;
+
+    sock.close(loop, comp, Server, self, closeHandler);
+    return .disarm;
+}
+
+pub fn closeHandler(
+    self_: ?*Server,
+    loop: *xev.Loop,
+    comp: *xev.Completion,
+    sock: xev.TCP,
+    e: xev.TCP.CloseError!void,
+) xev.CallbackAction {
+    _ = sock;
+    _ = loop;
+
+    e catch {
+        log.err("couldn't close socket", .{});
+    };
+
+    const self = self_.?;
+    self.comp_pool.destroy(comp);
+    return .disarm;
+}

--- a/src/tcp/Server.zig
+++ b/src/tcp/Server.zig
@@ -125,3 +125,19 @@ pub fn parseAddress(raw_addr: ?[:0]const u8) BindError!std.net.Address {
 
     return BindError.InvalidAddress;
 }
+
+test "parseAddress unix socket" {
+    const addr = "unix:///tmp/test.sock";
+    const expected = try std.net.Address.initUnix("/tmp/test.sock");
+    const actual = try parseAddress(addr);
+    const result = std.net.Address.eql(actual, expected);
+    try std.testing.expect(result == true);
+}
+
+test "parseAddress IP address" {
+    const addr = "tcp://127.0.0.1:9090";
+    const expected = try std.net.Address.parseIp4("127.0.0.1", 9090);
+    const actual = try parseAddress(addr);
+    const result = std.net.Address.eql(actual, expected);
+    try std.testing.expect(result == true);
+}

--- a/src/tcp/Server.zig
+++ b/src/tcp/Server.zig
@@ -105,9 +105,6 @@ pub fn parseAddress(raw_addr: ?[:0]const u8) BindError!std.net.Address {
 /// Deinitializes the server
 pub fn deinit(self: *Server) void {
     log.info("shutting down server", .{});
-    var c: xev.Completion = undefined;
-    self.socket.close(&self.loop, &c, Server, self, closeHandler);
-
     self.buf_pool.deinit();
     self.comp_pool.deinit();
     self.sock_pool.deinit();

--- a/src/tcp/Server.zig
+++ b/src/tcp/Server.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const xev = @import("xev");
 const Config = @import("../config/Config.zig");
 const connections = @import("./handlers/connections.zig");
+const App = @import("../App.zig");
 
 const Allocator = std.mem.Allocator;
 const CompletionPool = std.heap.MemoryPool(xev.Completion);
@@ -39,11 +40,15 @@ addr: std.net.Address,
 /// Maximum clients allowed
 max_clients: u8,
 
+/// A reference to the app's main mailbox to dispathc messages
+mailbox: *App.Mailbox.Queue,
+
 /// Initializes the server with the given allocator and address
 pub fn init(
     alloc: Allocator,
     addr: std.net.Address,
     max_clients: u8,
+    mailbox: *App.Mailbox.Queue,
 ) !Server {
     return Server{
         .alloc = alloc,
@@ -55,6 +60,7 @@ pub fn init(
         .clients_count = 0,
         .addr = addr,
         .max_clients = max_clients,
+        .mailbox = mailbox,
     };
 }
 

--- a/src/tcp/Server.zig
+++ b/src/tcp/Server.zig
@@ -58,36 +58,6 @@ pub fn init(
     };
 }
 
-const BindError = error{
-    NoAddress,
-    InvalidAddress,
-};
-
-/// Tries to generate a valid address to bind to
-/// TODO: Maybe unix sockets should start with unix://
-pub fn parseAddress(raw_addr: ?[:0]const u8) BindError!std.net.Address {
-    const addr = raw_addr orelse {
-        return BindError.NoAddress;
-    };
-
-    if (addr.len == 0) {
-        return BindError.NoAddress;
-    }
-
-    var iter = std.mem.splitScalar(u8, addr, ':');
-    const host = iter.next() orelse return BindError.InvalidAddress;
-    const port = iter.next() orelse return BindError.InvalidAddress;
-    const numPort = std.fmt.parseInt(u16, port, 10) catch {
-        return std.net.Address.initUnix(addr) catch BindError.InvalidAddress;
-    };
-
-    const ip = std.net.Address.parseIp4(host, numPort) catch {
-        return std.net.Address.initUnix(addr) catch BindError.InvalidAddress;
-    };
-
-    return ip;
-}
-
 /// Deinitializes the server
 pub fn deinit(self: *Server) void {
     log.info("shutting down server", .{});

--- a/src/tcp/Server.zig
+++ b/src/tcp/Server.zig
@@ -67,10 +67,12 @@ pub fn init(
 /// Deinitializes the server
 pub fn deinit(self: *Server) void {
     self.close();
+    log.info("closing server socket", .{});
+    log.info("deinitializing server", .{});
+    self.loop.deinit();
     self.comp_pool.deinit();
     self.sock_pool.deinit();
     self.buf_pool.deinit();
-    self.loop.deinit();
 }
 
 /// Starts the timer which tries to accept connections
@@ -81,16 +83,13 @@ pub fn start(self: *Server) !void {
     try connections.startAccepting(self);
     log.info("bound server to socket={any}", .{self.socket});
 
-    // TODO: Stop flag? Only necessary if we support signaling the server
+    // TODO(tale): Stop flag? Only necessary if we support signaling the server
     // from the main thread on an event, ie. configuration reloading.
-    while (true) {
-        try self.loop.run(.until_done);
-    }
+    try self.loop.run(.until_done);
 }
 
 /// Closes the server socket
 pub fn close(self: *Server) void {
-    log.info("closing server socket", .{});
     var c: xev.Completion = undefined;
     self.socket.close(&self.loop, &c, bool, null, (struct {
         fn callback(

--- a/src/tcp/Thread.zig
+++ b/src/tcp/Thread.zig
@@ -1,0 +1,50 @@
+//! Represents the libxev thread for handling TCP connections.
+pub const Thread = @This();
+
+const std = @import("std");
+const xev = @import("xev");
+const tcp = @import("../tcp.zig");
+const App = @import("../App.zig");
+
+const Allocator = std.mem.Allocator;
+const log = std.log.scoped(.tcp_thread);
+
+/// Allocator used for xev allocations.
+alloc: std.mem.Allocator,
+
+/// The TCP server for handling incoming connections.
+server: tcp.Server,
+
+/// Initialize the thread. This does not START the thread. This only sets
+/// up all the internal state necessary prior to starting the thread. It
+/// is up to the caller to start the thread with the threadMain entrypoint.
+pub fn init(alloc: Allocator) !Thread {
+    // TODO: Configurable addresses and socket paths
+    const addr = try std.net.Address.parseIp4("127.0.0.1", 9090);
+    var server = try tcp.Server.init(alloc, addr);
+    errdefer server.deinit();
+
+    return Thread{
+        .alloc = alloc,
+        .server = server,
+    };
+}
+
+/// Clean up the thread. This is only safe to call once the thread
+/// completes executing; the caller must join prior to this.
+pub fn deinit(self: *Thread) void {
+    self.server.deinit();
+}
+
+/// The main entrypoint for the thread.
+pub fn threadMain(self: *Thread) void {
+    self.threadMain_() catch |err| {
+        log.warn("error in tcp thread err={any}", .{err});
+    };
+}
+
+fn threadMain_(self: *Thread) !void {
+    log.debug("starting tcp thread", .{});
+    defer log.debug("tcp thread exited", .{});
+    try self.server.start();
+}

--- a/src/tcp/Thread.zig
+++ b/src/tcp/Thread.zig
@@ -20,7 +20,9 @@ server: ?Server,
 /// up all the internal state necessary prior to starting the thread. It
 /// is up to the caller to start the thread with the threadMain entrypoint.
 pub fn init(alloc: Allocator, mailbox: *App.Mailbox.Queue) !Thread {
-    const config = try Config.load(alloc);
+    var config = try Config.load(alloc);
+    defer config.deinit();
+
     const max_clients = config.@"remote-max-connections";
     const addr = config.@"remote-tcp-socket";
 

--- a/src/tcp/Thread.zig
+++ b/src/tcp/Thread.zig
@@ -5,7 +5,7 @@ const std = @import("std");
 const xev = @import("xev");
 const tcp = @import("../tcp.zig");
 const App = @import("../App.zig");
-const Config = @import("../Config.zig").Config;
+const Config = @import("../config/Config.zig");
 
 const Allocator = std.mem.Allocator;
 const log = std.log.scoped(.tcp_thread);

--- a/src/tcp/commands/ping.zig
+++ b/src/tcp/commands/ping.zig
@@ -1,0 +1,6 @@
+const std = @import("std");
+const build_config = @import("../../build_config.zig");
+
+pub fn ping() []const u8 {
+    return std.fmt.comptimePrint("PONG v={}\n", .{build_config.version});
+}

--- a/src/tcp/handlers/connections.zig
+++ b/src/tcp/handlers/connections.zig
@@ -1,0 +1,96 @@
+const xev = @import("xev");
+const std = @import("std");
+const Server = @import("../Server.zig").Server;
+const Command = @import("../Command.zig").Command;
+const reject_client = @import("./reject.zig").reject_client;
+const read_client = @import("./reader.zig").read_client;
+
+const log = std.log.scoped(.tcp_thread);
+
+/// Starts accepting client connections on the server's socket.
+/// Note: This first xev.Completion is not destroyed here because it gets used
+/// for an entire client connection lifecycle.
+pub fn startAccepting(self: *Server) !void {
+    const c = try self.comp_pool.create();
+    self.socket.accept(&self.loop, c, Server, self, aHandler);
+}
+
+/// Accepts a new client connection and starts reading from it until EOF.
+/// Once an accept handler enters, it queues for a new client connection.
+/// It essentially recursively calls itself until shutdown.
+fn aHandler(
+    self_: ?*Server,
+    _: *xev.Loop,
+    c: *xev.Completion,
+    e: xev.TCP.AcceptError!xev.TCP,
+) xev.CallbackAction {
+    const self = self_.?;
+    const new_c = self.comp_pool.create() catch {
+        log.err("couldn't allocate completion in pool", .{});
+        return .disarm;
+    };
+
+    // Accept a new client connection now that we have a new completion
+    self.socket.accept(&self.loop, new_c, Server, self, aHandler);
+
+    const sock = self.sock_pool.create() catch {
+        log.err("couldn't allocate socket in pool", .{});
+        return .disarm;
+    };
+
+    sock.* = e catch {
+        log.err("accept error", .{});
+        self.sock_pool.destroy(sock);
+        return .disarm;
+    };
+
+    if (self.clients_count == self.max_clients) {
+        log.warn("max clients reached, rejecting fd={d}", .{sock.fd});
+        reject_client(self, sock) catch return .rearm;
+        return .disarm;
+    }
+
+    log.info("accepted connection fd={d}", .{sock.fd});
+    self.clients_count += 1;
+
+    read_client(self, sock, c) catch {
+        log.err("couldn't read from client", .{});
+    };
+
+    return .disarm;
+}
+
+fn sHandler(
+    self_: ?*Server,
+    loop: *xev.Loop,
+    comp: *xev.Completion,
+    sock: xev.TCP,
+    e: xev.TCP.ShutdownError!void,
+) xev.CallbackAction {
+    e catch {
+        // Is this even possible?
+        log.err("couldn't shutdown socket", .{});
+    };
+
+    const self = self_.?;
+
+    sock.close(loop, comp, Server, self, cHandler);
+    return .disarm;
+}
+
+/// Closes the client connection and cleans up the completion.
+pub fn cHandler(
+    self_: ?*Server,
+    _: *xev.Loop,
+    comp: *xev.Completion,
+    _: xev.TCP,
+    e: xev.TCP.CloseError!void,
+) xev.CallbackAction {
+    e catch {
+        log.err("couldn't close socket", .{});
+    };
+
+    const self = self_.?;
+    self.comp_pool.destroy(comp);
+    return .disarm;
+}

--- a/src/tcp/handlers/reader.zig
+++ b/src/tcp/handlers/reader.zig
@@ -59,7 +59,7 @@ fn rHandler(
             continue;
         };
 
-        const res = try Command.handle(cmd);
+        const res = try Command.handle(cmd, self);
         @memcpy(b_w.ptr, res.ptr[0..res.len]);
     }
 

--- a/src/tcp/handlers/reader.zig
+++ b/src/tcp/handlers/reader.zig
@@ -1,0 +1,84 @@
+const xev = @import("xev");
+const std = @import("std");
+const Server = @import("../Server.zig").Server;
+const Command = @import("../Command.zig").Command;
+
+const log = std.log.scoped(.tcp_thread);
+
+pub fn read_client(
+    self: *Server,
+    client: *xev.TCP,
+    c: *xev.Completion,
+) !void {
+    const buf_r = self.buf_pool.create() catch return error.OutOfMemory;
+    client.read(&self.loop, c, .{ .slice = buf_r }, Server, self, rHandler);
+}
+
+fn rHandler(
+    self_: ?*Server,
+    l: *xev.Loop,
+    c: *xev.Completion,
+    s: xev.TCP,
+    b: xev.ReadBuffer,
+    e: xev.TCP.ReadError!usize,
+) xev.CallbackAction {
+    const self = self_.?;
+    const len = e catch |err| {
+        Server.destroyBuffer(self, b.slice);
+        switch (err) {
+            error.EOF => {
+                log.info("client disconnected fd={d}", .{s.fd});
+                self.clients_count -= 1;
+                s.close(l, c, Server, self, Server.closeHandler);
+                return .disarm;
+            },
+
+            else => {
+                log.err("client read error fd={d} err={any}", .{ s.fd, err });
+                return .disarm;
+            },
+        }
+    };
+
+    // Create the completion task and buffer for our command responses
+    const c_w = self.comp_pool.create() catch return .rearm;
+    const b_w = self.buf_pool.create() catch return .rearm;
+
+    // Split commands by newline
+    var iter = std.mem.splitScalar(u8, b.slice[0..len], '\n');
+    while (iter.next()) |line| {
+        // Skip empty lines
+        if (line.len == 0) {
+            continue;
+        }
+
+        const cmd = Command.parse(line) catch |err| {
+            const res = try Command.handleError(err);
+            @memcpy(b_w.ptr, res.ptr[0..res.len]);
+            continue;
+        };
+
+        const res = try Command.handle(cmd);
+        @memcpy(b_w.ptr, res.ptr[0..res.len]);
+    }
+
+    s.write(l, c_w, .{ .slice = b_w }, Server, self, wHandler);
+    return .rearm;
+}
+
+fn wHandler(
+    self_: ?*Server,
+    _: *xev.Loop,
+    _: *xev.Completion,
+    s: xev.TCP,
+    b: xev.WriteBuffer,
+    e: xev.TCP.WriteError!usize,
+) xev.CallbackAction {
+    const self = self_.?;
+    _ = e catch |err| {
+        log.err("client write error fd={d} err={any}", .{ s.fd, err });
+        Server.destroyBuffer(self, b.slice);
+    };
+
+    return .disarm;
+}

--- a/src/tcp/handlers/reader.zig
+++ b/src/tcp/handlers/reader.zig
@@ -2,6 +2,7 @@ const xev = @import("xev");
 const std = @import("std");
 const Server = @import("../Server.zig").Server;
 const Command = @import("../Command.zig").Command;
+const connections = @import("./connections.zig");
 
 const log = std.log.scoped(.tcp_thread);
 
@@ -29,7 +30,7 @@ fn rHandler(
             error.EOF => {
                 log.info("client disconnected fd={d}", .{s.fd});
                 self.clients_count -= 1;
-                s.close(l, c, Server, self, Server.closeHandler);
+                s.close(l, c, Server, self, connections.cHandler);
                 return .disarm;
             },
 

--- a/src/tcp/handlers/reject.zig
+++ b/src/tcp/handlers/reject.zig
@@ -1,6 +1,7 @@
 const xev = @import("xev");
 const std = @import("std");
 const Server = @import("../Server.zig").Server;
+const connections = @import("./connections.zig");
 
 const log = std.log.scoped(.tcp_thread);
 
@@ -36,6 +37,6 @@ fn wHandler(
         return .disarm;
     };
 
-    client.close(l, c, Server, self, Server.closeHandler);
+    client.close(l, c, Server, self, connections.cHandler);
     return .disarm;
 }

--- a/src/tcp/handlers/reject.zig
+++ b/src/tcp/handlers/reject.zig
@@ -1,0 +1,47 @@
+const xev = @import("xev");
+const std = @import("std");
+const Server = @import("../Server.zig").Server;
+
+const log = std.log.scoped(.tcp_thread);
+
+fn destroyBuffer(self: *Server, buf: []const u8) void {
+    self.buf_pool.destroy(@alignCast(
+        @as(*[1024]u8, @ptrFromInt(@intFromPtr(buf.ptr))),
+    ));
+}
+
+const RejectError = error{
+    AllocError,
+    WriteError,
+};
+
+// TODO: Support client rejection reasons.
+pub fn reject_client(self: *Server, c: *xev.TCP) !void {
+    const buf_w = self.buf_pool.create() catch return RejectError.AllocError;
+    const comp_w = self.comp_pool.create() catch {
+        destroyBuffer(self, buf_w);
+        return RejectError.AllocError;
+    };
+
+    @memcpy(buf_w.ptr, "ERR: Max connections reached\n");
+    c.write(&self.loop, comp_w, .{ .slice = buf_w }, Server, self, wHandler);
+}
+
+fn wHandler(
+    self_: ?*Server,
+    l: *xev.Loop,
+    c: *xev.Completion,
+    client: xev.TCP,
+    b: xev.WriteBuffer,
+    e: xev.TCP.WriteError!usize,
+) xev.CallbackAction {
+    const self = self_.?;
+    _ = e catch |err| {
+        destroyBuffer(self, b.slice);
+        log.err("write error {any}", .{err});
+        return .disarm;
+    };
+
+    client.close(l, c, Server, self, Server.closeHandler);
+    return .disarm;
+}


### PR DESCRIPTION
This sets the initial ground for a TCP based protocol in Ghostty, which works to address some of the foundation required for #601. This is very much a work-in-progress and I'm still new to Zig so please feel free to absolutely tear apart the code I wrote 😄. I opened this to get initial feedback on the implementation.

The general idea is that a separate thread runs a `libxev` loop that manages a TCP server. It's a primitive text-based protocol and you can test it yourself by adding `remote-tcp-socket = tcp://127.0.0.1:9090` to your config and then running `telnet localhost 9090` and typing `ping`.

Here's what's currently still TODO:
- [ ] Actually parsing arguments in the command handler (skipped because ping has none for now)
- [x] Should the configuration use `unix://` as a prefix for unix based sockets?
- [x] Testing, testing and lots of testing
- [x] I still need to cleanup, comment, and address a leak
- [ ] Where the TCP thread is spawned from needs to be decided
- [x] How do we want to support actually controlling things, pass in a ref to app's Mailbox?

There's some other things here and there I'll get to as well (I know there's a lot of extra fields, I haven't gotten around to cleaning up yet).