### PR TITLE
Recognize system theme

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/TerminalWindow.swift
@@ -643,6 +643,7 @@ fileprivate class WindowButtonsBackdropView: NSView {
 
 enum TerminalWindowTheme: String {
     case auto
+    case system
     case light
     case dark
 }


### PR DESCRIPTION
Currently, `window-theme` must be set to either "light" or "dark" to prevent the issue raised in #1709. Setting it to "system" will stil exhibit the issue.

This is due to a regression in eee58b9ce6e164ffd1b2382c9f730a10dc24c1ff:

- #1767 didn't add the "system" value to the enum as it wasn't necessary with the guard clause. Setting `window-theme` to "system" would end up with a nil `windowTheme` which would return.
- eee58b9ce6e164ffd1b2382c9f730a10dc24c1ff changed to an if statement that requires the presence of a window theme or it will continue.

The easiest fix is to extend the enum to also cover the "system" value.