### PR TITLE
`window-padding-color = extend` to extend nearest cell bg color to padding

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -20,6 +20,7 @@ pub const RepeatableCodepointMap = Config.RepeatableCodepointMap;
 pub const RepeatableFontVariation = Config.RepeatableFontVariation;
 pub const RepeatableString = Config.RepeatableString;
 pub const ShellIntegrationFeatures = Config.ShellIntegrationFeatures;
+pub const WindowPaddingColor = Config.WindowPaddingColor;
 
 // Alternate APIs
 pub const CAPI = @import("config/CAPI.zig");

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -669,6 +669,16 @@ keybind: Keybinds = .{},
 /// given a certain viewport size and grid cell size.
 @"window-padding-balance": bool = false,
 
+/// The color of the padding area of the window. Valid values are:
+///
+/// * `background` - The background color specified in `background`.
+/// * `extend` - Extend the background color of the nearest grid cell.
+///
+/// The default value is "extend". This allows for smooth resizing of a
+/// terminal grid without having visible empty areas around the edge. The edge
+/// cells may appear slightly larger due to the extension.
+@"window-padding-color": WindowPaddingColor = .extend,
+
 /// Synchronize rendering with the screen refresh rate. If true, this will
 /// minimize tearing and align redraws with the screen but may cause input
 /// latency. If false, this will maximize redraw frequency but may cause tearing,
@@ -2676,6 +2686,11 @@ pub const OptionAsAlt = enum {
     true,
     left,
     right,
+};
+
+pub const WindowPaddingColor = enum {
+    background,
+    extend,
 };
 
 /// Color represents a color using RGB.

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -66,9 +66,6 @@ config: DerivedConfig,
 /// The mailbox for communicating with the window.
 surface_mailbox: apprt.surface.Mailbox,
 
-/// Current font metrics defining our grid.
-grid_metrics: font.face.Metrics,
-
 /// Current screen size dimensions for this grid. This is set on the first
 /// resize event, and is not immediately available.
 screen_size: ?renderer.ScreenSize,
