### PR TITLE
wuffs: fix blend mode

### DIFF
--- a/pkg/wuffs/src/png.zig
+++ b/pkg/wuffs/src/png.zig
@@ -128,7 +128,7 @@ pub fn decode(alloc: Allocator, data: []const u8) Error!struct {
             decoder,
             &pixel_buffer,
             &source_buffer,
-            c.WUFFS_BASE__PIXEL_BLEND__SRC_OVER,
+            c.WUFFS_BASE__PIXEL_BLEND__SRC,
             work_slice,
             null,
         );

--- a/pkg/wuffs/src/swizzle.zig
+++ b/pkg/wuffs/src/swizzle.zig
@@ -82,7 +82,7 @@ fn swizzle(
             c.wuffs_base__empty_slice_u8(),
             src_fmt,
             c.wuffs_base__empty_slice_u8(),
-            c.WUFFS_BASE__PIXEL_BLEND__SRC_OVER,
+            c.WUFFS_BASE__PIXEL_BLEND__SRC,
         );
         if (!c.wuffs_base__status__is_ok(&status)) {
             const e = c.wuffs_base__status__message(&status);


### PR DESCRIPTION
Use WUFFS_BASE__PIXEL_BLEND__SRC instead of WUFFS_BASE__PIXEL_BLEND__SRC_OVER.