### PR TITLE
apprt config change notification, macOS transparent titlebar works with theme change

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -532,6 +532,11 @@ typedef struct {
   uint8_t b;
 } ghostty_action_color_change_s;
 
+// apprt.action.ConfigChange
+typedef struct {
+  ghostty_config_t config;
+} ghostty_action_config_change_s;
+
 // apprt.Action.Key
 typedef enum {
   GHOSTTY_ACTION_NEW_WINDOW,
@@ -568,6 +573,7 @@ typedef enum {
   GHOSTTY_ACTION_KEY_SEQUENCE,
   GHOSTTY_ACTION_COLOR_CHANGE,
   GHOSTTY_ACTION_CONFIG_CHANGE_CONDITIONAL_STATE,
+  GHOSTTY_ACTION_CONFIG_CHANGE,
 } ghostty_action_tag_e;
 
 typedef union {
@@ -592,6 +598,7 @@ typedef union {
   ghostty_action_secure_input_e secure_input;
   ghostty_action_key_sequence_s key_sequence;
   ghostty_action_color_change_s color_change;
+  ghostty_action_config_change_s config_change;
 } ghostty_action_u;
 
 typedef struct {

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -646,6 +646,7 @@ ghostty_info_s ghostty_info(void);
 
 ghostty_config_t ghostty_config_new();
 void ghostty_config_free(ghostty_config_t);
+ghostty_config_t ghostty_config_clone(ghostty_config_t);
 void ghostty_config_load_cli_args(ghostty_config_t);
 void ghostty_config_load_default_files(ghostty_config_t);
 void ghostty_config_load_recursive_files(ghostty_config_t);

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -69,6 +69,9 @@ class AppDelegate: NSObject,
     /// seconds since the process was launched.
     private var applicationLaunchTime: TimeInterval = 0
 
+    /// This is the current configuration from the Ghostty configuration that we need.
+    private var derivedConfig: DerivedConfig = DerivedConfig()
+
     /// The ghostty global state. Only one per process.
     let ghostty: Ghostty.App = Ghostty.App()
 
@@ -138,7 +141,7 @@ class AppDelegate: NSObject,
         menuCheckForUpdates?.action = #selector(SPUStandardUpdaterController.checkForUpdates(_:))
 
         // Initial config loading
-        configDidReload(ghostty)
+        ghosttyConfigDidChange(config: ghostty.config)
 
         // Start our update checker.
         updaterController.startUpdater()
@@ -160,6 +163,12 @@ class AppDelegate: NSObject,
             self,
             selector: #selector(quickTerminalDidChangeVisibility),
             name: .quickTerminalDidChangeVisibility,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(ghosttyConfigDidChange(_:)),
+            name: .ghosttyConfigDidChange,
             object: nil
         )
 
@@ -188,13 +197,13 @@ class AppDelegate: NSObject,
         // is possible to have other windows in a few scenarios:
         //   - if we're opening a URL since `application(_:openFile:)` is called before this.
         //   - if we're restoring from persisted state
-        if terminalManager.windows.count == 0 && ghostty.config.initialWindow {
+        if terminalManager.windows.count == 0 && derivedConfig.initialWindow {
             terminalManager.newWindow()
         }
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-        return ghostty.config.shouldQuitAfterLastWindowClosed
+        return derivedConfig.shouldQuitAfterLastWindowClosed
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
@@ -300,52 +309,52 @@ class AppDelegate: NSObject,
     }
 
     /// Sync all of our menu item keyboard shortcuts with the Ghostty configuration.
-    private func syncMenuShortcuts() {
+    private func syncMenuShortcuts(_ config: Ghostty.Config) {
         guard ghostty.readiness == .ready else { return }
 
-        syncMenuShortcut(action: "open_config", menuItem: self.menuOpenConfig)
-        syncMenuShortcut(action: "reload_config", menuItem: self.menuReloadConfig)
-        syncMenuShortcut(action: "quit", menuItem: self.menuQuit)
+        syncMenuShortcut(config, action: "open_config", menuItem: self.menuOpenConfig)
+        syncMenuShortcut(config, action: "reload_config", menuItem: self.menuReloadConfig)
+        syncMenuShortcut(config, action: "quit", menuItem: self.menuQuit)
 
-        syncMenuShortcut(action: "new_window", menuItem: self.menuNewWindow)
-        syncMenuShortcut(action: "new_tab", menuItem: self.menuNewTab)
-        syncMenuShortcut(action: "close_surface", menuItem: self.menuClose)
-        syncMenuShortcut(action: "close_window", menuItem: self.menuCloseWindow)
-        syncMenuShortcut(action: "close_all_windows", menuItem: self.menuCloseAllWindows)
-        syncMenuShortcut(action: "new_split:right", menuItem: self.menuSplitRight)
-        syncMenuShortcut(action: "new_split:down", menuItem: self.menuSplitDown)
+        syncMenuShortcut(config, action: "new_window", menuItem: self.menuNewWindow)
+        syncMenuShortcut(config, action: "new_tab", menuItem: self.menuNewTab)
+        syncMenuShortcut(config, action: "close_surface", menuItem: self.menuClose)
+        syncMenuShortcut(config, action: "close_window", menuItem: self.menuCloseWindow)
+        syncMenuShortcut(config, action: "close_all_windows", menuItem: self.menuCloseAllWindows)
+        syncMenuShortcut(config, action: "new_split:right", menuItem: self.menuSplitRight)
+        syncMenuShortcut(config, action: "new_split:down", menuItem: self.menuSplitDown)
 
-        syncMenuShortcut(action: "copy_to_clipboard", menuItem: self.menuCopy)
-        syncMenuShortcut(action: "paste_from_clipboard", menuItem: self.menuPaste)
-        syncMenuShortcut(action: "select_all", menuItem: self.menuSelectAll)
+        syncMenuShortcut(config, action: "copy_to_clipboard", menuItem: self.menuCopy)
+        syncMenuShortcut(config, action: "paste_from_clipboard", menuItem: self.menuPaste)
+        syncMenuShortcut(config, action: "select_all", menuItem: self.menuSelectAll)
 
-        syncMenuShortcut(action: "toggle_split_zoom", menuItem: self.menuZoomSplit)
-        syncMenuShortcut(action: "goto_split:previous", menuItem: self.menuPreviousSplit)
-        syncMenuShortcut(action: "goto_split:next", menuItem: self.menuNextSplit)
-        syncMenuShortcut(action: "goto_split:top", menuItem: self.menuSelectSplitAbove)
-        syncMenuShortcut(action: "goto_split:bottom", menuItem: self.menuSelectSplitBelow)
-        syncMenuShortcut(action: "goto_split:left", menuItem: self.menuSelectSplitLeft)
-        syncMenuShortcut(action: "goto_split:right", menuItem: self.menuSelectSplitRight)
-        syncMenuShortcut(action: "resize_split:up,10", menuItem: self.menuMoveSplitDividerUp)
-        syncMenuShortcut(action: "resize_split:down,10", menuItem: self.menuMoveSplitDividerDown)
-        syncMenuShortcut(action: "resize_split:right,10", menuItem: self.menuMoveSplitDividerRight)
-        syncMenuShortcut(action: "resize_split:left,10", menuItem: self.menuMoveSplitDividerLeft)
-        syncMenuShortcut(action: "equalize_splits", menuItem: self.menuEqualizeSplits)
+        syncMenuShortcut(config, action: "toggle_split_zoom", menuItem: self.menuZoomSplit)
+        syncMenuShortcut(config, action: "goto_split:previous", menuItem: self.menuPreviousSplit)
+        syncMenuShortcut(config, action: "goto_split:next", menuItem: self.menuNextSplit)
+        syncMenuShortcut(config, action: "goto_split:top", menuItem: self.menuSelectSplitAbove)
+        syncMenuShortcut(config, action: "goto_split:bottom", menuItem: self.menuSelectSplitBelow)
+        syncMenuShortcut(config, action: "goto_split:left", menuItem: self.menuSelectSplitLeft)
+        syncMenuShortcut(config, action: "goto_split:right", menuItem: self.menuSelectSplitRight)
+        syncMenuShortcut(config, action: "resize_split:up,10", menuItem: self.menuMoveSplitDividerUp)
+        syncMenuShortcut(config, action: "resize_split:down,10", menuItem: self.menuMoveSplitDividerDown)
+        syncMenuShortcut(config, action: "resize_split:right,10", menuItem: self.menuMoveSplitDividerRight)
+        syncMenuShortcut(config, action: "resize_split:left,10", menuItem: self.menuMoveSplitDividerLeft)
+        syncMenuShortcut(config, action: "equalize_splits", menuItem: self.menuEqualizeSplits)
 
-        syncMenuShortcut(action: "increase_font_size:1", menuItem: self.menuIncreaseFontSize)
-        syncMenuShortcut(action: "decrease_font_size:1", menuItem: self.menuDecreaseFontSize)
-        syncMenuShortcut(action: "reset_font_size", menuItem: self.menuResetFontSize)
-        syncMenuShortcut(action: "toggle_quick_terminal", menuItem: self.menuQuickTerminal)
-        syncMenuShortcut(action: "toggle_visibility", menuItem: self.menuToggleVisibility)
-        syncMenuShortcut(action: "inspector:toggle", menuItem: self.menuTerminalInspector)
+        syncMenuShortcut(config, action: "increase_font_size:1", menuItem: self.menuIncreaseFontSize)
+        syncMenuShortcut(config, action: "decrease_font_size:1", menuItem: self.menuDecreaseFontSize)
+        syncMenuShortcut(config, action: "reset_font_size", menuItem: self.menuResetFontSize)
+        syncMenuShortcut(config, action: "toggle_quick_terminal", menuItem: self.menuQuickTerminal)
+        syncMenuShortcut(config, action: "toggle_visibility", menuItem: self.menuToggleVisibility)
+        syncMenuShortcut(config, action: "inspector:toggle", menuItem: self.menuTerminalInspector)
 
-        syncMenuShortcut(action: "toggle_secure_input", menuItem: self.menuSecureInput)
+        syncMenuShortcut(config, action: "toggle_secure_input", menuItem: self.menuSecureInput)
 
         // This menu item is NOT synced with the configuration because it disables macOS
         // global fullscreen keyboard shortcut. The shortcut in the Ghostty config will continue
         // to work but it won't be reflected in the menu item.
         //
-        // syncMenuShortcut(action: "toggle_fullscreen", menuItem: self.menuToggleFullScreen)
+        // syncMenuShortcut(config, action: "toggle_fullscreen", menuItem: self.menuToggleFullScreen)
 
         // Dock menu
         reloadDockMenu()
@@ -353,9 +362,9 @@ class AppDelegate: NSObject,
 
     /// Syncs a single menu shortcut for the given action. The action string is the same
     /// action string used for the Ghostty configuration.
-    private func syncMenuShortcut(action: String, menuItem: NSMenuItem?) {
+    private func syncMenuShortcut(_ config: Ghostty.Config, action: String, menuItem: NSMenuItem?) {
         guard let menu = menuItem else { return }
-        guard let equiv = ghostty.config.keyEquivalent(for: action) else {
+        guard let equiv = config.keyEquivalent(for: action) else {
             // No shortcut, clear the menu item
             menu.keyEquivalent = ""
             menu.keyEquivalentModifierMask = []
@@ -422,6 +431,98 @@ class AppDelegate: NSObject,
         self.menuQuickTerminal?.state = if (quickController.visible) { .on } else { .off }
     }
 
+    @objc private func ghosttyConfigDidChange(_ notification: Notification) {
+        // We only care if the configuration is a global configuration, not a surface one.
+        guard notification.object == nil else { return }
+
+        // Get our managed configuration object out
+        guard let config = notification.userInfo?[
+            Notification.Name.GhosttyConfigChangeKey
+        ] as? Ghostty.Config else { return }
+
+        ghosttyConfigDidChange(config: config)
+    }
+
+    private func ghosttyConfigDidChange(config: Ghostty.Config) {
+        // Update the config we need to store
+        self.derivedConfig = DerivedConfig(config)
+
+        // Depending on the "window-save-state" setting we have to set the NSQuitAlwaysKeepsWindows
+        // configuration. This is the only way to carefully control whether macOS invokes the
+        // state restoration system.
+        switch (config.windowSaveState) {
+        case "never": UserDefaults.standard.setValue(false, forKey: "NSQuitAlwaysKeepsWindows")
+        case "always": UserDefaults.standard.setValue(true, forKey: "NSQuitAlwaysKeepsWindows")
+        case "default": fallthrough
+        default: UserDefaults.standard.removeObject(forKey: "NSQuitAlwaysKeepsWindows")
+        }
+
+        // Sync our auto-update settings
+        updaterController.updater.automaticallyChecksForUpdates =
+            config.autoUpdate == .check || config.autoUpdate == .download
+        updaterController.updater.automaticallyDownloadsUpdates =
+            config.autoUpdate == .download
+
+        // Config could change keybindings, so update everything that depends on that
+        syncMenuShortcuts(config)
+        terminalManager.relabelAllTabs()
+
+        // Config could change window appearance. We wrap this in an async queue because when
+        // this is called as part of application launch it can deadlock with an internal
+        // AppKit mutex on the appearance.
+        DispatchQueue.main.async { self.syncAppearance(config: config) }
+
+        // If we have configuration errors, we need to show them.
+        let c = ConfigurationErrorsController.sharedInstance
+        c.errors = config.errors
+        if (c.errors.count > 0) {
+            if (c.window == nil || !c.window!.isVisible) {
+                c.showWindow(self)
+            }
+        }
+
+        // We need to handle our global event tap depending on if there are global
+        // events that we care about in Ghostty.
+        if (ghostty_app_has_global_keybinds(ghostty.app!)) {
+            if (timeSinceLaunch > 5) {
+                // If the process has been running for awhile we enable right away
+                // because no windows are likely to pop up.
+                GlobalEventTap.shared.enable()
+            } else {
+                // If the process just started, we wait a couple seconds to allow
+                // the initial windows and so on to load so our permissions dialog
+                // doesn't get buried.
+                DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(2)) {
+                    GlobalEventTap.shared.enable()
+                }
+            }
+        } else {
+            GlobalEventTap.shared.disable()
+        }
+    }
+
+    /// Sync the appearance of our app with the theme specified in the config.
+    private func syncAppearance(config: Ghostty.Config) {
+        guard let theme = config.windowTheme else { return }
+        switch (theme) {
+        case "dark":
+            let appearance = NSAppearance(named: .darkAqua)
+            NSApplication.shared.appearance = appearance
+
+        case "light":
+            let appearance = NSAppearance(named: .aqua)
+            NSApplication.shared.appearance = appearance
+
+        case "auto":
+            let color = OSColor(config.backgroundColor)
+            let appearance = NSAppearance(named: color.isLightColor ? .aqua : .darkAqua)
+            NSApplication.shared.appearance = appearance
+
+        default:
+            NSApplication.shared.appearance = nil
+        }
+    }
+
     //MARK: - Restorable State
 
     /// We support NSSecureCoding for restorable state. Required as of macOS Sonoma (14) but a good idea anyways.
@@ -468,88 +569,6 @@ class AppDelegate: NSObject,
         }
 
         return nil
-    }
-
-    func configDidReload(_ state: Ghostty.App) {
-        // Depending on the "window-save-state" setting we have to set the NSQuitAlwaysKeepsWindows
-        // configuration. This is the only way to carefully control whether macOS invokes the
-        // state restoration system.
-        switch (ghostty.config.windowSaveState) {
-        case "never": UserDefaults.standard.setValue(false, forKey: "NSQuitAlwaysKeepsWindows")
-        case "always": UserDefaults.standard.setValue(true, forKey: "NSQuitAlwaysKeepsWindows")
-        case "default": fallthrough
-        default: UserDefaults.standard.removeObject(forKey: "NSQuitAlwaysKeepsWindows")
-        }
-
-        // Sync our auto-update settings
-        updaterController.updater.automaticallyChecksForUpdates =
-            ghostty.config.autoUpdate == .check || ghostty.config.autoUpdate == .download
-        updaterController.updater.automaticallyDownloadsUpdates =
-            ghostty.config.autoUpdate == .download
-
-        // Config could change keybindings, so update everything that depends on that
-        syncMenuShortcuts()
-        terminalManager.relabelAllTabs()
-
-        // Config could change window appearance. We wrap this in an async queue because when
-        // this is called as part of application launch it can deadlock with an internal
-        // AppKit mutex on the appearance.
-        DispatchQueue.main.async { self.syncAppearance() }
-
-        // Update all of our windows
-        terminalManager.windows.forEach { window in
-            window.controller.configDidReload()
-        }
-
-        // If we have configuration errors, we need to show them.
-        let c = ConfigurationErrorsController.sharedInstance
-        c.errors = state.config.errors
-        if (c.errors.count > 0) {
-            if (c.window == nil || !c.window!.isVisible) {
-                c.showWindow(self)
-            }
-        }
-
-        // We need to handle our global event tap depending on if there are global
-        // events that we care about in Ghostty.
-        if (ghostty_app_has_global_keybinds(ghostty.app!)) {
-            if (timeSinceLaunch > 5) {
-                // If the process has been running for awhile we enable right away
-                // because no windows are likely to pop up.
-                GlobalEventTap.shared.enable()
-            } else {
-                // If the process just started, we wait a couple seconds to allow
-                // the initial windows and so on to load so our permissions dialog
-                // doesn't get buried.
-                DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(2)) {
-                    GlobalEventTap.shared.enable()
-                }
-            }
-        } else {
-            GlobalEventTap.shared.disable()
-        }
-    }
-
-    /// Sync the appearance of our app with the theme specified in the config.
-    private func syncAppearance() {
-        guard let theme = ghostty.config.windowTheme else { return }
-        switch (theme) {
-        case "dark":
-            let appearance = NSAppearance(named: .darkAqua)
-            NSApplication.shared.appearance = appearance
-
-        case "light":
-            let appearance = NSAppearance(named: .aqua)
-            NSApplication.shared.appearance = appearance
-
-        case "auto":
-            let color = OSColor(ghostty.config.backgroundColor)
-            let appearance = NSAppearance(named: color.isLightColor ? .aqua : .darkAqua)
-            NSApplication.shared.appearance = appearance
-
-        default:
-            NSApplication.shared.appearance = nil
-        }
     }
 
     //MARK: - Dock Menu
@@ -629,7 +648,7 @@ class AppDelegate: NSObject,
         if quickController == nil {
             quickController = QuickTerminalController(
                 ghostty,
-                position: ghostty.config.quickTerminalPosition
+                position: derivedConfig.quickTerminalPosition
             )
         }
 
@@ -654,5 +673,23 @@ class AppDelegate: NSObject,
         }
 
         isVisible.toggle()
+    }
+
+    private struct DerivedConfig {
+        let initialWindow: Bool
+        let shouldQuitAfterLastWindowClosed: Bool
+        let quickTerminalPosition: QuickTerminalPosition
+
+        init() {
+            self.initialWindow = true
+            self.shouldQuitAfterLastWindowClosed = false
+            self.quickTerminalPosition = .top
+        }
+
+        init(_ config: Ghostty.Config) {
+            self.initialWindow = config.initialWindow
+            self.shouldQuitAfterLastWindowClosed = config.shouldQuitAfterLastWindowClosed
+            self.quickTerminalPosition = config.quickTerminalPosition
+        }
     }
 }

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -191,15 +191,10 @@ class TerminalController: BaseTerminalController {
     private func syncAppearance(_ surfaceConfig: Ghostty.SurfaceView.DerivedConfig) {
         guard let window = self.window as? TerminalWindow else { return }
 
-        // If our window is not visible, then delay this. This is possible specifically
-        // during state restoration but probably in other scenarios as well. To delay,
-        // we just loop directly on the dispatch queue. We have to delay because some
-        // APIs such as window blur have no effect unless the window is visible.
-        guard window.isVisible else {
-            // Weak window so that if the window changes or is destroyed we aren't holding a ref
-            DispatchQueue.main.async { [weak self] in self?.syncAppearance(surfaceConfig) }
-            return
-        }
+        // If our window is not visible, then we do nothing. Some things such as blurring
+        // have no effect if the window is not visible. Ultimately, we'll have this called
+        // at some point when a surface becomes focused.
+        guard window.isVisible else { return }
 
         // Set the font for the window and tab titles.
         if let titleFontName = surfaceConfig.windowTitleFontFamily {
@@ -233,7 +228,7 @@ class TerminalController: BaseTerminalController {
         let backgroundColor: OSColor
         if let surfaceTree {
             if let focusedSurface, surfaceTree.doesBorderTop(view: focusedSurface) {
-                backgroundColor = OSColor(focusedSurface.backgroundColor ?? derivedConfig.backgroundColor)
+                backgroundColor = OSColor(focusedSurface.backgroundColor ?? surfaceConfig.backgroundColor)
             } else {
                 // We don't have a focused surface or our surface doesn't border the
                 // top. We choose to match the color of the top-left most surface.

--- a/macos/Sources/Features/Terminal/TerminalRestorable.swift
+++ b/macos/Sources/Features/Terminal/TerminalRestorable.swift
@@ -65,8 +65,10 @@ class TerminalWindowRestoration: NSObject, NSWindowRestoration {
         }
 
         // If our configuration is "never" then we never restore the state
-        // no matter what.
-        if (appDelegate.terminalManager.ghostty.config.windowSaveState == "never") {
+        // no matter what. Note its safe to use "ghostty.config" directly here
+        // because window restoration is only ever invoked on app start so we
+        // don't have to deal with config reloads.
+        if (appDelegate.ghostty.config.windowSaveState == "never") {
             completionHandler(nil, nil)
             return
         }

--- a/macos/Sources/Ghostty/Ghostty.Action.swift
+++ b/macos/Sources/Ghostty/Ghostty.Action.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 import GhosttyKit
 
 extension Ghostty {
@@ -5,6 +6,33 @@ extension Ghostty {
 }
 
 extension Ghostty.Action {
+    struct ColorChange {
+        let kind: Kind
+        let color: Color
+
+        enum Kind {
+            case foreground
+            case background
+            case cursor
+            case palette(index: UInt8)
+        }
+
+        init(c: ghostty_action_color_change_s) {
+            switch (c.kind) {
+            case GHOSTTY_ACTION_COLOR_KIND_FOREGROUND:
+                self.kind = .foreground
+            case GHOSTTY_ACTION_COLOR_KIND_BACKGROUND:
+                self.kind = .background
+            case GHOSTTY_ACTION_COLOR_KIND_CURSOR:
+                self.kind = .cursor
+            default:
+                self.kind = .palette(index: UInt8(c.kind.rawValue))
+            }
+
+            self.color = Color(red: Double(c.r) / 255, green: Double(c.g) / 255, blue: Double(c.b) / 255)
+        }
+    }
+
     struct MoveTab {
         let amount: Int
 

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -515,7 +515,8 @@ extension Ghostty {
                 configChange(app, target: target, v: action.action.config_change)
 
             case GHOSTTY_ACTION_COLOR_CHANGE:
-                fallthrough
+                colorChange(app, target: target, change: action.action.color_change)
+
             case GHOSTTY_ACTION_CLOSE_ALL_WINDOWS:
                 fallthrough
             case GHOSTTY_ACTION_TOGGLE_TAB_OVERVIEW:
@@ -1187,6 +1188,32 @@ extension Ghostty {
                     assertionFailure()
                 }
             }
+
+        private static func colorChange(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s,
+            change: ghostty_action_color_change_s) {
+                switch (target.tag) {
+                case GHOSTTY_TARGET_APP:
+                    Ghostty.logger.warning("color change does nothing with an app target")
+                    return
+
+                case GHOSTTY_TARGET_SURFACE:
+                    guard let surface = target.target.surface else { return }
+                    guard let surfaceView = self.surfaceView(from: surface) else { return }
+                    NotificationCenter.default.post(
+                        name: .ghosttyColorDidChange,
+                        object: surfaceView,
+                        userInfo: [
+                            SwiftUI.Notification.Name.GhosttyColorChangeKey: Action.ColorChange(c: change)
+                        ]
+                    )
+
+                default:
+                    assertionFailure()
+                }
+        }
+
 
         // MARK: User Notifications
 

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -524,6 +524,9 @@ extension Ghostty {
             case GHOSTTY_ACTION_KEY_SEQUENCE:
                 keySequence(app, target: target, v: action.action.key_sequence)
 
+            case GHOSTTY_ACTION_CONFIG_CHANGE:
+                configChange(app, target: target, v: action.action.config_change)
+
             case GHOSTTY_ACTION_COLOR_CHANGE:
                 fallthrough
             case GHOSTTY_ACTION_CLOSE_ALL_WINDOWS:
@@ -1153,6 +1156,31 @@ extension Ghostty {
                         object: surfaceView
                     )
                 }
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        private static func configChange(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s,
+            v: ghostty_action_config_change_s) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                NotificationCenter.default.post(
+                    name: .ghosttyConfigChange,
+                    object: nil
+                )
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                NotificationCenter.default.post(
+                   name: .ghosttyConfigChange,
+                   object: surfaceView
+                )
 
             default:
                 assertionFailure()

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -39,6 +39,10 @@ extension Ghostty {
             }
         }
 
+        init(clone config: ghostty_config_t) {
+            self.config = ghostty_config_clone(config)
+        }
+
         deinit {
             self.config = nil
         }

--- a/macos/Sources/Ghostty/Ghostty.SplitNode.swift
+++ b/macos/Sources/Ghostty/Ghostty.SplitNode.swift
@@ -38,6 +38,16 @@ extension Ghostty {
             }
         }
 
+        func topLeft() -> SurfaceView {
+            switch (self) {
+            case .leaf(let leaf):
+                return leaf.surface
+
+            case .split(let container):
+                return container.topLeft.topLeft()
+            }
+        }
+
         /// Returns the view that would prefer receiving focus in this tree. This is always the
         /// top-left-most view. This is used when creating a split or closing a split to find the
         /// next view to send focus to.
@@ -133,6 +143,24 @@ extension Ghostty {
             case .split(let container):
                 return container.topLeft.findUUID(uuid: uuid) ??
                     container.bottomRight.findUUID(uuid: uuid)
+            }
+        }
+
+        /// Returns true if the surface borders the top. Assumes the view is in the tree.
+        func doesBorderTop(view: SurfaceView) -> Bool {
+            switch (self) {
+            case .leaf(let leaf):
+                return leaf.surface == view
+
+            case .split(let container):
+                switch (container.direction) {
+                case .vertical:
+                    return container.topLeft.doesBorderTop(view: view)
+
+                case .horizontal:
+                    return container.topLeft.doesBorderTop(view: view) ||
+                        container.bottomRight.doesBorderTop(view: view)
+                }
             }
         }
 

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -207,8 +207,8 @@ extension Ghostty {
 
 extension Notification.Name {
     /// Configuration change. If the object is nil then it is app-wide. Otherwise its surface-specific.
-    static let ghosttyConfigChange = Notification.Name("com.mitchellh.ghostty.configChange")
-    static let GhosttyConfigChangeKey = ghosttyConfigChange.rawValue
+    static let ghosttyConfigDidChange = Notification.Name("com.mitchellh.ghostty.configDidChange")
+    static let GhosttyConfigChangeKey = ghosttyConfigDidChange.rawValue
 
     /// Goto tab. Has tab index in the userinfo.
     static let ghosttyMoveTab = Notification.Name("com.mitchellh.ghostty.moveTab")
@@ -220,9 +220,6 @@ extension Notification.Name {
 extension Ghostty.Notification {
     /// Used to pass a configuration along when creating a new tab/window/split.
     static let NewSurfaceConfigKey = "com.mitchellh.ghostty.newSurfaceConfig"
-
-    /// Posted when the application configuration is reloaded.
-    static let ghosttyDidReloadConfig = Notification.Name("com.mitchellh.ghostty.didReloadConfig")
 
     /// Posted when a new split is requested. The sending object will be the surface that had focus. The
     /// userdata has one key "direction" with the direction to split to.

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -210,6 +210,10 @@ extension Notification.Name {
     static let ghosttyConfigDidChange = Notification.Name("com.mitchellh.ghostty.configDidChange")
     static let GhosttyConfigChangeKey = ghosttyConfigDidChange.rawValue
 
+    /// Color change. Object is the surface changing.
+    static let ghosttyColorDidChange = Notification.Name("com.mitchellh.ghostty.ghosttyColorDidChange")
+    static let GhosttyColorChangeKey = ghosttyColorDidChange.rawValue
+
     /// Goto tab. Has tab index in the userinfo.
     static let ghosttyMoveTab = Notification.Name("com.mitchellh.ghostty.moveTab")
     static let GhosttyMoveTabKey = ghosttyMoveTab.rawValue

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -206,6 +206,10 @@ extension Ghostty {
 // MARK: Surface Notification
 
 extension Notification.Name {
+    /// Configuration change. If the object is nil then it is app-wide. Otherwise its surface-specific.
+    static let ghosttyConfigChange = Notification.Name("com.mitchellh.ghostty.configChange")
+    static let GhosttyConfigChangeKey = ghosttyConfigChange.rawValue
+
     /// Goto tab. Has tab index in the userinfo.
     static let ghosttyMoveTab = Notification.Name("com.mitchellh.ghostty.moveTab")
     static let GhosttyMoveTabKey = ghosttyMoveTab.rawValue

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -51,6 +51,10 @@ extension Ghostty {
         /// The configuration derived from the Ghostty config so we don't need to rely on references.
         @Published private(set) var derivedConfig: DerivedConfig
 
+        /// The background color within the color palette of the surface. This is only set if it is
+        /// dynamically updated. Otherwise, the background color is the default background color.
+        @Published private(set) var backgroundColor: Color? = nil
+
         // An initial size to request for a window. This will only affect
         // then the view is moved to a new window.
         var initialSize: NSSize? = nil
@@ -151,6 +155,11 @@ extension Ghostty {
                 self,
                 selector: #selector(ghosttyConfigDidChange(_:)),
                 name: .ghosttyConfigDidChange,
+                object: self)
+            center.addObserver(
+                self,
+                selector: #selector(ghosttyColorDidChange(_:)),
+                name: .ghosttyColorDidChange,
                 object: self)
             center.addObserver(
                 self,
@@ -356,6 +365,21 @@ extension Ghostty {
 
             // Update our derived config
             self.derivedConfig = DerivedConfig(config)
+        }
+
+        @objc private func ghosttyColorDidChange(_ notification: SwiftUI.Notification) {
+            guard let change = notification.userInfo?[
+                SwiftUI.Notification.Name.GhosttyColorChangeKey
+            ] as? Ghostty.Action.ColorChange else { return }
+
+            switch (change.kind) {
+            case .background:
+                self.backgroundColor = change.color
+
+            default:
+                // We don't do anything for the other colors yet.
+                break
+            }
         }
 
         @objc private func windowDidChangeScreen(notification: SwiftUI.Notification) {

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -48,6 +48,9 @@ extension Ghostty {
         // Whether the pointer should be visible or not
         @Published private(set) var pointerStyle: BackportPointerStyle = .default
 
+        /// The configuration derived from the Ghostty config so we don't need to rely on references.
+        @Published private(set) var derivedConfig: DerivedConfig
+
         // An initial size to request for a window. This will only affect
         // then the view is moved to a new window.
         var initialSize: NSSize? = nil
@@ -114,6 +117,13 @@ extension Ghostty {
             self.markedText = NSMutableAttributedString()
             self.uuid = uuid ?? .init()
 
+            // Our initial config always is our application wide config.
+            if let appDelegate = NSApplication.shared.delegate as? AppDelegate {
+                self.derivedConfig = DerivedConfig(appDelegate.ghostty.config)
+            } else {
+                self.derivedConfig = DerivedConfig()
+            }
+
             // Initialize with some default frame size. The important thing is that this
             // is non-zero so that our layer bounds are non-zero so that our renderer
             // can do SOMETHING.
@@ -136,6 +146,11 @@ extension Ghostty {
                 self,
                 selector: #selector(ghosttyDidEndKeySequence),
                 name: Ghostty.Notification.didEndKeySequence,
+                object: self)
+            center.addObserver(
+                self,
+                selector: #selector(ghosttyConfigDidChange(_:)),
+                name: .ghosttyConfigDidChange,
                 object: self)
             center.addObserver(
                 self,
@@ -331,6 +346,16 @@ extension Ghostty {
 
         @objc private func ghosttyDidEndKeySequence(notification: SwiftUI.Notification) {
             keySequence = []
+        }
+
+        @objc private func ghosttyConfigDidChange(_ notification: SwiftUI.Notification) {
+            // Get our managed configuration object out
+            guard let config = notification.userInfo?[
+                SwiftUI.Notification.Name.GhosttyConfigChangeKey
+            ] as? Ghostty.Config else { return }
+
+            // Update our derived config
+            self.derivedConfig = DerivedConfig(config)
         }
 
         @objc private func windowDidChangeScreen(notification: SwiftUI.Notification) {
@@ -1023,6 +1048,27 @@ extension Ghostty {
             if focus {
                 self.window?.makeKeyAndOrderFront(self)
                 Ghostty.moveFocus(to: self)
+            }
+        }
+
+        struct DerivedConfig {
+            let backgroundColor: Color
+            let backgroundOpacity: Double
+            let macosWindowShadow: Bool
+            let windowTitleFontFamily: String?
+
+            init() {
+                self.backgroundColor = Color(NSColor.windowBackgroundColor)
+                self.backgroundOpacity = 1
+                self.macosWindowShadow = true
+                self.windowTitleFontFamily = nil
+            }
+
+            init(_ config: Ghostty.Config) {
+                self.backgroundColor = config.backgroundColor
+                self.backgroundOpacity = config.backgroundOpacity
+                self.macosWindowShadow = config.macosWindowShadow
+                self.windowTitleFontFamily = config.windowTitleFontFamily
             }
         }
     }

--- a/macos/Sources/Helpers/OSColor+Extension.swift
+++ b/macos/Sources/Helpers/OSColor+Extension.swift
@@ -21,6 +21,14 @@ extension OSColor {
         return (0.299 * r) + (0.587 * g) + (0.114 * b)
     }
 
+    var hexString: String? {
+        guard let rgb = usingColorSpace(.deviceRGB) else { return nil }
+        let red = Int(rgb.redComponent * 255)
+        let green = Int(rgb.greenComponent * 255)
+        let blue = Int(rgb.blueComponent * 255)
+        return String(format: "#%02X%02X%02X", red, green, blue)
+    }
+
     func darken(by amount: CGFloat) -> OSColor {
         var h: CGFloat = 0, s: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
         self.getHue(&h, saturation: &s, brightness: &b, alpha: &a)

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1127,6 +1127,13 @@ pub fn updateConfig(
     self.queueRender() catch |err| {
         log.warn("failed to notify renderer of config change err={}", .{err});
     };
+
+    // Notify the window
+    try self.rt_app.performAction(
+        .{ .surface = self },
+        .config_change,
+        .{ .config = config },
+    );
 }
 
 /// Returns true if the terminal has a selection.

--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -226,6 +226,7 @@ pub const App = struct {
             .color_change,
             .pwd,
             .config_change_conditional_state,
+            .config_change,
             => log.info("unimplemented action={}", .{action}),
         }
     }

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -488,6 +488,7 @@ pub fn performAction(
         .render_inspector,
         .renderer_health,
         .color_change,
+        .config_change,
         => log.warn("unimplemented action={}", .{action}),
     }
 }

--- a/src/config/CAPI.zig
+++ b/src/config/CAPI.zig
@@ -19,6 +19,7 @@ export fn ghostty_config_new() ?*Config {
 
     result.* = Config.default(global.alloc) catch |err| {
         log.err("error creating config err={}", .{err});
+        global.alloc.destroy(result);
         return null;
     };
 
@@ -30,6 +31,22 @@ export fn ghostty_config_free(ptr: ?*Config) void {
         v.deinit();
         global.alloc.destroy(v);
     }
+}
+
+/// Deep clone the configuration.
+export fn ghostty_config_clone(self: *Config) ?*Config {
+    const result = global.alloc.create(Config) catch |err| {
+        log.err("error allocating config err={}", .{err});
+        return null;
+    };
+
+    result.* = self.clone(global.alloc) catch |err| {
+        log.err("error cloning config err={}", .{err});
+        global.alloc.destroy(result);
+        return null;
+    };
+
+    return result;
 }
 
 /// Load the configuration from the CLI args.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -365,7 +365,6 @@ const c = @cImport({
 /// be fixed in a future update:
 ///
 ///   - macOS: titlebar tabs style is not updated when switching themes.
-///   - macOS: native titlebar style is not supported.
 ///
 theme: ?Theme = null,
 
@@ -2756,12 +2755,6 @@ pub fn finalize(self: *Config) !void {
             // This setting doesn't make sense with different light/dark themes
             // because it'll force the theme based on the Ghostty theme.
             if (self.@"window-theme" == .auto) self.@"window-theme" = .system;
-
-            // This is buggy with different light/dark themes and is noted
-            // in the documentation.
-            if (self.@"macos-titlebar-style" == .transparent) {
-                self.@"macos-titlebar-style" = .native;
-            }
         }
     }
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1518,6 +1518,13 @@ keybind: Keybinds = .{},
 /// This makes a more seamless window appearance but looks a little less
 /// typical for a macOS application and may not work well with all themes.
 ///
+/// The "transparent" style will also update in real-time to dynamic
+/// changes to the window background color, i.e. via OSC 11. To make this
+/// more aesthetically pleasing, this only happens if the terminal is
+/// a window, tab, or split that borders the top of the window. This
+/// avoids a disjointed appearance where the titlebar color changes
+/// but all the topmost terminals don't match.
+///
 /// The "tabs" style is a completely custom titlebar that integrates the
 /// tab bar into the titlebar. This titlebar always matches the background
 /// color of the terminal. There are some limitations to this style:
@@ -1535,11 +1542,6 @@ keybind: Keybinds = .{},
 /// The default value is "transparent". This is an opinionated choice
 /// but its one I think is the most aesthetically pleasing and works in
 /// most cases.
-///
-/// BUG: If a separate light/dark mode theme is configured with "theme",
-/// then `macos-titlebar-style = transparent` will not work correctly. To
-/// avoid ugly titlebars, `macos-titlebar-style` will become `native` if
-/// a separate light/dark theme is configured.
 ///
 /// Changing this option at runtime only applies to new windows.
 @"macos-titlebar-style": MacTitlebarStyle = .transparent,


### PR DESCRIPTION
Fixes #2374 

This is a bit of a refactor that also happens to fix a bug.

The major new thing in this PR is that there is a new apprt action `config_change`. This is sent whenever the configuration changes. Most importantly, this will target a specific surface is a _surface specific change_ happened. For example, one window is light mode and another is dark mode (which is... possible, ugh!). 

Apprts are intended to use this message to react to any possible new configuration changes. For example, on macOS, we now use this to update our transparent titlebar to the proper background color when light/dark mode theme changes are used. This was a limitation of the initial light/dark mode work. 

