### PR TITLE
terminal: differentiate OSC 133 continuation and secondary kinds

### DIFF
--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -1260,7 +1260,7 @@ pub fn Stream(comptime Handler: type) type {
                     if (@hasDecl(T, "promptStart")) {
                         switch (v.kind) {
                             .primary, .right => try self.handler.promptStart(v.aid, v.redraw),
-                            .continuation => try self.handler.promptContinuation(v.aid),
+                            .continuation, .secondary => try self.handler.promptContinuation(v.aid),
                         }
                         return;
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});


### PR DESCRIPTION
OSC 133 defines distinct continuation (c) and secondary (s) prompt kinds. They're both treated as prompt continuations but have different semantic meanings: `c` allows the user to "go back" and edit previous lines, while `s` does not.

We don't (yet) handle this "editable" distinction, but this change makes our OSC parser slightly more correct.