### PR TITLE
Add +list-actions CLI action to list keybind actions.

### DIFF
--- a/src/cli/action.zig
+++ b/src/cli/action.zig
@@ -8,6 +8,7 @@ const version = @import("version.zig");
 const list_keybinds = @import("list_keybinds.zig");
 const list_themes = @import("list_themes.zig");
 const list_colors = @import("list_colors.zig");
+const list_actions = @import("list_actions.zig");
 const show_config = @import("show_config.zig");
 const validate_config = @import("validate_config.zig");
 
@@ -32,6 +33,9 @@ pub const Action = enum {
 
     /// List named RGB colors
     @"list-colors",
+
+    /// List keybind actions colors
+    @"list-actions",
 
     /// Dump the config to stdout
     @"show-config",
@@ -127,6 +131,7 @@ pub const Action = enum {
             .@"list-keybinds" => try list_keybinds.run(alloc),
             .@"list-themes" => try list_themes.run(alloc),
             .@"list-colors" => try list_colors.run(alloc),
+            .@"list-actions" => try list_actions.run(alloc),
             .@"show-config" => try show_config.run(alloc),
             .@"validate-config" => try validate_config.run(alloc),
         };

--- a/src/cli/action.zig
+++ b/src/cli/action.zig
@@ -34,7 +34,7 @@ pub const Action = enum {
     /// List named RGB colors
     @"list-colors",
 
-    /// List keybind actions colors
+    /// List keybind actions
     @"list-actions",
 
     /// Dump the config to stdout

--- a/src/cli/list_actions.zig
+++ b/src/cli/list_actions.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+const args = @import("args.zig");
+const Action = @import("action.zig").Action;
+const Allocator = std.mem.Allocator;
+const help_strings = @import("help_strings");
+
+pub const Options = struct {
+    /// If `true`, print out documenation about the action associated with the
+    /// keybinds.
+    docs: bool = false,
+
+    pub fn deinit(self: Options) void {
+        _ = self;
+    }
+
+    /// Enables `-h` and `--help` to work.
+    pub fn help(self: Options) !void {
+        _ = self;
+        return Action.help_error;
+    }
+};
+
+/// The `list-actions` command is used to list all the available keybind actions
+/// for Ghostty.
+///
+/// The `--docs` argument will print out the documentation for each action.
+pub fn run(alloc: Allocator) !u8 {
+    var opts: Options = .{};
+    defer opts.deinit();
+
+    {
+        var iter = try std.process.argsWithAllocator(alloc);
+        defer iter.deinit();
+        try args.parse(Options, alloc, &opts, &iter);
+    }
+
+    const stdout = std.io.getStdOut().writer();
+    const info = @typeInfo(help_strings.KeybindAction);
+    inline for (info.Struct.decls) |field| {
+        try stdout.print("{s}", .{field.name});
+        if (opts.docs) {
+            try stdout.print(":\n", .{});
+            var iter = std.mem.splitScalar(u8, std.mem.trimRight(u8, @field(help_strings.KeybindAction, field.name), &std.ascii.whitespace), '\n');
+            while (iter.next()) |line| {
+                try stdout.print("  {s}\n", .{line});
+            }
+        } else {
+            try stdout.print("\n", .{});
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
As discussed recently in the Discord beta channel, here is a CLI action for listing all of the keybind actions (and optionally showing the docs).
