### PR TITLE
macOS: Context Menu

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -533,7 +533,7 @@ ghostty_input_mods_e ghostty_surface_key_translation_mods(ghostty_surface_t,
                                                           ghostty_input_mods_e);
 void ghostty_surface_key(ghostty_surface_t, ghostty_input_key_s);
 void ghostty_surface_text(ghostty_surface_t, const char*, uintptr_t);
-void ghostty_surface_mouse_button(ghostty_surface_t,
+bool ghostty_surface_mouse_button(ghostty_surface_t,
                                   ghostty_input_mouse_state_e,
                                   ghostty_input_mouse_button_e,
                                   ghostty_input_mods_e);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -533,6 +533,7 @@ ghostty_input_mods_e ghostty_surface_key_translation_mods(ghostty_surface_t,
                                                           ghostty_input_mods_e);
 void ghostty_surface_key(ghostty_surface_t, ghostty_input_key_s);
 void ghostty_surface_text(ghostty_surface_t, const char*, uintptr_t);
+bool ghostty_surface_mouse_captured(ghostty_surface_t);
 bool ghostty_surface_mouse_button(ghostty_surface_t,
                                   ghostty_input_mouse_state_e,
                                   ghostty_input_mouse_button_e,

--- a/macos/Ghostty.xcodeproj/project.pbxproj
+++ b/macos/Ghostty.xcodeproj/project.pbxproj
@@ -50,6 +50,8 @@
 		A59630A02AEF6AEB00D64628 /* TerminalManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A596309F2AEF6AEB00D64628 /* TerminalManager.swift */; };
 		A59630A22AF0415000D64628 /* Ghostty.TerminalSplit.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59630A12AF0415000D64628 /* Ghostty.TerminalSplit.swift */; };
 		A59630A42AF059BB00D64628 /* Ghostty.SplitNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59630A32AF059BB00D64628 /* Ghostty.SplitNode.swift */; };
+		A5985CD72C320C4500C57AD3 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5985CD62C320C4500C57AD3 /* String+Extension.swift */; };
+		A5985CD82C320C4500C57AD3 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5985CD62C320C4500C57AD3 /* String+Extension.swift */; };
 		A59FB5CF2AE0DB50009128F3 /* InspectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59FB5CE2AE0DB50009128F3 /* InspectorView.swift */; };
 		A59FB5D12AE0DEA7009128F3 /* MetalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59FB5D02AE0DEA7009128F3 /* MetalView.swift */; };
 		A5A1F8852A489D6800D1E8BC /* terminfo in Resources */ = {isa = PBXBuildFile; fileRef = A5A1F8842A489D6800D1E8BC /* terminfo */; };
@@ -111,6 +113,7 @@
 		A596309F2AEF6AEB00D64628 /* TerminalManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalManager.swift; sourceTree = "<group>"; };
 		A59630A12AF0415000D64628 /* Ghostty.TerminalSplit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ghostty.TerminalSplit.swift; sourceTree = "<group>"; };
 		A59630A32AF059BB00D64628 /* Ghostty.SplitNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ghostty.SplitNode.swift; sourceTree = "<group>"; };
+		A5985CD62C320C4500C57AD3 /* String+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		A59FB5CE2AE0DB50009128F3 /* InspectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectorView.swift; sourceTree = "<group>"; };
 		A59FB5D02AE0DEA7009128F3 /* MetalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalView.swift; sourceTree = "<group>"; };
 		A5A1F8842A489D6800D1E8BC /* terminfo */ = {isa = PBXFileReference; lastKnownFileType = folder; name = terminfo; path = "../zig-out/share/terminfo"; sourceTree = "<group>"; };
@@ -205,6 +208,7 @@
 				C159E81C2B66A06B00FDFE9C /* OSColor+Extension.swift */,
 				C1F26EA62B738B9900404083 /* NSView+Extension.swift */,
 				AEE8B3442B9AA39600260C5E /* NSPasteboard+Extension.swift */,
