### PR TITLE
[WIP] Add menu item for making Ghostty the default terminal

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -690,10 +690,10 @@ class AppDelegate: NSObject,
         return bundleID.isEqual(defaultTerminal())
     }
     
-    func defaultTerminal() -> String {
+    func defaultTerminal() -> String? {
         let unixExecutableContentType: CFString = "public.unix-executable" as CFString
         let unixHandler = LSCopyDefaultRoleHandlerForContentType(unixExecutableContentType, LSRolesMask.shell)
-        let current = unixHandler?.takeRetainedValue() as? String ?? ""
+        let current = unixHandler?.takeRetainedValue() as? String
         
         return current
     }

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -24,7 +24,7 @@ class AppDelegate: NSObject,
     @IBOutlet private var menuReloadConfig: NSMenuItem?
     @IBOutlet private var menuSecureInput: NSMenuItem?
     @IBOutlet private var menuQuit: NSMenuItem?
-    @IBOutlet private var menuMakeDefaultTerminal: NSMenuItem?
+    @IBOutlet private var menuMakeGhosttyDefaultTerminal: NSMenuItem?
 
     @IBOutlet private var menuNewWindow: NSMenuItem?
     @IBOutlet private var menuNewTab: NSMenuItem?
@@ -208,6 +208,9 @@ class AppDelegate: NSObject,
 
             ghostty_app_set_color_scheme(app, scheme)
         }
+        
+        // Check if Ghostty is already the default terminal
+        updateDefaultTerminalMenuItem()
     }
 
     func applicationDidBecomeActive(_ notification: Notification) {
@@ -666,13 +669,11 @@ class AppDelegate: NSObject,
     }
 
     @IBAction func makeGhosttyDefaultTerminal(_ sender: Any) {
-        Ghostty.logger.debug("Clicked makeDefaultTerminal")
         let ghosttyBundleID = Bundle.main.bundleIdentifier!
         setDefaultTerminal(bundleID: ghosttyBundleID)
     }
    
     @IBAction func makeTerminalDefaultTerminal(_ sender: Any) {
-        Ghostty.logger.debug("Clicked makeTerminalDefaultTerminal")
         let terminalBundleID = "com.apple.terminal"
         setDefaultTerminal(bundleID: terminalBundleID)
     }
@@ -687,7 +688,6 @@ class AppDelegate: NSObject,
     
     func isDefaultTerminal(bundleID: String) -> Bool {
         return bundleID.isEqual(defaultTerminal())
-        // return CFStringCompare(bundleID as CFString, unixHandler?.takeRetainedValue(), CFStringCompareFlags.compareBackwards) == CFComparisonResult.compareEqualTo
     }
     
     func defaultTerminal() -> String {
@@ -699,10 +699,14 @@ class AppDelegate: NSObject,
     }
     
     func setDefaultTerminal(bundleID: String) {
-        Ghostty.logger.debug("Setting default terminal to \(bundleID)")
-        Ghostty.logger.debug("Is Ghostty default? \(self.isGhosttyDefault())")
-        Ghostty.logger.debug("Is Terminal default? \(self.isTerminalDefault())")
-        Ghostty.logger.debug("Debugging default terminal: \(self.defaultTerminal())")
+     let unixExecutableContentType: CFString = "public.unix-executable" as CFString
+        LSSetDefaultRoleHandlerForContentType(unixExecutableContentType, LSRolesMask.shell, bundleID as CFString)
+       
+        updateDefaultTerminalMenuItem()
+    }
+    
+    func updateDefaultTerminalMenuItem() {
+        menuMakeGhosttyDefaultTerminal?.isEnabled = !self.isGhosttyDefault()
     }
 
     @IBAction func toggleQuickTerminal(_ sender: Any) {

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -665,8 +665,44 @@ class AppDelegate: NSObject,
         setSecureInput(.toggle)
     }
 
