### PR TITLE
zsh: Generalize shebang

### DIFF
--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 #
 # Based on (started as) a copy of Kitty's zsh integration. Kitty is
 # distributed under GPLv3, so this file is also distributed under GPLv3.


### PR DESCRIPTION
Hey! Tried to add the zsh shell integration and it's failing for me on NixOS

```console
/nix/store/lkqjw3yazk7d3il8a0rp11pvjxdyq281-ghostty-0.1.0/share/ghostty/shell-integration/zsh/ghostty-integration: bad interpreter: /bin/zsh: no such file or directory
```