### PR TITLE
font/coretext: use CTFontCreateForString for final codepoint fallback

### DIFF
--- a/pkg/macos/text/font.zig
+++ b/pkg/macos/text/font.zig
@@ -160,6 +160,10 @@ pub const Font = opaque {
         return @ptrFromInt(@intFromPtr(c.CTFontCopyDisplayName(@ptrCast(self))));
     }
 
+    pub fn copyPostScriptName(self: *Font) *foundation.String {
+        return @ptrFromInt(@intFromPtr(c.CTFontCopyPostScriptName(@ptrCast(self))));
+    }
+
     pub fn getSymbolicTraits(self: *Font) text.FontSymbolicTraits {
         return @bitCast(c.CTFontGetSymbolicTraits(@ptrCast(self)));
     }


### PR DESCRIPTION
Fixes #2499

We rely on CoreText's font discovery to find the best font for a fallback by using the character set attribute. It appears that for some codepoints, the character set attribute is not enough to find a font that supports the codepoint.

In this case, we use CTFontCreateForString to find the font that CoreText would use. The one subtlety here is we need to ignore the last resort font, which just has replacement glyphs for all codepoints.

We already had a function to do this for CJK characters (#1637) thankfully so we can just reuse that!

This also fixes a bug where CTFontCreateForString range param expects the range length to be utf16 code units, not utf32.