### PR TITLE
vim: fix comment syntax pattern

### DIFF
--- a/src/config/sublime_syntax.zig
+++ b/src/config/sublime_syntax.zig
@@ -14,7 +14,7 @@ const Template = struct {
         \\contexts:
         \\  main:
         \\    # Comments
-        \\    - match: '#.*$'
+        \\    - match: '^\s*#.*$'
         \\      scope: comment.line.number-sign.ghostty
         \\
         \\    # Keywords

--- a/src/config/vim.zig
+++ b/src/config/vim.zig
@@ -70,7 +70,7 @@ fn writeSyntax(writer: anytype) !void {
     try writer.writeAll(
         \\
         \\
-        \\syn match ghosttyConfigComment /#.*/ contains=@Spell
+        \\syn match ghosttyConfigComment /^\s*#.*/ contains=@Spell
         \\
         \\hi def link ghosttyConfigComment Comment
         \\hi def link ghosttyConfigKeyword Keyword


### PR DESCRIPTION
Only lines which contain (optional) whitespace followed by a # character are comments. We should not treat lines like "foreground = #aaa" as containing a comment.

Resolves #2719.