### PR TITLE
renderer: generalize the definition of "space"

### DIFF
--- a/src/renderer/cell.zig
+++ b/src/renderer/cell.zig
@@ -101,7 +101,7 @@ pub fn fgMode(
                 break :next_cp next_cell.codepoint();
             };
             if (next_cp == 0 or
-                next_cp == ' ' or
+                isSpace(next_cp) or
                 isPowerline(next_cp))
             {
                 break :text .normal;
@@ -110,6 +110,17 @@ pub fn fgMode(
             // Must be constrained
             break :text .constrained;
         },
+    };
+}
+
+// Some general spaces, others intentionally kept
+// to force the font to render as a fixed width.
+fn isSpace(char: u21) bool {
+    return switch (char) {
+        0x0020, // SPACE
+        0x2002, // EN SPACE
+        => true,
+        else => false,
     };
 }
 


### PR DESCRIPTION
In addition to the most common U+0020, there are many other types of spaces. For example, U+00A0 is a no-break space, and U+2002 is an en space. When considering whether symbols should be scaled, these more general types of spaces should also be treated as spaces.

Since this behavior is a kind of hack, not all general spaces (e.g., U+00A0) are included, to provide a method to force no scaling. U+2002 was specifically chosen because it is the option used by Kitty.

Kitty has detailed discussions on this, see https://github.com/kovidgoyal/kitty/issues/6750.