### PR TITLE
OSC8 Hyperlink Support

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -452,6 +452,7 @@ typedef void (*ghostty_runtime_show_desktop_notification_cb)(void*,
                                                              const char*);
 typedef void (
     *ghostty_runtime_update_renderer_health)(void*, ghostty_renderer_health_e);
+typedef void (*ghostty_runtime_mouse_over_link_cb)(void*, const char*, size_t);
 
 typedef struct {
   void* userdata;
@@ -481,6 +482,7 @@ typedef struct {
   ghostty_runtime_set_cell_size_cb set_cell_size_cb;
   ghostty_runtime_show_desktop_notification_cb show_desktop_notification_cb;
   ghostty_runtime_update_renderer_health update_renderer_health_cb;
+  ghostty_runtime_mouse_over_link_cb mouse_over_link_cb;
 } ghostty_runtime_config_s;
 
 //-------------------------------------------------------------------

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -93,7 +93,8 @@ extension Ghostty {
                 set_cell_size_cb: { userdata, width, height in App.setCellSize(userdata, width: width, height: height) },
                 show_desktop_notification_cb: { userdata, title, body in
                     App.showUserNotification(userdata, title: title, body: body) },
-                update_renderer_health_cb: { userdata, health in App.updateRendererHealth(userdata, health: health) }
+                update_renderer_health_cb: { userdata, health in App.updateRendererHealth(userdata, health: health) },
+                mouse_over_link_cb: { userdata, ptr, len in App.mouseOverLink(userdata, uri: ptr, len: len) }
             )
             
             // Create the ghostty app.
@@ -522,6 +523,17 @@ extension Ghostty {
             let surfaceView = self.surfaceUserdata(from: userdata)
             let backingSize = NSSize(width: Double(width), height: Double(height))
             surfaceView.cellSize = surfaceView.convertFromBacking(backingSize)
+        }
+        
+        static func mouseOverLink(_ userdata: UnsafeMutableRawPointer?, uri: UnsafePointer<CChar>?, len: Int) {
+            let surfaceView = self.surfaceUserdata(from: userdata)
+            guard len > 0 else {
+                surfaceView.hoverUrl = nil
+                return
+            }
+            
+            let buffer = Data(bytes: uri!, count: len)
+            surfaceView.hoverUrl = String(data: buffer, encoding: .utf8)
         }
 
         static func showUserNotification(_ userdata: UnsafeMutableRawPointer?, title: UnsafePointer<CChar>?, body: UnsafePointer<CChar>?) {

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -291,6 +291,7 @@ extension Ghostty {
         static func setCellSize(_ userdata: UnsafeMutableRawPointer?, width: UInt32, height: UInt32) {}
         static func showUserNotification(_ userdata: UnsafeMutableRawPointer?, title: UnsafePointer<CChar>?, body: UnsafePointer<CChar>?) {}
         static func updateRendererHealth(_ userdata: UnsafeMutableRawPointer?, health: ghostty_renderer_health_e) {}
+        static func mouseOverLink(_ userdata: UnsafeMutableRawPointer?, uri: UnsafePointer<CChar>?, len: Int) {}
         #endif
         
         #if os(macOS)

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -48,9 +48,12 @@ extension Ghostty {
 
         // Maintain whether our window has focus (is key) or not
         @State private var windowFocus: Bool = true
-
+        
+        // True if we're hovering over the left URL view, so we can show it on the right.
+        @State private var isHoveringURLLeft: Bool = false
+        
         @EnvironmentObject private var ghostty: Ghostty.App
-
+        
         var body: some View {
             let center = NotificationCenter.default
             
@@ -146,19 +149,35 @@ extension Ghostty {
                 .ghosttySurfaceView(surfaceView)
                 
                 // If we have a URL from hovering a link, we show that.
-                // TODO
                 if let url = surfaceView.hoverUrl {
                     let padding: CGFloat = 3
-                    HStack {
-                        VStack(alignment: .leading) {
+                    ZStack {
+                        HStack {
+                            VStack(alignment: .leading) {
+                                Spacer()
+                                
+                                Text(verbatim: url)
+                                    .padding(.init(top: padding, leading: padding, bottom: padding, trailing: padding))
+                                    .background(.background)
+                                    .opacity(isHoveringURLLeft ? 0 : 1)
+                                    .onHover(perform: { hovering in
+                                        isHoveringURLLeft = hovering
+                                    })
+                            }
                             Spacer()
-                            
-                            Text(verbatim: url)
-                                .padding(.init(top: padding, leading: padding, bottom: padding, trailing: padding))
-                                .background(.background)
                         }
                         
-                        Spacer()
+                        HStack {
+                            Spacer()
+                            VStack(alignment: .leading) {
+                                Spacer()
+                                
+                                Text(verbatim: url)
+                                    .padding(.init(top: padding, leading: padding, bottom: padding, trailing: padding))
+                                    .background(.background)
+                                    .opacity(isHoveringURLLeft ? 1 : 0)
+                            }
+                        }
                     }
                 }
                 

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -147,13 +147,13 @@ extension Ghostty {
                 
                 // If we have a URL from hovering a link, we show that.
                 // TODO
-                if (false) {
+                if let url = surfaceView.hoverUrl {
                     let padding: CGFloat = 3
                     HStack {
                         VStack(alignment: .leading) {
                             Spacer()
                             
-                            Text(verbatim: "http://example.com")
+                            Text(verbatim: url)
                                 .padding(.init(top: padding, leading: padding, bottom: padding, trailing: padding))
                                 .background(.background)
                         }

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -145,6 +145,23 @@ extension Ghostty {
                 }
                 .ghosttySurfaceView(surfaceView)
                 
+                // If we have a URL from hovering a link, we show that.
+                // TODO
+                if (false) {
+                    let padding: CGFloat = 3
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Spacer()
+                            
+                            Text(verbatim: "http://example.com")
+                                .padding(.init(top: padding, leading: padding, bottom: padding, trailing: padding))
+                                .background(.background)
+                        }
+                        
+                        Spacer()
+                    }
+                }
+                
                 // If our surface is not healthy, then we render an error view over it.
                 if (!surfaceView.healthy) {
                     Rectangle().fill(ghostty.config.backgroundColor)

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -26,6 +26,9 @@ extension Ghostty {
         
         // Any error while initializing the surface.
         @Published var error: Error? = nil
+        
+        // The hovered URL string
+        @Published var hoverUrl: String? = nil
 
         // An initial size to request for a window. This will only affect
         // then the view is moved to a new window.

--- a/macos/Sources/Ghostty/SurfaceView_UIKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_UIKit.swift
@@ -25,6 +25,9 @@ extension Ghostty {
         // Any error while initializing the surface.
         @Published var error: Error? = nil
         
+        // The hovered URL
+        @Published var hoverUrl: String? = nil
+        
         private(set) var surface: ghostty_surface_t?
         
         init(_ app: ghostty_app_t, baseConfig: SurfaceConfiguration? = nil, uuid: UUID? = nil) {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2736,9 +2736,13 @@ pub fn cursorPosCallback(
 
         try self.mouseReport(button, .motion, self.mouse.mods, pos);
 
-        // If we were previously over a link, we need to queue a
-        // render to undo the link state.
-        if (over_link) try self.queueRender();
+        // If we were previously over a link, we need to undo the link state.
+        // We also queue a render so the renderer can undo the rendered link
+        // state.
+        if (over_link) {
+            self.rt_surface.mouseOverLink(null);
+            try self.queueRender();
+        }
 
         // If we're doing mouse motion tracking, we do not support text
         // selection.

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2795,16 +2795,7 @@ pub fn cursorPosCallback(
     if (self.mouse.link_point) |last_vp| {
         // Mark the link's row as dirty.
         if (over_link) {
-            // TODO: This doesn't handle soft-wrapped links. Ideally this would
-            // be storing the link's start and end points and marking all rows
-            // between and including those as dirty, instead of just the row
-            // containing the part the cursor is hovering. This can result in
-            // a bit of jank.
-            if (self.renderer_state.terminal.screen.pages.pin(.{
-                .viewport = last_vp,
-            })) |pin| {
-                pin.markDirty();
-            }
+            self.renderer_state.terminal.screen.dirty.hyperlink_hover = true;
         }
 
         // If our last link viewport point is unchanged, then don't process

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2825,10 +2825,7 @@ pub fn cursorPosCallback(
     if (try self.linkAtPos(pos)) |_| {
         self.renderer_state.mouse.point = pos_vp;
         self.mouse.over_link = true;
-        // Mark the new link's row as dirty.
-        if (self.renderer_state.terminal.screen.pages.pin(.{ .viewport = pos_vp })) |pin| {
-            pin.markDirty();
-        }
+        self.renderer_state.terminal.screen.dirty.hyperlink_hover = true;
         try self.rt_surface.setMouseShape(.pointer);
         try self.queueRender();
     } else if (over_link) {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2825,7 +2825,14 @@ pub fn cursorPosCallback(
         try self.rt_surface.setMouseShape(.pointer);
 
         switch (link[0]) {
-            .open => {},
+            .open => {
+                const str = try self.io.terminal.screen.selectionString(self.alloc, .{
+                    .sel = link[1],
+                    .trim = false,
+                });
+                defer self.alloc.free(str);
+                self.rt_surface.mouseOverLink(str);
+            },
 
             ._open_osc8 => link: {
                 // Show the URL in the status bar

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -128,6 +128,11 @@ pub const App = struct {
 
         /// Called when the health of the renderer changes.
         update_renderer_health: ?*const fn (SurfaceUD, renderer.Health) void = null,
+
+        /// Called when the mouse goes over a link. The link target is the
+        /// parameter. The link target will be null if the mouse is no longer
+        /// over a link.
+        mouse_over_link: ?*const fn (SurfaceUD, ?[*]const u8, usize) void = null,
     };
 
     /// Special values for the goto_tab callback.
@@ -1100,6 +1105,19 @@ pub const Surface = struct {
         };
 
         func(self.userdata, health);
+    }
+
+    pub fn mouseOverLink(self: *const Surface, uri: ?[]const u8) void {
+        const func = self.app.opts.mouse_over_link orelse {
+            log.info("runtime embedder does not support over_link", .{});
+            return;
+        };
+
+        if (uri) |v| {
+            func(self.userdata, v.ptr, v.len);
+        } else {
+            func(self.userdata, null, 0);
+        }
     }
 };
 

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -649,6 +649,12 @@ pub const Surface = struct {
         self.cursor = new;
     }
 
+    pub fn mouseOverLink(self: *Surface, uri: ?[]const u8) void {
+        // We don't do anything in GLFW.
+        _ = self;
+        _ = uri;
+    }
+
     /// Set the visibility of the mouse cursor.
     pub fn setMouseVisibility(self: *Surface, visible: bool) void {
         self.window.setInputModeCursor(if (visible) .normal else .hidden);

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -917,6 +917,8 @@ pub fn mouseOverLink(self: *Surface, uri_: ?[]const u8) void {
 
     // Create the widget
     const label = c.gtk_label_new(uriZ.ptr);
+    c.gtk_widget_add_css_class(@ptrCast(label), "view");
+    c.gtk_widget_add_css_class(@ptrCast(label), "url-overlay");
     c.gtk_widget_set_halign(label, c.GTK_ALIGN_START);
     c.gtk_widget_set_valign(label, c.GTK_ALIGN_END);
     c.gtk_widget_set_margin_bottom(label, 2);

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -982,7 +982,6 @@ pub fn setMouseVisibility(self: *Surface, visible: bool) void {
 
 pub fn mouseOverLink(self: *Surface, uri_: ?[]const u8) void {
     const uri = uri_ orelse {
-        if (true) return;
         if (self.url_widget) |widget| {
             widget.deinit(self.overlay);
             self.url_widget = null;

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -879,6 +879,12 @@ pub fn setMouseVisibility(self: *Surface, visible: bool) void {
     c.gtk_widget_set_cursor(@ptrCast(self.gl_area), self.app.cursor_none);
 }
 
+pub fn mouseOverLink(self: *Surface, uri: ?[]const u8) void {
+    // TODO: GTK
+    _ = self;
+    _ = uri;
+}
+
 pub fn clipboardRequest(
     self: *Surface,
     clipboard_type: apprt.Clipboard,

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -992,7 +992,6 @@ pub fn setMouseVisibility(self: *Surface, visible: bool) void {
 
 pub fn mouseOverLink(self: *Surface, uri_: ?[]const u8) void {
     const uri = uri_ orelse {
-        if (true) return;
         if (self.url_widget) |*widget| {
             widget.deinit(self.overlay);
             self.url_widget = null;

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -270,6 +270,11 @@ pub const URLWidget = struct {
         };
     }
 
+    pub fn deinit(self: *URLWidget, overlay: *c.GtkOverlay) void {
+        c.gtk_overlay_remove_overlay(@ptrCast(overlay), @ptrCast(self.left));
+        c.gtk_overlay_remove_overlay(@ptrCast(overlay), @ptrCast(self.right));
+    }
+
     pub fn setText(self: *const URLWidget, str: [:0]const u8) void {
         c.gtk_label_set_text(@ptrCast(self.left), str.ptr);
         c.gtk_label_set_text(@ptrCast(self.right), str.ptr);
@@ -982,7 +987,7 @@ pub fn setMouseVisibility(self: *Surface, visible: bool) void {
 
 pub fn mouseOverLink(self: *Surface, uri_: ?[]const u8) void {
     const uri = uri_ orelse {
-        if (self.url_widget) |widget| {
+        if (self.url_widget) |*widget| {
             widget.deinit(self.overlay);
             self.url_widget = null;
         }

--- a/src/apprt/gtk/Tab.zig
+++ b/src/apprt/gtk/Tab.zig
@@ -104,8 +104,7 @@ pub fn init(self: *Tab, window: *Window, parent_: ?*CoreSurface) !void {
     self.elem = .{ .surface = surface };
 
     // Add Surface to the Tab
-    const gl_area_widget = @as(*c.GtkWidget, @ptrCast(surface.gl_area));
-    c.gtk_box_append(self.box, gl_area_widget);
+    c.gtk_box_append(self.box, surface.primaryWidget());
 
     // Add the notebook page (create tab).
     const parent_page_idx = switch (window.app.config.@"window-new-tab-position") {

--- a/src/apprt/gtk/style.css
+++ b/src/apprt/gtk/style.css
@@ -1,0 +1,3 @@
+label.url-overlay {
+  padding: 2px;
+}

--- a/src/apprt/gtk/style.css
+++ b/src/apprt/gtk/style.css
@@ -1,3 +1,11 @@
 label.url-overlay {
   padding: 2px;
 }
+
+label.url-overlay:hover {
+  opacity: 0;
+}
+
+label.url-overlay.hidden {
+  opacity: 0;
+}

--- a/src/input/Link.zig
+++ b/src/input/Link.zig
@@ -23,6 +23,10 @@ pub const Action = union(enum) {
     /// Open the full matched value using the default open program.
     /// For example, on macOS this is "open" and on Linux this is "xdg-open".
     open: void,
+
+    /// Open the OSC8 hyperlink under the mouse position. _-prefixed means
+    /// this can't be user-specified, it's only used internally.
+    _open_osc8: void,
 };
 
 pub const Highlight = union(enum) {

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -2005,7 +2005,7 @@ fn rebuildCells(
                 if (self.updateCell(
                     screen,
                     cell,
-                    if (link_match_set.orderedContains(screen, cell))
+                    if (link_match_set.contains(screen, cell))
                         .single
                     else
                         null,

--- a/src/renderer/link.zig
+++ b/src/renderer/link.zig
@@ -274,6 +274,21 @@ pub const MatchSet = struct {
         alloc.free(self.matches);
     }
 
+    /// Checks if the matchset contains the given pin. This is slower than
+    /// orderedContains but is stateless and more flexible since it doesn't
+    /// require the points to be in order.
+    pub fn contains(
+        self: *MatchSet,
+        screen: *const Screen,
+        pin: terminal.Pin,
+    ) bool {
+        for (self.matches) |sel| {
+            if (sel.contains(screen, pin)) return true;
+        }
+
+        return false;
+    }
+
     /// Checks if the matchset contains the given pt. The points must be
     /// given in left-to-right top-to-bottom order. This is a stateful
     /// operation and giving a point out of order can cause invalid

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -1162,6 +1162,24 @@ fn reflowPage(
                             },
                         }
 
+                        // If the source cell has a hyperlink we need to copy it
+                        if (src_cursor.page_cell.hyperlink) {
+                            const src_page = src_cursor.page;
+                            const dst_page = dst_cursor.page;
+                            const id = src_page.lookupHyperlink(src_cursor.page_cell).?;
+                            const src_link = src_page.hyperlink_set.get(src_page.memory, id);
+                            const dst_id = try dst_page.hyperlink_set.addContext(
+                                dst_page.memory,
+                                try src_link.dupe(src_page, dst_page),
+                                .{ .page = dst_page },
+                            );
+                            try dst_page.setHyperlink(
+                                dst_cursor.page_row,
+                                dst_cursor.page_cell,
+                                dst_id,
+                            );
+                        }
+
                         // If the source cell has a style, we need to copy it.
                         if (src_cursor.page_cell.style_id != stylepkg.default_id) {
                             const src_style = src_cursor.page.styles.get(

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -1166,6 +1166,12 @@ fn reflowPage(
                         if (src_cursor.page_cell.hyperlink) {
                             const src_page = src_cursor.page;
                             const dst_page = dst_cursor.page;
+
+                            // Pause integrity checks because setHyperlink
+                            // calls them but we're not ready yet.
+                            dst_page.pauseIntegrityChecks(true);
+                            defer dst_page.pauseIntegrityChecks(false);
+
                             const id = src_page.lookupHyperlink(src_cursor.page_cell).?;
                             const src_link = src_page.hyperlink_set.get(src_page.memory, id);
                             const dst_id = try dst_page.hyperlink_set.addContext(

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -949,6 +949,13 @@ pub fn clearCells(
         }
     }
 
+    // If we have hyperlinks, we need to clear those.
+    if (row.hyperlink) {
+        for (cells) |*cell| {
+            if (cell.hyperlink) page.clearHyperlink(row, cell);
+        }
+    }
+
     if (row.styled) {
         for (cells) |*cell| {
             if (cell.style_id == style.default_id) continue;

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1549,13 +1549,10 @@ pub fn cursorSetHyperlink(self: *Screen) !void {
     } else |err| switch (err) {
         // hyperlink_map is out of space, realloc the page to be larger
         error.OutOfMemory => {
-            _ = try self.pages.adjustCapacity(
+            _ = try self.adjustCapacity(
                 self.cursor.page_pin.page,
                 .{ .hyperlink_bytes = page.capacity.hyperlink_bytes * 2 },
             );
-
-            // Reload cursor since our cursor page has changed.
-            self.cursorReload();
 
             // Retry
             return try self.cursorSetHyperlink();

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -15,6 +15,8 @@ const pagepkg = @import("page.zig");
 const point = @import("point.zig");
 const size = @import("size.zig");
 const style = @import("style.zig");
+const hyperlink = @import("hyperlink.zig");
+const Offset = size.Offset;
 const Page = pagepkg.Page;
 const Row = pagepkg.Row;
 const Cell = pagepkg.Cell;
@@ -101,11 +103,33 @@ pub const Cursor = struct {
     /// our style when used.
     style_id: style.Id = style.default_id,
 
+    /// The hyperlink ID that is currently active for the cursor. A value
+    /// of zero means no hyperlink is active. (Implements OSC8, saying that
+    /// so code search can find it.).
+    hyperlink_id: hyperlink.Id = 0,
+
+    /// This is the implicit ID to use for hyperlinks that don't specify
+    /// an ID. We do an overflowing add to this so repeats can technically
+    /// happen with carefully crafted inputs but for real workloads its
+    /// highly unlikely -- and the fix is for the TUI program to use explicit
+    /// IDs.
+    hyperlink_implicit_id: size.OffsetInt = 0,
+
+    /// Heap-allocated hyperlink state so that we can recreate it when
+    /// the cursor page pin changes. We can't get it from the old screen
+    /// state because the page may be cleared. This is heap allocated
+    /// because its most likely null.
+    hyperlink: ?*Hyperlink = null,
+
     /// The pointers into the page list where the cursor is currently
     /// located. This makes it faster to move the cursor.
     page_pin: *PageList.Pin,
     page_row: *pagepkg.Row,
     page_cell: *pagepkg.Cell,
+
+    pub fn deinit(self: *Cursor, alloc: Allocator) void {
+        if (self.hyperlink) |link| link.destroy(alloc);
+    }
 };
 
 /// The visual style of the cursor. Whether or not it blinks
@@ -139,6 +163,31 @@ pub const CharsetState = struct {
 
     /// An array to map a charset slot to a lookup table.
     const CharsetArray = std.EnumArray(charsets.Slots, charsets.Charset);
+};
+
+pub const Hyperlink = struct {
+    id: ?[]const u8,
+    uri: []const u8,
+
+    pub fn create(
+        alloc: Allocator,
+        uri: []const u8,
+        id: ?[]const u8,
+    ) !*Hyperlink {
+        const self = try alloc.create(Hyperlink);
+        errdefer alloc.destroy(self);
+        self.id = if (id) |v| try alloc.dupe(u8, v) else null;
+        errdefer if (self.id) |v| alloc.free(v);
+        self.uri = try alloc.dupe(u8, uri);
+        errdefer alloc.free(self.uri);
+        return self;
+    }
+
+    pub fn destroy(self: *Hyperlink, alloc: Allocator) void {
+        if (self.id) |id| alloc.free(id);
+        alloc.free(self.uri);
+        alloc.destroy(self);
+    }
 };
 
 /// Initialize a new screen.
@@ -179,6 +228,7 @@ pub fn init(
 
 pub fn deinit(self: *Screen) void {
     self.kitty_images.deinit(self.alloc, self);
+    self.cursor.deinit(self.alloc);
     self.pages.deinit();
 }
 
@@ -220,6 +270,9 @@ pub fn assertIntegrity(self: *const Screen) void {
 ///   - Cursor location can be expensive to calculate with respect to the
 ///     specified region. It is faster to grab the cursor from the old
 ///     screen and then move it to the new screen.
+///   - Current hyperlink cursor state has heap allocations. Since clone
+///     is only for read-only operations, it is better to not have any
+///     hyperlink state. Note that already-written hyperlinks are cloned.
 ///
 /// If not mentioned above, then there isn't a specific reason right now
 /// to not copy some data other than we probably didn't need it and it
@@ -1311,6 +1364,104 @@ pub fn appendGrapheme(self: *Screen, cell: *Cell, cp: u21) !void {
             );
         },
     };
+}
+
+/// Start the hyperlink state. Future cells will be marked as hyperlinks with
+/// this state. Note that various terminal operations may clear the hyperlink
+/// state, such as switching screens (alt screen).
+pub fn startHyperlink(
+    self: *Screen,
+    uri: []const u8,
+    id_: ?[]const u8,
+) !void {
+    // End any prior hyperlink
+    self.endHyperlink();
+
+    // Create our hyperlink state.
+    const link = try Hyperlink.create(self.alloc, uri, id_);
+    errdefer link.destroy(self.alloc);
+
+    // TODO: look for previous hyperlink that matches this.
+
+    // Copy our URI into the page memory.
+    var page = &self.cursor.page_pin.page.data;
+    const string_alloc = &page.string_alloc;
+    const page_uri: Offset(u8).Slice = uri: {
+        const buf = try string_alloc.alloc(u8, page.memory, uri.len);
+        errdefer string_alloc.free(page.memory, buf);
+        @memcpy(buf, uri);
+
+        break :uri .{
+            .offset = size.getOffset(u8, page.memory, &buf[0]),
+            .len = uri.len,
+        };
+    };
+    errdefer string_alloc.free(
+        page.memory,
+        page_uri.offset.ptr(page.memory)[0..page_uri.len],
+    );
+
+    // Copy our ID into page memory or create an implicit ID via the counter
+    const page_id: hyperlink.Hyperlink.Id = if (id_) |id| explicit: {
+        const buf = try string_alloc.alloc(u8, page.memory, id.len);
+        errdefer string_alloc.free(page.memory, buf);
+        @memcpy(buf, id);
+
+        break :explicit .{
+            .explicit = .{
+                .offset = size.getOffset(u8, page.memory, &buf[0]),
+                .len = id.len,
+            },
+        };
+    } else implicit: {
+        defer self.cursor.hyperlink_implicit_id += 1;
+        break :implicit .{ .implicit = self.cursor.hyperlink_implicit_id };
+    };
+    errdefer switch (page_id) {
+        .implicit => self.cursor.hyperlink_implicit_id -= 1,
+        .explicit => |slice| string_alloc.free(
+            page.memory,
+            slice.offset.ptr(page.memory)[0..slice.len],
+        ),
+    };
+
+    // Put our hyperlink into the hyperlink set to get an ID
+    const id = try page.hyperlink_set.addContext(
+        page.memory,
+        .{ .id = page_id, .uri = page_uri },
+        .{ .page = page },
+    );
+    errdefer page.hyperlink_set.release(page.memory, id);
+
+    // Save it all
+    self.cursor.hyperlink = link;
+    self.cursor.hyperlink_id = id;
+}
+
+/// End the hyperlink state so that future cells aren't part of the
+/// current hyperlink (if any). This is safe to call multiple times.
+pub fn endHyperlink(self: *Screen) void {
+    // If we have no hyperlink state then do nothing
+    if (self.cursor.hyperlink_id == 0) {
+        assert(self.cursor.hyperlink == null);
+        return;
+    }
+
+    // Release the old hyperlink state. If there are cells using the
+    // hyperlink this will work because the creation creates a reference
+    // and all additional cells create a new reference. This release will
+    // just release our initial reference.
+    //
+    // If the ref count reaches zero the set will not delete the item
+    // immediately; it is kept around in case it is used again (this is
+    // how RefCountedSet works). This causes some memory fragmentation but
+    // is fine because if it is ever pruned the context deleted callback
+    // will be called.
+    var page = &self.cursor.page_pin.page.data;
+    page.hyperlink_set.release(page.memory, self.cursor.hyperlink_id);
+    self.cursor.hyperlink.?.destroy(self.alloc);
+    self.cursor.hyperlink_id = 0;
+    self.cursor.hyperlink = null;
 }
 
 /// Set the selection to the given selection. If this is a tracked selection
@@ -7261,12 +7412,40 @@ test "Screen: lineIterator soft wrap" {
     // try testing.expect(iter.next() == null);
 }
 
+test "Screen: hyperlink start/end" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, 5, 5, 0);
+    defer s.deinit();
+    try testing.expect(s.cursor.hyperlink_id == 0);
+    {
+        const page = &s.cursor.page_pin.page.data;
+        try testing.expectEqual(0, page.hyperlink_set.count());
+    }
+
+    try s.startHyperlink("http://example.com", null);
+    try testing.expect(s.cursor.hyperlink_id != 0);
+    {
+        const page = &s.cursor.page_pin.page.data;
+        try testing.expectEqual(1, page.hyperlink_set.count());
+    }
+
+    s.endHyperlink();
+    try testing.expect(s.cursor.hyperlink_id == 0);
+    {
+        const page = &s.cursor.page_pin.page.data;
+        try testing.expectEqual(0, page.hyperlink_set.count());
+    }
+}
+
 test "Screen: adjustCapacity cursor style ref count" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
     var s = try init(alloc, 5, 5, 0);
     defer s.deinit();
+
     try s.setAttribute(.{ .bold = {} });
     try s.testWriteString("1ABCD");
 

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -3307,13 +3307,6 @@ test "Screen: scrolling when viewport is pruned" {
     try s.testWriteString("1ABCD\n2EFGH\n3IJKL");
 
     {
-        // Test our contents rotated
-        const contents = try s.dumpStringAlloc(alloc, .{ .viewport = .{} });
-        defer alloc.free(contents);
-        try testing.expectEqualStrings("1ABCD\n2EFGH\n3IJKL", contents);
-    }
-
-    {
         try testing.expectEqual(point.Point{ .screen = .{
             .x = 0,
             .y = 0,

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -72,6 +72,10 @@ pub const Dirty = packed struct {
     /// Set when the selection is set or unset, regardless of if the
     /// selection is changed or not.
     selection: bool = false,
+
+    /// When an OSC8 hyperlink is hovered, we set the full screen as dirty
+    /// because links can span multiple lines.
+    hyperlink_hover: bool = false,
 };
 
 /// The cursor position.

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -8306,6 +8306,19 @@ test "Terminal: saveCursor protected pen" {
     try testing.expect(t.screen.cursor.protected);
 }
 
+test "Terminal: saveCursor doesn't modify hyperlink state" {
+    const alloc = testing.allocator;
+    var t = try init(alloc, .{ .cols = 3, .rows = 3 });
+    defer t.deinit(alloc);
+
+    try t.screen.startHyperlink("http://example.com", null);
+    const id = t.screen.cursor.hyperlink_id;
+    t.saveCursor();
+    try testing.expectEqual(id, t.screen.cursor.hyperlink_id);
+    try t.restoreCursor();
+    try testing.expectEqual(id, t.screen.cursor.hyperlink_id);
+}
+
 test "Terminal: setProtectedMode" {
     const alloc = testing.allocator;
     var t = try init(alloc, .{ .cols = 3, .rows = 3 });

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -2473,6 +2473,9 @@ pub fn alternateScreen(
         log.warn("cursor copy failed entering alt screen err={}", .{err});
     };
 
+    // We always end hyperlink state
+    self.screen.endHyperlink();
+
     if (options.clear_on_enter) {
         self.eraseDisplay(.complete, false);
     }
@@ -2505,6 +2508,9 @@ pub fn primaryScreen(
 
     // Mark our terminal as dirty
     self.flags.dirty.clear = true;
+
+    // We always end hyperlink state
+    self.screen.endHyperlink();
 
     // Restore the cursor from the primary screen. This should not
     // fail because we should not have to allocate memory since swapping

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -2541,6 +2541,7 @@ pub fn fullReset(self: *Terminal) void {
         log.warn("restore cursor on primary screen failed err={}", .{err});
     };
 
+    self.screen.endHyperlink();
     self.screen.charset = .{};
     self.modes = .{};
     self.flags = .{};
@@ -9957,6 +9958,15 @@ test "Terminal: fullReset with a non-empty pen" {
     }
 
     try testing.expectEqual(@as(style.Id, 0), t.screen.cursor.style_id);
+}
+
+test "Terminal: fullReset hyperlink" {
+    var t = try init(testing.allocator, .{ .cols = 80, .rows = 80 });
+    defer t.deinit(testing.allocator);
+
+    try t.screen.startHyperlink("http://example.com", null);
+    t.fullReset();
+    try testing.expectEqual(0, t.screen.cursor.hyperlink_id);
 }
 
 test "Terminal: fullReset with a non-empty saved cursor" {

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -5187,6 +5187,57 @@ test "Terminal: scrollDown simple" {
     }
 }
 
+test "Terminal: scrollDown hyperlink moves" {
+    const alloc = testing.allocator;
+    var t = try init(alloc, .{ .rows = 5, .cols = 5 });
+    defer t.deinit(alloc);
+
+    try t.screen.startHyperlink("http://example.com", null);
+    try t.printString("ABC");
+    t.screen.endHyperlink();
+    t.carriageReturn();
+    try t.linefeed();
+    try t.printString("DEF");
+    t.carriageReturn();
+    try t.linefeed();
+    try t.printString("GHI");
+    t.setCursorPos(2, 2);
+    t.scrollDown(1);
+
+    {
+        const str = try t.plainString(testing.allocator);
+        defer testing.allocator.free(str);
+        try testing.expectEqualStrings("\nABC\nDEF\nGHI", str);
+    }
+
+    for (0..3) |x| {
+        const list_cell = t.screen.pages.getCell(.{ .viewport = .{
+            .x = @intCast(x),
+            .y = 1,
+        } }).?;
+        const row = list_cell.row;
+        try testing.expect(row.hyperlink);
+        const cell = list_cell.cell;
+        try testing.expect(cell.hyperlink);
+        const id = list_cell.page.data.lookupHyperlink(cell).?;
+        try testing.expectEqual(@as(hyperlink.Id, 1), id);
+        const page = &list_cell.page.data;
+        try testing.expectEqual(1, page.hyperlink_set.count());
+    }
+    for (0..3) |x| {
+        const list_cell = t.screen.pages.getCell(.{ .viewport = .{
+            .x = @intCast(x),
+            .y = 0,
+        } }).?;
+        const row = list_cell.row;
+        try testing.expect(!row.hyperlink);
+        const cell = list_cell.cell;
+        try testing.expect(!cell.hyperlink);
+        const id = list_cell.page.data.lookupHyperlink(cell);
+        try testing.expect(id == null);
+    }
+}
+
 test "Terminal: scrollDown outside of scroll region" {
     const alloc = testing.allocator;
     var t = try init(alloc, .{ .rows = 5, .cols = 5 });
@@ -5253,6 +5304,112 @@ test "Terminal: scrollDown left/right scroll region" {
         const str = try t.plainString(testing.allocator);
         defer testing.allocator.free(str);
         try testing.expectEqualStrings("A   23\nDBC156\nGEF489\n HI7", str);
+    }
+}
+
+test "Terminal: scrollDown left/right scroll region hyperlink" {
+    const alloc = testing.allocator;
+    var t = try init(alloc, .{ .cols = 10, .rows = 10 });
+    defer t.deinit(alloc);
+
+    try t.screen.startHyperlink("http://example.com", null);
+    try t.printString("ABC123");
+    t.screen.endHyperlink();
+    t.carriageReturn();
+    try t.linefeed();
+    try t.printString("DEF456");
+    t.carriageReturn();
+    try t.linefeed();
+    try t.printString("GHI789");
+    t.scrolling_region.left = 1;
+    t.scrolling_region.right = 3;
+    t.setCursorPos(2, 2);
+    t.scrollDown(1);
+
+    {
+        const str = try t.plainString(testing.allocator);
+        defer testing.allocator.free(str);
+        try testing.expectEqualStrings("A   23\nDBC156\nGEF489\n HI7", str);
+    }
+
+    // First row preserves hyperlink where we didn't scroll
+    {
+        for (0..1) |x| {
+            const list_cell = t.screen.pages.getCell(.{ .viewport = .{
+                .x = @intCast(x),
+                .y = 0,
+            } }).?;
+            const row = list_cell.row;
+            try testing.expect(row.hyperlink);
+            const cell = list_cell.cell;
+            try testing.expect(cell.hyperlink);
+            const id = list_cell.page.data.lookupHyperlink(cell).?;
+            try testing.expectEqual(@as(hyperlink.Id, 1), id);
+            const page = &list_cell.page.data;
+            try testing.expectEqual(1, page.hyperlink_set.count());
+        }
+        for (1..4) |x| {
+            const list_cell = t.screen.pages.getCell(.{ .viewport = .{
+                .x = @intCast(x),
+                .y = 0,
+            } }).?;
+            const cell = list_cell.cell;
+            try testing.expect(!cell.hyperlink);
+            const id = list_cell.page.data.lookupHyperlink(cell);
+            try testing.expect(id == null);
+        }
+        for (4..6) |x| {
+            const list_cell = t.screen.pages.getCell(.{ .viewport = .{
+                .x = @intCast(x),
+                .y = 0,
+            } }).?;
+            const row = list_cell.row;
+            try testing.expect(row.hyperlink);
+            const cell = list_cell.cell;
+            try testing.expect(cell.hyperlink);
+            const id = list_cell.page.data.lookupHyperlink(cell).?;
+            try testing.expectEqual(@as(hyperlink.Id, 1), id);
+            const page = &list_cell.page.data;
+            try testing.expectEqual(1, page.hyperlink_set.count());
+        }
+    }
+
+    // Second row gets some hyperlinks
+    {
+        for (0..1) |x| {
+            const list_cell = t.screen.pages.getCell(.{ .viewport = .{
+                .x = @intCast(x),
+                .y = 1,
+            } }).?;
+            const cell = list_cell.cell;
+            try testing.expect(!cell.hyperlink);
+            const id = list_cell.page.data.lookupHyperlink(cell);
+            try testing.expect(id == null);
+        }
+        for (1..4) |x| {
+            const list_cell = t.screen.pages.getCell(.{ .viewport = .{
+                .x = @intCast(x),
+                .y = 1,
+            } }).?;
+            const row = list_cell.row;
+            try testing.expect(row.hyperlink);
+            const cell = list_cell.cell;
+            try testing.expect(cell.hyperlink);
+            const id = list_cell.page.data.lookupHyperlink(cell).?;
+            try testing.expectEqual(@as(hyperlink.Id, 1), id);
+            const page = &list_cell.page.data;
+            try testing.expectEqual(1, page.hyperlink_set.count());
+        }
+        for (4..6) |x| {
+            const list_cell = t.screen.pages.getCell(.{ .viewport = .{
+                .x = @intCast(x),
+                .y = 1,
+            } }).?;
+            const cell = list_cell.cell;
+            try testing.expect(!cell.hyperlink);
+            const id = list_cell.page.data.lookupHyperlink(cell);
+            try testing.expect(id == null);
+        }
     }
 }
 

--- a/src/terminal/bitmap_allocator.zig
+++ b/src/terminal/bitmap_allocator.zig
@@ -65,6 +65,9 @@ pub fn BitmapAllocator(comptime chunk_size: comptime_int) type {
 
         /// Allocate n elements of type T. This will return error.OutOfMemory
         /// if there isn't enough space in the backing buffer.
+        ///
+        /// Use (size.zig).getOffset to get the base offset from the backing
+        /// memory for portable storage.
         pub fn alloc(
             self: *Self,
             comptime T: type,

--- a/src/terminal/hash_map.zig
+++ b/src/terminal/hash_map.zig
@@ -857,7 +857,7 @@ fn HashMapUnmanaged(
         /// because capacity is rounded up to the next power of two. This is
         /// a design requirement for this hash map implementation.
         pub fn layoutForCapacity(new_capacity: Size) Layout {
-            assert(std.math.isPowerOfTwo(new_capacity));
+            assert(new_capacity == 0 or std.math.isPowerOfTwo(new_capacity));
 
             // Pack our metadata, keys, and values.
             const meta_start = @sizeOf(Header);

--- a/src/terminal/hyperlink.zig
+++ b/src/terminal/hyperlink.zig
@@ -93,5 +93,21 @@ pub const Set = RefCountedSet(
         pub fn eql(self: *const @This(), a: Hyperlink, b: Hyperlink) bool {
             return a.eql(self.page.?.memory, &b);
         }
+
+        pub fn deleted(self: *const @This(), link: Hyperlink) void {
+            const page = self.page.?;
+            const alloc = &page.string_alloc;
+            switch (link.id) {
+                .implicit => {},
+                .explicit => |v| alloc.free(
+                    page.memory,
+                    v.offset.ptr(page.memory)[0..v.len],
+                ),
+            }
+            alloc.free(
+                page.memory,
+                link.uri.offset.ptr(page.memory)[0..link.uri.len],
+            );
+        }
     },
 );

--- a/src/terminal/hyperlink.zig
+++ b/src/terminal/hyperlink.zig
@@ -1,0 +1,51 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const hash_map = @import("hash_map.zig");
+const AutoOffsetHashMap = hash_map.AutoOffsetHashMap;
+const size = @import("size.zig");
+const Offset = size.Offset;
+const Cell = @import("page.zig").Cell;
+const RefCountedSet = @import("ref_counted_set.zig").RefCountedSet;
+
+/// The unique identifier for a hyperlink. This is at most the number of cells
+/// that can fit in a single terminal page.
+pub const Id = size.CellCountInt;
+
+// The mapping of cell to hyperlink. We use an offset hash map to save space
+// since its very unlikely a cell is a hyperlink, so its a waste to store
+// the hyperlink ID in the cell itself.
+pub const Map = AutoOffsetHashMap(Offset(Cell), Id);
+
+/// The main entry for hyperlinks.
+pub const Hyperlink = struct {
+    id: union(enum) {
+        /// An explicitly provided ID via the OSC8 sequence.
+        explicit: Offset(u8).Slice,
+
+        /// No ID was provided so we auto-generate the ID based on an
+        /// incrementing counter. TODO: implement the counter
+        implicit: size.OffsetInt,
+    },
+
+    /// The URI for the actual link.
+    uri: Offset(u8).Slice,
+};
+
+/// The set of hyperlinks. This is ref-counted so that a set of cells
+/// can share the same hyperlink without duplicating the data.
+pub const Set = RefCountedSet(
+    Hyperlink,
+    Id,
+    size.CellCountInt,
+    struct {
+        pub fn hash(self: *const @This(), link: Hyperlink) u64 {
+            _ = self;
+            return link.hash();
+        }
+
+        pub fn eql(self: *const @This(), a: Hyperlink, b: Hyperlink) bool {
+            _ = self;
+            return a.eql(b);
+        }
+    },
+);

--- a/src/terminal/main.zig
+++ b/src/terminal/main.zig
@@ -6,6 +6,7 @@ const charsets = @import("charsets.zig");
 const stream = @import("stream.zig");
 const ansi = @import("ansi.zig");
 const csi = @import("csi.zig");
+const hyperlink = @import("hyperlink.zig");
 const sgr = @import("sgr.zig");
 const style = @import("style.zig");
 pub const apc = @import("apc.zig");
@@ -60,5 +61,6 @@ test {
     // Internals
     _ = @import("bitmap_allocator.zig");
     _ = @import("hash_map.zig");
+    _ = @import("ref_counted_set.zig");
     _ = @import("size.zig");
 }

--- a/src/terminal/osc.zig
+++ b/src/terminal/osc.zig
@@ -1451,6 +1451,18 @@ test "OSC: hyperlink with empty key and id" {
     try testing.expectEqualStrings(cmd.hyperlink_start.uri, "http://example.com");
 }
 
+test "OSC: hyperlink with empty uri" {
+    const testing = std.testing;
+
+    var p: Parser = .{};
+
+    const input = "8;id=foo;";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end('\x1b');
+    try testing.expect(cmd == null);
+}
+
 test "OSC: hyperlink end" {
     const testing = std.testing;
 

--- a/src/terminal/osc.zig
+++ b/src/terminal/osc.zig
@@ -133,6 +133,12 @@ pub const Command = union(enum) {
         body: []const u8,
     },
 
+    /// Start a hyperlink (OSC 8)
+    hyperlink_start: struct {
+        id: ?[]const u8 = null,
+        uri: []const u8,
+    },
+
     pub const ColorKind = union(enum) {
         palette: u8,
         foreground,
@@ -239,6 +245,7 @@ pub const Parser = struct {
         @"7",
         @"77",
         @"777",
+        @"8",
         @"9",
 
         // OSC 10 is used to query or set the current foreground color.
@@ -266,6 +273,10 @@ pub const Parser = struct {
         // Get/set color palette index
         color_palette_index,
         color_palette_index_end,
+
+        // Hyperlinks
+        hyperlink_param_key,
+        hyperlink_param_value,
 
         // Reset color palette index
         reset_color_palette_index,
@@ -333,6 +344,7 @@ pub const Parser = struct {
                 '4' => self.state = .@"4",
                 '5' => self.state = .@"5",
                 '7' => self.state = .@"7",
+                '8' => self.state = .@"8",
                 '9' => self.state = .@"9",
                 else => self.state = .invalid,
             },
@@ -556,6 +568,47 @@ pub const Parser = struct {
                 else => self.state = .invalid,
             },
 
+            .@"8" => switch (c) {
+                ';' => {
+                    self.command = .{ .hyperlink_start = .{
+                        .uri = "",
+                    } };
+
+                    self.state = .hyperlink_param_key;
+                    self.buf_start = self.buf_idx;
+                },
+                else => self.state = .invalid,
+            },
+
+            .hyperlink_param_key => switch (c) {
+                ';' => {
+                    self.state = .string;
+                    self.temp_state = .{ .str = &self.command.hyperlink_start.uri };
+                    self.buf_start = self.buf_idx;
+                },
+                '=' => {
+                    self.temp_state = .{ .key = self.buf[self.buf_start .. self.buf_idx - 1] };
+                    self.state = .hyperlink_param_value;
+                    self.buf_start = self.buf_idx;
+                },
+                else => {},
+            },
+
+            .hyperlink_param_value => switch (c) {
+                ':' => {
+                    self.endHyperlinkOptionValue();
+                    self.state = .hyperlink_param_key;
+                    self.buf_start = self.buf_idx;
+                },
+                ';' => {
+                    self.endHyperlinkOptionValue();
+                    self.state = .string;
+                    self.temp_state = .{ .str = &self.command.hyperlink_start.uri };
+                    self.buf_start = self.buf_idx;
+                },
+                else => {},
+            },
+
             .rxvt_extension => switch (c) {
                 'a'...'z' => {},
                 ';' => {
@@ -770,6 +823,24 @@ pub const Parser = struct {
 
         self.buf_dynamic = list;
         self.state = .allocable_string;
+    }
+
+    fn endHyperlinkOptionValue(self: *Parser) void {
+        const value = if (self.buf_start == self.buf_idx)
+            ""
+        else
+            self.buf[self.buf_start .. self.buf_idx - 1];
+
+        if (mem.eql(u8, self.temp_state.key, "id")) {
+            switch (self.command) {
+                .hyperlink_start => |*v| {
+                    // We treat empty IDs as null ids so that we can
+                    // auto-assign.
+                    if (value.len > 0) v.id = value;
+                },
+                else => {},
+            }
+        } else log.info("unknown hyperlink option: {s}", .{self.temp_state.key});
     }
 
     fn endSemanticOptionValue(self: *Parser) void {
@@ -1271,4 +1342,87 @@ test "OSC: empty param" {
 
     const cmd = p.end('\x1b');
     try testing.expect(cmd == null);
+}
+
+test "OSC: hyperlink" {
+    const testing = std.testing;
+
+    var p: Parser = .{};
+
+    const input = "8;;http://example.com";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end('\x1b').?;
+    try testing.expect(cmd == .hyperlink_start);
+    try testing.expectEqualStrings(cmd.hyperlink_start.uri, "http://example.com");
+}
+
+test "OSC: hyperlink with id set" {
+    const testing = std.testing;
+
+    var p: Parser = .{};
+
+    const input = "8;id=foo;http://example.com";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end('\x1b').?;
+    try testing.expect(cmd == .hyperlink_start);
+    try testing.expectEqualStrings(cmd.hyperlink_start.id.?, "foo");
+    try testing.expectEqualStrings(cmd.hyperlink_start.uri, "http://example.com");
+}
+
+test "OSC: hyperlink with empty id" {
+    const testing = std.testing;
+
+    var p: Parser = .{};
+
+    const input = "8;id=;http://example.com";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end('\x1b').?;
+    try testing.expect(cmd == .hyperlink_start);
+    try testing.expectEqual(null, cmd.hyperlink_start.id);
+    try testing.expectEqualStrings(cmd.hyperlink_start.uri, "http://example.com");
+}
+
+test "OSC: hyperlink with incomplete key" {
+    const testing = std.testing;
+
+    var p: Parser = .{};
+
+    const input = "8;id;http://example.com";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end('\x1b').?;
+    try testing.expect(cmd == .hyperlink_start);
+    try testing.expectEqual(null, cmd.hyperlink_start.id);
+    try testing.expectEqualStrings(cmd.hyperlink_start.uri, "http://example.com");
+}
+
+test "OSC: hyperlink with empty key" {
+    const testing = std.testing;
+
+    var p: Parser = .{};
+
+    const input = "8;=value;http://example.com";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end('\x1b').?;
+    try testing.expect(cmd == .hyperlink_start);
+    try testing.expectEqual(null, cmd.hyperlink_start.id);
+    try testing.expectEqualStrings(cmd.hyperlink_start.uri, "http://example.com");
+}
+
+test "OSC: hyperlink with empty key and id" {
+    const testing = std.testing;
+
+    var p: Parser = .{};
+
+    const input = "8;=value:id=foo;http://example.com";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end('\x1b').?;
+    try testing.expect(cmd == .hyperlink_start);
+    try testing.expectEqualStrings(cmd.hyperlink_start.id.?, "foo");
+    try testing.expectEqualStrings(cmd.hyperlink_start.uri, "http://example.com");
 }

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -58,7 +58,7 @@ const string_bytes_default = string_count_default * string_chunk;
 /// The cell multiplier is the number of cells per hyperlink entry that
 /// we support. A hyperlink can be longer than this multiplier; the multiplier
 /// just sets the total capacity to simplify adjustable size metrics.
-const hyperlink_count_default = 32;
+const hyperlink_count_default = 4;
 const hyperlink_bytes_default = hyperlink_count_default * @sizeOf(hyperlink.Set.Item);
 const hyperlink_cell_multiplier = 16;
 
@@ -681,6 +681,8 @@ pub const Page = struct {
                         .{ .page = self },
                     );
                     try self.setHyperlink(dst_row, dst_cell, dst_id);
+
+                    // TODO: copy the strings
                 }
                 if (src_cell.style_id != style.default_id) {
                     dst_row.styled = true;

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -677,12 +677,10 @@ pub const Page = struct {
                     const other_link = other.hyperlink_set.get(other.memory, id);
                     const dst_id = try self.hyperlink_set.addContext(
                         self.memory,
-                        other_link.*,
+                        try other_link.dupe(other, self),
                         .{ .page = self },
                     );
                     try self.setHyperlink(dst_row, dst_cell, dst_id);
-
-                    // TODO: copy the strings
                 }
                 if (src_cell.style_id != style.default_id) {
                     dst_row.styled = true;

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -916,7 +916,7 @@ pub const Page = struct {
     }
 
     /// Returns the hyperlink ID for the given cell.
-    pub fn lookupHyperlink(self: *const Page, cell: *Cell) ?hyperlink.Id {
+    pub fn lookupHyperlink(self: *const Page, cell: *const Cell) ?hyperlink.Id {
         const cell_offset = getOffset(Cell, self.memory, cell);
         const map = self.hyperlink_map.map(self.memory);
         return map.get(cell_offset);

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -290,7 +290,6 @@ pub const Page = struct {
         MissingStyle,
         UnmarkedStyleRow,
         MismatchedStyleRef,
-        ZombieStyles,
         InvalidStyleCount,
         InvalidSpacerTailLocation,
         InvalidSpacerHeadLocation,
@@ -505,14 +504,16 @@ pub const Page = struct {
                 }
             }
 
+            // NOTE: This is currently disabled because @qwerasd says that
+            // certain fast paths can cause this but its okay.
             // Just 1 zombie style might be the cursor style, so ignore it.
-            if (zombies > 1) {
-                log.warn(
-                    "page integrity violation zombie styles count={}",
-                    .{zombies},
-                );
-                return IntegrityError.ZombieStyles;
-            }
+            // if (zombies > 1) {
+            //     log.warn(
+            //         "page integrity violation zombie styles count={}",
+            //         .{zombies},
+            //     );
+            //     return IntegrityError.ZombieStyles;
+            // }
         }
     }
 

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -616,6 +616,13 @@ pub const Page = struct {
         x_start: usize,
         x_end_req: usize,
     ) CloneFromError!void {
+        // This whole operation breaks integrity until the end.
+        self.pauseIntegrityChecks(true);
+        defer {
+            self.pauseIntegrityChecks(false);
+            self.assertIntegrity();
+        }
+
         const cell_len = @min(self.size.cols, other.size.cols);
         const x_end = @min(x_end_req, cell_len);
         assert(x_start <= x_end);
@@ -715,9 +722,6 @@ pub const Page = struct {
                 last.wide = .narrow;
             }
         }
-
-        // The final page should remain consistent
-        self.assertIntegrity();
     }
 
     /// Get a single row. y must be valid.

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -643,6 +643,7 @@ pub const Page = struct {
                 copy.wrap = dst_row.wrap;
                 copy.wrap_continuation = dst_row.wrap_continuation;
                 copy.grapheme = dst_row.grapheme;
+                copy.hyperlink = dst_row.hyperlink;
                 copy.styled = dst_row.styled;
             }
 

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -34,37 +34,6 @@ const grapheme_count_default = GraphemeAlloc.bitmap_bit_size;
 const grapheme_bytes_default = grapheme_count_default * grapheme_chunk;
 const GraphemeMap = AutoOffsetHashMap(Offset(Cell), Offset(u21).Slice);
 
-/// The allocator for URIs (OSC8). We use a chunk size of 32 because
-/// URIs are usually pretty long and that let's us represent most
-/// bare domains in one chunk. This allocator is ALSO used for OSC8
-/// IDs. These are usually short but the chunk length should be good.
-const uri_chunk_len = 32;
-const uri_chunk = uri_chunk_len * @sizeOf(u8);
-const UriAlloc = BitmapAllocator(uri_chunk);
-
-/// The hyperlinks counts are shared between URI and hyperlink entries
-/// so it is a worst possible byte size. You probably don't need a large
-/// value here to accomodate many cells for typical (rare) hyperlink
-/// usage.
-const hyperlink_count_default = 0;
-const hyperlink_bytes_default = hyperlink_count_default * @max(
-    (uri_chunk * 2), // ID + URI
-    @sizeOf(HyperlinkEntry), // Entry
-);
-
-/// The hyperlink map and entry.
-const HyperlinkMap = AutoOffsetHashMap(Offset(Cell), HyperlinkEntry);
-const HyperlinkEntry = struct {
-    /// The ID for the hyperlink. This is always non-empty. We
-    /// auto-generate an ID if one is not provided by the user.
-    /// This is in UriAlloc.
-    id: Offset(u8).Slice,
-
-    /// The URI for the actual link.
-    /// This is in UriAlloc.
-    uri: Offset(u8).Slice,
-};
-
 /// A page represents a specific section of terminal screen. The primary
 /// idea of a page is that it is a fully self-contained unit that can be
 /// serialized, copied, etc. as a convenient way to represent a section
@@ -118,14 +87,6 @@ pub const Page = struct {
     /// Grapheme data is relatively rare so this is considered a slow
     /// path.
     grapheme_map: GraphemeMap,
-
-    /// The URI data for hyperlinks (URI + ID). This is relatively rare
-    /// so this defaults to a very small allocation size.
-    uri_alloc: UriAlloc,
-
-    /// The mapping of cells to the hyperlink associated with them. This
-    /// only has a value when a cell has the "hyperlink" flag set.
-    hyperlink_map: HyperlinkMap,
 
     /// The available set of styles in use on this page.
     styles: style.Set,
@@ -245,14 +206,6 @@ pub const Page = struct {
             .grapheme_map = GraphemeMap.init(
                 buf.add(l.grapheme_map_start),
                 l.grapheme_map_layout,
-            ),
-            .uri_alloc = UriAlloc.init(
-                buf.add(l.uri_alloc_start),
-                l.uri_alloc_layout,
-            ),
-            .hyperlink_map = HyperlinkMap.init(
-                buf.add(l.hyperlink_map_start),
-                l.hyperlink_map_layout,
             ),
             .size = .{ .cols = cap.cols, .rows = cap.rows },
             .capacity = cap,
@@ -1024,10 +977,6 @@ pub const Page = struct {
         grapheme_alloc_layout: GraphemeAlloc.Layout,
         grapheme_map_start: usize,
         grapheme_map_layout: GraphemeMap.Layout,
-        uri_alloc_start: usize,
-        uri_alloc_layout: UriAlloc.Layout,
-        hyperlink_map_start: usize,
-        hyperlink_map_layout: HyperlinkMap.Layout,
         capacity: Capacity,
     };
 
@@ -1066,16 +1015,7 @@ pub const Page = struct {
         const grapheme_map_start = alignForward(usize, grapheme_alloc_end, GraphemeMap.base_align);
         const grapheme_map_end = grapheme_map_start + grapheme_map_layout.total_size;
 
-        const uri_alloc_layout = UriAlloc.layout(cap.hyperlink_bytes);
-        const uri_alloc_start = alignForward(usize, grapheme_map_end, UriAlloc.base_align);
-        const uri_alloc_end = uri_alloc_start + uri_alloc_layout.total_size;
-
-        const hyperlink_count = @divFloor(cap.hyperlink_bytes, @sizeOf(HyperlinkEntry));
-        const hyperlink_map_layout = HyperlinkMap.layout(@intCast(hyperlink_count));
-        const hyperlink_map_start = alignForward(usize, uri_alloc_end, HyperlinkMap.base_align);
-        const hyperlink_map_end = hyperlink_map_start + hyperlink_map_layout.total_size;
-
-        const total_size = alignForward(usize, hyperlink_map_end, std.mem.page_size);
+        const total_size = alignForward(usize, grapheme_map_end, std.mem.page_size);
 
         return .{
             .total_size = total_size,
@@ -1091,10 +1031,6 @@ pub const Page = struct {
             .grapheme_alloc_layout = grapheme_alloc_layout,
             .grapheme_map_start = grapheme_map_start,
             .grapheme_map_layout = grapheme_map_layout,
-            .uri_alloc_start = uri_alloc_start,
-            .uri_alloc_layout = uri_alloc_layout,
-            .hyperlink_map_start = hyperlink_map_start,
-            .hyperlink_map_layout = hyperlink_map_layout,
             .capacity = cap,
         };
     }
@@ -1128,10 +1064,6 @@ pub const Capacity = struct {
     /// Number of bytes to allocate for grapheme data.
     grapheme_bytes: usize = grapheme_bytes_default,
 
-    /// Number of bytes to allocate for hyperlink data. The bytes
-    /// are shared use for IDs, URIs, and hyperlink entries.
-    hyperlink_bytes: usize = hyperlink_bytes_default,
-
     pub const Adjustment = struct {
         cols: ?size.CellCountInt = null,
     };
@@ -1157,9 +1089,7 @@ pub const Capacity = struct {
             // for rows & cells (which will allow us to calculate the number of
             // rows we can fit at a certain column width) we need to layout the
             // "meta" members of the page (i.e. everything else) from the end.
-            const hyperlink_map_start = alignBackward(usize, layout.total_size - layout.hyperlink_map_layout.total_size, HyperlinkMap.base_align);
-            const uri_alloc_start = alignBackward(usize, hyperlink_map_start - layout.uri_alloc_layout.total_size, UriAlloc.base_align);
-            const grapheme_map_start = alignBackward(usize, uri_alloc_start - layout.grapheme_map_layout.total_size, GraphemeMap.base_align);
+            const grapheme_map_start = alignBackward(usize, layout.total_size - layout.grapheme_map_layout.total_size, GraphemeMap.base_align);
             const grapheme_alloc_start = alignBackward(usize, grapheme_map_start - layout.grapheme_alloc_layout.total_size, GraphemeAlloc.base_align);
             const styles_start = alignBackward(usize, grapheme_alloc_start - layout.styles_layout.total_size, style.Set.base_align);
 

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -1231,8 +1231,8 @@ pub const std_capacity: Capacity = .{
     .cols = 215,
     .rows = 215,
     .styles = 128,
-    .hyperlink_cells = 32, // TODO: think about these numbers
-    .hyperlink_entries = 4,
+    .hyperlink_cells = 64, // TODO: think about these numbers
+    .hyperlink_entries = 32,
     .grapheme_bytes = 8192,
     .string_bytes = 2048,
 };

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -46,7 +46,7 @@ const UriAlloc = BitmapAllocator(uri_chunk);
 /// so it is a worst possible byte size. You probably don't need a large
 /// value here to accomodate many cells for typical (rare) hyperlink
 /// usage.
-const hyperlink_count_default = 1;
+const hyperlink_count_default = 0;
 const hyperlink_bytes_default = hyperlink_count_default * @max(
     (uri_chunk * 2), // ID + URI
     @sizeOf(HyperlinkEntry), // Entry

--- a/src/terminal/ref_counted_set.zig
+++ b/src/terminal/ref_counted_set.zig
@@ -270,7 +270,7 @@ pub fn RefCountedSet(
                     self.living += 1;
 
                     return if (added_id == id) null else added_id;
-                } else if (ctx.eql(base, value, items[id].value)) {
+                } else if (ctx.eql(value, items[id].value)) {
                     items[id].meta.ref += 1;
 
                     return null;
@@ -396,7 +396,7 @@ pub fn RefCountedSet(
             if (comptime @hasDecl(Context, "deleted")) {
                 // Inform the context struct that we're
                 // deleting the dead item's value for good.
-                ctx.deleted(base, item.value);
+                ctx.deleted(item.value);
             }
 
             self.psl_stats[item.meta.psl] -= 1;
@@ -429,7 +429,7 @@ pub fn RefCountedSet(
             const table = self.table.ptr(base);
             const items = self.items.ptr(base);
 
-            const hash: u64 = ctx.hash(base, value);
+            const hash: u64 = ctx.hash(value);
 
             for (0..self.max_psl + 1) |i| {
                 const p: usize = @intCast((hash + i) & self.layout.table_mask);
@@ -461,7 +461,7 @@ pub fn RefCountedSet(
                 // If the item is a part of the same probe sequence,
                 // we check if it matches the value we're looking for.
                 if (item.meta.psl == i and
-                    ctx.eql(base, value, item.value))
+                    ctx.eql(value, item.value))
                 {
                     return id;
                 }
@@ -487,7 +487,7 @@ pub fn RefCountedSet(
                 .meta = .{ .psl = 0, .ref = 0 },
             };
 
-            const hash: u64 = ctx.hash(base, value);
+            const hash: u64 = ctx.hash(value);
 
             var held_id: Id = new_id;
             var held_item: *Item = &new_item;
@@ -516,7 +516,7 @@ pub fn RefCountedSet(
                     if (comptime @hasDecl(Context, "deleted")) {
                         // Inform the context struct that we're
                         // deleting the dead item's value for good.
-                        ctx.deleted(base, item.value);
+                        ctx.deleted(item.value);
                     }
 
                     chosen_id = id;

--- a/src/terminal/ref_counted_set.zig
+++ b/src/terminal/ref_counted_set.zig
@@ -476,6 +476,8 @@ pub fn RefCountedSet(
         /// is ignored and the existing item's ID is returned.
         fn upsert(self: *Self, base: anytype, value: T, new_id: Id, ctx: Context) Id {
             // If the item already exists, return it.
+            // TODO: we should probably call deleted here on value since
+            // we're using the value already in the map
             if (self.lookup(base, value, ctx)) |id| return id;
 
             const table = self.table.ptr(base);

--- a/src/terminal/ref_counted_set.zig
+++ b/src/terminal/ref_counted_set.zig
@@ -264,7 +264,7 @@ pub fn RefCountedSet(
                     self.living += 1;
 
                     return if (added_id == id) null else added_id;
-                } else if (self.context.eql(value, items[id].value)) {
+                } else if (self.context.eql(base, value, items[id].value)) {
                     items[id].meta.ref += 1;
 
                     return null;
@@ -390,7 +390,7 @@ pub fn RefCountedSet(
             if (comptime @hasDecl(Context, "deleted")) {
                 // Inform the context struct that we're
                 // deleting the dead item's value for good.
-                self.context.deleted(item.value);
+                self.context.deleted(base, item.value);
             }
 
             self.psl_stats[item.meta.psl] -= 1;
@@ -423,7 +423,7 @@ pub fn RefCountedSet(
             const table = self.table.ptr(base);
             const items = self.items.ptr(base);
 
-            const hash: u64 = self.context.hash(value);
+            const hash: u64 = self.context.hash(base, value);
 
             for (0..self.max_psl + 1) |i| {
                 const p: usize = @intCast((hash + i) & self.layout.table_mask);
@@ -455,7 +455,7 @@ pub fn RefCountedSet(
                 // If the item is a part of the same probe sequence,
                 // we check if it matches the value we're looking for.
                 if (item.meta.psl == i and
-                    self.context.eql(value, item.value))
+                    self.context.eql(base, value, item.value))
                 {
                     return id;
                 }
@@ -481,7 +481,7 @@ pub fn RefCountedSet(
                 .meta = .{ .psl = 0, .ref = 0 },
             };
 
-            const hash: u64 = self.context.hash(value);
+            const hash: u64 = self.context.hash(base, value);
 
             var held_id: Id = new_id;
             var held_item: *Item = &new_item;
@@ -510,7 +510,7 @@ pub fn RefCountedSet(
                     if (comptime @hasDecl(Context, "deleted")) {
                         // Inform the context struct that we're
                         // deleting the dead item's value for good.
-                        self.context.deleted(item.value);
+                        self.context.deleted(base, item.value);
                     }
 
                     chosen_id = id;

--- a/src/terminal/ref_counted_set.zig
+++ b/src/terminal/ref_counted_set.zig
@@ -141,6 +141,16 @@ pub fn RefCountedSet(
 
             assert(cap <= @as(usize, @intCast(std.math.maxInt(Id))) + 1);
 
+            // Zero-cap set is valid, return special case
+            if (cap == 0) return .{
+                .cap = 0,
+                .table_cap = 0,
+                .table_mask = 0,
+                .table_start = 0,
+                .items_start = 0,
+                .total_size = 0,
+            };
+
             const table_cap: usize = std.math.ceilPowerOfTwoAssert(usize, cap);
             const items_cap: usize = @intFromFloat(load_factor * @as(f64, @floatFromInt(table_cap)));
 

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -1338,6 +1338,10 @@ pub fn Stream(comptime Handler: type) type {
                     _ = v;
                     @panic("TODO(osc8)");
                 },
+
+                .hyperlink_end => {
+                    @panic("TODO(osc8)");
+                },
             }
 
             // Fall through for when we don't have a handler.

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -1333,6 +1333,11 @@ pub fn Stream(comptime Handler: type) type {
                         return;
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
+
+                .hyperlink_start => |v| {
+                    _ = v;
+                    @panic("TODO(osc8)");
+                },
             }
 
             // Fall through for when we don't have a handler.

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -1335,12 +1335,17 @@ pub fn Stream(comptime Handler: type) type {
                 },
 
                 .hyperlink_start => |v| {
-                    _ = v;
-                    @panic("TODO(osc8)");
+                    if (@hasDecl(T, "startHyperlink")) {
+                        try self.handler.startHyperlink(v.uri, v.id);
+                        return;
+                    } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
 
                 .hyperlink_end => {
-                    @panic("TODO(osc8)");
+                    if (@hasDecl(T, "endHyperlink")) {
+                        try self.handler.endHyperlink();
+                        return;
+                    } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
             }
 

--- a/src/terminal/style.zig
+++ b/src/terminal/style.zig
@@ -247,15 +247,13 @@ pub const Set = RefCountedSet(
     Id,
     size.CellCountInt,
     struct {
-        pub fn hash(self: *const @This(), base: anytype, style: Style) u64 {
+        pub fn hash(self: *const @This(), style: Style) u64 {
             _ = self;
-            _ = base;
             return style.hash();
         }
 
-        pub fn eql(self: *const @This(), base: anytype, a: Style, b: Style) bool {
+        pub fn eql(self: *const @This(), a: Style, b: Style) bool {
             _ = self;
-            _ = base;
             return a.eql(b);
         }
     },

--- a/src/terminal/style.zig
+++ b/src/terminal/style.zig
@@ -6,11 +6,10 @@ const page = @import("page.zig");
 const size = @import("size.zig");
 const Offset = size.Offset;
 const OffsetBuf = size.OffsetBuf;
+const RefCountedSet = @import("ref_counted_set.zig").RefCountedSet;
 
 const Wyhash = std.hash.Wyhash;
 const autoHash = std.hash.autoHash;
-
-const RefCountedSet = @import("ref_counted_set.zig").RefCountedSet;
 
 /// The unique identifier for a style. This is at most the number of cells
 /// that can fit into a terminal page.

--- a/src/terminal/style.zig
+++ b/src/terminal/style.zig
@@ -247,13 +247,15 @@ pub const Set = RefCountedSet(
     Id,
     size.CellCountInt,
     struct {
-        pub fn hash(self: *const @This(), style: Style) u64 {
+        pub fn hash(self: *const @This(), base: anytype, style: Style) u64 {
             _ = self;
+            _ = base;
             return style.hash();
         }
 
-        pub fn eql(self: *const @This(), a: Style, b: Style) bool {
+        pub fn eql(self: *const @This(), base: anytype, a: Style, b: Style) bool {
             _ = self;
+            _ = base;
             return a.eql(b);
         }
     },

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -2358,6 +2358,14 @@ const StreamHandler = struct {
         }
     }
 
+    pub fn startHyperlink(self: *StreamHandler, uri: []const u8, id: ?[]const u8) !void {
+        try self.terminal.screen.startHyperlink(uri, id);
+    }
+
+    pub fn endHyperlink(self: *StreamHandler) !void {
+        self.terminal.screen.endHyperlink();
+    }
+
     pub fn deviceAttributes(
         self: *StreamHandler,
         req: terminal.DeviceAttributeReq,


### PR DESCRIPTION
Fixes #1197

This adds support for [OSC8 Hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda).

This PR is primarily focused on the core functionality. The links behave almost identically to #968: i.e. the underline only shows up on hover + ctrl/command. I think we can improve this behavior for OSC8 specifically in the future because the nature of OSC8 is that the TUI program _wants it_ to be a link. 

Since the URL is not obvious on a hyperlink, this PR also modifies the GUI to add a visual element to show the hovered URL. This behavior has been added to normal regex URLs too. 

https://github.com/ghostty-org/ghostty/assets/1299/9f187eb1-894d-43b9-9c71-1039848e2b3d

cc @rockorager @gpanders who were particularly interested in this.

