### PR TITLE
App applies conditional state, supports theme setting

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -675,6 +675,7 @@ void ghostty_app_open_config(ghostty_app_t);
 void ghostty_app_update_config(ghostty_app_t, ghostty_config_t);
 bool ghostty_app_needs_confirm_quit(ghostty_app_t);
 bool ghostty_app_has_global_keybinds(ghostty_app_t);
+void ghostty_app_set_color_scheme(ghostty_app_t, ghostty_color_scheme_e);
 
 ghostty_surface_config_s ghostty_surface_config_new();
 

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -1212,6 +1212,7 @@ extension Ghostty {
 
                 switch (target.tag) {
                 case GHOSTTY_TARGET_APP:
+                    // Notify the world that the app config changed
                     NotificationCenter.default.post(
                         name: .ghosttyConfigDidChange,
                         object: nil,
@@ -1219,6 +1220,14 @@ extension Ghostty {
                             SwiftUI.Notification.Name.GhosttyConfigChangeKey: config,
                         ]
                     )
+
+                    // We also REPLACE our app-level config when this happens. This lets
+                    // all the various things that depend on this but are still theme specific
+                    // such as split border color work.
+                    guard let app_ud = ghostty_app_userdata(app) else { return }
+                    let ghostty = Unmanaged<App>.fromOpaque(app_ud).takeUnretainedValue()
+                    ghostty.config = config
+
                     return
 
                 case GHOSTTY_TARGET_SURFACE:

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1357,6 +1357,22 @@ pub const CAPI = struct {
         return v.hasGlobalKeybinds();
     }
 
+    /// Update the color scheme of the app.
+    export fn ghostty_app_set_color_scheme(v: *App, scheme_raw: c_int) void {
+        const scheme = std.meta.intToEnum(apprt.ColorScheme, scheme_raw) catch {
+            log.warn(
+                "invalid color scheme to ghostty_surface_set_color_scheme value={}",
+                .{scheme_raw},
+            );
+            return;
+        };
+
+        v.core_app.colorSchemeEvent(v, scheme) catch |err| {
+            log.err("error setting color scheme err={}", .{err});
+            return;
+        };
+    }
+
     /// Returns initial surface options.
     export fn ghostty_surface_config_new() apprt.Surface.Options {
         return .{};


### PR DESCRIPTION
The prior light/dark mode awareness work works on surface-level APIs. As a result, configurations used at the app-level (such as split divider colors, inactive split opacity, etc.) are not aware of the current theme configurations and default to the "light" theme.

This commit adds APIs to specify app-level color scheme changes. This changes the configuration for the app and sets the default conditional state to use that new theme. This latter point makes it so that future surfaces use the correct theme on load rather than requiring some apprt event loop ticks. Some users have already reported a short "flicker" to load the correct theme, so this should help alleviate that.