### PR TITLE
Build with NixOS 24.05

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["namespace-profile-ghostty-md"]
+        os: ["namespace-profile-ghostty-24-04-md"]
 
         target: [
             aarch64-linux,
@@ -49,7 +49,7 @@ jobs:
 
   build-bench:
     # We build benchmarks on large because it uses ReleaseFast
-    runs-on: namespace-profile-ghostty-lg
+    runs-on: namespace-profile-ghostty-24-04-lg
     needs: test
     env:
       ZIG_LOCAL_CACHE_DIR: /zig/local-cache
@@ -78,7 +78,7 @@ jobs:
         run: nix develop -c zig build -Dapp-runtime=glfw -Demit-bench
 
   build-linux-libghostty:
-    runs-on: namespace-profile-ghostty-md
+    runs-on: namespace-profile-ghostty-24-04-md
     needs: test
     env:
       ZIG_LOCAL_CACHE_DIR: /zig/local-cache
@@ -110,7 +110,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [namespace-profile-ghostty-md, namespace-profile-ghostty-md-arm64]
+        os:
+          [
+            namespace-profile-ghostty-24-04-md,
+            namespace-profile-ghostty-24-04-arm64-md,
+          ]
     runs-on: ${{ matrix.os }}
     needs: test
     env:
@@ -138,6 +142,25 @@ jobs:
 
       - name: Test NixOS package build
         run: nix build .#ghostty
+
+  build-nix-unstable:
+    runs-on: namespace-profile-ghostty-24-04-md
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Install Nix and use that to run our tests so our environment matches exactly.
+      - uses: cachix/install-nix-action@V27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ghostty
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: Test NixOS package build
+        run: nix build .#ghostty-unstable-releasefast
 
   build-macos:
     runs-on: namespace-profile-ghostty-macos
@@ -287,7 +310,7 @@ jobs:
         run: Get-Content -Path ".\build.log"
 
   test:
-    runs-on: namespace-profile-ghostty-md
+    runs-on: namespace-profile-ghostty-24-04-md
     env:
       ZIG_LOCAL_CACHE_DIR: /zig/local-cache
       ZIG_GLOBAL_CACHE_DIR: /zig/global-cache
@@ -343,7 +366,7 @@ jobs:
         run: nix develop -c zig build test
 
   prettier:
-    runs-on: namespace-profile-ghostty-sm
+    runs-on: namespace-profile-ghostty-24-04-sm
     timeout-minutes: 60
     env:
       ZIG_LOCAL_CACHE_DIR: /zig/local-cache
@@ -369,7 +392,7 @@ jobs:
         run: nix develop -c prettier --check .
 
   alejandra:
-    runs-on: namespace-profile-ghostty-sm
+    runs-on: namespace-profile-ghostty-24-04-sm
     timeout-minutes: 60
     env:
       ZIG_LOCAL_CACHE_DIR: /zig/local-cache

--- a/README.md
+++ b/README.md
@@ -720,7 +720,51 @@ Below is an example:
 }
 ```
 
-You can also test the build of the nix package at any time by running `nix build .`.
+The `default` version of the Nix package builds Ghostty with NixOS 24.05.
+
+There are many variations of the package that use different versions of NixOS
+and different optimization flags to build:
+
+| Package                      | NixOS version | Optimization | glibc version | GTK version | Gnome version |
+| ---------------------------- | ------------- | ------------ | ------------- | ----------- | ------------- |
+| ghostty-24-05-debug          | 24.05         | Debug        | 2.39          | 4.14        | 46            |
+| ghostty-24-05-releasesafe    | 24.05         | ReleaseSafe  | 2.39          | 4.14        | 46            |
+| ghostty-24-05-releasefast    | 24.05         | ReleaseFast  | 2.39          | 4.14        | 46            |
+| ghostty-unstable-debug       | unstable      | Debug        | 2.39          | 4.14        | 46            |
+| ghostty-unstable-releasesafe | unstable      | ReleaseSafe  | 2.39          | 4.14        | 46            |
+| ghostty-unstable-releasefast | unstable      | ReleaseFast  | 2.39          | 4.14        | 46            |
+
+An example of how to use a non-default build of Ghostty:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    # NOTE: This will require your git SSH access to the repo.
+    #
+    # WARNING: Do NOT pin the `nixpkgs` input, as that will
+    # declare the cache useless. If you do, you will have
+    # to compile LLVM, Zig and Ghostty itself on your machine,
+    # which will take a very very long time.
+    ghostty = {
+      url = "git+ssh://git@github.com/ghostty-org/ghostty";
+    };
+  };
+
+  outputs = { nixpkgs, ghostty, ... }: {
+    nixosConfigurations.mysystem = nixpkgs.lib.nixosSystem {
+      modules = [
+        {
+          environment.systemPackages = [
+            ghostty.packages.x86_64-linux.ghostty-unstable-releasefast
+          ];
+        }
+      ];
+    };
+  };
+}
+```
 
 #### Updating the Zig Cache Fixed-Output Derivation Hash
 

