### PR TITLE
macos: change our minimum version to macOS 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ beta users using Ghostty as their primary terminal. See more in
 
 | Platform / Package | Links                                                                      | Notes                      |
 | ------------------ | -------------------------------------------------------------------------- | -------------------------- |
-| macOS              | [Tip ("Nightly")](https://github.com/ghostty-org/ghostty/releases/tag/tip) | MacOS 12+ Universal Binary |
+| macOS              | [Tip ("Nightly")](https://github.com/ghostty-org/ghostty/releases/tag/tip) | MacOS 13+ Universal Binary |
 | Linux              | [Build from Source](#developing-ghostty)                                   |                            |
 | Linux (NixOS/Nix)  | [Use the Flake](#nix-package)                                              |                            |
 | Linux (Arch)       | [Use the AUR package](https://aur.archlinux.org/packages/ghostty-git)      |                            |

--- a/build.zig
+++ b/build.zig
@@ -759,12 +759,10 @@ pub fn build(b: *std.Build) !void {
 /// be used generally, it should only be used for Darwin-based OS currently.
 fn osVersionMin(tag: std.Target.Os.Tag) ?std.Target.Query.OsVersion {
     return switch (tag) {
-        // The lowest supported version of macOS is 12.x because
-        // this is the first version to support Apple Silicon so it is
-        // the earliest version we can virtualize to test (I only have
-        // an Apple Silicon machine for macOS).
+        // We support back to the earliest officially supported version
+        // of macOS by Apple. EOL versions are not supported.
         .macos => .{ .semver = .{
-            .major = 12,
+            .major = 13,
             .minor = 0,
             .patch = 0,
         } },

--- a/macos/Ghostty.xcodeproj/project.pbxproj
+++ b/macos/Ghostty.xcodeproj/project.pbxproj
@@ -731,7 +731,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 0.1;
 				"OTHER_LDFLAGS[arch=*]" = "-lstdc++";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mitchellh.ghostty;
@@ -898,7 +898,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 0.1;
 				"OTHER_LDFLAGS[arch=*]" = "-lstdc++";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mitchellh.ghostty.debug;
@@ -951,7 +951,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 0.1;
 				"OTHER_LDFLAGS[arch=*]" = "-lstdc++";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mitchellh.ghostty;

--- a/macos/Sources/Features/Terminal/TerminalToolbar.swift
+++ b/macos/Sources/Features/Terminal/TerminalToolbar.swift
@@ -29,12 +29,7 @@ class TerminalToolbar: NSToolbar, NSToolbarDelegate {
         super.init(identifier: identifier)
 
         delegate = self
-
-        if #available(macOS 13.0, *) {
-            centeredItemIdentifiers.insert(.titleText)
-        } else {
-            centeredItemIdentifier = .titleText
-        }
+        centeredItemIdentifiers.insert(.titleText)
     }
 
     func toolbar(_ toolbar: NSToolbar,

--- a/macos/Sources/Ghostty/Ghostty.TerminalSplit.swift
+++ b/macos/Sources/Ghostty/Ghostty.TerminalSplit.swift
@@ -447,19 +447,6 @@ extension Ghostty {
             }
 
             window.makeFirstResponder(to)
-
-            // On newer versions of macOS everything above works great so we're done.
-            if #available(macOS 13, *) { return }
-
-            // On macOS 12, splits do not properly gain focus. I don't know why, but
-            // it seems like the `focused` SwiftUI method doesn't work. We use
-            // NotificationCenter as a blunt force instrument to make it work.
-            if #available(macOS 12, *) {
-                NotificationCenter.default.post(
-                    name: Notification.didBecomeFocusedSurface,
-                    object: to
-                )
-            }
         }
     }
 }

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -230,10 +230,6 @@ extension Ghostty.Notification {
     static let ghosttyToggleFullscreen = Notification.Name("com.mitchellh.ghostty.toggleFullscreen")
     static let FullscreenModeKey = ghosttyToggleFullscreen.rawValue
 
-    /// Notification that a surface is becoming focused. This is only sent on macOS 12 to
-    /// work around bugs. macOS 13+ should use the ".focused()" attribute.
-    static let didBecomeFocusedSurface = Notification.Name("com.mitchellh.ghostty.didBecomeFocusedSurface")
-
     /// Notification sent to toggle split maximize/unmaximize.
     static let didToggleSplitZoom = Notification.Name("com.mitchellh.ghostty.didToggleSplitZoom")
 

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -35,7 +35,7 @@ extension Ghostty {
 
         // The time this surface last became focused. This is a ContinuousClock.Instant
         // on supported platforms.
-        @Published var focusInstant: Any? = nil
+        @Published var focusInstant: ContinuousClock.Instant? = nil
 
         // Returns sizing information for the surface. This is the raw C
         // structure because I'm lazy.
@@ -232,10 +232,8 @@ extension Ghostty {
             }
 
             // On macOS 13+ we can store our continuous clock...
-            if #available(macOS 13, iOS 16, *) {
-                if (focused) {
-                    focusInstant = ContinuousClock.now
-                }
+            if (focused) {
+                focusInstant = ContinuousClock.now
             }
         }
 

--- a/macos/Sources/Ghostty/SurfaceView_UIKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_UIKit.swift
@@ -30,7 +30,7 @@ extension Ghostty {
 
         // The time this surface last became focused. This is a ContinuousClock.Instant
         // on supported platforms.
-        @Published var focusInstant: Any? = nil
+        @Published var focusInstant: ContinuousClock.Instant? = nil
 
         // Returns sizing information for the surface. This is the raw C
         // structure because I'm lazy.
@@ -73,10 +73,8 @@ extension Ghostty {
             ghostty_surface_set_focus(surface, focused)
 
             // On macOS 13+ we can store our continuous clock...
-            if #available(macOS 13, iOS 16, *) {
-                if (focused) {
-                    focusInstant = ContinuousClock.now
-                }
+            if (focused) {
+                focusInstant = ContinuousClock.now
             }
         }
 

--- a/macos/Sources/Helpers/Backport.swift
+++ b/macos/Sources/Helpers/Backport.swift
@@ -15,13 +15,7 @@ extension Scene {
 }
 
 extension Backport where Content: Scene {
-    func defaultSize(width: CGFloat, height: CGFloat) -> some Scene {
-        if #available(macOS 13, *) {
-            return content.defaultSize(width: width, height: height)
-        } else {
-            return content
-        }
-    }
+    // None currently
 }
 
 extension Backport where Content: View {

--- a/macos/Sources/Helpers/NSScreen+Extension.swift
+++ b/macos/Sources/Helpers/NSScreen+Extension.swift
@@ -29,11 +29,7 @@ extension NSScreen {
         // We need to see if our visible frame height is less than the full
         // screen height minus the menu and notch and such.
         let menuHeight = NSApp.mainMenu?.menuBarHeight ?? 0
-        let notchInset: CGFloat = if #available(macOS 12, *) {
-            safeAreaInsets.top
-        } else {
-            0
-        }
+        let notchInset: CGFloat = safeAreaInsets.top
         let boundaryAreaPadding = 5.0
 
         return visibleFrame.height < (frame.height - max(menuHeight, notchInset) - boundaryAreaPadding)


### PR DESCRIPTION
macOS 12 is officially EOL by Apple and the project only supports
officially supported versions of macOS. Once publicly released, users on
older macOS versions will have to use older released builds.