### PR TITLE
Fix copying the theme name

### DIFF
--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -382,8 +382,8 @@ const Preview = struct {
                                 self.tty.anyWriter(),
                                 self.themes[self.filtered.items[self.current]].theme,
                                 alloc,
-                            );
-                        if (key.matches('c', .{ .shift = true }))
+                            )
+                        else if (key.matches('c', .{ .shift = true }))
                             try self.vx.copyToSystemClipboard(
                                 self.tty.anyWriter(),
                                 self.themes[self.filtered.items[self.current]].path,


### PR DESCRIPTION
Prior to this change both C and c would copy the path to the theme even though the help screen claimed that c would copy the theme name.

There is a bug in libvaxis that results in both of these matches matching c:
  `key.matches('c', .{})`
	`key.matches('c', .{ .shift = true })`

Tested:
  Before the change: 'c' copies path and 'C' copies path
  After the change: 'c' copies the name and 'C' copies the path