### PR TITLE
terminal: when adjusting page capacity, account for cursor ref counts

### DIFF
--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -30,7 +30,7 @@ const page_preheat = 4;
 /// The list of pages in the screen. These are expected to be in order
 /// where the first page is the topmost page (scrollback) and the last is
 /// the bottommost page (the current active page).
-const List = std.DoublyLinkedList(Page);
+pub const List = std.DoublyLinkedList(Page);
 
 /// The memory pool we get page nodes from.
 const NodePool = std.heap.MemoryPool(List.Node);


### PR DESCRIPTION
This fixes an issue where when we adjusted the capacity of the page, the style ref count would be off by one (short by one). The unit test in this PR failed prior to the changes.

The issue is that when adjusting the capacity of a page, it happens on PageList which is unware of cursor state and therefore can't ensure to reference the active style.

This creates an `adjustCapacity` call on `Screen` which can properly handle this scenario.

cc @qwerasd205 