### PR TITLE
config: clone() needs to preserve conditionals of replay steps

### DIFF
--- a/src/config/conditional.zig
+++ b/src/config/conditional.zig
@@ -61,6 +61,17 @@ pub const Conditional = struct {
     value: []const u8,
 
     pub const Op = enum { eq, ne };
+
+    pub fn clone(
+        self: Conditional,
+        alloc: Allocator,
+    ) Allocator.Error!Conditional {
+        return .{
+            .key = self.key,
+            .op = self.op,
+            .value = try alloc.dupe(u8, self.value),
+        };
+    }
 };
 
 test "conditional enum match" {


### PR DESCRIPTION
Fixes #2791

This goes back to the previous implementation of clone that directly cloned values rather than using replay steps, because replay steps don't preserve conditionals on the iterator.

This works.

Another fix will be when we support some sort of conditional syntax and the replay iterator can yield that information. We have a unit test here so we can verify that then.