### PR TITLE
Fix: aerospace no longer resizes quick terminal and instead treats it as float

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalWindow.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalWindow.swift
@@ -13,10 +13,9 @@ class QuickTerminalWindow: NSWindow {
         // but I prefer to do it programmatically because the properties we
         // care about are less hidden.
         
-        // Set the base style mask to be HUD Window (which satisfies the AeroSpace
-        // window manager's heuristics allowing the quick terminal window to be
-        // unaffected by AeroSpace's window positioning and resizing)
-        self.styleMask = .hudWindow
+        // Add a custom identifier so third party apps can use the Accessibility
+        // API to apply special rules to the quick terminal. 
+        self.identifier = .init(rawValue: "com.mitchellh.ghostty.quickTerminal")
 
         // Remove the title completely. This will make the window square. One
         // downside is it also hides the cursor indications of resize but the

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalWindow.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalWindow.swift
@@ -16,6 +16,10 @@ class QuickTerminalWindow: NSWindow {
         // Add a custom identifier so third party apps can use the Accessibility
         // API to apply special rules to the quick terminal. 
         self.identifier = .init(rawValue: "com.mitchellh.ghostty.quickTerminal")
+        
+        // Set the correct AXSubrole of kAXFloatingWindowSubrole (allows
+        // AeroSpace to treat the Quick Terminal as a floating window)
+        self.setAccessibilitySubrole(.floatingWindow)
 
         // Remove the title completely. This will make the window square. One
         // downside is it also hides the cursor indications of resize but the

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalWindow.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalWindow.swift
@@ -12,6 +12,11 @@ class QuickTerminalWindow: NSWindow {
         // Note: almost all of this stuff can be done in the nib/xib directly
         // but I prefer to do it programmatically because the properties we
         // care about are less hidden.
+        
+        // Set the base style mask to be HUD Window (which satisfies the AeroSpace
+        // window manager's heuristics allowing the quick terminal window to be
+        // unaffected by AeroSpace's window positioning and resizing)
+        self.styleMask = .hudWindow
 
         // Remove the title completely. This will make the window square. One
         // downside is it also hides the cursor indications of resize but the


### PR DESCRIPTION
(also big thanks to joshbashed on discord for pointing me in the right direction. I was headed a completely different rabbit hole)