### PR TITLE
Run commands in a new Ghostty window/tab/split

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -253,7 +253,7 @@ pub fn newWindow(self: *App, rt_app: *apprt.App, msg: Message.NewWindow) !void {
             null;
     } else null;
 
-    try rt_app.newWindow(parent);
+    try rt_app.newWindow(.{ .parent = parent, .config = msg.config });
 }
 
 /// Start quitting
@@ -321,6 +321,9 @@ pub const Message = union(enum) {
     const NewWindow = struct {
         /// The parent surface
         parent: ?*Surface = null,
+
+        /// Custom configuration to use for the new window.
+        config: ?*Config = null,
     };
 };
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3399,7 +3399,7 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
 
         .new_tab => {
             if (@hasDecl(apprt.Surface, "newTab")) {
-                try self.rt_surface.newTab();
+                try self.rt_surface.newTab(.{});
             } else log.warn("runtime doesn't implement newTab", .{});
         },
 
@@ -3437,14 +3437,17 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
 
         .new_split => |direction| {
             if (@hasDecl(apprt.Surface, "newSplit")) {
-                try self.rt_surface.newSplit(switch (direction) {
-                    .right => .right,
-                    .down => .down,
-                    .auto => if (self.screen_size.width > self.screen_size.height)
-                        .right
-                    else
-                        .down,
-                });
+                try self.rt_surface.newSplit(
+                    switch (direction) {
+                        .right => .right,
+                        .down => .down,
+                        .auto => if (self.screen_size.width > self.screen_size.height)
+                            .right
+                        else
+                            .down,
+                    },
+                    .{},
+                );
             } else log.warn("runtime doesn't implement newSplit", .{});
         },
 
@@ -3663,6 +3666,22 @@ fn writeScreenFile(
             self.alloc,
             path,
         ), .unlocked),
+        .edit_window => {
+            if (@hasDecl(apprt.runtime.Surface, "openEditorWithPath"))
+                try self.rt_surface.openEditorWithPath(.window, path);
+        },
+        .edit_tab => {
+            if (@hasDecl(apprt.runtime.Surface, "openEditorWithPath"))
+                try self.rt_surface.openEditorWithPath(.tab, path);
+        },
+        .edit_split_right => {
+            if (@hasDecl(apprt.runtime.Surface, "openEditorWithPath"))
+                try self.rt_surface.openEditorWithPath(.split_right, path);
+        },
+        .edit_split_down => {
+            if (@hasDecl(apprt.runtime.Surface, "openEditorWithPath"))
+                try self.rt_surface.openEditorWithPath(.split_down, path);
+        },
     }
 }
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -225,13 +225,18 @@ pub const App = struct {
         surface.queueInspectorRender();
     }
 
