### PR TITLE
Action system fixups

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -379,9 +379,9 @@ typedef struct {
 
 // apprt.action.GotoTab
 typedef enum {
-  GHOSTTY_GOTO_TAB_PREVIOUS,
-  GHOSTTY_GOTO_TAB_NEXT,
-  GHOSTTY_GOTO_TAB_LAST,
+  GHOSTTY_GOTO_TAB_PREVIOUS = -1,
+  GHOSTTY_GOTO_TAB_NEXT = -2,
+  GHOSTTY_GOTO_TAB_LAST = -3,
 } ghostty_action_goto_tab_e;
 
 // apprt.action.Fullscreen

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -734,7 +734,7 @@ class TerminalController: NSWindowController, NSWindowDelegate,
         // Get the tab index from the notification
         guard let tabEnumAny = notification.userInfo?[Ghostty.Notification.GotoTabKey] else { return }
         guard let tabEnum = tabEnumAny as? ghostty_action_goto_tab_e else { return }
-        let tabIndex: Int32 = .init(bitPattern: tabEnum.rawValue)
+        let tabIndex: Int32 = tabEnum.rawValue
 
         guard let windowController = window.windowController else { return }
         guard let tabGroup = windowController.window?.tabGroup else { return }

--- a/src/App.zig
+++ b/src/App.zig
@@ -139,7 +139,7 @@ pub fn addSurface(self: *App, rt_surface: *apprt.Surface) !void {
     // It is up to the apprt if there is a quit timer at all and if it
     // should be canceled.
     rt_surface.app.performAction(
-        .{ .surface = &rt_surface.core_surface },
+        .app,
         .quit_timer,
         .stop,
     ) catch |err| {
@@ -173,7 +173,7 @@ pub fn deleteSurface(self: *App, rt_surface: *apprt.Surface) void {
     // If we have no surfaces, we can start the quit timer. It is up to the
     // apprt to determine if this is necessary.
     if (self.surfaces.items.len == 0) rt_surface.app.performAction(
-        .{ .surface = &rt_surface.core_surface },
+        .app,
         .quit_timer,
         .start,
     ) catch |err| {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1257,14 +1257,10 @@ pub fn setFontSize(self: *Surface, size: font.face.DesiredSize) !void {
     errdefer self.app.font_grid_set.deref(font_grid_key);
 
     // Set our cell size
-    try self.rt_app.performAction(
-        .{ .surface = self },
-        .cell_size,
-        .{
-            .width = font_grid.metrics.cell_width,
-            .height = font_grid.metrics.cell_height,
-        },
-    );
+    try self.setCellSize(.{
+        .width = font_grid.metrics.cell_width,
+        .height = font_grid.metrics.cell_height,
+    });
 
     // Notify our render thread of the new font stack. The renderer
     // MUST accept the new font grid and deref the old.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -441,6 +441,11 @@ pub const App = struct {
             else => {},
         }
 
+        log.debug("dispatching action target={s} action={} value={}", .{
+            @tagName(target),
+            action,
+            value,
+        });
         self.opts.action(
             self,
             target.cval(),


### PR DESCRIPTION
Fixes #2308

Some sloppy things:

* `quit_timer` action has to target app since the surface pointer is invalid
* libghostty tab enum was using wrong values, making previous/next/last not work on macOS
* font sizes weren't setting our cell metrics properly since I removed a valid call with an action by accident
* debug log action dispatch