### PR TITLE
scrollback: Include active area when writing scrollback to file

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3166,7 +3166,7 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
                 // the file and write the empty file to the pty so that this
                 // command always works on the primary screen.
                 const pages = &self.io.terminal.screen.pages;
-                if (pages.getBottomRight(.history)) |br| {
+                if (pages.getBottomRight(.active)) |br| {
                     const tl = pages.getTopLeft(.history);
                     try self.io.terminal.screen.dumpString(
                         file.writer(),


### PR DESCRIPTION
Writing scrollback to file is, among other usecases, an interrim solution for searching. Status quo is to only write history pages, and not the active area. This PR proposes that the scrollback write includes the active area, which I think is more useful. For example, you can then do less +G <super+shift+j> if you have long log output and then page and reverse-search through all of it. It's a bit surprising if the active area is missing.

It was suggested on Discord that variations of what gets written could be different keybindings (active-only, history-only, everything), but this PR's change is what I feel like the default should be.
