### PR TITLE
[WIP] Un-marked dirty row debug logging

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -757,6 +757,13 @@ fn changeConfig(self: *Surface, config: *const configpkg.Config) !void {
         self.showMouse();
     }
 
+    // Before sending any other config changes, we give the renderer a new font
+    // grid. We could check to see if there was an actual change to the font,
+    // but this is easier and pretty rare so it's not a performance concern.
+    //
+    // (Calling setFontSize builds and sends a new font grid to the renderer.)
+    try self.setFontSize(self.font_size);
+
     // We need to store our configs in a heap-allocated pointer so that
     // our messages aren't huge.
     var renderer_message = try renderer.Message.initChangeConfig(self.alloc, config);


### PR DESCRIPTION
I ended up implementing a fix pretty unrelated to the un-marked dirty logging on this branch, you'll have to forgive me for that 😄

The branch is named non-dirty-assertions, but "un-marked dirty" is more descriptive and I decided to make it just log for now instead of asserting, because it's easier to track down the source and what exactly triggers an un-marked dirty row if you can keep testing. In the future when our dirty tracking is a lot more robust these can be switched for assertions though, to make it easier to pick up on them while fuzzing.

Basically just keeps a list of hashes of row contents in their last built state and logs if a row not marked as dirty during a non-full rebuild has a different hash than previously. In debug mode only, of course.

Fixes #1745 -- the issue was a combination of things, my fix makes it so hot reloading font works properly (we weren't updating the font grid after a hot reload before, now we are), and fixes invalid shaper cache data sticking around when the font is changed.

Feel free to make any changes you deem necessary before merging. (Particularly, you may not like that I implemented the row hash logic on Pin instead of Page.)