+				A5985CD62C320C4500C57AD3 /* String+Extension.swift */,
 				C1F26EE72B76CBFC00404083 /* VibrantLayer.h */,
 				C1F26EE82B76CBFC00404083 /* VibrantLayer.m */,
 				A5CEAFDA29B8005900646FDA /* SplitView */,
@@ -503,6 +507,7 @@
 				A5333E1C2B5A1CE3008AEFF7 /* CrossKit.swift in Sources */,
 				A59444F729A2ED5200725BBA /* SettingsView.swift in Sources */,
 				A56D58862ACDDB4100508D2C /* Ghostty.Shell.swift in Sources */,
+				A5985CD72C320C4500C57AD3 /* String+Extension.swift in Sources */,
 				A59630A22AF0415000D64628 /* Ghostty.TerminalSplit.swift in Sources */,
 				A5FEB3002ABB69450068369E /* main.swift in Sources */,
 				A55B7BB829B6F53A0055DE60 /* Package.swift in Sources */,
@@ -537,6 +542,7 @@
 				A53D0C9C2B543F7B00305CE6 /* Package.swift in Sources */,
 				A53D0C9B2B543F3B00305CE6 /* Ghostty.App.swift in Sources */,
 				A5333E242B5A22D9008AEFF7 /* Ghostty.Shell.swift in Sources */,
