### PR TITLE
Multiple Kitty Graphics Fixes

### DIFF
--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -3124,7 +3124,7 @@ pub const Pin = struct {
                 else
                     true;
             }
-            return self.x >= top.x;
+            if (self.x < top.x) return false;
         }
         if (self.page == bottom.page) {
             if (self.y > bottom.y) return false;

--- a/src/terminal/kitty/graphics_storage.zig
+++ b/src/terminal/kitty/graphics_storage.zig
@@ -629,11 +629,17 @@ pub const ImageStorage = struct {
         ) Rect {
             const grid_size = self.gridSize(image, t);
 
-            var br = switch (self.pin.downOverflow(grid_size.rows)) {
+            var br = switch (self.pin.downOverflow(grid_size.rows - 1)) {
                 .offset => |v| v,
                 .overflow => |v| v.end,
             };
-            br.x = @min(self.pin.x + grid_size.cols, t.cols - 1);
+            br.x = @min(
+                // We need to sub one here because the x value is
+                // one width already. So if the image is width "1"
+                // then we add zero to X because X itelf is width 1.
+                self.pin.x + (grid_size.cols - 1),
+                t.cols - 1,
+            );
 
             return .{
                 .top_left = self.pin.*,

--- a/src/terminal/kitty/graphics_storage.zig
+++ b/src/terminal/kitty/graphics_storage.zig
@@ -267,12 +267,17 @@ pub const ImageStorage = struct {
             },
 
             .intersect_cell => |v| intersect_cell: {
+                if (v.x <= 0 or v.y <= 0) {
+                    log.warn("delete intersect cell coords must be at least 1", .{});
+                    break :intersect_cell;
+                }
+
                 self.deleteIntersecting(
                     alloc,
                     t,
                     .{ .active = .{
-                        .x = std.math.cast(size.CellCountInt, v.x) orelse break :intersect_cell,
-                        .y = std.math.cast(size.CellCountInt, v.y) orelse break :intersect_cell,
+                        .x = std.math.cast(size.CellCountInt, v.x - 1) orelse break :intersect_cell,
+                        .y = std.math.cast(size.CellCountInt, v.y - 1) orelse break :intersect_cell,
                     } },
                     v.delete,
                     {},
@@ -281,12 +286,17 @@ pub const ImageStorage = struct {
             },
 
             .intersect_cell_z => |v| intersect_cell_z: {
+                if (v.x <= 0 or v.y <= 0) {
+                    log.warn("delete intersect cell coords must be at least 1", .{});
+                    break :intersect_cell_z;
+                }
+
                 self.deleteIntersecting(
                     alloc,
                     t,
                     .{ .active = .{
-                        .x = std.math.cast(size.CellCountInt, v.x) orelse break :intersect_cell_z,
-                        .y = std.math.cast(size.CellCountInt, v.y) orelse break :intersect_cell_z,
+                        .x = std.math.cast(size.CellCountInt, v.x - 1) orelse break :intersect_cell_z,
+                        .y = std.math.cast(size.CellCountInt, v.y - 1) orelse break :intersect_cell_z,
                     } },
                     v.delete,
                     v.z,


### PR DESCRIPTION
Fixes #1922

Multiple bugs fixed:

* All deletion coordinates are 1-indexed, but we previously had them 0-indexed
* 0-indexed deletion is ignored (Kitty ignores)
* Image grid size calculation was off by one because we didn't count its starting cell as w=1/h=1
* Pin isBetween was wrong when the comparison was between the same terminal pages and y matched. This caused some intersection deletions to delete too much.