### PR TITLE
Fix linking freetype and glslang

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -975,7 +975,7 @@ fn addDeps(
 
         if (b.systemIntegrationOption("freetype", .{})) {
             step.linkSystemLibrary2("bzip2", dynamic_link_opts);
-            step.linkSystemLibrary2("freetype", dynamic_link_opts);
+            step.linkSystemLibrary2("freetype2", dynamic_link_opts);
         } else {
             step.linkLibrary(freetype_dep.artifact("freetype"));
             try static_libs.append(freetype_dep.artifact("freetype").getEmittedBin());
@@ -1068,6 +1068,7 @@ fn addDeps(
     step.root_module.addImport("glslang", glslang_dep.module("glslang"));
     if (b.systemIntegrationOption("glslang", .{})) {
         step.linkSystemLibrary2("glslang", dynamic_link_opts);
+        step.linkSystemLibrary2("glslang-default-resource-limits", dynamic_link_opts);
     } else {
         step.linkLibrary(glslang_dep.artifact("glslang"));
         try static_libs.append(glslang_dep.artifact("glslang").getEmittedBin());

--- a/pkg/cimgui/build.zig
+++ b/pkg/cimgui/build.zig
@@ -32,7 +32,7 @@ pub fn build(b: *std.Build) !void {
     };
 
     if (b.systemIntegrationOption("freetype", .{})) {
-        lib.linkSystemLibrary2("freetype", dynamic_link_opts);
+        lib.linkSystemLibrary2("freetype2", dynamic_link_opts);
     } else {
         const freetype = b.dependency("freetype", .{
             .target = target,

--- a/pkg/harfbuzz/build.zig
+++ b/pkg/harfbuzz/build.zig
@@ -76,7 +76,8 @@ pub fn build(b: *std.Build) !void {
         });
 
         if (b.systemIntegrationOption("freetype", .{})) {
-            lib.linkSystemLibrary2("freetype", dynamic_link_opts);
+            lib.linkSystemLibrary2("freetype2", dynamic_link_opts);
+            module.linkSystemLibrary("freetype2", dynamic_link_opts);
         } else {
             lib.linkLibrary(freetype.artifact("freetype"));
             module.addIncludePath(freetype.builder.dependency("freetype", .{}).path("include"));


### PR DESCRIPTION
This pull request intends to fix two issues with linking `freetype` and `glslang` libraries, as some distributions (e.g.: Arch Linux, Chimera Linux):
 - don't provide `freetype.pc` definitions, requiring `freetype2` to be used instead,
 - don't provide any pkg-config definitions for `glslang`, requiring `glslang-default-resource-limits` to be added manually
 