### PR TITLE
set default window size

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1022,8 +1022,7 @@ keybind: Keybinds = .{},
 @"window-colorspace": WindowColorspace = .srgb,
 
 /// The initial window size. This size is in terminal grid cells by default.
-/// Both values must be set to take effect. If only one value is set, it is
-/// ignored.
+/// Defaults to 100x34.
 ///
 /// We don't currently support specifying a size in pixels but a future change
 /// can enable that. If this isn't specified, the app runtime will determine
@@ -1048,8 +1047,8 @@ keybind: Keybinds = .{},
 /// window-decorations), then this will work as expected.
 ///
 /// Windows smaller than 10 wide by 4 high are not allowed.
-@"window-height": u32 = 0,
-@"window-width": u32 = 0,
+@"window-height": u32 = 34,
+@"window-width": u32 = 100,
 
 /// Whether to enable saving and restoring window state. Window state includes
 /// their position, size, tabs, splits, etc. Some window state requires shell


### PR DESCRIPTION
Since the initial window size is chosen by the runtime, it's likely that it's not going to be divisible by the cell size, which is a bit annoying when I set `window-step-resize = true`. This can be seen on the before and after screenshots below. On the "before" screenshot there's a padding at the bottom of the window even with `window-padding-y = 0`. With the window size specified the initial window size is divisible by the cell size and the problem disappears.

<img width="912" alt="before" src="https://github.com/user-attachments/assets/3d9989af-4290-49eb-8854-421aab5f29f4">
<img width="920" alt="after" src="https://github.com/user-attachments/assets/0559585b-939e-45cf-b795-213fb51ff675">