-    @IBAction func makeDefaultTerminal(_ sender: Any) {
+    @IBAction func makeGhosttyDefaultTerminal(_ sender: Any) {
         Ghostty.logger.debug("Clicked makeDefaultTerminal")
+        let ghosttyBundleID = Bundle.main.bundleIdentifier!
+        setDefaultTerminal(bundleID: ghosttyBundleID)
+    }
+   
+    @IBAction func makeTerminalDefaultTerminal(_ sender: Any) {
+        Ghostty.logger.debug("Clicked makeTerminalDefaultTerminal")
+        let terminalBundleID = "com.apple.terminal"
+        setDefaultTerminal(bundleID: terminalBundleID)
+    }
+   
+    func isGhosttyDefault() -> Bool {
+        return isDefaultTerminal(bundleID: Bundle.main.bundleIdentifier!)
+    }
+    
+    func isTerminalDefault() -> Bool {
+        return isDefaultTerminal(bundleID: "com.apple.terminal")
+    }
+    
+    func isDefaultTerminal(bundleID: String) -> Bool {
+        return bundleID.isEqual(defaultTerminal())
+        // return CFStringCompare(bundleID as CFString, unixHandler?.takeRetainedValue(), CFStringCompareFlags.compareBackwards) == CFComparisonResult.compareEqualTo
+    }
+    
+    func defaultTerminal() -> String {
+        let unixExecutableContentType: CFString = "public.unix-executable" as CFString
+        let unixHandler = LSCopyDefaultRoleHandlerForContentType(unixExecutableContentType, LSRolesMask.shell)
+        let current = unixHandler?.takeRetainedValue() as? String ?? ""
+        
+        return current
+    }
+    
+    func setDefaultTerminal(bundleID: String) {
+        Ghostty.logger.debug("Setting default terminal to \(bundleID)")
+        Ghostty.logger.debug("Is Ghostty default? \(self.isGhosttyDefault())")
+        Ghostty.logger.debug("Is Terminal default? \(self.isTerminalDefault())")
+        Ghostty.logger.debug("Debugging default terminal: \(self.defaultTerminal())")
     }
 
     @IBAction func toggleQuickTerminal(_ sender: Any) {

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -24,6 +24,7 @@ class AppDelegate: NSObject,
     @IBOutlet private var menuReloadConfig: NSMenuItem?
     @IBOutlet private var menuSecureInput: NSMenuItem?
     @IBOutlet private var menuQuit: NSMenuItem?
+    @IBOutlet private var menuMakeDefaultTerminal: NSMenuItem?
 
     @IBOutlet private var menuNewWindow: NSMenuItem?
     @IBOutlet private var menuNewTab: NSMenuItem?
@@ -662,6 +663,10 @@ class AppDelegate: NSObject,
 
     @IBAction func toggleSecureInput(_ sender: Any) {
         setSecureInput(.toggle)
+    }
+
+    @IBAction func makeDefaultTerminal(_ sender: Any) {
+        Ghostty.logger.debug("Clicked makeDefaultTerminal")
     }
 
     @IBAction func toggleQuickTerminal(_ sender: Any) {

--- a/macos/Sources/App/macOS/MainMenu.xib
+++ b/macos/Sources/App/macOS/MainMenu.xib
@@ -22,7 +22,7 @@
                 <outlet property="menuDecreaseFontSize" destination="kzb-SZ-dOA" id="Y1B-Vh-6Z2"/>
                 <outlet property="menuEqualizeSplits" destination="3gH-VD-vL9" id="SiZ-ce-FOF"/>
                 <outlet property="menuIncreaseFontSize" destination="CIH-ey-Z6x" id="hkc-9C-80E"/>
-                <outlet property="menuMakeDefaultTerminal" destination="gFP-FT-8g6" id="KNl-nG-qQv"/>
+                <outlet property="menuMakeGhosttyDefaultTerminal" destination="gFP-FT-8g6" id="m5T-sE-1oX"/>
                 <outlet property="menuMoveSplitDividerDown" destination="Zj7-2W-fdF" id="997-LL-nlN"/>
                 <outlet property="menuMoveSplitDividerLeft" destination="wSR-ny-j1a" id="HCZ-CI-2ob"/>
                 <outlet property="menuMoveSplitDividerRight" destination="CcX-ql-QU4" id="rIn-PK-fVM"/>

--- a/macos/Sources/App/macOS/MainMenu.xib
+++ b/macos/Sources/App/macOS/MainMenu.xib
@@ -86,10 +86,10 @@
                                     <action selector="toggleSecureInput:" target="bbz-4X-AYv" id="vWx-z8-5Sy"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Make Default Terminal" id="gFP-FT-8g6">
+                            <menuItem title="Make Ghostty Default Terminal" id="gFP-FT-8g6">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
-                                    <action selector="makeDefaultTerminal:" target="bbz-4X-AYv" id="CaP-G2-Cph"/>
+                                    <action selector="makeGhosttyDefaultTerminal:" target="bbz-4X-AYv" id="o1U-Dx-VR6"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="4je-JR-u6R"/>

--- a/macos/Sources/App/macOS/MainMenu.xib
+++ b/macos/Sources/App/macOS/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23094" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23504" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23094"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23504"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -22,6 +22,7 @@
                 <outlet property="menuDecreaseFontSize" destination="kzb-SZ-dOA" id="Y1B-Vh-6Z2"/>
                 <outlet property="menuEqualizeSplits" destination="3gH-VD-vL9" id="SiZ-ce-FOF"/>
                 <outlet property="menuIncreaseFontSize" destination="CIH-ey-Z6x" id="hkc-9C-80E"/>
+                <outlet property="menuMakeDefaultTerminal" destination="gFP-FT-8g6" id="KNl-nG-qQv"/>
                 <outlet property="menuMoveSplitDividerDown" destination="Zj7-2W-fdF" id="997-LL-nlN"/>
                 <outlet property="menuMoveSplitDividerLeft" destination="wSR-ny-j1a" id="HCZ-CI-2ob"/>
                 <outlet property="menuMoveSplitDividerRight" destination="CcX-ql-QU4" id="rIn-PK-fVM"/>
@@ -83,6 +84,12 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="toggleSecureInput:" target="bbz-4X-AYv" id="vWx-z8-5Sy"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Make Default Terminal" id="gFP-FT-8g6">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="makeDefaultTerminal:" target="bbz-4X-AYv" id="CaP-G2-Cph"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="4je-JR-u6R"/>


### PR DESCRIPTION
I looked at the [source code of iTerm2](https://github.com/gnachman/iTerm2/blob/803acf37f9e016e7d52a7ec5e9028759de8ad491/sources/iTermLaunchServices.m#L241-L247) to figure out how they do this, but this takes the same logic and implements it within Ghostty. There's also functions for setting the Terminal back to the default macOS Terminal, but these are not hooked up to the UI just yet (was unsure if they were wanted). 

Only thing blocking this pull request from being ready is disabling the menu item when Ghostty is already the default. 😅 