### PR TITLE
core: print current selection to file

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3201,6 +3201,8 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             // Open our selection file
             var file = try tmp_dir.dir.createFile("selection", .{});
             defer file.close();
+            // Screen.dumpString writes byte-by-byte, so buffer it
+            var buf_writer = std.io.bufferedWriter(file.writer());
 
             // Write the selection contents. This requires a lock.
             {
@@ -3216,11 +3218,12 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
 
                 if (self.io.terminal.screen.selection) |selection| {
                     try self.io.terminal.screen.dumpString(
-                        file.writer(),
+                        buf_writer.writer(),
                         .{ .tl = selection.start(), .br = selection.end(), .unwrap = true },
                     );
                 }
             }
+            try buf_writer.flush();
 
             // Get the final path
             var path_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1216,6 +1216,12 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
 
     try result.keybind.set.put(
         alloc,
+        .{ .key = .{ .translated = .j }, .mods = inputpkg.ctrlOrSuper(.{ .ctrl = true }) },
+        .{ .write_selection_file = {} },
+    );
+
+    try result.keybind.set.put(
+        alloc,
         .{ .key = .{ .translated = .j }, .mods = inputpkg.ctrlOrSuper(.{ .shift = true }) },
         .{ .write_scrollback_file = {} },
     );

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -199,6 +199,10 @@ pub const Action = union(enum) {
     /// number of prompts to jump forward, negative is backwards.
     jump_to_prompt: i16,
 
+    /// Write the selection into a temporary file and write the path to the file
+    /// to the tty.
+    write_selection_file: void,
+
     /// Write the entire scrollback into a temporary file and write the path to
     /// the file to the tty.
     write_scrollback_file: void,


### PR DESCRIPTION
this implements the ability to make an arbitrary selection and print it to a temp file. full disclosure, I heavily referenced (copy/pasted) the `write_scrollback_file`.. I'm not too familiar with the code base, so there may be a better implementation. if anyone has other suggestions, please let me know.

I was inspired by #679, but I'm not sure if it actually achieves that specific functionality. either way I think this is useful.