### PR TITLE
Tmux Control Mode Parser (ONLY the parser)

### DIFF
--- a/src/terminal/Parser.zig
+++ b/src/terminal/Parser.zig
@@ -800,7 +800,31 @@ test "csi: too many params" {
     }
 }
 
-test "dcs" {
+test "dcs: XTGETTCAP" {
+    var p = init();
+    _ = p.next(0x1B);
+    for ("P+") |c| {
+        const a = p.next(c);
+        try testing.expect(a[0] == null);
+        try testing.expect(a[1] == null);
+        try testing.expect(a[2] == null);
+    }
+
+    {
+        const a = p.next('q');
+        try testing.expect(p.state == .dcs_passthrough);
+        try testing.expect(a[0] == null);
+        try testing.expect(a[1] == null);
+        try testing.expect(a[2].? == .dcs_hook);
+
+        const hook = a[2].?.dcs_hook;
+        try testing.expectEqualSlices(u8, &[_]u8{'+'}, hook.intermediates);
+        try testing.expectEqualSlices(u16, &[_]u16{}, hook.params);
+        try testing.expectEqual('q', hook.final);
+    }
+}
+
+test "dcs: params" {
     var p = init();
     _ = p.next(0x1B);
     for ("P1000") |c| {

--- a/src/terminal/dcs.zig
+++ b/src/terminal/dcs.zig
@@ -395,25 +395,3 @@ test "tmux enter and implicit exit" {
         try testing.expect(cmd.tmux == .exit);
     }
 }
-
-test "tmux begin/end empty" {
-    const testing = std.testing;
-    const alloc = testing.allocator;
-
-    var h: Handler = .{};
-    defer h.deinit();
-    h.hook(alloc, .{ .params = &.{1000}, .final = 'p' }).?.deinit();
-    for ("%begin 1578922740 269 1\n") |byte| try testing.expect(h.put(byte) == null);
-    for ("%end 1578922740 269 1\n") |byte| try testing.expect(h.put(byte) == null);
-}
-
-test "tmux begin/error empty" {
-    const testing = std.testing;
-    const alloc = testing.allocator;
-
-    var h: Handler = .{};
-    defer h.deinit();
-    h.hook(alloc, .{ .params = &.{1000}, .final = 'p' }).?.deinit();
-    for ("%begin 1578922740 269 1\n") |byte| try testing.expect(h.put(byte) == null);
-    for ("%error 1578922740 269 1\n") |byte| try testing.expect(h.put(byte) == null);
-}

--- a/src/terminal/dcs.zig
+++ b/src/terminal/dcs.zig
@@ -98,6 +98,8 @@ pub const Handler = struct {
             .ignore,
             => {},
 
+            .tmux => {},
+
             .xtgettcap => |*list| {
                 if (list.items.len >= self.max_bytes) {
                     return error.OutOfMemory;
@@ -125,6 +127,8 @@ pub const Handler = struct {
             .inactive,
             .ignore,
             => null,
+
+            .tmux => null,
 
             .xtgettcap => |list| .{ .xtgettcap = .{ .data = list } },
 
@@ -157,6 +161,8 @@ pub const Handler = struct {
             .xtgettcap => |*list| list.deinit(),
 
             .decrqss => {},
+
+            .tmux => {},
         }
 
         self.state = .{ .inactive = {} };
@@ -170,10 +176,14 @@ pub const Command = union(enum) {
     /// DECRQSS
     decrqss: DECRQSS,
 
+    /// Tmux control mode
+    tmux: Tmux,
+
     pub fn deinit(self: Command) void {
         switch (self) {
             .xtgettcap => |*v| v.data.deinit(),
             .decrqss => {},
+            .tmux => {},
         }
     }
 
@@ -207,6 +217,12 @@ pub const Command = union(enum) {
         decstbm,
         decslrm,
     };
+
+    /// Tmux control mode
+    pub const Tmux = union(enum) {
+        enter: void,
+        exit: void,
+    };
 };
 
 const State = union(enum) {
@@ -225,6 +241,9 @@ const State = union(enum) {
         data: [2]u8 = undefined,
         len: u2 = 0,
     },
+
+    /// Tmux control mode: https://github.com/tmux/tmux/wiki/Control-Mode
+    tmux: void,
 };
 
 test "unknown DCS command" {

--- a/src/terminal/main.zig
+++ b/src/terminal/main.zig
@@ -20,6 +20,7 @@ pub const modes = @import("modes.zig");
 pub const page = @import("page.zig");
 pub const parse_table = @import("parse_table.zig");
 pub const size = @import("size.zig");
+pub const tmux = @import("tmux.zig");
 pub const x11_color = @import("x11_color.zig");
 
 pub const Charset = charsets.Charset;

--- a/src/terminal/tmux.zig
+++ b/src/terminal/tmux.zig
@@ -1,0 +1,170 @@
+//! This file contains the implementation for tmux control mode. See
+//! tmux(1) for more information on control mode. Some basics are documented
+//! here but this is not meant to be a comprehensive source of protocol
+//! documentation.
+
+const std = @import("std");
+const assert = std.debug.assert;
+
+const log = std.log.scoped(.terminal_tmux);
+
+/// A tmux control mode client. It is expected that the caller establishes
+/// the connection in some way (i.e. detects the opening DCS sequence). This
+/// just works on a byte stream.
+pub const Client = struct {
+    /// Current state of the client.
+    state: State = .idle,
+
+    /// The buffer used to store in-progress commands, output, etc.
+    buffer: std.ArrayList(u8),
+
+    /// The maximum size in bytes of the buffer. This is used to limit
+    /// memory usage. If the buffer exceeds this size, the client will
+    /// enter a broken state (the control mode session will be forcibly
+    /// exited and future data dropped).
+    max_bytes: usize = 1024 * 1024,
+
+    const State = enum {
+        /// Outside of any active command. This should drop any output
+        /// unless it is '%' on the first byte of a line.
+        idle,
+
+        /// We experienced unexpected input and are in a broken state
+        /// so we cannot continue processing.
+        broken,
+
+        /// Inside an active command (started with '%').
+        command,
+
+        /// Inside a begin/end block.
+        block,
+    };
+
+    pub fn deinit(self: *Client) void {
+        self.buffer.deinit();
+    }
+
+    // Handle a byte of input.
+    pub fn put(self: *Client, byte: u8) !?Notification {
+        if (self.buffer.items.len >= self.max_bytes) {
+            self.broken();
+            return error.OutOfMemory;
+        }
+
+        switch (self.state) {
+            // Drop because we're in a broken state.
+            .broken => return null,
+
+            // Waiting for a command so if the byte is not '%' then
+            // we're in a broken state. Return an exit command.
+            .idle => if (byte != '%') {
+                self.broken();
+                return .{ .exit = {} };
+            } else {
+                self.state = .command;
+            },
+
+            // If we're in a command and its not a newline then
+            // we accumulate. If it is a newline then we have a
+            // complete command we need to parse.
+            .command => if (byte == '\n') {
+                // We have a complete command, parse it.
+                return try self.parseNotification();
+            },
+
+            // If we're ina block then we accumulate until we see a newline
+            // and then we check to see if that line ended the block.
+            .block => if (byte == '\n') {
+                const idx = if (std.mem.lastIndexOfScalar(
+                    u8,
+                    self.buffer.items,
+                    '\n',
+                )) |v| v + 1 else 0;
+                const line = self.buffer.items[idx..];
+                if (std.mem.startsWith(u8, line, "%end") or
+                    std.mem.startsWith(u8, line, "%error"))
+                {
+                    // If it is an error then log it.
+                    if (std.mem.startsWith(u8, line, "%error")) {
+                        const output = self.buffer.items[0..idx];
+                        log.warn("tmux control mode error={s}", .{output});
+                    }
+
+                    // We ignore the rest of the line, see %begin for why.
+                    self.state = .idle;
+                    self.buffer.clearRetainingCapacity();
+                    return null;
+                }
+            },
+        }
+
+        try self.buffer.append(byte);
+
+        return null;
+    }
+
+    fn parseNotification(self: *Client) !?Notification {
+        assert(self.state == .command);
+
+        var it = std.mem.tokenizeScalar(u8, self.buffer.items, ' ');
+
+        // The command MUST exist because we guard entering the command
+        // state on seeing at least a '%'.
+        const cmd = it.next().?;
+        if (std.mem.eql(u8, cmd, "%begin")) {
+            // We don't use the rest of the tokens for now because tmux
+            // claims to guarantee that begin/end are always in order and
+            // never intermixed. In the future, we should probably validate
+            // this.
+            // TODO(tmuxcc): do this before merge?
+
+            // Move to block state because we expect a corresponding end/error
+            // and want to accumulate the data.
+            self.state = .block;
+            self.buffer.clearRetainingCapacity();
+            return null;
+        } else {
+            // Unknown command, log it and return to idle state.
+            log.warn("unknown tmux control mode command={s}", .{cmd});
+        }
+
+        // Successful exit, revert to idle state.
+        self.buffer.clearRetainingCapacity();
+        self.state = .idle;
+
+        return null;
+    }
+
+    // Mark the tmux state as broken.
+    fn broken(self: *Client) void {
+        self.state = .broken;
+        self.buffer.clearAndFree();
+    }
+};
+
+/// Possible notification types from tmux control mode. These are documented
+/// in tmux(1).
+pub const Notification = union(enum) {
+    enter: void,
+    exit: void,
+};
+
+test "tmux begin/end empty" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var c: Client = .{ .buffer = std.ArrayList(u8).init(alloc) };
+    defer c.deinit();
+    for ("%begin 1578922740 269 1\n") |byte| try testing.expect(try c.put(byte) == null);
+    for ("%end 1578922740 269 1\n") |byte| try testing.expect(try c.put(byte) == null);
+}
+
+test "tmux begin/error empty" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var c: Client = .{ .buffer = std.ArrayList(u8).init(alloc) };
+    defer c.deinit();
+    for ("%begin 1578922740 269 1\n") |byte| try testing.expect(try c.put(byte) == null);
+    for ("%error 1578922740 269 1\n") |byte| try testing.expect(try c.put(byte) == null);
+}

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1880,6 +1880,11 @@ const StreamHandler = struct {
     fn dcsCommand(self: *StreamHandler, cmd: *terminal.dcs.Command) !void {
         // log.warn("DCS command: {}", .{cmd});
         switch (cmd.*) {
+            .tmux => |tmux| {
+                // TODO: process it
+                log.warn("tmux control mode event unimplemented cmd={}", .{tmux});
+            },
+
             .xtgettcap => |*gettcap| {
                 const map = comptime terminfo.ghostty.xtgettcapMap();
                 while (gettcap.next()) |key| {
@@ -1887,6 +1892,7 @@ const StreamHandler = struct {
                     self.messageWriter(.{ .write_stable = response });
                 }
             },
+
             .decrqss => |decrqss| {
                 var response: [128]u8 = undefined;
                 var stream = std.io.fixedBufferStream(&response);

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1860,7 +1860,9 @@ const StreamHandler = struct {
     }
 
     pub fn dcsHook(self: *StreamHandler, dcs: terminal.DCS) !void {
-        self.dcs.hook(self.alloc, dcs);
+        var cmd = self.dcs.hook(self.alloc, dcs) orelse return;
+        defer cmd.deinit();
+        try self.dcsCommand(&cmd);
     }
 
     pub fn dcsPut(self: *StreamHandler, byte: u8) !void {


### PR DESCRIPTION
Related to #1935 

This adds the scaffolding for detecting and processing tmux control mode DCS sequences, aka "notifications" as tmux calls them. This doesn't implement all notifications, but implements the full lifecycle and has enough examples and tests to show how to easily add new notifications. 

This isn't hooked up to anything yet. I want to break this down into different phases as described in #1935.