### PR TITLE
Add GDK_DEBUG as default environment variable for linux

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -64,6 +64,14 @@ x11_xkb: ?x11.Xkb = null,
 pub fn init(core_app: *CoreApp, opts: Options) !App {
     _ = opts;
 
+    // We need to export GDK_DEBUG to run on Wayland after GTK 4.14.
+    // Older versions of GTK do not support these values so it is safe
+    // to always set this. Forwards versions are uncertain so we'll have to
+    // reassess...
+    //
+    // Upstream issue: https://gitlab.gnome.org/GNOME/gtk/-/issues/6589
+    _ = internal_os.setenv("GDK_DEBUG", "opengl,gl-disable-gles");
+
     // Load our configuration
     var config = try Config.load(core_app.alloc);
     errdefer config.deinit();

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -239,6 +239,8 @@ pub const GlobalState = struct {
             self.logging = .{ .disabled = {} };
         }
 
+        // We need to export GDK_DEBUG to run on wayland after gtk 4.14
+        if (builtin.target.os.tag == .linux) _ = internal_os.setenv("GDK_DEBUG", "opengl,gl-disable-gles");
         // I don't love the env var name but I don't have it in my heart
         // to parse CLI args 3 times (once for actions, once for config,
         // maybe once for logging) so for now this is an easy way to do

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -240,7 +240,9 @@ pub const GlobalState = struct {
         }
 
         // We need to export GDK_DEBUG to run on wayland after gtk 4.14
+        // Upstream issue: https://gitlab.gnome.org/GNOME/gtk/-/issues/6589
         if (builtin.target.os.tag == .linux) _ = internal_os.setenv("GDK_DEBUG", "opengl,gl-disable-gles");
+
         // I don't love the env var name but I don't have it in my heart
         // to parse CLI args 3 times (once for actions, once for config,
         // maybe once for logging) so for now this is an easy way to do

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -239,10 +239,6 @@ pub const GlobalState = struct {
             self.logging = .{ .disabled = {} };
         }
 
-        // We need to export GDK_DEBUG to run on wayland after gtk 4.14
-        // Upstream issue: https://gitlab.gnome.org/GNOME/gtk/-/issues/6589
-        if (builtin.target.os.tag == .linux) _ = internal_os.setenv("GDK_DEBUG", "opengl,gl-disable-gles");
-
         // I don't love the env var name but I don't have it in my heart
         // to parse CLI args 3 times (once for actions, once for config,
         // maybe once for logging) so for now this is an easy way to do


### PR DESCRIPTION
Since gtk 4.14, we need to define driver to run OpenGL on wayland as [gtk's issue](https://gitlab.gnome.org/GNOME/gtk/-/issues/6589)