### PR TITLE
macOS: Key Sequence UI

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -500,6 +500,12 @@ typedef enum {
   GHOSTTY_RENDERER_HEALTH_UNHEALTHY,
 } ghostty_action_renderer_health_e;
 
+// apprt.action.KeySequence
+typedef struct {
+  bool active;
+  ghostty_input_trigger_s trigger;
+} ghostty_action_key_sequence_s;
+
 // apprt.Action.Key
 typedef enum {
   GHOSTTY_ACTION_NEW_WINDOW,
@@ -531,6 +537,7 @@ typedef enum {
   GHOSTTY_ACTION_OPEN_CONFIG,
   GHOSTTY_ACTION_QUIT_TIMER,
   GHOSTTY_ACTION_SECURE_INPUT,
+  GHOSTTY_ACTION_KEY_SEQUENCE,
 } ghostty_action_tag_e;
 
 typedef union {
@@ -551,6 +558,7 @@ typedef union {
   ghostty_action_renderer_health_e renderer_health;
   ghostty_action_quit_timer_e quit_timer;
   ghostty_action_secure_input_e secure_input;
+  ghostty_action_key_sequence_s key_sequence;
 } ghostty_action_u;
 
 typedef struct {

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -515,6 +515,8 @@ extension Ghostty {
             case GHOSTTY_ACTION_TOGGLE_VISIBILITY:
                 toggleVisibility(app, target: target)
 
+            case GHOSTTY_ACTION_KEY_SEQUENCE:
+                fallthrough
             case GHOSTTY_ACTION_CLOSE_ALL_WINDOWS:
                 fallthrough
             case GHOSTTY_ACTION_TOGGLE_TAB_OVERVIEW:

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -516,7 +516,8 @@ extension Ghostty {
                 toggleVisibility(app, target: target)
 
             case GHOSTTY_ACTION_KEY_SEQUENCE:
-                fallthrough
+                keySequence(app, target: target, v: action.action.key_sequence)
+
             case GHOSTTY_ACTION_CLOSE_ALL_WINDOWS:
                 fallthrough
             case GHOSTTY_ACTION_TOGGLE_TAB_OVERVIEW:
@@ -1067,6 +1068,38 @@ extension Ghostty {
                         "health": v,
                     ]
                 )
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        private static func keySequence(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s,
+            v: ghostty_action_key_sequence_s) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                Ghostty.logger.warning("key sequence does nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                if v.active {
+                    NotificationCenter.default.post(
+                        name: Notification.didContinueKeySequence,
+                        object: surfaceView,
+                        userInfo: [
+                            Notification.KeySequenceKey: keyEquivalent(for: v.trigger) as Any
+                        ]
+                    )
+                } else {
+                    NotificationCenter.default.post(
+                        name: Notification.didEndKeySequence,
+                        object: surfaceView
+                    )
+                }
 
             default:
                 assertionFailure()

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -87,25 +87,6 @@ extension Ghostty {
 #if os(macOS)
         // MARK: - Keybindings
 
-        /// A convenience struct that has the key + modifiers for some keybinding.
-        struct KeyEquivalent: CustomStringConvertible {
-            let key: String
-            let modifiers: NSEvent.ModifierFlags
-
-            var description: String {
-                var key = self.key
-
-                // Note: the order below matters; it matches the ordering modifiers
-                // shown for macOS menu shortcut labels.
-                if modifiers.contains(.command) { key = "⌘\(key)" }
-                if modifiers.contains(.shift) { key = "⇧\(key)" }
-                if modifiers.contains(.option) { key = "⌥\(key)" }
-                if modifiers.contains(.control) { key = "⌃\(key)" }
-
-                return key
-            }
-        }
-
         /// Return the key equivalent for the given action. The action is the name of the action
         /// in the Ghostty configuration. For example `keybind = cmd+q=quit` in Ghostty
         /// configuration would be "quit" action.
@@ -115,33 +96,7 @@ extension Ghostty {
             guard let cfg = self.config else { return nil }
 
             let trigger = ghostty_config_trigger(cfg, action, UInt(action.count))
-            let equiv: String
-            switch (trigger.tag) {
-            case GHOSTTY_TRIGGER_TRANSLATED:
-                if let v = Ghostty.keyEquivalent(key: trigger.key.translated) {
-                    equiv = v
-                } else {
-                    return nil
-                }
-
-            case GHOSTTY_TRIGGER_PHYSICAL:
-                if let v = Ghostty.keyEquivalent(key: trigger.key.physical) {
-                    equiv = v
-                } else {
-                    return nil
-                }
-
-            case GHOSTTY_TRIGGER_UNICODE:
-                equiv = String(trigger.key.unicode)
-
-            default:
-                return nil
-            }
-
-            return KeyEquivalent(
-                key: equiv,
-                modifiers: Ghostty.eventModifierFlags(mods: trigger.mods)
-            )
+            return Ghostty.keyEquivalent(for: trigger)
         }
 #endif
 

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -262,7 +262,12 @@ extension Ghostty.Notification {
 
     /// Notification that renderer health changed
     static let didUpdateRendererHealth = Notification.Name("com.mitchellh.ghostty.didUpdateRendererHealth")
+
+    /// Notifications related to key sequences
+    static let didContinueKeySequence = Notification.Name("com.mitchellh.ghostty.didContinueKeySequence")
+    static let didEndKeySequence = Notification.Name("com.mitchellh.ghostty.didEndKeySequence")
+    static let KeySequenceKey = didContinueKeySequence.rawValue + ".key"
 }
 
 // Make the input enum hashable.
-extension ghostty_input_key_e : Hashable {}
+extension ghostty_input_key_e : @retroactive Hashable {}

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -184,6 +184,34 @@ extension Ghostty {
                 }
                 .ghosttySurfaceView(surfaceView)
 
+#if canImport(AppKit)
+                // If we are in the middle of a key sequence, then we show a visual element. We only
+                // support this on macOS currently although in theory we can support mobile with keyboards!
+                if !surfaceView.keySequence.isEmpty {
+                    let padding: CGFloat = 5
+                    VStack {
+                        Spacer()
+
+                        HStack {
+                            Text(verbatim: "Pending Key Sequence:")
+                            ForEach(0..<surfaceView.keySequence.count, id: \.description) { index in
+                                let key = surfaceView.keySequence[index]
+                                Text(verbatim: key.description)
+                                    .font(.system(.body, design: .monospaced))
+                                    .padding(3)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 5)
+                                            .fill(Color(NSColor.selectedTextBackgroundColor))
+                                    )
+                            }
+                        }
+                        .padding(.init(top: padding, leading: padding, bottom: padding, trailing: padding))
+                        .frame(maxWidth: .infinity)
+                        .background(.background)
+                    }
+                }
+#endif
+
                 // If we have a URL from hovering a link, we show that.
                 if let url = surfaceView.hoverUrl {
                     let padding: CGFloat = 3

--- a/src/App.zig
+++ b/src/App.zig
@@ -318,7 +318,7 @@ pub fn keyEvent(
     // Get the keybind entry for this event. We don't support key sequences
     // so we can look directly in the top-level set.
     const entry = rt_app.config.keybind.set.getEvent(event) orelse return false;
-    const leaf: input.Binding.Set.Leaf = switch (entry) {
+    const leaf: input.Binding.Set.Leaf = switch (entry.value_ptr.*) {
         // Sequences aren't supported. Our configuration parser verifies
         // this for global keybinds but we may still get an entry for
         // a non-global keybind.

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1697,7 +1697,7 @@ fn maybeHandleBinding(
     };
 
     // Determine if this entry has an action or if its a leader key.
-    const leaf: input.Binding.Set.Leaf = switch (entry) {
+    const leaf: input.Binding.Set.Leaf = switch (entry.value_ptr.*) {
         .leader => |set| {
             // Setup the next set we'll look at.
             self.keyboard.bindings = set;

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1709,6 +1709,18 @@ fn maybeHandleBinding(
                 try self.keyboard.queued.append(self.alloc, req);
             }
 
+            // Start or continue our key sequence
+            self.rt_app.performAction(
+                .{ .surface = self },
+                .key_sequence,
+                .{ .trigger = entry.key_ptr.* },
+            ) catch |err| {
+                log.warn(
+                    "failed to notify app of key sequence err={}",
+                    .{err},
+                );
+            };
+
             return .consumed;
         },
 
@@ -1795,6 +1807,18 @@ fn endKeySequence(
     action: KeySequenceQueued,
     mem: KeySequenceMemory,
 ) void {
+    // Notify apprt key sequence ended
+    self.rt_app.performAction(
+        .{ .surface = self },
+        .key_sequence,
+        .end,
+    ) catch |err| {
+        log.warn(
+            "failed to notify app of key sequence end err={}",
+            .{err},
+        );
+    };
+
     if (self.keyboard.queued.items.len > 0) {
         switch (action) {
             .flush => for (self.keyboard.queued.items) |write_req| {

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -203,6 +203,7 @@ pub const App = struct {
             .render_inspector,
             .quit_timer,
             .secure_input,
+            .key_sequence,
             .desktop_notification,
             .mouse_over_link,
             .cell_size,

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -411,6 +411,7 @@ pub fn performAction(
         .size_limit,
         .cell_size,
         .secure_input,
+        .key_sequence,
         .render_inspector,
         .renderer_health,
         => log.warn("unimplemented action={}", .{action}),

--- a/src/input.zig
+++ b/src/input.zig
@@ -23,6 +23,7 @@ pub const MousePressureStage = mouse.PressureStage;
 pub const ScrollMods = mouse.ScrollMods;
 pub const SplitFocusDirection = Binding.Action.SplitFocusDirection;
 pub const SplitResizeDirection = Binding.Action.SplitResizeDirection;
+pub const Trigger = Binding.Trigger;
 
 // Keymap is only available on macOS right now. We could implement it
 // in theory for XKB too on Linux but we don't need it right now.


### PR DESCRIPTION
Related to #2127 (doesn't fix since we still need a GTK UI)

This implements a UI for #2121. The most important part of this PR is the core cross-platform plumbing to get access to sequenced keybind information, not the UI itself. I think the UI itself could definitely use some love and improvement, and I'm happy for anyone to take that on. I think importantly, this gets us from _no UI at all_ to _some UI_ for key sequences.

This is macOS only. GTK shouldn't be hard to follow but would love any ideas (or even contributions) from our resident GTK experts, such as @jcollie @tristan957 etc.

## Demo

The "pending key sequence" only shows up while a pending key sequence is active. Once a key sequence is complete (either through successfully executed an action or typing a key that isn't part of the sequence) then it disappears. 

<img width="912" alt="image" src="https://github.com/user-attachments/assets/75c1f3e2-1b1a-4754-ad0d-8d0d97564e28">
