### PR TITLE
Undercurl fixes/improvements

### DIFF
--- a/src/font/sprite/underline.zig
+++ b/src/font/sprite/underline.zig
@@ -50,7 +50,7 @@ pub fn renderGlyph(
         // bottom of the cell. We want the top of the glyph to be at line_pos
         // from the TOP of the cell, and then offset by the offset_y from the
         // draw function.
-        .offset_y = @as(i32, @intCast(height - line_pos)) - offset_y,
+        .offset_y = @as(i32, @intCast(height -| line_pos)) - offset_y,
         .atlas_x = region.x,
         .atlas_y = region.y,
         .advance_x = @floatFromInt(width),

--- a/src/font/sprite/underline.zig
+++ b/src/font/sprite/underline.zig
@@ -81,7 +81,11 @@ fn drawSingle(alloc: Allocator, width: u32, thickness: u32) !CanvasAndOffset {
 
 /// Draw a double underline.
 fn drawDouble(alloc: Allocator, width: u32, thickness: u32) !CanvasAndOffset {
-    const height: u32 = thickness * 3;
+    // Our gap between lines will be at least 2px.
+    // (i.e. if our thickness is 1, we still have a gap of 2)
+    const gap = @max(2, thickness);
+
+    const height: u32 = thickness * 2 * gap;
     var canvas = try font.sprite.Canvas.init(alloc, width, height);
 
     canvas.rect(.{
@@ -93,7 +97,7 @@ fn drawDouble(alloc: Allocator, width: u32, thickness: u32) !CanvasAndOffset {
 
     canvas.rect(.{
         .x = 0,
-        .y = @intCast(thickness * 2),
+        .y = @intCast(thickness + gap),
         .width = width,
         .height = thickness,
     }, .on);


### PR DESCRIPTION
Fixes #2381 

Additionally, improves the undercurl rendering to look nicer.

- Undercurl wave amplitude is now based on the cell width and not the underline thickness, meaning it will be more uniform.
- The wave now always has enough room and won't be clipped off the bottom.
- The wave is now based on a loose approximation of an offset curve for the (co)sine wave, rather than just another vertically offset wave, this improves the perceived uniformity of thickness and looks a lot better.
- **(Bonus)** Minimum spacing of 2px between the double underline to avoid legibility issues with particularly thin underlines.

### Comparisons
||main|this PR|
|-|-|-|
|**6pt**|<img width="256" alt="image" src="https://github.com/user-attachments/assets/2207803c-b2bb-4a25-affc-98491ab39109">|<img width="256" alt="image" src="https://github.com/user-attachments/assets/a330b542-732c-48e0-9131-fc91d653b968">|
|***+100% thickness***|<img width="256" alt="image" src="https://github.com/user-attachments/assets/e8634f96-34e6-4c88-b17b-51a038677058">|<img width="256" alt="image" src="https://github.com/user-attachments/assets/51950b41-4de6-4cc6-b526-857c68414704">|
|**12pt**|<img width="256" alt="image" src="https://github.com/user-attachments/assets/e34c5b04-6115-48ea-8346-6e0cd3108bd2">|<img width="256" alt="image" src="https://github.com/user-attachments/assets/c67dfe0d-7143-4cab-b25c-3818701edcc8">|
|***+100% thickness***|<img width="256" alt="image" src="https://github.com/user-attachments/assets/a5b69943-7db9-4308-a9be-f183baa0b6f6">|<img width="256" alt="image" src="https://github.com/user-attachments/assets/74271645-6aa9-477e-a158-2e0e6f0bcb3f">|
|**48pt**|<img width="256" alt="image" src="https://github.com/user-attachments/assets/18109fdb-5f1d-463c-b998-8e8ca3d9a8a5">|<img width="256" alt="image" src="https://github.com/user-attachments/assets/8bc4f4f6-99de-4bf2-9de0-32cc1723ded7">|
|***+100% thickness***|<img width="256" alt="image" src="https://github.com/user-attachments/assets/ea1fcc69-0523-478d-a45f-7e35931f50d8">|<img width="256" alt="image" src="https://github.com/user-attachments/assets/1d6bd128-22d1-487f-ad26-f15c0f42066a">|

