### PR TITLE
Configuration errors improvements: exit on CLI errors, include line number and filepath

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -607,7 +607,6 @@ ghostty_info_s ghostty_info(void);
 ghostty_config_t ghostty_config_new();
 void ghostty_config_free(ghostty_config_t);
 void ghostty_config_load_cli_args(ghostty_config_t);
-void ghostty_config_load_string(ghostty_config_t, const char*, uintptr_t);
 void ghostty_config_load_default_files(ghostty_config_t);
 void ghostty_config_load_recursive_files(ghostty_config_t);
 void ghostty_config_finalize(ghostty_config_t);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -291,7 +291,7 @@ typedef struct {
 
 typedef struct {
   const char* message;
-} ghostty_error_s;
+} ghostty_diagnostic_s;
 
 typedef struct {
   double tl_px_x;
@@ -615,8 +615,8 @@ bool ghostty_config_get(ghostty_config_t, void*, const char*, uintptr_t);
 ghostty_input_trigger_s ghostty_config_trigger(ghostty_config_t,
                                                const char*,
                                                uintptr_t);
-uint32_t ghostty_config_errors_count(ghostty_config_t);
-ghostty_error_s ghostty_config_get_error(ghostty_config_t, uint32_t);
+uint32_t ghostty_config_diagnostics_count(ghostty_config_t);
+ghostty_diagnostic_s ghostty_config_get_diagnostic(ghostty_config_t, uint32_t);
 void ghostty_config_open();
 
 ghostty_app_t ghostty_app_new(const ghostty_runtime_config_s*,

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -22,15 +22,15 @@ extension Ghostty {
         var errors: [String] {
             guard let cfg = self.config else { return [] }
 
-            var errors: [String] = [];
-            let errCount = ghostty_config_errors_count(cfg)
-            for i in 0..<errCount {
-                let err = ghostty_config_get_error(cfg, UInt32(i))
-                let message = String(cString: err.message)
-                errors.append(message)
+            var diags: [String] = [];
+            let diagsCount = ghostty_config_diagnostics_count(cfg)
+            for i in 0..<diagsCount {
+                let diag = ghostty_config_get_diagnostic(cfg, UInt32(i))
+                let message = String(cString: diag.message)
+                diags.append(message)
             }
 
-            return errors
+            return diags
         }
 
         init() {
@@ -69,14 +69,14 @@ extension Ghostty {
 
             // Log any configuration errors. These will be automatically shown in a
             // pop-up window too.
-            let errCount = ghostty_config_errors_count(cfg)
-            if errCount > 0 {
-                logger.warning("config error: \(errCount) configuration errors on reload")
-                var errors: [String] = [];
-                for i in 0..<errCount {
-                    let err = ghostty_config_get_error(cfg, UInt32(i))
-                    let message = String(cString: err.message)
-                    errors.append(message)
+            let diagsCount = ghostty_config_diagnostics_count(cfg)
+            if diagsCount > 0 {
+                logger.warning("config error: \(diagsCount) configuration errors on reload")
+                var diags: [String] = [];
+                for i in 0..<diagsCount {
+                    let diag = ghostty_config_get_diagnostic(cfg, UInt32(i))
+                    let message = String(cString: diag.message)
+                    diags.append(message)
                     logger.warning("config error: \(message)")
                 }
             }

--- a/src/App.zig
+++ b/src/App.zig
@@ -231,10 +231,19 @@ fn drainMailbox(self: *App, rt_app: *apprt.App) !void {
             .open_config => try self.performAction(rt_app, .open_config),
             .new_window => |msg| try self.newWindow(rt_app, msg),
             .close => |surface| self.closeSurface(surface),
-            .quit => self.setQuit(),
             .surface_message => |msg| try self.surfaceMessage(msg.surface, msg.message),
             .redraw_surface => |surface| self.redrawSurface(rt_app, surface),
             .redraw_inspector => |surface| self.redrawInspector(rt_app, surface),
+
+            // If we're quitting, then we set the quit flag and stop
+            // draining the mailbox immediately. This lets us defer
+            // mailbox processing to the next tick so that the apprt
+            // can try to quick as quickly as possible.
+            .quit => {
+                log.info("quit message received, short circuiting mailbox drain", .{});
+                self.setQuit();
+                return;
+            },
         }
     }
 }

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -69,9 +69,13 @@ pub const App = struct {
         errdefer config.deinit();
 
         // If we had configuration errors, then log them.
-        if (!config._errors.empty()) {
-            for (config._errors.list.items) |err| {
-                log.warn("configuration error: {s}", .{err.message});
+        if (!config._diagnostics.empty()) {
+            var buf = std.ArrayList(u8).init(core_app.alloc);
+            defer buf.deinit();
+            for (config._diagnostics.items()) |diag| {
+                try diag.write(buf.writer());
+                log.warn("configuration error: {s}", .{buf.items});
+                buf.clearRetainingCapacity();
             }
         }
 

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -11,6 +11,7 @@ const Allocator = std.mem.Allocator;
 const glfw = @import("glfw");
 const macos = @import("macos");
 const objc = @import("objc");
+const cli = @import("../cli.zig");
 const input = @import("../input.zig");
 const internal_os = @import("../os/main.zig");
 const renderer = @import("../renderer.zig");
@@ -77,9 +78,18 @@ pub const App = struct {
                 log.warn("configuration error: {s}", .{buf.items});
                 buf.clearRetainingCapacity();
             }
+
+            // If we have any CLI errors, exit.
+            if (config._diagnostics.containsLocation(.cli)) {
+                log.warn("CLI errors detected, exiting", .{});
+                _ = core_app.mailbox.push(.{
+                    .quit = {},
+                }, .{ .forever = {} });
+            }
         }
 
         // Queue a single new window that starts on launch
+        // Note: above we may send a quit so this may never happen
         _ = core_app.mailbox.push(.{
             .new_window = .{},
         }, .{ .forever = {} });

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -131,6 +131,12 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
             log.warn("configuration error: {s}", .{buf.items});
             buf.clearRetainingCapacity();
         }
+
+        // If we have any CLI errors, exit.
+        if (config._diagnostics.containsLocation(.cli)) {
+            log.warn("CLI errors detected, exiting", .{});
+            std.posix.exit(1);
+        }
     }
 
     c.gtk_init();
@@ -1368,10 +1374,7 @@ fn gtkActionQuit(
     ud: ?*anyopaque,
 ) callconv(.C) void {
     const self: *App = @ptrCast(@alignCast(ud orelse return));
-    self.core_app.setQuit() catch |err| {
-        log.warn("error setting quit err={}", .{err});
-        return;
-    };
+    self.core_app.setQuit();
 }
 
 /// Action sent by the window manager asking us to present a specific surface to

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1,5 +1,10 @@
+const diags = @import("cli/diagnostics.zig");
+
 pub const args = @import("cli/args.zig");
 pub const Action = @import("cli/action.zig").Action;
+pub const DiagnosticList = diags.DiagnosticList;
+pub const Diagnostic = diags.Diagnostic;
+pub const Location = diags.Diagnostic.Location;
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -4,7 +4,7 @@ pub const args = @import("cli/args.zig");
 pub const Action = @import("cli/action.zig").Action;
 pub const DiagnosticList = diags.DiagnosticList;
 pub const Diagnostic = diags.Diagnostic;
-pub const Location = diags.Diagnostic.Location;
+pub const Location = diags.Location;
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/cli/args.zig
+++ b/src/cli/args.zig
@@ -3,8 +3,9 @@ const mem = std.mem;
 const assert = std.debug.assert;
 const Allocator = mem.Allocator;
 const ArenaAllocator = std.heap.ArenaAllocator;
-
-const ErrorList = @import("../config/ErrorList.zig");
+const diags = @import("diagnostics.zig");
+const Diagnostic = diags.Diagnostic;
+const DiagnosticList = diags.DiagnosticList;
 
 // TODO:
 //   - Only `--long=value` format is accepted. Do we want to allow
@@ -32,13 +33,18 @@ pub const Error = error{
 /// an arena allocator will be created (or reused if set already) for any
 /// allocations. Allocations are necessary for certain types, like `[]const u8`.
 ///
-/// If the destination type has a field "_errors" of type "ErrorList" then
-/// errors will be added to that list. In this case, the only error returned by
-/// parse are allocation errors.
+/// If the destination type has a field "_diagnostics", it must be of type
+/// "DiagnosticList" and any diagnostic messages will be added to that list.
+/// When diagnostics are present, only allocation errors will be returned.
 ///
 /// Note: If the arena is already non-null, then it will be used. In this
 /// case, in the case of an error some memory might be leaked into the arena.
-pub fn parse(comptime T: type, alloc: Allocator, dst: *T, iter: anytype) !void {
+pub fn parse(
+    comptime T: type,
+    alloc: Allocator,
+    dst: *T,
+    iter: anytype,
+) !void {
     const info = @typeInfo(T);
     assert(info == .Struct);
 
@@ -69,7 +75,11 @@ pub fn parse(comptime T: type, alloc: Allocator, dst: *T, iter: anytype) !void {
     while (iter.next()) |arg| {
         // Do manual parsing if we have a hook for it.
         if (@hasDecl(T, "parseManuallyHook")) {
-            if (!try dst.parseManuallyHook(arena_alloc, arg, iter)) return;
+            if (!try dst.parseManuallyHook(
+                arena_alloc,
+                arg,
+                iter,
+            )) return;
         }
 
         // If the destination supports help then we check for it, call
@@ -96,56 +106,39 @@ pub fn parse(comptime T: type, alloc: Allocator, dst: *T, iter: anytype) !void {
             };
 
             parseIntoField(T, arena_alloc, dst, key, value) catch |err| {
-                if (comptime !canTrackErrors(T)) return err;
+                if (comptime !canTrackDiags(T)) return err;
 
                 // The error set is dependent on comptime T, so we always add
                 // an extra error so we can have the "else" below.
                 const ErrSet = @TypeOf(err) || error{Unknown};
-                switch (@as(ErrSet, @errorCast(err))) {
+                const message: [:0]const u8 = switch (@as(ErrSet, @errorCast(err))) {
                     // OOM is not recoverable since we need to allocate to
                     // track more error messages.
                     error.OutOfMemory => return err,
+                    error.InvalidField => "unknown field",
+                    error.ValueRequired => "value required",
+                    error.InvalidValue => "invalid value",
+                    else => try std.fmt.allocPrintZ(
+                        arena_alloc,
+                        "unknown error {}",
+                        .{err},
+                    ),
+                };
 
-                    error.InvalidField => try dst._errors.add(arena_alloc, .{
-                        .message = try std.fmt.allocPrintZ(
-                            arena_alloc,
-                            "{s}: unknown field",
-                            .{key},
-                        ),
-                    }),
-
-                    error.ValueRequired => try dst._errors.add(arena_alloc, .{
-                        .message = try std.fmt.allocPrintZ(
-                            arena_alloc,
-                            "{s}: value required",
-                            .{key},
-                        ),
-                    }),
-
-                    error.InvalidValue => try dst._errors.add(arena_alloc, .{
-                        .message = try std.fmt.allocPrintZ(
-                            arena_alloc,
-                            "{s}: invalid value",
-                            .{key},
-                        ),
-                    }),
-
-                    else => try dst._errors.add(arena_alloc, .{
-                        .message = try std.fmt.allocPrintZ(
-                            arena_alloc,
-                            "{s}: unknown error {}",
-                            .{ key, err },
-                        ),
-                    }),
-                }
+                // Add our diagnostic
+                try dst._diagnostics.append(arena_alloc, .{
+                    .key = try arena_alloc.dupeZ(u8, key),
+                    .message = message,
+                    .location = Diagnostic.Location.fromIter(iter),
+                });
             };
         }
     }
 }
 
-/// Returns true if this type can track errors.
-fn canTrackErrors(comptime T: type) bool {
-    return @hasField(T, "_errors");
+/// Returns true if this type can track diagnostics.
+fn canTrackDiags(comptime T: type) bool {
+    return @hasField(T, "_diagnostics");
 }
 
 /// Parse a single key/value pair into the destination type T.
@@ -198,15 +191,6 @@ fn parseIntoField(
 
                         // 3 arg = (self, alloc, input) => void
                         3 => try @field(dst, field.name).parseCLI(alloc, value),
-
-                        // 4 arg = (self, alloc, errors, input) => void
-                        4 => if (comptime canTrackErrors(T)) {
-                            try @field(dst, field.name).parseCLI(alloc, &dst._errors, value);
-                        } else {
-                            var list: ErrorList = .{};
-                            try @field(dst, field.name).parseCLI(alloc, &list, value);
-                            if (!list.empty()) return error.InvalidValue;
-                        },
 
                         else => @compileError("parseCLI invalid argument count"),
                     }
@@ -468,7 +452,7 @@ test "parse: empty value resets to default" {
     try testing.expect(!data.b);
 }
 
-test "parse: error tracking" {
+test "parse: diagnostic tracking" {
     const testing = std.testing;
 
     var data: struct {
@@ -476,7 +460,7 @@ test "parse: error tracking" {
         b: enum { one } = .one,
 
         _arena: ?ArenaAllocator = null,
-        _errors: ErrorList = .{},
+        _diagnostics: DiagnosticList = .{},
     } = .{};
     defer if (data._arena) |arena| arena.deinit();
 
@@ -488,7 +472,48 @@ test "parse: error tracking" {
     try parse(@TypeOf(data), testing.allocator, &data, &iter);
     try testing.expect(data._arena != null);
     try testing.expectEqualStrings("42", data.a);
-    try testing.expect(!data._errors.empty());
+    try testing.expect(data._diagnostics.items().len == 1);
+    {
+        const diag = data._diagnostics.items()[0];
+        try testing.expectEqual(Diagnostic.Location.none, diag.location);
+        try testing.expectEqualStrings("what", diag.key);
+        try testing.expectEqualStrings("unknown field", diag.message);
+    }
+}
+
+test "parse: diagnostic location" {
+    const testing = std.testing;
+
+    var data: struct {
+        a: []const u8 = "",
+        b: enum { one, two } = .one,
+
+        _arena: ?ArenaAllocator = null,
+        _diagnostics: DiagnosticList = .{},
+    } = .{};
+    defer if (data._arena) |arena| arena.deinit();
+
+    var fbs = std.io.fixedBufferStream(
+        \\a=42
+        \\what
+        \\b=two
+    );
+    const r = fbs.reader();
+
+    const Iter = LineIterator(@TypeOf(r));
+    var iter: Iter = .{ .r = r, .filepath = "test" };
+    try parse(@TypeOf(data), testing.allocator, &data, &iter);
+    try testing.expect(data._arena != null);
+    try testing.expectEqualStrings("42", data.a);
+    try testing.expect(data.b == .two);
+    try testing.expect(data._diagnostics.items().len == 1);
+    {
+        const diag = data._diagnostics.items()[0];
+        try testing.expectEqualStrings("what", diag.key);
+        try testing.expectEqualStrings("unknown field", diag.message);
+        try testing.expectEqualStrings("test", diag.location.file.path);
+        try testing.expectEqual(2, diag.location.file.line);
+    }
 }
 
 test "parseIntoField: ignore underscore-prefixed fields" {
@@ -738,62 +763,6 @@ test "parseIntoField: struct with parse func" {
     try testing.expectEqual(@as([]const u8, "HELLO!"), data.a.v);
 }
 
-test "parseIntoField: struct with parse func with error tracking" {
-    const testing = std.testing;
-    var arena = ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    const alloc = arena.allocator();
-
-    var data: struct {
-        a: struct {
-            const Self = @This();
-
-            pub fn parseCLI(
-                _: Self,
-                parse_alloc: Allocator,
-                errors: *ErrorList,
-                value: ?[]const u8,
-            ) !void {
-                _ = value;
-                try errors.add(parse_alloc, .{ .message = "OH NO!" });
-            }
-        } = .{},
-
-        _errors: ErrorList = .{},
-    } = .{};
-
-    try parseIntoField(@TypeOf(data), alloc, &data, "a", "42");
-    try testing.expect(!data._errors.empty());
-}
-
-test "parseIntoField: struct with parse func with unsupported error tracking" {
-    const testing = std.testing;
-    var arena = ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    const alloc = arena.allocator();
-
-    var data: struct {
-        a: struct {
-            const Self = @This();
-
-            pub fn parseCLI(
-                _: Self,
-                parse_alloc: Allocator,
-                errors: *ErrorList,
-                value: ?[]const u8,
-            ) !void {
-                _ = value;
-                try errors.add(parse_alloc, .{ .message = "OH NO!" });
-            }
-        } = .{},
-    } = .{};
-
-    try testing.expectError(
-        error.InvalidValue,
-        parseIntoField(@TypeOf(data), alloc, &data, "a", "42"),
-    );
-}
-
 test "parseIntoField: tagged union" {
     const testing = std.testing;
     var arena = ArenaAllocator.init(testing.allocator);
@@ -899,7 +868,21 @@ pub fn LineIterator(comptime ReaderType: type) type {
         /// like 4 years and be wrong about this.
         pub const MAX_LINE_SIZE = 4096;
 
+        /// Our stateful reader.
         r: ReaderType,
+
+        /// Filepath that is used for diagnostics. This is only used for
+        /// diagnostic messages so it can be formatted however you want.
+        /// It is prefixed to the messages followed by the line number.
+        filepath: []const u8 = "",
+
+        /// The current line that we're on. This is 1-indexed because
+        /// lines are generally 1-indexed in the real world. The value
+        /// can be zero if we haven't read any lines yet.
+        line: usize = 0,
+
+        /// This is the buffer where we store the current entry that
+        /// is formatted to be compatible with the parse function.
         entry: [MAX_LINE_SIZE]u8 = [_]u8{ '-', '-' } ++ ([_]u8{0} ** (MAX_LINE_SIZE - 2)),
 
         pub fn next(self: *Self) ?[]const u8 {
@@ -911,6 +894,9 @@ pub fn LineIterator(comptime ReaderType: type) type {
                         // TODO: handle errors
                         unreachable;
                     } orelse return null;
+
+                    // Increment our line counter
+                    self.line += 1;
 
                     // Trim any whitespace (including CR) around it
                     const trim = std.mem.trim(u8, entry, whitespace ++ "\r");
@@ -958,6 +944,18 @@ pub fn LineIterator(comptime ReaderType: type) type {
             // of our buffer so that we can trick the CLI parser to treat it
             // as CLI args.
             return self.entry[0 .. buf.len + 2];
+        }
+
+        /// Modify the diagnostic so it includes richer context about
+        /// the location of the error.
+        pub fn location(self: *const Self) ?Diagnostic.Location {
+            // If we have no filepath then we have no location.
+            if (self.filepath.len == 0) return null;
+
+            return .{ .file = .{
+                .path = self.filepath,
+                .line = self.line,
+            } };
         }
     };
 }

--- a/src/cli/args.zig
+++ b/src/cli/args.zig
@@ -961,7 +961,7 @@ pub fn LineIterator(comptime ReaderType: type) type {
 }
 
 // Constructs a LineIterator (see docs for that).
-pub fn lineIterator(reader: anytype) LineIterator(@TypeOf(reader)) {
+fn lineIterator(reader: anytype) LineIterator(@TypeOf(reader)) {
     return .{ .r = reader };
 }
 

--- a/src/cli/args.zig
+++ b/src/cli/args.zig
@@ -129,7 +129,7 @@ pub fn parse(
                 try dst._diagnostics.append(arena_alloc, .{
                     .key = try arena_alloc.dupeZ(u8, key),
                     .message = message,
-                    .location = Diagnostic.Location.fromIter(iter),
+                    .location = diags.Location.fromIter(iter),
                 });
             };
         }
@@ -475,7 +475,7 @@ test "parse: diagnostic tracking" {
     try testing.expect(data._diagnostics.items().len == 1);
     {
         const diag = data._diagnostics.items()[0];
-        try testing.expectEqual(Diagnostic.Location.none, diag.location);
+        try testing.expectEqual(diags.Location.none, diag.location);
         try testing.expectEqualStrings("what", diag.key);
         try testing.expectEqualStrings("unknown field", diag.message);
     }
@@ -878,7 +878,7 @@ pub fn ArgsIterator(comptime Iterator: type) type {
         }
 
         /// Returns a location for a diagnostic message.
-        pub fn location(self: *const Self) ?Diagnostic.Location {
+        pub fn location(self: *const Self) ?diags.Location {
             return .{ .cli = self.index };
         }
     };
@@ -975,7 +975,7 @@ pub fn LineIterator(comptime ReaderType: type) type {
         }
 
         /// Returns a location for a diagnostic message.
-        pub fn location(self: *const Self) ?Diagnostic.Location {
+        pub fn location(self: *const Self) ?diags.Location {
             // If we have no filepath then we have no location.
             if (self.filepath.len == 0) return null;
 

--- a/src/cli/diagnostics.zig
+++ b/src/cli/diagnostics.zig
@@ -118,7 +118,7 @@ pub const DiagnosticList = struct {
         return self.list.items.len == 0;
     }
 
-    pub fn items(self: *DiagnosticList) []Diagnostic {
+    pub fn items(self: *const DiagnosticList) []const Diagnostic {
         return self.list.items;
     }
 };

--- a/src/cli/diagnostics.zig
+++ b/src/cli/diagnostics.zig
@@ -46,6 +46,8 @@ pub const Location = union(enum) {
         line: usize,
     },
 
+    pub const Key = @typeInfo(Location).Union.tag_type.?;
+
     pub fn fromIter(iter: anytype) Location {
         const Iter = t: {
             const T = @TypeOf(iter);
@@ -120,5 +122,18 @@ pub const DiagnosticList = struct {
 
     pub fn items(self: *const DiagnosticList) []const Diagnostic {
         return self.list.items;
+    }
+
+    /// Returns true if there are any diagnostics for the given
+    /// location type.
+    pub fn containsLocation(
+        self: *const DiagnosticList,
+        location: Location.Key,
+    ) bool {
+        for (self.list.items) |diag| {
+            if (diag.location == location) return true;
+        }
+
+        return false;
     }
 };

--- a/src/cli/diagnostics.zig
+++ b/src/cli/diagnostics.zig
@@ -15,31 +15,6 @@ pub const Diagnostic = struct {
     key: [:0]const u8 = "",
     message: [:0]const u8,
 
-    /// The possible locations for a diagnostic message. This is used
-    /// to provide context for the message.
-    pub const Location = union(enum) {
-        none,
-        cli: usize,
-        file: struct {
-            path: []const u8,
-            line: usize,
-        },
-
-        pub fn fromIter(iter: anytype) Location {
-            const Iter = t: {
-                const T = @TypeOf(iter);
-                break :t switch (@typeInfo(T)) {
-                    .Pointer => |v| v.child,
-                    .Struct => T,
-                    else => return .none,
-                };
-            };
-
-            if (!@hasDecl(Iter, "location")) return .none;
-            return iter.location() orelse .none;
-        }
-    };
-
     /// Write the full user-friendly diagnostic message to the writer.
     pub fn write(self: *const Diagnostic, writer: anytype) !void {
         switch (self.location) {
@@ -58,6 +33,31 @@ pub const Diagnostic = struct {
         }
 
         try writer.print("{s}", .{self.message});
+    }
+};
+
+/// The possible locations for a diagnostic message. This is used
+/// to provide context for the message.
+pub const Location = union(enum) {
+    none,
+    cli: usize,
+    file: struct {
+        path: []const u8,
+        line: usize,
+    },
+
+    pub fn fromIter(iter: anytype) Location {
+        const Iter = t: {
+            const T = @TypeOf(iter);
+            break :t switch (@typeInfo(T)) {
+                .Pointer => |v| v.child,
+                .Struct => T,
+                else => return .none,
+            };
+        };
+
+        if (!@hasDecl(Iter, "location")) return .none;
+        return iter.location() orelse .none;
     }
 };
 

--- a/src/cli/diagnostics.zig
+++ b/src/cli/diagnostics.zig
@@ -1,0 +1,124 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const assert = std.debug.assert;
+const Allocator = std.mem.Allocator;
+const build_config = @import("../build_config.zig");
+
+/// A diagnostic message from parsing. This is used to provide additional
+/// human-friendly warnings and errors about the parsed data.
+///
+/// All of the memory for the diagnostic is allocated from the arena
+/// associated with the config structure. If an arena isn't available
+/// then diagnostics are not supported.
+pub const Diagnostic = struct {
+    location: Location = .none,
+    key: [:0]const u8 = "",
+    message: [:0]const u8,
+
+    /// The possible locations for a diagnostic message. This is used
+    /// to provide context for the message.
+    pub const Location = union(enum) {
+        none,
+        cli: usize,
+        file: struct {
+            path: []const u8,
+            line: usize,
+        },
+
+        pub fn fromIter(iter: anytype) Location {
+            const Iter = t: {
+                const T = @TypeOf(iter);
+                break :t switch (@typeInfo(T)) {
+                    .Pointer => |v| v.child,
+                    .Struct => T,
+                    else => return .none,
+                };
+            };
+
+            if (!@hasDecl(Iter, "location")) return .none;
+            return iter.location() orelse .none;
+        }
+    };
+
+    /// Write the full user-friendly diagnostic message to the writer.
+    pub fn write(self: *const Diagnostic, writer: anytype) !void {
+        switch (self.location) {
+            .none => {},
+            .cli => |index| try writer.print("cli:{}:", .{index}),
+            .file => |file| try writer.print(
+                "{s}:{}:",
+                .{ file.path, file.line },
+            ),
+        }
+
+        if (self.key.len > 0) {
+            try writer.print("{s}: ", .{self.key});
+        } else if (self.location != .none) {
+            try writer.print(" ", .{});
+        }
+
+        try writer.print("{s}", .{self.message});
+    }
+};
+
+/// A list of diagnostics. The "_diagnostics" field must be this type
+/// for diagnostics to be supported. If this field is an incorrect type
+/// a compile-time error will be raised.
+///
+/// This is implemented as a simple wrapper around an array list
+/// so that we can inject some logic around adding diagnostics
+/// and potentially in the future structure them differently.
+pub const DiagnosticList = struct {
+    /// The list of diagnostics.
+    list: std.ArrayListUnmanaged(Diagnostic) = .{},
+
+    /// Precomputed data for diagnostics. This is used specifically
+    /// when we build libghostty so that we can precompute the messages
+    /// and return them via the C API without allocating memory at
+    /// call time.
+    precompute: Precompute = precompute_init,
+
+    const precompute_enabled = switch (build_config.artifact) {
+        // We enable precompute for tests so that the logic is
+        // semantically analyzed and run.
+        .exe, .wasm_module => builtin.is_test,
+
+        // We specifically want precompute for libghostty.
+        .lib => true,
+    };
+    const Precompute = if (precompute_enabled) struct {
+        messages: std.ArrayListUnmanaged([:0]const u8) = .{},
+    } else void;
+    const precompute_init: Precompute = if (precompute_enabled) .{} else {};
+
+    pub fn append(
+        self: *DiagnosticList,
+        alloc: Allocator,
+        diag: Diagnostic,
+    ) Allocator.Error!void {
+        try self.list.append(alloc, diag);
+        errdefer _ = self.list.pop();
+
+        if (comptime precompute_enabled) {
+            var buf = std.ArrayList(u8).init(alloc);
+            defer buf.deinit();
+            try diag.write(buf.writer());
+
+            const owned: [:0]const u8 = try buf.toOwnedSliceSentinel(0);
+            errdefer alloc.free(owned);
+
+            try self.precompute.messages.append(alloc, owned);
+            errdefer _ = self.precompute.messages.pop();
+
+            assert(self.precompute.messages.items.len == self.list.items.len);
+        }
+    }
+
+    pub fn empty(self: *const DiagnosticList) bool {
+        return self.list.items.len == 0;
+    }
+
+    pub fn items(self: *DiagnosticList) []Diagnostic {
+        return self.list.items;
+    }
+};

--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -882,7 +882,7 @@ const Preview = struct {
             next_start += child.height;
         }
 
-        if (!config._errors.empty()) {
+        if (config._diagnostics.items().len > 0) {
             const child = win.child(
                 .{
                     .x_off = x_off,
@@ -891,7 +891,7 @@ const Preview = struct {
                         .limit = width,
                     },
                     .height = .{
-                        .limit = if (config._errors.empty()) 0 else 2 + config._errors.list.items.len,
+                        .limit = if (config._diagnostics.items().len == 0) 0 else 2 + config._diagnostics.items().len,
                     },
                 },
             );
@@ -908,10 +908,14 @@ const Preview = struct {
                     },
                 );
             }
-            for (config._errors.list.items, 0..) |err, i| {
+
+            var buf = std.ArrayList(u8).init(alloc);
+            defer buf.deinit();
+            for (config._diagnostics.items(), 0..) |diag, i| {
+                try diag.write(buf.writer());
                 _ = try child.printSegment(
                     .{
-                        .text = err.message,
+                        .text = buf.items,
                         .style = self.ui_err(),
                     },
                     .{
@@ -919,6 +923,7 @@ const Preview = struct {
                         .col_offset = 2,
                     },
                 );
+                buf.clearRetainingCapacity();
             }
             next_start += child.height;
         }

--- a/src/cli/validate_config.zig
+++ b/src/cli/validate_config.zig
@@ -55,9 +55,14 @@ pub fn run(alloc: std.mem.Allocator) !u8 {
 
     try cfg.finalize();
 
-    if (!cfg._errors.empty()) {
-        for (cfg._errors.list.items) |err| {
-            try stdout.print("{s}\n", .{err.message});
+    if (cfg._diagnostics.items().len > 0) {
+        var buf = std.ArrayList(u8).init(alloc);
+        defer buf.deinit();
+
+        for (cfg._diagnostics.items()) |diag| {
+            try diag.write(buf.writer());
+            try stdout.print("{s}\n", .{buf.items});
+            buf.clearRetainingCapacity();
         }
 
         return 1;

--- a/src/config/CAPI.zig
+++ b/src/config/CAPI.zig
@@ -112,14 +112,15 @@ fn config_trigger_(
     return trigger.cval();
 }
 
-export fn ghostty_config_errors_count(self: *Config) u32 {
-    return @intCast(self._errors.list.items.len);
+export fn ghostty_config_diagnostics_count(self: *Config) u32 {
+    return @intCast(self._diagnostics.items().len);
 }
 
-export fn ghostty_config_get_error(self: *Config, idx: u32) Error {
-    if (idx >= self._errors.list.items.len) return .{};
-    const err = self._errors.list.items[idx];
-    return .{ .message = err.message.ptr };
+export fn ghostty_config_get_diagnostic(self: *Config, idx: u32) Diagnostic {
+    const items = self._diagnostics.items();
+    if (idx >= items.len) return .{};
+    const message = self._diagnostics.precompute.messages.items[idx];
+    return .{ .message = message.ptr };
 }
 
 export fn ghostty_config_open() void {
@@ -128,7 +129,7 @@ export fn ghostty_config_open() void {
     };
 }
 
-/// Sync with ghostty_error_s
-const Error = extern struct {
+/// Sync with ghostty_diagnostic_s
+const Diagnostic = extern struct {
     message: [*:0]const u8 = "",
 };

--- a/src/config/CAPI.zig
+++ b/src/config/CAPI.zig
@@ -39,24 +39,6 @@ export fn ghostty_config_load_cli_args(self: *Config) void {
     };
 }
 
-/// Load the configuration from a string in the same format as
-/// the file-based syntax for the desktop version of the terminal.
-export fn ghostty_config_load_string(
-    self: *Config,
-    str: [*]const u8,
-    len: usize,
-) void {
-    config_load_string_(self, str[0..len]) catch |err| {
-        log.err("error loading config err={}", .{err});
-    };
-}
-
-fn config_load_string_(self: *Config, str: []const u8) !void {
-    var fbs = std.io.fixedBufferStream(str);
-    var iter = cli.args.lineIterator(fbs.reader());
-    try cli.args.parse(Config, global.alloc, self, &iter);
-}
-
 /// Load the configuration from the default file locations. This
 /// is usually done first. The default file locations are locations
 /// such as the home directory.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2372,7 +2372,11 @@ pub fn loadCliArgs(self: *Config, alloc_gpa: Allocator) !void {
     if (iter.next()) |argv0| log.debug("skipping argv0 value={s}", .{argv0});
 
     // Parse the config from the CLI args
-    try self.loadIter(alloc_gpa, &iter);
+    {
+        const ArgsIter = cli.args.ArgsIterator(@TypeOf(iter));
+        var args_iter: ArgsIter = .{ .iterator = iter };
+        try self.loadIter(alloc_gpa, &args_iter);
+    }
 
     // If we are not loading the default files, then we need to
     // replay the steps up to this point so that we can rebuild

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2731,7 +2731,7 @@ pub fn parseManuallyHook(
 
         if (command.items.len == 0) {
             try self._diagnostics.append(alloc, .{
-                .location = cli.Diagnostic.Location.fromIter(iter),
+                .location = cli.Location.fromIter(iter),
                 .message = try std.fmt.allocPrintZ(
                     alloc,
                     "missing command after {s}",


### PR DESCRIPTION
Fixes #1063 
Fixes #2437 
Supersedes #2033 (Thanks @wpaulino for your initial work, I did take some inspiration)

Configuration errors are now known as "diagnostics" (to give us room to fit more than errors in the future since it's a more general reporting system). Diagnostics contain a location which can be used to generate error messages with context such as line numbers and file paths. 

The GTK and GLFW apprts now exit when an invalid CLI argument is given (#2437). macOS always behaved this way. 

