### PR TITLE
docs: Convert 'unfocused-split-fill' comments into doc block

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -389,11 +389,11 @@ palette: Palette = .{},
 /// valid value.
 @"unfocused-split-opacity": f64 = 0.7,
 
-// The color to dim the unfocused split. Unfocused splits are dimmed by
-// rendering a semi-transparent rectangle over the split. This sets the color of
-// that rectangle and can be used to carefully control the dimming effect.
-//
-// This will default to the background color.
+/// The color to dim the unfocused split. Unfocused splits are dimmed by
+/// rendering a semi-transparent rectangle over the split. This sets the color of
+/// that rectangle and can be used to carefully control the dimming effect.
+///
+/// This will default to the background color.
 @"unfocused-split-fill": ?Color = null,
 
 /// The command to run, usually a shell. If this is not an absolute path, it'll


### PR DESCRIPTION
# Summary

Pretty minor but the missing context inside `ghostty +show-config --default --docs` made me think it was experimental at first. Satisfying the trope of "gets added to project, makes day 1 documentation PR".

# Test Plan

```
> zig build
xcframework successfully written out to: /private/var/folders/3s/w_9thc5x5zj6d5vyf_9j9xw00000gn/T/tmp.FQ4vpGvCts/ghostty/macos/GhosttyKit.xcframework
> echo $?
0

> man -P 'grep unfocused-split-fill -A5' zig-out/share/man/man1/ghostty.1
       --unfocused-split-fill
              The color to dim the unfocused split.  Unfocused splits are dimmed by rendering a semi-transparent rectangle over the
              split.  This sets the color of that rectangle and can be used to carefully control the dimming effect.

              This will default to the background color.
```

Not exactly sure what the best way to get a runnable binary is on macOS, but this seems to be generated from the same stuff. 

`cd macos && xcodebuild` generated stuff, but `build/Ghostty.build/ReleaseLocal/Ghostty.build/Objects-normal/arm64/Binary/ghostty` gets killed immediately from what I assume might be code-signing problem? ¯\_(ツ)_/¯ 