### PR TITLE
Inspector: change color picker to use hex values

### DIFF
--- a/src/inspector/cell.zig
+++ b/src/inspector/cell.zig
@@ -140,7 +140,8 @@ pub const Cell = struct {
                 _ = cimgui.c.igColorEdit3(
                     "color_fg",
                     &color,
-                    cimgui.c.ImGuiColorEditFlags_NoPicker |
+                    cimgui.c.ImGuiColorEditFlags_DisplayHex |
+                        cimgui.c.ImGuiColorEditFlags_NoPicker |
                         cimgui.c.ImGuiColorEditFlags_NoLabel,
                 );
             },
@@ -154,7 +155,8 @@ pub const Cell = struct {
                 _ = cimgui.c.igColorEdit3(
                     "color_fg",
                     &color,
-                    cimgui.c.ImGuiColorEditFlags_NoPicker |
+                    cimgui.c.ImGuiColorEditFlags_DisplayHex |
+                        cimgui.c.ImGuiColorEditFlags_NoPicker |
                         cimgui.c.ImGuiColorEditFlags_NoLabel,
                 );
             },
@@ -177,7 +179,8 @@ pub const Cell = struct {
                 _ = cimgui.c.igColorEdit3(
                     "color_bg",
                     &color,
-                    cimgui.c.ImGuiColorEditFlags_NoPicker |
+                    cimgui.c.ImGuiColorEditFlags_DisplayHex |
+                        cimgui.c.ImGuiColorEditFlags_NoPicker |
                         cimgui.c.ImGuiColorEditFlags_NoLabel,
                 );
             },
@@ -191,7 +194,8 @@ pub const Cell = struct {
                 _ = cimgui.c.igColorEdit3(
                     "color_bg",
                     &color,
-                    cimgui.c.ImGuiColorEditFlags_NoPicker |
+                    cimgui.c.ImGuiColorEditFlags_DisplayHex |
+                        cimgui.c.ImGuiColorEditFlags_NoPicker |
                         cimgui.c.ImGuiColorEditFlags_NoLabel,
                 );
             },

--- a/src/inspector/cursor.zig
+++ b/src/inspector/cursor.zig
@@ -61,7 +61,8 @@ pub fn renderInTable(
             _ = cimgui.c.igColorEdit3(
                 "color_fg",
                 &color,
-                cimgui.c.ImGuiColorEditFlags_NoPicker |
+                cimgui.c.ImGuiColorEditFlags_DisplayHex |
+                    cimgui.c.ImGuiColorEditFlags_NoPicker |
                     cimgui.c.ImGuiColorEditFlags_NoLabel,
             );
         },
@@ -75,7 +76,8 @@ pub fn renderInTable(
             _ = cimgui.c.igColorEdit3(
                 "color_fg",
                 &color,
-                cimgui.c.ImGuiColorEditFlags_NoPicker |
+                cimgui.c.ImGuiColorEditFlags_DisplayHex |
+                    cimgui.c.ImGuiColorEditFlags_NoPicker |
                     cimgui.c.ImGuiColorEditFlags_NoLabel,
             );
         },
@@ -98,7 +100,8 @@ pub fn renderInTable(
             _ = cimgui.c.igColorEdit3(
                 "color_bg",
                 &color,
-                cimgui.c.ImGuiColorEditFlags_NoPicker |
+                cimgui.c.ImGuiColorEditFlags_DisplayHex |
+                    cimgui.c.ImGuiColorEditFlags_NoPicker |
                     cimgui.c.ImGuiColorEditFlags_NoLabel,
             );
         },
@@ -112,7 +115,8 @@ pub fn renderInTable(
             _ = cimgui.c.igColorEdit3(
                 "color_bg",
                 &color,
-                cimgui.c.ImGuiColorEditFlags_NoPicker |
+                cimgui.c.ImGuiColorEditFlags_DisplayHex |
+                    cimgui.c.ImGuiColorEditFlags_NoPicker |
                     cimgui.c.ImGuiColorEditFlags_NoLabel,
             );
         },


### PR DESCRIPTION
Hereby proposing a minor change to the inspector's color format as a PR.

The inspector currently show colors as decimal r,g,b values. With this change, the hex format is used instead.

The motivation for this is that references to color typically use the hex format. One example is the palette definitions in a color scheme. Using the inspector/cell picker to help create and debug color themes should be more convenient after this change.

If there's a usecase for the decimal format, we could add a config option or maybe a switch in the inspector UI.

After the change:

![image](https://github.com/user-attachments/assets/3617749a-0603-4596-991a-1b83479c7f4f)