+				A5985CD82C320C4500C57AD3 /* String+Extension.swift in Sources */,
 				C159E89D2B69A2EF00FDFE9C /* OSColor+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -868,10 +868,26 @@ extension Ghostty {
         }
         
         override func menu(for event: NSEvent) -> NSMenu? {
-            Ghostty.logger.warning("menu: event!")
-            return nil
-        }
+            // We only support right-click menus
+            guard event.type == .rightMouseDown else { return nil }
+            
+            // We need a surface
+            guard let surface = self.surface else { return nil }
+            
+            let menu = NSMenu()
+            
+            // If we have a selection, add copy
+            if ghostty_surface_has_selection(surface) {
+                menu.addItem(withTitle: "Copy", action: #selector(copy(_:)), keyEquivalent: "")
+            }
+            menu.addItem(withTitle: "Paste", action: #selector(paste(_:)), keyEquivalent: "")
+            
+            menu.addItem(NSMenuItem.separator())
+            menu.addItem(withTitle: "Toggle Terminal Inspector", action: #selector(TerminalController.toggleTerminalInspector(_:)), keyEquivalent: "")
 
+            return menu
+        }
+            
         // MARK: Menu Handlers
 
         @IBAction func copy(_ sender: Any?) {

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -471,15 +471,39 @@ extension Ghostty {
 
 
         override func rightMouseDown(with event: NSEvent) {
-            guard let surface = self.surface else { return }
+            guard let surface = self.surface else { return super.rightMouseDown(with: event) }
+            
             let mods = Ghostty.ghosttyMods(event.modifierFlags)
-            ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_RIGHT, mods)
+            if (ghostty_surface_mouse_button(
+                surface,
+                GHOSTTY_MOUSE_PRESS,
+                GHOSTTY_MOUSE_RIGHT,
+                mods
+            )) {
+                // Consumed
+                return
+            }
+            
+            // Mouse event not consumed
+            super.rightMouseDown(with: event)
         }
 
         override func rightMouseUp(with event: NSEvent) {
-            guard let surface = self.surface else { return }
+            guard let surface = self.surface else { return super.rightMouseUp(with: event) }
+            
             let mods = Ghostty.ghosttyMods(event.modifierFlags)
-            ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_RIGHT, mods)
+            if (ghostty_surface_mouse_button(
+                surface,
+                GHOSTTY_MOUSE_RELEASE,
+                GHOSTTY_MOUSE_RIGHT,
+                mods
+            )) {
+                // Handled
+                return
+            }
+            
+            // Mouse event not consumed
+            super.rightMouseUp(with: event)
         }
         
         override func mouseMoved(with event: NSEvent) {
@@ -841,6 +865,11 @@ extension Ghostty {
                 key_ev.text = ptr
                 ghostty_surface_key(surface, key_ev)
             }
+        }
+        
+        override func menu(for event: NSEvent) -> NSMenu? {
+            Ghostty.logger.warning("menu: event!")
+            return nil
         }
 
         // MARK: Menu Handlers

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -872,14 +872,6 @@ extension Ghostty {
             guard event.type == .rightMouseDown else { return nil }
             
             let menu = NSMenu()
-
-            // Windowing
-            menu.addItem(withTitle: "New Window", action: #selector(TerminalController.newWindow(_:)), keyEquivalent: "")
-            menu.addItem(withTitle: "New Tab", action: #selector(TerminalController.newTab(_:)), keyEquivalent: "")
-            menu.addItem(withTitle: "Split Right", action: #selector(TerminalController.splitRight(_:)), keyEquivalent: "")
-            menu.addItem(withTitle: "Split Down", action: #selector(TerminalController.splitDown(_:)), keyEquivalent: "")
-            menu.addItem(.separator())
-
             
             // If we have a selection, add copy
             if self.selectedRange().length > 0 {

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -871,18 +871,23 @@ extension Ghostty {
             // We only support right-click menus
             guard event.type == .rightMouseDown else { return nil }
             
-            // We need a surface
-            guard let surface = self.surface else { return nil }
-            
             let menu = NSMenu()
+
+            // Windowing
+            menu.addItem(withTitle: "New Window", action: #selector(TerminalController.newWindow(_:)), keyEquivalent: "")
+            menu.addItem(withTitle: "New Tab", action: #selector(TerminalController.newTab(_:)), keyEquivalent: "")
+            menu.addItem(withTitle: "Split Right", action: #selector(TerminalController.splitRight(_:)), keyEquivalent: "")
+            menu.addItem(withTitle: "Split Down", action: #selector(TerminalController.splitDown(_:)), keyEquivalent: "")
+            menu.addItem(.separator())
+
             
             // If we have a selection, add copy
-            if ghostty_surface_has_selection(surface) {
+            if self.selectedRange().length > 0 {
                 menu.addItem(withTitle: "Copy", action: #selector(copy(_:)), keyEquivalent: "")
             }
             menu.addItem(withTitle: "Paste", action: #selector(paste(_:)), keyEquivalent: "")
             
-            menu.addItem(NSMenuItem.separator())
+            menu.addItem(.separator())
             menu.addItem(withTitle: "Toggle Terminal Inspector", action: #selector(TerminalController.toggleTerminalInspector(_:)), keyEquivalent: "")
 
             return menu

--- a/macos/Sources/Helpers/String+Extension.swift
+++ b/macos/Sources/Helpers/String+Extension.swift
@@ -7,6 +7,7 @@ extension String {
         return self.prefix(maxLength) + trailing
     }
     
+    #if canImport(AppKit)
     func temporaryFile(_ filename: String = "temp") -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent(filename)
@@ -15,4 +16,5 @@ extension String {
         try? string.write(to: url, atomically: true, encoding: .utf8)
         return url
     }
+    #endif
 }

--- a/macos/Sources/Helpers/String+Extension.swift
+++ b/macos/Sources/Helpers/String+Extension.swift
@@ -1,0 +1,18 @@
+extension String {
+    func truncate(length: Int, trailing: String = "…") -> String {
+        let maxLength = length - trailing.count
+        guard maxLength > 0, !self.isEmpty, self.count > length else {
+            return self
+        }
+        return self.prefix(maxLength) + trailing
+    }
+    
+    func temporaryFile(_ filename: String = "temp") -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(filename)
+            .appendingPathExtension("txt")
+        let string = self
+        try? string.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+}

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2433,6 +2433,15 @@ pub fn mouseButtonCallback(
             break :pin pin;
         };
 
+        // If we already have a selection and the selection contains
+        // where we clicked then we don't want to modify the selection.
+        if (self.io.terminal.screen.selection) |prev_sel| {
+            if (prev_sel.contains(screen, pin)) break :sel;
+
+            // The selection doesn't contain our pin, so we create a new
+            // word selection where we clicked.
+        }
+
         const sel = screen.selectWord(pin) orelse break :sel;
         try self.setSelection(sel);
         try self.queueRender();

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2129,6 +2129,14 @@ fn mouseShiftCapture(self: *const Surface, lock: bool) bool {
     };
 }
 
+/// Returns true if the mouse is currently captured by the terminal
+/// (i.e. reporting events).
+pub fn mouseCaptured(self: *Surface) bool {
+    self.renderer_state.mutex.lock();
+    defer self.renderer_state.mutex.unlock();
+    return self.io.terminal.flags.mouse_event != .none;
+}
+
 /// Called for mouse button press/release events. This will return true
 /// if the mouse event was consumed in some way (i.e. the program is capturing
 /// mouse events). If the event was not consumed, then false is returned.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -710,10 +710,10 @@ pub const Surface = struct {
         action: input.MouseButtonState,
         button: input.MouseButton,
         mods: input.Mods,
-    ) void {
-        self.core_surface.mouseButtonCallback(action, button, mods) catch |err| {
+    ) bool {
+        return self.core_surface.mouseButtonCallback(action, button, mods) catch |err| {
             log.err("error in mouse button callback err={}", .{err});
-            return;
+            return false;
         };
     }
 
@@ -1638,8 +1638,8 @@ pub const CAPI = struct {
         action: input.MouseButtonState,
         button: input.MouseButton,
         mods: c_int,
-    ) void {
-        surface.mouseButtonCallback(
+    ) bool {
+        return surface.mouseButtonCallback(
             action,
             button,
             @bitCast(@as(

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1632,6 +1632,12 @@ pub const CAPI = struct {
         surface.textCallback(ptr[0..len]);
     }
 
+    /// Returns true if the surface currently has mouse capturing
+    /// enabled.
+    export fn ghostty_surface_mouse_captured(surface: *Surface) bool {
+        return surface.core_surface.mouseCaptured();
+    }
+
     /// Tell the surface that it needs to schedule a render
     export fn ghostty_surface_mouse_button(
         surface: *Surface,

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -1048,7 +1048,7 @@ pub const Surface = struct {
             else => unreachable,
         };
 
-        core_win.mouseButtonCallback(action, button, mods) catch |err| {
+        _ = core_win.mouseButtonCallback(action, button, mods) catch |err| {
             log.err("error in scroll callback err={}", .{err});
             return;
         };

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1164,7 +1164,7 @@ fn gtkMouseDown(
         self.grabFocus();
     }
 
-    self.core_surface.mouseButtonCallback(.press, button, mods) catch |err| {
+    _ = self.core_surface.mouseButtonCallback(.press, button, mods) catch |err| {
         log.err("error in key callback err={}", .{err});
         return;
     };
@@ -1184,7 +1184,7 @@ fn gtkMouseUp(
     const mods = translateMods(gtk_mods);
 
     const self = userdataSelf(ud.?);
-    self.core_surface.mouseButtonCallback(.release, button, mods) catch |err| {
+    _ = self.core_surface.mouseButtonCallback(.release, button, mods) catch |err| {
         log.err("error in key callback err={}", .{err});
         return;
     };


### PR DESCRIPTION
Fixes #1413 

This adds a context menu to the macOS app. I will follow up with GTK support in another PR.

Core changes:

* change the mouse callback API on Surface to return a bool if the mouse event was captured or not. This prevents the context menu from showing up when the terminal application itself captures right click (i.e. neovim).
* right click now selects word unless the right click is within the previous selection

![CleanShot 2024-06-30 at 15 21 54@2x](https://github.com/ghostty-org/ghostty/assets/1299/8cf8e65d-f005-4f4e-ba72-e358bfb5ec9c)

