### PR TITLE
Tentative fix for unexpected `font-codepoint-map` behavior

### DIFF
--- a/src/font/CodepointMap.zig
+++ b/src/font/CodepointMap.zig
@@ -54,8 +54,9 @@ pub fn add(self: *CodepointMap, alloc: Allocator, entry: Entry) !void {
 /// Get a descriptor for a codepoint.
 pub fn get(self: *const CodepointMap, cp: u21) ?discovery.Descriptor {
     const items = self.list.items(.range);
-    for (items, 0..) |range, forward_i| {
+    for (0..items.len) |forward_i| {
         const i = items.len - forward_i - 1;
+        const range = items[i];
         if (range[0] <= cp and cp <= range[1]) {
             const descs = self.list.items(.descriptor);
             return descs[i];
@@ -110,4 +111,15 @@ test "codepointmap" {
     // Non-matching
     try testing.expect(m.get(0) == null);
     try testing.expect(m.get(3) == null);
+
+    try m.add(alloc, .{ .range = .{ 3, 4 }, .descriptor = .{ .family = "C" } });
+    try m.add(alloc, .{ .range = .{ 5, 6 }, .descriptor = .{ .family = "D" } });
+    {
+        const d = m.get(3).?;
+        try testing.expectEqualStrings("C", d.family.?);
+    }
+    {
+        const d = m.get(1).?;
+        try testing.expectEqualStrings("B", d.family.?);
+    }
 }


### PR DESCRIPTION
In particular when configured to replace several ranges with multiple fonts.

Given the following `font-codepoint-map` config:

```
font-codepoint-map=U+0030-U+0039=Monaco       # 0-9
font-codepoint-map=U+0040=mononoki            # @
font-codepoint-map=U+0041-U+005a=Pixel Code   # A-Z
font-codepoint-map=U+0061-U+007a=Victor Mono  # a-z
```

I noticed a couple of unexpected behavior:

1. Codepoint ranges were assigned the wrong font
2. The declaration order had a direct impact on the font assignment (seemed to be rotating in some fashion)

<img width="595" alt="before" src="https://github.com/user-attachments/assets/4891070a-3506-4c5d-ad6b-4c87c36ed00c">

In the example above, the font assignment is as follow:

- `12345` → Victor Mono
- `@@@@@` → Pixel Code
- `ABCDE` → mononoki
- `abcde` → Monaco

Looking at the implementation:

https://github.com/ghostty-org/ghostty/blob/3e0a5d3a73a433cd5840165abd0a51c433505045/src/font/CodepointMap.zig#L54-L66

If my understanding is correct, for a given range index `n` in the `MultiArrayList` `CodepointMap.get(…)` returns the font descriptor at index `len - n - 1`. In other words, it returns the descriptor symmetrically opposite relative to the middle of the list.

I've added a couple test cases that I would expect to pass if my understanding of the expected behavior is correct, verified that they were broken under the current behavior, and updated the implementation of `CodepointMap.get(…)` accordingly.

My understanding of the original intent is to give priority to the latest range match in the list (which is a use case already tested by the `codepointmap` test, but which I believe happened to pass "by accident"), so I opted for a reverse traversal of the codepoint list.

This results is the following expected output:

| Before | After |
| ------ | ----- |
| <img width="595" alt="before" src="https://github.com/user-attachments/assets/4891070a-3506-4c5d-ad6b-4c87c36ed00c"> | <img width="595" alt="after" src="https://github.com/user-attachments/assets/1f8ff591-eb1d-4531-8907-c0fd42b42f89"> |

I've also confirmed that `font-codepoint-map` declaration order no longer impacted the font assignment.

I have close to no experience with Zig and it is unclear to me if the language offers a better syntax to iterate in reverse order over an array, so please let me know if that solution, and/or any other aspect of the PR, can be improved.