### PR TITLE
Fix build on Xcode 16

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -13,6 +13,7 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 //-------------------------------------------------------------------


### PR DESCRIPTION
Fixes the error `Type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int` at https://github.com/ghostty-org/ghostty/blob/cb790b8e399f85ba4156d59cd73c912d5ce340f2/include/ghostty.h#L455 when building with Xcode 16.

Without this, Xcode 16 can't build starting from https://github.com/ghostty-org/ghostty/commit/cb790b8e399f85ba4156d59cd73c912d5ce340f2 because of the use of `size_t`.