### PR TITLE
Various fixes for hyperlink instability

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -891,6 +891,14 @@ pub fn updateFrame(
 
     // Update all our data as tightly as possible within the mutex.
     var critical: Critical = critical: {
+        // const start = try std.time.Instant.now();
+        // const start_micro = std.time.microTimestamp();
+        // defer {
+        //     const end = std.time.Instant.now() catch unreachable;
+        //     // "[updateFrame critical time] <START us>\t<TIME_TAKEN us>"
+        //     std.log.err("[updateFrame critical time] {}\t{}", .{start_micro, end.since(start) / std.time.ns_per_us});
+        // }
+
         state.mutex.lock();
         defer state.mutex.unlock();
 

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1755,7 +1755,8 @@ pub fn cursorSetHyperlink(self: *Screen) !void {
         self.cursor.page_cell,
         self.cursor.hyperlink_id,
     )) {
-        // Success!
+        // Success, increase the refcount for the hyperlink.
+        page.hyperlink_set.use(page.memory, self.cursor.hyperlink_id);
         return;
     } else |err| switch (err) {
         // hyperlink_map is out of space, realloc the page to be larger

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1198,12 +1198,12 @@ pub fn reverseIndex(self: *Terminal) void {
     self.scrollDown(1);
 }
 
-// Set Cursor Position. Move cursor to the position indicated
-// by row and column (1-indexed). If column is 0, it is adjusted to 1.
-// If column is greater than the right-most column it is adjusted to
-// the right-most column. If row is 0, it is adjusted to 1. If row is
-// greater than the bottom-most row it is adjusted to the bottom-most
-// row.
+/// Set Cursor Position. Move cursor to the position indicated
+/// by row and column (1-indexed). If column is 0, it is adjusted to 1.
+/// If column is greater than the right-most column it is adjusted to
+/// the right-most column. If row is 0, it is adjusted to 1. If row is
+/// greater than the bottom-most row it is adjusted to the bottom-most
+/// row.
 pub fn setCursorPos(self: *Terminal, row_req: usize, col_req: usize) void {
     // If cursor origin mode is set the cursor row will be moved relative to
     // the top margin row and adjusted to be above or at bottom-most row in

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -2472,13 +2472,13 @@ pub fn alternateScreen(
     // Mark our terminal as dirty
     self.flags.dirty.clear = true;
 
+    // We always end hyperlink state
+    self.screen.endHyperlink();
+
     // Bring our pen with us
     self.screen.cursorCopy(old.cursor) catch |err| {
         log.warn("cursor copy failed entering alt screen err={}", .{err});
     };
-
-    // We always end hyperlink state
-    self.screen.endHyperlink();
 
     if (options.clear_on_enter) {
         self.eraseDisplay(.complete, false);

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -2472,11 +2472,10 @@ pub fn alternateScreen(
     // Mark our terminal as dirty
     self.flags.dirty.clear = true;
 
-    // We always end hyperlink state
-    self.screen.endHyperlink();
-
     // Bring our pen with us
-    self.screen.cursorCopy(old.cursor) catch |err| {
+    self.screen.cursorCopy(old.cursor, .{
+        .hyperlink = false,
+    }) catch |err| {
         log.warn("cursor copy failed entering alt screen err={}", .{err});
     };
 

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -745,15 +745,17 @@ pub const Page = struct {
                 if (src_cell.hyperlink) hyperlink: {
                     dst_row.hyperlink = true;
 
-                    // Fast-path: same page we can move it directly
+                    const id = other.lookupHyperlink(src_cell).?;
+
+                    // Fast-path: same page we can add with the same id.
                     if (other == self) {
-                        self.moveHyperlink(src_cell, dst_cell);
+                        self.hyperlink_set.use(self.memory, id);
+                        try self.setHyperlink(dst_row, dst_cell, id);
                         break :hyperlink;
                     }
 
                     // Slow-path: get the hyperlink from the other page,
                     // add it, and migrate.
-                    const id = other.lookupHyperlink(src_cell).?;
 
                     const dst_link = dst_link: {
                         // Fast path is we just dupe the hyperlink because

--- a/src/terminal/size.zig
+++ b/src/terminal/size.zig
@@ -26,8 +26,8 @@ pub fn Offset(comptime T: type) type {
 
         /// A slice of type T that stores via a base offset and len.
         pub const Slice = struct {
-            offset: Self,
-            len: usize,
+            offset: Self = .{},
+            len: usize = 0,
         };
 
         /// Returns a pointer to the start of the data, properly typed.


### PR DESCRIPTION
A handful of fixes mostly relating to managed memory handling, significantly improves stability of resizing with OSC8 links on screen.

- **Fix** double-counting in hyperlink set ***[No unit tests added]***
- **Fix** `clonePartialRowFrom` affecting the source row if it's on the same page, by *moving* hyperlink data, resulting in an invalid state due to cells marked as hyperlinks that have had their data moved elsewhere. This could be hit during scroll operations on the alt screen or with a scroll margin since `insertLines` and `deleteLines` use `clonePartialRowFrom` with the src and dst on the same page. ***[No unit tests added]***
- **Fix** reflow trying to clone non-existent managed memory in `moveLastRowToNewPage` by resetting managed memory markers before attempting any clones that may result in the row being moved. ***[No unit tests added]***
- **Fix** handling of hyperlinks in `cursorCopy` (which is, as of now, only used to transfer the cursor to and from the alt screen). Previously it would cause a crash if you switched to the alt screen while an OSC8 link was active on the cursor. ***[Unit tests added!]***
- **Refactor** `PageList.clone` to avoid a lot of excess work (which may have also had edge case logic errors somewhere in it, since this does seem to improve stability compared to not having it), making it a lot more straightforward, and actually improving screen clone times for the renderer by a significant margin. ***[No additional unit tests needed]*** *(unless you can figure out what exactly the edge cases it was getting wrong were... that seems like a lot of work though.)*