### PR TITLE
Prevent GTK from initializing Vulkan. This improves startup time

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -99,9 +99,11 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
         c.gtk_get_micro_version(),
     });
 
+    // Disabling Vulkan can improve startup times by hundreds of
+    // milliseconds on some systems
     if (version.atLeast(4, 16, 0)) {
         // From gtk 4.16, GDK_DEBUG is split into GDK_DEBUG and GDK_DISABLE
-        _ = internal_os.setenv("GDK_DISABLE", "gles-api");
+        _ = internal_os.setenv("GDK_DISABLE", "gles-api,vulkan");
         _ = internal_os.setenv("GDK_DEBUG", "opengl");
     } else if (version.atLeast(4, 14, 0)) {
         // We need to export GDK_DEBUG to run on Wayland after GTK 4.14.
@@ -110,7 +112,10 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
         // reassess...
         //
         // Upstream issue: https://gitlab.gnome.org/GNOME/gtk/-/issues/6589
+        _ = internal_os.setenv("GDK_DISABLE", "vulkan");
         _ = internal_os.setenv("GDK_DEBUG", "opengl,gl-disable-gles");
+    } else {
+        _ = internal_os.setenv("GDK_DISABLE", "vulkan");
     }
 
     if (version.atLeast(4, 14, 0)) {

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -100,9 +100,11 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
     });
 
     // Disabling Vulkan can improve startup times by hundreds of
-    // milliseconds on some systems
+    // milliseconds on some systems. We don't use Vulkan so we can just
+    // disable it.
     if (version.atLeast(4, 16, 0)) {
-        // From gtk 4.16, GDK_DEBUG is split into GDK_DEBUG and GDK_DISABLE
+        // From gtk 4.16, GDK_DEBUG is split into GDK_DEBUG and GDK_DISABLE.
+        // For the remainder of "why" see the 4.14 comment below.
         _ = internal_os.setenv("GDK_DISABLE", "gles-api,vulkan");
         _ = internal_os.setenv("GDK_DEBUG", "opengl");
     } else if (version.atLeast(4, 14, 0)) {
@@ -112,14 +114,14 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
         // reassess...
         //
         // Upstream issue: https://gitlab.gnome.org/GNOME/gtk/-/issues/6589
-        _ = internal_os.setenv("GDK_DISABLE", "vulkan");
-        _ = internal_os.setenv("GDK_DEBUG", "opengl,gl-disable-gles");
+        _ = internal_os.setenv("GDK_DEBUG", "opengl,gl-disable-gles,vulkan-disable");
     } else {
-        _ = internal_os.setenv("GDK_DISABLE", "vulkan");
+        _ = internal_os.setenv("GDK_DEBUG", "vulkan-disable");
     }
 
     if (version.atLeast(4, 14, 0)) {
-        // We need to export GSK_RENDERER to opengl because GTK uses ngl by default after 4.14
+        // We need to export GSK_RENDERER to opengl because GTK uses ngl by
+        // default after 4.14
         _ = internal_os.setenv("GSK_RENDERER", "opengl");
     }
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -843,6 +843,7 @@ const Subprocess = struct {
         // Don't leak these environment variables to child processes.
         if (comptime build_config.app_runtime == .gtk) {
             env.remove("GDK_DEBUG");
+            env.remove("GDK_DISABLE");
             env.remove("GSK_RENDERER");
         }
 


### PR DESCRIPTION
On my system, the overhead of initializing Vulkan adds hundreds of milliseconds of initial startup time to this application. This PR uses the `GDK_DISABLE` environment variable to stop GTK from initializing Vulkan.