### PR TITLE
apprt/gtk: override the top bar colors in libadwaita correctly

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -443,9 +443,7 @@ fn loadRuntimeCss(config: *const Config, provider: *c.GtkCssProvider) !void {
         \\ opacity: {d:.2};
         \\ background-color: rgb({d},{d},{d});
         \\}}
-        \\window.ghostty-theme-inherit headerbar,
-        \\window.ghostty-theme-inherit toolbarview > revealer > windowhandle,
-        \\window.ghostty-theme-inherit box > tabbar {{
+        \\.top-bar {{
         \\ background-color: rgb({d},{d},{d});
         \\ color: rgb({d},{d},{d});
         \\}}

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -95,11 +95,6 @@ pub fn init(self: *Window, app: *App) !void {
 
     c.gtk_window_set_icon_name(gtk_window, "com.mitchellh.ghostty");
 
-    // Apply class to color headerbar if window-theme is set to `ghostty`.
-    if (app.config.@"window-theme" == .ghostty) {
-        c.gtk_widget_add_css_class(@ptrCast(gtk_window), "ghostty-theme-inherit");
-    }
-
     // Remove the window's background if any of the widgets need to be transparent
     if (app.config.@"background-opacity" < 1) {
         c.gtk_widget_remove_css_class(@ptrCast(window), "background");


### PR DESCRIPTION
This is the way to override the color in libadwaita < 1.6. We can transition to named colors, specifically headerbar-{fg,bg}-color for libadwaita 1.6.

Fixes: #2266