### PR TITLE
macOS: Unleash the Framerate

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -542,6 +542,10 @@ uintptr_t ghostty_surface_pwd(ghostty_surface_t, char*, uintptr_t);
 bool ghostty_surface_has_selection(ghostty_surface_t);
 uintptr_t ghostty_surface_selection(ghostty_surface_t, char*, uintptr_t);
 
+#ifdef __APPLE__
+void ghostty_surface_set_display_id(ghostty_surface_t, uint32_t);
+#endif
+
 ghostty_inspector_t ghostty_surface_inspector(ghostty_surface_t);
 void ghostty_inspector_free(ghostty_surface_t);
 void ghostty_inspector_set_focus(ghostty_inspector_t, bool);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -504,6 +504,7 @@ ghostty_app_t ghostty_surface_app(ghostty_surface_t);
 bool ghostty_surface_transparent(ghostty_surface_t);
 bool ghostty_surface_needs_confirm_quit(ghostty_surface_t);
 void ghostty_surface_refresh(ghostty_surface_t);
+void ghostty_surface_draw(ghostty_surface_t);
 void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);
 void ghostty_surface_set_focus(ghostty_surface_t, bool);
 void ghostty_surface_set_occlusion(ghostty_surface_t, bool);

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -112,6 +112,11 @@ extension Ghostty {
                 selector: #selector(onUpdateRendererHealth),
                 name: Ghostty.Notification.didUpdateRendererHealth,
                 object: self)
+            center.addObserver(
+                self,
+                selector: #selector(windowDidChangeScreen),
+                name: NSWindow.didChangeScreenNotification,
+                object: nil)
             
             // Setup our surface. This will also initialize all the terminal IO.
             let surface_cfg = baseConfig ?? SurfaceConfiguration()
