### PR TITLE
font: runs do not split on bg color change

### DIFF
--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -356,15 +356,9 @@ test "run iterator: empty cells with background set" {
         );
         {
             const run = (try it.next(alloc)).?;
-            try testing.expectEqual(@as(u32, 1), shaper.hb_buf.getLength());
+            try testing.expectEqual(@as(u32, 3), shaper.hb_buf.getLength());
             const cells = try shaper.shape(run);
-            try testing.expectEqual(@as(usize, 1), cells.len);
-        }
-        {
-            const run = (try it.next(alloc)).?;
-            try testing.expectEqual(@as(u32, 2), shaper.hb_buf.getLength());
-            const cells = try shaper.shape(run);
-            try testing.expectEqual(@as(usize, 2), cells.len);
+            try testing.expectEqual(@as(usize, 3), cells.len);
         }
         try testing.expect(try it.next(alloc) == null);
     }
@@ -1124,7 +1118,7 @@ test "shape cell attribute change" {
         try testing.expectEqual(@as(usize, 2), count);
     }
 
-    // Changing bg color should split
+    // Changing bg color should not split
     {
         var screen = try terminal.Screen.init(alloc, 3, 10, 0);
         defer screen.deinit();
@@ -1146,7 +1140,7 @@ test "shape cell attribute change" {
             count += 1;
             _ = try shaper.shape(run);
         }
-        try testing.expectEqual(@as(usize, 2), count);
+        try testing.expectEqual(@as(usize, 1), count);
     }
 
     // Same bg color should not split


### PR DESCRIPTION
We previously split text runs for shaping on bg color changes. As pointed out in Discord, this is not necessary, since we can always color cells according to their desired background even if the text in the cell shapes to something else.

## Before

![CleanShot 2024-04-30 at 11 10 40@2x](https://github.com/mitchellh/ghostty/assets/1299/022d399e-b178-49f2-bba5-969e834062e5)


## After

![CleanShot 2024-04-30 at 11 10 18@2x](https://github.com/mitchellh/ghostty/assets/1299/6175e82b-7d1b-4f2a-afc9-1ff22bba78a9)
