### PR TITLE
macos: add a rounded corner to the URL hover view

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -172,7 +172,7 @@ extension Ghostty {
 
                 // If we have a URL from hovering a link, we show that.
                 if let url = surfaceView.hoverUrl {
-                    let padding: CGFloat = 3
+                    let padding: CGFloat = 5
                     ZStack {
                         HStack {
                             Spacer()
@@ -182,7 +182,7 @@ extension Ghostty {
                                 Text(verbatim: url)
                                     .padding(.init(top: padding, leading: padding, bottom: padding, trailing: padding))
                                     .background(
-                                        RoundedRectangle(cornerRadius: 3)
+                                        UnevenRoundedRectangle(cornerRadii: .init(topLeading: 9))
                                             .fill(.background)
                                     )
                                     .lineLimit(1)
@@ -190,7 +190,6 @@ extension Ghostty {
                                     .opacity(isHoveringURLLeft ? 1 : 0)
                             }
                         }
-                        .padding([.trailing, .bottom], padding)
 
                         HStack {
                             VStack(alignment: .leading) {
@@ -199,7 +198,7 @@ extension Ghostty {
                                 Text(verbatim: url)
                                     .padding(.init(top: padding, leading: padding, bottom: padding, trailing: padding))
                                     .background(
-                                        RoundedRectangle(cornerRadius: 3)
+                                        UnevenRoundedRectangle(cornerRadii: .init(topTrailing: 9))
                                             .fill(.background)
                                     )
                                     .lineLimit(1)
@@ -211,7 +210,6 @@ extension Ghostty {
                             }
                             Spacer()
                         }
-                        .padding([.leading, .bottom], padding)
                     }
                 }
 

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -181,12 +181,16 @@ extension Ghostty {
 
                                 Text(verbatim: url)
                                     .padding(.init(top: padding, leading: padding, bottom: padding, trailing: padding))
-                                    .background(.background)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 5)
+                                            .fill(.background)
+                                    )
                                     .lineLimit(1)
                                     .truncationMode(.middle)
                                     .opacity(isHoveringURLLeft ? 1 : 0)
                             }
                         }
+                        .padding([.trailing, .bottom], padding)
 
                         HStack {
                             VStack(alignment: .leading) {
@@ -194,7 +198,10 @@ extension Ghostty {
 
                                 Text(verbatim: url)
                                     .padding(.init(top: padding, leading: padding, bottom: padding, trailing: padding))
-                                    .background(.background)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 5)
+                                            .fill(.background)
+                                    )
                                     .lineLimit(1)
                                     .truncationMode(.middle)
                                     .opacity(isHoveringURLLeft ? 0 : 1)
@@ -204,6 +211,7 @@ extension Ghostty {
                             }
                             Spacer()
                         }
+                        .padding([.leading, .bottom], padding)
                     }
                 }
 

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -182,7 +182,7 @@ extension Ghostty {
                                 Text(verbatim: url)
                                     .padding(.init(top: padding, leading: padding, bottom: padding, trailing: padding))
                                     .background(
-                                        RoundedRectangle(cornerRadius: 5)
+                                        RoundedRectangle(cornerRadius: 3)
                                             .fill(.background)
                                     )
                                     .lineLimit(1)
@@ -199,7 +199,7 @@ extension Ghostty {
                                 Text(verbatim: url)
                                     .padding(.init(top: padding, leading: padding, bottom: padding, trailing: padding))
                                     .background(
-                                        RoundedRectangle(cornerRadius: 5)
+                                        RoundedRectangle(cornerRadius: 3)
                                             .fill(.background)
                                     )
                                     .lineLimit(1)

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -173,6 +173,7 @@ extension Ghostty {
                 // If we have a URL from hovering a link, we show that.
                 if let url = surfaceView.hoverUrl {
                     let padding: CGFloat = 5
+                    let cornerRadius: CGFloat = 9
                     ZStack {
                         HStack {
                             Spacer()
@@ -182,7 +183,7 @@ extension Ghostty {
                                 Text(verbatim: url)
                                     .padding(.init(top: padding, leading: padding, bottom: padding, trailing: padding))
                                     .background(
-                                        UnevenRoundedRectangle(cornerRadii: .init(topLeading: 9))
+                                        UnevenRoundedRectangle(cornerRadii: .init(topLeading: cornerRadius))
                                             .fill(.background)
                                     )
                                     .lineLimit(1)
@@ -198,7 +199,7 @@ extension Ghostty {
                                 Text(verbatim: url)
                                     .padding(.init(top: padding, leading: padding, bottom: padding, trailing: padding))
                                     .background(
-                                        UnevenRoundedRectangle(cornerRadii: .init(topTrailing: 9))
+                                        UnevenRoundedRectangle(cornerRadii: .init(topTrailing: cornerRadius))
                                             .fill(.background)
                                     )
                                     .lineLimit(1)


### PR DESCRIPTION
Also increase the internal padding by a small amount so it feels less cramped.