### PR TITLE
Stop GitHub workflow jobs from running on forks

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -2,6 +2,7 @@ on: [push, pull_request]
 name: Nix
 jobs:
   check-zig-cache-hash:
+    if: github.repository == 'ghostty-org/ghostty'
     runs-on: namespace-profile-ghostty-sm
     env:
       ZIG_LOCAL_CACHE_DIR: /zig/local-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -287,6 +287,7 @@ jobs:
         run: Get-Content -Path ".\build.log"
 
   test:
+    if: github.repository == 'ghostty-org/ghostty'
     runs-on: namespace-profile-ghostty-md
     env:
       ZIG_LOCAL_CACHE_DIR: /zig/local-cache
@@ -343,6 +344,7 @@ jobs:
         run: nix develop -c zig build test
 
   prettier:
+    if: github.repository == 'ghostty-org/ghostty'
     runs-on: namespace-profile-ghostty-sm
     timeout-minutes: 60
     env:
@@ -369,6 +371,7 @@ jobs:
         run: nix develop -c prettier --check .
 
   alejandra:
+    if: github.repository == 'ghostty-org/ghostty'
     runs-on: namespace-profile-ghostty-sm
     timeout-minutes: 60
     env:
@@ -395,6 +398,7 @@ jobs:
         run: nix develop -c alejandra --check .
 
   typos:
+    if: github.repository == 'ghostty-org/ghostty'
     runs-on: namespace-profile-ghostty-sm
     timeout-minutes: 60
     env:


### PR DESCRIPTION
Adds checks for `github.repository == 'ghostty-org/ghostty'` to each job in the Nix and Test workflows.

These checks cover the case when you manually enable Actions on your fork (they are disabled by default) to run your own workflows. The workflows will still run on every push to your fork, but all jobs will be skipped. Without this, jobs get stuck in the Queued status because of "Waiting for a runner to pick up this job..."

These checks do _not_ address the more common workflow errors on PRs because of the "Codesign app bundle" step. That was previously discussed [here](https://discord.com/channels/1005603569187160125/1005603569711452192/1270428554072424459).

I didn't add the check to jobs that depend on the `test` job (because `test` already has the check).