### PR TITLE
Config: cursor-style can bet set to block_hollow

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -325,6 +325,7 @@ palette: Palette = .{},
 ///   * `block`
 ///   * `bar`
 ///   * `underline`
+///   * `block_hollow`
 ///
 @"cursor-style": terminal.CursorStyle = .block,
 

--- a/src/renderer/cursor.zig
+++ b/src/renderer/cursor.zig
@@ -16,6 +16,7 @@ pub const CursorStyle = enum {
         return switch (style) {
             .bar => .bar,
             .block => .block,
+            .block_hollow => .block_hollow,
             .underline => .underline,
         };
     }

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -139,7 +139,7 @@ pub const Cursor = struct {
 /// The visual style of the cursor. Whether or not it blinks
 /// is determined by mode 12 (modes.zig). This mode is synchronized
 /// with CSI q, the same as xterm.
-pub const CursorStyle = enum { bar, block, underline };
+pub const CursorStyle = enum { bar, block, underline, block_hollow };
 
 /// Saved cursor state.
 pub const SavedCursor = struct {

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -139,7 +139,18 @@ pub const Cursor = struct {
 /// The visual style of the cursor. Whether or not it blinks
 /// is determined by mode 12 (modes.zig). This mode is synchronized
 /// with CSI q, the same as xterm.
-pub const CursorStyle = enum { bar, block, underline, block_hollow };
+pub const CursorStyle = enum {
+    bar, // DECSCUSR 5, 6
+    block, // DECSCUSR 1, 2
+    underline, // DECSCUSR 3, 4
+
+    /// The cursor styles below aren't known by DESCUSR and are custom
+    /// implemented in Ghostty. They are reported as some standard style
+    /// if requested, though.
+    /// Hollow block cursor. This is a block cursor with the center empty.
+    /// Reported as DECSCUSR 1 or 2 (block).
+    block_hollow,
+};
 
 /// Saved cursor state.
 pub const SavedCursor = struct {

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -208,6 +208,7 @@ pub const StreamHandler = struct {
                         const blink = self.terminal.modes.get(.cursor_blinking);
                         const style: u8 = switch (self.terminal.screen.cursor.cursor_style) {
                             .block => if (blink) 1 else 2,
+                            .block_hollow => if (blink) 1 else 2,
                             .underline => if (blink) 3 else 4,
                             .bar => if (blink) 5 else 6,
                         };

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -208,9 +208,12 @@ pub const StreamHandler = struct {
                         const blink = self.terminal.modes.get(.cursor_blinking);
                         const style: u8 = switch (self.terminal.screen.cursor.cursor_style) {
                             .block => if (blink) 1 else 2,
-                            .block_hollow => if (blink) 1 else 2,
                             .underline => if (blink) 3 else 4,
                             .bar => if (blink) 5 else 6,
+
+                            // Below here, the cursor styles aren't represented by
+                            // DECSCUSR so we map it to some other style.
+                            .block_hollow => if (blink) 1 else 2,
                         };
                         try writer.print("{d} q", .{style});
                     },


### PR DESCRIPTION
Fixes #2073


`cursor-style` can now also be set to `block_hollow`, no other changes in behavior are added.

(When dealing with `decscusr` I treated it as if it were of style `block` because afaict there is no wey to set `block_hollow` via `decscusr`. Take this with a bottle of salt since I'm a total newbie at zig and terminal emulation.)