### PR TITLE
nix: use stdenv from unstable to build the package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
 
       packages.${system} = let
         mkArgs = optimize: {
-          inherit (pkgs-unstable) zig_0_13;
+          inherit (pkgs-unstable) zig_0_13 stdenv;
           inherit optimize;
 
           revision = self.shortRev or self.dirtyShortRev or "dirty";


### PR DESCRIPTION
The Zig build hook from NixOS unstable uses some new things from the stdenv in unstable to build. It doesn't always fail for some reason (probably cache masking errors again).