### PR TITLE
sprites: dont thicken via font-thicken, add cursor thickness adjustment

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -184,6 +184,7 @@ const c = @cImport({
 @"adjust-underline-thickness": ?MetricModifier = null,
 @"adjust-strikethrough-position": ?MetricModifier = null,
 @"adjust-strikethrough-thickness": ?MetricModifier = null,
+@"adjust-cursor-thickness": ?MetricModifier = null,
 
 /// The method to use for calculating the cell width of a grapheme cluster.
 /// The default value is `unicode` which uses the Unicode standard to determine

--- a/src/font/SharedGrid.zig
+++ b/src/font/SharedGrid.zig
@@ -73,7 +73,6 @@ lock: std.Thread.RwLock,
 pub fn init(
     alloc: Allocator,
     resolver: CodepointResolver,
-    thicken: bool,
 ) !SharedGrid {
     // We need to support loading options since we use the size data
     assert(resolver.collection.load_options != null);
@@ -97,7 +96,7 @@ pub fn init(
     try result.glyphs.ensureTotalCapacity(alloc, 128);
 
     // Initialize our metrics.
-    try result.reloadMetrics(thicken);
+    try result.reloadMetrics();
 
     return result;
 }
@@ -111,7 +110,7 @@ pub fn deinit(self: *SharedGrid, alloc: Allocator) void {
     self.resolver.deinit(alloc);
 }
 
-fn reloadMetrics(self: *SharedGrid, thicken: bool) !void {
+fn reloadMetrics(self: *SharedGrid) !void {
     // Get our cell metrics based on a regular font ascii 'M'. Why 'M'?
     // Doesn't matter, any normal ASCII will do we're just trying to make
     // sure we use the regular font.
@@ -126,8 +125,7 @@ fn reloadMetrics(self: *SharedGrid, thicken: bool) !void {
     self.resolver.sprite = .{
         .width = self.metrics.cell_width,
         .height = self.metrics.cell_height,
-        .thickness = self.metrics.underline_thickness *
-            @as(u32, if (thicken) 2 else 1),
+        .thickness = self.metrics.underline_thickness,
         .underline_position = self.metrics.underline_position,
         .strikethrough_position = self.metrics.strikethrough_position,
     };
@@ -326,7 +324,7 @@ fn testGrid(mode: TestMode, alloc: Allocator, lib: Library) !SharedGrid {
     var r: CodepointResolver = .{ .collection = c };
     errdefer r.deinit(alloc);
 
-    return try init(alloc, r, false);
+    return try init(alloc, r);
 }
 
 test getIndex {

--- a/src/font/SharedGridSet.zig
+++ b/src/font/SharedGridSet.zig
@@ -144,7 +144,7 @@ pub fn ref(
             .discover = try self.discover(),
             .codepoint_map = key.codepoint_map,
         };
-    }, config.@"font-thicken");
+    });
     errdefer grid.deinit(self.alloc);
 
     return .{ gop.key_ptr.*, gop.value_ptr.grid };
@@ -358,7 +358,6 @@ pub const DerivedConfig = struct {
     @"font-variation-italic": configpkg.RepeatableFontVariation,
     @"font-variation-bold-italic": configpkg.RepeatableFontVariation,
     @"font-codepoint-map": configpkg.RepeatableCodepointMap,
-    @"font-thicken": bool,
     @"adjust-cell-width": ?Metrics.Modifier,
     @"adjust-cell-height": ?Metrics.Modifier,
     @"adjust-font-baseline": ?Metrics.Modifier,
@@ -366,6 +365,7 @@ pub const DerivedConfig = struct {
     @"adjust-underline-thickness": ?Metrics.Modifier,
     @"adjust-strikethrough-position": ?Metrics.Modifier,
     @"adjust-strikethrough-thickness": ?Metrics.Modifier,
+    @"adjust-cursor-thickness": ?Metrics.Modifier,
 
     /// Initialize a DerivedConfig. The config should be either a
     /// config.Config or another DerivedConfig to clone from.
@@ -388,7 +388,6 @@ pub const DerivedConfig = struct {
             .@"font-variation-italic" = try config.@"font-variation-italic".clone(alloc),
             .@"font-variation-bold-italic" = try config.@"font-variation-bold-italic".clone(alloc),
             .@"font-codepoint-map" = try config.@"font-codepoint-map".clone(alloc),
-            .@"font-thicken" = config.@"font-thicken",
             .@"adjust-cell-width" = config.@"adjust-cell-width",
             .@"adjust-cell-height" = config.@"adjust-cell-height",
             .@"adjust-font-baseline" = config.@"adjust-font-baseline",
@@ -396,6 +395,7 @@ pub const DerivedConfig = struct {
             .@"adjust-underline-thickness" = config.@"adjust-underline-thickness",
             .@"adjust-strikethrough-position" = config.@"adjust-strikethrough-position",
             .@"adjust-strikethrough-thickness" = config.@"adjust-strikethrough-thickness",
+            .@"adjust-cursor-thickness" = config.@"adjust-cursor-thickness",
 
             // This must be last so the arena contains all our allocations
             // from above since Zig does assignment in order.
@@ -532,6 +532,7 @@ pub const Key = struct {
             if (config.@"adjust-underline-thickness") |m| try set.put(alloc, .underline_thickness, m);
             if (config.@"adjust-strikethrough-position") |m| try set.put(alloc, .strikethrough_position, m);
             if (config.@"adjust-strikethrough-thickness") |m| try set.put(alloc, .strikethrough_thickness, m);
+            if (config.@"adjust-cursor-thickness") |m| try set.put(alloc, .cursor_thickness, m);
             break :set set;
         };
 

--- a/src/font/face/Metrics.zig
+++ b/src/font/face/Metrics.zig
@@ -21,6 +21,10 @@ underline_thickness: u32,
 strikethrough_position: u32,
 strikethrough_thickness: u32,
 
+/// The thickness in pixels of the cursor sprite. This has a default value
+/// because it is not determined by fonts but rather by user configuration.
+cursor_thickness: u32 = 1,
+
 /// Original cell width and height. These are used to render the cursor
 /// in the original cell size after modification.
 original_cell_width: ?u32 = null,

--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -1463,7 +1463,7 @@ fn testShaperWithFont(alloc: Allocator, font_req: TestFont) !TestShaper {
 
     const grid_ptr = try alloc.create(SharedGrid);
     errdefer alloc.destroy(grid_ptr);
-    grid_ptr.* = try SharedGrid.init(alloc, .{ .collection = c }, false);
+    grid_ptr.* = try SharedGrid.init(alloc, .{ .collection = c });
     errdefer grid_ptr.*.deinit(alloc);
 
     var shaper = try Shaper.init(alloc, .{});

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -1248,7 +1248,7 @@ fn testShaperWithFont(alloc: Allocator, font_req: TestFont) !TestShaper {
 
     const grid_ptr = try alloc.create(SharedGrid);
     errdefer alloc.destroy(grid_ptr);
-    grid_ptr.* = try SharedGrid.init(alloc, .{ .collection = c }, false);
+    grid_ptr.* = try SharedGrid.init(alloc, .{ .collection = c });
     errdefer grid_ptr.*.deinit(alloc);
 
     var shaper = try Shaper.init(alloc, .{});

--- a/src/font/sprite/Face.zig
+++ b/src/font/sprite/Face.zig
@@ -74,12 +74,20 @@ pub fn renderGlyph(
     // Safe to ".?" because of the above assertion.
     return switch (Kind.init(cp).?) {
         .box => box: {
+            const thickness = switch (cp) {
+                @intFromEnum(Sprite.cursor_rect),
+                @intFromEnum(Sprite.cursor_hollow_rect),
+                @intFromEnum(Sprite.cursor_bar),
+                => if (opts.grid_metrics) |m| m.cursor_thickness else self.thickness,
+                else => self.thickness,
+            };
+
             const f: Box, const y_offset: u32 = face: {
                 // Expected, usual values.
                 var f: Box = .{
                     .width = width,
                     .height = self.height,
-                    .thickness = self.thickness,
+                    .thickness = thickness,
                 };
 
                 // If the codepoint is unadjusted then we want to adjust


### PR DESCRIPTION
This does two things:
1. Stop doubling the thickness of all sprites when `font-thicken` is set to true. Following your comments in discord, this isn't needed anymore :P
2. Add an `adjust-cursor-thickness` config option. 
I tried to do it in the way that least infects other parts of the codebase: by adding a `Metrics` field and giving it a default, none of the renderers have to know about it existing. In my [last PR](https://github.com/mitchellh/ghostty/pull/1554) attempting this feature, I instead added a field to `Face` and put `adjust_cursor_thickness` in all the renderers' `DerivedConfig`s so they can set it every time they update the `font_group.group.sprite` face. I think this (new) is better, but still, you're far more familiar with this subsystem than I am. So let me know if you have a problem with this / what you think!

Relevant conversation: #1546, 