### PR TITLE
fix(kittygfx): don't respond to transmit commands with no i or I

### DIFF
--- a/src/terminal/kitty/graphics_image.zig
+++ b/src/terminal/kitty/graphics_image.zig
@@ -455,6 +455,12 @@ pub const Image = struct {
     data: []const u8 = "",
     transmit_time: std.time.Instant = undefined,
 
+    /// Set this to true if this image was loaded by a command that
+    /// doesn't specify an ID or number, since such commands should
+    /// not be responded to, even though we do currently give them
+    /// IDs in the public range (which is bad!).
+    implicit_id: bool = false,
+
     pub const Error = error{
         InternalError,
         InvalidData,

--- a/src/terminal/kitty/graphics_storage.zig
+++ b/src/terminal/kitty/graphics_storage.zig
@@ -31,6 +31,9 @@ pub const ImageStorage = struct {
 
     /// This is the next automatically assigned image ID. We start mid-way
     /// through the u32 range to avoid collisions with buggy programs.
+    /// TODO: This isn't good enough, it's perfectly legal for programs
+    ///       to use IDs in the latter half of the range and collisions
+    ///       are not gracefully handled.
     next_image_id: u32 = 2147483647,
 
     /// This is the next automatically assigned placement ID. This is never


### PR DESCRIPTION
If a transmit and display command does not specify an ID or a number, then it should not be responded to. We currently automatically assign IDs in this situation, which isn't ideal since collisions can happen which shouldn't, but this at least fixes the glaring observable issue where transmit-and-display commands yield unexpected OK responses.

This is a band-aid fix for #2197, and is actually more or less the fix suggested in #2195, but it's worth having until the architecture of the kitty image storage is reworked properly. I included multiple comments as reminders that the underlying issue needs to be fixed.