### PR TITLE
config: need to dupe filepath for diagnostics

### DIFF
--- a/src/cli/diagnostics.zig
+++ b/src/cli/diagnostics.zig
@@ -56,7 +56,7 @@ pub const Location = union(enum) {
 
     pub const Key = @typeInfo(Location).Union.tag_type.?;
 
-    pub fn fromIter(iter: anytype) Location {
+    pub fn fromIter(iter: anytype, alloc: Allocator) Allocator.Error!Location {
         const Iter = t: {
             const T = @TypeOf(iter);
             break :t switch (@typeInfo(T)) {
@@ -67,7 +67,7 @@ pub const Location = union(enum) {
         };
 
         if (!@hasDecl(Iter, "location")) return .none;
-        return iter.location() orelse .none;
+        return (try iter.location(alloc)) orelse .none;
     }
 
     pub fn clone(self: *const Location, alloc: Allocator) Allocator.Error!Location {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2988,7 +2988,7 @@ pub fn parseManuallyHook(
 
         if (command.items.len == 0) {
             try self._diagnostics.append(alloc, .{
-                .location = cli.Location.fromIter(iter),
+                .location = try cli.Location.fromIter(iter, alloc),
                 .message = try std.fmt.allocPrintZ(
                     alloc,
                     "missing command after {s}",


### PR DESCRIPTION
Fixes #2800

The source string with the filepath is not guaranteed to exist beyond the lifetime of the parse operation. We must copy it.