### PR TITLE
Fix background-opacity for the GTK backend, again

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -82,9 +82,9 @@ pub fn init(self: *Window, app: *App) !void {
 
     c.gtk_window_set_icon_name(gtk_window, "com.mitchellh.ghostty");
 
-    // Apply background opacity if we have it
+    // Remove the window's background if any of the widgets need to be transparent
     if (app.config.@"background-opacity" < 1) {
-        c.gtk_widget_set_opacity(@ptrCast(window), app.config.@"background-opacity");
+        c.gtk_widget_remove_css_class(@ptrCast(window), "background");
     }
 
     var header: ?*c.GtkHeaderBar = null;
@@ -126,6 +126,7 @@ pub fn init(self: *Window, app: *App) !void {
     // In debug we show a warning and apply the 'devel' class to the window.
     // This is a really common issue where people build from source in debug and performance is really bad.
     if (comptime std.debug.runtime_safety) {
+        const warning_box = c.gtk_box_new(c.GTK_ORIENTATION_VERTICAL, 0);
         const warning_text = "⚠️ You're running a debug build of Ghostty! Performance will be degraded.";
         if ((comptime adwaita.versionAtLeast(1, 3, 0)) and
             adwaita.enabled(&app.config) and
@@ -133,14 +134,16 @@ pub fn init(self: *Window, app: *App) !void {
         {
             const banner = c.adw_banner_new(warning_text);
             c.adw_banner_set_revealed(@ptrCast(banner), 1);
-            c.gtk_box_append(@ptrCast(box), @ptrCast(banner));
+            c.gtk_box_append(@ptrCast(warning_box), @ptrCast(banner));
         } else {
             const warning = c.gtk_label_new(warning_text);
             c.gtk_widget_set_margin_top(warning, 10);
             c.gtk_widget_set_margin_bottom(warning, 10);
-            c.gtk_box_append(@ptrCast(box), warning);
+            c.gtk_box_append(@ptrCast(warning_box), warning);
         }
         c.gtk_widget_add_css_class(@ptrCast(gtk_window), "devel");
+        c.gtk_widget_add_css_class(@ptrCast(warning_box), "background");
+        c.gtk_box_append(@ptrCast(box), warning_box);
     }
 
     self.notebook = Notebook.create(self, box);

--- a/src/apprt/gtk/notebook.zig
+++ b/src/apprt/gtk/notebook.zig
@@ -47,6 +47,10 @@ pub const Notebook = union(enum) {
         c.gtk_widget_set_vexpand(notebook_widget, 1);
         c.gtk_widget_set_hexpand(notebook_widget, 1);
 
+        // Remove the background from the stack widget
+        const stack = c.gtk_widget_get_last_child(notebook_widget);
+        c.gtk_widget_add_css_class(stack, "transparent");
+
         // All of our events
         _ = c.g_signal_connect_data(notebook, "page-added", c.G_CALLBACK(&gtkPageAdded), window, null, c.G_CONNECT_DEFAULT);
         _ = c.g_signal_connect_data(notebook, "page-removed", c.G_CALLBACK(&gtkPageRemoved), window, null, c.G_CONNECT_DEFAULT);

--- a/src/apprt/gtk/style-dark.css
+++ b/src/apprt/gtk/style-dark.css
@@ -1,0 +1,3 @@
+.transparent {
+  background-color: transparent;
+}

--- a/src/apprt/gtk/style-hc-dark.css
+++ b/src/apprt/gtk/style-hc-dark.css
@@ -1,0 +1,3 @@
+.transparent {
+  background-color: transparent;
+}

--- a/src/apprt/gtk/style-hc.css
+++ b/src/apprt/gtk/style-hc.css
@@ -1,0 +1,3 @@
+.transparent {
+  background-color: transparent;
+}

--- a/src/apprt/gtk/style.css
+++ b/src/apprt/gtk/style.css
@@ -32,3 +32,7 @@ label.size-overlay {
 label.size-overlay.hidden {
   opacity: 0;
 }
+
+.transparent {
+  background-color: transparent;
+}


### PR DESCRIPTION
Since #2095 was merged, I haven't been able to reproduce #1704, so this is a mostly-straightforward reapplication of #1690.

In my testing, this works with decorationless windows (alone, and with splits), decorated windows, and with Adwaita tabs. The transparency effect breaks with GTK tabs (setting `--gtk-adwaita=false` and spawning multiple tabs), but I think that's an issue with the `style.css` files not applying correctly which is unrelated to this PR (e.g. the hyperlink previews also don't have styles applied correctly in that case; they appear on both sides of the screen simultaneously).

Most importantly, it no longer breaks when spawning multiple windows on the same workspace.