### PR TITLE
Modified `window-decorations = none` option on macOS to maintain rounded edges

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -211,9 +211,16 @@ class TerminalController: BaseTerminalController {
             window.restorationClass = TerminalWindowRestoration.self
             window.identifier = .init(String(describing: TerminalWindowRestoration.self))
         }
-
+        
         // If window decorations are disabled, remove our title
-        if (!ghostty.config.windowDecorations) { window.styleMask.remove(.titled) }
+        if (!ghostty.config.windowDecorations) {
+            window.titleVisibility = .hidden
+            window.standardWindowButton(.closeButton)?.isHidden = true
+            window.standardWindowButton(.miniaturizeButton)?.isHidden = true
+            window.standardWindowButton(.zoomButton)?.isHidden = true
+            window.titlebarAppearsTransparent = true
+            window.styleMask.insert(.fullSizeContentView)
+        }
 
         // Terminals typically operate in sRGB color space and macOS defaults
         // to "native" which is typically P3. There is a lot more resources


### PR DESCRIPTION
Most terminal emulators on MacOS that support the removal of window decorations do such by hiding the navigation controls and title, while making the titlebar transparent. 

It's an aesthetic choice, but I believe that it does keep Ghostty's style more in line with the rounded look found on macOS

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/ff15389a-d110-4806-a634-e8069a835eca">


I do understand that some people don't like the extra padding caused by hiding the bar instead of removing it altogether, so another option would be to add multiple options for window-decorations on macOS.

`window-decorations = none`:
```swift
if (!ghostty.config.windowDecorations) { window.styleMask.remove(.titled) }
```
`window-decorations = none_rounded`:
```swift
if (!ghostty.config.windowDecorations) {
    window.titleVisibility = .hidden
    window.standardWindowButton(.closeButton)?.isHidden = true
    window.standardWindowButton(.miniaturizeButton)?.isHidden = true
    window.standardWindowButton(.zoomButton)?.isHidden = true
    window.titlebarAppearsTransparent = true
    window.styleMask.insert(.fullSizeContentView)
}
```
`window-decorations = transparent`:
```swift
if (!ghostty.config.windowDecorations) {
    window.titlebarAppearsTransparent = true
}
```

etc.