### PR TITLE
apprt/gtk: inline adwaita checks so comptime disables conditional paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -323,6 +323,9 @@ jobs:
       - name: Test GTK Build
         run: nix develop -c zig build -Dapp-runtime=gtk -Dgtk-libadwaita=true -Demit-docs
 
+      - name: Test GTK Build (No Libadwaita)
+        run: nix develop -c zig build -Dapp-runtime=gtk -Dgtk-libadwaita=false -Demit-docs
+
       - name: Test GLFW Build
         run: nix develop -c zig build -Dapp-runtime=glfw
 

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -108,9 +108,7 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
     }
 
     // If we're using libadwaita, log the version
-    if ((comptime adwaita.versionAtLeast(0, 0, 0)) and
-        adwaita.enabled(&config))
-    {
+    if (adwaita.enabled(&config)) {
         log.info("libadwaita version build={s} runtime={}.{}.{}", .{
             c.ADW_VERSION_S,
             c.adw_get_major_version(),
@@ -161,7 +159,7 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
         });
 
         // If not libadwaita, create a standard GTK application.
-        if ((comptime adwaita.versionAtLeast(0, 0, 0)) and
+        if ((comptime !adwaita.versionAtLeast(0, 0, 0)) or
             !adwaita.enabled(&config))
         {
             break :app @as(?*c.GtkApplication, @ptrCast(c.gtk_application_new(

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -244,14 +244,19 @@ pub fn deinit(self: *Window) void {
 }
 
 /// Returns true if this window should use an Adwaita window.
-fn isAdwWindow(self: *Window) bool {
+///
+/// This must be `inline` so that the comptime check noops conditional
+/// paths that are not enabled.
+inline fn isAdwWindow(self: *Window) bool {
     return (comptime adwaita.versionAtLeast(1, 4, 0)) and
         adwaita.enabled(&self.app.config) and
         self.app.config.@"gtk-titlebar" and
         adwaita.versionAtLeast(1, 4, 0);
 }
 
-fn hasAdwToolbar(self: *Window) bool {
+/// This must be `inline` so that the comptime check noops conditional
+/// paths that are not enabled.
+inline fn hasAdwToolbar(self: *Window) bool {
     return ((comptime adwaita.versionAtLeast(1, 4, 0)) and
         adwaita.enabled(&self.app.config) and
         adwaita.versionAtLeast(1, 4, 0) and

--- a/src/apprt/gtk/adwaita.zig
+++ b/src/apprt/gtk/adwaita.zig
@@ -8,7 +8,10 @@ const Config = @import("../../config.zig").Config;
 ///
 /// For a comptime version of this function, use `versionAtLeast` in
 /// a comptime context with all the version numbers set to 0.
-pub fn enabled(config: *const Config) bool {
+///
+/// This must be `inline` so that the comptime check noops conditional
+/// paths that are not enabled.
+pub inline fn enabled(config: *const Config) bool {
     return build_options.libadwaita and
         config.@"gtk-adwaita";
 }


### PR DESCRIPTION
This fixes building without libadwaita or building with an older version of libadwaita. This also updates the CI to test this.

cc @gpanders 