### PR TITLE
mdgen: use bold face for option and action names

### DIFF
--- a/src/build/mdgen/mdgen.zig
+++ b/src/build/mdgen/mdgen.zig
@@ -30,10 +30,10 @@ pub fn genConfig(writer: anytype, cli: bool) !void {
     inline for (@typeInfo(Config).Struct.fields) |field| {
         if (field.name[0] == '_') continue;
 
-        try writer.writeAll("`");
+        try writer.writeAll("**`");
         if (cli) try writer.writeAll("--");
         try writer.writeAll(field.name);
-        try writer.writeAll("`\n\n");
+        try writer.writeAll("`**\n\n");
         if (@hasDecl(help_strings.Config, field.name)) {
             var iter = std.mem.splitScalar(u8, @field(help_strings.Config, field.name), '\n');
             var first = true;
@@ -60,12 +60,12 @@ pub fn genActions(writer: anytype) !void {
         const action = std.meta.stringToEnum(Action, field.name).?;
 
         switch (action) {
-            .help => try writer.writeAll("`--help`\n\n"),
-            .version => try writer.writeAll("`--version`\n\n"),
+            .help => try writer.writeAll("**`--help`**\n\n"),
+            .version => try writer.writeAll("**`--version`**\n\n"),
             else => {
-                try writer.writeAll("`+");
+                try writer.writeAll("**`+");
                 try writer.writeAll(field.name);
-                try writer.writeAll("`\n\n");
+                try writer.writeAll("`**\n\n");
             },
         }
 
@@ -97,9 +97,9 @@ pub fn genKeybindActions(writer: anytype) !void {
     inline for (info.Union.fields) |field| {
         if (field.name[0] == '_') continue;
 
-        try writer.writeAll("`");
+        try writer.writeAll("**`");
         try writer.writeAll(field.name);
-        try writer.writeAll("`\n\n");
+        try writer.writeAll("`**\n\n");
 
         if (@hasDecl(help_strings.KeybindAction, field.name)) {
             var iter = std.mem.splitScalar(u8, @field(help_strings.KeybindAction, field.name), '\n');


### PR DESCRIPTION
This is a small aesthetic change. From my own experience (and a brief informal survey of other man pages in section 5), man pages commonly emphasize "keywords" like this in some fashion (either using bold or a different foreground color). This makes the man page easier to read since there is more distinction between the option name and its description.

## Before

![image](https://github.com/user-attachments/assets/3423910b-4df8-4f4a-8626-d6da01893b27)

![image](https://github.com/user-attachments/assets/0308f041-3a50-48c2-ac2b-14220e679cba)

## After

![image](https://github.com/user-attachments/assets/570411b9-8c25-4f80-8a40-1bb69fd2c8dd)

![image](https://github.com/user-attachments/assets/3d0d4217-8257-48bb-9bf6-978b1cbf16dd)
