### PR TITLE
Change order for processing links in mouse events

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3250,6 +3250,12 @@ pub fn cursorPosCallback(
         try self.queueRender();
     }
 
+    // Process new links. This used to happen after mouse reporting/click detection but
+    // led to indeterminate behavior. Moving this to the top of the function ensures that
+    // the link state is always correct and properly displayed for the user. Mouse events
+    // are still captured correctly and escaped when shift is utilized.
+    try self.mouseRefreshLinks(pos, pos_vp, over_link);
+
     // Do a mouse report
     if (self.io.terminal.flags.mouse_event != .none) report: {
         // Shift overrides mouse "grabbing" in the window, taken from Kitty.
@@ -3358,9 +3364,6 @@ pub fn cursorPosCallback(
             return;
         }
     }
-
-    // We can process new links.
-    try self.mouseRefreshLinks(pos, pos_vp, over_link);
 }
 
 /// Double-click dragging moves the selection one "word" at a time.


### PR DESCRIPTION
As discussed on [Discord](https://discord.com/channels/1005603569187160125/1005603569711452192/1304574662625329193), there's some funkiness when holding `super` and hovering over links while a mouse is captured. 

Here's a gif showing this issue:
![broken](https://github.com/user-attachments/assets/a07daa8e-e3cb-41dd-85d7-aa8d0667d3ab)

I was able to track this to [here](https://github.com/ghostty-org/ghostty/blob/main/src/Surface.zig#L3254), which results in us never escaping this block and therefore `mouseRefreshLinks` never runs. Through discussion on discord, the "current best" solution was changing the processing order around to always process links even if events are captured (at least until mouse logic is rewritten). This PR includes that change and some documentation around why that was moved with my understanding, please let me know if that is flawed. Here's the functionality now:
![fixed](https://github.com/user-attachments/assets/937f75f8-9c10-41ea-9428-ab116bd586f5)

As part of this discovery, I was able to also get debugging working within VSCode. Here's a gif of that:
![debug](https://github.com/user-attachments/assets/c4b64cbc-499b-4390-ba30-4e587184e657)

If that is useful, I can create a separate PR with those changes. For now, I'll link the instructions here.

# Debug

1. Create a `.vscode/` directory with the following files:

`extensions.json`:

```json
{
        // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
        // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp

        // List of extensions which should be recommended for users of this workspace.
        "recommendations": [
                "ziglang.vscode-zig",
                "llvm-vs-code-extensions.lldb-dap",
                "ms-vscode.cpptools-extension-pack"
        ],
        // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
        "unwantedRecommendations": [

        ]
}
```

`tasks.json`:

```json
{
    // See https://go.microsoft.com/fwlink/?LinkId=733558
    // for the documentation about the tasks.json format
    "version": "2.0.0",
    "tasks": [
        {
            "label": "ghostty build",
            "type": "shell",
            "command": "zig",
            "args": ["build", "-Dapp-runtime=glfw"]
        }
    ]
}
```

`launch.json`:

```json
{
    // Use IntelliSense to learn about possible attributes.
    // Hover to view descriptions of existing attributes.
    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
    "version": "0.2.0",
    "configurations": [
        {
            "name": "ghostty debug",
            "type": "lldb-dap",
            "request": "launch",
            "program": "${workspaceFolder}/zig-out/bin/ghostty",
            "args": [],
            "cwd": "${workspaceFolder}",
            "preLaunchTask": "ghostty build"
        }
    ]
}
```

2. Install the recommended extensions from `extensions.json`. Either search for them or install them from the extensions view and filter by `recommended`
3. Ensure your lldp-dap binary is set properly in your path or configure it in VSCode preferences. If you're on macOS, this is installed with Xcode and the path can be found by running: `xcrun -f lldb-dap`. You can set this in your path or set the path to the binary in VSCode preferences.