### PR TITLE
Change GSK_RENDERER to opengl instead ngl which is set by default

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -81,6 +81,9 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
     // Upstream issue: https://gitlab.gnome.org/GNOME/gtk/-/issues/6589
     _ = internal_os.setenv("GDK_DEBUG", "opengl,gl-disable-gles");
 
+    // We need to export GSK_RENDERER to opengl because GTK uses ngl by default after 4.14
+    _ = internal_os.setenv("GSK_RENDERER", "opengl");
+
     // Load our configuration
     var config = try Config.load(core_app.alloc);
     errdefer config.deinit();


### PR DESCRIPTION
When GTK 4.14 released, it used ngl by default with GSK_RENDERER. It leads to destroy VAO state when we closed tab or detached tab. It handles gl state incorrectly with our opengl engine.

This is a fix for that issue.