### PR TITLE
Include font copyright information into OFL.txt and add MIT license

### DIFF
--- a/src/font/res/MIT.txt
+++ b/src/font/res/MIT.txt
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/font/res/README.md
+++ b/src/font/res/README.md
@@ -3,15 +3,30 @@
 This project uses several fonts which fall under the SIL Open Font License (OFL-1.1) and MIT License:
 
 - Code New Roman (OFL-1.1)
+  - [© 2014 Sam Radian. All Rights Reserved.](https://github.com/chrissimpkins/codeface/blob/master/fonts/code-new-roman/license.txt)
 - Geist Mono (OFL-1.1)
+  - [Copyright (c) 2023 Vercel, in collaboration with basement.studio](https://github.com/vercel/geist-font/blob/main/LICENSE.txt)
 - Inconsolata (OFL-1.1)
+  - [Copyright 2006 The Inconsolata Project Authors](https://github.com/google/fonts/blob/main/ofl/inconsolata/OFL.txt)
 - JetBrains Mono (OFL-1.1)
+  - [Copyright 2020 The JetBrains Mono Project Authors (https://github.com/JetBrains/JetBrainsMono)](https://github.com/JetBrains/JetBrainsMono/blob/master/OFL.txt)
 - JuliaMono (OFL-1.1)
+  - [Copyright (c) 2020 - 2023, cormullion
+    with Reserved Font Name JuliaMono.](https://github.com/cormullion/juliamono/blob/master/LICENSE)
 - Kawkab Mono (OFL-1.1)
+  - [Copyright (c) 2015, Abdullah Arif (abdullah.a@gmail.com). Copyright 2010, 2012, 2014 Adobe Systems Incorporated (http://www.adobe.com/), with Reserved Font Name 'Source'. All Rights Reserved. Source is a trademark of Adobe Systems Incorporated in the United States and/or other countries.
+    ](https://github.com/aiaf/kawkab-mono/blob/master/OFL.txt)
 - Lilex (OFL-1.1)
+  - [Copyright 2019 The Lilex Project Authors (https://github.com/mishamyrt/Lilex)](https://github.com/mishamyrt/Lilex/blob/master/OFL.txt)
 - Monaspace Neon (OFL-1.1)
+  - [Copyright (c) 2023, GitHub https://github.com/githubnext/monaspace
+    with Reserved Font Name "Monaspace", including subfamilies: "Argon", "Neon", "Xenon", "Radon", and "Krypton"](https://github.com/githubnext/monaspace/blob/main/LICENSE)
 - Noto Emoji (OFL-1.1)
+  - [Copyright 2013 Google LLC](https://github.com/googlefonts/noto-emoji/blob/main/LICENSE)
 - Cozette (MIT)
+  - [Copyright (c) 2020, Slavfox](https://github.com/slavfox/Cozette/blob/main/LICENSE)
 
 A full copy of the OFL license can be found at [OFL.txt](./OFL.txt).
 An accompanying FAQ is also available at <https://openfontlicense.org/>.
+
+A full copy of the MIT license can be found at [MIT.txt](./MIT.txt).


### PR DESCRIPTION
The recent addition of OFL.txt (showing the font licenses) should include the copyright information as well. This commit strikes a balance by not including the duplicate license text for each font but rather adding the copyright text to OFL.txt and a link to the actual license.

Related to: #2688

This commit and any future commits by me (@markpeek) can be relicensed as needed in the future by @mitchellh 