### PR TITLE
kitty gfx: handle `q` with chunked transmissions properly

### DIFF
--- a/src/terminal/kitty/graphics_command.zig
+++ b/src/terminal/kitty/graphics_command.zig
@@ -69,6 +69,14 @@ pub const Parser = struct {
         self.data.deinit();
     }
 
+    /// Parse a complete command string.
+    pub fn parseString(alloc: Allocator, data: []const u8) !Command {
+        var parser = init(alloc);
+        defer parser.deinit();
+        for (data) |c| try parser.feed(c);
+        return try parser.complete();
+    }
+
     /// Feed a single byte to the parser.
     ///
     /// The first byte to start parsing should be the byte immediately following
@@ -281,6 +289,11 @@ pub const Response = struct {
     /// Returns true if this response is not an error.
     pub fn ok(self: Response) bool {
         return std.mem.eql(u8, self.message, "OK");
+    }
+
+    /// Empty response
+    pub fn empty(self: Response) bool {
+        return self.id == 0 and self.image_number == 0;
     }
 };
 

--- a/src/terminal/kitty/graphics_image.zig
+++ b/src/terminal/kitty/graphics_image.zig
@@ -36,10 +36,14 @@ pub const LoadingImage = struct {
     /// so that we display the image after it is fully loaded.
     display: ?command.Display = null,
 
+    /// Quiet is the quiet settings for the initial load command. This is
+    /// used if q isn't set on subsequent chunks.
+    quiet: command.Command.Quiet,
+
     /// Initialize a chunked immage from the first image transmission.
     /// If this is a multi-chunk image, this should only be the FIRST
     /// chunk.
-    pub fn init(alloc: Allocator, cmd: *command.Command) !LoadingImage {
+    pub fn init(alloc: Allocator, cmd: *const command.Command) !LoadingImage {
         // Build our initial image from the properties sent via the control.
         // These can be overwritten by the data loading process. For example,
         // PNG loading sets the width/height from the data.
@@ -55,6 +59,7 @@ pub const LoadingImage = struct {
             },
 
             .display = cmd.display(),
+            .quiet = cmd.quiet,
         };
 
         // Special case for the direct medium, we just add the chunk directly.


### PR DESCRIPTION
Fixes #2190

The `q` value with chunk transmissions is a bit complicated. The initial transmission ("start" command) `q` value is used for all subsequent chunks UNLESS a subsequent chunk specifies a `q >= 1`. If a chunk specifies `q >= 1`, then that `q` value is subsequently used for all future chunks unless another chunk specifies `q >= 1`. And so on.

This commit importantly also introduces the ability to test a full Kitty command from string request to structured response. This will let us prevent regressions in the future and ensure that we are correctly handling the complex underspecified behavior of Kitty Graphics.