### PR TITLE
SIMD base64 decode for Kitty graphics data

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1054,6 +1054,7 @@ fn addDeps(
 
         step.addCSourceFiles(.{
             .files = &.{
+                "src/simd/base64.cpp",
                 "src/simd/codepoint_width.cpp",
                 "src/simd/index_of.cpp",
                 "src/simd/vt.cpp",

--- a/src/simd/base64.cpp
+++ b/src/simd/base64.cpp
@@ -1,0 +1,20 @@
+#include <simdutf.h>
+
+extern "C" {
+
+size_t ghostty_simd_base64_max_length(const char* input, size_t length) {
+  return simdutf::maximal_binary_length_from_base64(input, length);
+}
+
+size_t ghostty_simd_base64_decode(const char* input,
+                                  size_t length,
+                                  char* output) {
+  simdutf::result r = simdutf::base64_to_binary(input, length, output);
+  if (r.error) {
+    return -1;
+  }
+
+  return r.count;
+}
+
+}  // extern "C"

--- a/src/simd/base64.zig
+++ b/src/simd/base64.zig
@@ -1,0 +1,39 @@
+const std = @import("std");
+
+// base64.cpp
+extern "c" fn ghostty_simd_base64_max_length(
+    input: [*]const u8,
+    len: usize,
+) usize;
+extern "c" fn ghostty_simd_base64_decode(
+    input: [*]const u8,
+    len: usize,
+    output: [*]u8,
+) isize;
+
+pub fn maxLen(input: []const u8) usize {
+    return ghostty_simd_base64_max_length(input.ptr, input.len);
+}
+
+pub fn decode(input: []const u8, output: []u8) error{Base64Invalid}![]const u8 {
+    const res = ghostty_simd_base64_decode(input.ptr, input.len, output.ptr);
+    if (res < 0) return error.Base64Invalid;
+    return output[0..@intCast(res)];
+}
+
+test "base64 maxLen" {
+    const testing = std.testing;
+    const len = maxLen("aGVsbG8gd29ybGQ=");
+    try testing.expectEqual(11, len);
+}
+
+test "base64 decode" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const input = "aGVsbG8gd29ybGQ=";
+    const len = maxLen(input);
+    const output = try alloc.alloc(u8, len);
+    defer alloc.free(output);
+    const str = try decode(input, output);
+    try testing.expectEqualStrings("hello world", str);
+}

--- a/src/simd/main.zig
+++ b/src/simd/main.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 
 pub usingnamespace @import("codepoint_width.zig");
+pub const base64 = @import("base64.zig");
 pub const index_of = @import("index_of.zig");
 pub const vt = @import("vt.zig");
 


### PR DESCRIPTION
Simply replaces our base64 decode with the simdutf base64 decode implementation. This alone improves Kitty graphics decoding time for directly transmitted graphics by ~5% under heavy load.