### PR TITLE
Fix: AdwTabOverview loses focus on close

### DIFF
--- a/src/apprt/gtk/Tab.zig
+++ b/src/apprt/gtk/Tab.zig
@@ -35,7 +35,7 @@ elem: Surface.Container.Elem,
 // We'll update this every time a Surface gains focus, so that we have it
 // when we switch to another Tab. Then when we switch back to this tab, we
 // can easily re-focus that terminal.
-focus_child: *Surface,
+focus_child: ?*Surface,
 
 pub fn create(alloc: Allocator, window: *Window, parent_: ?*CoreSurface) !*Tab {
     var tab = try alloc.create(Tab);
@@ -52,7 +52,7 @@ pub fn init(self: *Tab, window: *Window, parent_: ?*CoreSurface) !void {
         .label_text = undefined,
         .box = undefined,
         .elem = undefined,
-        .focus_child = undefined,
+        .focus_child = null,
     };
 
     // Create a Box in which we'll later keep either Surface or Split.

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -476,7 +476,8 @@ pub fn toggleWindowDecorations(self: *Window) void {
 /// Grabs focus on the currently selected tab.
 pub fn focusCurrentTab(self: *Window) void {
     const tab = self.notebook.currentTab() orelse return;
-    const gl_area = @as(*c.GtkWidget, @ptrCast(tab.focus_child.gl_area));
+    const surface = tab.focus_child orelse return;
+    const gl_area = @as(*c.GtkWidget, @ptrCast(surface.gl_area));
     _ = c.gtk_widget_grab_focus(gl_area);
 }
 
@@ -760,7 +761,8 @@ fn gtkActionReset(
 /// Returns the surface to use for an action.
 fn actionSurface(self: *Window) ?*CoreSurface {
     const tab = self.notebook.currentTab() orelse return null;
-    return &tab.focus_child.core_surface;
+    const surface = tab.focus_child orelse return null;
+    return &surface.core_surface;
 }
 
 fn userdataSelf(ud: *anyopaque) *Window {


### PR DESCRIPTION
Fixes #2256 

The issue is an upstream bug, so this contains a workaround, see the discussion in #2256 and the comments in this PR for details.