### PR TITLE
cli: handle mouse scroll before setting window

### DIFF
--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -502,20 +502,6 @@ const Preview = struct {
             .height = .{ .limit = win.height },
         });
 
-        if (self.filtered.items.len == 0) {
-            self.current = 0;
-            self.window = 0;
-        } else {
-            const start = self.window;
-            const end = self.window + theme_list.height - 1;
-            if (self.current > end)
-                self.window = self.current - theme_list.height + 1;
-            if (self.current < start)
-                self.window = self.current;
-            if (self.window >= self.filtered.items.len)
-                self.window = self.filtered.items.len - 1;
-        }
-
         var highlight: ?usize = null;
 
         if (self.mouse) |mouse| {
@@ -534,6 +520,20 @@ const Preview = struct {
                     highlight = mouse.row;
                 }
             }
+        }
+
+        if (self.filtered.items.len == 0) {
+            self.current = 0;
+            self.window = 0;
+        } else {
+            const start = self.window;
+            const end = self.window + theme_list.height - 1;
+            if (self.current > end)
+                self.window = self.current - theme_list.height + 1;
+            if (self.current < start)
+                self.window = self.current;
+            if (self.window >= self.filtered.items.len)
+                self.window = self.filtered.items.len - 1;
         }
 
         theme_list.fill(.{ .style = self.ui_standard() });


### PR DESCRIPTION
Scrolling would go past the end so that selection is not seen in the list (see video).

[Screencast from 2024-09-30 11-04-23.webm](https://github.com/user-attachments/assets/69bd175d-8b4e-40a2-8d5d-368d277f46f5)

Now that mouse effects are handled before clamping the selection is correctly set at the bottom as when using the keyboard to scroll.