### PR TITLE
os: std.ChildProcess -> std.process.Child

### DIFF
--- a/src/Command.zig
+++ b/src/Command.zig
@@ -1,14 +1,14 @@
 //! Command launches sub-processes. This is an alternate implementation to the
-//! Zig std.ChildProcess since at the time of authoring this, ChildProcess
+//! Zig std.process.Child since at the time of authoring this, std.process.Child
 //! didn't support the options necessary to spawn a shell attached to a pty.
 //!
-//! Consequently, I didn't implement a lot of features that std.ChildProcess
+//! Consequently, I didn't implement a lot of features that std.process.Child
 //! supports because we didn't need them. Cross-platform subprocessing is not
 //! a trivial thing to implement (I've done it in three separate languages now)
-//! so if we want to replatform onto std.ChildProcess I'd love to do that.
+//! so if we want to replatform onto std.process.Child I'd love to do that.
 //! This was just the fastest way to get something built.
 //!
-//! Issues with std.ChildProcess:
+//! Issues with std.process.Child:
 //!
 //!   * No pre_exec callback for logic after fork but before exec.
 //!   * posix_spawn is used for Mac, but doesn't support the necessary

--- a/src/os/flatpak.zig
+++ b/src/os/flatpak.zig
@@ -18,7 +18,7 @@ pub fn isFlatpak() bool {
 ///
 /// This always spawns its own thread and maintains its own GLib event loop.
 /// This makes it easy for the command to behave synchronously similar to
-/// std.process.ChildProcess.
+/// std.process.Child.
 ///
 /// There are lots of chances for low-hanging improvements here (automatic
 /// pipes, /dev/null, etc.) but this was purpose built for my needs so

--- a/src/os/homedir.zig
+++ b/src/os/homedir.zig
@@ -61,7 +61,7 @@ fn homeUnix(buf: []u8) !?[]u8 {
 
     // If all else fails, have the shell tell us...
     fba.reset();
-    const run = try std.ChildProcess.run(.{
+    const run = try std.process.Child.run(.{
         .allocator = fba.allocator(),
         .argv = &[_][]const u8{ "/bin/sh", "-c", "cd && pwd" },
         .max_output_bytes = fba.buffer.len / 2,


### PR DESCRIPTION
std.ChildProcess was deprecated in favor of std.process.Child a few releases back, and the old name is removed in Zig 0.13.0.