### PR TITLE
remove unnecessary fillRect call in coretext.zig

### DIFF
--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -325,20 +325,6 @@ pub const Face = struct {
         );
         defer ctx.release();
 
-        // Perform an initial fill. This ensures that we don't have any
-        // uninitialized pixels in the bitmap.
-        if (color.color)
-            ctx.setRGBFillColor(1, 1, 1, 0)
-        else
-            ctx.setGrayFillColor(0, 0);
-        ctx.fillRect(.{
-            .origin = .{ .x = 0, .y = 0 },
-            .size = .{
-                .width = @floatFromInt(width),
-                .height = @floatFromInt(height),
-            },
-        });
-
         ctx.setAllowsFontSmoothing(true);
         ctx.setShouldSmoothFonts(opts.thicken); // The amadeus "enthicken"
         ctx.setAllowsFontSubpixelQuantization(true);


### PR DESCRIPTION
I am very new to fonts/graphics but I am pretty sure this code is not actually doing anything because the alpha value is set to 0.  It's not a problem because the `@memset(buf, 0)` a few lines up is achieving the same outcome.

Many apologies if I have missed something and am totally misunderstanding this.