### PR TITLE
macos: implement resize overlay

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -404,6 +404,15 @@ typedef struct {
   const char* command;
 } ghostty_surface_config_s;
 
+typedef struct {
+  uint16_t columns;
+  uint16_t rows;
+  uint32_t width_px;
+  uint32_t height_px;
+  uint32_t cell_width_px;
+  uint32_t cell_height_px;
+} ghostty_surface_size_s;
+
 typedef void (*ghostty_runtime_wakeup_cb)(void*);
 typedef const ghostty_config_t (*ghostty_runtime_reload_config_cb)(void*);
 typedef void (*ghostty_runtime_open_config_cb)(void*);
@@ -530,6 +539,7 @@ void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);
 void ghostty_surface_set_focus(ghostty_surface_t, bool);
 void ghostty_surface_set_occlusion(ghostty_surface_t, bool);
 void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t);
+ghostty_surface_size_s ghostty_surface_size(ghostty_surface_t);
 void ghostty_surface_set_color_scheme(ghostty_surface_t,
                                       ghostty_color_scheme_e);
 ghostty_input_mods_e ghostty_surface_key_translation_mods(ghostty_surface_t,

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -331,5 +331,82 @@ extension Ghostty {
             let newColor = isLightBackground ? backgroundColor.darken(by: 0.08) : backgroundColor.darken(by: 0.4)
             return Color(newColor)
         }
+        
+        var resizeOverlay: ResizeOverlay {
+            guard let config = self.config else { return .after_first }
+            var v: UnsafePointer<Int8>? = nil
+            let key = "resize-overlay"
+            guard ghostty_config_get(config, &v, key, UInt(key.count)) else { return .after_first }
+            guard let ptr = v else { return .after_first }
+            let str = String(cString: ptr)
+            return ResizeOverlay(rawValue: str) ?? .after_first
+        }
+        
+        var resizeOverlayPosition: ResizeOverlayPosition {
+            let defaultValue = ResizeOverlayPosition.center
+            guard let config = self.config else { return defaultValue }
+            var v: UnsafePointer<Int8>? = nil
+            let key = "resize-overlay-position"
+            guard ghostty_config_get(config, &v, key, UInt(key.count)) else { return defaultValue }
+            guard let ptr = v else { return defaultValue }
+            let str = String(cString: ptr)
+            return ResizeOverlayPosition(rawValue: str) ?? defaultValue
+        }
+        
+        var resizeOverlayDuration: UInt {
+            guard let config = self.config else { return 1000 }
+            var v: UInt = 0
+            let key = "resize-overlay-duration"
+            _ = ghostty_config_get(config, &v, key, UInt(key.count))
+            return v;
+        }
+    }
+}
+
+// MARK: Configuration Enums
+
+extension Ghostty.Config {
+    enum ResizeOverlay : String {
+        case always
+        case never
+        case after_first = "after-first"
+    }
+    
+    enum ResizeOverlayPosition : String {
+        case center
+        case top_left = "top-left"
+        case top_center = "top-center"
+        case top_right = "top-right"
+        case bottom_left = "bottom-left"
+        case bottom_center = "bottom-center"
+        case bottom_right = "bottom-right"
+        
+        func top() -> Bool {
+            switch (self) {
+            case .top_left, .top_center, .top_right: return true;
+            default: return false;
+            }
+        }
+        
+        func bottom() -> Bool {
+            switch (self) {
+            case .bottom_left, .bottom_center, .bottom_right: return true;
+            default: return false;
+            }
+        }
+        
+        func left() -> Bool {
+            switch (self) {
+            case .top_left, .bottom_left: return true;
+            default: return false;
+            }
+        }
+        
+        func right() -> Bool {
+            switch (self) {
+            case .top_right, .bottom_right: return true;
+            default: return false;
+            }
+        }
     }
 }

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -312,8 +312,9 @@ extension Ghostty {
                             RoundedRectangle(cornerRadius: 4)
                                 .fill(.background)
                                 .shadow(radius: 3)
-                        ).lineLimit(1)
-                        .truncationMode(.middle)
+                        )
+                        .lineLimit(1)
+                        .truncationMode(.tail)
                     
                     if (!position.right()) {
                         Spacer()

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -52,6 +52,13 @@ extension Ghostty {
             return v
         }
         
+        // Returns sizing information for the surface. This is the raw C
+        // structure because I'm lazy.
+        var surfaceSize: ghostty_surface_size_s? {
+            guard let surface = self.surface else { return nil }
+            return ghostty_surface_size(surface)
+        }
+        
         // Returns the inspector instance for this surface, or nil if the
         // surface has been closed.
         var inspector: ghostty_inspector_t? {

--- a/macos/Sources/Ghostty/SurfaceView_UIKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_UIKit.swift
@@ -28,6 +28,13 @@ extension Ghostty {
         // The hovered URL
         @Published var hoverUrl: String? = nil
         
+        // Returns sizing information for the surface. This is the raw C
+        // structure because I'm lazy.
+        var surfaceSize: ghostty_surface_size_s? {
+            guard let surface = self.surface else { return nil }
+            return ghostty_surface_size(surface)
+        }
+        
         private(set) var surface: ghostty_surface_t?
         
         init(_ app: ghostty_app_t, baseConfig: SurfaceConfiguration? = nil, uuid: UUID? = nil) {

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1418,6 +1418,15 @@ pub const CAPI = struct {
         offset_len: u32,
     };
 
+    const SurfaceSize = extern struct {
+        columns: u16,
+        rows: u16,
+        width_px: u32,
+        height_px: u32,
+        cell_width_px: u32,
+        cell_height_px: u32,
+    };
+
     /// Create a new app.
     export fn ghostty_app_new(
         opts: *const apprt.runtime.App.Options,
@@ -1591,6 +1600,18 @@ pub const CAPI = struct {
     /// to the pty and the renderer.
     export fn ghostty_surface_set_size(surface: *Surface, w: u32, h: u32) void {
         surface.updateSize(w, h);
+    }
+
+    /// Return the size information a surface has.
+    export fn ghostty_surface_size(surface: *Surface) SurfaceSize {
+        return .{
+            .columns = surface.core_surface.grid_size.columns,
+            .rows = surface.core_surface.grid_size.rows,
+            .width_px = surface.core_surface.screen_size.width,
+            .height_px = surface.core_surface.screen_size.height,
+            .cell_width_px = surface.core_surface.cell_size.width,
+            .cell_height_px = surface.core_surface.cell_size.height,
+        };
     }
 
     /// Update the color scheme of the surface.

--- a/src/config/c_get.zig
+++ b/src/config/c_get.zig
@@ -60,6 +60,12 @@ fn getValue(ptr_raw: *anyopaque, value: anytype) bool {
             },
 
             .Struct => |info| {
+                // If the struct implements c_get then we call that
+                if (@hasDecl(@TypeOf(value), "c_get")) {
+                    value.c_get(ptr_raw);
+                    return true;
+                }
+
                 // Packed structs that are less than or equal to the
                 // size of a C int can be passed directly as their
                 // bit representation.

--- a/src/renderer/size.zig
+++ b/src/renderer/size.zig
@@ -43,8 +43,14 @@ pub const ScreenSize = struct {
         const grid_height = grid.rows * cell.height;
         const padded_width = grid_width + (padding.left + padding.right);
         const padded_height = grid_height + (padding.top + padding.bottom);
-        const leftover_width = self.width - padded_width;
-        const leftover_height = self.height - padded_height;
+
+        // Note these have to use a saturating subtraction to avoid underflow
+        // because our padding can cause the padded sizes to be larger than
+        // our real screen if the screen is shrunk to a minimal size such
+        // as 1x1.
+        const leftover_width = self.width -| padded_width;
+        const leftover_height = self.height -| padded_height;
+
         return .{
             .top = 0,
             .bottom = leftover_height,


### PR DESCRIPTION
Implements the resize overlay configurations completely, based on #2071.

https://github.com/user-attachments/assets/9817dd76-53fb-471e-82f2-297bf3ac71fd

