### PR TITLE
Change oniguruma link target from `oniguruma` to `onig`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1104,7 +1104,8 @@ fn addDeps(
     });
     step.root_module.addImport("oniguruma", oniguruma_dep.module("oniguruma"));
     if (b.systemIntegrationOption("oniguruma", .{})) {
-        step.linkSystemLibrary2("oniguruma", dynamic_link_opts);
+        // Oniguruma is compiled and distributed as libonig.so
+        step.linkSystemLibrary2("onig", dynamic_link_opts);
     } else {
         step.linkLibrary(oniguruma_dep.artifact("oniguruma"));
         try static_libs.append(oniguruma_dep.artifact("oniguruma").getEmittedBin());


### PR DESCRIPTION
Closes #2738

Compiling with system integration on for `ongiruma` previously failed due to not finding the link target named `liboniguruma.so` as it is distributed as `libonig.so`. Changing the link-target name to `onig` results in finding `libonig.so` which the library is distributed under as seen at https://pkgs.org/search/?q=oniguruma and compiled to at its source https://github.com/kkos/oniguruma in the 
> cmake_minimum_required(VERSION 3.1...3.5)
project(oniguruma
  VERSION 6.9.10
  LANGUAGES C)
> 
> set(PACKAGE onig)
set(PACKAGE_VERSION ${PROJECT_VERSION})
At https://github.com/kkos/oniguruma/blob/master/CMakeLists.txt

This was tested by successfully compiling with 
```zsh
ZIG_GLOBAL_CACHE_DIR="$(pwd)/.zig-cache" ./nix/build-support/fetch-zig-cache.sh
zig build --system "$(pwd)/.zig-cache/p" -Doptimize=ReleaseFast
```
Where previously the flag `-fno-sys=oniguruma` had to be provided as it failed to link

This change affects building on linux, but I don't think affects OSX targets as we compile a fat-binary statically linking everything there. I believe Windows also has onigurma as `onig.dll` 