### PR TITLE
doc: remove outdated statement for fullscreen option

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -668,9 +668,6 @@ link: RepeatableLink = .{},
 /// does not apply to tabs, splits, etc. However, this setting will apply to all
 /// new windows, not just the first one.
 ///
-/// On macOS, this always creates the window in native fullscreen. Non-native
-/// fullscreen is not currently supported with this setting.
-///
 /// On macOS, this setting does not work if window-decoration is set to
 /// "false", because native fullscreen on macOS requires window decorations
 /// to be set.


### PR DESCRIPTION
We can use `macos-non-native-fullscreen` with `fullscreen` together since #1377 was closed.