### PR TITLE
Remove shebang from non-executable script

### DIFF
--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -1,5 +1,3 @@
-#!/usr/bin/env zsh
-#
 # Based on (started as) a copy of Kitty's zsh integration. Kitty is
 # distributed under GPLv3, so this file is also distributed under GPLv3.
 # The license header is reproduced below:


### PR DESCRIPTION
Issue from #2672 related to PR #2674 
Missed removing the shebang as well on this one when making the zsh integration non-executable