### PR TITLE
adw: disable all of the default shortcuts

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -21,7 +21,7 @@ const Surface = @import("Surface.zig");
 const Tab = @import("Tab.zig");
 const c = @import("c.zig").c;
 const adwaita = @import("adwaita.zig");
-const Notebook = @import("./notebook.zig").Notebook;
+const Notebook = @import("notebook.zig").Notebook;
 
 const log = std.log.scoped(.gtk);
 

--- a/src/apprt/gtk/notebook.zig
+++ b/src/apprt/gtk/notebook.zig
@@ -66,6 +66,10 @@ pub const Notebook = union(enum) {
 
         const tab_view: *c.AdwTabView = c.adw_tab_view_new().?;
 
+        // Adwaita enables all of the shortcuts by default.
+        // We want to manage keybindings ourselves.
+        c.adw_tab_view_remove_shortcuts(tab_view, c.ADW_TAB_VIEW_SHORTCUT_ALL_SHORTCUTS);
+
         _ = c.g_signal_connect_data(tab_view, "page-attached", c.G_CALLBACK(&adwPageAttached), window, null, c.G_CONNECT_DEFAULT);
         _ = c.g_signal_connect_data(tab_view, "create-window", c.G_CALLBACK(&adwTabViewCreateWindow), window, null, c.G_CONNECT_DEFAULT);
         _ = c.g_signal_connect_data(tab_view, "notify::selected-page", c.G_CALLBACK(&adwSelectPage), window, null, c.G_CONNECT_DEFAULT);


### PR DESCRIPTION
There's a set of shortcuts enabled by default in adwaita, see https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/flags.TabViewShortcuts.html

We already bind keys like `alt+1...9` by default, so even if `alt+one=unbind`, the shortcut from adwaita will still take effect, this should not be what the user expected.

There are only shortcuts about move tabs we have not implemented yet, so it should not be a big deal if we disable all of them.