### PR TITLE
macos: Declare Ghostty as a Shell

### DIFF
--- a/macos/Ghostty-Info.plist
+++ b/macos/Ghostty-Info.plist
@@ -33,6 +33,14 @@
 				<string>public.directory</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Shell</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.unix-executable</string>
+			</array>
+		</dict>
 	</array>
 	<key>LSEnvironment</key>
 	<dict>


### PR DESCRIPTION
tbh I'm not exactly sure what this does, but Kitty/Hyper/iTerm2 all declare this.

https://github.com/kovidgoyal/kitty/blob/master/setup.py#L1419-L1422 https://gitlab.com/gnachman/iterm2/-/blob/master/plists/release-iTerm2.plist#L120-127 https://github.com/vercel/hyper/blob/master/electron-builder.json#L72-L79

I'm trying to get Ghostty to work correctly with OrbStack: https://github.com/orbstack/orbstack/issues/1012

And this stood out as the biggest difference.