### PR TITLE
Add information about community config tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ beta users using Ghostty as their primary terminal. See more in
 ### Configuration
 
 To configure Ghostty, you must use a configuration file. GUI-based configuration
-is on the roadmap but not yet supported. The configuration file must be
+is on the roadmap but not yet supported. In the meantime, there is a
+[community-built webtool](https://ghostty.zerebos.com/) that you can use to help
+generate and preview your configuration. The configuration file must be
 placed at `$XDG_CONFIG_HOME/ghostty/config`, which defaults to
 `~/.config/ghostty/config` if the [XDG environment is not set](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
 

--- a/README_TESTERS.md
+++ b/README_TESTERS.md
@@ -93,7 +93,9 @@ interest/acceptance for it before opening up some huge PR.
 
 There are also non-core help we can use: docs, website work, Discord bots,
 etc. etc. For example, a web UI to generate a configuration file would be
-cool. Or a web UI to preview your color settings.
+cool. Or a web UI to preview your color settings. There is currently one
+[community project](https://github.com/zerebos/ghostty-config) attempting
+to tackle both of these.
 
 ### Is Ghostty Open Source?
 


### PR DESCRIPTION
I never got a response in the Discord server about PRing this so I figured I would open the PR anyways.

I thought it might be a good idea to add this info into the README for all the testers currently using Ghostty. I also think it might be a good idea to have this in place before Ghostty goes public to potentially cut down on the number of incoming requests for help and support regarding configuration files and the inevitable duplicate requests for GUI settings.

If this isn't something you'd like to add, feel free to close this. If you want it adjusted in some way, let me know!