### PR TITLE
kitty graphics: respond OK with metadata on display actions

### DIFF
--- a/src/terminal/kitty/graphics_command.zig
+++ b/src/terminal/kitty/graphics_command.zig
@@ -256,16 +256,22 @@ pub const Response = struct {
         // We only encode a result if we have either an id or an image number.
         if (self.id == 0 and self.image_number == 0) return;
 
+        // Used to cheaply keep track if we need to add a comma before
+        // the next key-value pair.
+        var prior: bool = false;
+
         try writer.writeAll("\x1b_G");
         if (self.id > 0) {
+            prior = true;
             try writer.print("i={}", .{self.id});
         }
         if (self.image_number > 0) {
-            if (self.id > 0) try writer.writeByte(',');
+            if (prior) try writer.writeByte(',') else prior = true;
             try writer.print("I={}", .{self.image_number});
         }
         if (self.placement_id > 0) {
-            try writer.print(",p={}", .{self.placement_id});
+            if (prior) try writer.writeByte(',') else prior = true;
+            try writer.print("p={}", .{self.placement_id});
         }
         try writer.writeByte(';');
         try writer.writeAll(self.message);

--- a/src/terminal/kitty/graphics_exec.zig
+++ b/src/terminal/kitty/graphics_exec.zig
@@ -177,7 +177,7 @@ fn display(
     else
         storage.imageByNumber(d.image_number);
     const img = img_ orelse {
-        result.message = "EINVAL: image not found";
+        result.message = "ENOENT: image not found";
         return result;
     };
 

--- a/src/terminal/kitty/graphics_exec.zig
+++ b/src/terminal/kitty/graphics_exec.zig
@@ -140,12 +140,13 @@ fn transmit(
     // If there are more chunks expected we do not respond.
     if (load.more) return .{};
 
-    // After the image is added, set the ID in case it changed
-    result.id = load.image.id;
+    // If our image has no ID or number, we don't respond at all. Conversely,
+    // if we have either an ID or number, we always respond.
+    if (load.image.id == 0 and load.image.number == 0) return .{};
 
-    // If the original request had an image number, then we respond.
-    // Otherwise, we don't respond.
-    if (load.image.number == 0) return .{};
+    // After the image is added, set the ID in case it changed.
+    // The resulting image number and placement ID never change.
+    result.id = load.image.id;
 
     return result;
 }
@@ -253,8 +254,7 @@ fn display(
         },
     }
 
-    // Display does not result in a response on success
-    return .{};
+    return result;
 }
 
 /// Display a previously transmitted image.

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -304,7 +304,7 @@ pub const StreamHandler = struct {
                     try resp.encode(buf_stream.writer());
                     const final = buf_stream.getWritten();
                     if (final.len > 2) {
-                        // log.warn("kitty graphics response: {s}", .{std.fmt.fmtSliceHexLower(final)});
+                        log.debug("kitty graphics response: {s}", .{std.fmt.fmtSliceHexLower(final)});
                         self.messageWriter(try termio.Message.writeReq(self.alloc, final));
                     }
                 }


### PR DESCRIPTION
Fixes #2176

This fixes a few things we didn't match Kitty itself on:

  * When image ID or number is not found for display, we should specify `ENOENT` in the message, previously we did `EINVAL`
  * When any display action (`a=T`, `a=p`) is used, we should write a response if not quiet, previously we did not
  * When any transmission action (`a=t`, `a=T`) is used, we should respond if there is an image ID _or_ image number. Previously, we only responded if there was an image number.