### PR TITLE
core: support mouse button 6/7 for mouse reports

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2341,6 +2341,8 @@ fn mouseReport(
                 .right => 2,
                 .four => 64,
                 .five => 65,
+                .six => 66,
+                .seven => 67,
                 else => return, // unsupported
             };
         }


### PR DESCRIPTION
Fixes #2423

This corresponds to horizontal scroll on macOS and likely other mice.

Note the behavior on macOS for #2423 differs from Linux. On Linux, `shift+scroll` reports as `shift+4/5` (up/down). On macOS, the OS itself is reporting the event as left/right so it's reported as `shift+6/7`. When I say "the event itself" I mean the `NSEvent` given for the scroll event, so it is indistinguishable from a physical left/right unless you want to assume shift means it's changed. No other terminal on macOS that supports scroll wheel reporting undoes this so we follow suit and report as `shift+6/7`.