### PR TITLE
gtk: use Adwaita TabView when possible

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -107,6 +107,18 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
         }
     }
 
+    // If we're using libadwaita, log the version
+    if ((comptime adwaita.versionAtLeast(0, 0, 0)) and
+        adwaita.enabled(&config))
+    {
+        log.info("libadwaita version build={s} runtime={}.{}.{}", .{
+            c.ADW_VERSION_S,
+            c.adw_get_major_version(),
+            c.adw_get_minor_version(),
+            c.adw_get_micro_version(),
+        });
+    }
+
     // The "none" cursor is used for hiding the cursor
     const cursor_none = c.gdk_cursor_new_from_name("none", null);
     errdefer if (cursor_none) |cursor| c.g_object_unref(cursor);

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -149,7 +149,7 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
         });
 
         // If not libadwaita, create a standard GTK application.
-        if ((comptime adwaita.comptimeEnabled()) and
+        if ((comptime adwaita.versionAtLeast(0, 0, 0)) and
             !adwaita.enabled(&config))
         {
             break :app @as(?*c.GtkApplication, @ptrCast(c.gtk_application_new(

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -894,7 +894,7 @@ fn updateTitleLabels(self: *Surface) void {
 
     // If we have a tab and are the focused child, then we have to update the tab
     if (self.container.tab()) |tab| {
-        if (tab.focus_child == self) c.gtk_label_set_text(tab.label_text, title.ptr);
+        if (tab.focus_child == self) tab.setLabelText(title); // c.gtk_label_set_text(tab.label_text, title.ptr);
     }
 
     // If we have a window and are focused, then we have to update the window title.

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -894,7 +894,7 @@ fn updateTitleLabels(self: *Surface) void {
 
     // If we have a tab and are the focused child, then we have to update the tab
     if (self.container.tab()) |tab| {
-        if (tab.focus_child == self) tab.setLabelText(title); // c.gtk_label_set_text(tab.label_text, title.ptr);
+        if (tab.focus_child == self) tab.setLabelText(title);
     }
 
     // If we have a window and are focused, then we have to update the window title.

--- a/src/apprt/gtk/Tab.zig
+++ b/src/apprt/gtk/Tab.zig
@@ -55,37 +55,23 @@ pub fn init(self: *Tab, window: *Window, parent_: ?*CoreSurface) !void {
         .focus_child = undefined,
     };
 
-    // Build the tab label
-    const label_box_widget = c.gtk_box_new(c.GTK_ORIENTATION_HORIZONTAL, 0);
-    const label_box = @as(*c.GtkBox, @ptrCast(label_box_widget));
-    const label_text_widget = c.gtk_label_new("Ghostty");
-    const label_text: *c.GtkLabel = @ptrCast(label_text_widget);
-    c.gtk_box_append(label_box, label_text_widget);
-    self.label_text = label_text;
+    // // Wide style GTK tabs
+    // if (window.app.config.@"gtk-wide-tabs") {
+    //     c.gtk_widget_set_hexpand(label_box_widget, 1);
+    //     c.gtk_widget_set_halign(label_box_widget, c.GTK_ALIGN_FILL);
+    //     c.gtk_widget_set_hexpand(label_text_widget, 1);
+    //     c.gtk_widget_set_halign(label_text_widget, c.GTK_ALIGN_FILL);
 
-    // Build the close button for the tab
-    const label_close_widget = c.gtk_button_new_from_icon_name("window-close-symbolic");
-    const label_close: *c.GtkButton = @ptrCast(label_close_widget);
-    c.gtk_button_set_has_frame(label_close, 0);
-    c.gtk_box_append(label_box, label_close_widget);
+    //     // This ensures that tabs are always equal width. If they're too
+    //     // long, they'll be truncated with an ellipsis.
+    //     c.gtk_label_set_max_width_chars(label_text, 1);
+    //     c.gtk_label_set_ellipsize(label_text, c.PANGO_ELLIPSIZE_END);
 
-    // Wide style GTK tabs
-    if (window.app.config.@"gtk-wide-tabs") {
-        c.gtk_widget_set_hexpand(label_box_widget, 1);
-        c.gtk_widget_set_halign(label_box_widget, c.GTK_ALIGN_FILL);
-        c.gtk_widget_set_hexpand(label_text_widget, 1);
-        c.gtk_widget_set_halign(label_text_widget, c.GTK_ALIGN_FILL);
-
-        // This ensures that tabs are always equal width. If they're too
-        // long, they'll be truncated with an ellipsis.
-        c.gtk_label_set_max_width_chars(label_text, 1);
-        c.gtk_label_set_ellipsize(label_text, c.PANGO_ELLIPSIZE_END);
-
-        // We need to set a minimum width so that at a certain point
-        // the notebook will have an arrow button rather than shrinking tabs
-        // to an unreadably small size.
-        c.gtk_widget_set_size_request(label_text_widget, 100, 1);
-    }
+    //     // We need to set a minimum width so that at a certain point
+    //     // the notebook will have an arrow button rather than shrinking tabs
+    //     // to an unreadably small size.
+    //     c.gtk_widget_set_size_request(label_text_widget, 100, 1);
+    // }
 
     // Create a Box in which we'll later keep either Surface or Split.
     // Using a box makes it easier to maintain the tab contents because
@@ -106,47 +92,51 @@ pub fn init(self: *Tab, window: *Window, parent_: ?*CoreSurface) !void {
     // Add Surface to the Tab
     c.gtk_box_append(self.box, surface.primaryWidget());
 
-    // Add the notebook page (create tab).
-    const parent_page_idx = switch (window.app.config.@"window-new-tab-position") {
-        .current => c.gtk_notebook_get_current_page(window.notebook) + 1,
-        .end => c.gtk_notebook_get_n_pages(window.notebook),
-    };
+    try window.notebook.addTab(box_widget, "Ghostty");
 
-    const page_idx = c.gtk_notebook_insert_page(
-        window.notebook,
-        box_widget,
-        label_box_widget,
-        parent_page_idx,
-    );
-    if (page_idx < 0) {
-        log.warn("failed to add page to notebook", .{});
-        return error.GtkAppendPageFailed;
-    }
+    // const notebook: *c.GtkNotebook = window.notebook.as_notebook();
 
-    // Tab settings
-    c.gtk_notebook_set_tab_reorderable(window.notebook, box_widget, 1);
-    c.gtk_notebook_set_tab_detachable(window.notebook, box_widget, 1);
+    // // Add the notebook page (create tab).
+    // const parent_page_idx = switch (window.app.config.@"window-new-tab-position") {
+    //     .current => c.gtk_notebook_get_current_page(notebook) + 1,
+    //     .end => c.gtk_notebook_get_n_pages(notebook),
+    // };
 
-    // If we have multiple tabs, show the tab bar.
-    if (c.gtk_notebook_get_n_pages(window.notebook) > 1) {
-        c.gtk_notebook_set_show_tabs(window.notebook, 1);
-    }
+    // const page_idx = c.gtk_notebook_insert_page(
+    //     notebook,
+    //     box_widget,
+    //     label_box_widget,
+    //     parent_page_idx,
+    // );
+    // if (page_idx < 0) {
+    //     log.warn("failed to add page to notebook", .{});
+    //     return error.GtkAppendPageFailed;
+    // }
+
+    // // Tab settings
+    // c.gtk_notebook_set_tab_reorderable(notebook, box_widget, 1);
+    // c.gtk_notebook_set_tab_detachable(notebook, box_widget, 1);
+
+    // // If we have multiple tabs, show the tab bar.
+    // if (c.gtk_notebook_get_n_pages(notebook) > 1) {
+    //     c.gtk_notebook_set_show_tabs(notebook, 1);
+    // }
 
     // Set the userdata of the box to point to this tab.
     c.g_object_set_data(@ptrCast(box_widget), GHOSTTY_TAB, self);
 
-    // Clicks
-    const gesture_tab_click = c.gtk_gesture_click_new();
-    c.gtk_gesture_single_set_button(@ptrCast(gesture_tab_click), 0);
-    c.gtk_widget_add_controller(label_box_widget, @ptrCast(gesture_tab_click));
+    // // Clicks
+    // const gesture_tab_click = c.gtk_gesture_click_new();
+    // c.gtk_gesture_single_set_button(@ptrCast(gesture_tab_click), 0);
+    // c.gtk_widget_add_controller(label_box_widget, @ptrCast(gesture_tab_click));
 
-    // Attach all events
-    _ = c.g_signal_connect_data(label_close, "clicked", c.G_CALLBACK(&gtkTabCloseClick), self, null, c.G_CONNECT_DEFAULT);
-    _ = c.g_signal_connect_data(box_widget, "destroy", c.G_CALLBACK(&gtkDestroy), self, null, c.G_CONNECT_DEFAULT);
-    _ = c.g_signal_connect_data(gesture_tab_click, "pressed", c.G_CALLBACK(&gtkTabClick), self, null, c.G_CONNECT_DEFAULT);
+    // // Attach all events
+    // _ = c.g_signal_connect_data(label_close, "clicked", c.G_CALLBACK(&gtkTabCloseClick), self, null, c.G_CONNECT_DEFAULT);
+    // _ = c.g_signal_connect_data(box_widget, "destroy", c.G_CALLBACK(&gtkDestroy), self, null, c.G_CONNECT_DEFAULT);
+    // _ = c.g_signal_connect_data(gesture_tab_click, "pressed", c.G_CALLBACK(&gtkTabClick), self, null, c.G_CONNECT_DEFAULT);
 
-    // Switch to the new tab
-    c.gtk_notebook_set_current_page(window.notebook, page_idx);
+    // // Switch to the new tab
+    // c.gtk_notebook_set_current_page(notebook, page_idx);
 
     // We need to grab focus after Surface and Tab is added to the window. When
     // creating a Tab we want to always focus on the widget.
@@ -173,6 +163,18 @@ pub fn replaceElem(self: *Tab, elem: Surface.Container.Elem) void {
     // Add our new one
     c.gtk_box_append(self.box, elem.widget());
     self.elem = elem;
+}
+
+pub fn setLabelText(self: *Tab, title: [:0]const u8) void {
+    switch (self.window.notebook) {
+        .adw_tab_view => |tab_view| {
+            const page = c.adw_tab_view_get_page(tab_view, @ptrCast(self.box));
+            c.adw_tab_page_set_title(page, title.ptr);
+        },
+        .gtk_notebook => {
+            c.gtk_label_set_text(self.label_text, title.ptr);
+        }
+    }
 }
 
 /// Remove this tab from the window.

--- a/src/apprt/gtk/Tab.zig
+++ b/src/apprt/gtk/Tab.zig
@@ -124,10 +124,7 @@ pub fn init(self: *Tab, window: *Window, parent_: ?*CoreSurface) !void {
     //     c.gtk_notebook_set_show_tabs(notebook, 1);
     // }
 
-
-    // 
-
-    // // Attach all events
+    // Attach all events
     _ = c.g_signal_connect_data(box_widget, "destroy", c.G_CALLBACK(&gtkDestroy), self, null, c.G_CONNECT_DEFAULT);
 
     // We need to grab focus after Surface and Tab is added to the window. When
@@ -174,7 +171,7 @@ pub fn gtkTabCloseClick(_: *c.GtkButton, ud: ?*anyopaque) callconv(.C) void {
 
 fn gtkDestroy(v: *c.GtkWidget, ud: ?*anyopaque) callconv(.C) void {
     _ = v;
-    log.debug("tab box destroy", .{});
+    log.info("tab box destroy", .{});
 
     // When our box is destroyed, we want to destroy our tab, too.
     const tab: *Tab = @ptrCast(@alignCast(ud));

--- a/src/apprt/gtk/Tab.zig
+++ b/src/apprt/gtk/Tab.zig
@@ -92,7 +92,7 @@ pub fn init(self: *Tab, window: *Window, parent_: ?*CoreSurface) !void {
     // Add Surface to the Tab
     c.gtk_box_append(self.box, surface.primaryWidget());
 
-    try window.notebook.addTab(box_widget, "Ghostty");
+    try window.notebook.addTab(self, "Ghostty");
 
     // const notebook: *c.GtkNotebook = window.notebook.as_notebook();
 
@@ -132,11 +132,8 @@ pub fn init(self: *Tab, window: *Window, parent_: ?*CoreSurface) !void {
 
     // // Attach all events
     // _ = c.g_signal_connect_data(label_close, "clicked", c.G_CALLBACK(&gtkTabCloseClick), self, null, c.G_CONNECT_DEFAULT);
-    // _ = c.g_signal_connect_data(box_widget, "destroy", c.G_CALLBACK(&gtkDestroy), self, null, c.G_CONNECT_DEFAULT);
+    _ = c.g_signal_connect_data(box_widget, "destroy", c.G_CALLBACK(&gtkDestroy), self, null, c.G_CONNECT_DEFAULT);
     // _ = c.g_signal_connect_data(gesture_tab_click, "pressed", c.G_CALLBACK(&gtkTabClick), self, null, c.G_CONNECT_DEFAULT);
-
-    // // Switch to the new tab
-    // c.gtk_notebook_set_current_page(notebook, page_idx);
 
     // We need to grab focus after Surface and Tab is added to the window. When
     // creating a Tab we want to always focus on the widget.
@@ -166,15 +163,7 @@ pub fn replaceElem(self: *Tab, elem: Surface.Container.Elem) void {
 }
 
 pub fn setLabelText(self: *Tab, title: [:0]const u8) void {
-    switch (self.window.notebook) {
-        .adw_tab_view => |tab_view| {
-            const page = c.adw_tab_view_get_page(tab_view, @ptrCast(self.box));
-            c.adw_tab_page_set_title(page, title.ptr);
-        },
-        .gtk_notebook => {
-            c.gtk_label_set_text(self.label_text, title.ptr);
-        }
-    }
+    self.window.notebook.setTabLabel(self, title);
 }
 
 /// Remove this tab from the window.

--- a/src/apprt/gtk/Tab.zig
+++ b/src/apprt/gtk/Tab.zig
@@ -55,24 +55,6 @@ pub fn init(self: *Tab, window: *Window, parent_: ?*CoreSurface) !void {
         .focus_child = undefined,
     };
 
-    // // Wide style GTK tabs
-    // if (window.app.config.@"gtk-wide-tabs") {
-    //     c.gtk_widget_set_hexpand(label_box_widget, 1);
-    //     c.gtk_widget_set_halign(label_box_widget, c.GTK_ALIGN_FILL);
-    //     c.gtk_widget_set_hexpand(label_text_widget, 1);
-    //     c.gtk_widget_set_halign(label_text_widget, c.GTK_ALIGN_FILL);
-
-    //     // This ensures that tabs are always equal width. If they're too
-    //     // long, they'll be truncated with an ellipsis.
-    //     c.gtk_label_set_max_width_chars(label_text, 1);
-    //     c.gtk_label_set_ellipsize(label_text, c.PANGO_ELLIPSIZE_END);
-
-    //     // We need to set a minimum width so that at a certain point
-    //     // the notebook will have an arrow button rather than shrinking tabs
-    //     // to an unreadably small size.
-    //     c.gtk_widget_set_size_request(label_text_widget, 100, 1);
-    // }
-
     // Create a Box in which we'll later keep either Surface or Split.
     // Using a box makes it easier to maintain the tab contents because
     // we never need to change the root widget of the notebook page (tab).
@@ -95,34 +77,6 @@ pub fn init(self: *Tab, window: *Window, parent_: ?*CoreSurface) !void {
     // Set the userdata of the box to point to this tab.
     c.g_object_set_data(@ptrCast(box_widget), GHOSTTY_TAB, self);
     try window.notebook.addTab(self, "Ghostty");
-
-    // const notebook: *c.GtkNotebook = window.notebook.as_notebook();
-
-    // // Add the notebook page (create tab).
-    // const parent_page_idx = switch (window.app.config.@"window-new-tab-position") {
-    //     .current => c.gtk_notebook_get_current_page(notebook) + 1,
-    //     .end => c.gtk_notebook_get_n_pages(notebook),
-    // };
-
-    // const page_idx = c.gtk_notebook_insert_page(
-    //     notebook,
-    //     box_widget,
-    //     label_box_widget,
-    //     parent_page_idx,
-    // );
-    // if (page_idx < 0) {
-    //     log.warn("failed to add page to notebook", .{});
-    //     return error.GtkAppendPageFailed;
-    // }
-
-    // // Tab settings
-    // c.gtk_notebook_set_tab_reorderable(notebook, box_widget, 1);
-    // c.gtk_notebook_set_tab_detachable(notebook, box_widget, 1);
-
-    // // If we have multiple tabs, show the tab bar.
-    // if (c.gtk_notebook_get_n_pages(notebook) > 1) {
-    //     c.gtk_notebook_set_show_tabs(notebook, 1);
-    // }
 
     // Attach all events
     _ = c.g_signal_connect_data(box_widget, "destroy", c.G_CALLBACK(&gtkDestroy), self, null, c.G_CONNECT_DEFAULT);
@@ -171,7 +125,7 @@ pub fn gtkTabCloseClick(_: *c.GtkButton, ud: ?*anyopaque) callconv(.C) void {
 
 fn gtkDestroy(v: *c.GtkWidget, ud: ?*anyopaque) callconv(.C) void {
     _ = v;
-    log.info("tab box destroy", .{});
+    log.debug("tab box destroy", .{});
 
     // When our box is destroyed, we want to destroy our tab, too.
     const tab: *Tab = @ptrCast(@alignCast(ud));

--- a/src/apprt/gtk/Tab.zig
+++ b/src/apprt/gtk/Tab.zig
@@ -92,6 +92,8 @@ pub fn init(self: *Tab, window: *Window, parent_: ?*CoreSurface) !void {
     // Add Surface to the Tab
     c.gtk_box_append(self.box, surface.primaryWidget());
 
+    // Set the userdata of the box to point to this tab.
+    c.g_object_set_data(@ptrCast(box_widget), GHOSTTY_TAB, self);
     try window.notebook.addTab(self, "Ghostty");
 
     // const notebook: *c.GtkNotebook = window.notebook.as_notebook();
@@ -122,18 +124,11 @@ pub fn init(self: *Tab, window: *Window, parent_: ?*CoreSurface) !void {
     //     c.gtk_notebook_set_show_tabs(notebook, 1);
     // }
 
-    // Set the userdata of the box to point to this tab.
-    c.g_object_set_data(@ptrCast(box_widget), GHOSTTY_TAB, self);
 
-    // // Clicks
-    // const gesture_tab_click = c.gtk_gesture_click_new();
-    // c.gtk_gesture_single_set_button(@ptrCast(gesture_tab_click), 0);
-    // c.gtk_widget_add_controller(label_box_widget, @ptrCast(gesture_tab_click));
+    // 
 
     // // Attach all events
-    // _ = c.g_signal_connect_data(label_close, "clicked", c.G_CALLBACK(&gtkTabCloseClick), self, null, c.G_CONNECT_DEFAULT);
     _ = c.g_signal_connect_data(box_widget, "destroy", c.G_CALLBACK(&gtkDestroy), self, null, c.G_CONNECT_DEFAULT);
-    // _ = c.g_signal_connect_data(gesture_tab_click, "pressed", c.G_CALLBACK(&gtkTabClick), self, null, c.G_CONNECT_DEFAULT);
 
     // We need to grab focus after Surface and Tab is added to the window. When
     // creating a Tab we want to always focus on the widget.
@@ -171,7 +166,7 @@ pub fn remove(self: *Tab) void {
     self.window.closeTab(self);
 }
 
-fn gtkTabCloseClick(_: *c.GtkButton, ud: ?*anyopaque) callconv(.C) void {
+pub fn gtkTabCloseClick(_: *c.GtkButton, ud: ?*anyopaque) callconv(.C) void {
     const tab: *Tab = @ptrCast(@alignCast(ud));
     const window = tab.window;
     window.closeTab(tab);
@@ -186,7 +181,7 @@ fn gtkDestroy(v: *c.GtkWidget, ud: ?*anyopaque) callconv(.C) void {
     tab.destroy(tab.window.app.core_app.alloc);
 }
 
-fn gtkTabClick(
+pub fn gtkTabClick(
     gesture: *c.GtkGestureClick,
     _: c.gint,
     _: c.gdouble,

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -60,10 +60,10 @@ pub fn init(self: *Window, app: *App) !void {
     };
 
     // Create the window
-    const adw_window = (comptime adwaita.comptimeEnabled()) and
+    const adw_window =
+        (comptime adwaita.versionAtLeast(1, 4, 0)) and
         adwaita.enabled(&app.config) and
         app.config.@"gtk-titlebar" and
-        (comptime adwaita.versionAtLeast(1, 4, 0)) and
         adwaita.versionAtLeast(1, 4, 0);
     const window: *c.GtkWidget = if (adw_window)
         c.adw_application_window_new(app.app)
@@ -127,8 +127,7 @@ pub fn init(self: *Window, app: *App) !void {
     // This is a really common issue where people build from source in debug and performance is really bad.
     if (comptime std.debug.runtime_safety) {
         const warning_text = "⚠️ You're running a debug build of Ghostty! Performance will be degraded.";
-        if ((comptime adwaita.comptimeEnabled()) and
-            (comptime adwaita.versionAtLeast(1, 3, 0)) and
+        if ((comptime adwaita.versionAtLeast(1, 3, 0)) and
             adwaita.enabled(&app.config) and
             adwaita.versionAtLeast(1, 3, 0))
         {
@@ -161,8 +160,7 @@ pub fn init(self: *Window, app: *App) !void {
     // Our actions for the menu
     initActions(self);
 
-    if ((comptime adwaita.comptimeEnabled()) and
-        (comptime adwaita.versionAtLeast(1, 4, 0)) and
+    if ((comptime adwaita.versionAtLeast(1, 4, 0)) and
         adwaita.enabled(&app.config) and
         adwaita.versionAtLeast(1, 4, 0) and
         app.config.@"gtk-titlebar" and

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -113,13 +113,14 @@ pub fn init(self: *Window, app: *App) !void {
     // Create our box which will hold our widgets.
     const box = c.gtk_box_new(c.GTK_ORIENTATION_VERTICAL, 0);
 
-    // In debug we show a warning. This is a really common issue where
-    // people build from source in debug and performance is really bad.
+    // In debug we show a warning and apply the 'devel' class to the window.
+    // This is a really common issue where people build from source in debug and performance is really bad.
     if (comptime std.debug.runtime_safety) {
         const warning = c.gtk_label_new("⚠️ You're running a debug build of Ghostty! Performance will be degraded.");
         c.gtk_widget_set_margin_top(warning, 10);
         c.gtk_widget_set_margin_bottom(warning, 10);
         c.gtk_box_append(@ptrCast(box), warning);
+        c.gtk_widget_add_css_class(@ptrCast(gtk_window), "devel");
     }
 
     self.notebook = Notebook.create(self, box);

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -21,133 +21,9 @@ const Color = configpkg.Config.Color;
 const Surface = @import("Surface.zig");
 const Tab = @import("Tab.zig");
 const c = @import("c.zig").c;
+const Notebook = @import("./notebook.zig").Notebook;
 
 const log = std.log.scoped(.gtk);
-
-pub const Notebook = union(enum) {
-    adw_tab_view: *c.AdwTabView,
-    gtk_notebook: *c.GtkNotebook,
-
-    pub fn create(window: *Window) @This() {
-        const app = window.app;
-
-        // Create a notebook to hold our tabs.
-        const notebook_widget = c.gtk_notebook_new();
-        const notebook: *c.GtkNotebook = @ptrCast(notebook_widget);
-        const notebook_tab_pos: c_uint = switch (app.config.@"gtk-tabs-location") {
-            .top => c.GTK_POS_TOP,
-            .bottom => c.GTK_POS_BOTTOM,
-            .left => c.GTK_POS_LEFT,
-            .right => c.GTK_POS_RIGHT,
-        };
-        c.gtk_notebook_set_tab_pos(notebook, notebook_tab_pos);
-        c.gtk_notebook_set_scrollable(notebook, 1);
-        c.gtk_notebook_set_show_tabs(notebook, 0);
-        c.gtk_notebook_set_show_border(notebook, 0);
-
-        // This enables all Ghostty terminal tabs to be exchanged across windows.
-        c.gtk_notebook_set_group_name(notebook, "ghostty-terminal-tabs");
-
-        // This is important so the notebook expands to fit available space.
-        // Otherwise, it will be zero/zero in the box below.
-        c.gtk_widget_set_vexpand(notebook_widget, 1);
-        c.gtk_widget_set_hexpand(notebook_widget, 1);
-
-        // If we are in fullscreen mode, new windows start fullscreen.
-        if (app.config.fullscreen) c.gtk_window_fullscreen(window.window);
-
-        // All of our events
-        _ = c.g_signal_connect_data(window, "close-request", c.G_CALLBACK(&gtkCloseRequest), window, null, c.G_CONNECT_DEFAULT);
-        _ = c.g_signal_connect_data(window, "destroy", c.G_CALLBACK(&gtkDestroy), window, null, c.G_CONNECT_DEFAULT);
-        _ = c.g_signal_connect_data(notebook, "page-added", c.G_CALLBACK(&gtkPageAdded), window, null, c.G_CONNECT_DEFAULT);
-        _ = c.g_signal_connect_data(notebook, "page-removed", c.G_CALLBACK(&gtkPageRemoved), window, null, c.G_CONNECT_DEFAULT);
-        _ = c.g_signal_connect_data(notebook, "switch-page", c.G_CALLBACK(&gtkSwitchPage), window, null, c.G_CONNECT_DEFAULT);
-        _ = c.g_signal_connect_data(notebook, "create-window", c.G_CALLBACK(&gtkNotebookCreateWindow), window, null, c.G_CONNECT_DEFAULT);
-
-        return .{ .gtk_notebook = notebook };
-    }
-
-    pub fn as_widget(self: Notebook) *c.GtkWidget {
-        return switch (self) {
-            .adw_tab_view => |ptr| @ptrCast(@alignCast(ptr)),
-            .gtk_notebook => |ptr| @ptrCast(@alignCast(ptr)),
-        };
-    }
-
-    pub fn as_notebook(self: Notebook) *c.GtkNotebook {
-        return switch (self) {
-            .adw_tab_view => @panic("adw tab view"),
-            .gtk_notebook => |notebook| notebook,
-        };
-    }
-
-    pub fn nPages(self: Notebook) c_int {
-        return switch (self) {
-            .adw_tab_view => |tab_view| c.adw_tab_view_get_n_pages(tab_view),
-            .gtk_notebook => |notebook| c.gtk_notebook_get_n_pages(notebook),
-        };
-    }
-
-    pub fn currentPage(self: Notebook) c_int {
-        switch (self) {
-            .adw_tab_view => |tab_view| {
-                const page = c.adw_tab_view_get_selected_page(tab_view);
-                return c.adw_tab_view_get_page_position(tab_view, page);
-            },
-            .gtk_notebook => |notebook| return c.gtk_notebook_get_current_page(notebook),
-        }
-    }
-
-    pub fn currentTab(self: Notebook) ?*Tab {
-        const child = switch (self) {
-            .adw_tab_view => |tab_view| child: {
-                const page = c.adw_tab_view_get_selected_page(tab_view);
-                const child = c.adw_tab_page_get_child(page);
-                break :child child;
-            },
-            .gtk_notebook => |notebook| child: {
-                const page = self.currentPage();
-                break :child c.gtk_notebook_get_nth_page(notebook, page);
-            },
-        };
-        return @ptrCast(@alignCast(
-            c.g_object_get_data(@ptrCast(child), Tab.GHOSTTY_TAB) orelse return null,
-        ));
-    }
-
-    pub fn addTab(self: Notebook, tab_widget: *c.GtkWidget, title: [:0]const u8) !void {
-        switch (self) {
-            .adw_tab_view => |tab_view| {
-                const page = c.adw_tab_view_append(tab_view, tab_widget); 
-                c.adw_tab_page_set_title(page, title);
-            },
-            .gtk_notebook => |notebook| {
-                // Build the tab label
-                const label_box_widget = c.gtk_box_new(c.GTK_ORIENTATION_HORIZONTAL, 0);
-                const label_box = @as(*c.GtkBox, @ptrCast(label_box_widget));
-                const label_text_widget = c.gtk_label_new("Ghostty");
-                // const label_text: *c.GtkLabel = @ptrCast(label_text_widget);
-                c.gtk_box_append(label_box, label_text_widget);
-                // self.label_text = label_text;
-
-                // Build the close button for the tab
-                const label_close_widget = c.gtk_button_new_from_icon_name("window-close-symbolic");
-                const label_close: *c.GtkButton = @ptrCast(label_close_widget);
-                c.gtk_button_set_has_frame(label_close, 0);
-                c.gtk_box_append(label_box, label_close_widget);
-
-                const parent_page_idx = self.nPages();
-                const page_idx = c.gtk_notebook_insert_page(
-                    notebook,
-                    tab_widget,
-                    label_box_widget,
-                    parent_page_idx,
-                );
-                _ = page_idx;
-            }
-        }
-    }
-};
 
 app: *App,
 
@@ -246,17 +122,7 @@ pub fn init(self: *Window, app: *App) !void {
         c.gtk_box_append(@ptrCast(box), warning);
     }
 
-    const adwaita = build_options.libadwaita and app.config.@"gtk-adwaita";
-    if (adwaita) {
-        log.warn("using adwaita", .{});
-        const tab_view = c.adw_tab_view_new();
-        const tab_bar = c.adw_tab_bar_new();
-        c.gtk_box_append(@ptrCast(box), @ptrCast(@alignCast(tab_bar)));
-        c.adw_tab_bar_set_view(tab_bar, tab_view.?);
-        self.notebook = .{ .adw_tab_view = tab_view.? };
-    } else {
-        self.notebook = Notebook.create(self);
-    }
+    self.notebook = Notebook.create(self, box);
     c.gtk_box_append(@ptrCast(box), self.notebook.as_widget());
 
     self.context_menu = c.gtk_popover_menu_new_from_model(@ptrCast(@alignCast(self.app.context_menu)));
@@ -331,34 +197,12 @@ pub fn newTab(self: *Window, parent: ?*CoreSurface) !void {
 /// Close the tab for the given notebook page. This will automatically
 /// handle closing the window if there are no more tabs.
 pub fn closeTab(self: *Window, tab: *Tab) void {
-    const notebook: *c.GtkNotebook = self.notebook.as_notebook();
-    const page = c.gtk_notebook_get_page(notebook, @ptrCast(tab.box)) orelse return;
-
-    // Find page and tab which we're closing
-    const page_idx = getNotebookPageIndex(page);
-
-    // Remove the page. This will destroy the GTK widgets in the page which
-    // will trigger Tab cleanup.
-    c.gtk_notebook_remove_page(notebook, page_idx);
-
-    const remaining = c.gtk_notebook_get_n_pages(notebook);
-    switch (remaining) {
-        // If we have no more tabs we close the window
-        0 => c.gtk_window_destroy(self.window),
-
-        // If we have one more tab we hide the tab bar
-        1 => c.gtk_notebook_set_show_tabs(notebook, 0),
-
-        else => {},
-    }
-
-    // If we have remaining tabs, we need to make sure we grab focus.
-    if (remaining > 0) self.focusCurrentTab();
+    self.notebook.closeTab(tab);
 }
 
 /// Returns true if this window has any tabs.
 pub fn hasTabs(self: *const Window) bool {
-    return c.gtk_notebook_get_n_pages(self.notebook.as_notebook()) > 0;
+    return self.notebook.nPages() > 0;
 }
 
 /// Go to the previous tab for a surface.
@@ -368,9 +212,9 @@ pub fn gotoPreviousTab(self: *Window, surface: *Surface) void {
         return;
     };
 
-    const notebook: *c.GtkNotebook = self.notebook.as_notebook();
+    const notebook: *c.GtkNotebook = self.notebook.gtk_notebook;
     const page = c.gtk_notebook_get_page(notebook, @ptrCast(tab.box)) orelse return;
-    const page_idx = getNotebookPageIndex(page);
+    const page_idx = Notebook.getNotebookPageIndex(page);
 
     // The next index is the previous or we wrap around.
     const next_idx = if (page_idx > 0) page_idx - 1 else next_idx: {
@@ -392,9 +236,9 @@ pub fn gotoNextTab(self: *Window, surface: *Surface) void {
         return;
     };
 
-    const notebook: *c.GtkNotebook = self.notebook.as_notebook();
+    const notebook: *c.GtkNotebook = self.notebook.gtk_notebook;
     const page = c.gtk_notebook_get_page(notebook, @ptrCast(tab.box)) orelse return;
-    const page_idx = getNotebookPageIndex(page);
+    const page_idx = Notebook.getNotebookPageIndex(page);
     const max = c.gtk_notebook_get_n_pages(notebook) -| 1;
     const next_idx = if (page_idx < max) page_idx + 1 else 0;
     if (next_idx == page_idx) return;
@@ -405,15 +249,15 @@ pub fn gotoNextTab(self: *Window, surface: *Surface) void {
 
 /// Go to the next tab for a surface.
 pub fn gotoLastTab(self: *Window) void {
-    const max = c.gtk_notebook_get_n_pages(self.notebook) -| 1;
-    c.gtk_notebook_set_current_page(self.notebook, max);
+    const max = self.notebook.nPages()  -| 1;
+    c.gtk_notebook_set_current_page(self.notebook.gtk_notebook, max);
     self.focusCurrentTab();
 }
 
 /// Go to the specific tab index.
 pub fn gotoTab(self: *Window, n: usize) void {
     if (n == 0) return;
-    const notebook: *c.GtkNotebook = self.notebook.as_notebook();
+    const notebook: *c.GtkNotebook = self.notebook.gtk_notebook;
     const max = c.gtk_notebook_get_n_pages(notebook);
     const page_idx = std.math.cast(c_int, n - 1) orelse return;
     if (page_idx < max) {
@@ -442,13 +286,7 @@ pub fn toggleWindowDecorations(self: *Window) void {
 }
 
 /// Grabs focus on the currently selected tab.
-fn focusCurrentTab(self: *Window) void {
-    // const notebook: *c.GtkNotebook = self.notebook.as_notebook();
-    // const page_idx = c.gtk_notebook_get_current_page(notebook);
-    // const page = c.gtk_notebook_get_nth_page(notebook, page_idx);
-    // const tab: *Tab = @ptrCast(@alignCast(
-    //     c.g_object_get_data(@ptrCast(page), Tab.GHOSTTY_TAB) orelse return,
-    // ));
+pub fn focusCurrentTab(self: *Window) void {
     const tab = self.notebook.currentTab() orelse return;
     const gl_area = @as(*c.GtkWidget, @ptrCast(tab.focus_child.gl_area));
     _ = c.gtk_widget_grab_focus(gl_area);
@@ -463,81 +301,6 @@ fn gtkTabNewClick(_: *c.GtkButton, ud: ?*anyopaque) callconv(.C) void {
         log.warn("error performing binding action error={}", .{err});
         return;
     };
-}
-
-fn gtkPageAdded(
-    notebook: *c.GtkNotebook,
-    _: *c.GtkWidget,
-    page_idx: c.guint,
-    ud: ?*anyopaque,
-) callconv(.C) void {
-    const self = userdataSelf(ud.?);
-
-    // The added page can come from another window with drag and drop, thus we migrate the tab
-    // window to be self.
-    const page = c.gtk_notebook_get_nth_page(notebook, @intCast(page_idx));
-    const tab: *Tab = @ptrCast(@alignCast(
-        c.g_object_get_data(@ptrCast(page), Tab.GHOSTTY_TAB) orelse return,
-    ));
-    tab.window = self;
-
-    // Whenever a new page is added, we always grab focus of the
-    // currently selected page. This was added specifically so that when
-    // we drag a tab out to create a new window ("create-window" event)
-    // we grab focus in the new window. Without this, the terminal didn't
-    // have focus.
-    self.focusCurrentTab();
-}
-
-fn gtkPageRemoved(
-    _: *c.GtkNotebook,
-    _: *c.GtkWidget,
-    _: c.guint,
-    ud: ?*anyopaque,
-) callconv(.C) void {
-    const self = userdataSelf(ud.?);
-
-    const notebook: *c.GtkNotebook = self.notebook.as_notebook();
-
-    // Hide the tab bar if we only have one tab after removal
-    const remaining = c.gtk_notebook_get_n_pages(notebook);
-    if (remaining == 1) {
-        c.gtk_notebook_set_show_tabs(notebook, 0);
-    }
-}
-
-fn gtkSwitchPage(_: *c.GtkNotebook, page: *c.GtkWidget, _: usize, ud: ?*anyopaque) callconv(.C) void {
-    const self = userdataSelf(ud.?);
-    const gtk_label_box = @as(*c.GtkWidget, @ptrCast(c.gtk_notebook_get_tab_label(self.notebook.as_notebook(), page)));
-    const gtk_label = @as(*c.GtkLabel, @ptrCast(c.gtk_widget_get_first_child(gtk_label_box)));
-    const label_text = c.gtk_label_get_text(gtk_label);
-    c.gtk_window_set_title(self.window, label_text);
-}
-
-fn gtkNotebookCreateWindow(
-    _: *c.GtkNotebook,
-    page: *c.GtkWidget,
-    ud: ?*anyopaque,
-) callconv(.C) ?*c.GtkNotebook {
-    // The tab for the page is stored in the widget data.
-    const tab: *Tab = @ptrCast(@alignCast(
-        c.g_object_get_data(@ptrCast(page), Tab.GHOSTTY_TAB) orelse return null,
-    ));
-
-    const currentWindow = userdataSelf(ud.?);
-    const alloc = currentWindow.app.core_app.alloc;
-    const app = currentWindow.app;
-
-    // Create a new window
-    const window = Window.create(alloc, app) catch |err| {
-        log.warn("error creating new window error={}", .{err});
-        return null;
-    };
-
-    // And add it to the new window.
-    tab.window = window;
-
-    return window.notebook.as_notebook();
 }
 
 fn gtkRefocusTerm(v: *c.GtkWindow, ud: ?*anyopaque) callconv(.C) bool {
@@ -619,19 +382,6 @@ fn gtkDestroy(v: *c.GtkWidget, ud: ?*anyopaque) callconv(.C) void {
     const alloc = self.app.core_app.alloc;
     self.deinit();
     alloc.destroy(self);
-}
-
-fn getNotebookPageIndex(page: *c.GtkNotebookPage) c_int {
-    var value: c.GValue = std.mem.zeroes(c.GValue);
-    defer c.g_value_unset(&value);
-    _ = c.g_value_init(&value, c.G_TYPE_INT);
-    c.g_object_get_property(
-        @ptrCast(@alignCast(page)),
-        "position",
-        &value,
-    );
-
-    return c.g_value_get_int(&value);
 }
 
 fn gtkActionAbout(
@@ -773,7 +523,7 @@ fn gtkActionReset(
 /// Returns the surface to use for an action.
 fn actionSurface(self: *Window) ?*CoreSurface {
     const tab = self.notebook.currentTab() orelse return null;
-    // const notebook: *c.GtkNotebook = self.notebook.as_notebook();
+    // const notebook: *c.GtkNotebook = self.notebook.gtk_notebook;
     // const page_idx = c.gtk_notebook_get_current_page(notebook);
     // const page = c.gtk_notebook_get_nth_page(notebook, page_idx);
     // const tab: *Tab = @ptrCast(@alignCast(
@@ -782,6 +532,6 @@ fn actionSurface(self: *Window) ?*CoreSurface {
     return &tab.focus_child.core_surface;
 }
 
-fn userdataSelf(ud: *anyopaque) *Window {
+pub fn userdataSelf(ud: *anyopaque) *Window {
     return @ptrCast(@alignCast(ud));
 }

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -8,7 +8,6 @@ const Window = @This();
 const std = @import("std");
 const builtin = @import("builtin");
 const build_config = @import("../../build_config.zig");
-const build_options = @import("build_options");
 const Allocator = std.mem.Allocator;
 const assert = std.debug.assert;
 const configpkg = @import("../../config.zig");
@@ -61,9 +60,10 @@ pub fn init(self: *Window, app: *App) !void {
     };
 
     // Create the window
-    const adw_window = adwaita.enabled(&app.config) and
+    const adw_window = (comptime adwaita.comptimeEnabled()) and
+        adwaita.enabled(&app.config) and
         app.config.@"gtk-titlebar" and
-        comptime adwaita.versionAtLeast(1, 4, 0) and
+        (comptime adwaita.versionAtLeast(1, 4, 0)) and
         adwaita.versionAtLeast(1, 4, 0);
     const window: *c.GtkWidget = if (adw_window)
         c.adw_application_window_new(app.app)
@@ -127,8 +127,9 @@ pub fn init(self: *Window, app: *App) !void {
     // This is a really common issue where people build from source in debug and performance is really bad.
     if (comptime std.debug.runtime_safety) {
         const warning_text = "⚠️ You're running a debug build of Ghostty! Performance will be degraded.";
-        if (adwaita.enabled(&app.config) and
-            comptime adwaita.versionAtLeast(1, 3, 0) and
+        if ((comptime adwaita.comptimeEnabled()) and
+            (comptime adwaita.versionAtLeast(1, 3, 0)) and
+            adwaita.enabled(&app.config) and
             adwaita.versionAtLeast(1, 3, 0))
         {
             const banner = c.adw_banner_new(warning_text);
@@ -160,11 +161,12 @@ pub fn init(self: *Window, app: *App) !void {
     // Our actions for the menu
     initActions(self);
 
-    if (adwaita.enabled(&app.config) and
+    if ((comptime adwaita.comptimeEnabled()) and
+        (comptime adwaita.versionAtLeast(1, 4, 0)) and
+        adwaita.enabled(&app.config) and
+        adwaita.versionAtLeast(1, 4, 0) and
         app.config.@"gtk-titlebar" and
-        header != null and
-        comptime adwaita.versionAtLeast(1, 4, 0) and
-        adwaita.versionAtLeast(1, 4, 0))
+        header != null)
     {
         const toolbar_view: *c.AdwToolbarView = @ptrCast(c.adw_toolbar_view_new());
 

--- a/src/apprt/gtk/adwaita.zig
+++ b/src/apprt/gtk/adwaita.zig
@@ -1,0 +1,46 @@
+const std = @import("std");
+const c = @import("c.zig").c;
+const build_options = @import("build_options");
+const Config = @import("../../config.zig").Config;
+
+/// Returns true if Ghostty is configured to build with libadwaita and
+/// the configuration has enabled adwaita.
+pub fn enabled(config: *const Config) bool {
+    return build_options.libadwaita and
+        config.@"gtk-adwaita";
+}
+
+/// Verifies that the running libadwaita version is at least the given
+/// version. This will return false if Ghostty is configured to
+/// not build with libadwaita.
+///
+/// This can be run in both a comptime and runtime context. If it
+/// is run in a comptime context, it will only check the version
+/// in the headers. If it is run in a runtime context, it will
+/// check the actual version of the library we are linked against.
+/// So generally  you probably want to do both checks!
+pub fn versionAtLeast(
+    comptime major: u16,
+    comptime minor: u16,
+    comptime micro: u16,
+) bool {
+    if (comptime !build_options.libadwaita) return false;
+
+    // If our header has lower versions than the given version,
+    // we can return false immediately. This prevents us from
+    // compiling against unknown symbols and makes runtime checks
+    // very slightly faster.
+    if (comptime c.ADW_MAJOR_VERSION < major or
+        c.ADW_MINOR_VERSION < minor or
+        c.ADW_MICRO_VERSION < micro) return false;
+
+    // If we're in comptime then we can't check the runtime version.
+    if (@inComptime()) return true;
+
+    // We use the functions instead of the constants such as
+    // c.ADW_MINOR_VERSION because the function gets the actual
+    // runtime version.
+    return c.adw_get_major_version() >= major and
+        c.adw_get_minor_version() >= minor and
+        c.adw_get_micro_version() >= micro;
+}

--- a/src/apprt/gtk/adwaita.zig
+++ b/src/apprt/gtk/adwaita.zig
@@ -3,6 +3,11 @@ const c = @import("c.zig").c;
 const build_options = @import("build_options");
 const Config = @import("../../config.zig").Config;
 
+/// Returns true if Ghostty is configured to build with libadwaita.
+pub fn comptimeEnabled() bool {
+    return build_options.libadwaita;
+}
+
 /// Returns true if Ghostty is configured to build with libadwaita and
 /// the configuration has enabled adwaita.
 pub fn enabled(config: *const Config) bool {

--- a/src/apprt/gtk/adwaita.zig
+++ b/src/apprt/gtk/adwaita.zig
@@ -43,7 +43,13 @@ pub fn versionAtLeast(
     // We use the functions instead of the constants such as
     // c.ADW_MINOR_VERSION because the function gets the actual
     // runtime version.
-    return c.adw_get_major_version() >= major and
-        c.adw_get_minor_version() >= minor and
-        c.adw_get_micro_version() >= micro;
+    if (c.adw_get_major_version() >= major) {
+        if (c.adw_get_major_version() > major) return true;
+        if (c.adw_get_minor_version() >= minor) {
+            if (c.adw_get_minor_version() > minor) return true;
+            return c.adw_get_micro_version() >= micro;
+        }
+    }
+
+    return false;
 }

--- a/src/apprt/gtk/adwaita.zig
+++ b/src/apprt/gtk/adwaita.zig
@@ -3,13 +3,11 @@ const c = @import("c.zig").c;
 const build_options = @import("build_options");
 const Config = @import("../../config.zig").Config;
 
-/// Returns true if Ghostty is configured to build with libadwaita.
-pub fn comptimeEnabled() bool {
-    return build_options.libadwaita;
-}
-
 /// Returns true if Ghostty is configured to build with libadwaita and
 /// the configuration has enabled adwaita.
+///
+/// For a comptime version of this function, use `versionAtLeast` in
+/// a comptime context with all the version numbers set to 0.
 pub fn enabled(config: *const Config) bool {
     return build_options.libadwaita and
         config.@"gtk-adwaita";

--- a/src/apprt/gtk/notebook.zig
+++ b/src/apprt/gtk/notebook.zig
@@ -8,7 +8,7 @@ const adwaita = @import("adwaita.zig");
 
 const log = std.log.scoped(.gtk);
 
-const AdwTabView = if (adwaita.comptimeEnabled()) c.AdwTabView else anyopaque;
+const AdwTabView = if (adwaita.versionAtLeast(0, 0, 0)) c.AdwTabView else anyopaque;
 
 /// An abstraction over the GTK notebook and Adwaita tab view to manage
 /// all the terminal tabs in a window.
@@ -94,7 +94,7 @@ pub const Notebook = union(enum) {
     pub fn nPages(self: Notebook) c_int {
         return switch (self) {
             .gtk_notebook => |notebook| c.gtk_notebook_get_n_pages(notebook),
-            .adw_tab_view => |tab_view| if (comptime adwaita.comptimeEnabled())
+            .adw_tab_view => |tab_view| if (comptime adwaita.versionAtLeast(0, 0, 0))
                 c.adw_tab_view_get_n_pages(tab_view)
             else
                 unreachable,
@@ -104,7 +104,7 @@ pub const Notebook = union(enum) {
     pub fn currentPage(self: Notebook) c_int {
         switch (self) {
             .adw_tab_view => |tab_view| {
-                if (comptime !adwaita.comptimeEnabled()) unreachable;
+                if (comptime !adwaita.versionAtLeast(0, 0, 0)) unreachable;
                 const page = c.adw_tab_view_get_selected_page(tab_view);
                 return c.adw_tab_view_get_page_position(tab_view, page);
             },
@@ -116,7 +116,7 @@ pub const Notebook = union(enum) {
     pub fn currentTab(self: Notebook) ?*Tab {
         const child = switch (self) {
             .adw_tab_view => |tab_view| child: {
-                if (comptime !adwaita.comptimeEnabled()) unreachable;
+                if (comptime !adwaita.versionAtLeast(0, 0, 0)) unreachable;
                 const page = c.adw_tab_view_get_selected_page(tab_view) orelse return null;
                 const child = c.adw_tab_page_get_child(page);
                 break :child child;
@@ -136,7 +136,7 @@ pub const Notebook = union(enum) {
     pub fn gotoNthTab(self: Notebook, position: c_int) void {
         switch (self) {
             .adw_tab_view => |tab_view| {
-                if (comptime !adwaita.comptimeEnabled()) unreachable;
+                if (comptime !adwaita.versionAtLeast(0, 0, 0)) unreachable;
                 const page_to_select = c.adw_tab_view_get_nth_page(tab_view, position);
                 c.adw_tab_view_set_selected_page(tab_view, page_to_select);
             },
@@ -147,7 +147,7 @@ pub const Notebook = union(enum) {
     pub fn getTabPosition(self: Notebook, tab: *Tab) ?c_int {
         return switch (self) {
             .adw_tab_view => |tab_view| page_idx: {
-                if (comptime !adwaita.comptimeEnabled()) unreachable;
+                if (comptime !adwaita.versionAtLeast(0, 0, 0)) unreachable;
                 const page = c.adw_tab_view_get_page(tab_view, @ptrCast(tab.box)) orelse return null;
                 break :page_idx c.adw_tab_view_get_page_position(tab_view, page);
             },
@@ -186,7 +186,7 @@ pub const Notebook = union(enum) {
     pub fn setTabLabel(self: Notebook, tab: *Tab, title: [:0]const u8) void {
         switch (self) {
             .adw_tab_view => |tab_view| {
-                if (comptime !adwaita.comptimeEnabled()) unreachable;
+                if (comptime !adwaita.versionAtLeast(0, 0, 0)) unreachable;
                 const page = c.adw_tab_view_get_page(tab_view, @ptrCast(tab.box));
                 c.adw_tab_page_set_title(page, title.ptr);
             },
@@ -198,7 +198,7 @@ pub const Notebook = union(enum) {
         const box_widget: *c.GtkWidget = @ptrCast(tab.box);
         switch (self) {
             .adw_tab_view => |tab_view| {
-                if (comptime !adwaita.comptimeEnabled()) unreachable;
+                if (comptime !adwaita.versionAtLeast(0, 0, 0)) unreachable;
 
                 const page = c.adw_tab_view_append(tab_view, box_widget);
                 c.adw_tab_page_set_title(page, title.ptr);
@@ -269,7 +269,7 @@ pub const Notebook = union(enum) {
         const window = tab.window;
         switch (self) {
             .adw_tab_view => |tab_view| {
-                if (comptime !adwaita.comptimeEnabled()) unreachable;
+                if (comptime !adwaita.versionAtLeast(0, 0, 0)) unreachable;
 
                 const page = c.adw_tab_view_get_page(tab_view, @ptrCast(tab.box)) orelse return;
                 c.adw_tab_view_close_page(tab_view, page);

--- a/src/apprt/gtk/notebook.zig
+++ b/src/apprt/gtk/notebook.zig
@@ -63,7 +63,7 @@ pub const Notebook = union(enum) {
 
         const tab_view: *c.AdwTabView = c.adw_tab_view_new().?;
         c.gtk_box_append(@ptrCast(box), @ptrCast(@alignCast(tab_view)));
-        if (comptime !adwaita.versionAtLeast(1, 4, 0) or
+        if ((comptime !adwaita.versionAtLeast(1, 4, 0)) or
             !adwaita.versionAtLeast(1, 4, 0) or
             !app.config.@"gtk-titlebar")
         {

--- a/src/apprt/gtk/notebook.zig
+++ b/src/apprt/gtk/notebook.zig
@@ -1,0 +1,330 @@
+const std = @import("std");
+const c = @import("c.zig").c;
+const build_options = @import("build_options");
+
+const Window = @import("./Window.zig");
+const userdataSelf = Window.userdataSelf;
+const Tab = @import("./Tab.zig");
+
+const log = std.log.scoped(.gtk);
+
+const AdwTabView = if (build_options.libadwaita) c.AdwTabView else anyopaque;
+
+pub const Notebook = union(enum) {
+    adw_tab_view: *AdwTabView,
+    gtk_notebook: *c.GtkNotebook,
+
+    pub fn create(window: *Window, box: *c.GtkWidget) @This() {
+        const app = window.app;
+
+        const adwaita = build_options.libadwaita and app.config.@"gtk-adwaita";
+
+        if (adwaita) {
+            log.warn("using adwaita", .{});
+            const tab_view = c.adw_tab_view_new();
+            const tab_bar = c.adw_tab_bar_new();
+            c.gtk_box_append(@ptrCast(box), @ptrCast(@alignCast(tab_bar)));
+            c.adw_tab_bar_set_view(tab_bar, tab_view.?);
+
+            _ = c.g_signal_connect_data(tab_view, "page-attached", c.G_CALLBACK(&adwPageAttached), window, null, c.G_CONNECT_DEFAULT);
+            _ = c.g_signal_connect_data(tab_view, "create-window", c.G_CALLBACK(&adwTabViewCreateWindow), window, null, c.G_CONNECT_DEFAULT);
+
+            return .{ .adw_tab_view = tab_view.? };
+        }
+
+        // Create a notebook to hold our tabs.
+        const notebook_widget = c.gtk_notebook_new();
+        const notebook: *c.GtkNotebook = @ptrCast(notebook_widget);
+        const notebook_tab_pos: c_uint = switch (app.config.@"gtk-tabs-location") {
+            .top => c.GTK_POS_TOP,
+            .bottom => c.GTK_POS_BOTTOM,
+            .left => c.GTK_POS_LEFT,
+            .right => c.GTK_POS_RIGHT,
+        };
+        c.gtk_notebook_set_tab_pos(notebook, notebook_tab_pos);
+        c.gtk_notebook_set_scrollable(notebook, 1);
+        c.gtk_notebook_set_show_tabs(notebook, 0);
+        c.gtk_notebook_set_show_border(notebook, 0);
+
+        // This enables all Ghostty terminal tabs to be exchanged across windows.
+        c.gtk_notebook_set_group_name(notebook, "ghostty-terminal-tabs");
+
+        // This is important so the notebook expands to fit available space.
+        // Otherwise, it will be zero/zero in the box below.
+        c.gtk_widget_set_vexpand(notebook_widget, 1);
+        c.gtk_widget_set_hexpand(notebook_widget, 1);
+
+        // If we are in fullscreen mode, new windows start fullscreen.
+        if (app.config.fullscreen) c.gtk_window_fullscreen(window.window);
+
+        // All of our events
+        _ = c.g_signal_connect_data(notebook, "page-added", c.G_CALLBACK(&gtkPageAdded), window, null, c.G_CONNECT_DEFAULT);
+        _ = c.g_signal_connect_data(notebook, "page-removed", c.G_CALLBACK(&gtkPageRemoved), window, null, c.G_CONNECT_DEFAULT);
+        _ = c.g_signal_connect_data(notebook, "switch-page", c.G_CALLBACK(&gtkSwitchPage), window, null, c.G_CONNECT_DEFAULT);
+        _ = c.g_signal_connect_data(notebook, "create-window", c.G_CALLBACK(&gtkNotebookCreateWindow), window, null, c.G_CONNECT_DEFAULT);
+
+        return .{ .gtk_notebook = notebook };
+    }
+
+    pub fn as_widget(self: Notebook) *c.GtkWidget {
+        return switch (self) {
+            .adw_tab_view => |ptr| @ptrCast(@alignCast(ptr)),
+            .gtk_notebook => |ptr| @ptrCast(@alignCast(ptr)),
+        };
+    }
+
+    pub fn nPages(self: Notebook) c_int {
+        return switch (self) {
+            .adw_tab_view => |tab_view| if (build_options.libadwaita) c.adw_tab_view_get_n_pages(tab_view) else unreachable,
+            .gtk_notebook => |notebook| c.gtk_notebook_get_n_pages(notebook),
+        };
+    }
+
+    pub fn currentPage(self: Notebook) c_int {
+        switch (self) {
+            .adw_tab_view => |tab_view| {
+                if (!build_options.libadwaita) unreachable;
+                const page = c.adw_tab_view_get_selected_page(tab_view);
+                return c.adw_tab_view_get_page_position(tab_view, page);
+            },
+            .gtk_notebook => |notebook| return c.gtk_notebook_get_current_page(notebook),
+        }
+    }
+
+    pub fn currentTab(self: Notebook) ?*Tab {
+        const child = switch (self) {
+            .adw_tab_view => |tab_view| child: {
+                if (!build_options.libadwaita) unreachable;
+                const page = c.adw_tab_view_get_selected_page(tab_view) orelse return null;
+                const child = c.adw_tab_page_get_child(page);
+                break :child child;
+            },
+            .gtk_notebook => |notebook| child: {
+                const page = self.currentPage();
+                if (page == -1) return null;
+                log.info("currentPage_page_idx = {}", .{page});
+                break :child c.gtk_notebook_get_nth_page(notebook, page);
+            },
+        };
+        return @ptrCast(@alignCast(
+            c.g_object_get_data(@ptrCast(child), Tab.GHOSTTY_TAB) orelse return null,
+        ));
+    }
+
+    pub fn setTabLabel(self: Notebook, tab: *Tab, title: [:0]const u8) void {
+        switch (self) {
+            .adw_tab_view => |tab_view| {
+                if (!build_options.libadwaita) unreachable;
+                const page = c.adw_tab_view_get_page(tab_view, @ptrCast(tab.box));
+                c.adw_tab_page_set_title(page, title.ptr);
+            },
+            .gtk_notebook => c.gtk_label_set_text(tab.label_text, title.ptr),
+        }
+    }
+
+    pub fn addTab(self: Notebook, tab: *Tab, title: [:0]const u8) !void {
+        const box_widget: *c.GtkWidget = @ptrCast(tab.box);
+        switch (self) {
+            .adw_tab_view => |tab_view| {
+                if (!build_options.libadwaita) unreachable;
+
+                const page = c.adw_tab_view_append(tab_view, box_widget); 
+                c.adw_tab_page_set_title(page, title.ptr);
+
+                // Switch to the new tab
+                c.adw_tab_view_set_selected_page(tab_view, page);
+            },
+            .gtk_notebook => |notebook| {
+                // Build the tab label
+                const label_box_widget = c.gtk_box_new(c.GTK_ORIENTATION_HORIZONTAL, 0);
+                const label_box = @as(*c.GtkBox, @ptrCast(label_box_widget));
+                const label_text_widget = c.gtk_label_new("Ghostty");
+                const label_text: *c.GtkLabel = @ptrCast(label_text_widget);
+                c.gtk_box_append(label_box, label_text_widget);
+                tab.label_text = label_text;
+
+                // Build the close button for the tab
+                const label_close_widget = c.gtk_button_new_from_icon_name("window-close-symbolic");
+                const label_close: *c.GtkButton = @ptrCast(label_close_widget);
+                c.gtk_button_set_has_frame(label_close, 0);
+                c.gtk_box_append(label_box, label_close_widget);
+
+                const parent_page_idx = self.nPages();
+                const page_idx = c.gtk_notebook_insert_page(
+                    notebook,
+                    box_widget,
+                    label_box_widget,
+                    parent_page_idx,
+                );
+
+                if (self.nPages() > 1) {
+                    c.gtk_notebook_set_show_tabs(notebook, 1);
+                }
+
+                // Switch to the new tab
+                c.gtk_notebook_set_current_page(notebook, page_idx);
+            }
+        }
+    }
+
+    pub fn closeTab(self: Notebook, tab: *Tab) void {
+        switch (self) {
+            .adw_tab_view => |tab_view| {
+                if (!build_options.libadwaita) unreachable;
+
+                const page = c.adw_tab_view_get_page(tab_view, @ptrCast(tab.box)) orelse return;
+                c.adw_tab_view_close_page(tab_view, page);
+
+                // If we have no more tabs we close the window
+                if (self.nPages() == 0)
+                    c.gtk_window_destroy(tab.window.window);
+            },
+            .gtk_notebook => |notebook| {
+                const page = c.gtk_notebook_get_page(notebook, @ptrCast(tab.box)) orelse return;
+
+                // Find page and tab which we're closing
+                const page_idx = getNotebookPageIndex(page);
+
+                log.info("page_idx = {}", .{page_idx});
+
+                // Remove the page. This will destroy the GTK widgets in the page which
+                // will trigger Tab cleanup.
+                c.gtk_notebook_remove_page(notebook, page_idx);
+
+                const remaining = self.nPages();
+                switch (remaining) {
+                    // If we have no more tabs we close the window
+                    0 => c.gtk_window_destroy(tab.window.window),
+
+                    // If we have one more tab we hide the tab bar
+                    1 => c.gtk_notebook_set_show_tabs(notebook, 0),
+
+                    else => {},
+                }
+
+                // If we have remaining tabs, we need to make sure we grab focus.
+                if (remaining > 0) tab.window.focusCurrentTab();
+            }
+        }
+    }
+
+    pub fn getNotebookPageIndex(page: *c.GtkNotebookPage) c_int {
+        var value: c.GValue = std.mem.zeroes(c.GValue);
+        defer c.g_value_unset(&value);
+        _ = c.g_value_init(&value, c.G_TYPE_INT);
+        c.g_object_get_property(
+            @ptrCast(@alignCast(page)),
+            "position",
+            &value,
+        );
+
+        return c.g_value_get_int(&value);
+    }
+};
+
+fn gtkPageRemoved(
+    _: *c.GtkNotebook,
+    _: *c.GtkWidget,
+    _: c.guint,
+    ud: ?*anyopaque,
+) callconv(.C) void {
+    const self = userdataSelf(ud.?);
+
+    const notebook: *c.GtkNotebook = self.notebook.gtk_notebook;
+
+    // Hide the tab bar if we only have one tab after removal
+    const remaining = c.gtk_notebook_get_n_pages(notebook);
+    if (remaining == 1) {
+        c.gtk_notebook_set_show_tabs(notebook, 0);
+    }
+}
+
+fn adwPageAttached(
+  tab_view: *AdwTabView,
+  page: *c.AdwTabPage,
+  position: c_int,
+  ud: ?*anyopaque
+) callconv(.C) void {
+    _ = position; _ = tab_view;
+    const self = userdataSelf(ud.?);
+
+    const child = c.adw_tab_page_get_child(page);
+    const tab: *Tab = @ptrCast(@alignCast(c.g_object_get_data(@ptrCast(child), Tab.GHOSTTY_TAB) orelse return));
+    tab.window = self;
+
+    self.focusCurrentTab();
+}
+
+fn gtkPageAdded(
+    notebook: *c.GtkNotebook,
+    _: *c.GtkWidget,
+    page_idx: c.guint,
+    ud: ?*anyopaque,
+) callconv(.C) void {
+    const self = userdataSelf(ud.?);
+
+    // The added page can come from another window with drag and drop, thus we migrate the tab
+    // window to be self.
+    const page = c.gtk_notebook_get_nth_page(notebook, @intCast(page_idx));
+    const tab: *Tab = @ptrCast(@alignCast(
+        c.g_object_get_data(@ptrCast(page), Tab.GHOSTTY_TAB) orelse return,
+    ));
+    tab.window = self;
+
+    // Whenever a new page is added, we always grab focus of the
+    // currently selected page. This was added specifically so that when
+    // we drag a tab out to create a new window ("create-window" event)
+    // we grab focus in the new window. Without this, the terminal didn't
+    // have focus.
+    self.focusCurrentTab();
+}
+
+fn gtkSwitchPage(_: *c.GtkNotebook, page: *c.GtkWidget, _: usize, ud: ?*anyopaque) callconv(.C) void {
+    const self = userdataSelf(ud.?);
+    const gtk_label_box = @as(*c.GtkWidget, @ptrCast(c.gtk_notebook_get_tab_label(self.notebook.gtk_notebook, page)));
+    const gtk_label = @as(*c.GtkLabel, @ptrCast(c.gtk_widget_get_first_child(gtk_label_box)));
+    const label_text = c.gtk_label_get_text(gtk_label);
+    c.gtk_window_set_title(self.window, label_text);
+}
+
+fn adwTabViewCreateWindow(
+    _: *AdwTabView,
+    ud: ?*anyopaque,
+) callconv(.C) ?*AdwTabView {
+    const currentWindow = userdataSelf(ud.?);
+    const window = createWindow(currentWindow) catch |err| {
+        log.warn("error creating new window error={}", .{err});
+        return null;
+    };
+    return window.notebook.adw_tab_view;
+}
+
+fn gtkNotebookCreateWindow(
+    _: *c.GtkNotebook,
+    page: *c.GtkWidget,
+    ud: ?*anyopaque,
+) callconv(.C) ?*c.GtkNotebook {
+    // The tab for the page is stored in the widget data.
+    const tab: *Tab = @ptrCast(@alignCast(
+        c.g_object_get_data(@ptrCast(page), Tab.GHOSTTY_TAB) orelse return null,
+    ));
+
+    const currentWindow = userdataSelf(ud.?);
+    const window = createWindow(currentWindow) catch |err| {
+        log.warn("error creating new window error={}", .{err});
+        return null;
+    };
+
+    // And add it to the new window.
+    tab.window = window;
+
+    return window.notebook.gtk_notebook;
+}
+
+fn createWindow(currentWindow: *Window) !*Window {
+    const alloc = currentWindow.app.core_app.alloc;
+    const app = currentWindow.app;
+
+    // Create a new window
+    return Window.create(alloc, app);
+}

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1421,6 +1421,9 @@ keybind: Keybinds = .{},
 
 /// Determines the side of the screen that the GTK tab bar will stick to.
 /// Top, bottom, left, and right are supported. The default is top.
+///
+/// If this option has value `left` or `right` when using `libadwaita`, it falls
+/// back to `top`.
 @"gtk-tabs-location": GtkTabsLocation = .top,
 
 /// If `true` (default), then the Ghostty GTK tabs will be "wide." Wide tabs


### PR DESCRIPTION
<details>
<summary>👻 Adwaita - Gnome 46.3</summary>

![image](https://github.com/user-attachments/assets/6aadd265-ade1-4337-bc77-e1cea3b5b7e5)

</details>

<details>
<summary>👻 Adwaita - Gnome 42.9</summary>

![image](https://github.com/user-attachments/assets/7971f029-f547-4ed6-8d32-477e4f2e8316)

</details>

This moves the logic related to gdk_notebook to a new struct `Notebook` which is an enum dispatching to either the gtk_notebook or adw_tabview.

One improvement to make before merging is that there should no runtime cost to `Notebook` when `gtk-libadwaita = false` at build time.

I am opening as draft because quoting Mitchell on discord: 
> I've said in the past Im' open to using the adwaita APIs for more elements but want to see them introduced in a way that doesn't overburden the GTK backend too much. I'm pretty sure its possible.

as I am not sure my current approach is the best for limiting changes in the GTK backend.

With regards to #1122, the AdwTabview handles dropping tab on a tab from another window to move the tab to the new window.