### PR TITLE
regex: avoid escape characters by using a multiline string

### DIFF
--- a/src/config/url.zig
+++ b/src/config/url.zig
@@ -22,8 +22,13 @@ const oni = @import("oniguruma");
 ///
 /// There are many complicated cases where these heuristics break down, but
 /// handling them well requires a non-regex approach.
-pub const regex = "(?:" ++ url_scheme ++ ")(?:[\\w\\-.~:/?#\\[\\]@!$&*+,;=%]+(?:\\(\\w*\\))?)+(?<!\\.)";
-const url_scheme = "https?://|mailto:|ftp://|file:|ssh:|git://|ssh://|tel:|magnet:|ipfs://|ipns://|gemini://|gopher://|news:";
+pub const regex =
+    "(?:" ++ url_schemes ++
+    \\)(?:[\w\-.~:/?#\[\]@!$&*+,;=%]+(?:\(\w*\))?)+(?<!\.)
+;
+const url_schemes =
+    \\https?://|mailto:|ftp://|file:|ssh:|git://|ssh://|tel:|magnet:|ipfs://|ipns://|gemini://|gopher://|news:
+;
 
 test "url regex" {
     const testing = std.testing;


### PR DESCRIPTION
I'm using a multiline string to avoid escape characters in the regex string - thus making it a bit more readable.

We combine this with a regular string for the `url_scheme`.

Thanks @qwerasd205 for explaining you could combine these.