### PR TITLE
DRAFT: implement splitting leftwards and upwards

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -351,6 +351,8 @@ typedef struct {
 typedef enum {
   GHOSTTY_SPLIT_DIRECTION_RIGHT,
   GHOSTTY_SPLIT_DIRECTION_DOWN,
+  GHOSTTY_SPLIT_DIRECTION_LEFT,
+  GHOSTTY_SPLIT_DIRECTION_UP,
 } ghostty_action_split_direction_e;
 
 // apprt.action.GotoSplit

--- a/macos/Sources/Ghostty/Ghostty.SplitNode.swift
+++ b/macos/Sources/Ghostty/Ghostty.SplitNode.swift
@@ -253,6 +253,15 @@ extension Ghostty {
                 bottomRight.parent = self
             }
 
+            // Move the top left node to the bottom right and vice versa,
+            // preserving the size.
+            func swap() {
+                let topLeft: SplitNode = self.topLeft
+                self.topLeft = bottomRight
+                self.bottomRight = topLeft
+                self.split = 1 - self.split
+            }
+
             /// Resize the split by moving the split divider in the given
             /// direction by the given amount. If this container is not split
             /// in the given direction, navigate up the tree until we find a

--- a/macos/Sources/Ghostty/Ghostty.TerminalSplit.swift
+++ b/macos/Sources/Ghostty/Ghostty.TerminalSplit.swift
@@ -220,13 +220,21 @@ extension Ghostty {
             // Determine our desired direction
             guard let directionAny = notification.userInfo?["direction"] else { return }
             guard let direction = directionAny as? ghostty_action_split_direction_e else { return }
-            var splitDirection: SplitViewDirection
+            let splitDirection: SplitViewDirection
+            let swap: Bool
             switch (direction) {
             case GHOSTTY_SPLIT_DIRECTION_RIGHT:
                 splitDirection = .horizontal
-
+                swap = false
+            case GHOSTTY_SPLIT_DIRECTION_LEFT:
+                splitDirection = .horizontal
+                swap = true
             case GHOSTTY_SPLIT_DIRECTION_DOWN:
                 splitDirection = .vertical
+                swap = false
+            case GHOSTTY_SPLIT_DIRECTION_UP:
+                splitDirection = .vertical
+                swap = true
 
             default:
                 return
@@ -240,6 +248,12 @@ extension Ghostty {
 
             // See moveFocus comment, we have to run this whenever split changes.
             Ghostty.moveFocus(to: container.bottomRight.preferredFocus(), from: node!.preferredFocus())
+
+            // If we are swapping, swap now. We do this after our focus event
+            // so that focus is in the right place.
+            if swap {
+                container.swap()
+            }
         }
 
         /// This handles the event to move the split focus (i.e. previous/next) from a keyboard event.

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3835,7 +3835,9 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             .new_split,
             switch (direction) {
                 .right => .right,
+                .left => .left,
                 .down => .down,
+                .up => .up,
                 .auto => if (self.screen_size.width > self.screen_size.height)
                     .right
                 else

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -272,6 +272,8 @@ pub const Action = union(Key) {
 pub const SplitDirection = enum(c_int) {
     right,
     down,
+    left,
+    up,
 };
 
 // This is made extern (c_int) to make interop easier with our embedded

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -768,6 +768,8 @@ fn syncActionAccelerators(self: *App) !void {
     try self.syncActionAccelerator("win.new_tab", .{ .new_tab = {} });
     try self.syncActionAccelerator("win.split_right", .{ .new_split = .right });
     try self.syncActionAccelerator("win.split_down", .{ .new_split = .down });
+    try self.syncActionAccelerator("win.split_left", .{ .new_split = .left });
+    try self.syncActionAccelerator("win.split_up", .{ .new_split = .up });
     try self.syncActionAccelerator("win.copy", .{ .copy_to_clipboard = {} });
     try self.syncActionAccelerator("win.paste", .{ .paste_from_clipboard = {} });
     try self.syncActionAccelerator("win.reset", .{ .reset = {} });

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -373,6 +373,8 @@ fn initActions(self: *Window) void {
         .{ "new_tab", &gtkActionNewTab },
         .{ "split_right", &gtkActionSplitRight },
         .{ "split_down", &gtkActionSplitDown },
+        .{ "split_left", &gtkActionSplitLeft },
+        .{ "split_up", &gtkActionSplitUp },
         .{ "toggle_inspector", &gtkActionToggleInspector },
         .{ "copy", &gtkActionCopy },
         .{ "paste", &gtkActionPaste },
@@ -807,6 +809,32 @@ fn gtkActionSplitDown(
     const self: *Window = @ptrCast(@alignCast(ud orelse return));
     const surface = self.actionSurface() orelse return;
     _ = surface.performBindingAction(.{ .new_split = .down }) catch |err| {
+        log.warn("error performing binding action error={}", .{err});
+        return;
+    };
+}
+
+fn gtkActionSplitLeft(
+    _: *c.GSimpleAction,
+    _: *c.GVariant,
+    ud: ?*anyopaque,
+) callconv(.C) void {
+    const self: *Window = @ptrCast(@alignCast(ud orelse return));
+    const surface = self.actionSurface() orelse return;
+    _ = surface.performBindingAction(.{ .new_split = .left }) catch |err| {
+        log.warn("error performing binding action error={}", .{err});
+        return;
+    };
+}
+
+fn gtkActionSplitUp(
+    _: *c.GSimpleAction,
+    _: *c.GVariant,
+    ud: ?*anyopaque,
+) callconv(.C) void {
+    const self: *Window = @ptrCast(@alignCast(ud orelse return));
+    const surface = self.actionSurface() orelse return;
+    _ = surface.performBindingAction(.{ .new_split = .up }) catch |err| {
         log.warn("error performing binding action error={}", .{err});
         return;
     };

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -440,9 +440,9 @@ pub const Action = union(enum) {
     pub const SplitDirection = enum {
         right,
         down,
+        left,
+        up,
         auto, // splits along the larger direction
-
-        // Note: we don't support top or left yet
     };
 
     pub const SplitFocusDirection = enum {


### PR DESCRIPTION
Fixes #2227

Unresolved problems:

- [ ] Currently unimplemented on macOS :(
- [ ] What should be the default keybinds? The default keybinds for the existing two directions already make little sense as they are...
