### PR TITLE
Update libxev to improve mach port resource usage

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .dependencies = .{
         // Zig libs
         .libxev = .{
-            .url = "https://github.com/mitchellh/libxev/archive/b3f9918776b8700b337b7ebe769060328fe246b0.tar.gz",
-            .hash = "122044caf67c7833c7110dc93531031899e459a6818ed125a0bcfdb0b5243bd7700b",
+            .url = "https://github.com/mitchellh/libxev/archive/efde8a170836334901ed2d59c98bf832eb48ae3a.tar.gz",
+            .hash = "1220bf10f4fc109ca0b50520075e2e730900956e220adee616a01f3f91bc8a802695",
         },
         .mach_glfw = .{
             .url = "https://github.com/mitchellh/mach-glfw/archive/20c773d86df269722d8926f98bc8af26ebd90999.tar.gz",

--- a/nix/zigCacheHash.nix
+++ b/nix/zigCacheHash.nix
@@ -1,3 +1,3 @@
 # This file is auto-generated! check build-support/check-zig-cache-hash.sh for
 # more details.
-"sha256-D4ehUg3T+leY0C0DnGUiXEpHCaFp4nHIzDvtzo8X/Mc="
+"sha256-C+YVTjCuEDLZYZ9/bXfTI2bYVUKUtmxMQsttEcBJQwM="


### PR DESCRIPTION
Fixes #1836

Upstream: https://github.com/mitchellh/libxev/commit/efde8a170836334901ed2d59c98bf832eb48ae3a

![CleanShot 2024-06-23 at 21 38 10@2x](https://github.com/ghostty-org/ghostty/assets/1299/73c166a2-ccf3-4ccc-96b4-375739d18055)
