### PR TITLE
config: font-synthetic-style to enable/disable synthetic styles

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -14,6 +14,7 @@ pub const formatEntry = formatter.formatEntry;
 pub const ClipboardAccess = Config.ClipboardAccess;
 pub const CopyOnSelect = Config.CopyOnSelect;
 pub const CustomShaderAnimation = Config.CustomShaderAnimation;
+pub const FontSyntheticStyle = Config.FontSyntheticStyle;
 pub const FontStyle = Config.FontStyle;
 pub const Keybinds = Config.Keybinds;
 pub const MouseShiftCapture = Config.MouseShiftCapture;

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -107,6 +107,38 @@ const c = @cImport({
 @"font-style-italic": FontStyle = .{ .default = {} },
 @"font-style-bold-italic": FontStyle = .{ .default = {} },
 
+/// Control whether Ghostty should synthesize a style if the requested style is
+/// not available in the specified font-family.
+///
+/// Ghostty can synthesize bold, italic, and bold italic styles if the font
+/// does not have a specific style. For bold, this is done by drawing an
+/// outline around the glyph of varying thickness. For italic, this is done by
+/// applying a slant to the glyph. For bold italic, both of these are applied.
+///
+/// Synthetic styles are not perfect and will generally not look as good
+/// as a font that has the style natively. However, they are useful to
+/// provide styled text when the font does not have the style.
+///
+/// Set this to "false" or "true" to disable or enable synthetic styles
+/// completely. You can disable specific styles using "no-bold", "no-italic",
+/// and "no-bold-italic". You can disable multiple styles by separating them
+/// with a comma. For example, "no-bold,no-italic".
+///
+/// Available style keys are: `bold`, `italic`, `bold-italic`.
+///
+/// If synthetic styles are disabled, then the regular style will be used
+/// instead if the requested style is not available. If the font has the
+/// requested style, then the font will be used as-is since the style is
+/// not synthetic.
+///
+/// Warning! An easy mistake is to disable `bold` or `italic` but not
+/// `bold-italic`. Disabling only `bold` or `italic` will NOT disable either
+/// in the `bold-italic` style. If you want to disable `bold-italic`, you must
+/// explicitly disable it. You cannot partially disable `bold-italic`.
+///
+/// By default, synthetic styles are enabled.
+@"font-synthetic-style": FontSyntheticStyle = .{},
+
 /// Apply a font feature. This can be repeated multiple times to enable multiple
 /// font features. You can NOT set multiple font features with a single value
 /// (yet).
@@ -3880,6 +3912,13 @@ pub const FontStyle = union(enum) {
         try p.formatEntry(formatterpkg.entryFormatter("a", buf.writer()));
         try std.testing.expectEqualSlices(u8, "a = bold\n", buf.items);
     }
+};
+
+/// See `font-synthetic-style` for documentation.
+pub const FontSyntheticStyle = packed struct {
+    bold: bool = true,
+    italic: bool = true,
+    @"bold-italic": bool = true,
 };
 
 /// See "link" for documentation.

--- a/src/font/SharedGridSet.zig
+++ b/src/font/SharedGridSet.zig
@@ -128,7 +128,7 @@ pub fn ref(
         // Build our collection. This is the expensive operation that
         // involves finding fonts, loading them (maybe, some are deferred),
         // etc.
-        var c = try self.collection(&key, font_size);
+        var c = try self.collection(&key, font_size, config);
         errdefer c.deinit(self.alloc);
 
         // Setup our enabled/disabled styles
@@ -156,6 +156,7 @@ fn collection(
     self: *SharedGridSet,
     key: *const Key,
     size: DesiredSize,
+    config: *const DerivedConfig,
 ) !Collection {
     // A quick note on memory management:
     // - font_lib is owned by the SharedGridSet
@@ -300,7 +301,7 @@ fn collection(
 
     // Complete our styles to ensure we have something to satisfy every
     // possible style request.
-    try c.completeStyles(self.alloc);
+    try c.completeStyles(self.alloc, config.@"font-synthetic-style");
 
     return c;
 }
@@ -386,6 +387,7 @@ pub const DerivedConfig = struct {
     @"font-variation-italic": configpkg.RepeatableFontVariation,
     @"font-variation-bold-italic": configpkg.RepeatableFontVariation,
     @"font-codepoint-map": configpkg.RepeatableCodepointMap,
+    @"font-synthetic-style": configpkg.FontSyntheticStyle,
     @"adjust-cell-width": ?Metrics.Modifier,
     @"adjust-cell-height": ?Metrics.Modifier,
     @"adjust-font-baseline": ?Metrics.Modifier,
@@ -416,6 +418,7 @@ pub const DerivedConfig = struct {
             .@"font-variation-italic" = try config.@"font-variation-italic".clone(alloc),
             .@"font-variation-bold-italic" = try config.@"font-variation-bold-italic".clone(alloc),
             .@"font-codepoint-map" = try config.@"font-codepoint-map".clone(alloc),
+            .@"font-synthetic-style" = config.@"font-synthetic-style",
             .@"adjust-cell-width" = config.@"adjust-cell-width",
             .@"adjust-cell-height" = config.@"adjust-cell-height",
             .@"adjust-font-baseline" = config.@"adjust-font-baseline",


### PR DESCRIPTION
This adds a new configuration "font-synthetic-style" to enable or disable synthetic styles. This is different from "font-style-*" which specifies a named style or disables a style completely.

Instead, "font-synthetic-style" will disable only the creation of synthetic styles in the case a font does not support a given style. This is useful for users who want to obviously know when a font doesn't support a given style or a user who wants to explicitly only use the styles that were designed by the font designer.

The default value is to enable all synthetic styles.