### PR TITLE
terminal: select whole links if regex matches

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2735,9 +2735,16 @@ pub fn mouseButtonCallback(
             // word selection where we clicked.
         }
 
-        const sel = screen.selectWord(pin) orelse break :sel;
-        try self.setSelection(sel);
-        try self.queueRender();
+        // Check if the selection contains a link, if it does
+        // select the whole link, if it doesn't select a word.
+        if (screen.selectLink(pin) catch null) |sel| {
+            try self.setSelection(sel);
+            try self.queueRender();
+        } else {
+            const sel = screen.selectWord(pin) orelse break :sel;
+            try self.setSelection(sel);
+            try self.queueRender();
+        }
     }
 
     return false;


### PR DESCRIPTION
Still needs tests added, and a general lookover but it does work as intended.

Added a new function under `src/terminal/Screen.zig` called `selectLink`, this checks the selection against a regex to see if it is a link, otherwise returns null. 

Updated the logic in `src/Surface.zig` so it checks the link first, and if it catches null it selects a word instead.

Feel free to nitpick anything, might've missed something not 100% familiar with the codebase yet.