### PR TITLE
Fix `insertLines` and `deleteLines`

### DIFF
--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -433,7 +433,7 @@ pub fn clonePool(
 /// Adjust the capacity of a page within the pagelist of this screen.
 /// This handles some accounting if the page being modified is the
 /// cursor page.
-fn adjustCapacity(
+pub fn adjustCapacity(
     self: *Screen,
     page: *PageList.List.Node,
     adjustment: PageList.AdjustCapacity,
@@ -1792,7 +1792,7 @@ pub fn cursorSetHyperlink(self: *Screen) !void {
         return;
     } else |err| switch (err) {
         // hyperlink_map is out of space, realloc the page to be larger
-        error.OutOfMemory => {
+        error.HyperlinkMapOutOfMemory => {
             _ = try self.adjustCapacity(
                 self.cursor.page_pin.page,
                 .{ .hyperlink_bytes = page.capacity.hyperlink_bytes * 2 },

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -437,7 +437,7 @@ pub fn adjustCapacity(
     self: *Screen,
     page: *PageList.List.Node,
     adjustment: PageList.AdjustCapacity,
-) !*PageList.List.Node {
+) PageList.AdjustCapacityError!*PageList.List.Node {
     // If the page being modified isn't our cursor page then
     // this is a quick operation because we have no additional
     // accounting.

--- a/src/terminal/ref_counted_set.zig
+++ b/src/terminal/ref_counted_set.zig
@@ -227,7 +227,7 @@ pub fn RefCountedSet(
             }
 
             // If the item already exists, return it.
-            if (self.lookup(base, value, ctx)) |id| {
+            if (self.lookupContext(base, value, ctx)) |id| {
                 // Notify the context that the value is "deleted" because
                 // we're reusing the existing value in the set. This allows
                 // callers to clean up any resources associated with the value.
@@ -453,7 +453,10 @@ pub fn RefCountedSet(
 
         /// Find an item in the table and return its ID.
         /// If the item does not exist in the table, null is returned.
-        fn lookup(self: *Self, base: anytype, value: T, ctx: Context) ?Id {
+        pub fn lookup(self: *const Self, base: anytype, value: T) ?Id {
+            return self.lookupContext(base, value, self.context);
+        }
+        pub fn lookupContext(self: *const Self, base: anytype, value: T, ctx: Context) ?Id {
             const table = self.table.ptr(base);
             const items = self.items.ptr(base);
 
@@ -504,7 +507,7 @@ pub fn RefCountedSet(
         /// is ignored and the existing item's ID is returned.
         fn upsert(self: *Self, base: anytype, value: T, new_id: Id, ctx: Context) Id {
             // If the item already exists, return it.
-            if (self.lookup(base, value, ctx)) |id| {
+            if (self.lookupContext(base, value, ctx)) |id| {
                 // Notify the context that the value is "deleted" because
                 // we're reusing the existing value in the set. This allows
                 // callers to clean up any resources associated with the value.
@@ -519,7 +522,7 @@ pub fn RefCountedSet(
         /// Insert the given value into the hash table with the given ID.
         /// asserts that the value is not already present in the table.
         fn insert(self: *Self, base: anytype, value: T, new_id: Id, ctx: Context) Id {
-            assert(self.lookup(base, value, ctx) == null);
+            assert(self.lookupContext(base, value, ctx) == null);
 
             const table = self.table.ptr(base);
             const items = self.items.ptr(base);


### PR DESCRIPTION
Changes `insertLines` and `deleteLines` to handle adjusting page capacity when it's exceeded while moving rows. This can happen when scrolling lines with managed memory in to a different page which is already full of the given type of memory (most crashes that hit this seem to occur with hyperlinks, but it's theoretically possible with graphemes as well, and possibly even styles).

Benchmarks seem to show no performance degradation from the rewrite.

`insertLines` and `deleteLines` share like 99% of their functionality, and *really* should be abstracted to a shared function, probably on `Screen` not `Terminal`. I've left a `TODO` for this.

In order to do this I had to discriminate the source of the error from `clonePartialRowFrom`, and while doing that I did also fix a couple small bugs which were based on the assumption that it would only ever be used when cloning to a new, empty page with sufficient capacity.

**I didn't make any unit tests to cover the improved functionality**, but here's a list of tests that could/should be added:
- All `clonePartialRowFrom` errors should be tested, and it should be made sure they leave the page in a valid state.
- `insertLines` and `deleteLines` which move managed memory of all types across page boundaries in to a page whose managed memory for that type is full, requiring a capacity adjustment.

**Future work**:
- Unify `insertLines` and `deleteLines` functionality in single method on `Screen`.
- Create `movePartialRowFrom` function where the src row is allowed to be modified, which allows for fast paths that can reassigned managed memory within the same page; and use this instead of `clonePartialRowFrom` in the `insertLines` / `deleteLines` logic.
- Create an optimized fast path for `Screen.clone` that doesn't use `cloneFrom`, since there are assumptions that can be made (new pages with exact capacity) and optimizations (straight `memcpy`ing rows and managed memory sections) which should make it much faster.