### PR TITLE
window-padding-color improvements

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -717,7 +717,7 @@ keybind: Keybinds = .{},
 /// * The nearest row contains a perfect fit powerline character. These
 ///   don't look good extended.
 ///
-@"window-padding-color": WindowPaddingColor = .background,
+@"window-padding-color": WindowPaddingColor = .extend,
 
 /// Synchronize rendering with the screen refresh rate. If true, this will
 /// minimize tearing and align redraws with the screen but may cause input

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -701,6 +701,8 @@ keybind: Keybinds = .{},
 ///
 /// * `background` - The background color specified in `background`.
 /// * `extend` - Extend the background color of the nearest grid cell.
+/// * `extend-always` - Same as "extend" but always extends without applying
+///   any of the heuristics that disable extending noted below.
 ///
 /// The "extend" value will be disabled in certain scenarios. On primary
 /// screen applications (i.e. not something like Neovim), the color will not
@@ -2729,6 +2731,7 @@ pub const OptionAsAlt = enum {
 pub const WindowPaddingColor = enum {
     background,
     extend,
+    @"extend-always",
 };
 
 /// Color represents a color using RGB.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -712,10 +712,9 @@ keybind: Keybinds = .{},
 /// * The nearest row is a prompt row (requires shell integration). The
 ///   thinking here is that prompts often contain powerline glyphs that
 ///   do not look good extended.
+/// * The nearest row contains a perfect fit powerline character. These
+///   don't look good extended.
 ///
-/// The default value is "extend". This allows for smooth resizing of a
-/// terminal grid without having visible empty areas around the edge. The edge
-/// cells may appear slightly larger due to the extension.
 @"window-padding-color": WindowPaddingColor = .background,
 
 /// Synchronize rendering with the screen refresh rate. If true, this will

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -2118,6 +2118,8 @@ fn rebuildCells(
     //     std.log.warn("[rebuildCells time] {}\t{}", .{start_micro, end.since(start) / std.time.ns_per_us});
     // }
 
+    _ = screen_type; // we might use this again later so not deleting it yet
+
     // Create an arena for all our temporary allocations while rebuilding
     var arena = ArenaAllocator.init(self.alloc);
     defer arena.deinit();
@@ -2154,12 +2156,9 @@ fn rebuildCells(
         switch (self.config.padding_color) {
             .background => {},
 
-            .extend => {
-                self.uniforms.padding_extend.up = screen_type == .alternate;
-                self.uniforms.padding_extend.down = screen_type == .alternate;
-            },
-
-            .@"extend-always" => {
+            // For extension, assume we are extending in all directions.
+            // For "extend" this may be disabled due to heuristics below.
+            .extend, .@"extend-always" => {
                 self.uniforms.padding_extend = .{
                     .up = true,
                     .down = true,
@@ -2209,9 +2208,9 @@ fn rebuildCells(
             .background, .@"extend-always" => {},
 
             // Apply heuristics for padding extension.
-            .extend => if (y == 0 and screen_type == .primary) {
+            .extend => if (y == 0) {
                 self.uniforms.padding_extend.up = !row.neverExtendBg();
-            } else if (y == self.cells.size.rows - 1 and screen_type == .primary) {
+            } else if (y == self.cells.size.rows - 1) {
                 self.uniforms.padding_extend.down = !row.neverExtendBg();
             },
         }

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1964,7 +1964,14 @@ pub fn setScreenSize(
             padding_extend.right = true;
         },
 
-        else => {
+        .@"extend-always" => {
+            padding_extend.up = true;
+            padding_extend.down = true;
+            padding_extend.left = true;
+            padding_extend.right = true;
+        },
+
+        .background => {
             // Otherwise, disable all padding extension.
             padding_extend = .{};
         },
@@ -2146,9 +2153,19 @@ fn rebuildCells(
         // We also reset our padding extension depending on the screen type
         switch (self.config.padding_color) {
             .background => {},
+
             .extend => {
                 self.uniforms.padding_extend.up = screen_type == .alternate;
                 self.uniforms.padding_extend.down = screen_type == .alternate;
+            },
+
+            .@"extend-always" => {
+                self.uniforms.padding_extend = .{
+                    .up = true,
+                    .down = true,
+                    .left = true,
+                    .right = true,
+                };
             },
         }
     }
@@ -2187,12 +2204,16 @@ fn rebuildCells(
         // under certain conditions we feel are safe. This helps make some
         // scenarios look better while avoiding scenarios we know do NOT look
         // good.
-        if (self.config.padding_color == .extend) {
-            if (y == 0 and screen_type == .primary) {
+        switch (self.config.padding_color) {
+            // These already have the correct values set above.
+            .background, .@"extend-always" => {},
+
+            // Apply heuristics for padding extension.
+            .extend => if (y == 0 and screen_type == .primary) {
                 self.uniforms.padding_extend.up = !row.neverExtendBg();
             } else if (y == self.cells.size.rows - 1 and screen_type == .primary) {
                 self.uniforms.padding_extend.down = !row.neverExtendBg();
-            }
+            },
         }
 
         // Split our row into runs and shape each one.

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1955,13 +1955,19 @@ pub fn setScreenSize(
     }).add(padding);
 
     var padding_extend = self.uniforms.padding_extend;
-    if (self.config.padding_color == .extend) {
-        // If padding extension is enabled, we extend left and right always.
-        padding_extend.left = true;
-        padding_extend.right = true;
-    } else {
-        // Otherwise, disable all padding extension.
-        padding_extend = .{};
+    switch (self.config.padding_color) {
+        .extend => {
+            // If padding extension is enabled, we extend left and right always
+            // because there is no downside to this. Up/down is dependent
+            // on some heuristics (see rebuildCells).
+            padding_extend.left = true;
+            padding_extend.right = true;
+        },
+
+        else => {
+            // Otherwise, disable all padding extension.
+            padding_extend = .{};
+        },
     }
 
     // Set the size of the drawable surface to the bounds
@@ -2138,9 +2144,12 @@ fn rebuildCells(
         self.cells.reset();
 
         // We also reset our padding extension depending on the screen type
-        if (self.config.padding_color == .extend) {
-            self.uniforms.padding_extend.up = screen_type == .alternate;
-            self.uniforms.padding_extend.down = screen_type == .alternate;
+        switch (self.config.padding_color) {
+            .background => {},
+            .extend => {
+                self.uniforms.padding_extend.up = screen_type == .alternate;
+                self.uniforms.padding_extend.down = screen_type == .alternate;
+            },
         }
     }
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -1172,6 +1172,8 @@ pub fn rebuildCells(
     cursor_style_: ?renderer.CursorStyle,
     color_palette: *const terminal.color.Palette,
 ) !void {
+    _ = screen_type;
+
     // Bg cells at most will need space for the visible screen size
     self.cells_bg.clearRetainingCapacity();
     self.cells.clearRetainingCapacity();
@@ -1216,12 +1218,7 @@ pub fn rebuildCells(
         switch (self.config.padding_color) {
             .background => {},
 
-            .extend => {
-                self.padding_extend_top = screen_type == .alternate;
-                self.padding_extend_bottom = screen_type == .alternate;
-            },
-
-            .@"extend-always" => {
+            .extend, .@"extend-always" => {
                 self.padding_extend_top = true;
                 self.padding_extend_bottom = true;
             },
@@ -1283,9 +1280,9 @@ pub fn rebuildCells(
             .background, .@"extend-always" => {},
 
             // Apply heuristics for padding extension.
-            .extend => if (y == 0 and screen_type == .primary) {
+            .extend => if (y == 0) {
                 self.padding_extend_top = !row.neverExtendBg();
-            } else if (y == self.grid_size.rows - 1 and screen_type == .primary) {
+            } else if (y == self.grid_size.rows - 1) {
                 self.padding_extend_bottom = !row.neverExtendBg();
             },
         }

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -3272,8 +3272,25 @@ pub const Pin = struct {
             // extend because the default background color probably looks
             // good enough as an extension.
             switch (cell.content_tag) {
+                // We assume bg color cells are setting non-default colors.
                 .bg_color_palette, .bg_color_rgb => {},
+
+                // If its a codepoint cell we can check the style.
                 .codepoint, .codepoint_grapheme => {
+                    // For codepoint containing, we also never extend bg
+                    // if any cell has a powerline glyph because these are
+                    // perfect-fit.
+                    switch (cell.codepoint()) {
+                        // Powerline
+                        0xE0B0...0xE0C8,
+                        0xE0CA,
+                        0xE0CC...0xE0D2,
+                        0xE0D4,
+                        => return true,
+
+                        else => {},
+                    }
+
                     const s = self.style(cell);
                     if (s.bg_color == .none) return true;
                 },


### PR DESCRIPTION
* Add heuristic so power line cells disable `extend`
* Add `extend-always` configuration
* Use exhaustive switch statements so future values could be caught
* Don't always extend in alt screen, this was very uniformly disliked except for @qwerasd205 (you can now use the new `extend-always` which isn't identical but probably good enough)
* **This makes `extend` the default again.** I think the heuristics in this PR plus previous ones address all the major "ugly" scenarios to make this worth it.

cc @qwerasd205 