### PR TITLE
font: when presentation isn't found, always fallback to any

### DIFF
--- a/src/font/CodepointResolver.zig
+++ b/src/font/CodepointResolver.zig
@@ -211,8 +211,10 @@ pub fn getIndex(
         }
     }
 
-    // If this is already regular, we're done falling back.
-    if (style == .regular and p == null) return null;
+    // If this is regular with any matching presentation, then we are done
+    // there is nothing more we can do. Otherwise we fall through and do
+    // an any presentation search.
+    if (style == .regular and p_mode == .any) return null;
 
     // For non-regular fonts, we fall back to regular with any presentation
     return self.collection.getIndex(cp, .regular, .{ .any = {} });


### PR DESCRIPTION
Fixes #1808

When resolving a codepoint, we first attempt to find the default presentation (if an explicit one is not given), but we were not falling back to "any" in case that presentation was not found.

## Before

![CleanShot 2024-05-30 at 14 25 28@2x](https://github.com/mitchellh/ghostty/assets/1299/036a11f5-07c5-41d5-babd-d42897b0c8f1)

## After

![CleanShot 2024-05-30 at 14 24 49@2x](https://github.com/mitchellh/ghostty/assets/1299/c4b1d666-88ff-40ef-b3c6-cfbd18d17573)

**Note:** the emoji shows up small because the default presentation of this emoji is text presentation meaning it has a cell width of 1. Therefore, we have to resize it to constrain it within a cell.

## Correct (w/ Text Emoji Font Installed)

If your system has a valid text emoji font installed then we use that. The graphical version (with VS16 provided) will load the correct graphical version. This has always worked, this PR doesn't change this, I'm just showing it.

![CleanShot 2024-05-30 at 14 26 37@2x](https://github.com/mitchellh/ghostty/assets/1299/98c1a014-d801-4aca-81f7-6d7de72c68fc)
