### PR TITLE
macos build command add docs to build xcode project sucessfully

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,7 +600,7 @@ iOS SDKs installed (from inside Xcode → Settings → Platforms), and let's mov
 on to building Ghostty:
 
 ```shell-session
-$ zig build -Doptimize=ReleaseFast
+$ zig build -Doptimize=ReleaseFast -Demit-docs
 $ cd macos && xcodebuild
 ```
 


### PR DESCRIPTION
Xcode project expects `share/man` files, that are created only when `emit-docs` first