### PR TITLE
Remove "no_aliases" option from zsh integration

### DIFF
--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -37,7 +37,7 @@
 # builtins with `builtin` to avoid accidentally invoking user-defined functions.
 # We avoid `function` reserved word as an additional defensive measure.
 
-builtin emulate -L zsh -o no_warn_create_global -o no_aliases
+builtin emulate -L zsh -o no_warn_create_global
 
 [[ -o interactive ]]              || builtin return 0  # non-interactive shell
 (( ! $+_ghostty_state ))          || builtin return 0  # already initialized
@@ -82,7 +82,7 @@ builtin typeset -ag precmd_functions
 precmd_functions+=(_ghostty_deferred_init)
 
 _ghostty_deferred_init() {
-    builtin emulate -L zsh -o no_warn_create_global -o no_aliases
+    builtin emulate -L zsh -o no_warn_create_global
 
     # The directory where ghostty-integration is located: /../shell-integration/zsh.
     builtin local self_dir="${functions_source[_ghostty_deferred_init]:A:h}"
@@ -90,7 +90,7 @@ _ghostty_deferred_init() {
     # Enable semantic markup with OSC 133.
     _ghostty_precmd() {
         builtin local -i cmd_status=$?
-        builtin emulate -L zsh -o no_warn_create_global -o no_aliases
+        builtin emulate -L zsh -o no_warn_create_global
 
         # Don't write OSC 133 D when our precmd handler is invoked from zle.
         # Some plugins do that to update prompt on cd.
@@ -164,7 +164,7 @@ _ghostty_deferred_init() {
     }
 
     _ghostty_preexec() {
-        builtin emulate -L zsh -o no_warn_create_global -o no_aliases
+        builtin emulate -L zsh -o no_warn_create_global
 
         # This can potentially break user prompt. Oh well. The robustness of
         # this code can be improved in the case prompt_subst is set because


### PR DESCRIPTION
When using Ghostty with zsh my aliases stopped working. I'm not sure this is the right solution, but it solves the problem for me.

It looks to me like potentially aliasable commands are being prefixed with `builtin` anyway, so it might be safe to remove `no_aliases`. Otherwise perhaps there's a way to only set the option for the function duration, or to unset it before the function returns control .. or something. I'm not quite zsh-y enough to understand all the intricacies, sorry.

Before:

<img width="912" alt="image" src="https://github.com/user-attachments/assets/dc66a929-e939-4797-a4a6-d11a913f1da0">

After:

<img width="912" alt="image" src="https://github.com/user-attachments/assets/4ef83c33-2dcd-4382-b929-0172f672d8c3">

This is with a `.zshrc` stripped down to only sourcing the ghostty-integration.

<details>
<summary><code>sj26@Ironhide ~ % cat ~/.zshrc</code></summary>

```
# Ghostty shell integration for ZSH. This must be at the top of your zshrc!
if [ -n "${GHOSTTY_RESOURCES_DIR}" ]; then
    builtin source "${GHOSTTY_RESOURCES_DIR}/shell-integration/zsh/ghostty-integration"
fi
```

</details>

```
sj26@Ironhide ~ % which zsh
/bin/zsh
sj26@Ironhide ~ % zsh --version
zsh 5.9 (x86_64-apple-darwin23.0)
```

<details>
<summary><code>sj26@Ironhide ~ % set</code></summary>

```
'!'=0
'#'=0
'$'=74686
'*'=(  )
-=569XZilms
0=-/bin/zsh
'?'=0
@=(  )
ARGC=0
CDPATH=''
COLORTERM=truecolor
COLUMNS=88
COMMAND_MODE=unix2003
CPUTYPE=arm64
EGID=20
EUID=501
FIGNORE=''
FPATH=/usr/local/share/zsh/site-functions:/usr/share/zsh/site-functions:/usr/share/zsh/5.9/functions
FUNCNEST=700
GHOSTTY_BIN_DIR=/Applications/Ghostty.app/Contents/MacOS
GHOSTTY_RESOURCES_DIR=/Applications/Ghostty.app/Contents/Resources/ghostty
GHOSTTY_SHELL_INTEGRATION_NO_SUDO=1
GID=20
HISTCHARS='!^#'
HISTCMD=1013
HISTFILE=/Users/sj26/.zsh_history
HISTSIZE=2000
HOME=/Users/sj26
HOST=Ironhide.localdomain
IFS=$' \t\n\C-@'
KEYBOARD_HACK=''
KEYTIMEOUT=40
LANG=en_AU.UTF-8
LINENO=5
LINES=31
LISTMAX=100
LOGNAME=sj26
MACHTYPE=x86_64
MAILCHECK=60
MAILPATH=''
MANPATH=/usr/share/man:/usr/local/share/man:/usr/local/MacGPG2/share/man:/Applications/Ghostty.app/Contents/Resources/ghostty/../man:
MODULE_PATH=/usr/lib/zsh/5.9
NULLCMD=cat
OLDPWD=/Users/sj26
OPTARG=''
OPTIND=1
OSTYPE=darwin23.0
PATH=/Users/sj26/.orbstack/bin:/Users/sj26/.goenv/shims:/Users/sj26/.pyenv/shims:/Users/sj26/.nodenv/shims:/Users/sj26/.rbenv/shims:/opt/homebrew/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/usr/local/MacGPG2/bin:/Users/sj26/.cargo/bin:/Applications/Ghostty.app/Contents/MacOS
PPID=74685
PROMPT='%n@%m %1~ %# '
PROMPT2='%_> '
PROMPT3='?# '
PROMPT4='+%N:%i> '
PS1='%n@%m %1~ %# '
PS2='%_> '
PS3='?# '
PS4='+%N:%i> '
PSVAR=''
PWD=/Users/sj26
RANDOM=20200
READNULLCMD=more
SAVEHIST=1000
SECONDS=22
SHELL=/bin/zsh
SHLVL=1
SPROMPT='zsh: correct '\''%R'\'' to '\''%r'\'' [nyae]? '
SSH_AUTH_SOCK=/private/tmp/com.apple.launchd.tgsdwTdYDe/Listeners
TERM=xterm-ghostty
TERMINFO=/Applications/Ghostty.app/Contents/Resources/terminfo
TERM_PROGRAM=ghostty
TERM_PROGRAM_VERSION=0.1.0-main+3e9163e4
TIMEFMT='%J  %U user %S system %P cpu %*E total'
TMPDIR=/var/folders/d_/tm0qh4js6295wvw3hbdbn2680000gn/T/
TMPPREFIX=/tmp/zsh
TRY_BLOCK_ERROR=-1
TRY_BLOCK_INTERRUPT=-1
TTY=/dev/ttys005
TTYIDLE=0
UID=501
USER=sj26
USERNAME=sj26
VENDOR=apple
WATCH
WORDCHARS='*?_-.[]~=/&;!#$%^(){}<>'
XPC_FLAGS=0x0
XPC_SERVICE_NAME=0
ZSH_ARGZERO=-/bin/zsh
ZSH_EVAL_CONTEXT=toplevel
ZSH_NAME=zsh
ZSH_PATCHLEVEL=zsh-5.9-0-g73d3173
ZSH_SUBSHELL=0
ZSH_VERSION=5.9
_=set
__CFBundleIdentifier=com.mitchellh.ghostty
__CF_USER_TEXT_ENCODING=0x0:0:15
_ghostty_fd=13
_ghostty_state=1
aliases
argv=(  )
builtins
cdpath=(  )
chpwd_functions=( _ghostty_report_pwd )
commands
dirstack
dis_aliases
dis_builtins
dis_functions
dis_functions_source
dis_galiases
dis_patchars
dis_reswords
dis_saliases
errnos
fignore=(  )
fpath=( /usr/local/share/zsh/site-functions /usr/share/zsh/site-functions /usr/share/zsh/5.9/functions )
funcfiletrace
funcsourcetrace
funcstack
functions
functions_source
functrace
galiases
histchars='!^#'
history
historywords
jobdirs
jobstates
jobtexts
key=( [Backspace]=$'\C-?' [Delete]=$'\C-[[3~' [Down]=$'\C-[OB' [End]=$'\C-[OF' [F1]=$'\C-[OP' [F10]=$'\C-[[21~' [F11]=$'\C-[[23~' [F12]=$'\C-[[24~' [F13]=$'\C-[[1;2P' [F14]=$'\C-[[1;2Q' [F15]=$'\C-[[1;2R' [F16]=$'\C-[[1;2S' [F17]=$'\C-[[15;2~' [F18]=$'\C-[[17;2~' [F19]=$'\C-[[18;2~' [F2]=$'\C-[OQ' [F20]=$'\C-[[19;2~' [F3]=$'\C-[OR' [F4]=$'\C-[OS' [F5]=$'\C-[[15~' [F6]=$'\C-[[17~' [F7]=$'\C-[[18~' [F8]=$'\C-[[19~' [F9]=$'\C-[[20~' [Home]=$'\C-[OH' [Insert]=$'\C-[[2~' [Left]=$'\C-[OD' [PageDown]=$'\C-[[6~' [PageUp]=$'\C-[[5~' [Right]=$'\C-[OC' [Up]=$'\C-[OA' )
keymaps
mailpath=(  )
manpath=( /usr/share/man /usr/local/share/man /usr/local/MacGPG2/share/man /Applications/Ghostty.app/Contents/Resources/ghostty/../man '' )
module_path=( /usr/lib/zsh/5.9 )
modules
nameddirs
options
parameters
patchars
path=( /Users/sj26/.orbstack/bin /Users/sj26/.goenv/shims /Users/sj26/.pyenv/shims /Users/sj26/.nodenv/shims /Users/sj26/.rbenv/shims /opt/homebrew/bin /usr/local/bin /System/Cryptexes/App/usr/bin /usr/bin /bin /opt/homebrew/sbin /usr/local/sbin /usr/sbin /sbin /var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin /var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin /var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin /usr/local/MacGPG2/bin /Users/sj26/.cargo/bin /Applications/Ghostty.app/Contents/MacOS )
pipestatus=( 0 )
precmd_functions=( _ghostty_precmd )
preexec_functions=( _ghostty_preexec )
prompt='%n@%m %1~ %# '
psvar=(  )
reswords
saliases
signals=( EXIT HUP INT QUIT ILL TRAP ABRT EMT FPE KILL BUS SEGV SYS PIPE ALRM TERM URG STOP TSTP CONT CHLD TTIN TTOU IO XCPU XFSZ VTALRM PROF WINCH INFO USR1 USR2 ZERR DEBUG )
status=0
sysparams
termcap
terminfo
userdirs
usergroups
watch
widgets
zle_bracketed_paste=( $'\C-[[?2004h' $'\C-[[?2004l' )
zsh_eval_context=( toplevel )
zsh_scheduled_events
```

</details>