### PR TITLE
macos: quick terminal supports fullscreen

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -4,13 +4,8 @@ import SwiftUI
 import GhosttyKit
 
 /// A classic, tabbed terminal experience.
-class TerminalController: BaseTerminalController,
-                          FullscreenDelegate
-{
+class TerminalController: BaseTerminalController {
     override var windowNibName: NSNib.Name? { "Terminal" }
-
-    /// Fullscreen state management.
-    private(set) var fullscreenStyle: FullscreenStyle?
 
     /// This is set to true when we care about frame changes. This is a small optimization since
     /// this controller registers a listener for ALL frame change notifications and this lets us bail
@@ -197,63 +192,6 @@ class TerminalController: BaseTerminalController,
             // If there is transparency, calling this will make the titlebar opaque
             // so we only call this if we are opaque.
             window.updateTabBar()
-        }
-    }
-
-    // MARK: Fullscreen
-
-    /// Toggle fullscreen for the given mode.
-    func toggleFullscreen(mode: FullscreenMode) {
-        // We need a window to fullscreen
-        guard let window = self.window else { return }
-
-        // If we have a previous fullscreen style initialized, we want to check if
-        // our mode changed. If it changed and we're in fullscreen, we exit so we can
-        // toggle it next time. If it changed and we're not in fullscreen we can just
-        // switch the handler.
-        var newStyle = mode.style(for: window)
-        newStyle?.delegate = self
-        old: if let oldStyle = self.fullscreenStyle {
-            // If we're not fullscreen, we can nil it out so we get the new style
-            if !oldStyle.isFullscreen {
-                self.fullscreenStyle = newStyle
-                break old
-            }
-
-            assert(oldStyle.isFullscreen)
-
-            // We consider our mode changed if the types change (obvious) but
-            // also if its nil (not obvious) because nil means that the style has
-            // likely changed but we don't support it.
-            if newStyle == nil || type(of: newStyle) != type(of: oldStyle) {
-                // Our mode changed. Exit fullscreen (since we're toggling anyways)
-                // and then unset the style so that we replace it next time.
-                oldStyle.exit()
-                self.fullscreenStyle = nil
-
-                // We're done
-                return
-            }
-
-            // Style is the same.
-        } else {
-            // We have no previous style
-            self.fullscreenStyle = newStyle
-        }
-        guard let fullscreenStyle else { return }
-
-        if fullscreenStyle.isFullscreen {
-            fullscreenStyle.exit()
-        } else {
-            fullscreenStyle.enter()
-        }
-    }
-
-    func fullscreenDidChange() {
-        // For some reason focus can get lost when we change fullscreen. Regardless of
-        // mode above we just move it back.
-        if let focusedSurface {
-            Ghostty.moveFocus(to: focusedSurface)
         }
     }
 
@@ -583,7 +521,6 @@ class TerminalController: BaseTerminalController,
         let targetWindow = tabbedWindows[finalIndex]
         targetWindow.makeKeyAndOrderFront(nil)
     }
-
 
     @objc private func onToggleFullscreen(notification: SwiftUI.Notification) {
         guard let target = notification.object as? Ghostty.SurfaceView else { return }

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -376,9 +376,12 @@ pub const Action = union(enum) {
     ///
     ///   - It is a singleton; only one instance can exist at a time.
     ///   - It does not support tabs.
-    ///   - It does not support fullscreen.
     ///   - It will not be restored when the application is restarted
     ///     (for systems that support window restoration).
+    ///   - It supports fullscreen, but fullscreen will always be a non-native
+    ///     fullscreen (macos-non-native-fullscreen = true). This only applies
+    ///     to the quick terminal window. This is a requirement due to how
+    ///     the quick terminal is rendered.
     ///
     /// See the various configurations for the quick terminal in the
     /// configuration file to customize its behavior.


### PR DESCRIPTION
Fixes #2330

The quick terminal now supports fullscreen. The fullscreen mode is always non-native due to the quick terminal being a titleless, floating window.

When the quick terminal loses focus and animates out, it will always exit fullscreen mode.