### PR TITLE
fix: instead of overriding MANPATHs set by OS, append to them

### DIFF
--- a/src/os/env.zig
+++ b/src/os/env.zig
@@ -24,6 +24,9 @@ pub fn appendEnv(
 }
 
 /// Always append value to environment, even when it is empty.
+/// This is useful because some env vars (like MANPATH) want there
+/// to be an empty prefix to preserve existing values.
+///
 /// The returned value is always allocated so it must be freed.
 pub fn appendEnvAlways(
     alloc: Allocator,

--- a/src/os/env.zig
+++ b/src/os/env.zig
@@ -20,6 +20,16 @@ pub fn appendEnv(
     if (current.len == 0) return try alloc.dupe(u8, value);
 
     // Otherwise we must prefix.
+    return try appendEnvAlways(alloc, current, value);
+}
+
+/// Always append value to environment, even when it is empty.
+/// The returned value is always allocated so it must be freed.
+pub fn appendEnvAlways(
+    alloc: Allocator,
+    current: []const u8,
+    value: []const u8,
+) ![]u8 {
     return try std.fmt.allocPrint(alloc, "{s}{s}{s}", .{
         current,
         PATH_SEP,

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -648,13 +648,16 @@ const Subprocess = struct {
                     break :man;
                 };
 
-                const manpath = env.get("MANPATH") orelse "";
                 // Always append with colon in front, as it mean that if
                 // `MANPATH` is empty, then it should be treated as an extra
                 // path instead of overriding all paths set by OS.
                 try env.put(
                     "MANPATH",
-                    try internal_os.appendEnvAlways(alloc, manpath, dir),
+                    try internal_os.appendEnvAlways(
+                        alloc,
+                        env.get("MATHPATH") orelse "",
+                        dir,
+                    ),
                 );
             }
         }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -648,17 +648,14 @@ const Subprocess = struct {
                     break :man;
                 };
 
-                if (env.get("MANPATH")) |manpath| {
-                    // Append to the existing MANPATH. It's very unlikely that our bundle's
-                    // resources directory already appears here so we don't spend the time
-                    // searching for it.
-                    try env.put(
-                        "MANPATH",
-                        try internal_os.appendEnv(alloc, manpath, dir),
-                    );
-                } else {
-                    try env.put("MANPATH", dir);
-                }
+                const manpath = env.get("MANPATH") orelse "";
+                // Always append with colon in front, as it mean that if
+                // `MANPATH` is empty, then it should be treated as an extra
+                // path instead of overriding all paths set by OS.
+                try env.put(
+                    "MANPATH",
+                    try internal_os.appendEnvAlways(alloc, manpath, dir),
+                );
             }
         }
 


### PR DESCRIPTION
Quoting `man man`:

>  If MANPATH begins with a colon, it is appended to the default list;

Alternatively we can think about:

> if it ends with a colon, it is prepended to the default list;

To take preference over existing values, but that shouldn't be really a
problem, as there rather isn't much of another projects named `ghostty`.
