### PR TITLE
feat: make too big tab indices go to last tab

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -211,7 +211,7 @@ class TerminalController: BaseTerminalController {
             window.restorationClass = TerminalWindowRestoration.self
             window.identifier = .init(String(describing: TerminalWindowRestoration.self))
         }
-        
+
         // If window decorations are disabled, remove our title
         if (!ghostty.config.windowDecorations) { window.styleMask.remove(.titled) }
 
@@ -518,7 +518,10 @@ class TerminalController: BaseTerminalController {
             finalIndex = Int(tabIndex - 1)
         }
 
-        guard finalIndex >= 0 && finalIndex < tabbedWindows.count else { return }
+        guard finalIndex >= 0 else { return }
+        if finalIndex >= tabbedWindows.count {
+            finalIndex = tabbedWindows.count - 1
+        }
         let targetWindow = tabbedWindows[finalIndex]
         targetWindow.makeKeyAndOrderFront(nil)
     }

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -514,14 +514,14 @@ class TerminalController: BaseTerminalController {
                 return
             }
         } else {
-            // Tabs are 0-indexed here, so we subtract one from the key the user hit.
-            finalIndex = Int(tabIndex - 1)
+            // The configured value is 1-indexed.
+            guard tabIndex >= 1 else { return }
+
+            // If our index is outside our boundary then we use the max
+            finalIndex = min(Int(tabIndex - 1), tabbedWindows.count - 1)
         }
 
         guard finalIndex >= 0 else { return }
-        if finalIndex >= tabbedWindows.count {
-            finalIndex = tabbedWindows.count - 1
-        }
         let targetWindow = tabbedWindows[finalIndex]
         targetWindow.makeKeyAndOrderFront(nil)
     }

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -466,11 +466,10 @@ pub fn gotoLastTab(self: *Window) void {
 pub fn gotoTab(self: *Window, n: usize) void {
     if (n == 0) return;
     const max = self.notebook.nPages();
+    if (max == 0) return;
     const page_idx = std.math.cast(c_int, n - 1) orelse return;
-    if (page_idx < max) {
-        self.notebook.gotoNthTab(page_idx);
-        self.focusCurrentTab();
-    }
+    self.notebook.gotoNthTab(@min(page_idx, max - 1));
+    self.focusCurrentTab();
 }
 
 /// Toggle tab overview (if present)

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -297,7 +297,8 @@ pub const Action = union(enum) {
     /// Go to the last tab (the one with the highest index)
     last_tab: void,
 
-    /// Go to the tab with the specific number, 1-indexed.
+    /// Go to the tab with the specific number, 1-indexed. If the tab number
+    /// is higher than the number of tabs, this will go to the last tab.
     goto_tab: usize,
 
     /// Toggle the tab overview.


### PR DESCRIPTION
closes https://github.com/ghostty-org/ghostty/issues/2477

I couldn't test this out locally because I fail to build ghostty for macos ("metal not found")
I'll try to do that