### PR TITLE
termio: track whether fg/bg color is explicitly set

### DIFF
--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -200,9 +200,9 @@ pub fn init(self: *Termio, alloc: Allocator, opts: termio.Options) !void {
             .default_cursor_style = opts.config.cursor_style,
             .default_cursor_blink = opts.config.cursor_blink,
             .default_cursor_color = default_cursor_color,
-            .cursor_color = default_cursor_color,
-            .foreground_color = opts.config.foreground.toTerminalRGB(),
-            .background_color = opts.config.background.toTerminalRGB(),
+            .cursor_color = null,
+            .foreground_color = null,
+            .background_color = null,
         };
     };
 


### PR DESCRIPTION
Fixes: https://github.com/ghostty-org/ghostty/issues/2786

Make the foreground_color and background_color fields in the Terminal struct optional values so that we can determine if a foreground or background color was explicitly set with an OSC 10 or OSC 11 sequence. This makes the logic a bit simpler to reason about (i.e. `foreground_color` is now always "the color set by an OSC 10 sequence" while `default_foreground_color` is always "the color set by the config file") and also fixes an issue where an OSC 10 or OSC 11 query would not report the correct color after a config update changed the foreground or background color.

The `cursor_color` field was already optional, with the same semantics (it is only non-null when explicitly set with an OSC 12) so this brings all three of these fields into alignment.