### PR TITLE
deps: update libvaxis to v0.5.1

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -57,8 +57,8 @@
             .hash = "1220de23a3240e503397ea579de4fd85db422f537e10036ef74717c50164475813ce",
         },
         .zf = .{
-            .url = "git+https://github.com/natecraddock/zf.git?ref=main#bb27a917c3513785c6a91f0b1c10002a5029cacc",
-            .hash = "1220a74107c7f153a2f809e41c7fa7e8dbf75c91043e39fad998247804e5edac2cc8",
+            .url = "https://github.com/natecraddock/zf/archive/refs/tags/0.10.2.tar.gz",
+            .hash = "1220014ae47a57902e90aa7b4ff9751832ba1f426d7b138580db06859e0e9b51dfe5",
         },
         .z2d = .{
             .url = "git+https://github.com/vancluever/z2d?ref=main#285a796eb9c25a2389f087d008f0e60faf0b8eda",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -53,8 +53,8 @@
             .hash = "1220fac17a112b0dd11ec85e5b31a30f05bfaed897c03f31285276544db30d010c41",
         },
         .vaxis = .{
-            .url = "git+https://github.com/rockorager/libvaxis?ref=main#a1b43d24653670d612b91f0855b165e6c987b809",
-            .hash = "1220e4d6fc82c487178339422887fdfd5094b15c242fe31ad596c4b2fcdc60ef667f",
+            .url = "https://github.com/rockorager/libvaxis/archive/refs/tags/v0.5.1.tar.gz",
+            .hash = "1220de23a3240e503397ea579de4fd85db422f537e10036ef74717c50164475813ce",
         },
         .zf = .{
             .url = "git+https://github.com/natecraddock/zf.git?ref=main#bb27a917c3513785c6a91f0b1c10002a5029cacc",

--- a/nix/zigCacheHash.nix
+++ b/nix/zigCacheHash.nix
@@ -1,3 +1,3 @@
 # This file is auto-generated! check build-support/check-zig-cache-hash.sh for
 # more details.
-"sha256-fTNqNTfElvZPxJiNQJ/RxrSMCiKZPU3705CY7fznKhY="
+"sha256-K2BxuRk7B7h0xLvpOQIiKmVfhs7Zj5GjhizCDgRa080="

--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -289,9 +289,11 @@ const Preview = struct {
             while (it.next()) |token| try tokens.append(token);
 
             for (self.themes, 0..) |*theme, i| {
-                theme.rank = zf.rank(theme.theme, tokens.items, false, true);
-                if (theme.rank) |_|
-                    try self.filtered.append(i);
+                theme.rank = zf.rank(theme.theme, tokens.items, .{
+                    .to_lower = false,
+                    .plain = true,
+                });
+                if (theme.rank != null) try self.filtered.append(i);
             }
         } else {
             for (self.themes, 0..) |*theme, i| {


### PR DESCRIPTION
Update libvaxis to v0.5.1, which contains the new URL for the zg
dependency. The previous URL is now defunct, as zg has been transfered
to Sam Atman.
