### PR TITLE
apprt/gtk: respect window-new-tab-position again

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -949,8 +949,6 @@ keybind: Keybinds = .{},
 ///     or at the end if there are no focused tabs.
 ///
 ///   * `end` - Insert the new tab at the end of the tab list.
-///
-/// This configuration currently only works with GTK.
 @"window-new-tab-position": WindowNewTabPosition = .current,
 
 /// This controls when resize overlays are shown. Resize overlays are a


### PR DESCRIPTION
Fix regression from #2051 which seem to have removed the support for this config. Also this seems now supported in macos (at there is mention of it in the code) but I don't have a mac so I cannot test this.