### PR TITLE
macOS: add window-vsync option for vsync

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -615,6 +615,19 @@ keybind: Keybinds = .{},
 /// given a certain viewport size and grid cell size.
 @"window-padding-balance": bool = false,
 
+/// Synchronize rendering with the screen refresh rate. If true, this will
+/// minimize tearing and align redraws with the screen but may cause input
+/// latency. If false, this will maximize redraw frequency but may cause tearing,
+/// and under heavy load may use more CPU and power.
+///
+/// This defaults to false because out of the box a lot of users prefer to
+/// feel like the terminal is as responsive as possible.
+///
+/// Changing this value at runtime will only affect new terminals.
+///
+/// This setting is only supported currently on macOS.
+@"window-vsync": bool = false,
+
 /// If true, new windows and tabs will inherit the working directory of the
 /// previously focused window. If no window was previously focused, the default
 /// working directory will be used (the `working-directory` option).

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -572,6 +572,14 @@ pub fn hasAnimations(self: *const OpenGL) bool {
     return state.custom != null;
 }
 
+/// See Metal
+pub fn hasVsync(self: *const OpenGL) bool {
+    _ = self;
+
+    // OpenGL currently never has vsync
+    return false;
+}
+
 /// Callback when the focus changes for the terminal this is rendering.
 ///
 /// Must be called on the render thread.


### PR DESCRIPTION
This adds a new config `window-vsync` (defaults false). When true, all draws will align with screen vsync, minimizing tearing. This defaults to false because I believe people new to a terminal are looking for more responsiveness at the expense of tearing.

This is very little code because #1727 added most of the groundwork.