### PR TITLE
Native title proxy icons macos

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -232,9 +232,18 @@ class BaseTerminalController: NSWindowController,
 
     func titleDidChange(to: String) {
         guard let window else { return }
-
+        
         // Set the main window title
         window.title = to
+        
+        // Get the current working directory from the focused surface
+        if let pwd = focusedSurface?.pwd {
+            // Set the window's representedURL to the current working directory
+            window.representedURL = URL(fileURLWithPath: pwd)
+        } else {
+            // If we don't have a pwd, set representedURL to nil
+            window.representedURL = nil
+        }
     }
 
     func cellSizeDidChange(to: NSSize) {

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -211,9 +211,16 @@ class TerminalController: BaseTerminalController {
             window.restorationClass = TerminalWindowRestoration.self
             window.identifier = .init(String(describing: TerminalWindowRestoration.self))
         }
-
+        
         // If window decorations are disabled, remove our title
-        if (!ghostty.config.windowDecorations) { window.styleMask.remove(.titled) }
+        if (!ghostty.config.windowDecorations) {
+            window.titleVisibility = .hidden
+            window.standardWindowButton(.closeButton)?.isHidden = true
+            window.standardWindowButton(.miniaturizeButton)?.isHidden = true
+            window.standardWindowButton(.zoomButton)?.isHidden = true
+            window.titlebarAppearsTransparent = true
+            window.styleMask.insert(.fullSizeContentView)
+        }
 
         // Terminals typically operate in sRGB color space and macOS defaults
         // to "native" which is typically P3. There is a lot more resources

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -213,14 +213,7 @@ class TerminalController: BaseTerminalController {
         }
         
         // If window decorations are disabled, remove our title
-        if (!ghostty.config.windowDecorations) {
-            window.titleVisibility = .hidden
-            window.standardWindowButton(.closeButton)?.isHidden = true
-            window.standardWindowButton(.miniaturizeButton)?.isHidden = true
-            window.standardWindowButton(.zoomButton)?.isHidden = true
-            window.titlebarAppearsTransparent = true
-            window.styleMask.insert(.fullSizeContentView)
-        }
+        if (!ghostty.config.windowDecorations) { window.styleMask.remove(.titled) }
 
         // Terminals typically operate in sRGB color space and macOS defaults
         // to "native" which is typically P3. There is a lot more resources


### PR DESCRIPTION
Proxy icons are showing in the title for directories.

Proxy icons do not show in the title when you open up a file, such as using vim to edit a .zig file. 

Apologies for the number of commits, I'm still getting used to Github on Xcode.