### PR TITLE
macos: fix vertical resizing

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -1089,7 +1089,7 @@ extension Ghostty {
                 guard let surface = target.target.surface else { return }
                 guard let surfaceView = self.surfaceView(from: surface) else { return }
                 let backingSize = NSSize(width: Double(v.width), height: Double(v.height))
-                surfaceView.cellSize = surfaceView.convertFromBacking(backingSize)
+                surfaceView.cellSize = backingSize
 
             default:
                 assertionFailure()


### PR DESCRIPTION
With `window-step-resize = true` enabled, the resize step was inconsistent with the cell size, i.e. it was slightly smaller. This is visible on the screen capture below. In the video, the padding between the window bottom and the neovim statusbar gets smaller with every resize until the step is so small it doesn't fix even fit the cell anymore (the padding increases rapidly).

https://github.com/user-attachments/assets/1f4dd7ff-02fa-45b2-9846-dfb5d1ef5466

