### PR TITLE
Keybind features: System-global keybindings and target-all-terminal keybindings

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -527,6 +527,7 @@ ghostty_app_t ghostty_app_new(const ghostty_runtime_config_s*,
 void ghostty_app_free(ghostty_app_t);
 bool ghostty_app_tick(ghostty_app_t);
 void* ghostty_app_userdata(ghostty_app_t);
+bool ghostty_app_key(ghostty_app_t, ghostty_input_key_s);
 void ghostty_app_keyboard_changed(ghostty_app_t);
 void ghostty_app_open_config(ghostty_app_t);
 void ghostty_app_reload_config(ghostty_app_t);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -531,6 +531,7 @@ void ghostty_app_keyboard_changed(ghostty_app_t);
 void ghostty_app_open_config(ghostty_app_t);
 void ghostty_app_reload_config(ghostty_app_t);
 bool ghostty_app_needs_confirm_quit(ghostty_app_t);
+bool ghostty_app_has_global_keybinds(ghostty_app_t);
 
 ghostty_surface_config_s ghostty_surface_config_new();
 

--- a/macos/Ghostty.xcodeproj/project.pbxproj
+++ b/macos/Ghostty.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		A5CBD0562C9E65B80017A1AE /* DraggableWindowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CBD0552C9E65A50017A1AE /* DraggableWindowView.swift */; };
 		A5CBD0582C9F30960017A1AE /* Cursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CBD0572C9F30860017A1AE /* Cursor.swift */; };
 		A5CBD0592C9F37B10017A1AE /* Backport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CEAFFE29C2410700646FDA /* Backport.swift */; };
+		A5CBD06B2CA322430017A1AE /* GlobalEventTap.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CBD06A2CA322320017A1AE /* GlobalEventTap.swift */; };
 		A5CC36132C9CD72D004D6760 /* SecureInputOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CC36122C9CD729004D6760 /* SecureInputOverlay.swift */; };
 		A5CC36152C9CDA06004D6760 /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CC36142C9CDA03004D6760 /* View+Extension.swift */; };
 		A5CDF1912AAF9A5800513312 /* ConfigurationErrors.xib in Resources */ = {isa = PBXBuildFile; fileRef = A5CDF1902AAF9A5800513312 /* ConfigurationErrors.xib */; };
@@ -131,6 +132,7 @@
 		A5B3053D299BEAAB0047F10C /* Ghostty.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Ghostty.entitlements; sourceTree = "<group>"; };
 		A5CBD0552C9E65A50017A1AE /* DraggableWindowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraggableWindowView.swift; sourceTree = "<group>"; };
 		A5CBD0572C9F30860017A1AE /* Cursor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cursor.swift; sourceTree = "<group>"; };
+		A5CBD06A2CA322320017A1AE /* GlobalEventTap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalEventTap.swift; sourceTree = "<group>"; };
 		A5CC36122C9CD729004D6760 /* SecureInputOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureInputOverlay.swift; sourceTree = "<group>"; };
 		A5CC36142C9CDA03004D6760 /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		A5CDF1902AAF9A5800513312 /* ConfigurationErrors.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ConfigurationErrors.xib; sourceTree = "<group>"; };
@@ -199,6 +201,7 @@
 		A53426362A7DC53000EBB7A2 /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				A5CBD0672CA2704E0017A1AE /* Global Keybinds */,
 				A56D58872ACDE6BE00508D2C /* Services */,
 				A59630982AEE1C4400D64628 /* Terminal */,
 				A5E112912AF73E4D00C6E0C2 /* ClipboardConfirmation */,
