### PR TITLE
shaper/coretext: reset font cache on grid change

### DIFF
--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -59,6 +59,10 @@ pub const Shaper = struct {
     /// attributed strings.
     cached_fonts: std.ArrayListUnmanaged(?*macos.foundation.Dictionary),
 
+    /// The grid that our cached fonts correspond to.
+    /// If the grid changes then we need to reset our cache.
+    cached_font_grid: ?*font.SharedGrid,
+
     /// The list of CoreFoundation objects to release on the dedicated
     /// release thread. This is built up over the course of shaping and
     /// sent to the release thread when endFrame is called.
@@ -241,6 +245,7 @@ pub const Shaper = struct {
             .features = feats,
             .writing_direction = writing_direction,
             .cached_fonts = .{},
+            .cached_font_grid = null,
             .cf_release_pool = .{},
             .cf_release_thread = cf_release_thread,
             .cf_release_thr = cf_release_thr,
@@ -487,6 +492,24 @@ pub const Shaper = struct {
         grid: *font.SharedGrid,
         index: font.Collection.Index,
     ) !*macos.foundation.Dictionary {
+        // If this grid doesn't match the one we've cached fonts for,
+        // then we reset the cache list since it's no longer valid.
+        if (grid != self.cached_font_grid) {
+            // Put all the currently cached fonts in to
+            // the release pool before clearing the list.
+            try self.cf_release_pool.ensureUnusedCapacity(
+                self.alloc,
+                self.cached_fonts.items.len,
+            );
+            for (self.cached_fonts.items) |ft| {
+                if (ft) |f| self.cf_release_pool.appendAssumeCapacity(f);
+            }
+
+            self.cached_fonts.clearRetainingCapacity();
+
+            self.cached_font_grid = grid;
+        }
+
         const index_int = index.int();
 
         // The cached fonts are indexed directly by the font index, since


### PR DESCRIPTION
Not doing this caused issues with spacing of ligatures and multi-substitutions when changing the font size with cmd +/-