### PR TITLE
os: log stderr from open command

### DIFF
--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -13,5 +13,24 @@ pub fn open(alloc: Allocator, url: []const u8) !void {
     };
 
     var exe = std.process.Child.init(argv, alloc);
+
+    // Pipe stdout/stderr so we can collect output from the command
+    exe.stdout_behavior = .Pipe;
+    exe.stderr_behavior = .Pipe;
+    var stdout = std.ArrayList(u8).init(alloc);
+    var stderr = std.ArrayList(u8).init(alloc);
+    defer {
+        stdout.deinit();
+        stderr.deinit();
+    }
+
     try exe.spawn();
+
+    // 50 KiB is the default value used by std.process.Child.run
+    try exe.collectOutput(&stdout, &stderr, 50 * 1024);
+
+    _ = try exe.wait();
+    if (stderr.items.len > 0) {
+        std.log.err("os.open: {s}", .{stderr.items});
+    }
 }


### PR DESCRIPTION
Fixes: https://github.com/mitchellh/ghostty/issues/1778

This is not a "fix" in the sense that there is any bug in Ghostty we are addressing, but it may be useful to log the error output (if any) from running an external command.

A future improvement could be to propagate the error message up to the apprt and display it in a proper dialogue window. That of course is a larger change, so for now just log stderr.

This makes the assumption that all of the OS "open" tools log errors to stderr. This is true for `open` on macOS, but I haven't tested with `xdg-open` on Linux or `rundll32` on Windows.