### PR TITLE
core: simplify scroll math, fix horizontal scroll direction on macOS

### DIFF
--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1379,7 +1379,11 @@ fn gtkMouseScroll(
     const scroll_mods: input.ScrollMods = .{};
 
     self.core_surface.scrollCallback(
-        scaled.x,
+        // We invert because we apply natural scrolling to the values.
+        // This behavior has existed for years without Linux users complaining
+        // but I suspect we'll have to make this configurable in the future
+        // or read a system setting.
+        scaled.x * -1,
         scaled.y * -1,
         scroll_mods,
     ) catch |err| {


### PR DESCRIPTION
This simplifies the math for calculating scroll vectors based on mouse scroll events. This was done to fix inverted horizontal scrolling on macOS with natural scrolling enabled. Many assertions were added for assumptions and our preconditions are clearly documented.

The preconditions are:

  * Apprt scroll offsets are negative down/left, positive up/right
  * Terminal vertical scroll is postive down, negative up (opposite since scroll for a terminal means how many rows to move down).
  * `Surface.scrollCallback` is always call with an apprt offset.
  * Apprt is responsible for implementing natural scrolling. Surface always assumes negative is down/left.

## Validate Behavior

I want to validate our behavior against xterm, Kitty, and iTerm for supported modes for each terminal.

- [x] macOS: mouse reporting non-precision + precision
- [x] Linux: mouse reporting non-precision (precision not supported)
- [x] macOS: cursor key application mode precision + non-precision
- [x] macOS: cursor key normal mode precision + non-precision
- [x] Linux: cursor key application mode non-precision
- [x] Linux: cursor key normal mode non-precision
- [x] macOS: viewport scroll
- [x] Linux: viewport scroll