### PR TITLE
gtk: implement unfocused-split opacity and fill

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -70,6 +70,10 @@ x11_xkb: ?x11.Xkb = null,
 /// and initialization was successful.
 transient_cgroup_base: ?[]const u8 = null,
 
+/// True if we have initialized runtime CSS. We only need to do this once for the application, but
+/// we can't perform the intialization until we have created a window
+runtime_css_intialized: bool = false,
+
 pub fn init(core_app: *CoreApp, opts: Options) !App {
     _ = opts;
 

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -392,10 +392,8 @@ fn loadRuntimeCss(config: *const Config, provider: *c.GtkCssProvider) !void {
     const fmt =
         \\widget.unfocused-split {{
         \\ opacity: {d:.2};
-        \\}}
-        \\.ghostty-surface>stack {{
         \\ background-color: rgb({d},{d},{d});
-        \\}}"
+        \\}}
     ;
     // The length required is always less than the length of the pre-formatted string:
     // -> '{d:.2}' gets replaced with max 4 bytes (0.00)
@@ -413,7 +411,7 @@ fn loadRuntimeCss(config: *const Config, provider: *c.GtkCssProvider) !void {
         },
     );
     // Clears any previously loaded CSS from this provider
-    c.gtk_css_provider_load_from_string(provider, css);
+    c.gtk_css_provider_load_from_data(provider, css, @intCast(css.len));
 }
 
 /// Called by CoreApp to wake up the event loop.

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -389,10 +389,22 @@ fn syncActionAccelerator(
 
 fn loadRuntimeCss(config: *const Config, provider: *c.GtkCssProvider) !void {
     const fill: Config.Color = config.@"unfocused-split-fill" orelse config.background;
-    var css_buf: [128]u8 = undefined;
+    const fmt =
+        \\widget.unfocused-split {{
+        \\ opacity: {d:.2};
+        \\}}
+        \\.ghostty-surface>stack {{
+        \\ background-color: rgb({d},{d},{d});
+        \\}}"
+    ;
+    // The length required is always less than the length of the pre-formatted string:
+    // -> '{d:.2}' gets replaced with max 4 bytes (0.00)
+    // -> each {d} could be replaced with max 3 bytes
+    var css_buf: [fmt.len]u8 = undefined;
+
     const css = try std.fmt.bufPrintZ(
         &css_buf,
-        "widget.unfocused-split {{ opacity: {d:.2}; }}\n.ghostty-surface>stack {{ background-color: rgb({d},{d},{d});}}",
+        fmt,
         .{
             config.@"unfocused-split-opacity",
             fill.r,

--- a/src/apprt/gtk/Split.zig
+++ b/src/apprt/gtk/Split.zig
@@ -77,6 +77,7 @@ pub fn init(
         .parent = &sibling.core_surface,
     });
     errdefer surface.destroy(alloc);
+    sibling.dimSurface();
 
     // Create the actual GTKPaned, attach the proper children.
     const orientation: c_uint = switch (direction) {

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1809,6 +1809,9 @@ fn gtkFocusEnter(_: *c.GtkEventControllerFocus, ud: ?*anyopaque) callconv(.C) vo
     // Notify our IM context
     c.gtk_im_context_focus_in(self.im_context);
 
+    // Unconditionally remove the unfocused split css class
+    c.gtk_widget_remove_css_class(@ptrCast(@alignCast(self.gl_area)), "unfocused-split");
+
     // Notify our surface
     self.core_surface.focusCallback(true) catch |err| {
         log.err("error in focus callback err={}", .{err});
@@ -1822,6 +1825,14 @@ fn gtkFocusLeave(_: *c.GtkEventControllerFocus, ud: ?*anyopaque) callconv(.C) vo
 
     // Notify our IM context
     c.gtk_im_context_focus_out(self.im_context);
+
+    // We only add the unfocused-split class if we are actually a split
+    switch (self.container) {
+        .split_br,
+        .split_tl,
+        => c.gtk_widget_add_css_class(@ptrCast(@alignCast(self.gl_area)), "unfocused-split"),
+        else => {},
+    }
 
     self.core_surface.focusCallback(false) catch |err| {
         log.err("error in focus callback err={}", .{err});

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1836,16 +1836,11 @@ fn gtkFocusLeave(_: *c.GtkEventControllerFocus, ud: ?*anyopaque) callconv(.C) vo
     // Notify our IM context
     c.gtk_im_context_focus_out(self.im_context);
 
-    // We only add the unfocused-split widget if we are actually a split
+    // We only dim the surface if we are a split
     switch (self.container) {
         .split_br,
         .split_tl,
-        => blk: {
-            if (self.unfocused_widget != null) break :blk;
-            self.unfocused_widget = c.gtk_drawing_area_new();
-            c.gtk_widget_add_css_class(self.unfocused_widget.?, "unfocused-split");
-            c.gtk_overlay_add_overlay(self.overlay, self.unfocused_widget.?);
-        },
+        => self.dimSurface(),
         else => {},
     }
 
@@ -1853,6 +1848,15 @@ fn gtkFocusLeave(_: *c.GtkEventControllerFocus, ud: ?*anyopaque) callconv(.C) vo
         log.err("error in focus callback err={}", .{err});
         return;
     };
+}
+
+/// Adds the unfocused_widget to the overlay. If the unfocused_widget has already been added, this
+/// is a no-op
+pub fn dimSurface(self: *Surface) void {
+    if (self.unfocused_widget != null) return;
+    self.unfocused_widget = c.gtk_drawing_area_new();
+    c.gtk_widget_add_css_class(self.unfocused_widget.?, "unfocused-split");
+    c.gtk_overlay_add_overlay(self.overlay, self.unfocused_widget.?);
 }
 
 fn gtkCloseConfirmation(

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -107,7 +107,6 @@ pub fn init(self: *Window, app: *App) !void {
 
     // Create a notebook to hold our tabs.
     const notebook_widget = c.gtk_notebook_new();
-    c.gtk_widget_add_css_class(notebook_widget, "ghostty-surface");
     const notebook: *c.GtkNotebook = @ptrCast(notebook_widget);
     self.notebook = notebook;
     const notebook_tab_pos: c_uint = switch (app.config.@"gtk-tabs-location") {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -409,8 +409,6 @@ palette: Palette = .{},
 /// is 0.15. This value still looks weird but you can at least see what's going
 /// on. A value outside of the range 0.15 to 1 will be clamped to the nearest
 /// valid value.
-///
-/// This is only supported on macOS.
 @"unfocused-split-opacity": f64 = 0.7,
 
 /// The color to dim the unfocused split. Unfocused splits are dimmed by
@@ -418,8 +416,6 @@ palette: Palette = .{},
 /// that rectangle and can be used to carefully control the dimming effect.
 ///
 /// This will default to the background color.
-///
-/// This is only supported on macOS.
 @"unfocused-split-fill": ?Color = null,
 
 /// The command to run, usually a shell. If this is not an absolute path, it'll


### PR DESCRIPTION
For a long time, us GTK users have been subject to lesser UX by not knowing which split was focused. Improve the GTK UX by implementing both unfocused-split-opacity and unfocused-split-fill. This is implemented by setting the background-color of the notebook stack, and conditionally applying a new css class "unfocused-split" to the unfocused split.

## Before
![image](https://github.com/ghostty-org/ghostty/assets/476352/3ce1f2f2-22f0-46ee-aa06-be08c77a9aa9)

## After
![image](https://github.com/ghostty-org/ghostty/assets/476352/c166d92c-7d4a-4237-8a13-32cc56ebafe0)