### PR TITLE
macOS: Quick Terminal focus improvements

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -177,13 +177,24 @@ class QuickTerminalController: BaseTerminalController {
             position.setInitial(in: window.animator(), on: screen)
         }, completionHandler: {
             guard wasKey else { return }
-            self.focusNextWindow()
+            self.focusNextWindow(on: screen)
         })
     }
 
-    private func focusNextWindow() {
-        // We only want to consider windows that are visible
-        let windows = NSApp.windows.filter { $0.isVisible }
+    private func focusNextWindow(on screen: NSScreen) {
+        let windows = NSApp.windows.filter {
+            // Visible, otherwise we'll make an invisible window visible.
+            guard $0.isVisible else { return false }
+
+            // Same screen, just a preference...
+            guard $0.screen == screen else { return false }
+
+            // Same space (virtual screen). Otherwise we'll force an animation to
+            // another space which is very jarring.
+            guard $0.isOnActiveSpace else { return false }
+
+            return true
+        }
 
         // If we have no windows there is nothing to focus.
         guard !windows.isEmpty else { return }


### PR DESCRIPTION
This PR improves focus behavior:

* When the quick terminal is dismissed, we use `NSWindow.orderOut` which handles next app focus properly. This fixes an issue where we would try to focus a Ghostty window on another space and trigger a full desktop animation.

* The quick terminal will attempt to refocus the previously focused application when it was animated in. This behavior is only valid so long as (1) Ghostty wasn't the focused application when the quick terminal appeared (2) You don't focus out to another Ghostty window (i.e. with the mouse) and (3) The previously focused application is still running.

