### PR TITLE
terminal/kitty: shared memory size may be larger than expected for pages

### DIFF
--- a/src/terminal/kitty/graphics_command.zig
+++ b/src/terminal/kitty/graphics_command.zig
@@ -368,6 +368,15 @@ pub const Transmission = struct {
         // but they are formats that a png may decode to that we
         // support.
         grey_alpha,
+
+        pub fn bpp(self: Format) u8 {
+            return switch (self) {
+                .grey_alpha => 2,
+                .rgb => 3,
+                .rgba => 4,
+                .png => unreachable, // Must be validated before
+            };
+        }
     };
 
     pub const Medium = enum {


### PR DESCRIPTION
The shared memory segment size must be a multiple of page size. This means that it may be larger than our expected image size. In this case, we trim the padding at the end.