### PR TITLE
Clean up Kitty color protocol by using a union

### DIFF
--- a/src/terminal/kitty/color.zig
+++ b/src/terminal/kitty/color.zig
@@ -56,12 +56,9 @@ pub const Kind = union(enum) {
         _ = layout;
         _ = opts;
 
-        // Format as a number if its a palette color otherwise
-        // format as a string.
-        if (self == .palette) {
-            try writer.print("{d}", .{self.palette});
-        } else {
-            try writer.print("{s}", .{@tagName(self.special)});
+        switch (self) {
+            .palette => |p| try writer.print("{d}", .{p}),
+            .special => |s| try writer.print("{s}", .{@tagName(s)}),
         }
     }
 };

--- a/src/terminal/kitty/color.zig
+++ b/src/terminal/kitty/color.zig
@@ -36,15 +36,8 @@ pub const Kind = union(enum) {
     special: Special,
 
     pub fn parse(key: []const u8) ?Kind {
-        return kind: {
-            const s = std.meta.stringToEnum(Special, key) orelse {
-                const p = std.fmt.parseUnsigned(u8, key, 10) catch {
-                    break :kind null;
-                };
-                break :kind Kind{ .palette = p };
-            };
-            break :kind Kind{ .special = s };
-        };
+        if (std.meta.stringToEnum(Special, key)) |s| return Kind{ .special = s };
+        return Kind{ .palette = std.fmt.parseUnsigned(u8, key, 10) catch return null };
     }
 
     pub fn format(

--- a/src/terminal/kitty/color.zig
+++ b/src/terminal/kitty/color.zig
@@ -36,8 +36,8 @@ pub const Kind = union(enum) {
     special: Special,
 
     pub fn parse(key: []const u8) ?Kind {
-        if (std.meta.stringToEnum(Special, key)) |s| return Kind{ .special = s };
-        return Kind{ .palette = std.fmt.parseUnsigned(u8, key, 10) catch return null };
+        if (std.meta.stringToEnum(Special, key)) |s| return .{ .special = s };
+        return .{ .palette = std.fmt.parseUnsigned(u8, key, 10) catch return null };
     }
 
     pub fn format(

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1345,25 +1345,20 @@ pub const StreamHandler = struct {
                         self.terminal.color_palette.colors[palette] = v.color;
                         self.terminal.color_palette.mask.unset(palette);
                     },
+
                     .special => |special| {
                         const msg: renderer.Message = switch (special) {
                             .foreground => msg: {
                                 self.foreground_color = v.color;
-                                break :msg .{
-                                    .foreground_color = v.color,
-                                };
+                                break :msg .{ .foreground_color = v.color };
                             },
                             .background => msg: {
                                 self.background_color = v.color;
-                                break :msg .{
-                                    .background_color = v.color,
-                                };
+                                break :msg .{ .background_color = v.color };
                             },
                             .cursor => msg: {
                                 self.cursor_color = v.color;
-                                break :msg .{
-                                    .cursor_color = v.color,
-                                };
+                                break :msg .{ .cursor_color = v.color };
                             },
                             else => {
                                 log.warn(
@@ -1385,25 +1380,20 @@ pub const StreamHandler = struct {
                         self.terminal.color_palette.colors[palette] = self.terminal.default_palette[palette];
                         self.terminal.color_palette.mask.unset(palette);
                     },
+
                     .special => |special| {
                         const msg: renderer.Message = switch (special) {
                             .foreground => msg: {
                                 self.foreground_color = self.default_foreground_color;
-                                break :msg .{
-                                    .foreground_color = self.default_foreground_color,
-                                };
+                                break :msg .{ .foreground_color = self.default_foreground_color };
                             },
                             .background => msg: {
                                 self.background_color = self.default_background_color;
-                                break :msg .{
-                                    .background_color = self.default_background_color,
-                                };
+                                break :msg .{ .background_color = self.default_background_color };
                             },
                             .cursor => msg: {
                                 self.cursor_color = self.default_cursor_color;
-                                break :msg .{
-                                    .cursor_color = self.default_cursor_color,
-                                };
+                                break :msg .{ .cursor_color = self.default_cursor_color };
                             },
                             else => {
                                 log.warn(


### PR DESCRIPTION
Non-exhaustive enums should be avoided, use a union to make the code cleaner and safer.