### PR TITLE
adw: allow creating new tabs in a tab overview with no open tabs

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -444,7 +444,7 @@ fn gtkNewTabFromOverview(_: *c.GtkWidget, ud: ?*anyopaque) callconv(.C) ?*c.GObj
     assert(self.isAdwWindow());
 
     const alloc = self.app.core_app.alloc;
-    const surface = self.actionSurface() orelse return null;
+    const surface = self.actionSurface();
     const tab = Tab.create(alloc, self, surface) catch return null;
     return tab.adw_tab_page;
 }


### PR DESCRIPTION
Repro:
1) Start up Ghostty and create two windows.
2) On one window, open up the tab overview and close all of the tabs. 
3) The window will not dissapear and should show that you have no open
   tabs because the 2nd Ghostty window is keeping Ghostty from quitting.
4) Clicking on the "New Tab" button has no effect.

Fix is to allow creating a new tab even though there is no action surface.