### PR TITLE
apprt/gtk: implement context menu

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -797,13 +797,7 @@ fn initContextMenu(self: *App) void {
     const menu = c.g_menu_new();
     errdefer c.g_object_unref(menu);
 
-    {
-        const section = c.g_menu_new();
-        defer c.g_object_unref(section);
-        c.g_menu_append_section(menu, null, @ptrCast(@alignCast(section)));
-        c.g_menu_append(section, "Copy", "win.copy");
-        c.g_menu_append(section, "Paste", "win.paste");
-    }
+    createContextMenuCopyPasteSection(menu, false);
 
     {
         const section = c.g_menu_new();
@@ -821,6 +815,20 @@ fn initContextMenu(self: *App) void {
     }
 
     self.context_menu = menu;
+}
+
+fn createContextMenuCopyPasteSection(menu: ?*c.GMenu, has_selection: bool) void {
+    const section = c.g_menu_new();
+    defer c.g_object_unref(section);
+    c.g_menu_prepend_section(menu, null, @ptrCast(@alignCast(section)));
+    // FIXME: Feels really hackish, but disabling sensitivity on this doesn't seems to work(?)
+    c.g_menu_append(section, "Copy", if (has_selection) "win.copy" else "noop");
+    c.g_menu_append(section, "Paste", "win.paste");
+}
+
+pub fn refreshContextMenu(self: *App, has_selection: bool) void {
+    c.g_menu_remove(self.context_menu, 0);
+    createContextMenuCopyPasteSection(self.context_menu, has_selection);
 }
 
 fn isValidAppId(app_id: [:0]const u8) bool {

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -53,6 +53,9 @@ cursor_none: ?*c.GdkCursor,
 /// The shared application menu.
 menu: ?*c.GMenu = null,
 
+/// The shared context menu.
+context_menu: ?*c.GMenu = null,
+
 /// The configuration errors window, if it is currently open.
 config_errors_window: ?*ConfigErrorsWindow = null,
 
@@ -300,6 +303,7 @@ pub fn terminate(self: *App) void {
 
     if (self.cursor_none) |cursor| c.g_object_unref(cursor);
     if (self.menu) |menu| c.g_object_unref(menu);
+    if (self.context_menu) |context_menu| c.g_object_unref(context_menu);
     if (self.transient_cgroup_base) |path| self.core_app.alloc.free(path);
 
     self.config.deinit();
@@ -364,6 +368,8 @@ fn syncActionAccelerators(self: *App) !void {
     try self.syncActionAccelerator("win.new_tab", .{ .new_tab = {} });
     try self.syncActionAccelerator("win.split_right", .{ .new_split = .right });
     try self.syncActionAccelerator("win.split_down", .{ .new_split = .down });
+    try self.syncActionAccelerator("win.copy", .{ .copy_to_clipboard = {} });
+    try self.syncActionAccelerator("win.paste", .{ .paste_from_clipboard = {} });
 }
 
 fn syncActionAccelerator(
@@ -460,6 +466,7 @@ pub fn run(self: *App) !void {
     // Setup our menu items
     self.initActions();
     self.initMenu();
+    self.initContextMenu();
 
     // On startup, we want to check for configuration errors right away
     // so we can show our error window. We also need to setup other initial
@@ -784,6 +791,36 @@ fn initMenu(self: *App) void {
     // }
 
     self.menu = menu;
+}
+
+fn initContextMenu(self: *App) void {
+    const menu = c.g_menu_new();
+    errdefer c.g_object_unref(menu);
+
+    {
+        const section = c.g_menu_new();
+        defer c.g_object_unref(section);
+        c.g_menu_append_section(menu, null, @ptrCast(@alignCast(section)));
+        c.g_menu_append(section, "Copy", "win.copy");
+        c.g_menu_append(section, "Paste", "win.paste");
+    }
+
+    {
+        const section = c.g_menu_new();
+        defer c.g_object_unref(section);
+        c.g_menu_append_section(menu, null, @ptrCast(@alignCast(section)));
+        c.g_menu_append(section, "Split Right", "win.split_right");
+        c.g_menu_append(section, "Split Down", "win.split_down");
+    }
+
+    {
+        const section = c.g_menu_new();
+        defer c.g_object_unref(section);
+        c.g_menu_append_section(menu, null, @ptrCast(@alignCast(section)));
+        c.g_menu_append(section, "Terminal Inspector", "win.toggle_inspector");
+    }
+
+    self.context_menu = menu;
 }
 
 fn isValidAppId(app_id: [:0]const u8) bool {

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1177,10 +1177,7 @@ fn showContextMenu(self: *Surface, x: f32, y: f32) void {
         return;
     };
 
-    var point: c.graphene_point_t = .{
-        .x = x,
-        .y = y,
-    };
+    var point: c.graphene_point_t = .{ .x = x, .y = y };
     if (c.gtk_widget_compute_point(
         self.primaryWidget(),
         @ptrCast(window.window),
@@ -1199,9 +1196,7 @@ fn showContextMenu(self: *Surface, x: f32, y: f32) void {
     };
 
     c.gtk_popover_set_pointing_to(@ptrCast(@alignCast(window.context_menu)), &rect);
-
     self.app.refreshContextMenu(self.core_surface.hasSelection());
-
     c.gtk_popover_popup(@ptrCast(@alignCast(window.context_menu)));
 }
 

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1357,19 +1357,14 @@ fn gtkMouseDown(
         self.grabFocus();
     }
 
-    // Allow forcing context menu to open with ctrl in apps that would normally consume the click
-    if (button == .right and mods.ctrl) {
-        self.showContextMenu(@floatCast(x), @floatCast(y));
-        return;
-    }
-
     const consumed = self.core_surface.mouseButtonCallback(.press, button, mods) catch |err| {
         log.err("error in key callback err={}", .{err});
         return;
     };
 
-    // If a right click isn't consumed, mouseButtonCallback selects the hovered word and returns false.
-    // We can use this to handle the context menu opening under normal scenarios.
+    // If a right click isn't consumed, mouseButtonCallback selects the hovered
+    // word and returns false. We can use this to handle the context menu
+    // opening under normal scenarios.
     if (!consumed and button == .right) {
         self.showContextMenu(@floatCast(x), @floatCast(y));
     }

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1199,6 +1199,9 @@ fn showContextMenu(self: *Surface, x: f32, y: f32) void {
     };
 
     c.gtk_popover_set_pointing_to(@ptrCast(@alignCast(window.context_menu)), &rect);
+
+    self.app.refreshContextMenu(self.core_surface.hasSelection());
+
     c.gtk_popover_popup(@ptrCast(@alignCast(window.context_menu)));
 }
 


### PR DESCRIPTION
Implements a context menu for GTK:

## Without selection:
![image](https://github.com/user-attachments/assets/fa53bf7b-3b05-4fc5-be13-80732482fa73)

## With selection:
![image](https://github.com/user-attachments/assets/8917448d-04bf-455b-83f5-8be01d6656c6)

Tried to match behaviour in other GTK apps with the menu preferring to open down and right from the cursor, if possible.

## A couple notes:
Left a FIXME in place for disabling copy while nothing is selected. Currently I'm just setting the button action to `noop` which feels really hackish, but from trying multiple different approaches this was the best one by far. (Suggestions welcome).

Setting sensitivity to disabled on the menu item didn't seem to work from what I tried, while removing the menu item completely causes some nasty artifacts where the menu is displayed when it still hasn't finished doing layout again.

**Which brings me to the second note:**
Currently we're storing a reference to the same `PopoverMenu` and reusing it when we could be doing the same approach as with AppKit and just creating it on the fly as needed. 

This however causes some problems like the menu becoming a scrollable list for some reason (this I suspect to be just a skill issue on my end, since I can't find other GTK apps doing the same thing) and having this ugly relayout happening when you open the menu. 

*Nautilus creates a new `PopoverMenu` every time you right click on something*

https://github.com/user-attachments/assets/c49730ae-04eb-4a3f-9b07-b88b32ee7ef1

The video doesn't really show it well on anything other than the longer menus, but in person it's really noticeable.
