### PR TITLE
ECMA 48 is de jure: as stated by law

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,9 +375,9 @@ test cases.
 
 We believe Ghostty is one of the most compliant terminal emulators available.
 
-Terminal behavior is partially a dejour standard
+Terminal behavior is partially a de jure standard
 (i.e. [ECMA-48](https://ecma-international.org/publications-and-standards/standards/ecma-48/))
-but mostly a defacto standard as defined by popular terminal emulators
+but mostly a de facto standard as defined by popular terminal emulators
 worldwide. Ghostty takes the approach that our behavior is defined by
 (1) standards, if available, (2) xterm, if the feature exists, (3)
 other popular terminals, in that order. This defines what the Ghostty project


### PR DESCRIPTION
I am actually not sure if this was meant as a sly pun. It definitely works that way, terminals are _de jour_ meaning _of the day_, but the contrastive with _de facto_  makes me lean toward typo / malaprop. 

The thing is it's a good pun, and I almost let it be for that reason. But I lean towards unintended, so here's a patch, feel free to close it if I read it wrong, er, right? Y'know.