### PR TITLE
bash: stop modifying HISTCONTROL in bash-preexec.sh

### DIFF
--- a/src/shell-integration/bash/bash-preexec.sh
+++ b/src/shell-integration/bash/bash-preexec.sh
@@ -310,7 +310,13 @@ __bp_install() {
     fi
 
     # Adjust our HISTCONTROL Variable if needed.
-    __bp_adjust_histcontrol
+    #
+    # GHOSTTY: Don't modify HISTCONTROL. This hack is only needed to improve the
+    # accuracy of the command argument passed to the preexec functions, and we
+    # don't use that argument in our bash shell integration script (and nor does
+    # the __bp_original_debug_trap function above, which is the only other active
+    # preexec function).
+    #__bp_adjust_histcontrol
 
     # Issue #25. Setting debug trap for subshells causes sessions to exit for
     # backgrounded subshell commands (e.g. (pwd)& ). Believe this is a bug in Bash.


### PR DESCRIPTION
This hack is only needed to improve the accuracy of the command argument passed to the preexec functions, and we don't use that argument in our bash shell integration script (and nor does the __bp_original_debug_trap function above, which is the only other active preexec function).

See also:
- https://github.com/rcaloras/bash-preexec/issues/147
- https://github.com/rcaloras/bash-preexec/issues/115

Fixes #2269