### PR TITLE
build(deps): bump iTerm2-Color-Schemes to a34aeb1

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -48,8 +48,8 @@
         // Other
         .apple_sdk = .{ .path = "./pkg/apple-sdk" },
         .iterm2_themes = .{
-            .url = "https://github.com/mbadolato/iTerm2-Color-Schemes/archive/53acae071801e0de6ed160315869abb9bdaf20fa.tar.gz",
-            .hash = "12201575c5a2b21c2e110593773040cddcd357544038092d18bd98fc5a2141354bbd",
+            .url = "https://github.com/mbadolato/iTerm2-Color-Schemes/archive/a34aeb1f505707a35102fe95984d4bea4a85eb3e.tar.gz",
+            .hash = "12209b67d451ff9c61b2779eb22d38dab8deee49c533c5610f48cb8d0162f959be7b",
         },
     },
 }


### PR DESCRIPTION
Low-effort PR to get my feet wet, but this also adds the new default Neovim colorschemes @gpanders
