### PR TITLE
Pin to Zig 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ expand this to other platforms.
 
 ## Developing Ghostty
 
-To build Ghostty, you need [Zig](https://ziglang.org/) installed.
+To build Ghostty, you need [Zig 0.12](https://ziglang.org/) installed.
 
 On Linux, you may need to install additional dependencies. See
 [Linux Installation Tips](#linux-installation-tips). On macOS, you
@@ -444,17 +444,11 @@ Ghostty must pass within these Nix environments.
 
 > [!NOTE]
 >
-> **Zig nightly is required.** Ghostty is built against the nightly
-> releases of Zig while it is still in beta. I plan on stabilizing on a release
-> version when I get closer to generally releasing this to ease downstream
-> packagers. You can find binary releases of nightly builds on the
+> **Zig 0.12 is required.** Ghostty only guarantees that it can build
+> against 0.12. Zig is still a fast-moving project so it is likely newer
+> versions will not be able to build Ghostty yet. You can find binary
+> releases of Zig release builds on the
 > [Zig downloads page](https://ziglang.org/download/).
-
-Under some conditions, the very latest Zig nightly may not work (for example,
-when Zig introduces breaking changes that Ghostty or our dependencies haven't
-been upated for). To be sure what Zig version will work, see the `build.zig`
-file which has a constant `required_zig`. Ghostty plans to pin to Zig 0.12
-once it is released, which will make all of this much easier.
 
 With Zig and necessary dependencies installed, a binary can be built using
 `zig build`:

--- a/build.zig
+++ b/build.zig
@@ -20,12 +20,11 @@ const XCFrameworkStep = @import("src/build/XCFrameworkStep.zig");
 const Version = @import("src/build/Version.zig");
 const Command = @import("src/Command.zig");
 
-// Do a comptime Zig version requirement. The required Zig version is
-// somewhat arbitrary: it is meant to be a version that we feel works well,
-// but we liberally update it. In the future, we'll be more careful about
-// using released versions so that package managers can integrate better.
+// Do a comptime Zig version requirement. This is the minimum required
+// Zig version. We don't check a maximum so that devs can try newer
+// versions but this is the only version we guarantee to work.
 comptime {
-    const required_zig = "0.12.0-dev.3676+21a6a1b0f";
+    const required_zig = "0.12.0";
     const current_zig = builtin.zig_version;
     const min_zig = std.SemanticVersion.parse(required_zig) catch unreachable;
     if (current_zig.order(min_zig) == .lt) {

--- a/flake.lock
+++ b/flake.lock
@@ -131,11 +131,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1688221086,
-        "narHash": "sha256-cdW6qUL71cNWhHCpMPOJjlw0wzSRP0pVlRn2vqX/VVg=",
+        "lastModified": 1713687659,
+        "narHash": "sha256-Yd8KuOBpZ0Slau/NxFhMPJI0gBxeax0vq/FD0rqKwuQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cd99c2b3c9f160cd004318e0697f90bbd5960825",
+        "rev": "f2d7a289c5a5ece8521dd082b81ac7e4a57c2c5c",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -145,27 +145,10 @@
         "type": "github"
       }
     },
-    "nixpkgs-zig-0-12": {
-      "locked": {
-        "lastModified": 1713479535,
-        "narHash": "sha256-PnquFNhs0vtXwHkKk44dmnrNTMMCQelgi8pS/DGh6Ks=",
-        "owner": "vancluever",
-        "repo": "nixpkgs",
-        "rev": "153458bf17bfeedd3ab8b9a3250ba1168135e8ae",
-        "type": "github"
-      },
-      "original": {
-        "owner": "vancluever",
-        "ref": "vancluever-zig-0-12",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "nixpkgs-stable": "nixpkgs-stable",
         "nixpkgs-unstable": "nixpkgs-unstable",
-        "nixpkgs-zig-0-12": "nixpkgs-zig-0-12",
         "zig": "zig",
         "zls": "zls"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713476117,
-        "narHash": "sha256-97U178Ob/D+EYiGMg/ne7je292ZLCghclhXiPfIfpdQ=",
+        "lastModified": 1713659103,
+        "narHash": "sha256-WgWH0HPGsxd7Ov5M4Ug7qjmxbTeG8517xO6hY3198tU=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "8f336c6f54b57492ac1d8a7385a79fefac84b7dc",
+        "rev": "a13735003a235a2e4e202b47277129f99bfc9294",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
 
       packages.${system} = let
         mkArgs = optimize: {
-          inherit (pkgs-zig-0-12) zig_0_12;
+          inherit (pkgs-unstable) zig_0_12;
           inherit optimize;
 
           revision = self.shortRev or self.dirtyShortRev or "dirty";

--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
         inherit (pkgs-unstable) tracy;
         inherit (zls.packages.${system}) zls;
 
-        zig = zig.packages.${system}.master;
+        zig = zig.packages.${system}."0.12.0";
         wraptest = pkgs-stable.callPackage ./nix/wraptest.nix {};
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -9,16 +9,6 @@
     # system glibc that the user is building for.
     nixpkgs-stable.url = "github:nixos/nixpkgs/release-23.05";
 
-    # This is a nixpkgs mirror (based off of master) that contains
-    # patches for Zig 0.12 (master/nightly).
-    #
-    # This gives an up-to-date Zig that contains the nixpkgs patches,
-    # specifically the ones relating to NativeTargetInfo
-    # (https://github.com/ziglang/zig/issues/15898) in addition to the base
-    # hooks. This is used in the package (i.e. packages.ghostty, not the
-    # devShell) to build a Zig that can be included in a NixOS configuration.
-    nixpkgs-zig-0-12.url = "github:vancluever/nixpkgs/vancluever-zig-0-12";
-
     zig = {
       url = "github:mitchellh/zig-overlay";
       inputs.nixpkgs.follows = "nixpkgs-stable";
@@ -34,7 +24,6 @@
     self,
     nixpkgs-unstable,
     nixpkgs-stable,
-    nixpkgs-zig-0-12,
     zig,
     zls,
     ...
@@ -42,7 +31,6 @@
     builtins.foldl' nixpkgs-stable.lib.recursiveUpdate {} (builtins.map (system: let
       pkgs-stable = nixpkgs-stable.legacyPackages.${system};
       pkgs-unstable = nixpkgs-unstable.legacyPackages.${system};
-      pkgs-zig-0-12 = nixpkgs-zig-0-12.legacyPackages.${system};
     in {
       devShell.${system} = pkgs-stable.callPackage ./nix/devShell.nix {
         inherit (pkgs-unstable) tracy;


### PR DESCRIPTION
This pins our release to Zig 0.12. 

For the devShell we still use my overlay but the 0.12 release. I wasn't able to update to the upstream binary release of 0.12 because it was failing CI due to glibc errors.

For the Nix package we use the upstream 0.12 release. 