### PR TITLE
config: `-e` CLI flag automatically implies `gtk-single-instance=false`

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -432,7 +432,9 @@ palette: Palette = .{},
 ///
 /// If you're using the `ghostty` CLI there is also a shortcut to run a command
 /// with arguments directly: you can use the `-e` flag. For example: `ghostty -e
-/// fish --with --custom --args`.
+/// fish --with --custom --args`. The `-e` flag also automatically sets
+/// `gtk-single-instance = false` (no matter what) to ensure that a new
+/// instance is launched and the CLI args are respected.
 command: ?[]const u8 = null,
 
 /// If true, keep the terminal open after the command exits. Normally, the
@@ -2094,6 +2096,11 @@ pub fn parseManuallyHook(self: *Config, alloc: Allocator, arg: []const u8, iter:
         }
 
         self.command = command.items[0 .. command.items.len - 1];
+
+        // When "-e" is used on the command line then we always disabled
+        // single instance mode because single instance mode is incompatible
+        // with CLI flags.
+        self.@"gtk-single-instance" = .false;
 
         // Do not continue, we consumed everything.
         return false;


### PR DESCRIPTION
`gtk-single-instance` should already be doing desktop-only detection and in most cases it does. But there are some cases where it isn't and we haven't quite tracked it down yet.

In any case, when `-e` is used from the CLI, we definitely do not want to launch in single instance mode because `-e` is typically used in scripts or for one-off instances. This forces gtk-single-instance to false.