### PR TITLE
Purge @hasDecl from apprt APIs

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -549,6 +549,9 @@ extension Ghostty {
         }
 
         static func setPasswordInput(_ userdata: UnsafeMutableRawPointer?, value: Bool) {
+            // We don't currently allow global password input being set from this.
+            guard let userdata else { return }
+            
             let surfaceView = self.surfaceUserdata(from: userdata)
             guard let appState = self.appState(fromView: surfaceView) else { return }
             guard appState.config.autoSecureInput else { return }

--- a/src/App.zig
+++ b/src/App.zig
@@ -241,19 +241,17 @@ fn redrawInspector(self: *App, rt_app: *apprt.App, surface: *apprt.Surface) !voi
 
 /// Create a new window
 pub fn newWindow(self: *App, rt_app: *apprt.App, msg: Message.NewWindow) !void {
-    if (!@hasDecl(apprt.App, "newWindow")) {
-        log.warn("newWindow is not supported by this runtime", .{});
-        return;
-    }
+    const target: apprt.Target = target: {
+        const parent = msg.parent orelse break :target .app;
+        if (self.hasSurface(parent)) break :target .{ .surface = parent };
+        break :target .app;
+    };
 
-    const parent = if (msg.parent) |parent| parent: {
-        break :parent if (self.hasSurface(parent))
-            parent
-        else
-            null;
-    } else null;
-
-    try rt_app.newWindow(parent);
+    try rt_app.performAction(
+        target,
+        .new_window,
+        {},
+    );
 }
 
 /// Start quitting

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -838,9 +838,16 @@ fn passwordInput(self: *Surface, v: bool) !void {
     }
 
     // Notify our apprt so it can do whatever it wants.
-    if (@hasDecl(apprt.Surface, "setPasswordInput")) {
-        self.rt_surface.setPasswordInput(v);
-    }
+    self.rt_app.performAction(
+        .{ .surface = self },
+        .secure_input,
+        v,
+    ) catch |err| {
+        // We ignore this error because we don't want to fail this
+        // entire operation just because the apprt failed to set
+        // the secure input state.
+        log.warn("apprt failed to set secure input state err={}", .{err});
+    };
 
     try self.queueRender();
 }

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3663,35 +3663,27 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             v,
         ),
 
-        .new_tab => {
-            if (@hasDecl(apprt.Surface, "newTab")) {
-                try self.rt_surface.newTab();
-            } else log.warn("runtime doesn't implement newTab", .{});
-        },
+        .new_tab => try self.rt_app.performAction(
+            .{ .surface = self },
+            .new_tab,
+            {},
+        ),
 
