### PR TITLE
Wide cell boundary conditions in ECH & DCH + soft-wrap reset correctness

### DIFF
--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -3172,34 +3172,6 @@ pub const Pin = struct {
         set.set(self.y);
     }
 
-    /// Resets the soft-wrap state of the row this pin is on, appropriately
-    /// handling the wrap and wrap_continuation flags for the previous and
-    /// next row as well.
-    ///
-    /// DOES NOT handle clearing spacer heads.
-    /// Use `Screen.splitCellBoundary` for that.
-    ///
-    /// TODO: test
-    pub fn resetWrap(self: Pin) void {
-        const rac = self.rowAndCell();
-
-        // This row does not wrap
-        rac.row.wrap = false;
-
-        // This row is not wrapped to
-        rac.row.wrap_continuation = false;
-
-        // The previous row does not wrap to this row
-        if (self.up(1)) |prev_row| {
-            prev_row.rowAndCell().row.wrap = false;
-        }
-
-        // The next row is not wrapped to
-        if (self.down(1)) |next_row| {
-            next_row.rowAndCell().row.wrap_continuation = false;
-        }
-    }
-
     /// Returns true if the row of this pin should never have its background
     /// color extended for filling padding space in the renderer. This is
     /// a set of heuristics that help making our padding look better.

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -3172,6 +3172,34 @@ pub const Pin = struct {
         set.set(self.y);
     }
 
