### PR TITLE
Reflow rework, various fixes

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1753,7 +1753,7 @@ pub fn scrollCallback(
         };
     };
 
-    log.info("scroll: delta_y={} delta_x={}", .{ y.delta, x.delta });
+    // log.info("scroll: delta_y={} delta_x={}", .{ y.delta, x.delta });
 
     {
         self.renderer_state.mutex.lock();

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -5554,7 +5554,7 @@ test "PageList resize (no reflow) more cols with spacer head" {
             const rac = page.getRowAndCell(1, 0);
             rac.cell.* = .{
                 .content_tag = .codepoint,
-                .content = .{ .codepoint = ' ' },
+                .content = .{ .codepoint = 0 },
                 .wide = .spacer_head,
             };
         }
@@ -5570,7 +5570,7 @@ test "PageList resize (no reflow) more cols with spacer head" {
             const rac = page.getRowAndCell(1, 1);
             rac.cell.* = .{
                 .content_tag = .codepoint,
-                .content = .{ .codepoint = ' ' },
+                .content = .{ .codepoint = 0 },
                 .wide = .spacer_tail,
             };
         }
@@ -5593,7 +5593,7 @@ test "PageList resize (no reflow) more cols with spacer head" {
         }
         {
             const rac = page.getRowAndCell(1, 0);
-            try testing.expectEqual(@as(u21, ' '), rac.cell.content.codepoint);
+            try testing.expectEqual(@as(u21, 0), rac.cell.content.codepoint);
             try testing.expectEqual(pagepkg.Cell.Wide.narrow, rac.cell.wide);
         }
         {
@@ -6465,12 +6465,13 @@ test "PageList resize reflow more cols unwrap wide spacer head" {
             const rac = page.getRowAndCell(1, 0);
             rac.cell.* = .{
                 .content_tag = .codepoint,
-                .content = .{ .codepoint = ' ' },
+                .content = .{ .codepoint = 0 },
                 .wide = .spacer_head,
             };
         }
         {
             const rac = page.getRowAndCell(0, 1);
+            rac.row.wrap_continuation = true;
             rac.cell.* = .{
                 .content_tag = .codepoint,
                 .content = .{ .codepoint = '😀' },
@@ -6481,7 +6482,7 @@ test "PageList resize reflow more cols unwrap wide spacer head" {
             const rac = page.getRowAndCell(1, 1);
             rac.cell.* = .{
                 .content_tag = .codepoint,
-                .content = .{ .codepoint = ' ' },
+                .content = .{ .codepoint = 0 },
                 .wide = .spacer_tail,
             };
         }
@@ -6509,7 +6510,7 @@ test "PageList resize reflow more cols unwrap wide spacer head" {
         }
         {
             const rac = page.getRowAndCell(2, 0);
-            try testing.expectEqual(@as(u21, ' '), rac.cell.content.codepoint);
+            try testing.expectEqual(@as(u21, 0), rac.cell.content.codepoint);
             try testing.expectEqual(pagepkg.Cell.Wide.spacer_tail, rac.cell.wide);
         }
     }
@@ -6542,6 +6543,7 @@ test "PageList resize reflow more cols unwrap wide spacer head across two rows" 
         }
         {
             const rac = page.getRowAndCell(0, 1);
+            rac.row.wrap_continuation = true;
             rac.row.wrap = true;
             rac.cell.* = .{
                 .content_tag = .codepoint,
@@ -6552,12 +6554,13 @@ test "PageList resize reflow more cols unwrap wide spacer head across two rows" 
             const rac = page.getRowAndCell(1, 1);
             rac.cell.* = .{
                 .content_tag = .codepoint,
-                .content = .{ .codepoint = ' ' },
+                .content = .{ .codepoint = 0 },
                 .wide = .spacer_head,
             };
         }
         {
             const rac = page.getRowAndCell(0, 2);
+            rac.row.wrap_continuation = true;
             rac.cell.* = .{
                 .content_tag = .codepoint,
                 .content = .{ .codepoint = '😀' },
@@ -6568,7 +6571,7 @@ test "PageList resize reflow more cols unwrap wide spacer head across two rows" 
             const rac = page.getRowAndCell(1, 2);
             rac.cell.* = .{
                 .content_tag = .codepoint,
-                .content = .{ .codepoint = ' ' },
+                .content = .{ .codepoint = 0 },
                 .wide = .spacer_tail,
             };
         }
@@ -6601,7 +6604,7 @@ test "PageList resize reflow more cols unwrap wide spacer head across two rows" 
         }
         {
             const rac = page.getRowAndCell(3, 0);
-            try testing.expectEqual(@as(u21, ' '), rac.cell.content.codepoint);
+            try testing.expectEqual(@as(u21, 0), rac.cell.content.codepoint);
             try testing.expectEqual(pagepkg.Cell.Wide.spacer_head, rac.cell.wide);
         }
         {
@@ -6611,7 +6614,7 @@ test "PageList resize reflow more cols unwrap wide spacer head across two rows" 
         }
         {
             const rac = page.getRowAndCell(1, 1);
-            try testing.expectEqual(@as(u21, ' '), rac.cell.content.codepoint);
+            try testing.expectEqual(@as(u21, 0), rac.cell.content.codepoint);
             try testing.expectEqual(pagepkg.Cell.Wide.spacer_tail, rac.cell.wide);
         }
     }
@@ -6644,6 +6647,7 @@ test "PageList resize reflow more cols unwrap still requires wide spacer head" {
         }
         {
             const rac = page.getRowAndCell(0, 1);
+            rac.row.wrap_continuation = true;
             rac.cell.* = .{
                 .content_tag = .codepoint,
                 .content = .{ .codepoint = '😀' },
@@ -6654,7 +6658,7 @@ test "PageList resize reflow more cols unwrap still requires wide spacer head" {
             const rac = page.getRowAndCell(1, 1);
             rac.cell.* = .{
                 .content_tag = .codepoint,
-                .content = .{ .codepoint = ' ' },
+                .content = .{ .codepoint = 0 },
                 .wide = .spacer_tail,
             };
         }
@@ -6692,7 +6696,7 @@ test "PageList resize reflow more cols unwrap still requires wide spacer head" {
         }
         {
             const rac = page.getRowAndCell(1, 1);
-            try testing.expectEqual(@as(u21, ' '), rac.cell.content.codepoint);
+            try testing.expectEqual(@as(u21, 0), rac.cell.content.codepoint);
             try testing.expectEqual(pagepkg.Cell.Wide.spacer_tail, rac.cell.wide);
         }
     }
@@ -7054,12 +7058,13 @@ test "PageList resize reflow less cols wraps spacer head" {
             const rac = page.getRowAndCell(3, 0);
             rac.cell.* = .{
                 .content_tag = .codepoint,
-                .content = .{ .codepoint = ' ' },
+                .content = .{ .codepoint = 0 },
                 .wide = .spacer_head,
             };
         }
         {
             const rac = page.getRowAndCell(0, 1);
+            rac.row.wrap_continuation = true;
             rac.cell.* = .{
                 .content_tag = .codepoint,
                 .content = .{ .codepoint = '😀' },
@@ -7070,7 +7075,7 @@ test "PageList resize reflow less cols wraps spacer head" {
             const rac = page.getRowAndCell(1, 1);
             rac.cell.* = .{
                 .content_tag = .codepoint,
-                .content = .{ .codepoint = ' ' },
+                .content = .{ .codepoint = 0 },
                 .wide = .spacer_tail,
             };
         }
@@ -7108,7 +7113,7 @@ test "PageList resize reflow less cols wraps spacer head" {
         }
         {
             const rac = page.getRowAndCell(1, 1);
-            try testing.expectEqual(@as(u21, ' '), rac.cell.content.codepoint);
+            try testing.expectEqual(@as(u21, 0), rac.cell.content.codepoint);
             try testing.expectEqual(pagepkg.Cell.Wide.spacer_tail, rac.cell.wide);
         }
     }
@@ -7552,7 +7557,7 @@ test "PageList resize reflow less cols to eliminate a wide char" {
             const rac = page.getRowAndCell(1, 0);
             rac.cell.* = .{
                 .content_tag = .codepoint,
-                .content = .{ .codepoint = ' ' },
+                .content = .{ .codepoint = 0 },
                 .wide = .spacer_tail,
             };
         }
@@ -7604,7 +7609,7 @@ test "PageList resize reflow less cols to wrap a wide char" {
             const rac = page.getRowAndCell(2, 0);
             rac.cell.* = .{
                 .content_tag = .codepoint,
-                .content = .{ .codepoint = ' ' },
+                .content = .{ .codepoint = 0 },
                 .wide = .spacer_tail,
             };
         }
@@ -7637,7 +7642,7 @@ test "PageList resize reflow less cols to wrap a wide char" {
         }
         {
             const rac = page.getRowAndCell(1, 1);
-            try testing.expectEqual(@as(u21, ' '), rac.cell.content.codepoint);
+            try testing.expectEqual(@as(u21, 0), rac.cell.content.codepoint);
             try testing.expectEqual(pagepkg.Cell.Wide.spacer_tail, rac.cell.wide);
         }
     }

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -2337,6 +2337,7 @@ pub fn dumpString(
     opts: DumpString,
 ) !void {
     var blank_rows: usize = 0;
+    var blank_cells: usize = 0;
 
     var iter = opts.tl.rowIterator(.right_down, opts.br);
     while (iter.next()) |row_offset| {
@@ -2363,7 +2364,12 @@ pub fn dumpString(
             blank_rows += 1;
         }
 
-        var blank_cells: usize = 0;
+        if (!row.wrap_continuation or !opts.unwrap) {
+            // We should also reset blank cell counts at the start of each row
+            // unless we're unwrapping and this row is a wrap continuation.
+            blank_cells = 0;
+        }
+
         for (cells) |*cell| {
             // Skip spacers
             switch (cell.wide) {
@@ -2379,7 +2385,7 @@ pub fn dumpString(
                 continue;
             }
             if (blank_cells > 0) {
-                for (0..blank_cells) |_| try writer.writeByte(' ');
+                try writer.writeByteNTimes(' ', blank_cells);
                 blank_cells = 0;
             }
 

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -343,7 +343,7 @@ pub fn print(self: *Terminal, c: u21) !void {
                         if (self.screen.cursor.x == right_limit - 1) {
                             if (!self.modes.get(.wraparound)) return;
                             self.printCell(
-                                ' ',
+                                0,
                                 if (right_limit == self.cols) .spacer_head else .narrow,
                             );
                             try self.printWrap();
@@ -353,7 +353,7 @@ pub fn print(self: *Terminal, c: u21) !void {
 
                         // Write our spacer
                         self.screen.cursorRight(1);
-                        self.printCell(' ', .spacer_tail);
+                        self.printCell(0, .spacer_tail);
 
                         // Move the cursor again so we're beyond our spacer
                         if (self.screen.cursor.x == right_limit - 1) {
@@ -478,19 +478,19 @@ pub fn print(self: *Terminal, c: u21) !void {
                 // We only create a spacer head if we're at the real edge
                 // of the screen. Otherwise, we clear the space with a narrow.
                 // This allows soft wrapping to work correctly.
-                self.printCell(' ', if (right_limit == self.cols) .spacer_head else .narrow);
+                self.printCell(0, if (right_limit == self.cols) .spacer_head else .narrow);
                 try self.printWrap();
             }
 
             self.screen.cursorMarkDirty();
             self.printCell(c, .wide);
             self.screen.cursorRight(1);
-            self.printCell(' ', .spacer_tail);
+            self.printCell(0, .spacer_tail);
         } else {
             // This is pretty broken, terminals should never be only 1-wide.
             // We sould prevent this downstream.
             self.screen.cursorMarkDirty();
-            self.printCell(' ', .narrow);
+            self.printCell(0, .narrow);
         },
 
         else => unreachable,
@@ -2777,7 +2777,7 @@ test "Terminal: print wide char in single-width terminal" {
     {
         const list_cell = t.screen.pages.getCell(.{ .screen = .{ .x = 0, .y = 0 } }).?;
         const cell = list_cell.cell;
-        try testing.expectEqual(@as(u21, ' '), cell.content.codepoint);
+        try testing.expectEqual(@as(u21, 0), cell.content.codepoint);
         try testing.expectEqual(Cell.Wide.narrow, cell.wide);
     }
 
@@ -2928,7 +2928,7 @@ test "Terminal: print multicodepoint grapheme, disabled mode 2027" {
     {
         const list_cell = t.screen.pages.getCell(.{ .screen = .{ .x = 1, .y = 0 } }).?;
         const cell = list_cell.cell;
-        try testing.expectEqual(@as(u21, ' '), cell.content.codepoint);
+        try testing.expectEqual(@as(u21, 0), cell.content.codepoint);
         try testing.expect(!cell.hasGrapheme());
         try testing.expectEqual(Cell.Wide.spacer_tail, cell.wide);
         try testing.expect(list_cell.page.data.lookupGrapheme(cell) == null);
@@ -2945,7 +2945,7 @@ test "Terminal: print multicodepoint grapheme, disabled mode 2027" {
     {
         const list_cell = t.screen.pages.getCell(.{ .screen = .{ .x = 3, .y = 0 } }).?;
         const cell = list_cell.cell;
-        try testing.expectEqual(@as(u21, ' '), cell.content.codepoint);
+        try testing.expectEqual(@as(u21, 0), cell.content.codepoint);
         try testing.expect(!cell.hasGrapheme());
         try testing.expectEqual(Cell.Wide.spacer_tail, cell.wide);
         try testing.expect(list_cell.page.data.lookupGrapheme(cell) == null);
@@ -2961,7 +2961,7 @@ test "Terminal: print multicodepoint grapheme, disabled mode 2027" {
     {
         const list_cell = t.screen.pages.getCell(.{ .screen = .{ .x = 5, .y = 0 } }).?;
         const cell = list_cell.cell;
-        try testing.expectEqual(@as(u21, ' '), cell.content.codepoint);
+        try testing.expectEqual(@as(u21, 0), cell.content.codepoint);
         try testing.expect(!cell.hasGrapheme());
         try testing.expectEqual(Cell.Wide.spacer_tail, cell.wide);
         try testing.expect(list_cell.page.data.lookupGrapheme(cell) == null);
@@ -3091,7 +3091,7 @@ test "Terminal: print multicodepoint grapheme, mode 2027" {
     {
         const list_cell = t.screen.pages.getCell(.{ .screen = .{ .x = 1, .y = 0 } }).?;
         const cell = list_cell.cell;
-        try testing.expectEqual(@as(u21, ' '), cell.content.codepoint);
+        try testing.expectEqual(@as(u21, 0), cell.content.codepoint);
         try testing.expect(!cell.hasGrapheme());
         try testing.expectEqual(Cell.Wide.spacer_tail, cell.wide);
     }
@@ -3780,7 +3780,7 @@ test "Terminal: print wide char at right margin does not create spacer head" {
     {
         const list_cell = t.screen.pages.getCell(.{ .screen = .{ .x = 4, .y = 0 } }).?;
         const cell = list_cell.cell;
-        try testing.expectEqual(@as(u21, ' '), cell.content.codepoint);
+        try testing.expectEqual(@as(u21, 0), cell.content.codepoint);
         try testing.expectEqual(Cell.Wide.narrow, cell.wide);
 
         const row = list_cell.row;
@@ -7431,8 +7431,8 @@ test "Terminal: deleteLines wide character spacer head" {
         defer testing.allocator.free(str);
         const unwrapped_str = try t.plainStringUnwrapped(testing.allocator);
         defer testing.allocator.free(unwrapped_str);
-        try testing.expectEqualStrings("BBBB \n\u{1F600}CCC", str);
-        try testing.expectEqualStrings("BBBB \n\u{1F600}CCC", unwrapped_str);
+        try testing.expectEqualStrings("BBBB\n\u{1F600}CCC", str);
+        try testing.expectEqualStrings("BBBB\n\u{1F600}CCC", unwrapped_str);
     }
 }
 
@@ -7472,7 +7472,7 @@ test "Terminal: deleteLines wide character spacer head left scroll margin" {
         defer testing.allocator.free(str);
         const unwrapped_str = try t.plainStringUnwrapped(testing.allocator);
         defer testing.allocator.free(unwrapped_str);
-        try testing.expectEqualStrings("AABB \nBBCCC\n\u{1F600}", str);
+        try testing.expectEqualStrings("AABB\nBBCCC\n\u{1F600}", str);
         try testing.expectEqualStrings("AABB BBCCC\u{1F600}", unwrapped_str);
     }
 }
@@ -7513,7 +7513,7 @@ test "Terminal: deleteLines wide character spacer head right scroll margin" {
         defer testing.allocator.free(str);
         const unwrapped_str = try t.plainStringUnwrapped(testing.allocator);
         defer testing.allocator.free(unwrapped_str);
-        try testing.expectEqualStrings("BBBBA\n\u{1F600}CC \n    C", str);
+        try testing.expectEqualStrings("BBBBA\n\u{1F600}CC\n    C", str);
         try testing.expectEqualStrings("BBBBA\u{1F600}CC     C", unwrapped_str);
     }
 }
@@ -7597,7 +7597,7 @@ test "Terminal: deleteLines wide character spacer head left (< 2) and right scro
         defer testing.allocator.free(str);
         const unwrapped_str = try t.plainStringUnwrapped(testing.allocator);
         defer testing.allocator.free(unwrapped_str);
-        try testing.expectEqualStrings("ABBBA\nB CC \n    C", str);
+        try testing.expectEqualStrings("ABBBA\nB CC\n    C", str);
         try testing.expectEqualStrings("ABBBAB CC     C", unwrapped_str);
     }
 }
@@ -7633,7 +7633,7 @@ test "Terminal: deleteLines wide characters split by left/right scroll region bo
     {
         const str = try t.plainString(testing.allocator);
         defer testing.allocator.free(str);
-        try testing.expectEqualStrings("A B A\n     ", str);
+        try testing.expectEqualStrings("A B A", str);
     }
 }
 
@@ -8600,7 +8600,7 @@ test "Terminal: deleteChars split wide character from end" {
     {
         const list_cell = t.screen.pages.getCell(.{ .screen = .{ .x = 1, .y = 0 } }).?;
         const cell = list_cell.cell;
-        try testing.expectEqual(@as(u21, ' '), cell.content.codepoint);
+        try testing.expectEqual(@as(u21, 0), cell.content.codepoint);
         try testing.expectEqual(Cell.Wide.spacer_tail, cell.wide);
     }
 }

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -942,7 +942,7 @@ pub const Page = struct {
         map.removeByPtr(entry.key_ptr);
         cell.hyperlink = false;
 
-        // Mark that we no longer have graphemes, also search the row
+        // Mark that we no longer have hyperlinks, also search the row
         // to make sure its state is correct.
         const cells = row.cells.ptr(self.memory)[0..self.size.cols];
         for (cells) |c| if (c.hyperlink) return;
@@ -990,6 +990,18 @@ pub const Page = struct {
         const value = entry.value_ptr.*;
         map.removeByPtr(entry.key_ptr);
         map.putAssumeCapacity(dst_offset, value);
+    }
+
+    /// Returns the number of hyperlinks in the page. This isn't the byte
+    /// size but the total number of unique cells that have hyperlink data.
+    pub fn hyperlinkCount(self: *const Page) usize {
+        return self.hyperlink_map.map(self.memory).count();
+    }
+
+    /// Returns the hyperlink capacity for the page. This isn't the byte
+    /// size but the number of unique cells that can have hyperlink data.
+    pub fn hyperlinkCapacity(self: *const Page) usize {
+        return self.hyperlink_map.map(self.memory).capacity();
     }
 
     /// Append a codepoint to the given cell as a grapheme.
@@ -1112,6 +1124,12 @@ pub const Page = struct {
     /// size but the total number of unique cells that have grapheme data.
     pub fn graphemeCount(self: *const Page) usize {
         return self.grapheme_map.map(self.memory).count();
+    }
+
+    /// Returns the grapheme capacity for the page. This isn't the byte
+    /// size but the number of unique cells that can have grapheme data.
+    pub fn graphemeCapacity(self: *const Page) usize {
+        return self.grapheme_map.map(self.memory).capacity();
     }
 
     /// Returns the bitset for the dirty bits on this page.

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -684,11 +684,12 @@ pub const Page = struct {
                     // add it, and migrate.
                     const id = other.lookupHyperlink(src_cell).?;
                     const other_link = other.hyperlink_set.get(other.memory, id);
-                    const dst_id = try self.hyperlink_set.addContext(
+                    const dst_id = try self.hyperlink_set.addWithIdContext(
                         self.memory,
                         try other_link.dupe(other, self),
+                        id,
                         .{ .page = self },
-                    );
+                    ) orelse id;
                     try self.setHyperlink(dst_row, dst_cell, dst_id);
                 }
                 if (src_cell.style_id != style.default_id) {
@@ -705,13 +706,11 @@ pub const Page = struct {
                     // Slow path: Get the style from the other
                     // page and add it to this page's style set.
                     const other_style = other.styles.get(other.memory, src_cell.style_id);
-                    if (try self.styles.addWithId(
+                    dst_cell.style_id = try self.styles.addWithId(
                         self.memory,
                         other_style.*,
                         src_cell.style_id,
-                    )) |id| {
-                        dst_cell.style_id = id;
-                    }
+                    ) orelse src_cell.style_id;
                 }
             }
         }

--- a/src/terminal/ref_counted_set.zig
+++ b/src/terminal/ref_counted_set.zig
@@ -237,11 +237,6 @@ pub fn RefCountedSet(
                 return id;
             }
 
-            // Notify the context that the value is "deleted" if we return an
-            // error. This allows callers to clean up any resources associated
-            // with the value.
-            errdefer if (comptime @hasDecl(Context, "deleted")) ctx.deleted(value);
-
             // If the item doesn't exist, we need an available ID.
             if (self.next_id >= self.layout.cap) {
                 // Arbitrarily chosen, threshold for rehashing.


### PR DESCRIPTION
- Fixes #1857
- *Probably* fixes #1851
- Also fixes various other reflow-related page content corruptions.

The new reflow impl passes all tests (some of which were testing for incorrect behavior before, which I fixed) and passes my manual sanity check where I run the terminal, create a bunch of scrollback with various things in it, then resize a bunch to see if any of it ends up getting messed up or any asserts are hit.