### PR TITLE
D-Bus and SystemD activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,24 @@ on the search path for a lot of software (such as Gnome and KDE) and
 installing into a prefix with `-p` sets up a directory structure to ensure
 all features of Ghostty work.
 
+### Linux D-Bus Debugging Tips
+
+The GTK runtime uses D-Bus behind the scenes for sending signals and other features. Debug and release
+builds use different names and paths on the D-Bus bus so that they can run simultaneously.
+
+| Type of Build | NAME                        | PATH                         |
+| ------------- | --------------------------- | ---------------------------- |
+| Release       | com.mitchellh.ghostty       | /com/mitchellh/ghostty       |
+| Debug         | com.mitchellh.ghostty-debug | /com/mitchellh/ghostty_debug |
+
+- Introspect
+
+      gdbus introspect --session --dest ${NAME} --object-path ${PATH}
+
+- Monitor
+
+      gdbus monitor --session --dest ${NAME}
+
 ### Mac `.app`
 
 To build the official, fully featured macOS application, you must

--- a/build.zig
+++ b/build.zig
@@ -147,6 +147,12 @@ pub fn build(b: *std.Build) !void {
         config.app_runtime == .none and
         (!emit_bench and !emit_test_exe and !emit_helpgen);
 
+    const linux_systemd_desktop = b.option(
+        bool,
+        "linux-systemd-desktop",
+        "Install advanced desktop integration files that use systemd user units and D-Bus activation.",
+    ) orelse true;
+
     // On NixOS, the built binary from `zig build` needs to patch the rpath
     // into the built binary for it to be portable across the NixOS system
     // it was built for. We default this to true if we can detect we're in
@@ -465,8 +471,12 @@ pub fn build(b: *std.Build) !void {
         // Desktop file so that we have an icon and other metadata
         if (config.flatpak) {
             b.installFile("dist/linux/app-flatpak.desktop", "share/applications/com.mitchellh.ghostty.desktop");
+        } else if (linux_systemd_desktop) {
+            b.installFile("dist/linux/release-systemd/app.desktop", "share/applications/com.mitchellh.ghostty.desktop");
+            b.installFile("dist/linux/release-systemd/dbus.service", "share/dbus-1/services/com.mitchellh.ghostty.service");
+            b.installFile("dist/linux/release-systemd/systemd.service", "lib/systemd/user/com.mitchellh.ghostty.service");
         } else {
-            b.installFile("dist/linux/app.desktop", "share/applications/com.mitchellh.ghostty.desktop");
+            b.installFile("dist/linux/release/app.desktop", "share/applications/com.mitchellh.ghostty.desktop");
         }
 
         // Various icons that our application can use, including the icon

--- a/dist/linux/debug-systemd/app.desktop
+++ b/dist/linux/debug-systemd/app.desktop
@@ -1,16 +1,20 @@
 [Desktop Entry]
-Name=Ghostty
+Version=1.0
+Name=Ghostty (Debug)
 Type=Application
 Comment=A terminal emulator
-Exec=ghostty
+TryExec=ghostty
+Exec=ghostty %F
 Icon=com.mitchellh.ghostty
 Categories=System;TerminalEmulator;
 Keywords=terminal;tty;pty;
 StartupNotify=true
+StartupWMClass=com.mitchellh.ghostty-debug
 Terminal=false
-Actions=new-window;
+Actions=new_window;
 X-GNOME-UsesNotifications=true
+DBusActivatable=true
 
-[Desktop Action new-window]
+[Desktop Action new_window]
 Name=New Window
 Exec=ghostty

--- a/dist/linux/debug-systemd/dbus.service
+++ b/dist/linux/debug-systemd/dbus.service
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=com.mitchellh.ghostty-debug
+SystemdService=com.mitchellh.ghostty-debug.service
+Exec=ghostty

--- a/dist/linux/debug-systemd/systemd.service
+++ b/dist/linux/debug-systemd/systemd.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Ghostty
+
+[Service]
+Type=dbus
+BusName=com.mitchellh.ghostty-debug
+ExecStart=ghostty

--- a/dist/linux/debug/app.desktop
+++ b/dist/linux/debug/app.desktop
@@ -1,0 +1,19 @@
+[Desktop Entry]
+Version=1.0
+Name=Ghostty (Debug)
+Type=Application
+Comment=A terminal emulator
+TryExec=ghostty
+Exec=ghostty %F
+Icon=com.mitchellh.ghostty
+Categories=System;TerminalEmulator;
+Keywords=terminal;tty;pty;
+StartupNotify=true
+StartupWMClass=com.mitchellh.ghostty-debug
+Terminal=false
+Actions=new_window;
+X-GNOME-UsesNotifications=true
+
+[Desktop Action new_window]
+Name=New Window
+Exec=ghostty

--- a/dist/linux/release-systemd/app.desktop
+++ b/dist/linux/release-systemd/app.desktop
@@ -1,0 +1,20 @@
+[Desktop Entry]
+Version=1.0
+Name=Ghostty
+Type=Application
+Comment=A terminal emulator
+TryExec=ghostty
+Exec=ghostty %F
+Icon=com.mitchellh.ghostty
+Categories=System;TerminalEmulator;
+Keywords=terminal;tty;pty;
+StartupNotify=true
+StartupWMClass=com.mitchellh.ghostty
+Terminal=false
+Actions=new_window;
+X-GNOME-UsesNotifications=true
+DBusActivatable=true
+
+[Desktop Action new_window]
+Name=New Window
+Exec=ghostty

--- a/dist/linux/release-systemd/dbus.service
+++ b/dist/linux/release-systemd/dbus.service
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=com.mitchellh.ghostty
+SystemdService=com.mitchellh.ghostty.service
+Exec=ghostty

--- a/dist/linux/release-systemd/systemd.service
+++ b/dist/linux/release-systemd/systemd.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Ghostty
+
+[Service]
+Type=dbus
+BusName=com.mitchellh.ghostty
+ExecStart=ghostty

--- a/dist/linux/release/app.desktop
+++ b/dist/linux/release/app.desktop
@@ -1,0 +1,19 @@
+[Desktop Entry]
+Version=1.0
+Name=Ghostty
+Type=Application
+Comment=A terminal emulator
+TryExec=ghostty
+Exec=ghostty %F
+Icon=com.mitchellh.ghostty
+Categories=System;TerminalEmulator;
+Keywords=terminal;tty;pty;
+StartupNotify=true
+StartupWMClass=com.mitchellh.ghostty
+Terminal=false
+Actions=new_window;
+X-GNOME-UsesNotifications=true
+
+[Desktop Action new_window]
+Name=New Window
+Exec=ghostty

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -146,7 +146,7 @@ class AppDelegate: NSObject,
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-        return ghostty.config.shouldQuitAfterLastWindowClosed
+        return ghostty.config.shouldQuitAfterLastWindowClosed != "never"
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -151,12 +151,13 @@ extension Ghostty {
         /// details on what each means. We only add documentation if there is a strange conversion
         /// due to the embedded library and Swift.
         
-        var shouldQuitAfterLastWindowClosed: Bool {
-            guard let config = self.config else { return true }
-            var v = false;
+        var shouldQuitAfterLastWindowClosed: String {
+            guard let config = self.config else { return "never" }
+            var v: UnsafePointer<Int8>? = nil;
             let key = "quit-after-last-window-closed"
-            _ = ghostty_config_get(config, &v, key, UInt(key.count))
-            return v
+            guard ghostty_config_get(config, &v, key, UInt(key.count)) else { return "never" }
+            guard let ptr = v else { return "never" };
+            return String(cString: ptr)
         }
         
         var windowColorspace: String {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -167,6 +167,11 @@ in
 
       mkdir -p "$out/nix-support"
 
+      sed -i -e "s@^Exec=.*ghostty@Exec=$out/bin/ghostty@" $out/share/applications/com.mitchellh.ghostty.desktop
+      sed -i -e "s@^TryExec=.*ghostty@TryExec=$out/bin/ghostty@" $out/share/applications/com.mitchellh.ghostty.desktop
+      sed -i -e "s@^Exec=.*ghostty@Exec=$out/bin/ghostty@" $out/share/dbus-1/services/com.mitchellh.ghostty.service
+      sed -i -e "s@^ExecStart=.*ghostty@ExecStart=$out/bin/ghostty@" $out/lib/systemd/user/com.mitchellh.ghostty.service
+
       mkdir -p "$terminfo/share"
       mv "$terminfo_src" "$terminfo/share/terminfo"
       ln -sf "$terminfo/share/terminfo" "$terminfo_src"
@@ -179,6 +184,7 @@ in
     '';
 
     postFixup = ''
+      # explicitly add libX11 to the rpath because it's dynamically loaded
       patchelf --add-rpath "${lib.makeLibraryPath [libX11]}" "$out/bin/.ghostty-wrapped"
     '';
 

--- a/src/App.zig
+++ b/src/App.zig
@@ -309,7 +309,7 @@ pub const Message = union(enum) {
     redraw_inspector: *apprt.Surface,
 
     const NewWindow = struct {
-        /// The parent surface
+        /// The parent surface.
         parent: ?*Surface = null,
     };
 };

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -282,8 +282,8 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
     const css_provider = c.gtk_css_provider_new();
     try loadRuntimeCss(&config, css_provider);
 
-    // Run a small no-op function so that we don't get stuck in
-    // g_main_context_iteration forever if there are no open surfaces.
+    // Run a small no-op function every 500 milliseconds so that we don't get
+    // stuck in g_main_context_iteration forever if there are no open surfaces.
     _ = c.g_timeout_add(500, gtkTimeout, null);
 
     return .{
@@ -517,7 +517,7 @@ pub fn run(self: *App) !void {
 
                         // If the background timeout is not null, check to see
                         // if the timeout has elapsed.
-                        if (self.config.@"background-timeout".duration) |duration| {
+                        if (self.config.@"quit-after-last-window-closed-delay".duration) |duration| {
                             const now = try std.time.Instant.now();
 
                             if (now.since(last_one) > duration)

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -545,6 +545,7 @@ fn realize(self: *Surface) !void {
     // Get our new surface config
     var config = try apprt.surface.newConfig(self.app.core_app, &self.app.config);
     defer config.deinit();
+
     if (!self.parent_surface) {
         // A hack, see the "parent_surface" field for more information.
         config.@"working-directory" = self.app.config.@"working-directory";

--- a/src/apprt/gtk/dbus/background.zig
+++ b/src/apprt/gtk/dbus/background.zig
@@ -1,0 +1,124 @@
+const std = @import("std");
+const c = @import("../c.zig");
+const CoreApp = @import("../../../App.zig");
+
+const log = std.log.scoped(.gtk_dbus);
+
+const UserData = struct {
+    core_app: *CoreApp,
+    dbus_connection: *c.DBusConnection,
+};
+
+pub fn requestBackgroundStart(core_app: *CoreApp, dbus_connection: *c.GDBusConnection) !void {
+    const name = c.g_dbus_connection_get_unique_name(dbus_connection);
+    log.info("dbus connection unique name: {s}", .{name});
+
+    const sender = try core_app.alloc.dupe(u8, std.mem.span(name)[1..]);
+    defer core_app.alloc.free(sender);
+    std.mem.replaceScalar(u8, sender, '.', '_');
+
+    var buf: [128]u8 = undefined;
+    const handle = try std.fmt.bufPrintZ(&buf, "/org/freedesktop/portal/desktop/request/{s}/ghostty_background_{d}", .{ sender, std.crypto.random.int(u32) });
+    log.info("handle: {s}", .{handle});
+
+    _ = c.g_dbus_connection_signal_subscribe(
+        dbus_connection,
+        null,
+        "org.freedesktop.portal.Request",
+        "Response",
+        &buf,
+        null,
+        c.G_DBUS_SIGNAL_FLAGS_NONE,
+        &requestBackgroundResult,
+        core_app,
+        null,
+    );
+
+    const options = c.g_variant_builder_new(c.G_VARIANT_TYPE("a{sv}"));
+    defer c.g_variant_builder_unref(options);
+
+    c.g_variant_builder_add(options, "{sv}", "handle_token", c.g_variant_new("s", "background"));
+    c.g_variant_builder_add(options, "{sv}", "reason", c.g_variant_new("s", "because we're cool"));
+    c.g_variant_builder_add(options, "{sv}", "autostart", c.g_variant_new("b", @as(u32, 0)));
+
+    const command = c.g_variant_builder_new(c.G_VARIANT_TYPE("as"));
+    defer c.g_variant_builder_unref(command);
+    c.g_variant_builder_add(command, "s", "ghostty");
+
+    c.g_variant_builder_add(options, "{sv}", "commandline", c.g_variant_builder_end(command));
+    c.g_variant_builder_add(options, "{sv}", "dbus-activatable", c.g_variant_new("b", @as(u32, 0)));
+
+    const params = c.g_variant_new(
+        "(s@a{sv})",
+        "",
+        c.g_variant_builder_end(options),
+    );
+    _ = c.g_variant_ref_sink(params);
+    defer c.g_variant_unref(params);
+
+    c.g_dbus_connection_call(
+        dbus_connection, // connection
+        "org.freedesktop.portal.Desktop", // bus name
+        "/org/freedesktop/portal/desktop", // object path
+        "org.freedesktop.portal.Background", // interface name
+        "RequestBackground", // method name
+        params, // parameters
+        null,
+        // c.G_VARIANT_TYPE("(o)"), // reply type
+        c.G_DBUS_CALL_FLAGS_NONE, // flags
+        -1, // timeout_msec
+        null, // cancellable
+        requestBackgroundFinish,
+        @ptrCast(dbus_connection),
+    );
+}
+
+fn requestBackgroundFinish(source_object: ?*c.GObject, res: ?*c.GAsyncResult, user_data: ?*anyopaque) callconv(.C) void {
+    _ = source_object;
+    const dbus_connection: *c.GDBusConnection = @ptrCast(@alignCast(user_data orelse unreachable));
+
+    var err: ?*c.GError = null;
+    defer if (err) |e| c.g_error_free(e);
+
+    const value = c.g_dbus_connection_call_finish(
+        dbus_connection,
+        res,
+        &err,
+    ) orelse {
+        if (err) |e| log.err("unable to request background: {s}", .{e.message});
+        return;
+    };
+    defer c.g_variant_unref(value);
+
+    log.err("return type: {s}", .{c.g_variant_get_type_string(value)});
+
+    if (c.g_variant_is_of_type(value, c.G_VARIANT_TYPE("(o)")) != 1) {
+        log.err("wrong return type: {s}", .{c.g_variant_get_type_string(value)});
+        return;
+    }
+
+    var path: ?[*c]u8 = null;
+    c.g_variant_get(value, "(o)", &path);
+    defer if (path) |p| c.g_free(p);
+
+    if (path) |p| {
+        log.warn("background path: {s}", .{p});
+    } else {
+        log.warn("error with path", .{});
+    }
+}
+
+fn requestBackgroundResult(
+    _: ?*c.GDBusConnection,
+    _: [*c]const u8,
+    _: [*c]const u8,
+    _: [*c]const u8,
+    _: [*c]const u8,
+    parameters: ?*c.GVariant,
+    user_data: ?*anyopaque,
+) callconv(.C) void {
+    _ = parameters;
+    _ = user_data;
+
+    log.info("request background result", .{});
+}

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -896,11 +896,11 @@ else switch (builtin.os.tag) {
 
 /// If `quit-after-last-window-closed` is set to `after-timeout`, this controls
 /// how long Ghostty will stay running after the last open surface has been
-/// closed.  If the `background-timeout` is unset Ghostty will remain running
-/// indefinitely. The duration should be long enough to allow Ghostty to
-/// initialize and open it's first window. The duration is specified as a series
-/// of numbers followed by time units. Whitespace is allowed between numbers and
-/// units. The allowed time units are as follows:
+/// closed.  If `quit-after-last-window-closed-delay` is unset Ghostty will
+/// remain running indefinitely. The duration should be long enough to allow
+/// Ghostty to initialize and open it's first window. The duration is specified
+/// as a series of numbers followed by time units. Whitespace is allowed between
+/// numbers and units. The allowed time units are as follows:
 ///
 ///   * `y` - 365 SI days, or 8760 hours, or 31536000 seconds. No adjustments
 ///     are made for leap years or leap seconds.
@@ -918,10 +918,10 @@ else switch (builtin.os.tag) {
 ///
 /// The maximum value is `584y 49w 23h 34m 33s 709ms 551µs 615ns`.
 ///
-/// By default the `background-timeout` is set to five minutes.
+/// By default `quit-after-last-window-closed-delay` is set to five minutes.
 ///
 /// Only implemented on Linux.
-@"background-timeout": Duration = .{ .duration = 5 * std.time.ns_per_min },
+@"quit-after-last-window-closed-delay": Duration = .{ .duration = 5 * std.time.ns_per_min },
 
 /// Whether to enable shell integration auto-injection or not. Shell integration
 /// greatly enhances the terminal experience by enabling a number of features:

--- a/src/os/dbus.zig
+++ b/src/os/dbus.zig
@@ -1,0 +1,21 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+/// Returns true if the program was launched by D-Bus activation.
+///
+/// On Linux GTK, this returns true if the program was launched using D-Bus
+/// activation. It will return false if Ghostty was launched any other way.
+///
+/// For other platforms and app runtimes, this returns false.
+pub fn launchedByDBusActivation() bool {
+    return switch (builtin.os.tag) {
+
+        // On Linux, D-Bus activation sets `DBUS_STARTER_ADDRESS` and
+        // `DBUS_STARTER_BUS_TYPE`. If these environment variables are present
+        // (no matter the value) we were launched by D-Bus activation.
+        .linux => std.posix.getenv("DBUS_STARTER_ADDRESS") != null and std.posix.getenv("DBUS_STARTER_BUS_TYPE") != null,
+
+        // No other system supports D-Bus so always return false.
+        else => false,
+    };
+}

--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -3,6 +3,7 @@
 //! also OS-specific features and conventions.
 
 pub usingnamespace @import("env.zig");
+pub usingnamespace @import("dbus.zig");
 pub usingnamespace @import("desktop.zig");
 pub usingnamespace @import("file.zig");
 pub usingnamespace @import("flatpak.zig");
@@ -13,6 +14,7 @@ pub usingnamespace @import("mouse.zig");
 pub usingnamespace @import("open.zig");
 pub usingnamespace @import("pipe.zig");
 pub usingnamespace @import("resourcesdir.zig");
+pub usingnamespace @import("systemd.zig");
 pub const CFReleaseThread = @import("cf_release_thread.zig");
 pub const TempDir = @import("TempDir.zig");
 pub const cgroup = @import("cgroup.zig");

--- a/src/os/systemd.zig
+++ b/src/os/systemd.zig
@@ -1,6 +1,12 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
+const log = std.log.scoped(.systemd);
+
+const c = @cImport({
+    @cInclude("unistd.h");
+});
+
 /// Returns true if the program was launched as a systemd service.
 ///
 /// On Linux, this returns true if the program was launched as a systemd
@@ -9,12 +15,45 @@ const builtin = @import("builtin");
 /// For other platforms and app runtimes, this returns false.
 pub fn launchedBySystemd() bool {
     return switch (builtin.os.tag) {
-        // On Linux, systemd sets the `INVOCATION_ID` (v232+) and the
-        // `JOURNAL_STREAM` (v231+) enviroment variables. If these environment
-        // variables are present (no matter the value) we were launched by
-        // systemd. This can be fooled if Ghostty is launched from another
-        // terminal that does not clean up these environment variables.
-        .linux => std.posix.getenv("INVOCATION_ID") != null and std.posix.getenv("JOURNAL_STREAM") != null,
+        .linux => linux: {
+            // On Linux, systemd sets the `INVOCATION_ID` (v232+) and the
+            // `JOURNAL_STREAM` (v231+) enviroment variables. If these
+            // environment variables are not present we were not launched by
+            // systemd.
+
+            if (std.posix.getenv("INVOCATION_ID") == null) break :linux false;
+            if (std.posix.getenv("JOURNAL_STREAM") == null) break :linux false;
+
+            // If `INVOCATION_ID` and `JOURNAL_STREAM` are present, check to make sure
+            // that our parent process is actually `systemd`, not some other terminal
+            // emulator that doesn't clean up those environment variables.
+
+            const ppid = c.getppid();
+
+            // If the parent PID is 1 we'll assume that it's `systemd` as other init systems
+            // are unlikely.
+
+            if (ppid == 1) break :linux true;
+
+            // If the parent PID is not 1 we need to check to see if we were launched by
+            // a user systemd daemon. Do that by checking the `/proc/<ppid>/exe` symlink
+            // to see if it ends with `/systemd`.
+
+            var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+            const path = std.fmt.bufPrint(&path_buf, "/proc/{d}/exe", .{ppid}) catch {
+                log.err("unable to format path to exe {d}", .{ppid});
+                break :linux false;
+            };
+            var link_buf: [std.fs.max_path_bytes]u8 = undefined;
+            const link = std.fs.readLinkAbsolute(path, &link_buf) catch {
+                log.err("unable to read link '{s}'", .{path});
+                break :linux false;
+            };
+
+            if (std.mem.endsWith(u8, link, "/systemd")) break :linux true;
+
+            break :linux false;
+        },
 
         // No other system supports systemd so always return false.
         else => false,

--- a/src/os/systemd.zig
+++ b/src/os/systemd.zig
@@ -47,7 +47,9 @@ pub fn launchedBySystemd() bool {
             var link_buf: [std.fs.max_path_bytes]u8 = undefined;
             const link = std.fs.readLinkAbsolute(path, &link_buf) catch {
                 log.err("unable to read link '{s}'", .{path});
-                break :linux false;
+                // Some systems prohibit access to /proc/<pid>/exe for some
+                // reason so don't fail if we can't read the link.
+                break :linux true;
             };
 
             if (std.mem.endsWith(u8, link, "/systemd")) break :linux true;

--- a/src/os/systemd.zig
+++ b/src/os/systemd.zig
@@ -1,0 +1,22 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+/// Returns true if the program was launched as a systemd service.
+///
+/// On Linux, this returns true if the program was launched as a systemd
+/// service. It will return false if Ghostty was launched any other way.
+///
+/// For other platforms and app runtimes, this returns false.
+pub fn launchedBySystemd() bool {
+    return switch (builtin.os.tag) {
+        // On Linux, systemd sets the `INVOCATION_ID` (v232+) and the
+        // `JOURNAL_STREAM` (v231+) enviroment variables. If these environment
+        // variables are present (no matter the value) we were launched by
+        // systemd. This can be fooled if Ghostty is launched from another
+        // terminal that does not clean up these environment variables.
+        .linux => std.posix.getenv("INVOCATION_ID") != null and std.posix.getenv("JOURNAL_STREAM") != null,
+
+        // No other system supports systemd so always return false.
+        else => false,
+    };
+}

--- a/src/os/systemd.zig
+++ b/src/os/systemd.zig
@@ -70,7 +70,7 @@ pub fn launchedBySystemd() bool {
                 };
                 const comm_data = comm_data_buf[0..comm_size];
 
-                if (std.mem.eql(u8, comm_data, "systemd")) break :linux true;
+                if (std.mem.eql(u8, std.mem.trimRight(u8, comm_data, "\n"), "systemd")) break :linux true;
 
                 break :linux false;
             };

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -691,6 +691,17 @@ const Subprocess = struct {
             env.remove("GSK_RENDERER");
         }
 
+        // On Linux, remove some environment variables that are set when Ghostty
+        // is launched from a `.desktop` file or by D-Bus activation.
+        if (comptime builtin.os.tag == .linux) {
+            env.remove("GIO_LAUNCHED_DESKTOP_FILE");
+            env.remove("GIO_LAUNCHED_DESKTOP_FILE_PID");
+            env.remove("DBUS_STARTER_ADDRESS");
+            env.remove("DBUS_STARTER_BUS_TYPE");
+            env.remove("INVOCATION_ID");
+            env.remove("JOURNAL_STREAM");
+        }
+
         // Setup our shell integration, if we can.
         const integrated_shell: ?shell_integration.Shell, const shell_command: []const u8 = shell: {
             const default_shell_command = cfg.command orelse switch (builtin.os.tag) {


### PR DESCRIPTION
This updates Ghostty to use D-Bus and SystemD activation to start. In addition to making future Gnome/GTK integration easier, this also implements a "background daemon" mode (Fixing #2010). The configuration variable `quit-after-last-window-closed` is changed to an enum that takes `always`, `never`, and `after-timeout`. Always works like `true` used to and `never` works like `false` used to. If set to `after-timeout` Ghostty will quit a configurable delay after the last surface is closed. This is set by default to five minutes. The timeout only works on Linux for now.

I attempted to update the macOS code to support the change to `quit-after-last-window-closed` but I have no way to test the changes so I didn't attempt to implement the background timeout.