### PR TITLE
renderer: do not extend padding color if any cell has default bg color

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -2224,9 +2224,15 @@ fn rebuildCells(
 
             // Apply heuristics for padding extension.
             .extend => if (y == 0) {
-                self.uniforms.padding_extend.up = !row.neverExtendBg();
+                self.uniforms.padding_extend.up = !row.neverExtendBg(
+                    color_palette,
+                    self.background_color,
+                );
             } else if (y == self.cells.size.rows - 1) {
-                self.uniforms.padding_extend.down = !row.neverExtendBg();
+                self.uniforms.padding_extend.down = !row.neverExtendBg(
+                    color_palette,
+                    self.background_color,
+                );
             },
         }
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -1296,9 +1296,15 @@ pub fn rebuildCells(
 
             // Apply heuristics for padding extension.
             .extend => if (y == 0) {
-                self.padding_extend_top = !row.neverExtendBg();
+                self.padding_extend_top = !row.neverExtendBg(
+                    color_palette,
+                    self.background_color,
+                );
             } else if (y == self.grid_size.rows - 1) {
-                self.padding_extend_bottom = !row.neverExtendBg();
+                self.padding_extend_bottom = !row.neverExtendBg(
+                    color_palette,
+                    self.background_color,
+                );
             },
         }
 


### PR DESCRIPTION
Before, cells that were explicitly set to match the default bg color were treated as if they did NOT have the default and extending would occur. We now check the exact RGB of each cell. This is already the documented behavior so this should just bring expectations more in line.