### PR TITLE
feat: add validate-config action

### DIFF
--- a/src/cli/action.zig
+++ b/src/cli/action.zig
@@ -9,6 +9,7 @@ const list_keybinds = @import("list_keybinds.zig");
 const list_themes = @import("list_themes.zig");
 const list_colors = @import("list_colors.zig");
 const show_config = @import("show_config.zig");
+const validate_config = @import("validate_config.zig");
 
 /// Special commands that can be invoked via CLI flags. These are all
 /// invoked by using `+<action>` as a CLI flag. The only exception is
@@ -34,6 +35,9 @@ pub const Action = enum {
 
     /// Dump the config to stdout
     @"show-config",
+
+    // Validate passed config file
+    @"validate-config",
 
     pub const Error = error{
         /// Multiple actions were detected. You can specify at most one
@@ -124,6 +128,7 @@ pub const Action = enum {
             .@"list-themes" => try list_themes.run(alloc),
             .@"list-colors" => try list_colors.run(alloc),
             .@"show-config" => try show_config.run(alloc),
+            .@"validate-config" => try validate_config.run(alloc),
         };
     }
 

--- a/src/cli/validate_config.zig
+++ b/src/cli/validate_config.zig
@@ -20,7 +20,12 @@ pub const Options = struct {
     }
 };
 
-/// The `validate-config` command is used to validate a Ghostty config
+/// The `validate-config` command is used to validate a Ghostty config file.
+///
+/// When executed without any arguments, this will load the config from the default location.
+///
+/// The `--config-file` argument can be passed to validate a specific target config
+/// file in a non-default location.
 pub fn run(alloc: std.mem.Allocator) !u8 {
     var opts: Options = .{};
     defer opts.deinit();

--- a/src/cli/validate_config.zig
+++ b/src/cli/validate_config.zig
@@ -42,14 +42,17 @@ pub fn run(alloc: std.mem.Allocator) !u8 {
         const abs_path = try std.fs.cwd().realpath(config_path, &buf);
 
         try cfg.loadFile(alloc, abs_path);
-
-        if (!cfg._errors.empty()) {
-            try stdout.print("Config is not valid path={s}", .{config_path});
-            return 1;
-        }
     } else {
         try cfg.loadDefaultFiles(alloc);
     }
 
-    return 0;
+    if (!cfg._errors.empty()) {
+        for (cfg._errors.list.items) |err| {
+            try stdout.print("{s}\n", .{err.message});
+        }
+
+        return 1;
+    }
+
+    return 1;
 }

--- a/src/cli/validate_config.zig
+++ b/src/cli/validate_config.zig
@@ -1,0 +1,59 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const args = @import("args.zig");
+const Action = @import("action.zig").Action;
+const Config = @import("../config.zig").Config;
+const cli = @import("../cli.zig");
+
+pub const Options = struct {
+    /// The path of the config file to validate
+    @"config-file": ?[:0]const u8 = null,
+
+    pub fn deinit(self: Options) void {
+        _ = self;
+    }
+
+    /// Enables "-h" and "--help" to work.
+    pub fn help(self: Options) !void {
+        _ = self;
+        return Action.help_error;
+    }
+};
+
+/// The `validate-config` command is used to validate a Ghostty config
+pub fn run(alloc: std.mem.Allocator) !u8 {
+    var opts: Options = .{};
+    defer opts.deinit();
+
+    {
+        var iter = try std.process.argsWithAllocator(alloc);
+        defer iter.deinit();
+        try args.parse(Options, alloc, &opts, &iter);
+    }
+
+    const stdout = std.io.getStdOut().writer();
+
+    // If a config path is passed, validate it, otherwise validate usual config options
+    if (opts.@"config-file") |config_path| {
+        const cwd = std.fs.cwd();
+
+        if (cwd.openFile(config_path, .{})) |file| {
+            defer file.close();
+
+            var cfg = try Config.default(alloc);
+            defer cfg.deinit();
+
+            var buf_reader = std.io.bufferedReader(file.reader());
+            var iter = cli.args.lineIterator(buf_reader.reader());
+            try cfg.loadIter(alloc, &iter);
+            try cfg.loadRecursiveFiles(alloc);
+            try cfg.finalize();
+        } else |err| {
+            try stdout.print("{any}", .{err});
+        }
+    } else {
+        _ = try Config.load(alloc);
+    }
+
+    return 0;
+}

