### PR TITLE
Index should create scrollback anytime top scroll region is top line

### DIFF
--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1114,17 +1114,6 @@ pub fn index(self: *Terminal) !void {
             self.scrolling_region.left == 0 and
             self.scrolling_region.right == self.cols - 1)
         {
-            // If our scrolling region is the full screen, this is an
-            // easy and fast operation since we can just call grow.
-            if (self.scrolling_region.bottom == self.rows - 1) {
-                try self.screen.cursorDownScroll();
-                return;
-            }
-
-            // Our scrolling region is partially down the screen. In this
-            // case we need to move the top of the scroll region into
-            // scrollback while keeping the bottom of the scroll region
-            // at the bottom of the screen.
             try self.screen.cursorScrollAbove();
             return;
         }


### PR DESCRIPTION
Fixes #2112. See that issue for details.

~~This slows down this case by 3x using a custom vtebench benchmark I made (see below)~~. With the custom vtebench benchmark below, speed has improved in this PR over `main`. All standard vtebench benchmarks appear unaffected, they must not test this case.

## vtebench

vtebench doesn't have a benchmark covering this case, so I wrote one:

setup:

```sh
#!/bin/sh

# tty="/dev/$(ps -o tty= -p $$)"
# lines=$(tput lines < $tty)
# the above wasn't working, change this to whatever your terminal is
lines=23

printf "\e[$lines;1H"
printf "X"
printf "\e[1;$((lines - 1))r"
printf "\e[$((lines - 1));1H"
```

benchmark:

```sh
#!/bin/sh

# Scroll all lines up as quickly as possible.

printf "y\n"
```

Results:

<img width="1038" alt="image" src="https://github.com/user-attachments/assets/123d6dd7-3a3f-47fc-931c-931b68654efc">
