### PR TITLE
Revert cc29f0686379187733fe8824a2bea3ec63d93448

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -266,10 +266,6 @@ pub fn build(b: *std.Build) !void {
             exe.addWin32ResourceFile(.{
                 .file = b.path("dist/windows/ghostty.rc"),
             });
-
-            // Building with LTO on Windows is broken.
-            // https://github.com/ziglang/zig/issues/15958
-            exe.want_lto = false;
         }
 
         // If we're installing, we get the install step so we can add


### PR DESCRIPTION
The change made in cc29f0686379187733fe8824a2bea3ec63d93448 is no longer necessary since Windows LTO was fixed in Zig 0.12.0 which is the required Zig for ghostty now. The tracking issue https://github.com/ziglang/zig/issues/15958 has been closed.