### PR TITLE
ci: add renderer, font engine macOS build+test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,6 +172,41 @@ jobs:
           cd macos
           xcodebuild -target Ghostty-iOS "CODE_SIGNING_ALLOWED=NO"
 
+  build-macos-matrix:
+    strategy:
+      fail-fast: false
+      matrix:
+        renderer: [opengl, metal]
+
+        font_backend:
+          [
+            freetype,
+            coretext,
+            coretext_freetype,
+            coretext_harfbuzz,
+            coretext_noshape,
+          ]
+    runs-on: namespace-profile-ghostty-macos
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Install Nix and use that to run our tests so our environment matches exactly.
+      - uses: cachix/install-nix-action@v26
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v14
+        with:
+          name: ghostty
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: Test
+        run: nix develop -c zig build test -Dapp-runtime=glfw -Drenderer=${{ matrix.renderer }} -Dfont-backend=${{ matrix.font_backend }}
+
+      - name: Build
+        run: nix develop -c zig build -Dapp-runtime=glfw -Drenderer=${{ matrix.renderer }} -Dfont-backend=${{ matrix.font_backend }}
+
   build-windows:
     runs-on: windows-2019
     # this will not stop other jobs from running

--- a/src/font/SharedGridSet.zig
+++ b/src/font/SharedGridSet.zig
@@ -233,7 +233,7 @@ fn collection(
     // people add other emoji fonts to their system, we always want to
     // prefer the official one. Users can override this by explicitly
     // specifying a font-family for emoji.
-    if (comptime builtin.target.isDarwin()) apple_emoji: {
+    if (comptime builtin.target.isDarwin() and Discover != void) apple_emoji: {
         const disco = try self.discover() orelse break :apple_emoji;
         var disco_it = try disco.discover(self.alloc, .{
             .family = "Apple Color Emoji",

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -1213,7 +1213,7 @@ fn testShaperWithFont(alloc: Allocator, font_req: TestFont) !TestShaper {
         .{ .size = .{ .points = 12 } },
     ) });
 
-    if (font.options.backend != .coretext) {
+    if (comptime !font.options.backend.hasCoretext()) {
         // Coretext doesn't support Noto's format
         _ = try c.add(alloc, .regular, .{ .loaded = try Face.init(
             lib,


### PR DESCRIPTION
It's getting too difficult to make sure all of these possible combinations always pass tests and build. 

We only ship a couple configurations which ARE tested but I want to keep these other combinations working because they're useful for local test and development and it also keeps our interfaces honest.