### PR TITLE
fix: vaxis recursive deps issue

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1018,6 +1018,9 @@ fn addDeps(
     const vaxis_dep = b.dependency("vaxis", .{
         .target = target,
         .optimize = optimize,
+        .libxev = false,
+        .images = false,
+        .text_input = false,
     });
 
     // Wasm we do manually since it is such a different build.


### PR DESCRIPTION
In issue https://github.com/ghostty-org/ghostty/issues/2058 we discovered that the addition of a zig dependency that itself has dependencies causes a failure to build in the nix sandbox (because the initial zigCache `zig build --fetch` does not fully resolve the recursive dependency tree). This change suggested by @rockorager and tested by me to be working on x86_64 NixOS linux.