### PR TITLE
Use clone3 / CLONE_INTO_CGROUP on Linux

### DIFF
--- a/src/Command.zig
+++ b/src/Command.zig
@@ -32,8 +32,6 @@ const EnvMap = std.process.EnvMap;
 
 const PreExecFn = fn (*Command) void;
 
-const log = std.log.scoped(.command);
-
 /// Path to the command to run. This must be an absolute path. This
 /// library does not do PATH lookup.
 path: []const u8,

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -138,7 +138,7 @@ fn startPosix(self: *Command, arena: Allocator) !void {
     else
         @compileError("missing env vars");
 
-    const pid: linux.pid_t = switch (builtin.os.tag) {
+    const pid: posix.pid_t = switch (builtin.os.tag) {
         .linux => if (self.linux_cgroup) |cgroup| try internal_os.cgroup.cloneInto(cgroup) else try posix.fork(),
         else => try posix.fork(),
     };

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1315,6 +1315,7 @@ const Subprocess = struct {
                 }
             }).callback,
             .data = self,
+            .linux_cgroup = self.linux_cgroup,
         };
         try cmd.start(alloc);
         errdefer killCommand(&cmd) catch |err| {
@@ -1345,13 +1346,6 @@ const Subprocess = struct {
     fn childPreExec(self: *Subprocess) !void {
         // Setup our pty
         try self.pty.?.childPreExec();
-
-        // If we have a cgroup set, then we want to move into that cgroup.
-        if (comptime builtin.os.tag == .linux) {
-            if (self.linux_cgroup) |cgroup| {
-                try internal_os.cgroup.moveInto(cgroup, 0);
-            }
-        }
     }
 
     /// Called to notify that we exited externally so we can unset our

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -897,7 +897,7 @@ const Subprocess = struct {
     pty: ?Pty = null,
     command: ?Command = null,
     flatpak_command: ?FlatpakHostCommand = null,
-    linux_cgroup: termio.Options.LinuxCgroup = termio.Options.linux_cgroup_default,
+    linux_cgroup: Command.LinuxCgroup = Command.linux_cgroup_default,
 
     /// Initialize the subprocess. This will NOT start it, this only sets
     /// up the internal state necessary to start it later.
@@ -1196,8 +1196,8 @@ const Subprocess = struct {
 
         // If we have a cgroup, then we copy that into our arena so the
         // memory remains valid when we start.
-        const linux_cgroup: termio.Options.LinuxCgroup = cgroup: {
-            const default = termio.Options.linux_cgroup_default;
+        const linux_cgroup: Command.LinuxCgroup = cgroup: {
+            const default = Command.linux_cgroup_default;
             if (comptime builtin.os.tag != .linux) break :cgroup default;
             const path = opts.linux_cgroup orelse break :cgroup default;
             break :cgroup try alloc.dupe(u8, path);

--- a/src/termio/Options.zig
+++ b/src/termio/Options.zig
@@ -4,6 +4,7 @@ const builtin = @import("builtin");
 const xev = @import("xev");
 const apprt = @import("../apprt.zig");
 const renderer = @import("../renderer.zig");
+const Command = @import("../Command.zig");
 const Config = @import("../config.zig").Config;
 const termio = @import("../termio.zig");
 
@@ -45,7 +46,4 @@ surface_mailbox: apprt.surface.Mailbox,
 
 /// The cgroup to apply to the started termio process, if able by
 /// the termio implementation. This only applies to Linux.
-linux_cgroup: LinuxCgroup = linux_cgroup_default,
-
-pub const LinuxCgroup = if (builtin.os.tag == .linux) ?[]const u8 else void;
-pub const linux_cgroup_default = if (LinuxCgroup == void) {} else null;
+linux_cgroup: Command.LinuxCgroup = Command.linux_cgroup_default,


### PR DESCRIPTION
Use clone3 / CLONE_INTO_CGROUP to have the Linux kernel create the process in the correct cgroup rather than move the process into the cgroup after it is created.