### PR TITLE
make +version hyperlink to the github commit

### DIFF
--- a/src/cli/version.zig
+++ b/src/cli/version.zig
@@ -10,7 +10,17 @@ pub fn run(alloc: Allocator) !u8 {
     _ = alloc;
 
     const stdout = std.io.getStdOut().writer();
+    const tty = std.io.getStdOut().isTty();
+
+    if (tty) if (build_config.version.build) |commit_hash| {
+        try stdout.print(
+            "\x1b]8;;https://github.com/ghostty-org/ghostty/commit/{s}\x1b\\",
+            .{commit_hash},
+        );
+    };
     try stdout.print("Ghostty {s}\n\n", .{build_config.version_string});
+    if (tty) try stdout.print("\x1b]8;;\x1b\\", .{});
+
     try stdout.print("Build Config\n", .{});
     try stdout.print("  - Zig version: {s}\n", .{builtin.zig_version_string});
     try stdout.print("  - build mode : {}\n", .{builtin.mode});


### PR DESCRIPTION
just a little thing that would always cross my mind when i ran `+version` :p. 
i chose to do nothing if there isnt a build hash in the version e.g. `1.0.0`, not sure if this is best, it wont be very helpful once ghostty has releases but neither would something like defaulting to main, maybe we could link to tags?