### PR TITLE
gtk: resize overlay improvements

### DIFF
--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -496,7 +496,7 @@ pub fn init(self: *Surface, app: *App, opts: Options) !void {
         .container = .{ .none = {} },
         .overlay = @ptrCast(overlay),
         .gl_area = @ptrCast(gl_area),
-        .resize_overlay = ResizeOverlay.init(self, &app.config, @ptrCast(overlay)),
+        .resize_overlay = ResizeOverlay.init(self),
         .title_text = null,
         .core_surface = undefined,
         .font_size = font_size,
@@ -1310,7 +1310,7 @@ fn gtkResize(area: *c.GtkGLArea, width: c.gint, height: c.gint, ud: ?*anyopaque)
             return;
         };
 
-        self.resize_overlay.maybeShowResizeOverlay();
+        self.resize_overlay.maybeShow();
     }
 }
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -870,10 +870,6 @@ keybind: Keybinds = .{},
 ///                     subsequently resized.
 ///
 /// The default is `after-first`.
-///
-/// Changing this value at runtime and reloading the configuration will take
-/// effect immediately on macOS, but will only affect new terminals on
-/// Linux.
 @"resize-overlay": ResizeOverlay = .@"after-first",
 
 /// If resize overlays are enabled, this controls the position of the overlay.


### PR DESCRIPTION
* runtime changing of `resize-overlay` now works on GTK
* shorten function names in ResizeOverlay
* improve documentation