### PR TITLE
GTK: Fix clicking on desktop notifications

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -178,15 +178,6 @@ pub fn focusedSurface(self: *const App) ?*Surface {
     return surface;
 }
 
-/// Is this the last focused surface. This is only valid while on the main
-/// thread before tick is called.
-pub fn isFocused(self: *const App, surface: *const Surface) bool {
-    if (!self.hasSurface(surface)) return false;
-    const focused = self.focused_surface orelse return false;
-    if (!self.hasSurface(focused)) return false;
-    return surface == focused;
-}
-
 /// Returns true if confirmation is needed to quit the app. It is up to
 /// the apprt to call this.
 pub fn needsConfirmQuit(self: *const App) bool {

--- a/src/App.zig
+++ b/src/App.zig
@@ -178,6 +178,15 @@ pub fn focusedSurface(self: *const App) ?*Surface {
     return surface;
 }
 
+/// Is this the last focused surface. This is only valid while on the main
+/// thread before tick is called.
+pub fn isFocused(self: *const App, surface: *const Surface) bool {
+    if (!self.hasSurface(surface)) return false;
+    const focused = self.focused_surface orelse return false;
+    if (!self.hasSurface(focused)) return false;
+    return surface == focused;
+}
+
 /// Returns true if confirmation is needed to quit the app. It is up to
 /// the apprt to call this.
 pub fn needsConfirmQuit(self: *const App) bool {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -816,6 +816,8 @@ pub fn handleMessage(self: *Surface, msg: Message) !void {
         .renderer_health => |health| self.updateRendererHealth(health),
 
         .report_color_scheme => try self.reportColorScheme(),
+
+        .present_surface => try self.presentSurface(),
     }
 }
 
@@ -4156,6 +4158,14 @@ fn crashThreadState(self: *Surface) crash.sentry.ThreadState {
         .type = .main,
         .surface = self,
     };
+}
+
+/// Tell the surface to present itself to the user. This may involve raising the
+/// window and switching tabs.
+fn presentSurface(self: *Surface) !void {
+    if (@hasDecl(apprt.Surface, "presentSurface")) {
+        self.rt_surface.presentSurface();
+    } else log.warn("runtime doesn't support presentSurface", .{});
 }
 
 pub const face_ttf = @embedFile("font/res/JetBrainsMono-Regular.ttf");

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -382,8 +382,8 @@ fn updateConfigErrors(self: *App) !void {
 
 fn syncActionAccelerators(self: *App) !void {
     try self.syncActionAccelerator("app.quit", .{ .quit = {} });
-    try self.syncActionAccelerator("app.open_config", .{ .open_config = {} });
-    try self.syncActionAccelerator("app.reload_config", .{ .reload_config = {} });
+    try self.syncActionAccelerator("app.open-config", .{ .open_config = {} });
+    try self.syncActionAccelerator("app.reload-config", .{ .reload_config = {} });
     try self.syncActionAccelerator("win.toggle_inspector", .{ .inspector = .toggle });
     try self.syncActionAccelerator("win.close", .{ .close_surface = {} });
     try self.syncActionAccelerator("win.new_window", .{ .new_window = {} });
@@ -870,8 +870,8 @@ fn initActions(self: *App) void {
     // https://docs.gtk.org/gio/type_func.Action.name_is_valid.html
     const actions = .{
         .{ "quit", &gtkActionQuit, null },
-        .{ "open_config", &gtkActionOpenConfig, null },
-        .{ "reload_config", &gtkActionReloadConfig, null },
+        .{ "open-config", &gtkActionOpenConfig, null },
+        .{ "reload-config", &gtkActionReloadConfig, null },
         .{ "present-surface", &gtkActionPresentSurface, c.G_VARIANT_TYPE("t") },
     };
 
@@ -912,8 +912,8 @@ fn initMenu(self: *App) void {
         defer c.g_object_unref(section);
         c.g_menu_append_section(menu, null, @ptrCast(@alignCast(section)));
         c.g_menu_append(section, "Terminal Inspector", "win.toggle_inspector");
-        c.g_menu_append(section, "Open Configuration", "app.open_config");
-        c.g_menu_append(section, "Reload Configuration", "app.reload_config");
+        c.g_menu_append(section, "Open Configuration", "app.open-config");
+        c.g_menu_append(section, "Reload Configuration", "app.reload-config");
         c.g_menu_append(section, "About Ghostty", "win.about");
     }
 

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -861,11 +861,17 @@ fn gtkActionPresentSurface(
 /// This is called to setup the action map that this application supports.
 /// This should be called only once on startup.
 fn initActions(self: *App) void {
+    // The set of actions. Each action has (in order):
+    // [0] The action name
+    // [1] The callback function
+    // [2] The GVariantType of the parameter
+    //
+    // For action names:
+    // https://docs.gtk.org/gio/type_func.Action.name_is_valid.html
     const actions = .{
         .{ "quit", &gtkActionQuit, null },
         .{ "open_config", &gtkActionOpenConfig, null },
         .{ "reload_config", &gtkActionReloadConfig, null },
-        // https://docs.gtk.org/gio/type_func.Action.name_is_valid.html
         .{ "present-surface", &gtkActionPresentSurface, c.G_VARIANT_TYPE("t") },
     };
 

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1146,12 +1146,10 @@ pub fn showDesktopNotification(
 
     const notification = c.g_notification_new(t.ptr);
     defer c.g_object_unref(notification);
-
     c.g_notification_set_body(notification, body.ptr);
 
     const icon = c.g_themed_icon_new("com.mitchellh.ghostty");
     defer c.g_object_unref(icon);
-
     c.g_notification_set_icon(notification, icon);
 
     const pointer = c.g_variant_new_uint64(@intFromPtr(&self.core_surface));

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1144,19 +1144,28 @@ pub fn showDesktopNotification(
         else => title,
     };
 
-    const notif = c.g_notification_new(t.ptr);
-    defer c.g_object_unref(notif);
-    c.g_notification_set_body(notif, body.ptr);
+    const notification = c.g_notification_new(t.ptr);
+    defer c.g_object_unref(notification);
+
+    c.g_notification_set_body(notification, body.ptr);
 
     const icon = c.g_themed_icon_new("com.mitchellh.ghostty");
     defer c.g_object_unref(icon);
-    c.g_notification_set_icon(notif, icon);
+
+    c.g_notification_set_icon(notification, icon);
+
+    const pointer = c.g_variant_new_uint64(@intFromPtr(&self.core_surface));
+    c.g_notification_set_default_action_and_target_value(
+        notification,
+        "app.present-surface",
+        pointer,
+    );
 
     const g_app: *c.GApplication = @ptrCast(self.app.app);
 
     // We set the notification ID to the body content. If the content is the
     // same, this notification may replace a previous notification
-    c.g_application_send_notification(g_app, body.ptr, notif);
+    c.g_application_send_notification(g_app, body.ptr, notification);
 }
 
 fn showContextMenu(self: *Surface, x: f32, y: f32) void {
@@ -1966,4 +1975,15 @@ fn translateMods(state: c.GdkModifierType) input.Mods {
     // Lock is dependent on the X settings but we just assume caps lock.
     if (state & c.GDK_LOCK_MASK != 0) mods.caps_lock = true;
     return mods;
+}
+
+pub fn presentSurface(self: *Surface) void {
+    if (self.container.window()) |window| {
+        if (self.container.tab()) |tab| {
+            if (window.notebook.getTabPosition(tab)) |position|
+                window.notebook.gotoNthTab(position);
+        }
+        c.gtk_window_present(window.window);
+    }
+    self.grabFocus();
 }

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -61,6 +61,10 @@ pub const Message = union(enum) {
     /// Report the color scheme
     report_color_scheme: void,
 
+    /// Tell the surface to present itself to the user. This may require raising
+    /// a window and switching tabs.
+    present_surface: void,
+
     pub const ReportTitleStyle = enum {
         csi_21_t,
 


### PR DESCRIPTION
Currently, clicking on a desktop notification will bring Ghostty to the foreground, but it won't necessarily bring the right window to the top and it won't switch tabs or change the focus on splits.

With this patch, clicking on a desktop notification will raise the correct window, change to the correct tab, and focus on the correct split that send the original desktop notification.