### PR TITLE
Use standard GitHub Actions committer info

### DIFF
--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Tip Tag
         run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -fa tip -m "Latest Continuous Release" ${GITHUB_SHA}
           git push --force origin tip
 


### PR DESCRIPTION
This committer links to https://github.com/apps/github-actions and shows GitHub Actions' metadata:

<img width="243" alt="image" src="https://github.com/user-attachments/assets/6c5733f0-3862-4d61-84c3-892f55c7f1cb">

Unsure if this makes much of a visible difference for tags, at least on GitHub, but would be good for automated commits if we did them in the future.