### PR TITLE
[DRAFT] Autoupdate Configuration Option(s)

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -12,6 +12,7 @@
 extern "C" {
 #endif
 
+#include <stddef.h>
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -109,6 +109,12 @@ class AppDelegate: NSObject,
         // Initial config loading
         configDidReload(ghostty)
         
+        updaterController.updater.updateCheckInterval = 60
+        updaterController.updater.automaticallyChecksForUpdates =
+            ghostty.config.autoUpdates == "check" || ghostty.config.autoUpdates == "download"
+        updaterController.updater.automaticallyDownloadsUpdates =
+            ghostty.config.autoUpdates == "download"
+        
         // Register our service provider. This must happen after everything is initialized.
         NSApp.servicesProvider = ServiceProvider()
         

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -331,5 +331,16 @@ extension Ghostty {
             let newColor = isLightBackground ? backgroundColor.darken(by: 0.08) : backgroundColor.darken(by: 0.4)
             return Color(newColor)
         }
+        
+        var autoUpdates: String {
+            let defaultValue = "off"
+            guard let config = self.config else { return defaultValue }
+            
+            let key = "auto-updates"
+            var value: UnsafePointer<Int8>? = nil
+            guard ghostty_config_get(config, &value, key, UInt(key.count)) else { return defaultValue }
+            guard let pointer = value else { return defaultValue }
+            return String(cString: pointer)
+        }
     }
 }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1161,6 +1161,13 @@ term: []const u8 = "xterm-ghostty",
 /// running. Defaults to an empty string if not set.
 @"enquiry-response": []const u8 = "",
 
+/// This controls the automatic update functionality on macOS by setting the
+/// properties on the Squirrel automatic update component. By default this is
+/// set to "off" which doesn't do anything. The "check" option will automatically
+/// check for updates but will NOT download them, while as the "download" option
+/// will both check AND download updates automatically for the user.
+@"auto-updates": AutoUpdates = .off,
+
 /// This is set by the CLI parser for deinit.
 _arena: ?ArenaAllocator = null,
 
@@ -3639,4 +3646,11 @@ pub const LinuxCgroup = enum {
     never,
     always,
     @"single-instance",
+};
+
+/// See auto-updates
+pub const AutoUpdates = enum {
+    check,
+    download,
+    off,
 };


### PR DESCRIPTION
This pull request is attempting to allow configuring Sparkle's autoupdate settings via the Ghostty config.

Currently the only configuration option "implemented" is the following
```
auto-updates = { check, download, off }
```
The `check` value tells sparkle to check but not automatically download.
The `download` value tells sparkle to both check and download automatically.
The `off` value disables auto update functionality completely.

---

Currently the logic is implemented allowing this to work, however despite both the [`automaticallyChecksForUpdates`](https://sparkle-project.github.io/documentation/api-reference/Classes/SPUUpdater.html#/c:objc(cs)SPUUpdater(py)automaticallyChecksForUpdates) and [`automaticallyDownloadsUpdates`](https://sparkle-project.github.io/documentation/api-reference/Classes/SPUUpdater.html#/c:objc(cs)SPUUpdater(py)automaticallyDownloadsUpdates) being set in the swift `AppDelegate` after loading the Ghostty config, Sparkle refuses to check at the configured interval or on startup.