### PR TITLE
renderer: disable window-padding-color=extend in certain scenarios

### DIFF
--- a/pkg/opengl/Program.zig
+++ b/pkg/opengl/Program.zig
@@ -104,6 +104,7 @@ pub fn setUniform(
 
     // Perform the correct call depending on the type of the value.
     switch (@TypeOf(value)) {
+        bool => glad.context.Uniform1i.?(loc, if (value) 1 else 0),
         comptime_int => glad.context.Uniform1i.?(loc, value),
         f32 => glad.context.Uniform1f.?(loc, value),
         @Vector(2, f32) => glad.context.Uniform2f.?(loc, value[0], value[1]),

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -674,6 +674,17 @@ keybind: Keybinds = .{},
 /// * `background` - The background color specified in `background`.
 /// * `extend` - Extend the background color of the nearest grid cell.
 ///
+/// The "extend" value will be disabled in certain scenarios. On primary
+/// screen applications (i.e. not something like Neovim), the color will not
+/// be extended vertically if any of the following are true:
+///
+/// * The nearest row has any cells that have the default backgroudn color.
+///   The thinking is that in this case, the default background color looks
+///   fine as a padding color.
+/// * The nearest row is a prompt row (requires shell integration). The
+///   thinking here is that prompts often contain powerline glyphs that
+///   do not look good extended.
+///
 /// The default value is "extend". This allows for smooth resizing of a
 /// terminal grid without having visible empty areas around the edge. The edge
 /// cells may appear slightly larger due to the extension.

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -124,6 +124,10 @@ pub const Uniforms = extern struct {
     /// top, right, bottom, left.
     grid_padding: [4]f32 align(16),
 
+    /// True if vertical padding gets the extended color of the nearest row.
+    padding_extend_top: bool align(1),
+    padding_extend_bottom: bool align(1),
+
     /// The minimum contrast ratio for text. The contrast ratio is calculated
     /// according to the WCAG 2.0 spec.
     min_contrast: f32 align(4),

--- a/src/renderer/shaders/cell.metal
+++ b/src/renderer/shaders/cell.metal
@@ -5,6 +5,8 @@ struct Uniforms {
   float2 cell_size;
   ushort2 grid_size;
   float4 grid_padding;
+  bool padding_extend_top;
+  bool padding_extend_bottom;
   float min_contrast;
   ushort2 cursor_pos;
   uchar4 cursor_color;
@@ -101,11 +103,14 @@ vertex CellBgVertexOut cell_bg_vertex(unsigned int vid [[vertex_id]],
   cell_size_scaled.x = cell_size_scaled.x * input.cell_width;
 
   // If we're at the edge of the grid, we add our padding to the background
-  // to extend it. Note: grid_padding is top/right/bottom/left.
-  if (input.grid_pos.y == 0) {
+  // to extend it. Note: grid_padding is top/right/bottom/left. We always
+  // extend horiziontally because there is no downside but there are various
+  // heuristics to disable vertical extension.
+  if (input.grid_pos.y == 0 && uniforms.padding_extend_top) {
     cell_pos.y -= uniforms.grid_padding.r;
     cell_size_scaled.y += uniforms.grid_padding.r;
-  } else if (input.grid_pos.y == uniforms.grid_size.y - 1) {
+  } else if (input.grid_pos.y == uniforms.grid_size.y - 1 &&
+             uniforms.padding_extend_bottom) {
     cell_size_scaled.y += uniforms.grid_padding.b;
   }
   if (input.grid_pos.x == 0) {

--- a/src/renderer/shaders/cell.v.glsl
+++ b/src/renderer/shaders/cell.v.glsl
@@ -57,6 +57,8 @@ uniform sampler2D text_color;
 uniform vec2 cell_size;
 uniform vec2 grid_size;
 uniform vec4 grid_padding;
+uniform bool padding_vertical_top;
+uniform bool padding_vertical_bottom;
 uniform mat4 projection;
 uniform float min_contrast;
 
@@ -171,10 +173,10 @@ void main() {
     case MODE_BG:
         // If we're at the edge of the grid, we add our padding to the background
         // to extend it. Note: grid_padding is top/right/bottom/left.
-        if (grid_coord.y == 0) {
+        if (grid_coord.y == 0 && padding_vertical_top) {
             cell_pos.y -= grid_padding.r;
             cell_size_scaled.y += grid_padding.r;
-        } else if (grid_coord.y == grid_size.y - 1) {
+        } else if (grid_coord.y == grid_size.y - 1 && padding_vertical_bottom) {
             cell_size_scaled.y += grid_padding.b;
         }
         if (grid_coord.x == 0) {


### PR DESCRIPTION
There are scenarios where this configuration looks bad. This commit introduces some heuristics to prevent it. Here are the heuristics:

  * Extension is always enabled on alt screen.
  * Extension is disabled if a row contains any default bg color. The thinking is that in this scenario, using the default bg color looks just fine.
  * Extension is disabled if a row is marked as a prompt (using semantic prompt sequences). The thinking here is that prompts often contain perfect fit glyphs such as Powerline glyphs and those look bad when extended.

This introduces some CPU cost to the extension feature but it should be minimal and respects dirty tracking. This is unfortunate but the feature makes many terminal scenarios look much better and the performance cost is minimal so I believe it is worth it.

Further heuristics are likely warranted but this should be a good starting set.