### PR TITLE
zig13 - fix some basic build errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .direnv/
 .flatpak-builder/
 zig-cache/
+.zig-cache/
 zig-out/
 /result*
 example/*.wasm

--- a/src/cli/list_colors.zig
+++ b/src/cli/list_colors.zig
@@ -31,7 +31,7 @@ pub fn run(alloc: std.mem.Allocator) !u8 {
 
     var keys = std.ArrayList([]const u8).init(alloc);
     defer keys.deinit();
-    for (x11_color.map.kvs) |kv| try keys.append(kv.key);
+    for (x11_color.map.keys()) |key| try keys.append(key);
 
     std.mem.sortUnstable([]const u8, keys.items, {}, struct {
         fn lessThan(_: void, lhs: []const u8, rhs: []const u8) bool {

--- a/src/input/keycodes.zig
+++ b/src/input/keycodes.zig
@@ -44,7 +44,7 @@ pub const Entry = struct {
 /// key value for Entry.
 const code_to_key = code_to_key: {
     @setEvalBranchQuota(5000);
-    break :code_to_key std.ComptimeStringMap(Key, .{
+    break :code_to_key std.StaticStringMap(Key).initComptime(.{
         .{ "KeyA", .a },
         .{ "KeyB", .b },
         .{ "KeyC", .c },

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -123,8 +123,8 @@ fn logFn(
     const prefix = if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
 
     // Lock so we are thread-safe
-    std.debug.getStderrMutex().lock();
-    defer std.debug.getStderrMutex().unlock();
+    std.debug.lockStdErr();
+    defer std.debug.unlockStdErr();
 
     // On Mac, we use unified logging. To view this:
     //

--- a/src/terminfo/Source.zig
+++ b/src/terminfo/Source.zig
@@ -65,7 +65,7 @@ pub fn encode(self: Source, writer: anytype) !void {
     }
 }
 
-/// Returns a ComptimeStringMap for all of the capabilities in this terminfo.
+/// Returns a StaticStringMap for all of the capabilities in this terminfo.
 /// The value is the value that should be sent as a response to XTGETTCAP.
 /// Important: the value is the FULL response included the escape sequences.
 pub fn xtgettcapMap(comptime self: Source) std.StaticStringMap([]const u8) {


### PR DESCRIPTION
Some very basic fixes I got in before I hit some difficulties with onigurama c library.

- `zig-cache` renamed to `.zig-cache`. I think it makes sense to keep the old gitignore entry.
- `ComptimeStringMap api changes
- ` std.debug.lockStdErr();` deprecated
