### PR TITLE
shell-integration: bash must be explicitly enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,9 @@ function fine within Ghostty with the above mentioned shell integration features
 inoperative. **If you want to disable automatic shell integration,** set
 `shell-integration = none` in your configuration file.
 
+Automatic `bash` shell integration requires Bash version 4 or later and must be
+explicitly enabled by setting `shell-integration = bash`.
+
 **For the automatic shell integration to work,** Ghostty must either be run
 from the macOS app bundle or be installed in a location where the contents of
 `zig-out/share` are available somewhere above the directory where Ghostty

--- a/src/shell-integration/README.md
+++ b/src/shell-integration/README.md
@@ -18,7 +18,11 @@ our integration script (`bash/ghostty.bash`). This prevents Bash from loading
 its normal startup files, which becomes our script's responsibility (along with
 disabling POSIX mode).
 
+Because automatic Bash shell integration requires Bash version 4 or later, it
+must be explicitly enabled (`shell-integration = bash`).
+
 Bash shell integration can also be sourced manually from `bash/ghostty.bash`.
+This also works for older versions of Bash.
 
 ### Elvish
 

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -57,7 +57,11 @@ pub fn setup(
     };
 
     const result: ShellIntegration = shell: {
-        if (std.mem.eql(u8, "bash", exe)) {
+        // For now, bash integration must be explicitly enabled via force_shell.
+        // Our automatic shell integration requires bash version 4 or later,
+        // and systems like macOS continue to ship bash version 3 by default.
+        // This approach avoids the cost of performing a runtime version check.
+        if (std.mem.eql(u8, "bash", exe) and force_shell == .bash) {
             const new_command = try setupBash(
                 alloc_arena,
                 command,
@@ -128,6 +132,8 @@ test "force shell" {
 /// bash from loading its normal startup files, which becomes
 /// our script's responsibility (along with disabling POSIX
 /// mode).
+///
+/// This approach requires bash version 4 or later.
 ///
 /// This returns a new (allocated) shell command string that
 /// enables the integration or null if integration failed.


### PR DESCRIPTION
For now, bash integration must be explicitly enabled (by setting `shell-integration = bash`). Our automatic shell integration requires bash version 4 or later, and systems like macOS continue to ship bash version 3 by default. This approach avoids the cost of performing a runtime version check.