@@ -320,6 +325,19 @@ extension Ghostty {
             guard let healthAny = notification.userInfo?["health"] else { return }
             guard let health = healthAny as? ghostty_renderer_health_e else { return }
             healthy = health == GHOSTTY_RENDERER_HEALTH_OK
+        }
+        
+        @objc private func windowDidChangeScreen(notification: SwiftUI.Notification) {
+            guard let window = self.window else { return }
+            guard let object = notification.object as? NSWindow, window == object else { return }
+            guard let screen = window.screen else { return }
+            guard let surface = self.surface else { return }
+            
+            // When the window changes screens, we need to update libghostty with the screen
+            // ID. If vsync is enabled, this will be used with the CVDisplayLink to ensure
+            // the proper refresh rate is going.
+            let id = (screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as! NSNumber).uint32Value
+            ghostty_surface_set_display_id(surface, id)
         }
         
         // MARK: - NSView

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -439,7 +439,7 @@ extension Ghostty {
 
         override func updateLayer() {
             guard let surface = self.surface else { return }
-            ghostty_surface_refresh(surface);
+            ghostty_surface_draw(surface);
         }
         
         override func acceptsFirstMouse(for event: NSEvent?) -> Bool {

--- a/pkg/macos/video/display_link.zig
+++ b/pkg/macos/video/display_link.zig
@@ -52,8 +52,9 @@ pub const DisplayLink = opaque {
     // pass this through.
     pub fn setOutputCallback(
         self: *DisplayLink,
-        comptime callbackFn: *const fn (*DisplayLink, ?*anyopaque) void,
-        userinfo: ?*anyopaque,
+        comptime Userdata: type,
+        comptime callbackFn: *const fn (*DisplayLink, ?*Userdata) void,
+        userinfo: ?*Userdata,
     ) Error!void {
         if (c.CVDisplayLinkSetOutputCallback(
             @ptrCast(self),
@@ -71,7 +72,10 @@ pub const DisplayLink = opaque {
                     _ = flagsIn;
                     _ = flagsOut;
 
-                    callbackFn(displayLink, inner_userinfo);
+                    callbackFn(
+                        displayLink,
+                        @alignCast(@ptrCast(inner_userinfo)),
+                    );
                     return c.kCVReturnSuccess;
                 }
             }).callback),

--- a/pkg/macos/video/display_link.zig
+++ b/pkg/macos/video/display_link.zig
@@ -36,6 +36,17 @@ pub const DisplayLink = opaque {
         return c.CVDisplayLinkIsRunning(@ptrCast(self)) != 0;
     }
 
+    pub fn setCurrentCGDisplay(
+        self: *DisplayLink,
+        display_id: c.CGDirectDisplayID,
+    ) Error!void {
+        if (c.CVDisplayLinkSetCurrentCGDisplay(
+            @ptrCast(self),
+            display_id,
+        ) != c.kCVReturnSuccess)
+            return error.InvalidOperation;
+    }
+
     // Note: this purposely throws away a ton of arguments I didn't need.
     // It would be trivial to refactor this into Zig types and properly
     // pass this through.

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -553,6 +553,13 @@ pub fn close(self: *Surface) void {
     self.rt_surface.close(self.needsConfirmQuit());
 }
 
+/// Forces the surface to render. This is useful for when the surface
+/// is in the middle of animation (such as a resize, etc.) or when
+/// the render timer is managed manually by the apprt.
+pub fn draw(self: *Surface) !void {
+    try self.renderer_thread.draw_now.notify();
+}
+
 /// Activate the inspector. This will begin collecting inspection data.
 /// This will not affect the GUI. The GUI must use performAction to
 /// show/hide the inspector UI.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1737,6 +1737,15 @@ pub const CAPI = struct {
 
     // Inspector Metal APIs are only available on Apple systems
     usingnamespace if (builtin.target.isDarwin()) struct {
+        export fn ghostty_surface_set_display_id(ptr: *Surface, display_id: u32) void {
+            const surface = &ptr.core_surface;
+            _ = surface.renderer_thread.mailbox.push(
+                .{ .macos_display_id = display_id },
+                .{ .forever = {} },
+            );
+            surface.renderer_thread.wakeup.notify() catch {};
+        }
+
         export fn ghostty_inspector_metal_init(ptr: *Inspector, device: objc.c.id) bool {
             return ptr.initMetal(objc.Object.fromId(device));
         }

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -653,6 +653,13 @@ pub const Surface = struct {
         };
     }
 
+    pub fn draw(self: *Surface) void {
+        self.core_surface.draw() catch |err| {
+            log.err("error in draw err={}", .{err});
+            return;
+        };
+    }
+
     pub fn updateContentScale(self: *Surface, x: f64, y: f64) void {
         // We are an embedded API so the caller can send us all sorts of
         // garbage. We want to make sure that the float values are valid
@@ -1523,6 +1530,12 @@ pub const CAPI = struct {
     /// Tell the surface that it needs to schedule a render
     export fn ghostty_surface_refresh(surface: *Surface) void {
         surface.refresh();
+    }
+
+    /// Tell the surface that it needs to schedule a render
+    /// call as soon as possible (NOW if possible).
+    export fn ghostty_surface_draw(surface: *Surface) void {
+        surface.draw();
     }
 
     /// Update the size of a surface. This will trigger resize notifications

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -723,6 +723,18 @@ fn gridSize(self: *Metal) ?renderer.GridSize {
 /// Must be called on the render thread.
 pub fn setFocus(self: *Metal, focus: bool) !void {
     self.focused = focus;
+
+    // If we're not focused, then we want to stop the display link
+    // because it is a waste of resources and we can move to pure
+    // change-driven updates.
+    if (comptime DisplayLink != void) link: {
+        const display_link = self.display_link orelse break :link;
+        if (focus) {
+            display_link.start() catch {};
+        } else {
+            display_link.stop() catch {};
+        }
+    }
 }
 
 /// Set the new font size.

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -101,6 +101,11 @@ cells: mtl_cell.Contents,
 /// If this is true, we do a full cell rebuild on the next frame.
 cells_rebuild: bool = true,
 
+/// Set to true after rebuildCells is called. This can be used
+/// to determine if any possible changes have been made to the
+/// cells for the draw call.
+cells_rebuilt: bool = false,
+
 /// The current GPU uniform values.
 uniforms: mtl_shaders.Uniforms,
 
@@ -967,6 +972,12 @@ pub fn updateFrame(
 /// Draw the frame to the screen.
 pub fn drawFrame(self: *Metal, surface: *apprt.Surface) !void {
     _ = surface;
+
+    // If our cells are not rebuilt, do a no-op draw. This means
+    // that no possible new data can exist that would warrant a full
+    // GPU update, our existing drawable is valid.
+    if (!self.cells_rebuilt) return;
+    self.cells_rebuilt = false;
 
     // Wait for a frame to be available.
     const frame = self.gpu_state.nextFrame();
@@ -1987,6 +1998,9 @@ fn rebuildCells(
 
     // We always mark our rebuild flag as false since we're done.
     self.cells_rebuild = false;
+
+    // Update that our cells rebuilt
+    self.cells_rebuilt = true;
 
     // Log some things
     // log.debug("rebuildCells complete cached_runs={}", .{

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -747,10 +747,8 @@ pub fn setVisible(self: *Metal, visible: bool) void {
     if (comptime DisplayLink != void) link: {
         const display_link = self.display_link orelse break :link;
         if (visible and self.focused) {
-            log.warn("starting display link because window is visible", .{});
             display_link.start() catch {};
         } else {
-            log.warn("stopping display link because window is not visible", .{});
             display_link.stop() catch {};
         }
     }

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -737,6 +737,25 @@ pub fn setFocus(self: *Metal, focus: bool) !void {
     }
 }
 
+/// Callback when the window is visible or occluded.
+///
+/// Must be called on the render thread.
+pub fn setVisible(self: *Metal, visible: bool) void {
+    // If we're not visible, then we want to stop the display link
+    // because it is a waste of resources and we can move to pure
+    // change-driven updates.
+    if (comptime DisplayLink != void) link: {
+        const display_link = self.display_link orelse break :link;
+        if (visible and self.focused) {
+            log.warn("starting display link because window is visible", .{});
+            display_link.start() catch {};
+        } else {
+            log.warn("stopping display link because window is not visible", .{});
+            display_link.stop() catch {};
+        }
+    }
+}
+
 /// Set the new font size.
 ///
 /// Must be called on the render thread.

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -579,6 +579,14 @@ pub fn setFocus(self: *OpenGL, focus: bool) !void {
     self.focused = focus;
 }
 
+/// Callback when the window is visible or occluded.
+///
+/// Must be called on the render thread.
+pub fn setVisible(self: *OpenGL, visible: bool) void {
+    _ = self;
+    _ = visible;
+}
+
 /// Set the new font size.
 ///
 /// Must be called on the render thread.

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -422,18 +422,21 @@ fn wakeupCallback(
     t.drainMailbox() catch |err|
         log.err("error draining mailbox err={}", .{err});
 
-    // If the timer is already active then we don't have to do anything.
-    if (t.render_c.state() == .active) return .rearm;
+    // Render immediately
+    _ = renderCallback(t, undefined, undefined, {});
 
-    // Timer is not active, let's start it
-    t.render_h.run(
-        &t.loop,
-        &t.render_c,
-        10,
-        Thread,
-        t,
-        renderCallback,
-    );
+    // // If the timer is already active then we don't have to do anything.
+    // if (t.render_c.state() == .active) return .rearm;
+    //
+    // // Timer is not active, let's start it
+    // t.render_h.run(
+    //     &t.loop,
+    //     &t.render_c,
+    //     10,
+    //     Thread,
+    //     t,
+    //     renderCallback,
+    // );
 
     return .rearm;
 }

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -425,6 +425,10 @@ fn wakeupCallback(
     // Render immediately
     _ = renderCallback(t, undefined, undefined, {});
 
+    // The below is not used anymore but if we ever want to introduce
+    // a configuration to introduce a delay to coalesce renders, we can
+    // use this.
+    //
     // // If the timer is already active then we don't have to do anything.
     // if (t.render_c.state() == .active) return .rearm;
     //

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -375,6 +375,12 @@ fn drainMailbox(self: *Thread) !void {
             },
 
             .inspector => |v| self.flags.has_inspector = v,
+
+            .macos_display_id => |v| {
+                if (@hasDecl(renderer.Renderer, "setMacOSDisplayID")) {
+                    try self.renderer.setMacOSDisplayID(v);
+                }
+            },
         }
     }
 }

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -272,6 +272,9 @@ fn drainMailbox(self: *Thread) !void {
                 // still be happening.
                 if (v) self.drawFrame();
 
+                // Notify the renderer so it can update any state.
+                self.renderer.setVisible(v);
+
                 // Note that we're explicitly today not stopping any
                 // cursor timers, draw timers, etc. These things have very
                 // little resource cost and properly maintaining their active

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -14,7 +14,7 @@ const App = @import("../App.zig");
 const Allocator = std.mem.Allocator;
 const log = std.log.scoped(.renderer_thread);
 
-const DRAW_INTERVAL = 33; // 30 FPS
+const DRAW_INTERVAL = 8; // 120 FPS
 const CURSOR_BLINK_INTERVAL = 600;
 
 /// The type used for sending messages to the IO thread. For now this is
@@ -498,7 +498,7 @@ fn renderCallback(
     ) catch |err|
         log.warn("error rendering err={}", .{err});
 
-    // Draw
+    // Draw immediately
     t.drawFrame();
 
     return .disarm;

--- a/src/renderer/message.zig
+++ b/src/renderer/message.zig
@@ -69,6 +69,9 @@ pub const Message = union(enum) {
     /// Activate or deactivate the inspector.
     inspector: bool,
 
+    /// The macOS display ID has changed for the window.
+    macos_display_id: u32,
+
     /// Initialize a change_config message.
     pub fn initChangeConfig(alloc: Allocator, config: *const configpkg.Config) !Message {
         const thread_ptr = try alloc.create(renderer.Thread.DerivedConfig);

--- a/src/renderer/metal/cell.zig
+++ b/src/renderer/metal/cell.zig
@@ -124,6 +124,13 @@ pub const Contents = struct {
         self.text.shrinkAndFree(alloc, text_reserved_len);
     }
 
+    /// Reset the cell contents to an empty state without resizing.
+    pub fn reset(self: *Contents) void {
+        @memset(self.map, .{});
+        self.bgs.clearRetainingCapacity();
+        self.text.shrinkRetainingCapacity(text_reserved_len);
+    }
+
     /// Returns the slice of fg cell contents to sync with the GPU.
     pub fn fgCells(self: *const Contents) []const mtl_shaders.CellText {
         const start: usize = if (self.cursor) 0 else 1;


### PR DESCRIPTION
Due to recent improvements (#1726, #1725, #1717), our update frame times have now improved on my machine by roughly 95% (from an average 35k microseconds to ~2k microseconds). As such, we can now remove many limiting factors to our frame rate that we had before to prevent IO slowdowns due to long lock times, frame builds, etc.

This PR also lays much of the groundwork to enable vsync, but this PR explicitly does not enable vsync nor does it have an option to enable vsync presently. The goal of this PR is to try to get the display updated as quickly as possible. The results speak for themselves (see below).

If we find it useful, in a future PR I can add a vsync option.

## Before

https://github.com/mitchellh/ghostty/assets/1299/ff9a5363-dedb-4c7b-8481-0dc09f3e9ef7

## After

https://github.com/mitchellh/ghostty/assets/1299/0a317480-2b15-4d66-a1cc-cde28f1d8dea

## IO Benchmark

**No noticable impact** from the renderer grabbing the lock more often.

![CleanShot 2024-05-04 at 20 10 54@2x](https://github.com/mitchellh/ghostty/assets/1299/9d9f65f5-ffe4-4da7-a1fb-0005f952902b)