### PR TITLE
coretext: let macOS choose the font for CJK Unified Ideographs

### DIFF
--- a/pkg/macos/text/font.zig
+++ b/pkg/macos/text/font.zig
@@ -51,6 +51,10 @@ pub const Font = opaque {
         return @ptrCast(@constCast(c.CTFontCopyFeatures(@ptrCast(self))));
     }
 
+    pub fn copyDefaultCascadeListForLanguages(self: *Font) *foundation.Array {
+        return @ptrCast(@constCast(c.CTFontCopyDefaultCascadeListForLanguages(@ptrCast(self), null)));
+    }
+
     pub fn getGlyphCount(self: *Font) usize {
         return @intCast(c.CTFontGetGlyphCount(@ptrCast(self)));
     }

--- a/pkg/macos/text/font.zig
+++ b/pkg/macos/text/font.zig
@@ -18,6 +18,18 @@ pub const Font = opaque {
         ) orelse Allocator.Error.OutOfMemory;
     }
 
+    pub fn createForString(
+        self: *Font,
+        str: *foundation.String,
+        range: foundation.Range,
+    ) ?*Font {
+        return @ptrCast(@constCast(c.CTFontCreateForString(
+            @ptrCast(self),
+            @ptrCast(str),
+            @bitCast(range),
+        )));
+    }
+
     pub fn copyWithAttributes(
         self: *Font,
         size: f32,

--- a/src/font/CodepointResolver.zig
+++ b/src/font/CodepointResolver.zig
@@ -172,7 +172,7 @@ pub fn getIndex(
         if (self.discover) |disco| discover: {
             const load_opts = self.collection.load_options orelse
                 break :discover;
-            var disco_it = disco.discover(alloc, .{
+            var disco_it = disco.discoverFallback(alloc, &self.collection, .{
                 .codepoint = cp,
                 .size = load_opts.size.points,
                 .bold = style == .bold or style == .bold_italic,

--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -288,7 +288,7 @@ pub const Fontconfig = struct {
     }
 
     pub fn discoverFallback(
-        self: *const CoreText,
+        self: *const Fontconfig,
         alloc: Allocator,
         collection: *Collection,
         desc: Descriptor,


### PR DESCRIPTION
Fixes #1637 

Unicode has [a block known as "CJK Unified Ideographs."](http://unicode.org/charts/PDF/U4E00.pdf). These are codepoints that have multiple renderings based on the language they are contextually written in. 

Ghostty has always used its own font fallback discovery mechanism because it lets us choose the best _terminal_ font, prioritizing things like monospace, similar grid metrics, etc. However, we never took into account _locale_ which is critical for choosing the right glyphs for the CJK space.

Unfortunately, CoreText doesn't give us a great API to do this at the low level discovery layer. They provide a recommended, higher level `CTFontCreateForString` (and similar) APIs to let CoreText do all the font discovery for us for a given string. But, this API doesn't honor monospace requests and other stylistic elements. Ugh.

As a compromise, this PR retains our custom font fallback mechanism _except for_ codepoints in the CJK Unified Ideographs block. In the CJK block, we use the CoreText API.