### PR TITLE
Fix quit-after-last-window-closed=true, quit-after-last-window-closed-delay=null

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -529,8 +529,8 @@ pub fn startQuitTimer(self: *App) void {
     // This is a no-op unless we are configured to quit after last window is closed.
     if (!self.config.@"quit-after-last-window-closed") return;
 
-    // If a delay is configured, set a timeout function to quit after the delay.
     if (self.config.@"quit-after-last-window-closed-delay") |v| {
+        // If a delay is configured, set a timeout function to quit after the delay.
         const ms: u64 = std.math.divTrunc(
             u64,
             v.duration,
@@ -538,6 +538,10 @@ pub fn startQuitTimer(self: *App) void {
         ) catch std.math.maxInt(c.guint);
         const t = std.math.cast(c.guint, ms) orelse std.math.maxInt(c.guint);
         self.quit_timer = .{ .active = c.g_timeout_add(t, gtkQuitTimerExpired, self) };
+    } else {
+        // If no delay is configured, we still need a 0ms timer to break out of
+        // g_main_context_iteration so that control returns to our code.
+        self.quit_timer = .{ .active = c.g_timeout_add(0, gtkQuitTimerExpired, self) };
     }
 }
 

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -539,9 +539,8 @@ pub fn startQuitTimer(self: *App) void {
         const t = std.math.cast(c.guint, ms) orelse std.math.maxInt(c.guint);
         self.quit_timer = .{ .active = c.g_timeout_add(t, gtkQuitTimerExpired, self) };
     } else {
-        // If no delay is configured, we still need a 0ms timer to break out of
-        // g_main_context_iteration so that control returns to our code.
-        self.quit_timer = .{ .active = c.g_timeout_add(0, gtkQuitTimerExpired, self) };
+        // If no delay is configured, treat it as expired.
+        self.quit_timer = .{ .expired = {} };
     }
 }
 


### PR DESCRIPTION
The case when `quit-after-last-window-closed=true` and `quit-after-last-window-closed-delay=null` was broken because control gets stuck inside `g_main_context_iteration` and never returns to our code. In that case add a 0ms timer that will return control flow from GLib back to our code so that we can quit.

Fixes #2039