### PR TITLE
macos: update Sparkle to 2.6.3

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -29,7 +29,7 @@ jobs:
       # Setup Sparkle
       - name: Setup Sparkle
         env:
-          SPARKLE_VERSION: 2.5.1
+          SPARKLE_VERSION: 2.6.3
         run: |
           mkdir -p .action/sparkle
           cd .action/sparkle

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -53,7 +53,7 @@ jobs:
       # Setup Sparkle
       - name: Setup Sparkle
         env:
-          SPARKLE_VERSION: 2.5.1
+          SPARKLE_VERSION: 2.6.3
         run: |
           mkdir -p .action/sparkle
           cd .action/sparkle

--- a/macos/Ghostty.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Ghostty.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,14 +1,15 @@
 {
+  "originHash" : "e721da7f9826abdffcb6185e886155efa2514bd6234475f1afa893e29eb258d6",
   "pins" : [
     {
       "identity" : "sparkle",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "1f07f4096e52f19b5e7abaa697b7fc592b7ff57c",
-        "version" : "2.5.1"
+        "revision" : "b456fd404954a9e13f55aa0c88cd5a40b8399638",
+        "version" : "2.6.3"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }


### PR DESCRIPTION
There are numerous fixes since our previous version (2.5.1) and I believe at least one is one that users have hit where unarchiving didn't work properly despite a properly built archive. I'm hoping this improves that.

Besides this, there is one major security fix. I think it was low risk to our project currently but I read through it and it is sensible to protect against the case.