### PR TITLE
cli(list-keybinds): format key sequences

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3430,7 +3430,7 @@ pub const Keybinds = struct {
                 []const u8,
                 std.fmt.bufPrint(
                     &buf,
-                    "{}={}",
+                    "{}{}",
                     .{ k, v },
                 ) catch return error.OutOfMemory,
             );

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -800,11 +800,20 @@ pub const Set = struct {
             _ = opts;
 
             switch (self) {
-                .leader => @panic("TODO"),
+                .leader => |set| {
+                    // the leader key was already printed.
+                    var iter = set.bindings.iterator();
+                    while (iter.next()) |binding| {
+                        try writer.print(
+                            ">{s}{s}",
+                            .{ binding.key_ptr.*, binding.value_ptr.* },
+                        );
+                    }
+                },
 
                 .action, .action_unconsumed => |action| {
                     // action implements the format
-                    try writer.print("{s}", .{action});
+                    try writer.print("={s}", .{action});
                 },
             }
         }


### PR DESCRIPTION
Implement formatting of key sequences in the list-keybinds command when
*not* pretty printing. Pretty printing will come in a separate commit.
The print style for that needs some thought, but in the meantime this
removes the panic cause by redirecting output of the command.