--- a/example/app.ts
+++ b/example/app.ts
@@ -102,12 +102,12 @@ fetch(url.href)
     group_add_face(
       group,
       0 /* regular */,
-      deferred_face_new(font_name.ptr, font_name.len, 0 /* text */)
+      deferred_face_new(font_name.ptr, font_name.len, 0 /* text */),
     );
     group_add_face(
       group,
       0 /* regular */,
-      deferred_face_new(font_name.ptr, font_name.len, 1 /* emoji */)
+      deferred_face_new(font_name.ptr, font_name.len, 1 /* emoji */),
     );
 
     // Initialize our sprite font, without this we just use the browser.
@@ -168,7 +168,7 @@ fetch(url.href)
       group_cache,
       cp,
       0,
-      -1 /* best choice */
+      -1 /* best choice */,
     );
     group_cache_render_glyph(group_cache, font_idx, cp, -1);
 

--- a/flake.lock
+++ b/flake.lock
@@ -52,24 +52,6 @@
         "type": "github"
       }
     },
-    "flake-utils_3": {
-      "inputs": {
-        "systems": "systems_3"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -103,41 +85,41 @@
         "url": "https://raw.githubusercontent.com/ziglang/zig/0fb2015fd3422fc1df364995f9782dfe7255eccd/doc/langref.html.in"
       }
     },
