### PR TITLE
macos: Make "Settings…" menu item open config file in Application Sup…

### DIFF
--- a/src/config/edit.zig
+++ b/src/config/edit.zig
@@ -7,21 +7,23 @@ const internal_os = @import("../os/main.zig");
 /// paths the main config file could be in.
 pub fn open(alloc_gpa: Allocator) !void {
     // default location
-    var config_path = try internal_os.xdg.config(alloc_gpa, .{ .subdir = "ghostty/config" });
+    const config_path = config_path: {
+        const xdg_config_path = try internal_os.xdg.config(alloc_gpa, .{ .subdir = "ghostty/config" });
 
-    if (comptime builtin.os.tag == .macos) {
-        const xdg_config_exists = if (std.fs.accessAbsolute(config_path, std.fs.File.OpenFlags{})) true else |err| switch (err) {
-            error.BadPathName => false,
-            error.FileNotFound => false,
-            else => true,
-        };
+        if (comptime builtin.os.tag == .macos) macos: {
+            if (std.fs.accessAbsolute(xdg_config_path, .{})) {
+                break :macos;
+            } else |err| switch (err) {
+                error.BadPathName, error.FileNotFound => {},
+                else => break :macos,
+            }
 
-        if (!xdg_config_exists) {
-            alloc_gpa.free(config_path);
-            config_path = try internal_os.macos.appSupportDir(alloc_gpa, "config");
+            alloc_gpa.free(xdg_config_path);
+            break :config_path try internal_os.macos.appSupportDir(alloc_gpa, "config");
         }
-    }
 
+        break :config_path xdg_config_path;
+    };
     defer alloc_gpa.free(config_path);
 
     // Create config directory recursively.

--- a/src/config/edit.zig
+++ b/src/config/edit.zig
@@ -11,6 +11,7 @@ pub fn open(alloc_gpa: Allocator) !void {
         const xdg_config_path = try internal_os.xdg.config(alloc_gpa, .{ .subdir = "ghostty/config" });
 
         if (comptime builtin.os.tag == .macos) macos: {
+            // On macOS, use the application support path if the XDG path doesn't exists.
             if (std.fs.accessAbsolute(xdg_config_path, .{})) {
                 break :macos;
             } else |err| switch (err) {


### PR DESCRIPTION
…port

...unless ~/.config/ghostty/config already exists, then that is opened. (Or whatever $XDG_CONFIG_HOME points to.)

If both files exists, ghostty reads first the one in ~/.config/ghostty/config and then the one in Application Support, and merges the settings. In that case, the menu item opens the file at ~/.config.

Fixes #2890.