-    pub fn newWindow(self: *App, parent: ?*CoreSurface) !void {
+    pub fn newWindow(self: *App, opts: struct {
+        parent: ?*CoreSurface = null,
+        config: ?*Config = null,
+    }) !void {
         _ = self;
+
+        if (opts.config != null) log.warn("embedded runtime does not support creating new windows with custom configs", .{});
 
         // Right now we only support creating a new window with a parent
         // through this code.
         // The other case is handled by the embedding runtime.
-        if (parent) |surface| {
+        if (opts.parent) |surface| {
             try surface.rt_surface.newWindow();
         }
     }
@@ -474,11 +479,15 @@ pub const Surface = struct {
         func(self.userdata, mode);
     }
 
-    pub fn newSplit(self: *const Surface, direction: apprt.SplitDirection) !void {
+    pub fn newSplit(self: *const Surface, direction: apprt.SplitDirection, opts: struct {
+        config: ?*Config = null,
+    }) !void {
         const func = self.app.opts.new_split orelse {
             log.info("runtime embedder does not support splits", .{});
             return;
         };
+
+        if (opts.config != null) log.warn("embedded runtime does not support creating new splits with a custom config", .{});
 
         const options = self.newSurfaceOptions();
         func(self.userdata, direction, options);
@@ -1035,11 +1044,15 @@ pub const Surface = struct {
         func(self.userdata, nonNativeFullscreen);
     }
 
-    pub fn newTab(self: *const Surface) !void {
+    pub fn newTab(self: *const Surface, opts: struct {
+        config: ?*Config = null,
+    }) !void {
         const func = self.app.opts.new_tab orelse {
             log.info("runtime embedder does not support new_tab", .{});
             return;
         };
+
+        if (opts.config != null) log.warn("embedded runtime does not support creating new tabs with a custom config", .{});
 
         const options = self.newSurfaceOptions();
         func(self.userdata, options);

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1783,7 +1783,7 @@ pub const CAPI = struct {
 
     /// Request that the surface split in the given direction.
     export fn ghostty_surface_split(ptr: *Surface, direction: apprt.SplitDirection) void {
-        ptr.newSplit(direction) catch {};
+        ptr.newSplit(direction, .{}) catch {};
     }
 
     /// Focus on the next split (if any).

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -565,7 +565,10 @@ pub fn redrawInspector(self: *App, surface: *Surface) void {
 }
 
 /// Called by CoreApp to create a new window with a new surface.
-pub fn newWindow(self: *App, parent_: ?*CoreSurface) !void {
+pub fn newWindow(self: *App, opts: struct {
+    parent: ?*CoreSurface = null,
+    config: ?*configpkg.Config = null,
+}) !void {
     const alloc = self.core_app.alloc;
 
     // Allocate a fixed pointer for our window. We try to minimize
@@ -578,7 +581,7 @@ pub fn newWindow(self: *App, parent_: ?*CoreSurface) !void {
     var window = try Window.create(alloc, self);
 
     // Add our initial tab
-    try window.newTab(parent_);
+    try window.newTab(.{ .parent = opts.parent, .config = opts.config });
 }
 
 fn quit(self: *App) void {

--- a/src/apprt/gtk/Split.zig
+++ b/src/apprt/gtk/Split.zig
@@ -9,6 +9,7 @@ const apprt = @import("../../apprt.zig");
 const font = @import("../../font/main.zig");
 const input = @import("../../input.zig");
 const CoreSurface = @import("../../Surface.zig");
+const Config = @import("../../config.zig").Config;
 
 const Surface = @import("Surface.zig");
 const Tab = @import("Tab.zig");
@@ -59,10 +60,13 @@ pub fn create(
     alloc: Allocator,
     sibling: *Surface,
     direction: apprt.SplitDirection,
+    opts: struct {
+        config: ?*Config = null,
+    },
 ) !*Split {
     var split = try alloc.create(Split);
     errdefer alloc.destroy(split);
-    try split.init(sibling, direction);
+    try split.init(sibling, direction, .{ .config = opts.config });
     return split;
 }
 
@@ -70,11 +74,15 @@ pub fn init(
     self: *Split,
     sibling: *Surface,
     direction: apprt.SplitDirection,
+    opts: struct {
+        config: ?*Config = null,
+    },
 ) !void {
     // Create the new child surface for the other direction.
     const alloc = sibling.app.core_app.alloc;
     var surface = try Surface.create(alloc, sibling.app, .{
         .parent = &sibling.core_surface,
+        .config = opts.config,
     });
     errdefer surface.destroy(alloc);
     sibling.dimSurface();

--- a/src/apprt/gtk/Tab.zig
+++ b/src/apprt/gtk/Tab.zig
@@ -9,6 +9,7 @@ const assert = std.debug.assert;
 const font = @import("../../font/main.zig");
 const input = @import("../../input.zig");
 const CoreSurface = @import("../../Surface.zig");
+const Config = @import("../../config/Config.zig");
 
 const Surface = @import("Surface.zig");
 const Window = @import("Window.zig");
@@ -37,16 +38,21 @@ elem: Surface.Container.Elem,
 // can easily re-focus that terminal.
 focus_child: *Surface,
 
-pub fn create(alloc: Allocator, window: *Window, parent_: ?*CoreSurface) !*Tab {
+const Options = struct {
+    parent: ?*CoreSurface = null,
+    config: ?*Config = null,
+};
+
+pub fn create(alloc: Allocator, window: *Window, opts: Options) !*Tab {
     var tab = try alloc.create(Tab);
     errdefer alloc.destroy(tab);
-    try tab.init(window, parent_);
+    try tab.init(window, opts);
     return tab;
 }
 
 /// Initialize the tab, create a surface, and add it to the window. "self"
 /// needs to be a stable pointer, since it is used for GTK events.
-pub fn init(self: *Tab, window: *Window, parent_: ?*CoreSurface) !void {
+pub fn init(self: *Tab, window: *Window, opts: Options) !void {
     self.* = .{
         .window = window,
         .label_text = undefined,
@@ -97,7 +103,8 @@ pub fn init(self: *Tab, window: *Window, parent_: ?*CoreSurface) !void {
 
     // Create the initial surface since all tabs start as a single non-split
     var surface = try Surface.create(window.app.core_app.alloc, window.app, .{
-        .parent = parent_,
+        .parent = opts.parent,
+        .config = opts.config,
     });
     errdefer surface.unref();
     surface.container = .{ .tab_ = self };

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -207,9 +207,12 @@ pub fn deinit(self: *Window) void {
 }
 
 /// Add a new tab to this window.
-pub fn newTab(self: *Window, parent: ?*CoreSurface) !void {
+pub fn newTab(self: *Window, opts: struct {
+    parent: ?*CoreSurface = null,
+    config: ?*configpkg.Config = null,
+}) !void {
     const alloc = self.app.core_app.alloc;
-    _ = try Tab.create(alloc, self, parent);
+    _ = try Tab.create(alloc, self, .{ .parent = opts.parent, .config = opts.config });
 
     // TODO: When this is triggered through a GTK action, the new surface
     // redraws correctly. When it's triggered through keyboard shortcuts, it

--- a/src/build/fish_completions.zig
+++ b/src/build/fish_completions.zig
@@ -12,7 +12,7 @@ pub const fish_completions = comptimeGenerateFishCompletions();
 
 fn comptimeGenerateFishCompletions() []const u8 {
     comptime {
-        @setEvalBranchQuota(16000);
+        @setEvalBranchQuota(17000);
         var counter = std.io.countingWriter(std.io.null_writer);
         try writeFishCompletions(&counter.writer());
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -24,6 +24,7 @@ pub const RepeatableFontVariation = Config.RepeatableFontVariation;
 pub const RepeatableString = Config.RepeatableString;
 pub const ShellIntegrationFeatures = Config.ShellIntegrationFeatures;
 pub const WindowPaddingColor = Config.WindowPaddingColor;
+pub const RepeatableURIHandler = Config.RepeatableURIHandler;
 
 // Alternate APIs
 pub const CAPI = @import("config/CAPI.zig");

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -459,6 +459,25 @@ palette: Palette = .{},
 /// instance is launched and the CLI args are respected.
 command: ?[]const u8 = null,
 
+/// A command to use to open/edit text files in a terminal window (using
+/// something like Helix, Flow, Vim, NeoVim, Emacs, or Nano). If this is not set,
+/// Ghostty will check the `EDITOR` environment variable for the command. If
+/// the `EDITOR` environment variable is not set, Ghostty will fall back to `vi`
+/// (similar to how many Linux/Unix systems operate).
+///
+/// This command will be used to open/edit files when Ghostty receives a signal
+/// from the operating system to open a file. Currently implemented on the GTK
+/// runtime only.
+///
+/// The command may contain additional arguments besides the path to the
+/// editor's binary. The files that are to be opened will be added to the end of
+/// the command. For example, if `editor` was set to `emacs -nx` and you tried
+/// to open `README` and `hello.c` in your home directory, the final command
+/// would look like
+///
+///     emacs -nx /home/user/README /home/user/hello.c
+editor: ?[]const u8 = null,
+
 /// If true, keep the terminal open after the command exits. Normally, the
 /// terminal window closes when the running command (such as a shell) exits.
 /// With this true, the terminal window will stay open until any keypress is

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -232,13 +232,23 @@ pub const Action = union(enum) {
     ///
     ///   - `paste`: Paste the file path into the terminal.
     ///   - `open`: Open the file in the default OS editor for text files.
-    ///   - `edit_window`: Create a new window, and open the file in your editor.
-    ///   - `edit_tab`: Create a new tab, and open the file in your editor.
-    ///   - `edit_split_right`: Create a new split right, and open the file in your editor.
-    ///   - `edit_split_down`: Create a new split down, and open the file in your editor.
-    ///
-    /// `edit_window`, `edit_tab`, `edit_split_right`, and `edit_split_down` are
-    /// supported on GTK only.
+    ///   - `silent`: Run a command "in the background" to process the file. The
+    ///     command is constructed using the `editor` configuration setting or
+    ///     your `EDITOR` environment variable.
+    ///   - `edit_window`: Create a new window, and open the file in your
+    ///     editor. The command is constructed using the `editor` configuration
+    ///     setting or your `EDITOR` environment variable. (GTK only.)
+    ///   - `edit_tab`: Create a new tab, and open the file in your editor. The
+    ///     command is constructed using the `editor` configuration setting or
+    ///     your `EDITOR` environment variable. (GTK only.)
+    ///   - `edit_split_right`: Create a new split right, and open the file
+    ///     in your editor. The command is constructed using the `editor`
+    ///     configuration setting or your `EDITOR` environment variable. (GTK
+    ///     only.)
+    ///   - `edit_split_down`: Create a new split down, and open the file
+    ///     in your editor. The command is constructed using the `editor`
+    ///     configuration setting or your `EDITOR` environment variable. (GTK
+    ///     only.)
     ///
     /// See the configuration setting `editor` for more information on how
     /// Ghostty determines your editor.
@@ -249,13 +259,23 @@ pub const Action = union(enum) {
     ///
     ///   - `paste`: Paste the file path into the terminal.
     ///   - `open`: Open the file in the default OS editor for text files.
-    ///   - `edit_window`: Create a new window, and open the file in your editor.
-    ///   - `edit_tab`: Create a new tab, and open the file in your editor.
-    ///   - `edit_split_right`: Create a new split right, and open the file in your editor.
-    ///   - `edit_split_down`: Create a new split down, and open the file in your editor.
-    ///
-    /// `edit_window`, `edit_tab`, `edit_split_right`, and `edit_split_down` are
-    /// supported on GTK only.
+    ///   - `silent`: Run a command "in the background" to process the file. The
+    ///     command is constructed using the `editor` configuration setting or
+    ///     your `EDITOR` environment variable.
+    ///   - `edit_window`: Create a new window, and open the file in your
+    ///     editor. The command is constructed using the `editor` configuration
+    ///     setting or your `EDITOR` environment variable. (GTK only.)
+    ///   - `edit_tab`: Create a new tab, and open the file in your editor. The
+    ///     command is constructed using the `editor` configuration setting or
+    ///     your `EDITOR` environment variable. (GTK only.)
+    ///   - `edit_split_right`: Create a new split right, and open the file
+    ///     in your editor. The command is constructed using the `editor`
+    ///     configuration setting or your `EDITOR` environment variable. (GTK
+    ///     only.)
+    ///   - `edit_split_down`: Create a new split down, and open the file
+    ///     in your editor. The command is constructed using the `editor`
+    ///     configuration setting or your `EDITOR` environment variable. (GTK
+    ///     only.)
     ///
     /// See the configuration setting `editor` for more information on how
     /// Ghostty determines your editor.
@@ -267,13 +287,23 @@ pub const Action = union(enum) {
     ///
     ///   - `paste`: Paste the file path into the terminal.
     ///   - `open`: Open the file in the default OS editor for text files.
-    ///   - `edit_window`: Create a new window, and open the file in your editor.
-    ///   - `edit_tab`: Create a new tab, and open the file in your editor.
-    ///   - `edit_split_right`: Create a new split right, and open the file in your editor.
-    ///   - `edit_split_down`: Create a new split down, and open the file in your editor.
-    ///
-    /// `edit_window`, `edit_tab`, `edit_split_right`, and `edit_split_down` are
-    /// supported on GTK only.
+    ///   - `silent`: Run a command "in the background" to process the file. The
+    ///     command is constructed using the `editor` configuration setting or
+    ///     your `EDITOR` environment variable.
+    ///   - `edit_window`: Create a new window, and open the file in your
+    ///     editor. The command is constructed using the `editor` configuration
+    ///     setting or your `EDITOR` environment variable. (GTK only.)
+    ///   - `edit_tab`: Create a new tab, and open the file in your editor. The
+    ///     command is constructed using the `editor` configuration setting or
+    ///     your `EDITOR` environment variable. (GTK only.)
+    ///   - `edit_split_right`: Create a new split right, and open the file
+    ///     in your editor. The command is constructed using the `editor`
+    ///     configuration setting or your `EDITOR` environment variable. (GTK
+    ///     only.)
+    ///   - `edit_split_down`: Create a new split down, and open the file
+    ///     in your editor. The command is constructed using the `editor`
+    ///     configuration setting or your `EDITOR` environment variable. (GTK
+    ///     only.)
     ///
     /// See the configuration setting `editor` for more information on how
     /// Ghostty determines your editor.
@@ -401,6 +431,7 @@ pub const Action = union(enum) {
     pub const WriteScreenAction = enum {
         paste,
         open,
+        silent,
         edit_window,
         edit_tab,
         edit_split_right,

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -227,22 +227,56 @@ pub const Action = union(enum) {
     /// number of prompts to jump forward, negative is backwards.
     jump_to_prompt: i16,
 
-    /// Write the entire scrollback into a temporary file. The action
-    /// determines what to do with the filepath. Valid values are:
+    /// Write the entire scrollback into a temporary file. The action determines
+    /// what to do with the file. Valid values are:
     ///
-    ///   - "paste": Paste the file path into the terminal.
-    ///   - "open": Open the file in the default OS editor for text files.
+    ///   - `paste`: Paste the file path into the terminal.
+    ///   - `open`: Open the file in the default OS editor for text files.
+    ///   - `edit_window`: Create a new window, and open the file in your editor.
+    ///   - `edit_tab`: Create a new tab, and open the file in your editor.
+    ///   - `edit_split_right`: Create a new split right, and open the file in your editor.
+    ///   - `edit_split_down`: Create a new split down, and open the file in your editor.
     ///
+    /// `edit_window`, `edit_tab`, `edit_split_right`, and `edit_split_down` are
+    /// supported on GTK only.
+    ///
+    /// See the configuration setting `editor` for more information on how
+    /// Ghostty determines your editor.
     write_scrollback_file: WriteScreenAction,
 
-    /// Same as write_scrollback_file but writes the full screen contents.
-    /// See write_scrollback_file for available values.
+    /// Write the full screen contents into a temporary file. The action
+    /// determines what to do with the file. Valid values are:
+    ///
+    ///   - `paste`: Paste the file path into the terminal.
+    ///   - `open`: Open the file in the default OS editor for text files.
+    ///   - `edit_window`: Create a new window, and open the file in your editor.
+    ///   - `edit_tab`: Create a new tab, and open the file in your editor.
+    ///   - `edit_split_right`: Create a new split right, and open the file in your editor.
+    ///   - `edit_split_down`: Create a new split down, and open the file in your editor.
+    ///
+    /// `edit_window`, `edit_tab`, `edit_split_right`, and `edit_split_down` are
+    /// supported on GTK only.
+    ///
+    /// See the configuration setting `editor` for more information on how
+    /// Ghostty determines your editor.
     write_screen_file: WriteScreenAction,
 
-    /// Same as write_scrollback_file but writes the selected text.
-    /// If there is no selected text this does nothing (it doesn't
-    /// even create an empty file). See write_scrollback_file for
-    /// available values.
+    /// Writes the selected text into a temporary file. If there is no selected
+    /// text this action does nothing (it doesn't even create an empty file).
+    /// The action determines what to do with the file. Valid values are:
+    ///
+    ///   - `paste`: Paste the file path into the terminal.
+    ///   - `open`: Open the file in the default OS editor for text files.
+    ///   - `edit_window`: Create a new window, and open the file in your editor.
+    ///   - `edit_tab`: Create a new tab, and open the file in your editor.
+    ///   - `edit_split_right`: Create a new split right, and open the file in your editor.
+    ///   - `edit_split_down`: Create a new split down, and open the file in your editor.
+    ///
+    /// `edit_window`, `edit_tab`, `edit_split_right`, and `edit_split_down` are
+    /// supported on GTK only.
+    ///
+    /// See the configuration setting `editor` for more information on how
+    /// Ghostty determines your editor.
     write_selection_file: WriteScreenAction,
 
     /// Open a new window.
@@ -367,6 +401,10 @@ pub const Action = union(enum) {
     pub const WriteScreenAction = enum {
         paste,
         open,
+        edit_window,
+        edit_tab,
+        edit_split_right,
+        edit_split_down,
     };
 
     // Extern because it is used in the embedded runtime ABI.

--- a/src/input/Link.zig
+++ b/src/input/Link.zig
@@ -20,8 +20,8 @@ action: Action,
 highlight: Highlight,
 
 pub const Action = union(enum) {
-    /// Open the full matched value using the default open program.
-    /// For example, on macOS this is "open" and on Linux this is "xdg-open".
+    /// Use the `uri-handler` configuation setting to handle clicking on the
+    /// link.
     open: void,
 
     /// Open the OSC8 hyperlink under the mouse position. _-prefixed means

--- a/src/os/editor.zig
+++ b/src/os/editor.zig
@@ -1,17 +1,16 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const Config = @import("../config.zig").Config;
 
-pub fn getEditor(alloc: std.mem.Allocator, config: *const Config) ![]const u8 {
+pub fn getEditor(alloc: std.mem.Allocator, editor: ?[]const u8) ![]const u8 {
     // figure out what our editor is
-    if (config.editor) |editor| return try alloc.dupe(u8, editor);
+    if (editor) |e| return try alloc.dupe(u8, e);
     switch (builtin.os.tag) {
         .windows => {
             if (std.process.getenvW(std.unicode.utf8ToUtf16LeStringLiteral("EDITOR"))) |win_editor| {
                 return try std.unicode.utf16leToUtf8Alloc(alloc, win_editor);
             }
         },
-        else => if (std.posix.getenv("EDITOR")) |editor| return alloc.dupe(u8, editor),
+        else => if (std.posix.getenv("EDITOR")) |e| return alloc.dupe(u8, e),
     }
     return alloc.dupe(u8, "vi");
 }

--- a/src/os/editor.zig
+++ b/src/os/editor.zig
@@ -1,0 +1,17 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const Config = @import("../config.zig").Config;
+
+pub fn getEditor(alloc: std.mem.Allocator, config: *const Config) ![]const u8 {
+    // figure out what our editor is
+    if (config.editor) |editor| return try alloc.dupe(u8, editor);
+    switch (builtin.os.tag) {
+        .windows => {
+            if (std.process.getenvW(std.unicode.utf8ToUtf16LeStringLiteral("EDITOR"))) |win_editor| {
+                return try std.unicode.utf16leToUtf8Alloc(alloc, win_editor);
+            }
+        },
+        else => if (std.posix.getenv("EDITOR")) |editor| return alloc.dupe(u8, editor),
+    }
+    return alloc.dupe(u8, "vi");
+}

--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -13,6 +13,7 @@ const mouse = @import("mouse.zig");
 const openpkg = @import("open.zig");
 const pipepkg = @import("pipe.zig");
 const resourcesdir = @import("resourcesdir.zig");
+const editor = @import("editor.zig");
 
 // Namespaces
 pub const cgroup = @import("cgroup.zig");
@@ -41,3 +42,4 @@ pub const clickInterval = mouse.clickInterval;
 pub const open = openpkg.open;
 pub const pipe = pipepkg.pipe;
 pub const resourcesDir = resourcesdir.resourcesDir;
+pub const getEditor = editor.getEditor;

--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -40,6 +40,7 @@ pub const ensureLocale = locale.ensureLocale;
 pub const macosVersionAtLeast = macos_version.macosVersionAtLeast;
 pub const clickInterval = mouse.clickInterval;
 pub const open = openpkg.open;
+pub const run = openpkg.run;
 pub const pipe = pipepkg.pipe;
 pub const resourcesDir = resourcesdir.resourcesDir;
 pub const getEditor = editor.getEditor;

--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -1,23 +1,9 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
+const isFlatpak = @import("flatpak.zig").isFlatpak;
 
-/// Open a URL in the default handling application.
-///
-/// Any output on stderr is logged as a warning in the application logs.
-/// Output on stdout is ignored.
-pub fn open(alloc: Allocator, url: []const u8) !void {
-    // Some opener commands terminate after opening (macOS open) and some do not
-    // (xdg-open). For those which do not terminate, we do not want to wait for
-    // the process to exit to collect stderr.
-    const argv, const wait = switch (builtin.os.tag) {
-        .linux => .{ &.{ "xdg-open", url }, false },
-        .macos => .{ &.{ "open", url }, true },
-        .windows => .{ &.{ "rundll32", "url.dll,FileProtocolHandler", url }, false },
-        .ios => return error.Unimplemented,
-        else => @compileError("unsupported OS"),
-    };
-
+fn execute(alloc: Allocator, argv: []const []const u8, comptime wait: bool) !void {
     var exe = std.process.Child.init(argv, alloc);
 
     if (comptime wait) {
@@ -46,4 +32,68 @@ pub fn open(alloc: Allocator, url: []const u8) !void {
         // users to debug why some open commands may not work as expected.
         if (stderr.items.len > 0) std.log.err("open stderr={s}", .{stderr.items});
     }
+}
+
+/// Run a command using the system shell to simplify parsing the command line
+pub fn run(gpa_alloc: Allocator, cmd: []const u8) !void {
+    var arena = std.heap.ArenaAllocator.init(gpa_alloc);
+    const arena_alloc = arena.allocator();
+    defer arena.deinit();
+
+    const argv, const wait = switch (builtin.os.tag) {
+        .ios => return error.Unimplemented,
+        .windows => result: {
+            // We run our shell wrapped in `cmd.exe` so that we don't have
+            // to parse the command line ourselves if it has arguments.
+
+            // Note we don't free any of the memory below since it is
+            // allocated in the arena.
+            var list = std.ArrayList([]const u8).init(arena_alloc);
+            const windir = try std.process.getEnvVarOwned(arena_alloc, "WINDIR");
+            const shell = try std.fs.path.join(arena_alloc, &[_][]const u8{
+                windir,
+                "System32",
+                "cmd.exe",
+            });
+
+            try list.append(shell);
+            try list.append("/C");
+            try list.append(cmd);
+            break :result .{ try list.toOwnedSlice(), false };
+        },
+        else => result: {
+            // We run our shell wrapped in `/bin/sh` so that we don't have
+            // to parse the command line ourselves if it has arguments.
+            // Additionally, some environments (NixOS, I found) use /bin/sh
+            // to setup some environment variables that are important to
+            // have set.
+            var list = std.ArrayList([]const u8).init(arena_alloc);
+            try list.append("/bin/sh");
+            if (isFlatpak()) try list.append("-l");
+            try list.append("-c");
+            try list.append(cmd);
+            break :result .{ try list.toOwnedSlice(), true };
+        },
+    };
+
+    try execute(gpa_alloc, argv, wait);
+}
+
+/// Open a URL in the default handling application.
+///
+/// Any output on stderr is logged as a warning in the application logs.
+/// Output on stdout is ignored.
+pub fn open(gpa_alloc: Allocator, url: []const u8) !void {
+    // Some opener commands terminate after opening (macOS open) and some do not
+    // (xdg-open). For those which do not terminate, we do not want to wait for
+    // the process to exit to collect stderr.
+    const argv, const wait = switch (builtin.os.tag) {
+        .linux => .{ &.{ "xdg-open", url }, false },
+        .macos => .{ &.{ "open", url }, true },
+        .windows => .{ &.{ "rundll32", "url.dll,FileProtocolHandler", url }, false },
+        .ios => return error.Unimplemented,
+        else => @compileError("unsupported OS"),
+    };
+
+    try execute(gpa_alloc, argv, wait);
 }


### PR DESCRIPTION
This PR adds the plumbing to launch new commands in a Ghostty surface.

This is used to do the following:

- Adds options to `write_scrollback_file`, `write_screen_file`, and `write_selection_file` to create a new window, tab, or split and open up that file using your editor.

- Clicking on a URL can create a new window, tab, or split and run a custom command in that new surface.

[Screencast from 2024-08-16 22-47-37.webm](https://github.com/user-attachments/assets/abf2a383-8933-4c26-8ec3-881cbd5ff172)

[Screencast from 2024-08-17 22-13-41.webm](https://github.com/user-attachments/assets/daecd235-0b95-4ab1-965b-7f08c009d1ff)
