### PR TITLE
feat(shell-integration): add automatic integration for Elvish

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3414,6 +3414,7 @@ pub const ShellIntegration = enum {
     bash,
     fish,
     zsh,
+    elvish,
 };
 
 /// Shell integration features

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -847,7 +847,7 @@ keybind: Keybinds = .{},
 ///
 ///   * `detect` - Detect the shell based on the filename.
 ///
-///   * `bash`, `fish`, `zsh` - Use this specific shell injection scheme.
+///   * `bash`, `elvish`, `fish`, `zsh` - Use this specific shell injection scheme.
 ///
 /// The default value is `detect`.
 @"shell-integration": ShellIntegration = .detect,
@@ -3412,9 +3412,9 @@ pub const ShellIntegration = enum {
     none,
     detect,
     bash,
+    elvish,
     fish,
     zsh,
-    elvish,
 };
 
 /// Shell integration features

--- a/src/shell-integration/README.md
+++ b/src/shell-integration/README.md
@@ -19,6 +19,7 @@ its normal startup files, which becomes our script's responsibility (along with
 disabling POSIX mode).
 
 Bash shell integration can also be sourced manually from `bash/ghostty.bash`.
+
 ### Elvish
 
 For [Elvish](https://elv.sh), `$GHOSTTY_RESOURCES_DIR/src/shell-integration`
@@ -54,4 +55,3 @@ For `zsh`, Ghostty sets `ZDOTDIR` so that it loads our configuration
 from the `zsh` directory. The existing `ZDOTDIR` is retained so that
 after loading the Ghostty shell integration the normal Zsh loading
 sequence occurs.
-

--- a/src/shell-integration/README.md
+++ b/src/shell-integration/README.md
@@ -19,8 +19,19 @@ its normal startup files, which becomes our script's responsibility (along with
 disabling POSIX mode).
 
 Bash shell integration can also be sourced manually from `bash/ghostty.bash`.
-
 ### Elvish
+
+For [Elvish](https://elv.sh), `$GHOSTTY_RESOURCES_DIR/src/shell-integration`
+contains an `./elvish/lib/ghostty-integration.elv` file.
+
+Elvish, on startup, searches for paths defined in `XDG_DATA_DIRS`
+variable for `./elvish/lib/*.elv` files and imports them. They are thus
+made available for use as modules by way of `use <filename>`.
+
+Ghostty launches Elvish, passing the environment with `XDG_DATA_DIRS`prepended
+with `$GHOSTTY_RESOURCES_DIR/src/shell-integration`. It contains
+`./elvish/lib/ghostty-integration.elv`. The user can then import it
+by `use ghostty-integration`, which will run the integration routines.
 
 The [Elvish](https://elv.sh) shell integration is supported by
 the community and is not officially supported by Ghostty. We distribute
@@ -43,3 +54,4 @@ For `zsh`, Ghostty sets `ZDOTDIR` so that it loads our configuration
 from the `zsh` directory. The existing `ZDOTDIR` is retained so that
 after loading the Ghostty shell integration the normal Zsh loading
 sequence occurs.
+

--- a/src/shell-integration/elvish/lib/ghostty-integration.elv
+++ b/src/shell-integration/elvish/lib/ghostty-integration.elv
@@ -1,6 +1,6 @@
 {
   fn restore-xdg-dirs {
-    var integration-dir = $E:GHOSTTY_FISH_XDG_DIR
+    var integration-dir = $E:GHOSTTY_INTEGRATION_DIR
     var xdg-dirs = [(str:split ':' $E:XDG_DATA_DIRS)]
     var len = (count $xdg-dirs)
 
@@ -27,9 +27,9 @@
     } else {
       set-env XDG_DATA_DIRS (str:join ':' $xdg-dirs)
     }
-    unset-env GHOSTTY_FISH_XDG_DIR
+    unset-env GHOSTTY_INTEGRATION_DIR
   }
-  if (and (has-env GHOSTTY_FISH_XDG_DIR) (has-env XDG_DATA_DIRS)) {
+  if (and (has-env GHOSTTY_INTEGRATION_DIR) (has-env XDG_DATA_DIRS)) {
     restore-xdg-dirs
   }
 }
@@ -117,4 +117,3 @@
     edit:add-var sudo~ $sudo-with-terminfo~
   }
 }
