### PR TITLE
cli: skip argv0 and actions when parsing CLI flags

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -238,7 +238,7 @@ fn drainMailbox(self: *App, rt_app: *apprt.App) !void {
             // If we're quitting, then we set the quit flag and stop
             // draining the mailbox immediately. This lets us defer
             // mailbox processing to the next tick so that the apprt
-            // can try to quick as quickly as possible.
+            // can try to quit as quickly as possible.
             .quit => {
                 log.info("quit message received, short circuiting mailbox drain", .{});
                 self.setQuit();

--- a/src/cli/crash_report.zig
+++ b/src/cli/crash_report.zig
@@ -33,9 +33,9 @@ pub fn run(alloc_gpa: Allocator) !u8 {
     defer opts.deinit();
 
     {
-        var iter = try std.process.argsWithAllocator(alloc);
+        var iter = try args.argsIterator(alloc_gpa);
         defer iter.deinit();
-        try args.parse(Options, alloc, &opts, &iter);
+        try args.parse(Options, alloc_gpa, &opts, &iter);
     }
 
     const crash_dir = try crash.defaultDir(alloc);

--- a/src/cli/list_actions.zig
+++ b/src/cli/list_actions.zig
@@ -29,7 +29,7 @@ pub fn run(alloc: Allocator) !u8 {
     defer opts.deinit();
 
     {
-        var iter = try std.process.argsWithAllocator(alloc);
+        var iter = try args.argsIterator(alloc);
         defer iter.deinit();
         try args.parse(Options, alloc, &opts, &iter);
     }

--- a/src/cli/list_colors.zig
+++ b/src/cli/list_colors.zig
@@ -22,7 +22,7 @@ pub fn run(alloc: std.mem.Allocator) !u8 {
     defer opts.deinit();
 
     {
-        var iter = try std.process.argsWithAllocator(alloc);
+        var iter = try args.argsIterator(alloc);
         defer iter.deinit();
         try args.parse(Options, alloc, &opts, &iter);
     }

--- a/src/cli/list_fonts.zig
+++ b/src/cli/list_fonts.zig
@@ -53,7 +53,7 @@ pub const Config = struct {
 /// specific styles. It is not guaranteed that only those styles are returned,
 /// it will just prioritize fonts that match those styles.
 pub fn run(alloc: Allocator) !u8 {
-    var iter = try std.process.argsWithAllocator(alloc);
+    var iter = try args.argsIterator(alloc);
     defer iter.deinit();
     return try runArgs(alloc, &iter);
 }

--- a/src/cli/list_keybinds.zig
+++ b/src/cli/list_keybinds.zig
@@ -52,7 +52,7 @@ pub fn run(alloc: Allocator) !u8 {
     defer opts.deinit();
 
     {
-        var iter = try std.process.argsWithAllocator(alloc);
+        var iter = try args.argsIterator(alloc);
         defer iter.deinit();
         try args.parse(Options, alloc, &opts, &iter);
     }

--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -91,7 +91,7 @@ pub fn run(gpa_alloc: std.mem.Allocator) !u8 {
     defer opts.deinit();
 
     {
-        var iter = try std.process.argsWithAllocator(gpa_alloc);
+        var iter = try args.argsIterator(gpa_alloc);
         defer iter.deinit();
         try args.parse(Options, gpa_alloc, &opts, &iter);
     }

--- a/src/cli/show_config.zig
+++ b/src/cli/show_config.zig
@@ -60,7 +60,7 @@ pub fn run(alloc: Allocator) !u8 {
     defer opts.deinit();
 
     {
-        var iter = try std.process.argsWithAllocator(alloc);
+        var iter = try args.argsIterator(alloc);
         defer iter.deinit();
         try args.parse(Options, alloc, &opts, &iter);
     }

--- a/src/cli/validate_config.zig
+++ b/src/cli/validate_config.zig
@@ -32,7 +32,7 @@ pub fn run(alloc: std.mem.Allocator) !u8 {
     defer opts.deinit();
 
     {
-        var iter = try std.process.argsWithAllocator(alloc);
+        var iter = try args.argsIterator(alloc);
         defer iter.deinit();
         try args.parse(Options, alloc, &opts, &iter);
     }
@@ -46,7 +46,6 @@ pub fn run(alloc: std.mem.Allocator) !u8 {
     if (opts.@"config-file") |config_path| {
         var buf: [std.fs.max_path_bytes]u8 = undefined;
         const abs_path = try std.fs.cwd().realpath(config_path, &buf);
-
         try cfg.loadFile(alloc, abs_path);
         try cfg.loadRecursiveFiles(alloc);
     } else {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2365,18 +2365,10 @@ pub fn loadCliArgs(self: *Config, alloc_gpa: Allocator) !void {
         counter[i] = @field(self, field).list.items.len;
     }
 
-    // Initialize our CLI iterator. The first argument is always assumed
-    // to be the program name so we skip over that.
-    var iter = try internal_os.args.iterator(alloc_gpa);
+    // Initialize our CLI iterator.
+    var iter = try cli.args.argsIterator(alloc_gpa);
     defer iter.deinit();
-    if (iter.next()) |argv0| log.debug("skipping argv0 value={s}", .{argv0});
-
-    // Parse the config from the CLI args
-    {
-        const ArgsIter = cli.args.ArgsIterator(@TypeOf(iter));
-        var args_iter: ArgsIter = .{ .iterator = iter };
-        try self.loadIter(alloc_gpa, &args_iter);
-    }
+    try self.loadIter(alloc_gpa, &iter);
 
     // If we are not loading the default files, then we need to
     // replay the steps up to this point so that we can rebuild


### PR DESCRIPTION
This fixes a regression from #2454. In that PR, we added an error when positional arguments are detected. I believe that's correct, but we were silently relying on the previous behavior in the CLI commands.

This commit changes the CLI commands to use a new argsIterator function that creates an iterator that skips the first argument (argv0). This is the same behavior that the config parsing does and now uses this shared logic.

This also makes it so the argsIterator ignores actions (`+things`) and we document that we expect those to be handled earlier.