### PR TITLE
Support changing the cursor style for unfocused windows

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -442,6 +442,10 @@ palette: Palette = .{},
 ///
 @"cursor-style": terminal.CursorStyle = .block,
 
+/// The style of the cursor when the window is not focused. All valid values
+/// supported by `cursor-style` are accepted here as well.
+@"cursor-style-unfocused": terminal.CursorStyle = .block_hollow,
+
 /// Sets the default blinking state of the cursor. This is just the default
 /// state; running programs may override the cursor style using `DECSCUSR` (`CSI
 /// q`).

--- a/src/renderer/cursor.zig
+++ b/src/renderer/cursor.zig
@@ -51,8 +51,8 @@ pub fn style(
     // If the cursor is explicitly not visible by terminal mode, we don't render.
     if (!state.terminal.modes.get(.cursor_visible)) return null;
 
-    // If we're not focused, our cursor is always visible so that
-    // we can show the hollow box.
+    // If we're not focused, our cursor is always visible showing the
+    // specified style.
     if (!focused) return Style.fromTerminal(state.terminal.screen.cursor.cursor_style_unfocused);
 
     // If the cursor is blinking and our blink state is not visible,

--- a/src/renderer/cursor.zig
+++ b/src/renderer/cursor.zig
@@ -53,7 +53,7 @@ pub fn style(
 
     // If we're not focused, our cursor is always visible so that
     // we can show the hollow box.
-    if (!focused) return .block_hollow;
+    if (!focused) return Style.fromTerminal(state.terminal.screen.cursor.cursor_style_unfocused);
 
     // If the cursor is blinking and our blink state is not visible,
     // then we don't show the cursor.
@@ -72,6 +72,7 @@ test "cursor: default uses configured style" {
     defer term.deinit(alloc);
 
     term.screen.cursor.cursor_style = .bar;
+    term.screen.cursor.cursor_style_unfocused = .underline;
     term.modes.set(.cursor_blinking, true);
 
     var state: State = .{
@@ -81,8 +82,8 @@ test "cursor: default uses configured style" {
     };
 
     try testing.expect(style(&state, true, true) == .bar);
-    try testing.expect(style(&state, false, true) == .block_hollow);
-    try testing.expect(style(&state, false, false) == .block_hollow);
+    try testing.expect(style(&state, false, true) == .underline);
+    try testing.expect(style(&state, false, false) == .underline);
     try testing.expect(style(&state, true, false) == null);
 }
 

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -91,6 +91,9 @@ pub const Cursor = struct {
     /// encouraged to set their own default.
     cursor_style: CursorStyle = .block,
 
+    /// The visual style of the cursor when the window is not focused.
+    cursor_style_unfocused: CursorStyle = .block_hollow,
+
     /// The "last column flag (LCF)" as its called. If this is set then the
     /// next character print will force a soft-wrap.
     pending_wrap: bool = false,

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -79,6 +79,7 @@ pub const DerivedConfig = struct {
     palette: terminal.color.Palette,
     image_storage_limit: usize,
     cursor_style: terminal.CursorStyle,
+    cursor_style_unfocused: terminal.CursorStyle,
     cursor_blink: ?bool,
     cursor_color: ?configpkg.Config.Color,
     cursor_invert: bool,
@@ -101,6 +102,7 @@ pub const DerivedConfig = struct {
             .palette = config.palette.value,
             .image_storage_limit = config.@"image-storage-limit",
             .cursor_style = config.@"cursor-style",
+            .cursor_style_unfocused = config.@"cursor-style-unfocused",
             .cursor_blink = config.@"cursor-style-blink",
             .cursor_color = config.@"cursor-color",
             .cursor_invert = config.@"cursor-invert-fg-bg",
@@ -167,6 +169,7 @@ pub fn init(self: *Termio, alloc: Allocator, opts: termio.Options) !void {
 
     // Set our default cursor style
     term.screen.cursor.cursor_style = opts.config.cursor_style;
+    term.screen.cursor.cursor_style_unfocused = opts.config.cursor_style_unfocused;
 
     // Setup our terminal size in pixels for certain requests.
     term.width_px = term.cols * opts.size.cell.width;


### PR DESCRIPTION
This adds the `cursor-style-unfocused` config option (called `cursor-shape-unfocused` in kitty).

Setting it to `bar` for example looks like this when then the window is not focused.
![a terminal prompt with a bar cursor](https://github.com/user-attachments/assets/8ff5771c-4ba9-4a93-a89b-8d5de30f5d0d)

Before it would always show a `block_hollow` like this:
![a terminal prompt with a outlined/hollow block at the end](https://github.com/user-attachments/assets/0852340d-d510-44d6-abaa-d26437c80e6c)