### PR TITLE
font/shaper: periodically reset LRU in cache to avoid slowdown

### DIFF
--- a/src/lru.zig
+++ b/src/lru.zig
@@ -15,6 +15,13 @@ pub fn AutoHashMap(comptime K: type, comptime V: type) type {
 
 /// HashMap implementation that supports least-recently-used eviction.
 ///
+/// Beware of the Zig bug where a hashmap gets slower over time
+/// (https://github.com/ziglang/zig/issues/17851). This LRU uses a hashmap
+/// and evictions will cause this issue to appear. Callers should keep
+/// track of eviction counts and periodically reinitialize the LRU to
+/// avoid this issue. The LRU itself can't do this because it doesn't
+/// know how to free values.
+///
 /// Note: This is a really elementary CS101 version of an LRU right now.
 /// This is done initially to get something working. Once we have it working,
 /// we can benchmark and improve if this ends up being a source of slowness.


### PR DESCRIPTION
See: https://github.com/ziglang/zig/issues/17851

Users were noticing that frame render times got slower over time. I believe (thanks to community for pointing it out) that this is partially the culprit.

This works around this issue by clearing and reinitializing the LRU after a certain number of evictions. When the Zig issue has a better resolution (either rehash() as a workaround or a better hash implementation overall) we can change this.

**To be completely honest,** I'm not sure if this is actually a Zig issue or if our LRU is just garbage. In any case, I'd like to merge this as a mitigation and continue to hunt down improvements.

## Before

After 60s:

```
warning: rebuildCells time=32650us
warning: rebuildCells time=33434us
warning: rebuildCells time=34278us
warning: rebuildCells time=34355us
warning: rebuildCells time=36812us
```

## After

After 60s:

```
warning: rebuildCells time=30163us
warning: rebuildCells time=25997us
warning: rebuildCells time=29742us
warning: rebuildCells time=30240us
warning: rebuildCells time=28794us
warning: rebuildCells time=27179us
warning: rebuildCells time=28480us
```