### PR TITLE
macOS Autoupdate Configuration Option(s)

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -12,6 +12,7 @@
 extern "C" {
 #endif
 
+#include <stddef.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -12,7 +12,6 @@
 extern "C" {
 #endif
 
-#include <stddef.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -75,7 +75,7 @@ class AppDelegate: NSObject,
     override init() {
         terminalManager = TerminalManager(ghostty)
         updaterController = SPUStandardUpdaterController(
-            startingUpdater: true,
+            startingUpdater: false,
             updaterDelegate: updaterDelegate,
             userDriverDelegate: nil
         )
@@ -108,13 +108,10 @@ class AppDelegate: NSObject,
 
         // Initial config loading
         configDidReload(ghostty)
-        
-        updaterController.updater.updateCheckInterval = 60
-        updaterController.updater.automaticallyChecksForUpdates =
-            ghostty.config.autoUpdates == "check" || ghostty.config.autoUpdates == "download"
-        updaterController.updater.automaticallyDownloadsUpdates =
-            ghostty.config.autoUpdates == "download"
-        
+
+        // Start our update checker.
+        updaterController.startUpdater()
+
         // Register our service provider. This must happen after everything is initialized.
         NSApp.servicesProvider = ServiceProvider()
 
@@ -381,6 +378,12 @@ class AppDelegate: NSObject,
         case "default": fallthrough
         default: UserDefaults.standard.removeObject(forKey: "NSQuitAlwaysKeepsWindows")
         }
+
+        // Sync our auto-update settings
+        updaterController.updater.automaticallyChecksForUpdates =
+            ghostty.config.autoUpdate == .check || ghostty.config.autoUpdate == .download
+        updaterController.updater.automaticallyDownloadsUpdates =
+            ghostty.config.autoUpdate == .download
 
         // Config could change keybindings, so update everything that depends on that
         syncMenuShortcuts()

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -108,7 +108,13 @@ class AppDelegate: NSObject,
 
         // Initial config loading
         configDidReload(ghostty)
-
+        
+        updaterController.updater.updateCheckInterval = 60
+        updaterController.updater.automaticallyChecksForUpdates =
+            ghostty.config.autoUpdates == "check" || ghostty.config.autoUpdates == "download"
+        updaterController.updater.automaticallyDownloadsUpdates =
+            ghostty.config.autoUpdates == "download"
+        
         // Register our service provider. This must happen after everything is initialized.
         NSApp.servicesProvider = ServiceProvider()
 

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -75,6 +75,9 @@ class AppDelegate: NSObject,
     override init() {
         terminalManager = TerminalManager(ghostty)
         updaterController = SPUStandardUpdaterController(
+            // Important: we must not start the updater here because we need to read our configuration
+            // first to determine whether we're automatically checking, downloading, etc. The updater
+            // is started later in applicationDidFinishLaunching
             startingUpdater: false,
             updaterDelegate: updaterDelegate,
             userDriverDelegate: nil

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -360,6 +360,17 @@ extension Ghostty {
             _ = ghostty_config_get(config, &v, key, UInt(key.count))
             return v;
         }
+
+        var autoUpdates: String {
+            let defaultValue = "off"
+            guard let config = self.config else { return defaultValue }
+            let key = "auto-updates"
+            
+            var value: UnsafePointer<Int8>? = nil
+            guard ghostty_config_get(config, &value, key, UInt(key.count)) else { return defaultValue }
+            guard let pointer = value else { return defaultValue }
+            return String(cString: pointer)
+        }
     }
 }
 

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -361,15 +361,15 @@ extension Ghostty {
             return v;
         }
 
-        var autoUpdates: String {
-            let defaultValue = "off"
+        var autoUpdate: AutoUpdate {
+            let defaultValue = AutoUpdate.check
             guard let config = self.config else { return defaultValue }
-            let key = "auto-updates"
-            
-            var value: UnsafePointer<Int8>? = nil
-            guard ghostty_config_get(config, &value, key, UInt(key.count)) else { return defaultValue }
-            guard let pointer = value else { return defaultValue }
-            return String(cString: pointer)
+            var v: UnsafePointer<Int8>? = nil
+            let key = "auto-update"
+            guard ghostty_config_get(config, &v, key, UInt(key.count)) else { return defaultValue }
+            guard let ptr = v else { return defaultValue }
+            let str = String(cString: ptr)
+            return AutoUpdate(rawValue: str) ?? defaultValue
         }
     }
 }
@@ -377,6 +377,12 @@ extension Ghostty {
 // MARK: Configuration Enums
 
 extension Ghostty.Config {
+    enum AutoUpdate : String {
+        case off
+        case check
+        case download
+    }
+
     enum ResizeOverlay : String {
         case always
         case never

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1462,12 +1462,29 @@ term: []const u8 = "xterm-ghostty",
 /// running. Defaults to an empty string if not set.
 @"enquiry-response": []const u8 = "",
 
-/// This controls the automatic update functionality on macOS by setting the
-/// properties on the Squirrel automatic update component. By default this is
-/// set to "off" which doesn't do anything. The "check" option will automatically
-/// check for updates but will NOT download them, while as the "download" option
-/// will both check AND download updates automatically for the user.
-@"auto-updates": AutoUpdates = .off,
+/// Control the auto-update functionality of Ghostty. This is only supported
+/// on macOS currently, since Linux builds are distributed via package
+/// managers that are not centrally controlled by Ghostty.
+///
+/// Checking or downloading an update does not send any information to
+/// the project beyond standard network information mandated by the
+/// underlying protocols. To put it another way: Ghostty doesn't explicitly
+/// add any tracking to the update process. The update process works by
+/// downloading information about the latest version and comparing it
+/// client-side to the current version.
+///
+/// Valid values are:
+///
+///  * `off` - Disable auto-updates.
+///  * `check` - Check for updates and notify the user if an update is
+///    available, but do not automatically download or install the update.
+///  * `download` - Check for updates, automatically download the update,
+///    notify the user, but do not automatically install the update.
+///
+/// The default value is `check`.
+///
+/// Changing this value at runtime works after a small delay.
+@"auto-update": AutoUpdate = .check,
 
 /// This is set by the CLI parser for deinit.
 _arena: ?ArenaAllocator = null,
@@ -4104,10 +4121,10 @@ pub const LinuxCgroup = enum {
 };
 
 /// See auto-updates
-pub const AutoUpdates = enum {
+pub const AutoUpdate = enum {
+    off,
     check,
     download,
-    off,
 };
 
 pub const Duration = struct {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1462,6 +1462,13 @@ term: []const u8 = "xterm-ghostty",
 /// running. Defaults to an empty string if not set.
 @"enquiry-response": []const u8 = "",
 
+/// This controls the automatic update functionality on macOS by setting the
+/// properties on the Squirrel automatic update component. By default this is
+/// set to "off" which doesn't do anything. The "check" option will automatically
+/// check for updates but will NOT download them, while as the "download" option
+/// will both check AND download updates automatically for the user.
+@"auto-updates": AutoUpdates = .off,
+
 /// This is set by the CLI parser for deinit.
 _arena: ?ArenaAllocator = null,
 
@@ -4094,6 +4101,13 @@ pub const LinuxCgroup = enum {
     never,
     always,
     @"single-instance",
+};
+
+/// See auto-updates
+pub const AutoUpdates = enum {
+    check,
+    download,
+    off,
 };
 
 pub const Duration = struct {


### PR DESCRIPTION
This pull request is attempting to allow configuring Sparkle's autoupdate settings via the Ghostty config.

Currently the only configuration option "implemented" is the following
```
auto-updates = { check, download, off }
```
The `check` value tells sparkle to check but not automatically download.
The `download` value tells sparkle to both check and download automatically.
The `off` value disables auto update functionality completely.

---

Currently the logic is implemented allowing this to work, however despite both the [`automaticallyChecksForUpdates`](https://sparkle-project.github.io/documentation/api-reference/Classes/SPUUpdater.html#/c:objc(cs)SPUUpdater(py)automaticallyChecksForUpdates) and [`automaticallyDownloadsUpdates`](https://sparkle-project.github.io/documentation/api-reference/Classes/SPUUpdater.html#/c:objc(cs)SPUUpdater(py)automaticallyDownloadsUpdates) being set in the swift `AppDelegate` after loading the Ghostty config, Sparkle refuses to check at the configured interval or on startup.