### PR TITLE
Mouse Pressure Support and QuickLook on macOS

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -558,6 +558,7 @@ uintptr_t ghostty_surface_selection(ghostty_surface_t, char*, uintptr_t);
 void ghostty_surface_set_display_id(ghostty_surface_t, uint32_t);
 void* ghostty_surface_quicklook_font(ghostty_surface_t);
 void ghostty_surface_selection_range(ghostty_surface_t, uint32_t*, uint32_t*);
+void ghostty_surface_selection_point(ghostty_surface_t, double*, double*);
 #endif
 
 ghostty_inspector_t ghostty_surface_inspector(ghostty_surface_t);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -557,6 +557,7 @@ uintptr_t ghostty_surface_selection(ghostty_surface_t, char*, uintptr_t);
 #ifdef __APPLE__
 void ghostty_surface_set_display_id(ghostty_surface_t, uint32_t);
 void* ghostty_surface_quicklook_font(ghostty_surface_t);
+void ghostty_surface_selection_range(ghostty_surface_t, uint32_t*, uint32_t*);
 #endif
 
 ghostty_inspector_t ghostty_surface_inspector(ghostty_surface_t);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -374,6 +374,13 @@ typedef struct {
 } ghostty_error_s;
 
 typedef struct {
+  double tl_px_x;
+  double tl_px_y;
+  uint32_t offset_start;
+  uint32_t offset_len;
+} ghostty_selection_s;
+
+typedef struct {
   void* nsview;
 } ghostty_platform_macos_s;
 
@@ -557,8 +564,7 @@ uintptr_t ghostty_surface_selection(ghostty_surface_t, char*, uintptr_t);
 #ifdef __APPLE__
 void ghostty_surface_set_display_id(ghostty_surface_t, uint32_t);
 void* ghostty_surface_quicklook_font(ghostty_surface_t);
-void ghostty_surface_selection_range(ghostty_surface_t, uint32_t*, uint32_t*);
-void ghostty_surface_selection_point(ghostty_surface_t, double*, double*);
+bool ghostty_surface_selection_info(ghostty_surface_t, ghostty_selection_s*);
 #endif
 
 ghostty_inspector_t ghostty_surface_inspector(ghostty_surface_t);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -535,6 +535,7 @@ void ghostty_surface_mouse_scroll(ghostty_surface_t,
                                   double,
                                   double,
                                   ghostty_input_scroll_mods_t);
+void ghostty_surface_mouse_pressure(ghostty_surface_t, uint32_t, double);
 void ghostty_surface_ime_point(ghostty_surface_t, double*, double*);
 void ghostty_surface_request_close(ghostty_surface_t);
 void ghostty_surface_split(ghostty_surface_t, ghostty_split_direction_e);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -556,6 +556,7 @@ uintptr_t ghostty_surface_selection(ghostty_surface_t, char*, uintptr_t);
 
 #ifdef __APPLE__
 void ghostty_surface_set_display_id(ghostty_surface_t, uint32_t);
