### PR TITLE
gtk: add "search with selection" keybind action and context menu item

### DIFF
--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1112,7 +1112,9 @@ fn showContextMenu(self: *Surface, x: f32, y: f32) void {
     };
 
     c.gtk_popover_set_pointing_to(@ptrCast(@alignCast(window.context_menu)), &rect);
-    self.app.refreshContextMenu(self.core_surface.hasSelection());
+    const selection = self.core_surface.selectionString(self.app.core_app.alloc) catch null;
+    defer if (selection) |s| self.app.core_app.alloc.free(s);
+    self.app.refreshContextMenu(window.window, selection);
     c.gtk_popover_popup(@ptrCast(@alignCast(window.context_menu)));
 }
 

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -367,6 +367,7 @@ fn initActions(self: *Window) void {
         .{ "toggle_inspector", &gtkActionToggleInspector },
         .{ "copy", &gtkActionCopy },
         .{ "paste", &gtkActionPaste },
+        .{ "search", &gtkActionSearch },
         .{ "reset", &gtkActionReset },
     };
 
@@ -805,6 +806,19 @@ fn gtkActionPaste(
     const self: *Window = @ptrCast(@alignCast(ud orelse return));
     const surface = self.actionSurface() orelse return;
     _ = surface.performBindingAction(.{ .paste_from_clipboard = {} }) catch |err| {
+        log.warn("error performing binding action error={}", .{err});
+        return;
+    };
+}
+
+fn gtkActionSearch(
+    _: *c.GSimpleAction,
+    _: *c.GVariant,
+    ud: ?*anyopaque,
+) callconv(.C) void {
+    const self: *Window = @ptrCast(@alignCast(ud orelse return));
+    const surface = self.actionSurface() orelse return;
+    _ = surface.performBindingAction(.{ .search_with_selection = {} }) catch |err| {
         log.warn("error performing binding action error={}", .{err});
         return;
     };

--- a/src/config.zig
+++ b/src/config.zig
@@ -26,6 +26,7 @@ pub const RepeatableString = Config.RepeatableString;
 pub const RepeatablePath = Config.RepeatablePath;
 pub const ShellIntegrationFeatures = Config.ShellIntegrationFeatures;
 pub const WindowPaddingColor = Config.WindowPaddingColor;
+pub const SearchProvider = Config.SearchProvider;
 
 // Alternate APIs
 pub const CAPI = @import("config/CAPI.zig");

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -232,6 +232,12 @@ pub const Action = union(enum) {
     paste_from_clipboard: void,
     paste_from_selection: void,
 
+    /// Launch an internet search using the native OS mechanisms with the
+    /// selected text from the focused surface. This is a no-op if there is no
+    /// selected text in the focused surface. See the configuration variable
+    /// `search-provider` for information on how to select a search provider.
+    search_with_selection: void,
+
     /// Increase/decrease the font size by a certain amount.
     increase_font_size: f32,
     decrease_font_size: f32,
@@ -600,6 +606,7 @@ pub const Action = union(enum) {
             .toggle_window_decorations,
             .toggle_secure_input,
             .crash,
+            .search_with_selection,
             => .surface,
 
             // These are less obvious surface actions. They're surface


### PR DESCRIPTION
This adds the ability to launch an internet search with any selected text on the active surface. If there is no selected text, the action is a no-op. Search providers are configured using the `search-provider` configuration entry and can be chosen from a set of predefined options or a supplied custom URI.

This only implements the context menu for GTK but extending this to macOS should be fairly easy as most of the logic is in the core. The keybind action should work on macOS as-is although it is not assigned a keybind by default.

![Screenshot from 2024-09-28 17-19-30](https://github.com/user-attachments/assets/c4621b15-fcc8-441d-94c3-149605981686)
![Screenshot from 2024-09-28 17-20-52](https://github.com/user-attachments/assets/0a371d55-f3bf-461d-83ac-a2ac67b38d7f)
