### PR TITLE
kitty kbd: progressive enhancement `=` mode off by one

### DIFF
--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -1226,9 +1226,9 @@ pub fn Stream(comptime Handler: type) type {
                                 1;
 
                             const mode: kitty.KeySetMode = switch (number) {
-                                0 => .set,
-                                1 => .@"or",
-                                2 => .not,
+                                1 => .set,
+                                2 => .@"or",
+                                3 => .not,
                                 else => {
                                     log.warn("invalid setKittyKeyboard command: {}", .{input});
                                     break :set;


### PR DESCRIPTION
Fixes #2161

Amazing we didn't find this for over a year, I guess very few programs use the `CSI = n u` format. But Fish recently started using it heavily and immediately was broken. 

Verified this by comparing our flag stack to `kitty --debug-input` which logs its own flag stack.