-

--- a/src/shell-integration/elvish/lib/ghostty-integration.elv
+++ b/src/shell-integration/elvish/lib/ghostty-integration.elv
@@ -1,6 +1,6 @@
 {
   fn restore-xdg-dirs {
-    var integration-dir = $E:GHOSTTY_INTEGRATION_DIR
+    var integration-dir = $E:GHOSTTY_SHELL_INTEGRATION_XDG_DIR
     var xdg-dirs = [(str:split ':' $E:XDG_DATA_DIRS)]
     var len = (count $xdg-dirs)
 
@@ -27,9 +27,9 @@
     } else {
       set-env XDG_DATA_DIRS (str:join ':' $xdg-dirs)
     }
-    unset-env GHOSTTY_INTEGRATION_DIR
+    unset-env GHOSTTY_SHELL_INTEGRATION_XDG_DIR
   }
-  if (and (has-env GHOSTTY_INTEGRATION_DIR) (has-env XDG_DATA_DIRS)) {
+  if (and (has-env GHOSTTY_SHELL_INTEGRATION_XDG_DIR) (has-env XDG_DATA_DIRS)) {
     restore-xdg-dirs
   }
 }

--- a/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
+++ b/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
@@ -6,7 +6,7 @@
 
 function ghostty_restore_xdg_data_dir -d "restore the original XDG_DATA_DIR value"
     # If we don't have our own data dir then we don't need to do anything.
-    if not set -q GHOSTTY_FISH_XDG_DIR
+    if not set -q GHOSTTY_INTEGRATION_DIR
         return
     end
 
@@ -19,7 +19,7 @@ function ghostty_restore_xdg_data_dir -d "restore the original XDG_DATA_DIR valu
     set --function --path xdg_data_dirs "$XDG_DATA_DIRS"
 
     # If our data dir is in the list then remove it.
-    if set --function index (contains --index "$GHOSTTY_FISH_XDG_DIR" $xdg_data_dirs)
+    if set --function index (contains --index "$GHOSTTY_INTEGRATION_DIR" $xdg_data_dirs)
         set --erase --function xdg_data_dirs[$index]
     end
 
@@ -30,7 +30,7 @@ function ghostty_restore_xdg_data_dir -d "restore the original XDG_DATA_DIR valu
         set --erase --global XDG_DATA_DIRS
     end
 
-    set --erase GHOSTTY_FISH_XDG_DIR
+    set --erase GHOSTTY_INTEGRATION_DIR
 end
 
 function ghostty_exit -d "exit the shell integration setup"

--- a/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
+++ b/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
@@ -6,7 +6,7 @@
 
 function ghostty_restore_xdg_data_dir -d "restore the original XDG_DATA_DIR value"
     # If we don't have our own data dir then we don't need to do anything.
-    if not set -q GHOSTTY_INTEGRATION_DIR
+    if not set -q GHOSTTY_SHELL_INTEGRATION_XDG_DIR
         return
     end
 
@@ -19,7 +19,7 @@ function ghostty_restore_xdg_data_dir -d "restore the original XDG_DATA_DIR valu
     set --function --path xdg_data_dirs "$XDG_DATA_DIRS"
 
     # If our data dir is in the list then remove it.
-    if set --function index (contains --index "$GHOSTTY_INTEGRATION_DIR" $xdg_data_dirs)
+    if set --function index (contains --index "$GHOSTTY_SHELL_INTEGRATION_XDG_DIR" $xdg_data_dirs)
         set --erase --function xdg_data_dirs[$index]
     end
 
