### PR TITLE
Make sure a potential port component is considered during hostname validation for OSC 7 handling and shell integration

### DIFF
--- a/src/os/hostname.zig
+++ b/src/os/hostname.zig
@@ -1,22 +1,21 @@
 const std = @import("std");
 const posix = std.posix;
 
-const HostnameParsingError = error{
+pub const HostnameParsingError = error{
     NoHostnameInUri,
     NoSpaceLeft,
 };
 
-const LocalHostnameValidationError = error{
-    PermissionDenied,
-    Unexpected,
-};
-
-pub fn bufPrintHostnameFromFileUri(buf: []u8, uri: std.Uri) HostnameParsingError![]const u8 {
+/// Print the hostname from a file URI into a buffer.
+pub fn bufPrintHostnameFromFileUri(
+    buf: []u8,
+    uri: std.Uri,
+) HostnameParsingError![]const u8 {
     // Get the raw string of the URI. Its unclear to me if the various
     // tags of this enum guarantee no percent-encoding so we just
     // check all of it. This isn't a performance critical path.
-    const host_component = uri.host orelse return HostnameParsingError.NoHostnameInUri;
-    const host = switch (host_component) {
+    const host_component = uri.host orelse return error.NoHostnameInUri;
+    const host: []const u8 = switch (host_component) {
         .raw => |v| v,
         .percent_encoded => |v| v,
     };
@@ -31,42 +30,42 @@ pub fn bufPrintHostnameFromFileUri(buf: []u8, uri: std.Uri) HostnameParsingError
     // If that's not the case we just return the plain URI hostname directly.
     // NOTE: This implementation is not sufficient to verify a valid mac address, but
     //       it's probably sufficient for this specific purpose.
-    if (host.len != 14 or std.mem.count(u8, host, ":") != 4) {
-        return host;
-    }
+    if (host.len != 14 or std.mem.count(u8, host, ":") != 4) return host;
 
-    if (uri.port) |port| {
-        // If the port is not a 2-digit number we're not looking at a partial MAC-address,
-        // and instead just a regular port so we return the plain URI hostname.
-        if (port < 10 or port > 99) {
-            return host;
-        }
+    // If we don't have a port then we can return the hostname as-is because
+    // it's not a partial MAC-address.
+    const port = uri.port orelse return host;
 
-        var fbs = std.io.fixedBufferStream(buf);
-        std.fmt.format(fbs.writer().any(), "{s}:{d}", .{ host, port }) catch |err| switch (err) {
-            error.NoSpaceLeft => return HostnameParsingError.NoSpaceLeft,
-            else => unreachable,
-        };
+    // If the port is not a 2-digit number we're not looking at a partial
+    // MAC-address, and instead just a regular port so we return the plain
+    // URI hostname.
+    if (port < 10 or port > 99) return host;
 
-        return fbs.getWritten();
-    }
+    var fbs = std.io.fixedBufferStream(buf);
+    try std.fmt.format(
+        fbs.writer(),
+        "{s}:{d}",
+        .{ host, port },
+    );
 
-    return host;
+    return fbs.getWritten();
 }
 
+pub const LocalHostnameValidationError = error{
+    PermissionDenied,
+    Unexpected,
+};
+
+/// Checks if a hostname is local to the current machine. This matches
+/// both "localhost" and the current hostname of the machine (as returned
+/// by `gethostname`).
 pub fn isLocalHostname(hostname: []const u8) LocalHostnameValidationError!bool {
     // A 'localhost' hostname is always considered local.
-    if (std.mem.eql(u8, "localhost", hostname)) {
-        return true;
-    }
+    if (std.mem.eql(u8, "localhost", hostname)) return true;
 
     // If hostname is not "localhost" it must match our hostname.
     var buf: [posix.HOST_NAME_MAX]u8 = undefined;
-    const ourHostname = posix.gethostname(&buf) catch |err| switch (err) {
-        error.PermissionDenied => return LocalHostnameValidationError.PermissionDenied,
-        error.Unexpected => return LocalHostnameValidationError.Unexpected,
-    };
-
+    const ourHostname = try posix.gethostname(&buf);
     return std.mem.eql(u8, hostname, ourHostname);
 }
 
@@ -75,7 +74,6 @@ test "bufPrintHostnameFromFileUri succeeds with ascii hostname" {
 
     var buf: [posix.HOST_NAME_MAX]u8 = undefined;
     const actual = try bufPrintHostnameFromFileUri(&buf, uri);
-
     try std.testing.expectEqualStrings("localhost", actual);
 }
 
@@ -84,7 +82,6 @@ test "bufPrintHostnameFromFileUri succeeds with hostname as mac address" {
 
     var buf: [posix.HOST_NAME_MAX]u8 = undefined;
     const actual = try bufPrintHostnameFromFileUri(&buf, uri);
-
     try std.testing.expectEqualStrings("12:34:56:78:90:12", actual);
 }
 
@@ -94,7 +91,6 @@ test "bufPrintHostnameFromFileUri returns only hostname when there is a port com
 
     var four_port_buf: [posix.HOST_NAME_MAX]u8 = undefined;
     const four_port_actual = try bufPrintHostnameFromFileUri(&four_port_buf, four_port_uri);
-
     try std.testing.expectEqualStrings("has-a-port", four_port_actual);
 
     // Second: try with a 2-digit port to test mac-address handling.
@@ -102,7 +98,6 @@ test "bufPrintHostnameFromFileUri returns only hostname when there is a port com
 
     var two_port_buf: [posix.HOST_NAME_MAX]u8 = undefined;
     const two_port_actual = try bufPrintHostnameFromFileUri(&two_port_buf, two_port_uri);
-
     try std.testing.expectEqualStrings("has-a-port", two_port_actual);
 
     // Third: try with a mac-address that has a port-component added to it to test mac-address handling.
@@ -110,7 +105,6 @@ test "bufPrintHostnameFromFileUri returns only hostname when there is a port com
 
     var mac_with_port_buf: [posix.HOST_NAME_MAX]u8 = undefined;
     const mac_with_port_actual = try bufPrintHostnameFromFileUri(&mac_with_port_buf, mac_with_port_uri);
-
     try std.testing.expectEqualStrings("12:34:56:78:90:12", mac_with_port_actual);
 }
 
@@ -119,7 +113,6 @@ test "bufPrintHostnameFromFileUri returns NoHostnameInUri error when hostname is
 
     var buf: [posix.HOST_NAME_MAX]u8 = undefined;
     const actual = bufPrintHostnameFromFileUri(&buf, uri);
-
     try std.testing.expectError(HostnameParsingError.NoHostnameInUri, actual);
 }
 
@@ -128,7 +121,6 @@ test "bufPrintHostnameFromFileUri returns NoSpaceLeft error when provided buffer
 
     var buf: [5]u8 = undefined;
     const actual = bufPrintHostnameFromFileUri(&buf, uri);
-
     try std.testing.expectError(HostnameParsingError.NoSpaceLeft, actual);
 }
 
