### PR TITLE
Sequenced Keybindings

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1325,7 +1325,7 @@ pub fn keyCallback(
     // Before encoding, we see if we have any keybindings for this
     // key. Those always intercept before any encoding tasks.
     binding: {
-        const binding_action: input.Binding.Action, const binding_trigger: input.Binding.Trigger, const consumed = action: {
+        const binding_entry: input.Binding.Set.Entry, const binding_trigger: input.Binding.Trigger = action: {
             const binding_mods = event.mods.binding();
             var trigger: input.Binding.Trigger = .{
                 .mods = binding_mods,
@@ -1336,14 +1336,12 @@ pub fn keyCallback(
             if (set.get(trigger)) |v| break :action .{
                 v,
                 trigger,
-                set.getConsumed(trigger),
             };
 
             trigger.key = .{ .physical = event.physical_key };
             if (set.get(trigger)) |v| break :action .{
                 v,
                 trigger,
-                set.getConsumed(trigger),
             };
 
             if (event.unshifted_codepoint > 0) {
@@ -1351,12 +1349,16 @@ pub fn keyCallback(
                 if (set.get(trigger)) |v| break :action .{
                     v,
                     trigger,
-                    set.getConsumed(trigger),
                 };
             }
 
             break :binding;
         };
+        const binding_action = switch (binding_entry) {
+            .leader => break :binding, // TODO
+            .action, .action_unconsumed => |action| action,
+        };
+        const consumed = binding_entry == .action;
 
         // We only execute the binding on press/repeat but we still consume
         // the key on release so that we don't send any release events.

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1473,12 +1473,14 @@ fn maybeHandleBinding(
     switch (event.action) {
         // Release events never trigger a binding but we need to check if
         // we consumed the press event so we don't encode the release.
-        .release => if (self.keyboard.last_trigger) |last| {
-            if (last == event.bindingHash()) {
-                // We don't reset the last trigger on release because
-                // an apprt may send multiple release events for a single
-                // press event.
-                return .consumed;
+        .release => {
+            if (self.keyboard.last_trigger) |last| {
+                if (last == event.bindingHash()) {
+                    // We don't reset the last trigger on release because
+                    // an apprt may send multiple release events for a single
+                    // press event.
+                    return .consumed;
+                }
             }
 
             return null;

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -889,6 +889,13 @@ fn changeConfig(self: *Surface, config: *const configpkg.Config) !void {
         self.showMouse();
     }
 
+    // If we are in the middle of a key sequence, clear it.
+    self.keyboard.bindings = null;
+    if (self.keyboard.queued.items.len > 0) {
+        for (self.keyboard.queued.items) |req| req.deinit();
+        self.keyboard.queued.clearAndFree(self.alloc);
+    }
+
     // Before sending any other config changes, we give the renderer a new font
     // grid. We could check to see if there was an actual change to the font,
     // but this is easier and pretty rare so it's not a performance concern.

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1355,7 +1355,11 @@ pub fn keyCallback(
             break :binding;
         };
         const binding_action = switch (binding_entry) {
-            .leader => break :binding, // TODO
+            .leader => {
+                // TODO
+                log.warn("sequenced keybinds are not supported yet", .{});
+                break :binding;
+            },
             .action, .action_unconsumed => |action| action,
         };
         const consumed = binding_entry == .action;

--- a/src/cli/list_keybinds.zig
+++ b/src/cli/list_keybinds.zig
@@ -117,13 +117,17 @@ fn prettyPrint(alloc: Allocator, keybinds: Config.Keybinds) !u8 {
     var widest_key: usize = 0;
     var buf: [64]u8 = undefined;
     while (iter.next()) |bind| {
+        const action = switch (bind.value_ptr.*) {
+            .leader => continue, // TODO: support this
+            .action, .action_unconsumed => |action| action,
+        };
         const key = switch (bind.key_ptr.key) {
             .translated => |k| try std.fmt.bufPrint(&buf, "{s}", .{@tagName(k)}),
             .physical => |k| try std.fmt.bufPrint(&buf, "physical:{s}", .{@tagName(k)}),
             .unicode => |c| try std.fmt.bufPrint(&buf, "{u}", .{c}),
         };
         widest_key = @max(widest_key, win.gwidth(key));
-        try bindings.append(.{ .trigger = bind.key_ptr.*, .action = bind.value_ptr.* });
+        try bindings.append(.{ .trigger = bind.key_ptr.*, .action = action });
     }
     std.mem.sort(Binding, bindings.items, {}, Binding.lessThan);
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3322,10 +3322,17 @@ pub const Keybinds = struct {
 
     /// Compare if two of our value are requal. Required by Config.
     pub fn equal(self: Keybinds, other: Keybinds) bool {
+        return equalSet(&self.set, &other.set);
+    }
+
+    fn equalSet(
+        self: *const inputpkg.Binding.Set,
+        other: *const inputpkg.Binding.Set,
+    ) bool {
         // Two keybinds are considered equal if their primary bindings
         // are the same. We don't compare reverse mappings and such.
-        const self_map = self.set.bindings;
-        const other_map = other.set.bindings;
+        const self_map = &self.bindings;
+        const other_map = &other.bindings;
 
         // If the count of mappings isn't identical they can't be equal
         if (self_map.count() != other_map.count()) return false;
@@ -3341,7 +3348,11 @@ pub const Keybinds = struct {
                 std.meta.activeTag(other_entry.value_ptr.*)) return false;
 
             switch (self_entry.value_ptr.*) {
-                .leader => @panic("TODO"),
+                // They're equal if both leader sets are equal.
+                .leader => if (!equalSet(
+                    self_entry.value_ptr.*.leader,
+                    other_entry.value_ptr.*.leader,
+                )) return false,
 
                 // Actions are compared by field directly
                 inline .action, .action_unconsumed => |_, tag| if (!equalField(

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -625,6 +625,10 @@ class: ?[:0]const u8 = null,
 /// is sometimes called a leader key, a key chord, a key table, etc. There
 /// is no hardcoded limit on the number of parts in a sequence.
 ///
+/// Warning: if you define a sequence as a CLI argument to `ghostty`,
+/// you probably have to quote the keybind since `>` is a special character
+/// in most shells. Example: ghostty --keybind='ctrl+a>n=new_window'
+///
 /// A trigger sequence has some special handling:
 ///
 ///   * Ghostty will wait an indefinite amount of time for the next key in

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -618,6 +618,32 @@ class: ?[:0]const u8 = null,
 /// or the alias. When debugging keybinds, the non-aliased modifier will always
 /// be used in output.
 ///
+/// You may also specify multiple triggers separated by `>` to require a
+/// sequence of triggers to activate the action. For example,
+/// `ctrl+a>n=new_window` will only trigger the `new_window` action if the
+/// user presses `ctrl+a` followed separately by `n`. In other software, this
+/// is sometimes called a leader key, a key chord, a key table, etc. There
+/// is no hardcoded limit on the number of parts in a sequence.
+///
+/// A trigger sequence has some special handling:
+///
+///   * Ghostty will wait an indefinite amount of time for the next key in
+///     the sequence. There is no way to specify a timeout. The only way to
+///     force the output of a prefix key is to assign another keybind to
+///     specifically output that key (i.e. `ctrl+a>ctrl+a=text:foo`) or
+///     press an unbound key which will send both keys to the program.
+///
+///   * If a prefix in a sequence is previously bound, the sequence will
+///     override the previous binding. For example, if `ctrl+a` is bound to
+///     `new_window` and `ctrl+a>n` is bound to `new_tab`, pressing `ctrl+a`
+///     will do nothing.
+///
+///   * Adding to the above, if a previously bound sequence prefix is
+///     used in a new, non-sequence binding, the entire previously bound
+///     sequence will be unbound. For example, if you bind `ctrl+a>n` and
+///     `ctrl+a>t`, and then bind `ctrl+a` directly, both `ctrl+a>n` and
+///     `ctrl+a>t` will become unbound.
+///
 /// Action is the action to take when the trigger is satisfied. It takes the
 /// format `action` or `action:param`. The latter form is only valid if the
 /// action requires a parameter.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3311,15 +3311,8 @@ pub const Keybinds = struct {
             return;
         }
 
-        const binding = try inputpkg.Binding.parse(value);
-        switch (binding.action) {
-            .unbind => self.set.remove(binding.trigger),
-            else => if (binding.consumed) {
-                try self.set.put(alloc, binding.trigger, binding.action);
-            } else {
-                try self.set.putUnconsumed(alloc, binding.trigger, binding.action);
-            },
-        }
+        // Let our much better tested binding package handle parsing and storage.
+        try self.set.parseAndPut(alloc, value);
     }
 
     /// Deep copy of the struct. Required by Config.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3317,13 +3317,7 @@ pub const Keybinds = struct {
 
     /// Deep copy of the struct. Required by Config.
     pub fn clone(self: *const Keybinds, alloc: Allocator) !Keybinds {
-        // TODO: leaders
-        return .{
-            .set = .{
-                .bindings = try self.set.bindings.clone(alloc),
-                .reverse = try self.set.reverse.clone(alloc),
-            },
-        };
+        return .{ .set = try self.set.clone(alloc) };
     }
 
     /// Compare if two of our value are requal. Required by Config.

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -763,13 +763,6 @@ pub const Set = struct {
         std.hash_map.default_max_load_percentage,
     );
 
-    const UnconsumedMap = std.HashMapUnmanaged(
-        Trigger,
-        void,
-        Context(Trigger),
-        std.hash_map.default_max_load_percentage,
-    );
-
     /// The set of bindings.
     bindings: HashMap = .{},
 

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -1020,7 +1020,6 @@ pub const Set = struct {
             }
         }
 
-        // TODO: i hate this error handling
         gop.value_ptr.* = if (consumed) .{
             .action = action,
         } else .{

--- a/src/input/key.zig
+++ b/src/input/key.zig
@@ -54,6 +54,29 @@ pub const KeyEvent = struct {
         if (self.utf8.len == 0) return self.mods;
         return self.mods.unset(self.consumed_mods);
     }
+
+    /// Returns a unique hash for this key event to be used for tracking
+    /// uniquess specifically with bindings. This omits fields that are
+    /// irrelevant for bindings.
+    pub fn bindingHash(self: KeyEvent) u64 {
+        var hasher = std.hash.Wyhash.init(0);
+
+        // These are all the fields that are explicitly part of Trigger.
+        std.hash.autoHash(&hasher, self.key);
+        std.hash.autoHash(&hasher, self.physical_key);
+        std.hash.autoHash(&hasher, self.unshifted_codepoint);
+        std.hash.autoHash(&hasher, self.mods.binding());
+
+        // Notes on unmapped things and why:
+        //
+        // - action: we don't have action-specific bindings right now
+        //   AND we want to know if a key resulted in a binding regardless
+        //   of action because a press should also ignore a release and so on.
+        //
+        // We can add to this if there is other confusion.
+
+        return hasher.final();
+    }
 };
 
 /// A bitmask for all key modifiers.

--- a/src/termio/message.zig
+++ b/src/termio/message.zig
@@ -179,7 +179,7 @@ pub fn MessageData(comptime Elem: type, comptime small_size: comptime_int) type 
         pub fn deinit(self: Self) void {
             switch (self) {
                 .small, .stable => {},
-                .alloc => |v| v.alloc.free(v.alloc.data),
+                .alloc => |v| v.alloc.free(v.data),
             }
         }
 


### PR DESCRIPTION
Fixes #1420 

This adds support for **sequenced keybinds.** In other programs these are sometimes called key chords, leader sequence, key tables, etc (these are also all slightly _different_ concepts if you really dig into the details, but in the same category). Effectively, they're the ability to specify a keybinding not happen unless a _sequence of separate key inputs is given_. As examples, these are commonly present in tmux, emacs, etc.

Sequenced key binds use the existing `keybind` configuration, but introduce a new symbol `>` as a way to separate the sequenced triggers. For example, `ctrl+a>b=text:hello` will write the text "hello" after the users presses `ctrl+a` and then `b`. Some behavioral details (in the documentation, too):

  * Ghostty will wait an indefinite amount of time for valid sequences. If you type `ctrl+a` and you have any children defined, Ghostty will wait _forever_ for an input.
  * Ghostty will flush all inputs once an invalid sequence is given. For example, if you bind `ctrl+a>b` and type `ctrl+a>c`, then Ghostty will encode and send `ctrl+a` followed by `c` to the pty.
  * Ghostty will consume all inputs on valid sequences. If you bind `ctrl+a>b` and trigger it, both `ctrl+a` _and_ `b` are consumed.
  * The previously existing `unconsumed:` feature will apply to the _full sequence_. If you bind `unconsumed:ctrl+a>b` then triggering the sequence will encode and flush both `ctrl+a` and `b`. There is no way today to only unconsumed a partial sequence.
   * If a prefix in a sequence is previously bound, the sequence will override the previous binding. For example, if `ctrl+a` is bound to `new_window` and `ctrl+a>n` is bound to `new_tab`, pressing `ctrl+a` will do nothing.
   * Adding to the above, if a previously bound sequence prefix is used in a new, non-sequence binding, the entire previously bound sequence will be unbound. For example, if you bind `ctrl+a>n` and `ctrl+a>t`, and then bind `ctrl+a` directly, both `ctrl+a>n` and `ctrl+a>t` will become unbound.

## Future Work

* This PR **does not include UI feedback** that a keyboard sequence is present/pending. This creates an awkward and somewhat dangerous user experience today: Ghostty can be waiting for a sequence and it may seem like Ghostty ignored your input. There is no feedback to show this state. I noted this in #1420 and plan to integrate this feature after.
* The `+show-keybinds` CLI action silently ignores key sequences. cc @rockorager 