### PR TITLE
termio: fixes to kitty color reporting

### DIFF
--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1418,7 +1418,7 @@ pub const StreamHandler = struct {
         var buf = std.ArrayList(u8).init(self.alloc);
         defer buf.deinit();
         const writer = buf.writer();
-        try writer.writeAll("\x1b[21");
+        try writer.writeAll("\x1b]21");
 
         for (request.list.items) |item| {
             switch (item) {
@@ -1435,7 +1435,7 @@ pub const StreamHandler = struct {
                             },
                         },
                     } orelse {
-                        log.warn("no color configured for {}", .{key});
+                        try writer.print(";{}=", .{key});
                         continue;
                     };
 


### PR DESCRIPTION
The kitty color report response is an OSC, not a CSI, so change `[` to `]`. Colors which are unset should be reported with `{key}=`.

Ref: https://sw.kovidgoyal.net/kitty/color-stack/

>For example, if the client sends:
>
>```
><OSC> 21 ; foreground=? ; cursor=? <ST>
>```
>
>The terminal responds:
>
>```
><OSC> 21 ; foreground=rgb:ff/00/00 ; cursor= <ST>
>```
>
>This indicates that the foreground color is red and the cursor color is undefined