### PR TITLE
font: fix sign of usWinDescent interpretation

### DIFF
--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -647,7 +647,9 @@ pub const Face = struct {
             const win_descent: f64 = @floatFromInt(os2.usWinDescent);
             break :vertical_metrics .{
                 win_ascent * px_per_unit,
-                win_descent * px_per_unit,
+                // usWinDescent is *positive* -> down unlike sTypoDescender
+                // and hhea.Descender, so we flip its sign to fix this.
+                -win_descent * px_per_unit,
                 0.0,
             };
         };

--- a/src/font/face/freetype.zig
+++ b/src/font/face/freetype.zig
@@ -689,7 +689,9 @@ pub const Face = struct {
             const win_descent: f64 = @floatFromInt(os2.usWinDescent);
             break :vertical_metrics .{
                 win_ascent * px_per_unit,
-                win_descent * px_per_unit,
+                // usWinDescent is *positive* -> down unlike sTypoDescender
+                // and hhea.Descender, so we flip its sign to fix this.
+                -win_descent * px_per_unit,
                 0.0,
             };
         };


### PR DESCRIPTION
comment explains

In the future we should probably find or craft example fonts that have weird metrics in their tables and make unit tests for them.