### PR TITLE
font/sprite: undercurl minimum thickness improvement

### DIFF
--- a/src/font/sprite/underline.zig
+++ b/src/font/sprite/underline.zig
@@ -165,7 +165,11 @@ fn drawCurly(alloc: Allocator, width: u32, thickness: u32) !CanvasAndOffset {
     const float_width: f64 = @floatFromInt(width);
     // Because of we way we draw the undercurl, we end up making it around 1px
     // thicker than it should be, to fix this we just reduce the thickness by 1.
-    const float_thick: f64 = @floatFromInt(@max(1, thickness -| 1));
+    //
+    // We use a minimum thickness of 0.414 because this empirically produces
+    // the nicest undercurls at 1px underline thickness; thinner tends to look
+    // too thin compared to straight underlines and has artefacting.
+    const float_thick: f64 = @max(0.414, @as(f64, @floatFromInt(thickness -| 1)));
 
     // Calculate the wave period for a single character
     //   `2 * pi...` = 1 peak per character


### PR DESCRIPTION
A small but significant improvement to the undercurl rendering at 1px underline thickness to better match the thickness of the straight underlines (previously minimum thickness was too thick)
||Before|After|
|-|-|-|
|**Small font size**|<img width="38" alt="image" src="https://github.com/user-attachments/assets/59f23618-f7f3-475e-a0e6-bd0df3350a2a">|<img width="38" alt="image" src="https://github.com/user-attachments/assets/104ebc90-75b4-49b8-ad9a-c496d360f8da">|
|**Adjusted thinner**|<img width="84" alt="image" src="https://github.com/user-attachments/assets/cd3dbf85-6de4-48ea-b37f-002d987c56a6">|<img width="84" alt="image" src="https://github.com/user-attachments/assets/336f07a9-7520-4cd7-9575-84a4825e911a">|