### PR TITLE
macos: swap out pointerVisible with NSCursor.setHiddenUntilMouseMoves

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -59,23 +59,6 @@ extension Ghostty {
 
         @EnvironmentObject private var ghostty: Ghostty.App
 
-        #if canImport(AppKit)
-        // The visibility state of the mouse pointer
-        private var pointerVisibility: BackportVisibility {
-            // If our window or surface loses focus we always bring it back
-            if (!windowFocus || !surfaceFocus) {
-                return .visible
-            }
-
-            // If we have window focus then it depends on surface state
-            if (surfaceView.pointerVisible) {
-                return .visible
-            } else {
-                return .hidden
-            }
-        }
-        #endif
-
         var body: some View {
             let center = NotificationCenter.default
 
@@ -96,7 +79,6 @@ extension Ghostty {
                         .focusedValue(\.ghosttySurfaceView, surfaceView)
                         .focusedValue(\.ghosttySurfaceCellSize, surfaceView.cellSize)
                     #if canImport(AppKit)
-                        .backport.pointerVisibility(pointerVisibility)
                         .backport.pointerStyle(surfaceView.pointerStyle)
                         .onReceive(pubBecomeKey) { notification in
                             guard let window = notification.object as? NSWindow else { return }

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -46,7 +46,6 @@ extension Ghostty {
         @Published var surfaceSize: ghostty_surface_size_s? = nil
 
         // Whether the pointer should be visible or not
-        @Published private(set) var pointerVisible: Bool = true
         @Published private(set) var pointerStyle: BackportPointerStyle = .default
 
         // An initial size to request for a window. This will only affect
@@ -309,7 +308,11 @@ extension Ghostty {
         }
 
         func setCursorVisibility(_ visible: Bool) {
-            pointerVisible = visible
+            // Technically this action could be called anytime we want to
+            // change the mouse visibility but at the time of writing this
+            // mouse-hide-while-typing is the only use case so this is the
+            // preferred method.
+            NSCursor.setHiddenUntilMouseMoves(!visible)
         }
 
         // MARK: - Notifications

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -449,11 +449,10 @@ palette: Palette = .{},
 /// way to implement it.
 @"cursor-click-to-move": bool = true,
 
-/// Hide the mouse immediately when typing. The mouse becomes visible again when
-/// the mouse is used. The mouse is only hidden if the mouse cursor is over the
-/// active terminal surface.
-///
-/// macOS: This feature requires macOS 15.0 (Sequoia) or later.
+/// Hide the mouse immediately when typing. The mouse becomes visible again
+/// when the mouse is used (button, movement, etc.). Platform-specific behavior
+/// may dictate other scenarios where the mouse is shown. For example on macOS,
+/// the mouse is shown again when a new window, tab, or split is created.
 @"mouse-hide-while-typing": bool = false,
 
 /// Determines whether running programs can detect the shift key pressed with a


### PR DESCRIPTION
Fixes #2695

We had various issues with the pointerVisible property on macOS, including the pointer not being hidden when it should be. Our only use case today is mouse hide while typing so
NSCursor.setHiddenUntilMouseMoves is a better fit!