### PR TITLE
font/coretext: font-thicken renders with additional padding on context

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1174,6 +1174,8 @@ fn setCellSize(self: *Surface, size: renderer.CellSize) !void {
 ///
 /// This can only be called from the main thread.
 pub fn setFontSize(self: *Surface, size: font.face.DesiredSize) !void {
+    log.debug("set font size size={}", .{size.points});
+
     // Update our font size so future changes work
     self.font_size = size;
 


### PR DESCRIPTION
Improves #2122

At certain font sizes, this avoids clipping the text. This is due to a limitation of the CoreText API, which does not provide a way to measure the exact size of the text that will be rendered when antialiasing is enabled. In the comparison before notice the top border of the `o`.

Before:

![CleanShot 2024-08-19 at 20 53 38@2x](https://github.com/user-attachments/assets/3533e993-ca06-4a9f-a63c-2d54c9486901)

After:

![CleanShot 2024-08-19 at 20 52 38@2x](https://github.com/user-attachments/assets/5260fda8-b5eb-4f3d-a489-919a49da3b1f)
