### PR TITLE
Underline Fixes

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -631,7 +631,7 @@ pub fn init(alloc: Allocator, options: renderer.Options) !Metal {
             .min_contrast = options.config.min_contrast,
             .cursor_pos = .{ std.math.maxInt(u16), std.math.maxInt(u16) },
             .cursor_color = undefined,
-            .wide_cursor = false,
+            .cursor_wide = false,
         },
 
         // Fonts
@@ -2035,7 +2035,7 @@ pub fn setScreenSize(
         .min_contrast = old.min_contrast,
         .cursor_pos = old.cursor_pos,
         .cursor_color = old.cursor_color,
-        .wide_cursor = old.wide_cursor,
+        .cursor_wide = old.cursor_wide,
     };
 
     // Reset our cell contents if our grid size has changed.
@@ -2358,13 +2358,17 @@ fn rebuildCells(
             const wide = screen.cursor.page_cell.wide;
 
             self.uniforms.cursor_pos = .{
+                // If we are a spacer tail of a wide cell, our cursor needs
+                // to move back one cell. The saturate is to ensure we don't
+                // overflow but this shouldn't happen with well-formed input.
                 switch (wide) {
                     .narrow, .spacer_head, .wide => screen.cursor.x,
                     .spacer_tail => screen.cursor.x -| 1,
                 },
                 screen.cursor.y,
             };
-            self.uniforms.wide_cursor = switch (wide) {
+
+            self.uniforms.cursor_wide = switch (wide) {
                 .narrow, .spacer_head => false,
                 .wide, .spacer_tail => true,
             };
@@ -2563,7 +2567,7 @@ fn updateCell(
 
         const color = style.underlineColor(palette) orelse colors.fg;
 
-        try self.cells.add(self.alloc, .underline, .{
+        var gpu_cell: mtl_cell.Key.underline.CellType() = .{
             .mode = .fg,
             .grid_pos = .{ @intCast(coord.x), @intCast(coord.y) },
             .constraint_width = 1,
@@ -2574,21 +2578,12 @@ fn updateCell(
                 @intCast(render.glyph.offset_x),
                 @intCast(render.glyph.offset_y),
             },
-        });
+        };
+        try self.cells.add(self.alloc, .underline, gpu_cell);
         // If it's a wide cell we need to underline the right half as well.
         if (cell.gridWidth() > 1 and coord.x < self.cells.size.columns - 1) {
-            try self.cells.add(self.alloc, .underline, .{
-                .mode = .fg,
-                .grid_pos = .{ @intCast(coord.x + 1), @intCast(coord.y) },
-                .constraint_width = 1,
-                .color = .{ color.r, color.g, color.b, alpha },
-                .glyph_pos = .{ render.glyph.atlas_x, render.glyph.atlas_y },
-                .glyph_size = .{ render.glyph.width, render.glyph.height },
-                .bearings = .{
-                    @intCast(render.glyph.offset_x),
-                    @intCast(render.glyph.offset_y),
-                },
-            });
+            gpu_cell.grid_pos[0] = @intCast(coord.x + 1);
+            try self.cells.add(self.alloc, .underline, gpu_cell);
         }
     }
 
@@ -2646,7 +2641,7 @@ fn updateCell(
             },
         );
 
-        try self.cells.add(self.alloc, .strikethrough, .{
+        var gpu_cell: mtl_cell.Key.strikethrough.CellType() = .{
             .mode = .fg,
             .grid_pos = .{ @intCast(coord.x), @intCast(coord.y) },
             .constraint_width = 1,
@@ -2657,21 +2652,12 @@ fn updateCell(
                 @intCast(render.glyph.offset_x),
                 @intCast(render.glyph.offset_y),
             },
-        });
+        };
+        try self.cells.add(self.alloc, .strikethrough, gpu_cell);
         // If it's a wide cell we need to strike through the right half as well.
         if (cell.gridWidth() > 1 and coord.x < self.cells.size.columns - 1) {
-            try self.cells.add(self.alloc, .strikethrough, .{
-                .mode = .fg,
-                .grid_pos = .{ @intCast(coord.x + 1), @intCast(coord.y) },
-                .constraint_width = 1,
-                .color = .{ colors.fg.r, colors.fg.g, colors.fg.b, alpha },
-                .glyph_pos = .{ render.glyph.atlas_x, render.glyph.atlas_y },
-                .glyph_size = .{ render.glyph.width, render.glyph.height },
-                .bearings = .{
-                    @intCast(render.glyph.offset_x),
-                    @intCast(render.glyph.offset_y),
-                },
-            });
+            gpu_cell.grid_pos[0] = @intCast(coord.x + 1);
+            try self.cells.add(self.alloc, .strikethrough, gpu_cell);
         }
     }
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -1338,6 +1338,10 @@ pub fn rebuildCells(
             };
 
             for (shaper_cells) |shaper_cell| {
+                // The shaper can emit null glyphs representing the right half
+                // of wide characters, we don't need to do anything with them.
+                if (shaper_cell.glyph_index == null) continue;
+
                 // If this cell falls within our preedit range then we skip it.
                 // We do this so we don't have conflicting data on the same
                 // cell.
@@ -1779,7 +1783,7 @@ fn updateCell(
             font.sprite_index,
             @intFromEnum(sprite),
             .{
-                .cell_width = if (cell.wide == .wide) 2 else 1,
+                .cell_width = 1,
                 .grid_metrics = self.grid_metrics,
             },
         );
@@ -1790,7 +1794,7 @@ fn updateCell(
             .mode = .fg,
             .grid_col = @intCast(x),
             .grid_row = @intCast(y),
-            .grid_width = cell.gridWidth(),
+            .grid_width = 1,
             .glyph_x = render.glyph.atlas_x,
             .glyph_y = render.glyph.atlas_y,
             .glyph_width = render.glyph.width,
@@ -1806,6 +1810,29 @@ fn updateCell(
             .bg_b = bg[2],
             .bg_a = bg[3],
         });
+        // If it's a wide cell we need to underline the right half as well.
+        if (cell.gridWidth() > 1 and x < self.grid_size.columns - 1) {
+            try self.cells.append(self.alloc, .{
+                .mode = .fg,
+                .grid_col = @intCast(x + 1),
+                .grid_row = @intCast(y),
+                .grid_width = 1,
+                .glyph_x = render.glyph.atlas_x,
+                .glyph_y = render.glyph.atlas_y,
+                .glyph_width = render.glyph.width,
+                .glyph_height = render.glyph.height,
+                .glyph_offset_x = render.glyph.offset_x,
+                .glyph_offset_y = render.glyph.offset_y,
+                .r = color.r,
+                .g = color.g,
+                .b = color.b,
+                .a = alpha,
+                .bg_r = bg[0],
+                .bg_g = bg[1],
+                .bg_b = bg[2],
+                .bg_a = bg[3],
+            });
+        }
     }
 
     // If the shaper cell has a glyph, draw it.
