### PR TITLE
config: change macos-option-as-alt default to left

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1456,8 +1456,13 @@ keybind: Keybinds = .{},
 /// Note that if an *Option*-sequence doesn't produce a printable character, it
 /// will be treated as *Alt* regardless of this setting. (i.e. `alt+ctrl+a`).
 ///
+/// The default value is `left`. This allows alt-based bindings to work
+/// with the left *Option* key while still allowing the right *Option* key
+/// to be used for Unicode input. This is a common setup for users of
+/// certain keyboard layouts.
+///
 /// This does not work with GLFW builds.
-@"macos-option-as-alt": OptionAsAlt = .false,
+@"macos-option-as-alt": OptionAsAlt = .left,
 
 /// Whether to enable the macOS window shadow. The default value is true.
 /// With some window managers and window transparency settings, you may


### PR DESCRIPTION
As suggested: https://github.com/ghostty-org/ghostty/discussions/2363#discussioncomment-10824847

This allows users of non-US keyboard layouts to continue to use the right option key for input methods, while still being able to use the the left option key as alt for keybindings.

This is a bit of an experiment to see if this is a good default for everyone. This is in response to very common confusion of US keyboard layouts where "alt" doesn't work along with the very common use of non-US layouts where the right option key is used for input methods. I think this will strike the right balance for most users.