### PR TITLE
inspector: fallback to unicode if key event is invalid

### DIFF
--- a/src/inspector/key.zig
+++ b/src/inspector/key.zig
@@ -52,7 +52,18 @@ pub const Event = struct {
         if (self.event.mods.ctrl) try writer.writeAll("Ctrl+");
         if (self.event.mods.alt) try writer.writeAll("Alt+");
         if (self.event.mods.super) try writer.writeAll("Super+");
-        try writer.writeAll(@tagName(self.event.key));
+
+        try writer.writeAll(key: {
+            if (self.event.key != .invalid) {
+                break :key @tagName(self.event.key);
+            }
+
+            if (self.event.utf8.len > 0) {
+                break :key self.event.utf8;
+            }
+
+            break :key @tagName(.invalid);
+        });
 
         // Deadkey
         if (self.event.composing) try writer.writeAll(" (composing)");

--- a/src/inspector/key.zig
+++ b/src/inspector/key.zig
@@ -53,16 +53,11 @@ pub const Event = struct {
         if (self.event.mods.alt) try writer.writeAll("Alt+");
         if (self.event.mods.super) try writer.writeAll("Super+");
 
-        try writer.writeAll(key: {
-            if (self.event.key != .invalid) {
-                break :key @tagName(self.event.key);
-            }
-
-            if (self.event.utf8.len > 0) {
-                break :key self.event.utf8;
-            }
-
-            break :key @tagName(.invalid);
+        // Write our key. If we have an invalid key we attempt to write
+        // the utf8 associated with it if we have it to handle non-ascii.
+        try writer.writeAll(switch (self.event.key) {
+            .invalid => if (self.event.utf8.len > 0) self.event.utf8 else @tagName(.invalid),
+            else => @tagName(self.event.key),
         });
 
         // Deadkey


### PR DESCRIPTION
This prevents non-ascii characters like Ö from being displayed as invalid
was part of #1802 

Before:
![image](https://github.com/ghostty-org/ghostty/assets/15076013/ca32922e-acc1-4409-828a-8e2f05700f0c)

After:
![image](https://github.com/ghostty-org/ghostty/assets/15076013/8c636439-e288-4130-ae81-967ae656c32e)

the exact implementation of this may be up to debate since it can be done in a:
- block
- switch case
- if branch

