### PR TITLE
Add Config Option to Limit Number of Processes

### DIFF
--- a/src/apprt/gtk/cgroup.zig
+++ b/src/apprt/gtk/cgroup.zig
@@ -71,6 +71,14 @@ pub fn init(app: *App) ![]const u8 {
         });
     }
 
+    // Configure the "max" pids limit. This is a hard limit and cannot be
+    // exceeded.
+    if (app.config.@"linux-cgroup-processes-limit") |limit| {
+        try internal_os.cgroup.configureProcessesLimit(surfaces, .{
+            .processes = limit,
+        });
+    }
+
     return transient;
 }
 

--- a/src/apprt/gtk/cgroup.zig
+++ b/src/apprt/gtk/cgroup.zig
@@ -66,16 +66,16 @@ pub fn init(app: *App) ![]const u8 {
     // can be monitored by things like systemd-oomd to kill if needed,
     // versus an instant hard kill.
     if (app.config.@"linux-cgroup-memory-limit") |limit| {
-        try internal_os.cgroup.configureMemoryLimit(surfaces, .{
-            .high = limit,
+        try internal_os.cgroup.configureLimit(surfaces, .{
+            .memory_high = limit,
         });
     }
 
     // Configure the "max" pids limit. This is a hard limit and cannot be
     // exceeded.
     if (app.config.@"linux-cgroup-processes-limit") |limit| {
-        try internal_os.cgroup.configureProcessesLimit(surfaces, .{
-            .processes = limit,
+        try internal_os.cgroup.configureLimit(surfaces, .{
+            .pids_max = limit,
         });
     }
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1276,6 +1276,13 @@ keybind: Keybinds = .{},
 /// pressure.
 @"linux-cgroup-memory-limit": ?u64 = null,
 
+/// Number of processes limit for any individual terminal process (tab, split,
+/// window, etc.). If this is unset then no limit will be set.
+///
+/// Note that this sets the "pids.max" configuration for the process number
+/// controller, which is a hard limit.
+@"linux-cgroup-processes-limit": ?u64 = null,
+
 /// If this is false, then any cgroup initialization (for linux-cgroup)
 /// will be allowed to fail and the failure is ignored. This is useful if
 /// you view cgroup isolation as a "nice to have" and not a critical resource

--- a/src/os/cgroup.zig
+++ b/src/os/cgroup.zig
@@ -180,45 +180,19 @@ pub fn configureControllers(
     try file.writer().writeAll(v);
 }
 
-pub const MemoryLimit = union(enum) {
-    /// memory.high
-    high: usize,
+pub const Limit = union(enum) {
+    memory_high: usize,
+    pids_max: usize,
 };
 
-/// Configure the memory limit for the given cgroup. Use the various
-/// fields in MemoryLimit to configure a specific type of limit.
-pub fn configureMemoryLimit(cgroup: []const u8, limit: MemoryLimit) !void {
+/// Configure a limit for the given cgroup. Use the various
+/// fields in Limit to configure a specific type of limit.
+pub fn configureLimit(cgroup: []const u8, limit: Limit) !void {
     assert(cgroup[0] == '/');
 
     const filename, const size = switch (limit) {
-        .high => |v| .{ "memory.high", v },
-    };
-
-    // Open our file
-    var buf: [std.fs.max_path_bytes]u8 = undefined;
-    const path = try std.fmt.bufPrint(
-        &buf,
-        "/sys/fs/cgroup{s}/{s}",
-        .{ cgroup, filename },
-    );
-    const file = try std.fs.cwd().openFile(path, .{ .mode = .write_only });
-    defer file.close();
-
-    // Write our limit in bytes
-    try file.writer().print("{}", .{size});
-}
-
-pub const ProcessesLimit = union(enum) {
-    /// pids.max
-    processes: usize,
-};
-
-/// Configure the number of processes for the given cgroup.
-pub fn configureProcessesLimit(cgroup: []const u8, limit: ProcessesLimit) !void {
-    assert(cgroup[0] == '/');
-
-    const filename, const size = switch (limit) {
-        .processes => |v| .{ "pids.max", v },
+        .memory_high => |v| .{ "memory.high", v },
+        .pids_max => |v| .{ "pids.max", v },
     };
 
     // Open our file

--- a/src/os/cgroup.zig
+++ b/src/os/cgroup.zig
@@ -207,3 +207,30 @@ pub fn configureMemoryLimit(cgroup: []const u8, limit: MemoryLimit) !void {
     // Write our limit in bytes
     try file.writer().print("{}", .{size});
 }
+
+pub const ProcessesLimit = union(enum) {
+    /// pids.max
+    processes: usize,
+};
+
+/// Configure the number of processes for the given cgroup.
+pub fn configureProcessesLimit(cgroup: []const u8, limit: ProcessesLimit) !void {
+    assert(cgroup[0] == '/');
+
+    const filename, const size = switch (limit) {
+        .processes => |v| .{ "pids.max", v },
+    };
+
+    // Open our file
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(
+        &buf,
+        "/sys/fs/cgroup{s}/{s}",
+        .{ cgroup, filename },
+    );
+    const file = try std.fs.cwd().openFile(path, .{ .mode = .write_only });
+    defer file.close();
+
+    // Write our limit in bytes
+    try file.writer().print("{}", .{size});
+}


### PR DESCRIPTION
To protect your system and ghostty from misbehaving programs that launch too many processes for the system to handle (e.g. like a fork bomb), this implements an option to limit the number of processes that can be started in a surface.

A fork bomb for example or other misbehaving program would then only take down one surface and not the entire system.

Side node:
If I am right in issue #2084, this feature does not actually work on a per surface basis but on all surfaces. If this is the case, it could probably be fixed together. Chances are, that I am wrong though 😉

Further improvements that could be done:
- unify way to set cgroup attributes
- set sane default: 10% of system max?