### PR TITLE
Revert "Change oniguruma link target from `oniguruma` to `onig`" to prefer using pkg-config

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1120,8 +1120,7 @@ fn addDeps(
     });
     step.root_module.addImport("oniguruma", oniguruma_dep.module("oniguruma"));
     if (b.systemIntegrationOption("oniguruma", .{})) {
-        // Oniguruma is compiled and distributed as libonig.so
-        step.linkSystemLibrary2("onig", dynamic_link_opts);
+        step.linkSystemLibrary2("oniguruma", dynamic_link_opts);
     } else {
         step.linkLibrary(oniguruma_dep.artifact("oniguruma"));
         try static_libs.append(oniguruma_dep.artifact("oniguruma").getEmittedBin());


### PR DESCRIPTION
This reverts commit daa0fe00b16989cf4696c686aab33b80763834a3. It is correct to use the pkg-config name instead of the literal dylib name. Sorry I didn't know about pkg-config needing to be installed at the time and zig searching for the lib directly as a fallback