### PR TITLE
cli: fix integer overflow in `+list-themes` if window is too narrow

### DIFF
--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -1068,19 +1068,21 @@ const Preview = struct {
                         .col_offset = 2,
                     },
                 );
-                for (10..child.width) |col| {
-                    _ = try child.print(
-                        &.{
-                            .{
-                                .text = "─",
-                                .style = color238,
+                if (child.width > 10) {
+                    for (10..child.width) |col| {
+                        _ = try child.print(
+                            &.{
+                                .{
+                                    .text = "─",
+                                    .style = color238,
+                                },
                             },
-                        },
-                        .{
-                            .row_offset = 1,
-                            .col_offset = col,
-                        },
-                    );
+                            .{
+                                .row_offset = 1,
+                                .col_offset = col,
+                            },
+                        );
+                    }
                 }
             }
             _ = try child.print(
@@ -1118,19 +1120,21 @@ const Preview = struct {
                         .col_offset = 2,
                     },
                 );
-                for (10..child.width) |col| {
-                    _ = try child.print(
-                        &.{
-                            .{
-                                .text = "─",
-                                .style = color238,
+                if (child.width > 10) {
+                    for (10..child.width) |col| {
+                        _ = try child.print(
+                            &.{
+                                .{
+                                    .text = "─",
+                                    .style = color238,
+                                },
                             },
-                        },
-                        .{
-                            .row_offset = 3,
-                            .col_offset = col,
-                        },
-                    );
+                            .{
+                                .row_offset = 3,
+                                .col_offset = col,
+                            },
+                        );
+                    }
                 }
             }
             _ = try child.print(
@@ -1383,19 +1387,21 @@ const Preview = struct {
                         .col_offset = 2,
                     },
                 );
-                for (10..child.width) |col| {
-                    _ = try child.print(
-                        &.{
-                            .{
-                                .text = "─",
-                                .style = color238,
+                if (child.width > 10) {
+                    for (10..child.width) |col| {
+                        _ = try child.print(
+                            &.{
+                                .{
+                                    .text = "─",
+                                    .style = color238,
+                                },
                             },
-                        },
-                        .{
-                            .row_offset = 21,
-                            .col_offset = col,
-                        },
-                    );
+                            .{
+                                .row_offset = 21,
+                                .col_offset = col,
+                            },
+                        );
+                    }
                 }
             }
             _ = try child.print(


### PR DESCRIPTION
Reproduction is to resize the window to it's minimum width and then run `ghostty +list-themes`. Ghostty will crash because Zig for loops don't like having a range where the end is smaller than the start.