### PR TITLE
editorconfig: indent styles for shell scripts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.{sh,bash}]
+indent_size = 2
+indent_style = space
+
+[bash-preexec.sh]
+indent_size = 4
+indent_style = space


### PR DESCRIPTION
We're consistently using 2-space indentation in our shell scripts with the exception of bash-prefix.sh, which is a vendored script uses 4-space indentation (https://github.com/rcaloras/bash-preexec).

Add editorconfig rules to help maintain this consistency going forward.