### PR TITLE
docs: warn about `window-decoration` disables tabs functionality

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -668,7 +668,7 @@ keybind: Keybinds = .{},
 ///
 ///   * `true`
 ///   * `false` - windows won't have native decorations, i.e. titlebar and
-///      borders. Tabs and tab overview will be disabled.
+///      borders. On MacOS this also disabled tabs and tab overview.
 
 @"window-decoration": bool = true,
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -664,8 +664,12 @@ keybind: Keybinds = .{},
 /// configuration `font-size` will be used.
 @"window-inherit-font-size": bool = true,
 
-/// If false, windows won't have native decorations, i.e. titlebar and
-/// borders.
+/// Valid values:
+///
+///   * `true`
+///   * `false` - windows won't have native decorations, i.e. titlebar and
+///      borders. Tabs and tab overview will be disabled.
+
 @"window-decoration": bool = true,
 
 /// The font that will be used for the application's window and tab titles.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -668,7 +668,7 @@ keybind: Keybinds = .{},
 ///
 ///   * `true`
 ///   * `false` - windows won't have native decorations, i.e. titlebar and
-///      borders. On MacOS this also disabled tabs and tab overview.
+///      borders. On MacOS this also disables tabs and tab overview.
 
 @"window-decoration": bool = true,
 


### PR DESCRIPTION
I've noticed that disabling `window-decoration` also disables tabs and tab overview (`cmd+shift+\`). I think it is worth calling out in the docs for the config option.