### PR TITLE
renderer/metal: prefer low‐power GPUs

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -207,6 +207,7 @@ pub const GPUState = struct {
         for (&self.frames) |*frame| frame.deinit();
         self.instance.deinit();
         self.queue.release();
+        self.device.release();
     }
 
     /// Get the next frame state to draw to. This will wait on the

--- a/src/renderer/metal/api.zig
+++ b/src/renderer/metal/api.zig
@@ -175,4 +175,4 @@ pub const MTLSize = extern struct {
     depth: c_ulong,
 };
 
-pub extern "c" fn MTLCreateSystemDefaultDevice() ?*anyopaque;
+pub extern "c" fn MTLCopyAllDevices() ?*anyopaque;


### PR DESCRIPTION
Some Intel MacBook Pro laptops have both an integrated and discrete GPU and support automatically switching between them. The system uses the integrated GPU by default, but the default Metal device on those systems is the discrete GPU. This means that Metal‐using applications activate it by default, presumably as the intended audience is high‐performance graphics applications.

This is unfortunate for productivity applications like terminals, however, as the discrete GPU decreases battery life and worsens the thermal throttling problems these machines have always had. Prefer to use an integrated GPU when present and not using an external GPU.

The behaviour should be unchanged on Apple Silicon, as the platform only supports one GPU. I have confirmed that the resulting app runs, works, and doesn’t activate the AMD GPU on my MacBook Pro, but have not done any measurements of the resulting performance impact. If it is considered sufficiently noticeable, a GPU preference setting could be added.

See <https://github.com/zed-industries/zed/issues/5124>, <https://github.com/zed-industries/zed/pull/13685>, <https://github.com/zed-industries/zed/pull/14738>, and <https://github.com/zed-industries/zed/pull/14744> for discussion, measurements, and changes relating to this issue in the Zed project. The logic implemented here reflects what Zed ended up settling on.

The [Metal documentation] recommends using `MTLCopyAllDevicesWithObserver` to receive notifications of when the list of available GPUs changes, such as when external GPUs are connected or disconnected. I didn’t bother implementing that because it seemed like a lot of fussy work to deal with migrating everything to a new GPU on the fly just for a niche use case on a legacy platform. Zed doesn’t implement it and I haven’t heard about anyone complaining that their computer caught fire when they unplugged an external GPU, so hopefully it’s fine.

[Metal documentation]: https://developer.apple.com/documentation/metal/gpu_devices_and_work_submission/multi-gpu_systems/finding_multiple_gpus_on_an_intel-based_mac

Closes: #2572

---

This depends on https://github.com/mitchellh/zig-objc/pull/10, and will need updating to include the new dependency version before merging; unfortunately I don’t seem to have permissions to open a draft PR. I could have done the iteration in a simpler way with more overhead here, as it’s hardly a bottleneck of any kind, but it was a fun learning exercise to implement `NSFastEnumeration`‐based iteration, and hopefully it will be generally useful for Objective‐C bridging 😅

As with that PR, this is my first Zig code ever and I’m more than happy to hear any feedback about the code style.

I hereby agree to make these contributions available under any of the [`MIT`](https://spdx.org/licenses/MIT.html), [`MIT-Modern-Variant`](https://spdx.org/licenses/MIT-Modern-Variant.html), or [`X11`](https://spdx.org/licenses/X11.html) licences, at your option.