### PR TITLE
Cache font shaping results

### DIFF
--- a/src/font/main.zig
+++ b/src/font/main.zig
@@ -14,6 +14,7 @@ pub const Glyph = @import("Glyph.zig");
 pub const Metrics = face.Metrics;
 pub const shape = @import("shape.zig");
 pub const Shaper = shape.Shaper;
+pub const ShaperCache = shape.Cache;
 pub const SharedGrid = @import("SharedGrid.zig");
 pub const SharedGridSet = @import("SharedGridSet.zig");
 pub const sprite = @import("sprite.zig");

--- a/src/font/shape.zig
+++ b/src/font/shape.zig
@@ -4,6 +4,7 @@ pub const harfbuzz = @import("shaper/harfbuzz.zig");
 pub const coretext = @import("shaper/coretext.zig");
 pub const web_canvas = @import("shaper/web_canvas.zig");
 pub usingnamespace @import("shaper/run.zig");
+pub const Cache = @import("shaper/Cache.zig");
 
 /// Shaper implementation for our compile options.
 pub const Shaper = switch (options.backend) {
@@ -56,3 +57,8 @@ pub const Options = struct {
     /// support applying features globally.
     features: []const []const u8 = &.{},
 };
+
+test {
+    _ = Cache;
+    _ = Shaper;
+}

--- a/src/font/shaper/Cache.zig
+++ b/src/font/shaper/Cache.zig
@@ -1,0 +1,77 @@
+//! This structure caches the shaped cells for a given text run.
+//!
+//! At one point, shaping was the most expensive part of rendering text
+//! (accounting for 96% of frame time on my machine). To speed it up, this
+//! was introduced so that shaping results can be cached depending on the
+//! run.
+//!
+//! The cache key is the text run. The text run builds its own hash value
+//! based on the font, style, codepoint, etc. This just utilizes the hash that
+//! the text run provides.
+pub const Cache = @This();
+
+const std = @import("std");
+const assert = std.debug.assert;
+const Allocator = std.mem.Allocator;
+const font = @import("../main.zig");
+const lru = @import("../../lru.zig");
+
+/// Our LRU is the run hash to the shaped cells.
+const LRU = lru.AutoHashMap(u64, []font.shape.Cell);
+
+/// The cache of shaped cells.
+map: LRU,
+
+pub fn init() Cache {
+    // Note: this is very arbitrary. Increasing this number will increase
+    // the cache hit rate, but also increase the memory usage. We should do
+    // some more empirical testing to see what the best value is.
+    const capacity = 1024;
+
+    return .{ .map = LRU.init(capacity) };
+}
+
+pub fn deinit(self: *Cache, alloc: Allocator) void {
+    var it = self.map.map.iterator();
+    while (it.next()) |entry| alloc.free(entry.value_ptr.*.data.value);
+    self.map.deinit(alloc);
+}
+
+/// Get the shaped cells for the given text run or null if they are not
+/// in the cache.
+pub fn get(self: *const Cache, run: font.shape.TextRun) ?[]const font.shape.Cell {
+    return self.map.get(run.hash);
+}
+
+/// Insert the shaped cells for the given text run into the cache. The
+/// cells will be duplicated.
+pub fn put(
+    self: *Cache,
+    alloc: Allocator,
+    run: font.shape.TextRun,
+    cells: []const font.shape.Cell,
+) Allocator.Error!void {
+    const copy = try alloc.dupe(font.shape.Cell, cells);
+    const gop = try self.map.getOrPut(alloc, run.hash);
+    if (gop.evicted) |evicted| alloc.free(evicted.value);
+    gop.value_ptr.* = copy;
+}
+
+test Cache {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var c = Cache.init();
+    defer c.deinit(alloc);
+
+    var run: font.shape.TextRun = undefined;
+    run.hash = 1;
+    try testing.expect(c.get(run) == null);
+    try c.put(alloc, run, &.{
+        .{ .x = 0, .glyph_index = 0 },
+        .{ .x = 1, .glyph_index = 1 },
+    });
+
+    const actual = c.get(run).?;
+    try testing.expect(actual.len == 2);
+}

--- a/src/font/shaper/run.zig
+++ b/src/font/shaper/run.zig
@@ -250,6 +250,9 @@ pub const RunIterator = struct {
         // Add our length to the hash as an additional mechanism to avoid collisions
         autoHash(&hasher, j - self.i);
 
+        // Add our font index
+        autoHash(&hasher, current_font);
+
         // Move our cursor. Must defer since we use self.i below.
         defer self.i = j;
 

--- a/src/lru.zig
+++ b/src/lru.zig
@@ -150,7 +150,7 @@ pub fn HashMap(
         }
 
         /// Get a value for a key.
-        pub fn get(self: *Self, key: K) ?V {
+        pub fn get(self: *const Self, key: K) ?V {
             if (@sizeOf(Context) != 0) {
                 @compileError("getContext must be used.");
             }
@@ -158,7 +158,7 @@ pub fn HashMap(
         }
 
         /// See get
-        pub fn getContext(self: *Self, key: K, ctx: Context) ?V {
+        pub fn getContext(self: *const Self, key: K, ctx: Context) ?V {
             const node = self.map.getContext(key, ctx) orelse return null;
             return node.data.value;
         }

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1669,6 +1669,12 @@ fn rebuildCells(
     cursor_style_: ?renderer.CursorStyle,
     color_palette: *const terminal.color.Palette,
 ) !void {
+    // const start = try std.time.Instant.now();
+    // defer {
+    //     const end = std.time.Instant.now() catch unreachable;
+    //     std.log.warn("rebuildCells time={}us", .{end.since(start) / std.time.ns_per_us});
+    // }
+
     // Create an arena for all our temporary allocations while rebuilding
     var arena = ArenaAllocator.init(self.alloc);
     defer arena.deinit();
@@ -1851,9 +1857,9 @@ fn rebuildCells(
     }
 
     // Log some things
-    log.debug("rebuildCells complete cached_runs={}", .{
-        self.font_shaper_cache.count(),
-    });
+    // log.debug("rebuildCells complete cached_runs={}", .{
+    //     self.font_shaper_cache.count(),
+    // });
 }
 
 fn updateCell(

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1849,6 +1849,11 @@ fn rebuildCells(
             x += if (cp.wide) 2 else 1;
         }
     }
+
+    // Log some things
+    log.debug("rebuildCells complete cached_runs={}", .{
+        self.font_shaper_cache.count(),
+    });
 }
 
 fn updateCell(


### PR DESCRIPTION
This PR introduces an LRU cache for font shaping results by text run. 

In my quest to get _all the frames_, I identified that font shaping was taking up 95+% of the time spent in `updateFrame`. Even with the experimental dirty tracking work, when a full screen changed (i.e. most rows become dirty), I noticed that our updateFrame times were unacceptable. This led to this discovery and I felt I had to get shaping times down.

Font shaping is a pure operation with the following pseudo-signature: **`(cell contents, font) -> shaping results`** It doesn't matter what _style_ the cells are in. It doesn't matter what _row_ or what _cell offset_. Cell contents plus font equals consistent shaping results.

An important thing worth pointing out is due to the cache key, this means that shaping results will remain cached even through terminal scrolling (i.e. scroll regions) or if the same contents are repainted anywhere. This dramatically speeds up programs that scroll, like editors.

Therefore, this PR introduces a simple LRU cache in the renderer for this. The LRU cache is independent of font subsystems (rasterizer, shaper) and renderer. The renderer requires small modifications to integrate it.

Some notes:

* The LRU cache implementation itself is naive. An improvement to the LRU would likely yield improvements. I implemented a CS101-level LRU in `lru.zig` because its easy to do and fast to implement. Someone, please, help. lol.
* The LRU capacity is fixed currently at some somewhat arbitrary number. I'm still toying around with this number.
* False positives are possible since we only compare the final hash value. This would result in rendering artifacts but the core state is valid. We can improve this by improving our hash inputs. 

PR TODO:

- [x] Tweak LRU capacity value
- [x] OpenGL