### PR TITLE
libghostty: unified action dispatch

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -30,7 +30,9 @@ typedef void* ghostty_config_t;
 typedef void* ghostty_surface_t;
 typedef void* ghostty_inspector_t;
 
-// Enums are up top so we can reference them later.
+// All the types below are fully defined and must be kept in sync with
+// their Zig counterparts. Any changes to these types MUST have an associated
+// Zig change.
 typedef enum {
   GHOSTTY_PLATFORM_INVALID,
   GHOSTTY_PLATFORM_MACOS,
@@ -47,33 +49,6 @@ typedef enum {
   GHOSTTY_CLIPBOARD_REQUEST_OSC_52_READ,
   GHOSTTY_CLIPBOARD_REQUEST_OSC_52_WRITE,
 } ghostty_clipboard_request_e;
-
-typedef enum {
-  GHOSTTY_SPLIT_RIGHT,
-  GHOSTTY_SPLIT_DOWN
-} ghostty_split_direction_e;
-
-typedef enum {
-  GHOSTTY_SPLIT_FOCUS_PREVIOUS,
-  GHOSTTY_SPLIT_FOCUS_NEXT,
-  GHOSTTY_SPLIT_FOCUS_TOP,
-  GHOSTTY_SPLIT_FOCUS_LEFT,
-  GHOSTTY_SPLIT_FOCUS_BOTTOM,
-  GHOSTTY_SPLIT_FOCUS_RIGHT,
-} ghostty_split_focus_direction_e;
-
-typedef enum {
-  GHOSTTY_SPLIT_RESIZE_UP,
-  GHOSTTY_SPLIT_RESIZE_DOWN,
-  GHOSTTY_SPLIT_RESIZE_LEFT,
-  GHOSTTY_SPLIT_RESIZE_RIGHT,
-} ghostty_split_resize_direction_e;
-
-typedef enum {
-  GHOSTTY_INSPECTOR_TOGGLE,
-  GHOSTTY_INSPECTOR_SHOW,
-  GHOSTTY_INSPECTOR_HIDE,
-} ghostty_inspector_mode_e;
 
 typedef enum {
   GHOSTTY_MOUSE_RELEASE,
@@ -96,55 +71,6 @@ typedef enum {
   GHOSTTY_MOUSE_MOMENTUM_CANCELLED,
   GHOSTTY_MOUSE_MOMENTUM_MAY_BEGIN,
 } ghostty_input_mouse_momentum_e;
-
-typedef enum {
-  GHOSTTY_MOUSE_SHAPE_DEFAULT,
-  GHOSTTY_MOUSE_SHAPE_CONTEXT_MENU,
-  GHOSTTY_MOUSE_SHAPE_HELP,
-  GHOSTTY_MOUSE_SHAPE_POINTER,
-  GHOSTTY_MOUSE_SHAPE_PROGRESS,
-  GHOSTTY_MOUSE_SHAPE_WAIT,
-  GHOSTTY_MOUSE_SHAPE_CELL,
-  GHOSTTY_MOUSE_SHAPE_CROSSHAIR,
-  GHOSTTY_MOUSE_SHAPE_TEXT,
-  GHOSTTY_MOUSE_SHAPE_VERTICAL_TEXT,
-  GHOSTTY_MOUSE_SHAPE_ALIAS,
-  GHOSTTY_MOUSE_SHAPE_COPY,
-  GHOSTTY_MOUSE_SHAPE_MOVE,
-  GHOSTTY_MOUSE_SHAPE_NO_DROP,
-  GHOSTTY_MOUSE_SHAPE_NOT_ALLOWED,
-  GHOSTTY_MOUSE_SHAPE_GRAB,
-  GHOSTTY_MOUSE_SHAPE_GRABBING,
-  GHOSTTY_MOUSE_SHAPE_ALL_SCROLL,
-  GHOSTTY_MOUSE_SHAPE_COL_RESIZE,
-  GHOSTTY_MOUSE_SHAPE_ROW_RESIZE,
-  GHOSTTY_MOUSE_SHAPE_N_RESIZE,
-  GHOSTTY_MOUSE_SHAPE_E_RESIZE,
-  GHOSTTY_MOUSE_SHAPE_S_RESIZE,
-  GHOSTTY_MOUSE_SHAPE_W_RESIZE,
-  GHOSTTY_MOUSE_SHAPE_NE_RESIZE,
-  GHOSTTY_MOUSE_SHAPE_NW_RESIZE,
-  GHOSTTY_MOUSE_SHAPE_SE_RESIZE,
-  GHOSTTY_MOUSE_SHAPE_SW_RESIZE,
-  GHOSTTY_MOUSE_SHAPE_EW_RESIZE,
-  GHOSTTY_MOUSE_SHAPE_NS_RESIZE,
-  GHOSTTY_MOUSE_SHAPE_NESW_RESIZE,
-  GHOSTTY_MOUSE_SHAPE_NWSE_RESIZE,
-  GHOSTTY_MOUSE_SHAPE_ZOOM_IN,
-  GHOSTTY_MOUSE_SHAPE_ZOOM_OUT,
-} ghostty_mouse_shape_e;
-
-typedef enum {
-  GHOSTTY_NON_NATIVE_FULLSCREEN_FALSE,
-  GHOSTTY_NON_NATIVE_FULLSCREEN_TRUE,
-  GHOSTTY_NON_NATIVE_FULLSCREEN_VISIBLE_MENU,
-} ghostty_non_native_fullscreen_e;
-
-typedef enum {
-  GHOSTTY_TAB_PREVIOUS = -1,
-  GHOSTTY_TAB_NEXT = -2,
-  GHOSTTY_TAB_LAST = -3,
-} ghostty_tab_e;
 
 typedef enum {
   GHOSTTY_COLOR_SCHEME_LIGHT = 0,
@@ -357,14 +283,6 @@ typedef enum {
   GHOSTTY_BUILD_MODE_RELEASE_SMALL,
 } ghostty_build_mode_e;
 
-typedef enum {
-  GHOSTTY_RENDERER_HEALTH_OK,
-  GHOSTTY_RENDERER_HEALTH_UNHEALTHY,
-} ghostty_renderer_health_e;
-
-// Fully defined types. This MUST be kept in sync with equivalent Zig
-// structs. To find the Zig struct, grep for this type name. The documentation
-// for all of these types is available in the Zig source.
 typedef struct {
   ghostty_build_mode_e build_mode;
   const char* version;
@@ -414,13 +332,229 @@ typedef struct {
   uint32_t cell_height_px;
 } ghostty_surface_size_s;
 
+// apprt.Target.Key
+typedef enum {
+  GHOSTTY_TARGET_APP,
+  GHOSTTY_TARGET_SURFACE,
+} ghostty_target_tag_e;
+
+typedef union {
+  ghostty_surface_t surface;
+} ghostty_target_u;
+
+typedef struct {
+  ghostty_target_tag_e tag;
+  ghostty_target_u target;
+} ghostty_target_s;
+
+// apprt.action.SplitDirection
+typedef enum {
+  GHOSTTY_SPLIT_DIRECTION_RIGHT,
+  GHOSTTY_SPLIT_DIRECTION_DOWN,
+} ghostty_action_split_direction_e;
+
+// apprt.action.GotoSplit
+typedef enum {
+  GHOSTTY_GOTO_SPLIT_PREVIOUS,
+  GHOSTTY_GOTO_SPLIT_NEXT,
+  GHOSTTY_GOTO_SPLIT_TOP,
+  GHOSTTY_GOTO_SPLIT_LEFT,
+  GHOSTTY_GOTO_SPLIT_BOTTOM,
+  GHOSTTY_GOTO_SPLIT_RIGHT,
+} ghostty_action_goto_split_e;
+
+// apprt.action.ResizeSplit.Direction
+typedef enum {
+  GHOSTTY_RESIZE_SPLIT_UP,
+  GHOSTTY_RESIZE_SPLIT_DOWN,
+  GHOSTTY_RESIZE_SPLIT_LEFT,
+  GHOSTTY_RESIZE_SPLIT_RIGHT,
+} ghostty_action_resize_split_direction_e;
+
+// apprt.action.ResizeSplit
+typedef struct {
+  uint16_t amount;
+  ghostty_action_resize_split_direction_e direction;
+} ghostty_action_resize_split_s;
+
+// apprt.action.GotoTab
+typedef enum {
+  GHOSTTY_GOTO_TAB_PREVIOUS,
+  GHOSTTY_GOTO_TAB_NEXT,
+  GHOSTTY_GOTO_TAB_LAST,
+} ghostty_action_goto_tab_e;
+
+// apprt.action.Fullscreen
+typedef enum {
+  GHOSTTY_FULLSCREEN_NATIVE,
+  GHOSTTY_FULLSCREEN_NON_NATIVE,
+  GHOSTTY_FULLSCREEN_NON_NATIVE_VISIBLE_MENU,
+} ghostty_action_fullscreen_e;
+
+// apprt.action.SecureInput
+typedef enum {
+  GHOSTTY_SECURE_INPUT_ON,
+  GHOSTTY_SECURE_INPUT_OFF,
+  GHOSTTY_SECURE_INPUT_TOGGLE,
+} ghostty_action_secure_input_e;
+
+// apprt.action.Inspector
+typedef enum {
+  GHOSTTY_INSPECTOR_TOGGLE,
+  GHOSTTY_INSPECTOR_SHOW,
+  GHOSTTY_INSPECTOR_HIDE,
+} ghostty_action_inspector_e;
+
+// apprt.action.QuitTimer
+typedef enum {
+  GHOSTTY_QUIT_TIMER_START,
+  GHOSTTY_QUIT_TIMER_STOP,
+} ghostty_action_quit_timer_e;
+
+// apprt.action.DesktopNotification.C
+typedef struct {
+  const char* title;
+  const char* body;
+} ghostty_action_desktop_notification_s;
+
+// apprt.action.SetTitle.C
+typedef struct {
+  const char* title;
+} ghostty_action_set_title_s;
+
+// terminal.MouseShape
+typedef enum {
+  GHOSTTY_MOUSE_SHAPE_DEFAULT,
+  GHOSTTY_MOUSE_SHAPE_CONTEXT_MENU,
+  GHOSTTY_MOUSE_SHAPE_HELP,
+  GHOSTTY_MOUSE_SHAPE_POINTER,
+  GHOSTTY_MOUSE_SHAPE_PROGRESS,
+  GHOSTTY_MOUSE_SHAPE_WAIT,
+  GHOSTTY_MOUSE_SHAPE_CELL,
+  GHOSTTY_MOUSE_SHAPE_CROSSHAIR,
+  GHOSTTY_MOUSE_SHAPE_TEXT,
+  GHOSTTY_MOUSE_SHAPE_VERTICAL_TEXT,
+  GHOSTTY_MOUSE_SHAPE_ALIAS,
+  GHOSTTY_MOUSE_SHAPE_COPY,
+  GHOSTTY_MOUSE_SHAPE_MOVE,
+  GHOSTTY_MOUSE_SHAPE_NO_DROP,
+  GHOSTTY_MOUSE_SHAPE_NOT_ALLOWED,
+  GHOSTTY_MOUSE_SHAPE_GRAB,
+  GHOSTTY_MOUSE_SHAPE_GRABBING,
+  GHOSTTY_MOUSE_SHAPE_ALL_SCROLL,
+  GHOSTTY_MOUSE_SHAPE_COL_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_ROW_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_N_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_E_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_S_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_W_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_NE_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_NW_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_SE_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_SW_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_EW_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_NS_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_NESW_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_NWSE_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_ZOOM_IN,
+  GHOSTTY_MOUSE_SHAPE_ZOOM_OUT,
+} ghostty_action_mouse_shape_e;
+
+// apprt.action.MouseVisibility
+typedef enum {
+  GHOSTTY_MOUSE_VISIBLE,
+  GHOSTTY_MOUSE_HIDDEN,
+} ghostty_action_mouse_visibility_e;
+
+// apprt.action.MouseOverLink
+typedef struct {
+  const char* url;
+  size_t len;
+} ghostty_action_mouse_over_link_s;
+
+// apprt.action.SizeLimit
+typedef struct {
+  uint32_t min_width;
+  uint32_t min_height;
+  uint32_t max_width;
+  uint32_t max_height;
+} ghostty_action_size_limit_s;
+
+// apprt.action.InitialSize
+typedef struct {
+  uint32_t width;
+  uint32_t height;
+} ghostty_action_initial_size_s;
+
+// apprt.action.CellSize
+typedef struct {
+  uint32_t width;
+  uint32_t height;
+} ghostty_action_cell_size_s;
+
+// renderer.Health
+typedef enum {
+  GHOSTTY_RENDERER_HEALTH_OK,
+  GHOSTTY_RENDERER_HEALTH_UNHEALTHY,
+} ghostty_action_renderer_health_e;
+
+// apprt.Action.Key
+typedef enum {
+  GHOSTTY_ACTION_NEW_WINDOW,
+  GHOSTTY_ACTION_NEW_TAB,
+  GHOSTTY_ACTION_NEW_SPLIT,
+  GHOSTTY_ACTION_CLOSE_ALL_WINDOWS,
+  GHOSTTY_ACTION_TOGGLE_FULLSCREEN,
+  GHOSTTY_ACTION_TOGGLE_WINDOW_DECORATIONS,
+  GHOSTTY_ACTION_GOTO_TAB,
+  GHOSTTY_ACTION_GOTO_SPLIT,
+  GHOSTTY_ACTION_RESIZE_SPLIT,
+  GHOSTTY_ACTION_EQUALIZE_SPLITS,
+  GHOSTTY_ACTION_TOGGLE_SPLIT_ZOOM,
+  GHOSTTY_ACTION_PRESENT_TERMINAL,
+  GHOSTTY_ACTION_SIZE_LIMIT,
+  GHOSTTY_ACTION_INITIAL_SIZE,
+  GHOSTTY_ACTION_CELL_SIZE,
+  GHOSTTY_ACTION_INSPECTOR,
+  GHOSTTY_ACTION_RENDER_INSPECTOR,
+  GHOSTTY_ACTION_DESKTOP_NOTIFICATION,
+  GHOSTTY_ACTION_SET_TITLE,
+  GHOSTTY_ACTION_MOUSE_SHAPE,
+  GHOSTTY_ACTION_MOUSE_VISIBILITY,
+  GHOSTTY_ACTION_MOUSE_OVER_LINK,
+  GHOSTTY_ACTION_RENDERER_HEALTH,
+  GHOSTTY_ACTION_OPEN_CONFIG,
+  GHOSTTY_ACTION_QUIT_TIMER,
+  GHOSTTY_ACTION_SECURE_INPUT,
+} ghostty_action_tag_e;
+
+typedef union {
+  ghostty_action_split_direction_e new_split;
+  ghostty_action_fullscreen_e toggle_fullscreen;
+  ghostty_action_goto_tab_e goto_tab;
+  ghostty_action_goto_split_e goto_split;
+  ghostty_action_resize_split_s resize_split;
+  ghostty_action_size_limit_s size_limit;
+  ghostty_action_initial_size_s initial_size;
+  ghostty_action_cell_size_s cell_size;
+  ghostty_action_inspector_e inspector;
+  ghostty_action_desktop_notification_s desktop_notification;
+  ghostty_action_set_title_s set_title;
+  ghostty_action_mouse_shape_e mouse_shape;
+  ghostty_action_mouse_visibility_e mouse_visibility;
+  ghostty_action_mouse_over_link_s mouse_over_link;
+  ghostty_action_renderer_health_e renderer_health;
+  ghostty_action_quit_timer_e quit_timer;
+  ghostty_action_secure_input_e secure_input;
+} ghostty_action_u;
+
+typedef struct {
+  ghostty_action_tag_e tag;
+  ghostty_action_u action;
+} ghostty_action_s;
+
 typedef void (*ghostty_runtime_wakeup_cb)(void*);
 typedef const ghostty_config_t (*ghostty_runtime_reload_config_cb)(void*);
-typedef void (*ghostty_runtime_open_config_cb)(void*);
-typedef void (*ghostty_runtime_set_title_cb)(void*, const char*);
-typedef void (*ghostty_runtime_set_mouse_shape_cb)(void*,
-                                                   ghostty_mouse_shape_e);
-typedef void (*ghostty_runtime_set_mouse_visibility_cb)(void*, bool);
 typedef void (*ghostty_runtime_read_clipboard_cb)(void*,
                                                   ghostty_clipboard_e,
                                                   void*);
@@ -433,71 +567,21 @@ typedef void (*ghostty_runtime_write_clipboard_cb)(void*,
                                                    const char*,
                                                    ghostty_clipboard_e,
                                                    bool);
-typedef void (*ghostty_runtime_new_split_cb)(void*,
-                                             ghostty_split_direction_e,
-                                             ghostty_surface_config_s);
-typedef void (*ghostty_runtime_new_tab_cb)(void*, ghostty_surface_config_s);
-typedef void (*ghostty_runtime_new_window_cb)(void*, ghostty_surface_config_s);
-typedef void (*ghostty_runtime_control_inspector_cb)(void*,
-                                                     ghostty_inspector_mode_e);
 typedef void (*ghostty_runtime_close_surface_cb)(void*, bool);
-typedef void (*ghostty_runtime_focus_split_cb)(void*,
-                                               ghostty_split_focus_direction_e);
-typedef void (*ghostty_runtime_resize_split_cb)(
-    void*,
-    ghostty_split_resize_direction_e,
-    uint16_t);
-typedef void (*ghostty_runtime_equalize_splits_cb)(void*);
-typedef void (*ghostty_runtime_toggle_split_zoom_cb)(void*);
-typedef void (*ghostty_runtime_goto_tab_cb)(void*, int32_t);
-typedef void (*ghostty_runtime_toggle_fullscreen_cb)(
-    void*,
-    ghostty_non_native_fullscreen_e);
-typedef void (*ghostty_runtime_set_initial_window_size_cb)(void*,
-                                                           uint32_t,
-                                                           uint32_t);
-typedef void (*ghostty_runtime_render_inspector_cb)(void*);
-typedef void (*ghostty_runtime_set_cell_size_cb)(void*, uint32_t, uint32_t);
-typedef void (*ghostty_runtime_show_desktop_notification_cb)(void*,
-                                                             const char*,
-                                                             const char*);
-typedef void (
-    *ghostty_runtime_update_renderer_health)(void*, ghostty_renderer_health_e);
-typedef void (*ghostty_runtime_mouse_over_link_cb)(void*, const char*, size_t);
-typedef void (*ghostty_runtime_set_password_input_cb)(void*, bool);
-typedef void (*ghostty_runtime_toggle_secure_input_cb)();
+typedef void (*ghostty_runtime_action_cb)(ghostty_app_t,
+                                          ghostty_target_s,
+                                          ghostty_action_s);
 
 typedef struct {
   void* userdata;
   bool supports_selection_clipboard;
   ghostty_runtime_wakeup_cb wakeup_cb;
+  ghostty_runtime_action_cb action_cb;
   ghostty_runtime_reload_config_cb reload_config_cb;
-  ghostty_runtime_open_config_cb open_config_cb;
-  ghostty_runtime_set_title_cb set_title_cb;
-  ghostty_runtime_set_mouse_shape_cb set_mouse_shape_cb;
-  ghostty_runtime_set_mouse_visibility_cb set_mouse_visibility_cb;
   ghostty_runtime_read_clipboard_cb read_clipboard_cb;
   ghostty_runtime_confirm_read_clipboard_cb confirm_read_clipboard_cb;
   ghostty_runtime_write_clipboard_cb write_clipboard_cb;
-  ghostty_runtime_new_split_cb new_split_cb;
-  ghostty_runtime_new_tab_cb new_tab_cb;
-  ghostty_runtime_new_window_cb new_window_cb;
-  ghostty_runtime_control_inspector_cb control_inspector_cb;
   ghostty_runtime_close_surface_cb close_surface_cb;
-  ghostty_runtime_focus_split_cb focus_split_cb;
-  ghostty_runtime_resize_split_cb resize_split_cb;
-  ghostty_runtime_equalize_splits_cb equalize_splits_cb;
-  ghostty_runtime_toggle_split_zoom_cb toggle_split_zoom_cb;
-  ghostty_runtime_goto_tab_cb goto_tab_cb;
-  ghostty_runtime_toggle_fullscreen_cb toggle_fullscreen_cb;
-  ghostty_runtime_set_initial_window_size_cb set_initial_window_size_cb;
-  ghostty_runtime_render_inspector_cb render_inspector_cb;
-  ghostty_runtime_set_cell_size_cb set_cell_size_cb;
-  ghostty_runtime_show_desktop_notification_cb show_desktop_notification_cb;
-  ghostty_runtime_update_renderer_health update_renderer_health_cb;
-  ghostty_runtime_mouse_over_link_cb mouse_over_link_cb;
-  ghostty_runtime_set_password_input_cb set_password_input_cb;
-  ghostty_runtime_toggle_secure_input_cb toggle_secure_input_cb;
 } ghostty_runtime_config_s;
 
 //-------------------------------------------------------------------
@@ -538,7 +622,9 @@ ghostty_surface_config_s ghostty_surface_config_new();
 
 ghostty_surface_t ghostty_surface_new(ghostty_app_t, ghostty_surface_config_s*);
 void ghostty_surface_free(ghostty_surface_t);
+void* ghostty_surface_userdata(ghostty_surface_t);
 ghostty_app_t ghostty_surface_app(ghostty_surface_t);
+ghostty_surface_config_s ghostty_surface_inherited_config(ghostty_surface_t);
 bool ghostty_surface_needs_confirm_quit(ghostty_surface_t);
 void ghostty_surface_refresh(ghostty_surface_t);
 void ghostty_surface_draw(ghostty_surface_t);
@@ -569,11 +655,11 @@ void ghostty_surface_mouse_scroll(ghostty_surface_t,
 void ghostty_surface_mouse_pressure(ghostty_surface_t, uint32_t, double);
 void ghostty_surface_ime_point(ghostty_surface_t, double*, double*);
 void ghostty_surface_request_close(ghostty_surface_t);
-void ghostty_surface_split(ghostty_surface_t, ghostty_split_direction_e);
+void ghostty_surface_split(ghostty_surface_t, ghostty_action_split_direction_e);
 void ghostty_surface_split_focus(ghostty_surface_t,
-                                 ghostty_split_focus_direction_e);
+                                 ghostty_action_goto_split_e);
 void ghostty_surface_split_resize(ghostty_surface_t,
-                                  ghostty_split_resize_direction_e,
+                                  ghostty_action_resize_split_direction_e,
                                   uint16_t);
 void ghostty_surface_split_equalize(ghostty_surface_t);
 bool ghostty_surface_binding_action(ghostty_surface_t, const char*, uintptr_t);

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -484,6 +484,24 @@ class AppDelegate: NSObject,
         dockMenu.addItem(newTab)
     }
 
+    //MARK: - Global State
+
+    func setSecureInput(_ mode: Ghostty.SetSecureInput) {
+        let input = SecureInput.shared
+        switch (mode) {
+        case .on:
+            input.global = true
+
+        case .off:
+            input.global = false
+
+        case .toggle:
+            input.global.toggle()
+        }
+        self.menuSecureInput?.state = if (input.global) { .on } else { .off }
+        UserDefaults.standard.set(input.global, forKey: "SecureInput")
+    }
+
     //MARK: - IB Actions
 
     @IBAction func openConfig(_ sender: Any?) {
@@ -525,9 +543,6 @@ class AppDelegate: NSObject,
     }
 
     @IBAction func toggleSecureInput(_ sender: Any) {
-        let input = SecureInput.shared
-        input.global.toggle()
-        self.menuSecureInput?.state = if (input.global) { .on } else { .off }
-        UserDefaults.standard.set(input.global, forKey: "SecureInput")
+        setSecureInput(.toggle)
     }
 }

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -551,12 +551,12 @@ class TerminalController: NSWindowController, NSWindowDelegate,
 
     @IBAction func splitRight(_ sender: Any) {
         guard let surface = focusedSurface?.surface else { return }
-        ghostty.split(surface: surface, direction: GHOSTTY_SPLIT_RIGHT)
+        ghostty.split(surface: surface, direction: GHOSTTY_SPLIT_DIRECTION_RIGHT)
     }
 
     @IBAction func splitDown(_ sender: Any) {
         guard let surface = focusedSurface?.surface else { return }
-        ghostty.split(surface: surface, direction: GHOSTTY_SPLIT_DOWN)
+        ghostty.split(surface: surface, direction: GHOSTTY_SPLIT_DIRECTION_DOWN)
     }
 
     @IBAction func splitZoom(_ sender: Any) {
@@ -732,8 +732,9 @@ class TerminalController: NSWindowController, NSWindowDelegate,
         guard let window = self.window else { return }
 
         // Get the tab index from the notification
-        guard let tabIndexAny = notification.userInfo?[Ghostty.Notification.GotoTabKey] else { return }
-        guard let tabIndex = tabIndexAny as? Int32 else { return }
+        guard let tabEnumAny = notification.userInfo?[Ghostty.Notification.GotoTabKey] else { return }
+        guard let tabEnum = tabEnumAny as? ghostty_action_goto_tab_e else { return }
+        let tabIndex: Int32 = .init(bitPattern: tabEnum.rawValue)
 
         guard let windowController = window.windowController else { return }
         guard let tabGroup = windowController.window?.tabGroup else { return }
@@ -747,19 +748,19 @@ class TerminalController: NSWindowController, NSWindowDelegate,
             guard let selectedWindow = tabGroup.selectedWindow else { return }
             guard let selectedIndex = tabbedWindows.firstIndex(where: { $0 == selectedWindow }) else { return }
 
-            if (tabIndex == GHOSTTY_TAB_PREVIOUS.rawValue) {
+            if (tabIndex == GHOSTTY_GOTO_TAB_PREVIOUS.rawValue) {
                 if (selectedIndex == 0) {
                     finalIndex = tabbedWindows.count - 1
                 } else {
                     finalIndex = selectedIndex - 1
                 }
-            } else if (tabIndex == GHOSTTY_TAB_NEXT.rawValue) {
+            } else if (tabIndex == GHOSTTY_GOTO_TAB_NEXT.rawValue) {
                 if (selectedIndex == tabbedWindows.count - 1) {
                     finalIndex = 0
                 } else {
                     finalIndex = selectedIndex + 1
                 }
-            } else if (tabIndex == GHOSTTY_TAB_LAST.rawValue) {
+            } else if (tabIndex == GHOSTTY_GOTO_TAB_LAST.rawValue) {
                 finalIndex = tabbedWindows.count - 1
             } else {
                 return
@@ -783,9 +784,9 @@ class TerminalController: NSWindowController, NSWindowDelegate,
         guard let window = self.window else { return }
 
         // Check whether we use non-native fullscreen
-        guard let useNonNativeFullscreenAny = notification.userInfo?[Ghostty.Notification.NonNativeFullscreenKey] else { return }
-        guard let useNonNativeFullscreen = useNonNativeFullscreenAny as? ghostty_non_native_fullscreen_e else { return }
-        self.fullscreenHandler.toggleFullscreen(window: window, nonNativeFullscreen: useNonNativeFullscreen)
+        guard let fullscreenModeAny = notification.userInfo?[Ghostty.Notification.FullscreenModeKey] else { return }
+        guard let fullscreenMode = fullscreenModeAny as? ghostty_action_fullscreen_e else { return }
+        self.fullscreenHandler.toggleFullscreen(window: window, mode: fullscreenMode)
 
         // For some reason focus always gets lost when we toggle fullscreen, so we set it back.
         if let focusedSurface {

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -67,36 +67,12 @@ extension Ghostty {
                 userdata: Unmanaged.passUnretained(self).toOpaque(),
                 supports_selection_clipboard: false,
                 wakeup_cb: { userdata in App.wakeup(userdata) },
+                action_cb: { app, target, action in App.action(app!, target: target, action: action) },
                 reload_config_cb: { userdata in App.reloadConfig(userdata) },
-                open_config_cb: { userdata in App.openConfig(userdata) },
-                set_title_cb: { userdata, title in App.setTitle(userdata, title: title) },
-                set_mouse_shape_cb: { userdata, shape in App.setMouseShape(userdata, shape: shape) },
-                set_mouse_visibility_cb: { userdata, visible in App.setMouseVisibility(userdata, visible: visible) },
                 read_clipboard_cb: { userdata, loc, state in App.readClipboard(userdata, location: loc, state: state) },
                 confirm_read_clipboard_cb: { userdata, str, state, request in App.confirmReadClipboard(userdata, string: str, state: state, request: request ) },
                 write_clipboard_cb: { userdata, str, loc, confirm in App.writeClipboard(userdata, string: str, location: loc, confirm: confirm) },
-                new_split_cb: { userdata, direction, surfaceConfig in App.newSplit(userdata, direction: direction, config: surfaceConfig) },
-                new_tab_cb: { userdata, surfaceConfig in App.newTab(userdata, config: surfaceConfig) },
-                new_window_cb: { userdata, surfaceConfig in App.newWindow(userdata, config: surfaceConfig) },
-                control_inspector_cb: { userdata, mode in App.controlInspector(userdata, mode: mode) },
-                close_surface_cb: { userdata, processAlive in App.closeSurface(userdata, processAlive: processAlive) },
-                focus_split_cb: { userdata, direction in App.focusSplit(userdata, direction: direction) },
-                resize_split_cb: { userdata, direction, amount in
-                    App.resizeSplit(userdata, direction: direction, amount: amount) },
-                equalize_splits_cb: { userdata in
-                    App.equalizeSplits(userdata) },
-                toggle_split_zoom_cb: { userdata in App.toggleSplitZoom(userdata) },
-                goto_tab_cb: { userdata, n in App.gotoTab(userdata, n: n) },
-                toggle_fullscreen_cb: { userdata, nonNativeFullscreen in App.toggleFullscreen(userdata, nonNativeFullscreen: nonNativeFullscreen) },
-                set_initial_window_size_cb: { userdata, width, height in App.setInitialWindowSize(userdata, width: width, height: height) },
-                render_inspector_cb: { userdata in App.renderInspector(userdata) },
-                set_cell_size_cb: { userdata, width, height in App.setCellSize(userdata, width: width, height: height) },
-                show_desktop_notification_cb: { userdata, title, body in
-                    App.showUserNotification(userdata, title: title, body: body) },
-                update_renderer_health_cb: { userdata, health in App.updateRendererHealth(userdata, health: health) },
-                mouse_over_link_cb: { userdata, ptr, len in App.mouseOverLink(userdata, uri: ptr, len: len) },
-                set_password_input_cb: { userdata, value in App.setPasswordInput(userdata, value: value) },
-                toggle_secure_input_cb: { App.toggleSecureInput() }
+                close_surface_cb: { userdata, processAlive in App.closeSurface(userdata, processAlive: processAlive) }
             )
 
             // Create the ghostty app.
@@ -185,7 +161,7 @@ extension Ghostty {
             }
         }
 
-        func split(surface: ghostty_surface_t, direction: ghostty_split_direction_e) {
+        func split(surface: ghostty_surface_t, direction: ghostty_action_split_direction_e) {
             ghostty_surface_split(surface, direction)
         }
 
@@ -254,11 +230,8 @@ extension Ghostty {
         // MARK: Ghostty Callbacks (iOS)
 
         static func wakeup(_ userdata: UnsafeMutableRawPointer?) {}
+        static func action(_ app: ghostty_app_t, target: ghostty_target_s, action: ghostty_action_s) {}
         static func reloadConfig(_ userdata: UnsafeMutableRawPointer?) -> ghostty_config_t? { return nil }
-        static func openConfig(_ userdata: UnsafeMutableRawPointer?) {}
-        static func setTitle(_ userdata: UnsafeMutableRawPointer?, title: UnsafePointer<CChar>?) {}
-        static func setMouseShape(_ userdata: UnsafeMutableRawPointer?, shape: ghostty_mouse_shape_e) {}
-        static func setMouseVisibility(_ userdata: UnsafeMutableRawPointer?, visible: Bool) {}
         static func readClipboard(
             _ userdata: UnsafeMutableRawPointer?,
             location: ghostty_clipboard_e,
@@ -279,30 +252,7 @@ extension Ghostty {
             confirm: Bool
         ) {}
 
-        static func newSplit(
-            _ userdata: UnsafeMutableRawPointer?,
-            direction: ghostty_split_direction_e,
-            config: ghostty_surface_config_s
-        ) {}
-
-        static func newTab(_ userdata: UnsafeMutableRawPointer?, config: ghostty_surface_config_s) {}
-        static func newWindow(_ userdata: UnsafeMutableRawPointer?, config: ghostty_surface_config_s) {}
-        static func controlInspector(_ userdata: UnsafeMutableRawPointer?, mode: ghostty_inspector_mode_e) {}
         static func closeSurface(_ userdata: UnsafeMutableRawPointer?, processAlive: Bool) {}
-        static func focusSplit(_ userdata: UnsafeMutableRawPointer?, direction: ghostty_split_focus_direction_e) {}
-        static func resizeSplit(_ userdata: UnsafeMutableRawPointer?, direction: ghostty_split_resize_direction_e, amount: UInt16) {}
-        static func equalizeSplits(_ userdata: UnsafeMutableRawPointer?) {}
-        static func toggleSplitZoom(_ userdata: UnsafeMutableRawPointer?) {}
-        static func gotoTab(_ userdata: UnsafeMutableRawPointer?, n: Int32) {}
-        static func toggleFullscreen(_ userdata: UnsafeMutableRawPointer?, nonNativeFullscreen: ghostty_non_native_fullscreen_e) {}
-        static func setInitialWindowSize(_ userdata: UnsafeMutableRawPointer?, width: UInt32, height: UInt32) {}
-        static func renderInspector(_ userdata: UnsafeMutableRawPointer?) {}
-        static func setCellSize(_ userdata: UnsafeMutableRawPointer?, width: UInt32, height: UInt32) {}
-        static func showUserNotification(_ userdata: UnsafeMutableRawPointer?, title: UnsafePointer<CChar>?, body: UnsafePointer<CChar>?) {}
-        static func updateRendererHealth(_ userdata: UnsafeMutableRawPointer?, health: ghostty_renderer_health_e) {}
-        static func mouseOverLink(_ userdata: UnsafeMutableRawPointer?, uri: UnsafePointer<CChar>?, len: Int) {}
-        static func setPasswordInput(_ userdata: UnsafeMutableRawPointer?, value: Bool) {}
-        static func toggleSecureInput() {}
         #endif
 
         #if os(macOS)
@@ -318,69 +268,11 @@ extension Ghostty {
 
         // MARK: Ghostty Callbacks (macOS)
 
-        static func newSplit(_ userdata: UnsafeMutableRawPointer?, direction: ghostty_split_direction_e, config: ghostty_surface_config_s) {
-            let surface = self.surfaceUserdata(from: userdata)
-            NotificationCenter.default.post(name: Notification.ghosttyNewSplit, object: surface, userInfo: [
-                "direction": direction,
-                Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: config),
-            ])
-        }
-
         static func closeSurface(_ userdata: UnsafeMutableRawPointer?, processAlive: Bool) {
             let surface = self.surfaceUserdata(from: userdata)
             NotificationCenter.default.post(name: Notification.ghosttyCloseSurface, object: surface, userInfo: [
                 "process_alive": processAlive,
             ])
-        }
-
-        static func focusSplit(_ userdata: UnsafeMutableRawPointer?, direction: ghostty_split_focus_direction_e) {
-            let surface = self.surfaceUserdata(from: userdata)
-            guard let splitDirection = SplitFocusDirection.from(direction: direction) else { return }
-            NotificationCenter.default.post(
-                name: Notification.ghosttyFocusSplit,
-                object: surface,
-                userInfo: [
-                    Notification.SplitDirectionKey: splitDirection,
-                ]
-            )
-        }
-
-        static func resizeSplit(_ userdata: UnsafeMutableRawPointer?, direction: ghostty_split_resize_direction_e, amount: UInt16) {
-            let surface = self.surfaceUserdata(from: userdata)
-            guard let resizeDirection = SplitResizeDirection.from(direction: direction) else { return }
-            NotificationCenter.default.post(
-                name: Notification.didResizeSplit,
-                object: surface,
-                userInfo: [
-                    Notification.ResizeSplitDirectionKey: resizeDirection,
-                    Notification.ResizeSplitAmountKey: amount,
-                ]
-            )
-        }
-
-        static func equalizeSplits(_ userdata: UnsafeMutableRawPointer?) {
-            let surface = self.surfaceUserdata(from: userdata)
-            NotificationCenter.default.post(name: Notification.didEqualizeSplits, object: surface)
-        }
-
-        static func toggleSplitZoom(_ userdata: UnsafeMutableRawPointer?) {
-            let surface = self.surfaceUserdata(from: userdata)
-
-            NotificationCenter.default.post(
-                name: Notification.didToggleSplitZoom,
-                object: surface
-            )
-        }
-
-        static func gotoTab(_ userdata: UnsafeMutableRawPointer?, n: Int32) {
-            let surface = self.surfaceUserdata(from: userdata)
-            NotificationCenter.default.post(
-                name: Notification.ghosttyGotoTab,
-                object: surface,
-                userInfo: [
-                    Notification.GotoTabKey: n,
-                ]
-            )
         }
 
         static func readClipboard(_ userdata: UnsafeMutableRawPointer?, location: ghostty_clipboard_e, state: UnsafeMutableRawPointer?) {
@@ -454,10 +346,6 @@ extension Ghostty {
             )
         }
 
-        static func openConfig(_ userdata: UnsafeMutableRawPointer?) {
-            ghostty_config_open();
-        }
-
         static func reloadConfig(_ userdata: UnsafeMutableRawPointer?) -> ghostty_config_t? {
             let newConfig = Config()
             guard newConfig.loaded else {
@@ -488,98 +376,647 @@ extension Ghostty {
             DispatchQueue.main.async { state.appTick() }
         }
 
-        static func renderInspector(_ userdata: UnsafeMutableRawPointer?) {
-            let surface = self.surfaceUserdata(from: userdata)
-            NotificationCenter.default.post(
-                name: Notification.inspectorNeedsDisplay,
-                object: surface
-            )
+        /// Determine if a given notification should be presented to the user when Ghostty is running in the foreground.
+        func shouldPresentNotification(notification: UNNotification) -> Bool {
+            let userInfo = notification.request.content.userInfo
+            guard let uuidString = userInfo["surface"] as? String,
+                  let uuid = UUID(uuidString: uuidString),
+                  let surface = delegate?.findSurface(forUUID: uuid),
+                  let window = surface.window else { return false }
+            return !window.isKeyWindow || !surface.focused
         }
 
-        static func setTitle(_ userdata: UnsafeMutableRawPointer?, title: UnsafePointer<CChar>?) {
-            let surfaceView = self.surfaceUserdata(from: userdata)
-            guard let titleStr = String(cString: title!, encoding: .utf8) else { return }
-            DispatchQueue.main.async {
-                surfaceView.title = titleStr
-            }
+        /// Returns the GhosttyState from the given userdata value.
+        static private func appState(fromView view: SurfaceView) -> App? {
+            guard let surface = view.surface else { return nil }
+            guard let app = ghostty_surface_app(surface) else { return nil }
+            guard let app_ud = ghostty_app_userdata(app) else { return nil }
+            return Unmanaged<App>.fromOpaque(app_ud).takeUnretainedValue()
         }
 
-        static func setMouseShape(_ userdata: UnsafeMutableRawPointer?, shape: ghostty_mouse_shape_e) {
-            let surfaceView = self.surfaceUserdata(from: userdata)
-            surfaceView.setCursorShape(shape)
+        /// Returns the surface view from the userdata.
+        static private func surfaceUserdata(from userdata: UnsafeMutableRawPointer?) -> SurfaceView {
+            return Unmanaged<SurfaceView>.fromOpaque(userdata!).takeUnretainedValue()
         }
 
-        static func setMouseVisibility(_ userdata: UnsafeMutableRawPointer?, visible: Bool) {
-            let surfaceView = self.surfaceUserdata(from: userdata)
-            surfaceView.setCursorVisibility(visible)
+        static private func surfaceView(from surface: ghostty_surface_t) -> SurfaceView? {
+            guard let surface_ud = ghostty_surface_userdata(surface) else { return nil }
+            return Unmanaged<SurfaceView>.fromOpaque(surface_ud).takeUnretainedValue()
         }
 
-        static func toggleFullscreen(_ userdata: UnsafeMutableRawPointer?, nonNativeFullscreen: ghostty_non_native_fullscreen_e) {
-            let surface = self.surfaceUserdata(from: userdata)
-            NotificationCenter.default.post(
-                name: Notification.ghosttyToggleFullscreen,
-                object: surface,
-                userInfo: [
-                    Notification.NonNativeFullscreenKey: nonNativeFullscreen,
-                ]
-            )
-        }
+        // MARK: Actions (macOS)
 
-        static func setInitialWindowSize(_ userdata: UnsafeMutableRawPointer?, width: UInt32, height: UInt32) {
-            // We need a window to set the frame
-            let surfaceView = self.surfaceUserdata(from: userdata)
-            surfaceView.initialSize = NSMakeSize(Double(width), Double(height))
-        }
+        static func action(_ app: ghostty_app_t, target: ghostty_target_s, action: ghostty_action_s) {
+            // Make sure it a target we understand so all our action handlers can assert
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP, GHOSTTY_TARGET_SURFACE:
+                break
 
-        static func setCellSize(_ userdata: UnsafeMutableRawPointer?, width: UInt32, height: UInt32) {
-            let surfaceView = self.surfaceUserdata(from: userdata)
-            let backingSize = NSSize(width: Double(width), height: Double(height))
-            surfaceView.cellSize = surfaceView.convertFromBacking(backingSize)
-        }
-
-        static func mouseOverLink(_ userdata: UnsafeMutableRawPointer?, uri: UnsafePointer<CChar>?, len: Int) {
-            let surfaceView = self.surfaceUserdata(from: userdata)
-            guard len > 0 else {
-                surfaceView.hoverUrl = nil
+            default:
+                Ghostty.logger.warning("unknown action target=\(target.tag.rawValue)")
                 return
             }
 
-            let buffer = Data(bytes: uri!, count: len)
-            surfaceView.hoverUrl = String(data: buffer, encoding: .utf8)
+            // Action dispatch
+            switch (action.tag) {
+            case GHOSTTY_ACTION_NEW_WINDOW:
+                newWindow(app, target: target)
+
+            case GHOSTTY_ACTION_NEW_TAB:
+                newTab(app, target: target)
+
+            case GHOSTTY_ACTION_NEW_SPLIT:
+                newSplit(app, target: target, direction: action.action.new_split)
+
+            case GHOSTTY_ACTION_TOGGLE_FULLSCREEN:
+                toggleFullscreen(app, target: target, mode: action.action.toggle_fullscreen)
+
+            case GHOSTTY_ACTION_GOTO_TAB:
+                gotoTab(app, target: target, tab: action.action.goto_tab)
+
+            case GHOSTTY_ACTION_GOTO_SPLIT:
+                gotoSplit(app, target: target, direction: action.action.goto_split)
+
+            case GHOSTTY_ACTION_RESIZE_SPLIT:
+                resizeSplit(app, target: target, resize: action.action.resize_split)
+
+            case GHOSTTY_ACTION_EQUALIZE_SPLITS:
+                equalizeSplits(app, target: target)
+
+            case GHOSTTY_ACTION_TOGGLE_SPLIT_ZOOM:
+                toggleSplitZoom(app, target: target)
+
+            case GHOSTTY_ACTION_INSPECTOR:
+                controlInspector(app, target: target, mode: action.action.inspector)
+
+            case GHOSTTY_ACTION_RENDER_INSPECTOR:
+                renderInspector(app, target: target)
+
+            case GHOSTTY_ACTION_DESKTOP_NOTIFICATION:
+                showDesktopNotification(app, target: target, n: action.action.desktop_notification)
+
+            case GHOSTTY_ACTION_SET_TITLE:
+                setTitle(app, target: target, v: action.action.set_title)
+
+            case GHOSTTY_ACTION_OPEN_CONFIG:
+                ghostty_config_open()
+
+            case GHOSTTY_ACTION_SECURE_INPUT:
+                toggleSecureInput(app, target: target, mode: action.action.secure_input)
+
+            case GHOSTTY_ACTION_MOUSE_SHAPE:
+                setMouseShape(app, target: target, shape: action.action.mouse_shape)
+
+            case GHOSTTY_ACTION_MOUSE_VISIBILITY:
+                setMouseVisibility(app, target: target, v: action.action.mouse_visibility)
+
+            case GHOSTTY_ACTION_MOUSE_OVER_LINK:
+                setMouseOverLink(app, target: target, v: action.action.mouse_over_link)
+
+            case GHOSTTY_ACTION_INITIAL_SIZE:
+                setInitialSize(app, target: target, v: action.action.initial_size)
+
+            case GHOSTTY_ACTION_CELL_SIZE:
+                setCellSize(app, target: target, v: action.action.cell_size)
+
+            case GHOSTTY_ACTION_RENDERER_HEALTH:
+                rendererHealth(app, target: target, v: action.action.renderer_health)
+
+            case GHOSTTY_ACTION_CLOSE_ALL_WINDOWS:
+                fallthrough
+            case GHOSTTY_ACTION_TOGGLE_WINDOW_DECORATIONS:
+                fallthrough
+            case GHOSTTY_ACTION_PRESENT_TERMINAL:
+                fallthrough
+            case GHOSTTY_ACTION_SIZE_LIMIT:
+                fallthrough
+            case GHOSTTY_ACTION_QUIT_TIMER:
+                Ghostty.logger.info("known but unimplemented action action=\(action.tag.rawValue)")
+
+            default:
+                Ghostty.logger.warning("unknown action action=\(action.tag.rawValue)")
+            }
         }
 
-        static func setPasswordInput(_ userdata: UnsafeMutableRawPointer?, value: Bool) {
-            // We don't currently allow global password input being set from this.
-            guard let userdata else { return }
-            
-            let surfaceView = self.surfaceUserdata(from: userdata)
-            guard let appState = self.appState(fromView: surfaceView) else { return }
-            guard appState.config.autoSecureInput else { return }
-            surfaceView.passwordInput = value
+        private static func newWindow(_ app: ghostty_app_t, target: ghostty_target_s) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                NotificationCenter.default.post(
+                    name: Notification.ghosttyNewWindow,
+                    object: nil,
+                    userInfo: [:]
+                )
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                NotificationCenter.default.post(
+                    name: Notification.ghosttyNewWindow,
+                    object: surfaceView,
+                    userInfo: [
+                        Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: ghostty_surface_inherited_config(surface)),
+                    ]
+                )
+
+
+            default:
+                assertionFailure()
+            }
         }
 
-        static func toggleSecureInput() {
-            guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
-            appDelegate.toggleSecureInput(self)
-        }
+        private static func newTab(_ app: ghostty_app_t, target: ghostty_target_s) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                NotificationCenter.default.post(
+                    name: Notification.ghosttyNewTab,
+                    object: nil,
+                    userInfo: [:]
+                )
 
-        static func showUserNotification(_ userdata: UnsafeMutableRawPointer?, title: UnsafePointer<CChar>?, body: UnsafePointer<CChar>?) {
-            let surfaceView = self.surfaceUserdata(from: userdata)
-            guard let title = String(cString: title!, encoding: .utf8) else { return }
-            guard let body = String(cString: body!, encoding: .utf8) else { return }
-
-            let center = UNUserNotificationCenter.current()
-            center.requestAuthorization(options: [.alert, .sound]) { _, error in
-                if let error = error {
-                    AppDelegate.logger.error("Error while requesting notification authorization: \(error)")
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                guard let appState = self.appState(fromView: surfaceView) else { return }
+                guard appState.config.windowDecorations else {
+                    let alert = NSAlert()
+                    alert.messageText = "Tabs are disabled"
+                    alert.informativeText = "Enable window decorations to use tabs"
+                    alert.addButton(withTitle: "OK")
+                    alert.alertStyle = .warning
+                    _ = alert.runModal()
+                    return
                 }
-            }
 
-            center.getNotificationSettings() { settings in
-                guard settings.authorizationStatus == .authorized else { return }
-                surfaceView.showUserNotification(title: title, body: body)
+                NotificationCenter.default.post(
+                    name: Notification.ghosttyNewTab,
+                    object: surfaceView,
+                    userInfo: [
+                        Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: ghostty_surface_inherited_config(surface)),
+                    ]
+                )
+
+
+            default:
+                assertionFailure()
             }
         }
+
+        private static func newSplit(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s,
+            direction: ghostty_action_split_direction_e) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                // New split does nothing with an app target
+                Ghostty.logger.warning("new split does nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+
+                NotificationCenter.default.post(
+                    name: Notification.ghosttyNewSplit,
+                    object: surfaceView,
+                    userInfo: [
+                        "direction": direction,
+                        Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: ghostty_surface_inherited_config(surface)),
+                    ]
+                )
+
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        private static func toggleFullscreen(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s,
+            mode: ghostty_action_fullscreen_e) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                Ghostty.logger.warning("toggle fullscreen does nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                NotificationCenter.default.post(
+                    name: Notification.ghosttyToggleFullscreen,
+                    object: surfaceView,
+                    userInfo: [
+                        Notification.FullscreenModeKey: mode,
+                    ]
+                )
+
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        private static func gotoTab(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s,
+            tab: ghostty_action_goto_tab_e) {
+                switch (target.tag) {
+                case GHOSTTY_TARGET_APP:
+                    Ghostty.logger.warning("goto tab does nothing with an app target")
+                    return
+
+                case GHOSTTY_TARGET_SURFACE:
+                    guard let surface = target.target.surface else { return }
+                    guard let surfaceView = self.surfaceView(from: surface) else { return }
+                    NotificationCenter.default.post(
+                        name: Notification.ghosttyGotoTab,
+                        object: surfaceView,
+                        userInfo: [
+                            Notification.GotoTabKey: tab,
+                        ]
+                    )
+
+                default:
+                    assertionFailure()
+                }
+        }
+
+        private static func gotoSplit(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s,
+            direction: ghostty_action_goto_split_e) {
+                switch (target.tag) {
+                case GHOSTTY_TARGET_APP:
+                    Ghostty.logger.warning("goto split does nothing with an app target")
+                    return
+
+                case GHOSTTY_TARGET_SURFACE:
+                    guard let surface = target.target.surface else { return }
+                    guard let surfaceView = self.surfaceView(from: surface) else { return }
+                    NotificationCenter.default.post(
+                        name: Notification.ghosttyFocusSplit,
+                        object: surfaceView,
+                        userInfo: [
+                            Notification.SplitDirectionKey: SplitFocusDirection.from(direction: direction) as Any,
+                        ]
+                    )
+
+                default:
+                    assertionFailure()
+                }
+        }
+
+        private static func resizeSplit(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s,
+            resize: ghostty_action_resize_split_s) {
+                switch (target.tag) {
+                case GHOSTTY_TARGET_APP:
+                    Ghostty.logger.warning("resize split does nothing with an app target")
+                    return
+
+                case GHOSTTY_TARGET_SURFACE:
+                    guard let surface = target.target.surface else { return }
+                    guard let surfaceView = self.surfaceView(from: surface) else { return }
+                    guard let resizeDirection = SplitResizeDirection.from(direction: resize.direction) else { return }
+                    NotificationCenter.default.post(
+                        name: Notification.didResizeSplit,
+                        object: surfaceView,
+                        userInfo: [
+                            Notification.ResizeSplitDirectionKey: resizeDirection,
+                            Notification.ResizeSplitAmountKey: resize.amount,
+                        ]
+                    )
+
+                default:
+                    assertionFailure()
+                }
+        }
+
+        private static func equalizeSplits(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                Ghostty.logger.warning("equalize splits does nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                NotificationCenter.default.post(
+                    name: Notification.didEqualizeSplits,
+                    object: surfaceView
+                )
+
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        private static func toggleSplitZoom(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                Ghostty.logger.warning("toggle split zoom does nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                NotificationCenter.default.post(
+                    name: Notification.didToggleSplitZoom,
+                    object: surfaceView
+                )
+
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        private static func controlInspector(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s,
+            mode: ghostty_action_inspector_e) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                Ghostty.logger.warning("toggle split zoom does nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                NotificationCenter.default.post(
+                    name: Notification.didControlInspector,
+                    object: surfaceView,
+                    userInfo: ["mode": mode]
+                )
+
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        private static func showDesktopNotification(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s,
+            n: ghostty_action_desktop_notification_s) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                Ghostty.logger.warning("toggle split zoom does nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                guard let title = String(cString: n.title!, encoding: .utf8) else { return }
+                guard let body = String(cString: n.body!, encoding: .utf8) else { return }
+
+                let center = UNUserNotificationCenter.current()
+                center.requestAuthorization(options: [.alert, .sound]) { _, error in
+                    if let error = error {
+                        Ghostty.logger.error("Error while requesting notification authorization: \(error)")
+                    }
+                }
+
+                center.getNotificationSettings() { settings in
+                    guard settings.authorizationStatus == .authorized else { return }
+                    surfaceView.showUserNotification(title: title, body: body)
+                }
+
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        private static func toggleSecureInput(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s,
+            mode mode_raw: ghostty_action_secure_input_e
+        ) {
+            guard let mode = SetSecureInput.from(mode_raw) else { return }
+
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
+                appDelegate.setSecureInput(mode)
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                guard let appState = self.appState(fromView: surfaceView) else { return }
+                guard appState.config.autoSecureInput else { return }
+
+                switch (mode) {
+                case .on:
+                    surfaceView.passwordInput = true
+
+                case .off:
+                    surfaceView.passwordInput = false
+
+                case .toggle:
+                    surfaceView.passwordInput = !surfaceView.passwordInput
+                }
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        private static func setTitle(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s,
+            v: ghostty_action_set_title_s) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                Ghostty.logger.warning("set title does nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                guard let title = String(cString: v.title!, encoding: .utf8) else { return }
+
+                // We must set this in a dispatchqueue to avoid a deadlock on startup on some
+                // versions of macOS. I unfortunately didn't document the exact versions so
+                // I don't know when its safe to remove this.
+                DispatchQueue.main.async {
+                    surfaceView.title = title
+                }
+
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        private static func setMouseShape(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s,
+            shape: ghostty_action_mouse_shape_e) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                Ghostty.logger.warning("set mouse shapes nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                surfaceView.setCursorShape(shape)
+
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        private static func setMouseVisibility(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s,
+            v: ghostty_action_mouse_visibility_e) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                Ghostty.logger.warning("set mouse shapes nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                switch (v) {
+                case GHOSTTY_MOUSE_VISIBLE:
+                    surfaceView.setCursorVisibility(true)
+
+                case GHOSTTY_MOUSE_HIDDEN:
+                    surfaceView.setCursorVisibility(false)
+
+                default:
+                    return
+                }
+
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        private static func setMouseOverLink(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s,
+            v: ghostty_action_mouse_over_link_s) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                Ghostty.logger.warning("mouse over link does nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                guard v.len > 0 else {
+                    surfaceView.hoverUrl = nil
+                    return
+                }
+
+                let buffer = Data(bytes: v.url!, count: v.len)
+                surfaceView.hoverUrl = String(data: buffer, encoding: .utf8)
+
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        private static func setInitialSize(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s,
+            v: ghostty_action_initial_size_s) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                Ghostty.logger.warning("mouse over link does nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                surfaceView.initialSize = NSMakeSize(Double(v.width), Double(v.height))
+
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        private static func setCellSize(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s,
+            v: ghostty_action_cell_size_s) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                Ghostty.logger.warning("mouse over link does nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                let backingSize = NSSize(width: Double(v.width), height: Double(v.height))
+                surfaceView.cellSize = surfaceView.convertFromBacking(backingSize)
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        private static func renderInspector(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                Ghostty.logger.warning("mouse over link does nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                NotificationCenter.default.post(
+                    name: Notification.inspectorNeedsDisplay,
+                    object: surfaceView
+                )
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        private static func rendererHealth(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s,
+            v: ghostty_action_renderer_health_e) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                Ghostty.logger.warning("mouse over link does nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                NotificationCenter.default.post(
+                    name: Notification.didUpdateRendererHealth,
+                    object: surfaceView,
+                    userInfo: [
+                        "health": v,
+                    ]
+                )
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        // MARK: User Notifications
 
         /// Handle a received user notification. This is called when a user notification is clicked or dismissed by the user
         func handleUserNotification(response: UNNotificationResponse) {
@@ -598,86 +1035,6 @@ extension Ghostty {
             default:
                 break
             }
-        }
-
-        /// Determine if a given notification should be presented to the user when Ghostty is running in the foreground.
-        func shouldPresentNotification(notification: UNNotification) -> Bool {
-            let userInfo = notification.request.content.userInfo
-            guard let uuidString = userInfo["surface"] as? String,
-                  let uuid = UUID(uuidString: uuidString),
-                  let surface = delegate?.findSurface(forUUID: uuid),
-                  let window = surface.window else { return false }
-            return !window.isKeyWindow || !surface.focused
-        }
-
-        static func newTab(_ userdata: UnsafeMutableRawPointer?, config: ghostty_surface_config_s) {
-            let surface = self.surfaceUserdata(from: userdata)
-
-            guard let appState = self.appState(fromView: surface) else { return }
-            guard appState.config.windowDecorations else {
-                let alert = NSAlert()
-                alert.messageText = "Tabs are disabled"
-                alert.informativeText = "Enable window decorations to use tabs"
-                alert.addButton(withTitle: "OK")
-                alert.alertStyle = .warning
-                _ = alert.runModal()
-                return
-            }
-
-            NotificationCenter.default.post(
-                name: Notification.ghosttyNewTab,
-                object: surface,
-                userInfo: [
-                    Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: config),
-                ]
-            )
-        }
-
-        static func newWindow(_ userdata: UnsafeMutableRawPointer?, config: ghostty_surface_config_s) {
-            let surface: SurfaceView? = if let userdata {
-                self.surfaceUserdata(from: userdata)
-            } else {
-                nil
-            }
-
-            NotificationCenter.default.post(
-                name: Notification.ghosttyNewWindow,
-                object: surface,
-                userInfo: [
-                    Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: config),
-                ]
-            )
-        }
-
-        static func controlInspector(_ userdata: UnsafeMutableRawPointer?, mode: ghostty_inspector_mode_e) {
-            let surface = self.surfaceUserdata(from: userdata)
-            NotificationCenter.default.post(name: Notification.didControlInspector, object: surface, userInfo: [
-                "mode": mode,
-            ])
-        }
-
-        static func updateRendererHealth(_ userdata: UnsafeMutableRawPointer?, health: ghostty_renderer_health_e) {
-            let surface = self.surfaceUserdata(from: userdata)
-            NotificationCenter.default.post(
-                name: Notification.didUpdateRendererHealth,
-                object: surface,
-                userInfo: [
-                    "health": health,
-                ]
-            )
-        }
-
-        /// Returns the GhosttyState from the given userdata value.
-        static private func appState(fromView view: SurfaceView) -> App? {
-            guard let surface = view.surface else { return nil }
-            guard let app = ghostty_surface_app(surface) else { return nil }
-            guard let app_ud = ghostty_app_userdata(app) else { return nil }
-            return Unmanaged<App>.fromOpaque(app_ud).takeUnretainedValue()
-        }
-
-        /// Returns the surface view from the userdata.
-        static private func surfaceUserdata(from userdata: UnsafeMutableRawPointer?) -> SurfaceView {
-            return Unmanaged<SurfaceView>.fromOpaque(userdata!).takeUnretainedValue()
         }
 
         #endif

--- a/macos/Sources/Ghostty/Ghostty.TerminalSplit.swift
+++ b/macos/Sources/Ghostty/Ghostty.TerminalSplit.swift
@@ -219,13 +219,13 @@ extension Ghostty {
 
             // Determine our desired direction
             guard let directionAny = notification.userInfo?["direction"] else { return }
-            guard let direction = directionAny as? ghostty_split_direction_e else { return }
+            guard let direction = directionAny as? ghostty_action_split_direction_e else { return }
             var splitDirection: SplitViewDirection
             switch (direction) {
-            case GHOSTTY_SPLIT_RIGHT:
+            case GHOSTTY_SPLIT_DIRECTION_RIGHT:
                 splitDirection = .horizontal
 
-            case GHOSTTY_SPLIT_DOWN:
+            case GHOSTTY_SPLIT_DIRECTION_DOWN:
                 splitDirection = .vertical
 
             default:

--- a/macos/Sources/Ghostty/InspectorView.swift
+++ b/macos/Sources/Ghostty/InspectorView.swift
@@ -55,7 +55,7 @@ extension Ghostty {
         private func onControlInspector(_ notification: SwiftUI.Notification) {
             // Determine our mode
             guard let modeAny = notification.userInfo?["mode"] else { return }
-            guard let mode = modeAny as? ghostty_inspector_mode_e else { return }
+            guard let mode = modeAny as? ghostty_action_inspector_e else { return }
 
             switch (mode) {
             case GHOSTTY_INSPECTOR_TOGGLE:

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -39,32 +39,54 @@ extension Ghostty {
     }
 }
 
-// MARK: Surface Notifications
+// MARK: Swift Types for C Types
 
 extension Ghostty {
+    enum SetSecureInput {
+        case on
+        case off
+        case toggle
+
+        static func from(_ c: ghostty_action_secure_input_e) -> Self? {
+            switch (c) {
+            case GHOSTTY_SECURE_INPUT_ON:
+                return .on
+
+            case GHOSTTY_SECURE_INPUT_OFF:
+                return .off
+
+            case GHOSTTY_SECURE_INPUT_TOGGLE:
+                return .toggle
+
+            default:
+                return nil
+            }
+        }
+    }
+
     /// An enum that is used for the directions that a split focus event can change.
     enum SplitFocusDirection {
         case previous, next, top, bottom, left, right
 
         /// Initialize from a Ghostty API enum.
-        static func from(direction: ghostty_split_focus_direction_e) -> Self? {
+        static func from(direction: ghostty_action_goto_split_e) -> Self? {
             switch (direction) {
-            case GHOSTTY_SPLIT_FOCUS_PREVIOUS:
+            case GHOSTTY_GOTO_SPLIT_PREVIOUS:
                 return .previous
 
-            case GHOSTTY_SPLIT_FOCUS_NEXT:
+            case GHOSTTY_GOTO_SPLIT_NEXT:
                 return .next
 
-            case GHOSTTY_SPLIT_FOCUS_TOP:
+            case GHOSTTY_GOTO_SPLIT_TOP:
                 return .top
 
-            case GHOSTTY_SPLIT_FOCUS_BOTTOM:
+            case GHOSTTY_GOTO_SPLIT_BOTTOM:
                 return .bottom
 
-            case GHOSTTY_SPLIT_FOCUS_LEFT:
+            case GHOSTTY_GOTO_SPLIT_LEFT:
                 return .left
 
-            case GHOSTTY_SPLIT_FOCUS_RIGHT:
+            case GHOSTTY_GOTO_SPLIT_RIGHT:
                 return .right
 
             default:
@@ -72,25 +94,25 @@ extension Ghostty {
             }
         }
 
-        func toNative() -> ghostty_split_focus_direction_e {
+        func toNative() -> ghostty_action_goto_split_e {
             switch (self) {
             case .previous:
-                return GHOSTTY_SPLIT_FOCUS_PREVIOUS
+                return GHOSTTY_GOTO_SPLIT_PREVIOUS
 
             case .next:
-                return GHOSTTY_SPLIT_FOCUS_NEXT
+                return GHOSTTY_GOTO_SPLIT_NEXT
 
             case .top:
-                return GHOSTTY_SPLIT_FOCUS_TOP
+                return GHOSTTY_GOTO_SPLIT_TOP
 
             case .bottom:
-                return GHOSTTY_SPLIT_FOCUS_BOTTOM
+                return GHOSTTY_GOTO_SPLIT_BOTTOM
 
             case .left:
-                return GHOSTTY_SPLIT_FOCUS_LEFT
+                return GHOSTTY_GOTO_SPLIT_LEFT
 
             case .right:
-                return GHOSTTY_SPLIT_FOCUS_RIGHT
+                return GHOSTTY_GOTO_SPLIT_RIGHT
             }
         }
     }
@@ -99,31 +121,31 @@ extension Ghostty {
     enum SplitResizeDirection {
         case up, down, left, right
 
-        static func from(direction: ghostty_split_resize_direction_e) -> Self? {
+        static func from(direction: ghostty_action_resize_split_direction_e) -> Self? {
             switch (direction) {
-            case GHOSTTY_SPLIT_RESIZE_UP:
+            case GHOSTTY_RESIZE_SPLIT_UP:
                 return .up;
-            case GHOSTTY_SPLIT_RESIZE_DOWN:
+            case GHOSTTY_RESIZE_SPLIT_DOWN:
                 return .down;
-            case GHOSTTY_SPLIT_RESIZE_LEFT:
+            case GHOSTTY_RESIZE_SPLIT_LEFT:
                 return .left;
-            case GHOSTTY_SPLIT_RESIZE_RIGHT:
+            case GHOSTTY_RESIZE_SPLIT_RIGHT:
                 return .right;
             default:
                 return nil
             }
         }
 
-        func toNative() -> ghostty_split_resize_direction_e {
+        func toNative() -> ghostty_action_resize_split_direction_e {
             switch (self) {
             case .up:
-                return GHOSTTY_SPLIT_RESIZE_UP;
+                return GHOSTTY_RESIZE_SPLIT_UP;
             case .down:
-                return GHOSTTY_SPLIT_RESIZE_DOWN;
+                return GHOSTTY_RESIZE_SPLIT_DOWN;
             case .left:
-                return GHOSTTY_SPLIT_RESIZE_LEFT;
+                return GHOSTTY_RESIZE_SPLIT_LEFT;
             case .right:
-                return GHOSTTY_SPLIT_RESIZE_RIGHT;
+                return GHOSTTY_RESIZE_SPLIT_RIGHT;
             }
         }
     }
@@ -174,6 +196,8 @@ extension Ghostty {
     }
 }
 
+// MARK: Surface Notifications
+
 extension Ghostty.Notification {
     /// Used to pass a configuration along when creating a new tab/window/split.
     static let NewSurfaceConfigKey = "com.mitchellh.ghostty.newSurfaceConfig"
@@ -201,7 +225,7 @@ extension Ghostty.Notification {
 
     /// Toggle fullscreen of current window
     static let ghosttyToggleFullscreen = Notification.Name("com.mitchellh.ghostty.toggleFullscreen")
-    static let NonNativeFullscreenKey = ghosttyToggleFullscreen.rawValue
+    static let FullscreenModeKey = ghosttyToggleFullscreen.rawValue
 
     /// Notification that a surface is becoming focused. This is only sent on macOS 12 to
     /// work around bugs. macOS 13+ should use the ".focused()" attribute.

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -251,7 +251,7 @@ extension Ghostty {
             }
         }
 
-        func setCursorShape(_ shape: ghostty_mouse_shape_e) {
+        func setCursorShape(_ shape: ghostty_action_mouse_shape_e) {
             switch (shape) {
             case GHOSTTY_MOUSE_SHAPE_DEFAULT:
                 pointerStyle = .default
@@ -312,7 +312,7 @@ extension Ghostty {
 
         @objc private func onUpdateRendererHealth(notification: SwiftUI.Notification) {
             guard let healthAny = notification.userInfo?["health"] else { return }
-            guard let health = healthAny as? ghostty_renderer_health_e else { return }
+            guard let health = healthAny as? ghostty_action_renderer_health_e else { return }
             healthy = health == GHOSTTY_RENDERER_HEALTH_OK
         }
 
@@ -926,12 +926,12 @@ extension Ghostty {
 
         @IBAction func splitRight(_ sender: Any) {
             guard let surface = self.surface else { return }
-            ghostty_surface_split(surface, GHOSTTY_SPLIT_RIGHT)
+            ghostty_surface_split(surface, GHOSTTY_SPLIT_DIRECTION_RIGHT)
         }
 
         @IBAction func splitDown(_ sender: Any) {
             guard let surface = self.surface else { return }
-            ghostty_surface_split(surface, GHOSTTY_SPLIT_DOWN)
+            ghostty_surface_split(surface, GHOSTTY_SPLIT_DIRECTION_DOWN)
         }
 
         @objc func resetTerminal(_ sender: Any) {

--- a/macos/Sources/Helpers/FullScreenHandler.swift
+++ b/macos/Sources/Helpers/FullScreenHandler.swift
@@ -13,8 +13,18 @@ class FullScreenHandler {
     var isInNonNativeFullscreen: Bool = false
     var isInFullscreen: Bool = false
 
-    func toggleFullscreen(window: NSWindow, nonNativeFullscreen: ghostty_non_native_fullscreen_e) {
-        let useNonNativeFullscreen = nonNativeFullscreen != GHOSTTY_NON_NATIVE_FULLSCREEN_FALSE
+    func toggleFullscreen(window: NSWindow, mode: ghostty_action_fullscreen_e) {
+        let useNonNativeFullscreen = switch (mode) {
+        case GHOSTTY_FULLSCREEN_NATIVE:
+            false
+
+        case GHOSTTY_FULLSCREEN_NON_NATIVE, GHOSTTY_FULLSCREEN_NON_NATIVE_VISIBLE_MENU:
+            true
+
+        default:
+            false
+        }
+        
         if isInFullscreen {
             if useNonNativeFullscreen || isInNonNativeFullscreen {
                 leaveFullscreen(window: window)
@@ -27,7 +37,7 @@ class FullScreenHandler {
             isInFullscreen = false
         } else {
             if useNonNativeFullscreen {
-                let hideMenu = nonNativeFullscreen != GHOSTTY_NON_NATIVE_FULLSCREEN_VISIBLE_MENU
+                let hideMenu = mode != GHOSTTY_FULLSCREEN_NON_NATIVE_VISIBLE_MENU
                 enterFullscreen(window: window, hideMenu: hideMenu)
                 isInNonNativeFullscreen = true
             } else {

--- a/src/apprt.zig
+++ b/src/apprt.zig
@@ -31,7 +31,6 @@ pub const ClipboardRequest = structs.ClipboardRequest;
 pub const ClipboardRequestType = structs.ClipboardRequestType;
 pub const ColorScheme = structs.ColorScheme;
 pub const CursorPos = structs.CursorPos;
-pub const DesktopNotification = structs.DesktopNotification;
 pub const IMEPos = structs.IMEPos;
 pub const Selection = structs.Selection;
 pub const SurfaceSize = structs.SurfaceSize;

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -784,18 +784,6 @@ pub fn setInitialWindowSize(self: *const Surface, width: u32, height: u32) !void
     );
 }
 
-pub fn setCellSize(self: *const Surface, width: u32, height: u32) !void {
-    _ = self;
-    _ = width;
-    _ = height;
-}
-
-pub fn setSizeLimits(self: *Surface, min: apprt.SurfaceSize, max_: ?apprt.SurfaceSize) !void {
-    _ = self;
-    _ = min;
-    _ = max_;
-}
-
 pub fn grabFocus(self: *Surface) void {
     if (self.container.tab()) |tab| tab.focus_child = self;
 
@@ -1920,10 +1908,4 @@ pub fn present(self: *Surface) void {
     }
 
     self.grabFocus();
-}
-
-pub fn updateRendererHealth(self: *const Surface, health: renderer.Health) void {
-    // We don't support this in GTK.
-    _ = self;
-    _ = health;
 }

--- a/src/apprt/structs.zig
+++ b/src/apprt/structs.zig
@@ -52,16 +52,6 @@ pub const ClipboardRequest = union(ClipboardRequestType) {
     osc_52_write: Clipboard,
 };
 
-/// A desktop notification.
-pub const DesktopNotification = struct {
-    /// The title of the notification. May be an empty string to not show a
-    /// title.
-    title: []const u8,
-
-    /// The body of a notification. This will always be shown.
-    body: []const u8,
-};
-
 /// The color scheme in use (light vs dark).
 pub const ColorScheme = enum(u2) {
     light = 0,


### PR DESCRIPTION
## What?

First, this commit modifies libghostty to use a single unified action dispatch system based on a tagged union versus the one-off callback system that was previously in place. This change simplifies the code on both the core and consumer sides of the library. Importantly, as we introduce new actions, we can now maintain ABI compatibility so long as our union size does not change (something I don't promise yet).

Second, this moves a lot more of the functions call on a surface into the action system. This affects all apprts and continues the previous work of introducing a more unified API for optional surface features.

Similar to #2301, this PR is prone to trivial typo-style errors in converting from the old style to the new. I tested each action on macOS but it's possible other apprts have some issues. I hope not! In any case, if any issues are introduced they will be trivial to fix.

## Why?

- Less (almost zero!) special opt-in methods for apprts (continuing the spirit of #2301)
- A better story about ABI compatibility eventually for libghostty
- Much easier to ship new functionality that interacts with apprts. 