### PR TITLE
macos: implement ctrl+command+d for quicklook under cursor

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -565,6 +565,10 @@ uintptr_t ghostty_surface_selection(ghostty_surface_t, char*, uintptr_t);
 #ifdef __APPLE__
 void ghostty_surface_set_display_id(ghostty_surface_t, uint32_t);
 void* ghostty_surface_quicklook_font(ghostty_surface_t);
+uintptr_t ghostty_surface_quicklook_word(ghostty_surface_t,
+                                         char*,
+                                         uintptr_t,
+                                         ghostty_selection_s*);
 bool ghostty_surface_selection_info(ghostty_surface_t, ghostty_selection_s*);
 #endif
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3061,7 +3061,7 @@ pub fn colorSchemeCallback(self: *Surface, scheme: apprt.ColorScheme) !void {
     if (report) try self.reportColorScheme();
 }
 
-fn posToViewport(self: Surface, xpos: f64, ypos: f64) terminal.point.Coordinate {
+pub fn posToViewport(self: Surface, xpos: f64, ypos: f64) terminal.point.Coordinate {
     // xpos/ypos need to be adjusted for window padding
     // (i.e. "window-padding-*" settings.
     const pad = if (self.config.window_padding_balance)


### PR DESCRIPTION
This is a standard macOS shortcut.

The critical complicated detail here is that it does NOT modify the currently active text selection the same way force click does.

https://github.com/ghostty-org/ghostty/assets/1299/2f22fe2f-29a0-46d0-8ef1-20a86536c605

