### PR TITLE
cli: automatically enclose parameters in double quotes

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2755,9 +2755,14 @@ pub fn parseManuallyHook(
         var command = std.ArrayList(u8).init(alloc);
         errdefer command.deinit();
 
+        // Parameters following `-e` must be enclosed in double quotes
+        // to prevent arguments with spaces from being treated
+        // as two separate parameters.
         while (iter.next()) |param| {
             try self._replay_steps.append(alloc, .{ .arg = try alloc.dupe(u8, param) });
+            try command.append('"');
             try command.appendSlice(param);
+            try command.append('"');
             try command.append(' ');
         }
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -916,7 +916,7 @@ keybind: Keybinds = .{},
 ///   * `false` - windows won't have native decorations, i.e. titlebar and
 ///      borders. On macOS this also disables tabs and tab overview.
 ///
-/// The "toggle_window_decoration" keybind action can be used to create
+/// The "toggle_window_decorations" keybind action can be used to create
 /// a keybinding to toggle this setting at runtime.
 ///
 /// Changing this configuration in your configuration and reloading will


### PR DESCRIPTION
When starting ghostty with the following parameters:
```sh
ghostty -e prog param1 "param2 with spaces"
```
Since the shell treats words separated by spaces as separate arguments passed to ghostty, the list of arguments received by ghostty will be
```zig
.{ "prog", "param1", "param2 with spaces" }
```
Therefore, ghostty will execute
```sh
/bin/sh -c prog param1 param2 with spaces
```
`sh` will parse its own arguments, but in this case, it cannot treat `param2 with spaces` as a whole to be used as a single argument because it is ambiguous. At the same time, if `param2` contains parentheses, `sh` will also interpret the parentheses in `param2` as part of its own syntax, resulting in a syntax error.

In other words, we must retain the parameter information when using `-e`, while avoiding the parentheses in the parameters being interpreted as its syntax (this is not an issue that `ghostty -e` should handle). The best strategy at the moment should be to enclose each parameter in parentheses and pass each parameter as a separate string.

Fixes https://github.com/ghostty-org/ghostty/issues/2632