### PR TITLE
font: coretext_freetype backend supports font variations

### DIFF
--- a/pkg/macos/foundation/number.zig
+++ b/pkg/macos/foundation/number.zig
@@ -15,7 +15,7 @@ pub const Number = opaque {
         )))) orelse Allocator.Error.OutOfMemory;
     }
 
-    pub fn getValue(self: *Number, comptime t: NumberType, ptr: *t.ValueType()) bool {
+    pub fn getValue(self: *const Number, comptime t: NumberType, ptr: *t.ValueType()) bool {
         return c.CFNumberGetValue(
             @ptrCast(self),
             @intFromEnum(t),

--- a/pkg/macos/text/font.zig
+++ b/pkg/macos/text/font.zig
@@ -145,7 +145,7 @@ pub const Font = opaque {
         );
     }
 
-    pub fn copyAttribute(self: *Font, comptime attr: text.FontAttribute) attr.Value() {
+    pub fn copyAttribute(self: *Font, comptime attr: text.FontAttribute) ?attr.Value() {
         return @ptrFromInt(@intFromPtr(c.CTFontCopyAttribute(
             @ptrCast(self),
             @ptrCast(attr.key()),

--- a/pkg/macos/text/font_descriptor.zig
+++ b/pkg/macos/text/font_descriptor.zig
@@ -54,7 +54,7 @@ pub const FontDescriptor = opaque {
         c.CFRelease(self);
     }
 
-    pub fn copyAttribute(self: *const FontDescriptor, comptime attr: FontAttribute) attr.Value() {
+    pub fn copyAttribute(self: *const FontDescriptor, comptime attr: FontAttribute) ?attr.Value() {
         return @ptrFromInt(@intFromPtr(c.CTFontDescriptorCopyAttribute(
             @ptrCast(self),
             @ptrCast(attr.key()),
@@ -153,7 +153,7 @@ pub const FontAttribute = enum {
             .enabled => *foundation.Number,
             .downloadable => *anyopaque, // CFBoolean
             .downloaded => *anyopaque, // CFBoolean
-            .variation_axes => ?*foundation.Array,
+            .variation_axes => *foundation.Array,
         };
     }
 };

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1981,7 +1981,8 @@ pub const CAPI = struct {
             // at 1x but callers of this should be using scaled or apply
             // scale themselves.
             const size: f32 = size: {
-                const num = face.font.copyAttribute(.size);
+                const num = face.font.copyAttribute(.size) orelse
+                    break :size 12;
                 defer num.release();
                 var v: f32 = 12;
                 _ = num.getValue(.float, &v);

--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -613,7 +613,7 @@ pub const CoreText = struct {
         // Get our symbolic traits for the descriptor so we can compare
         // boolean attributes like bold, monospace, etc.
         const symbolic_traits: macos.text.FontSymbolicTraits = traits: {
-            const traits = ct_desc.copyAttribute(.traits);
+            const traits = ct_desc.copyAttribute(.traits) orelse break :traits .{};
             defer traits.release();
 
             const key = macos.text.FontTraitKey.symbolic.key();
@@ -626,7 +626,8 @@ pub const CoreText = struct {
         score_acc.monospace = symbolic_traits.monospace;
 
         score_acc.style = style: {
-            const style = ct_desc.copyAttribute(.style_name);
+            const style = ct_desc.copyAttribute(.style_name) orelse
+                break :style .unmatched;
             defer style.release();
 
             // If we have a specific desired style, attempt to search for that.


### PR DESCRIPTION
This backend is only used for dev so this shouldn't affect anyone in release.

This does contain an important fix where font attributes can be null so that should make release builds safer but I don't know any cases where in practice this returned null in our usage.