### PR TITLE
graphics: set default transmission format as .rgba

### DIFF
--- a/src/terminal/kitty/graphics_command.zig
+++ b/src/terminal/kitty/graphics_command.zig
@@ -366,7 +366,7 @@ pub const Command = struct {
 };
 
 pub const Transmission = struct {
-    format: Format = .rgb, // f
+    format: Format = .rgba, // f
     medium: Medium = .direct, // t
     width: u32 = 0, // s
     height: u32 = 0, // v

--- a/src/terminal/kitty/graphics_exec.zig
+++ b/src/terminal/kitty/graphics_exec.zig
@@ -475,3 +475,23 @@ test "kittygfx more chunks with chunk increasing q" {
         try testing.expect(resp == null);
     }
 }
+
+test "kittygfx default format is rgba" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t = try Terminal.init(alloc, .{ .rows = 5, .cols = 5 });
+    defer t.deinit(alloc);
+
+    const cmd = try command.Parser.parseString(
+        alloc,
+        "a=t,t=d,i=1,s=1,v=2,c=10,r=1;///////////",
+    );
+    defer cmd.deinit(alloc);
+    const resp = execute(alloc, &t, &cmd).?;
+    try testing.expect(resp.ok());
+
+    const storage = &t.screen.kitty_images;
+    const img = storage.imageById(1).?;
+    try testing.expectEqual(command.Transmission.Format.rgba, img.format);
+}


### PR DESCRIPTION
The default format for transmission is defined as RGBA (f=32) in the
Kitty Graphics specification. When no format is specified, this can
result in an error for length checking.

Fixes: #2212
Reference: https://sw.kovidgoyal.net/kitty/graphics-protocol/#control-data-reference