@@ -370,6 +373,14 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		A5CBD0672CA2704E0017A1AE /* Global Keybinds */ = {
+			isa = PBXGroup;
+			children = (
+				A5CBD06A2CA322320017A1AE /* GlobalEventTap.swift */,
+			);
+			path = "Global Keybinds";
+			sourceTree = "<group>";
+		};
 		A5CEAFDA29B8005900646FDA /* SplitView */ = {
 			isa = PBXGroup;
 			children = (
@@ -529,6 +540,7 @@
 				A59630972AEE163600D64628 /* HostingWindow.swift in Sources */,
 				A59630A02AEF6AEB00D64628 /* TerminalManager.swift in Sources */,
 				A51BFC2B2B30F6BE00E92F16 /* UpdateDelegate.swift in Sources */,
+				A5CBD06B2CA322430017A1AE /* GlobalEventTap.swift in Sources */,
 				AEE8B3452B9AA39600260C5E /* NSPasteboard+Extension.swift in Sources */,
 				A53426352A7DA53D00EBB7A2 /* AppDelegate.swift in Sources */,
 				A5CBD0582C9F30960017A1AE /* Cursor.swift in Sources */,

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -418,6 +418,14 @@ class AppDelegate: NSObject,
                 c.showWindow(self)
             }
         }
+
+        // If our reload adds global keybinds and we don't have ax permissions then
+        // we need to request them.
+        global: if (ghostty_app_has_global_keybinds(ghostty.app!)) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) {
+                GlobalEventTap.shared.enable()
+            }
+        }
     }
 
     /// Sync the appearance of our app with the theme specified in the config.

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -431,8 +431,8 @@ class AppDelegate: NSObject,
             }
         }
 
