### PR TITLE
optionally hide mouse when using arrow keys or typing

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1565,13 +1565,17 @@ pub fn keyCallback(
         if (self.io.terminal.modes.get(.disable_keyboard)) return .consumed;
     }
 
-    // If this input event has text, then we hide the mouse if configured.
+    // If this input event has text or is an arrow key, then we hide the mouse if configured.
     // We only do this on pressed events to avoid hiding the mouse when we
     // change focus due to a keybinding (i.e. switching tabs).
     if (self.config.mouse_hide_while_typing and
         event.action == .press and
         !self.mouse.hidden and
-        event.utf8.len > 0)
+        (event.utf8.len > 0 or
+        event.key == input.Key.up or
+        event.key == input.Key.down or
+        event.key == input.Key.left or
+        event.key == input.Key.right))
     {
         self.hideMouse();
     }


### PR DESCRIPTION
In addition to optionally hide the mouse when typing text, this also hides the mouse when using the arrow keys if the ghostty config contains `mouse-hide-while-typing = true`.

See #2531 and let me know if you think this is a bad idea or would like to have an extra config option for this behavior.