### PR TITLE
termio: use surface messages to trigger password input state

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -818,7 +818,26 @@ pub fn handleMessage(self: *Surface, msg: Message) !void {
         .report_color_scheme => try self.reportColorScheme(),
 
         .present_surface => try self.presentSurface(),
+
+        .password_input => |v| try self.passwordInput(v),
     }
+}
+
+/// Called when the terminal detects there is a password input prompt.
+fn passwordInput(self: *Surface, v: bool) !void {
+    {
+        self.renderer_state.mutex.lock();
+        defer self.renderer_state.mutex.unlock();
+
+        // If our password input state is unchanged then we don't
+        // waste time doing anything more.
+        const old = self.io.terminal.flags.password_input;
+        if (old == v) return;
+
+        self.io.terminal.flags.password_input = v;
+    }
+
+    try self.queueRender();
 }
 
 /// Sends a DSR response for the current color scheme to the pty.

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -65,6 +65,11 @@ pub const Message = union(enum) {
     /// a window and switching tabs.
     present_surface: void,
 
+    /// Notifies the surface that password input has started within
+    /// the terminal. This should always be followed by a false value
+    /// unless the surface exits.
+    password_input: bool,
+
     pub const ReportTitleStyle = enum {
         csi_21_t,
 


### PR DESCRIPTION
This modifies #2262 to use surface messages to trigger password input state rather than doing it directly on the IO thread and notifying the renderer. The primary motivation is that this will allow us to trigger apprt events and thus enable things such as #1325 or any other UI indication. 