### PR TITLE
config: add "initial-command" config, "-e" sets that

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -66,6 +66,11 @@ font_grid_set: font.SharedGridSet,
 last_notification_time: ?std.time.Instant = null,
 last_notification_digest: u64 = 0,
 
+/// Set to false once we've created at least one surface. This
+/// never goes true again. This can be used by surfaces to determine
+/// if they are the first surface.
+first: bool = true,
+
 pub const CreateError = Allocator.Error || font.SharedGridSet.InitError;
 
 /// Initialize the main app instance. This creates the main window, sets

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -474,13 +474,19 @@ pub fn init(
         .config = derived_config,
     };
 
+    // The command we're going to execute
+    const command: ?[]const u8 = if (app.first)
+        config.@"initial-command" orelse config.command
+    else
+        config.command;
+
     // Start our IO implementation
     // This separate block ({}) is important because our errdefers must
     // be scoped here to be valid.
     {
         // Initialize our IO backend
         var io_exec = try termio.Exec.init(alloc, .{
-            .command = config.command,
+            .command = command,
             .shell_integration = config.@"shell-integration",
             .shell_integration_features = config.@"shell-integration-features",
             .working_directory = config.@"working-directory",
@@ -618,9 +624,9 @@ pub fn init(
         // For xdg-terminal-exec execution we special-case and set the window
         // title to the command being executed. This allows window managers
         // to set custom styling based on the command being executed.
-        const command = config.command orelse break :xdg;
-        if (command.len > 0) {
-            const title = alloc.dupeZ(u8, command) catch |err| {
+        const v = command orelse break :xdg;
+        if (v.len > 0) {
+            const title = alloc.dupeZ(u8, v) catch |err| {
                 log.warn(
                     "error copying command for title, title will not be set err={}",
                     .{err},
@@ -635,6 +641,9 @@ pub fn init(
             );
         }
     }
+
+    // We are no longer the first surface
+    app.first = false;
 }
 
 pub fn deinit(self: *Surface) void {


### PR DESCRIPTION
Fixes #2601

It is more expected behavior that `-e` affects only the first window. By introducing a dedicated configuration we avoid making `-e` too magical: its simply syntax sugar for setting the "initial-command" configuration.