### PR TITLE
Fix multiple deprecated names for Zig lib/std

### DIFF
--- a/src/Command.zig
+++ b/src/Command.zig
@@ -394,7 +394,7 @@ pub fn expandPath(alloc: Allocator, cmd: []const u8) !?[]u8 {
     };
     defer if (builtin.os.tag == .windows) alloc.free(PATH);
 
-    var path_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
     var it = std.mem.tokenizeScalar(u8, PATH, std.fs.path.delimiter);
     var seen_eacces = false;
     while (it.next()) |search_path| {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3591,7 +3591,7 @@ fn writeScreenFile(
     try buf_writer.flush();
 
     // Get the final path
-    var path_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
     const path = try tmp_dir.dir.realpath(@tagName(loc), &path_buf);
 
     switch (write_action) {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1864,7 +1864,7 @@ pub fn loadCliArgs(self: *Config, alloc_gpa: Allocator) !void {
 
     // Config files loaded from the CLI args are relative to pwd
     if (self.@"config-file".value.list.items.len > 0) {
-        var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+        var buf: [std.fs.max_path_bytes]u8 = undefined;
         try self.expandPaths(try std.fs.cwd().realpath(".", &buf));
     }
 }
@@ -2097,7 +2097,7 @@ pub fn finalize(self: *Config) !void {
                     }
 
                     if (wd_home) {
-                        var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+                        var buf: [std.fs.max_path_bytes]u8 = undefined;
                         if (try internal_os.home(&buf)) |home| {
                             self.@"working-directory" = try alloc.dupe(u8, home);
                         }
@@ -2899,7 +2899,7 @@ pub const RepeatablePath = struct {
 
             // If it isn't absolute, we need to make it absolute relative
             // to the base.
-            var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+            var buf: [std.fs.max_path_bytes]u8 = undefined;
             const abs = dir.realpath(path, &buf) catch |err| {
                 try errors.add(alloc, .{
                     .message = try std.fmt.allocPrintZ(

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -375,7 +375,7 @@ pub const Action = union(enum) {
                 // ordering
                 comptime assert(info.is_tuple);
 
-                var it = std.mem.split(u8, param, ",");
+                var it = std.mem.splitAny(u8, param, ",");
                 var value: field.type = undefined;
                 inline for (info.fields) |field_| {
                     const next = it.next() orelse return Error.InvalidFormat;

--- a/src/os/cgroup.zig
+++ b/src/os/cgroup.zig
@@ -8,7 +8,7 @@ const log = std.log.scoped(.@"linux-cgroup");
 
 /// Returns the path to the cgroup for the given pid.
 pub fn current(alloc: Allocator, pid: std.os.linux.pid_t) !?[]const u8 {
-    var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
 
     // Read our cgroup by opening /proc/<pid>/cgroup and reading the first
     // line. The first line will look something like this:
@@ -39,7 +39,7 @@ pub fn create(
     child: []const u8,
     move: ?std.os.linux.pid_t,
 ) !void {
-    var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
     const path = try std.fmt.bufPrint(&buf, "/sys/fs/cgroup{s}/{s}", .{ cgroup, child });
     try std.fs.cwd().makePath(path);
 
@@ -61,7 +61,7 @@ pub fn moveInto(
     cgroup: []const u8,
     pid: std.os.linux.pid_t,
 ) !void {
-    var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
     const path = try std.fmt.bufPrint(&buf, "/sys/fs/cgroup{s}/cgroup.procs", .{cgroup});
     const file = try std.fs.cwd().openFile(path, .{ .mode = .write_only });
     defer file.close();
@@ -71,7 +71,7 @@ pub fn moveInto(
 /// Use clone3 to have the kernel create a new process with the correct cgroup
 /// rather than moving the process to the correct cgroup later.
 pub fn cloneInto(cgroup: []const u8) !posix.pid_t {
-    var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
     const path = try std.fmt.bufPrintZ(&buf, "/sys/fs/cgroup{s}", .{cgroup});
 
     // Get a file descriptor that refers to the cgroup directory in the cgroup
@@ -133,7 +133,7 @@ pub fn cloneInto(cgroup: []const u8) !posix.pid_t {
 /// than allocating a bunch of copies for an array.
 pub fn controllers(alloc: Allocator, cgroup: []const u8) ![]const u8 {
     assert(cgroup[0] == '/');
-    var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
 
     // Read the available controllers. These will be space separated.
     const path = try std.fmt.bufPrint(
@@ -165,7 +165,7 @@ pub fn configureControllers(
     v: []const u8,
 ) !void {
     assert(cgroup[0] == '/');
-    var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
 
     // Read the available controllers. These will be space separated.
     const path = try std.fmt.bufPrint(
@@ -195,7 +195,7 @@ pub fn configureMemoryLimit(cgroup: []const u8, limit: MemoryLimit) !void {
     };
 
     // Open our file
-    var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
     const path = try std.fmt.bufPrint(
         &buf,
         "/sys/fs/cgroup{s}/{s}",

--- a/src/os/resourcesdir.zig
+++ b/src/os/resourcesdir.zig
@@ -24,12 +24,12 @@ pub fn resourcesDir(alloc: std.mem.Allocator) !?[]const u8 {
     const sentinel = "terminfo/ghostty.termcap";
 
     // Get the path to our running binary
-    var exe_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var exe_buf: [std.fs.max_path_bytes]u8 = undefined;
     var exe: []const u8 = std.fs.selfExePath(&exe_buf) catch return null;
 
     // We have an exe path! Climb the tree looking for the terminfo
     // bundle as we expect it.
-    var dir_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
     while (std.fs.path.dirname(exe)) |dir| {
         exe = dir;
 
@@ -56,7 +56,7 @@ pub fn resourcesDir(alloc: std.mem.Allocator) !?[]const u8 {
 /// seems roughly right.
 ///
 /// "buf" must be large enough to fit base + sub + suffix. This is generally
-/// MAX_PATH_BYTES so its not a big deal.
+/// max_path_bytes so its not a big deal.
 pub fn maybeDir(
     buf: []u8,
     base: []const u8,

--- a/src/terminal/kitty/graphics_image.zig
+++ b/src/terminal/kitty/graphics_image.zig
@@ -74,7 +74,7 @@ pub const LoadingImage = struct {
             }
         }
 
-        var abs_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+        var abs_buf: [std.fs.max_path_bytes]u8 = undefined;
         const path = posix.realpath(cmd.data, &abs_buf) catch |err| {
             log.warn("failed to get absolute path: {}", .{err});
             return error.InvalidData;
@@ -197,7 +197,7 @@ pub const LoadingImage = struct {
 
             // The temporary dir is sometimes a symlink. On macOS for
             // example /tmp is /private/var/...
-            var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+            var buf: [std.fs.max_path_bytes]u8 = undefined;
             if (posix.realpath(dir, &buf)) |real_dir| {
                 if (std.mem.startsWith(u8, path, real_dir)) return true;
             } else |_| {}
@@ -627,7 +627,7 @@ test "image load: rgb, not compressed, temporary file" {
         .data = data,
     });
 
-    var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
     const path = try tmp_dir.dir.realpath("image.data", &buf);
 
     var cmd: command.Command = .{
@@ -664,7 +664,7 @@ test "image load: rgb, not compressed, regular file" {
         .data = data,
     });
 
-    var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
     const path = try tmp_dir.dir.realpath("image.data", &buf);
 
     var cmd: command.Command = .{
@@ -699,7 +699,7 @@ test "image load: png, not compressed, regular file" {
         .data = data,
     });
 
-    var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
     const path = try tmp_dir.dir.realpath("image.data", &buf);
 
     var cmd: command.Command = .{

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -589,7 +589,7 @@ const Subprocess = struct {
 
             // Assume that the resources directory is adjacent to the terminfo
             // database
-            var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+            var buf: [std.fs.max_path_bytes]u8 = undefined;
             const dir = try std.fmt.bufPrint(&buf, "{s}/terminfo", .{
                 std.fs.path.dirname(base) orelse unreachable,
             });
@@ -607,7 +607,7 @@ const Subprocess = struct {
 
         // Add our binary to the path if we can find it.
         ghostty_path: {
-            var exe_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+            var exe_buf: [std.fs.max_path_bytes]u8 = undefined;
             const exe_bin_path = std.fs.selfExePath(&exe_buf) catch |err| {
                 log.warn("failed to get ghostty exe path err={}", .{err});
                 break :ghostty_path;
@@ -642,7 +642,7 @@ const Subprocess = struct {
         // Add the man pages from our application bundle to MANPATH.
         if (comptime builtin.target.isDarwin()) {
             if (cfg.resources_dir) |resources_dir| man: {
-                var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+                var buf: [std.fs.max_path_bytes]u8 = undefined;
                 const dir = std.fmt.bufPrint(&buf, "{s}/../man", .{resources_dir}) catch |err| {
                     log.warn("error building manpath, man pages may not be available err={}", .{err});
                     break :man;

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -204,7 +204,7 @@ fn setupBash(
     if (!posix and env.get("HISTFILE") == null) {
         var home_buf: [1024]u8 = undefined;
         if (try homedir.home(&home_buf)) |home| {
-            var histfile_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+            var histfile_buf: [std.fs.max_path_bytes]u8 = undefined;
             const histfile = try std.fmt.bufPrint(
                 &histfile_buf,
                 "{s}/.bash_history",
@@ -223,7 +223,7 @@ fn setupBash(
     }
 
     // Set our new ENV to point to our integration script.
-    var path_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
     const integ_dir = try std.fmt.bufPrint(
         &path_buf,
         "{s}/shell-integration/bash/ghostty.bash",
@@ -433,7 +433,7 @@ fn setupXdgDataDirs(
     resource_dir: []const u8,
     env: *EnvMap,
 ) !void {
-    var path_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
 
     // Get our path to the shell integration directory.
     const integ_dir = try std.fmt.bufPrint(
@@ -484,7 +484,7 @@ fn setupZsh(
     }
 
     // Set our new ZDOTDIR
-    var path_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
     const integ_dir = try std.fmt.bufPrint(
         &path_buf,
         "{s}/shell-integration/zsh",


### PR DESCRIPTION
Zig's compilation threw several errors regarding used constant and function names from the Zig Standard Library that are deprecated. These changes fixed the compilation for me.

$ zig version
0.14.0-dev.208+854e86c56