### PR TITLE
build: strip symbols from release builds

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -237,6 +237,11 @@ pub fn build(b: *std.Build) !void {
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
+        .strip = switch (optimize) {
+            .Debug => false,
+            .ReleaseSafe => false,
+            .ReleaseFast, .ReleaseSmall => true,
+        },
     }) else null;
 
     // Exe


### PR DESCRIPTION
This significantly reduces the size of the binary.