### PR TITLE
gtk: allow running in the background

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -135,6 +135,9 @@ pub fn updateConfig(self: *App, config: *const Config) !void {
 pub fn addSurface(self: *App, rt_surface: *apprt.Surface) !void {
     try self.surfaces.append(self.alloc, rt_surface);
 
+    // Since we have non-zero surfaces, we can cancel the quit timer.
+    // It is up to the apprt if there is a quit timer at all and if it
+    // should be canceled.
     if (@hasDecl(apprt.App, "cancelQuitTimer")) rt_surface.app.cancelQuitTimer();
 }
 
@@ -161,7 +164,10 @@ pub fn deleteSurface(self: *App, rt_surface: *apprt.Surface) void {
         i += 1;
     }
 
-    if (@hasDecl(apprt.App, "startQuitTimer") and self.surfaces.items.len == 0) rt_surface.app.startQuitTimer();
+    // If we have no surfaces, we can start the quit timer. It is up to the
+    // apprt to determine if this is necessary.
+    if (@hasDecl(apprt.App, "startQuitTimer") and
+        self.surfaces.items.len == 0) rt_surface.app.startQuitTimer();
 }
 
 /// The last focused surface. This is only valid while on the main thread

--- a/src/App.zig
+++ b/src/App.zig
@@ -134,6 +134,8 @@ pub fn updateConfig(self: *App, config: *const Config) !void {
 /// The surface must be from the pool.
 pub fn addSurface(self: *App, rt_surface: *apprt.Surface) !void {
     try self.surfaces.append(self.alloc, rt_surface);
+
+    if (@hasDecl(apprt.App, "cancelQuitTimer")) rt_surface.app.cancelQuitTimer();
 }
 
 /// Delete the surface from the known surface list. This will NOT call the
@@ -158,6 +160,8 @@ pub fn deleteSurface(self: *App, rt_surface: *apprt.Surface) void {
 
         i += 1;
     }
+
+    if (@hasDecl(apprt.App, "startQuitTimer") and self.surfaces.items.len == 0) rt_surface.app.startQuitTimer();
 }
 
 /// The last focused surface. This is only valid while on the main thread

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -512,11 +512,10 @@ pub fn run(self: *App) !void {
                 if (self.config.@"quit-after-last-window-closed") {
                     // If the background timeout is not zero, check to see if
                     // the timeout has elapsed.
-                    if (self.config.@"quit-after-last-window-closed-delay".duration != 0) {
+                    if (self.config.@"quit-after-last-window-closed-delay") |duration| {
                         const now = try std.time.Instant.now();
 
-                        if (now.since(last_one) > self.config.@"quit-after-last-window-closed-delay".duration) {
-                            log.info("timeout elapsed", .{});
+                        if (now.since(last_one) > duration.duration) {
                             // The timeout has elapsed, quit.
                             break :q true;
                         }
@@ -525,7 +524,7 @@ pub fn run(self: *App) !void {
                         break :q false;
                     }
 
-                    // `quit-after-last-window-closed-delay` is zero, don't quit.
+                    // `quit-after-last-window-closed-delay` is not set, don't quit.
                     break :q false;
                 }
 

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -523,11 +523,7 @@ pub fn gtkQuitTimerExpired(ud: ?*anyopaque) callconv(.C) c.gboolean {
 /// This will get called when there are no more open surfaces.
 pub fn startQuitTimer(self: *App) void {
     // Cancel any previous timeout.
-    if (self.quit_timer_source) |source| {
-        if (c.g_source_remove(source) == c.FALSE)
-            log.warn("unable to remove quit timer {d}", .{source});
-        self.quit_timer_source = null;
-    }
+    self.cancelQuitTimer();
 
     // This is a no-op unless we are configured to quit after last window is closed.
     if (!self.config.@"quit-after-last-window-closed") return;

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3899,7 +3899,7 @@ pub const Duration = struct {
 
         var i: usize = 0;
         for (units) |unit| {
-            if (value > unit.factor) {
+            if (value >= unit.factor) {
                 if (i > 0) writer.writeAll(" ") catch unreachable;
                 const remainder = value % unit.factor;
                 const quotient = (value - remainder) / unit.factor;

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2222,9 +2222,16 @@ pub fn finalize(self: *Config) !void {
     // always the URL matcher.
     if (!self.@"link-url") self.link.links.items = self.link.links.items[1..];
 
+    // We warn when the quit-after-last-window-closed-delay is set to a very
+    // short value because it can cause Ghostty to quit before the first
+    // window is even shown.
     if (self.@"quit-after-last-window-closed-delay") |duration| {
-        if (duration.duration < 5 * std.time.ns_per_s)
-            log.warn("quit-after-last-window-closed-delay is set to a very short value ({}), which might cause problems", .{duration});
+        if (duration.duration < 5 * std.time.ns_per_s) {
+            log.warn(
+                "quit-after-last-window-closed-delay is set to a very short value ({}), which might cause problems",
+                .{duration},
+            );
+        }
     }
 }
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -880,10 +880,45 @@ keybind: Keybinds = .{},
 /// true. If set to false, surfaces will close without any confirmation.
 @"confirm-close-surface": bool = true,
 
-/// Whether or not to quit after the last window is closed. This defaults to
-/// false. Currently only supported on macOS. On Linux, the process always exits
-/// after the last window is closed.
+/// Whether or not to quit after the last surface is closed. This
+/// defaults to `false`. On Linux, if this is `true`, Ghostty can delay
+/// quitting fully for a configurable amount. See the documentation of
+/// `quit-after-last-window-closed-delay` for more information.
 @"quit-after-last-window-closed": bool = false,
+
+/// If `quit-after-last-window-closed` is `true`, this controls how long
+/// Ghostty will stay running after the last open surface has been closed.  If
+/// `quit-after-last-window-closed-delay` is set to 0 ns Ghostty will remain
+/// running indefinitely. The duration should be at least long enough to allow
+/// Ghostty to initialize and open it's first window, but this is not enforced
+/// nor will a warning be issued. The duration is specified as a series of
+/// numbers followed by time units. Whitespace is allowed between numbers and
+/// units. The allowed time units are as follows:
+///
+///   * `y` - 365 SI days, or 8760 hours, or 31536000 seconds. No adjustments
+///     are made for leap years or leap seconds.
+///   * `d` - one SI day, or 86400 seconds.
+///   * `h` - one hour, or 3600 seconds.
+///   * `m` - one minute, or 60 seconds.
+///   * `s` - one second.
+///   * `ms` - one millisecond, or 0.001 second.
+///   * `us` or `µs` - one microsecond, or 0.000001 second.
+///   * `ns` - one nanosecond, or 0.000000001 second.
+///
+/// Examples:
+///   * `1h30m`
+///   * `45s`
+///
+/// The maximum value is `584y 49w 23h 34m 33s 709ms 551µs 615ns`.
+///
+/// By default `quit-after-last-window-closed-delay` is set to `0 ns`.
+///
+/// Only implemented on Linux.
+@"quit-after-last-window-closed-delay": Duration = .{ .duration = 0 },
+
+/// This controls whether an initial window is created when Ghostty is run. Only
+/// implemented on Linux.
+@"initial-window": bool = true,
 
 /// Whether to enable shell integration auto-injection or not. Shell integration
 /// greatly enhances the terminal experience by enabling a number of features:
@@ -1109,15 +1144,16 @@ keybind: Keybinds = .{},
 /// must always be able to move themselves into an isolated cgroup.
 @"linux-cgroup-hard-fail": bool = false,
 
-/// If true, the Ghostty GTK application will run in single-instance mode:
-/// each new `ghostty` process launched will result in a new window if there
-/// is already a running process.
+/// If `true`, the Ghostty GTK application will run in single-instance mode:
+/// each new `ghostty` process launched will result in a new window if there is
+/// already a running process.
 ///
-/// If false, each new ghostty process will launch a separate application.
+/// If `false`, each new ghostty process will launch a separate application.
 ///
-/// The default value is `desktop` which will default to `true` if Ghostty
-/// detects it was launched from the `.desktop` file such as an app launcher.
-/// If Ghostty is launched from the command line, it will default to `false`.
+/// The default value is `detect` which will default to `true` if Ghostty
+/// detects that it was launched from the `.desktop` file such as an app
+/// launcher (like Gnome Shell)  or by D-Bus activation. If Ghostty is launched
+/// from the command line, it will default to `false`.
 ///
 /// Note that debug builds of Ghostty have a separate single-instance ID
 /// so you can test single instance without conflicting with release builds.
@@ -3753,3 +3789,211 @@ pub const LinuxCgroup = enum {
     always,
     @"single-instance",
 };
+
+pub const Duration = struct {
+    duration: u64 = 0,
+
+    pub fn clone(self: *const @This(), _: Allocator) !@This() {
+        return .{ .duration = self.duration };
+    }
+
+    pub fn equal(self: @This(), other: @This()) bool {
+        return self.duration == other.duration;
+    }
+
+    pub fn parseCLI(self: *@This(), _: Allocator, input: ?[]const u8) !void {
+        var remaining = input orelse {
+            self.duration = 0;
+            return;
+        };
+
+        const units = [_]struct {
+            name: []const u8,
+            factor: u64,
+        }{
+            .{ .name = "y", .factor = 365 * std.time.ns_per_day },
+            .{ .name = "w", .factor = std.time.ns_per_week },
+            .{ .name = "d", .factor = std.time.ns_per_day },
+            .{ .name = "h", .factor = std.time.ns_per_hour },
+            .{ .name = "m", .factor = std.time.ns_per_min },
+            .{ .name = "s", .factor = std.time.ns_per_s },
+            .{ .name = "ms", .factor = std.time.ns_per_ms },
+            .{ .name = "us", .factor = std.time.ns_per_us },
+            .{ .name = "µs", .factor = std.time.ns_per_us },
+            .{ .name = "ns", .factor = 1 },
+        };
+
+        var value: ?u64 = null;
+
+        while (remaining.len > 0) {
+            // Skip over whitespace before the number
+            while (remaining.len > 0 and std.ascii.isWhitespace(remaining[0])) {
+                remaining = remaining[1..];
+            }
+            // There was whitespace at the end, that's OK
+            if (remaining.len == 0) break;
+
+            // Find the longest number
+            const number = number: {
+                var prev_number: ?u64 = null;
+                var prev_remaining: ?[]const u8 = null;
+                for (1..remaining.len + 1) |index| {
+                    prev_number = std.fmt.parseUnsigned(u64, remaining[0..index], 10) catch {
+                        if (prev_remaining) |prev| remaining = prev;
+                        break :number prev_number;
+                    };
+                    prev_remaining = remaining[index..];
+                }
+                if (prev_remaining) |prev| remaining = prev;
+                break :number prev_number;
+            } orelse return error.InvalidValue;
+
+            // Skip over any whitespace between the number and the unit
+            while (remaining.len > 0 and std.ascii.isWhitespace(remaining[0])) {
+                remaining = remaining[1..];
+            }
+
+            // A number without a unit is invalid
+            if (remaining.len == 0) return error.InvalidValue;
+
+            // Find the longest matching unit. Needs to be the longest matching
+            // to distinguish 'm' from 'ms'.
+            const factor = factor: {
+                var prev_factor: ?u64 = null;
+                var prev_index: ?usize = null;
+                for (1..remaining.len + 1) |index| {
+                    const next_factor = next: {
+                        for (units) |unit| {
+                            if (std.mem.eql(u8, unit.name, remaining[0..index])) {
+                                break :next unit.factor;
+                            }
+                        }
+                        break :next null;
+                    };
+                    if (next_factor) |next| {
+                        prev_factor = next;
+                        prev_index = index;
+                    }
+                }
+                if (prev_index) |index| {
+                    remaining = remaining[index..];
+                }
+                break :factor prev_factor;
+            } orelse return error.InvalidValue;
+
+            if (value) |v|
+                value = v + number * factor
+            else
+                value = number * factor;
+        }
+
+        self.duration = value orelse 0;
+    }
+
+    pub fn formatEntry(self: @This(), formatter: anytype) !void {
+        var buf: [64]u8 = undefined;
+        var fbs = std.io.fixedBufferStream(&buf);
+        const writer = fbs.writer();
+
+        var value = self.duration;
+
+        const units = [_]struct {
+            name: []const u8,
+            factor: u64,
+        }{
+            .{ .name = "y", .factor = 365 * std.time.ns_per_day },
+            .{ .name = "w", .factor = std.time.ns_per_week },
+            .{ .name = "d", .factor = std.time.ns_per_day },
+            .{ .name = "h", .factor = std.time.ns_per_hour },
+            .{ .name = "m", .factor = std.time.ns_per_min },
+            .{ .name = "s", .factor = std.time.ns_per_s },
+            .{ .name = "ms", .factor = std.time.ns_per_ms },
+            .{ .name = "µs", .factor = std.time.ns_per_us },
+            .{ .name = "ns", .factor = 1 },
+        };
+
+        var i: usize = 0;
+        for (units) |unit| {
+            if (value > unit.factor) {
+                if (i > 0) writer.writeAll(" ") catch unreachable;
+                const remainder = value % unit.factor;
+                const quotient = (value - remainder) / unit.factor;
+                writer.print("{d}{s}", .{ quotient, unit.name }) catch unreachable;
+                value = remainder;
+                i += 1;
+            }
+        }
+
+        try formatter.formatEntry([]const u8, fbs.getWritten());
+    }
+};
+
+test "parse duration" {
+    var d: Duration = undefined;
+
+    try d.parseCLI(std.testing.allocator, "");
+    try std.testing.expectEqual(@as(u64, 0), d.duration);
+
+    try d.parseCLI(std.testing.allocator, "0ns");
+    try std.testing.expectEqual(@as(u64, 0), d.duration);
+
+    try d.parseCLI(std.testing.allocator, "1ns");
+    try std.testing.expectEqual(@as(u64, 1), d.duration);
+
+    try d.parseCLI(std.testing.allocator, "100ns");
+    try std.testing.expectEqual(@as(u64, 100), d.duration);
+
+    try d.parseCLI(std.testing.allocator, "1µs");
+    try std.testing.expectEqual(@as(u64, 1000), d.duration);
+
+    try d.parseCLI(std.testing.allocator, "1µs1ns");
+    try std.testing.expectEqual(@as(u64, 1001), d.duration);
+
+    try d.parseCLI(std.testing.allocator, "1µs 1ns");
+    try std.testing.expectEqual(@as(u64, 1001), d.duration);
+
+    try d.parseCLI(std.testing.allocator, " 1µs1ns");
+    try std.testing.expectEqual(@as(u64, 1001), d.duration);
+
+    try d.parseCLI(std.testing.allocator, "1µs1ns ");
+    try std.testing.expectEqual(@as(u64, 1001), d.duration);
+
+    try d.parseCLI(std.testing.allocator, "1y");
+    try std.testing.expectEqual(@as(u64, 365 * std.time.ns_per_day), d.duration);
+
+    try d.parseCLI(std.testing.allocator, "1d");
+    try std.testing.expectEqual(@as(u64, std.time.ns_per_day), d.duration);
+
+    try d.parseCLI(std.testing.allocator, "1h");
+    try std.testing.expectEqual(@as(u64, std.time.ns_per_hour), d.duration);
+
+    try d.parseCLI(std.testing.allocator, "1m");
+    try std.testing.expectEqual(@as(u64, std.time.ns_per_min), d.duration);
+
+    try d.parseCLI(std.testing.allocator, "1s");
+    try std.testing.expectEqual(@as(u64, std.time.ns_per_s), d.duration);
+
+    try d.parseCLI(std.testing.allocator, "1ms");
+    try std.testing.expectEqual(@as(u64, std.time.ns_per_ms), d.duration);
+
+    try d.parseCLI(std.testing.allocator, "30s");
+    try std.testing.expectEqual(@as(u64, 30 * std.time.ns_per_s), d.duration);
+
+    try d.parseCLI(std.testing.allocator, "584y 49w 23h 34m 33s 709ms 551µs 615ns");
+    try std.testing.expectEqual(std.math.maxInt(u64), d.duration);
+
+    try std.testing.expectError(error.InvalidValue, d.parseCLI(std.testing.allocator, "1"));
+    try std.testing.expectError(error.InvalidValue, d.parseCLI(std.testing.allocator, "s"));
+    try std.testing.expectError(error.InvalidValue, d.parseCLI(std.testing.allocator, "1x"));
+    try std.testing.expectError(error.InvalidValue, d.parseCLI(std.testing.allocator, "1 "));
+}
+
+test "format duration" {
+    const testing = std.testing;
+    var buf = std.ArrayList(u8).init(testing.allocator);
+    defer buf.deinit();
+
+    var p: Duration = .{ .duration = std.math.maxInt(u64) };
+    try p.formatEntry(formatterpkg.entryFormatter("a", buf.writer()));
+    try std.testing.expectEqualStrings("a = 584y 49w 23h 34m 33s 709ms 551µs 615ns\n", buf.items);
+}

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -916,8 +916,11 @@ keybind: Keybinds = .{},
 /// Only implemented on Linux.
 @"quit-after-last-window-closed-delay": ?Duration = null,
 
-/// This controls whether an initial window is created when Ghostty is run. Only
-/// implemented on Linux.
+/// This controls whether an initial window is created when Ghostty
+/// is run. Note that if `quit-after-last-window-closed` is `true` and
+/// `quit-after-last-window-closed-delay` is set, setting `initial-window` to
+/// `false` will mean that Ghostty will quit after the configured delay if no
+/// window is ever created. Only implemented on Linux.
 @"initial-window": bool = true,
 
 /// Whether to enable shell integration auto-injection or not. Shell integration

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2205,6 +2205,11 @@ pub fn finalize(self: *Config) !void {
     // If URLs are disabled, cut off the first link. The first link is
     // always the URL matcher.
     if (!self.@"link-url") self.link.links.items = self.link.links.items[1..];
+
+    if (self.@"quit-after-last-window-closed-delay") |duration| {
+        if (duration.duration < 5 * std.time.ns_per_s)
+            log.warn("quit-after-last-window-closed-delay is set to a very short value ({}), which might cause problems", .{duration});
+    }
 }
 
 /// Callback for src/cli/args.zig to allow us to handle special cases

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -107,6 +107,11 @@ pub fn main() !MainReturn {
     var app_runtime = try apprt.App.init(app, .{});
     defer app_runtime.terminate();
 
+    // Since - by definition - there are no surfaces when first started, the
+    // quit timer may need to be started. The start timer will get cancelled if/
+    // when the first surface is created.
+    if (@hasDecl(apprt.App, "startQuitTimer")) app_runtime.startQuitTimer();
+
     // Run the GUI event loop
     try app_runtime.run();
 }


### PR DESCRIPTION
This patch fixes #2010 by implementing `quit-after-last-window-closed` for the GTK apprt. It also adds the ability for the GTK apprt to exit after a delay once all surfaces have been closed and adds the ability to start Ghostty without opening an initial window.