### PR TITLE
Implements initial-window=false for macOS

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -173,7 +173,7 @@ class AppDelegate: NSObject,
         // is possible to have other windows in a few scenarios:
         //   - if we're opening a URL since `application(_:openFile:)` is called before this.
         //   - if we're restoring from persisted state
-        if terminalManager.windows.count == 0 {
+        if terminalManager.windows.count == 0 && ghostty.config.initialWindow {
             terminalManager.newWindow()
         }
     }
@@ -587,7 +587,7 @@ class AppDelegate: NSObject,
         if !isVisible {
             NSApp.activate(ignoringOtherApps: true)
         }
-        
+
         isVisible.toggle()
     }
 }

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -151,6 +151,14 @@ extension Ghostty {
         /// details on what each means. We only add documentation if there is a strange conversion
         /// due to the embedded library and Swift.
 
+        var initialWindow: Bool {
+            guard let config = self.config else { return true }
+            var v = true;
+            let key = "initial-window"
+            _ = ghostty_config_get(config, &v, key, UInt(key.count))
+            return v
+        }
+
         var shouldQuitAfterLastWindowClosed: Bool {
             guard let config = self.config else { return true }
             var v = false;

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1229,7 +1229,7 @@ keybind: Keybinds = .{},
 /// is run. Note that if `quit-after-last-window-closed` is `true` and
 /// `quit-after-last-window-closed-delay` is set, setting `initial-window` to
 /// `false` will mean that Ghostty will quit after the configured delay if no
-/// window is ever created. Only implemented on Linux.
+/// window is ever created. Only implemented on Linux and macOS.
 @"initial-window": bool = true,
 
 /// The position of the "quick" terminal window. To learn more about the


### PR DESCRIPTION
Closes https://github.com/ghostty-org/ghostty/issues/2361

Tested with empty config, `initial-window=true` in config, and `initial-window=false` in config, and all behaves as expected.