### PR TITLE
macOS: fix quicklook position

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -864,7 +864,7 @@ extension Ghostty {
             }
 
             // Ghostty coordinate system is top-left, convert to bottom-left for AppKit
-            let pt = NSMakePoint(info.tl_px_x - 2, frame.size.height - info.tl_px_y + 2)
+            let pt = NSMakePoint(info.tl_px_x, frame.size.height - info.tl_px_y)
             let str = NSAttributedString.init(string: text, attributes: attributes)
             self.showDefinition(for: str, at: pt);
         }


### PR DESCRIPTION
Account for padding and properly calculate text baseline, since that is the position that the NSView `showDefinition` method ultimately needs.

### Comparison
*(The issue here is exaggerated by setting padding to 50px)*
|Before|After|
|-|-|
|<img width="423" alt="image" src="https://github.com/user-attachments/assets/3592a4f5-d7ae-43ca-bd79-ee2b86578854">|<img width="471" alt="image" src="https://github.com/user-attachments/assets/cd7e1c63-64b8-459c-86ac-9b96e4a94428">|
|Offset from the target text|Aligned with the target text|

---

> [!NOTE]
> While working on this fix I found an issue where the assert in `src/terminal/Screen.zig` line `369` that the selection is tracked while cloning the screen can be violated. It happens while doing a mix of clicking and dragging to select and using the force press gesture to quicklook. I think quicklook clears the selection improperly (maybe with a thread race?) but I didn't look in to it very deep.