### PR TITLE
macos: use notification to detect when quick terminal shows/hides

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -155,6 +155,14 @@ class AppDelegate: NSObject,
             matching: [.keyDown],
             handler: localEventHandler)
 
+        // Notifications
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(quickTerminalDidChangeVisibility),
+            name: .quickTerminalDidChangeVisibility,
+            object: nil
+        )
+
         // Configure user notifications
         let actions = [
             UNNotificationAction(identifier: Ghostty.userNotificationActionShow, title: "Show")
@@ -409,6 +417,11 @@ class AppDelegate: NSObject,
         return event
     }
 
+    @objc private func quickTerminalDidChangeVisibility(_ notification: Notification) {
+        guard let quickController = notification.object as? QuickTerminalController else { return }
+        self.menuQuickTerminal?.state = if (quickController.visible) { .on } else { .off }
+    }
+
     //MARK: - Restorable State
 
     /// We support NSSecureCoding for restorable state. Required as of macOS Sonoma (14) but a good idea anyways.
@@ -622,8 +635,6 @@ class AppDelegate: NSObject,
 
         guard let quickController = self.quickController else { return }
         quickController.toggle()
-
-        self.menuQuickTerminal?.state = if (quickController.visible) { .on } else { .off }
     }
 
     /// Toggles visibility of all Ghosty Terminal windows. When hidden, activates Ghostty as the frontmost application

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -140,6 +140,12 @@ class QuickTerminalController: BaseTerminalController {
         guard !visible else { return }
         visible = true
 
+        // Notify the change
+        NotificationCenter.default.post(
+            name: .quickTerminalDidChangeVisibility,
+            object: self
+        )
+
         // If we have a previously focused application and it isn't us, then
         // we want to store it so we can restore state later.
         if !NSApp.isActive {
@@ -169,6 +175,12 @@ class QuickTerminalController: BaseTerminalController {
         // Set our visibility state
         guard visible else { return }
         visible = false
+
+        // Notify the change
+        NotificationCenter.default.post(
+            name: .quickTerminalDidChangeVisibility,
+            object: self
+        )
 
         animateWindowOut(window: window, to: position)
     }
@@ -349,4 +361,9 @@ class QuickTerminalController: BaseTerminalController {
     @objc private func ghosttyDidReloadConfig(notification: SwiftUI.Notification) {
         syncAppearance()
     }
+}
+
+extension Notification.Name {
+    /// The quick terminal did become hidden or visible.
+    static let quickTerminalDidChangeVisibility = Notification.Name("QuickTerminalDidChangeVisibility")
 }


### PR DESCRIPTION
Fixes #2474