### PR TITLE
macos: add configuration support for quick-terminal-size

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -67,7 +67,7 @@ class QuickTerminalController: BaseTerminalController {
         syncAppearance()
 
         // Setup our initial size based on our configured position
-        position.setLoaded(window)
+        position.setLoaded(window, size: ghostty.config.quickTerminalSize)
 
         // Setup our content
         window.contentView = NSHostingView(rootView: TerminalView(

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalPosition.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalPosition.swift
@@ -7,7 +7,7 @@ enum QuickTerminalPosition : String {
     case right
 
     /// Set the loaded state for a window.
-    func setLoaded(_ window: NSWindow) {
+    func setLoaded(_ window: NSWindow, size: Double) {
         guard let screen = window.screen ?? NSScreen.main else { return }
         switch (self) {
         case .top, .bottom:
@@ -15,14 +15,14 @@ enum QuickTerminalPosition : String {
                 origin: window.frame.origin,
                 size: .init(
                     width: screen.frame.width,
-                    height: screen.frame.height / 4)
+                    height: screen.frame.height * CGFloat(size))
             ), display: false)
 
         case .left, .right:
             window.setFrame(.init(
                 origin: window.frame.origin,
                 size: .init(
-                    width: screen.frame.width / 4,
+                    width: screen.frame.width / CGFloat(size),
                     height: screen.frame.height)
             ), display: false)
         }

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -382,6 +382,14 @@ extension Ghostty {
             let str = String(cString: ptr)
             return QuickTerminalScreen(fromGhosttyConfig: str) ?? .main
         }
+
+        var quickTerminalSize: Double {
+            guard let config = self.config else { return 0.25 }
+            var v: Double = 0.25
+            let key = "quick-terminal-size"
+            _ = ghostty_config_get(config, &v, key, UInt(key.count))
+            return v
+        }
         #endif
 
         var resizeOverlay: ResizeOverlay {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1266,6 +1266,21 @@ keybind: Keybinds = .{},
 /// by the operating system.
 @"quick-terminal-screen": QuickTerminalScreen = .main,
 
+/// This size of the quick terminal screen based on the quick-terminal-position.
+///
+/// This value should be a floating-point number between 0 and 1,
+/// where 1 means it occupies the entire screen.
+///
+/// The default value is 0.25, meaning the quick terminal will occupy 25%
+/// of the screen's dimension. When quick-terminal-position is set to `left` or `right`,
+/// the dimension is the screen's width. When quick-terminal-position is set to `top` or `bottom`,
+/// the dimension is the screen's height.
+///
+/// Examples:
+///   * Setting to 0.5 will make the quick terminal occupy 50% of the screen.
+///   * Setting to 1 will make it occupy 100% of the screen.
+@"quick-terminal-size": f64 = 0.25,
+
 /// Whether to enable shell integration auto-injection or not. Shell integration
 /// greatly enhances the terminal experience by enabling a number of features:
 ///
@@ -2653,6 +2668,9 @@ pub fn finalize(self: *Config) !void {
     // Minimmum window size
     if (self.@"window-width" > 0) self.@"window-width" = @max(10, self.@"window-width");
     if (self.@"window-height" > 0) self.@"window-height" = @max(4, self.@"window-height");
+
+    // Clamp quick terminal size
+    if (self.@"quick-window-size" > 0) self.@"quick-window-size" = @min(0.25, @max(1, self.@"quick-window-size"));
 
     // If URLs are disabled, cut off the first link. The first link is
     // always the URL matcher.


### PR DESCRIPTION
Introduces `quick-terminal-size` config property to allow scaling the quick size window's initial size (based on position). 