### PR TITLE
macos/opengl: lock context while rendering to stop resize crashes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1117,6 +1117,10 @@ fn addDeps(
         step.root_module.addImport("macos", macos_dep.module("macos"));
         step.linkLibrary(macos_dep.artifact("macos"));
         try static_libs.append(macos_dep.artifact("macos").getEmittedBin());
+
+        if (config.renderer == .opengl) {
+            step.linkFramework("OpenGL");
+        }
     }
 
     // cimgui

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -2030,6 +2030,14 @@ pub fn drawFrame(self: *OpenGL, surface: *apprt.Surface) !void {
         }
     }
 
+    const is_darwin = builtin.target.isDarwin();
+    const ogl = if (comptime is_darwin) @cImport({
+        @cInclude("OpenGL/OpenGL.h");
+    }) else {};
+    const cgl_ctx = if (comptime is_darwin) ogl.CGLGetCurrentContext();
+    if (comptime is_darwin) _ = ogl.CGLLockContext(cgl_ctx);
+    defer _ = if (comptime is_darwin) ogl.CGLUnlockContext(cgl_ctx);
+
     // Draw our terminal cells
     try self.drawCellProgram(gl_state);
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -2030,6 +2030,12 @@ pub fn drawFrame(self: *OpenGL, surface: *apprt.Surface) !void {
         }
     }
 
+    // In the "OpenGL Programming Guide for Mac" it explains that: "When you
+    // use an NSOpenGLView object with OpenGL calls that are issued from a
+    // thread other than the main one, you must set up mutex locking."
+    // This locks the context and avoids crashes that can happen due to
+    // races with the underlying Metal layer that Apple is using to
+    // implement OpenGL.
     const is_darwin = builtin.target.isDarwin();
     const ogl = if (comptime is_darwin) @cImport({
         @cInclude("OpenGL/OpenGL.h");


### PR DESCRIPTION
A kinda hacky fix to a crash caused by accessing the GL context from multiple threads during window resize operations. This is simply to allow somewhat sane testing + development of the OpenGL renderer while on macOS.

This is hacky code and there's probably a subtly better way to do it, feel free to change before merge :p