### PR TITLE
apprt/macos,gtk: unfocused splits now highlight hovered links

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -556,7 +556,10 @@ bool ghostty_surface_mouse_button(ghostty_surface_t,
                                   ghostty_input_mouse_state_e,
                                   ghostty_input_mouse_button_e,
                                   ghostty_input_mods_e);
-void ghostty_surface_mouse_pos(ghostty_surface_t, double, double);
+void ghostty_surface_mouse_pos(ghostty_surface_t,
+                               double,
+                               double,
+                               ghostty_input_mods_e);
 void ghostty_surface_mouse_scroll(ghostty_surface_t,
                                   double,
                                   double,

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -505,7 +505,8 @@ extension Ghostty {
 
             // Convert window position to view position. Note (0, 0) is bottom left.
             let pos = self.convert(event.locationInWindow, from: nil)
-            ghostty_surface_mouse_pos(surface, pos.x, frame.height - pos.y)
+            let mods = Ghostty.ghosttyMods(event.modifierFlags)
+            ghostty_surface_mouse_pos(surface, pos.x, frame.height - pos.y, mods)
 
             // If focus follows mouse is enabled then move focus to this surface.
             if let window = self.window as? TerminalWindow,

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -763,7 +763,12 @@ pub const Surface = struct {
         };
     }
 
-    pub fn cursorPosCallback(self: *Surface, x: f64, y: f64) void {
+    pub fn cursorPosCallback(
+        self: *Surface,
+        x: f64,
+        y: f64,
+        mods: input.Mods,
+    ) void {
         // Convert our unscaled x/y to scaled.
         self.cursor_pos = self.cursorPosToPixels(.{
             .x = @floatCast(x),
@@ -776,7 +781,7 @@ pub const Surface = struct {
             return;
         };
 
-        self.core_surface.cursorPosCallback(self.cursor_pos) catch |err| {
+        self.core_surface.cursorPosCallback(self.cursor_pos, mods) catch |err| {
             log.err("error in cursor pos callback err={}", .{err});
             return;
         };
@@ -1716,8 +1721,20 @@ pub const CAPI = struct {
     }
 
     /// Update the mouse position within the view.
-    export fn ghostty_surface_mouse_pos(surface: *Surface, x: f64, y: f64) void {
-        surface.cursorPosCallback(x, y);
+    export fn ghostty_surface_mouse_pos(
+        surface: *Surface,
+        x: f64,
+        y: f64,
+        mods: c_int,
+    ) void {
+        surface.cursorPosCallback(
+            x,
+            y,
+            @bitCast(@as(
+                input.Mods.Backing,
+                @truncate(@as(c_uint, @bitCast(mods))),
+            )),
+        );
     }
 
     export fn ghostty_surface_mouse_scroll(

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -1040,7 +1040,7 @@ pub const Surface = struct {
         core_win.cursorPosCallback(.{
             .x = @floatCast(pos.xpos),
             .y = @floatCast(pos.ypos),
-        }) catch |err| {
+        }, null) catch |err| {
             log.err("error in cursor pos callback err={}", .{err});
             return;
         };

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1386,7 +1386,7 @@ fn gtkMouseUp(
 }
 
 fn gtkMouseMotion(
-    _: *c.GtkEventControllerMotion,
+    ec: *c.GtkEventControllerMotion,
     x: c.gdouble,
     y: c.gdouble,
     ud: ?*anyopaque,
@@ -1415,7 +1415,12 @@ fn gtkMouseMotion(
         self.grabFocus();
     }
 
-    self.core_surface.cursorPosCallback(self.cursor_pos) catch |err| {
+    // Get our modifiers
+    const event = c.gtk_event_controller_get_current_event(@ptrCast(ec));
+    const gtk_mods = c.gdk_event_get_modifier_state(event);
+    const mods = translateMods(gtk_mods);
+
+    self.core_surface.cursorPosCallback(self.cursor_pos, mods) catch |err| {
         log.err("error in cursor pos callback err={}", .{err});
         return;
     };


### PR DESCRIPTION
Fixes #1547

The core change to make this work is to make the cursor position callback support taking updated modifiers. On both macOS and GTK, cursor position events also provide the pressed modifiers so we can pass those in.