### PR TITLE
terminal: OSC7 with empty URL resets the pwd to nil

### DIFF
--- a/src/terminal/osc.zig
+++ b/src/terminal/osc.zig
@@ -641,7 +641,7 @@ pub const Parser = struct {
             .@"7" => switch (c) {
                 ';' => {
                     self.command = .{ .report_pwd = .{ .value = "" } };
-
+                    self.complete = true;
                     self.state = .string;
                     self.temp_state = .{ .str = &self.command.report_pwd.value };
                     self.buf_start = self.buf_idx;
@@ -1382,6 +1382,18 @@ test "OSC: report pwd" {
     try testing.expect(std.mem.eql(u8, "file:///tmp/example", cmd.report_pwd.value));
 }
 
+test "OSC: report pwd empty" {
+    const testing = std.testing;
+
+    var p: Parser = .{};
+
+    const input = "7;";
+    for (input) |ch| p.next(ch);
+    const cmd = p.end(null).?;
+    try testing.expect(cmd == .report_pwd);
+    try testing.expect(std.mem.eql(u8, "", cmd.report_pwd.value));
+}
+
 test "OSC: pointer cursor" {
     const testing = std.testing;
 
@@ -1393,17 +1405,6 @@ test "OSC: pointer cursor" {
     const cmd = p.end(null).?;
     try testing.expect(cmd == .mouse_shape);
     try testing.expect(std.mem.eql(u8, "pointer", cmd.mouse_shape.value));
-}
-
-test "OSC: report pwd empty" {
-    const testing = std.testing;
-
-    var p: Parser = .{};
-
-    const input = "7;";
-    for (input) |ch| p.next(ch);
-
-    try testing.expect(p.end(null) == null);
 }
 
 test "OSC: longer than buffer" {


### PR DESCRIPTION
When an empty string is given to OSC7, the pwd is reset to nil (as if the terminal never received a pwd report to begin with). This is analogous to how OSC0/2 reset the title to nil when given an empty string.

This is practically useful for macOS because it allows our proxy icon to also be reset instead of being stuck on the last known path.

This breaks from any known terminal behavior. As far as I can find, this is totally unspecified so we're somewhat free to do what we want. I don't think any terminal programs depend on this behavior, so I think it's safe to change it.