+    /// Resets the soft-wrap state of the row this pin is on, appropriately
+    /// handling the wrap and wrap_continuation flags for the previous and
+    /// next row as well.
+    ///
+    /// DOES NOT handle clearing spacer heads.
+    /// Use `Screen.splitCellBoundary` for that.
+    ///
+    /// TODO: test
+    pub fn resetWrap(self: Pin) void {
+        const rac = self.rowAndCell();
+
+        // This row does not wrap
+        rac.row.wrap = false;
+
+        // This row is not wrapped to
+        rac.row.wrap_continuation = false;
+
+        // The previous row does not wrap to this row
+        if (self.up(1)) |prev_row| {
+            prev_row.rowAndCell().row.wrap = false;
+        }
+
+        // The next row is not wrapped to
+        if (self.down(1)) |next_row| {
+            next_row.rowAndCell().row.wrap_continuation = false;
+        }
+    }
+
     /// Returns true if the row of this pin should never have its background
     /// color extended for filling padding space in the renderer. This is
     /// a set of heuristics that help making our padding look better.

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1044,6 +1044,11 @@ pub fn cursorMarkDirty(self: *Screen) void {
 /// Reset the cursor row's soft-wrap state and the cursor's pending wrap.
 /// Also handles clearing the spacer head on the cursor row and resetting
 /// the wrap_continuation flag on the next row if necessary.
+///
+/// NOTE(qwerasd): This method is not scrolling region aware, and cannot be
+/// since it's on Screen not Terminal. This needs to be addressed down the
+/// line. Not an extremely urgent issue since it's an edge case of an edge
+/// case, but not ideal.
 pub fn cursorResetWrap(self: *Screen) void {
     // Reset the cursor's pending wrap state
     self.cursor.pending_wrap = false;
@@ -1323,7 +1328,7 @@ pub fn clearPrompt(self: *Screen) void {
 /// function with `x = a` and `x = b + 1`. It is okay if `x` is out of bounds by
 /// 1, this will be interpreted correctly.
 ///
-/// DOES NOT MODIFY ROW WRAP STATE! See `resetWrap` for that.
+/// DOES NOT MODIFY ROW WRAP STATE! See `cursorResetWrap` for that.
 ///
 /// The following boundary conditions are handled:
 ///
@@ -1339,6 +1344,11 @@ pub fn clearPrompt(self: *Screen) void {
 ///
 /// - `x == cols` and `x - 1` is a spacer head:
 ///   o `x - 1` will be cleared.
+///
+/// NOTE(qwerasd): This method is not scrolling region aware, and cannot be
+/// since it's on Screen not Terminal. This needs to be addressed down the
+/// line. Not an extremely urgent issue since it's an edge case of an edge
+/// case, but not ideal.
 pub fn splitCellBoundary(
     self: *Screen,
     x: size.CellCountInt,

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -6083,7 +6083,7 @@ test "Terminal: eraseChars wide char wrap boundary conditions" {
 
         const unwrapped = try t.plainStringUnwrapped(alloc);
         defer testing.allocator.free(unwrapped);
-        try testing.expectEqualStrings(".......\n    cde\n😀......", unwrapped);
+        try testing.expectEqualStrings(".......     cde\n😀......", unwrapped);
     }
 }
 
@@ -9049,7 +9049,7 @@ test "Terminal: deleteChars wide char wrap boundary conditions" {
 
         const unwrapped = try t.plainStringUnwrapped(alloc);
         defer testing.allocator.free(unwrapped);
-        try testing.expectEqualStrings(".......\n cde\n😀......", unwrapped);
+        try testing.expectEqualStrings(".......  cde\n😀......", unwrapped);
     }
 }
 

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1917,18 +1917,9 @@ pub fn deleteChars(self: *Terminal, count_req: usize) void {
     // We can only insert blanks up to our remaining cols
     const count = @min(count_req, rem);
 
-    self.screen.splitCellBoundary(
-        self.screen.cursor.page_pin.*,
-        self.screen.cursor.x,
-    );
-    self.screen.splitCellBoundary(
-        self.screen.cursor.page_pin.*,
-        self.screen.cursor.x + count,
-    );
-    self.screen.splitCellBoundary(
-        self.screen.cursor.page_pin.*,
-        self.scrolling_region.right + 1,
-    );
+    self.screen.splitCellBoundary(self.screen.cursor.x);
+    self.screen.splitCellBoundary(self.screen.cursor.x + count);
+    self.screen.splitCellBoundary(self.scrolling_region.right + 1);
 
     // This is the amount of space at the right of the scroll region
     // that will NOT be blank, so we need to shift the correct cols right.
@@ -1982,14 +1973,8 @@ pub fn eraseChars(self: *Terminal, count_req: usize) void {
     // TODO(qwerasd): This isn't actually correct if you take in to account
     // protected modes. We need to figure out how to make `clearCells` or at
     // least `clearUnprotectedCells` handle boundary conditions...
-    self.screen.splitCellBoundary(
-        self.screen.cursor.page_pin.*,
-        self.screen.cursor.x,
-    );
-    self.screen.splitCellBoundary(
-        self.screen.cursor.page_pin.*,
-        end,
-    );
+    self.screen.splitCellBoundary(self.screen.cursor.x);
+    self.screen.splitCellBoundary(end);
 
     // Reset our row's soft-wrap.
     self.screen.cursorResetWrap();

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1907,28 +1907,28 @@ pub fn deleteChars(self: *Terminal, count_req: usize) void {
     if (self.screen.cursor.x < self.scrolling_region.left or
         self.screen.cursor.x > self.scrolling_region.right) return;
 
-    // This resets the soft-wrap of this line
-    self.screen.cursor.page_row.wrap = false;
-
-    // This resets the pending wrap state
-    self.screen.cursor.pending_wrap = false;
-
     // left is just the cursor position but as a multi-pointer
     const left: [*]Cell = @ptrCast(self.screen.cursor.page_cell);
     var page = &self.screen.cursor.page_pin.page.data;
-
-    // If our X is a wide spacer tail then we need to erase the
-    // previous cell too so we don't split a multi-cell character.
-    if (self.screen.cursor.page_cell.wide == .spacer_tail) {
-        assert(self.screen.cursor.x > 0);
-        self.screen.clearCells(page, self.screen.cursor.page_row, (left - 1)[0..2]);
-    }
 
     // Remaining cols from our cursor to the right margin.
     const rem = self.scrolling_region.right - self.screen.cursor.x + 1;
 
     // We can only insert blanks up to our remaining cols
     const count = @min(count_req, rem);
+
+    self.screen.splitCellBoundary(
+        self.screen.cursor.page_pin.*,
+        self.screen.cursor.x,
+    );
+    self.screen.splitCellBoundary(
+        self.screen.cursor.page_pin.*,
+        self.screen.cursor.x + count,
+    );
+    self.screen.splitCellBoundary(
+        self.screen.cursor.page_pin.*,
+        self.scrolling_region.right + 1,
+    );
 
     // This is the amount of space at the right of the scroll region
     // that will NOT be blank, so we need to shift the correct cols right.
@@ -1941,35 +1941,6 @@ pub fn deleteChars(self: *Terminal, count_req: usize) void {
 
         const right: [*]Cell = left + (scroll_amount - 1);
 
-        const end: *Cell = @ptrCast(right + count);
-        switch (end.wide) {
-            .narrow, .wide => {},
-
-            // If our end is a spacer head then we need to clear it since
-            // spacer heads must be at the end.
-            .spacer_head => {
-                self.screen.clearCells(page, self.screen.cursor.page_row, end[0..1]);
-            },
-
-            // If our last cell we're shifting is wide, then we need to clear
-            // it to be empty so we don't split the multi-cell char.
-            .spacer_tail => {
-                const wide: [*]Cell = right + count - 1;
-                assert(wide[0].wide == .wide);
-                self.screen.clearCells(page, self.screen.cursor.page_row, wide[0..2]);
-            },
-        }
-
-        // If our first cell is a wide char then we need to also clear
-        // the spacer tail following it.
-        if (x[0].wide == .wide) {
-            self.screen.clearCells(
-                page,
-                self.screen.cursor.page_row,
-                x[0..2],
-            );
-        }
-
         while (@intFromPtr(x) <= @intFromPtr(right)) : (x += 1) {
             const src: *Cell = @ptrCast(x + count);
             const dst: *Cell = @ptrCast(x);
@@ -1980,18 +1951,15 @@ pub fn deleteChars(self: *Terminal, count_req: usize) void {
     // Insert blanks. The blanks preserve the background color.
     self.screen.clearCells(page, self.screen.cursor.page_row, x[0 .. rem - scroll_amount]);
 
+    // Our row's soft-wrap is always reset.
+    self.screen.cursorResetWrap();
+
     // Our row is always dirty
     self.screen.cursorMarkDirty();
 }
 
 pub fn eraseChars(self: *Terminal, count_req: usize) void {
     const count = @max(count_req, 1);
-
-    // This resets the soft-wrap of this line
-    self.screen.cursor.page_row.wrap = false;
-
-    // This resets the pending wrap state
-    self.screen.cursor.pending_wrap = false;
 
     // Our last index is at most the end of the number of chars we have
     // in the current line.
@@ -2008,6 +1976,23 @@ pub fn eraseChars(self: *Terminal, count_req: usize) void {
 
         break :end end;
     };
+
+    // Handle any boundary conditions on the edges of the erased area.
+    //
+    // TODO(qwerasd): This isn't actually correct if you take in to account
+    // protected modes. We need to figure out how to make `clearCells` or at
+    // least `clearUnprotectedCells` handle boundary conditions...
+    self.screen.splitCellBoundary(
+        self.screen.cursor.page_pin.*,
+        self.screen.cursor.x,
+    );
+    self.screen.splitCellBoundary(
+        self.screen.cursor.page_pin.*,
+        end,
+    );
+
+    // Reset our row's soft-wrap.
+    self.screen.cursorResetWrap();
 
     // Mark our cursor row as dirty
     self.screen.cursorMarkDirty();
@@ -2051,8 +2036,8 @@ pub fn eraseLine(
                 x -= 1;
             }
 
-            // This resets the soft-wrap of this line
-            self.screen.cursor.page_row.wrap = false;
+            // Reset our row's soft-wrap.
+            self.screen.cursorResetWrap();
 
             break :right .{ x, self.cols };
         },


### PR DESCRIPTION
Adds tests for boundary conditions involving wide chars for ECH & DCH and fixes them with a helper function `Screen.splitCellBoundary`.

Also introduces `Screen.cursorResetWrap` which resets the wrap state for the cursor row (and the cursor's pending wrap) in a correct way, accounting for spacer heads and the previous and next row's wrap flags as well. A few functions in `Terminal` previously just did `self.screen.cursor_row.wrap = false` and called it a day which can result in orphaned spacer heads and improper `wrap` or `wrap_continuation` flags on the prev and next rows.

An important `TODO` I left is in `eraseChars`, technically the boundary condition handling is still insufficient there, since it's not accounting for protected cells creating additional boundaries, or eliminating the two boundaries that are actually being handled at all.