### PR TITLE
consider any paste with bracketed paste closer unsafe

### DIFF
--- a/src/terminal/sanitize.zig
+++ b/src/terminal/sanitize.zig
@@ -2,7 +2,8 @@ const std = @import("std");
 
 /// Returns true if the data looks safe to paste.
 pub fn isSafePaste(data: []const u8) bool {
-    return std.mem.indexOf(u8, data, "\n") == null;
+    return std.mem.indexOf(u8, data, "\n") == null and
+        std.mem.indexOf(u8, data, "\x1b[201~") == null;
 }
 
 test isSafePaste {


### PR DESCRIPTION
Thanks to: https://thejh.net/misc/website-terminal-copy-paste

If a paste has the ending sentinel value for a bracketed paste ("\x1b[201~") then the shell may start processing data faster. We now consider this unsafe even if the `clipboard-paste-bracketed-safe` setting is true.

The first example in the URL above already was safe in Ghostty. The second previously executed code. It now triggers unsafe paste confirmation:

![CleanShot 2024-06-08 at 14 40 43@2x](https://github.com/ghostty-org/ghostty/assets/1299/245667f5-af9e-43a6-8ba4-3a15d2141d17)