@@ -139,10 +131,12 @@ test "isLocalHostname returns true when provided hostname is localhost" {
 test "isLocalHostname returns true when hostname is local" {
     var buf: [posix.HOST_NAME_MAX]u8 = undefined;
     const localHostname = try posix.gethostname(&buf);
-
     try std.testing.expect(try isLocalHostname(localHostname));
 }
 
 test "isLocalHostname returns false when hostname is not local" {
-    try std.testing.expectEqual(false, try isLocalHostname("not-the-local-hostname"));
+    try std.testing.expectEqual(
+        false,
+        try isLocalHostname("not-the-local-hostname"),
+    );
 }

--- a/src/os/hostname.zig
+++ b/src/os/hostname.zig
@@ -42,3 +42,18 @@ pub fn isLocalHostname(hostname: []const u8) !bool {
 
     return std.mem.eql(u8, hostname, ourHostname);
 }
+
+test "isLocalHostname returns true when provided hostname is localhost" {
+    try std.testing.expect(try isLocalHostname("localhost"));
+}
+
+test "isLocalHostname returns true when hostname is local" {
+    var buf: [posix.HOST_NAME_MAX]u8 = undefined;
+    const localHostname = try posix.gethostname(&buf);
+
+    try std.testing.expect(try isLocalHostname(localHostname));
+}
+
+test "isLocalHostname returns false when hostname is not local" {
+    try std.testing.expectEqual(false, try isLocalHostname("not-the-local-hostname"));
+}

--- a/src/os/hostname.zig
+++ b/src/os/hostname.zig
@@ -1,0 +1,44 @@
+const std = @import("std");
+const posix = std.posix;
+
+pub fn bufPrintHostnameFromFileUri(buf: []u8, uri: std.Uri) ![]const u8 {
+    // Get the raw string of the URI. Its unclear to me if the various
+    // tags of this enum guarantee no percent-encoding so we just
+    // check all of it. This isn't a performance critical path.
+    const host_component = uri.host orelse return error.NoHostnameInUri;
+    const host = switch (host_component) {
+        .raw => |v| v,
+        .percent_encoded => |v| v,
+    };
+
+    // When the "Private Wi-Fi address" setting is toggled on macOS the hostname
+    // is set to a string of digits separated by a colon, e.g. '12:34:56:78:90:12'.
+    // The URI will be parsed as if the last set o digit is a port, so we need to
+    // make sure that part is included when it's set.
+    if (uri.port) |port| {
+        var fbs = std.io.fixedBufferStream(buf);
+        std.fmt.format(fbs.writer().any(), "{s}:{d}", .{ host, port }) catch |err| switch (err) {
+            error.NoSpaceLeft => return error.NoSpaceLeft,
+            else => unreachable,
+        };
+
+        return fbs.getWritten();
+    }
+
+    return host;
+}
+
+pub fn isLocalHostname(hostname: []const u8) !bool {
+    // A 'localhost' hostname is always considered local.
+    if (std.mem.eql(u8, "localhost", hostname)) {
+        return true;
+    }
+
+    // If hostname is not "localhost" it must match our hostname.
+    var buf: [posix.HOST_NAME_MAX]u8 = undefined;
+    const ourHostname = posix.gethostname(&buf) catch |err| {
+        return err;
+    };
+
+    return std.mem.eql(u8, hostname, ourHostname);
+}

--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -17,6 +17,7 @@ const resourcesdir = @import("resourcesdir.zig");
 // Namespaces
 pub const args = @import("args.zig");
 pub const cgroup = @import("cgroup.zig");
+pub const hostname = @import("hostname.zig");
 pub const passwd = @import("passwd.zig");
 pub const xdg = @import("xdg.zig");
 pub const windows = @import("windows.zig");
@@ -42,3 +43,7 @@ pub const clickInterval = mouse.clickInterval;
 pub const open = openpkg.open;
 pub const pipe = pipepkg.pipe;
 pub const resourcesDir = resourcesdir.resourcesDir;
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -43,7 +43,3 @@ pub const clickInterval = mouse.clickInterval;
 pub const open = openpkg.open;
 pub const pipe = pipepkg.pipe;
 pub const resourcesDir = resourcesdir.resourcesDir;
-
-test {
-    @import("std").testing.refAllDecls(@This());
-}

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1057,13 +1057,36 @@ pub const StreamHandler = struct {
             // Get the raw string of the URI. Its unclear to me if the various
             // tags of this enum guarantee no percent-encoding so we just
             // check all of it. This isn't a performance critical path.
-            const host = switch (host_component) {
-                .raw => |v| v,
-                .percent_encoded => |v| v,
+            const host = host: {
+                const h = switch (host_component) {
+                    .raw => |v| v,
+                    .percent_encoded => |v| v,
+                };
+                if (h.len == 0 or std.mem.eql(u8, "localhost", h)) {
+                    break :host_valid true;
+                }
+
+                // When the "Private Wi-Fi address" setting is toggled on macOS the hostname
+                // is set to a string of digits separated by a colon, e.g. '12:34:56:78:90:12'.
+                // The URI will be parsed as if the last set o digit is a port, so we need to
+                // make sure that part is included when it's set.
+                if (uri.port) |port| {
+                    // 65_535 is considered the highest port number on Linux.
+                    const PORT_NUMBER_MAX_DIGITS = 5;
+
+                    // Make sure there is space for a max length hostname + the max number of digits.
+                    var host_and_port_buf: [posix.HOST_NAME_MAX + PORT_NUMBER_MAX_DIGITS]u8 = undefined;
+
+                    const host_and_port = std.fmt.bufPrint(&host_and_port_buf, "{s}:{d}", .{ h, port }) catch |err| {
+                        log.warn("failed to get full hostname for OSC 7 validation: {}", .{err});
+                        break :host_valid false;
+                    };
+
+                    break :host host_and_port;
+                } else {
+                    break :host h;
+                }
             };
-            if (host.len == 0 or std.mem.eql(u8, "localhost", host)) {
-                break :host_valid true;
-            }
 
             // Otherwise, it must match our hostname.
             var buf: [posix.HOST_NAME_MAX]u8 = undefined;

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1030,6 +1030,48 @@ pub const StreamHandler = struct {
         self.terminal.markSemanticPrompt(.command);
     }
 
+    pub fn bufPrintHostnameFromFileUri(buf: []u8, uri: std.Uri) ![]const u8 {
+        // Get the raw string of the URI. Its unclear to me if the various
+        // tags of this enum guarantee no percent-encoding so we just
+        // check all of it. This isn't a performance critical path.
+        const host_component = uri.host orelse return error.NoHostnameInUri;
+        const host = switch (host_component) {
+            .raw => |v| v,
+            .percent_encoded => |v| v,
+        };
+
+        // When the "Private Wi-Fi address" setting is toggled on macOS the hostname
+        // is set to a string of digits separated by a colon, e.g. '12:34:56:78:90:12'.
+        // The URI will be parsed as if the last set o digit is a port, so we need to
+        // make sure that part is included when it's set.
+        if (uri.port) |port| {
+            var fbs = std.io.fixedBufferStream(buf);
+            std.fmt.format(fbs.writer().any(), "{s}:{d}", .{ host, port }) catch |err| switch (err) {
+                error.NoSpaceLeft => return error.NoSpaceLeft,
+                else => unreachable,
+            };
+
+            return fbs.getWritten();
+        }
+
+        return host;
+    }
+
+    pub fn isLocalHostname(hostname: []const u8) !bool {
+        // A 'localhost' hostname is always considered local.
+        if (std.mem.eql(u8, "localhost", hostname)) {
+            return true;
+        }
+
+        // If hostname is not "localhost" it must match our hostname.
+        var buf: [posix.HOST_NAME_MAX]u8 = undefined;
+        const ourHostname = posix.gethostname(&buf) catch |err| {
+            return err;
+        };
+
+        return std.mem.eql(u8, hostname, ourHostname);
+    }
+
     pub fn reportPwd(self: *StreamHandler, url: []const u8) !void {
         if (builtin.os.tag == .windows) {
             log.warn("reportPwd unimplemented on windows", .{});
@@ -1048,57 +1090,34 @@ pub const StreamHandler = struct {
             return;
         }
 
+        // RFC 793 defines port numbers as 16-bit numbers. 5 digits is sufficient to represent
+        // the maximum since 2^16 - 1 = 65_535.
+        // See https://www.rfc-editor.org/rfc/rfc793#section-3.1.
+        const PORT_NUMBER_MAX_DIGITS = 5;
+        // Make sure there is space for a max length hostname + the max number of digits.
+        var host_and_port_buf: [posix.HOST_NAME_MAX + PORT_NUMBER_MAX_DIGITS]u8 = undefined;
+
+        const hostname = bufPrintHostnameFromFileUri(&host_and_port_buf, uri) catch |err| switch (err) {
+            error.NoHostnameInUri => {
+                log.warn("OSC 7 uri must contain a hostname: {}", .{err});
+                return;
+            },
+            error.NoSpaceLeft => |e| {
+                log.warn("failed to get full hostname for OSC 7 validation: {}", .{e});
+                return;
+            },
+        };
+
         // OSC 7 is a little sketchy because anyone can send any value from
         // any host (such an SSH session). The best practice terminals follow
         // is to valid the hostname to be local.
-        const host_valid = host_valid: {
-            const host_component = uri.host orelse break :host_valid false;
-
-            // Get the raw string of the URI. Its unclear to me if the various
-            // tags of this enum guarantee no percent-encoding so we just
-            // check all of it. This isn't a performance critical path.
-            const host = host: {
-                const h = switch (host_component) {
-                    .raw => |v| v,
-                    .percent_encoded => |v| v,
-                };
-                if (h.len == 0 or std.mem.eql(u8, "localhost", h)) {
-                    break :host_valid true;
-                }
-
-                // When the "Private Wi-Fi address" setting is toggled on macOS the hostname
-                // is set to a string of digits separated by a colon, e.g. '12:34:56:78:90:12'.
-                // The URI will be parsed as if the last set o digit is a port, so we need to
-                // make sure that part is included when it's set.
-                if (uri.port) |port| {
-                    // RFC 793 defines port numbers as 16-bit numbers. 5 digits is sufficient to represent
-                    // the maximum since 2^16 - 1 = 65_535.
-                    // See https://www.rfc-editor.org/rfc/rfc793#section-3.1.
-                    const PORT_NUMBER_MAX_DIGITS = 5;
-
-                    // Make sure there is space for a max length hostname + the max number of digits.
-                    var host_and_port_buf: [posix.HOST_NAME_MAX + PORT_NUMBER_MAX_DIGITS]u8 = undefined;
-
-                    const host_and_port = std.fmt.bufPrint(&host_and_port_buf, "{s}:{d}", .{ h, port }) catch |err| {
-                        log.warn("failed to get full hostname for OSC 7 validation: {}", .{err});
-                        break :host_valid false;
-                    };
-
-                    break :host host_and_port;
-                } else {
-                    break :host h;
-                }
-            };
-
-            // Otherwise, it must match our hostname.
-            var buf: [posix.HOST_NAME_MAX]u8 = undefined;
-            const hostname = posix.gethostname(&buf) catch |err| {
+        const host_valid = isLocalHostname(hostname) catch |err| switch (err) {
+            error.PermissionDenied, error.Unexpected => {
                 log.warn("failed to get hostname for OSC 7 validation: {}", .{err});
-                break :host_valid false;
-            };
-
-            break :host_valid std.mem.eql(u8, host, hostname);
+                return;
+            },
         };
+
         if (!host_valid) {
             log.warn("OSC 7 host must be local", .{});
             return;

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1071,7 +1071,9 @@ pub const StreamHandler = struct {
                 // The URI will be parsed as if the last set o digit is a port, so we need to
                 // make sure that part is included when it's set.
                 if (uri.port) |port| {
-                    // 65_535 is considered the highest port number on Linux.
+                    // RFC 793 defines port numbers as 16-bit numbers. 5 digits is sufficient to represent
+                    // the maximum since 2^16 - 1 = 65_535.
+                    // See https://www.rfc-editor.org/rfc/rfc793#section-3.1.
                     const PORT_NUMBER_MAX_DIGITS = 5;
 
                     // Make sure there is space for a max length hostname + the max number of digits.

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -5,6 +5,7 @@ const xev = @import("xev");
 const apprt = @import("../apprt.zig");
 const build_config = @import("../build_config.zig");
 const configpkg = @import("../config.zig");
+const hostname = @import("../os/hostname.zig");
 const renderer = @import("../renderer.zig");
 const termio = @import("../termio.zig");
 const terminal = @import("../terminal/main.zig");
@@ -1030,48 +1031,6 @@ pub const StreamHandler = struct {
         self.terminal.markSemanticPrompt(.command);
     }
 
-    pub fn bufPrintHostnameFromFileUri(buf: []u8, uri: std.Uri) ![]const u8 {
-        // Get the raw string of the URI. Its unclear to me if the various
-        // tags of this enum guarantee no percent-encoding so we just
-        // check all of it. This isn't a performance critical path.
-        const host_component = uri.host orelse return error.NoHostnameInUri;
-        const host = switch (host_component) {
-            .raw => |v| v,
-            .percent_encoded => |v| v,
-        };
-
-        // When the "Private Wi-Fi address" setting is toggled on macOS the hostname
-        // is set to a string of digits separated by a colon, e.g. '12:34:56:78:90:12'.
-        // The URI will be parsed as if the last set o digit is a port, so we need to
-        // make sure that part is included when it's set.
-        if (uri.port) |port| {
-            var fbs = std.io.fixedBufferStream(buf);
-            std.fmt.format(fbs.writer().any(), "{s}:{d}", .{ host, port }) catch |err| switch (err) {
-                error.NoSpaceLeft => return error.NoSpaceLeft,
-                else => unreachable,
-            };
-
-            return fbs.getWritten();
-        }
-
-        return host;
-    }
-
-    pub fn isLocalHostname(hostname: []const u8) !bool {
-        // A 'localhost' hostname is always considered local.
-        if (std.mem.eql(u8, "localhost", hostname)) {
-            return true;
-        }
-
-        // If hostname is not "localhost" it must match our hostname.
-        var buf: [posix.HOST_NAME_MAX]u8 = undefined;
-        const ourHostname = posix.gethostname(&buf) catch |err| {
-            return err;
-        };
-
-        return std.mem.eql(u8, hostname, ourHostname);
-    }
-
     pub fn reportPwd(self: *StreamHandler, url: []const u8) !void {
         if (builtin.os.tag == .windows) {
             log.warn("reportPwd unimplemented on windows", .{});
@@ -1097,7 +1056,7 @@ pub const StreamHandler = struct {
         // Make sure there is space for a max length hostname + the max number of digits.
         var host_and_port_buf: [posix.HOST_NAME_MAX + PORT_NUMBER_MAX_DIGITS]u8 = undefined;
 
-        const hostname = bufPrintHostnameFromFileUri(&host_and_port_buf, uri) catch |err| switch (err) {
+        const hostname_from_uri = hostname.bufPrintHostnameFromFileUri(&host_and_port_buf, uri) catch |err| switch (err) {
             error.NoHostnameInUri => {
                 log.warn("OSC 7 uri must contain a hostname: {}", .{err});
                 return;
@@ -1111,7 +1070,7 @@ pub const StreamHandler = struct {
         // OSC 7 is a little sketchy because anyone can send any value from
         // any host (such an SSH session). The best practice terminals follow
         // is to valid the hostname to be local.
-        const host_valid = isLocalHostname(hostname) catch |err| switch (err) {
+        const host_valid = hostname.isLocalHostname(hostname_from_uri) catch |err| switch (err) {
             error.PermissionDenied, error.Unexpected => {
                 log.warn("failed to get hostname for OSC 7 validation: {}", .{err});
                 return;


### PR DESCRIPTION
## Description

Fixes https://github.com/ghostty-org/ghostty/issues/2484

The reason shell integration would break when macOS users enable the Private Wi-Fi Address is because the hostname is changed to something like `12:34:56:78:90:12`. The hostname passed via OSC 7 is assumed to be a URI, and the URI parser in the Zig standard library (correctly, I think) assumes the last portion before the URI path preceded by a colon (`:`) is a port.

This set of changes makes sure the port is included when comparing the hostname passed in via OSC 7 control sequences to what we get from `posix.gethostname`.

## Testing instructions

1. On your Mac, open Wi-Fi settings &rarr; click the meatball menu for the currently connected network &rarr; click "Network settings…" &rarr; Enable "Private Wi-Fi address". I've set mine to "Rotating", but I don't think that matters so long as it's on.
2. Checkout `trunk` and build the full Mac app by running `zig build && cd mac && xcodebuild && cd ..`
    * **Note:** you **MUST** use the full mac build, the issue doesn't occur with the GLFW runtime.
3. Run the built app `open mac/build/ReleaseLocal/Ghostty.app`.
4. `cd` to any directory that's not the default directory.
5. Open a new tab or split, and notice that the new tab or split is opened in the default directory used when you open a new terminal instead of your current working directory (CWD).
6. Checkout this branch, repeat steps (1)-(5), but make sure the CWD is preserved in step (5).
