### PR TITLE
inspector: fix mode prefix by prepending '?' only to private modes

### DIFF
--- a/src/inspector/Inspector.zig
+++ b/src/inspector/Inspector.zig
@@ -596,7 +596,7 @@ fn renderModesWindow(self: *Inspector) void {
             _ = cimgui.c.igTableSetColumnIndex(1);
             cimgui.c.igText(
                 "%s%d",
-                if (tag.ansi) "?" else "",
+                if (tag.ansi) "" else "?",
                 @as(u32, @intCast(tag.value)),
             );
         }


### PR DESCRIPTION
The inspector lists modes by their parameter when used to enable or
disable the mode. Private modes are enabled by using a '?' in the
sequence - however this '?' character was prepended to the ANSI modes.
