### PR TITLE
coretext: force LTR font shaping

### DIFF
--- a/pkg/macos/build.zig.zon
+++ b/pkg/macos/build.zig.zon
@@ -1,6 +1,7 @@
 .{
     .name = "macos",
     .version = "0.1.0",
+    .paths = .{""},
     .dependencies = .{
         .apple_sdk = .{ .path = "../apple-sdk" },
     },

--- a/pkg/macos/text.zig
+++ b/pkg/macos/text.zig
@@ -6,6 +6,7 @@ pub usingnamespace @import("text/font_manager.zig");
 pub usingnamespace @import("text/frame.zig");
 pub usingnamespace @import("text/framesetter.zig");
 pub usingnamespace @import("text/line.zig");
+pub usingnamespace @import("text/paragraph_style.zig");
 pub usingnamespace @import("text/run.zig");
 pub usingnamespace @import("text/stylized_strings.zig");
 

--- a/pkg/macos/text/paragraph_style.zig
+++ b/pkg/macos/text/paragraph_style.zig
@@ -34,10 +34,13 @@ pub const ParagraphStyleSpecifier = enum(c_uint) {
     base_writing_direction = 13,
 };
 
-pub const WritingDirection = enum(i8) {
+/// https://developer.apple.com/documentation/uikit/nswritingdirectionattributename?language=objc
+pub const WritingDirection = enum(c_int) {
     natural = -1,
-    left_to_right = 0,
-    right_to_left = 1,
+    ltr = 0,
+    rtl = 1,
+    lro = 2,
+    rlo = 3,
 };
 
 test ParagraphStyle {

--- a/pkg/macos/text/paragraph_style.zig
+++ b/pkg/macos/text/paragraph_style.zig
@@ -1,0 +1,46 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const Allocator = std.mem.Allocator;
+const foundation = @import("../foundation.zig");
+const graphics = @import("../graphics.zig");
+const text = @import("../text.zig");
+const c = @import("c.zig");
+
+// https://developer.apple.com/documentation/coretext/ctparagraphstyle?language=objc
+pub const ParagraphStyle = opaque {
+    pub fn create(
+        settings: []const ParagraphStyleSetting,
+    ) Allocator.Error!*ParagraphStyle {
+        return @ptrCast(@constCast(c.CTParagraphStyleCreate(
+            @ptrCast(settings.ptr),
+            settings.len,
+        )));
+    }
+
+    pub fn release(self: *ParagraphStyle) void {
+        foundation.CFRelease(self);
+    }
+};
+
+/// https://developer.apple.com/documentation/coretext/ctparagraphstylesetting?language=objc
+pub const ParagraphStyleSetting = extern struct {
+    spec: ParagraphStyleSpecifier,
+    value_size: usize,
+    value: *const anyopaque,
+};
+
+/// https://developer.apple.com/documentation/coretext/ctparagraphstylespecifier?language=objc
+pub const ParagraphStyleSpecifier = enum(c_uint) {
+    base_writing_direction = 13,
+};
+
+pub const WritingDirection = enum(i8) {
+    natural = -1,
+    left_to_right = 0,
+    right_to_left = 1,
+};
+
+test ParagraphStyle {
+    const p = try ParagraphStyle.create(&.{});
+    defer p.release();
+}

--- a/pkg/macos/text/stylized_strings.zig
+++ b/pkg/macos/text/stylized_strings.zig
@@ -4,11 +4,13 @@ const c = @import("c.zig");
 pub const StringAttribute = enum {
     font,
     paragraph_style,
+    writing_direction,
 
     pub fn key(self: StringAttribute) *foundation.String {
         return @ptrFromInt(@intFromPtr(switch (self) {
             .font => c.kCTFontAttributeName,
             .paragraph_style => c.kCTParagraphStyleAttributeName,
+            .writing_direction => c.kCTWritingDirectionAttributeName,
         }));
     }
 };

--- a/pkg/macos/text/stylized_strings.zig
+++ b/pkg/macos/text/stylized_strings.zig
@@ -3,10 +3,12 @@ const c = @import("c.zig");
 
 pub const StringAttribute = enum {
     font,
+    paragraph_style,
 
     pub fn key(self: StringAttribute) *foundation.String {
         return @ptrFromInt(@intFromPtr(switch (self) {
             .font => c.kCTFontAttributeName,
+            .paragraph_style => c.kCTParagraphStyleAttributeName,
         }));
     }
 };


### PR DESCRIPTION
Fixes #1737 

We don't support RTL so if the shaper gives us RTL coordinates our rendering gets really messed up. We're tracking minimal RTL support in #1442. This behavior now matches Harfbuzz.

This PR also contains a bunch of adding CoreText APIs I tried but didn't end up using. I'm keeping them here in case we ever use them in the future.

## Before

![CleanShot 2024-05-08 at 10 13 25@2x](https://github.com/mitchellh/ghostty/assets/1299/7715a7b5-2c27-4be2-84e3-fcfa2ed69caa)


## After

![CleanShot 2024-05-08 at 10 13 08@2x](https://github.com/mitchellh/ghostty/assets/1299/98e5f0cb-05d6-4a64-b3d2-bc8444f19d1a)
