### PR TITLE
Action that writes both scrollback and active screen to file.

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3337,6 +3337,11 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             }, .unlocked);
         },
 
+        .write_all_file => |v| try self.writeScreenFile(
+            .all,
+            v,
+        ),
+
         .write_screen_file => |v| try self.writeScreenFile(
             .screen,
             v,
@@ -3537,6 +3542,7 @@ fn closingAction(action: input.Binding.Action) bool {
 
 /// The portion of the screen to write for writeScreenFile.
 const WriteScreenLoc = enum {
+    all, // Full screen and history (scrollback)
     screen, // Full screen
     history, // History (scrollback)
     selection, // Selected text
@@ -3587,6 +3593,14 @@ fn writeScreenFile(
                     pages.getTopLeft(.screen),
                     pages.getBottomRight(.screen) orelse
                         break :screen null,
+                    false,
+                );
+            },
+
+            .all => all: {
+                break :all terminal.Selection.init(
+                    pages.getTopLeft(.history),
+                    pages.getBottomRight(.screen) orelse break :all null,
                     false,
                 );
             },

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -203,22 +203,35 @@ pub const Action = union(enum) {
     /// number of prompts to jump forward, negative is backwards.
     jump_to_prompt: i16,
 
-    /// Write the entire scrollback into a temporary file. The action
-    /// determines what to do with the filepath. Valid values are:
+    /// Write the entire scrollback _and_ the active screen into a temporary
+    /// file. The action determines what to do with the filepath. Valid values
+    /// are:
     ///
     ///   - "paste": Paste the file path into the terminal.
     ///   - "open": Open the file in the default OS editor for text files.
+    write_all_file: WriteScreenAction,
+
+    /// Write the entire scrollback into a temporary file. Note that this does
+    /// not include the contents of the active screen. The action determines
+    /// what to do with the filepath. Valid values are:
     ///
+    ///   - "paste": Paste the file path into the terminal.
+    ///   - "open": Open the file in the default OS editor for text files.
     write_scrollback_file: WriteScreenAction,
 
-    /// Same as write_scrollback_file but writes the full screen contents.
-    /// See write_scrollback_file for available values.
+    /// Write the active screen into a temporary file. The action determines
+    /// what to do with the filepath. Valid values are:
+    ///
+    ///   - "paste": Paste the file path into the terminal.
+    ///   - "open": Open the file in the default OS editor for text files.
     write_screen_file: WriteScreenAction,
 
-    /// Same as write_scrollback_file but writes the selected text.
-    /// If there is no selected text this does nothing (it doesn't
-    /// even create an empty file). See write_scrollback_file for
-    /// available values.
+    /// Write the selected text into a temporary file. If there is no selected
+    /// text this does nothing (it doesn't even create an empty file). The
+    /// action determines what to do with the filepath. Valid values are:
+    ///
+    ///   - "paste": Paste the file path into the terminal.
+    ///   - "open": Open the file in the default OS editor for text files.
     write_selection_file: WriteScreenAction,
 
     /// Open a new window.


### PR DESCRIPTION
Currently, you can write the scrollback to a file, write the active screen to a file, but not both. This adds an action that writes both to a file.