### PR TITLE
macos: show clickable mouse pointer when hovering over secure input

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -92,7 +92,10 @@ jobs:
       # codesigning. IMPORTANT: this must NOT run in a Nix environment.
       # Nix breaks xcodebuild so this has to be run outside.
       - name: Build Ghostty.app
-        run: cd macos && xcodebuild -target Ghostty -configuration Release
+        run: |
+          cd macos
+          sudo xcode-select -s /Applications/Xcode_16.0.app
+          xcodebuild -target Ghostty -configuration Release
 
       # We inject the "build number" as simply the number of commits since HEAD.
       # This will be a monotonically always increasing build number that we use.
@@ -240,7 +243,10 @@ jobs:
       # codesigning. IMPORTANT: this must NOT run in a Nix environment.
       # Nix breaks xcodebuild so this has to be run outside.
       - name: Build Ghostty.app
-        run: cd macos && xcodebuild -target Ghostty -configuration Release
+        run: |
+          cd macos
+          sudo xcode-select -s /Applications/Xcode_16.0.app
+          xcodebuild -target Ghostty -configuration Release
 
       # We inject the "build number" as simply the number of commits since HEAD.
       # This will be a monotonically always increasing build number that we use.

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -140,7 +140,10 @@ jobs:
       # codesigning. IMPORTANT: this must NOT run in a Nix environment.
       # Nix breaks xcodebuild so this has to be run outside.
       - name: Build Ghostty.app
-        run: cd macos && xcodebuild -target Ghostty -configuration Release
+        run: |
+          cd macos
+          sudo xcode-select -s /Applications/Xcode_16.0.app
+          xcodebuild -target Ghostty -configuration Release
 
       # We inject the "build number" as simply the number of commits since HEAD.
       # This will be a monotonically always increasing build number that we use.
@@ -321,7 +324,10 @@ jobs:
       # codesigning. IMPORTANT: this must NOT run in a Nix environment.
       # Nix breaks xcodebuild so this has to be run outside.
       - name: Build Ghostty.app
-        run: cd macos && xcodebuild -target Ghostty -configuration Release
+        run: |
+          cd macos
+          sudo xcode-select -s /Applications/Xcode_16.0.app
+          xcodebuild -target Ghostty -configuration Release
 
       # We inject the "build number" as simply the number of commits since HEAD.
       # This will be a monotonically always increasing build number that we use.
@@ -490,7 +496,10 @@ jobs:
       # codesigning. IMPORTANT: this must NOT run in a Nix environment.
       # Nix breaks xcodebuild so this has to be run outside.
       - name: Build Ghostty.app
-        run: cd macos && xcodebuild -target Ghostty -configuration Release
+        run: |
+          cd macos
+          sudo xcode-select -s /Applications/Xcode_16.0.app
+          xcodebuild -target Ghostty -configuration Release
 
       # We inject the "build number" as simply the number of commits since HEAD.
       # This will be a monotonically always increasing build number that we use.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,6 +160,9 @@ jobs:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
+      - name: XCode Select
+        run: sudo xcode-select -s /Applications/Xcode_16.0.app
+
       # GhosttyKit is the framework that is built from Zig for our native
       # Mac app to access.
       - name: Build GhosttyKit

--- a/macos/Sources/Features/Secure Input/SecureInputOverlay.swift
+++ b/macos/Sources/Features/Secure Input/SecureInputOverlay.swift
@@ -39,6 +39,7 @@ struct SecureInputOverlay: View {
                     .onTapGesture {
                         isPopover = true
                     }
+                    .backport.pointerStyle(.link)
                     .padding(.top, 10)
                     .padding(.trailing, 10)
                     .popover(isPresented: $isPopover, arrowEdge: .bottom) {

--- a/macos/Sources/Helpers/Backport.swift
+++ b/macos/Sources/Helpers/Backport.swift
@@ -23,3 +23,28 @@ extension Backport where Content: Scene {
         }
     }
 }
+
+extension Backport where Content: View {
+    func pointerStyle(_ style: BackportPointerStyle) -> some View {
+        if #available(macOS 15, *) {
+            return content.pointerStyle(style.official)
+        } else {
+            return content
+        }
+    }
+
+    enum BackportPointerStyle {
+        case grabIdle
+        case grabActive
+        case link
+
+        @available(macOS 15, *)
+        var official: PointerStyle {
+            switch self {
+            case .grabIdle: return .grabIdle
+            case .grabActive: return .grabActive
+            case .link: return .link
+            }
+        }
+    }
+}


### PR DESCRIPTION
This only works on macOS 15 because it uses the new `pointerStyle` API. I don't have the interest to backport this to older macOS versions but I'm happy to accept a PR if someone else wants to do it.