### PR TITLE
macos: rectangle select only requires option + drag

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -146,7 +146,7 @@ class BaseTerminalController: NSWindowController,
     }
 
     // MARK: Notifications
-
+    
     @objc private func didChangeScreenParametersNotification(_ notification: Notification) {
         // If we have a window that is visible and it is outside the bounds of the
         // screen then we clamp it back to within the screen.

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3468,7 +3468,7 @@ fn dragLeftClickSingle(
         try self.setSelection(if (selected) terminal.Selection.init(
             drag_pin,
             drag_pin,
-            self.mouse.mods.ctrlOrSuper() and self.mouse.mods.alt,
+            SurfaceMouse.isRectangleSelectState(self.mouse.mods),
         ) else null);
 
         return;
@@ -3503,7 +3503,7 @@ fn dragLeftClickSingle(
         try self.setSelection(terminal.Selection.init(
             start,
             drag_pin,
-            self.mouse.mods.ctrlOrSuper() and self.mouse.mods.alt,
+            SurfaceMouse.isRectangleSelectState(self.mouse.mods),
         ));
         return;
     }

--- a/src/surface_mouse.zig
+++ b/src/surface_mouse.zig
@@ -113,12 +113,17 @@ fn eligibleMouseShapeKeyEvent(physical_key: input.Key) bool {
         physical_key.leftOrRightAlt();
 }
 
-fn isRectangleSelectState(mods: input.Mods) bool {
-    return mods.ctrlOrSuper() and mods.alt;
-}
-
 fn isMouseModeOverrideState(mods: input.Mods) bool {
     return mods.shift;
+}
+
+/// Returns true if our modifiers put us in a state where dragging
+/// should cause a rectangle select.
+pub fn isRectangleSelectState(mods: input.Mods) bool {
+    return if (comptime builtin.target.isDarwin())
+        mods.alt
+    else
+        mods.ctrlOrSuper() and mods.alt;
 }
 
 test "keyToMouseShape" {


### PR DESCRIPTION
Fixes #2537

This matches Terminal.app. iTerm2 requires cmd+option (our old behavior). Kitty doesn't seem to support rectangle select or I couldn't figure out how to make it work. WezTerm matches Terminal.app too. Outside of terminal emulators, this is also the rectangular select binding for neovim.