### PR TITLE
macos: unicode keybindings must convert to string properly

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.Input.swift
+++ b/macos/Sources/Ghostty/Ghostty.Input.swift
@@ -50,7 +50,8 @@ extension Ghostty {
             }
 
         case GHOSTTY_TRIGGER_UNICODE:
-            equiv = String(trigger.key.unicode)
+            guard let scalar = UnicodeScalar(trigger.key.unicode) else { return nil }
+            equiv = String(scalar)
 
         default:
             return nil


### PR DESCRIPTION
Fixes #2848

The proper way to convert a unicode scalar in Swift is to use the `String` initializer that takes a `UnicodeScalar` as an argument. We were converting a number to a string before, which is incorrect.