### PR TITLE
Add weekly iterm2-colorschemes update workflow

### DIFF
--- a/.github/workflows/update-colorschemes.yml
+++ b/.github/workflows/update-colorschemes.yml
@@ -1,0 +1,53 @@
+name: Update iTerm2 colorschemes
+on:
+  schedule:
+    # Once a week
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+jobs:
+  update-iterm2-schemes:
+    if: github.repository == 'ghostty-org/ghostty'
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed for create-pull-request action
+      contents: write
+      pull-requests: write
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Setup Nix
+      uses: cachix/install-nix-action@v30
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+
+    - name: Run zig fetch
+      id: zig_fetch
+      run: |
+        UPSTREAM_REV="$(curl "https://api.github.com/repos/mbadolato/iTerm2-Color-Schemes/commits/master" | jq -r '.sha')"
+        nix develop -c zig fetch --save="iterm2_themes" "https://github.com/mbadolato/iTerm2-Color-Schemes/archive/$UPSTREAM_REV.tar.gz"
+        echo "upstream_rev=$UPSTREAM_REV" >> "$GITHUB_OUTPUT"
+
+    - name: Update zig cache hash
+      run: |
+        # Only proceed if build.zig.zon has changed
+        if [ "$(git status build.zig.zon --porcelain)" ]; then
+          nix develop -c ./nix/build-support/check-zig-cache-hash.sh --update
+        fi
+
+    - name: Create pull request
+      uses: peter-evans/create-pull-request@v7
+      with:
+        title: Update iTerm2 colorschemes
+        base: main
+        branch: iterm2_colors_action
+        commit-message: "deps: Update iTerm2 color schemes"
+        add-paths: |
+          build.zig.zon
+          nix/zigCacheHash.nix
+        body: |
+          Upstream revision: https://github.com/mbadolato/iTerm2-Color-Schemes/tree/${{ steps.zig_fetch.outputs.upstream_rev }}
+        labels: dependencies
+

--- a/.github/workflows/update-colorschemes.yml
+++ b/.github/workflows/update-colorschemes.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Update zig cache hash
       run: |
         # Only proceed if build.zig.zon has changed
-        if [ "$(git status build.zig.zon --porcelain)" ]; then
+        if ! git diff --exit-code build.zig.zon; then
           nix develop -c ./nix/build-support/check-zig-cache-hash.sh --update
         fi
 


### PR DESCRIPTION
I've added a weekly github actions workflow that automatically creates a PR to update the iTerm2 colorschemes dependency and the zig cache hash alongside it. I'm using a third-party action to create the pull request such that it won't create another PR if a pending one exists already, and will force-push to the PR branch (iterm2_colors_action) instead.

I noticed that the other workflows made use of namespace runners and caching along with a cachix action, but I haven't included them here yet. I could update the workflow to match those if you'd like.