### PR TITLE
docs: add a note about config reload to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ documented in the comments. You also can search for the
 [public config files](https://github.com/search?q=path%3Aghostty%2Fconfig&type=code)
 of many Ghostty users for examples and inspiration.
 
+> [!NOTE]
+>
+> Configuration can be reloaded on the fly with the `reload_config`
+>command. Not all configuration options can  change without restarting Ghostty.
+>Any options that require a restart should  be documented.
+
 #### Configuration Errors
 
 If your configuration file has any errors, Ghostty does its best to ignore

--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ of many Ghostty users for examples and inspiration.
 > [!NOTE]
 >
 > Configuration can be reloaded on the fly with the `reload_config`
->command. Not all configuration options can  change without restarting Ghostty.
->Any options that require a restart should  be documented.
+> command. Not all configuration options can change without restarting Ghostty.
+> Any options that require a restart should be documented.
 
 #### Configuration Errors
 


### PR DESCRIPTION
<img width="938" alt="image" src="https://github.com/ghostty-org/ghostty/assets/555011/e2111eff-34a2-4b8d-815c-859d194f5305">

Added a small section about config reload, and included the expectation that any config option that can't be reloaded is documented.