### PR TITLE
termio: correct comment about windows support

### DIFF
--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -154,7 +154,7 @@ pub fn threadEnter(
         processExit,
     );
 
-    // Start our termios timer. We only support this on Windows.
+    // Start our termios timer. We don't support this on Windows.
     // Fundamentally, we could support this on Windows so we're just
     // waiting for someone to implement it.
     if (comptime builtin.os.tag != .windows) {


### PR DESCRIPTION
The comment has conflicting information about supporting windows. This removes the incorrect information that only windows is supported.