### PR TITLE
command: fix hostname test compatibility

### DIFF
--- a/src/Command.zig
+++ b/src/Command.zig
@@ -440,9 +440,9 @@ fn isExecutable(mode: std.fs.File.Mode) bool {
     return mode & 0o0111 != 0;
 }
 
-// `hostname` is present on both *nix and windows
+// `uname -n` is the *nix equivalent of `hostname.exe` on Windows
 test "expandPath: hostname" {
-    const executable = if (builtin.os.tag == .windows) "hostname.exe" else "hostname";
+    const executable = if (builtin.os.tag == .windows) "hostname.exe" else "uname";
     const path = (try expandPath(testing.allocator, executable)).?;
     defer testing.allocator.free(path);
     try testing.expect(path.len > executable.len);


### PR DESCRIPTION
`hostname` is not guaranteed on *nix as in the comment. For example, Arch does not have hostname by default.

`uname -n` is supposed to be the POSIX way to get the hostname, so I replaced `hostname` with `uname`.

(I assumed that it is not that important to have a same name binary on platforms, since we have to add `.exe` on Windows anyway)

(And also, I did agree to the MIT relicensing, but I changed my email since then, so I will agree to the relicensing again here)