### PR TITLE
macos: make non-native fullscreen windows not resizeable

### DIFF
--- a/macos/Sources/Helpers/Fullscreen.swift
+++ b/macos/Sources/Helpers/Fullscreen.swift
@@ -198,6 +198,10 @@ class NonNativeFullscreen: FullscreenBase, FullscreenStyle {
         // Being untitled let's our content take up the full frame.
         window.styleMask.remove(.titled)
 
+        // We dont' want the non-native fullscreen window to be resizable
+        // from the edges.
+        window.styleMask.remove(.resizable)
+
         // Focus window
         window.makeKeyAndOrderFront(nil)
 


### PR DESCRIPTION
I've noticed that I can resize a non-native fullscreen window when selecting text to copy. I think it shouldn't be resizeable.