### PR TITLE
apprt/gtk: add option to color header bars with theme colors

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -179,7 +179,7 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
         c.adw_style_manager_set_color_scheme(
             style_manager,
             switch (config.@"window-theme") {
-                .auto => auto: {
+                .auto, .ghostty => auto: {
                     const lum = config.background.toTerminalRGB().perceivedLuminance();
                     break :auto if (lum > 0.5)
                         c.ADW_COLOR_SCHEME_PREFER_LIGHT
@@ -417,11 +417,19 @@ fn syncActionAccelerator(
 }
 
 fn loadRuntimeCss(config: *const Config, provider: *c.GtkCssProvider) !void {
-    const fill: Config.Color = config.@"unfocused-split-fill" orelse config.background;
+    const unfocused_fill: Config.Color = config.@"unfocused-split-fill" orelse config.background;
+    const headerbar_background = config.background;
+    const headerbar_foreground = config.foreground;
+
     const fmt =
         \\widget.unfocused-split {{
         \\ opacity: {d:.2};
         \\ background-color: rgb({d},{d},{d});
+        \\}}
+        \\window.ghostty-theme-inherit headerbar,
+        \\window.ghostty-theme-inherit toolbarview > revealer > windowhandle {{
+        \\ background-color: rgb({d},{d},{d});
+        \\ color: rgb({d},{d},{d});
         \\}}
     ;
     // The length required is always less than the length of the pre-formatted string:
@@ -434,9 +442,15 @@ fn loadRuntimeCss(config: *const Config, provider: *c.GtkCssProvider) !void {
         fmt,
         .{
             1.0 - config.@"unfocused-split-opacity",
-            fill.r,
-            fill.g,
-            fill.b,
+            unfocused_fill.r,
+            unfocused_fill.g,
+            unfocused_fill.b,
+            headerbar_background.r,
+            headerbar_background.g,
+            headerbar_background.b,
+            headerbar_foreground.r,
+            headerbar_foreground.g,
+            headerbar_foreground.b,
         },
     );
     // Clears any previously loaded CSS from this provider

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -87,6 +87,11 @@ pub fn init(self: *Window, app: *App) !void {
 
     c.gtk_window_set_icon_name(gtk_window, "com.mitchellh.ghostty");
 
+    // Apply class to color headerbar if window-theme is set to `ghostty`.
+    if (app.config.@"window-theme" == .ghostty) {
+        c.gtk_widget_add_css_class(@ptrCast(gtk_window), "ghostty-theme-inherit");
+    }
+
     // Remove the window's background if any of the widgets need to be transparent
     if (app.config.@"background-opacity" < 1) {
         c.gtk_widget_remove_css_class(@ptrCast(window), "background");

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -859,6 +859,8 @@ keybind: Keybinds = .{},
 ///   * `system` - Use the system theme.
 ///   * `light` - Use the light theme regardless of system theme.
 ///   * `dark` - Use the dark theme regardless of system theme.
+///   * `ghostty` - Use the background and foreground colors specified in the ghostty
+///     config file. This value is only supported with `gtk-adwaita` enabled.
 ///
 /// On macOS, if `macos-titlebar-style` is "tabs", the window theme will be
 /// automatically set based on the luminosity of the terminal background color.
@@ -4048,6 +4050,7 @@ pub const WindowTheme = enum {
     system,
     light,
     dark,
+    ghostty,
 };
 
 /// See window-colorspace

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -859,8 +859,9 @@ keybind: Keybinds = .{},
 ///   * `system` - Use the system theme.
 ///   * `light` - Use the light theme regardless of system theme.
 ///   * `dark` - Use the dark theme regardless of system theme.
-///   * `ghostty` - Use the background and foreground colors specified in the ghostty
-///     config file. This value is only supported with `gtk-adwaita` enabled.
+///   * `ghostty` - Use the background and foreground colors specified in the
+///     Ghostty configuration. This is only supported on Linux builds with
+///     libadwaita and `gtk-adwaita` enabled.
 ///
 /// On macOS, if `macos-titlebar-style` is "tabs", the window theme will be
 /// automatically set based on the luminosity of the terminal background color.


### PR DESCRIPTION
This adds an option to color the header bar with the config (theme) colors. Implements #2150 only for libadwaita.

I am not sure `window-theme=theme` is the most descriptive name for the variant here, maybe something like `window-theme=config` would be better?

Here is an example with `adw-toolbar-style=flat` and `theme=WarmNeon`

![image](https://github.com/user-attachments/assets/ec6b75c9-0bf4-421e-b3f2-e1f4e895857c)
