### PR TITLE
Detect mouse leave events, use it to reset hover states

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -354,6 +354,7 @@ extension Ghostty {
             addTrackingArea(NSTrackingArea(
                 rect: frame,
                 options: [
+                    .mouseEnteredAndExited,
                     .mouseMoved,
 
                     // Only send mouse events that happen in our visible (not obscured) rect
@@ -484,6 +485,14 @@ extension Ghostty {
 
             // Mouse event not consumed
             super.rightMouseUp(with: event)
+        }
+
+        override func mouseExited(with event: NSEvent) {
+            guard let surface = self.surface else { return }
+
+            // Negative values indicate cursor has left the viewport
+            let mods = Ghostty.ghosttyMods(event.modifierFlags)
+            ghostty_surface_mouse_pos(surface, -1, -1, mods)
         }
 
         override func mouseMoved(with event: NSEvent) {


### PR DESCRIPTION
Not a reported issue, one I found on my own. Previously: if you were hovering over a URL on the edge of the surface and then exit the surface, the hover state would stay. We should reset the hover state. This bug (and subsequent fix) applies to both macOS and GTK.

## Before Demo (Broken)


https://github.com/user-attachments/assets/9b220aae-b10d-43e1-bb16-d518fe229bed



## After Demo (Fixed)

https://github.com/user-attachments/assets/b6679130-5c69-4444-9340-f7861cf6f6e5

