### PR TITLE
Initialize GL without drawing anything when `initial-window=false`

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -1163,6 +1163,7 @@ fn newWindow(self: *App, parent_: ?*CoreSurface, hidden: bool) !void {
     // freed when the window is closed.
     var window = try Window.create(alloc, self, hidden);
 
+    // The window should be destroyed if hidden == true
     if (!hidden) {
         // Add our initial tab
         try window.newTab(parent_);

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -54,7 +54,7 @@ toast_overlay: ?*c.GtkWidget,
 /// See adwTabOverviewOpen for why we have this.
 adw_tab_overview_focus_timer: ?c.guint = null,
 
-pub fn create(alloc: Allocator, app: *App) !*Window {
+pub fn create(alloc: Allocator, app: *App, hidden: bool) !*Window {
     // Allocate a fixed pointer for our window. We try to minimize
     // allocations but windows and other GUI requirements are so minimal
     // compared to the steady-state terminal operation so we use heap
@@ -64,11 +64,11 @@ pub fn create(alloc: Allocator, app: *App) !*Window {
     // freed when the window is closed.
     var window = try alloc.create(Window);
     errdefer alloc.destroy(window);
-    try window.init(app);
+    try window.init(app, hidden);
     return window;
 }
 
-pub fn init(self: *Window, app: *App) !void {
+pub fn init(self: *Window, app: *App, hidden: bool) !void {
     // Set up our own state
     self.* = .{
         .app = app,
@@ -361,6 +361,10 @@ pub fn init(self: *Window, app: *App) !void {
 
     // Show the window
     c.gtk_widget_show(window);
+    if (hidden) {
+        c.gtk_widget_hide(window);
+        c.gtk_window_destroy(gtk_window);
+    }
 }
 
 /// Sets up the GTK actions for the window scope. Actions are how GTK handles

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -361,6 +361,9 @@ pub fn init(self: *Window, app: *App, hidden: bool) !void {
 
     // Show the window
     c.gtk_widget_show(window);
+    // Showing the window widget should be enough to clear
+    // the startup hurdle of initializing EGL for the first
+    // time. Now we just need to hide and deinit the window
     if (hidden) {
         c.gtk_widget_hide(window);
         c.gtk_window_destroy(gtk_window);

--- a/src/apprt/gtk/notebook.zig
+++ b/src/apprt/gtk/notebook.zig
@@ -490,5 +490,5 @@ fn createWindow(currentWindow: *Window) !*Window {
     const app = currentWindow.app;
 
     // Create a new window
-    return Window.create(alloc, app);
+    return Window.create(alloc, app, false);
 }


### PR DESCRIPTION
This PR addresses another big startup hitch, which is the initialization of the first window. This PR makes it so that when `initial-window=false`, it initializes the GL context and hides the window before it can draw anything. If you're running ghostty as a background service on your system, this makes the first window launch as quickly as if the first window had already been spawned.

(I agree for these contributions to be re-licensed under MIT)