### PR TITLE
Conditional compilation against different GTK versions

### DIFF
--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -822,9 +822,15 @@ pub fn shouldClose(self: *const Surface) bool {
 }
 
 pub fn getContentScale(self: *const Surface) !apprt.ContentScale {
-    // Future: detect GTK version 4.12+ and use gdk_surface_get_scale so we
-    // can support fractional scaling.
-    const gtk_scale: f32 = @floatFromInt(c.gtk_widget_get_scale_factor(@ptrCast(self.gl_area)));
+    const gtk_scale: f32 = scale: {
+        if (comptime c.gtkVersionMinimum(4, 12)) {
+            const native = c.gtk_widget_get_native(@ptrCast(self.gl_area));
+            const surface = c.gtk_native_get_surface(native);
+            break :scale @floatCast(c.gdk_surface_get_scale(surface));
+        } else {
+            break :scale @floatFromInt(c.gtk_widget_get_scale_factor(@ptrCast(self.gl_area)));
+        }
+    };
 
     // If we are on X11, we also have to scale using Xft.dpi
     const xft_dpi_scale = if (!x11.is_current_display_server()) 1.0 else xft_scale: {

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -21,7 +21,8 @@ const ClipboardConfirmationWindow = @import("ClipboardConfirmationWindow.zig");
 const ResizeOverlay = @import("ResizeOverlay.zig");
 const inspector = @import("inspector.zig");
 const gtk_key = @import("key.zig");
-const c = @import("c.zig").c;
+const cpkg = @import("c.zig");
+const c = cpkg.c;
 const x11 = @import("x11.zig");
 
 const log = std.log.scoped(.gtk_surface);
@@ -823,7 +824,7 @@ pub fn shouldClose(self: *const Surface) bool {
 
 pub fn getContentScale(self: *const Surface) !apprt.ContentScale {
     const gtk_scale: f32 = scale: {
-        if (comptime c.gtkVersionMinimum(4, 12)) {
+        if (comptime cpkg.gtkVersionAtLeast(4, 12)) {
             const native = c.gtk_widget_get_native(@ptrCast(self.gl_area));
             const surface = c.gtk_native_get_surface(native);
             break :scale @floatCast(c.gdk_surface_get_scale(surface));

--- a/src/apprt/gtk/c.zig
+++ b/src/apprt/gtk/c.zig
@@ -18,7 +18,7 @@ pub const c = @cImport({
     @cInclude("ghostty_gtk_compat.h");
 });
 
-pub fn gtkVersionMinimum(comptime major: c_int, comptime minor: c_int) bool {
+pub fn gtkVersionAtLeast(comptime major: c_int, comptime minor: c_int) bool {
     return (c.GTK_MAJOR_VERSION > major or
         (c.GTK_MAJOR_VERSION == major and c.GTK_MINOR_VERSION >= minor));
 }

--- a/src/apprt/gtk/c.zig
+++ b/src/apprt/gtk/c.zig
@@ -17,3 +17,8 @@ pub const c = @cImport({
     // compatibility
     @cInclude("ghostty_gtk_compat.h");
 });
+
+pub fn gtkVersionMinimum(comptime major: c_int, comptime minor: c_int) bool {
+    return (c.GTK_MAJOR_VERSION > major or
+        (c.GTK_MAJOR_VERSION == major and c.GTK_MINOR_VERSION >= minor));
+}


### PR DESCRIPTION
Adds a comptime function to enable conditional compilation against different GTK versions that have added new API calls in newer versions of GTK.

Use this function to get fractional scaling information for GTK surfaces, which is only available with GTK 4.12+.