### PR TITLE
Unified metrics fixes

### DIFF
--- a/pkg/freetype/face.zig
+++ b/pkg/freetype/face.zig
@@ -217,6 +217,7 @@ pub const SfntTag = enum(c_int) {
             .os2 => c.TT_OS2,
             .head => c.TT_Header,
             .post => c.TT_Postscript,
+            .hhea => c.TT_HoriHeader,
             else => unreachable, // As-needed...
         };
     }

--- a/src/font/sprite/cursor.zig
+++ b/src/font/sprite/cursor.zig
@@ -1,0 +1,61 @@
+//! This file renders cursor sprites.
+const std = @import("std");
+const builtin = @import("builtin");
+const assert = std.debug.assert;
+const Allocator = std.mem.Allocator;
+const font = @import("../main.zig");
+const Sprite = font.sprite.Sprite;
+
+/// Draw a cursor.
+pub fn renderGlyph(
+    alloc: Allocator,
+    atlas: *font.Atlas,
+    sprite: Sprite,
+    width: u32,
+    height: u32,
+    thickness: u32,
+) !font.Glyph {
+    // Make a canvas of the desired size
+    var canvas = try font.sprite.Canvas.init(alloc, width, height);
+    defer canvas.deinit(alloc);
+
+    // Draw the appropriate sprite
+    switch (sprite) {
+        Sprite.cursor_rect => canvas.rect(.{
+            .x = 0,
+            .y = 0,
+            .width = width,
+            .height = height,
+        }, .on),
+        Sprite.cursor_hollow_rect => {
+            // left
+            canvas.rect(.{ .x = 0, .y = 0, .width = thickness, .height = height }, .on);
+            // right
+            canvas.rect(.{ .x = width -| thickness, .y = 0, .width = thickness, .height = height }, .on);
+            // top
+            canvas.rect(.{ .x = 0, .y = 0, .width = width, .height = thickness }, .on);
+            // bottom
+            canvas.rect(.{ .x = 0, .y = height -| thickness, .width = width, .height = thickness }, .on);
+        },
+        Sprite.cursor_bar => canvas.rect(.{
+            .x = 0,
+            .y = 0,
+            .width = thickness,
+            .height = height,
+        }, .on),
+        else => unreachable,
+    }
+
+    // Write the drawing to the atlas
+    const region = try canvas.writeAtlas(alloc, atlas);
+
+    return font.Glyph{
+        .width = width,
+        .height = height,
+        .offset_x = 0,
+        .offset_y = @intCast(height),
+        .atlas_x = region.x,
+        .atlas_y = region.y,
+        .advance_x = @floatFromInt(width),
+    };
+}


### PR DESCRIPTION
Fix a couple issues that arose from the unified metrics stuff.

One is that cursor sprites weren't rendering wide for wide characters- I've extracted cursor rendering to a separate file so it's not mixed in with Box any more, it should be correct now.

The other issue is that I was assuming most fonts had sane `sTypo*` metrics for vertical sizing, but I was very wrong, so I've replaced the extraction of the vertical metrics with code that performs a similar process to what FreeType does to determine a font's ascent. This fixes the problem, here's an example with a font with the issue:
|Before|After|
|-|-|
|<img width="752" alt="image" src="https://github.com/user-attachments/assets/71752b0c-35d7-4c35-b5bb-301149d906a7" />|<img width="752" alt="image" src="https://github.com/user-attachments/assets/2f9ae8ce-9f3a-4701-b0fe-e032da7e2246" />|