### PR TITLE
fix: report correct screen pixel size

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -500,6 +500,7 @@ pub fn init(
 
         try termio.Termio.init(&self.io, alloc, .{
             .grid_size = grid_size,
+            .cell_size = cell_size,
             .screen_size = screen_size,
             .padding = padding,
             .full_config = config,
@@ -1331,6 +1332,7 @@ fn setCellSize(self: *Surface, size: renderer.CellSize) !void {
     self.io.queueMessage(.{
         .resize = .{
             .grid_size = self.grid_size,
+            .cell_size = self.cell_size,
             .screen_size = self.screen_size,
             .padding = self.padding,
         },
@@ -1435,6 +1437,7 @@ fn resize(self: *Surface, size: renderer.ScreenSize) !void {
     self.io.queueMessage(.{
         .resize = .{
             .grid_size = self.grid_size,
+            .cell_size = self.cell_size,
             .screen_size = self.screen_size,
             .padding = self.padding,
         },

--- a/src/termio/Options.zig
+++ b/src/termio/Options.zig
@@ -11,6 +11,9 @@ const termio = @import("../termio.zig");
 /// The size of the terminal grid.
 grid_size: renderer.GridSize,
 
+/// The size of a single cell, in pixels.
+cell_size: renderer.CellSize,
+
 /// The size of the viewport in pixels.
 screen_size: renderer.ScreenSize,
 

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -383,6 +383,7 @@ fn coalesceCallback(
         cb.io.resize(
             &cb.data,
             v.grid_size,
+            v.cell_size,
             v.screen_size,
             v.padding,
         ) catch |err| {

--- a/src/termio/message.zig
+++ b/src/termio/message.zig
@@ -20,6 +20,9 @@ pub const Message = union(enum) {
         /// The grid size for the given screen size with padding applied.
         grid_size: renderer.GridSize,
 
+        /// The updated cell size.
+        cell_size: renderer.CellSize,
+
         /// The full screen (drawable) size. This does NOT include padding.
         /// This should be sent on to the renderer.
         screen_size: renderer.ScreenSize,


### PR DESCRIPTION
Mode 2048 and CSI 14 t are size report control sequences which contain
the text area size in pixels. The text area is defined to be the extents
of the grid (rows and columns). Ghostty calculates the available size
for the text area by setting the available padding, and then filling as
much of the remaining space as possible. However, if there are remainder
pixels these are still reported as part of the text area size.

Pass the cell_size geometry through so that we can always report the
correct value: columns * cell width and rows * cell height.