-        .previous_tab => {
-            if (@hasDecl(apprt.Surface, "gotoTab")) {
-                self.rt_surface.gotoTab(.previous);
-            } else log.warn("runtime doesn't implement gotoTab", .{});
-        },
-
-        .next_tab => {
-            if (@hasDecl(apprt.Surface, "gotoTab")) {
-                self.rt_surface.gotoTab(.next);
-            } else log.warn("runtime doesn't implement gotoTab", .{});
-        },
-
-        .last_tab => {
-            if (@hasDecl(apprt.Surface, "gotoTab")) {
-                self.rt_surface.gotoTab(.last);
-            } else log.warn("runtime doesn't implement gotoTab", .{});
-        },
-
-        .goto_tab => |n| {
-            if (@hasDecl(apprt.Surface, "gotoTab")) {
-                self.rt_surface.gotoTab(@enumFromInt(n));
-            } else log.warn("runtime doesn't implement gotoTab", .{});
-        },
+        inline .previous_tab,
+        .next_tab,
+        .last_tab,
+        .goto_tab,
+        => |v, tag| try self.rt_app.performAction(
+            .{ .surface = self },
+            .goto_tab,
+            switch (tag) {
+                .previous_tab => .previous,
+                .next_tab => .next,
+                .last_tab => .last,
+                .goto_tab => @enumFromInt(v),
+                else => comptime unreachable,
+            },
+        ),
 
         .new_split => |direction| {
             if (@hasDecl(apprt.Surface, "newSplit")) {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -747,11 +747,7 @@ pub fn handleMessage(self: *Surface, msg: Message) !void {
         },
 
         .report_title => |style| {
-            const title: ?[:0]const u8 = title: {
-                if (!@hasDecl(apprt.runtime.Surface, "getTitle")) break :title null;
-                break :title self.rt_surface.getTitle();
-            };
-
+            const title: ?[:0]const u8 = self.rt_surface.getTitle();
             const data = switch (style) {
                 .csi_21_t => try std.fmt.allocPrint(
                     self.alloc,
@@ -901,7 +897,6 @@ fn modsChanged(self: *Surface, mods: input.Mods) void {
 /// Called when our renderer health state changes.
 fn updateRendererHealth(self: *Surface, health: renderer.Health) void {
     log.warn("renderer health status change status={}", .{health});
-    if (!@hasDecl(apprt.runtime.Surface, "updateRendererHealth")) return;
     self.rt_surface.updateRendererHealth(health);
 }
 
@@ -1158,10 +1153,8 @@ fn setSelection(self: *Surface, sel_: ?terminal.Selection) !void {
 
     // Check if our runtime supports the selection clipboard at all.
     // We can save a lot of work if it doesn't.
-    if (@hasDecl(apprt.runtime.Surface, "supportsClipboard")) {
-        if (!self.rt_surface.supportsClipboard(clipboard)) {
-            return;
-        }
+    if (!self.rt_surface.supportsClipboard(clipboard)) {
+        return;
     }
 
     const buf = self.io.terminal.screen.selectionString(self.alloc, .{

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3670,39 +3670,18 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
         },
 
         .previous_tab => {
-            if (@hasDecl(apprt.Surface, "hasTabs")) {
-                if (!self.rt_surface.hasTabs()) {
-                    log.debug("surface has no tabs, ignoring previous_tab binding", .{});
-                    return false;
-                }
-            }
-
             if (@hasDecl(apprt.Surface, "gotoTab")) {
                 self.rt_surface.gotoTab(.previous);
             } else log.warn("runtime doesn't implement gotoTab", .{});
         },
 
         .next_tab => {
-            if (@hasDecl(apprt.Surface, "hasTabs")) {
-                if (!self.rt_surface.hasTabs()) {
-                    log.debug("surface has no tabs, ignoring next_tab binding", .{});
-                    return false;
-                }
-            }
-
             if (@hasDecl(apprt.Surface, "gotoTab")) {
                 self.rt_surface.gotoTab(.next);
             } else log.warn("runtime doesn't implement gotoTab", .{});
         },
 
         .last_tab => {
-            if (@hasDecl(apprt.Surface, "hasTabs")) {
-                if (!self.rt_surface.hasTabs()) {
-                    log.debug("surface has no tabs, ignoring last_tab binding", .{});
-                    return false;
-                }
-            }
-
             if (@hasDecl(apprt.Surface, "gotoTab")) {
                 self.rt_surface.gotoTab(.last);
             } else log.warn("runtime doesn't implement gotoTab", .{});

--- a/src/apprt.zig
+++ b/src/apprt.zig
@@ -12,9 +12,9 @@ const std = @import("std");
 const builtin = @import("builtin");
 const build_config = @import("build_config.zig");
 
-const action = @import("apprt/action.zig");
 const structs = @import("apprt/structs.zig");
 
+pub const action = @import("apprt/action.zig");
 pub const glfw = @import("apprt/glfw.zig");
 pub const gtk = @import("apprt/gtk.zig");
 pub const none = @import("apprt/none.zig");

--- a/src/apprt.zig
+++ b/src/apprt.zig
@@ -32,10 +32,8 @@ pub const ClipboardRequestType = structs.ClipboardRequestType;
 pub const ColorScheme = structs.ColorScheme;
 pub const CursorPos = structs.CursorPos;
 pub const DesktopNotification = structs.DesktopNotification;
-pub const GotoTab = structs.GotoTab;
 pub const IMEPos = structs.IMEPos;
 pub const Selection = structs.Selection;
-pub const SplitDirection = structs.SplitDirection;
 pub const SurfaceSize = structs.SurfaceSize;
 
 /// The implementation to use for the app runtime. This is comptime chosen

--- a/src/apprt.zig
+++ b/src/apprt.zig
@@ -12,6 +12,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const build_config = @import("build_config.zig");
 
+const action = @import("apprt/action.zig");
 const structs = @import("apprt/structs.zig");
 
 pub const glfw = @import("apprt/glfw.zig");
@@ -20,6 +21,9 @@ pub const none = @import("apprt/none.zig");
 pub const browser = @import("apprt/browser.zig");
 pub const embedded = @import("apprt/embedded.zig");
 pub const surface = @import("apprt/surface.zig");
+
+pub const Action = action.Action;
+pub const Target = action.Target;
 
 pub const ContentScale = structs.ContentScale;
 pub const Clipboard = structs.Clipboard;
@@ -84,4 +88,6 @@ pub const Runtime = enum {
 test {
     _ = Runtime;
     _ = runtime;
+    _ = action;
+    _ = structs;
 }

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -2,9 +2,33 @@ const std = @import("std");
 const assert = std.debug.assert;
 const CoreSurface = @import("../Surface.zig");
 
-/// The possible actions an apprt has to react to.
+/// The possible actions an apprt has to react to. Actions are one-way
+/// messages that are sent to the app runtime to trigger some behavior.
+///
+/// Actions are very often key binding actions but can also be triggered
+/// by lifecycle events. For example, the `quit_timer` action is not bindable.
+///
+/// Importantly, actions are generally OPTIONAL to implement by an apprt.
+/// Required functionality is called directly on the runtime structure so
+/// there is a compiler error if an action is not implemented.
 pub const Action = union(enum) {
+    /// Open a new window. The target determines whether properties such
+    /// as font size should be inherited.
     new_window,
+
+    /// Close all open windows.
+    close_all_windows,
+
+    /// Open the Ghostty configuration. This is platform-specific about
+    /// what it means; it can mean opening a dedicated UI or just opening
+    /// a file in a text editor.
+    open_config,
+
+    /// Called when there are no more surfaces and the app should quit
+    /// after the configured delay. This can be cancelled by sending
+    /// another quit_timer action with "stop". Multiple "starts" shouldn't
+    /// happen and can be ignored or cause a restart it isn't that important.
+    quit_timer: enum { start, stop },
 
     /// The enum of keys in the tagged union.
     pub const Key = @typeInfo(Action).Union.tag_type.?;

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -30,6 +30,13 @@ pub const Action = union(enum) {
     /// happen and can be ignored or cause a restart it isn't that important.
     quit_timer: enum { start, stop },
 
+    /// Set the secure input functionality on or off. "Secure input" means
+    /// that the user is currently at some sort of prompt where they may be
+    /// entering a password or other sensitive information. This can be used
+    /// by the app runtime to change the appearance of the cursor, setup
+    /// system APIs to not log the input, etc.
+    secure_input: bool,
+
     /// The enum of keys in the tagged union.
     pub const Key = @typeInfo(Action).Union.tag_type.?;
 

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -2,6 +2,14 @@ const std = @import("std");
 const assert = std.debug.assert;
 const CoreSurface = @import("../Surface.zig");
 
+/// The target for an action. This is generally the thing that had focus
+/// while the action was made but the concept of "focus" is not guaranteed
+/// since actions can also be triggered by timers, scripts, etc.
+pub const Target = union(enum) {
+    app,
+    surface: *CoreSurface,
+};
+
 /// The possible actions an apprt has to react to. Actions are one-way
 /// messages that are sent to the app runtime to trigger some behavior.
 ///
@@ -69,7 +77,7 @@ pub const Action = union(enum) {
     /// after the configured delay. This can be cancelled by sending
     /// another quit_timer action with "stop". Multiple "starts" shouldn't
     /// happen and can be ignored or cause a restart it isn't that important.
-    quit_timer: enum { start, stop },
+    quit_timer: QuitTimer,
 
     /// Set the secure input functionality on or off. "Secure input" means
     /// that the user is currently at some sort of prompt where they may be
@@ -90,14 +98,6 @@ pub const Action = union(enum) {
 
         unreachable;
     }
-};
-
-/// The target for an action. This is generally the thing that had focus
-/// while the action was made but the concept of "focus" is not guaranteed
-/// since actions can also be triggered by timers, scripts, etc.
-pub const Target = union(enum) {
-    app,
-    surface: *CoreSurface,
 };
 
 // This is made extern (c_int) to make interop easier with our embedded
@@ -163,6 +163,11 @@ pub const Inspector = enum(c_int) {
     toggle,
     show,
     hide,
+};
+
+pub const QuitTimer = enum(c_int) {
+    start,
+    stop,
 };
 
 /// The desktop notification to show.

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -1,0 +1,29 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const CoreSurface = @import("../Surface.zig");
+
+/// The possible actions an apprt has to react to.
+pub const Action = union(enum) {
+    new_window,
+
+    /// The enum of keys in the tagged union.
+    pub const Key = @typeInfo(Action).Union.tag_type.?;
+
+    /// Returns the value type for the given key.
+    pub fn Value(comptime key: Key) type {
+        inline for (@typeInfo(Action).Union.fields) |field| {
+            const field_key = @field(Key, field.name);
+            if (field_key == key) return field.type;
+        }
+
+        unreachable;
+    }
+};
+
+/// The target for an action. This is generally the thing that had focus
+/// while the action was made but the concept of "focus" is not guaranteed
+/// since actions can also be triggered by timers, scripts, etc.
+pub const Target = union(enum) {
+    app,
+    surface: *CoreSurface,
+};

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -21,12 +21,32 @@ pub const Action = union(enum) {
     /// the tab should be opened in a new window.
     new_tab,
 
+    /// Create a new split. The value determines the location of the split
+    /// relative to the target.
+    new_split: SplitDirection,
+
+    /// Close all open windows.
+    close_all_windows,
+
+    /// Toggle whether window directions are shown.
+    toggle_window_decorations,
+
     /// Jump to a specific tab. Must handle the scenario that the tab
     /// value is invalid.
     goto_tab: GotoTab,
 
-    /// Close all open windows.
-    close_all_windows,
+    /// Jump to a specific split.
+    goto_split: GotoSplit,
+
+    /// Resize the split in the given direction.
+    resize_split: ResizeSplit,
+
+    /// Equalize all the splits in the target window.
+    equalize_splits,
+
+    /// Toggle whether a split is zoomed or not. A zoomed split is resized
+    /// to take up the entire window.
+    toggle_split_zoom,
 
     /// Open the Ghostty configuration. This is platform-specific about
     /// what it means; it can mean opening a dedicated UI or just opening
@@ -44,7 +64,7 @@ pub const Action = union(enum) {
     /// entering a password or other sensitive information. This can be used
     /// by the app runtime to change the appearance of the cursor, setup
     /// system APIs to not log the input, etc.
-    secure_input: bool,
+    secure_input: SecureInput,
 
     /// The enum of keys in the tagged union.
     pub const Key = @typeInfo(Action).Union.tag_type.?;
@@ -68,6 +88,38 @@ pub const Target = union(enum) {
     surface: *CoreSurface,
 };
 
+// This is made extern (c_int) to make interop easier with our embedded
+// runtime. The small size cost doesn't make a difference in our union.
+pub const SplitDirection = enum(c_int) {
+    right,
+    down,
+};
+
+// This is made extern (c_int) to make interop easier with our embedded
+// runtime. The small size cost doesn't make a difference in our union.
+pub const GotoSplit = enum(c_int) {
+    previous,
+    next,
+
+    top,
+    left,
+    bottom,
+    right,
+};
+
+/// The amount to resize the split by and the direction to resize it in.
+pub const ResizeSplit = struct {
+    amount: u16,
+    direction: Direction,
+
+    pub const Direction = enum(c_int) {
+        up,
+        down,
+        left,
+        right,
+    };
+};
+
 /// The tab to jump to. This is non-exhaustive so that integer values represent
 /// the index (zero-based) of the tab to jump to. Negative values are special
 /// values.
@@ -76,4 +128,10 @@ pub const GotoTab = enum(c_int) {
     next = -2,
     last = -3,
     _,
+};
+
+pub const SecureInput = enum(c_int) {
+    on,
+    off,
+    toggle,
 };

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -16,6 +16,15 @@ pub const Action = union(enum) {
     /// as font size should be inherited.
     new_window,
 
+    /// Open a new tab. If the target is a surface it should be opened in
+    /// the same window as the surface. If the target is the app then
+    /// the tab should be opened in a new window.
+    new_tab,
+
+    /// Jump to a specific tab. Must handle the scenario that the tab
+    /// value is invalid.
+    goto_tab: GotoTab,
+
     /// Close all open windows.
     close_all_windows,
 
@@ -57,4 +66,14 @@ pub const Action = union(enum) {
 pub const Target = union(enum) {
     app,
     surface: *CoreSurface,
+};
+
+/// The tab to jump to. This is non-exhaustive so that integer values represent
+/// the index (zero-based) of the tab to jump to. Negative values are special
+/// values.
+pub const GotoTab = enum(c_int) {
+    previous = -1,
+    next = -2,
+    last = -3,
+    _,
 };

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -28,6 +28,9 @@ pub const Action = union(enum) {
     /// Close all open windows.
     close_all_windows,
 
+    /// Toggle fullscreen mode.
+    toggle_fullscreen: Fullscreen,
+
     /// Toggle whether window directions are shown.
     toggle_window_decorations,
 
@@ -47,6 +50,15 @@ pub const Action = union(enum) {
     /// Toggle whether a split is zoomed or not. A zoomed split is resized
     /// to take up the entire window.
     toggle_split_zoom,
+
+    /// Present the target terminal whether its a tab, split, or window.
+    present_terminal,
+
+    /// Control whether the inspector is shown or hidden.
+    inspector: Inspector,
+
+    /// Show a desktop notification.
+    desktop_notification: DesktopNotification,
 
     /// Open the Ghostty configuration. This is platform-specific about
     /// what it means; it can mean opening a dedicated UI or just opening
@@ -130,8 +142,31 @@ pub const GotoTab = enum(c_int) {
     _,
 };
 
+/// The fullscreen mode to toggle to if we're moving to fullscreen.
+pub const Fullscreen = enum(c_int) {
+    native,
+
+    /// macOS has a non-native fullscreen mode that is more like a maximized
+    /// window. This is much faster to enter and exit than the native mode.
+    macos_non_native,
+    macos_non_native_visible_menu,
+};
+
 pub const SecureInput = enum(c_int) {
     on,
     off,
     toggle,
+};
+
+/// The inspector mode to toggle to if we're toggling the inspector.
+pub const Inspector = enum(c_int) {
+    toggle,
+    show,
+    hide,
+};
+
+/// The desktop notification to show.
+pub const DesktopNotification = struct {
+    title: [:0]const u8,
+    body: [:0]const u8,
 };

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -147,6 +147,8 @@ pub const App = struct {
                 .surface => |v| v,
             }),
 
+            .toggle_fullscreen => self.toggleFullscreen(target),
+
             .open_config => try configpkg.edit.open(self.app.alloc),
 
             // Unimplemented
@@ -155,11 +157,14 @@ pub const App = struct {
             .resize_split,
             .equalize_splits,
             .toggle_split_zoom,
+            .present_terminal,
             .close_all_windows,
             .toggle_window_decorations,
             .goto_tab,
+            .inspector,
             .quit_timer,
             .secure_input,
+            .desktop_notification,
             => log.info("unimplemented action={}", .{action}),
         }
     }
@@ -182,8 +187,12 @@ pub const App = struct {
     }
 
     /// Toggle the window to fullscreen mode.
-    pub fn toggleFullscreen(self: *App, surface: *Surface) void {
+    fn toggleFullscreen(self: *App, target: apprt.Target) void {
         _ = self;
+        const surface: *Surface = switch (target) {
+            .app => return,
+            .surface => |v| v.rt_surface,
+        };
         const win = surface.window;
 
         if (surface.isFullscreen()) {
@@ -560,10 +569,6 @@ pub const Surface = struct {
     /// Checks if the glfw window is in fullscreen.
     pub fn isFullscreen(self: *Surface) bool {
         return self.window.getMonitor() != null;
-    }
-
-    pub fn toggleFullscreen(self: *Surface, _: Config.NonNativeFullscreen) void {
-        self.app.toggleFullscreen(self);
     }
 
     /// Close this surface.

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -150,7 +150,13 @@ pub const App = struct {
             .open_config => try configpkg.edit.open(self.app.alloc),
 
             // Unimplemented
+            .new_split,
+            .goto_split,
+            .resize_split,
+            .equalize_splits,
+            .toggle_split_zoom,
             .close_all_windows,
+            .toggle_window_decorations,
             .goto_tab,
             .quit_timer,
             .secure_input,

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -127,6 +127,23 @@ pub const App = struct {
         glfw.postEmptyEvent();
     }
 
+    /// Perform a given action.
+    pub fn performAction(
+        self: *App,
+        target: apprt.Target,
+        comptime action: apprt.Action.Key,
+        value: apprt.Action.Value(action),
+    ) !void {
+        _ = value;
+
+        switch (action) {
+            .new_window => _ = try self.newSurface(switch (target) {
+                .app => null,
+                .surface => |v| v,
+            }),
+        }
+    }
+
     /// Open the configuration in the system editor.
     pub fn openConfig(self: *App) !void {
         try configpkg.edit.open(self.app.alloc);
@@ -193,11 +210,6 @@ pub const App = struct {
         };
 
         win.setMonitor(monitor, 0, 0, video_mode.getWidth(), video_mode.getHeight(), 0);
-    }
-
-    /// Create a new window for the app.
-    pub fn newWindow(self: *App, parent_: ?*CoreSurface) !void {
-        _ = try self.newSurface(parent_);
     }
 
     /// Create a new tab in the parent surface.

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -141,12 +141,14 @@ pub const App = struct {
                 .app => null,
                 .surface => |v| v,
             }),
-        }
-    }
 
-    /// Open the configuration in the system editor.
-    pub fn openConfig(self: *App) !void {
-        try configpkg.edit.open(self.app.alloc);
+            .open_config => try configpkg.edit.open(self.app.alloc),
+
+            // Unimplemented
+            .close_all_windows,
+            .quit_timer,
+            => log.warn("unimplemented action={}", .{action}),
+        }
     }
 
     /// Reload the configuration. This should return the new configuration.

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -147,7 +147,8 @@ pub const App = struct {
             // Unimplemented
             .close_all_windows,
             .quit_timer,
-            => log.warn("unimplemented action={}", .{action}),
+            .secure_input,
+            => log.info("unimplemented action={}", .{action}),
         }
     }
 

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -411,7 +411,6 @@ pub const Surface = struct {
     /// Initialize the surface into the given self pointer. This gives a
     /// stable pointer to the destination that can be used for callbacks.
     pub fn init(self: *Surface, app: *App) !void {
-
         // Create our window
         const win = glfw.Window.create(
             640,
@@ -713,6 +712,23 @@ pub const Surface = struct {
     /// Set the visibility of the mouse cursor.
     pub fn setMouseVisibility(self: *Surface, visible: bool) void {
         self.window.setInputModeCursor(if (visible) .normal else .hidden);
+    }
+
+    pub fn updateRendererHealth(self: *const Surface, health: renderer.Health) void {
+        // We don't support this in GLFW.
+        _ = self;
+        _ = health;
+    }
+
+    pub fn supportsClipboard(
+        self: *const Surface,
+        clipboard_type: apprt.Clipboard,
+    ) bool {
+        _ = self;
+        return switch (clipboard_type) {
+            .standard => true,
+            .selection, .primary => comptime builtin.os.tag == .linux,
+        };
     }
 
     /// Start an async clipboard request.

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -1098,8 +1098,12 @@ fn gtkActionPresentSurface(
         return;
     }
 
-    // Convert that u64 to pointer to a core surface.
-    const surface: *CoreSurface = @ptrFromInt(c.g_variant_get_uint64(parameter));
+    // Convert that u64 to pointer to a core surface. A value of zero
+    // means that there was no target surface for the notification so
+    // we dont' focus any surface.
+    const ptr_int: u64 = c.g_variant_get_uint64(parameter);
+    if (ptr_int == 0) return;
+    const surface: *CoreSurface = @ptrFromInt(ptr_int);
 
     // Send a message through the core app mailbox rather than presenting the
     // surface directly so that it can validate that the surface pointer is

--- a/src/apprt/gtk/Split.zig
+++ b/src/apprt/gtk/Split.zig
@@ -7,7 +7,6 @@ const Allocator = std.mem.Allocator;
 const assert = std.debug.assert;
 const apprt = @import("../../apprt.zig");
 const font = @import("../../font/main.zig");
-const input = @import("../../input.zig");
 const CoreSurface = @import("../../Surface.zig");
 
 const Surface = @import("Surface.zig");
@@ -21,14 +20,14 @@ pub const Orientation = enum {
     horizontal,
     vertical,
 
-    pub fn fromDirection(direction: apprt.SplitDirection) Orientation {
+    pub fn fromDirection(direction: apprt.action.SplitDirection) Orientation {
         return switch (direction) {
             .right => .horizontal,
             .down => .vertical,
         };
     }
 
-    pub fn fromResizeDirection(direction: input.SplitResizeDirection) Orientation {
+    pub fn fromResizeDirection(direction: apprt.action.ResizeSplit.Direction) Orientation {
         return switch (direction) {
             .up, .down => .vertical,
             .left, .right => .horizontal,
@@ -58,7 +57,7 @@ bottom_right: Surface.Container.Elem,
 pub fn create(
     alloc: Allocator,
     sibling: *Surface,
-    direction: apprt.SplitDirection,
+    direction: apprt.action.SplitDirection,
 ) !*Split {
     var split = try alloc.create(Split);
     errdefer alloc.destroy(split);
@@ -69,7 +68,7 @@ pub fn create(
 pub fn init(
     self: *Split,
     sibling: *Surface,
-    direction: apprt.SplitDirection,
+    direction: apprt.action.SplitDirection,
 ) !void {
     // Create the new child surface for the other direction.
     const alloc = sibling.app.core_app.alloc;
@@ -164,7 +163,11 @@ fn removeChild(
 }
 
 /// Move the divider in the given direction by the given amount.
-pub fn moveDivider(self: *Split, direction: input.SplitResizeDirection, amount: u16) void {
+pub fn moveDivider(
+    self: *Split,
+    direction: apprt.action.ResizeSplit.Direction,
+    amount: u16,
+) void {
     const min_pos = 10;
 
     const pos = c.gtk_paned_get_position(self.paned);
@@ -263,7 +266,7 @@ fn updateChildren(self: *const Split) void {
 
 /// A mapping of direction to the element (if any) in that direction.
 pub const DirectionMap = std.EnumMap(
-    input.SplitFocusDirection,
+    apprt.action.GotoSplit,
     ?*Surface,
 );
 

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -9,6 +9,7 @@ const configpkg = @import("../../config.zig");
 const apprt = @import("../../apprt.zig");
 const font = @import("../../font/main.zig");
 const input = @import("../../input.zig");
+const renderer = @import("../../renderer.zig");
 const terminal = @import("../../terminal/main.zig");
 const CoreSurface = @import("../../Surface.zig");
 const internal_os = @import("../../os/main.zig");
@@ -940,6 +941,19 @@ pub fn mouseOverLink(self: *Surface, uri_: ?[]const u8) void {
     }
 
     self.url_widget = URLWidget.init(self, uriZ);
+}
+
+pub fn supportsClipboard(
+    self: *const Surface,
+    clipboard_type: apprt.Clipboard,
+) bool {
+    _ = self;
+    return switch (clipboard_type) {
+        .standard,
+        .selection,
+        .primary,
+        => true,
+    };
 }
 
 pub fn clipboardRequest(
@@ -1906,4 +1920,10 @@ pub fn present(self: *Surface) void {
     }
 
     self.grabFocus();
+}
+
+pub fn updateRendererHealth(self: *const Surface, health: renderer.Health) void {
+    // We don't support this in GTK.
+    _ = self;
+    _ = health;
 }

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -790,11 +790,6 @@ pub fn newTab(self: *Surface) !void {
     try window.newTab(&self.core_surface);
 }
 
-pub fn hasTabs(self: *const Surface) bool {
-    const window = self.container.window() orelse return false;
-    return window.hasTabs();
-}
-
 pub fn gotoTab(self: *Surface, tab: apprt.GotoTab) void {
     const window = self.container.window() orelse {
         log.info(

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -459,7 +459,7 @@ pub fn gotoTab(self: *Window, n: usize) void {
 }
 
 /// Toggle fullscreen for this window.
-pub fn toggleFullscreen(self: *Window, _: configpkg.NonNativeFullscreen) void {
+pub fn toggleFullscreen(self: *Window) void {
     const is_fullscreen = c.gtk_window_is_fullscreen(self.window);
     if (is_fullscreen == 0) {
         c.gtk_window_fullscreen(self.window);

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -421,11 +421,6 @@ pub fn closeTab(self: *Window, tab: *Tab) void {
     self.notebook.closeTab(tab);
 }
 
-/// Returns true if this window has any tabs.
-pub fn hasTabs(self: *const Window) bool {
-    return self.notebook.nPages() > 0;
-}
-
 /// Go to the previous tab for a surface.
 pub fn gotoPreviousTab(self: *Window, surface: *Surface) void {
     const tab = surface.container.tab() orelse {

--- a/src/apprt/structs.zig
+++ b/src/apprt/structs.zig
@@ -62,16 +62,6 @@ pub const DesktopNotification = struct {
     body: []const u8,
 };
 
-/// The tab to jump to. This is non-exhaustive so that integer values represent
-/// the index (zero-based) of the tab to jump to. Negative values are special
-/// values.
-pub const GotoTab = enum(c_int) {
-    previous = -1,
-    next = -2,
-    last = -3,
-    _,
-};
-
 // This is made extern (c_int) to make interop easier with our embedded
 // runtime. The small size cost doesn't make a difference in our union.
 pub const SplitDirection = enum(c_int) {

--- a/src/apprt/structs.zig
+++ b/src/apprt/structs.zig
@@ -62,13 +62,6 @@ pub const DesktopNotification = struct {
     body: []const u8,
 };
 
-// This is made extern (c_int) to make interop easier with our embedded
-// runtime. The small size cost doesn't make a difference in our union.
-pub const SplitDirection = enum(c_int) {
-    right,
-    down,
-};
-
 /// The color scheme in use (light vs dark).
 pub const ColorScheme = enum(u2) {
     light = 0,

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -410,8 +410,7 @@ pub const Action = union(enum) {
         // Note: we don't support top or left yet
     };
 
-    // Extern because it is used in the embedded runtime ABI.
-    pub const SplitFocusDirection = enum(c_int) {
+    pub const SplitFocusDirection = enum {
         previous,
         next,
 
@@ -421,8 +420,7 @@ pub const Action = union(enum) {
         right,
     };
 
-    // Extern because it is used in the embedded runtime ABI.
-    pub const SplitResizeDirection = enum(c_int) {
+    pub const SplitResizeDirection = enum {
         up,
         down,
         left,

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -438,7 +438,7 @@ pub const Action = union(enum) {
     };
 
     // Extern because it is used in the embedded runtime ABI.
-    pub const InspectorMode = enum(c_int) {
+    pub const InspectorMode = enum {
         toggle,
         show,
         hide,


### PR DESCRIPTION
This removes `@hasDecl` from all but one use case for apprt APIs. 

**Motivation:** `@hasDecl` is a highly error-prone way to do feature detection. As an apprt author, it is hard to determine what decls need to be implemented to magically gain functionality, and one small typo and your feature doesn't work. Bleh! 

As a replacement, we do two things:

  * **Require more decls.** Some checks were simply... removed, and the APIs are now required by all apprts. They are stubbed in the apprts that don't implement the feature. None of our feature checks changed any behavior if they weren't supported so we didn't need to implement feature detection at all.

  * **A new tagged union based "action" system.** "Actions" are what we call one-way messages to _do something_ in an apprt: create a window, resize a split, open the inspector, etc. We now used a tagged union and a central dispatch function to perform actions. This makes it crystal clear for apprt authors what the full list of actions they _could_ support is, and optionally choose to ignore any messages they want.

A note on "all but one" above: there is one more use case we still have `hasDecl` and that is only for grabbing the cgroup if available. I plan on purging this using the "property" system noted in the future section below.

## Future

A couple future items:

1. Purging more `@hasDecl` from the codebase. I don't plan on purging it completely because there are some valid use cases (C header feature detection for example), but I want to bring our usage down significantly.

2. Modify `libghostty` callback soup to a single dispatch function with a tagged union.

3. As an analog to the "action" system, I want to add a tagged-union "property" system for one way _reads_ from apprts. This would be used for querying information without parameters where the properties may not be globally available. 