### PR TITLE
Font Improvements

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -52,10 +52,17 @@ const c = @cImport({
 ///
 /// The specific styles (bold, italic, bold italic) do not need to be
 /// explicitly set. If a style is not set, then the regular style (font-family)
-/// will be searched for stylistic variants. If an italic style is not found,
-/// Ghostty will auto-italicize the regular style by applying a slant. If
-/// a bold style is not found, Ghostty will look for another monospace
-/// font.
+/// will be searched for stylistic variants. If a stylistic variant is not
+/// found, Ghostty will use the regular style. This prevents falling back to a
+/// different font family just to get a style such as bold. This also applies
+/// if you explictly speciy a font family for a style. For example, if you
+/// set `font-family-bold = FooBar` and "FooBar" cannot be found, Ghostty will
+/// use whatever font is set for `font-family` for the bold style.
+///
+/// Finally, some styles may be synthesized if they are not supported.
+/// For example, if a font does not have an italic style and no alternative
+/// italic font is specified, Ghostty will synthesize an italic style by
+/// applying a slant to the regular style.
 ///
 /// You can disable styles completely by using the `font-style` set of
 /// configurations. See the documentation for `font-style` for more information.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -55,7 +55,7 @@ const c = @cImport({
 /// will be searched for stylistic variants. If a stylistic variant is not
 /// found, Ghostty will use the regular style. This prevents falling back to a
 /// different font family just to get a style such as bold. This also applies
-/// if you explictly speciy a font family for a style. For example, if you
+/// if you explicitly specify a font family for a style. For example, if you
 /// set `font-family-bold = FooBar` and "FooBar" cannot be found, Ghostty will
 /// use whatever font is set for `font-family` for the bold style.
 ///

--- a/src/font/CodepointResolver.zig
+++ b/src/font/CodepointResolver.zig
@@ -383,7 +383,7 @@ test getIndex {
     var lib = try Library.init();
     defer lib.deinit();
 
-    var c = try Collection.init(alloc);
+    var c = Collection.init();
     c.load_options = .{ .library = lib };
 
     {
@@ -464,7 +464,7 @@ test "getIndex disabled font style" {
     var lib = try Library.init();
     defer lib.deinit();
 
-    var c = try Collection.init(alloc);
+    var c = Collection.init();
     c.load_options = .{ .library = lib };
 
     _ = try c.add(alloc, .regular, .{ .loaded = try Face.init(
@@ -516,7 +516,7 @@ test "getIndex box glyph" {
     var lib = try Library.init();
     defer lib.deinit();
 
-    const c = try Collection.init(alloc);
+    const c = Collection.init();
 
     var r: CodepointResolver = .{
         .collection = c,

--- a/src/font/Collection.zig
+++ b/src/font/Collection.zig
@@ -282,7 +282,25 @@ pub fn completeStyles(self: *Collection, alloc: Allocator) CompleteError!void {
     const bold_italic_list = self.faces.getPtr(.bold_italic);
     if (bold_italic_list.count() == 0) {
         log.warn("bold italic style not available, using italic font", .{});
-        try bold_italic_list.append(alloc, .{ .alias = italic_list.at(0) });
+
+        // Nested alias isn't allowed so if the italic entry is an
+        // alias then we use the aliased entry.
+        const italic_entry = italic_list.at(0);
+        switch (italic_entry.*) {
+            .alias => |v| try bold_italic_list.append(
+                alloc,
+                .{ .alias = v },
+            ),
+
+            .loaded,
+            .fallback_loaded,
+            .deferred,
+            .fallback_deferred,
+            => try bold_italic_list.append(
+                alloc,
+                .{ .alias = italic_entry },
+            ),
+        }
     }
 }
 

--- a/src/font/Collection.zig
+++ b/src/font/Collection.zig
@@ -346,10 +346,11 @@ pub fn setSize(self: *Collection, size: DesiredSize) !void {
 /// small style count.
 ///
 /// We use a segmented list because the entry values must be pointer-stable
-/// to support the "alias" field in Entry. SegmentedList also lets us do
-/// a prealloc which is great for performance since most happy path cases
-/// do not use many font fallbacks.
-const StyleArray = std.EnumArray(Style, std.SegmentedList(Entry, 4));
+/// to support the "alias" field in Entry.
+///
+/// WARNING: We cannot use any prealloc yet for the segmented list because
+/// the collection is copied around by value and pointers aren't stable.
+const StyleArray = std.EnumArray(Style, std.SegmentedList(Entry, 0));
 
 /// Load options are used to configure all the details a Collection
 /// needs to load deferred faces.

--- a/src/font/SharedGrid.zig
+++ b/src/font/SharedGrid.zig
@@ -325,7 +325,7 @@ const TestMode = enum { normal };
 fn testGrid(mode: TestMode, alloc: Allocator, lib: Library) !SharedGrid {
     const testFont = @import("test.zig").fontRegular;
 
-    var c = try Collection.init(alloc);
+    var c = Collection.init();
     c.load_options = .{ .library = lib };
 
     switch (mode) {

--- a/src/font/SharedGridSet.zig
+++ b/src/font/SharedGridSet.zig
@@ -481,7 +481,7 @@ pub const Key = struct {
                 .style = style,
                 .size = font_size.points,
                 .bold = style == null,
-                .variations = config.@"font-variation".list.items,
+                .variations = config.@"font-variation-bold".list.items,
             });
         }
         for (config.@"font-family-italic".list.items) |family| {
@@ -491,7 +491,7 @@ pub const Key = struct {
                 .style = style,
                 .size = font_size.points,
                 .italic = style == null,
-                .variations = config.@"font-variation".list.items,
+                .variations = config.@"font-variation-italic".list.items,
             });
         }
         for (config.@"font-family-bold-italic".list.items) |family| {
@@ -502,7 +502,7 @@ pub const Key = struct {
                 .size = font_size.points,
                 .bold = style == null,
                 .italic = style == null,
-                .variations = config.@"font-variation".list.items,
+                .variations = config.@"font-variation-bold-italic".list.items,
             });
         }
 

--- a/src/font/SharedGridSet.zig
+++ b/src/font/SharedGridSet.zig
@@ -218,15 +218,6 @@ fn collection(
             load_options.faceOptions(),
         ) },
     );
-    _ = try c.add(
-        self.alloc,
-        .bold,
-        .{ .fallback_loaded = try Face.init(
-            self.font_lib,
-            face_bold_ttf,
-            load_options.faceOptions(),
-        ) },
-    );
 
     // On macOS, always search for and add the Apple Emoji font
     // as our preferred emoji font for fallback. We do this in case
@@ -271,8 +262,9 @@ fn collection(
         );
     }
 
-    // Auto-italicize
-    try c.autoItalicize(self.alloc);
+    // Complete our styles to ensure we have something to satisfy every
+    // possible style request.
+    try c.completeStyles(self.alloc);
 
     return c;
 }

--- a/src/font/SharedGridSet.zig
+++ b/src/font/SharedGridSet.zig
@@ -167,7 +167,7 @@ fn collection(
         .metric_modifiers = key.metric_modifiers,
     };
 
-    var c = try Collection.init(self.alloc);
+    var c = Collection.init();
     errdefer c.deinit(self.alloc);
     c.load_options = load_options;
 

--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -453,22 +453,22 @@ pub const CoreText = struct {
             // here.
 
             if (desc.bold and desc.italic) {
-                const items = collection.faces.get(.bold_italic).items;
-                if (items.len > 0) {
+                const entries = collection.faces.get(.bold_italic);
+                if (entries.count() > 0) {
                     break :original try collection.getFace(.{ .style = .bold_italic });
                 }
             }
 
             if (desc.bold) {
-                const items = collection.faces.get(.bold).items;
-                if (items.len > 0) {
+                const entries = collection.faces.get(.bold);
+                if (entries.count() > 0) {
                     break :original try collection.getFace(.{ .style = .bold });
                 }
             }
 
             if (desc.italic) {
-                const items = collection.faces.get(.italic).items;
-                if (items.len > 0) {
+                const entries = collection.faces.get(.italic);
+                if (entries.count() > 0) {
                     break :original try collection.getFace(.{ .style = .italic });
                 }
             }

--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -1746,7 +1746,7 @@ fn testShaperWithFont(alloc: Allocator, font_req: TestFont) !TestShaper {
     var lib = try Library.init();
     errdefer lib.deinit();
 
-    var c = try Collection.init(alloc);
+    var c = Collection.init();
     c.load_options = .{ .library = lib };
 
     // Setup group

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -1207,7 +1207,7 @@ fn testShaperWithFont(alloc: Allocator, font_req: TestFont) !TestShaper {
     var lib = try Library.init();
     errdefer lib.deinit();
 
-    var c = try Collection.init(alloc);
+    var c = Collection.init();
     c.load_options = .{ .library = lib };
 
     // Setup group


### PR DESCRIPTION
Fixes #2141
Improves #2140 

Multiple fixes or improvements:

* If a style isn't found for a defined font family, we fallback to the regular face instead of looking for a fallback family that supports the style. This is less jarring. (#2141)

* If bold italic isn't supported, we fallback to italic first if it's available. If italic isn't available, we fallback to the regular font style.

* If a font variation setting is set (`font-variation-*`) and the defined font style is not found, then we retry searching for the font family without the style bits set. This addresses fonts that don't set that they support certain styles. (#2140)

* Non-regular font variations are now respected. This was a typo where we were only applying the regular font variation (`font-variation`) and ignoring styled variations (`font-variation-bold`). No reported bug for this. 
