### PR TITLE
Handle mixed-color fonts

### DIFF
--- a/pkg/freetype/face.zig
+++ b/pkg/freetype/face.zig
@@ -116,11 +116,11 @@ pub const Face = struct {
         alloc: Allocator,
         tag: Tag,
     ) (Allocator.Error || Error)!?[]u8 {
-        const tag_u64: u64 = @intCast(@as(u32, @bitCast(tag)));
+        const tag_c: c_ulong = @intCast(@as(u32, @bitCast(tag)));
 
         // Get the length of the table in bytes
         var len: c_ulong = 0;
-        var res = c.FT_Load_Sfnt_Table(self.handle, tag_u64, 0, null, &len);
+        var res = c.FT_Load_Sfnt_Table(self.handle, tag_c, 0, null, &len);
         _ = intToError(res) catch |err| return err;
 
         // If our length is zero we don't have a table.
@@ -129,7 +129,7 @@ pub const Face = struct {
         // Allocate a buffer to hold the table and load it
         const buf = try alloc.alloc(u8, len);
         errdefer alloc.free(buf);
-        res = c.FT_Load_Sfnt_Table(self.handle, tag_u64, 0, buf.ptr, &len);
+        res = c.FT_Load_Sfnt_Table(self.handle, tag_c, 0, buf.ptr, &len);
         _ = intToError(res) catch |err| return err;
 
         return buf;
@@ -137,9 +137,9 @@ pub const Face = struct {
 
     /// Check whether a given SFNT table is available in a face.
     pub fn hasSfntTable(self: Face, tag: Tag) bool {
-        const tag_u64: u64 = @intCast(@as(u32, @bitCast(tag)));
+        const tag_c: c_ulong = @intCast(@as(u32, @bitCast(tag)));
         var len: c_ulong = 0;
-        const res = c.FT_Load_Sfnt_Table(self.handle, tag_u64, 0, null, &len);
+        const res = c.FT_Load_Sfnt_Table(self.handle, tag_c, 0, null, &len);
         _ = intToError(res) catch return false;
         return len != 0;
     }

--- a/pkg/freetype/face.zig
+++ b/pkg/freetype/face.zig
@@ -135,6 +135,15 @@ pub const Face = struct {
         return buf;
     }
 
+    /// Check whether a given SFNT table is available in a face.
+    pub fn hasSfntTable(self: Face, tag: Tag) bool {
+        const tag_u64: u64 = @intCast(@as(u32, @bitCast(tag)));
+        var len: c_ulong = 0;
+        const res = c.FT_Load_Sfnt_Table(self.handle, tag_u64, 0, null, &len);
+        _ = intToError(res) catch return false;
+        return len != 0;
+    }
+
     /// Retrieve the font variation descriptor for a font.
     pub fn getMMVar(self: Face) Error!*c.FT_MM_Var {
         var result: *c.FT_MM_Var = undefined;

--- a/pkg/freetype/face.zig
+++ b/pkg/freetype/face.zig
@@ -26,6 +26,12 @@ pub const Face = struct {
         return c.FT_HAS_COLOR(self.handle);
     }
 
+    /// A macro that returns true whenever a face object contains an ‘sbix’
+    /// OpenType table and outline glyphs.
+    pub fn hasSBIX(self: Face) bool {
+        return c.FT_HAS_SBIX(self.handle);
+    }
+
     /// A macro that returns true whenever a face object contains some
     /// multiple masters.
     pub fn hasMultipleMasters(self: Face) bool {

--- a/pkg/freetype/main.zig
+++ b/pkg/freetype/main.zig
@@ -4,6 +4,7 @@ pub const Library = @import("Library.zig");
 pub usingnamespace @import("computations.zig");
 pub usingnamespace @import("errors.zig");
 pub usingnamespace @import("face.zig");
+pub usingnamespace @import("tag.zig");
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/pkg/freetype/tag.zig
+++ b/pkg/freetype/tag.zig
@@ -1,0 +1,17 @@
+/// FT_Tag
+pub const Tag = packed struct(u32) {
+    d: u8,
+    c: u8,
+    b: u8,
+    a: u8,
+
+    pub fn init(v: *const [4]u8) Tag {
+        return .{ .a = v[0], .b = v[1], .c = v[2], .d = v[3] };
+    }
+
+    /// Converts the ID to a string. The return value is only valid
+    /// for the lifetime of the self pointer.
+    pub fn str(self: Tag) [4]u8 {
+        return .{ self.a, self.b, self.c, self.d };
+    }
+};

--- a/pkg/macos/foundation/base.zig
+++ b/pkg/macos/foundation/base.zig
@@ -16,3 +16,20 @@ pub const Range = extern struct {
         return @bitCast(c.CFRangeMake(@intCast(loc), @intCast(len)));
     }
 };
+
+pub const FourCharCode = packed struct(u32) {
+    d: u8,
+    c: u8,
+    b: u8,
+    a: u8,
+
+    pub fn init(v: *const [4]u8) FourCharCode {
+        return .{ .a = v[0], .b = v[1], .c = v[2], .d = v[3] };
+    }
+
+    /// Converts the ID to a string. The return value is only valid
+    /// for the lifetime of the self pointer.
+    pub fn str(self: FourCharCode) [4]u8 {
+        return .{ self.a, self.b, self.c, self.d };
+    }
+};

--- a/pkg/macos/foundation/data.zig
+++ b/pkg/macos/foundation/data.zig
@@ -20,8 +20,12 @@ pub const Data = opaque {
         foundation.CFRelease(self);
     }
 
-    pub fn getPointer(self: *Data) *const anyopaque {
+    pub fn getPointer(self: *Data) [*]const u8 {
         return @ptrCast(c.CFDataGetBytePtr(@ptrCast(self)));
+    }
+
+    pub fn getLength(self: *Data) usize {
+        return @intCast(c.CFDataGetLength(@ptrCast(self)));
     }
 };
 

--- a/pkg/macos/text/font.zig
+++ b/pkg/macos/text/font.zig
@@ -67,6 +67,14 @@ pub const Font = opaque {
         return @ptrCast(@constCast(c.CTFontCopyDefaultCascadeListForLanguages(@ptrCast(self), null)));
     }
 
+    pub fn copyTable(self: *Font, tag: FontTableTag) ?*foundation.Data {
+        return @constCast(@ptrCast(c.CTFontCopyTable(
+            @ptrCast(self),
+            @intFromEnum(tag),
+            c.kCTFontTableOptionNoOptions,
+        )));
+    }
+
     pub fn getGlyphCount(self: *Font) usize {
         return @intCast(c.CTFontGetGlyphCount(@ptrCast(self)));
     }
@@ -193,6 +201,16 @@ pub const FontOrientation = enum(c_uint) {
     default = c.kCTFontOrientationDefault,
     horizontal = c.kCTFontOrientationHorizontal,
     vertical = c.kCTFontOrientationVertical,
+};
+
+pub const FontTableTag = enum(u32) {
+    svg = c.kCTFontTableSVG,
+    _,
+
+    pub fn init(v: *const [4]u8) FontTableTag {
+        const raw: u32 = @bitCast(foundation.FourCharCode.init(v));
+        return @enumFromInt(raw);
+    }
 };
 
 test {

--- a/src/font/CodepointResolver.zig
+++ b/src/font/CodepointResolver.zig
@@ -294,13 +294,14 @@ fn getIndexCodepointOverride(
 pub fn getPresentation(
     self: *CodepointResolver,
     index: Collection.Index,
+    glyph_index: u32,
 ) !Presentation {
     if (index.special()) |sp| return switch (sp) {
         .sprite => .text,
     };
 
     const face = try self.collection.getFace(index);
-    return face.presentation;
+    return if (face.isColorGlyph(glyph_index)) .emoji else .text;
 }
 
 /// Render a glyph by glyph index into the given font atlas and return

--- a/src/font/CodepointResolver.zig
+++ b/src/font/CodepointResolver.zig
@@ -291,7 +291,10 @@ fn getIndexCodepointOverride(
 
 /// Returns the presentation for a specific font index. This is useful for
 /// determining what atlas is needed.
-pub fn getPresentation(self: *CodepointResolver, index: Collection.Index) !Presentation {
+pub fn getPresentation(
+    self: *CodepointResolver,
+    index: Collection.Index,
+) !Presentation {
     if (index.special()) |sp| return switch (sp) {
         .sprite => .text,
     };

--- a/src/font/DeferredFace.zig
+++ b/src/font/DeferredFace.zig
@@ -281,6 +281,7 @@ pub fn hasCodepoint(self: DeferredFace, cp: u32, p: ?Presentation) bool {
         => {
             // If we are using coretext, we check the loaded CT font.
             if (self.ct) |ct| {
+                // TODO(mixed-fonts): handle presentation on a glyph level
                 if (p) |desired_p| {
                     const traits = ct.font.getSymbolicTraits();
                     const actual_p: Presentation = if (traits.color_glyphs) .emoji else .text;

--- a/src/font/DeferredFace.zig
+++ b/src/font/DeferredFace.zig
@@ -281,7 +281,12 @@ pub fn hasCodepoint(self: DeferredFace, cp: u32, p: ?Presentation) bool {
         => {
             // If we are using coretext, we check the loaded CT font.
             if (self.ct) |ct| {
-                // TODO(mixed-fonts): handle presentation on a glyph level
+                // This presentation check isn't as detailed as isColorGlyph
+                // because forced presentation modes are only used for emoji and
+                // emoji should always have color glyphs set. This can be
+                // more correct by using the isColorGlyph logic but I'd want
+                // to find a font that actualy requires this so we can write
+                // a test for it before changing it.
                 if (p) |desired_p| {
                     const traits = ct.font.getSymbolicTraits();
                     const actual_p: Presentation = if (traits.color_glyphs) .emoji else .text;

--- a/src/font/SharedGrid.zig
+++ b/src/font/SharedGrid.zig
@@ -253,7 +253,7 @@ pub fn renderGlyph(
     if (gop.found_existing) return gop.value_ptr.*;
 
     // Get the presentation to determine what atlas to use
-    const p = try self.resolver.getPresentation(index);
+    const p = try self.resolver.getPresentation(index, glyph_index);
     const atlas: *font.Atlas = switch (p) {
         .text => &self.atlas_greyscale,
         .emoji => &self.atlas_color,

--- a/src/font/face.zig
+++ b/src/font/face.zig
@@ -48,6 +48,15 @@ pub const DesiredSize = struct {
     }
 };
 
+/// Glyph index into a face.
+pub const GlyphIndex = struct {
+    /// The index in the face.
+    index: u32,
+
+    /// True if the glyph is a colored glyph.
+    color: bool,
+};
+
 /// A font variation setting. The best documentation for this I know of
 /// is actually the CSS font-variation-settings property on MDN:
 /// https://developer.mozilla.org/en-US/docs/Web/CSS/font-variation-settings

--- a/src/font/face.zig
+++ b/src/font/face.zig
@@ -48,15 +48,6 @@ pub const DesiredSize = struct {
     }
 };
 
-/// Glyph index into a face.
-pub const GlyphIndex = struct {
-    /// The index in the face.
-    index: u32,
-
-    /// True if the glyph is a colored glyph.
-    color: bool,
-};
-
 /// A font variation setting. The best documentation for this I know of
 /// is actually the CSS font-variation-settings property on MDN:
 /// https://developer.mozilla.org/en-US/docs/Web/CSS/font-variation-settings

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -238,7 +238,7 @@ pub const Face = struct {
 
     /// Returns the glyph index for the given Unicode code point. If this
     /// face doesn't support this glyph, null is returned.
-    pub fn glyphIndex(self: Face, cp: u32) ?u16 {
+    pub fn glyphIndex(self: Face, cp: u32) ?u32 {
         // Turn UTF-32 into UTF-16 for CT API
         var unichars: [2]u16 = undefined;
         const pair = macos.foundation.stringGetSurrogatePairForLongCharacter(cp, &unichars);

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -253,9 +253,6 @@ pub const Face = struct {
         // to decode down into exactly one glyph ID.
         if (pair) assert(glyphs[1] == 0);
 
-        // If we have colorization information, then check if this
-        // glyph is colorized.
-
         return @intCast(glyphs[0]);
     }
 
@@ -600,6 +597,8 @@ pub const Face = struct {
     }
 };
 
+/// The state associated with a font face that may have colorized glyphs.
+/// This is used to determine if a specific glyph ID is colorized.
 const ColorState = struct {
     /// True if there is an sbix font table. For now, the mere presence
     /// of an sbix font table causes us to assume the glyph is colored.

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -7,7 +7,6 @@ const harfbuzz = @import("harfbuzz");
 const font = @import("../main.zig");
 const opentype = @import("../opentype.zig");
 const quirks = @import("../../quirks.zig");
-const GlyphIndex = font.face.GlyphIndex;
 
 const log = std.log.scoped(.font_face);
 

--- a/src/font/face/freetype.zig
+++ b/src/font/face/freetype.zig
@@ -216,6 +216,11 @@ pub const Face = struct {
         // sbix table is always true for now
         if (self.face.hasSBIX()) return true;
 
+        // CBDT/CBLC tables always imply colorized glyphs.
+        // These are used by Noto.
+        if (self.face.hasSfntTable(freetype.Tag.init("CBDT"))) return true;
+        if (self.face.hasSfntTable(freetype.Tag.init("CBLC"))) return true;
+
         // Otherwise, load the glyph and see what format it is in.
         self.face.loadGlyph(glyph_id, .{
             .render = true,
@@ -697,6 +702,13 @@ test "color emoji" {
     defer ft_font.deinit();
 
     _ = try ft_font.renderGlyph(alloc, &atlas, ft_font.glyphIndex('🥸').?, .{});
+
+    // Make sure this glyph has color
+    {
+        try testing.expect(ft_font.hasColor());
+        const glyph_id = ft_font.glyphIndex('🥸').?;
+        try testing.expect(ft_font.isColorGlyph(glyph_id));
+    }
 
     // resize
     {

--- a/src/font/face/freetype.zig
+++ b/src/font/face/freetype.zig
@@ -15,7 +15,6 @@ const Allocator = std.mem.Allocator;
 const font = @import("../main.zig");
 const Glyph = font.Glyph;
 const Library = font.Library;
-const Presentation = font.Presentation;
 const convert = @import("freetype_convert.zig");
 const fastmem = @import("../../fastmem.zig");
 const quirks = @import("../../quirks.zig");
@@ -31,10 +30,6 @@ pub const Face = struct {
 
     /// Harfbuzz font corresponding to this face.
     hb_font: harfbuzz.Font,
-
-    /// The presentation for this font. This is a heuristic since fonts don't have
-    /// a way to declare this. We just assume a font with color is an emoji font.
-    presentation: Presentation,
 
     /// Metrics for this font face. These are useful for renderers.
     metrics: font.face.Metrics,
@@ -67,16 +62,9 @@ pub const Face = struct {
             .lib = lib.lib,
             .face = face,
             .hb_font = hb_font,
-            .presentation = if (face.hasColor()) .emoji else .text,
             .metrics = calcMetrics(face, opts.metric_modifiers),
         };
         result.quirks_disable_default_font_features = quirks.disableDefaultFontFeatures(&result);
-
-        // See coretext.zig which has a similar check for this.
-        if (result.presentation == .emoji and result.glyphIndex('🥸') == null) {
-            log.warn("font has colorized glyphs but isn't emoji, treating as text", .{});
-            result.presentation = .text;
-        }
 
         // In debug mode, we output information about available variation axes,
         // if they exist.
@@ -219,8 +207,27 @@ pub const Face = struct {
 
     /// Returns true if this font is colored. This can be used by callers to
     /// determine what kind of atlas to pass in.
-    fn hasColor(self: Face) bool {
+    pub fn hasColor(self: Face) bool {
         return self.face.hasColor();
+    }
+
+    /// Returns true if the given glyph ID is colorized.
+    pub fn isColorGlyph(self: *const Face, glyph_id: u32) bool {
+        // sbix table is always true for now
+        if (self.face.hasSBIX()) return true;
+
+        // Otherwise, load the glyph and see what format it is in.
+        self.face.loadGlyph(glyph_id, .{
+            .render = true,
+            .color = self.face.hasColor(),
+            .no_bitmap = !self.face.hasColor(),
+        }) catch return false;
+
+        // If the glyph is SVG we assume colorized
+        const glyph = self.face.handle.*.glyph;
+        if (glyph.*.format == freetype.c.FT_GLYPH_FORMAT_SVG) return true;
+
+        return false;
     }
 
     /// Render a glyph using the glyph index. The rendered glyph is stored in the
@@ -655,8 +662,6 @@ test {
     );
     defer ft_font.deinit();
 
-    try testing.expectEqual(Presentation.text, ft_font.presentation);
-
     // Generate all visible ASCII
     var i: u8 = 32;
     while (i < 127) : (i += 1) {
@@ -690,8 +695,6 @@ test "color emoji" {
         .{ .size = .{ .points = 12, .xdpi = 96, .ydpi = 96 } },
     );
     defer ft_font.deinit();
-
-    try testing.expectEqual(Presentation.emoji, ft_font.presentation);
 
     _ = try ft_font.renderGlyph(alloc, &atlas, ft_font.glyphIndex('🥸').?, .{});
 

--- a/src/font/main.zig
+++ b/src/font/main.zig
@@ -12,6 +12,7 @@ pub const DeferredFace = @import("DeferredFace.zig");
 pub const Face = face.Face;
 pub const Glyph = @import("Glyph.zig");
 pub const Metrics = face.Metrics;
+pub const opentype = @import("opentype.zig");
 pub const shape = @import("shape.zig");
 pub const Shaper = shape.Shaper;
 pub const ShaperCache = shape.Cache;

--- a/src/font/main.zig
+++ b/src/font/main.zig
@@ -160,7 +160,7 @@ pub const Style = enum(u3) {
     bold_italic = 3,
 };
 
-/// The presentation for a an emoji.
+/// The presentation for an emoji.
 pub const Presentation = enum(u1) {
     text = 0, // U+FE0E
     emoji = 1, // U+FEOF

--- a/src/font/opentype.zig
+++ b/src/font/opentype.zig
@@ -1,0 +1,7 @@
+const svg = @import("opentype/svg.zig");
+
+pub const SVG = svg.SVG;
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/font/opentype/svg.zig
+++ b/src/font/opentype/svg.zig
@@ -2,7 +2,12 @@ const std = @import("std");
 const assert = std.debug.assert;
 const font = @import("../main.zig");
 
-/// SVG glyphs description table:
+/// SVG glyphs description table.
+///
+/// This struct is focused purely on the operations we need for Ghostty,
+/// namely to be able to look up whether an glyph ID is present in the SVG
+/// table or not. This struct isn't meant to be a general purpose SVG table
+/// reader.
 ///
 /// References:
 /// - https://www.w3.org/2013/10/SVG_in_OpenType/#thesvg

--- a/src/font/opentype/svg.zig
+++ b/src/font/opentype/svg.zig
@@ -1,0 +1,108 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const font = @import("../main.zig");
+
+/// SVG glyphs description table:
+///
+/// References:
+/// - https://www.w3.org/2013/10/SVG_in_OpenType/#thesvg
+/// - https://learn.microsoft.com/en-us/typography/opentype/spec/svg
+pub const SVG = struct {
+    /// The start and end glyph IDs (inclusive) that are present in the
+    /// table. This is used to very quickly include/exclude a glyph from
+    /// the table.
+    start_glyph_id: u16,
+    end_glyph_id: u16,
+
+    /// All records in the table.
+    records: []const [12]u8,
+
+    pub fn init(data: []const u8) !SVG {
+        var fbs = std.io.fixedBufferStream(data);
+        const reader = fbs.reader();
+
+        // Version
+        if (try reader.readInt(u16, .big) != 0) {
+            return error.SVGVersionNotSupported;
+        }
+
+        // Offset
+        const offset = try reader.readInt(u32, .big);
+
+        // Seek to the offset to get our document list
+        try fbs.seekTo(offset);
+
+        // Get our document records along with the start/end glyph range.
+        const len = try reader.readInt(u16, .big);
+        const records: [*]const [12]u8 = @ptrCast(data[try fbs.getPos()..]);
+        const start_range = try glyphRange(&records[0]);
+        const end_range = if (len == 1) start_range else try glyphRange(&records[(len - 1)]);
+
+        return .{
+            .start_glyph_id = start_range[0],
+            .end_glyph_id = end_range[1],
+            .records = records[0..len],
+        };
+    }
+
+    pub fn hasGlyph(self: SVG, glyph_id: u16) bool {
+        // Fast path: outside the table range
+        if (glyph_id < self.start_glyph_id or glyph_id > self.end_glyph_id) {
+            return false;
+        }
+
+        // Fast path, matches the start/end glyph IDs
+        if (glyph_id == self.start_glyph_id or glyph_id == self.end_glyph_id) {
+            return true;
+        }
+
+        // Slow path: binary search our records
+        return std.sort.binarySearch(
+            [12]u8,
+            glyph_id,
+            self.records,
+            {},
+            compareGlyphId,
+        ) != null;
+    }
+
+    fn compareGlyphId(_: void, glyph_id: u16, record: [12]u8) std.math.Order {
+        const start, const end = glyphRange(&record) catch return .lt;
+        if (glyph_id < start) {
+            return .lt;
+        } else if (glyph_id > end) {
+            return .gt;
+        } else {
+            return .eq;
+        }
+    }
+
+    fn glyphRange(record: []const u8) !struct { u16, u16 } {
+        var fbs = std.io.fixedBufferStream(record);
+        const reader = fbs.reader();
+        return .{
+            try reader.readInt(u16, .big),
+            try reader.readInt(u16, .big),
+        };
+    }
+};
+
+test "SVG" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const testFont = @import("../test.zig").fontJuliaMono;
+
+    var lib = try font.Library.init();
+    defer lib.deinit();
+
+    var face = try font.Face.init(lib, testFont, .{ .size = .{ .points = 12 } });
+    defer face.deinit();
+
+    const table = (try face.copyTable(alloc, "SVG ")).?;
+    defer alloc.free(table);
+
+    const svg = try SVG.init(table);
+    try testing.expectEqual(11482, svg.start_glyph_id);
+    try testing.expectEqual(11482, svg.end_glyph_id);
+    try testing.expect(svg.hasGlyph(11482));
+}


### PR DESCRIPTION
Fixes #1768 

It was previously assumed that a font was either colorized or non-colorized. Both CoreText and Freetype provide face-level APIs to determine if a font "has color." This information was used by Ghostty to rasterize glyphs to the correct atlas (monotone vs RGBA), handle variation selectors (VS15/VS16), and more. 

#1768 showed that when a font that has a mix of colorized and non-colorized glyphs are used, Ghostty behaved poorly on both macOS (CoreText) and Linux (Freetype) due to the aforementioned assumption.

This PR moves colorization detection from the face to the individual glyph level. Instead of asking "is this font colorized?" we now ask "is this specific glyph ID colorized?" This allows us to have font faces that mix colorized and non-colorized glyphs, such as Julia Mono.

Glyph-level colorization detection isn't an API available on either CoreText or Freetype. To detect colorization at the glyph level, we use some heuristics. We'll have to tune these over time as different fonts emerge, but the current set of rules should work for all known fonts that the community is currently using and that we previously supported. I want to avoid modifying this algorithm until we have fonts that behave differently so we can add unit tests. The algorithm:

  * If an `sbix` opentype table is on the font, the glyph is colored no matter what.
  * If `CBDT` or `CBLC` opentype tables are present, the glyph is colored no matter what
  * If an `SVG ` table is present _and_ the glyph is present in the table, it is colored
  * Else, non-colored

Note: the U+E800 glyph in Julia Mono shows up blank on Linux because freetype isn't configured with SVG support. That was true prior to this PR too. However, Freetype has been configured to support glyph-level colorization in this PR so once we compile in SVG support we should be good to go.

## Before

This is with hacky bandaid #1799 which forces non-colorization of mixed color fonts. 

Note that the Julia logo is gray...

![CleanShot 2024-05-28 at 20 47 29@2x](https://github.com/mitchellh/ghostty/assets/1299/2252ef54-fcf3-4547-93bd-faa05d789baa)

## After

![CleanShot 2024-05-28 at 20 46 57@2x](https://github.com/mitchellh/ghostty/assets/1299/08febc23-fa00-43d6-a0d5-e549418e706f)