@@ -1866,7 +1893,7 @@ fn updateCell(
             font.sprite_index,
             @intFromEnum(font.Sprite.strikethrough),
             .{
-                .cell_width = if (cell.wide == .wide) 2 else 1,
+                .cell_width = 1,
                 .grid_metrics = self.grid_metrics,
             },
         );
@@ -1875,7 +1902,7 @@ fn updateCell(
             .mode = .fg,
             .grid_col = @intCast(x),
             .grid_row = @intCast(y),
-            .grid_width = cell.gridWidth(),
+            .grid_width = 1,
             .glyph_x = render.glyph.atlas_x,
             .glyph_y = render.glyph.atlas_y,
             .glyph_width = render.glyph.width,
@@ -1891,6 +1918,29 @@ fn updateCell(
             .bg_b = bg[2],
             .bg_a = bg[3],
         });
+        // If it's a wide cell we need to strike through the right half as well.
+        if (cell.gridWidth() > 1 and x < self.grid_size.columns - 1) {
+            try self.cells.append(self.alloc, .{
+                .mode = .fg,
+                .grid_col = @intCast(x + 1),
+                .grid_row = @intCast(y),
+                .grid_width = 1,
+                .glyph_x = render.glyph.atlas_x,
+                .glyph_y = render.glyph.atlas_y,
+                .glyph_width = render.glyph.width,
+                .glyph_height = render.glyph.height,
+                .glyph_offset_x = render.glyph.offset_x,
+                .glyph_offset_y = render.glyph.offset_y,
+                .r = colors.fg.r,
+                .g = colors.fg.g,
+                .b = colors.fg.b,
+                .a = alpha,
+                .bg_r = bg[0],
+                .bg_g = bg[1],
+                .bg_b = bg[2],
+                .bg_a = bg[3],
+            });
+        }
     }
 
     return true;

