### PR TITLE
Implement Kitty Color Protocol (OSC 21)

### DIFF
--- a/src/inspector/termio.zig
+++ b/src/inspector/termio.zig
@@ -259,6 +259,11 @@ pub const VTEvent = struct {
                 }
             },
 
+            .Struct => try md.put(
+                key,
+                try alloc.dupeZ(u8, @typeName(Value)),
+            ),
+
             else => switch (Value) {
                 u8 => try md.put(
                     key,

--- a/src/terminal/color.zig
+++ b/src/terminal/color.zig
@@ -208,9 +208,11 @@ pub const RGB = struct {
     ///    where <red>, <green>, and <blue> are floating point values between
     ///    0.0 and 1.0 (inclusive).
     ///
-    /// 3. #hhh, #hhhhhh, #hhhhhhhhh #hhhhhhhhhhhh
+    /// 3. #rgb, #rrggbb, #rrrgggbbb #rrrrggggbbbb
     ///
-    ///    where `h` is a single hexadecimal digit.
+    ///    where `r`, `g`, and `b` are a single hexadecimal digit.
+    ///    These specifiy a color with 4, 8, 12, and 16 bits of precision
+    ///    per color channel.
     pub fn parse(value: []const u8) !RGB {
         if (value.len == 0) {
             return error.InvalidFormat;

--- a/src/terminal/color.zig
+++ b/src/terminal/color.zig
@@ -208,7 +208,7 @@ pub const RGB = struct {
     ///    where <red>, <green>, and <blue> are floating point values between
     ///    0.0 and 1.0 (inclusive).
     ///
-    /// 3. #hhhhhh
+    /// 3. #hhh, #hhhhhh, #hhhhhhhhh #hhhhhhhhhhhh
     ///
     ///    where `h` is a single hexadecimal digit.
     pub fn parse(value: []const u8) !RGB {
@@ -217,15 +217,30 @@ pub const RGB = struct {
         }
 
         if (value[0] == '#') {
-            if (value.len != 7) {
-                return error.InvalidFormat;
-            }
+            switch (value.len) {
+                4 => return RGB{
+                    .r = try RGB.fromHex(value[1..2]),
+                    .g = try RGB.fromHex(value[2..3]),
+                    .b = try RGB.fromHex(value[3..4]),
+                },
+                7 => return RGB{
+                    .r = try RGB.fromHex(value[1..3]),
+                    .g = try RGB.fromHex(value[3..5]),
+                    .b = try RGB.fromHex(value[5..7]),
+                },
+                10 => return RGB{
+                    .r = try RGB.fromHex(value[1..4]),
+                    .g = try RGB.fromHex(value[4..7]),
+                    .b = try RGB.fromHex(value[7..10]),
+                },
+                13 => return RGB{
+                    .r = try RGB.fromHex(value[1..5]),
+                    .g = try RGB.fromHex(value[5..9]),
+                    .b = try RGB.fromHex(value[9..13]),
+                },
 
-            return RGB{
-                .r = try RGB.fromHex(value[1..3]),
-                .g = try RGB.fromHex(value[3..5]),
-                .b = try RGB.fromHex(value[5..7]),
-            };
+                else => return error.InvalidFormat,
+            }
         }
 
         // Check for X11 named colors. We allow whitespace around the edges
@@ -308,6 +323,9 @@ test "RGB.parse" {
     try testing.expectEqual(RGB{ .r = 127, .g = 160, .b = 0 }, try RGB.parse("rgb:7f/a0a0/0"));
     try testing.expectEqual(RGB{ .r = 255, .g = 255, .b = 255 }, try RGB.parse("rgb:f/ff/fff"));
     try testing.expectEqual(RGB{ .r = 255, .g = 255, .b = 255 }, try RGB.parse("#ffffff"));
+    try testing.expectEqual(RGB{ .r = 255, .g = 255, .b = 255 }, try RGB.parse("#fff"));
+    try testing.expectEqual(RGB{ .r = 255, .g = 255, .b = 255 }, try RGB.parse("#fffffffff"));
+    try testing.expectEqual(RGB{ .r = 255, .g = 255, .b = 255 }, try RGB.parse("#ffffffffffff"));
     try testing.expectEqual(RGB{ .r = 255, .g = 0, .b = 16 }, try RGB.parse("#ff0010"));
 
     try testing.expectEqual(RGB{ .r = 0, .g = 0, .b = 0 }, try RGB.parse("black"));

--- a/src/terminal/kitty.zig
+++ b/src/terminal/kitty.zig
@@ -1,6 +1,7 @@
 //! Types and functions related to Kitty protocols.
 
 const key = @import("kitty/key.zig");
+pub const color = @import("kitty/color.zig");
 pub const graphics = @import("kitty/graphics.zig");
 
 pub const KeyFlags = key.Flags;

--- a/src/terminal/kitty/color.zig
+++ b/src/terminal/kitty/color.zig
@@ -1,0 +1,92 @@
+const std = @import("std");
+const terminal = @import("../main.zig");
+const RGB = terminal.color.RGB;
+const Terminator = terminal.osc.Terminator;
+
+pub const OSC = struct {
+    pub const Request = union(enum) {
+        query: Kind,
+        set: struct { key: Kind, color: RGB },
+        reset: Kind,
+    };
+
+    /// list of requests
+    list: std.ArrayList(Request),
+
+    /// We must reply with the same string terminator (ST) as used in the
+    /// request.
+    terminator: Terminator = .st,
+};
+
+pub const Kind = enum(u9) {
+    // Make sure that this stays in sync with the higest numbered enum
+    // value.
+    pub const max: u9 = 263;
+
+    // These _must_ start at 256 since enum values 0-255 are reserved
+    // for the palette.
+    foreground = 256,
+    background = 257,
+    selection_foreground = 258,
+    selection_background = 259,
+    cursor = 260,
+    cursor_text = 261,
+    visual_bell = 262,
+    second_transparent_background = 263,
+    _,
+
+    /// Return the palette index that this kind is representing
+    /// or null if its a special color.
+    pub fn palette(self: Kind) ?u8 {
+        return std.math.cast(u8, @intFromEnum(self)) orelse null;
+    }
+
+    pub fn format(
+        self: Kind,
+        comptime layout: []const u8,
+        opts: std.fmt.FormatOptions,
+        writer: anytype,
+    ) !void {
+        _ = layout;
+        _ = opts;
+
+        // Format as a number if its a palette color otherwise
+        // format as a string.
+        if (self.palette()) |idx| {
+            try writer.print("{}", .{idx});
+        } else {
+            try writer.print("{s}", .{@tagName(self)});
+        }
+    }
+};
+
+test "OSC: kitty color protocol kind" {
+    const info = @typeInfo(Kind);
+
+    try std.testing.expectEqual(false, info.Enum.is_exhaustive);
+
+    var min: usize = std.math.maxInt(info.Enum.tag_type);
+    var max: usize = 0;
+
+    inline for (info.Enum.fields) |field| {
+        if (field.value > max) max = field.value;
+        if (field.value < min) min = field.value;
+    }
+
+    try std.testing.expect(min >= 256);
+    try std.testing.expect(max == Kind.max);
+}
+
+test "OSC: kitty color protocol kind string" {
+    const testing = std.testing;
+
+    var buf: [256]u8 = undefined;
+    {
+        const actual = try std.fmt.bufPrint(&buf, "{}", .{Kind.foreground});
+        try testing.expectEqualStrings("foreground", actual);
+    }
+    {
+        const actual = try std.fmt.bufPrint(&buf, "{}", .{@as(Kind, @enumFromInt(42))});
+        try testing.expectEqualStrings("42", actual);
+    }
+}

--- a/src/terminal/osc.zig
+++ b/src/terminal/osc.zig
@@ -1679,36 +1679,63 @@ test "OSC: kitty color protocol" {
     const cmd = p.end('\x1b').?;
     try testing.expect(cmd == .kitty_color_protocol);
     try testing.expectEqual(@as(usize, 9), cmd.kitty_color_protocol.list.items.len);
-    try testing.expect(cmd.kitty_color_protocol.list.items[0] == .query);
-    try testing.expectEqual(@as(Command.KittyColorProtocol.Kind, .foreground), cmd.kitty_color_protocol.list.items[0].query);
-    try testing.expect(cmd.kitty_color_protocol.list.items[1] == .set);
-    try testing.expectEqual(@as(Command.KittyColorProtocol.Kind, .background), cmd.kitty_color_protocol.list.items[1].set.key);
-    try testing.expectEqual(@as(u8, 0xf0), cmd.kitty_color_protocol.list.items[1].set.color.r);
-    try testing.expectEqual(@as(u8, 0xf8), cmd.kitty_color_protocol.list.items[1].set.color.g);
-    try testing.expectEqual(@as(u8, 0xff), cmd.kitty_color_protocol.list.items[1].set.color.b);
-    try testing.expect(cmd.kitty_color_protocol.list.items[2] == .set);
-    try testing.expectEqual(@as(Command.KittyColorProtocol.Kind, .cursor), cmd.kitty_color_protocol.list.items[2].set.key);
-    try testing.expectEqual(@as(u8, 0xf0), cmd.kitty_color_protocol.list.items[2].set.color.r);
-    try testing.expectEqual(@as(u8, 0xf8), cmd.kitty_color_protocol.list.items[2].set.color.g);
-    try testing.expectEqual(@as(u8, 0xff), cmd.kitty_color_protocol.list.items[2].set.color.b);
-    try testing.expect(cmd.kitty_color_protocol.list.items[3] == .reset);
-    try testing.expectEqual(@as(Command.KittyColorProtocol.Kind, .cursor_text), cmd.kitty_color_protocol.list.items[3].reset);
-    try testing.expect(cmd.kitty_color_protocol.list.items[4] == .reset);
-    try testing.expectEqual(@as(Command.KittyColorProtocol.Kind, .visual_bell), cmd.kitty_color_protocol.list.items[4].reset);
-    try testing.expect(cmd.kitty_color_protocol.list.items[5] == .query);
-    try testing.expectEqual(@as(Command.KittyColorProtocol.Kind, .selection_background), cmd.kitty_color_protocol.list.items[5].query);
-    try testing.expect(cmd.kitty_color_protocol.list.items[6] == .set);
-    try testing.expectEqual(@as(Command.KittyColorProtocol.Kind, .selection_background), cmd.kitty_color_protocol.list.items[6].set.key);
-    try testing.expectEqual(@as(u8, 0xaa), cmd.kitty_color_protocol.list.items[6].set.color.r);
-    try testing.expectEqual(@as(u8, 0xbb), cmd.kitty_color_protocol.list.items[6].set.color.g);
-    try testing.expectEqual(@as(u8, 0xcc), cmd.kitty_color_protocol.list.items[6].set.color.b);
-    try testing.expect(cmd.kitty_color_protocol.list.items[7] == .query);
-    try testing.expectEqual(@as(Command.KittyColorProtocol.Kind, @enumFromInt(2)), cmd.kitty_color_protocol.list.items[7].query);
-    try testing.expect(cmd.kitty_color_protocol.list.items[8] == .set);
-    try testing.expectEqual(@as(Command.KittyColorProtocol.Kind, @enumFromInt(3)), cmd.kitty_color_protocol.list.items[8].set.key);
-    try testing.expectEqual(@as(u8, 0xff), cmd.kitty_color_protocol.list.items[8].set.color.r);
-    try testing.expectEqual(@as(u8, 0xff), cmd.kitty_color_protocol.list.items[8].set.color.g);
-    try testing.expectEqual(@as(u8, 0xff), cmd.kitty_color_protocol.list.items[8].set.color.b);
+    {
+        const item = cmd.kitty_color_protocol.list.items[0];
+        try testing.expect(item == .query);
+        try testing.expectEqual(Command.KittyColorProtocol.Kind.foreground, item.query);
+    }
+    {
+        const item = cmd.kitty_color_protocol.list.items[1];
+        try testing.expect(item == .set);
+        try testing.expectEqual(Command.KittyColorProtocol.Kind.background, item.set.key);
+        try testing.expectEqual(@as(u8, 0xf0), item.set.color.r);
+        try testing.expectEqual(@as(u8, 0xf8), item.set.color.g);
+        try testing.expectEqual(@as(u8, 0xff), item.set.color.b);
+    }
+    {
+        const item = cmd.kitty_color_protocol.list.items[2];
+        try testing.expect(item == .set);
+        try testing.expectEqual(Command.KittyColorProtocol.Kind.cursor, item.set.key);
+        try testing.expectEqual(@as(u8, 0xf0), item.set.color.r);
+        try testing.expectEqual(@as(u8, 0xf8), item.set.color.g);
+        try testing.expectEqual(@as(u8, 0xff), item.set.color.b);
+    }
+    {
+        const item = cmd.kitty_color_protocol.list.items[3];
+        try testing.expect(item == .reset);
+        try testing.expectEqual(Command.KittyColorProtocol.Kind.cursor_text, item.reset);
+    }
+    {
+        const item = cmd.kitty_color_protocol.list.items[4];
+        try testing.expect(item == .reset);
+        try testing.expectEqual(Command.KittyColorProtocol.Kind.visual_bell, item.reset);
+    }
+    {
+        const item = cmd.kitty_color_protocol.list.items[5];
+        try testing.expect(item == .query);
+        try testing.expectEqual(Command.KittyColorProtocol.Kind.selection_background, item.query);
+    }
+    {
+        const item = cmd.kitty_color_protocol.list.items[6];
+        try testing.expect(item == .set);
+        try testing.expectEqual(Command.KittyColorProtocol.Kind.selection_background, item.set.key);
+        try testing.expectEqual(@as(u8, 0xaa), item.set.color.r);
+        try testing.expectEqual(@as(u8, 0xbb), item.set.color.g);
+        try testing.expectEqual(@as(u8, 0xcc), item.set.color.b);
+    }
+    {
+        const item = cmd.kitty_color_protocol.list.items[7];
+        try testing.expect(item == .query);
+        try testing.expectEqual(@as(Command.KittyColorProtocol.Kind, @enumFromInt(2)), item.query);
+    }
+    {
+        const item = cmd.kitty_color_protocol.list.items[8];
+        try testing.expect(item == .set);
+        try testing.expectEqual(@as(Command.KittyColorProtocol.Kind, @enumFromInt(3)), item.set.key);
+        try testing.expectEqual(@as(u8, 0xff), item.set.color.r);
+        try testing.expectEqual(@as(u8, 0xff), item.set.color.g);
+        try testing.expectEqual(@as(u8, 0xff), item.set.color.b);
+    }
 }
 
 test "OSC: kitty color protocol kind" {

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -1393,6 +1393,13 @@ pub fn Stream(comptime Handler: type) type {
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
 
+                .kitty_color_protocol => |v| {
+                    if (@hasDecl(T, "sendKittyColorReport")) {
+                        try self.handler.sendKittyColorReport(v);
+                        return;
+                    } else log.warn("unimplemented OSC callback: {}", .{cmd});
+                },
+
                 .show_desktop_notification => |v| {
                     if (@hasDecl(T, "showDesktopNotification")) {
                         try self.handler.showDesktopNotification(v.title, v.body);

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1302,7 +1302,10 @@ pub const StreamHandler = struct {
         }
     }
 
-    pub fn sendKittyColorReport(self: *StreamHandler, request: terminal.osc.Command.KittyColorProtocol) !void {
+    pub fn sendKittyColorReport(
+        self: *StreamHandler,
+        request: terminal.kitty.color.OSC,
+    ) !void {
         var buf = std.ArrayList(u8).init(self.alloc);
         defer buf.deinit();
         const writer = buf.writer();


### PR DESCRIPTION
Kitty 0.36.0 added support for a new OSC escape sequence for quering, setting, and resetting the terminal colors. Details can be found [here](https://sw.kovidgoyal.net/kitty/color-stack/#setting-and-querying-colors).

This fully parses the OSC 21 escape sequences, but only supports actually querying and changing the foreground color, the background color, and the cursor color because that's what Ghostty currently supports. Adding support for the other settings that Kitty supports changing ranges from easy (cursor text) to difficult (visual bell, second transparent background color).