### PR TITLE
build: fix version detection if there is no .git folder available

### DIFF
--- a/src/build/Version.zig
+++ b/src/build/Version.zig
@@ -19,8 +19,18 @@ branch: []const u8,
 pub fn detect(b: *std.Build) !Version {
     // Execute a bunch of git commands to determine the automatic version.
     var code: u8 = 0;
+
+    const root_path = b.build_root.path orelse ".";
+
+    // Check that we're within a git checkout with a .git folder, if not, bail early.
+    const git_path = try std.fs.path.join(b.allocator, &[_][]const u8{ root_path, ".git" });
+    std.fs.cwd().access(git_path, .{}) catch |err| switch (err) {
+        error.FileNotFound => return error.GitNotFound,
+        else => return err,
+    };
+
     const branch: []const u8 = b.runAllowFail(
-        &[_][]const u8{ "git", "-C", b.build_root.path orelse ".", "rev-parse", "--abbrev-ref", "HEAD" },
+        &[_][]const u8{ "git", "-C", root_path, "rev-parse", "--abbrev-ref", "HEAD" },
         &code,
         .Ignore,
     ) catch |err| switch (err) {
@@ -30,7 +40,7 @@ pub fn detect(b: *std.Build) !Version {
 
     const short_hash = short_hash: {
         const output = b.runAllowFail(
-            &[_][]const u8{ "git", "-C", b.build_root.path orelse ".", "log", "--pretty=format:%h", "-n", "1" },
+            &[_][]const u8{ "git", "-C", root_path, "log", "--pretty=format:%h", "-n", "1" },
             &code,
             .Ignore,
         ) catch |err| switch (err) {
@@ -42,7 +52,7 @@ pub fn detect(b: *std.Build) !Version {
     };
 
     const tag = b.runAllowFail(
-        &[_][]const u8{ "git", "-C", b.build_root.path orelse ".", "describe", "--exact-match", "--tags" },
+        &[_][]const u8{ "git", "-C", root_path, "describe", "--exact-match", "--tags" },
         &code,
         .Ignore,
     ) catch |err| switch (err) {
@@ -54,7 +64,7 @@ pub fn detect(b: *std.Build) !Version {
     _ = b.runAllowFail(&[_][]const u8{
         "git",
         "-C",
-        b.build_root.path orelse ".",
+        root_path,
         "diff",
         "--quiet",
         "--exit-code",


### PR DESCRIPTION
This path already handles if `git`, the binary, is missing. But we should also check if this is building from a git checkout, hence having a .git/ folder in the root. This would happen when building from a source tarball for example.