### PR TITLE
macos: fix unwanted resize in non native fullscreen

### DIFF
--- a/macos/Sources/Helpers/Fullscreen.swift
+++ b/macos/Sources/Helpers/Fullscreen.swift
@@ -167,9 +167,9 @@ class NonNativeFullscreen: FullscreenBase, FullscreenStyle {
         self.savedState = savedState
 
         // We hide the dock if the window is on a screen with the dock.
-        // This is crazy but at least on macOS 15.0, you must hide the dock
-        // FIRST then hide the menu. If you do the opposite, it does not
-        // work.
+        // We must hide the dock FIRST then hide the menu:
+        // If you specify autoHideMenuBar, it must be accompanied by either hideDock or autoHideDock.
+        // https://developer.apple.com/documentation/appkit/nsapplication/presentationoptions-swift.struct
         if (savedState.dock) {
             hideDock()
         }

--- a/macos/Sources/Helpers/Fullscreen.swift
+++ b/macos/Sources/Helpers/Fullscreen.swift
@@ -167,6 +167,9 @@ class NonNativeFullscreen: FullscreenBase, FullscreenStyle {
         self.savedState = savedState
 
         // We hide the dock if the window is on a screen with the dock.
+        // This is crazy but at least on macOS 15.0, you must hide the dock
+        // FIRST then hide the menu. If you do the opposite, it does not
+        // work.
         if (savedState.dock) {
             hideDock()
         }
@@ -175,18 +178,6 @@ class NonNativeFullscreen: FullscreenBase, FullscreenStyle {
         if (properties.hideMenu) {
             hideMenu()
         }
-
-        // When this window becomes or resigns main we need to run some logic.
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(windowDidBecomeMain),
-            name: NSWindow.didBecomeMainNotification,
-            object: window)
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(windowDidResignMain),
-            name: NSWindow.didResignMainNotification,
-            object: window)
 
         // When we change screens we need to redo everything.
         NotificationCenter.default.addObserver(
@@ -218,8 +209,6 @@ class NonNativeFullscreen: FullscreenBase, FullscreenStyle {
         // Remove all our notifications. We remove them one by one because
         // we don't want to remove the observers that our superclass sets.
         let center = NotificationCenter.default
-        center.removeObserver(self, name: NSWindow.didBecomeMainNotification, object: window)
-        center.removeObserver(self, name: NSWindow.didResignMainNotification, object: window)
         center.removeObserver(self, name: NSWindow.didChangeScreenNotification, object: window)
 
         // Unhide our elements
@@ -309,42 +298,6 @@ class NonNativeFullscreen: FullscreenBase, FullscreenStyle {
         // to do to get the screen change right so instead of breaking
         // we just exit out. The user can re-enter fullscreen thereafter.
         exit()
-    }
-
-    @objc func windowDidBecomeMain(_ notification: Notification) {
-        guard let savedState else { return }
-
-        // This should always be true due to how we register but just be sure
-        guard let object = notification.object as? NSWindow,
-              object == window else { return }
-
-        // This is crazy but at least on macOS 15.0, you must hide the dock
-        // FIRST then hide the menu. If you do the opposite, it does not
-        // work.
-
-        if savedState.dock {
-            hideDock()
-        }
-
-        if (properties.hideMenu) {
-            hideMenu()
-        }
-    }
-
-    @objc func windowDidResignMain(_ notification: Notification) {
-        guard let savedState else { return }
-
-        // This should always be true due to how we register but just be sure
-        guard let object = notification.object as? NSWindow,
-              object == window else { return }
-
-        if (properties.hideMenu) {
-            unhideMenu()
-        }
-
-        if savedState.dock {
-            unhideDock()
-        }
     }
 
     // MARK: Dock


### PR DESCRIPTION
Fixes #2516 

Those changes mean that when we have one ghostty window in non-native fullscreen and another ghostty window not in fullscreen switching to not fullscreen window won't cause appearing menu bar and dock. I think it looks good:
![Screenshot 2024-12-07 at 19 18 33](https://github.com/user-attachments/assets/125eb18f-3b2f-469a-a5ba-0469dd12462a)

If we implement detection and make menu bar and dock appear for not fullscreen window in this case it will cause the fullscreen window to change its size and will look bad.

Non-native fullscreen works bad with multiple screens in either way. E.g. switching to a non-native fullscreen window would cause menubar disappering on another screen or switching to not fullscreen window would show menu bar over fullscreen window on another screen. I think nobody would want non-native fullscreen with multiple screens.