### PR TITLE
apprt/adw: reapply headerbar colors in toolbarview

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -929,6 +929,13 @@ fn loadRuntimeCss(
                 \\  --headerbar-bg-color: rgb({d},{d},{d});
                 \\  --headerbar-backdrop-color: oklab(from var(--headerbar-bg-color) calc(l * 0.9) a b / alpha);
                 \\}}
+                \\windowhandle {{
+                \\  background-color: var(--headerbar-bg-color);
+                \\  color: var(--headerbar-fg-color);
+                \\}}
+                \\windowhandle:backdrop {{
+                \\ background-color: var(--headerbar-backdrop-color);
+                \\}}
             , .{
                 headerbar_foreground.r,
                 headerbar_foreground.g,


### PR DESCRIPTION
Fixes a regression in ca42b4ca1c7a9319b7fbc17cabab0cbb4120f0fb that caused the headerbar to no longer use the same color as the ghostty-theme.


| Before                                                                                                                 	| After                                                                                                                  	|
|------------------------------------------------------------------------------------------------------------------------	|------------------------------------------------------------------------------------------------------------------------	|
| ![Ghostty window with dark headerbar](https://github.com/user-attachments/assets/9b082d15-7282-4cc1-ba8a-5b49bbf93094) 	| ![Ghostty window with blue headerbar](https://github.com/user-attachments/assets/1cd04b18-7d38-4085-9597-0ca153e00168) 	|
