### PR TITLE
gtk: prevent split separator from becoming transparent

### DIFF
--- a/src/apprt/gtk/style-dark.css
+++ b/src/apprt/gtk/style-dark.css
@@ -1,3 +1,8 @@
 .transparent {
   background-color: transparent;
 }
+
+separator {
+  background-color: rgba(36, 36, 36, 1);
+  background-clip: content-box;
+}

--- a/src/apprt/gtk/style.css
+++ b/src/apprt/gtk/style.css
@@ -36,3 +36,8 @@ label.size-overlay.hidden {
 .transparent {
   background-color: transparent;
 }
+
+separator {
+  background-color: rgba(250, 250, 250, 1);
+  background-clip: content-box;
+}


### PR DESCRIPTION
Before:
![Screenshot from 2024-09-13 09-52-25](https://github.com/user-attachments/assets/202ec2cb-ea94-4caf-a65a-69f4a45f9b81)
After:
![Screenshot from 2024-09-13 09-58-43](https://github.com/user-attachments/assets/2671d0db-88d4-4e56-8494-64a4caab3a11)

