### PR TITLE
Sequoia titlebar tabs fix

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -634,6 +634,12 @@ class TerminalController: NSWindowController, NSWindowDelegate,
 
         // Custom toolbar-based title used when titlebar tabs are enabled.
         if let toolbar = window.toolbar as? TerminalToolbar {
+            if (window.titlebarTabs) {
+                // Updating the title text as above automatically reveals the
+                // native title view in macOS 15.0 and above. Since we're using
+                // a custom view instead, we need to re-hide it.
+                window.titleVisibility = .hidden
+            }
             toolbar.titleText = to
         }
     }


### PR DESCRIPTION
Fixes 3 problems present in macOS 15.0, relating to titlebar tabs
- On launch, tabs aren't properly placed in titlebar, instead aren't accessible (also affects Sonoma, fixes #2209); resolved by waiting a tick before trying to shove the tabs in the titlebar 🤷 
- Title appears in titlebar twice on macOS 15.0, resolved by setting the window's titlebar visibility to hidden in another place 🤷
- Toolbar collapsed items indicator appears when there are tabs, resolved by finding the indicator in the view hierarchy and hiding it directly 🤷

These solutions are very hacky, but they work afaict. Ideally we'll be replacing the titlebar tabs with a custom solution soon-ish which should fix our need for this mess of hacks.

> [!NOTE]
> There are some whitespace issues in the code, they need to be fixed, someone used tabs and/or the wrong number of spaces in a few places. I decided against including the whitespace fixes in this PR to make it easier to review.

> [!WARNING]
> Fully untested on Sonoma and earlier. I only tested on Sequoia, someone should test this on earlier versions before it's pushed I think.
