### PR TITLE
macos: trigger fullscreenDidChange on any fullscreen event

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -57,6 +57,7 @@ class QuickTerminalController: BaseTerminalController {
     // MARK: NSWindowController
 
     override func windowDidLoad() {
+        super.windowDidLoad()
         guard let window = self.window else { return }
 
         // The controller is the window delegate so we can detect events such as

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -404,7 +404,21 @@ class BaseTerminalController: NSWindowController,
         }
     }
 
-    //MARK: - NSWindowDelegate
+    // MARK: NSWindowController
+
+    override func windowDidLoad() {
+        guard let window else { return }
+
+        // We always initialize our fullscreen style to native if we can because
+        // initialization sets up some state (i.e. observers). If its set already
+        // somehow we don't do this.
+        if fullscreenStyle == nil {
+            fullscreenStyle = NativeFullscreen(window)
+            fullscreenStyle?.delegate = self
+        }
+    }
+
+    // MARK: NSWindowDelegate
 
     // This is called when performClose is called on a window (NOT when close()
     // is called directly). performClose is called primarily when UI elements such

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -275,6 +275,7 @@ class TerminalController: BaseTerminalController {
     }
 
     override func windowDidLoad() {
+        super.windowDidLoad()
         guard let window = window as? TerminalWindow else { return }
 
         // I copy this because we may change the source in the future but also because


### PR DESCRIPTION
Fixes #2840
Related to #2842

This builds on #2842 by missing a key situation: when native fullscreen is toggled using the menu bar items it doesn't go through our `FullscreenStyle` machinery so we don't trigger fullscreen change events.

This commit makes it so that our FullscreenStyle always listens for native fullscreen change (even in non-native modes) to fire a fullscreen did change event. This way we can always rely on the event to be fired when fullscreen changes no matter what.