### PR TITLE
macos: ime coordinate needs to be converted from view to window coords

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -971,11 +971,14 @@ extension Ghostty.SurfaceView: NSTextInputClient {
 
         // Ghostty coordinates are in top-left (0, 0) so we have to convert to
         // bottom-left since that is what UIKit expects
-        let rect = NSMakeRect(x, frame.size.height - y, 0, 0)
+        let viewRect = NSMakeRect(x, frame.size.height - y, 0, 0)
+        
+        // Convert the point to the window coordinates
+        let winRect = self.convert(viewRect, to: nil)
 
         // Convert from view to screen coordinates
-        guard let window = self.window else { return rect }
-        return window.convertToScreen(rect)
+        guard let window = self.window else { return winRect }
+        return window.convertToScreen(winRect)
     }
 
     func insertText(_ string: Any, replacementRange: NSRange) {


### PR DESCRIPTION
Fixes #1756

We previously converted from view to screen coordinates but if the view doesn't take up the full window then the view coordinates are wrong. We need to convert to window coordinates in the middle.

## After

(See before in #1756)

![CleanShot 2024-05-10 at 20 47 44@2x](https://github.com/mitchellh/ghostty/assets/1299/29ac40a3-cd59-4f86-9c6a-abd64fd463b4)
