### PR TITLE
Make vim ftdetect file pattern more flexible

### DIFF
--- a/src/config/vim.zig
+++ b/src/config/vim.zig
@@ -3,7 +3,7 @@ const Config = @import("Config.zig");
 
 /// This is the associated Vim file as named by the variable.
 pub const syntax = comptimeGenSyntax();
-pub const ftdetect = "au BufRead,BufNewFile */.config/ghostty/config set ft=ghostty\n";
+pub const ftdetect = "au BufRead,BufNewFile */ghostty/config set ft=ghostty\n";
 pub const ftplugin =
     \\" Vim filetype plugin file
     \\" Language: Ghostty config file


### PR DESCRIPTION
The current file detect pattern is not flexible to custom `XDG_CONFIG_HOME` locations, but for my use case it's not flexible to editing the config files with [chezmoi](https://chezmoi.io), which renames the `.config` directory to `dot_config`. This change makes the file pattern only match `ghostty/config` with any parent directory.
