### PR TITLE
Fix slow scroll in tui apps

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2336,7 +2336,7 @@ pub fn scrollCallback(
 
         // If we're scrolling up or down, then send a mouse event.
         if (self.io.terminal.flags.mouse_event != .none) {
-            if (y.delta != 0) {
+            for (0..@abs(y.delta)) |_| {
                 const pos = try self.rt_surface.getCursorPos();
                 try self.mouseReport(switch (y.direction()) {
                     .up_right => .four,
@@ -2344,7 +2344,7 @@ pub fn scrollCallback(
                 }, .press, self.mouse.mods, pos);
             }
 
-            if (x.delta != 0) {
+            for (0..@abs(x.delta)) |_| {
                 const pos = try self.rt_surface.getCursorPos();
                 try self.mouseReport(switch (x.direction()) {
                     .up_right => .six,


### PR DESCRIPTION
scrollCallback sends only one mouseReport action per scroll, even if |delta| > 1. That makes scrolling inside apps such as nvim or helix much slower than scrolling in console.


Comparison with alacritty:

https://github.com/user-attachments/assets/085b0348-50cd-4385-a03c-14e771c15910

