### PR TITLE
Metal optimizations

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1371,9 +1371,9 @@ fn drawPostShader(
         void,
         objc.sel("drawPrimitives:vertexStart:vertexCount:"),
         .{
-            @intFromEnum(mtl.MTLPrimitiveType.triangle_strip),
+            @intFromEnum(mtl.MTLPrimitiveType.triangle),
             @as(c_ulong, 0),
-            @as(c_ulong, 4),
+            @as(c_ulong, 3),
         },
     );
 }

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1179,7 +1179,7 @@ pub fn drawFrame(self: *Metal, surface: *apprt.Surface) !void {
         try self.drawImagePlacements(encoder, self.image_placements.items[0..self.image_bg_end]);
 
         // Then draw background cells
-        try self.drawCellBgs(encoder, frame, self.cells.size.columns * self.cells.size.rows);
+        try self.drawCellBgs(encoder, frame);
 
         // Then draw images under text
         try self.drawImagePlacements(encoder, self.image_placements.items[self.image_bg_end..self.image_text_end]);
@@ -1503,12 +1503,7 @@ fn drawCellBgs(
     self: *Metal,
     encoder: objc.Object,
     frame: *const FrameState,
-    len: usize,
 ) !void {
-    // This triggers an assertion in the Metal API if we try to draw
-    // with an instance count of 0 so just bail.
-    if (len == 0) return;
-
     // Use our shader pipeline
     encoder.msgSend(
         void,

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -2443,12 +2443,12 @@ fn updateCell(
             break :bg_alpha @intFromFloat(bg_alpha);
         };
 
-        self.cells.bg_cells[coord.y * self.cells.size.columns + coord.x] = .{
+        self.cells.bgCell(coord.y, coord.x).* = .{
             rgb.r, rgb.g, rgb.b, bg_alpha,
         };
 
         if (cell.gridWidth() > 1 and coord.x < self.cells.size.columns - 1) {
-            self.cells.bg_cells[coord.y * self.cells.size.columns + coord.x + 1] = .{
+            self.cells.bgCell(coord.y, coord.x).* = .{
                 rgb.r, rgb.g, rgb.b, bg_alpha,
             };
         }
@@ -2645,11 +2645,11 @@ fn addPreeditCell(
     };
 
     // Add our opaque background cell
-    self.cells.bg_cells[coord.y * self.cells.size.columns + coord.x] = .{
+    self.cells.bgCell(coord.y, coord.x).* = .{
         bg.r, bg.g, bg.b, 255,
     };
     if (cp.wide and coord.x < self.cells.size.columns - 1) {
-        self.cells.bg_cells[coord.y * self.cells.size.columns + coord.x + 1] = .{
+        self.cells.bgCell(coord.y, coord.x + 1).* = .{
             bg.r, bg.g, bg.b, 255,
         };
     }

--- a/src/renderer/metal/api.zig
+++ b/src/renderer/metal/api.zig
@@ -51,11 +51,13 @@ pub const MTLIndexType = enum(c_ulong) {
 pub const MTLVertexFormat = enum(c_ulong) {
     uchar4 = 3,
     ushort2 = 13,
+    short2 = 16,
     float2 = 29,
     float4 = 31,
     int2 = 33,
     uint = 36,
     uint2 = 37,
+    uint4 = 39,
     uchar = 45,
 };
 

--- a/src/renderer/metal/cell.zig
+++ b/src/renderer/metal/cell.zig
@@ -195,9 +195,7 @@ pub const Contents = struct {
     pub fn clear(self: *Contents, y: terminal.size.CellCountInt) void {
         assert(y < self.size.rows);
 
-        for (self.bg_cells[y * self.size.columns ..][0..self.size.columns]) |*cell| {
-            cell.* = .{ 0, 0, 0, 0 };
-        }
+        @memset(self.bg_cells[y * self.size.columns ..][0..self.size.columns], .{ 0, 0, 0, 0 });
 
         // We have a special list containing the cursor cell at the start
         // of our fg row pool, so we need to add 1 to the y to get the

--- a/src/renderer/metal/cell.zig
+++ b/src/renderer/metal/cell.zig
@@ -75,6 +75,8 @@ fn ArrayListPool(comptime T: type) type {
 pub const Contents = struct {
     size: renderer.GridSize = .{ .rows = 0, .columns = 0 },
 
+    /// Flat array containing cell background colors for the terminal grid.
+    /// Index with `bg_cells[y * size.columns + x]`.
     bg_cells: []mtl_shaders.CellBg = undefined,
 
     /// The ArrayListPool which holds all of the foreground cells. When sized

--- a/src/renderer/metal/cell.zig
+++ b/src/renderer/metal/cell.zig
@@ -116,7 +116,7 @@ pub const Contents = struct {
     ) !void {
         self.size = size;
 
-        const cell_count = size.columns * size.rows;
+        const cell_count = @as(usize, size.columns) * @as(usize, size.rows);
 
         const bg_cells = try alloc.alloc(mtl_shaders.CellBg, cell_count);
         errdefer alloc.free(bg_cells);

--- a/src/renderer/metal/cell.zig
+++ b/src/renderer/metal/cell.zig
@@ -118,7 +118,7 @@ pub const Contents = struct {
 
         const cell_count = size.columns * size.rows;
 
-        const bg_cells = (try alloc.alloc(mtl_shaders.CellBg, cell_count))[0..cell_count];
+        const bg_cells = try alloc.alloc(mtl_shaders.CellBg, cell_count);
         errdefer alloc.free(bg_cells);
 
         @memset(bg_cells, .{0, 0, 0, 0});

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -124,9 +124,10 @@ pub const Uniforms = extern struct {
     /// top, right, bottom, left.
     grid_padding: [4]f32 align(16),
 
-    /// True if vertical padding gets the extended color of the nearest row.
-    padding_extend_top: bool align(1),
-    padding_extend_bottom: bool align(1),
+    /// Bit mask defining which directions to
+    /// extend cell colors in to the padding.
+    /// Order, LSB first: left, right, up, down
+    padding_extend: PaddingExtend align(1),
 
     /// The minimum contrast ratio for text. The contrast ratio is calculated
     /// according to the WCAG 2.0 spec.
@@ -135,6 +136,14 @@ pub const Uniforms = extern struct {
     /// The cursor position and color.
     cursor_pos: [2]u16 align(4),
     cursor_color: [4]u8 align(4),
+
+    const PaddingExtend = packed struct(u8) {
+        left: bool = false,
+        right: bool = false,
+        up: bool = false,
+        down: bool = false,
+        _padding: u4 = 0,
+    };
 };
 
 /// The uniforms used for custom postprocess shaders.


### PR DESCRIPTION
This PR significantly reworks the Metal shaders for memory efficiency. Additionally I've adjusted the formatting of the shader code for readability, and normalized the naming conventions.

There are two main changes that affect memory efficiency.
1. Background cells are now a static sized buffer of `cols * rows` total `uchar4`s representing the cell colors, which are drawn with a single fullscreen shader.
2. I've taken steps to optimize the foreground (text) cell vertex data, namely:
    - Background color (4 bytes) has been removed, since it can be fetched from the bg color buffer based on grid position.
    - I demoted the glyph bearings from `[2]i32` to `[2]i16`, it seems like a sane expectation to me that the bearings will never be more than 32K pixels in a given direction.
    - I have reorganized the structs to be as compact as possible in memory, so that the size (with padding) is now 32 bytes, as opposed to the prior size which was something like 56 bytes.

Beyond this, I have added a couple other small optimizations, such as a fullscreen vertex shader that uses a single triangle, and using pixel coordinates to sample the glyph texture so that conversion to normalized coordinates isn't necessary.

### Results
Experimentally I saw a ~20% reduction in total GPU memory use, and a ~80% reduction in max allocated buffer size.

### TODO
> [!CAUTION]
> There is a very real chance that this PR could have issues under macOS 13 for Intel processors, due to the known bugginess of the macOS 13 Intel Metal drivers. Comprehensive testing on an Intel mac running macOS 13 must be performed before this can be merged.
- [ ] Verify correct behavior on an Intel mac under macOS 13. **DO NOT MERGE WITHOUT TESTING**