### PR TITLE
Include file/line context for config file errors

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -506,7 +506,7 @@ ghostty_info_s ghostty_info(void);
 ghostty_config_t ghostty_config_new();
 void ghostty_config_free(ghostty_config_t);
 void ghostty_config_load_cli_args(ghostty_config_t);
-void ghostty_config_load_string(ghostty_config_t, const char*, uintptr_t);
+void ghostty_config_load_string(ghostty_config_t, const char*, uintptr_t, const char*, uintptr_t);
 void ghostty_config_load_default_files(ghostty_config_t);
 void ghostty_config_load_recursive_files(ghostty_config_t);
 void ghostty_config_finalize(ghostty_config_t);

--- a/src/bench/codepoint-width.zig
+++ b/src/bench/codepoint-width.zig
@@ -70,7 +70,7 @@ pub fn main() !void {
     {
         var iter = try std.process.argsWithAllocator(alloc);
         defer iter.deinit();
-        try cli.args.parse(Args, alloc, &args, &iter);
+        try cli.args.parse(Args, @TypeOf(iter), alloc, &args, &iter);
     }
 
     const reader = std.io.getStdIn().reader();

--- a/src/bench/grapheme-break.zig
+++ b/src/bench/grapheme-break.zig
@@ -62,7 +62,7 @@ pub fn main() !void {
     {
         var iter = try std.process.argsWithAllocator(alloc);
         defer iter.deinit();
-        try cli.args.parse(Args, alloc, &args, &iter);
+        try cli.args.parse(Args, @TypeOf(iter), alloc, &args, &iter);
     }
 
     const reader = std.io.getStdIn().reader();

--- a/src/bench/page-init.zig
+++ b/src/bench/page-init.zig
@@ -47,7 +47,7 @@ pub fn main() !void {
     {
         var iter = try std.process.argsWithAllocator(alloc);
         defer iter.deinit();
-        try cli.args.parse(Args, alloc, &args, &iter);
+        try cli.args.parse(Args, @TypeOf(iter), alloc, &args, &iter);
     }
 
     // Handle the modes that do not depend on terminal state first.

--- a/src/bench/parser.zig
+++ b/src/bench/parser.zig
@@ -29,7 +29,7 @@ pub fn main() !void {
         errdefer args.deinit();
         var iter = try std.process.argsWithAllocator(alloc);
         defer iter.deinit();
-        try cli.args.parse(Args, alloc, &args, &iter);
+        try cli.args.parse(Args, @TypeOf(iter), alloc, &args, &iter);
         break :args args;
     };
     defer args.deinit();

--- a/src/bench/stream.zig
+++ b/src/bench/stream.zig
@@ -86,7 +86,7 @@ pub fn main() !void {
     {
         var iter = try std.process.argsWithAllocator(alloc);
         defer iter.deinit();
-        try cli.args.parse(Args, alloc, &args, &iter);
+        try cli.args.parse(Args, @TypeOf(iter), alloc, &args, &iter);
     }
 
     const reader = std.io.getStdIn().reader();

--- a/src/cli/crash_report.zig
+++ b/src/cli/crash_report.zig
@@ -35,7 +35,7 @@ pub fn run(alloc_gpa: Allocator) !u8 {
     {
         var iter = try std.process.argsWithAllocator(alloc);
         defer iter.deinit();
-        try args.parse(Options, alloc, &opts, &iter);
+        try args.parse(Options, @TypeOf(iter), alloc, &opts, &iter);
     }
 
     const crash_dir = try crash.defaultDir(alloc);

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -25,7 +25,7 @@ pub fn run(alloc: Allocator) !u8 {
     {
         var iter = try std.process.argsWithAllocator(alloc);
         defer iter.deinit();
-        try args.parse(Options, alloc, &opts, &iter);
+        try args.parse(Options, @TypeOf(iter), alloc, &opts, &iter);
     }
 
     const stdout = std.io.getStdOut().writer();

--- a/src/cli/list_actions.zig
+++ b/src/cli/list_actions.zig
@@ -31,7 +31,7 @@ pub fn run(alloc: Allocator) !u8 {
     {
         var iter = try std.process.argsWithAllocator(alloc);
         defer iter.deinit();
-        try args.parse(Options, alloc, &opts, &iter);
+        try args.parse(Options, @TypeOf(iter), alloc, &opts, &iter);
     }
 
     const stdout = std.io.getStdOut().writer();

--- a/src/cli/list_colors.zig
+++ b/src/cli/list_colors.zig
@@ -24,7 +24,7 @@ pub fn run(alloc: std.mem.Allocator) !u8 {
     {
         var iter = try std.process.argsWithAllocator(alloc);
         defer iter.deinit();
-        try args.parse(Options, alloc, &opts, &iter);
+        try args.parse(Options, @TypeOf(iter), alloc, &opts, &iter);
     }
 
     const stdout = std.io.getStdOut().writer();

--- a/src/cli/list_fonts.zig
+++ b/src/cli/list_fonts.zig
@@ -55,13 +55,13 @@ pub const Config = struct {
 pub fn run(alloc: Allocator) !u8 {
     var iter = try std.process.argsWithAllocator(alloc);
     defer iter.deinit();
-    return try runArgs(alloc, &iter);
+    return try runArgs(@TypeOf(iter), alloc, &iter);
 }
 
-fn runArgs(alloc_gpa: Allocator, argsIter: anytype) !u8 {
+fn runArgs(comptime Iter: type, alloc_gpa: Allocator, argsIter: *Iter) !u8 {
     var config: Config = .{};
     defer config.deinit();
-    try args.parse(Config, alloc_gpa, &config, argsIter);
+    try args.parse(Config, Iter, alloc_gpa, &config, argsIter);
 
     // Use an arena for all our memory allocs
     var arena = ArenaAllocator.init(alloc_gpa);

--- a/src/cli/list_keybinds.zig
+++ b/src/cli/list_keybinds.zig
@@ -54,7 +54,7 @@ pub fn run(alloc: Allocator) !u8 {
     {
         var iter = try std.process.argsWithAllocator(alloc);
         defer iter.deinit();
-        try args.parse(Options, alloc, &opts, &iter);
+        try args.parse(Options, @TypeOf(iter), alloc, &opts, &iter);
     }
 
     var config = if (opts.default) try Config.default(alloc) else try Config.load(alloc);

--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -56,7 +56,7 @@ pub fn run(gpa_alloc: std.mem.Allocator) !u8 {
     {
         var iter = try std.process.argsWithAllocator(gpa_alloc);
         defer iter.deinit();
-        try args.parse(Options, gpa_alloc, &opts, &iter);
+        try args.parse(Options, @TypeOf(iter), gpa_alloc, &opts, &iter);
     }
 
     var arena = std.heap.ArenaAllocator.init(gpa_alloc);

--- a/src/cli/show_config.zig
+++ b/src/cli/show_config.zig
@@ -62,7 +62,7 @@ pub fn run(alloc: Allocator) !u8 {
     {
         var iter = try std.process.argsWithAllocator(alloc);
         defer iter.deinit();
-        try args.parse(Options, alloc, &opts, &iter);
+        try args.parse(Options, @TypeOf(iter), alloc, &opts, &iter);
     }
 
     var config = if (opts.default) try Config.default(alloc) else try Config.load(alloc);

--- a/src/cli/validate_config.zig
+++ b/src/cli/validate_config.zig
@@ -34,7 +34,7 @@ pub fn run(alloc: std.mem.Allocator) !u8 {
     {
         var iter = try std.process.argsWithAllocator(alloc);
         defer iter.deinit();
-        try args.parse(Options, alloc, &opts, &iter);
+        try args.parse(Options, @TypeOf(iter), alloc, &opts, &iter);
     }
 
     const stdout = std.io.getStdOut().writer();

--- a/src/config/CAPI.zig
+++ b/src/config/CAPI.zig
@@ -54,7 +54,7 @@ export fn ghostty_config_load_string(
 fn config_load_string_(self: *Config, str: []const u8) !void {
     var fbs = std.io.fixedBufferStream(str);
     var iter = cli.args.lineIterator(fbs.reader());
-    try cli.args.parse(Config, global.alloc, self, &iter);
+    try cli.args.parse(Config, @TypeOf(iter), global.alloc, self, &iter);
 }
 
 /// Load the configuration from the default file locations. This

--- a/src/config/CAPI.zig
+++ b/src/config/CAPI.zig
@@ -43,17 +43,19 @@ export fn ghostty_config_load_cli_args(self: *Config) void {
 /// the file-based syntax for the desktop version of the terminal.
 export fn ghostty_config_load_string(
     self: *Config,
-    str: [*]const u8,
-    len: usize,
+    filepath: [*]const u8,
+    filepath_len: usize,
+    contents: [*]const u8,
+    contents_len: usize,
 ) void {
-    config_load_string_(self, str[0..len]) catch |err| {
+    config_load_string_(self, filepath[0..filepath_len], contents[0..contents_len]) catch |err| {
         log.err("error loading config err={}", .{err});
     };
 }
 
-fn config_load_string_(self: *Config, str: []const u8) !void {
-    var fbs = std.io.fixedBufferStream(str);
-    var iter = cli.args.lineIterator(fbs.reader());
+fn config_load_string_(self: *Config, filepath: []const u8, contents: []const u8) !void {
+    var fbs = std.io.fixedBufferStream(contents);
+    var iter = cli.args.lineIterator(fbs.reader(), filepath);
     try cli.args.parse(Config, @TypeOf(iter), global.alloc, self, &iter);
 }
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2962,9 +2962,9 @@ pub const Color = packed struct(u24) {
         var result: Color = undefined;
         comptime var i: usize = 0;
         inline while (i < 6) : (i += 2) {
-            const v: u8 =
-                ((try std.fmt.charToDigit(trimmed[i], 16)) * 16) +
-                try std.fmt.charToDigit(trimmed[i + 1], 16);
+            const hi = std.fmt.charToDigit(trimmed[i], 16) catch return error.InvalidValue;
+            const lo = std.fmt.charToDigit(trimmed[i + 1], 16) catch return error.InvalidValue;
+            const v: u8 = hi * 16 + lo;
 
             @field(result, switch (i) {
                 0 => "r",
@@ -3017,7 +3017,7 @@ pub const Palette = struct {
         const eqlIdx = std.mem.indexOf(u8, value, "=") orelse
             return error.InvalidValue;
 
-        const key = try std.fmt.parseInt(u8, value[0..eqlIdx], 10);
+        const key = std.fmt.parseInt(u8, value[0..eqlIdx], 10) catch return error.InvalidValue;
         const rgb = try Color.parseCLI(value[eqlIdx + 1 ..]);
         self.value[key] = .{ .r = rgb.r, .g = rgb.g, .b = rgb.b };
     }
@@ -3061,7 +3061,7 @@ pub const Palette = struct {
         const testing = std.testing;
 
         var p: Self = .{};
-        try testing.expectError(error.Overflow, p.parseCLI("256=#AABBCC"));
+        try testing.expectError(error.InvalidValue, p.parseCLI("256=#AABBCC"));
     }
 
     test "formatConfig" {

--- a/src/config/Wasm.zig
+++ b/src/config/Wasm.zig
@@ -33,17 +33,19 @@ export fn config_free(ptr: ?*Config) void {
 /// the file-based syntax for the desktop version of the terminal.
 export fn config_load_string(
     self: *Config,
-    str: [*]const u8,
-    len: usize,
+    filepath: [*]const u8,
+    filepath_len: usize,
+    contents: [*]const u8,
+    contents_len: usize,
 ) void {
-    config_load_string_(self, str[0..len]) catch |err| {
+    config_load_string_(self, filepath[0..filepath_len], contents[0..contents_len]) catch |err| {
         log.err("error loading config err={}", .{err});
     };
 }
 
-fn config_load_string_(self: *Config, str: []const u8) !void {
-    var fbs = std.io.fixedBufferStream(str);
-    var iter = cli.args.lineIterator(fbs.reader());
+fn config_load_string_(self: *Config, filepath: []const u8, contents: []const u8) !void {
+    var fbs = std.io.fixedBufferStream(contents);
+    var iter = cli.args.lineIterator(fbs.reader(), filepath);
     try cli.args.parse(Config, @TypeOf(iter), alloc, self, &iter);
 }
 

--- a/src/config/Wasm.zig
+++ b/src/config/Wasm.zig
@@ -44,7 +44,7 @@ export fn config_load_string(
 fn config_load_string_(self: *Config, str: []const u8) !void {
     var fbs = std.io.fixedBufferStream(str);
     var iter = cli.args.lineIterator(fbs.reader());
-    try cli.args.parse(Config, alloc, self, &iter);
+    try cli.args.parse(Config, @TypeOf(iter), alloc, self, &iter);
 }
 
 export fn config_finalize(self: *Config) void {


### PR DESCRIPTION
Closes #1063.

As per my [comment](https://github.com/ghostty-org/ghostty/issues/1063#issuecomment-2259601763) in the issue, I opted to only include context for file errors. Happy to discuss alternatives if more context for CLI config errors is desired. I also improved the error formatting a bit along the way.