### PR TITLE
Add an out of bounds check for mouse-selected themes in +list-themes

### DIFF
--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -515,7 +515,9 @@ const Preview = struct {
                 }
                 if (theme_list.hasMouse(mouse)) |_| {
                     if (mouse.button == .left and mouse.type == .release) {
-                        self.current = self.window + mouse.row;
+                        if (self.window + mouse.row < self.filtered.items.len) {
+                            self.current = self.window + mouse.row;
+                        }
                     }
                     highlight = mouse.row;
                 }

--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -515,8 +515,9 @@ const Preview = struct {
                 }
                 if (theme_list.hasMouse(mouse)) |_| {
                     if (mouse.button == .left and mouse.type == .release) {
-                        if (self.window + mouse.row < self.filtered.items.len) {
-                            self.current = self.window + mouse.row;
+                        const selection = self.window + mouse.row;
+                        if (selection < self.filtered.items.len) {
+                            self.current = selection;
                         }
                     }
                     highlight = mouse.row;


### PR DESCRIPTION
Currently, clicking on an empty row after searching for something in the themes list can cause a theme not present in the filtered list to be selected. Also, resizing the terminal window to a smaller size with the list scrolled to the end and then increasing its size again can lead to blank rows being displayed, which can cause a crash when clicked. I've added an out of bounds check for this.