### PR TITLE
Macos proxy icon fix

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -236,8 +236,14 @@ class BaseTerminalController: NSWindowController,
         // Set the main window title
         window.title = to
         
+    }
+    
+    func proxyIconURLDidChange(to: URL?){
+        
+        guard let window else { return }
+        
         // Get the current working directory from the focused surface
-        if let pwd = focusedSurface?.pwd {
+        if ghostty.config.macosTitlebarProxyIcon == "visible", let pwd = focusedSurface?.pwd {
             // Set the window's representedURL to the current working directory
             window.representedURL = URL(fileURLWithPath: pwd)
         } else {

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -238,7 +238,7 @@ class BaseTerminalController: NSWindowController,
         
     }
     
-    func proxyIconURLDidChange(to: URL?){
+    func pwdDidChange(to: URL?){
         
         guard let window else { return }
         

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -235,12 +235,12 @@ class BaseTerminalController: NSWindowController,
         
         // Set the main window title
         window.title = to
-        
+
     }
     
     func pwdDidChange(to: URL?) {
         guard let window else { return }
-        
+
         if ghostty.config.macosTitlebarProxyIcon == .visible {
             // Use the 'to' URL directly
             window.representedURL = to

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -238,19 +238,17 @@ class BaseTerminalController: NSWindowController,
         
     }
     
-    func pwdDidChange(to: URL?){
-        
+    func pwdDidChange(to: URL?) {
         guard let window else { return }
         
-        // Get the current working directory from the focused surface
-        if ghostty.config.macosTitlebarProxyIcon == .visible, let pwd = focusedSurface?.pwd {
-            // Set the window's representedURL to the current working directory
-            window.representedURL = URL(fileURLWithPath: pwd)
+        if ghostty.config.macosTitlebarProxyIcon == .visible {
+            // Use the 'to' URL directly
+            window.representedURL = to
         } else {
-            // If we don't have a pwd, set representedURL to nil
             window.representedURL = nil
         }
     }
+
 
     func cellSizeDidChange(to: NSSize) {
         guard ghostty.config.windowStepResize else { return }

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -243,7 +243,7 @@ class BaseTerminalController: NSWindowController,
         guard let window else { return }
         
         // Get the current working directory from the focused surface
-        if ghostty.config.macosTitlebarProxyIcon == "visible", let pwd = focusedSurface?.pwd {
+        if ghostty.config.macosTitlebarProxyIcon == .visible, let pwd = focusedSurface?.pwd {
             // Set the window's representedURL to the current working directory
             window.representedURL = URL(fileURLWithPath: pwd)
         } else {

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -307,6 +307,10 @@ class TerminalController: BaseTerminalController {
             window.standardWindowButton(.closeButton)?.isHidden = true
             window.standardWindowButton(.miniaturizeButton)?.isHidden = true
             window.standardWindowButton(.zoomButton)?.isHidden = true
+            
+            // Hide document icon button(proxy icon)
+            window.representedURL = nil
+            window.standardWindowButton(.documentIconButton)?.isHidden = true
 
             // Disallow tabbing if the titlebar is hidden, since that will (should) also hide the tab bar.
             window.tabbingMode = .disallowed

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -307,10 +307,6 @@ class TerminalController: BaseTerminalController {
             window.standardWindowButton(.closeButton)?.isHidden = true
             window.standardWindowButton(.miniaturizeButton)?.isHidden = true
             window.standardWindowButton(.zoomButton)?.isHidden = true
-            
-            // Hide document icon button(proxy icon)
-            window.representedURL = nil
-            window.standardWindowButton(.documentIconButton)?.isHidden = true
 
             // Disallow tabbing if the titlebar is hidden, since that will (should) also hide the tab bar.
             window.tabbingMode = .disallowed

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -310,6 +310,14 @@ class TerminalController: BaseTerminalController {
 
             // Disallow tabbing if the titlebar is hidden, since that will (should) also hide the tab bar.
             window.tabbingMode = .disallowed
+
+            // Nuke it from orbit -- hide the titlebar container entirely, just in case. There are
+            // some operations that appear to bring back the titlebar visibility so this ensures
+            // it is gone forever.
+            if let themeFrame = window.contentView?.superview,
+               let titleBarContainer = themeFrame.firstDescendant(withClassName: "NSTitlebarContainerView") {
+                titleBarContainer.isHidden = true
+            }
         }
 
         // In various situations, macOS automatically tabs new windows. Ghostty handles

--- a/macos/Sources/Features/Terminal/TerminalView.swift
+++ b/macos/Sources/Features/Terminal/TerminalView.swift
@@ -10,6 +10,9 @@ protocol TerminalViewDelegate: AnyObject {
 
     /// The title of the terminal should change.
     func titleDidChange(to: String)
+    
+    /// The URL of the proxy icon should change.
+    func proxyIconURLDidChange(to: URL?)
 
     /// The cell size changed.
     func cellSizeDidChange(to: NSSize)
@@ -62,7 +65,15 @@ struct TerminalView<ViewModel: TerminalViewModel>: View {
 
         return title
     }
-
+    
+    // The proxy icon URL for our window
+    private var proxyIconURL: URL? {
+        guard let proxyURLString = focusedSurface?.pwd else {
+            return nil
+        }
+        return URL(string: proxyURLString)
+    }
+    
     var body: some View {
         switch ghostty.readiness {
         case .loading:
@@ -86,6 +97,10 @@ struct TerminalView<ViewModel: TerminalViewModel>: View {
                     }
                     .onChange(of: title) { newValue in
                         self.delegate?.titleDidChange(to: newValue)
+                    }
+                    .onChange(of: proxyIconURL) { newValue in
+                        self.delegate?.proxyIconURLDidChange(to: newValue)
+                        
                     }
                     .onChange(of: cellSize) { newValue in
                         guard let size = newValue else { return }

--- a/macos/Sources/Features/Terminal/TerminalView.swift
+++ b/macos/Sources/Features/Terminal/TerminalView.swift
@@ -71,7 +71,8 @@ struct TerminalView<ViewModel: TerminalViewModel>: View {
         guard let proxyURLString = focusedSurface?.pwd else {
             return nil
         }
-        return URL(string: proxyURLString)
+        // Use fileURLWithPath initializer for file paths
+        return URL(fileURLWithPath: proxyURLString)
     }
     
     var body: some View {

--- a/macos/Sources/Features/Terminal/TerminalView.swift
+++ b/macos/Sources/Features/Terminal/TerminalView.swift
@@ -100,7 +100,6 @@ struct TerminalView<ViewModel: TerminalViewModel>: View {
                     }
                     .onChange(of: proxyIconURL) { newValue in
                         self.delegate?.proxyIconURLDidChange(to: newValue)
-                        
                     }
                     .onChange(of: cellSize) { newValue in
                         guard let size = newValue else { return }

--- a/macos/Sources/Features/Terminal/TerminalView.swift
+++ b/macos/Sources/Features/Terminal/TerminalView.swift
@@ -11,8 +11,8 @@ protocol TerminalViewDelegate: AnyObject {
     /// The title of the terminal should change.
     func titleDidChange(to: String)
     
-    /// The URL of the proxy icon should change.
-    func proxyIconURLDidChange(to: URL?)
+    /// The URL of the pwd should change.
+    func pwdDidChange(to: URL?)
 
     /// The cell size changed.
     func cellSizeDidChange(to: NSSize)
@@ -99,7 +99,7 @@ struct TerminalView<ViewModel: TerminalViewModel>: View {
                         self.delegate?.titleDidChange(to: newValue)
                     }
                     .onChange(of: proxyIconURL) { newValue in
-                        self.delegate?.proxyIconURLDidChange(to: newValue)
+                        self.delegate?.pwdDidChange(to: newValue)
                     }
                     .onChange(of: cellSize) { newValue in
                         guard let size = newValue else { return }

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -229,15 +229,15 @@ extension Ghostty {
             return String(cString: ptr)
         }
         
-        var macosTitlebarProxyIcon: Ghostty.MacOSTitlebarProxyIcon {
-            let defaultValue = Ghostty.MacOSTitlebarProxyIcon.visible
+        var macosTitlebarProxyIcon: MacOSTitlebarProxyIcon {
+            let defaultValue = MacOSTitlebarProxyIcon.visible
             guard let config = self.config else { return defaultValue }
             var v: UnsafePointer<Int8>? = nil
             let key = "macos-titlebar-proxy-icon"
             guard ghostty_config_get(config, &v, key, UInt(key.count)) else { return defaultValue }
             guard let ptr = v else { return defaultValue }
             let str = String(cString: ptr)
-            return Ghostty.MacOSTitlebarProxyIcon(rawValue: str) ?? defaultValue
+            return MacOSTitlebarProxyIcon(rawValue: str) ?? defaultValue
         }
 
         var macosWindowShadow: Bool {

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -228,6 +228,16 @@ extension Ghostty {
             guard let ptr = v else { return defaultValue }
             return String(cString: ptr)
         }
+        
+        var macosTitlebarProxyIcon: String {
+            let defaultValue = "visible"
+            guard let config = self.config else { return defaultValue }
+            var v: UnsafePointer<Int8>? = nil
+            let key = "macos-titlebar-proxy-icon"
+            guard ghostty_config_get(config, &v, key, UInt(key.count)) else { return defaultValue }
+            guard let ptr = v else { return defaultValue }
+            return String(cString: ptr)
+        }
 
         var macosWindowShadow: Bool {
             guard let config = self.config else { return false }

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -229,14 +229,15 @@ extension Ghostty {
             return String(cString: ptr)
         }
         
-        var macosTitlebarProxyIcon: String {
-            let defaultValue = "visible"
+        var macosTitlebarProxyIcon: Ghostty.MacOSTitlebarProxyIcon {
+            let defaultValue = Ghostty.MacOSTitlebarProxyIcon.visible
             guard let config = self.config else { return defaultValue }
             var v: UnsafePointer<Int8>? = nil
             let key = "macos-titlebar-proxy-icon"
             guard ghostty_config_get(config, &v, key, UInt(key.count)) else { return defaultValue }
             guard let ptr = v else { return defaultValue }
-            return String(cString: ptr)
+            let str = String(cString: ptr)
+            return Ghostty.MacOSTitlebarProxyIcon(rawValue: str) ?? defaultValue
         }
 
         var macosWindowShadow: Bool {

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -194,6 +194,13 @@ extension Ghostty {
             }
         }
     }
+    
+    /// Enum for the macos-titlebar-proxy-icon config option
+    enum MacOSTitlebarProxyIcon: String {
+        case visible
+        case hidden
+    }
+    
 }
 
 // MARK: Surface Notifications

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1444,9 +1444,20 @@ keybind: Keybinds = .{},
 /// Changing this option at runtime only applies to new windows.
 @"macos-titlebar-style": MacTitlebarStyle = .transparent,
 
-/// State of the proxy icon for the macOS titlebar.
-/// The "hidden" style hides the proxy icon.
-/// The default value is "visible".
+/// Whether the proxy icon in the macOS titlebar is visible. The proxy icon
+/// is the icon that represents the folder of the current working directory.
+/// You can see this very clearly in the macOS built-in Terminal.app
+/// titlebar.
+///
+/// The proxy icon is only visible with the native macOS titlebar style.
+///
+/// The default value is `visible`.
+///
+/// This setting can be changed at runtime and will affect all currently
+/// open windows but only after their working directory changes again.
+/// Therefore, to make this work after changing the setting, you must
+/// usually `cd` to a different directory, open a different file in an
+/// editor, etc.
 @"macos-titlebar-proxy-icon": MacTitlebarProxyIcon = .visible,
 
 /// If `true`, the *Option* key will be treated as *Alt*. This makes terminal

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1444,6 +1444,11 @@ keybind: Keybinds = .{},
 /// Changing this option at runtime only applies to new windows.
 @"macos-titlebar-style": MacTitlebarStyle = .transparent,
 
+/// State of the proxy icon for the macOS titlebar.
+/// The "hidden" style hides the proxy icon.
+/// The default value is "visible".
+@"macos-titlebar-proxy-icon": MacTitlebarProxyIcon = .visible,
+
 /// If `true`, the *Option* key will be treated as *Alt*. This makes terminal
 /// sequences expecting *Alt* to work properly, but will break Unicode input
 /// sequences on macOS if you use them via the *Alt* key. You may set this to
@@ -4427,6 +4432,12 @@ pub const MacTitlebarStyle = enum {
     native,
     transparent,
     tabs,
+    hidden,
+};
+
+/// See macos-titlebar-proxy-icon
+pub const MacTitlebarProxyIcon: type = enum {
+    visible,
     hidden,
 };
 


### PR DESCRIPTION
Added the configuration option to hide/show the macOS proxy icon. 

`macos-titlebar-proxy-icon = hidden` will hide the proxy icon, default value is visible. 