### PR TITLE
Add space to `commentstring` in Vim plugin

### DIFF
--- a/src/config/vim.zig
+++ b/src/config/vim.zig
@@ -16,7 +16,7 @@ pub const ftplugin =
     \\endif
     \\let b:did_ftplugin = 1
     \\
-    \\setlocal commentstring=#%s
+    \\setlocal commentstring=#\ %s
     \\setlocal iskeyword+=-
     \\
     \\" Use syntax keywords for completion


### PR DESCRIPTION
See https://github.com/vim/vim/pull/14843 and https://github.com/neovim/neovim/commit/2f5b8a009280eba995aecf67d1e8d99b7c72c51c. Neovim now has built-in commenting but doesn't add spaces so this means the plugin can be used without overriding the commentstring if you're not using a commenting plugin.