### PR TITLE
feat: add `macos-window-shadow`

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -71,8 +71,8 @@ class TerminalController: NSWindowController, NSWindowDelegate,
         super.init(window: nil)
         
         // Initialize our initial surface.
-        guard let ghostty_app = ghostty.app else { preconditionFailure("app must be loaded") }
-        self.surfaceTree = tree ?? .leaf(.init(ghostty_app, baseConfig: base))
+        guard ghostty.app != nil else { preconditionFailure("app must be loaded") }
+        self.surfaceTree = tree ?? .leaf(.init(ghostty, baseConfig: base))
         
         // Setup our notifications for behaviors
         let center = NotificationCenter.default

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -236,6 +236,14 @@ extension Ghostty {
             return v
         }
         
+        var macosWindowShadow: Bool {
+            guard let config = self.config else { return false }
+            var v = false;
+            let key = "macos-window-shadow"
+            _ = ghostty_config_get(config, &v, key, UInt(key.count))
+            return v
+        }
+
         var backgroundColor: Color {
             var rgb: UInt32 = 0
             let bg_key = "background"

--- a/macos/Sources/Ghostty/Ghostty.SplitNode.swift
+++ b/macos/Sources/Ghostty/Ghostty.SplitNode.swift
@@ -168,13 +168,13 @@ extension Ghostty {
         }
 
         class Leaf: ObservableObject, Equatable, Hashable, Codable {
-            let app: ghostty_app_t
+            let app: Ghostty.App
             @Published var surface: SurfaceView
 
             weak var parent: SplitNode.Container?
 
             /// Initialize a new leaf which creates a new terminal surface.
-            init(_ app: ghostty_app_t, baseConfig: SurfaceConfiguration? = nil, uuid: UUID? = nil) {
+            init(_ app: Ghostty.App, baseConfig: SurfaceConfiguration? = nil, uuid: UUID? = nil) {
                 self.app = app
                 self.surface = SurfaceView(app, baseConfig: baseConfig, uuid: uuid)
             }
@@ -182,14 +182,14 @@ extension Ghostty {
             // MARK: - Hashable
             
             func hash(into hasher: inout Hasher) {
-                hasher.combine(app)
+                hasher.combine(app.app)
                 hasher.combine(surface)
             }
             
             // MARK: - Equatable
             
             static func == (lhs: Leaf, rhs: Leaf) -> Bool {
-                return lhs.app == rhs.app && lhs.surface === rhs.surface
+                return lhs.app.app == rhs.app.app && lhs.surface === rhs.surface
             }
             
             // MARK: - Codable
@@ -203,7 +203,7 @@ extension Ghostty {
                 // Decoding uses the global Ghostty app
                 guard let del = NSApplication.shared.delegate,
                       let appDel = del as? AppDelegate,
-                      let app = appDel.ghostty.app else {
+                      appDel.ghostty.app != nil else {
                     throw TerminalRestoreError.delegateInvalid
                 }
                 
@@ -212,7 +212,7 @@ extension Ghostty {
                 var config = SurfaceConfiguration()
                 config.workingDirectory = try container.decode(String?.self, forKey: .pwd)
                 
-                self.init(app, baseConfig: config, uuid: uuid)
+                self.init(appDel.ghostty, baseConfig: config, uuid: uuid)
             }
             
             func encode(to encoder: Encoder) throws {
@@ -223,7 +223,7 @@ extension Ghostty {
         }
 
         class Container: ObservableObject, Equatable, Hashable, Codable {
-            let app: ghostty_app_t
+            let app: Ghostty.App
             let direction: SplitViewDirection
 
             @Published var topLeft: SplitNode
@@ -335,7 +335,7 @@ extension Ghostty {
             // MARK: - Hashable
             
             func hash(into hasher: inout Hasher) {
-                hasher.combine(app)
+                hasher.combine(app.app)
                 hasher.combine(direction)
                 hasher.combine(topLeft)
                 hasher.combine(bottomRight)
@@ -344,7 +344,7 @@ extension Ghostty {
             // MARK: - Equatable
             
             static func == (lhs: Container, rhs: Container) -> Bool {
-                return lhs.app == rhs.app &&
+                return lhs.app.app == rhs.app.app &&
                     lhs.direction == rhs.direction &&
                     lhs.topLeft == rhs.topLeft &&
                     lhs.bottomRight == rhs.bottomRight
@@ -363,12 +363,12 @@ extension Ghostty {
                 // Decoding uses the global Ghostty app
                 guard let del = NSApplication.shared.delegate,
                       let appDel = del as? AppDelegate,
-                      let app = appDel.ghostty.app else {
+                      appDel.ghostty.app != nil else {
                     throw TerminalRestoreError.delegateInvalid
                 }
                 
                 let container = try decoder.container(keyedBy: CodingKeys.self)
-                self.app = app
+                self.app = appDel.ghostty
                 self.direction = try container.decode(SplitViewDirection.self, forKey: .direction)
                 self.split = try container.decode(CGFloat.self, forKey: .split)
                 self.topLeft = try container.decode(SplitNode.self, forKey: .topLeft)

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -9,8 +9,8 @@ extension Ghostty {
         @FocusedValue(\.ghosttySurfaceTitle) private var surfaceTitle: String?
 
         var body: some View {
-            if let app = self.ghostty.app {
-                SurfaceForApp(app) { surfaceView in
+            if self.ghostty.app != nil {
+                SurfaceForApp(self.ghostty) { surfaceView in
                     SurfaceWrapper(surfaceView: surfaceView)
                 }
                 .navigationTitle(surfaceTitle ?? "Ghostty")
@@ -24,7 +24,7 @@ extension Ghostty {
 
         @StateObject private var surfaceView: SurfaceView
 
-        init(_ app: ghostty_app_t, @ViewBuilder content: @escaping ((SurfaceView) -> Content)) {
+        init(_ app: Ghostty.App, @ViewBuilder content: @escaping ((SurfaceView) -> Content)) {
             _surfaceView = StateObject(wrappedValue: SurfaceView(app))
             self.content = content
         }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -976,6 +976,9 @@ keybind: Keybinds = .{},
 /// This option only applies to new windows when changed.
 @"macos-titlebar-tabs": bool = false,
 
+/// If `true`, render the drop shadow behind the macOS window.
+@"macos-window-shadow": bool = true,
+
 /// If `true`, the *Option* key will be treated as *Alt*. This makes terminal
 /// sequences expecting *Alt* to work properly, but will break Unicode input
 /// sequences on macOS if you use them via the *Alt* key. You may set this to


### PR DESCRIPTION
**Reasons for changes**
I wanted Ghostty to match the appearance of Terminal.app. As it stands currently, translucent backgrounds don't have a window border or shadow. This PR brings us up to parity with Terminal.app's translucent window offering.

**Changes**
- Plumb through `Ghostty.App` down to the SurfaceView constructor (it was already consuming a `ghostty_app_t`) to reach into the configuration when styling a window and check whether or not to apply a shadow.

<h3>Before (equivalent to `macos-window-shadow` = false)</h3>
<img width="903" alt="image" src="https://github.com/ghostty-org/ghostty/assets/15584994/57649de0-6216-4f9d-bb26-83fbcaed235a">


<h3>After (`macos-window-shadow` = true)</h3>
<img width="899" alt="image" src="https://github.com/ghostty-org/ghostty/assets/15584994/cee76bcd-c222-4a57-a0b5-1de554760003">


<small>Terminal.app for reference</small>
<img width="920" alt="Screenshot 2024-06-07 at 12 25 01 AM" src="https://github.com/ghostty-org/ghostty/assets/15584994/0c1de7ac-f370-4efb-b8e3-35a743108d13">
