### PR TITLE
Rename Split Horizontally/Vertically to Split Right/Down

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -26,8 +26,8 @@ class AppDelegate: NSObject,
     
     @IBOutlet private var menuNewWindow: NSMenuItem?
     @IBOutlet private var menuNewTab: NSMenuItem?
-    @IBOutlet private var menuSplitHorizontal: NSMenuItem?
-    @IBOutlet private var menuSplitVertical: NSMenuItem?
+    @IBOutlet private var menuSplitRight: NSMenuItem?
+    @IBOutlet private var menuSplitDown: NSMenuItem?
     @IBOutlet private var menuClose: NSMenuItem?
     @IBOutlet private var menuCloseWindow: NSMenuItem?
     @IBOutlet private var menuCloseAllWindows: NSMenuItem?
@@ -257,8 +257,8 @@ class AppDelegate: NSObject,
         syncMenuShortcut(action: "close_surface", menuItem: self.menuClose)
         syncMenuShortcut(action: "close_window", menuItem: self.menuCloseWindow)
         syncMenuShortcut(action: "close_all_windows", menuItem: self.menuCloseAllWindows)
-        syncMenuShortcut(action: "new_split:right", menuItem: self.menuSplitHorizontal)
-        syncMenuShortcut(action: "new_split:down", menuItem: self.menuSplitVertical)
+        syncMenuShortcut(action: "new_split:right", menuItem: self.menuSplitRight)
+        syncMenuShortcut(action: "new_split:down", menuItem: self.menuSplitDown)
         
         syncMenuShortcut(action: "copy_to_clipboard", menuItem: self.menuCopy)
         syncMenuShortcut(action: "paste_from_clipboard", menuItem: self.menuPaste)

--- a/macos/Sources/App/macOS/MainMenu.xib
+++ b/macos/Sources/App/macOS/MainMenu.xib
@@ -126,16 +126,16 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>
-                            <menuItem title="Split Horizontally" id="VUR-Ld-nLx">
+                            <menuItem title="Split Right" id="VUR-Ld-nLx">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
-                                    <action selector="splitHorizontally:" target="-1" id="cv2-Xg-FR4"/>
+                                    <action selector="splitRight:" target="-1" id="cv2-Xg-FR4"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Split Vertically" id="UDZ-4y-6xL">
+                            <menuItem title="Split Down" id="UDZ-4y-6xL">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
-                                    <action selector="splitVertically:" target="-1" id="c6x-CF-u52"/>
+                                    <action selector="splitDown:" target="-1" id="c6x-CF-u52"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="sjq-M1-UGS"/>

--- a/macos/Sources/App/macOS/MainMenu.xib
+++ b/macos/Sources/App/macOS/MainMenu.xib
@@ -41,8 +41,8 @@
                 <outlet property="menuSelectSplitLeft" destination="cTK-oy-KuV" id="Jpr-5q-dqz"/>
                 <outlet property="menuSelectSplitRight" destination="upj-mc-L7X" id="nLY-o1-lky"/>
                 <outlet property="menuServices" destination="aQe-vS-j8Q" id="uWQ-Wo-T1L"/>
-                <outlet property="menuSplitHorizontal" destination="VUR-Ld-nLx" id="RxO-Zw-ovb"/>
-                <outlet property="menuSplitVertical" destination="UDZ-4y-6xL" id="fgZ-Wb-8OR"/>
+                <outlet property="menuSplitRight" destination="VUR-Ld-nLx" id="RxO-Zw-ovb"/>
+                <outlet property="menuSplitDown" destination="UDZ-4y-6xL" id="fgZ-Wb-8OR"/>
                 <outlet property="menuTerminalInspector" destination="QwP-M5-fvh" id="wJi-Dh-S9f"/>
                 <outlet property="menuToggleFullScreen" destination="8kY-Pi-KaY" id="yQg-6V-OO6"/>
                 <outlet property="menuZoomSplit" destination="oPd-mn-IEH" id="wTu-jK-egI"/>

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -461,12 +461,12 @@ class TerminalController: NSWindowController, NSWindowDelegate,
         })
     }
     
-    @IBAction func splitHorizontally(_ sender: Any) {
+    @IBAction func splitRight(_ sender: Any) {
         guard let surface = focusedSurface?.surface else { return }
         ghostty.split(surface: surface, direction: GHOSTTY_SPLIT_RIGHT)
     }
     
-    @IBAction func splitVertically(_ sender: Any) {
+    @IBAction func splitDown(_ sender: Any) {
         guard let surface = focusedSurface?.surface else { return }
         ghostty.split(surface: surface, direction: GHOSTTY_SPLIT_DOWN)
     }


### PR DESCRIPTION
I make the following suggestion through a PR since I already tried this locally and have a branch ready:

- Rename Split Horizontally to Split Right
- Rename Split Vertically to Split Down

Rationale:

The terms horizontal and vertical are ambiguous in the context of splitting (does it mean the splitter is vertical, or are the panes organized vertically?) Different apps pick different interpretations, so people get confused.

IntelliJ made the same change as above based on user feedback: https://youtrack.jetbrains.com/issue/IJPL-130991/Split-Vertically-and-Split-Horizontally-are-ambiguous-and-should-be-renamed

It looks like this in IntelliJ IDEA:
<img width="147" alt="image" src="https://github.com/mitchellh/ghostty/assets/34946442/3f7ac847-4af9-4250-a026-0ae89e7c7f84">

Ghostty is using the left/right/up/down nomenclature in other menu items. In the codebase, SplitDirection is already right/down.

Downside: this is going to make people ask for Split Left/Split Up :)