### PR TITLE
Rate limit desktop notifications

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -45,6 +45,12 @@ quit: bool,
 /// same font configuration.
 font_grid_set: font.SharedGridSet,
 
+// Used to rate limit desktop notifications. Some platforms (notably macOS) will
+// run out of resources if desktop notifications are sent too fast and the OS
+// will kill Ghostty.
+last_notification_time: ?std.time.Instant = null,
+last_notification_digest: u64 = 0,
+
 /// Initialize the main app instance. This creates the main window, sets
 /// up the renderer state, compiles the shaders, etc. This is the primary
 /// "startup" logic.

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3513,7 +3513,7 @@ fn showDesktopNotification(self: *Surface, title: [:0]const u8, body: [:0]const 
         if (last_notification_time) |last| {
             if (std.mem.eql(u8, &last_notification_digest, &new_notification_digest)) {
                 if (now.since(last) < 5 * std.time.ns_per_s) {
-                    log.warn("suppressing identical notification", .{});
+                    log.warn("suppressing identical desktop notification", .{});
                     return;
                 }
             }


### PR DESCRIPTION
Add a once-per-second rate limit for all desktop notifications and a once-per-five-seconds rate limit for duplicate desktop notifications.

Fixes #1759.

