### PR TITLE
Crash envelope rich decoding, fix parsing multiple items, serialization

### DIFF
--- a/src/crash/sentry.zig
+++ b/src/crash/sentry.zig
@@ -270,7 +270,7 @@ pub const Transport = struct {
 
     fn shouldDiscard(envelope: *const crash.Envelope) !bool {
         // If we have an event item then we're good.
-        for (envelope.items) |item| {
+        for (envelope.items.items) |item| {
             if (item.itemType() == .event) return false;
         }
 

--- a/src/crash/sentry.zig
+++ b/src/crash/sentry.zig
@@ -271,7 +271,7 @@ pub const Transport = struct {
     fn shouldDiscard(envelope: *const crash.Envelope) !bool {
         // If we have an event item then we're good.
         for (envelope.items) |item| {
-            if (item.type == .event) return false;
+            if (item.itemType() == .event) return false;
         }
 
         return true;

--- a/src/crash/sentry_envelope.zig
+++ b/src/crash/sentry_envelope.zig
@@ -417,7 +417,7 @@ pub const ObjectMapUnmanaged = std.StringArrayHashMapUnmanaged(std.json.Value);
 
 /// The options we must use for serialization.
 const json_opts: std.json.StringifyOptions = .{
-    // This is the default but I want to be explicit beacuse its
+    // This is the default but I want to be explicit because its
     // VERY important for the correctness of the envelope. This is
     // the only whitespace type in std.json that doesn't emit newlines.
     // All JSON headers in the envelope must be on a single line.


### PR DESCRIPTION
This iterates on the Sentry envelope parser in our codebase and adds the following:

  * Fixes a bug where we didn't properly parse multiple items if the items were length-prefixed.
  * Adds the ability to serialize a decoded `Envelope` back to the serialized format.
  * Adds the functionality to decode items to structured types, starting with `Attachment`. This groundwork should make it trivial to add more formats.

I was going to continue working on a minidump parser and some other things in this PR but the bug fix above encouraged me to make this a standalone PR because that could potentially mask actual crash reports. 