### PR TITLE
Fix a few RefCountedSet problems

### DIFF
--- a/src/inspector/page.zig
+++ b/src/inspector/page.zig
@@ -37,7 +37,7 @@ pub fn render(page: *const terminal.Page) void {
         }
         {
             _ = cimgui.c.igTableSetColumnIndex(1);
-            cimgui.c.igText("%d", page.styles.count(page.memory));
+            cimgui.c.igText("%d", page.styles.count());
         }
     }
     {

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -490,6 +490,12 @@ pub fn clone(
             src.* = old_dst;
             dirty.setValue(i, dirty.isSet(i + chunk.start));
         }
+
+        // We need to clear the rows we're about to truncate.
+        for (len..page.data.size.rows) |i| {
+            page.data.clearCells(&rows[i], 0, page.data.size.cols);
+        }
+
         page.data.size.rows = @intCast(len);
         total_rows += len;
 

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -1845,7 +1845,7 @@ pub const AdjustCapacity = struct {
     /// Adjust the number of styles in the page. This may be
     /// rounded up if necessary to fit alignment requirements,
     /// but it will never be rounded down.
-    styles: ?u16 = null,
+    styles: ?usize = null,
 
     /// Adjust the number of available grapheme bytes in the page.
     grapheme_bytes: ?usize = null,
@@ -1877,7 +1877,7 @@ pub fn adjustCapacity(
     var cap = page.data.capacity;
 
     if (adjustment.styles) |v| {
-        const aligned = try std.math.ceilPowerOfTwo(u16, v);
+        const aligned = try std.math.ceilPowerOfTwo(usize, v);
         cap.styles = @max(cap.styles, aligned);
     }
     if (adjustment.grapheme_bytes) |v| {

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -2826,8 +2826,8 @@ test "Terminal: print over wide char with bold" {
     try t.print(0x1F600); // Smiley face
     // verify we have styles in our style map
     {
-        const page = t.screen.cursor.page_pin.page.data;
-        try testing.expectEqual(@as(usize, 1), page.styles.count(page.memory));
+        const page = &t.screen.cursor.page_pin.page.data;
+        try testing.expectEqual(@as(usize, 1), page.styles.count());
     }
 
     // Go back and overwrite with no style
@@ -2837,8 +2837,8 @@ test "Terminal: print over wide char with bold" {
 
     // verify our style is gone
     {
-        const page = t.screen.cursor.page_pin.page.data;
-        try testing.expectEqual(@as(usize, 0), page.styles.count(page.memory));
+        const page = &t.screen.cursor.page_pin.page.data;
+        try testing.expectEqual(@as(usize, 0), page.styles.count());
     }
 
     try testing.expect(t.isDirty(.{ .screen = .{ .x = 0, .y = 0 } }));
@@ -2856,8 +2856,8 @@ test "Terminal: print over wide char with bg color" {
     try t.print(0x1F600); // Smiley face
     // verify we have styles in our style map
     {
-        const page = t.screen.cursor.page_pin.page.data;
-        try testing.expectEqual(@as(usize, 1), page.styles.count(page.memory));
+        const page = &t.screen.cursor.page_pin.page.data;
+        try testing.expectEqual(@as(usize, 1), page.styles.count());
     }
 
     // Go back and overwrite with no style
@@ -2867,8 +2867,8 @@ test "Terminal: print over wide char with bg color" {
 
     // verify our style is gone
     {
-        const page = t.screen.cursor.page_pin.page.data;
-        try testing.expectEqual(@as(usize, 0), page.styles.count(page.memory));
+        const page = &t.screen.cursor.page_pin.page.data;
+        try testing.expectEqual(@as(usize, 0), page.styles.count());
     }
 
     try testing.expect(t.isDirty(.{ .screen = .{ .x = 0, .y = 0 } }));
@@ -3322,7 +3322,7 @@ test "Terminal: overwrite multicodepoint grapheme clears grapheme data" {
     try testing.expectEqual(@as(usize, 2), t.screen.cursor.x);
 
     // We should have one cell with graphemes
-    const page = t.screen.cursor.page_pin.page.data;
+    const page = &t.screen.cursor.page_pin.page.data;
     try testing.expectEqual(@as(usize, 1), page.graphemeCount());
 
     // Move back and overwrite wide
@@ -3362,7 +3362,7 @@ test "Terminal: overwrite multicodepoint grapheme tail clears grapheme data" {
     try testing.expectEqual(@as(usize, 2), t.screen.cursor.x);
 
     // We should have one cell with graphemes
-    const page = t.screen.cursor.page_pin.page.data;
+    const page = &t.screen.cursor.page_pin.page.data;
     try testing.expectEqual(@as(usize, 1), page.graphemeCount());
 
     // Move back and overwrite wide
@@ -4534,8 +4534,8 @@ test "Terminal: insertLines handles style refs" {
     try t.setAttribute(.{ .unset = {} });
 
     // verify we have styles in our style map
-    const page = t.screen.cursor.page_pin.page.data;
-    try testing.expectEqual(@as(usize, 1), page.styles.count(page.memory));
+    const page = &t.screen.cursor.page_pin.page.data;
+    try testing.expectEqual(@as(usize, 1), page.styles.count());
 
     t.setCursorPos(2, 2);
     t.insertLines(1);
@@ -4547,7 +4547,7 @@ test "Terminal: insertLines handles style refs" {
     }
 
     // verify we have no styles in our style map
-    try testing.expectEqual(@as(usize, 0), page.styles.count(page.memory));
+    try testing.expectEqual(@as(usize, 0), page.styles.count());
 }
 
 test "Terminal: insertLines outside of scroll region" {
@@ -5336,14 +5336,14 @@ test "Terminal: eraseChars handles refcounted styles" {
     try t.print('C');
 
     // verify we have styles in our style map
-    const page = t.screen.cursor.page_pin.page.data;
-    try testing.expectEqual(@as(usize, 1), page.styles.count(page.memory));
+    const page = &t.screen.cursor.page_pin.page.data;
+    try testing.expectEqual(@as(usize, 1), page.styles.count());
 
     t.setCursorPos(1, 1);
     t.eraseChars(2);
 
     // verify we have no styles in our style map
-    try testing.expectEqual(@as(usize, 0), page.styles.count(page.memory));
+    try testing.expectEqual(@as(usize, 0), page.styles.count());
 }
 
 test "Terminal: eraseChars protected attributes respected with iso" {
@@ -7043,7 +7043,7 @@ test "Terminal: bold style" {
         const cell = list_cell.cell;
         try testing.expectEqual(@as(u21, 'A'), cell.content.codepoint);
         try testing.expect(cell.style_id != 0);
-        const page = t.screen.cursor.page_pin.page.data;
+        const page = &t.screen.cursor.page_pin.page.data;
         try testing.expect(page.styles.refCount(page.memory, t.screen.cursor.style_id) > 1);
     }
 }
@@ -7067,8 +7067,8 @@ test "Terminal: garbage collect overwritten" {
     }
 
     // verify we have no styles in our style map
-    const page = t.screen.cursor.page_pin.page.data;
-    try testing.expectEqual(@as(usize, 0), page.styles.count(page.memory));
+    const page = &t.screen.cursor.page_pin.page.data;
+    try testing.expectEqual(@as(usize, 0), page.styles.count());
 }
 
 test "Terminal: do not garbage collect old styles in use" {
@@ -7089,8 +7089,8 @@ test "Terminal: do not garbage collect old styles in use" {
     }
 
     // verify we have no styles in our style map
-    const page = t.screen.cursor.page_pin.page.data;
-    try testing.expectEqual(@as(usize, 1), page.styles.count(page.memory));
+    const page = &t.screen.cursor.page_pin.page.data;
+    try testing.expectEqual(@as(usize, 1), page.styles.count());
 }
 
 test "Terminal: print with style marks the row as styled" {
@@ -7425,7 +7425,7 @@ test "Terminal: insertBlanks deleting graphemes" {
     try t.print(0x1F467);
 
     // We should have one cell with graphemes
-    const page = t.screen.cursor.page_pin.page.data;
+    const page = &t.screen.cursor.page_pin.page.data;
     try testing.expectEqual(@as(usize, 1), page.graphemeCount());
 
     t.setCursorPos(1, 1);
@@ -7461,7 +7461,7 @@ test "Terminal: insertBlanks shift graphemes" {
     try t.print(0x1F467);
 
     // We should have one cell with graphemes
-    const page = t.screen.cursor.page_pin.page.data;
+    const page = &t.screen.cursor.page_pin.page.data;
     try testing.expectEqual(@as(usize, 1), page.graphemeCount());
 
     t.setCursorPos(1, 1);

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -1027,7 +1027,7 @@ pub const Capacity = struct {
     rows: size.CellCountInt,
 
     /// Number of unique styles that can be used on this page.
-    styles: u16 = 16,
+    styles: usize = 16,
 
     /// Number of bytes to allocate for grapheme data.
     grapheme_bytes: usize = grapheme_bytes_default,

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -500,7 +500,7 @@ pub const Page = struct {
         return result;
     }
 
-    pub const CloneFromError = Allocator.Error || error{OutOfMemory};
+    pub const CloneFromError = Allocator.Error || style.Set.AddError;
 
     /// Clone the contents of another page into this page. The capacities
     /// can be different, but the size of the other page must fit into

--- a/src/terminal/ref_counted_set.zig
+++ b/src/terminal/ref_counted_set.zig
@@ -374,7 +374,7 @@ pub fn RefCountedSet(
         }
 
         /// Get the current number of non-dead items in the set.
-        pub fn count(self: *Self) usize {
+        pub fn count(self: *const Self) usize {
             return self.living;
         }
 

--- a/src/terminal/ref_counted_set.zig
+++ b/src/terminal/ref_counted_set.zig
@@ -401,7 +401,7 @@ pub fn RefCountedSet(
             items[id] = .{};
 
             var p: Id = item.meta.bucket;
-            var n: Id = @addWithOverflow(p, 1)[0] & self.layout.table_mask;
+            var n: Id = (p +% 1) & self.layout.table_mask;
 
             while (table[n] != 0 and items[table[n]].meta.psl > 0) {
                 items[table[n]].meta.bucket = p;
@@ -410,7 +410,7 @@ pub fn RefCountedSet(
                 self.psl_stats[items[table[n]].meta.psl] += 1;
                 table[p] = table[n];
                 p = n;
-                n = @addWithOverflow(n, 1)[0] & self.layout.table_mask;
+                n = (p +% 1) & self.layout.table_mask;
             }
 
             while (self.max_psl > 0 and self.psl_stats[self.max_psl] == 0) {

--- a/src/terminal/ref_counted_set.zig
+++ b/src/terminal/ref_counted_set.zig
@@ -339,10 +339,7 @@ pub fn RefCountedSet(
 
             assert(item.meta.ref > 0);
             item.meta.ref -= 1;
-
-            if (item.meta.ref == 0) {
-                self.living -= 1;
-            }
+            if (item.meta.ref == 0) self.living -= 1;
         }
 
         /// Release a specified number of references to an item by its ID.


### PR DESCRIPTION
Fixes #1873 and a few problems that made themselves known after/while fixing that one, specifically:
- Memory leak in `PageList.clone`
- Under-utilization of possible `Id` space because capacity size limited by `Id`
- Bad input causes repeated `OutOfMemory` errors to grow the set beyond what it can grow to or what is necessary-- fixed by introducing `NeedsRehash` error for cases where new IDs are not accessible to the Set but at least 10% of the currently used IDs belong to dead items.