### PR TITLE
macOS: resize overlay improvements

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -29,7 +29,11 @@ extension Ghostty {
         
         // The hovered URL string
         @Published var hoverUrl: String? = nil
-
+        
+        // The time this surface last became focused. This is a ContinuousClock.Instant
+        // on supported platforms.
+        @Published var focusInstant: Any? = nil
+        
         // An initial size to request for a window. This will only affect
         // then the view is moved to a new window.
         var initialSize: NSSize? = nil
@@ -208,6 +212,13 @@ extension Ghostty {
             guard self.focused != focused else { return }
             self.focused = focused
             ghostty_surface_set_focus(surface, focused)
+            
+            // On macOS 13+ we can store our continuous clock...
+            if #available(macOS 13, iOS 16, *) {
+                if (focused) {
+                    focusInstant = ContinuousClock.now
+                }
+            }
         }
 
         func sizeDidChange(_ size: CGSize) {

--- a/macos/Sources/Ghostty/SurfaceView_UIKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_UIKit.swift
@@ -28,6 +28,10 @@ extension Ghostty {
         // The hovered URL
         @Published var hoverUrl: String? = nil
         
+        // The time this surface last became focused. This is a ContinuousClock.Instant
+        // on supported platforms.
+        @Published var focusInstant: Any? = nil
+        
         // Returns sizing information for the surface. This is the raw C
         // structure because I'm lazy.
         var surfaceSize: ghostty_surface_size_s? {
@@ -67,6 +71,13 @@ extension Ghostty {
         func focusDidChange(_ focused: Bool) {
             guard let surface = self.surface else { return }
             ghostty_surface_set_focus(surface, focused)
+            
+            // On macOS 13+ we can store our continuous clock...
+            if #available(macOS 13, iOS 16, *) {
+                if (focused) {
+                    focusInstant = ContinuousClock.now
+                }
+            }
         }
 
         func sizeDidChange(_ size: CGSize) {


### PR DESCRIPTION
**Do not show resize overlay until a start delay has passed (Fixes #2079)**. This could be improved by waiting for some coalescing period initially instead of a timer, but that was a lot more work. I noted this in the comments in case someone wants to take this on.

**Do not show resize overlay when surface recently gained focus.** SwiftUI does a lot of resizing lazily, so this avoids showing the overlay when we recently focused back on a backgrounded window that was delaying resizing. This only works on macOS 13+.