### PR TITLE
terminal: parse CSI t 22/23 for push/pop title

### DIFF
--- a/src/terminal/csi.zig
+++ b/src/terminal/csi.zig
@@ -40,3 +40,11 @@ pub const SizeReportStyle = enum {
     csi_18_t,
     csi_21_t,
 };
+
+/// XTWINOPS CSI 22/23
+pub const TitlePushPop = struct {
+    op: Op,
+    index: u16,
+
+    pub const Op = enum { push, pop };
+};


### PR DESCRIPTION
Related to #2668

This just implements the VT stream parsing. The actual handling of these events still needs to be done. I'm doing these separately to separate out parsing from implementation.