### PR TITLE
Avoid coloring when using native tabs

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -259,13 +259,6 @@ class TerminalController: NSWindowController, NSWindowDelegate,
         // when cascading.
         window.center()
 
-        // Set the background color of the window
-        let backgroundColor = NSColor(ghostty.config.backgroundColor)
-        window.backgroundColor = backgroundColor
-
-        // This makes sure our titlebar renders correctly when there is a transparent background
-        window.titlebarColor = backgroundColor.withAlphaComponent(ghostty.config.backgroundOpacity)
-        
         // Make sure our theme is set on the window so styling is correct.
         if let windowTheme = ghostty.config.windowTheme {
             window.windowTheme = .init(rawValue: windowTheme)
@@ -282,6 +275,13 @@ class TerminalController: NSWindowController, NSWindowDelegate,
             }
         }
         
+        // Set the background color of the window
+        let backgroundColor = NSColor(ghostty.config.backgroundColor)
+        window.backgroundColor = backgroundColor
+
+        // This makes sure our titlebar renders correctly when there is a transparent background
+        window.titlebarColor = backgroundColor.withAlphaComponent(ghostty.config.backgroundOpacity)
+
         // Initialize our content view to the SwiftUI root
         window.contentView = NSHostingView(rootView: TerminalView(
             ghostty: self.ghostty,

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -173,6 +173,8 @@ class TerminalController: NSWindowController, NSWindowDelegate,
             window.titlebarFont = nil
         }
         
+        guard window.hasStyledTabs else { return }
+
         // The titlebar is always updated. We don't need to worry about opacity
         // because we handle it here.
         let backgroundColor = OSColor(ghostty.config.backgroundColor)
@@ -275,12 +277,14 @@ class TerminalController: NSWindowController, NSWindowDelegate,
             }
         }
         
-        // Set the background color of the window
-        let backgroundColor = NSColor(ghostty.config.backgroundColor)
-        window.backgroundColor = backgroundColor
+        if window.hasStyledTabs {
+            // Set the background color of the window
+            let backgroundColor = NSColor(ghostty.config.backgroundColor)
+            window.backgroundColor = backgroundColor
 
-        // This makes sure our titlebar renders correctly when there is a transparent background
-        window.titlebarColor = backgroundColor.withAlphaComponent(ghostty.config.backgroundOpacity)
+            // This makes sure our titlebar renders correctly when there is a transparent background
+            window.titlebarColor = backgroundColor.withAlphaComponent(ghostty.config.backgroundOpacity)
+        }
 
         // Initialize our content view to the SwiftUI root
         window.contentView = NSHostingView(rootView: TerminalView(

--- a/macos/Sources/Features/Terminal/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/TerminalWindow.swift
@@ -136,14 +136,8 @@ class TerminalWindow: NSWindow {
 
         updateResetZoomTitlebarButtonVisibility()
 
-        // The remainder of the styles we only apply if we're on "auto" theming
-        // because they conflict with the appearance being forced a certain
-        // direction. Titlebar tabs are excluded (they always style the titlebar)
-        // because historically this is how they've always worked. So this
-        // exclusion only applies to native tabs. See issue #1709. 
-        if let windowTheme, windowTheme != .auto && !titlebarTabs {
-            return
-        }
+        // The remainder of this function only applies to styled tabs.
+        guard hasStyledTabs else { return }
 
 		titlebarSeparatorStyle = tabbedWindows != nil && !titlebarTabs ? .line : .none
 
@@ -176,6 +170,20 @@ class TerminalWindow: NSWindow {
     }
 
     // MARK: - Tab Bar Styling
+
+    // This is true if we should apply styles to the titlebar or tab bar.
+    var hasStyledTabs: Bool {
+        // If we have titlebar tabs then we always style.
+        guard !titlebarTabs else { return true }
+
+        // This should never happen, but if we don't have a theme set then
+        // we just style the tabs. Either response here is probably okay.
+        guard let windowTheme else { return true }
+
+        // We only style if the window theme is auto. Any other specific
+        // window theme type will always show up as that native theme.
+        return windowTheme == .auto
+    }
 
     var hasVeryDarkBackground: Bool {
         backgroundColor.luminance < 0.05


### PR DESCRIPTION
As noted in https://github.com/mitchellh/ghostty/pull/1767#issuecomment-2119361525, the background color leaks through when using the native tab bar.

This is the same issue that was addressed in #1527. (Interestingly, the screenshot there is slightly darker so I guess it wasn't addressing it fully.)

## Screenshots

The two screenshots show before and after this change.

![image](https://github.com/mitchellh/ghostty/assets/19824/5ac2db7a-7de8-4ff2-b154-d217cbd052df)

![image](https://github.com/mitchellh/ghostty/assets/19824/81ad1ba7-5f96-4b0b-9ba3-a1b54d9e601c)