### PR TITLE
Fix tab relabelling when opening >9 tabs

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -118,7 +118,8 @@ class TerminalController: NSWindowController, NSWindowDelegate,
     
     /// Update the accessory view of each tab according to the keyboard
     /// shortcut that activates it (if any). This is called when the key window
-    /// changes and when a window is closed.
+    /// changes, when a window is closed, and when tabs are reordered
+    /// with the mouse.
     func relabelTabs() {
         // Reset this to false. It'll be set back to true later.
         tabListenForFrame = false

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -130,13 +130,13 @@ class TerminalController: NSWindowController, NSWindowDelegate,
         // otherwise the accessory view doesn't matter.
         tabListenForFrame = windows.count > 1
 
-        for (index, window) in windows.enumerated() {
-            guard index < 9 else {
+        for (tab, window) in zip(1..., windows) {
+            guard tab <= 9 else {
                 window.keyEquivalent = ""
                 continue
             }
 
-            let action = "goto_tab:\(index + 1)"
+            let action = "goto_tab:\(tab)"
 
             if let equiv = ghostty.config.keyEquivalent(for: action) {
                 window.keyEquivalent = "\(equiv)"

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -130,11 +130,18 @@ class TerminalController: NSWindowController, NSWindowDelegate,
         // otherwise the accessory view doesn't matter.
         tabListenForFrame = windows.count > 1
 
-        for (index, window) in windows.enumerated().prefix(9) {
+        for (index, window) in windows.enumerated() {
+            guard index < 9 else {
+                window.keyEquivalent = ""
+                continue
+            }
+
             let action = "goto_tab:\(index + 1)"
 
             if let equiv = ghostty.config.keyEquivalent(for: action) {
                 window.keyEquivalent = "\(equiv)"
+            } else {
+                window.keyEquivalent = ""
             }
         }
     }

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -129,15 +129,16 @@ class TerminalController: NSWindowController, NSWindowDelegate,
         // We only listen for frame changes if we have more than 1 window,
         // otherwise the accessory view doesn't matter.
         tabListenForFrame = windows.count > 1
-
+        
         for (tab, window) in zip(1..., windows) {
+            // We need to clear any windows beyond this because they have had
+            // a keyEquivalent set previously.
             guard tab <= 9 else {
                 window.keyEquivalent = ""
                 continue
             }
 
             let action = "goto_tab:\(tab)"
-
             if let equiv = ghostty.config.keyEquivalent(for: action) {
                 window.keyEquivalent = "\(equiv)"
             } else {


### PR DESCRIPTION
This fixes some related tab problems:
1. When you have 9+ tabs and open a new tab, the former 9th tab becomes the 10th tab, so we need to clear its label. Without this, you can get multiple tabs labelled as ⌘9. The fix could be as simple as clearing the 10th tab's label, but...
2. When you have 10+ tabs and drag a labelled tab to the right of the first 9 tabs, its label is not cleared (we only relabel the first 9 tabs). In this case, the tab could be dragged to any arbitrary position. We can't clear the specific tab's label, so we have to relabel _all_ the tabs. This may have been an oversight in https://github.com/ghostty-org/ghostty/pull/801.
3. I think there's some edge cases if someone unsets some of the ⌘1-9 keybindings. Fixed this by clearing the label on those tabs too.
4. Similar to 1), but if you enable `View > Show Tab Bar`, the 10th tab is labelled as ⌘1. Still not sure why that was happening, but relabelling all the tabs fixes it for free.