### PR TITLE
config: move optional path parsing into RepeatablePath

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -23,6 +23,7 @@ pub const OptionAsAlt = Config.OptionAsAlt;
 pub const RepeatableCodepointMap = Config.RepeatableCodepointMap;
 pub const RepeatableFontVariation = Config.RepeatableFontVariation;
 pub const RepeatableString = Config.RepeatableString;
+pub const RepeatablePath = Config.RepeatablePath;
 pub const ShellIntegrationFeatures = Config.ShellIntegrationFeatures;
 pub const WindowPaddingColor = Config.WindowPaddingColor;
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3314,7 +3314,15 @@ pub const RepeatablePath = struct {
         var buf: [std.fs.max_path_bytes + 1]u8 = undefined;
         for (self.value.items) |item| {
             const value = switch (item) {
-                .optional => |path| try std.fmt.bufPrint(&buf, "?{s}", .{path}),
+                .optional => |path| std.fmt.bufPrint(
+                    &buf,
+                    "?{s}",
+                    .{path},
+                ) catch |err| switch (err) {
+                    // Required for builds on Linux where NoSpaceLeft
+                    // isn't an allowed error for fmt.
+                    error.NoSpaceLeft => return error.OutOfMemory,
+                },
                 .required => |path| path,
             };
 

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -347,7 +347,7 @@ pub const DerivedConfig = struct {
     bold_is_bright: bool,
     min_contrast: f32,
     padding_color: configpkg.WindowPaddingColor,
-    custom_shaders: std.ArrayListUnmanaged([:0]const u8),
+    custom_shaders: configpkg.RepeatablePath,
     links: link.Set,
     vsync: bool,
 
@@ -360,7 +360,7 @@ pub const DerivedConfig = struct {
         const alloc = arena.allocator();
 
         // Copy our shaders
-        const custom_shaders = try config.@"custom-shader".value.list.clone(alloc);
+        const custom_shaders = try config.@"custom-shader".value.clone(alloc);
 
         // Copy our font features
         const font_features = try config.@"font-feature".list.clone(alloc);
@@ -540,7 +540,7 @@ pub fn init(alloc: Allocator, options: renderer.Options) !Metal {
     // Load our custom shaders
     const custom_shaders: []const [:0]const u8 = shadertoy.loadFromFiles(
         arena_alloc,
-        options.config.custom_shaders.items,
+        options.config.custom_shaders,
         .msl,
     ) catch |err| err: {
         log.warn("error loading custom shaders err={}", .{err});
@@ -549,7 +549,7 @@ pub fn init(alloc: Allocator, options: renderer.Options) !Metal {
 
     // If we have custom shaders then setup our state
     var custom_shader_state: ?CustomShaderState = state: {
-        if (custom_shaders.len == 0) break :state null;
+        if (custom_shaders.value.items.len == 0) break :state null;
 
         // Build our sampler for our texture
         var sampler = try mtl_sampler.Sampler.init(gpu_state.device);

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -360,7 +360,7 @@ pub const DerivedConfig = struct {
         const alloc = arena.allocator();
 
         // Copy our shaders
-        const custom_shaders = try config.@"custom-shader".value.clone(alloc);
+        const custom_shaders = try config.@"custom-shader".clone(alloc);
 
         // Copy our font features
         const font_features = try config.@"font-feature".list.clone(alloc);
@@ -549,7 +549,7 @@ pub fn init(alloc: Allocator, options: renderer.Options) !Metal {
 
     // If we have custom shaders then setup our state
     var custom_shader_state: ?CustomShaderState = state: {
-        if (custom_shaders.value.items.len == 0) break :state null;
+        if (custom_shaders.len == 0) break :state null;
 
         // Build our sampler for our texture
         var sampler = try mtl_sampler.Sampler.init(gpu_state.device);

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -301,7 +301,7 @@ pub const DerivedConfig = struct {
     bold_is_bright: bool,
     min_contrast: f32,
     padding_color: configpkg.WindowPaddingColor,
-    custom_shaders: std.ArrayListUnmanaged([:0]const u8),
+    custom_shaders: configpkg.RepeatablePath,
     links: link.Set,
 
     pub fn init(
@@ -313,7 +313,7 @@ pub const DerivedConfig = struct {
         const alloc = arena.allocator();
 
         // Copy our shaders
-        const custom_shaders = try config.@"custom-shader".value.list.clone(alloc);
+        const custom_shaders = try config.@"custom-shader".clone(alloc);
 
         // Copy our font features
         const font_features = try config.@"font-feature".list.clone(alloc);
@@ -2327,7 +2327,7 @@ const GLState = struct {
         const custom_state: ?custom.State = custom: {
             const shaders: []const [:0]const u8 = shadertoy.loadFromFiles(
                 arena_alloc,
-                config.custom_shaders.items,
+                config.custom_shaders,
                 .glsl,
             ) catch |err| err: {
                 log.warn("error loading custom shaders err={}", .{err});


### PR DESCRIPTION
This commit refactors RepeatablePath to contain a list of tagged unions containing "optional" and "required" variants. Both variants have a null terminated file path as their payload, but the tag dictates whether the path must exist or not. This implemenation is used to force consumers to handle the optional vs. required distinction.

This also moves the parsing of optional file paths into RepeatablePath's parseCLI function. This allows the code to be better unit tested. Since RepeatablePath no longer contains a simple list of RepeatableStrings, many other of its methods needed to be reimplemented as well.

Because all of this functionality is built into the RepeatablePath type, other config options which also use RepeatablePath gain the ability to specify optional paths as well. Right now this is only the "custom-shaders" option. The code paths in the renderer to load shader files has been updated accordingly.

In the original optional config file parsing, the leading ? character was removed when paths were expanded. Thus, when config files were actually loaded recursively, they appeared to be regular (required) config files and an error occurred if the file did not exist. **This issue was not found during testing because the presence of the "theme" option masks the error**. I am not sure why the presence of "theme" does this, I did not dig into that.

Now because the "optional" or "required" state of each path is tracked in the enum tag the "optional" status of the path is preserved after being expanded to an absolute path.

Finally, this commit fixes a bug where missing "config-file" files were not included in the +show-config command (i.e. if a user had `config-file = foo.conf` and `foo.conf` did not exist, then `ghostty +show-config` would only display `config-file =`). This bug applied to `custom-shaders` too, where it has also been fixed.