### PR TITLE
apprt/gtk: support window-theme != ghostty

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -443,7 +443,9 @@ fn loadRuntimeCss(config: *const Config, provider: *c.GtkCssProvider) !void {
         \\ opacity: {d:.2};
         \\ background-color: rgb({d},{d},{d});
         \\}}
-        \\.top-bar {{
+        \\window.window-theme-ghostty .top-bar,
+        \\window.window-theme-ghostty .bottom-bar,
+        \\window.window-theme-ghostty box > tabbar {{
         \\ background-color: rgb({d},{d},{d});
         \\ color: rgb({d},{d},{d});
         \\}}

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -95,6 +95,11 @@ pub fn init(self: *Window, app: *App) !void {
 
     c.gtk_window_set_icon_name(gtk_window, "com.mitchellh.ghostty");
 
+    // Apply class to color headerbar if window-theme is set to `ghostty`.
+    if (app.config.@"window-theme" == .ghostty) {
+        c.gtk_widget_add_css_class(@ptrCast(gtk_window), "window-theme-ghostty");
+    }
+
     // Remove the window's background if any of the widgets need to be transparent
     if (app.config.@"background-opacity" < 1) {
         c.gtk_widget_remove_css_class(@ptrCast(window), "background");


### PR DESCRIPTION
Follow up to #2293

 - apply colors only for window-theme=ghostty (with `.window-theme-ghostty` class)
 - support for gtk-tabs-location=bottom (`.bottom-bar` selector)
 - support for gtk-titlebar=false (`box > tabbar` selector)