-        // If our reload adds global keybinds and we don't have ax permissions then
-        // we need to request them.
+        // We need to handle our global event tap depending on if there are global
+        // events that we care about in Ghostty.
         if (ghostty_app_has_global_keybinds(ghostty.app!)) {
             if (timeSinceLaunch > 5) {
                 // If the process has been running for awhile we enable right away

--- a/macos/Sources/Features/Global Keybinds/GlobalEventTap.swift
+++ b/macos/Sources/Features/Global Keybinds/GlobalEventTap.swift
@@ -22,6 +22,7 @@ class GlobalEventTap {
     // don't have permissions.
     private var enableTimer: Timer? = nil
 
+    // Private init so it can't be constructed outside of our singleton
     private init() {}
 
     deinit {

--- a/macos/Sources/Features/Global Keybinds/GlobalEventTap.swift
+++ b/macos/Sources/Features/Global Keybinds/GlobalEventTap.swift
@@ -1,0 +1,150 @@
+import Cocoa
+import CoreGraphics
+import Carbon
+import OSLog
+import GhosttyKit
+
+// Manages the event tap to monitor global events, currently only used for
+// global keybindings.
+class GlobalEventTap {
+    static let shared = GlobalEventTap()
+
+    fileprivate static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier!,
+        category: String(describing: GlobalEventTap.self)
+    )
+
+    // The event tap used for global event listening. This is non-nil if it is
+    // created.
+    private var eventTap: CFMachPort? = nil
+
+    // This is the timer used to retry enabling the global event tap if we
+    // don't have permissions.
+    private var enableTimer: Timer? = nil
+
+    private init() {}
+
+    deinit {
+        disable()
+    }
+
+    // Enable the global event tap. This is safe to call if it is already enabled.
+    // If enabling fails due to permissions, this will start a timer to retry since
+    // accessibility permissions take affect immediately.
+    func enable() {
+        if (eventTap != nil) {
+            // Already enabled
+            return
+        }
+
+        // If we are already trying to enable, then stop the timer and restart it.
+        if let enableTimer {
+            enableTimer.invalidate()
+        }
+
+        // Try to enable the event tap immediately. If this succeeds then we're done!
+        if (tryEnable()) {
+            return
+        }
+
+        // Failed, probably due to permissions. The permissions dialog should've
+        // popped up. We retry on a timer since once the permisisons are granted
+        // then they take affect immediately.
+        enableTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
+            _ = self.tryEnable()
+        }
+    }
+
+    // Disable the global event tap. This is safe to call if it is already disabled.
+    func disable() {
+        // Stop our enable timer if it is on
+        if let enableTimer {
+            enableTimer.invalidate()
+            self.enableTimer = nil
+        }
+
+        // Stop our event tap
+        if let eventTap {
+            Self.logger.debug("invalidating event tap mach port")
+            CFMachPortInvalidate(eventTap)
+            self.eventTap = nil
+        }
+    }
+
+    // Try to enable the global event type, returns false if it fails.
+    private func tryEnable() -> Bool {
+        // The events we care about
+        let eventMask = [
+            CGEventType.keyDown
+        ].reduce(CGEventMask(0), { $0 | (1 << $1.rawValue)})
+
+        // Try to create it
+        guard let eventTap = CGEvent.tapCreate(
+                tap: .cgSessionEventTap,
+                place: .headInsertEventTap,
+                options: .defaultTap,
+                eventsOfInterest: eventMask,
+                callback: cgEventFlagsChangedHandler(proxy:type:cgEvent:userInfo:),
+                userInfo: nil
+        ) else {
+            // Return false if creation failed. This is usually because we don't have
+            // Accessibility permissions but can probably be other reasons I don't
+            // know about.
+            Self.logger.debug("creating global event tap failed, missing permissions?")
+            return false
+        }
+
+        // Store our event tap
+        self.eventTap = eventTap
+
+        // If we have an enable timer we always want to disable it
+        if let enableTimer {
+            enableTimer.invalidate()
+            self.enableTimer = nil
+        }
+
+        // Attach our event tap to the main run loop. Note if you don't do this then
+        // the event tap will block every
+        CFRunLoopAddSource(
+            CFRunLoopGetMain(),
+            CFMachPortCreateRunLoopSource(nil, eventTap, 0),
+            .commonModes
+        )
+
+        Self.logger.info("global event tap enabled for global keybinds")
+        return true
+    }
+}
+
+fileprivate func cgEventFlagsChangedHandler(
+    proxy: CGEventTapProxy,
+    type: CGEventType,
+    cgEvent: CGEvent,
+    userInfo: UnsafeMutableRawPointer?
+) -> Unmanaged<CGEvent>? {
+    let result = Unmanaged.passUnretained(cgEvent)
+
+    // We only care about keydown events
+    guard type == .keyDown else { return result }
+
+    // We need an app delegate to get the Ghostty app instance
+    guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return result }
+    guard let ghostty = appDelegate.ghostty.app else { return result }
+
+    // We need an NSEvent for our logic below
+    guard let event: NSEvent = .init(cgEvent: cgEvent) else { return result }
+
+    // Build our event input and call ghostty
+    var key_ev = ghostty_input_key_s()
+    key_ev.action = GHOSTTY_ACTION_PRESS
+    key_ev.mods = Ghostty.ghosttyMods(event.modifierFlags)
+    key_ev.keycode = UInt32(event.keyCode)
+    key_ev.text = nil
+    key_ev.composing = false
+    if (ghostty_app_key(ghostty, key_ev)) {
+        GlobalEventTap.logger.info("global key event handled event=\(event)")
+        return nil
+    }
+
+    return result
+}

--- a/macos/Sources/Features/Global Keybinds/GlobalEventTap.swift
+++ b/macos/Sources/Features/Global Keybinds/GlobalEventTap.swift
@@ -49,7 +49,7 @@ class GlobalEventTap {
         }
 
         // Failed, probably due to permissions. The permissions dialog should've
-        // popped up. We retry on a timer since once the permisisons are granted
+        // popped up. We retry on a timer since once the permissions are granted
         // then they take affect immediately.
         enableTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
             _ = self.tryEnable()

--- a/macos/Sources/Features/Terminal/TerminalManager.swift
+++ b/macos/Sources/Features/Terminal/TerminalManager.swift
@@ -78,6 +78,12 @@ class TerminalManager {
             window.toggleFullScreen(nil)
         }
 
+        // If our app isn't active, we make it active. All new_window actions
+        // force our app to be active.
+        if !NSApp.isActive {
+            NSApp.activate(ignoringOtherApps: true)
+        }
+
         // We're dispatching this async because otherwise the lastCascadePoint doesn't
         // take effect. Our best theory is there is some next-event-loop-tick logic
         // that Cocoa is doing that we need to be after.

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -631,7 +631,11 @@ extension Ghostty {
         }
 
         static func newWindow(_ userdata: UnsafeMutableRawPointer?, config: ghostty_surface_config_s) {
-            let surface = self.surfaceUserdata(from: userdata)
+            let surface: SurfaceView? = if let userdata {
+                self.surfaceUserdata(from: userdata)
+            } else {
+                nil
+            }
 
             NotificationCenter.default.post(
                 name: Notification.ghosttyNewWindow,

--- a/src/App.zig
+++ b/src/App.zig
@@ -317,6 +317,7 @@ pub fn performAction(
         .unbind => unreachable,
         .ignore => {},
         .quit => try self.setQuit(),
+        .new_window => try self.newWindow(rt_app, .{ .parent = null }),
         .open_config => try self.openConfig(rt_app),
         .reload_config => try self.reloadConfig(rt_app),
         .close_all_windows => {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1605,8 +1605,7 @@ fn maybeHandleBinding(
             return .consumed;
         },
 
-        .action => |v| .{ v, true },
-        .action_unconsumed => |v| .{ v, false },
+        .leaf => |leaf| .{ leaf.action, leaf.flags.consumed },
     };
 
     // We have an action, so at this point we're handling SOMETHING so

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1561,19 +1561,8 @@ fn maybeHandleBinding(
     const entry: input.Binding.Set.Entry = entry: {
         const set = self.keyboard.bindings orelse &self.config.keybind.set;
 
-        var trigger: input.Binding.Trigger = .{
-            .mods = event.mods.binding(),
-            .key = .{ .translated = event.key },
-        };
-        if (set.get(trigger)) |v| break :entry v;
-
-        trigger.key = .{ .physical = event.physical_key };
-        if (set.get(trigger)) |v| break :entry v;
-
-        if (event.unshifted_codepoint > 0) {
-            trigger.key = .{ .unicode = event.unshifted_codepoint };
-            if (set.get(trigger)) |v| break :entry v;
-        }
+        // Get our entry from the set for the given event.
+        if (set.getEvent(event)) |v| break :entry v;
 
         // No entry found. If we're not looking at the root set of the
         // bindings we need to encode everything up to this point and

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -208,9 +208,6 @@ pub const App = struct {
         target: KeyTarget,
         event: KeyEvent,
     ) !bool {
-        // NOTE: If this is updated, take a look at Surface.keyCallback as well.
-        // Their logic is very similar but not identical.
-
         const action = event.action;
         const keycode = event.keycode;
         const mods = event.mods;

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -161,6 +161,19 @@ pub const App = struct {
         self.keymap.deinit();
     }
 
+    /// Returns true if there are any global keybinds in the configuration.
+    pub fn hasGlobalKeybinds(self: *const App) bool {
+        var it = self.config.keybind.set.bindings.iterator();
+        while (it.next()) |entry| {
+            switch (entry.value_ptr.*) {
+                .leader => {},
+                .leaf => |leaf| if (leaf.flags.global) return true,
+            }
+        }
+
+        return false;
+    }
+
     /// This should be called whenever the keyboard layout was changed.
     pub fn reloadKeymap(self: *App) !void {
         // Reload the keymap
@@ -1512,6 +1525,11 @@ pub const CAPI = struct {
     /// Returns true if the app needs to confirm quitting.
     export fn ghostty_app_needs_confirm_quit(v: *App) bool {
         return v.core_app.needsConfirmQuit();
+    }
+
+    /// Returns true if the app has global keybinds.
+    export fn ghostty_app_has_global_keybinds(v: *App) bool {
+        return v.hasGlobalKeybinds();
     }
 
     /// Returns initial surface options.

--- a/src/cli/list_keybinds.zig
+++ b/src/cli/list_keybinds.zig
@@ -116,7 +116,7 @@ fn prettyPrint(alloc: Allocator, keybinds: Config.Keybinds) !u8 {
     while (iter.next()) |bind| {
         const action = switch (bind.value_ptr.*) {
             .leader => continue, // TODO: support this
-            .action, .action_unconsumed => |action| action,
+            .leaf => |leaf| leaf.action,
         };
         const key = switch (bind.key_ptr.key) {
             .translated => |k| try std.fmt.bufPrint(&buf, "{s}", .{@tagName(k)}),

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -651,7 +651,8 @@ class: ?[:0]const u8 = null,
 @"working-directory": ?[]const u8 = null,
 
 /// Key bindings. The format is `trigger=action`. Duplicate triggers will
-/// overwrite previously set values.
+/// overwrite previously set values. The list of actions is available in
+/// the documentation or using the `ghostty +list-actions` command.
 ///
 /// Trigger: `+`-separated list of keys and modifiers. Example: `ctrl+a`,
 /// `ctrl+shift+b`, `up`. Some notes:
@@ -722,6 +723,9 @@ class: ?[:0]const u8 = null,
 ///   * `text:text` - Send a string. Uses Zig string literal syntax.
 ///     i.e. `text:\x15` sends Ctrl-U.
 ///
+///   * All other actions can be found in the documentation or by using the
+///     `ghostty +list-actions` command.
+///
 /// Some notes for the action:
 ///
 ///   * The parameter is taken as-is after the `:`. Double quotes or
@@ -736,11 +740,38 @@ class: ?[:0]const u8 = null,
 ///     removes ALL keybindings up to this point, including the default
 ///     keybindings.
 ///
-/// A keybind by default causes the input to be consumed. This means that the
-/// associated encoding (if any) will not be sent to the running program
-/// in the terminal. If you wish to send the encoded value to the program,
-/// specify the "unconsumed:" prefix before the entire keybind. For example:
-/// "unconsumed:ctrl+a=reload_config"
+/// The keybind trigger can be prefixed with some special values to change
+/// the behavior of the keybind. These are:
+///
+///   * `unconsumed:` - Do not consume the input. By default, a keybind
+///     will consume the input, meaning that the associated encoding (if
+///     any) will not be sent to the running program in the terminal. If
+///     you wish to send the encoded value to the program, specify the
+///     `unconsumed:` prefix before the entire keybind. For example:
+///     `unconsumed:ctrl+a=reload_config`
+///
+///   * `global:` - Make the keybind global. By default, keybinds only work
+///     within Ghostty and under the right conditions (application focused,
+///     sometimes terminal focused, etc.). If you want a keybind to work
+///     globally across your system (i.e. even when Ghostty is not focused),
+///     specify this prefix. Note: this does not work in all environments;
+///     see the additional notes below for more information.
+///
+/// Multiple prefixes can be specified. For example,
+/// `global:unconsumed:ctrl+a=reload_config` will make the keybind global
+/// and not consume the input to reload the config.
+///
+/// A note on `global:`: this feature is only supported on macOS. On macOS,
+/// this feature requires accessibility permissions to be granted to Ghostty.
+/// When a `global:` keybind is specified and Ghostty is launched or reloaded,
+/// Ghostty will attempt to request these permissions. If the permissions are
+/// not granted, the keybind will not work. On macOS, you can find these
+/// permissions in System Preferences -> Privacy & Security -> Accessibility.
+///
+/// Additionally, `global:` keybinds associated with actions that affect
+/// a specific terminal surface will target the last focused terminal surface
+/// within Ghostty. There is not a way to target a specific terminal surface
+/// with a `global:` keybind.
 keybind: Keybinds = .{},
 
 /// Horizontal window padding. This applies padding between the terminal cells

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -704,6 +704,9 @@ class: ?[:0]const u8 = null,
 ///     `ctrl+a>t`, and then bind `ctrl+a` directly, both `ctrl+a>n` and
 ///     `ctrl+a>t` will become unbound.
 ///
+///   * Trigger sequences are not allowed for `global:` or `all:`-prefixed
+///     triggers. This is a limitation we could remove in the future.
+///
 /// Action is the action to take when the trigger is satisfied. It takes the
 /// format `action` or `action:param`. The latter form is only valid if the
 /// action requires a parameter.
@@ -762,7 +765,10 @@ class: ?[:0]const u8 = null,
 ///     any) will not be sent to the running program in the terminal. If
 ///     you wish to send the encoded value to the program, specify the
 ///     `unconsumed:` prefix before the entire keybind. For example:
-///     `unconsumed:ctrl+a=reload_config`
+///     `unconsumed:ctrl+a=reload_config`. `global:` and `all:`-prefixed
+///     keybinds will always consume the input regardless of this setting.
+///     Since they are not associated with a specific terminal surface,
+///     they're never encoded.
 ///
 /// Multiple prefixes can be specified. For example,
 /// `global:unconsumed:ctrl+a=reload_config` will make the keybind global

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -770,6 +770,11 @@ class: ?[:0]const u8 = null,
 ///     Since they are not associated with a specific terminal surface,
 ///     they're never encoded.
 ///
+/// Keybind trigger are not unique per prefix combination. For example,
+/// `ctrl+a` and `global:ctrl+a` are not two separate keybinds. The keybind
+/// set later will overwrite the keybind set earlier. In this case, the
+/// `global:` keybind will be used.
+///
 /// Multiple prefixes can be specified. For example,
 /// `global:unconsumed:ctrl+a=reload_config` will make the keybind global
 /// and not consume the input to reload the config.

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -279,7 +279,8 @@ pub const Action = union(enum) {
     /// available values.
     write_selection_file: WriteScreenAction,
 
-    /// Open a new window.
+    /// Open a new window. If the application isn't currently focused,
+    /// this will bring it to the front.
     new_window: void,
 
     /// Open a new tab.
@@ -562,6 +563,10 @@ pub const Action = union(enum) {
             .quit,
             => .app,
 
+            // These are app but can be special-cased in a surface context.
+            .new_window,
+            => .app,
+
             // Obviously surface actions.
             .csi,
             .esc,
@@ -593,12 +598,12 @@ pub const Action = union(enum) {
             .toggle_window_decorations,
             .toggle_secure_input,
             .crash,
+            => .surface,
 
             // These are less obvious surface actions. They're surface
             // actions because they are relevant to the surface they
             // come from. For example `new_window` needs to be sourced to
             // a surface so inheritance can be done correctly.
-            .new_window,
             .new_tab,
             .previous_tab,
             .next_tab,

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -2030,7 +2030,12 @@ test "set: consumed state" {
     try testing.expect(s.get(.{ .key = .{ .translated = .a } }).? == .leaf);
     try testing.expect(s.get(.{ .key = .{ .translated = .a } }).?.leaf.flags.consumed);
 
-    try s.putUnconsumed(alloc, .{ .key = .{ .translated = .a } }, .{ .new_window = {} });
+    try s.putFlags(
+        alloc,
+        .{ .key = .{ .translated = .a } },
+        .{ .new_window = {} },
+        .{ .consumed = false },
+    );
     try testing.expect(s.get(.{ .key = .{ .translated = .a } }).? == .leaf);
     try testing.expect(!s.get(.{ .key = .{ .translated = .a } }).?.leaf.flags.consumed);
 


### PR DESCRIPTION
This PR introduces two distinct but related features:

  * **System-global keybindings.** These are notated with the prefix `global:`. These keybindings will work globally on the system, regardless of what application is focused. This currently only works for macOS and requires accessibility privileges. More on this UX later.

  * **Target-all-terminal keybindings.** These are notated with the prefix `all:`. These keybindings target all running terminal surfaces (windows, tabs, splits) in the Ghostty process. This can be used for example to implement `increase_font_size` across the entire application: `keybind = all:cmd+plus=increase_font_size:1`. This works on macOS and Linux.

The documentation on the various edge cases and details about these new features is immense. Please see `src/config/Config.zig` since I think this will answer most questions. If there are any improvements to docs I can make please suggest them.

## macOS Accessibility Privilege

The `global:` keybind feature requires the accessibility privilege on macOS. Ghostty will automatically request this whenever the configuration contains any `global:` key binds. If there are no `global:` bindings presenting the configuration, Ghostty will not request or use the accessibility privilege.

Note that if a user has already denied it, macOS will not pop up the request prompt again. There is currently no UX to detect this but that's something I'd love to see improved in the future. Detection is trivial, but the UX around the detection requires much more thought.

You can see a demo of this in the video below.

## Demo: System-Global Keybinds

We use `keybind = global:cmd+period=new_window` to create a keybind that creates and focuses a new Ghostty window regardless of what application is in focus. This can mimic a "quick terminal" type feature:

https://github.com/user-attachments/assets/148217bc-d64c-4319-b9a3-d42360b6714c

## Demo: Target-all-terminal Binding

We use `keybind = all:cmd+j=text:hello` to write text in all terminals.


https://github.com/user-attachments/assets/ec82f308-2977-4b5d-9b52-3c743da0a313

