### PR TITLE
bash: add bash completion generation

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -13,6 +13,7 @@ const config_vim = @import("src/config/vim.zig");
 const config_sublime_syntax = @import("src/config/sublime_syntax.zig");
 const fish_completions = @import("src/build/fish_completions.zig");
 const zsh_completions = @import("src/build/zsh_completions.zig");
+const bash_completions = @import("src/build/bash_completions.zig");
 const build_config = @import("src/build_config.zig");
 const BuildConfig = build_config.BuildConfig;
 const WasmTarget = @import("src/os/wasm/target.zig").Target;
@@ -514,6 +515,18 @@ pub fn build(b: *std.Build) !void {
             .source_dir = wf.getDirectory(),
             .install_dir = .prefix,
             .install_subdir = "share/zsh/site-functions",
+        });
+    }
+
+    // bash shell completions
+    {
+        const wf = b.addWriteFiles();
+        _ = wf.add("ghostty.bash", bash_completions.bash_completions);
+
+        b.installDirectory(.{
+            .source_dir = wf.getDirectory(),
+            .install_dir = .prefix,
+            .install_subdir = "share/bash-completion/completions",
         });
     }
 

--- a/src/build/bash_completions.zig
+++ b/src/build/bash_completions.zig
@@ -1,0 +1,278 @@
+const std = @import("std");
+
+const Config = @import("../config/Config.zig");
+const Action = @import("../cli/action.zig").Action;
+
+/// A bash completions configuration that contains all the available commands
+/// and options.
+///
+/// Notes: bash completion support for --<key>=<value> depends on setting the completion
+/// system to _not_ print a space following each successful completion (see -o nospace).
+/// This results leading or tailing spaces being necessary to move onto the next match.
+///
+/// bash completion will read = as it's own completiong word regardless of whether or not
+/// it's part of an on going completion like --<key>=. Working around this requires looking
+/// backward in the command line args to pretend the = is an empty string
+/// see: https://www.gnu.org/software/gnuastro/manual/html_node/Bash-TAB-completion-tutorial.html
+pub const bash_completions = comptimeGenerateBashCompletions();
+
+fn comptimeGenerateBashCompletions() []const u8 {
+    comptime {
+        @setEvalBranchQuota(50000);
+        var counter = std.io.countingWriter(std.io.null_writer);
+        try writeBashCompletions(&counter.writer());
+
+        var buf: [counter.bytes_written]u8 = undefined;
+        var stream = std.io.fixedBufferStream(&buf);
+        try writeBashCompletions(stream.writer());
+        const final = buf;
+        return final[0..stream.getWritten().len];
+    }
+}
+
+fn writeBashCompletions(writer: anytype) !void {
+    const pad1 = "  ";
+    const pad2 = pad1 ++ pad1;
+    const pad3 = pad2 ++ pad1;
+    const pad4 = pad3 ++ pad1;
+
+    try writer.writeAll(
+        \\#!/usr/bin/env bash
+        \\
+        \\# -o nospace requires we add back a space when a completion is finished
+        \\# and not part of a --key= completion
+        \\appendSpaces () {
+        \\  for idx in "${!COMPREPLY[@]}"; do
+        \\    [ -n "${COMPREPLY[idx]}" ] && COMPREPLY[idx]="${COMPREPLY[idx]} ";
+        \\  done
+        \\}
+        \\
+        \\_fonts () {
+        \\  local IFS=$'\n'
+        \\  mapfile -t COMPREPLY < <( compgen -P '"' -S '"' -W "$(ghostty +list-fonts | grep '^[A-Z]' )" -- "$cur")
+        \\}
+        \\
+        \\_themes() {
+        \\  local IFS=$'\n'
+        \\  mapfile -t COMPREPLY < <( compgen -P '"' -S '"' -W "$(ghostty +list-themes | sed -E 's/^(.*) \(.*$/\1/')" -- "$cur")
+        \\}
+        \\
+        \\config="--help"
+        \\config+=" --version"
+        \\
+    );
+
+    for (@typeInfo(Config).Struct.fields) |field| {
+        if (field.name[0] == '_') continue;
+        try writer.writeAll("config+=\" --" ++ field.name ++ "=\"\n");
+    }
+
+    try writer.writeAll(
+        \\
+        \\_handleConfig () {
+        \\  case "$prev" in
+        \\
+    );
+
+    for (@typeInfo(Config).Struct.fields) |field| {
+        if (field.name[0] == '_') continue;
+        try writer.writeAll(pad2 ++ "--" ++ field.name ++ ") ");
+
+        if (std.mem.startsWith(u8, field.name, "font-family"))
+            try writer.writeAll("_fonts ;;")
+        else if (std.mem.eql(u8, "theme", field.name))
+            try writer.writeAll("_themes ;;")
+        else if (std.mem.eql(u8, "working-directory", field.name))
+            try writer.writeAll("mapfile -t COMPREPLY < <( compgen -d -- \"$cur\" ); appendSpaces ;;")
+        else if (field.type == Config.RepeatablePath)
+            try writer.writeAll("mapfile -t COMPREPLY < <( compgen -f -- \"$cur\" ); appendSpaces ;;")
+        else {
+            const compgenPrefix = "mapfile -t COMPREPLY < <( compgen -W \"";
+            const compgenSuffix = "\" -- \"$cur\" ); appendSpaces ;;";
+            switch (@typeInfo(field.type)) {
+                .Bool => try writer.writeAll(compgenPrefix ++ "true false" ++ compgenSuffix),
+                .Enum => |info| {
+                    try writer.writeAll(compgenPrefix);
+                    for (info.fields, 0..) |f, i| {
+                        if (i > 0) try writer.writeAll(" ");
+                        try writer.writeAll(f.name);
+                    }
+                    try writer.writeAll(compgenSuffix);
+                },
+                .Struct => |info| {
+                    if (!@hasDecl(field.type, "parseCLI") and info.layout == .@"packed") {
+                        try writer.writeAll(compgenPrefix);
+                        for (info.fields, 0..) |f, i| {
+                            if (i > 0) try writer.writeAll(" ");
+                            try writer.writeAll(f.name ++ " no-" ++ f.name);
+                        }
+                        try writer.writeAll(compgenSuffix);
+                    } else {
+                        try writer.writeAll("return ;;");
+                    }
+                },
+                else => try writer.writeAll("return ;;"),
+            }
+        }
+
+        try writer.writeAll("\n");
+    }
+
+    try writer.writeAll(
+        \\    *) mapfile -t COMPREPLY < <( compgen -W "$config" -- "$cur" ) ;;
+        \\  esac
+        \\
+        \\  return 0
+        \\}
+        \\
+        \\
+    );
+
+    for (@typeInfo(Action).Enum.fields) |field| {
+        if (std.mem.eql(u8, "help", field.name)) continue;
+        if (std.mem.eql(u8, "version", field.name)) continue;
+
+        const options = @field(Action, field.name).options();
+        // assumes options will never be created with only <_name> members
+        if (@typeInfo(options).Struct.fields.len == 0) continue;
+
+        var buffer: [field.name.len]u8 = undefined;
+        const safeName: []u8 = buffer[0..field.name.len];
+        @memcpy(safeName, field.name);
+
+        std.mem.replaceScalar(u8, safeName, '-', '_');
+        try writer.writeAll(safeName ++ "=\"");
+
+        {
+            var count = 0;
+            for (@typeInfo(options).Struct.fields) |opt| {
+                if (opt.name[0] == '_') continue;
+                if (count > 0) try writer.writeAll(" ");
+                try writer.writeAll("--" ++ opt.name ++ "=");
+                count += 1;
+            }
+        }
+        try writer.writeAll(" --help\"\n");
+    }
+
+    try writer.writeAll(
+        \\
+        \\_handleActions () {
+        \\  case "${COMP_WORDS[1]}" in
+        \\
+    );
+
+    for (@typeInfo(Action).Enum.fields) |field| {
+        if (std.mem.eql(u8, "help", field.name)) continue;
+        if (std.mem.eql(u8, "version", field.name)) continue;
+
+        const options = @field(Action, field.name).options();
+        if (@typeInfo(options).Struct.fields.len == 0) continue;
+
+        // bash doesn't allow variable names containing '-' so replace them
+        var buffer: [field.name.len]u8 = undefined;
+        const safeName: []u8 = buffer[0..field.name.len];
+        _ = std.mem.replace(u8, field.name, "-", "_", safeName);
+
+        try writer.writeAll(pad2 ++ "+" ++ field.name ++ ")\n");
+        try writer.writeAll(pad3 ++ "case $prev in\n");
+        for (@typeInfo(options).Struct.fields) |opt| {
+            if (opt.name[0] == '_') continue;
+
+            try writer.writeAll(pad4 ++ "--" ++ opt.name ++ ") ");
+
+            const compgenPrefix = "mapfile -t COMPREPLY < <( compgen -W \"";
+            const compgenSuffix = "\" -- \"$cur\" ); appendSpaces ;;";
+            switch (@typeInfo(opt.type)) {
+                .Bool => try writer.writeAll(compgenPrefix ++ "true false" ++ compgenSuffix),
+                .Enum => |info| {
+                    try writer.writeAll(compgenPrefix);
+                    for (info.opts, 0..) |f, i| {
+                        if (i > 0) try writer.writeAll(" ");
+                        try writer.writeAll(f.name);
+                    }
+                    try writer.writeAll(compgenSuffix);
+                },
+                else => {
+                    if (std.mem.eql(u8, "config-file", opt.name)) {
+                        try writer.writeAll("mapfile -t COMPREPLY < <( compgen -f -- \"$cur\" ); appendSpaces ;;");
+                    } else try writer.writeAll("return;;");
+                },
+            }
+            try writer.writeAll("\n");
+        }
+        try writer.writeAll(pad4 ++ "*) mapfile -t COMPREPLY < <( compgen -W \"$" ++ safeName ++ "\" -- \"$cur\" ) ;;\n");
+        try writer.writeAll(
+            \\      esac
+            \\    ;;
+            \\
+        );
+    }
+
+    try writer.writeAll(
+        \\    *) mapfile -t COMPREPLY < <( compgen -W "--help" -- "$cur" ) ;;
+        \\  esac
+        \\
+        \\  return 0
+        \\}
+        \\
+        \\topLevel="-e"
+        \\topLevel+=" --help"
+        \\topLevel+=" --version"
+        \\
+    );
+
+    for (@typeInfo(Action).Enum.fields) |field| {
+        if (std.mem.eql(u8, "help", field.name)) continue;
+        if (std.mem.eql(u8, "version", field.name)) continue;
+
+        try writer.writeAll("topLevel+=\" +" ++ field.name ++ "\"\n");
+    }
+
+    try writer.writeAll(
+        \\
+        \\_ghostty () {
+        \\  COMPREPLY=()
+        \\  if [ "$2" = "=" ]; then cur=""
+        \\  else                    cur="$2"
+        \\  fi
+        \\
+        \\  if [ "$3" = "=" ]; then prev="${COMP_WORDS[COMP_CWORD-2]}"
+        \\  else                    prev="${COMP_WORDS[COMP_CWORD-1]}"
+        \\  fi
+        \\
+        \\  if [[ "$2" == \"*\" ]]; then
+        \\    COMPREPLY=( "$cur " );
+        \\    return;
+        \\  fi
+        \\
+        \\  cword=$COMP_CWORD
+        \\
+        \\  case "$cword" in
+        \\    1)
+        \\      case "${COMP_WORDS[1]}" in
+        \\        -e | --help | --version) return 0 ;;
+        \\        --*) _handleConfig ;;
+        \\        *) mapfile -t COMPREPLY < <( compgen -W "${topLevel}" -- "$cur" ); appendSpaces ;;
+        \\      esac
+        \\      ;;
+        \\    *)
+        \\      case "$prev" in
+        \\        -e | --help | --version) return 0 ;;
+        \\        *)
+        \\          case "${COMP_WORDS[1]}" in
+        \\            --*) _handleConfig ;;
+        \\            +*) _handleActions ;;
+        \\          esac
+        \\          ;;
+        \\      esac
+        \\      ;;
+        \\  esac
+        \\
+        \\  return 0
+        \\}
+        \\
+        \\complete -o nospace -o bashdefault -F _ghostty ghostty
+        \\
+    );
+}

