### PR TITLE
Track dirty bits in more places

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -929,9 +929,6 @@ pub fn updateFrame(
                 if (v > 0) break :rebuild true;
             }
 
-            // Temporary while: https://github.com/mitchellh/ghostty/issues/1731
-            if (true) break :rebuild true;
-
             break :rebuild false;
         };
 

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -2023,6 +2023,12 @@ pub fn eraseRow(
         }
     }
 
+    {
+        // Set all the rows as dirty in this page
+        var dirty = page.data.dirtyBitSet();
+        dirty.setRangeValue(.{ .start = pn.y, .end = page.data.size.rows }, true);
+    }
+
     // We iterate through all of the following pages in order to move their
     // rows up by 1 as well.
     while (page.next) |next| {
@@ -2053,6 +2059,10 @@ pub fn eraseRow(
         rows = next_rows;
 
         fastmem.rotateOnce(Row, rows[0..page.data.size.rows]);
+
+        // Set all the rows as dirty
+        var dirty = page.data.dirtyBitSet();
+        dirty.setRangeValue(.{ .start = 0, .end = page.data.size.rows }, true);
 
         // Our tracked pins for this page need to be updated.
         // If the pin is in row 0 that means the corresponding row has

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -2322,6 +2322,10 @@ pub fn eraseRows(
         // Our new size is the amount we scrolled
         chunk.page.data.size.rows = @intCast(scroll_amount);
         erased += chunk.end;
+
+        // Set all the rows as dirty
+        var dirty = chunk.page.data.dirtyBitSet();
+        dirty.setRangeValue(.{ .start = 0, .end = chunk.page.data.size.rows }, true);
     }
 
     // If we deleted active, we need to regrow because one of our invariants

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -473,6 +473,11 @@ pub fn clone(
             continue;
         }
 
+        // We want to maintain the dirty bits from the original page so
+        // instead of setting a range we grab the dirty bit and then
+        // set it on the new page in the new location.
+        var dirty = page.data.dirtyBitSet();
+
         // Kind of slow, we want to shift the rows up in the page up to
         // end and then resize down.
         const rows = page.data.rows.ptr(page.data.memory);
@@ -483,6 +488,7 @@ pub fn clone(
             const old_dst = dst.*;
             dst.* = src.*;
             src.* = old_dst;
+            dirty.setValue(i, dirty.isSet(i + chunk.start));
         }
         page.data.size.rows = @intCast(len);
         total_rows += len;

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -633,6 +633,9 @@ pub fn cursorDownScroll(self: *Screen) !void {
         self.cursor.page_row = page_rac.row;
         self.cursor.page_cell = page_rac.cell;
 
+        // Our new row is always dirty
+        self.cursorMarkDirty();
+
         // Clear the new row so it gets our bg color. We only do this
         // if we have a bg color at all.
         if (self.cursor.style.bg_color != .none) {
@@ -2889,6 +2892,7 @@ test "Screen: cursorAbsolute across pages preserves style" {
         try testing.expect(styleval.flags.bold);
     }
 }
+
 test "Screen: scrolling" {
     const testing = std.testing;
     const alloc = testing.allocator;
@@ -2966,6 +2970,12 @@ test "Screen: scrolling with a single-row screen with scrollback" {
         defer alloc.free(contents);
         try testing.expectEqualStrings("", contents);
     }
+
+    // Active should be dirty
+    try testing.expect(s.pages.isDirty(.{ .active = .{ .x = 0, .y = 0 } }));
+
+    // Our scrollback should not be dirty
+    try testing.expect(!s.pages.isDirty(.{ .screen = .{ .x = 0, .y = 0 } }));
 
     s.scroll(.{ .delta_row = -1 });
     {


### PR DESCRIPTION
Fixes #1731 

There were multiple places we weren't properly tracking or detecting dirtiness:

* `PageList.eraseRow`
* `Screen.cursorDownScroll`
* `PageList.Clone` when we have to shift rows up we weren't shifting the dirty bits
* When the viewport changes we need to rebuild the screen