### PR TITLE
gtk: pass surface to clipboard window by reference instead of by value

### DIFF
--- a/src/apprt/gtk/ClipboardConfirmationWindow.zig
+++ b/src/apprt/gtk/ClipboardConfirmationWindow.zig
@@ -17,13 +17,13 @@ window: *c.GtkWindow,
 view: PrimaryView,
 
 data: [:0]u8,
-core_surface: CoreSurface,
+core_surface: *CoreSurface,
 pending_req: apprt.ClipboardRequest,
 
 pub fn create(
     app: *App,
     data: []const u8,
-    core_surface: CoreSurface,
+    core_surface: *CoreSurface,
     request: apprt.ClipboardRequest,
 ) !void {
     if (app.clipboard_confirmation_window != null) return error.WindowAlreadyExists;
@@ -54,7 +54,7 @@ fn init(
     self: *ClipboardConfirmation,
     app: *App,
     data: []const u8,
-    core_surface: CoreSurface,
+    core_surface: *CoreSurface,
     request: apprt.ClipboardRequest,
 ) !void {
     // Create the window

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1051,7 +1051,7 @@ pub fn clipboardRequest(
 }
 
 pub fn setClipboardString(
-    self: *const Surface,
+    self: *Surface,
     val: [:0]const u8,
     clipboard_type: apprt.Clipboard,
     confirm: bool,
@@ -1065,7 +1065,7 @@ pub fn setClipboardString(
     ClipboardConfirmationWindow.create(
         self.app,
         val,
-        self.core_surface,
+        &self.core_surface,
         .{ .osc_52_write = clipboard_type },
     ) catch |window_err| {
         log.err("failed to create clipboard confirmation window err={}", .{window_err});
@@ -1113,7 +1113,7 @@ fn gtkClipboardRead(
             ClipboardConfirmationWindow.create(
                 self.app,
                 str,
-                self.core_surface,
+                &self.core_surface,
                 req.state,
             ) catch |window_err| {
                 log.err("failed to create clipboard confirmation window err={}", .{window_err});


### PR DESCRIPTION
The surface might be mutated during the clipboard confirmation (resized in my case), leading to the copied cursor `page_pin` being invalidated.

Fixes #1714. Would be nice if @stgarf can verify this.

I agree to the MIT relicensing.