### PR TITLE
adw: clear stored tab overview timer

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -571,6 +571,7 @@ fn adwTabOverviewOpen(
 fn adwTabOverviewFocusTimer(
     self: *Window,
 ) callconv(.C) c.gboolean {
+    self.adw_tab_overview_focus_timer = null;
     self.focusCurrentTab();
 
     // Remove the timer


### PR DESCRIPTION
This prevents a GTK warning introduced in #2260 :

```
(process:354789): GLib-CRITICAL **: 19:07:01.853: Source ID 511 was not found when attempting to remove it
```

which happens when trying to remove a timer (already removed because it ended) here:

https://github.com/ghostty-org/ghostty/blob/59c1c41be178fae164a5ea404f2c76099638716a/src/apprt/gtk/Window.zig#L559-L561