### PR TITLE
Dirty Tracking

### DIFF
--- a/src/font/DeferredFace.zig
+++ b/src/font/DeferredFace.zig
@@ -83,9 +83,13 @@ pub const WebCanvas = struct {
 pub fn deinit(self: *DeferredFace) void {
     switch (options.backend) {
         .fontconfig_freetype => if (self.fc) |*fc| fc.deinit(),
-        .coretext, .coretext_freetype, .coretext_harfbuzz => if (self.ct) |*ct| ct.deinit(),
         .freetype => {},
         .web_canvas => if (self.wc) |*wc| wc.deinit(),
+        .coretext,
+        .coretext_freetype,
+        .coretext_harfbuzz,
+        .coretext_noshape,
+        => if (self.ct) |*ct| ct.deinit(),
     }
     self.* = undefined;
 }
@@ -98,7 +102,11 @@ pub fn familyName(self: DeferredFace, buf: []u8) ![]const u8 {
         .fontconfig_freetype => if (self.fc) |fc|
             return (try fc.pattern.get(.family, 0)).string,
 
-        .coretext, .coretext_freetype, .coretext_harfbuzz => if (self.ct) |ct| {
+        .coretext,
+        .coretext_freetype,
+        .coretext_harfbuzz,
+        .coretext_noshape,
+        => if (self.ct) |ct| {
             const family_name = ct.font.copyAttribute(.family_name);
             return family_name.cstringPtr(.utf8) orelse unsupported: {
                 break :unsupported family_name.cstring(buf, .utf8) orelse
@@ -121,7 +129,11 @@ pub fn name(self: DeferredFace, buf: []u8) ![]const u8 {
         .fontconfig_freetype => if (self.fc) |fc|
             return (try fc.pattern.get(.fullname, 0)).string,
 
-        .coretext, .coretext_freetype, .coretext_harfbuzz => if (self.ct) |ct| {
+        .coretext,
+        .coretext_freetype,
+        .coretext_harfbuzz,
+        .coretext_noshape,
+        => if (self.ct) |ct| {
             const display_name = ct.font.copyDisplayName();
             return display_name.cstringPtr(.utf8) orelse unsupported: {
                 // "NULL if the internal storage of theString does not allow
@@ -147,7 +159,7 @@ pub fn load(
 ) !Face {
     return switch (options.backend) {
         .fontconfig_freetype => try self.loadFontconfig(lib, opts),
-        .coretext, .coretext_harfbuzz => try self.loadCoreText(lib, opts),
+        .coretext, .coretext_harfbuzz, .coretext_noshape => try self.loadCoreText(lib, opts),
         .coretext_freetype => try self.loadCoreTextFreetype(lib, opts),
         .web_canvas => try self.loadWebCanvas(opts),
 
@@ -262,7 +274,11 @@ pub fn hasCodepoint(self: DeferredFace, cp: u32, p: ?Presentation) bool {
             }
         },
 
-        .coretext, .coretext_freetype, .coretext_harfbuzz => {
+        .coretext,
+        .coretext_freetype,
+        .coretext_harfbuzz,
+        .coretext_noshape,
+        => {
             // If we are using coretext, we check the loaded CT font.
             if (self.ct) |ct| {
                 if (p) |desired_p| {

--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -14,8 +14,12 @@ const log = std.log.scoped(.discovery);
 pub const Discover = switch (options.backend) {
     .freetype => void, // no discovery
     .fontconfig_freetype => Fontconfig,
-    .coretext, .coretext_freetype, .coretext_harfbuzz => CoreText,
     .web_canvas => void, // no discovery
+    .coretext,
+    .coretext_freetype,
+    .coretext_harfbuzz,
+    .coretext_noshape,
+    => CoreText,
 };
 
 /// Descriptor is used to search for fonts. The only required field

--- a/src/font/face.zig
+++ b/src/font/face.zig
@@ -13,7 +13,11 @@ pub const Face = switch (options.backend) {
     .coretext_freetype,
     => freetype.Face,
 
-    .coretext, .coretext_harfbuzz => coretext.Face,
+    .coretext,
+    .coretext_harfbuzz,
+    .coretext_noshape,
+    => coretext.Face,
+
     .web_canvas => web_canvas.Face,
 };
 

--- a/src/font/library.zig
+++ b/src/font/library.zig
@@ -16,6 +16,7 @@ pub const Library = switch (options.backend) {
     // Some backends such as CT and Canvas don't have a "library"
     .coretext,
     .coretext_harfbuzz,
+    .coretext_noshape,
     .web_canvas,
     => NoopLibrary,
 };

--- a/src/font/main.zig
+++ b/src/font/main.zig
@@ -61,6 +61,9 @@ pub const Backend = enum {
     /// CoreText for font discovery and rendering, HarfBuzz for shaping
     coretext_harfbuzz,
 
+    /// CoreText for font discovery and rendering, no shaping.
+    coretext_noshape,
+
     /// Use the browser font system and the Canvas API (wasm). This limits
     /// the available fonts to browser fonts (anything Canvas natively
     /// supports).
@@ -97,6 +100,7 @@ pub const Backend = enum {
 
             .coretext,
             .coretext_harfbuzz,
+            .coretext_noshape,
             .web_canvas,
             => false,
         };
@@ -107,6 +111,7 @@ pub const Backend = enum {
             .coretext,
             .coretext_freetype,
             .coretext_harfbuzz,
+            .coretext_noshape,
             => true,
 
             .freetype,
@@ -124,6 +129,7 @@ pub const Backend = enum {
             .coretext,
             .coretext_freetype,
             .coretext_harfbuzz,
+            .coretext_noshape,
             .web_canvas,
             => false,
         };
@@ -138,6 +144,7 @@ pub const Backend = enum {
             => true,
 
             .coretext,
+            .coretext_noshape,
             .web_canvas,
             => false,
         };

--- a/src/font/shape.zig
+++ b/src/font/shape.zig
@@ -1,5 +1,6 @@
 const builtin = @import("builtin");
 const options = @import("main.zig").options;
+pub const noop = @import("shaper/noop.zig");
 pub const harfbuzz = @import("shaper/harfbuzz.zig");
 pub const coretext = @import("shaper/coretext.zig");
 pub const web_canvas = @import("shaper/web_canvas.zig");
@@ -18,6 +19,8 @@ pub const Shaper = switch (options.backend) {
     // shaper because the coretext shaper requests CoreText
     // font faces.
     .coretext => coretext.Shaper,
+
+    .coretext_noshape => noop.Shaper,
 
     .web_canvas => web_canvas.Shaper,
 };
@@ -61,4 +64,7 @@ pub const Options = struct {
 test {
     _ = Cache;
     _ = Shaper;
+
+    // Always test noop
+    _ = noop;
 }

--- a/src/font/shaper/noop.zig
+++ b/src/font/shaper/noop.zig
@@ -1,0 +1,143 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const Allocator = std.mem.Allocator;
+const trace = @import("tracy").trace;
+const font = @import("../main.zig");
+const Face = font.Face;
+const Collection = font.Collection;
+const DeferredFace = font.DeferredFace;
+const Group = font.Group;
+const GroupCache = font.GroupCache;
+const Library = font.Library;
+const SharedGrid = font.SharedGrid;
+const Style = font.Style;
+const Presentation = font.Presentation;
+const terminal = @import("../../terminal/main.zig");
+
+const log = std.log.scoped(.font_shaper);
+
+/// Shaper that doesn't do any shaping. Each individual codepoint is mapped
+/// directly to the detected text run font's glyph index.
+pub const Shaper = struct {
+    /// The allocated used for the feature list and cell buf.
+    alloc: Allocator,
+
+    /// The string used for shaping the current run.
+    run_state: RunState,
+
+    /// The shared memory used for shaping results.
+    cell_buf: CellBuf,
+
+    const CellBuf = std.ArrayListUnmanaged(font.shape.Cell);
+    const CodepointList = std.ArrayListUnmanaged(Codepoint);
+    const Codepoint = struct {
+        codepoint: u32,
+        cluster: u32,
+    };
+
+    const RunState = struct {
+        codepoints: CodepointList = .{},
+
+        fn deinit(self: *RunState, alloc: Allocator) void {
+            self.codepoints.deinit(alloc);
+        }
+
+        fn reset(self: *RunState) !void {
+            self.codepoints.clearRetainingCapacity();
+        }
+    };
+
+    /// The cell_buf argument is the buffer to use for storing shaped results.
+    /// This should be at least the number of columns in the terminal.
+    pub fn init(alloc: Allocator, opts: font.shape.Options) !Shaper {
+        _ = opts;
+
+        return Shaper{
+            .alloc = alloc,
+            .cell_buf = .{},
+            .run_state = .{},
+        };
+    }
+
+    pub fn deinit(self: *Shaper) void {
+        self.cell_buf.deinit(self.alloc);
+        self.run_state.deinit(self.alloc);
+    }
+
+    pub fn runIterator(
+        self: *Shaper,
+        grid: *SharedGrid,
+        screen: *const terminal.Screen,
+        row: terminal.Pin,
+        selection: ?terminal.Selection,
+        cursor_x: ?usize,
+    ) font.shape.RunIterator {
+        return .{
+            .hooks = .{ .shaper = self },
+            .grid = grid,
+            .screen = screen,
+            .row = row,
+            .selection = selection,
+            .cursor_x = cursor_x,
+        };
+    }
+
+    pub fn shape(self: *Shaper, run: font.shape.TextRun) ![]const font.shape.Cell {
+        const state = &self.run_state;
+
+        // Special fonts aren't shaped and their codepoint == glyph so we
+        // can just return the codepoints as-is.
+        if (run.font_index.special() != null) {
+            self.cell_buf.clearRetainingCapacity();
+            try self.cell_buf.ensureTotalCapacity(self.alloc, state.codepoints.items.len);
+            for (state.codepoints.items) |entry| {
+                self.cell_buf.appendAssumeCapacity(.{
+                    .x = @intCast(entry.cluster),
+                    .glyph_index = @intCast(entry.codepoint),
+                });
+            }
+
+            return self.cell_buf.items;
+        }
+
+        // Go through the run and map each codepoint to a glyph index.
+        self.cell_buf.clearRetainingCapacity();
+
+        // Note: this is digging into some internal details, we should maybe
+        // expose a public API for this.
+        const face = try run.grid.resolver.collection.getFace(run.font_index);
+        for (state.codepoints.items) |entry| {
+            const glyph_index = face.glyphIndex(entry.codepoint);
+            try self.cell_buf.append(self.alloc, .{
+                .x = @intCast(entry.cluster),
+                .glyph_index = glyph_index,
+            });
+        }
+
+        return self.cell_buf.items;
+    }
+
+    /// The hooks for RunIterator.
+    pub const RunIteratorHook = struct {
+        shaper: *Shaper,
+
+        pub fn prepare(self: *RunIteratorHook) !void {
+            try self.shaper.run_state.reset();
+        }
+
+        pub fn addCodepoint(self: RunIteratorHook, cp: u32, cluster: u32) !void {
+            try self.shaper.run_state.codepoints.append(self.shaper.alloc, .{
+                .codepoint = cp,
+                .cluster = cluster,
+            });
+        }
+
+        pub fn finalize(self: RunIteratorHook) !void {
+            _ = self;
+        }
+    };
+};
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -795,6 +795,11 @@ pub fn updateFrame(
             const v: Int = @bitCast(state.terminal.flags.dirty);
             if (v > 0) self.cells_rebuild = true;
         }
+        {
+            const Int = @typeInfo(terminal.Screen.Dirty).Struct.backing_integer.?;
+            const v: Int = @bitCast(state.terminal.screen.dirty);
+            if (v > 0) self.cells_rebuild = true;
+        }
 
         // Reset the dirty flags in the terminal and screen. We assume
         // that our rebuild will be successful since so we optimize for

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -132,8 +132,7 @@ pub const GPUState = struct {
     // is comptime because there isn't a good reason to change this at
     // runtime and there is a lot of complexity to support it. For comptime,
     // this is useful for debugging.
-    // TODO(mitchellh): enable triple-buffering when we improve our frame times
-    const BufferCount = 1;
+    const BufferCount = 3;
 
     /// The frame data, the current frame index, and the semaphore protecting
     /// the frame data. This is used to implement double/triple/etc. buffering.

--- a/src/renderer/metal/buffer.zig
+++ b/src/renderer/metal/buffer.zig
@@ -64,7 +64,12 @@ pub fn Buffer(comptime T: type) type {
             return ptr[0..len];
         }
 
-        /// Sync new contents to the buffer.
+        /// Sync new contents to the buffer. The data is expected to be the
+        /// complete contents of the buffer. If the amont of data is larger
+        /// than the buffer length, the buffer will be reallocated.
+        ///
+        /// If the amount of data is smaller than the buffer length, the
+        /// remaining data in the buffer is left untouched.
         pub fn sync(self: *Self, device: objc.Object, data: []const T) !void {
             // If we need more bytes than our buffer has, we need to reallocate.
             const req_bytes = data.len * @sizeOf(T);

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -1917,6 +1917,7 @@ fn createPage(
     self: *PageList,
     cap: Capacity,
 ) !*List.Node {
+    log.debug("create page cap={}", .{cap});
     return try createPageExt(&self.pool, cap, &self.page_size);
 }
 

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -4601,7 +4601,10 @@ test "PageList eraseRowBounded full rows single page" {
 
     // The erased rows should be dirty
     try testing.expect(!s.isDirty(.{ .active = .{ .x = 0, .y = 4 } }));
-    for (5..10) |y| try testing.expect(s.isDirty(.{ .active = .{ .x = 0, .y = y } }));
+    for (5..10) |y| try testing.expect(s.isDirty(.{ .active = .{
+        .x = 0,
+        .y = @intCast(y),
+    } }));
 
     // Our pin should move to the first page
     try testing.expectEqual(s.pages.first.?, p_in.page);
@@ -4662,7 +4665,10 @@ test "PageList eraseRowBounded full rows two pages" {
 
     // The erased rows should be dirty
     try testing.expect(!s.isDirty(.{ .active = .{ .x = 0, .y = 3 } }));
-    for (4..8) |y| try testing.expect(s.isDirty(.{ .active = .{ .x = 0, .y = y } }));
+    for (4..8) |y| try testing.expect(s.isDirty(.{ .active = .{
+        .x = 0,
+        .y = @intCast(y),
+    } }));
 
     // In page in first page is shifted
     try testing.expectEqual(s.pages.last.?.prev.?, p_first.page);

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -4861,7 +4861,9 @@ test "PageList clone full dirty" {
 
     // Should still be dirty
     try testing.expect(s2.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
+    try testing.expect(!s2.isDirty(.{ .active = .{ .x = 0, .y = 1 } }));
     try testing.expect(s2.isDirty(.{ .active = .{ .x = 0, .y = 12 } }));
+    try testing.expect(!s2.isDirty(.{ .active = .{ .x = 0, .y = 14 } }));
     try testing.expect(s2.isDirty(.{ .active = .{ .x = 0, .y = 23 } }));
 }
 

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -1917,7 +1917,7 @@ fn createPage(
     self: *PageList,
     cap: Capacity,
 ) !*List.Node {
-    log.debug("create page cap={}", .{cap});
+    // log.debug("create page cap={}", .{cap});
     return try createPageExt(&self.pool, cap, &self.page_size);
 }
 

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -2999,7 +2999,7 @@ pub const Pin = struct {
 
     /// Mark this pin location as dirty.
     /// TODO: test
-    pub fn markDirty(self: *Pin) void {
+    pub fn markDirty(self: Pin) void {
         var set = self.page.data.dirtyBitSet();
         set.set(self.y);
     }

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -2102,6 +2102,10 @@ pub fn eraseRowBounded(
         page.data.clearCells(&rows[pn.y], 0, page.data.size.cols);
         fastmem.rotateOnce(Row, rows[pn.y..][0 .. limit + 1]);
 
+        // Set all the rows as dirty
+        var dirty = page.data.dirtyBitSet();
+        dirty.setRangeValue(.{ .start = pn.y, .end = pn.y + limit }, true);
+
         // Update pins in the shifted region.
         var pin_it = self.tracked_pins.keyIterator();
         while (pin_it.next()) |p_ptr| {
@@ -2122,6 +2126,12 @@ pub fn eraseRowBounded(
     }
 
     fastmem.rotateOnce(Row, rows[pn.y..page.data.size.rows]);
+
+    // All the rows in the page are dirty below the erased row.
+    {
+        var dirty = page.data.dirtyBitSet();
+        dirty.setRangeValue(.{ .start = pn.y, .end = page.data.size.rows }, true);
+    }
 
     // We need to keep track of how many rows we've shifted so that we can
     // determine at what point we need to do a partial shift on subsequent
@@ -2165,6 +2175,10 @@ pub fn eraseRowBounded(
             page.data.clearCells(&rows[0], 0, page.data.size.cols);
             fastmem.rotateOnce(Row, rows[0 .. shifted_limit + 1]);
 
+            // Set all the rows as dirty
+            var dirty = page.data.dirtyBitSet();
+            dirty.setRangeValue(.{ .start = 0, .end = shifted_limit }, true);
+
             // Update pins in the shifted region.
             var pin_it = self.tracked_pins.keyIterator();
             while (pin_it.next()) |p_ptr| {
@@ -2182,6 +2196,10 @@ pub fn eraseRowBounded(
         }
 
         fastmem.rotateOnce(Row, rows[0..page.data.size.rows]);
+
+        // Set all the rows as dirty
+        var dirty = page.data.dirtyBitSet();
+        dirty.setRangeValue(.{ .start = 0, .end = page.data.size.rows }, true);
 
         // Account for the rows shifted in this page.
         shifted += page.data.size.rows;
@@ -2937,6 +2955,11 @@ pub fn clearDirty(self: *PageList) void {
         set.unsetAll();
         page = p.next;
     }
+}
+
+/// Returns true if the point is dirty, used for testing.
+pub fn isDirty(self: *const PageList, pt: point.Point) bool {
+    return self.getCell(pt).?.isDirty();
 }
 
 /// Represents an exact x/y coordinate within the screen. This is called
@@ -4513,6 +4536,13 @@ test "PageList eraseRowBounded less than full row" {
     try s.eraseRowBounded(.{ .active = .{ .y = 5 } }, 3);
     try testing.expectEqual(s.rows, s.totalRows());
 
+    // The erased rows should be dirty
+    try testing.expect(!s.isDirty(.{ .active = .{ .x = 0, .y = 4 } }));
+    try testing.expect(s.isDirty(.{ .active = .{ .x = 0, .y = 5 } }));
+    try testing.expect(s.isDirty(.{ .active = .{ .x = 0, .y = 6 } }));
+    try testing.expect(s.isDirty(.{ .active = .{ .x = 0, .y = 7 } }));
+    try testing.expect(!s.isDirty(.{ .active = .{ .x = 0, .y = 8 } }));
+
     try testing.expectEqual(s.pages.first.?, p_top.page);
     try testing.expectEqual(@as(usize, 4), p_top.y);
     try testing.expectEqual(@as(usize, 0), p_top.x);
@@ -4541,6 +4571,12 @@ test "PageList eraseRowBounded with pin at top" {
     try s.eraseRowBounded(.{ .active = .{ .y = 0 } }, 3);
     try testing.expectEqual(s.rows, s.totalRows());
 
+    // The erased rows should be dirty
+    try testing.expect(s.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
+    try testing.expect(s.isDirty(.{ .active = .{ .x = 0, .y = 1 } }));
+    try testing.expect(s.isDirty(.{ .active = .{ .x = 0, .y = 2 } }));
+    try testing.expect(!s.isDirty(.{ .active = .{ .x = 0, .y = 3 } }));
+
     try testing.expectEqual(s.pages.first.?, p_top.page);
     try testing.expectEqual(@as(usize, 0), p_top.y);
     try testing.expectEqual(@as(usize, 0), p_top.x);
@@ -4562,6 +4598,10 @@ test "PageList eraseRowBounded full rows single page" {
     // Erase only a few rows in our active
     try s.eraseRowBounded(.{ .active = .{ .y = 5 } }, 10);
     try testing.expectEqual(s.rows, s.totalRows());
+
+    // The erased rows should be dirty
+    try testing.expect(!s.isDirty(.{ .active = .{ .x = 0, .y = 4 } }));
+    for (5..10) |y| try testing.expect(s.isDirty(.{ .active = .{ .x = 0, .y = y } }));
 
     // Our pin should move to the first page
     try testing.expectEqual(s.pages.first.?, p_in.page);
@@ -4619,6 +4659,10 @@ test "PageList eraseRowBounded full rows two pages" {
 
     // Erase only a few rows in our active
     try s.eraseRowBounded(.{ .active = .{ .y = 4 } }, 4);
+
+    // The erased rows should be dirty
+    try testing.expect(!s.isDirty(.{ .active = .{ .x = 0, .y = 3 } }));
+    for (4..8) |y| try testing.expect(s.isDirty(.{ .active = .{ .x = 0, .y = y } }));
 
     // In page in first page is shifted
     try testing.expectEqual(s.pages.last.?.prev.?, p_first.page);

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -719,6 +719,12 @@ fn cursorChangePin(self: *Screen, new: Pin) void {
     };
 }
 
+/// Mark the cursor position as dirty.
+/// TODO: test
+pub fn cursorMarkDirty(self: *Screen) void {
+    self.cursor.page_pin.markDirty();
+}
+
 /// Options for scrolling the viewport of the terminal grid. The reason
 /// we have this in addition to PageList.Scroll is because we have additional
 /// scroll behaviors that are not part of the PageList.Scroll enum.

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -4987,10 +4987,14 @@ test "Terminal: scrollDown simple" {
     try t.linefeed();
     try t.printString("GHI");
     t.setCursorPos(2, 2);
+
     const cursor = t.screen.cursor;
+    t.clearDirty();
     t.scrollDown(1);
     try testing.expectEqual(cursor.x, t.screen.cursor.x);
     try testing.expectEqual(cursor.y, t.screen.cursor.y);
+
+    for (0..5) |y| try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = y } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -5013,10 +5017,17 @@ test "Terminal: scrollDown outside of scroll region" {
     try t.printString("GHI");
     t.setTopAndBottomMargin(3, 4);
     t.setCursorPos(2, 2);
+
     const cursor = t.screen.cursor;
+    t.clearDirty();
     t.scrollDown(1);
     try testing.expectEqual(cursor.x, t.screen.cursor.x);
     try testing.expectEqual(cursor.y, t.screen.cursor.y);
+
+    try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
+    try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = 1 } }));
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 2 } }));
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 3 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -5040,10 +5051,14 @@ test "Terminal: scrollDown left/right scroll region" {
     t.scrolling_region.left = 1;
     t.scrolling_region.right = 3;
     t.setCursorPos(2, 2);
+
     const cursor = t.screen.cursor;
+    t.clearDirty();
     t.scrollDown(1);
     try testing.expectEqual(cursor.x, t.screen.cursor.x);
     try testing.expectEqual(cursor.y, t.screen.cursor.y);
+
+    for (0..4) |y| try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = y } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -5067,10 +5082,14 @@ test "Terminal: scrollDown outside of left/right scroll region" {
     t.scrolling_region.left = 1;
     t.scrolling_region.right = 3;
     t.setCursorPos(1, 1);
+
     const cursor = t.screen.cursor;
+    t.clearDirty();
     t.scrollDown(1);
     try testing.expectEqual(cursor.x, t.screen.cursor.x);
     try testing.expectEqual(cursor.y, t.screen.cursor.y);
+
+    for (0..4) |y| try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = y } }));
 
     {
         const str = try t.plainString(testing.allocator);

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -131,6 +131,10 @@ pub const Dirty = packed struct {
 
     /// Set when the reverse colors mode is modified.
     reverse_colors: bool = false,
+
+    /// Screen clear of some kind. This can be due to a screen change,
+    /// erase display, etc.
+    clear: bool = false,
 };
 
 /// The event types that can be reported for mouse-related activities.
@@ -2095,6 +2099,9 @@ pub fn eraseDisplay(
                 self,
                 .{ .all = true },
             );
+
+            // Cleared screen dirty bit
+            self.flags.dirty.clear = true;
         },
 
         .below => {
@@ -2453,6 +2460,9 @@ pub fn alternateScreen(
     // Mark kitty images as dirty so they redraw
     self.screen.kitty_images.dirty = true;
 
+    // Mark our terminal as dirty
+    self.flags.dirty.clear = true;
+
     // Bring our pen with us
     self.screen.cursorCopy(old.cursor) catch |err| {
         log.warn("cursor copy failed entering alt screen err={}", .{err});
@@ -2487,6 +2497,9 @@ pub fn primaryScreen(
 
     // Mark kitty images as dirty so they redraw
     self.screen.kitty_images.dirty = true;
+
+    // Mark our terminal as dirty
+    self.flags.dirty.clear = true;
 
     // Restore the cursor from the primary screen. This should not
     // fail because we should not have to allocate memory since swapping

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -4425,7 +4425,14 @@ test "Terminal: insertLines simple" {
     try t.linefeed();
     try t.printString("GHI");
     t.setCursorPos(2, 2);
+
+    t.clearDirty();
     t.insertLines(1);
+
+    try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 1 } }));
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 2 } }));
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 3 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -4523,7 +4530,13 @@ test "Terminal: insertLines outside of scroll region" {
     try t.printString("GHI");
     t.setTopAndBottomMargin(3, 4);
     t.setCursorPos(2, 2);
+
+    t.clearDirty();
     t.insertLines(1);
+
+    try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
+    try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = 1 } }));
+    try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = 2 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -4549,7 +4562,14 @@ test "Terminal: insertLines top/bottom scroll region" {
     try t.printString("123");
     t.setTopAndBottomMargin(1, 3);
     t.setCursorPos(2, 2);
+
+    t.clearDirty();
     t.insertLines(1);
+
+    try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 1 } }));
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 2 } }));
+    try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = 3 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -4623,7 +4643,13 @@ test "Terminal: insertLines with scroll region" {
 
     t.setTopAndBottomMargin(1, 2);
     t.setCursorPos(1, 1);
+
+    t.clearDirty();
     t.insertLines(1);
+
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 1 } }));
+    try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = 2 } }));
 
     try t.print('X');
 
@@ -4658,7 +4684,12 @@ test "Terminal: insertLines more than remaining" {
     t.setCursorPos(2, 1);
 
     // Insert a bunch of  lines
+    t.clearDirty();
     t.insertLines(20);
+
+    try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 1 } }));
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 2 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -4758,7 +4789,14 @@ test "Terminal: insertLines left/right scroll region" {
     t.scrolling_region.left = 1;
     t.scrolling_region.right = 3;
     t.setCursorPos(2, 2);
+
+    t.clearDirty();
     t.insertLines(1);
+
+    try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 1 } }));
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 2 } }));
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 3 } }));
 
     {
         const str = try t.plainString(testing.allocator);

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -5881,11 +5881,10 @@ test "Terminal: index bottom of scroll region" {
     try t.index();
     try t.print('X');
 
-    // TODO(dirty)
-    // try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
-    // try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 1 } }));
-    // try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 2 } }));
-    // try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = 3 } }));
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 1 } }));
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 2 } }));
+    try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = 3 } }));
 
     {
         const str = try t.plainString(testing.allocator);

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -8662,7 +8662,13 @@ test "Terminal: eraseDisplay simple erase below" {
     try t.linefeed();
     for ("GHI") |c| try t.print(c);
     t.setCursorPos(2, 2);
+
+    t.clearDirty();
     t.eraseDisplay(.below, false);
+
+    try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 1 } }));
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 2 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -8840,7 +8846,12 @@ test "Terminal: eraseDisplay simple erase above" {
     try t.linefeed();
     for ("GHI") |c| try t.print(c);
     t.setCursorPos(2, 2);
+
+    t.clearDirty();
     t.eraseDisplay(.above, false);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 1 } }));
