### PR TITLE
feat: Update MacOS about dialog

### DIFF
--- a/macos/Sources/Features/About/About.xib
+++ b/macos/Sources/Features/About/About.xib
@@ -14,7 +14,7 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" titlebarAppearsTransparent="YES" id="QvC-M9-y7g">
-            <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" fullSizeContentView="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="300" height="172"/>
             <rect key="screenRect" x="0.0" y="0.0" width="3008" height="1667"/>

--- a/macos/Sources/Features/About/AboutController.swift
+++ b/macos/Sources/Features/About/AboutController.swift
@@ -10,6 +10,7 @@ class AboutController: NSWindowController, NSWindowDelegate {
     override func windowDidLoad() {
         guard let window = window else { return }
         window.center()
+        window.isMovableByWindowBackground = true
         window.contentView = NSHostingView(rootView: AboutView())
     }
 

--- a/macos/Sources/Features/About/AboutView.swift
+++ b/macos/Sources/Features/About/AboutView.swift
@@ -4,23 +4,23 @@ struct AboutView: View {
     @Environment(\.openURL) var openURL
 
     /// Eventually this should be a redirect like https://go.ghostty.dev/discord or https://go.ghostty.dev/github
-    @State var discordLink: String = "https://discord.gg/ghostty"
-    @State var githubLink: String = "https://github.com/ghostty-org/ghostty"
+    private let discordLink = URL(string: "https://discord.gg/ghostty")
+    private let githubLink = URL(string: "https://github.com/ghostty-org/ghostty")
 
     /// Read the commit from the bundle.
-    var build: String? { Bundle.main.infoDictionary?["CFBundleVersion"] as? String }
-    var commit: String? { Bundle.main.infoDictionary?["GhosttyCommit"] as? String }
-    var version: String? { Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String }
-    var copyright: String? { Bundle.main.infoDictionary?["NSHumanReadableCopyright"] as? String }
+    private var build: String? { Bundle.main.infoDictionary?["CFBundleVersion"] as? String }
+    private var commit: String? { Bundle.main.infoDictionary?["GhosttyCommit"] as? String }
+    private var version: String? { Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String }
+    private var copyright: String? { Bundle.main.infoDictionary?["NSHumanReadableCopyright"] as? String }
 
-    struct ValuePair<Value: Equatable>: Identifiable {
+    private struct ValuePair<Value: Equatable>: Identifiable {
         var id = UUID()
         public let key: LocalizedStringResource
         public let value: Value
 
     }
 
-    var computedStrings: [ValuePair<String>] {
+    private var computedStrings: [ValuePair<String>] {
         let list: [ValuePair<String?>] = [
             ValuePair(key: "Version", value: self.version),
             ValuePair(key: "Build", value: self.build),
@@ -37,7 +37,7 @@ struct AboutView: View {
     }
 
     #if os(macOS)
-    struct VisualEffectBackground: NSViewRepresentable {
+    private struct VisualEffectBackground: NSViewRepresentable {
         let material: NSVisualEffectView.Material
         let blendingMode: NSVisualEffectView.BlendingMode
         let isEmphasized: Bool
@@ -103,16 +103,17 @@ struct AboutView: View {
                 .frame(maxWidth: .infinity)
 
                 HStack(spacing: 8) {
-                    Button("Discord") {
-                        guard let url = URL(string: discordLink) else { return
+                    if let url = discordLink {
+                        Button("Discord") {
+                            openURL(url)
                         }
-                        openURL(url)
                     }
-                    Button("Github") {
-                        guard let url = URL(string: githubLink) else { return
+                    if let url = githubLink {
+                        Button("GitHub") {
+                            openURL(url)
                         }
-                        openURL(url)
                     }
+
                 }
 
                 if let copy = self.copyright {

--- a/macos/Sources/Features/About/AboutView.swift
+++ b/macos/Sources/Features/About/AboutView.swift
@@ -76,7 +76,7 @@ struct AboutView: View {
                     Text("Ghostty")
                         .bold()
                         .font(.title)
-                    Text("Fast, native, feature-rich terminal emulator pushing modern features.")
+                    Text("Fast, native, feature-rich terminal \nemulator pushing modern features.")
                         .multilineTextAlignment(.center)
                         .fixedSize(horizontal: false, vertical: true)
                         .font(.caption)

--- a/macos/Sources/Features/About/AboutView.swift
+++ b/macos/Sources/Features/About/AboutView.swift
@@ -83,6 +83,7 @@ struct AboutView: View {
                         .tint(.secondary)
                         .opacity(0.8)
                 }
+                .textSelection(.enabled)
                 VStack(spacing: 2) {
                     ForEach(computedStrings) { item in
 
@@ -97,6 +98,7 @@ struct AboutView: View {
                                     .opacity(0.8)
                         }
                         .font(.callout)
+                        .textSelection(.enabled)
                         .frame(maxWidth: .infinity)
                     }
                 }
@@ -119,6 +121,7 @@ struct AboutView: View {
                 if let copy = self.copyright {
                     Text(copy)
                         .font(.caption)
+                        .textSelection(.enabled)
                         .tint(.secondary)
                         .opacity(0.8)
                         .multilineTextAlignment(.center)

--- a/macos/Sources/Features/About/AboutView.swift
+++ b/macos/Sources/Features/About/AboutView.swift
@@ -1,35 +1,142 @@
 import SwiftUI
 
 struct AboutView: View {
+    @Environment(\.openURL) var openURL
+
+    /// Eventually this should be a redirect like https://go.ghostty.dev/discord or https://go.ghostty.dev/github
+    @State var discordLink: String = "https://discord.gg/ghostty"
+    @State var githubLink: String = "https://github.com/ghostty-org/ghostty"
+
     /// Read the commit from the bundle.
     var build: String? { Bundle.main.infoDictionary?["CFBundleVersion"] as? String }
     var commit: String? { Bundle.main.infoDictionary?["GhosttyCommit"] as? String }
     var version: String? { Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String }
+    var copyright: String? { Bundle.main.infoDictionary?["NSHumanReadableCopyright"] as? String }
+
+    struct ValuePair<Value: Equatable>: Identifiable {
+        var id = UUID()
+        public let key: LocalizedStringResource
+        public let value: Value
+
+    }
+
+    var computedStrings: [ValuePair<String>] {
+        let list: [ValuePair<String?>] = [
+            ValuePair(key: "Version", value: self.version),
+            ValuePair(key: "Build", value: self.build),
+            ValuePair(key: "Commit", value: self.commit == "" ? nil : self.commit)
+        ]
+
+        let strings: [ValuePair<String>] = list.compactMap {
+            guard let value = $0.value else { return nil }
+
+            return ValuePair(key: $0.key, value: value)
+        }
+
+        return strings
+    }
+
+    #if os(macOS)
+    struct VisualEffectBackground: NSViewRepresentable {
+        let material: NSVisualEffectView.Material
+        let blendingMode: NSVisualEffectView.BlendingMode
+        let isEmphasized: Bool
+
+        init(material: NSVisualEffectView.Material, blendingMode: NSVisualEffectView.BlendingMode = .behindWindow, isEmphasized: Bool = false) {
+            self.material = material
+            self.blendingMode = blendingMode
+            self.isEmphasized = isEmphasized
+        }
+
+        func updateNSView(_ nsView: NSVisualEffectView, context: Context) {
+            nsView.material = material
+            nsView.blendingMode = blendingMode
+            nsView.isEmphasized = isEmphasized
+        }
+
+        func makeNSView(context: Context) -> NSVisualEffectView {
+            let visualEffect = NSVisualEffectView()
+
+            visualEffect.autoresizingMask = [.width, .height]
+
+            return visualEffect
+        }
+    }
+    #endif
 
     var body: some View {
         VStack(alignment: .center) {
             Image("AppIconImage")
                 .resizable()
                 .aspectRatio(contentMode: .fit)
-                .frame(maxHeight: 96)
+                .frame(height: 128)
 
-            Text("Ghostty")
-                .font(.title3)
-                .textSelection(.enabled)
+            VStack(alignment: .center, spacing: 32) {
+                VStack(alignment: .center, spacing: 8) {
+                    Text("Ghostty")
+                        .bold()
+                        .font(.title)
+                    Text("Fast, native, feature-rich terminal emulator pushing modern features.")
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .font(.caption)
+                        .tint(.secondary)
+                        .opacity(0.8)
+                }
+                VStack(spacing: 2) {
+                    ForEach(computedStrings) { item in
 
-            if let version = self.version {
-                Text("Version: \(version)")
-                    .font(.body)
-                    .textSelection(.enabled)
+                        HStack(spacing: 4) {
+                                Text(item.key)
+                                    .frame(width: 126, alignment: .trailing)
+                                    .padding(.trailing, 2)
+                                Text(item.value)
+                                    .frame(width: 125, alignment: .leading)
+                                    .padding(.leading, 2)
+                                    .tint(.secondary)
+                                    .opacity(0.8)
+                        }
+                        .font(.callout)
+                        .frame(maxWidth: .infinity)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+
+                HStack(spacing: 8) {
+                    Button("Discord") {
+                        guard let url = URL(string: discordLink) else { return
+                        }
+                        openURL(url)
+                    }
+                    Button("Github") {
+                        guard let url = URL(string: githubLink) else { return
+                        }
+                        openURL(url)
+                    }
+                }
+
+                if let copy = self.copyright {
+                    Text(copy)
+                        .font(.caption)
+                        .tint(.secondary)
+                        .opacity(0.8)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: .infinity)
+                }
             }
-
-            if let build = self.build {
-                Text("Build: \(build)")
-                    .font(.body)
-                    .textSelection(.enabled)
-            }
+            .frame(maxWidth: .infinity)
         }
-        .frame(minWidth: 300)
-        .padding()
+        .padding(.top, 8)
+        .padding(32)
+        .frame(minWidth: 256)
+        #if os(macOS)
+        .background(VisualEffectBackground(material: .underWindowBackground).ignoresSafeArea())
+        #endif
+    }
+}
+
+struct AboutView_Previews: PreviewProvider {
+    static var previews: some View {
+        AboutView()
     }
 }


### PR DESCRIPTION
This PR updates the About dialog (`Ghostty -> About`) to match that of macOS. This was inspired by the modern macOS About This Mac dialog.

![Ghostty about dialoge](https://github.com/user-attachments/assets/6fc6e2b0-c0a0-4fc6-893b-ef0579e5debc)