### PR TITLE
adw: add option to choose toolbar style

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -183,6 +183,14 @@ pub fn init(self: *Window, app: *App) !void {
         }
         c.adw_toolbar_view_set_content(toolbar_view, box);
 
+        const toolbar_style: c.AdwToolbarStyle = switch (self.app.config.@"adw-toolbar-style") {
+            .flat => c.ADW_TOOLBAR_FLAT,
+            .raised => c.ADW_TOOLBAR_RAISED,
+            .@"raised-border" => c.ADW_TOOLBAR_RAISED_BORDER,
+        };
+        c.adw_toolbar_view_set_top_bar_style(toolbar_view, toolbar_style);
+        c.adw_toolbar_view_set_bottom_bar_style(toolbar_view, toolbar_style);
+
         c.adw_application_window_set_content(@ptrCast(gtk_window), @ptrCast(@alignCast(toolbar_view)));
     } else {
         // The box is our main child

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -132,6 +132,7 @@ pub fn init(self: *Window, app: *App) !void {
             adwaita.versionAtLeast(1, 3, 0))
         {
             const banner = c.adw_banner_new(warning_text);
+            c.adw_banner_set_revealed(@ptrCast(banner), 1);
             c.gtk_box_append(@ptrCast(box), @ptrCast(banner));
         } else {
             const warning = c.gtk_label_new(warning_text);

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1426,6 +1426,12 @@ keybind: Keybinds = .{},
 /// back to `top`.
 @"gtk-tabs-location": GtkTabsLocation = .top,
 
+/// Determines the appearance of the top and bottom bars when using the adwaita tab bar.
+/// If set to `flat`, top and bottom bars are flat with the terminal window.
+/// If set to `raised`, top and bottom bars cast a shadow on the terminal area.
+/// `raised-border` is similar to `raised` but the shadow is replaced with a more subtle border.
+@"adw-toolbar-style": AdwToolBarStyle = .raised,
+
 /// If `true` (default), then the Ghostty GTK tabs will be "wide." Wide tabs
 /// are the new typical Gnome style where tabs fill their available space.
 /// If you set this to `false` then tabs will only take up space they need,
@@ -4062,6 +4068,13 @@ pub const GtkTabsLocation = enum {
     bottom,
     left,
     right,
+};
+
+/// See adw-toolbar-style
+pub const AdwToolBarStyle = enum {
+    flat,
+    raised,
+    @"raised-border",
 };
 
 /// See mouse-shift-capture

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1426,11 +1426,19 @@ keybind: Keybinds = .{},
 /// back to `top`.
 @"gtk-tabs-location": GtkTabsLocation = .top,
 
-/// Determines the appearance of the top and bottom bars when using the adwaita tab bar.
-/// If set to `flat`, top and bottom bars are flat with the terminal window.
-/// If set to `raised`, top and bottom bars cast a shadow on the terminal area.
-/// `raised-border` is similar to `raised` but the shadow is replaced with a more subtle border.
-@"adw-toolbar-style": AdwToolBarStyle = .raised,
+/// Determines the appearance of the top and bottom bars when using the
+/// adwaita tab bar. This requires `gtk-adwaita` to be enabled (it is
+/// by default).
+///
+/// Valid values are:
+///
+///  * `flat` - Top and bottom bars are flat with the terminal window.
+///  * `raised` - Top and bottom bars cast a shadow on the terminal area.
+///  * `raised-border` - Similar to `raised` but the shadow is replaced with a
+///    more subtle border.
+///
+/// Changing this value at runtime will only affect new windows.
+@"adw-toolbar-style": AdwToolbarStyle = .raised,
 
 /// If `true` (default), then the Ghostty GTK tabs will be "wide." Wide tabs
 /// are the new typical Gnome style where tabs fill their available space.
@@ -4071,7 +4079,7 @@ pub const GtkTabsLocation = enum {
 };
 
 /// See adw-toolbar-style
-pub const AdwToolBarStyle = enum {
+pub const AdwToolbarStyle = enum {
     flat,
     raised,
     @"raised-border",


### PR DESCRIPTION
Follow up to #2051, this adds an option to choose the toolbar style (it sets both [`top-bar-style`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/property.ToolbarView.top-bar-style.html) and [`bottom-bar-style`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/property.ToolbarView.bottom-bar-style.html)).

The default is set to `raised` because `flat` may look "weird" when the theme has a different colour than the header bar. This is also nice to configure since `flat` will play nicely with a feature like #2150.

### `adw-toolbar-style=raised` (default)

It casts a small shadow at the boundary between the bar and the terminal area.

![image](https://github.com/user-attachments/assets/350959f6-8990-4d59-8d01-ddcfb6a89517)

### `adw-toolbar-style=raised-border`

This is the same as `raised` but with a more subtle border.

![image](https://github.com/user-attachments/assets/881a2d56-2d9f-48d6-9f8d-84c28fad7487)


### `adw-toolbar-style=flat`

Current state.

![image](https://github.com/user-attachments/assets/0152fe68-b00c-4a14-9376-88ac1a059c56)