+void* ghostty_surface_quicklook_font(ghostty_surface_t);
 #endif
 
 ghostty_inspector_t ghostty_surface_inspector(ghostty_surface_t);

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -1006,11 +1006,21 @@ extension Ghostty.SurfaceView: NSTextInputClient {
         guard let surface = self.surface else {
             return NSMakeRect(frame.origin.x, frame.origin.y, 0, 0)
         }
-
+        
         // Ghostty will tell us where it thinks an IME keyboard should render.
         var x: Double = 0;
         var y: Double = 0;
-        ghostty_surface_ime_point(surface, &x, &y)
+        
+        // QuickLook never gives us a matching range to our selection so if we detect
+        // this then we return the top-left selection point rather than the cursor point.
+        // This is hacky but I can't think of a better way to get the right IME vs. QuickLook
+        // point right now. I'm sure I'm missing something fundamental...
+        if range.length > 0 && range != self.selectedRange() {
+            // QuickLook
+            ghostty_surface_selection_point(surface, &x, &y)
+        } else {
+            ghostty_surface_ime_point(surface, &x, &y)
+        }
 
         // Ghostty coordinates are in top-left (0, 0) so we have to convert to
         // bottom-left since that is what UIKit expects

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -578,6 +578,13 @@ extension Ghostty {
         }
         
         override func pressureChange(with event: NSEvent) {
+            guard let surface = self.surface else { return }
+            
+            // Notify Ghostty first. We do this because this will let Ghostty handle
+            // state setup that we'll need for later pressure handling (such as
+            // QuickLook)
+            ghostty_surface_mouse_pressure(surface, UInt32(event.stage), Double(event.pressure))
+            
             // Pressure stage 2 is force click. We only want to execute this on the
             // initial transition to stage 2, and not for any repeated events.
             guard self.prevPressureStage < 2 else { return }

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -450,6 +450,9 @@ extension Ghostty {
             guard let surface = self.surface else { return }
             let mods = Ghostty.ghosttyMods(event.modifierFlags)
             ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, mods)
+            
+            // Release pressure
+            ghostty_surface_mouse_pressure(surface, 0, 0)
         }
 
         override func otherMouseDown(with event: NSEvent) {

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -1,4 +1,3 @@
-import QuickLookUI
 import SwiftUI
 import UserNotifications
 import GhosttyKit
@@ -914,31 +913,6 @@ extension Ghostty {
                 Ghostty.moveFocus(to: self)
             }
         }
-        
-        // MARK: QuickLook
-        
-        private var quickLookURL: NSURL?
-        
-        override func quickLook(with event: NSEvent) {
-            /* TODO
-            guard let panel = QLPreviewPanel.shared() else { return }
-            panel.delegate = self
-            panel.dataSource = self
-            panel.makeKeyAndOrderFront(self)
-             */
-        }
-    }
-}
-    
-// MARK: QuickLook Delegates
-
-extension Ghostty.SurfaceView: QLPreviewPanelDelegate, QLPreviewPanelDataSource {
-    func numberOfPreviewItems(in panel: QLPreviewPanel!) -> Int {
-        return quickLookURL != nil ? 1 : 0
-    }
-    
-    func  previewPanel(_ panel: QLPreviewPanel!, previewItemAt index: Int) -> (any QLPreviewItem)! {
-        return quickLookURL ?? nil
     }
 }
 

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -1018,8 +1018,10 @@ extension Ghostty.SurfaceView: NSTextInputClient {
             // QuickLook
             var sel: ghostty_selection_s = ghostty_selection_s();
             if ghostty_surface_selection_info(surface, &sel) {
-                x = sel.tl_px_x;
-                y = sel.tl_px_y;
+                // The -2/+2 here is subjective. QuickLook seems to offset the rectangle
+                // a bit and I think these small adjustments make it look more natural.
+                x = sel.tl_px_x - 2;
+                y = sel.tl_px_y + 2;
             } else {
                 ghostty_surface_ime_point(surface, &x, &y)
             }

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -962,7 +962,7 @@ extension Ghostty.SurfaceView: NSTextInputClient {
     }
 
     func attributedSubstring(forProposedRange range: NSRange, actualRange: NSRangePointer?) -> NSAttributedString? {
-        Ghostty.logger.warning("pressure substring range=\(range) selectedRange=\(self.selectedRange())")
+        // Ghostty.logger.warning("pressure substring range=\(range) selectedRange=\(self.selectedRange())")
         guard let surface = self.surface else { return nil }
         guard ghostty_surface_has_selection(surface) else { return nil }
         

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -716,6 +716,17 @@ pub const Surface = struct {
         };
     }
 
+    pub fn mousePressureCallback(
+        self: *Surface,
+        stage: input.MousePressureStage,
+        pressure: f64,
+    ) void {
+        self.core_surface.mousePressureCallback(stage, pressure) catch |err| {
+            log.err("error in mouse pressure callback err={}", .{err});
+            return;
+        };
+    }
+
     pub fn scrollCallback(
         self: *Surface,
         xoff: f64,
@@ -1646,6 +1657,25 @@ pub const CAPI = struct {
             y,
             @bitCast(@as(u8, @truncate(@as(c_uint, @bitCast(scroll_mods))))),
         );
+    }
+
+    export fn ghostty_surface_mouse_pressure(
+        surface: *Surface,
+        stage_raw: u32,
+        pressure: f64,
+    ) void {
+        const stage = std.meta.intToEnum(
+            input.MousePressureStage,
+            stage_raw,
+        ) catch {
+            log.warn(
+                "invalid mouse pressure stage value={}",
+                .{stage_raw},
+            );
+            return;
+        };
+
+        surface.mousePressureCallback(stage, pressure);
     }
 
     export fn ghostty_surface_ime_point(surface: *Surface, x: *f64, y: *f64) void {

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1823,6 +1823,16 @@ pub const CAPI = struct {
             len.* = range.len;
         }
 
+        export fn ghostty_surface_selection_point(
+            ptr: *Surface,
+            x: *f64,
+            y: *f64,
+        ) void {
+            const point = ptr.core_surface.selectionPoint() orelse return;
+            x.* = point.x;
+            y.* = point.y;
+        }
+
         export fn ghostty_inspector_metal_init(ptr: *Inspector, device: objc.c.id) bool {
             return ptr.initMetal(objc.Object.fromId(device));
         }

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1803,6 +1803,26 @@ pub const CAPI = struct {
             return copy;
         }
 
+        /// This returns the start and length of the current selection range
+        /// in viewport coordinates. If the selection is not visible in the
+        /// viewport completely then this will return 0,0. This rather odd
+        /// detail is due to the current usage of this in the macOS app where
+        /// selections are only meaningful if they're in the viewport. We can
+        /// change this behavior if we have something useful to do with the
+        /// selection range outside of the viewport in the future.
+        export fn ghostty_surface_selection_range(
+            ptr: *Surface,
+            start: *u32,
+            len: *u32,
+        ) void {
+            start.* = 0;
+            len.* = 0;
+
+            const range = ptr.core_surface.selectionRange() orelse return;
+            start.* = range.start;
+            len.* = range.len;
+        }
+
         export fn ghostty_inspector_metal_init(ptr: *Inspector, device: objc.c.id) bool {
             return ptr.initMetal(objc.Object.fromId(device));
         }

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1799,6 +1799,9 @@ pub const CAPI = struct {
             const collection = &grid.resolver.collection;
             const face = collection.getFace(.{}) catch return null;
 
+            // TODO(pressure-click): the font size below only does
+            // the initial font size and not the current font size.
+
             // The font is not the right size by default so we need
             // to set it to our configured window size.
             const copy = face.font.copyWithAttributes(

--- a/src/apprt/structs.zig
+++ b/src/apprt/structs.zig
@@ -74,3 +74,18 @@ pub const ColorScheme = enum(u2) {
     light = 0,
     dark = 1,
 };
+
+/// Selection information
+pub const Selection = struct {
+    /// Top-left point of the selection in the viewport in scaled
+    /// window pixels. (0,0) is the top-left of the window.
+    tl_x_px: f64,
+    tl_y_px: f64,
+
+    /// The offset of the selection start in cells from the top-left
+    /// of the viewport.
+    ///
+    /// This is a strange metric but its used by macOS.
+    offset_start: u32,
+    offset_len: u32,
+};

--- a/src/input/mouse.zig
+++ b/src/input/mouse.zig
@@ -63,6 +63,22 @@ pub const MouseMomentum = enum(u3) {
     may_begin = 6,
 };
 
+/// The pressure stage of a pressure-sensitive input device.
+///
+/// This currently only supports the stages that macOS supports.
+pub const MousePressureStage = enum(u2) {
+    /// The input device is unpressed.
+    none = 0,
+
+    /// The input device is pressed a normal amount. On macOS trackpads,
+    /// this is after a "click".
+    normal = 1,
+
+    /// The input device is pressed a deep amount. On macOS trackpads,
+    /// this is after a "force click".
+    deep = 2,
+};
+
 /// The bitmask for mods for scroll events.
 pub const ScrollMods = packed struct(u8) {
     /// True if this is a high-precision scroll event. For example, Apple


### PR DESCRIPTION
This PR does a few things:

**Makes the core aware of "mouse pressure" for pressure-sensitive mouse devices.** This could apply to Linux too. In the future we could expose mouse pressure and stages in new VT sequences.

**Connects macOS mouse pressure to support "force click."** On macOS this does word select so that QuickLook works as expected.

**Makes QuickLook work on macOS.** See video below.

This should also lay the foundation for contextual (right-click) menus in the future. 


https://github.com/ghostty-org/ghostty/assets/1299/b60239b0-b90a-4da1-92ae-c9cb0c4a65bc