-    "nixpkgs-stable": {
+    "nixpkgs-24-05": {
       "locked": {
-        "lastModified": 1705957679,
-        "narHash": "sha256-Q8LJaVZGJ9wo33wBafvZSzapYsjOaNjP/pOnSiKVGHY=",
+        "lastModified": 1720691131,
+        "narHash": "sha256-CWT+KN8aTPyMIx8P303gsVxUnkinIz0a/Cmasz1jyIM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9a333eaa80901efe01df07eade2c16d183761fa3",
+        "rev": "a046c1202e11b62cbede5385ba64908feb7bfac4",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "release-23.05",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1719082008,
-        "narHash": "sha256-jHJSUH619zBQ6WdC21fFAlDxHErKVDJ5fpN0Hgx4sjs=",
+        "lastModified": 1720542800,
+        "narHash": "sha256-ZgnNHuKV6h2+fQ5LuqnUaqZey1Lqqt5dTUAiAnqH0QQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9693852a2070b398ee123a329e68f0dab5526681",
+        "rev": "feb2849fdeb70028c70d73b848214b00d324a497",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "nixpkgs-stable": "nixpkgs-stable",
+        "nixpkgs-24-05": "nixpkgs-24-05",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "zig": "zig",
         "zls": "zls"
@@ -173,58 +155,20 @@
         "type": "github"
       }
     },
-    "systems_3": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "zig": {
       "inputs": {
-        "flake-compat": [],
+        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": [
-          "nixpkgs-stable"
+          "nixpkgs-24-05"
         ]
       },
       "locked": {
-        "lastModified": 1717848532,
-        "narHash": "sha256-d+xIUvSTreHl8pAmU1fnmkfDTGQYCn2Rb/zOwByxS2M=",
+        "lastModified": 1720786233,
+        "narHash": "sha256-MW1yTbTvDSNu3LnU3rpkdaF8Xxb3D3kHqFfIerzwk98=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "02fc5cc555fc14fda40c42d7c3250efa43812b43",
-        "type": "github"
-      },
-      "original": {
-        "owner": "mitchellh",
-        "repo": "zig-overlay",
-        "type": "github"
-      }
-    },
-    "zig-overlay": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils_3",
-        "nixpkgs": [
-          "zls",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1718539737,
-        "narHash": "sha256-hvQ900gSqzGnJWMRQwv65TixciIbC44iX0Nh5ENRwCU=",
-        "owner": "mitchellh",
-        "repo": "zig-overlay",
-        "rev": "6eb42ce6f85d247b1aecf854c45d80902821d0ad",
+        "rev": "ecfeb1f4c2970aac4a8281382ea27dbc1861c821",
         "type": "github"
       },
       "original": {
@@ -239,16 +183,18 @@
         "gitignore": "gitignore",
         "langref": "langref",
         "nixpkgs": [
-          "nixpkgs-stable"
+          "nixpkgs-24-05"
         ],
-        "zig-overlay": "zig-overlay"
+        "zig-overlay": [
+          "zig"
+        ]
       },
       "locked": {
-        "lastModified": 1718930611,
-        "narHash": "sha256-FtfVhs6XHNfSQRQorrrz03nD0LCNp2FCnGllRntHBts=",
+        "lastModified": 1720719728,
+        "narHash": "sha256-uPe4sqNB661tIi4U6YvHR9BpN8ozIcmxUJxcxI9tD1o=",
         "owner": "zigtools",
         "repo": "zls",
-        "rev": "0b9746b60c2020ab948f6556f1c729858b82a0f0",
+        "rev": "b8dd9cbbcc7591159f28eb41c21315f5ef5ca995",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,67 +2,84 @@
   description = "👻";
 
   inputs = {
-    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-
-    # We want to stay as up to date as possible but need to be careful that the
-    # glibc versions used by our dependencies from Nix are compatible with the
-    # system glibc that the user is building for.
-    nixpkgs-stable.url = "github:nixos/nixpkgs/release-23.05";
+    nixpkgs-24-05.url = "github:nixos/nixpkgs/nixos-24.05";
+    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
 
     zig = {
       url = "github:mitchellh/zig-overlay";
       inputs = {
-        nixpkgs.follows = "nixpkgs-stable";
-        flake-compat.follows = "";
+        nixpkgs.follows = "nixpkgs-24-05";
       };
     };
 
     zls = {
       url = "github:zigtools/zls/master";
-      inputs.nixpkgs.follows = "nixpkgs-stable";
+      inputs = {
+        nixpkgs.follows = "nixpkgs-24-05";
+        zig-overlay.follows = "zig";
+      };
     };
   };
 
   outputs = {
     self,
+    nixpkgs-24-05,
     nixpkgs-unstable,
-    nixpkgs-stable,
     zig,
     zls,
-    ...
   }:
-    builtins.foldl' nixpkgs-stable.lib.recursiveUpdate {} (builtins.map (system: let
-      pkgs-stable = nixpkgs-stable.legacyPackages.${system};
-      pkgs-unstable = nixpkgs-unstable.legacyPackages.${system};
-    in {
-      devShell.${system} = pkgs-stable.callPackage ./nix/devShell.nix {
-        inherit (pkgs-unstable) tracy;
-        inherit (zls.packages.${system}) zls;
+    builtins.foldl' nixpkgs-24-05.lib.attrsets.recursiveUpdate {} (
+      builtins.map
+      (
+        system: let
+          pkgs-24-05 = import nixpkgs-24-05 {
+            inherit system;
+          };
+          pkgs-unstable = import nixpkgs-unstable {
+            inherit system;
+          };
+        in {
+          devShells.${system} = {
+            default = self.devShells.${system}."ghostty-24-05";
+            "ghostty-24-05" = pkgs-24-05.callPackage ./nix/devShell.nix {
+              zig_0_13 = zig.packages.${system}."0.13.0";
+              zls = zls.packages.${system}.zls;
+              wraptest = pkgs-24-05.callPackage ./nix/wraptest.nix {};
+            };
+            "ghostty-unstable" = pkgs-unstable.callPackage ./nix/devShell.nix {
+              zig_0_13 = zig.packages.${system}."0.13.0";
+              zls = zls.packages.${system}.zls;
+              wraptest = pkgs-24-05.callPackage ./nix/wraptest.nix {};
+            };
+          };
 
-        zig = zig.packages.${system}."0.13.0";
-        wraptest = pkgs-stable.callPackage ./nix/wraptest.nix {};
-      };
+          packages.${system} = let
+            mkArgs = optimize: {
+              inherit (pkgs-unstable) zig_0_13 lib;
+              inherit optimize;
 
-      packages.${system} = let
-        mkArgs = optimize: {
-          inherit (pkgs-unstable) zig_0_13 lib;
-          inherit optimize;
+              revision = self.shortRev or self.dirtyShortRev or "dirty";
+            };
+          in {
+            default = self.packages.${system}.ghostty;
+            ghostty = self.packages.${system}.ghostty-releasefast;
+            ghostty-debug = self.packages.${system}.ghostty-24-05-debug;
+            ghostty-releasesafe = self.packages.${system}.ghostty-24-05-releasesafe;
+            ghostty-releasefast = self.packages.${system}.ghostty-24-05-releasefast;
+            ghostty-24-05-debug = pkgs-24-05.callPackage ./nix/package.nix (mkArgs "Debug");
+            ghostty-24-05-releasesafe = pkgs-24-05.callPackage ./nix/package.nix (mkArgs "ReleaseSafe");
+            ghostty-24-05-releasefast = pkgs-24-05.callPackage ./nix/package.nix (mkArgs "ReleaseFast");
+            ghostty-unstable-debug = pkgs-24-05.callPackage ./nix/package.nix (mkArgs "Debug");
+            ghostty-unstable-releasesafe = pkgs-24-05.callPackage ./nix/package.nix (mkArgs "ReleaseSafe");
+            ghostty-unstable-releasefast = pkgs-24-05.callPackage ./nix/package.nix (mkArgs "ReleaseFast");
+          };
 
-          revision = self.shortRev or self.dirtyShortRev or "dirty";
-        };
-      in rec {
-        ghostty-debug = pkgs-stable.callPackage ./nix/package.nix (mkArgs "Debug");
-        ghostty-releasesafe = pkgs-stable.callPackage ./nix/package.nix (mkArgs "ReleaseSafe");
-        ghostty-releasefast = pkgs-stable.callPackage ./nix/package.nix (mkArgs "ReleaseFast");
-
-        ghostty = ghostty-releasefast;
-        default = ghostty;
-      };
-
-      formatter.${system} = pkgs-stable.alejandra;
-
+          formatter.${system} = pkgs-24-05.alejandra;
+        }
+      )
       # Our supported systems are the same supported systems as the Zig binaries.
-    }) (builtins.attrNames zig.packages));
+      (builtins.attrNames zig.packages)
+    );
 
   nixConfig = {
     extra-substituters = ["https://ghostty.cachix.org"];

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -21,7 +21,7 @@
   wabt,
   wasmtime,
   wraptest,
-  zig,
+  zig_0_13,
   zip,
   zls,
   llvmPackages_latest,
@@ -86,7 +86,7 @@ in
         pandoc
         pkg-config
         scdoc
-        zig
+        zig_0_13
         zip
 
         # For web and wasm stuff
@@ -99,7 +99,6 @@ in
         # Testing
         parallel
         python3
-        tracy
         vttest
         hyperfine
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -34,7 +34,7 @@
   # https://github.com/ziglang/zig/issues/14281#issuecomment-1624220653 is
   # ultimately acted on and has made its way to a nixpkgs implementation, this
   # can probably be removed in favor of that.
-  zig012Hook = zig_0_13.hook.overrideAttrs {
+  zig_hook = zig_0_13.hook.overrideAttrs {
     zig_default_flags = "-Dcpu=baseline -Doptimize=${optimize}";
   };
 
@@ -79,7 +79,7 @@
     name = "ghostty-cache";
     nativeBuildInputs = [
       git
-      zig_0_13.hook
+      zig_hook
     ];
 
     dontConfigure = true;
@@ -117,7 +117,7 @@ in
       ncurses
       pandoc
       pkg-config
-      zig012Hook
+      zig_hook
       wrapGAppsHook4
     ];
 


### PR DESCRIPTION
NixOS 23.05 is long discontinued, but until Ubuntu 24.04 becomes more widely available in CI systems we're stuck with it because NixOS 23.11 and newer switched to a `glibc` that won't run on Ubuntu 20.04 or Ubuntu 22.04.

In the meantime this patch adds the ability for those that choose to do so the ability to easily build with newer NixOS versions. CI builds on the beta GitHub Ubuntu 24.04 runners are done so that we aren't surprised by incompatibilities that might be introduced in newer NixOS versions.

The default version of NixOS used for "normal" builds remains NixOS 23.05 but that is more explicitly called out in the GitHub workflows.