### PR TITLE
apprt/gtk: remove adw_tab_page from tab

### DIFF
--- a/src/apprt/gtk/Tab.zig
+++ b/src/apprt/gtk/Tab.zig
@@ -37,11 +37,6 @@ elem: Surface.Container.Elem,
 // can easily re-focus that terminal.
 focus_child: *Surface,
 
-/// If the notebook implementation is AdwTabView, then this is the tab's
-/// AdwTabPage. If we have libadwaita disabled then this will be undefined
-/// memory and is unsafe to use.
-adw_tab_page: *c.GObject,
-
 pub fn create(alloc: Allocator, window: *Window, parent_: ?*CoreSurface) !*Tab {
     var tab = try alloc.create(Tab);
     errdefer alloc.destroy(tab);
@@ -58,7 +53,6 @@ pub fn init(self: *Tab, window: *Window, parent_: ?*CoreSurface) !void {
         .box = undefined,
         .elem = undefined,
         .focus_child = undefined,
-        .adw_tab_page = undefined,
     };
 
     // Create a Box in which we'll later keep either Surface or Split.
@@ -82,9 +76,7 @@ pub fn init(self: *Tab, window: *Window, parent_: ?*CoreSurface) !void {
 
     // Set the userdata of the box to point to this tab.
     c.g_object_set_data(@ptrCast(box_widget), GHOSTTY_TAB, self);
-    if (try window.notebook.addTab(self, "Ghostty")) |page| {
-        self.adw_tab_page = page;
-    }
+    try window.notebook.addTab(self, "Ghostty");
 
     // Attach all events
     _ = c.g_signal_connect_data(box_widget, "destroy", c.G_CALLBACK(&gtkDestroy), self, null, c.G_CONNECT_DEFAULT);

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -439,14 +439,14 @@ fn gtkTabNewClick(_: *c.GtkButton, ud: ?*anyopaque) callconv(.C) void {
 
 /// Create a new tab from the AdwTabOverview. We can't copy gtkTabNewClick
 /// because we need to return an AdwTabPage from this function.
-fn gtkNewTabFromOverview(_: *c.GtkWidget, ud: ?*anyopaque) callconv(.C) ?*c.GObject {
-    const self: *Window = @ptrCast(@alignCast(ud orelse return null));
+fn gtkNewTabFromOverview(_: *c.GtkWidget, ud: ?*anyopaque) callconv(.C) ?*c.AdwTabPage {
+    const self: *Window = userdataSelf(ud.?);
     assert(self.isAdwWindow());
 
     const alloc = self.app.core_app.alloc;
     const surface = self.actionSurface();
     const tab = Tab.create(alloc, self, surface) catch return null;
-    return tab.adw_tab_page;
+    return c.adw_tab_view_get_page(self.notebook.adw_tab_view, @ptrCast(@alignCast(tab.box)));
 }
 
 fn gtkRefocusTerm(v: *c.GtkWindow, ud: ?*anyopaque) callconv(.C) bool {

--- a/src/apprt/gtk/notebook.zig
+++ b/src/apprt/gtk/notebook.zig
@@ -205,10 +205,8 @@ pub const Notebook = union(enum) {
         };
     }
 
-    /// Adds a new tab with the given title to the notebook. If the notebook
-    /// is an adwaita tab view, this will return an AdwTabPage. If the notebook
-    /// is a GTK notebook, this will return null.
-    pub fn addTab(self: Notebook, tab: *Tab, title: [:0]const u8) !?*c.GObject {
+    /// Adds a new tab with the given title to the notebook.
+    pub fn addTab(self: Notebook, tab: *Tab, title: [:0]const u8) !void {
         const box_widget: *c.GtkWidget = @ptrCast(tab.box);
         switch (self) {
             .adw_tab_view => |tab_view| {
@@ -219,8 +217,6 @@ pub const Notebook = union(enum) {
 
                 // Switch to the new tab
                 c.adw_tab_view_set_selected_page(tab_view, page);
-
-                return @ptrCast(@alignCast(page));
             },
             .gtk_notebook => |notebook| {
                 // Build the tab label
@@ -276,8 +272,6 @@ pub const Notebook = union(enum) {
 
                 // Switch to the new tab
                 c.gtk_notebook_set_current_page(notebook, page_idx);
-
-                return null;
             },
         }
     }


### PR DESCRIPTION
This is a NFC. In a few places of notebook a `AdwTabPage` is needed from a `Tab` and `adw_tab_view_get_page(tab_view, widget)` is used. This removes the `adw_tab_page` field from `Tab` in favor of `adw_tab_view_get_page` in the only place where it is used for consistency.