### PR TITLE
[docs] Add a note to the README about restarting the app after config…

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,10 @@ ghostty +list-themes
 ...
 ```
 
-On macOS, the themes are built-in to the `Ghostty.app` bundle. On Linux,
-theme support requires a valid Ghostty resources dir ("share" directory).
+On macOS, the themes are built-in to the `Ghostty.app` bundle. Note: to reload the 
+configuration, you must quit (Cmd-Q) and restart ghostty. 
+
+On Linux, theme support requires a valid Ghostty resources dir ("share" directory).
 More details about how to validate the resources directory on Linux
 is covered in the [shell integration section](#shell-integration-installation-and-verification).
 


### PR DESCRIPTION
… changes

I was confused by the lack of color theme refresh until I read this helpful comment on Discord: https://discord.com/channels/1005603569187160125/1304477676584570900/1304478280073744487

Added a quick note to the README for future people like me.