### PR TITLE
editorconfig: add swift style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,8 @@ indent_style = space
 [bash-preexec.sh]
 indent_size = 4
 indent_style = space
+
+[*.swift]
+indent_size = 4
+indent_style = space
+trim_trailing_whitespace = true


### PR DESCRIPTION
Xcode 16 introduces support for EditorConfig-based editor settings. Many
other editors also support EditorConfig.

In particular, this enables trailing whitespace trimming for Swift source files.