+    try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = 2 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -9018,7 +9029,10 @@ test "Terminal: eraseDisplay protected complete" {
     t.setProtectedMode(.dec);
     try t.print('X');
     t.setCursorPos(t.screen.cursor.y + 1, 4);
+
+    t.clearDirty();
     t.eraseDisplay(.complete, true);
+    for (0..t.rows) |y| try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = y } }));
 
     {
         const str = try t.plainString(testing.allocator);

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -4975,7 +4975,10 @@ test "Terminal: scrollUp full top/bottomleft/right scroll region" {
     t.scrollUp(4);
 
     try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
-    for (1..5) |y| try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = y } }));
+    for (1..5) |y| try testing.expect(t.isDirty(.{ .active = .{
+        .x = 0,
+        .y = @intCast(y),
+    } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -5004,7 +5007,10 @@ test "Terminal: scrollDown simple" {
     try testing.expectEqual(cursor.x, t.screen.cursor.x);
     try testing.expectEqual(cursor.y, t.screen.cursor.y);
 
-    for (0..5) |y| try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = y } }));
+    for (0..5) |y| try testing.expect(t.isDirty(.{ .active = .{
+        .x = 0,
+        .y = @intCast(y),
+    } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -5068,7 +5074,10 @@ test "Terminal: scrollDown left/right scroll region" {
     try testing.expectEqual(cursor.x, t.screen.cursor.x);
     try testing.expectEqual(cursor.y, t.screen.cursor.y);
 
-    for (0..4) |y| try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = y } }));
+    for (0..4) |y| try testing.expect(t.isDirty(.{ .active = .{
+        .x = 0,
+        .y = @intCast(y),
+    } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -5099,7 +5108,10 @@ test "Terminal: scrollDown outside of left/right scroll region" {
     try testing.expectEqual(cursor.x, t.screen.cursor.x);
     try testing.expectEqual(cursor.y, t.screen.cursor.y);
 
-    for (0..4) |y| try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = y } }));
+    for (0..4) |y| try testing.expect(t.isDirty(.{ .active = .{
+        .x = 0,
+        .y = @intCast(y),
+    } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -5809,7 +5821,10 @@ test "Terminal: index bottom of primary screen with scroll region" {
     try t.index();
     try t.print('X');
 
-    for (0..4) |y| try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = y } }));
+    for (0..4) |y| try testing.expect(!t.isDirty(.{ .active = .{
+        .x = 0,
+        .y = @intCast(y),
+    } }));
     try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 4 } }));
 
     {
@@ -6579,7 +6594,10 @@ test "Terminal: deleteLines with scroll region, cursor outside of region" {
     t.clearDirty();
     t.deleteLines(1);
 
-    for (0..4) |y| try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = y } }));
+    for (0..4) |y| try testing.expect(!t.isDirty(.{ .active = .{
+        .x = 0,
+        .y = @intCast(y),
+    } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -6657,7 +6675,10 @@ test "Terminal: deleteLines left/right scroll region" {
     t.deleteLines(1);
 
     try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
-    for (1..3) |y| try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = y } }));
+    for (1..3) |y| try testing.expect(t.isDirty(.{ .active = .{
+        .x = 0,
+        .y = @intCast(y),
+    } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -6685,7 +6706,10 @@ test "Terminal: deleteLines left/right scroll region from top" {
     t.clearDirty();
     t.deleteLines(1);
 
-    for (0..3) |y| try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = y } }));
+    for (0..3) |y| try testing.expect(t.isDirty(.{ .active = .{
+        .x = 0,
+        .y = @intCast(y),
+    } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -6714,7 +6738,10 @@ test "Terminal: deleteLines left/right scroll region high count" {
     t.deleteLines(100);
 
     try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
-    for (1..3) |y| try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = y } }));
+    for (1..3) |y| try testing.expect(t.isDirty(.{ .active = .{
+        .x = 0,
+        .y = @intCast(y),
+    } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -7078,7 +7105,10 @@ test "Terminal: DECALN" {
     try testing.expectEqual(@as(usize, 0), t.screen.cursor.y);
     try testing.expectEqual(@as(usize, 0), t.screen.cursor.x);
 
-    for (0..t.rows) |y| try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = y } }));
+    for (0..t.rows) |y| try testing.expect(t.isDirty(.{ .active = .{
+        .x = 0,
+        .y = @intCast(y),
+    } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -9032,7 +9062,10 @@ test "Terminal: eraseDisplay protected complete" {
 
     t.clearDirty();
     t.eraseDisplay(.complete, true);
-    for (0..t.rows) |y| try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = y } }));
+    for (0..t.rows) |y| try testing.expect(t.isDirty(.{ .active = .{
+        .x = 0,
+        .y = @intCast(y),
+    } }));
 
     {
         const str = try t.plainString(testing.allocator);

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1856,6 +1856,9 @@ pub fn deleteChars(self: *Terminal, count_req: usize) void {
 
     // Insert blanks. The blanks preserve the background color.
     self.screen.clearCells(page, self.screen.cursor.page_row, x[0 .. rem - scroll_amount]);
+
+    // Our row is always dirty
+    self.screen.cursorMarkDirty();
 }
 
 pub fn eraseChars(self: *Terminal, count_req: usize) void {
@@ -7549,7 +7552,10 @@ test "Terminal: deleteChars" {
     for ("ABCDE") |c| try t.print(c);
     t.setCursorPos(1, 2);
 
+    t.clearDirty();
     t.deleteChars(2);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
+
     {
         const str = try t.plainString(testing.allocator);
         defer testing.allocator.free(str);
@@ -7565,7 +7571,10 @@ test "Terminal: deleteChars zero count" {
     for ("ABCDE") |c| try t.print(c);
     t.setCursorPos(1, 2);
 
+    t.clearDirty();
     t.deleteChars(0);
+    try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
+
     {
         const str = try t.plainString(testing.allocator);
         defer testing.allocator.free(str);
@@ -7581,7 +7590,10 @@ test "Terminal: deleteChars more than half" {
     for ("ABCDE") |c| try t.print(c);
     t.setCursorPos(1, 2);
 
+    t.clearDirty();
     t.deleteChars(3);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
+
     {
         const str = try t.plainString(testing.allocator);
         defer testing.allocator.free(str);
@@ -7597,7 +7609,10 @@ test "Terminal: deleteChars more than line width" {
     for ("ABCDE") |c| try t.print(c);
     t.setCursorPos(1, 2);
 
+    t.clearDirty();
     t.deleteChars(10);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
+
     {
         const str = try t.plainString(testing.allocator);
         defer testing.allocator.free(str);
@@ -7613,7 +7628,10 @@ test "Terminal: deleteChars should shift left" {
     for ("ABCDE") |c| try t.print(c);
     t.setCursorPos(1, 2);
 
+    t.clearDirty();
     t.deleteChars(1);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
+
     {
         const str = try t.plainString(testing.allocator);
         defer testing.allocator.free(str);
@@ -7675,7 +7693,10 @@ test "Terminal: deleteChars simple operation" {
 
     try t.printString("ABC123");
     t.setCursorPos(1, 3);
+
+    t.clearDirty();
     t.deleteChars(2);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -7726,7 +7747,9 @@ test "Terminal: deleteChars outside scroll region" {
     t.scrolling_region.left = 2;
     t.scrolling_region.right = 4;
     try testing.expect(t.screen.cursor.pending_wrap);
+    t.clearDirty();
     t.deleteChars(2);
+    try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
     try testing.expect(t.screen.cursor.pending_wrap);
 
     {
@@ -7745,7 +7768,10 @@ test "Terminal: deleteChars inside scroll region" {
     t.scrolling_region.left = 2;
     t.scrolling_region.right = 4;
     t.setCursorPos(1, 4);
+
+    t.clearDirty();
     t.deleteChars(1);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
 
     {
         const str = try t.plainString(testing.allocator);

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1959,6 +1959,9 @@ pub fn eraseLine(
     // a valid mode at this point.
     self.screen.cursor.pending_wrap = false;
 
+    // We always mark our row as dirty
+    self.screen.cursorMarkDirty();
+
     // Start of our cells
     const cells: [*]Cell = cells: {
         const cells: [*]Cell = @ptrCast(self.screen.cursor.page_cell);
@@ -8050,7 +8053,9 @@ test "Terminal: eraseLine simple erase right" {
 
     for ("ABCDE") |c| try t.print(c);
     t.setCursorPos(1, 3);
+    t.clearDirty();
     t.eraseLine(.right, false);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -8146,7 +8151,9 @@ test "Terminal: eraseLine right wide character" {
     try t.print('橋');
     for ("DE") |c| try t.print(c);
     t.setCursorPos(1, 4);
+    t.clearDirty();
     t.eraseLine(.right, false);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -8163,7 +8170,9 @@ test "Terminal: eraseLine right protected attributes respected with iso" {
     t.setProtectedMode(.iso);
     for ("ABC") |c| try t.print(c);
     t.setCursorPos(1, 1);
+    t.clearDirty();
     t.eraseLine(.right, false);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -8182,7 +8191,9 @@ test "Terminal: eraseLine right protected attributes ignored with dec most recen
     t.setProtectedMode(.dec);
     t.setProtectedMode(.off);
     t.setCursorPos(1, 2);
+    t.clearDirty();
     t.eraseLine(.right, false);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -8199,7 +8210,9 @@ test "Terminal: eraseLine right protected attributes ignored with dec set" {
     t.setProtectedMode(.dec);
     for ("ABC") |c| try t.print(c);
     t.setCursorPos(1, 2);
+    t.clearDirty();
     t.eraseLine(.right, false);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -8218,7 +8231,9 @@ test "Terminal: eraseLine right protected requested" {
     t.setProtectedMode(.dec);
     try t.print('X');
     t.setCursorPos(t.screen.cursor.y + 1, 4);
+    t.clearDirty();
     t.eraseLine(.right, true);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -8234,7 +8249,9 @@ test "Terminal: eraseLine simple erase left" {
 
     for ("ABCDE") |c| try t.print(c);
     t.setCursorPos(1, 3);
+    t.clearDirty();
     t.eraseLine(.left, false);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -8250,7 +8267,9 @@ test "Terminal: eraseLine left resets wrap" {
 
     for ("ABCDE") |c| try t.print(c);
     try testing.expect(t.screen.cursor.pending_wrap);
+    t.clearDirty();
     t.eraseLine(.left, false);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
     try testing.expect(!t.screen.cursor.pending_wrap);
     try t.print('B');
 
@@ -8303,7 +8322,9 @@ test "Terminal: eraseLine left wide character" {
     try t.print('橋');
     for ("DE") |c| try t.print(c);
     t.setCursorPos(1, 3);
+    t.clearDirty();
     t.eraseLine(.left, false);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -8320,7 +8341,9 @@ test "Terminal: eraseLine left protected attributes respected with iso" {
     t.setProtectedMode(.iso);
     for ("ABC") |c| try t.print(c);
     t.setCursorPos(1, 1);
+    t.clearDirty();
     t.eraseLine(.left, false);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -8339,7 +8362,9 @@ test "Terminal: eraseLine left protected attributes ignored with dec most recent
     t.setProtectedMode(.dec);
     t.setProtectedMode(.off);
     t.setCursorPos(1, 2);
+    t.clearDirty();
     t.eraseLine(.left, false);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -8356,7 +8381,9 @@ test "Terminal: eraseLine left protected attributes ignored with dec set" {
     t.setProtectedMode(.dec);
     for ("ABC") |c| try t.print(c);
     t.setCursorPos(1, 2);
+    t.clearDirty();
     t.eraseLine(.left, false);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -8375,7 +8402,9 @@ test "Terminal: eraseLine left protected requested" {
     t.setProtectedMode(.dec);
     try t.print('X');
     t.setCursorPos(t.screen.cursor.y + 1, 8);
+    t.clearDirty();
     t.eraseLine(.left, true);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -8425,7 +8454,9 @@ test "Terminal: eraseLine complete protected attributes respected with iso" {
     t.setProtectedMode(.iso);
     for ("ABC") |c| try t.print(c);
     t.setCursorPos(1, 1);
+    t.clearDirty();
     t.eraseLine(.complete, false);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -8444,7 +8475,9 @@ test "Terminal: eraseLine complete protected attributes ignored with dec most re
     t.setProtectedMode(.dec);
     t.setProtectedMode(.off);
     t.setCursorPos(1, 2);
+    t.clearDirty();
     t.eraseLine(.complete, false);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -8461,7 +8494,9 @@ test "Terminal: eraseLine complete protected attributes ignored with dec set" {
     t.setProtectedMode(.dec);
     for ("ABC") |c| try t.print(c);
     t.setCursorPos(1, 2);
+    t.clearDirty();
     t.eraseLine(.complete, false);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -8480,7 +8515,9 @@ test "Terminal: eraseLine complete protected requested" {
     t.setProtectedMode(.dec);
     try t.print('X');
     t.setCursorPos(t.screen.cursor.y + 1, 8);
+    t.clearDirty();
     t.eraseLine(.complete, true);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -8496,6 +8533,7 @@ test "Terminal: tabClear single" {
 
     try t.horizontalTab();
     t.tabClear(.current);
+    try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
     t.setCursorPos(1, 1);
     try t.horizontalTab();
     try testing.expectEqual(@as(usize, 16), t.screen.cursor.x);
@@ -8507,6 +8545,7 @@ test "Terminal: tabClear all" {
     defer t.deinit(alloc);
 
     t.tabClear(.all);
+    try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
     t.setCursorPos(1, 1);
     try t.horizontalTab();
     try testing.expectEqual(@as(usize, 29), t.screen.cursor.x);
@@ -8519,6 +8558,7 @@ test "Terminal: printRepeat simple" {
 
     try t.printString("A");
     try t.printRepeat(1);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -8534,6 +8574,7 @@ test "Terminal: printRepeat wrap" {
 
     try t.printString("    A");
     try t.printRepeat(1);
+    try testing.expect(t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
 
     {
         const str = try t.plainString(testing.allocator);
@@ -8548,6 +8589,7 @@ test "Terminal: printRepeat no previous character" {
     defer t.deinit(alloc);
 
     try t.printRepeat(1);
+    try testing.expect(!t.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
 
     {
         const str = try t.plainString(testing.allocator);

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -2383,6 +2383,9 @@ pub fn resize(
         }
     }
 
+    // Whenever we resize we just mark it as a screen clear
+    self.flags.dirty.clear = true;
+
     // Set our size
     self.cols = cols;
     self.rows = rows;

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -114,7 +114,24 @@ flags: packed struct {
     /// then we want to capture the shift key for the mouse protocol
     /// if the configuration allows it.
     mouse_shift_capture: enum(u2) { null, false, true } = .null,
+
+    /// Dirty flags for the renderer.
+    dirty: Dirty = .{},
 } = .{},
+
+/// This is a set of dirty flags the renderer can use to determine
+/// what parts of the screen need to be redrawn. It is up to the renderer
+/// to clear these flags.
+///
+/// This only contains dirty flags for terminal state, not for the screen
+/// state. The screen state has its own dirty flags.
+pub const Dirty = packed struct {
+    /// Set when the color palette is modified in any way.
+    palette: bool = false,
+
+    /// Set when the reverse colors mode is modified.
+    reverse_colors: bool = false,
+};
 
 /// The event types that can be reported for mouse-related activities.
 /// These are all mutually exclusive (hence in a single enum).

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -91,6 +91,44 @@ pub const Page = struct {
     /// The available set of styles in use on this page.
     styles: style.Set,
 
+    /// The offset to the first mask of dirty bits in the page.
+    ///
+    /// The dirty bits is a contiguous array of usize where each bit represents
+    /// a row in the page, in order. If the bit is set, then the row is dirty
+    /// and requires a redraw. Dirty status is only ever meant to convey that
+    /// a cell has changed visually. A cell which changes in a way that doesn't
+    /// affect the visual representation may not be marked as dirty.
+    ///
+    /// Dirty tracking may have false positives but should never have false
+    /// negatives. A false negative would result in a visual artifact on the
+    /// screen.
+    ///
+    /// Dirty bits are only ever unset by consumers of a page. The page
+    /// structure itself does not unset dirty bits since the page does not
+    /// know when a cell has been redrawn.
+    ///
+    /// As implementation background: it may seem that dirty bits should be
+    /// stored elsewhere and not on the page itself, because the only data
+    /// that could possibly change is in the active area of a terminal
+    /// historically and that area is small compared to the typical scrollback.
+    /// My original thinking was to put the dirty bits on Screen instead and
+    /// have them only track the active area. However, I decided to put them
+    /// into the page directly for a few reasons:
+    ///
+    ///   1. It's simpler. The page is a self-contained unit and it's nice
+    ///      to have all the data for a page in one place.
+    ///
+    ///   2. It's cheap. Even a very large page might have 1000 rows and
+    ///      that's only ~128 bytes of 64-bit integers to track all the dirty
+    ///      bits. Compared to the hundreds of kilobytes a typical page
+    ///      consumes, this is nothing.
+    ///
+    ///   3. It's more flexible. If we ever want to implement new terminal
+    ///      features that allow non-active area to be dirty, we can do that
+    ///      with minimal dirty-tracking work.
+    ///
+    dirty: Offset(usize),
+
     /// The current dimensions of the page. The capacity may be larger
     /// than this. This allows us to allocate a larger page than necessary
     /// and also to resize a page smaller witout reallocating.
@@ -155,6 +193,7 @@ pub const Page = struct {
             .memory = @alignCast(buf.start()[0..l.total_size]),
             .rows = rows,
             .cells = cells,
+            .dirty = buf.member(usize, l.dirty_start),
             .styles = style.Set.init(
                 buf.add(l.styles_start),
                 l.styles_layout,
@@ -866,12 +905,26 @@ pub const Page = struct {
         return self.grapheme_map.map(self.memory).count();
     }
 
+    /// Returns the bitset for the dirty bits on this page.
+    ///
+    /// The returned value is a DynamicBitSetUnmanaged but it is NOT
+    /// actually dynamic; do NOT call resize on this. It is safe to
+    /// read and write but do not resize it.
+    pub fn dirtyBitSet(self: *const Page) std.DynamicBitSetUnmanaged {
+        return .{
+            .bit_length = self.capacity.rows,
+            .masks = self.dirty.ptr(self.memory),
+        };
+    }
+
     pub const Layout = struct {
         total_size: usize,
         rows_start: usize,
         rows_size: usize,
         cells_start: usize,
         cells_size: usize,
+        dirty_start: usize,
+        dirty_size: usize,
         styles_start: usize,
         styles_layout: style.Set.Layout,
         grapheme_alloc_start: usize,
@@ -892,8 +945,19 @@ pub const Page = struct {
         const cells_start = alignForward(usize, rows_end, @alignOf(Cell));
         const cells_end = cells_start + (cells_count * @sizeOf(Cell));
 
+        // The division below cannot fail because our row count cannot
+        // exceed the maximum value of usize.
+        const dirty_bit_length: usize = rows_count;
+        const dirty_usize_length: usize = std.math.divCeil(
+            usize,
+            dirty_bit_length,
+            @bitSizeOf(usize),
+        ) catch unreachable;
+        const dirty_start = alignForward(usize, cells_end, @alignOf(usize));
+        const dirty_end: usize = dirty_start + (dirty_usize_length * @sizeOf(usize));
+
         const styles_layout = style.Set.layout(cap.styles);
-        const styles_start = alignForward(usize, cells_end, style.Set.base_align);
+        const styles_start = alignForward(usize, dirty_end, style.Set.base_align);
         const styles_end = styles_start + styles_layout.total_size;
 
         const grapheme_alloc_layout = GraphemeAlloc.layout(cap.grapheme_bytes);
@@ -913,6 +977,8 @@ pub const Page = struct {
             .rows_size = rows_end - rows_start,
             .cells_start = cells_start,
             .cells_size = cells_end - cells_start,
+            .dirty_start = dirty_start,
+            .dirty_size = dirty_end - dirty_start,
             .styles_start = styles_start,
             .styles_layout = styles_layout,
             .grapheme_alloc_start = grapheme_alloc_start,
@@ -981,9 +1047,18 @@ pub const Capacity = struct {
             const grapheme_alloc_start = alignBackward(usize, grapheme_map_start - layout.grapheme_alloc_layout.total_size, GraphemeAlloc.base_align);
             const styles_start = alignBackward(usize, grapheme_alloc_start - layout.styles_layout.total_size, style.Set.base_align);
 
-            const available_size = styles_start;
-            const size_per_row = @sizeOf(Row) + (@sizeOf(Cell) * @as(usize, @intCast(cols)));
-            const new_rows = @divFloor(available_size, size_per_row);
+            // The size per row is:
+            //   - The row metadata itself
+            //   - The cells per row (n=cols)
+            //   - 1 bit for dirty tracking
+            const bits_per_row: usize = size: {
+                var bits: usize = @bitSizeOf(Row); // Row metadata
+                bits += @bitSizeOf(Cell) * @as(usize, @intCast(cols)); // Cells (n=cols)
+                bits += 1; // The dirty bit
+                break :size bits;
+            };
+            const available_bits: usize = styles_start * 8;
+            const new_rows: usize = @divFloor(available_bits, bits_per_row);
 
             // If our rows go to zero then we can't fit any row metadata
             // for the desired number of columns.
@@ -1315,6 +1390,10 @@ test "Page init" {
         .styles = 32,
     });
     defer page.deinit();
+
+    // Dirty set should be empty
+    const dirty = page.dirtyBitSet();
+    try std.testing.expectEqual(@as(usize, 0), dirty.count());
 }
 
 test "Page read and write cells" {

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -500,11 +500,16 @@ pub const Page = struct {
 
         const other_rows = other.rows.ptr(other.memory)[y_start..y_end];
         const rows = self.rows.ptr(self.memory)[0 .. y_end - y_start];
-        for (rows, other_rows) |*dst_row, *src_row| try self.cloneRowFrom(
-            other,
-            dst_row,
-            src_row,
-        );
+        for (rows, other_rows) |*dst_row, *src_row| {
+            try self.cloneRowFrom(other, dst_row, src_row);
+        }
+
+        // Set our dirty range for all the rows we copied
+        var dirty_set = self.dirtyBitSet();
+        dirty_set.setRangeValue(.{
+            .start = 0,
+            .end = y_end - y_start,
+        }, true);
 
         // We should remain consistent
         self.assertIntegrity();

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -917,6 +917,20 @@ pub const Page = struct {
         };
     }
 
+    /// Returns true if the given row is dirty. This is NOT very
+    /// efficient if you're checking many rows and you should use
+    /// dirtyBitSet directly instead.
+    pub fn isRowDirty(self: *const Page, y: usize) bool {
+        return self.dirtyBitSet().isSet(y);
+    }
+
+    /// Returns true if this page is dirty at all. If you plan on
+    /// checking any additional rows, you should use dirtyBitSet and
+    /// check this on your own so you have the set available.
+    pub fn isDirty(self: *const Page) bool {
+        return self.dirtyBitSet().findFirstSet() != null;
+    }
+
     pub const Layout = struct {
         total_size: usize,
         rows_start: usize,


### PR DESCRIPTION
This introduces dirty tracking to the core terminal state for renderers to use to more efficiently generate new GPU data. The primary benefit of this is in _renderer CPU usage_. While this does improve frame times in many cases, FPS will always be dictated by worst case frame times and this doesn't improve worst case (whole screen changes) frame times. 

**Note this PR is Metal only.** The OpenGL renderer doesn't yet take advantage of dirty bits. There are bigger issues I want to address in the OpenGL renderer (#1667) so I haven't added it there. 

There are multiple places where there is dirty state:

  * The page data tracks dirty state for changes in the page contents.
  * The screen tracks dirty state for changes in screen state that affect rendering such as selection.
  * The terminal itself tracks dirty state for terminal state that affects rendering such as reverse mode changing, palette changes, etc.

## Benchmarks

### Renderer Frame Times

Holding `j` (scroll down) in fullscreen Neovim on 6k display.

You can see that the dirty tracking allows us to have some free frames but otherwise rebuild times are about the same, as we'd expect since most of the screen is changing.

```
New:
warning: rebuildCells time=0us
warning: rebuildCells time=1768us
warning: rebuildCells time=0us
warning: rebuildCells time=1876us
warning: rebuildCells time=0us
warning: rebuildCells time=1760us
warning: rebuildCells time=2us
warning: rebuildCells time=2231us
warning: rebuildCells time=0us
warning: rebuildCells time=1909us
warning: rebuildCells time=0us
warning: rebuildCells time=1925us

Old 
warning: rebuildCells time=1940us
warning: rebuildCells time=1629us
warning: rebuildCells time=1664us
warning: rebuildCells time=1659us
warning: rebuildCells time=2198us
warning: rebuildCells time=1803us
warning: rebuildCells time=1964us
warning: rebuildCells time=1983us
warning: rebuildCells time=1624us
```

### Terminal IO Performance

In `vtebench` benchmarks, introducing dirty tracking shows no real measurable difference:

![CleanShot_2024-05-01_at_20 34 572x](https://github.com/mitchellh/ghostty/assets/1299/362675c2-e648-4cc0-a11d-067b19288718)