@@ -583,18 +580,6 @@ pub fn init(alloc: Allocator, options: renderer.Options) !Metal {
     var shaders = try Shaders.init(alloc, gpu_state.device, custom_shaders);
     errdefer shaders.deinit(alloc);
 
-    // Initialize all the data that requires a critical font section.
-    const font_critical: struct {
-        metrics: font.Metrics,
-    } = font_critical: {
-        const grid = options.font_grid;
-        grid.lock.lockShared();
-        defer grid.lock.unlockShared();
-        break :font_critical .{
-            .metrics = grid.metrics,
-        };
-    };
-
     const display_link: ?DisplayLink = switch (builtin.os.tag) {
         .macos => if (options.config.vsync)
             try macos.video.DisplayLink.createWithActiveCGDisplays()
@@ -608,7 +593,6 @@ pub fn init(alloc: Allocator, options: renderer.Options) !Metal {
         .alloc = alloc,
         .config = options.config,
         .surface_mailbox = options.surface_mailbox,
-        .grid_metrics = font_critical.metrics,
         .screen_size = null,
         .padding = options.padding,
         .focused = true,
@@ -773,8 +757,8 @@ fn gridSize(self: *Metal) ?renderer.GridSize {
     return renderer.GridSize.init(
         screen_size.subPadding(self.padding.explicit),
         .{
-            .width = self.grid_metrics.cell_width,
-            .height = self.grid_metrics.cell_height,
+            .width = self.font_grid.metrics.cell_width,
+            .height = self.font_grid.metrics.cell_height,
         },
     );
 }
@@ -829,11 +813,6 @@ pub fn setFontGrid(self: *Metal, grid: *font.SharedGrid) void {
         frame.greyscale_modified = 0;
         frame.color_modified = 0;
     }
-
-    // Get our metrics from the grid. This doesn't require a lock because
-    // the metrics are never recalculated.
-    const metrics = grid.metrics;
-    self.grid_metrics = metrics;
 
     // Reset our shaper cache. If our font changed (not just the size) then
     // the data in the shaper cache may be invalid and cannot be used, so we
@@ -1724,8 +1703,8 @@ fn prepKittyVirtualPlacement(
     const rp = p.renderPlacement(
         storage,
         &image,
-        self.grid_metrics.cell_width,
-        self.grid_metrics.cell_height,
+        self.font_grid.metrics.cell_width,
+        self.font_grid.metrics.cell_height,
     ) catch |err| {
         log.warn("error rendering virtual placement err={}", .{err});
         return;
@@ -1785,7 +1764,7 @@ fn prepKittyPlacement(
         const vp_y = t.screen.pages.pointFromPin(.screen, top.*).?.screen.y;
         const img_y = t.screen.pages.pointFromPin(.screen, rect.top_left).?.screen.y;
         const offset_cells = vp_y - img_y;
-        const offset_pixels = offset_cells * self.grid_metrics.cell_height;
+        const offset_pixels = offset_cells * self.font_grid.metrics.cell_height;
         break :offset_y @intCast(offset_pixels);
     } else 0;
 
@@ -1813,8 +1792,8 @@ fn prepKittyPlacement(
         image.height -| source_y;
 
     // Calculate the width/height of our image.
-    const dest_width = if (p.columns > 0) p.columns * self.grid_metrics.cell_width else source_width;
-    const dest_height = if (p.rows > 0) p.rows * self.grid_metrics.cell_height else source_height;
+    const dest_width = if (p.columns > 0) p.columns * self.font_grid.metrics.cell_width else source_width;
+    const dest_height = if (p.rows > 0) p.rows * self.font_grid.metrics.cell_height else source_height;
 
     // Accumulate the placement
     if (image.width > 0 and image.height > 0) {
@@ -1939,8 +1918,8 @@ pub fn setScreenSize(
             dim,
             grid_size,
             .{
-                .width = self.grid_metrics.cell_width,
-                .height = self.grid_metrics.cell_height,
+                .width = self.font_grid.metrics.cell_width,
+                .height = self.font_grid.metrics.cell_height,
             },
         )
     else
@@ -1954,8 +1933,8 @@ pub fn setScreenSize(
         .background => .{},
 
         .extend => dim.blankPadding(padding, grid_size, .{
-            .width = self.grid_metrics.cell_width,
-            .height = self.grid_metrics.cell_height,
+            .width = self.font_grid.metrics.cell_width,
+            .height = self.font_grid.metrics.cell_height,
         }).add(padding),
     };
 
@@ -1975,8 +1954,8 @@ pub fn setScreenSize(
             -1 * @as(f32, @floatFromInt(padding.top)),
         ),
         .cell_size = .{
-            @floatFromInt(self.grid_metrics.cell_width),
-            @floatFromInt(self.grid_metrics.cell_height),
+            @floatFromInt(self.font_grid.metrics.cell_width),
+            @floatFromInt(self.font_grid.metrics.cell_height),
         },
         .grid_size = .{
             grid_size.columns,
@@ -2075,7 +2054,7 @@ pub fn setScreenSize(
         };
     }
 
-    log.debug("screen size screen={} grid={}, cell_width={} cell_height={}", .{ dim, grid_size, self.grid_metrics.cell_width, self.grid_metrics.cell_height });
+    log.debug("screen size screen={} grid={}, cell_width={} cell_height={}", .{ dim, grid_size, self.font_grid.metrics.cell_width, self.font_grid.metrics.cell_height });
 }
 
 /// Convert the terminal state to GPU cells stored in CPU memory. These
@@ -2439,7 +2418,7 @@ fn updateCell(
             shaper_run.font_index,
             glyph_index,
             .{
-                .grid_metrics = self.grid_metrics,
+                .grid_metrics = self.font_grid.metrics,
                 .thicken = self.config.font_thicken,
             },
         );
@@ -2490,7 +2469,7 @@ fn updateCell(
             @intFromEnum(sprite),
             .{
                 .cell_width = if (cell.wide == .wide) 2 else 1,
-                .grid_metrics = self.grid_metrics,
+                .grid_metrics = self.font_grid.metrics,
             },
         );
 
@@ -2515,7 +2494,7 @@ fn updateCell(
             @intFromEnum(font.Sprite.strikethrough),
             .{
                 .cell_width = if (cell.wide == .wide) 2 else 1,
-                .grid_metrics = self.grid_metrics,
+                .grid_metrics = self.font_grid.metrics,
             },
         );
 
@@ -2572,7 +2551,7 @@ fn addCursor(
         @intFromEnum(sprite),
         .{
             .cell_width = if (wide) 2 else 1,
-            .grid_metrics = self.grid_metrics,
+            .grid_metrics = self.font_grid.metrics,
         },
     ) catch |err| {
         log.warn("error rendering cursor glyph err={}", .{err});
@@ -2606,7 +2585,7 @@ fn addPreeditCell(
         @intCast(cp.codepoint),
         .regular,
         .text,
-        .{ .grid_metrics = self.grid_metrics },
+        .{ .grid_metrics = self.font_grid.metrics },
     ) catch |err| {
         log.warn("error rendering preedit glyph err={}", .{err});
         return;

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -106,20 +106,31 @@ pub const Image = extern struct {
 
 /// The uniforms that are passed to the terminal cell shader.
 pub const Uniforms = extern struct {
+    // Note: all of the explicit aligmnments are copied from the
+    // MSL developer reference just so that we can be sure that we got
+    // it all exactly right.
+
     /// The projection matrix for turning world coordinates to normalized.
     /// This is calculated based on the size of the screen.
-    projection_matrix: math.Mat,
+    projection_matrix: math.Mat align(16),
 
     /// Size of a single cell in pixels, unscaled.
-    cell_size: [2]f32,
+    cell_size: [2]f32 align(8),
+
+    /// Size of the grid in columns and rows.
+    grid_size: [2]u16 align(4),
+
+    /// The padding around the terminal grid in pixels. In order:
+    /// top, right, bottom, left.
+    grid_padding: [4]f32 align(16),
 
     /// The minimum contrast ratio for text. The contrast ratio is calculated
     /// according to the WCAG 2.0 spec.
-    min_contrast: f32,
+    min_contrast: f32 align(4),
 
     /// The cursor position and color.
-    cursor_pos: [2]u16,
-    cursor_color: [4]u8,
+    cursor_pos: [2]u16 align(4),
+    cursor_color: [4]u8 align(4),
 };
 
 /// The uniforms used for custom postprocess shaders.

--- a/src/renderer/shaders/cell.metal
+++ b/src/renderer/shaders/cell.metal
@@ -102,11 +102,16 @@ vertex CellBgVertexOut cell_bg_vertex(unsigned int vid [[vertex_id]],
 
   // If we're at the edge of the grid, we add our padding to the background
   // to extend it. Note: grid_padding is top/right/bottom/left.
-  // TODO: top/left
-  if (input.grid_pos.y == uniforms.grid_size.y - 1) {
+  if (input.grid_pos.y == 0) {
+    cell_pos.y -= uniforms.grid_padding.r;
+    cell_size_scaled.y += uniforms.grid_padding.r;
+  } else if (input.grid_pos.y == uniforms.grid_size.y - 1) {
     cell_size_scaled.y += uniforms.grid_padding.b;
   }
-  if (input.grid_pos.x == uniforms.grid_size.x - 1) {
+  if (input.grid_pos.x == 0) {
+    cell_pos.x -= uniforms.grid_padding.a;
+    cell_size_scaled.x += uniforms.grid_padding.a;
+  } else if (input.grid_pos.x == uniforms.grid_size.x - 1) {
     cell_size_scaled.x += uniforms.grid_padding.g;
   }
 

--- a/src/renderer/shaders/cell.metal
+++ b/src/renderer/shaders/cell.metal
@@ -3,6 +3,8 @@ using namespace metal;
 struct Uniforms {
   float4x4 projection_matrix;
   float2 cell_size;
+  ushort2 grid_size;
+  float4 grid_padding;
   float min_contrast;
   ushort2 cursor_pos;
   uchar4 cursor_color;
@@ -97,6 +99,16 @@ vertex CellBgVertexOut cell_bg_vertex(unsigned int vid [[vertex_id]],
   // Scaled cell size for the cell width
   float2 cell_size_scaled = uniforms.cell_size;
   cell_size_scaled.x = cell_size_scaled.x * input.cell_width;
+
+  // If we're at the edge of the grid, we add our padding to the background
+  // to extend it. Note: grid_padding is top/right/bottom/left.
+  // TODO: top/left
+  if (input.grid_pos.y == uniforms.grid_size.y - 1) {
+    cell_size_scaled.y += uniforms.grid_padding.b;
+  }
+  if (input.grid_pos.x == uniforms.grid_size.x - 1) {
+    cell_size_scaled.x += uniforms.grid_padding.g;
+  }
 
   // Turn the cell position into a vertex point depending on the
   // vertex ID. Since we use instanced drawing, we have 4 vertices

--- a/src/renderer/shaders/cell.v.glsl
+++ b/src/renderer/shaders/cell.v.glsl
@@ -55,6 +55,8 @@ flat out uint mode;
 uniform sampler2D text;
 uniform sampler2D text_color;
 uniform vec2 cell_size;
+uniform vec2 grid_size;
+uniform vec4 grid_padding;
 uniform mat4 projection;
 uniform float min_contrast;
 
@@ -167,6 +169,21 @@ void main() {
 
     switch (mode) {
     case MODE_BG:
+        // If we're at the edge of the grid, we add our padding to the background
+        // to extend it. Note: grid_padding is top/right/bottom/left.
+        if (grid_coord.y == 0) {
+            cell_pos.y -= grid_padding.r;
+            cell_size_scaled.y += grid_padding.r;
+        } else if (grid_coord.y == grid_size.y - 1) {
+            cell_size_scaled.y += grid_padding.b;
+        }
+        if (grid_coord.x == 0) {
+            cell_pos.x -= grid_padding.a;
+            cell_size_scaled.x += grid_padding.a;
+        } else if (grid_coord.x == grid_size.x - 1) {
+            cell_size_scaled.x += grid_padding.g;
+        }
+
         // Calculate the final position of our cell in world space.
         // We have to add our cell size since our vertices are offset
         // one cell up and to the left. (Do the math to verify yourself)

--- a/src/renderer/size.zig
+++ b/src/renderer/size.zig
@@ -34,6 +34,25 @@ pub const ScreenSize = struct {
         };
     }
 
+    /// Calculates the amount of blank space around the grid. This is possible
+    /// when padding isn't balanced.
+    ///
+    /// The "self" screen size here should be the unpadded screen.
+    pub fn blankPadding(self: ScreenSize, padding: Padding, grid: GridSize, cell: CellSize) Padding {
+        const grid_width = grid.columns * cell.width;
+        const grid_height = grid.rows * cell.height;
+        const padded_width = grid_width + (padding.left + padding.right);
+        const padded_height = grid_height + (padding.top + padding.bottom);
+        const leftover_width = self.width - padded_width;
+        const leftover_height = self.height - padded_height;
+        return .{
+            .top = 0,
+            .bottom = leftover_height,
+            .right = leftover_width,
+            .left = 0,
+        };
+    }
+
     /// Returns true if two sizes are equal.
     pub fn equals(self: ScreenSize, other: ScreenSize) bool {
         return self.width == other.width and self.height == other.height;


### PR DESCRIPTION
Fixes #2002 

This adds a new configuration `window-padding-color` with the values `background` and `extend`. The docs in the diff explain it best, but in short: `background` is the old behavior, `extend` is the new behavior in this PR.

As background, Ghostty supports smooth window resizing, meaning you can resize a Ghostty window to a specific pixel value. However, a terminal grid is a fixed size based on cell width/height. If the window dimensions aren't perfectly divisible with the grid dimensions, then you have some padding. Ghostty has many configurations to manage this padding. The padding color up to this point has been your `background` configuration value.

The `extend` value will instead fill the padding color with the nearest grid cell background color. This creates the illusion of a perfectly sized grid at pixel level granularities. **This is the new default value,** since I think in most cases it looks much more pleasing.

## Before

![CleanShot 2024-08-03 at 16 34 38@2x](https://github.com/user-attachments/assets/ff58082f-8522-4908-95b2-0d22be1bffdb)

## After

![CleanShot 2024-08-03 at 16 34 11@2x](https://github.com/user-attachments/assets/bff9e489-fcab-4980-823a-d01e81c42e24)
