### PR TITLE
Update CI Runners to Ubuntu 24.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,10 @@
-on: [push, pull_request]
+on:
+  push: {}
+  pull_request: {}
+  workflow_dispatch: {}
+
 name: Test
+
 jobs:
   build:
     strategy:

--- a/example/app.ts
+++ b/example/app.ts
@@ -102,12 +102,12 @@ fetch(url.href)
     group_add_face(
       group,
       0 /* regular */,
-      deferred_face_new(font_name.ptr, font_name.len, 0 /* text */)
+      deferred_face_new(font_name.ptr, font_name.len, 0 /* text */),
     );
     group_add_face(
       group,
       0 /* regular */,
-      deferred_face_new(font_name.ptr, font_name.len, 1 /* emoji */)
+      deferred_face_new(font_name.ptr, font_name.len, 1 /* emoji */),
     );
 
     // Initialize our sprite font, without this we just use the browser.
@@ -168,7 +168,7 @@ fetch(url.href)
       group_cache,
       cp,
       0,
-      -1 /* best choice */
+      -1 /* best choice */,
     );
     group_cache_render_glyph(group_cache, font_idx, cp, -1);
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1705957679,
-        "narHash": "sha256-Q8LJaVZGJ9wo33wBafvZSzapYsjOaNjP/pOnSiKVGHY=",
+        "lastModified": 1726062281,
+        "narHash": "sha256-PyFVySdGj3enKqm8RQuo4v1KLJLmNLOq2yYOHsI6e2Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9a333eaa80901efe01df07eade2c16d183761fa3",
+        "rev": "e65aa8301ba4f0ab8cb98f944c14aa9da07394f8",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "release-23.05",
+        "ref": "release-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     # We want to stay as up to date as possible but need to be careful that the
     # glibc versions used by our dependencies from Nix are compatible with the
     # system glibc that the user is building for.
-    nixpkgs-stable.url = "github:nixos/nixpkgs/release-23.05";
+    nixpkgs-stable.url = "github:nixos/nixpkgs/release-24.05";
 
     zig = {
       url = "github:mitchellh/zig-overlay";

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
 
       packages.${system} = let
         mkArgs = optimize: {
-          inherit (pkgs-unstable) zig_0_13 lib;
+          inherit (pkgs-unstable) zig_0_13;
           inherit optimize;
 
           revision = self.shortRev or self.dirtyShortRev or "dirty";


### PR DESCRIPTION
This is actually all done server side so there aren't meaningful changes here. But if this works we're going to try to update our flake version too.