### PR TITLE
terminal/kitty: increase value buffer, make 'H' and 'V' i32

### DIFF
--- a/src/terminal/apc.zig
+++ b/src/terminal/apc.zig
@@ -122,6 +122,26 @@ test "garbage Kitty command" {
     try testing.expect(h.end() == null);
 }
 
+test "Kitty command with overflow u32" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var h: Handler = .{};
+    h.start();
+    for ("Ga=p,i=10000000000") |c| h.feed(alloc, c);
+    try testing.expect(h.end() == null);
+}
+
+test "Kitty command with overflow i32" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var h: Handler = .{};
+    h.start();
+    for ("Ga=p,i=1,z=-9999999999") |c| h.feed(alloc, c);
+    try testing.expect(h.end() == null);
+}
+
 test "valid Kitty command" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/terminal/kitty/graphics_exec.zig
+++ b/src/terminal/kitty/graphics_exec.zig
@@ -495,3 +495,37 @@ test "kittygfx default format is rgba" {
     const img = storage.imageById(1).?;
     try testing.expectEqual(command.Transmission.Format.rgba, img.format);
 }
+
+test "kittygfx test valid u32 (expect invalid image ID)" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t = try Terminal.init(alloc, .{ .rows = 5, .cols = 5 });
+    defer t.deinit(alloc);
+
+    const cmd = try command.Parser.parseString(
+        alloc,
+        "a=p,i=4294967295",
+    );
+    defer cmd.deinit(alloc);
+    const resp = execute(alloc, &t, &cmd).?;
+    try testing.expect(!resp.ok());
+    try testing.expectEqual(resp.message, "ENOENT: image not found");
+}
+
+test "kittygfx test valid i32 (expect invalid image ID)" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t = try Terminal.init(alloc, .{ .rows = 5, .cols = 5 });
+    defer t.deinit(alloc);
+
+    const cmd = try command.Parser.parseString(
+        alloc,
+        "a=p,i=1,z=-2147483648",
+    );
+    defer cmd.deinit(alloc);
+    const resp = execute(alloc, &t, &cmd).?;
+    try testing.expect(!resp.ok());
+    try testing.expectEqual(resp.message, "ENOENT: image not found");
+}


### PR DESCRIPTION
This commit increases the value buffer to 11 characters - this is technically what it should be to allow for large negative integers (i.e., 2.4 billion plus the sign character).

Additionally corrected the types for 'H' (horizontal offset) and 'V' (vertical offset) - these are supposed to be i32 versus u32.

Added some extra tests to test all of this stuff as well.

I've also added a few more tests to help track these cases.