### PR TITLE
sgr: add support for legacy double underline

### DIFF
--- a/src/terminal/sgr.zig
+++ b/src/terminal/sgr.zig
@@ -165,6 +165,8 @@ pub const Parser = struct {
 
             9 => return Attribute{ .strikethrough = {} },
 
+            21 => return Attribute{ .underline = .double },
+
             22 => return Attribute{ .reset_bold = {} },
 
             23 => return Attribute{ .reset_italic = {} },


### PR DESCRIPTION
SGR 21 is defined to be a double underline. This behavior is common
among many terminals, notably xterm.

References: [https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Functions-using-CSI-_-ordered-by-the-final-character_s_](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Functions-using-CSI-_-ordered-by-the-final-character_s_)