--- a/src/build/bash_completions.zig
+++ b/src/build/bash_completions.zig
@@ -37,47 +37,12 @@ fn writeBashCompletions(writer: anytype) !void {
     const pad4 = pad3 ++ pad1;
 
     try writer.writeAll(
-        \\
         \\# -o nospace requires we add back a space when a completion is finished
         \\# and not part of a --key= completion
         \\addSpaces() {
         \\  for idx in "${!COMPREPLY[@]}"; do
         \\    [ -n "${COMPREPLY[idx]}" ] && COMPREPLY[idx]="${COMPREPLY[idx]} ";
         \\  done
-        \\}
-        \\
-        \\_fonts() {
-        \\  local IFS=$'\n'
-        \\  mapfile -t COMPREPLY < <( compgen -P '"' -S '"' -W "$($ghostty +list-fonts | grep '^[A-Z]' )" -- "$cur")
-        \\}
-        \\
-        \\_themes() {
-        \\  local IFS=$'\n'
-        \\  mapfile -t COMPREPLY < <( compgen -P '"' -S '"' -W "$($ghostty +list-themes | sed -E 's/^(.*) \(.*$/\1/')" -- "$cur")
-        \\}
-        \\
-        \\_files() {
-        \\  mapfile -t COMPREPLY < <( compgen -o filenames -f -- "$cur" )
-        \\  for i in "${!COMPREPLY[@]}"; do
-        \\    if [[ -d "${COMPREPLY[i]}" ]]; then
-        \\      COMPREPLY[i]="${COMPREPLY[i]}/";
-        \\    fi
-        \\    if [[ -f "${COMPREPLY[i]}" ]]; then
-        \\      COMPREPLY[i]="${COMPREPLY[i]} ";
-        \\    fi
-        \\  done
-        \\}
-        \\
-        \\_dirs() {
-        \\  mapfile -t COMPREPLY < <( compgen -o dirnames -d -- "$cur" )
-        \\  for i in "${!COMPREPLY[@]}"; do
-        \\    if [[ -d "${COMPREPLY[i]}" ]]; then
-        \\      COMPREPLY[i]="${COMPREPLY[i]}/";
-        \\    fi
-        \\  done
-        \\  if [[ "${#COMPREPLY[@]}" == 0 && -d "$cur" ]]; then
-        \\    COMPREPLY=( "$cur " )
-        \\  fi
         \\}
         \\
         \\config="--help"
@@ -102,13 +67,13 @@ fn writeBashCompletions(writer: anytype) !void {
         try writer.writeAll(pad2 ++ "--" ++ field.name ++ ") ");
 
         if (std.mem.startsWith(u8, field.name, "font-family"))
-            try writer.writeAll("_fonts ;;")
+            try writer.writeAll("return ;;")
         else if (std.mem.eql(u8, "theme", field.name))
-            try writer.writeAll("_themes ;;")
+            try writer.writeAll("return ;;")
         else if (std.mem.eql(u8, "working-directory", field.name))
-            try writer.writeAll("_dirs ;;")
+            try writer.writeAll("return ;;")
         else if (field.type == Config.RepeatablePath)
-            try writer.writeAll("_files ;;")
+            try writer.writeAll("return ;;")
         else {
             const compgenPrefix = "mapfile -t COMPREPLY < <( compgen -W \"";
             const compgenSuffix = "\" -- \"$cur\" ); addSpaces ;;";
@@ -218,7 +183,7 @@ fn writeBashCompletions(writer: anytype) !void {
                 },
                 else => {
                     if (std.mem.eql(u8, "config-file", opt.name)) {
-                        try writer.writeAll("_files ;;");
+                        try writer.writeAll("return ;;");
                     } else try writer.writeAll("return;;");
                 },
             }
@@ -266,12 +231,6 @@ fn writeBashCompletions(writer: anytype) !void {
         \\  else                    prev="${COMP_WORDS[COMP_CWORD-1]}"
         \\  fi
         \\
-        \\  # current completion is double quoted add a space so the curor progresses
-        \\  if [[ "$2" == \"*\" ]]; then
-        \\    COMPREPLY=( "$cur " );
-        \\    return;
-        \\  fi
-        \\
         \\  case "$COMP_CWORD" in
         \\    1)
         \\      case "${COMP_WORDS[1]}" in
@@ -284,12 +243,6 @@ fn writeBashCompletions(writer: anytype) !void {
         \\      case "$prev" in
         \\        -e | --help | --version) return 0 ;;
         \\        *)
-        \\          if [[ "=" != "${COMP_WORDS[COMP_CWORD]}" && $prevWasEq != true ]]; then
-        \\            # must be completing with a space after the key eg: '--<key> '
-        \\            # clear out prev so we don't run any of the key specific completions
-        \\            prev=""
-        \\          fi
-        \\        
         \\          case "${COMP_WORDS[1]}" in
         \\            --*) _handleConfig ;;
         \\            +*) _handleActions ;;

--- a/src/build/bash_completions.zig
+++ b/src/build/bash_completions.zig
@@ -69,7 +69,7 @@ fn writeBashCompletions(writer: anytype) !void {
 
     try writer.writeAll(
         \\
-        \\_handleConfig () {
+        \\_handleConfig() {
         \\  case "$prev" in
         \\
     );
@@ -232,23 +232,23 @@ fn writeBashCompletions(writer: anytype) !void {
     try writer.writeAll(
         \\
         \\_ghostty () {
-        \\  COMPREPLY=()
+        \\  cur=""; prev=""; prevWasEq=false; COMPREPLY=()
+        \\
         \\  if [ "$2" = "=" ]; then cur=""
         \\  else                    cur="$2"
         \\  fi
         \\
-        \\  if [ "$3" = "=" ]; then prev="${COMP_WORDS[COMP_CWORD-2]}"
+        \\  if [ "$3" = "=" ]; then prev="${COMP_WORDS[COMP_CWORD-2]}"; prevWasEq=true;
         \\  else                    prev="${COMP_WORDS[COMP_CWORD-1]}"
         \\  fi
         \\
+        \\  # current completion is double quoted add a space so the curor progresses
         \\  if [[ "$2" == \"*\" ]]; then
         \\    COMPREPLY=( "$cur " );
         \\    return;
         \\  fi
         \\
-        \\  cword=$COMP_CWORD
-        \\
-        \\  case "$cword" in
+        \\  case "$COMP_CWORD" in
         \\    1)
         \\      case "${COMP_WORDS[1]}" in
         \\        -e | --help | --version) return 0 ;;
@@ -260,6 +260,12 @@ fn writeBashCompletions(writer: anytype) !void {
         \\      case "$prev" in
         \\        -e | --help | --version) return 0 ;;
         \\        *)
+        \\          if [[ "=" != "${COMP_WORDS[COMP_CWORD]}" && $prevWasEq != true ]]; then
+        \\            # must be completing with a space after the key eg: '--<key> '
+        \\            # clear out prev so we don't run any of the key specific completions
+        \\            prev=""
+        \\          fi
+        \\        
         \\          case "${COMP_WORDS[1]}" in
         \\            --*) _handleConfig ;;
         \\            +*) _handleActions ;;


### PR DESCRIPTION
Bash completions on par with fish and zsh completions. There's a lot of room to add additional custom completions in all three languages. (see `key) return;;` for cases)

I've noticed a few mistakes with the other completions I'll raise as a separate PR.

<details>
  <summary>Generated ghostty.bash - updated</summary>

```bash

# -o nospace requires we add back a space when a completion is finished
# and not part of a --key= completion
addSpaces() {
  for idx in "${!COMPREPLY[@]}"; do
    [ -n "${COMPREPLY[idx]}" ] && COMPREPLY[idx]="${COMPREPLY[idx]} ";
  done
}

_fonts() {
  local IFS=$'\n'
  mapfile -t COMPREPLY < <( compgen -P '"' -S '"' -W "$($ghostty +list-fonts | grep '^[A-Z]' )" -- "$cur")
}

_themes() {
  local IFS=$'\n'
  mapfile -t COMPREPLY < <( compgen -P '"' -S '"' -W "$($ghostty +list-themes | sed -E 's/^(.*) \(.*$/\1/')" -- "$cur")
}

_files() {
  mapfile -t COMPREPLY < <( compgen -o filenames -f -- "$cur" )
  for i in "${!COMPREPLY[@]}"; do
    if [[ -d "${COMPREPLY[i]}" ]]; then
      COMPREPLY[i]="${COMPREPLY[i]}/";
    fi
    if [[ -f "${COMPREPLY[i]}" ]]; then
      COMPREPLY[i]="${COMPREPLY[i]} ";
    fi
  done
}

_dirs() {
  mapfile -t COMPREPLY < <( compgen -o dirnames -d -- "$cur" )
  for i in "${!COMPREPLY[@]}"; do
    if [[ -d "${COMPREPLY[i]}" ]]; then
      COMPREPLY[i]="${COMPREPLY[i]}/";
    fi
  done
  if [[ "${#COMPREPLY[@]}" == 0 && -d "$cur" ]]; then
    COMPREPLY=( "$cur " )
  fi
}

config="--help"
config+=" --version"
config+=" --font-family="
config+=" --font-family-bold="
config+=" --font-family-italic="
config+=" --font-family-bold-italic="
config+=" --font-style="
config+=" --font-style-bold="
config+=" --font-style-italic="
config+=" --font-style-bold-italic="
config+=" --font-synthetic-style="
config+=" --font-feature="
config+=" --font-size="
config+=" --font-variation="
config+=" --font-variation-bold="
config+=" --font-variation-italic="
config+=" --font-variation-bold-italic="
config+=" --font-codepoint-map="
config+=" --font-thicken="
config+=" --adjust-cell-width="
config+=" --adjust-cell-height="
config+=" --adjust-font-baseline="
config+=" --adjust-underline-position="
config+=" --adjust-underline-thickness="
config+=" --adjust-strikethrough-position="
config+=" --adjust-strikethrough-thickness="
config+=" --adjust-cursor-thickness="
config+=" --grapheme-width-method="
config+=" --freetype-load-flags="
config+=" --theme="
config+=" --background="
config+=" --foreground="
config+=" --selection-foreground="
config+=" --selection-background="
config+=" --selection-invert-fg-bg="
config+=" --minimum-contrast="
config+=" --palette="
config+=" --cursor-color="
config+=" --cursor-invert-fg-bg="
config+=" --cursor-opacity="
config+=" --cursor-style="
config+=" --cursor-style-blink="
config+=" --cursor-text="
config+=" --cursor-click-to-move="
config+=" --mouse-hide-while-typing="
config+=" --mouse-shift-capture="
config+=" --mouse-scroll-multiplier="
config+=" --background-opacity="
config+=" --background-blur-radius="
config+=" --unfocused-split-opacity="
config+=" --unfocused-split-fill="
config+=" --command="
config+=" --initial-command="
config+=" --wait-after-command="
config+=" --abnormal-command-exit-runtime="
config+=" --scrollback-limit="
config+=" --link="
config+=" --link-url="
config+=" --fullscreen="
config+=" --title="
config+=" --class="
config+=" --x11-instance-name="
config+=" --working-directory="
config+=" --keybind="
config+=" --window-padding-x="
config+=" --window-padding-y="
config+=" --window-padding-balance="
config+=" --window-padding-color="
config+=" --window-vsync="
config+=" --window-inherit-working-directory="
config+=" --window-inherit-font-size="
config+=" --window-decoration="
config+=" --window-title-font-family="
config+=" --window-theme="
config+=" --window-colorspace="
config+=" --window-height="
config+=" --window-width="
config+=" --window-save-state="
config+=" --window-step-resize="
config+=" --window-new-tab-position="
config+=" --resize-overlay="
config+=" --resize-overlay-position="
config+=" --resize-overlay-duration="
config+=" --focus-follows-mouse="
config+=" --clipboard-read="
config+=" --clipboard-write="
config+=" --clipboard-trim-trailing-spaces="
config+=" --clipboard-paste-protection="
config+=" --clipboard-paste-bracketed-safe="
config+=" --image-storage-limit="
config+=" --copy-on-select="
config+=" --click-repeat-interval="
config+=" --config-file="
config+=" --config-default-files="
config+=" --confirm-close-surface="
config+=" --quit-after-last-window-closed="
config+=" --quit-after-last-window-closed-delay="
config+=" --initial-window="
config+=" --quick-terminal-position="
config+=" --quick-terminal-screen="
config+=" --quick-terminal-animation-duration="
config+=" --shell-integration="
config+=" --shell-integration-features="
config+=" --osc-color-report-format="
config+=" --vt-kam-allowed="
config+=" --custom-shader="
config+=" --custom-shader-animation="
config+=" --macos-non-native-fullscreen="
config+=" --macos-titlebar-style="
config+=" --macos-titlebar-proxy-icon="
config+=" --macos-option-as-alt="
config+=" --macos-window-shadow="
config+=" --macos-auto-secure-input="
config+=" --macos-secure-input-indication="
config+=" --linux-cgroup="
config+=" --linux-cgroup-memory-limit="
config+=" --linux-cgroup-processes-limit="
config+=" --linux-cgroup-hard-fail="
config+=" --gtk-single-instance="
config+=" --gtk-titlebar="
config+=" --gtk-tabs-location="
config+=" --adw-toolbar-style="
config+=" --gtk-wide-tabs="
config+=" --gtk-adwaita="
config+=" --desktop-notifications="
config+=" --bold-is-bright="
config+=" --term="
config+=" --enquiry-response="
config+=" --auto-update="

_handleConfig() {
  case "$prev" in
    --font-family) _fonts ;;
    --font-family-bold) _fonts ;;
    --font-family-italic) _fonts ;;
    --font-family-bold-italic) _fonts ;;
    --font-style) return ;;
    --font-style-bold) return ;;
    --font-style-italic) return ;;
    --font-style-bold-italic) return ;;
    --font-synthetic-style) mapfile -t COMPREPLY < <( compgen -W "bold no-bold italic no-italic bold-italic no-bold-italic" -- "$cur" ); addSpaces ;;
    --font-feature) return ;;
    --font-size) return ;;
    --font-variation) return ;;
    --font-variation-bold) return ;;
    --font-variation-italic) return ;;
    --font-variation-bold-italic) return ;;
    --font-codepoint-map) return ;;
    --font-thicken) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --adjust-cell-width) return ;;
    --adjust-cell-height) return ;;
    --adjust-font-baseline) return ;;
    --adjust-underline-position) return ;;
    --adjust-underline-thickness) return ;;
    --adjust-strikethrough-position) return ;;
    --adjust-strikethrough-thickness) return ;;
    --adjust-cursor-thickness) return ;;
    --grapheme-width-method) mapfile -t COMPREPLY < <( compgen -W "legacy unicode" -- "$cur" ); addSpaces ;;
    --freetype-load-flags) mapfile -t COMPREPLY < <( compgen -W "hinting no-hinting force-autohint no-force-autohint monochrome no-monochrome autohint no-autohint" -- "$cur" ); addSpaces ;;
    --theme) _themes ;;
    --background) return ;;
    --foreground) return ;;
    --selection-foreground) return ;;
    --selection-background) return ;;
    --selection-invert-fg-bg) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --minimum-contrast) return ;;
    --palette) return ;;
    --cursor-color) return ;;
    --cursor-invert-fg-bg) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --cursor-opacity) return ;;
    --cursor-style) mapfile -t COMPREPLY < <( compgen -W "bar block underline block_hollow" -- "$cur" ); addSpaces ;;
    --cursor-style-blink) return ;;
    --cursor-text) return ;;
    --cursor-click-to-move) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --mouse-hide-while-typing) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --mouse-shift-capture) mapfile -t COMPREPLY < <( compgen -W "false true always never" -- "$cur" ); addSpaces ;;
    --mouse-scroll-multiplier) return ;;
    --background-opacity) return ;;
    --background-blur-radius) return ;;
    --unfocused-split-opacity) return ;;
    --unfocused-split-fill) return ;;
    --command) return ;;
    --initial-command) return ;;
    --wait-after-command) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --abnormal-command-exit-runtime) return ;;
    --scrollback-limit) return ;;
    --link) return ;;
    --link-url) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --fullscreen) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --title) return ;;
    --class) return ;;
    --x11-instance-name) return ;;
    --working-directory) _dirs ;;
    --keybind) return ;;
    --window-padding-x) return ;;
    --window-padding-y) return ;;
    --window-padding-balance) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --window-padding-color) mapfile -t COMPREPLY < <( compgen -W "background extend extend-always" -- "$cur" ); addSpaces ;;
    --window-vsync) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --window-inherit-working-directory) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --window-inherit-font-size) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --window-decoration) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --window-title-font-family) return ;;
    --window-theme) mapfile -t COMPREPLY < <( compgen -W "auto system light dark ghostty" -- "$cur" ); addSpaces ;;
    --window-colorspace) mapfile -t COMPREPLY < <( compgen -W "srgb display-p3" -- "$cur" ); addSpaces ;;
    --window-height) return ;;
    --window-width) return ;;
    --window-save-state) mapfile -t COMPREPLY < <( compgen -W "default never always" -- "$cur" ); addSpaces ;;
    --window-step-resize) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --window-new-tab-position) mapfile -t COMPREPLY < <( compgen -W "current end" -- "$cur" ); addSpaces ;;
    --resize-overlay) mapfile -t COMPREPLY < <( compgen -W "always never after-first" -- "$cur" ); addSpaces ;;
    --resize-overlay-position) mapfile -t COMPREPLY < <( compgen -W "center top-left top-center top-right bottom-left bottom-center bottom-right" -- "$cur" ); addSpaces ;;
    --resize-overlay-duration) return ;;

    --clipboard-read) mapfile -t COMPREPLY < <( compgen -W "allow deny ask" -- "$cur" ); addSpaces ;;
    --clipboard-write) mapfile -t COMPREPLY < <( compgen -W "allow deny ask" -- "$cur" ); addSpaces ;;
    --clipboard-trim-trailing-spaces) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --clipboard-paste-protection) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --clipboard-paste-bracketed-safe) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --image-storage-limit) return ;;
    --copy-on-select) mapfile -t COMPREPLY < <( compgen -W "false true clipboard" -- "$cur" ); addSpaces ;;
    --click-repeat-interval) return ;;
    --config-file) _files ;;
    --config-default-files) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --confirm-close-surface) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --quit-after-last-window-closed) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --quit-after-last-window-closed-delay) return ;;
    --initial-window) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --quick-terminal-position) mapfile -t COMPREPLY < <( compgen -W "top bottom left right" -- "$cur" ); addSpaces ;;
    --quick-terminal-screen) mapfile -t COMPREPLY < <( compgen -W "main mouse macos-menu-bar" -- "$cur" ); addSpaces ;;
    --quick-terminal-animation-duration) return ;;
    --shell-integration) mapfile -t COMPREPLY < <( compgen -W "none detect bash elvish fish zsh" -- "$cur" ); addSpaces ;;
    --shell-integration-features) mapfile -t COMPREPLY < <( compgen -W "cursor no-cursor sudo no-sudo title no-title" -- "$cur" ); addSpaces ;;
    --osc-color-report-format) mapfile -t COMPREPLY < <( compgen -W "none 8-bit 16-bit" -- "$cur" ); addSpaces ;;
    --vt-kam-allowed) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --custom-shader) _files ;;
    --custom-shader-animation) mapfile -t COMPREPLY < <( compgen -W "false true always" -- "$cur" ); addSpaces ;;
    --macos-non-native-fullscreen) mapfile -t COMPREPLY < <( compgen -W "false true visible-menu" -- "$cur" ); addSpaces ;;
    --macos-titlebar-style) mapfile -t COMPREPLY < <( compgen -W "native transparent tabs hidden" -- "$cur" ); addSpaces ;;
    --macos-titlebar-proxy-icon) mapfile -t COMPREPLY < <( compgen -W "visible hidden" -- "$cur" ); addSpaces ;;
    --macos-option-as-alt) return ;;
    --macos-window-shadow) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --macos-auto-secure-input) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --macos-secure-input-indication) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --linux-cgroup) mapfile -t COMPREPLY < <( compgen -W "never always single-instance" -- "$cur" ); addSpaces ;;
    --linux-cgroup-memory-limit) return ;;
    --linux-cgroup-processes-limit) return ;;
    --linux-cgroup-hard-fail) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --gtk-single-instance) mapfile -t COMPREPLY < <( compgen -W "desktop false true" -- "$cur" ); addSpaces ;;
    --gtk-titlebar) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --gtk-tabs-location) mapfile -t COMPREPLY < <( compgen -W "top bottom left right" -- "$cur" ); addSpaces ;;
    --adw-toolbar-style) mapfile -t COMPREPLY < <( compgen -W "flat raised raised-border" -- "$cur" ); addSpaces ;;
    --gtk-wide-tabs) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --gtk-adwaita) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --desktop-notifications) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --bold-is-bright) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
    --term) return ;;
    --enquiry-response) return ;;
    --auto-update) mapfile -t COMPREPLY < <( compgen -W "off check download" -- "$cur" ); addSpaces ;;
    *) mapfile -t COMPREPLY < <( compgen -W "$config" -- "$cur" ) ;;
  esac

  return 0
}

list_fonts="--family= --style= --bold= --italic= --help"
list_keybinds="--default= --docs= --plain= --help"
list_themes="--path= --plain= --help"
list_actions="--docs= --help"
show_config="--default= --changes-only= --docs= --help"
validate_config="--config-file= --help"

_handleActions() {
  case "${COMP_WORDS[1]}" in
    +list-fonts)
      case $prev in
        --family) return;;
        --style) return;;
        --bold) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
        --italic) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
        *) mapfile -t COMPREPLY < <( compgen -W "$list_fonts" -- "$cur" ) ;;
      esac
    ;;
    +list-keybinds)
      case $prev in
        --default) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
        --docs) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
        --plain) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
        *) mapfile -t COMPREPLY < <( compgen -W "$list_keybinds" -- "$cur" ) ;;
      esac
    ;;
    +list-themes)
      case $prev in
        --path) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
        --plain) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
        *) mapfile -t COMPREPLY < <( compgen -W "$list_themes" -- "$cur" ) ;;
      esac
    ;;
    +list-actions)
      case $prev in
        --docs) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
        *) mapfile -t COMPREPLY < <( compgen -W "$list_actions" -- "$cur" ) ;;
      esac
    ;;
    +show-config)
      case $prev in
        --default) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
        --changes-only) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
        --docs) mapfile -t COMPREPLY < <( compgen -W "true false" -- "$cur" ); addSpaces ;;
        *) mapfile -t COMPREPLY < <( compgen -W "$show_config" -- "$cur" ) ;;
      esac
    ;;
    +validate-config)
      case $prev in
        --config-file) _files ;;
        *) mapfile -t COMPREPLY < <( compgen -W "$validate_config" -- "$cur" ) ;;
      esac
    ;;
    *) mapfile -t COMPREPLY < <( compgen -W "--help" -- "$cur" ) ;;
  esac

  return 0
}

topLevel="-e"
topLevel+=" --help"
topLevel+=" --version"
topLevel+=" +list-fonts"
topLevel+=" +list-keybinds"
topLevel+=" +list-themes"
topLevel+=" +list-colors"
topLevel+=" +list-actions"
topLevel+=" +show-config"
topLevel+=" +validate-config"
topLevel+=" +crash-report"

_ghostty() {
  cur=""; prev=""; prevWasEq=false; COMPREPLY=()
  ghostty="$1"

  if [ "$2" = "=" ]; then cur=""
  else                    cur="$2"
  fi

  if [ "$3" = "=" ]; then prev="${COMP_WORDS[COMP_CWORD-2]}"; prevWasEq=true;
  else                    prev="${COMP_WORDS[COMP_CWORD-1]}"
  fi

  # current completion is double quoted add a space so the curor progresses
  if [[ "$2" == \"*\" ]]; then
    COMPREPLY=( "$cur " );
    return;
  fi

  case "$COMP_CWORD" in
    1)
      case "${COMP_WORDS[1]}" in
        -e | --help | --version) return 0 ;;
        --*) _handleConfig ;;
        *) mapfile -t COMPREPLY < <( compgen -W "${topLevel}" -- "$cur" ); addSpaces ;;
      esac
      ;;
    *)
      case "$prev" in
        -e | --help | --version) return 0 ;;
        *)
          if [[ "=" != "${COMP_WORDS[COMP_CWORD]}" && $prevWasEq != true ]]; then
            # must be completing with a space after the key eg: '--<key> '
            # clear out prev so we don't run any of the key specific completions
            prev=""
          fi

          case "${COMP_WORDS[1]}" in
            --*) _handleConfig ;;
            +*) _handleActions ;;
          esac
          ;;
      esac
      ;;
  esac

  return 0
}

complete -o nospace -o bashdefault -F _ghostty ghostty
```
</details>

cc @jparise 
I agree to re-license my commits to MIT
Closes #2053