### PR TITLE
macos: regain window focus on inspector toggle

### DIFF
--- a/macos/Sources/Ghostty/InspectorView.swift
+++ b/macos/Sources/Ghostty/InspectorView.swift
@@ -37,6 +37,19 @@ extension Ghostty {
                 }
             }
             .onReceive(pubInspector) { onControlInspector($0) }
+            .onChange(of: surfaceView.inspectorVisible) { inspectorVisible in
+                // When we show the inspector, we want to focus on the inspector.
+                // When we hide the inspector, we want to move focus back to the surface.
+                if (inspectorVisible) {
+                    // We need to delay this until SwiftUI shows the inspector.
+                    DispatchQueue.main.async {
+                        _ = surfaceView.resignFirstResponder()
+                        inspectorFocus = true
+                    }
+                } else {
+                    Ghostty.moveFocus(to: surfaceView)
+                }
+            }
         }
         
         private func onControlInspector(_ notification: SwiftUI.Notification) {
@@ -56,18 +69,6 @@ extension Ghostty {
                 
             default:
                 return
-            }
-            
-            // When we show the inspector, we want to focus on the inspector.
-            // When we hide the inspector, we want to move focus back to the surface.
-            if (surfaceView.inspectorVisible) {
-                // We need to delay this until SwiftUI shows the inspector.
-                DispatchQueue.main.async {
-                    _ = surfaceView.resignFirstResponder()
-                    inspectorFocus = true
-                }
-            } else {
-                Ghostty.moveFocus(to: surfaceView)
             }
         }
     }


### PR DESCRIPTION
Fixes #734

I don't know much about SwiftUI, but here's why I think this works.

- Moving the `inspectorVisible` logic to an `onChange` ensures the view has at least seen that change.
- The dispatch to the main thread is still necessary to ensure the view hierarchy has completely updated after `inspectorVisible`.

Note that this fix is to correctly regain focus. We still lose window focus very briefly.