### PR TITLE
core: mouse shift escape applies to all buttons, not just left

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2240,7 +2240,7 @@ pub fn mouseButtonCallback(
         if (self.io.terminal.flags.mouse_event != .none) report: {
             // If we have shift-pressed and we aren't allowed to capture it,
             // then we do not do a mouse report.
-            if (mods.shift and button == .left and !shift_capture) break :report;
+            if (mods.shift and !shift_capture) break :report;
 
             // In any other mouse button scenario without shift pressed we
             // clear the selection since the underlying application can handle


### PR DESCRIPTION
Fixes #1905