### PR TITLE
Detect password input and render lock glyph

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1826,17 +1826,12 @@ pub fn focusCallback(self: *Surface, focused: bool) !void {
     // Schedule render which also drains our mailbox
     try self.queueRender();
 
-    // Update the focus state and notify the terminal about the focus event if
-    // it is requesting it
+    // Update the focus state and notify the terminal
     {
         self.renderer_state.mutex.lock();
         self.io.terminal.flags.focused = focused;
-        const focus_event = self.io.terminal.modes.get(.focus_event);
         self.renderer_state.mutex.unlock();
-
-        if (focus_event) {
-            self.io.queueMessage(.{ .focused = focused }, .unlocked);
-        }
+        self.io.queueMessage(.{ .focused = focused }, .unlocked);
     }
 }
 

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -55,6 +55,11 @@ const NullPty = struct {
         _ = self;
     }
 
+    pub fn getMode(self: Pty) error{GetModeFailed}!Mode {
+        _ = self;
+        return .{};
+    }
+
     pub fn setSize(self: *Pty, size: winsize) !void {
         _ = self;
         _ = size;

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -947,11 +947,14 @@ pub fn updateFrame(
         errdefer screen_copy.deinit();
 
         // Whether to draw our cursor or not.
-        const cursor_style = renderer.cursorStyle(
-            state,
-            self.focused,
-            cursor_blink_visible,
-        );
+        const cursor_style = if (state.terminal.flags.password_input)
+            .lock
+        else
+            renderer.cursorStyle(
+                state,
+                self.focused,
+                cursor_blink_visible,
+            );
 
         // Get our preedit state
         const preedit: ?renderer.State.Preedit = preedit: {
@@ -2652,24 +2655,52 @@ fn addCursor(
         break :alpha @intFromFloat(@ceil(alpha));
     };
 
-    const sprite: font.Sprite = switch (cursor_style) {
-        .block => .cursor_rect,
-        .block_hollow => .cursor_hollow_rect,
-        .bar => .cursor_bar,
-        .underline => .underline,
-    };
+    const render = switch (cursor_style) {
+        .block,
+        .block_hollow,
+        .bar,
+        .underline,
+        => render: {
+            const sprite: font.Sprite = switch (cursor_style) {
+                .block => .cursor_rect,
+                .block_hollow => .cursor_hollow_rect,
+                .bar => .cursor_bar,
+                .underline => .underline,
+                .lock => unreachable,
+            };
 
-    const render = self.font_grid.renderGlyph(
-        self.alloc,
-        font.sprite_index,
-        @intFromEnum(sprite),
-        .{
-            .cell_width = if (wide) 2 else 1,
-            .grid_metrics = self.grid_metrics,
+            break :render self.font_grid.renderGlyph(
+                self.alloc,
+                font.sprite_index,
+                @intFromEnum(sprite),
+                .{
+                    .cell_width = if (wide) 2 else 1,
+                    .grid_metrics = self.grid_metrics,
+                },
+            ) catch |err| {
+                log.warn("error rendering cursor glyph err={}", .{err});
+                return;
+            };
         },
-    ) catch |err| {
-        log.warn("error rendering cursor glyph err={}", .{err});
-        return;
+
+        .lock => self.font_grid.renderCodepoint(
+            self.alloc,
+            0xF023, // lock symbol
+            .regular,
+            .text,
+            .{
+                .cell_width = if (wide) 2 else 1,
+                .grid_metrics = self.grid_metrics,
+            },
+        ) catch |err| {
+            log.warn("error rendering cursor glyph err={}", .{err});
+            return;
+        } orelse {
+            // This should never happen because we embed nerd
+            // fonts so we just log and return instead of fallback.
+            log.warn("failed to find lock symbol for cursor codepoint=0xF023", .{});
+            return;
+        },
     };
 
     self.cells.setCursor(.{

--- a/src/renderer/cursor.zig
+++ b/src/renderer/cursor.zig
@@ -6,10 +6,14 @@ const State = @import("State.zig");
 /// This is a superset of terminal cursor styles since the renderer supports
 /// some additional cursor states such as the hollow block.
 pub const Style = enum {
+    // Typical cursor input styles
     block,
     block_hollow,
     bar,
     underline,
+
+    // Special cursor styles
+    lock,
 
     /// Create a cursor style from the terminal style request.
     pub fn fromTerminal(term: terminal.CursorStyle) ?Style {

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -119,6 +119,11 @@ flags: packed struct {
     /// True if the window is focused.
     focused: bool = true,
 
+    /// True if the terminal is in a password entry mode. This is set
+    /// to true based on termios state. This is set
+    /// to true based on termios state.
+    password_input: bool = false,
+
     /// Dirty flags for the renderer.
     dirty: Dirty = .{},
 } = .{},

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -21,11 +21,15 @@ const terminal = @import("../terminal/main.zig");
 const termio = @import("../termio.zig");
 const Command = @import("../Command.zig");
 const SegmentedPool = @import("../segmented_pool.zig").SegmentedPool;
-const Pty = @import("../pty.zig").Pty;
+const ptypkg = @import("../pty.zig");
+const Pty = ptypkg.Pty;
 const EnvMap = std.process.EnvMap;
 const windows = internal_os.windows;
 
 const log = std.log.scoped(.io_exec);
+
+/// The termios poll rate in milliseconds.
+const TERMIOS_POLL_MS = 500;
 
 /// The subprocess state for our exec backend.
 subprocess: Subprocess,
@@ -114,6 +118,12 @@ pub fn threadEnter(
     var process = try xev.Process.init(pid);
     errdefer process.deinit();
 
+    // Start our timer to read termios state changes. This is used
+    // to detect things such as when password input is being done
+    // so we can render the terminal in a different way.
+    var termios_timer = try xev.Timer.init();
+    errdefer termios_timer.deinit();
+
     // Start our read thread
     const read_thread = try std.Thread.spawn(
         .{},
@@ -131,7 +141,8 @@ pub fn threadEnter(
         .process = process,
         .read_thread = read_thread,
         .read_thread_pipe = pipe[1],
-        .read_thread_fd = if (builtin.os.tag == .windows) pty_fds.read else {},
+        .read_thread_fd = pty_fds.read,
+        .termios_timer = termios_timer,
     } };
 
     // Start our process watcher
@@ -142,6 +153,20 @@ pub fn threadEnter(
         td,
         processExit,
     );
+
+    // Start our termios timer. We only support this on Windows.
+    // Fundamentally, we could support this on Windows so we're just
+    // waiting for someone to implement it.
+    if (comptime builtin.os.tag != .windows) {
+        termios_timer.run(
+            td.loop,
+            &td.backend.exec.termios_timer_c,
+            TERMIOS_POLL_MS,
+            termio.Termio.ThreadData,
+            td,
+            termiosTimer,
+        );
+    }
 }
 
 pub fn threadExit(self: *Exec, td: *termio.Termio.ThreadData) void {
@@ -359,6 +384,62 @@ fn processExit(
     return .disarm;
 }
 
+fn termiosTimer(
+    td_: ?*termio.Termio.ThreadData,
+    _: *xev.Loop,
+    _: *xev.Completion,
+    r: xev.Timer.RunError!void,
+) xev.CallbackAction {
+    // This should never happen because we guard starting our
+    // timer on windows but we want this assertion to fire if
+    // we ever do start the timer on windows.
+    // TODO: support on windows
+    if (comptime builtin.os.tag == .windows) {
+        @panic("termios timer not implemented on Windows");
+    }
+
+    _ = r catch |err| switch (err) {
+        // This is sent when our timer is canceled. That's fine.
+        error.Canceled => return .disarm,
+
+        else => {
+            log.warn("error in termios timer callback err={}", .{err});
+            @panic("crash in termios timer callback");
+        },
+    };
+
+    const td = td_.?;
+    assert(td.backend == .exec);
+    const exec = &td.backend.exec;
+
+    // This is kind of hacky but we rebuild a Pty struct to get the
+    // termios data.
+    const mode: ptypkg.Mode = (Pty{
+        .master = exec.read_thread_fd,
+        .slave = undefined,
+    }).getMode() catch |err| err: {
+        log.warn("error getting termios mode err={}", .{err});
+
+        // If we have an error we return the default mode values
+        // which are the likely values.
+        break :err .{};
+    };
+
+    log.warn("termios mode={}", .{mode});
+
+    // Repeat the timer
+    exec.termios_timer.run(
+        td.loop,
+        &exec.termios_timer_c,
+        TERMIOS_POLL_MS,
+        termio.Termio.ThreadData,
+        td,
+        termiosTimer,
+    );
+
+    return .disarm;
+}
+
 pub fn queueWrite(
     self: *Exec,
     alloc: Allocator,
@@ -498,7 +579,11 @@ pub const ThreadData = struct {
     /// Reader thread state
     read_thread: std.Thread,
     read_thread_pipe: posix.fd_t,
-    read_thread_fd: if (builtin.os.tag == .windows) posix.fd_t else void,
+    read_thread_fd: posix.fd_t,
+
+    /// The timer to detect termios state changes.
+    termios_timer: xev.Timer,
+    termios_timer_c: xev.Completion = .{},
 
     pub fn deinit(self: *ThreadData, alloc: Allocator) void {
         posix.close(self.read_thread_pipe);
@@ -514,6 +599,9 @@ pub const ThreadData = struct {
 
         // Stop our write stream
         self.write_stream.deinit();
+
+        // Stop our termios timer
+        self.termios_timer.deinit();
     }
 };
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -29,7 +29,7 @@ const windows = internal_os.windows;
 const log = std.log.scoped(.io_exec);
 
 /// The termios poll rate in milliseconds.
-const TERMIOS_POLL_MS = 500;
+const TERMIOS_POLL_MS = 200;
 
 /// The subprocess state for our exec backend.
 subprocess: Subprocess,

--- a/src/termio/backend.zig
+++ b/src/termio/backend.zig
@@ -62,6 +62,16 @@ pub const Backend = union(Kind) {
         }
     }
 
+    pub fn focusGained(
+        self: *Backend,
+        td: *termio.Termio.ThreadData,
+        focused: bool,
+    ) !void {
+        switch (self.*) {
+            .exec => |*exec| try exec.focusGained(td, focused),
+        }
+    }
+
     pub fn resize(
         self: *Backend,
         grid_size: renderer.GridSize,


### PR DESCRIPTION
Fixes #2066 
Progresses on #1325 

This detects a likely password input prompt and changes the cursor to be a lock symbol:

![CleanShot 2024-09-18 at 11 15 32@2x](https://github.com/user-attachments/assets/8453911a-7a56-41ee-a2a1-bbb04455629a)

The password input detection is based on the same logic WezTerm uses (MIT licensed). Namely, we detect when the termios is canonical and not echo. We also use the same lock symbol (codepoint 0xF023), which is safe because Ghostty ships with nerd font symbols. Besides that, our implementation is different.

Our implementation sets up a poller in the IO thread to poll the termios of the pty. This is set at 200ms currently which can cause a very slight but noticeable delay in changing the cursor but has no perceptible impact on CPU usage. We unfortunately have to use a poller because there is no event-driven way to detect termios changes.

The poller only runs while the surface is focused, so there is no linearly increasing CPU requirement for surfaces either.