### PR TITLE
metal: precompile shaders as part of the build

### DIFF
--- a/pkg/macos/dispatch.zig
+++ b/pkg/macos/dispatch.zig
@@ -1,0 +1,8 @@
+pub const c = @import("dispatch/c.zig");
+pub const data = @import("dispatch/data.zig");
+pub const queue = @import("dispatch/queue.zig");
+pub const Data = data.Data;
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/pkg/macos/dispatch/c.zig
+++ b/pkg/macos/dispatch/c.zig
@@ -1,0 +1,3 @@
+pub usingnamespace @cImport({
+    @cInclude("dispatch/dispatch.h");
+});

--- a/pkg/macos/dispatch/data.zig
+++ b/pkg/macos/dispatch/data.zig
@@ -1,0 +1,31 @@
+const std = @import("std");
+const foundation = @import("../foundation.zig");
+const c = @import("c.zig");
+
+pub const Data = opaque {
+    pub const DESTRUCTOR_DEFAULT = c.DISPATCH_DATA_DESTRUCTOR_DEFAULT;
+
+    pub fn create(
+        data: []const u8,
+        queue: ?*anyopaque,
+        destructor: ?*anyopaque,
+    ) !*Data {
+        return dispatch_data_create(
+            data.ptr,
+            data.len,
+            queue,
+            destructor,
+        ) orelse return error.OutOfMemory;
+    }
+
+    pub fn release(data: *Data) void {
+        foundation.c.CFRelease(data);
+    }
+};
+
+extern "c" fn dispatch_data_create(
+    data: [*]const u8,
+    len: usize,
+    queue: ?*anyopaque,
+    destructor: ?*anyopaque,
+) ?*Data;

--- a/pkg/macos/dispatch/queue.zig
+++ b/pkg/macos/dispatch/queue.zig
@@ -1,0 +1,8 @@
+const std = @import("std");
+const c = @import("c.zig");
+
+pub const Queue = *anyopaque; // dispatch_queue_t
+
+pub fn getMain() Queue {
+    return c.dispatch_get_main_queue().?;
+}

--- a/pkg/macos/main.zig
+++ b/pkg/macos/main.zig
@@ -1,5 +1,6 @@
 pub const foundation = @import("foundation.zig");
 pub const animation = @import("animation.zig");
+pub const dispatch = @import("dispatch.zig");
 pub const graphics = @import("graphics.zig");
 pub const os = @import("os.zig");
 pub const text = @import("text.zig");

--- a/src/build/MetallibStep.zig
+++ b/src/build/MetallibStep.zig
@@ -1,0 +1,48 @@
+/// A zig build step that compiles a set of ".metal" files into a
+/// ".metallib" file.
+const MetallibStep = @This();
+
+const std = @import("std");
+const Step = std.Build.Step;
+const RunStep = std.Build.Step.Run;
+const LazyPath = std.Build.LazyPath;
+
+pub const Options = struct {
+    /// The name of the xcframework to create.
+    name: []const u8,
+
+    /// The Metal source files.
+    sources: []const LazyPath,
+};
+
+step: *Step,
+output: LazyPath,
+
+pub fn create(b: *std.Build, opts: Options) *MetallibStep {
+    const self = b.allocator.create(MetallibStep) catch @panic("OOM");
+
+    const run_ir = RunStep.create(
+        b,
+        b.fmt("metal {s}", .{opts.name}),
+    );
+    run_ir.addArgs(&.{ "xcrun", "-sdk", "macosx", "metal", "-o" });
+    const output_ir = run_ir.addOutputFileArg(b.fmt("{s}.ir", .{opts.name}));
+    run_ir.addArgs(&.{"-c"});
+    for (opts.sources) |source| run_ir.addFileArg(source);
+
+    const run_lib = RunStep.create(
+        b,
+        b.fmt("metallib {s}", .{opts.name}),
+    );
+    run_lib.addArgs(&.{ "xcrun", "-sdk", "macosx", "metallib", "-o" });
+    const output_lib = run_lib.addOutputFileArg(b.fmt("{s}.metallib", .{opts.name}));
+    run_lib.addFileArg(output_ir);
+    run_lib.step.dependOn(&run_ir.step);
+
+    self.* = .{
+        .step = &run_lib.step,
+        .output = output_lib,
+    };
+
+    return self;
+}

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -159,7 +159,7 @@ fn initLibrary(device: objc.Object) !objc.Object {
     const start = try std.time.Instant.now();
 
     const data = try macos.dispatch.Data.create(
-        @embedFile("../shaders/Ghostty.metallib"),
+        @embedFile("ghostty_metallib"),
         macos.dispatch.queue.getMain(),
         macos.dispatch.Data.DESTRUCTOR_DEFAULT,
     );

--- a/src/renderer/shaders/cell.metal
+++ b/src/renderer/shaders/cell.metal
@@ -1,3 +1,5 @@
+#include <metal_stdlib>
+
 using namespace metal;
 
 struct Uniforms {
@@ -291,6 +293,7 @@ fragment float4 cell_text_fragment(CellTextVertexOut in [[stage_in]],
   constexpr sampler textureSampler(address::clamp_to_edge, filter::linear);
 
   switch (in.mode) {
+    default:
     case MODE_TEXT_CURSOR:
     case MODE_TEXT_CONSTRAINED:
     case MODE_TEXT_POWERLINE:


### PR DESCRIPTION
This precompiles the Metal shaders rather than compiling them at runtime. 

* This improves the shader load time by a factor of 15x but the original load time was already around `400us` on my machine so that won't be noticeable. It's still nice. 
* In theory this should allow Metal to do more optimizations to the shaders too but I'm not sure we'll actually benefit from that.
* The main benefit is this compiles/verifies shaders as part of CI, so any shader bugs will be caught by tests.