### PR TITLE
terminal: reset should preserve desired default mode values

### DIFF
--- a/src/terminal/main.zig
+++ b/src/terminal/main.zig
@@ -47,6 +47,7 @@ pub const CursorStyle = Screen.CursorStyle;
 pub const CursorStyleReq = ansi.CursorStyle;
 pub const DeviceAttributeReq = ansi.DeviceAttributeReq;
 pub const Mode = modes.Mode;
+pub const ModePacked = modes.ModePacked;
 pub const ModifyKeyFormat = ansi.ModifyKeyFormat;
 pub const ProtectedMode = ansi.ProtectedMode;
 pub const StatusLineType = ansi.StatusLineType;

--- a/src/terminal/modes.zig
+++ b/src/terminal/modes.zig
@@ -21,6 +21,17 @@ pub const ModeState = struct {
     /// a real-world issue but we need to be aware of a DoS vector.
     saved: ModePacked = .{},
 
+    /// The default values for the modes. This is used to reset
+    /// the modes to their default values during reset.
+    default: ModePacked = .{},
+
+    /// Reset the modes to their default values. This also clears the
+    /// saved state.
+    pub fn reset(self: *ModeState) void {
+        self.values = self.default;
+        self.saved = .{};
+    }
+
     /// Set a mode to a value.
     pub fn set(self: *ModeState, mode: Mode, value: bool) void {
         switch (mode) {


### PR DESCRIPTION
Fixes #2857

Some terminal modes always reset, but there are others that should be conditional based on how the terminal's default state is configured. Primarily from #2857 is the grapheme clustering mode (mode 2027) which was always resetting to false but should be conditional based on the the `grapheme-width-method` configuration.