### PR TITLE
Linux: Launch each terminal surface into its own cgroup

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -404,6 +404,16 @@ pub fn init(
         .renderer_wakeup = render_thread.wakeup,
         .renderer_mailbox = render_thread.mailbox,
         .surface_mailbox = .{ .surface = self, .app = app_mailbox },
+
+        // Get the cgroup if we're on linux and have the decl. I'd love
+        // to change this from a decl to a surface options struct because
+        // then we can do memory management better (don't need to retain
+        // the string around).
+        .linux_cgroup = if (comptime builtin.os.tag == .linux and
+            @hasDecl(apprt.runtime.Surface, "cgroup"))
+            rt_surface.cgroup()
+        else
+            termio.Options.linux_cgroup_default,
     });
     errdefer io.deinit();
 

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -405,6 +405,13 @@ pub fn run(self: *App) !void {
                 "failed to initialize cgroups, terminals will not be isolated err={}",
                 .{err},
             );
+
+            // If we have hard fail enabled then we exit now.
+            if (self.config.@"linux-cgroup-hard-fail") {
+                log.err("linux-cgroup-hard-fail enabled, exiting", .{});
+                return error.CgroupInitFailed;
+            }
+
             break :cgroup;
         };
 

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -358,7 +358,7 @@ pub fn init(self: *Surface, app: *App, opts: Options) !void {
         var buf: [256]u8 = undefined;
         const name = std.fmt.bufPrint(
             &buf,
-            "surface({X}).scope",
+            "surfaces/{X}.service",
             .{@intFromPtr(self)},
         ) catch unreachable;
 

--- a/src/apprt/gtk/cgroup.zig
+++ b/src/apprt/gtk/cgroup.zig
@@ -52,6 +52,15 @@ pub fn init(app: *App) ![]const u8 {
     // I don't know a scenario where this fails yet.
     try enableControllers(alloc, transient);
 
+    // Configure the "high" memory limit. This limit is used instead
+    // of "max" because it's a soft limit that can be exceeded and
+    // can be monitored by things like systemd-oomd to kill if needed,
+    // versus an instant hard kill.
+    // try internal_os.cgroup.configureMemoryLimit(transient, .{
+    //     // 1GB
+    //     .high = 1 * 1024 * 1024 * 1024,
+    // });
+
     return transient;
 }
 

--- a/src/apprt/gtk/cgroup.zig
+++ b/src/apprt/gtk/cgroup.zig
@@ -166,8 +166,8 @@ fn createScope(connection: *c.GDBusConnection) !void {
         &err,
     ) orelse {
         if (err) |e| log.err(
-            "creating transient cgroup scope failed err={s}",
-            .{e.message},
+            "creating transient cgroup scope failed code={} err={s}",
+            .{ e.code, e.message },
         );
         return error.DbusCallFailed;
     };

--- a/src/apprt/gtk/cgroup.zig
+++ b/src/apprt/gtk/cgroup.zig
@@ -41,6 +41,11 @@ pub fn init(app: *App) ![]const u8 {
     errdefer alloc.free(transient);
     log.info("transient scope created cgroup={s}", .{transient});
 
+    // Create the app cgroup and put ourselves in it. This is
+    // required because controllers can't be configured while a
+    // process is in a cgroup.
+    try internal_os.cgroup.create(transient, "app.scope", pid);
+
     // Enable all of our cgroup controllers. If these fail then
     // we just log. We can't reasonably undo what we've done above
     // so we log the warning and still return the transient group.

--- a/src/apprt/gtk/cgroup.zig
+++ b/src/apprt/gtk/cgroup.zig
@@ -36,6 +36,7 @@ pub fn init(app: *App) ![]const u8 {
             pid,
         ) orelse "";
         if (!std.mem.eql(u8, original, current)) break :transient current;
+        alloc.free(current);
         std.time.sleep(25 * std.time.ns_per_ms);
     };
     errdefer alloc.free(transient);

--- a/src/apprt/gtk/cgroup.zig
+++ b/src/apprt/gtk/cgroup.zig
@@ -1,0 +1,129 @@
+/// Contains all the logic for putting the Ghostty process and
+/// each individual surface into its own cgroup.
+const std = @import("std");
+const assert = std.debug.assert;
+const Allocator = std.mem.Allocator;
+const c = @import("c.zig");
+const App = @import("App.zig");
+const internal_os = @import("../../os/main.zig");
+
+const log = std.log.scoped(.gtk_systemd_cgroup);
+
+/// Initialize the cgroup for the app. This will create our
+/// transient scope, initialize the cgroups we use for the app,
+/// configure them, and return the cgroup path for the app.
+pub fn init(app: *App) ![]const u8 {
+    const pid = std.os.linux.getpid();
+    const alloc = app.core_app.alloc;
+    const connection = c.g_application_get_dbus_connection(@ptrCast(app.app)) orelse
+        return error.DbusConnectionRequired;
+
+    // Get our initial cgroup. We need this so we can compare
+    // and detect when we've switched to our transient group.
+    const original = try internal_os.linux.cgroupPath(
+        alloc,
+        pid,
+    ) orelse "";
+    defer alloc.free(original);
+
+    // Create our transient scope. If this succeeds then the unit
+    // was created, but we may not have moved into it yet, so we need
+    // to do a dumb busy loop to wait for the move to complete.
+    try createScope(connection);
+    const transient = transient: while (true) {
+        const current = try internal_os.linux.cgroupPath(
+            alloc,
+            pid,
+        ) orelse "";
+        if (!std.mem.eql(u8, original, current)) break :transient current;
+        std.time.sleep(25 * std.time.ns_per_ms);
+    };
+    errdefer alloc.free(transient);
+    log.info("transient scope created cgroup={s}", .{transient});
+
+    return transient;
+}
+
+/// Create a transient systemd scope unit for the current process.
+///
+/// On success this will return the name of the transient scope
+/// cgroup prefix, allocated with the given allocator.
+fn createScope(connection: *c.GDBusConnection) !void {
+    // Our pid that we will move into the cgroup
+    const pid: c.guint32 = @intCast(std.os.linux.getpid());
+
+    // The unit name needs to be unique. We use the pid for this.
+    var name_buf: [256]u8 = undefined;
+    const name = std.fmt.bufPrintZ(
+        &name_buf,
+        "app-ghostty-transient-{}.scope",
+        .{pid},
+    ) catch unreachable;
+
+    // Initialize our builder to build up our parameters
+    var builder: c.GVariantBuilder = undefined;
+    c.g_variant_builder_init(&builder, c.G_VARIANT_TYPE("(ssa(sv)a(sa(sv)))"));
+    c.g_variant_builder_add(&builder, "s", name.ptr);
+    c.g_variant_builder_add(&builder, "s", "fail");
+    {
+        // Properties
+        c.g_variant_builder_open(&builder, c.G_VARIANT_TYPE("a(sv)"));
+        defer c.g_variant_builder_close(&builder);
+
+        // https://www.freedesktop.org/software/systemd/man/latest/systemd-oomd.service.html
+        c.g_variant_builder_add(
+            &builder,
+            "(sv)",
+            "ManagedOOMMemoryPressure",
+            c.g_variant_new_string("kill"),
+        );
+
+        // Delegate
+        c.g_variant_builder_add(
+            &builder,
+            "(sv)",
+            "Delegate",
+            c.g_variant_new_boolean(1),
+        );
+
+        // Pid to move into the unit
+        c.g_variant_builder_add(
+            &builder,
+            "(sv)",
+            "PIDs",
+            c.g_variant_new_fixed_array(
+                c.G_VARIANT_TYPE("u"),
+                &pid,
+                1,
+                @sizeOf(c.guint32),
+            ),
+        );
+    }
+    {
+        // Aux
+        c.g_variant_builder_open(&builder, c.G_VARIANT_TYPE("a(sa(sv))"));
+        defer c.g_variant_builder_close(&builder);
+    }
+
+    var err: ?*c.GError = null;
+    defer if (err) |e| c.g_error_free(e);
+    _ = c.g_dbus_connection_call_sync(
+        connection,
+        "org.freedesktop.systemd1",
+        "/org/freedesktop/systemd1",
+        "org.freedesktop.systemd1.Manager",
+        "StartTransientUnit",
+        c.g_variant_builder_end(&builder),
+        c.G_VARIANT_TYPE("(o)"),
+        c.G_DBUS_CALL_FLAGS_NONE,
+        -1,
+        null,
+        &err,
+    ) orelse {
+        if (err) |e| log.err(
+            "creating transient cgroup scope failed err={s}",
+            .{e.message},
+        );
+        return error.DbusCallFailed;
+    };
+}

--- a/src/apprt/gtk/cgroup.zig
+++ b/src/apprt/gtk/cgroup.zig
@@ -20,7 +20,7 @@ pub fn init(app: *App) ![]const u8 {
 
     // Get our initial cgroup. We need this so we can compare
     // and detect when we've switched to our transient group.
-    const original = try internal_os.linux.cgroupPath(
+    const original = try internal_os.cgroup.current(
         alloc,
         pid,
     ) orelse "";
@@ -31,7 +31,7 @@ pub fn init(app: *App) ![]const u8 {
     // to do a dumb busy loop to wait for the move to complete.
     try createScope(connection);
     const transient = transient: while (true) {
-        const current = try internal_os.linux.cgroupPath(
+        const current = try internal_os.cgroup.current(
             alloc,
             pid,
         ) orelse "";
@@ -52,7 +52,7 @@ pub fn init(app: *App) ![]const u8 {
 
 /// Enable all the cgroup controllers for the given cgroup.
 fn enableControllers(alloc: Allocator, cgroup: []const u8) !void {
-    const raw = try internal_os.linux.cgroupControllers(alloc, cgroup);
+    const raw = try internal_os.cgroup.controllers(alloc, cgroup);
     defer alloc.free(raw);
 
     // Build our string builder for enabling all controllers

--- a/src/apprt/gtk/cgroup.zig
+++ b/src/apprt/gtk/cgroup.zig
@@ -67,8 +67,11 @@ fn enableControllers(alloc: Allocator, cgroup: []const u8) !void {
         if (it.rest().len > 0) try builder.append(' ');
     }
 
-    // TODO
-    log.warn("enabling controllers={s}", .{builder.items});
+    // Enable them all
+    try internal_os.cgroup.configureControllers(
+        cgroup,
+        builder.items,
+    );
 }
 
 /// Create a transient systemd scope unit for the current process.

--- a/src/apprt/gtk/cgroup.zig
+++ b/src/apprt/gtk/cgroup.zig
@@ -57,10 +57,11 @@ pub fn init(app: *App) ![]const u8 {
     // of "max" because it's a soft limit that can be exceeded and
     // can be monitored by things like systemd-oomd to kill if needed,
     // versus an instant hard kill.
-    // try internal_os.cgroup.configureMemoryLimit(transient, .{
-    //     // 1GB
-    //     .high = 1 * 1024 * 1024 * 1024,
-    // });
+    if (app.config.@"linux-cgroup-memory-limit") |limit| {
+        try internal_os.cgroup.configureMemoryLimit(transient, .{
+            .high = limit,
+        });
+    }
 
     return transient;
 }

--- a/src/build/fish_completions.zig
+++ b/src/build/fish_completions.zig
@@ -12,7 +12,7 @@ pub const fish_completions = comptimeGenerateFishCompletions();
 
 fn comptimeGenerateFishCompletions() []const u8 {
     comptime {
-        @setEvalBranchQuota(13000);
+        @setEvalBranchQuota(15000);
         var counter = std.io.countingWriter(std.io.null_writer);
         try writeFishCompletions(&counter.writer());
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1003,6 +1003,10 @@ keybind: Keybinds = .{},
 /// more likely to have many windows, tabs, etc. so cgroup isolation is a
 /// big benefit.
 ///
+/// This feature requires systemd. If systemd is unavailable, cgroup
+/// initialization will fail. By default, this will not prevent Ghostty
+/// from working (see linux-cgroup-hard-fail).
+///
 /// Valid values are:
 ///
 ///   * `never` - Never use cgroups.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -988,6 +988,30 @@ keybind: Keybinds = .{},
 /// This does not work with GLFW builds.
 @"macos-option-as-alt": OptionAsAlt = .false,
 
+/// Put every surface (tab, split, window) into a dedicated Linux cgroup.
+///
+/// This makes it so that resource management can be done on a per-surface
+/// granularity. For example, if a shell program is using too much memory,
+/// only that shell will be killed by the oom monitor instead of the entire
+/// Ghostty process. Similarly, if a shell program is using too much CPU,
+/// only that surface will be CPU-throttled.
+///
+/// This will cause startup times to be slower (a hundred milliseconds or so),
+/// so the default value is "single-instance." In single-instance mode, only
+/// one instance of Ghostty is running (see gtk-single-instance) so the startup
+/// time is a one-time cost. Additionally, single instance Ghostty is much
+/// more likely to have many windows, tabs, etc. so cgroup isolation is a
+/// big benefit.
+///
+/// Valid values are:
+///
+///   * `never` - Never use cgroups.
+///   * `always` - Always use cgroups.
+///   * `single-instance` - Enable cgroups only for Ghostty instances launched
+///     as single-instance applications (see gtk-single-instance).
+///
+@"linux-cgroup": LinuxCgroup = .@"single-instance",
+
 /// If true, the Ghostty GTK application will run in single-instance mode:
 /// each new `ghostty` process launched will result in a new window if there
 /// is already a running process.
@@ -3494,4 +3518,11 @@ pub const WindowNewTabPosition = enum {
 pub const GraphemeWidthMethod = enum {
     legacy,
     unicode,
+};
+
+/// See linux-cgroup
+pub const LinuxCgroup = enum {
+    never,
+    always,
+    @"single-instance",
 };

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1012,6 +1012,19 @@ keybind: Keybinds = .{},
 ///
 @"linux-cgroup": LinuxCgroup = .@"single-instance",
 
+/// If this is false, then any cgroup initialization (for linux-cgroup)
+/// will be allowed to fail and the failure is ignored. This is useful if
+/// you view cgroup isolation as a "nice to have" and not a critical resource
+/// management feature, because Ghostty startup will not fail if cgroup APIs
+/// fail.
+///
+/// If this is true, then any cgroup initialization failure will cause
+/// Ghostty to exit or new surfaces to not be created.
+///
+/// Note: this currently only affects cgroup initialization. Subprocesses
+/// must always be able to move themselves into an isolated cgroup.
+@"linux-cgroup-hard-fail": bool = false,
+
 /// If true, the Ghostty GTK application will run in single-instance mode:
 /// each new `ghostty` process launched will result in a new window if there
 /// is already a running process.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1012,6 +1012,15 @@ keybind: Keybinds = .{},
 ///
 @"linux-cgroup": LinuxCgroup = .@"single-instance",
 
+/// Memory limit for any individual terminal process (tab, split, window,
+/// etc.) in bytes. If this is unset then no memory limit will be set.
+///
+/// Note that this sets the "memory.high" configuration for the memory
+/// controller, which is a soft limit. You should configure something like
+/// systemd-oom to handle killing processes that have too much memory
+/// pressure.
+@"linux-cgroup-memory-limit": ?u64 = null,
+
 /// If this is false, then any cgroup initialization (for linux-cgroup)
 /// will be allowed to fail and the failure is ignored. This is useful if
 /// you view cgroup isolation as a "nice to have" and not a critical resource

--- a/src/os/cgroup.zig
+++ b/src/os/cgroup.zig
@@ -52,6 +52,18 @@ pub fn create(
     }
 }
 
+/// Move the given PID into the given cgroup.
+pub fn moveInto(
+    cgroup: []const u8,
+    pid: std.os.linux.pid_t,
+) !void {
+    var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    const path = try std.fmt.bufPrint(&buf, "/sys/fs/cgroup{s}/cgroup.procs", .{cgroup});
+    const file = try std.fs.cwd().openFile(path, .{ .mode = .write_only });
+    defer file.close();
+    try file.writer().print("{}", .{pid});
+}
+
 /// Returns all available cgroup controllers for the given cgroup.
 /// The cgroup should have a '/'-prefix.
 ///

--- a/src/os/cgroup.zig
+++ b/src/os/cgroup.zig
@@ -3,7 +3,7 @@ const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 
 /// Returns the path to the cgroup for the given pid.
-pub fn cgroupPath(alloc: Allocator, pid: std.os.linux.pid_t) !?[]const u8 {
+pub fn current(alloc: Allocator, pid: std.os.linux.pid_t) !?[]const u8 {
     var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
 
     // Read our cgroup by opening /proc/<pid>/cgroup and reading the first
@@ -35,7 +35,7 @@ pub fn cgroupPath(alloc: Allocator, pid: std.os.linux.pid_t) !?[]const u8 {
 /// controllers from the /sys/fs directory. This avoids some extra
 /// work since creating an iterator over this is easy and much cheaper
 /// than allocating a bunch of copies for an array.
-pub fn cgroupControllers(alloc: Allocator, cgroup: []const u8) ![]const u8 {
+pub fn controllers(alloc: Allocator, cgroup: []const u8) ![]const u8 {
     assert(cgroup[0] == '/');
     var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
 

--- a/src/os/cgroup.zig
+++ b/src/os/cgroup.zig
@@ -61,3 +61,25 @@ pub fn controllers(alloc: Allocator, cgroup: []const u8) ![]const u8 {
     const result = std.mem.trimRight(u8, contents, " \r\n");
     return try alloc.dupe(u8, result);
 }
+
+/// Configure the set of controllers in the cgroup. The "v" should
+/// be in a valid format for "cgroup.subtree_control"
+pub fn configureControllers(
+    cgroup: []const u8,
+    v: []const u8,
+) !void {
+    assert(cgroup[0] == '/');
+    var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+
+    // Read the available controllers. These will be space separated.
+    const path = try std.fmt.bufPrint(
+        &buf,
+        "/sys/fs/cgroup{s}/cgroup.subtree_control",
+        .{cgroup},
+    );
+    const file = try std.fs.cwd().openFile(path, .{ .mode = .write_only });
+    defer file.close();
+
+    // Write
+    try file.writer().writeAll(v);
+}

--- a/src/os/linux.zig
+++ b/src/os/linux.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 
 /// Returns the path to the cgroup for the given pid.
@@ -24,5 +25,39 @@ pub fn cgroupPath(alloc: Allocator, pid: std.os.linux.pid_t) !?[]const u8 {
     // Find the last ':'
     const idx = std.mem.lastIndexOfScalar(u8, contents, ':') orelse return null;
     const result = std.mem.trimRight(u8, contents[idx + 1 ..], " \r\n");
+    return try alloc.dupe(u8, result);
+}
+
+/// Returns all available cgroup controllers for the given cgroup.
+/// The cgroup should have a '/'-prefix.
+///
+/// The returned list of is the raw space-separated list of
+/// controllers from the /sys/fs directory. This avoids some extra
+/// work since creating an iterator over this is easy and much cheaper
+/// than allocating a bunch of copies for an array.
+pub fn cgroupControllers(alloc: Allocator, cgroup: []const u8) ![]const u8 {
+    assert(cgroup[0] == '/');
+    var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+
+    // Read the available controllers. These will be space separated.
+    const path = try std.fmt.bufPrint(
+        &buf,
+        "/sys/fs/cgroup{s}/cgroup.controllers",
+        .{cgroup},
+    );
+    const file = try std.fs.cwd().openFile(path, .{});
+    defer file.close();
+
+    // Read it all into memory -- we don't expect this file to ever
+    // be that large.
+    var buf_reader = std.io.bufferedReader(file.reader());
+    const contents = try buf_reader.reader().readAllAlloc(
+        alloc,
+        1 * 1024 * 1024, // 1MB
+    );
+    defer alloc.free(contents);
+
+    // Return our raw list of controllers
+    const result = std.mem.trimRight(u8, contents, " \r\n");
     return try alloc.dupe(u8, result);
 }

--- a/src/os/linux.zig
+++ b/src/os/linux.zig
@@ -1,0 +1,28 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+/// Returns the path to the cgroup for the given pid.
+pub fn cgroupPath(alloc: Allocator, pid: std.os.linux.pid_t) !?[]const u8 {
+    var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+
+    // Read our cgroup by opening /proc/<pid>/cgroup and reading the first
+    // line. The first line will look something like this:
+    // 0::/user.slice/user-1000.slice/session-1.scope
+    // The cgroup path is the third field.
+    const path = try std.fmt.bufPrint(&buf, "/proc/{}/cgroup", .{pid});
+    const file = try std.fs.cwd().openFile(path, .{});
+    defer file.close();
+
+    // Read it all into memory -- we don't expect this file to ever be that large.
+    var buf_reader = std.io.bufferedReader(file.reader());
+    const contents = try buf_reader.reader().readAllAlloc(
+        alloc,
+        1 * 1024 * 1024, // 1MB
+    );
+    defer alloc.free(contents);
+
+    // Find the last ':'
+    const idx = std.mem.lastIndexOfScalar(u8, contents, ':') orelse return null;
+    const result = std.mem.trimRight(u8, contents[idx + 1 ..], " \r\n");
+    return try alloc.dupe(u8, result);
+}

--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -13,6 +13,7 @@ pub usingnamespace @import("open.zig");
 pub usingnamespace @import("pipe.zig");
 pub usingnamespace @import("resourcesdir.zig");
 pub const TempDir = @import("TempDir.zig");
+pub const linux = @import("linux.zig");
 pub const passwd = @import("passwd.zig");
 pub const xdg = @import("xdg.zig");
 pub const windows = @import("windows.zig");

--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -13,7 +13,7 @@ pub usingnamespace @import("open.zig");
 pub usingnamespace @import("pipe.zig");
 pub usingnamespace @import("resourcesdir.zig");
 pub const TempDir = @import("TempDir.zig");
-pub const linux = @import("linux.zig");
+pub const cgroup = @import("cgroup.zig");
 pub const passwd = @import("passwd.zig");
 pub const xdg = @import("xdg.zig");
 pub const windows = @import("windows.zig");

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -179,7 +179,14 @@ pub fn init(alloc: Allocator, opts: termio.Options) !Exec {
     term.width_px = subprocess.screen_size.width;
     term.height_px = subprocess.screen_size.height;
 
-    return Exec{
+    // TODO: make work
+    if (comptime builtin.os.tag == .linux) {
+        if (opts.linux_cgroup) |cgroup| {
+            log.warn("DESIRED cgroup={s}", .{cgroup});
+        }
+    }
+
+    return .{
         .alloc = alloc,
         .terminal = term,
         .subprocess = subprocess,

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -179,13 +179,6 @@ pub fn init(alloc: Allocator, opts: termio.Options) !Exec {
     term.width_px = subprocess.screen_size.width;
     term.height_px = subprocess.screen_size.height;
 
-    // TODO: make work
-    if (comptime builtin.os.tag == .linux) {
-        if (opts.linux_cgroup) |cgroup| {
-            log.warn("DESIRED cgroup={s}", .{cgroup});
-        }
-    }
-
     return .{
         .alloc = alloc,
         .terminal = term,
@@ -904,6 +897,7 @@ const Subprocess = struct {
     pty: ?Pty = null,
     command: ?Command = null,
     flatpak_command: ?FlatpakHostCommand = null,
+    linux_cgroup: termio.Options.LinuxCgroup = termio.Options.linux_cgroup_default,
 
     /// Initialize the subprocess. This will NOT start it, this only sets
     /// up the internal state necessary to start it later.
@@ -1200,6 +1194,15 @@ const Subprocess = struct {
         else
             null;
 
+        // If we have a cgroup, then we copy that into our arena so the
+        // memory remains valid when we start.
+        const linux_cgroup: termio.Options.LinuxCgroup = cgroup: {
+            const default = termio.Options.linux_cgroup_default;
+            if (comptime builtin.os.tag != .linux) break :cgroup default;
+            const path = opts.linux_cgroup orelse break :cgroup default;
+            break :cgroup try alloc.dupe(u8, path);
+        };
+
         // Our screen size should be our padded size
         const padded_size = opts.screen_size.subPadding(opts.padding);
 
@@ -1210,6 +1213,7 @@ const Subprocess = struct {
             .args = args,
             .grid_size = opts.grid_size,
             .screen_size = padded_size,
+            .linux_cgroup = linux_cgroup,
         };
     }
 
@@ -1303,12 +1307,14 @@ const Subprocess = struct {
             .pseudo_console = if (builtin.os.tag == .windows) pty.pseudo_console else {},
             .pre_exec = if (builtin.os.tag == .windows) null else (struct {
                 fn callback(cmd: *Command) void {
-                    const p = cmd.getData(Pty) orelse unreachable;
-                    p.childPreExec() catch |err|
-                        log.err("error initializing child: {}", .{err});
+                    const sp = cmd.getData(Subprocess) orelse unreachable;
+                    sp.childPreExec() catch |err| log.err(
+                        "error initializing child: {}",
+                        .{err},
+                    );
                 }
             }).callback,
-            .data = &self.pty.?,
+            .data = self,
         };
         try cmd.start(alloc);
         errdefer killCommand(&cmd) catch |err| {
@@ -1328,6 +1334,22 @@ const Subprocess = struct {
                 .write = pty.master,
             },
         };
+    }
+
+    /// This should be called after fork but before exec in the child process.
+    /// To repeat: this function RUNS IN THE FORKED CHILD PROCESS before
+    /// exec is called; it does NOT run in the main Ghostty process.
+    fn childPreExec(self: *Subprocess) !void {
+        // Setup our pty
+        try self.pty.?.childPreExec();
+
+        // If we have a cgroup set, then we want to move into that cgroup.
+        if (comptime builtin.os.tag == .linux) {
+            if (self.linux_cgroup) |cgroup| {
+                // TODO: do it
+                _ = cgroup;
+            }
+        }
     }
 
     /// Called to notify that we exited externally so we can unset our

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1346,8 +1346,7 @@ const Subprocess = struct {
         // If we have a cgroup set, then we want to move into that cgroup.
         if (comptime builtin.os.tag == .linux) {
             if (self.linux_cgroup) |cgroup| {
-                // TODO: do it
-                _ = cgroup;
+                try internal_os.cgroup.moveInto(cgroup, 0);
             }
         }
     }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1321,6 +1321,9 @@ const Subprocess = struct {
             log.warn("error killing command during cleanup err={}", .{err});
         };
         log.info("started subcommand path={s} pid={?}", .{ self.args[0], cmd.pid });
+        if (comptime builtin.os.tag == .linux) {
+            log.info("subcommand cgroup={s}", .{self.linux_cgroup orelse "-"});
+        }
 
         self.command = cmd;
         return switch (builtin.os.tag) {

--- a/src/termio/Options.zig
+++ b/src/termio/Options.zig
@@ -1,5 +1,6 @@
 //! The options that are used to configure a terminal IO implementation.
 
+const builtin = @import("builtin");
 const xev = @import("xev");
 const apprt = @import("../apprt.zig");
 const renderer = @import("../renderer.zig");
@@ -41,3 +42,10 @@ renderer_mailbox: *renderer.Thread.Mailbox,
 
 /// The mailbox for sending the surface messages.
 surface_mailbox: apprt.surface.Mailbox,
+
+/// The cgroup to apply to the started termio process, if able by
+/// the termio implementation. This only applies to Linux.
+linux_cgroup: LinuxCgroup = linux_cgroup_default,
+
+pub const LinuxCgroup = if (builtin.os.tag == .linux) ?[]const u8 else void;
+pub const linux_cgroup_default = if (LinuxCgroup == void) {} else null;


### PR DESCRIPTION
Fixes #1566 

This PR launches each terminal surface (tab, split, window, etc.) into its own dedicated cgroup. The primary benefit is that resource throttling and process killing (i.e. oom-handling) is isolated to a single surface rather than the entire Ghostty application. Poorly behaved programs you run from the terminal are now better isolated to not impact the entire terminal.

A number of new configurations are introduced:

  * `linux-cgroup` - Controls whether the cgroup feature is enabled at all. By default, it is only enabled if Ghostty is running in "single instance" mode. This default is because cgroup initialization has a significant (~100ms or so) startup cost and the resource management only makes sense if you have multiple surfaces, which a single instance app is likely to have. You can change this config to never or always, too.

  * `linux-cgroup-memory-limit` - A memory limit in bytes to apply to terminal surfaces. By default we don't apply any. This will only apply to the terminals and not to the entire Ghostty application. This is a soft limit ("memory.high" in cgroup v2 terminology), so it is up to external applications (i.e. systemd-oom) to handle this, but the kernel will put memory pressure on the running application if its reached.

  * `linux-cgroup-hard-fail` - By default, Ghostty's cgroup feature is _best effort_. If any cgroup configuration fails, Ghostty will continue as if the cgroup feature didn't exist. If you want any cgroup failure to fail Ghostty or surface creation, set this to true. This defaults to false.

Additional configurations and resource controls can be introduced in the future where it makes sense. Additionally, we can expose per-surface resource configurations when we complete issues like #601.

## Demo

![CleanShot 2024-06-05 at 10 44 20@2x](https://github.com/ghostty-org/ghostty/assets/1299/8fda84c6-4c52-450e-9933-afb8e44c67b4)