--- a/src/cli/validate_config.zig
+++ b/src/cli/validate_config.zig
@@ -6,7 +6,8 @@ const Config = @import("../config.zig").Config;
 const cli = @import("../cli.zig");
 
 pub const Options = struct {
-    /// The path of the config file to validate
+    /// The path of the config file to validate. If this isn't specified,
+    /// then the default config file paths will be validated.
     @"config-file": ?[:0]const u8 = null,
 
     pub fn deinit(self: Options) void {
@@ -43,7 +44,7 @@ pub fn run(alloc: std.mem.Allocator) !u8 {
 
     // If a config path is passed, validate it, otherwise validate default configs
     if (opts.@"config-file") |config_path| {
-        var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+        var buf: [std.fs.max_path_bytes]u8 = undefined;
         const abs_path = try std.fs.cwd().realpath(config_path, &buf);
 
         try cfg.loadFile(alloc, abs_path);
@@ -59,7 +60,7 @@ pub fn run(alloc: std.mem.Allocator) !u8 {
             try stdout.print("{s}\n", .{err.message});
         }
 
-        return 65;
+        return 1;
     }
 
     return 0;

--- a/src/cli/validate_config.zig
+++ b/src/cli/validate_config.zig
@@ -42,17 +42,20 @@ pub fn run(alloc: std.mem.Allocator) !u8 {
         const abs_path = try std.fs.cwd().realpath(config_path, &buf);
 
         try cfg.loadFile(alloc, abs_path);
+        try cfg.loadRecursiveFiles(alloc);
     } else {
-        try cfg.loadDefaultFiles(alloc);
+        cfg = try Config.load(alloc);
     }
+
+    try cfg.finalize();
 
     if (!cfg._errors.empty()) {
         for (cfg._errors.list.items) |err| {
             try stdout.print("{s}\n", .{err.message});
         }
 
-        return 1;
+        return 65;
     }
 
-    return 1;
+    return 0;
 }

--- a/src/cli/validate_config.zig
+++ b/src/cli/validate_config.zig
@@ -38,7 +38,10 @@ pub fn run(alloc: std.mem.Allocator) !u8 {
 
     // If a config path is passed, validate it, otherwise validate default configs
     if (opts.@"config-file") |config_path| {
-        try cfg.loadFile(alloc, config_path);
+        var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+        const abs_path = try std.fs.cwd().realpath(config_path, &buf);
+
+        try cfg.loadFile(alloc, abs_path);
 
         if (!cfg._errors.empty()) {
             try stdout.print("Config is not valid path={s}", .{config_path});

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1686,6 +1686,7 @@ pub fn loadIter(
     try cli.args.parse(Config, alloc, self, iter);
 }
 
+/// Load configuration from the target config file at `path`.
 pub fn loadFile(self: *Config, alloc: Allocator, path: []const u8) !void {
     var file = try std.fs.cwd().openFile(path, .{});
     defer file.close();

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1687,6 +1687,8 @@ pub fn loadIter(
 }
 
 /// Load configuration from the target config file at `path`.
+///
+/// `path` must be resolved and absolute.
 pub fn loadFile(self: *Config, alloc: Allocator, path: []const u8) !void {
     assert(std.fs.path.isAbsolute(path));
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1688,6 +1688,8 @@ pub fn loadIter(
 
 /// Load configuration from the target config file at `path`.
 pub fn loadFile(self: *Config, alloc: Allocator, path: []const u8) !void {
+    assert(std.fs.path.isAbsolute(path));
+
     var file = try std.fs.cwd().openFile(path, .{});
     defer file.close();
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1687,9 +1687,7 @@ pub fn loadIter(
 }
 
 pub fn loadFile(self: *Config, alloc: Allocator, path: []const u8) !void {
-    const cwd = std.fs.cwd();
-
-    var file = try cwd.openFile(path, .{});
+    var file = try std.fs.cwd().openFile(path, .{});
     defer file.close();
 
     std.log.info("reading configuration file path={s}", .{path});

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1686,22 +1686,27 @@ pub fn loadIter(
     try cli.args.parse(Config, alloc, self, iter);
 }
 
+pub fn loadFile(self: *Config, alloc: Allocator, path: []const u8) !void {
+    const cwd = std.fs.cwd();
+
+    var file = try cwd.openFile(path, .{});
+    defer file.close();
+
+    std.log.info("reading configuration file path={s}", .{path});
+
+    var buf_reader = std.io.bufferedReader(file.reader());
+    var iter = cli.args.lineIterator(buf_reader.reader());
+    try self.loadIter(alloc, &iter);
+    try self.expandPaths(std.fs.path.dirname(path).?);
+}
+
 /// Load the configuration from the default configuration file. The default
 /// configuration file is at `$XDG_CONFIG_HOME/ghostty/config`.
 pub fn loadDefaultFiles(self: *Config, alloc: Allocator) !void {
     const config_path = try internal_os.xdg.config(alloc, .{ .subdir = "ghostty/config" });
     defer alloc.free(config_path);
 
-    const cwd = std.fs.cwd();
-    if (cwd.openFile(config_path, .{})) |file| {
-        defer file.close();
-        std.log.info("reading configuration file path={s}", .{config_path});
-
-        var buf_reader = std.io.bufferedReader(file.reader());
-        var iter = cli.args.lineIterator(buf_reader.reader());
-        try self.loadIter(alloc, &iter);
-        try self.expandPaths(std.fs.path.dirname(config_path).?);
-    } else |err| switch (err) {
+    self.loadFile(alloc, config_path) catch |err| switch (err) {
         error.FileNotFound => std.log.info(
             "homedir config not found, not loading path={s}",
             .{config_path},
@@ -1711,7 +1716,7 @@ pub fn loadDefaultFiles(self: *Config, alloc: Allocator) !void {
             "error reading config file, not loading err={} path={s}",
             .{ err, config_path },
         ),
-    }
+    };
 }
 
 /// Load and parse the CLI args.


### PR DESCRIPTION
In looking ahead at ideally maintaining both NixOS and `home-manager` modules for Ghostty, there's a precedent for more loosely typing module configuration options for tools that support a wide variety of them in `nixpkgs`, and instead ensuring validation during the build process.

For an example of what this pattern might look like, both the [Prometheus](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/monitoring/prometheus/default.nix#L29-L37) and [Nginx](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/web-servers/nginx/default.nix#L146-L147) NixOS modules implement it a similar way we might for Ghostty - running the generated config file through a validation step with the target binary.

As it stands, Ghostty doesn't have a CLI action one could call to validate a target config. This PR adds a simple CLI action `+validate-config` that either validates the default config locations without flags, or can be passed a `--config-file` flag to validate a target config. This would enable us to create a NixOS/HM module for Ghostty with config validation on build, somewhat like the following:

```nix
{
  config,
  pkgs,
  lib,
  ...
}:
with lib;
let
  cfg = config.programs.ghostty;

  settingsFormat = generators.toINI {
    mkKeyValue = generators.mkKeyValueDefault {
      mkValueString = generators.mkValueStringDefault;
    } " = ";
  };

  ghosttyConfigCheck =
    file:
    pkgs.runCommandLocal "ghostty-config-check" { nativeBuildInputs = [ cfg.package ]; } ''
      ln -s ${file} $out
      ghostty +validate-config --config-file=$out
    '';
in
{
  options.programs.ghostty = {
    enable = mkEnableOption "ghostty";
    package = mkPackageOption "ghostty" pkgs { };
    config = mkOption {
      # Restrict this to a subset of allowed config value types
      type = types.attrsOf types.anything;
      default = { };
    };
  };

  config = mkIf cfg.enabled {
    xdg.configFile."ghostty-config" = {
      target = ".ghostty/config";
      source =
        let
          rawConfig = pkgs.writeText "ghostty-config" (settingsFormat cfg.config);
        in
        ghosttyConfigCheck rawConfig;
    };
  };
}

```

If one were to build a configuration with this module and invalid config options, it would fail to build with the validation errors printed in the build log. Validating this way removes a lot of maintenance overhead for module maintainers - we don't have to keep all config options typed, we don't have to keep the module tracking a certain config structure based on available upstream Ghostty versions, etc.