### PR TITLE
gtk: use correct function to destroy window

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -92,13 +92,9 @@ pub fn init(self: *Window, app: *App) !void {
             break :window window;
         }
     };
+    errdefer c.gtk_window_destroy(@ptrCast(window));
 
     const gtk_window: *c.GtkWindow = @ptrCast(window);
-    errdefer if (self.isAdwWindow()) {
-        c.adw_application_window_destroy(window);
-    } else {
-        c.gtk_application_window_destroy(gtk_window);
-    };
     self.window = gtk_window;
     c.gtk_window_set_title(gtk_window, "Ghostty");
     c.gtk_window_set_default_size(gtk_window, 1000, 600);


### PR DESCRIPTION
adw_application_window_destroy and gtk_application_window_destroy do not exist. I believe that this didn't trigger a compile error because the errdefer got compiled out because there are no potential error returns after this code in the function.