### PR TITLE
feat: add `macos-title-bar-luminance-check`

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -265,6 +265,8 @@ class TerminalController: NSWindowController, NSWindowDelegate,
         if let windowTheme = ghostty.config.windowTheme {
             window.windowTheme = .init(rawValue: windowTheme)
         }
+        
+        window.titleBarLuminanceCheck = ghostty.config.titleBarLuminanceCheck
 
         // Handle titlebar tabs config option. Something about what we do while setting up the
         // titlebar tabs interferes with the window restore process unless window.tabbingMode

--- a/macos/Sources/Features/Terminal/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/TerminalWindow.swift
@@ -151,7 +151,7 @@ class TerminalWindow: NSWindow {
 			if let titlebarContainer = contentView?.superview?.subviews.first(where: {
 				$0.className == "NSTitlebarContainerView"
 			}), let effectView = titlebarContainer.descendants(withClassName: "NSVisualEffectView").first {
-				effectView.isHidden = titlebarTabs || !titlebarTabs && !hasVeryDarkBackground
+				effectView.isHidden = titlebarTabs || !titlebarTabs && !hasVeryDarkBackground && !titleBarLuminanceCheck
 			}
 
 			effectViewIsHidden = true
@@ -188,6 +188,8 @@ class TerminalWindow: NSWindow {
     var hasVeryDarkBackground: Bool {
         backgroundColor.luminance < 0.05
     }
+    
+    var titleBarLuminanceCheck: Bool
 
     private var newTabButtonImageLayer: VibrantLayer? = nil
 

--- a/macos/Sources/Features/Terminal/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/TerminalWindow.swift
@@ -151,7 +151,7 @@ class TerminalWindow: NSWindow {
 			if let titlebarContainer = contentView?.superview?.subviews.first(where: {
 				$0.className == "NSTitlebarContainerView"
 			}), let effectView = titlebarContainer.descendants(withClassName: "NSVisualEffectView").first {
-				effectView.isHidden = titlebarTabs || !titlebarTabs && !hasVeryDarkBackground && !titleBarLuminanceCheck
+				effectView.isHidden = titlebarTabs || titleBarLuminanceCheck && !titlebarTabs && !hasVeryDarkBackground
 			}
 
 			effectViewIsHidden = true
@@ -189,7 +189,7 @@ class TerminalWindow: NSWindow {
         backgroundColor.luminance < 0.05
     }
     
-    var titleBarLuminanceCheck: Bool
+    var titleBarLuminanceCheck: Bool = true
 
     private var newTabButtonImageLayer: VibrantLayer? = nil
 

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -236,6 +236,14 @@ extension Ghostty {
             return v
         }
         
+        var titleBarLuminanceCheck: Bool {
+            guard let config = self.config else { return false }
+            var v = false;
+            let key = "macos-title-bar-luminance-check"
+            _ = ghostty_config_get(config, &v, key, UInt(key.count))
+            return v
+        }
+
         var backgroundColor: Color {
             var rgb: UInt32 = 0
             let bg_key = "background"

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -976,6 +976,10 @@ keybind: Keybinds = .{},
 /// This option only applies to new windows when changed.
 @"macos-titlebar-tabs": bool = false,
 
+/// If `true`, check the luminance of the background and show the custom effect
+/// (custom colored titlebars) )if the luminance is too low.
+@"macos-title-bar-luminance-check": bool = true,
+
 /// If `true`, the *Option* key will be treated as *Alt*. This makes terminal
 /// sequences expecting *Alt* to work properly, but will break Unicode input
 /// sequences on macOS if you use them via the *Alt* key. You may set this to


### PR DESCRIPTION
**Reason for changes**
I (and others) have expressed interest in retaining the previous title bar appearance (that looks more like other dark mode apps on macOS, like Terminal.app) I don't want to step on the work of whoever was creating new title bars.

**Changes**
I've introduced `macos-title-bar-luminance-check`, which can be used to forcibly disable the luminance check used to disable (hide) the effect view despite the background colors luminance.

<h3>Before</h3>
<img width="800" alt="image" src="https://github.com/ghostty-org/ghostty/assets/15584994/2e4fc644-629c-4b45-bd58-bbc2d4202be6">

<h3>After</h3>
<img width="800" alt="image" src="https://github.com/ghostty-org/ghostty/assets/15584994/a4fddac3-8b40-44ce-8072-7eca55ea9766">
