### PR TITLE
Undercurl tweaks

### DIFF
--- a/src/font/sprite/underline.zig
+++ b/src/font/sprite/underline.zig
@@ -163,7 +163,9 @@ fn drawDashed(alloc: Allocator, width: u32, thickness: u32) !CanvasAndOffset {
 /// geometry.
 fn drawCurly(alloc: Allocator, width: u32, thickness: u32) !CanvasAndOffset {
     const float_width: f64 = @floatFromInt(width);
-    const float_thick: f64 = @floatFromInt(thickness);
+    // Because of we way we draw the undercurl, we end up making it around 1px
+    // thicker than it should be, to fix this we just reduce the thickness by 1.
+    const float_thick: f64 = @floatFromInt(@max(1, thickness -| 1));
 
     // Calculate the wave period for a single character
     //   `2 * pi...` = 1 peak per character

--- a/src/font/sprite/underline.zig
+++ b/src/font/sprite/underline.zig
@@ -187,7 +187,9 @@ fn drawCurly(alloc: Allocator, width: u32, thickness: u32) !CanvasAndOffset {
     // follow Xiaolin Wu's antialias algorithm to draw the curve
     var x: u32 = 0;
     while (x < width) : (x += 1) {
-        const t: f64 = @as(f64, @floatFromInt(x)) * wave_period;
+        // We sample the wave function at the *middle* of each
+        // pixel column, to ensure that it renders symmetrically.
+        const t: f64 = (@as(f64, @floatFromInt(x)) + 0.5) * wave_period;
         // Use the slope at this location to add thickness to
         // the line on this column, counteracting the thinning
         // caused by the slope.


### PR DESCRIPTION
- Correct thickness to account for the 1px thickening caused by how we render the undercurl
- Correct sampling to sample the center of each pixel column rather than the left side, to ensure that it's symmetrical (most noticeable when an undercurl is drawn for a single cell)
 
These are very small changes and should be an easy merge.

|Before|After|
|-|-|
|<img width="255" alt="image" src="https://github.com/user-attachments/assets/de58f4e7-8d47-42ee-8e3e-e79fcebe66bb">|<img width="255" alt="image" src="https://github.com/user-attachments/assets/bfc6ae2d-e108-4470-acf1-631472c5cd2d">|
|<img width="76" alt="image" src="https://github.com/user-attachments/assets/3724c0b6-166f-48fb-827a-7fda45892ce8">|<img width="76" alt="image" src="https://github.com/user-attachments/assets/855b5266-a87d-4583-8de8-7fae6a4db641">|