### PR TITLE
Various Performance Changes

### DIFF
--- a/pkg/macos/foundation/string.zig
+++ b/pkg/macos/foundation/string.zig
@@ -19,6 +19,17 @@ pub const String = opaque {
         )))) orelse Allocator.Error.OutOfMemory;
     }
 
+    pub fn createWithCharactersNoCopy(
+        unichars: []const u16,
+    ) *String {
+        return @as(*String, @ptrFromInt(@intFromPtr(c.CFStringCreateWithCharactersNoCopy(
+            null,
+            @ptrCast(unichars.ptr),
+            @intCast(unichars.len),
+            foundation.c.kCFAllocatorNull,
+        ))));
+    }
+
     pub fn release(self: *String) void {
         c.CFRelease(self);
     }

--- a/src/cache_table.zig
+++ b/src/cache_table.zig
@@ -46,7 +46,7 @@ pub fn CacheTable(
     comptime bucket_size: u8,
 ) type {
     return struct {
-        const Self = CacheTable(K, V, Context, bucket_count, bucket_size);
+        const Self = @This();
 
         const KV = struct {
             key: K,

--- a/src/cache_table.zig
+++ b/src/cache_table.zig
@@ -55,6 +55,7 @@ pub fn CacheTable(
 
         comptime {
             assert(std.math.isPowerOfTwo(bucket_count));
+            assert(bucket_count <= std.math.maxInt(usize));
         }
 
         /// `bucket_count` buckets containing `bucket_size` KV pairs each.
@@ -79,7 +80,7 @@ pub fn CacheTable(
         /// make room then it is returned in a struct with its key and value.
         pub fn put(self: *Self, key: K, value: V) ?KV {
             const kv: KV = .{ .key = key, .value = value };
-            const idx: u64 = self.context.hash(key) % bucket_count;
+            const idx: usize = @intCast(self.context.hash(key) % bucket_count);
 
             // If we have space available in the bucket then we just append
             if (self.lengths[idx] < bucket_size) {
@@ -105,8 +106,7 @@ pub fn CacheTable(
         ///
         /// Returns null if no item is found with the provided key.
         pub fn get(self: *Self, key: K) ?V {
-            const idx = self.context.hash(key) % bucket_count;
-
+            const idx: usize = @intCast(self.context.hash(key) % bucket_count);
             const len = self.lengths[idx];
             var i: usize = len;
             while (i > 0) {

--- a/src/cache_table.zig
+++ b/src/cache_table.zig
@@ -1,0 +1,135 @@
+const fastmem = @import("./fastmem.zig");
+
+const std = @import("std");
+const assert = std.debug.assert;
+
+/// An associative data structure used for efficiently storing and
+/// retrieving values which are able to be recomputed if necessary.
+///
+/// This structure is effectively a hash table with fixed-sized buckets.
+///
+/// When inserting an item in to a full bucket, the least recently used
+/// item is replaced.
+///
+/// To achieve this, when an item is accessed, it's moved to the end of
+/// the bucket, and the rest of the items are moved over to fill the gap.
+///
+/// This should provide very good query performance and keep frequently
+/// accessed items cached indefinitely.
+///
+/// Parameters:
+///
+/// `Context`
+///   A type containing methods to define CacheTable behaviors.
+///   - `fn hash(*Context, K) u64`    - Return a hash for a key.
+///   - `fn eql(*Context, K, K) bool` - Check two keys for equality.
+///
+///   - `fn evicted(*Context, K, V) void` - [OPTIONAL] Eviction callback.
+///     If present, called whenever an item is evicted from the cache.
+///
+/// `bucket_count`
+///   Should ideally be close to the median number of important items that
+///   you expect to be cached at any given point.
+///
+///   Performance will suffer if this is not a power of 2.
+///
+/// `bucket_size`
+///   should be larger if you expect a large number of unimportant items to
+///   enter the cache at a time. Having larger buckets will avoid important
+///   items being dropped from the cache prematurely.
+///
+pub fn CacheTable(
+    comptime K: type,
+    comptime V: type,
+    comptime Context: type,
+    comptime bucket_count: usize,
+    comptime bucket_size: u8,
+) type {
+    return struct {
+        const Self = CacheTable(K, V, Context, bucket_count, bucket_size);
+
+        const KV = struct {
+            key: K,
+            value: V,
+        };
+
+        /// `bucket_count` buckets containing `bucket_size` KV pairs each.
+        ///
+        /// We don't need to initialize this memory because we don't use it
+        /// unless it's within a bucket's stored length, which will guarantee
+        /// that we put actual items there.
+        buckets: [bucket_count][bucket_size]KV = undefined,
+
+        /// We use this array to keep track of how many slots in each bucket
+        /// have actual items in them. Once all the buckets fill up this will
+        /// become a pointless check, but hopefully branch prediction picks
+        /// up on it at that point. The memory cost isn't too bad since it's
+        /// just bytes, so should be a fraction the size of the main table.
+        lengths: [bucket_count]u8 = [_]u8{0} ** bucket_count,
+
+        /// An instance of the context structure.
+        /// Must be initialized before calling any operations.
+        context: Context,
+
+        /// Adds an item to the cache table. If an old value was removed to
+        /// make room then it is returned in a struct with its key and value.
+        pub fn put(self: *Self, key: K, value: V) ?KV {
+            const idx: u64 = self.context.hash(key) % bucket_count;
+
+            const kv = .{
+                .key = key,
+                .value = value,
+            };
+
+            if (self.lengths[idx] < bucket_size) {
+                self.buckets[idx][self.lengths[idx]] = kv;
+                self.lengths[idx] += 1;
+                return null;
+            }
+
+            assert(self.lengths[idx] == bucket_size);
+
+            const evicted = fastmem.rotateIn(KV, &self.buckets[idx], kv);
+
+            if (comptime @hasDecl(Context, "evicted")) {
+                self.context.evicted(evicted.key, evicted.value);
+            }
+
+            return evicted;
+        }
+
+        /// Retrieves an item from the cache table.
+        ///
+        /// Returns null if no item is found with the provided key.
+        pub fn get(self: *Self, key: K) ?V {
+            const idx = self.context.hash(key) % bucket_count;
+
+            const len = self.lengths[idx];
+            var i: usize = len;
+            while (i > 0) {
+                i -= 1;
+                if (self.context.eql(key, self.buckets[idx][i].key)) {
+                    defer fastmem.rotateOnce(KV, self.buckets[idx][i..len]);
+                    return self.buckets[idx][i].value;
+                }
+            }
+
+            return null;
+        }
+
+        /// Removes all items from the cache table.
+        ///
+        /// If your `Context` has an `evicted` method,
+        /// it will be called with all removed items.
+        pub fn clear(self: *Self) void {
+            if (comptime @hasDecl(Context, "evicted")) {
+                for (self.buckets, self.lengths) |b, l| {
+                    for (b[0..l]) |kv| {
+                        self.context.evicted(kv.key, kv.value);
+                    }
+                }
+            }
+            @memset(&self.lengths, 0);
+        }
+    };
+}

--- a/src/cf_release_thread.zig
+++ b/src/cf_release_thread.zig
@@ -1,0 +1,185 @@
+//! Represents the CFRelease thread. Pools of CFTypeRefs are sent to
+//! this thread to be released, so that their release callback logic
+//! doesn't block the execution of a high throughput thread like the
+//! renderer thread.
+pub const Thread = @This();
+
+const std = @import("std");
+const builtin = @import("builtin");
+const xev = @import("xev");
+const macos = @import("macos");
+
+const BlockingQueue = @import("./blocking_queue.zig").BlockingQueue;
+
+const Allocator = std.mem.Allocator;
+const log = std.log.scoped(.cf_release_thread);
+
+pub const Message = union(enum) {
+    /// Release a slice of CFTypeRefs. Uses alloc to
+    /// free the slice after releasing all the refs.
+    release: struct{
+        refs: []*anyopaque,
+        alloc: Allocator,
+    },
+};
+
+/// The type used for sending messages to the thread. For now this is
+/// hardcoded with a capacity. We can make this a comptime parameter in
+/// the future if we want it configurable.
+pub const Mailbox = BlockingQueue(Message, 64);
+
+/// Allocator used for some state
+alloc: std.mem.Allocator,
+
+/// The main event loop for the thread. The user data of this loop
+/// is always the allocator used to create the loop. This is a convenience
+/// so that users of the loop always have an allocator.
+loop: xev.Loop,
+
+/// This can be used to wake up the thread.
+wakeup: xev.Async,
+wakeup_c: xev.Completion = .{},
+
+/// This can be used to stop the thread on the next loop iteration.
+stop: xev.Async,
+stop_c: xev.Completion = .{},
+
+/// The mailbox that can be used to send this thread messages. Note
+/// this is a blocking queue so if it is full you will get errors (or block).
+mailbox: *Mailbox,
+
+flags: packed struct {
+    /// This is set to true only when an abnormal exit is detected. It
+    /// tells our mailbox system to drain and ignore all messages.
+    drain: bool = false,
+} = .{},
+
+/// Initialize the thread. This does not START the thread. This only sets
+/// up all the internal state necessary prior to starting the thread. It
+/// is up to the caller to start the thread with the threadMain entrypoint.
+pub fn init(
+    alloc: Allocator,
+) !Thread {
+    // Create our event loop.
+    var loop = try xev.Loop.init(.{});
+    errdefer loop.deinit();
+
+    // This async handle is used to "wake up" the thread to collect objects.
+    var wakeup_h = try xev.Async.init();
+    errdefer wakeup_h.deinit();
+
+    // This async handle is used to stop the loop and force the thread to end.
+    var stop_h = try xev.Async.init();
+    errdefer stop_h.deinit();
+
+    // The mailbox for messaging this thread
+    var mailbox = try Mailbox.create(alloc);
+    errdefer mailbox.destroy(alloc);
+
+    return Thread{
+        .alloc = alloc,
+        .loop = loop,
+        .wakeup = wakeup_h,
+        .stop = stop_h,
+        .mailbox = mailbox,
+    };
+}
+
+/// Clean up the thread. This is only safe to call once the thread
+/// completes executing; the caller must join prior to this.
+pub fn deinit(self: *Thread) void {
+    self.stop.deinit();
+    self.wakeup.deinit();
+    self.loop.deinit();
+
+    // Nothing can possibly access the mailbox anymore, destroy it.
+    self.mailbox.destroy(self.alloc);
+}
+
+/// The main entrypoint for the thread.
+pub fn threadMain(self: *Thread) void {
+    // Call child function so we can use errors...
+    self.threadMain_() catch |err| {
+        log.warn("error in cf release thread err={}", .{err});
+    };
+
+    // If our loop is not stopped, then we need to keep running so that
+    // messages are drained and we can wait for the surface to send a stop
+    // message.
+    if (!self.loop.flags.stopped) {
+        log.warn("abrupt cf release thread exit detected, starting xev to drain mailbox", .{});
+        defer log.debug("cf release thread fully exiting after abnormal failure", .{});
+        self.flags.drain = true;
+        self.loop.run(.until_done) catch |err| {
+            log.err("failed to start xev loop for draining err={}", .{err});
+        };
+    }
+}
+
+fn threadMain_(self: *Thread) !void {
+    defer log.debug("cf release thread exited", .{});
+
+    // Start the async handlers. We start these first so that they're
+    // registered even if anything below fails so we can drain the mailbox.
+    self.wakeup.wait(&self.loop, &self.wakeup_c, Thread, self, wakeupCallback);
+    self.stop.wait(&self.loop, &self.stop_c, Thread, self, stopCallback);
+
+    // Run
+    log.debug("starting cf release thread", .{});
+    defer log.debug("starting cf release thread shutdown", .{});
+    try self.loop.run(.until_done);
+}
+
+/// Drain the mailbox, handling all the messages in our terminal implementation.
+fn drainMailbox(self: *Thread) !void {
+    // If we're draining, we just drain the mailbox and return.
+    if (self.flags.drain) {
+        while (self.mailbox.pop()) |_| {}
+        return;
+    }
+
+    while (self.mailbox.pop()) |message| {
+        // log.debug("mailbox message={}", .{message});
+        switch (message) {
+            .release => |msg| {
+                for (msg.refs) |ref| {
+                    macos.foundation.CFRelease(ref);
+                }
+                // log.debug("Released {} CFTypeRefs.", .{ msg.refs.len });
+                msg.alloc.free(msg.refs);
+            }
+        }
+    }
+}
+
+fn wakeupCallback(
+    self_: ?*Thread,
+    _: *xev.Loop,
+    _: *xev.Completion,
+    r: xev.Async.WaitError!void,
+) xev.CallbackAction {
+    _ = r catch |err| {
+        log.err("error in wakeup err={}", .{err});
+        return .rearm;
+    };
+
+    const t = self_.?;
+
+    // When we wake up, we check the mailbox. Mailbox producers should
+    // wake up our thread after publishing.
+    t.drainMailbox() catch |err|
+        log.err("error draining mailbox err={}", .{err});
+
+    return .rearm;
+}
+
+fn stopCallback(
+    self_: ?*Thread,
+    _: *xev.Loop,
+    _: *xev.Completion,
+    r: xev.Async.WaitError!void,
+) xev.CallbackAction {
+    _ = r catch unreachable;
+    self_.?.loop.stop();
+    return .disarm;
+}

--- a/src/fastmem.zig
+++ b/src/fastmem.zig
@@ -22,12 +22,57 @@ pub inline fn copy(comptime T: type, dest: []T, source: []const T) void {
     }
 }
 
+/// Moves the first item to the end.
+/// For the reverse of this, use `fastmem.rotateOnceR`.
+///
 /// Same as std.mem.rotate(T, items, 1) but more efficient by using memmove
 /// and a tmp var for the single rotated item instead of 3 calls to reverse.
+///
+/// e.g. `0 1 2 3` -> `1 2 3 0`.
 pub inline fn rotateOnce(comptime T: type, items: []T) void {
     const tmp = items[0];
     move(T, items[0 .. items.len - 1], items[1..items.len]);
     items[items.len - 1] = tmp;
+}
+
+/// Moves the last item to the start.
+/// Reverse operation of `fastmem.rotateOnce`.
+///
+/// Same as std.mem.rotate(T, items, items.len - 1) but more efficient by
+/// using memmove and a tmp var for the single rotated item instead of 3
+/// calls to reverse.
+///
+/// e.g. `0 1 2 3` -> `3 0 1 2`.
+pub inline fn rotateOnceR(comptime T: type, items: []T) void {
+    const tmp = items[items.len - 1];
+    move(T, items[1..items.len], items[0 .. items.len - 1]);
+    items[0] = tmp;
+}
+
+/// Rotates a new item in to the end of a slice.
+/// The first item from the slice is removed and returned.
+///
+/// e.g. rotating `4` in to `0 1 2 3` makes it `1 2 3 4` and returns `0`.
+///
+/// For the reverse of this, use `fastmem.rotateInR`.
+pub inline fn rotateIn(comptime T: type, items: []T, item: T) T {
+    const removed = items[0];
+    move(T, items[0 .. items.len - 1], items[1..items.len]);
+    items[items.len - 1] = item;
+    return removed;
+}
+
+/// Rotates a new item in to the start of a slice.
+/// The last item from the slice is removed and returned.
+///
+/// e.g. rotating `4` in to `0 1 2 3` makes it `4 0 1 2` and returns `3`.
+///
+/// Reverse operation of `fastmem.rotateIn`.
+pub inline fn rotateInR(comptime T: type, items: []T, item: T) T {
+    const removed = items[items.len - 1];
+    move(T, items[1..items.len], items[0 .. items.len - 1]);
+    items[0] = item;
+    return removed;
 }
 
 extern "c" fn memcpy(*anyopaque, *const anyopaque, usize) *anyopaque;

--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -599,6 +599,14 @@ test "run iterator: empty cells with background set" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
+    var cf_release_pool = std.ArrayList(*anyopaque).init(alloc);
+    defer {
+        for (cf_release_pool.items) |ref| {
+            macos.foundation.CFRelease(ref);
+        }
+        cf_release_pool.deinit();
+    }
+
     var testdata = try testShaper(alloc);
     defer testdata.deinit();
 
@@ -638,7 +646,7 @@ test "run iterator: empty cells with background set" {
         );
         {
             const run = (try it.next(alloc)).?;
-            const cells = try shaper.shape(run);
+            const cells = try shaper.shape(run, &cf_release_pool);
             try testing.expectEqual(@as(usize, 3), cells.len);
         }
         try testing.expect(try it.next(alloc) == null);
@@ -648,6 +656,14 @@ test "run iterator: empty cells with background set" {
 test "shape" {
     const testing = std.testing;
     const alloc = testing.allocator;
+
+    var cf_release_pool = std.ArrayList(*anyopaque).init(alloc);
+    defer {
+        for (cf_release_pool.items) |ref| {
+            macos.foundation.CFRelease(ref);
+        }
+        cf_release_pool.deinit();
+    }
 
     var testdata = try testShaper(alloc);
     defer testdata.deinit();
@@ -675,7 +691,7 @@ test "shape" {
     var count: usize = 0;
     while (try it.next(alloc)) |run| {
         count += 1;
-        _ = try shaper.shape(run);
+        _ = try shaper.shape(run, &cf_release_pool);
     }
     try testing.expectEqual(@as(usize, 1), count);
 }
@@ -683,6 +699,14 @@ test "shape" {
 test "shape nerd fonts" {
     const testing = std.testing;
     const alloc = testing.allocator;
+
+    var cf_release_pool = std.ArrayList(*anyopaque).init(alloc);
+    defer {
+        for (cf_release_pool.items) |ref| {
+            macos.foundation.CFRelease(ref);
+        }
+        cf_release_pool.deinit();
+    }
 
     var testdata = try testShaperWithFont(alloc, .nerd_font);
     defer testdata.deinit();
@@ -710,7 +734,7 @@ test "shape nerd fonts" {
     var count: usize = 0;
     while (try it.next(alloc)) |run| {
         count += 1;
-        _ = try shaper.shape(run);
+        _ = try shaper.shape(run, &cf_release_pool);
     }
     try testing.expectEqual(@as(usize, 1), count);
 }
@@ -718,6 +742,14 @@ test "shape nerd fonts" {
 test "shape inconsolata ligs" {
     const testing = std.testing;
     const alloc = testing.allocator;
+
+    var cf_release_pool = std.ArrayList(*anyopaque).init(alloc);
+    defer {
+        for (cf_release_pool.items) |ref| {
+            macos.foundation.CFRelease(ref);
+        }
+        cf_release_pool.deinit();
+    }
 
     var testdata = try testShaper(alloc);
     defer testdata.deinit();
@@ -739,7 +771,7 @@ test "shape inconsolata ligs" {
         while (try it.next(alloc)) |run| {
             count += 1;
 
-            const cells = try shaper.shape(run);
+            const cells = try shaper.shape(run, &cf_release_pool);
             try testing.expectEqual(@as(usize, 2), cells.len);
             try testing.expect(cells[0].glyph_index != null);
             try testing.expect(cells[1].glyph_index == null);
@@ -764,7 +796,7 @@ test "shape inconsolata ligs" {
         while (try it.next(alloc)) |run| {
             count += 1;
 
-            const cells = try shaper.shape(run);
+            const cells = try shaper.shape(run, &cf_release_pool);
             try testing.expectEqual(@as(usize, 3), cells.len);
             try testing.expect(cells[0].glyph_index != null);
             try testing.expect(cells[1].glyph_index == null);
@@ -777,6 +809,14 @@ test "shape inconsolata ligs" {
 test "shape monaspace ligs" {
     const testing = std.testing;
     const alloc = testing.allocator;
+
+    var cf_release_pool = std.ArrayList(*anyopaque).init(alloc);
+    defer {
+        for (cf_release_pool.items) |ref| {
+            macos.foundation.CFRelease(ref);
+        }
+        cf_release_pool.deinit();
+    }
 
     var testdata = try testShaperWithFont(alloc, .monaspace_neon);
     defer testdata.deinit();
@@ -798,7 +838,7 @@ test "shape monaspace ligs" {
         while (try it.next(alloc)) |run| {
             count += 1;
 
-            const cells = try shaper.shape(run);
+            const cells = try shaper.shape(run, &cf_release_pool);
             try testing.expectEqual(@as(usize, 3), cells.len);
             try testing.expect(cells[0].glyph_index != null);
             try testing.expect(cells[1].glyph_index == null);
@@ -812,6 +852,14 @@ test "shape monaspace ligs" {
 test "shape left-replaced lig in last run" {
     const testing = std.testing;
     const alloc = testing.allocator;
+
+    var cf_release_pool = std.ArrayList(*anyopaque).init(alloc);
+    defer {
+        for (cf_release_pool.items) |ref| {
+            macos.foundation.CFRelease(ref);
+        }
+        cf_release_pool.deinit();
+    }
 
     var testdata = try testShaperWithFont(alloc, .geist_mono);
     defer testdata.deinit();
@@ -833,7 +881,7 @@ test "shape left-replaced lig in last run" {
         while (try it.next(alloc)) |run| {
             count += 1;
 
-            const cells = try shaper.shape(run);
+            const cells = try shaper.shape(run, &cf_release_pool);
             try testing.expectEqual(@as(usize, 3), cells.len);
             try testing.expect(cells[0].glyph_index != null);
             try testing.expect(cells[1].glyph_index == null);
@@ -847,6 +895,14 @@ test "shape left-replaced lig in last run" {
 test "shape left-replaced lig in early run" {
     const testing = std.testing;
     const alloc = testing.allocator;
+
+    var cf_release_pool = std.ArrayList(*anyopaque).init(alloc);
+    defer {
+        for (cf_release_pool.items) |ref| {
+            macos.foundation.CFRelease(ref);
+        }
+        cf_release_pool.deinit();
+    }
 
     var testdata = try testShaperWithFont(alloc, .geist_mono);
     defer testdata.deinit();
@@ -866,7 +922,7 @@ test "shape left-replaced lig in early run" {
         );
 
         const run = (try it.next(alloc)).?;
-        const cells = try shaper.shape(run);
+        const cells = try shaper.shape(run, &cf_release_pool);
         try testing.expectEqual(@as(usize, 4), cells.len);
         try testing.expect(cells[0].glyph_index != null);
         try testing.expect(cells[1].glyph_index == null);
@@ -879,6 +935,14 @@ test "shape left-replaced lig in early run" {
 test "shape U+3C9 with JB Mono" {
     const testing = std.testing;
     const alloc = testing.allocator;
+
+    var cf_release_pool = std.ArrayList(*anyopaque).init(alloc);
+    defer {
+        for (cf_release_pool.items) |ref| {
+            macos.foundation.CFRelease(ref);
+        }
+        cf_release_pool.deinit();
+    }
 
     var testdata = try testShaperWithFont(alloc, .jetbrains_mono);
     defer testdata.deinit();
@@ -901,7 +965,7 @@ test "shape U+3C9 with JB Mono" {
         var cell_count: usize = 0;
         while (try it.next(alloc)) |run| {
             run_count += 1;
-            const cells = try shaper.shape(run);
+            const cells = try shaper.shape(run, &cf_release_pool);
             cell_count += cells.len;
         }
         try testing.expectEqual(@as(usize, 1), run_count);
@@ -912,6 +976,14 @@ test "shape U+3C9 with JB Mono" {
 test "shape emoji width" {
     const testing = std.testing;
     const alloc = testing.allocator;
+
+    var cf_release_pool = std.ArrayList(*anyopaque).init(alloc);
+    defer {
+        for (cf_release_pool.items) |ref| {
+            macos.foundation.CFRelease(ref);
+        }
+        cf_release_pool.deinit();
+    }
 
     var testdata = try testShaper(alloc);
     defer testdata.deinit();
@@ -933,7 +1005,7 @@ test "shape emoji width" {
         while (try it.next(alloc)) |run| {
             count += 1;
 
-            const cells = try shaper.shape(run);
+            const cells = try shaper.shape(run, &cf_release_pool);
             try testing.expectEqual(@as(usize, 1), cells.len);
         }
         try testing.expectEqual(@as(usize, 1), count);
@@ -943,6 +1015,14 @@ test "shape emoji width" {
 test "shape emoji width long" {
     const testing = std.testing;
     const alloc = testing.allocator;
+
+    var cf_release_pool = std.ArrayList(*anyopaque).init(alloc);
+    defer {
+        for (cf_release_pool.items) |ref| {
+            macos.foundation.CFRelease(ref);
+        }
+        cf_release_pool.deinit();
+    }
 
     var testdata = try testShaper(alloc);
     defer testdata.deinit();
@@ -972,7 +1052,7 @@ test "shape emoji width long" {
     var count: usize = 0;
     while (try it.next(alloc)) |run| {
         count += 1;
-        const cells = try shaper.shape(run);
+        const cells = try shaper.shape(run, &cf_release_pool);
 
         // screen.testWriteString isn't grapheme aware, otherwise this is one
         try testing.expectEqual(@as(usize, 5), cells.len);
@@ -983,6 +1063,14 @@ test "shape emoji width long" {
 test "shape variation selector VS15" {
     const testing = std.testing;
     const alloc = testing.allocator;
+
+    var cf_release_pool = std.ArrayList(*anyopaque).init(alloc);
+    defer {
+        for (cf_release_pool.items) |ref| {
+            macos.foundation.CFRelease(ref);
+        }
+        cf_release_pool.deinit();
+    }
 
     var testdata = try testShaper(alloc);
     defer testdata.deinit();
@@ -1009,7 +1097,7 @@ test "shape variation selector VS15" {
     var count: usize = 0;
     while (try it.next(alloc)) |run| {
         count += 1;
-        const cells = try shaper.shape(run);
+        const cells = try shaper.shape(run, &cf_release_pool);
         try testing.expectEqual(@as(usize, 1), cells.len);
     }
     try testing.expectEqual(@as(usize, 1), count);
@@ -1018,6 +1106,14 @@ test "shape variation selector VS15" {
 test "shape variation selector VS16" {
     const testing = std.testing;
     const alloc = testing.allocator;
+
+    var cf_release_pool = std.ArrayList(*anyopaque).init(alloc);
+    defer {
+        for (cf_release_pool.items) |ref| {
+            macos.foundation.CFRelease(ref);
+        }
+        cf_release_pool.deinit();
+    }
 
     var testdata = try testShaper(alloc);
     defer testdata.deinit();
@@ -1044,7 +1140,7 @@ test "shape variation selector VS16" {
     var count: usize = 0;
     while (try it.next(alloc)) |run| {
         count += 1;
-        const cells = try shaper.shape(run);
+        const cells = try shaper.shape(run, &cf_release_pool);
         try testing.expectEqual(@as(usize, 1), cells.len);
     }
     try testing.expectEqual(@as(usize, 1), count);
@@ -1053,6 +1149,14 @@ test "shape variation selector VS16" {
 test "shape with empty cells in between" {
     const testing = std.testing;
     const alloc = testing.allocator;
+
+    var cf_release_pool = std.ArrayList(*anyopaque).init(alloc);
+    defer {
+        for (cf_release_pool.items) |ref| {
+            macos.foundation.CFRelease(ref);
+        }
+        cf_release_pool.deinit();
+    }
 
     var testdata = try testShaper(alloc);
     defer testdata.deinit();
@@ -1077,7 +1181,7 @@ test "shape with empty cells in between" {
     while (try it.next(alloc)) |run| {
         count += 1;
 
-        const cells = try shaper.shape(run);
+        const cells = try shaper.shape(run, &cf_release_pool);
         try testing.expectEqual(@as(usize, 1), count);
         try testing.expectEqual(@as(usize, 7), cells.len);
     }
@@ -1086,6 +1190,14 @@ test "shape with empty cells in between" {
 test "shape Chinese characters" {
     const testing = std.testing;
     const alloc = testing.allocator;
+
+    var cf_release_pool = std.ArrayList(*anyopaque).init(alloc);
+    defer {
+        for (cf_release_pool.items) |ref| {
+            macos.foundation.CFRelease(ref);
+        }
+        cf_release_pool.deinit();
+    }
 
     var testdata = try testShaper(alloc);
     defer testdata.deinit();
@@ -1115,7 +1227,7 @@ test "shape Chinese characters" {
     while (try it.next(alloc)) |run| {
         count += 1;
 
-        const cells = try shaper.shape(run);
+        const cells = try shaper.shape(run, &cf_release_pool);
         try testing.expectEqual(@as(usize, 4), cells.len);
         try testing.expectEqual(@as(u16, 0), cells[0].x);
         try testing.expectEqual(@as(u16, 0), cells[1].x);
@@ -1128,6 +1240,14 @@ test "shape Chinese characters" {
 test "shape box glyphs" {
     const testing = std.testing;
     const alloc = testing.allocator;
+
+    var cf_release_pool = std.ArrayList(*anyopaque).init(alloc);
+    defer {
+        for (cf_release_pool.items) |ref| {
+            macos.foundation.CFRelease(ref);
+        }
+        cf_release_pool.deinit();
+    }
 
     var testdata = try testShaper(alloc);
     defer testdata.deinit();
@@ -1154,7 +1274,7 @@ test "shape box glyphs" {
     var count: usize = 0;
     while (try it.next(alloc)) |run| {
         count += 1;
-        const cells = try shaper.shape(run);
+        const cells = try shaper.shape(run, &cf_release_pool);
         try testing.expectEqual(@as(usize, 2), cells.len);
         try testing.expectEqual(@as(u32, 0x2500), cells[0].glyph_index.?);
         try testing.expectEqual(@as(u16, 0), cells[0].x);
@@ -1167,6 +1287,14 @@ test "shape box glyphs" {
 test "shape selection boundary" {
     const testing = std.testing;
     const alloc = testing.allocator;
+
+    var cf_release_pool = std.ArrayList(*anyopaque).init(alloc);
+    defer {
+        for (cf_release_pool.items) |ref| {
+            macos.foundation.CFRelease(ref);
+        }
+        cf_release_pool.deinit();
+    }
 
     var testdata = try testShaper(alloc);
     defer testdata.deinit();
@@ -1194,7 +1322,7 @@ test "shape selection boundary" {
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
             count += 1;
-            _ = try shaper.shape(run);
+            _ = try shaper.shape(run, &cf_release_pool);
         }
         try testing.expectEqual(@as(usize, 1), count);
     }
@@ -1217,7 +1345,7 @@ test "shape selection boundary" {
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
             count += 1;
-            _ = try shaper.shape(run);
+            _ = try shaper.shape(run, &cf_release_pool);
         }
         try testing.expectEqual(@as(usize, 2), count);
     }
@@ -1240,7 +1368,7 @@ test "shape selection boundary" {
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
             count += 1;
-            _ = try shaper.shape(run);
+            _ = try shaper.shape(run, &cf_release_pool);
         }
         try testing.expectEqual(@as(usize, 2), count);
     }
@@ -1263,7 +1391,7 @@ test "shape selection boundary" {
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
             count += 1;
-            _ = try shaper.shape(run);
+            _ = try shaper.shape(run, &cf_release_pool);
         }
         try testing.expectEqual(@as(usize, 3), count);
     }
@@ -1286,7 +1414,7 @@ test "shape selection boundary" {
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
             count += 1;
-            _ = try shaper.shape(run);
+            _ = try shaper.shape(run, &cf_release_pool);
         }
         try testing.expectEqual(@as(usize, 3), count);
     }
@@ -1295,6 +1423,14 @@ test "shape selection boundary" {
 test "shape cursor boundary" {
     const testing = std.testing;
     const alloc = testing.allocator;
+
+    var cf_release_pool = std.ArrayList(*anyopaque).init(alloc);
+    defer {
+        for (cf_release_pool.items) |ref| {
+            macos.foundation.CFRelease(ref);
+        }
+        cf_release_pool.deinit();
+    }
 
     var testdata = try testShaper(alloc);
     defer testdata.deinit();
@@ -1318,7 +1454,7 @@ test "shape cursor boundary" {
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
             count += 1;
-            _ = try shaper.shape(run);
+            _ = try shaper.shape(run, &cf_release_pool);
         }
         try testing.expectEqual(@as(usize, 1), count);
     }
@@ -1337,7 +1473,7 @@ test "shape cursor boundary" {
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
             count += 1;
-            _ = try shaper.shape(run);
+            _ = try shaper.shape(run, &cf_release_pool);
         }
         try testing.expectEqual(@as(usize, 2), count);
     }
@@ -1356,7 +1492,7 @@ test "shape cursor boundary" {
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
             count += 1;
-            _ = try shaper.shape(run);
+            _ = try shaper.shape(run, &cf_release_pool);
         }
         try testing.expectEqual(@as(usize, 3), count);
     }
@@ -1375,7 +1511,7 @@ test "shape cursor boundary" {
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
             count += 1;
-            _ = try shaper.shape(run);
+            _ = try shaper.shape(run, &cf_release_pool);
         }
         try testing.expectEqual(@as(usize, 2), count);
     }
@@ -1384,6 +1520,14 @@ test "shape cursor boundary" {
 test "shape cursor boundary and colored emoji" {
     const testing = std.testing;
     const alloc = testing.allocator;
+
+    var cf_release_pool = std.ArrayList(*anyopaque).init(alloc);
+    defer {
+        for (cf_release_pool.items) |ref| {
+            macos.foundation.CFRelease(ref);
+        }
+        cf_release_pool.deinit();
+    }
 
     var testdata = try testShaper(alloc);
     defer testdata.deinit();
@@ -1407,7 +1551,7 @@ test "shape cursor boundary and colored emoji" {
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
             count += 1;
-            _ = try shaper.shape(run);
+            _ = try shaper.shape(run, &cf_release_pool);
         }
         try testing.expectEqual(@as(usize, 1), count);
     }
@@ -1426,7 +1570,7 @@ test "shape cursor boundary and colored emoji" {
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
             count += 1;
-            _ = try shaper.shape(run);
+            _ = try shaper.shape(run, &cf_release_pool);
         }
         try testing.expectEqual(@as(usize, 1), count);
     }
@@ -1443,7 +1587,7 @@ test "shape cursor boundary and colored emoji" {
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
             count += 1;
-            _ = try shaper.shape(run);
+            _ = try shaper.shape(run, &cf_release_pool);
         }
         try testing.expectEqual(@as(usize, 1), count);
     }
@@ -1452,6 +1596,14 @@ test "shape cursor boundary and colored emoji" {
 test "shape cell attribute change" {
     const testing = std.testing;
     const alloc = testing.allocator;
+
+    var cf_release_pool = std.ArrayList(*anyopaque).init(alloc);
+    defer {
+        for (cf_release_pool.items) |ref| {
+            macos.foundation.CFRelease(ref);
+        }
+        cf_release_pool.deinit();
+    }
 
     var testdata = try testShaper(alloc);
     defer testdata.deinit();
@@ -1473,7 +1625,7 @@ test "shape cell attribute change" {
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
             count += 1;
-            _ = try shaper.shape(run);
+            _ = try shaper.shape(run, &cf_release_pool);
         }
         try testing.expectEqual(@as(usize, 1), count);
     }
@@ -1497,7 +1649,7 @@ test "shape cell attribute change" {
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
             count += 1;
-            _ = try shaper.shape(run);
+            _ = try shaper.shape(run, &cf_release_pool);
         }
         try testing.expectEqual(@as(usize, 2), count);
     }
@@ -1522,7 +1674,7 @@ test "shape cell attribute change" {
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
             count += 1;
-            _ = try shaper.shape(run);
+            _ = try shaper.shape(run, &cf_release_pool);
         }
         try testing.expectEqual(@as(usize, 2), count);
     }
@@ -1547,7 +1699,7 @@ test "shape cell attribute change" {
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
             count += 1;
-            _ = try shaper.shape(run);
+            _ = try shaper.shape(run, &cf_release_pool);
         }
         try testing.expectEqual(@as(usize, 1), count);
     }
@@ -1571,7 +1723,7 @@ test "shape cell attribute change" {
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
             count += 1;
-            _ = try shaper.shape(run);
+            _ = try shaper.shape(run, &cf_release_pool);
         }
         try testing.expectEqual(@as(usize, 1), count);
     }

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -74,6 +74,10 @@ pub const Shaper = struct {
         self.hb_feats.deinit(self.alloc);
     }
 
+    pub fn endFrame(self: *const Shaper) void {
+        _ = self;
+    }
+
     /// Returns an iterator that returns one text run at a time for the
     /// given terminal row. Note that text runs are are only valid one at a time
     /// for a Shaper struct since they share state.

--- a/src/font/shaper/noop.zig
+++ b/src/font/shaper/noop.zig
@@ -64,6 +64,10 @@ pub const Shaper = struct {
         self.run_state.deinit(self.alloc);
     }
 
+    pub fn endFrame(self: *const Shaper) void {
+        _ = self;
+    }
+
     pub fn runIterator(
         self: *Shaper,
         grid: *SharedGrid,

--- a/src/font/shaper/web_canvas.zig
+++ b/src/font/shaper/web_canvas.zig
@@ -52,6 +52,10 @@ pub const Shaper = struct {
         self.* = undefined;
     }
 
+    pub fn endFrame(self: *const Shaper) void {
+        _ = self;
+    }
+
     /// Returns an iterator that returns one text run at a time for the
     /// given terminal row. Note that text runs are are only valid one at a time
     /// for a Shaper struct since they share state.

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -319,6 +319,7 @@ test {
 
     // TODO
     _ = @import("blocking_queue.zig");
+    _ = @import("cache_table.zig");
     _ = @import("config.zig");
     _ = @import("lru.zig");
 }

--- a/src/os/cf_release_thread.zig
+++ b/src/os/cf_release_thread.zig
@@ -9,15 +9,15 @@ const builtin = @import("builtin");
 const xev = @import("xev");
 const macos = @import("macos");
 
-const BlockingQueue = @import("./blocking_queue.zig").BlockingQueue;
+const BlockingQueue = @import("../blocking_queue.zig").BlockingQueue;
 
 const Allocator = std.mem.Allocator;
 const log = std.log.scoped(.cf_release_thread);
 
 pub const Message = union(enum) {
-    /// Release a slice of CFTypeRefs. Uses alloc to
-    /// free the slice after releasing all the refs.
-    release: struct{
+    /// Release a slice of CFTypeRefs. Uses alloc to free the slice after
+    /// releasing all the refs.
+    release: struct {
         refs: []*anyopaque,
         alloc: Allocator,
     },
@@ -142,12 +142,10 @@ fn drainMailbox(self: *Thread) !void {
         // log.debug("mailbox message={}", .{message});
         switch (message) {
             .release => |msg| {
-                for (msg.refs) |ref| {
-                    macos.foundation.CFRelease(ref);
-                }
+                for (msg.refs) |ref| macos.foundation.CFRelease(ref);
                 // log.debug("Released {} CFTypeRefs.", .{ msg.refs.len });
                 msg.alloc.free(msg.refs);
-            }
+            },
         }
     }
 }

--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -1,5 +1,6 @@
 //! The "os" package contains utilities for interfacing with the operating
-//! system.
+//! system. These aren't restricted to syscalls or low-level operations, but
+//! also OS-specific features and conventions.
 
 pub usingnamespace @import("env.zig");
 pub usingnamespace @import("desktop.zig");
@@ -12,6 +13,7 @@ pub usingnamespace @import("mouse.zig");
 pub usingnamespace @import("open.zig");
 pub usingnamespace @import("pipe.zig");
 pub usingnamespace @import("resourcesdir.zig");
+pub const CFReleaseThread = @import("cf_release_thread.zig");
 pub const TempDir = @import("TempDir.zig");
 pub const cgroup = @import("cgroup.zig");
 pub const passwd = @import("passwd.zig");

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -15,6 +15,7 @@ const xev = @import("xev");
 const apprt = @import("../apprt.zig");
 const configpkg = @import("../config.zig");
 const font = @import("../font/main.zig");
+const os = @import("../os/main.zig");
 const terminal = @import("../terminal/main.zig");
 const renderer = @import("../renderer.zig");
 const math = @import("../math.zig");
@@ -25,10 +26,9 @@ const shadertoy = @import("shadertoy.zig");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const ArenaAllocator = std.heap.ArenaAllocator;
+const CFReleaseThread = os.CFReleaseThread;
 const Terminal = terminal.Terminal;
 const Health = renderer.Health;
-
-const CFReleaseThread = @import("../cf_release_thread.zig");
 
 const mtl = @import("metal/api.zig");
 const mtl_buffer = @import("metal/buffer.zig");

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1877,9 +1877,11 @@ fn rebuildCells(
     color_palette: *const terminal.color.Palette,
 ) !void {
     // const start = try std.time.Instant.now();
+    // const start_micro = std.time.microTimestamp();
     // defer {
     //     const end = std.time.Instant.now() catch unreachable;
-    //     std.log.warn("rebuildCells time={}us", .{end.since(start) / std.time.ns_per_us});
+    //     // "[rebuildCells time] <START us>\t<TIME_TAKEN us>"
+    //     std.log.warn("[rebuildCells time] {}\t{}", .{start_micro, end.since(start) / std.time.ns_per_us});
     // }
 
     // Create an arena for all our temporary allocations while rebuilding

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -732,6 +732,10 @@ pub fn updateFrame(
             critical.cursor_style,
             &critical.color_palette,
         );
+
+        // Notify our shaper we're done for the frame. For some shapers like
+        // CoreText this triggers off-thread cleanup logic.
+        self.font_shaper.endFrame();
     }
 }
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -1025,16 +1025,7 @@ pub fn rebuildCells(
         while (try iter.next(self.alloc)) |run| {
             // Try to read the cells from the shaping cache if we can.
             const shaper_cells = self.font_shaper_cache.get(run) orelse cache: {
-                const cells = if (font.options.backend == .coretext) ct: {
-                    var cf_release_pool = std.ArrayList(*anyopaque).init(self.alloc);
-                    defer {
-                        for (cf_release_pool.items) |ref| {
-                            @import("macos").foundation.CFRelease(ref);
-                        }
-                        cf_release_pool.deinit();
-                    }
-                    break :ct try self.font_shaper.shape(run, &cf_release_pool);
-                } else try self.font_shaper.shape(run);
+                const cells = try self.font_shaper.shape(run);
 
                 // Try to cache them. If caching fails for any reason we continue
                 // because it is just a performance optimization, not a correctness

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -1025,7 +1025,16 @@ pub fn rebuildCells(
         while (try iter.next(self.alloc)) |run| {
             // Try to read the cells from the shaping cache if we can.
             const shaper_cells = self.font_shaper_cache.get(run) orelse cache: {
-                const cells = try self.font_shaper.shape(run);
+                const cells = if (font.options.backend == .coretext) ct: {
+                    var cf_release_pool = std.ArrayList(*anyopaque).init(self.alloc);
+                    defer {
+                        for (cf_release_pool.items) |ref| {
+                            @import("macos").foundation.CFRelease(ref);
+                        }
+                        cf_release_pool.deinit();
+                    }
+                    break :ct try self.font_shaper.shape(run, &cf_release_pool);
+                } else try self.font_shaper.shape(run);
 
                 // Try to cache them. If caching fails for any reason we continue
                 // because it is just a performance optimization, not a correctness

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -197,7 +197,7 @@ pub const Page = struct {
             .styles = style.Set.init(
                 buf.add(l.styles_start),
                 l.styles_layout,
-                style.StyleSetContext{},
+                .{},
             ),
             .grapheme_alloc = GraphemeAlloc.init(
                 buf.add(l.grapheme_alloc_start),

--- a/src/terminal/ref_counted_set.zig
+++ b/src/terminal/ref_counted_set.zig
@@ -431,8 +431,7 @@ pub fn RefCountedSet(
             const hash: u64 = self.context.hash(value);
 
             for (0..self.max_psl + 1) |i| {
-                const p = (hash + i) & self.layout.table_mask;
-
+                const p: usize = @intCast((hash + i) & self.layout.table_mask);
                 const id = table[p];
 
                 // Empty bucket, our item cannot have probed to

--- a/src/terminal/style.zig
+++ b/src/terminal/style.zig
@@ -62,11 +62,11 @@ pub const Style = struct {
                     _ = try writer.write("Color.none");
                 },
                 .palette => |p| {
-                    _ = try writer.print("Color.palette{{ {} }}", .{ p });
+                    _ = try writer.print("Color.palette{{ {} }}", .{p});
                 },
                 .rgb => |rgb| {
                     _ = try writer.print("Color.rgb{{ {}, {}, {} }}", .{ rgb.r, rgb.g, rgb.b });
-                }
+                },
             }
         }
     };
@@ -243,23 +243,21 @@ pub const Style = struct {
     }
 };
 
-pub const StyleSetContext = struct {
-    pub fn hash(self: *StyleSetContext, style: Style) u64 {
-        _ = self;
-        return style.hash();
-    }
-
-    pub fn eql(self: *StyleSetContext, a: Style, b: Style) bool {
-        _ = self;
-        return a.eql(b);
-    }
-};
-
 pub const Set = RefCountedSet(
     Style,
     Id,
     size.CellCountInt,
-    StyleSetContext,
+    struct {
+        pub fn hash(self: *const @This(), style: Style) u64 {
+            _ = self;
+            return style.hash();
+        }
+
+        pub fn eql(self: *const @This(), a: Style, b: Style) bool {
+            _ = self;
+            return a.eql(b);
+        }
+    },
 );
 
 test "Set basic usage" {
@@ -272,7 +270,7 @@ test "Set basic usage" {
     const style: Style = .{ .flags = .{ .bold = true } };
     const style2: Style = .{ .flags = .{ .italic = true } };
 
-    var set = Set.init(OffsetBuf.init(buf), layout, StyleSetContext{});
+    var set = Set.init(OffsetBuf.init(buf), layout, .{});
 
     // Add style
     const id = try set.add(buf, style);


### PR DESCRIPTION
This PR comprises 4 separate performance-focused improvements. These are generally explained for the most part by the commit messages and comments in files, but I'll give a brief summary here:
1. Introduces CacheTable structure, a "forgetful" hashtable that can be generically used for caching various things; right now only applied to the shaper cache.
2. Introduces RefCountedSet structure, a generic structure for efficiently storing and querying reference counted items with associated IDs; right now only applied to `Style.Set`.
3. In the CoreText shaper, cache fonts between calls to `shape`, to avoid running the expensive `CTFontCreateCopyWithAttributes` method repeatedly.
4. Create dedicated thread to call `CFRelease` on CoreFoundation objects that are produced during shaping, since these calls can result in expensive cleanup in an object's release callback.

### Benchmarks
To validate the improvements from these changes, I ran a benchmark after each one, measuring `rebuildCells` times during a 5 second run of `cmatrix -u0` (first 15 samples are removed) - since `cmatrix` performance under the CoreText shaper being poor was the motivating issue that I aimed to address when looking in to these changes.

<img width="983" alt="image" src="https://github.com/ghostty-org/ghostty/assets/7241851/cf56f4c9-db8e-4e69-8bb7-9af2a431afa9">

### Note
I have one more change in mind. The shaper interface as used by the renderer code currently results in some serious bottlenecks, wasted duplication of expensive work, and cache inefficiencies. I have a subtle but important change to the shaper interface planned which I've validated on my test branch to have a significant impact since it addresses the main problems quite well. I was originally going to include the change in this PR but life has been getting in the way lately so I decided it's better to get these changes in now since they can stand on their own. When I get around to implementing it, I expect the `rebuildCells` times under that benchmark to be around 2000µs, which ought to be good enough I think.