### PR TITLE
Use syntax highlighting for the config in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ placed at `$XDG_CONFIG_HOME/ghostty/config`, which defaults to
 
 The file format is documented below as an example:
 
-```
+```ini
 # The syntax is "key = value". The whitespace around the equals doesn't matter.
 background = 282c34
 foreground= ffffff

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The file format is documented below as an example:
 ```ini
 # The syntax is "key = value". The whitespace around the equals doesn't matter.
 background = 282c34
-foreground= ffffff
+foreground = ffffff
 
 # Comments start with a `#` and are only valid on their own line.
 # Blank lines are ignored!


### PR DESCRIPTION
Hey, just realized `ghostty` uses a config format similar to ini so I thought it would be nice to apply syntax hightlighting.

Also, fixed a small spacing issue :)