### PR TITLE
update zig-objc

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1227,14 +1227,7 @@ fn addDeps(
             .optimize = optimize,
         });
 
-        // This is a bit of a hack that should probably be fixed upstream
-        // in zig-objc, but we need to add the apple SDK paths to the
-        // zig-objc module so that it can find the objc runtime headers.
-        const module = objc_dep.module("objc");
-        module.resolved_target = step.root_module.resolved_target;
-        try @import("apple_sdk").addPaths(b, module);
-        step.root_module.addImport("objc", module);
-
+        step.root_module.addImport("objc", objc_dep.module("objc"));
         step.root_module.addImport("macos", macos_dep.module("macos"));
         step.linkLibrary(macos_dep.artifact("macos"));
         try static_libs.append(macos_dep.artifact("macos").getEmittedBin());

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -14,8 +14,8 @@
             .lazy = true,
         },
         .zig_objc = .{
-            .url = "https://github.com/mitchellh/zig-objc/archive/fe5ac419530cf800294369d996133fe9cd067aec.tar.gz",
-            .hash = "122034b3e15d582d8d101a7713e5f13c872b8b8eb6d9cb47515b8e34ee75e122630d",
+            .url = "https://github.com/mitchellh/zig-objc/archive/7e1acc8a45227fcdf0163cc1d9360a4f8b70e33e.tar.gz",
+            .hash = "122060402a6931a32ee40538291fd87d3eee7b43739c7ac63573f4f5b8deea7ce214",
         },
         .zig_js = .{
             .url = "https://github.com/mitchellh/zig-js/archive/d0b8b0a57c52fbc89f9d9fecba75ca29da7dd7d1.tar.gz",

--- a/nix/zigCacheHash.nix
+++ b/nix/zigCacheHash.nix
@@ -1,3 +1,3 @@
 # This file is auto-generated! check build-support/check-zig-cache-hash.sh for
 # more details.
-"sha256-5LBZAExb4PJefW+M0Eo+TcoszhBdIFTGBOv6lte5L0Q="
+"sha256-SmBLDC1DqAcccoWoHyBsHKVqNr3sBYW1b+YwAXhFZyY="


### PR DESCRIPTION
This fixes a hack we had around apple paths since we do this now upstream in zig-objc. This also adds in support for NSFastEnumeration needed for #2586