### PR TITLE
macos: quick terminal animate duration

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -197,7 +197,7 @@ class QuickTerminalController: BaseTerminalController {
         // Run the animation that moves our window into the proper place and makes
         // it visible.
         NSAnimationContext.runAnimationGroup({ context in
-            context.duration = 0.2
+            context.duration = ghostty.config.quickTerminalAnimateDuration
             context.timingFunction = .init(name: .easeIn)
             position.setFinal(in: window.animator(), on: screen)
         }, completionHandler: {
@@ -287,7 +287,7 @@ class QuickTerminalController: BaseTerminalController {
         }
 
         NSAnimationContext.runAnimationGroup({ context in
-            context.duration = 0.2
+            context.duration = ghostty.config.quickTerminalAnimateDuration
             context.timingFunction = .init(name: .easeIn)
             position.setInitial(in: window.animator(), on: screen)
         }, completionHandler: {

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -197,7 +197,7 @@ class QuickTerminalController: BaseTerminalController {
         // Run the animation that moves our window into the proper place and makes
         // it visible.
         NSAnimationContext.runAnimationGroup({ context in
-            context.duration = ghostty.config.quickTerminalAnimateDuration
+            context.duration = ghostty.config.quickTerminalAnimationDuration
             context.timingFunction = .init(name: .easeIn)
             position.setFinal(in: window.animator(), on: screen)
         }, completionHandler: {
@@ -287,7 +287,7 @@ class QuickTerminalController: BaseTerminalController {
         }
 
         NSAnimationContext.runAnimationGroup({ context in
-            context.duration = ghostty.config.quickTerminalAnimateDuration
+            context.duration = ghostty.config.quickTerminalAnimationDuration
             context.timingFunction = .init(name: .easeIn)
             position.setInitial(in: window.animator(), on: screen)
         }, completionHandler: {

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -343,6 +343,14 @@ extension Ghostty {
             let str = String(cString: ptr)
             return QuickTerminalScreen(fromGhosttyConfig: str) ?? .main
         }
+
+        var quickTerminalAnimateDuration: Double {
+            guard let config = self.config else { return 0.2 }
+            var v: Double = 0.2
+            let key = "quick-terminal-animate-duration"
+            _ = ghostty_config_get(config, &v, key, UInt(key.count))
+            return v
+        }
         #endif
 
         var resizeOverlay: ResizeOverlay {

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -344,10 +344,10 @@ extension Ghostty {
             return QuickTerminalScreen(fromGhosttyConfig: str) ?? .main
         }
 
-        var quickTerminalAnimateDuration: Double {
+        var quickTerminalAnimationDuration: Double {
             guard let config = self.config else { return 0.2 }
             var v: Double = 0.2
-            let key = "quick-terminal-animate-duration"
+            let key = "quick-terminal-animation-duration"
             _ = ghostty_config_get(config, &v, key, UInt(key.count))
             return v
         }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1270,6 +1270,10 @@ keybind: Keybinds = .{},
 /// by the operating system.
 @"quick-terminal-screen": QuickTerminalScreen = .main,
 
+/// Duration (in seconds) of the quick terminal enter and exit animation.
+/// Set it to 0 to disable animation.
+@"quick-terminal-animate-duration": f64 = 0.2,
+
 /// Whether to enable shell integration auto-injection or not. Shell integration
 /// greatly enhances the terminal experience by enabling a number of features:
 ///

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1271,8 +1271,9 @@ keybind: Keybinds = .{},
 @"quick-terminal-screen": QuickTerminalScreen = .main,
 
 /// Duration (in seconds) of the quick terminal enter and exit animation.
-/// Set it to 0 to disable animation.
-@"quick-terminal-animate-duration": f64 = 0.2,
+/// Set it to 0 to disable animation completely. This can be changed at
+/// runtime.
+@"quick-terminal-animation-duration": f64 = 0.2,
 
 /// Whether to enable shell integration auto-injection or not. Shell integration
 /// greatly enhances the terminal experience by enabling a number of features:


### PR DESCRIPTION
This makes the quick terminal more closely replicate my personal "Hotkey Window" settings on iTerm2.  (I've also replicated the same setup using HammerSmith and kitty, it's a big deal for me!)

These new settings are exercised by this config:
```
quick-terminal-position = full
quick-terminal-animate = false
```

I considered making a new quick-terminal-size config item that would control the fraction of the screen the quick terminal covers (defaulting to 4) but that seemed like a more invasive change and this covers my use case.

I wasn't entirely sure about my values in `initialOriginal` and `finalOrigin` but this seems to work correctly in animated and non-animated modes.

Happy to close this and create an issue if that would be more appropriate.