### PR TITLE
chore: add .gitignore files for xcodebuild.nvim

### DIFF
--- a/macos/.gitignore
+++ b/macos/.gitignore
@@ -3,3 +3,7 @@
 build/
 xcuserdata/
 DerivedData/
+
+# xcodebuild.nvim support
+.nvim/xcodebuild
+buildServer.json


### PR DESCRIPTION
[xcodebuild.nvim](https://github.com/wojciech-kulik/xcodebuild.nvim) is
a plugin for neovim that allows for development of xcode projects. It
generate some files that need to be ignored.