--- a/src/renderer/metal/cell.zig
+++ b/src/renderer/metal/cell.zig
@@ -14,7 +14,7 @@ pub const Key = enum {
     strikethrough,
 
     /// Returns the GPU vertex type for this key.
-    fn CellType(self: Key) type {
+    pub fn CellType(self: Key) type {
         return switch (self) {
             .bg => mtl_shaders.CellBg,
 
@@ -125,7 +125,7 @@ pub const Contents = struct {
         const bg_cells = try alloc.alloc(mtl_shaders.CellBg, cell_count);
         errdefer alloc.free(bg_cells);
 
-        @memset(bg_cells, .{0, 0, 0, 0});
+        @memset(bg_cells, .{ 0, 0, 0, 0 });
 
         // The foreground lists can hold 3 types of items:
         // - Glyphs
@@ -231,7 +231,7 @@ test Contents {
     for (0..rows) |y| {
         try testing.expect(c.fg_rows.lists[y + 1].items.len == 0);
         for (0..cols) |x| {
-            try testing.expectEqual(.{0, 0, 0, 0}, c.bgCell(y, x).*);
+            try testing.expectEqual(.{ 0, 0, 0, 0 }, c.bgCell(y, x).*);
         }
     }
     // And the cursor row should have a capacity of 1 and also be empty.
@@ -256,7 +256,7 @@ test Contents {
     for (0..rows) |y| {
         try testing.expect(c.fg_rows.lists[y + 1].items.len == 0);
         for (0..cols) |x| {
-            try testing.expectEqual(.{0, 0, 0, 0}, c.bgCell(y, x).*);
+            try testing.expectEqual(.{ 0, 0, 0, 0 }, c.bgCell(y, x).*);
         }
     }
 

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -138,7 +138,7 @@ pub const Uniforms = extern struct {
     cursor_color: [4]u8 align(4),
 
     // Whether the cursor is 2 cells wide.
-    wide_cursor: bool align(1),
+    cursor_wide: bool align(1),
 
     const PaddingExtend = packed struct(u8) {
         left: bool = false,

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -137,6 +137,9 @@ pub const Uniforms = extern struct {
     cursor_pos: [2]u16 align(4),
     cursor_color: [4]u8 align(4),
 
+    // Whether the cursor is 2 cells wide.
+    wide_cursor: bool align(1),
+
     const PaddingExtend = packed struct(u8) {
         left: bool = false,
         right: bool = false,

--- a/src/renderer/shaders/cell.metal
+++ b/src/renderer/shaders/cell.metal
@@ -18,7 +18,7 @@ struct Uniforms {
   float min_contrast;
   ushort2 cursor_pos;
   uchar4 cursor_color;
-  bool wide_cursor;
+  bool cursor_wide;
 };
 
 //-------------------------------------------------------------------
@@ -296,7 +296,7 @@ vertex CellTextVertexOut cell_text_vertex(
     in.mode != MODE_TEXT_CURSOR &&
     (
       in.grid_pos.x == uniforms.cursor_pos.x ||
-      uniforms.wide_cursor &&
+      uniforms.cursor_wide &&
         in.grid_pos.x == uniforms.cursor_pos.x + 1
     ) &&
     in.grid_pos.y == uniforms.cursor_pos.y

--- a/src/renderer/shaders/cell.metal
+++ b/src/renderer/shaders/cell.metal
@@ -18,6 +18,7 @@ struct Uniforms {
   float min_contrast;
   ushort2 cursor_pos;
   uchar4 cursor_color;
+  bool wide_cursor;
 };
 
 //-------------------------------------------------------------------
@@ -293,7 +294,11 @@ vertex CellTextVertexOut cell_text_vertex(
   // If this cell is the cursor cell, then we need to change the color.
   if (
     in.mode != MODE_TEXT_CURSOR &&
-    in.grid_pos.x == uniforms.cursor_pos.x &&
+    (
+      in.grid_pos.x == uniforms.cursor_pos.x ||
+      uniforms.wide_cursor &&
+        in.grid_pos.x == uniforms.cursor_pos.x + 1
+    ) &&
     in.grid_pos.y == uniforms.cursor_pos.y
   ) {
     out.color = float4(uniforms.cursor_color) / 255.0f;


### PR DESCRIPTION
- Fixes #2342 by correcting an invalid assumption that there will only ever be 1 glyph under the cursor when in fact there can be arbitrarily many. I didn't bother implementing this the same way as we do in Metal (by having the cursor pos in the uniforms and handling inverting in the shader), instead I just replaced the single nullable cursor cell variable with an array list.
- Fixes #2344 by skipping null shaper cells, always rendering decorations at a cell width of 1, and handling decoration of the right half of wide characters at the same time as the left half.

> [!NOTE]
> I didn't have enough time today to thoroughly test this for edge cases, so the changes may break something else. I'm particularly suspicious of my choice to fully skip null shaper cells, since I imagine this might cause issues with background coloring, but I'm not totally sure.