### PR TITLE
gtk: use CSS variables and color calcs introduced in 4.16

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -110,7 +110,8 @@ pub fn init(self: *Window, app: *App) !void {
     c.gtk_window_set_icon_name(gtk_window, "com.mitchellh.ghostty");
 
     // Apply class to color headerbar if window-theme is set to `ghostty` and
-    // GTK version is before 4.16.
+    // GTK version is before 4.16. The conditional is because above 4.16
+    // we use GTK CSS color variables.
     if (!version.atLeast(4, 16, 0) and app.config.@"window-theme" == .ghostty) {
         c.gtk_widget_add_css_class(@ptrCast(gtk_window), "window-theme-ghostty");
     }

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -23,6 +23,7 @@ const c = @import("c.zig").c;
 const adwaita = @import("adwaita.zig");
 const gtk_key = @import("key.zig");
 const Notebook = @import("notebook.zig").Notebook;
+const version = @import("version.zig");
 
 const log = std.log.scoped(.gtk);
 
@@ -108,8 +109,9 @@ pub fn init(self: *Window, app: *App) !void {
 
     c.gtk_window_set_icon_name(gtk_window, "com.mitchellh.ghostty");
 
-    // Apply class to color headerbar if window-theme is set to `ghostty`.
-    if (app.config.@"window-theme" == .ghostty) {
+    // Apply class to color headerbar if window-theme is set to `ghostty` and
+    // GTK version is before 4.16.
+    if (!version.atLeast(4, 16, 0) and app.config.@"window-theme" == .ghostty) {
         c.gtk_widget_add_css_class(@ptrCast(gtk_window), "window-theme-ghostty");
     }
 


### PR DESCRIPTION
This takes advantage of CSS variables and color expressions to improve the `window-theme=ghostty` support. The only visible difference from the previous implementation is that the header bar will darken if the Ghostty window is in the background, which is standard for GTK apps.

This is conditional at runtime. If Ghostty detects that you're running against GTK 4.16 or newer it will use the CSS variables and color calcs. If you're running against older versions it will use CSS classes to achieve nearly the same effect.

cc: @vancluever @tristan957 