### PR TITLE
terminal: support using the bright palette for bold text

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1030,7 +1030,7 @@ keybind: Keybinds = .{},
 /// notifications using certain escape sequences such as OSC 9 or OSC 777.
 @"desktop-notifications": bool = true,
 
-/// If `true`, the bold text will use its bright palette
+/// If `true`, the bold text will use the bright color palette.
 @"bold-is-bright": bool = false,
 
 /// This will be used to set the `TERM` environment variable.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1030,6 +1030,9 @@ keybind: Keybinds = .{},
 /// notifications using certain escape sequences such as OSC 9 or OSC 777.
 @"desktop-notifications": bool = true,
 
+/// If `true`, the bold text will use its bright palette
+@"bold-is-bright": bool = false,
+
 /// This will be used to set the `TERM` environment variable.
 /// HACK: We set this with an `xterm` prefix because vim uses that to enable key
 /// protocols (specifically this will enable `modifyOtherKeys`), among other

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -323,6 +323,7 @@ pub const DerivedConfig = struct {
     selection_background: ?terminal.color.RGB,
     selection_foreground: ?terminal.color.RGB,
     invert_selection_fg_bg: bool,
+    bold_is_bright: bool,
     min_contrast: f32,
     custom_shaders: std.ArrayListUnmanaged([:0]const u8),
     links: link.Set,
@@ -375,6 +376,7 @@ pub const DerivedConfig = struct {
             .background = config.background.toTerminalRGB(),
             .foreground = config.foreground.toTerminalRGB(),
             .invert_selection_fg_bg = config.@"selection-invert-fg-bg",
+            .bold_is_bright = config.@"bold-is-bright",
             .min_contrast = @floatCast(config.@"minimum-contrast"),
 
             .selection_background = if (config.@"selection-background") |bg|
@@ -2118,12 +2120,12 @@ fn updateCell(
             // In normal mode, background and fg match the cell. We
             // un-optionalize the fg by defaulting to our fg color.
             .bg = style.bg(cell, palette),
-            .fg = style.fg(palette) orelse self.foreground_color,
+            .fg = style.fg(palette, self.config.bold_is_bright) orelse self.foreground_color,
         } else .{
             // In inverted mode, the background MUST be set to something
             // (is never null) so it is either the fg or default fg. The
             // fg is either the bg or default background.
-            .bg = style.fg(palette) orelse self.foreground_color,
+            .bg = style.fg(palette, self.config.bold_is_bright) orelse self.foreground_color,
             .fg = style.bg(cell, palette) orelse self.background_color,
         };
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -243,6 +243,7 @@ pub const DerivedConfig = struct {
     selection_background: ?terminal.color.RGB,
     selection_foreground: ?terminal.color.RGB,
     invert_selection_fg_bg: bool,
+    bold_is_bright: bool,
     min_contrast: f32,
     custom_shaders: std.ArrayListUnmanaged([:0]const u8),
     links: link.Set,
@@ -294,6 +295,7 @@ pub const DerivedConfig = struct {
             .background = config.background.toTerminalRGB(),
             .foreground = config.foreground.toTerminalRGB(),
             .invert_selection_fg_bg = config.@"selection-invert-fg-bg",
+            .bold_is_bright = config.@"bold-is-bright",
             .min_contrast = @floatCast(config.@"minimum-contrast"),
 
             .selection_background = if (config.@"selection-background") |bg|
@@ -1337,12 +1339,12 @@ fn updateCell(
             // In normal mode, background and fg match the cell. We
             // un-optionalize the fg by defaulting to our fg color.
             .bg = style.bg(cell, palette),
-            .fg = style.fg(palette) orelse self.foreground_color,
+            .fg = style.fg(palette, self.config.bold_is_bright) orelse self.foreground_color,
         } else .{
             // In inverted mode, the background MUST be set to something
             // (is never null) so it is either the fg or default fg. The
             // fg is either the bg or default background.
-            .bg = style.fg(palette) orelse self.foreground_color,
+            .bg = style.fg(palette, self.config.bold_is_bright) orelse self.foreground_color,
             .fg = style.bg(cell, palette) orelse self.background_color,
         };
 

--- a/src/terminal/style.zig
+++ b/src/terminal/style.zig
@@ -85,10 +85,19 @@ pub const Style = struct {
     pub fn fg(
         self: Style,
         palette: *const color.Palette,
+        bold_is_bright: bool,
     ) ?color.RGB {
         return switch (self.fg_color) {
             .none => null,
-            .palette => |idx| palette[idx],
+            .palette => |idx| palette: {
+                if (bold_is_bright and self.flags.bold) {
+                    const bright_offset = @intFromEnum(color.Name.bright_black);
+
+                    if (idx < bright_offset)
+                        break :palette palette[idx + bright_offset];
+                }
+                break :palette palette[idx];
+            },
             .rgb => |rgb| rgb,
         };
     }

--- a/src/terminal/style.zig
+++ b/src/terminal/style.zig
@@ -92,10 +92,10 @@ pub const Style = struct {
             .palette => |idx| palette: {
                 if (bold_is_bright and self.flags.bold) {
                     const bright_offset = @intFromEnum(color.Name.bright_black);
-
                     if (idx < bright_offset)
                         break :palette palette[idx + bright_offset];
                 }
+
                 break :palette palette[idx];
             },
             .rgb => |rgb| rgb,


### PR DESCRIPTION
implements #1791

disabled:
![image](https://github.com/mitchellh/ghostty/assets/15076013/27bfc697-f713-4edd-941c-8b8991bc1b90)

enabled:
![image](https://github.com/mitchellh/ghostty/assets/15076013/16abcb81-a314-4db1-9d2e-a75cf31dd524)

there may be a cleaner way to implement this, but I am still very new to this codebase and don't quite know all the ins and outs yet.