### PR TITLE
renderer: kitty image with y offset should stretch image

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1660,7 +1660,7 @@ fn prepKittyGraphics(
         const source_height = if (p.source_height > 0)
             @min(image.height, p.source_height)
         else
-            image.height -| offset_y;
+            image.height -| source_y;
 
         // Calculate the width/height of our image.
         const dest_width = if (p.columns > 0) p.columns * self.grid_metrics.cell_width else source_width;

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -850,7 +850,7 @@ fn prepKittyGraphics(
         const source_height = if (p.source_height > 0)
             @min(image.height, p.source_height)
         else
-            image.height -| offset_y;
+            image.height -| source_y;
 
         // Calculate the width/height of our image.
         const dest_width = if (p.columns > 0) p.columns * self.grid_metrics.cell_width else source_width;


### PR DESCRIPTION
Fixes #1784

This was just a misunderstanding of the "spec." When both a y offset into the image is specified and a height, the image should be stretched. I mistakingly thought that the image should be offset (even with this misunderstanding there was a data corruption bug).

This resolves the issue and output matches Kitty.