### PR TITLE
Fix copying the theme name

### DIFF
--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -383,7 +383,7 @@ const Preview = struct {
                                 self.themes[self.filtered.items[self.current]].theme,
                                 alloc,
                             );
-                        if (key.matches('c', .{ .shift = true }))
+                        if (key.matches('C', .{ .shift = true }))
                             try self.vx.copyToSystemClipboard(
                                 self.tty.anyWriter(),
                                 self.themes[self.filtered.items[self.current]].path,


### PR DESCRIPTION
Prior to this change both `C` and `c` would copy the path to the theme even though the help screen claimed that `c` would copy the theme name.

The problem was that the codepoint for `C` is `C` not `c`. The fact that the shift modifier is coming along is not sufficient to distinguish the two cases.

Tested:
  Before the change: 'c' copies path and 'C' copies path
	After the change: 'c' copies the name and 'C' copies the path