### PR TITLE
coretext: set variations on deferred face load

### DIFF
--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -79,7 +79,7 @@ pub const Descriptor = struct {
 
             // This is not correct, but we don't currently depend on the
             // hash value being different based on decimal values of variations.
-            autoHash(hasher, @as(u64, @intFromFloat(variation.value)));
+            autoHash(hasher, @as(i64, @intFromFloat(variation.value)));
         }
     }
 
@@ -384,6 +384,7 @@ pub const CoreText = struct {
         return DiscoverIterator{
             .alloc = alloc,
             .list = zig_list,
+            .variations = desc.variations,
             .i = 0,
         };
     }
@@ -420,6 +421,7 @@ pub const CoreText = struct {
             return DiscoverIterator{
                 .alloc = alloc,
                 .list = list,
+                .variations = desc.variations,
                 .i = 0,
             };
         }
@@ -443,6 +445,7 @@ pub const CoreText = struct {
             return DiscoverIterator{
                 .alloc = alloc,
                 .list = list,
+                .variations = desc.variations,
                 .i = 0,
             };
         }
@@ -721,6 +724,7 @@ pub const CoreText = struct {
     pub const DiscoverIterator = struct {
         alloc: Allocator,
         list: []const *macos.text.FontDescriptor,
+        variations: []const Variation,
         i: usize,
 
         pub fn deinit(self: *DiscoverIterator) void {
@@ -756,7 +760,10 @@ pub const CoreText = struct {
             defer self.i += 1;
 
             return DeferredFace{
-                .ct = .{ .font = font },
+                .ct = .{
+                    .font = font,
+                    .variations = self.variations,
+                },
             };
         }
     };

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -229,6 +229,9 @@ pub const Face = struct {
         vs: []const font.face.Variation,
         opts: font.face.Options,
     ) !void {
+        // If we have no variations, we don't need to do anything.
+        if (vs.len == 0) return;
+
         // Create a new font descriptor with all the variations set.
         var desc = self.font.copyDescriptor();
         defer desc.release();


### PR DESCRIPTION
This commit makes CoreText behave a lot like FreeType where we set the variation axes on the deferred face load. This fixes a bug where the `slnt` variation axis could not be set with CoreText with the Monaspace Argon Variable font.

This was a bug found in Discord. Specifically, with the Monaspace Argon Variable font, the `slnt` variation axis could not be set with CoreText. I'm not sure _exactly_ what causes this but I suspect it has to do with the `slnt` axis being a negative value. I'm not sure if this is a bug with CoreText or not.

What was happening was that with CoreText, we set the variation axes during discovery and expect them to be preserved in the resulting discovered faces. That seems to be true with the `wght` axis but not the `slnt` axis for whatever reason.