### PR TITLE
extend mouse-hide-while-typing to also hide the mouse when using keys such as arrow keys or backspace (non-modifier keys)

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1565,13 +1565,13 @@ pub fn keyCallback(
         if (self.io.terminal.modes.get(.disable_keyboard)) return .consumed;
     }
 
-    // If this input event has text, then we hide the mouse if configured.
+    // If this input event sends data to pty, we hide the mouse if configured.
     // We only do this on pressed events to avoid hiding the mouse when we
     // change focus due to a keybinding (i.e. switching tabs).
     if (self.config.mouse_hide_while_typing and
         event.action == .press and
         !self.mouse.hidden and
-        event.utf8.len > 0)
+        !event.key.modifier())
     {
         self.hideMouse();
     }


### PR DESCRIPTION
See discussion #2538

expand the `mouse-hide-while-typing = true` effect by also hiding the mouse whenever a non-modifier key is pressed instead of checking for utf-8 value of a keypress this should also capture other data sent to pty such as pressing arrow keys or backspace.