### PR TITLE
fix(terminal/PageList): ensure enough pages before first page reuse

### DIFF
--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -1694,7 +1694,7 @@ pub fn grow(self: *PageList) !?*List.Node {
     // If allocation would exceed our max size, we prune the first page.
     // We don't need to reallocate because we can simply reuse that first
     // page.
-    if (self.page_size + PagePool.item_size > self.maxSize()) prune: {
+    if (self.pages.len > 1 and self.page_size + PagePool.item_size > self.maxSize()) prune: {
         // If we need to add more memory to ensure our active area is
         // satisfied then we do not prune.
         if (self.growRequiredForActive()) break :prune;

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -1694,7 +1694,14 @@ pub fn grow(self: *PageList) !?*List.Node {
     // If allocation would exceed our max size, we prune the first page.
     // We don't need to reallocate because we can simply reuse that first
     // page.
-    if (self.pages.len > 1 and self.page_size + PagePool.item_size > self.maxSize()) prune: {
+    //
+    // We only take this path if we have more than one page since pruning
+    // reuses the popped page. It is possible to have a single page and
+    // exceed the max size if that page was adjusted to be larger after
+    // initial allocation.
+    if (self.pages.len > 1 and
+        self.page_size + PagePool.item_size > self.maxSize())
+    prune: {
         // If we need to add more memory to ensure our active area is
         // satisfied then we do not prune.
         if (self.growRequiredForActive()) break :prune;


### PR DESCRIPTION
Running [alacritty/vtebench](https://github.com/alacritty/vtebench) on some machines causes Ghostty to fail on `assert(first != last)` when trying to grow scrollback. We now make sure we have enough pages before trying to reuse pages.

The vtebench now runs successfully on my machine (and one more tester's machine which previously also failed).