### PR TITLE
bash: always send "end of command" prompt sequence

### DIFF
--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -140,7 +140,8 @@ function __ghostty_precmd() {
       fi
     fi
 
-    if test "$_ghostty_executing" != "0"; then
+    if test "$_ghostty_executing" != ""; then
+      # End of current command. Report its status.
       builtin printf "\033]133;D;%s;aid=%s\007" "$ret" "$BASHPID"
     fi
 
@@ -152,6 +153,7 @@ function __ghostty_precmd() {
       builtin printf "\e]7;kitty-shell-cwd://%s%s\a" "$HOSTNAME" "$PWD"
     fi
 
+    # Fresh line and start of prompt.
     builtin printf "\033]133;A;aid=%s\007" "$BASHPID"
     _ghostty_executing=0
 }


### PR DESCRIPTION
I noticed that both wezterm[0] and the OSC 133 reference script[1] (upon which wezterm and our bash integration appear to be based) always send the "end of prompt" sequence in their precmd functions (except during their first execution, when no previous command has been executed).

This is a subtle logical difference: `$_ghostty_executing=""` (first run) versus `$_ghostty_executing="0"` (reentrancy check). I'm not sure how much a difference it makes except in rare edge case scenarios, but I think it makes sense to be consistent and always report the end of the current command.

[0] https://github.com/wez/wezterm/blob/main/assets/shell-integration/wezterm.sh#L479
[1] https://gitlab.freedesktop.org/Per_Bothner/specifications/-/blob/master/proposals/prompts-data/shell-integration.bash