### PR TITLE
macOS: prevent ctrl-return key equivalent

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -692,6 +692,11 @@ extension Ghostty {
                 // sound and we don't like the beep sound.
                 equivalent = "_"
 
+            case "\r":
+                // Pass C-<return> through verbatim
+                // (prevent the default context menu equivalent)
+                equivalent = "\r"
+
             default:
                 // Ignore other events
                 return false


### PR DESCRIPTION
macOS 15 adds this as a default key equivalent to show the context menu, this is annoying, so we capture the event and tell macOS we handled it.

Fixes #2292 

> [!NOTE]
> While implementing this I noticed the fact that we translate `ctrl-/` in to `ctrl-_` for some reason? This doesn't seem like correct behavior, and the comment is not very elucidating...

#### Future Work:
- Add Ghostty keybind action to open the context menu on the current surface, for people who actually want that behavior for some reason.
- Automatically determine if a given key equivalent is bound by Ghostty and capture it in the same way if so, so that people can override system key equivalents with Ghostty keybinds successfully.
- Maybe add a config to Ghostty for key equivalents to capture, so that if the user wants Ghostty to capture a specific equivalent it can.