### PR TITLE
coretext - minor fixes

### DIFF
--- a/pkg/macos/text/font.zig
+++ b/pkg/macos/text/font.zig
@@ -81,7 +81,7 @@ pub const Font = opaque {
         );
     }
 
-    pub fn getBoundingRectForGlyphs(
+    pub fn getBoundingRectsForGlyphs(
         self: *Font,
         orientation: FontOrientation,
         glyphs: []const graphics.Glyph,
@@ -197,11 +197,11 @@ test {
 
     // Bounding rect
     {
-        var rect = font.getBoundingRectForGlyphs(.horizontal, &glyphs, null);
+        var rect = font.getBoundingRectsForGlyphs(.horizontal, &glyphs, null);
         try testing.expect(rect.size.width > 0);
 
         var singles: [1]graphics.Rect = undefined;
-        rect = font.getBoundingRectForGlyphs(.horizontal, &glyphs, &singles);
+        rect = font.getBoundingRectsForGlyphs(.horizontal, &glyphs, &singles);
         try testing.expect(rect.size.width > 0);
         try testing.expect(singles[0].size.width > 0);
     }

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -424,6 +424,18 @@ pub const Face = struct {
         var advances: [glyphs.len]macos.graphics.Size = undefined;
         _ = self.font.getAdvancesForGlyphs(.horizontal, &glyphs, &advances);
 
+        // std.log.warn("renderGlyph rect={} width={} height={} render_x={} render_y={} offset_y={} ascent={} cell_height={} cell_baseline={}", .{
+        //     rect,
+        //     width,
+        //     height,
+        //     render_x,
+        //     render_y,
+        //     offset_y,
+        //     glyph_ascent,
+        //     self.metrics.cell_height,
+        //     self.metrics.cell_baseline,
+        // });
+
         return .{
             .width = width,
             .height = height,
@@ -524,6 +536,9 @@ pub const Face = struct {
             .strikethrough_position = @intFromFloat(strikethrough_position),
             .strikethrough_thickness = @intFromFloat(strikethrough_thickness),
         };
+
+        // std.log.warn("font size size={d}", .{ct_font.getSize()});
+        // std.log.warn("font metrics={}", .{result});
 
         return result;
     }

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -396,7 +396,6 @@ pub const Face = struct {
         const offset_y: i32 = offset_y: {
             // Our Y coordinate in 3D is (0, 0) bottom left, +y is UP.
             // We need to calculate our baseline from the bottom of a cell.
-            //const baseline_from_bottom: f64 = @floatFromInt(self.metrics.cell_baseline);
             const baseline_from_bottom: f64 = @floatFromInt(metrics.cell_baseline);
 
             // Next we offset our baseline by the bearing in the font. We
@@ -424,18 +423,6 @@ pub const Face = struct {
         // Get our advance
         var advances: [glyphs.len]macos.graphics.Size = undefined;
         _ = self.font.getAdvancesForGlyphs(.horizontal, &glyphs, &advances);
-
-        // std.log.warn("renderGlyph rect={} width={} height={} render_x={} render_y={} offset_y={} ascent={} cell_height={} cell_baseline={}", .{
-        //     rect,
-        //     width,
-        //     height,
-        //     render_x,
-        //     render_y,
-        //     offset_y,
-        //     glyph_ascent,
-        //     self.metrics.cell_height,
-        //     self.metrics.cell_baseline,
-        // });
 
         return .{
             .width = width,
@@ -537,9 +524,6 @@ pub const Face = struct {
             .strikethrough_position = @intFromFloat(strikethrough_position),
             .strikethrough_thickness = @intFromFloat(strikethrough_thickness),
         };
-
-        // std.log.warn("font size size={d}", .{ct_font.getSize()});
-        // std.log.warn("font metrics={}", .{result});
 
         return result;
     }

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -242,7 +242,7 @@ pub const Face = struct {
         var glyphs = [_]macos.graphics.Glyph{@intCast(glyph_index)};
 
         // Get the bounding rect for rendering this glyph.
-        const rect = self.font.getBoundingRectForGlyphs(.horizontal, &glyphs, null);
+        const rect = self.font.getBoundingRectsForGlyphs(.horizontal, &glyphs, null);
 
         // The x/y that we render the glyph at. The Y value has to be flipped
         // because our coordinates in 3D space are (0, 0) bottom left with

--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -379,7 +379,6 @@ pub const Shaper = struct {
 
         pub fn prepare(self: *RunIteratorHook) !void {
             try self.shaper.run_state.reset();
-            // log.warn("----------- run reset -------------", .{});
         }
 
         pub fn addCodepoint(self: RunIteratorHook, cp: u32, cluster: u32) !void {
@@ -398,7 +397,6 @@ pub const Shaper = struct {
                 .codepoint = cp,
                 .cluster = cluster,
             });
-            // log.warn("run cp={X}", .{cp});
 
             // If the UTF-16 codepoint is a pair then we need to insert
             // a dummy entry so that the CTRunGetStringIndices() function

--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -379,6 +379,7 @@ pub const Shaper = struct {
 
         pub fn prepare(self: *RunIteratorHook) !void {
             try self.shaper.run_state.reset();
+            // log.warn("----------- run reset -------------", .{});
         }
 
         pub fn addCodepoint(self: RunIteratorHook, cp: u32, cluster: u32) !void {
@@ -397,6 +398,7 @@ pub const Shaper = struct {
                 .codepoint = cp,
                 .cluster = cluster,
             });
+            // log.warn("run cp={X}", .{cp});
 
             // If the UTF-16 codepoint is a pair then we need to insert
             // a dummy entry so that the CTRunGetStringIndices() function

--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -304,19 +304,16 @@ pub const Shaper = struct {
 
             // Get our glyphs and positions
             const glyphs = try ctrun.getGlyphs(alloc);
-            const positions = try ctrun.getPositions(alloc);
             const advances = try ctrun.getAdvances(alloc);
             const indices = try ctrun.getStringIndices(alloc);
-            assert(glyphs.len == positions.len);
             assert(glyphs.len == advances.len);
             assert(glyphs.len == indices.len);
 
             for (
                 glyphs,
-                positions,
                 advances,
                 indices,
-            ) |glyph, pos, advance, index| {
+            ) |glyph, advance, index| {
                 try self.cell_buf.ensureUnusedCapacity(
                     self.alloc,
                     glyphs.len,
@@ -351,15 +348,7 @@ pub const Shaper = struct {
                 // Advances apply to the NEXT cell.
                 cell_offset.x += advance.width;
                 cell_offset.y += advance.height;
-
-                _ = pos;
-                // const i = self.cell_buf.items.len - 1;
-                // log.warn(
-                //     "i={} codepoint={} glyph={} pos={} advance={} index={} cluster={}",
-                //     .{ i, self.codepoints.items[index].codepoint, glyph, pos, advance, index, cluster },
-                // );
             }
-            //log.warn("-------------------------------", .{});
         }
 
         // If our last cell doesn't match our last cluster then we have


### PR DESCRIPTION
A few minor details I noticed while reading through the coretext code. No worries if you don't want any of these - just ended up making these changes on my local branch for my own understanding.

1. Fix typo where an `s` was dropped from `CTFontGetBoundingRectsForGlyphs` in the ziggified layer. It's slightly confusing because it returns a single rect which encompasses all the glyphs passed in but in our case it's only passing one glyph.
2. Remove unnecessary `ctrun.getPositions()` which is never actually used.
3. Remove some commented out log statements and one that wasn't commented out.
