### PR TITLE
rename ComptimeStringMap to StaticStringMap

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1485,7 +1485,7 @@ fn root() []const u8 {
 }
 
 /// ANSI escape codes for colored log output
-const color_map = std.ComptimeStringMap([]const u8, .{
+const color_map = std.StaticStringMap([]const u8).initComptime(.{
     &.{ "black", "30m" },
     &.{ "blue", "34m" },
     &.{ "b", "1m" },

--- a/src/cli/list_colors.zig
+++ b/src/cli/list_colors.zig
@@ -31,7 +31,7 @@ pub fn run(alloc: std.mem.Allocator) !u8 {
 
     var keys = std.ArrayList([]const u8).init(alloc);
     defer keys.deinit();
-    for (x11_color.map.kvs) |kv| try keys.append(kv.key);
+    for (x11_color.map.keys()) |key| try keys.append(key);
 
     std.mem.sortUnstable([]const u8, keys.items, {}, struct {
         fn lessThan(_: void, lhs: []const u8, rhs: []const u8) bool {

--- a/src/input/keycodes.zig
+++ b/src/input/keycodes.zig
@@ -44,7 +44,7 @@ pub const Entry = struct {
 /// key value for Entry.
 const code_to_key = code_to_key: {
     @setEvalBranchQuota(5000);
-    break :code_to_key std.ComptimeStringMap(Key, .{
+    break :code_to_key std.StaticStringMap(Key).initComptime(.{
         .{ "KeyA", .a },
         .{ "KeyB", .b },
         .{ "KeyC", .c },

--- a/src/terminal/mouse_shape.zig
+++ b/src/terminal/mouse_shape.zig
@@ -47,7 +47,7 @@ pub const MouseShape = enum(c_int) {
     }
 };
 
-const string_map = std.ComptimeStringMap(MouseShape, .{
+const string_map = std.StaticStringMap(MouseShape).initComptime(.{
     // W3C
     .{ "default", .default },
     .{ "context-menu", .context_menu },

--- a/src/terminal/x11_color.zig
+++ b/src/terminal/x11_color.zig
@@ -5,7 +5,7 @@ const RGB = @import("color.zig").RGB;
 /// The map of all available X11 colors.
 pub const map = colorMap() catch @compileError("failed to parse rgb.txt");
 
-fn colorMap() !type {
+fn colorMap() !std.StaticStringMapWithEql(RGB, std.static_string_map.eqlAsciiIgnoreCase) {
     @setEvalBranchQuota(100_000);
 
     const KV = struct { []const u8, RGB };
@@ -31,11 +31,10 @@ fn colorMap() !type {
     }
     assert(i == len);
 
-    return std.ComptimeStringMapWithEql(
+    return std.StaticStringMapWithEql(
         RGB,
-        kvs,
-        std.comptime_string_map.eqlAsciiIgnoreCase,
-    );
+        std.static_string_map.eqlAsciiIgnoreCase,
+    ).initComptime(kvs);
 }
 
 /// This is the rgb.txt file from the X11 project. This was last sourced

--- a/src/terminfo/Source.zig
+++ b/src/terminfo/Source.zig
@@ -68,7 +68,7 @@ pub fn encode(self: Source, writer: anytype) !void {
 /// Returns a ComptimeStringMap for all of the capabilities in this terminfo.
 /// The value is the value that should be sent as a response to XTGETTCAP.
 /// Important: the value is the FULL response included the escape sequences.
-pub fn xtgettcapMap(comptime self: Source) type {
+pub fn xtgettcapMap(comptime self: Source) std.StaticStringMap([]const u8) {
     const KV = struct { []const u8, []const u8 };
 
     // We have all of our capabilities plus To, TN, and RGB which aren't
@@ -145,7 +145,7 @@ pub fn xtgettcapMap(comptime self: Source) type {
     }
 
     const kvs_final = kvs;
-    return std.ComptimeStringMap([]const u8, &kvs_final);
+    return std.StaticStringMap([]const u8).initComptime(&kvs_final);
 }
 
 fn hexencode(comptime input: []const u8) []const u8 {


### PR DESCRIPTION
Fix std.ComptimeStringMap instances to std.StaticStringMap after latest Zig master changes.