### PR TITLE
build: -Dpie default to true in system package mode

### DIFF
--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -80,7 +80,9 @@ relevant to package maintainers:
 
 - `--system`: The path to the offline cache directory. This disables
   any package fetching from the internet. This flag also triggers all
-  dependencies to be dynamically linked by default.
+  dependencies to be dynamically linked by default. This flag also makes
+  the binary a PIE (Position Independent Executable) by default (override
+  with `-Dpie`).
 
 - `-Doptimize=ReleaseFast`: Build with optimizations enabled and safety checks
   disabled. This is the recommended build mode for distribution. I'd prefer

--- a/build.zig
+++ b/build.zig
@@ -57,6 +57,11 @@ pub fn build(b: *std.Build) !void {
         break :target result;
     };
 
+    // This is set to true when we're building a system package. For now
+    // this is trivially detected using the "system_package_mode" bool
+    // but we may want to make this more sophisticated in the future.
+    const system_package: bool = b.graph.system_package_mode;
+
     const wasm_target: WasmTarget = .browser;
 
     // We use env vars throughout the build so we grab them immediately here.
@@ -101,8 +106,8 @@ pub fn build(b: *std.Build) !void {
     const pie = b.option(
         bool,
         "pie",
-        "Build a Position Independent Executable",
-    ) orelse false;
+        "Build a Position Independent Executable. Default true for system packages.",
+    ) orelse system_package;
 
     const conformance = b.option(
         []const u8,


### PR DESCRIPTION
Fixes #2673

Rather than document this too much, I think it makes sense to just default this to true when system package mode is enabled (`--system`) since it seems that in multiple package ecosystems this is the desired behavior.

This can still be overridden by setting `-Dpie=false`.