### PR TITLE
Mouse movement events are sent with shift until a button is pressed

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3040,8 +3040,13 @@ pub fn cursorPosCallback(
     // Do a mouse report
     if (self.io.terminal.flags.mouse_event != .none) report: {
         // Shift overrides mouse "grabbing" in the window, taken from Kitty.
-        if (self.mouse.mods.shift and
-            !self.mouseShiftCapture(false)) break :report;
+        // This only applies if there is a mouse button pressed so that
+        // movement reports are not affected.
+        if (self.mouse.mods.shift and !self.mouseShiftCapture(false)) {
+            for (self.mouse.click_state) |state| {
+                if (state != .release) break :report;
+            }
+        }
 
         // We use the first mouse button we find pressed in order to report
         // since the spec (afaict) does not say...


### PR DESCRIPTION
Ghostty was previously treating shift as a way to always stop mouse reporting. That's true for mouse button events, but not for mouse movement events. For mouse movement events, shift should be treated as a modifier until a button (any mouse button) is pressed. Once it is pressed, we pause mouse reporting until all buttons are released.

Found by @ldemailly. This matches the behavior of Kitty, Alacritty, WezTerm, and xterm.