### PR TITLE
apprt/gtk: toggle_window_decorations keybinding

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3504,6 +3504,12 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             } else log.warn("runtime doesn't implement toggleFullscreen", .{});
         },
 
+        .toggle_window_decorations => {
+            if (@hasDecl(apprt.Surface, "toggleWindowDecorations")) {
+                self.rt_surface.toggleWindowDecorations();
+            } else log.warn("runtime doesn't implement toggleWindowDecorations", .{});
+        },
+
         .select_all => {
             const sel = self.io.terminal.screen.selectAll();
             if (sel) |s| {

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -721,6 +721,18 @@ pub fn toggleFullscreen(self: *Surface, mac_non_native: configpkg.NonNativeFulls
     window.toggleFullscreen(mac_non_native);
 }
 
+pub fn toggleWindowDecorations(self: *Surface) void {
+    const window = self.container.window() orelse {
+        log.info(
+            "toggleWindowDecorations invalid for container={s}",
+            .{@tagName(self.container)},
+        );
+        return;
+    };
+
+    window.toggleWindowDecorations();
+}
+
 pub fn getTitleLabel(self: *Surface) ?*c.GtkWidget {
     switch (self.title) {
         .none => return null,

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -571,6 +571,11 @@ class: ?[:0]const u8 = null,
 ///
 ///   * only a single key input is allowed, `ctrl+a+b` is invalid.
 ///
+///   * the key input can be prefixed with `physical:` to specify a
+///     physical key mapping rather than a logical one. A physical key
+///     mapping responds to the hardware keycode and not the keycode
+///     translated by any system keyboard layouts. Example: "ctrl+physical:a"
+///
 /// Valid modifiers are `shift`, `ctrl` (alias: `control`), `alt` (alias: `opt`,
 /// `option`), and `super` (alias: `cmd`, `command`). You may use the modifier
 /// or the alias. When debugging keybinds, the non-aliased modifier will always
@@ -608,6 +613,12 @@ class: ?[:0]const u8 = null,
 ///   * `keybind=clear` will clear all set keybindings. Warning: this
 ///     removes ALL keybindings up to this point, including the default
 ///     keybindings.
+///
+/// A keybind by default causes the input to be consumed. This means that the
+/// associated encoding (if any) will not be sent to the running program
+/// in the terminal. If you wish to send the encoded value to the program,
+/// specify the "unconsumed:" prefix before the entire keybind. For example:
+/// "unconsumed:ctrl+a=reload_config"
 keybind: Keybinds = .{},
 
 /// Window padding. This applies padding between the terminal cells and the
@@ -669,7 +680,12 @@ keybind: Keybinds = .{},
 ///   * `true`
 ///   * `false` - windows won't have native decorations, i.e. titlebar and
 ///      borders. On MacOS this also disables tabs and tab overview.
-
+///
+/// The "toggle_window_decoration" keybind action can be used to create
+/// a keybinding to toggle this setting at runtime.
+///
+/// Changing this configuration in your configuration and reloading will
+/// only affect new windows. Existing windows will not be affected.
 @"window-decoration": bool = true,
 
 /// The font that will be used for the application's window and tab titles.
@@ -780,17 +796,6 @@ keybind: Keybinds = .{},
 //
 // Default is false.
 @"focus-follows-mouse": bool = false,
-
-/// When enabled, the full GTK titlebar is displayed instead of your window
-/// manager's simple titlebar. The behavior of this option will vary with your
-/// window manager.
-///
-/// This option does nothing when `window-decoration` is false or when running
-/// under macOS.
-///
-/// Changing this value at runtime and reloading the configuration will only
-/// affect new windows.
-@"gtk-titlebar": bool = true,
 
 /// Whether to allow programs running in the terminal to read/write to the
 /// system clipboard (OSC 52, for googling). The default is to allow clipboard
@@ -1101,6 +1106,17 @@ keybind: Keybinds = .{},
 /// Note that debug builds of Ghostty have a separate single-instance ID
 /// so you can test single instance without conflicting with release builds.
 @"gtk-single-instance": GtkSingleInstance = .desktop,
+
+/// When enabled, the full GTK titlebar is displayed instead of your window
+/// manager's simple titlebar. The behavior of this option will vary with your
+/// window manager.
+///
+/// This option does nothing when `window-decoration` is false or when running
+/// under macOS.
+///
+/// Changing this value at runtime and reloading the configuration will only
+/// affect new windows.
+@"gtk-titlebar": bool = true,
 
 /// Determines the side of the screen that the GTK tab bar will stick to.
 /// Top, bottom, left, and right are supported. The default is top.

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -266,6 +266,9 @@ pub const Action = union(enum) {
     /// Toggle fullscreen mode of window.
     toggle_fullscreen: void,
 
+    /// Toggle window decorations on and off. This only works on Linux.
+    toggle_window_decorations: void,
+
     /// Quit ghostty.
     quit: void,
 


### PR DESCRIPTION
Fixes #1943

This keybinding toggles window decorations at runtime. It is unbound by default. It only works on GTK.