### PR TITLE
macOS: URL preview limited to one line, truncate

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -153,6 +153,20 @@ extension Ghostty {
                     let padding: CGFloat = 3
                     ZStack {
                         HStack {
+                            Spacer()
+                            VStack(alignment: .leading) {
+                                Spacer()
+                                
+                                Text(verbatim: url)
+                                    .padding(.init(top: padding, leading: padding, bottom: padding, trailing: padding))
+                                    .background(.background)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                                    .opacity(isHoveringURLLeft ? 1 : 0)
+                            }
+                        }
+                        
+                        HStack {
                             VStack(alignment: .leading) {
                                 Spacer()
                                 
@@ -167,20 +181,6 @@ extension Ghostty {
                                     })
                             }
                             Spacer()
-                        }
-                        
-                        HStack {
-                            Spacer()
-                            VStack(alignment: .leading) {
-                                Spacer()
-                                
-                                Text(verbatim: url)
-                                    .padding(.init(top: padding, leading: padding, bottom: padding, trailing: padding))
-                                    .background(.background)
-                                    .lineLimit(1)
-                                    .truncationMode(.middle)
-                                    .opacity(isHoveringURLLeft ? 1 : 0)
-                            }
                         }
                     }
                 }

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -159,6 +159,8 @@ extension Ghostty {
                                 Text(verbatim: url)
                                     .padding(.init(top: padding, leading: padding, bottom: padding, trailing: padding))
                                     .background(.background)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
                                     .opacity(isHoveringURLLeft ? 0 : 1)
                                     .onHover(perform: { hovering in
                                         isHoveringURLLeft = hovering
@@ -175,6 +177,8 @@ extension Ghostty {
                                 Text(verbatim: url)
                                     .padding(.init(top: padding, leading: padding, bottom: padding, trailing: padding))
                                     .background(.background)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
                                     .opacity(isHoveringURLLeft ? 1 : 0)
                             }
                         }

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -224,6 +224,7 @@ pub const URLWidget = struct {
     pub fn init(surface: *const Surface, str: [:0]const u8) URLWidget {
         // Create the left
         const left = c.gtk_label_new(str.ptr);
+        c.gtk_label_set_ellipsize(@ptrCast(left), c.PANGO_ELLIPSIZE_MIDDLE);
         c.gtk_widget_add_css_class(@ptrCast(left), "view");
         c.gtk_widget_add_css_class(@ptrCast(left), "url-overlay");
         c.gtk_widget_set_halign(left, c.GTK_ALIGN_START);
@@ -232,6 +233,7 @@ pub const URLWidget = struct {
 
         // Create the right
         const right = c.gtk_label_new(str.ptr);
+        c.gtk_label_set_ellipsize(@ptrCast(right), c.PANGO_ELLIPSIZE_MIDDLE);
         c.gtk_widget_add_css_class(@ptrCast(right), "hidden");
         c.gtk_widget_add_css_class(@ptrCast(right), "view");
         c.gtk_widget_add_css_class(@ptrCast(right), "url-overlay");


### PR DESCRIPTION
Fixes #1933


<img width="912" alt="image" src="https://github.com/ghostty-org/ghostty/assets/1299/ece01662-1336-4b6a-b762-008be99ae0f2">