### PR TITLE
macos: support linkable AboutView properties

### DIFF
--- a/macos/Sources/Features/About/AboutView.swift
+++ b/macos/Sources/Features/About/AboutView.swift
@@ -3,32 +3,13 @@ import SwiftUI
 struct AboutView: View {
     @Environment(\.openURL) var openURL
 
-    private let githubLink = URL(string: "https://github.com/ghostty-org/ghostty")
+    private let githubURL = URL(string: "https://github.com/ghostty-org/ghostty")
 
     /// Read the commit from the bundle.
     private var build: String? { Bundle.main.infoDictionary?["CFBundleVersion"] as? String }
     private var commit: String? { Bundle.main.infoDictionary?["GhosttyCommit"] as? String }
     private var version: String? { Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String }
     private var copyright: String? { Bundle.main.infoDictionary?["NSHumanReadableCopyright"] as? String }
-
-    private var properties: [KeyValue<String>] {
-        let list: [KeyValue<String?>] = [
-            .init(key: "Version", value: version),
-            .init(key: "Build", value: build),
-            .init(key: "Commit", value: commit == "" ? nil : commit)
-        ]
-
-        return list.compactMap {
-            guard let value = $0.value else { return nil }
-            return .init(key: $0.key, value: value)
-        }
-    }
-
-    private struct KeyValue<Value: Equatable>: Identifiable {
-        var id = UUID()
-        public let key: LocalizedStringResource
-        public let value: Value
-    }
 
     #if os(macOS)
     // This creates a background style similar to the Apple "About My Mac" Window
@@ -80,27 +61,23 @@ struct AboutView: View {
                         .opacity(0.8)
                 }
                 .textSelection(.enabled)
+
                 VStack(spacing: 2) {
-                    ForEach(properties) { item in
-                        HStack(spacing: 4) {
-                                Text(item.key)
-                                    .frame(width: 126, alignment: .trailing)
-                                    .padding(.trailing, 2)
-                                Text(item.value)
-                                    .frame(width: 125, alignment: .leading)
-                                    .padding(.leading, 2)
-                                    .tint(.secondary)
-                                    .opacity(0.8)
-                        }
-                        .font(.callout)
-                        .textSelection(.enabled)
-                        .frame(maxWidth: .infinity)
+                    if let version {
+                        propertyRow("Version", text: version)
+                    }
+                    if let build {
+                        propertyRow("Build", text: build)
+                    }
+                    if let commit, commit != "",
+                       let url = githubURL?.appendingPathComponent("/commits/\(commit)") {
+                        propertyRow("Commit", text: commit, url: url)
                     }
                 }
                 .frame(maxWidth: .infinity)
 
                 HStack(spacing: 8) {
-                    if let url = githubLink {
+                    if let url = githubURL {
                         Button("GitHub") {
                             openURL(url)
                         }
@@ -126,6 +103,33 @@ struct AboutView: View {
         #if os(macOS)
         .background(VisualEffectBackground(material: .underWindowBackground).ignoresSafeArea())
         #endif
+    }
+
+    private func propertyRow(_ label: LocalizedStringResource, text: String, url: URL? = nil) -> some View {
+        HStack(spacing: 4) {
+                Text(label)
+                    .frame(width: 126, alignment: .trailing)
+                    .padding(.trailing, 2)
+            if let url {
+                Link(destination: url) {
+                    propertyText(text)
+                }
+            } else {
+                propertyText(text)
+            }
+        }
+        .font(.callout)
+        .textSelection(.enabled)
+        .frame(maxWidth: .infinity)
+    }
+
+    private func propertyText(_ text: String) -> some View {
+        Text(text)
+            .frame(width: 125, alignment: .leading)
+            .padding(.leading, 2)
+            .tint(.secondary)
+            .opacity(0.8)
+            .monospaced()
     }
 }
 

--- a/macos/Sources/Features/About/AboutView.swift
+++ b/macos/Sources/Features/About/AboutView.swift
@@ -106,9 +106,9 @@ struct AboutView: View {
     }
 
     private struct PropertyRow: View {
-        let label: String
-        let text: String
-        let url: URL?
+        private let label: String
+        private let text: String
+        private let url: URL?
 
         init(label: String, text: String, url: URL? = nil) {
             self.label = label

--- a/macos/Sources/Features/About/AboutView.swift
+++ b/macos/Sources/Features/About/AboutView.swift
@@ -118,9 +118,9 @@ struct AboutView: View {
 
         var body: some View {
             HStack(spacing: 4) {
-                    Text(label)
-                        .frame(width: 126, alignment: .trailing)
-                        .padding(.trailing, 2)
+                Text(label)
+                    .frame(width: 126, alignment: .trailing)
+                    .padding(.trailing, 2)
                 if let url {
                     Link(destination: url) {
                         PropertyText(text: text)

--- a/macos/Sources/Features/About/AboutView.swift
+++ b/macos/Sources/Features/About/AboutView.swift
@@ -64,14 +64,14 @@ struct AboutView: View {
 
                 VStack(spacing: 2) {
                     if let version {
-                        propertyRow("Version", text: version)
+                        PropertyRow(label: "Version", text: version)
                     }
                     if let build {
-                        propertyRow("Build", text: build)
+                        PropertyRow(label: "Build", text: build)
                     }
                     if let commit, commit != "",
                        let url = githubURL?.appendingPathComponent("/commits/\(commit)") {
-                        propertyRow("Commit", text: commit, url: url)
+                        PropertyRow(label: "Commit", text: commit, url: url)
                     }
                 }
                 .frame(maxWidth: .infinity)
@@ -105,31 +105,47 @@ struct AboutView: View {
         #endif
     }
 
-    private func propertyRow(_ label: LocalizedStringResource, text: String, url: URL? = nil) -> some View {
-        HStack(spacing: 4) {
-                Text(label)
-                    .frame(width: 126, alignment: .trailing)
-                    .padding(.trailing, 2)
-            if let url {
-                Link(destination: url) {
-                    propertyText(text)
-                }
-            } else {
-                propertyText(text)
-            }
+    private struct PropertyRow: View {
+        let label: String
+        let text: String
+        let url: URL?
+
+        init(label: String, text: String, url: URL? = nil) {
+            self.label = label
+            self.text = text
+            self.url = url
         }
-        .font(.callout)
-        .textSelection(.enabled)
-        .frame(maxWidth: .infinity)
+
+        var body: some View {
+            HStack(spacing: 4) {
+                    Text(label)
+                        .frame(width: 126, alignment: .trailing)
+                        .padding(.trailing, 2)
+                if let url {
+                    Link(destination: url) {
+                        PropertyText(text: text)
+                    }
+                } else {
+                    PropertyText(text: text)
+                }
+            }
+            .font(.callout)
+            .textSelection(.enabled)
+            .frame(maxWidth: .infinity)
+        }
     }
 
-    private func propertyText(_ text: String) -> some View {
-        Text(text)
-            .frame(width: 125, alignment: .leading)
-            .padding(.leading, 2)
-            .tint(.secondary)
-            .opacity(0.8)
-            .monospaced()
+    private struct PropertyText: View {
+        let text: String
+
+        var body: some View {
+            Text(text)
+                .frame(width: 125, alignment: .leading)
+                .padding(.leading, 2)
+                .tint(.secondary)
+                .opacity(0.8)
+                .monospaced()
+        }
     }
 }
 

--- a/macos/Sources/Features/About/AboutView.swift
+++ b/macos/Sources/Features/About/AboutView.swift
@@ -116,6 +116,15 @@ struct AboutView: View {
             self.url = url
         }
 
+        @ViewBuilder private var textView: some View {
+            Text(text)
+                .frame(width: 125, alignment: .leading)
+                .padding(.leading, 2)
+                .tint(.secondary)
+                .opacity(0.8)
+                .monospaced()
+        }
+
         var body: some View {
             HStack(spacing: 4) {
                 Text(label)
@@ -123,28 +132,15 @@ struct AboutView: View {
                     .padding(.trailing, 2)
                 if let url {
                     Link(destination: url) {
-                        PropertyText(text: text)
+                        textView
                     }
                 } else {
-                    PropertyText(text: text)
+                    textView
                 }
             }
             .font(.callout)
             .textSelection(.enabled)
             .frame(maxWidth: .infinity)
-        }
-    }
-
-    private struct PropertyText: View {
-        let text: String
-
-        var body: some View {
-            Text(text)
-                .frame(width: 125, alignment: .leading)
-                .padding(.leading, 2)
-                .tint(.secondary)
-                .opacity(0.8)
-                .monospaced()
         }
     }
 }


### PR DESCRIPTION
This allows us to enrich the build's commit property as a GitHub link.

This change also displays the property values using a monospaced font, which I think looks a little nicer (especially the commit SHA).

<img width="412" alt="Screenshot 2024-11-15 at 7 57 44 PM" src="https://github.com/user-attachments/assets/bd9f437a-fbf9-4abb-bd6a-df004ca6f6bc">
