### PR TITLE
gtk: implement toggle_split_zoom

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -471,12 +471,12 @@ pub fn performAction(
         .mouse_shape => try self.setMouseShape(target, value),
         .mouse_over_link => self.setMouseOverLink(target, value),
         .toggle_tab_overview => self.toggleTabOverview(target),
+        .toggle_split_zoom => self.toggleSplitZoom(target),
         .toggle_window_decorations => self.toggleWindowDecorations(target),
         .quit_timer => self.quitTimer(value),
 
         // Unimplemented
         .close_all_windows,
-        .toggle_split_zoom,
         .toggle_quick_terminal,
         .toggle_visibility,
         .size_limit,
@@ -668,6 +668,13 @@ fn toggleTabOverview(_: *App, target: apprt.Target) void {
 
             window.toggleTabOverview();
         },
+    }
+}
+
+fn toggleSplitZoom(_: *App, target: apprt.Target) void {
+    switch (target) {
+        .app => {},
+        .surface => |surface| surface.rt_surface.toggleSplitZoom(),
     }
 }
 

--- a/src/apprt/gtk/Split.zig
+++ b/src/apprt/gtk/Split.zig
@@ -77,6 +77,7 @@ pub fn init(
     });
     errdefer surface.destroy(alloc);
     sibling.dimSurface();
+    sibling.setSplitZoom(false);
 
     // Create the actual GTKPaned, attach the proper children.
     const orientation: c_uint = switch (direction) {
@@ -258,7 +259,7 @@ pub fn grabFocus(self: *Split) void {
 /// Update the paned children to represent the current state.
 /// This should be called anytime the top/left or bottom/right
 /// element is changed.
-fn updateChildren(self: *const Split) void {
+pub fn updateChildren(self: *const Split) void {
     // We have to set both to null. If we overwrite the pane with
     // the same value, then GTK bugs out (the GL area unrealizes
     // and never rerealizes).
@@ -372,7 +373,15 @@ fn directionNext(self: *const Split, from: Side) ?struct {
     }
 }
 
+pub fn detachTopLeft(self: *const Split) void {
+    c.gtk_paned_set_start_child(self.paned, null);
+}
+
+pub fn detachBottomRight(self: *const Split) void {
+    c.gtk_paned_set_end_child(self.paned, null);
+}
+
 fn removeChildren(self: *const Split) void {
-    c.gtk_paned_set_start_child(@ptrCast(self.paned), null);
-    c.gtk_paned_set_end_child(@ptrCast(self.paned), null);
+    self.detachTopLeft();
+    self.detachBottomRight();
 }

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -317,8 +317,7 @@ pub const Action = union(enum) {
     /// Focus on a split in a given direction.
     goto_split: SplitFocusDirection,
 
-    /// zoom/unzoom the current split. This is currently only supported
-    /// on macOS. Contributions welcome for other platforms.
+    /// zoom/unzoom the current split.
     toggle_split_zoom: void,
 
     /// Resize the current split by moving the split divider in the given


### PR DESCRIPTION
Closes #2493.

The currently zoomed in split is unzoomed when:
 - creating a new split.
 - moving to another split (_i.e._ focusing another surface).

I was not able to compare the behavior with mac version so I would appreciate some feedback from folks having access to both.