### PR TITLE
gtk: One's complement the opacity of overlay for unfocused splits

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -422,7 +422,7 @@ fn loadRuntimeCss(config: *const Config, provider: *c.GtkCssProvider) !void {
         &css_buf,
         fmt,
         .{
-            config.@"unfocused-split-opacity",
+            1.0 - config.@"unfocused-split-opacity",
             fill.r,
             fill.g,
             fill.b,


### PR DESCRIPTION
`unfocused-split-opacity = 1.0` currently results in unfocused splits to be fully covered by the overlay.

The case where the split if fully opaque (`unfocused-split-opacity = 1.0`) should result in the overlay being fully transparent (`opacity: 0.0`). This would be consistent with how this is implemented in the macos app:

https://github.com/ghostty-org/ghostty/blob/dcc492f19b0540939ba923d6ef4041c534d08684/macos/Sources/Ghostty/Ghostty.Config.swift#L302

cc @rockorager since you implemented the feature in #1937. Maybe I am missing some context here.