@@ -30,7 +30,7 @@ function ghostty_restore_xdg_data_dir -d "restore the original XDG_DATA_DIR valu
         set --erase --global XDG_DATA_DIRS
     end
 
-    set --erase GHOSTTY_INTEGRATION_DIR
+    set --erase GHOSTTY_SHELL_INTEGRATION_XDG_DIR
 end
 
 function ghostty_exit -d "exit the shell integration setup"

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1024,6 +1024,7 @@ const Subprocess = struct {
                 .none => break :shell .{ null, default_shell_command },
                 .detect => null,
                 .bash => .bash,
+                .elvish => .elvish,
                 .fish => .fish,
                 .zsh => .zsh,
             };

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -12,6 +12,7 @@ pub const Shell = enum {
     bash,
     fish,
     zsh,
+    elvish,
 };
 
 /// The result of setting up a shell integration.
@@ -47,6 +48,7 @@ pub fn setup(
         .bash => "bash",
         .fish => "fish",
         .zsh => "zsh",
+        .elvish => "elvish",
     } else exe: {
         // The command can include arguments. Look for the first space
         // and use the basename of the first part as the command's exe.
@@ -72,6 +74,14 @@ pub fn setup(
             try setupFish(alloc_arena, resource_dir, env);
             break :shell .{
                 .shell = .fish,
+                .command = command,
+            };
+        }
+
+        if (std.mem.eql(u8, "elvish", exe)) {
+            try setupElvish(alloc_arena, resource_dir, env);
+            break :shell .{
+                .shell = .elvish,
                 .command = command,
             };
         }
@@ -450,6 +460,18 @@ fn setupFish(
         // No XDG_DATA_DIRS set, we just set it our desired value.
         try env.put("XDG_DATA_DIRS", integ_dir);
     }
+}
+
+/// Setup the Elvish automatic shell integration.
+/// This reuses integration primitives of Fish, as Elvish also
+/// loads config in XDG_DATA_DIRS (except it imports
+/// "./elvish/lib/*.elv" files).
+fn setupElvish(
+    alloc_arena: Allocator,
+    resource_dir: []const u8,
+    env: *EnvMap,
+) !void {
+    try setupFish(alloc_arena, resource_dir, env);
 }
 
 /// Setup the zsh automatic shell integration. This works by setting

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -419,8 +419,8 @@ test "bash: preserve ENV" {
 /// their modules from paths in `XDG_DATA_DIRS` env variable.
 ///
 /// Path of shell-integration dir is prepended to `XDG_DATA_DIRS`.
-/// It is also saved in `GHOSTTY_INTEGRATION_DIR` variable so that
-/// the shell can refer to it and safely remove this directory
+/// It is also saved in `GHOSTTY_SHELL_INTEGRATION_XDG_DIR` variable
+/// so that the shell can refer to it and safely remove this directory
 /// from `XDG_DATA_DIRS` when integration is complete.
 fn setupXdgDataDirs(
     alloc_arena: Allocator,
@@ -439,7 +439,7 @@ fn setupXdgDataDirs(
     // Set an env var so we can remove this from XDG_DATA_DIRS later.
     // This happens in the shell integration config itself. We do this
     // so that our modifications don't interfere with other commands.
-    try env.put("GHOSTTY_INTEGRATION_DIR", integ_dir);
+    try env.put("GHOSTTY_SHELL_INTEGRATION_XDG_DIR", integ_dir);
 
     if (env.get("XDG_DATA_DIRS")) |old| {
         // We have an old value, We need to prepend our value to it.


### PR DESCRIPTION
Depends on PR #1772.

Fish automatic integration taken as an example.
Just like Fish, Elvish checks `XDG_DATA_DIRS` for its modules.
Thus, Fish integration in zig is reused, and integration in
Elvish now removes `GHOSTTY_FISH_XDG_DIR` environment variable
on launch.