### PR TITLE
renderer: use fg as extension color for covering glyphs (U+2588)

### DIFF
--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -9,6 +9,7 @@ const testing = std.testing;
 const Allocator = std.mem.Allocator;
 const ArenaAllocator = std.heap.ArenaAllocator;
 const link = @import("link.zig");
+const isCovering = @import("cell.zig").isCovering;
 const fgMode = @import("cell.zig").fgMode;
 const shadertoy = @import("shadertoy.zig");
 const apprt = @import("../apprt.zig");
@@ -1646,6 +1647,15 @@ fn updateCell(
             break :colors BgFg{
                 .bg = res.bg,
                 .fg = res.bg orelse self.background_color,
+            };
+        }
+
+        // If our cell has a covering glyph, then our bg is set to our fg
+        // so that padding extension works correctly.
+        if (!selected and isCovering(cell.codepoint())) {
+            break :colors .{
+                .bg = res.fg,
+                .fg = res.fg,
             };
         }
 

--- a/src/renderer/cell.zig
+++ b/src/renderer/cell.zig
@@ -2,6 +2,18 @@ const ziglyph = @import("ziglyph");
 const font = @import("../font/main.zig");
 const terminal = @import("../terminal/main.zig");
 
+/// Returns true if a codepoint for a cell is a covering character. A covering
+/// character is a character that covers the entire cell. This is used to
+/// make window-padding-color=extend work better. See #2099.
+pub fn isCovering(cp: u21) bool {
+    return switch (cp) {
+        // U+2588 FULL BLOCK
+        0x2588 => true,
+
+        else => false,
+    };
+}
+
 pub const FgMode = enum {
     /// Normal non-colored text rendering. The text can leave the cell
     /// size if it is larger than the cell to allow for ligatures.


### PR DESCRIPTION
Fixes #2099

This is another heuristic of sorts to make `window-padding-color=extend` look better by default. If a fully covering glyph is used then we use the fg color to extend rather than the background.

This doesn't account for fonts that may do this for whatever codepoints, but I think that's a special scenario that we should just recommend disabling this feature.