### PR TITLE
gtk/adw: conditional tab keybindings

### DIFF
--- a/src/apprt/gtk/notebook.zig
+++ b/src/apprt/gtk/notebook.zig
@@ -66,9 +66,11 @@ pub const Notebook = union(enum) {
 
         const tab_view: *c.AdwTabView = c.adw_tab_view_new().?;
 
-        // Adwaita enables all of the shortcuts by default.
-        // We want to manage keybindings ourselves.
-        c.adw_tab_view_remove_shortcuts(tab_view, c.ADW_TAB_VIEW_SHORTCUT_ALL_SHORTCUTS);
+        if (comptime adwaita.versionAtLeast(1, 2, 0)) {
+            // Adwaita enables all of the shortcuts by default.
+            // We want to manage keybindings ourselves.
+            c.adw_tab_view_remove_shortcuts(tab_view, c.ADW_TAB_VIEW_SHORTCUT_ALL_SHORTCUTS);
+        }
 
         _ = c.g_signal_connect_data(tab_view, "page-attached", c.G_CALLBACK(&adwPageAttached), window, null, c.G_CONNECT_DEFAULT);
         _ = c.g_signal_connect_data(tab_view, "create-window", c.G_CALLBACK(&adwTabViewCreateWindow), window, null, c.G_CONNECT_DEFAULT);

--- a/src/apprt/gtk/notebook.zig
+++ b/src/apprt/gtk/notebook.zig
@@ -66,7 +66,7 @@ pub const Notebook = union(enum) {
 
         const tab_view: *c.AdwTabView = c.adw_tab_view_new().?;
 
-        if (comptime adwaita.versionAtLeast(1, 2, 0)) {
+        if (comptime adwaita.versionAtLeast(1, 2, 0) and adwaita.versionAtLeast(1, 2, 0)) {
             // Adwaita enables all of the shortcuts by default.
             // We want to manage keybindings ourselves.
             c.adw_tab_view_remove_shortcuts(tab_view, c.ADW_TAB_VIEW_SHORTCUT_ALL_SHORTCUTS);


### PR DESCRIPTION
adw_tab_view_remove_shortcuts (and related APIs) was added in libadwaita 1.2.0.