### PR TITLE
Fish/zsh completion simple fixes

### DIFF
--- a/src/build/fish_completions.zig
+++ b/src/build/fish_completions.zig
@@ -9,7 +9,7 @@ pub const fish_completions = comptimeGenerateFishCompletions();
 
 fn comptimeGenerateFishCompletions() []const u8 {
     comptime {
-        @setEvalBranchQuota(18000);
+        @setEvalBranchQuota(50000);
         var counter = std.io.countingWriter(std.io.null_writer);
         try writeFishCompletions(&counter.writer());
 
@@ -38,7 +38,7 @@ fn writeFishCompletions(writer: anytype) !void {
 
     try writer.writeAll("complete -c ghostty -f\n");
 
-    try writer.writeAll("complete -c ghostty -l help -f\n");
+    try writer.writeAll("complete -c ghostty -s e -l help -f\n");
     try writer.writeAll("complete -c ghostty -n \"not __fish_seen_subcommand_from $commands\" -l version -f\n");
 
     for (@typeInfo(Config).Struct.fields) |field| {

--- a/src/build/zsh_completions.zig
+++ b/src/build/zsh_completions.zig
@@ -32,7 +32,7 @@ fn writeZshCompletions(writer: anytype) !void {
         \\}
         \\
         \\_themes() {
-        \\  local theme_list=$(ghostty +list-themes | sed -E 's/^(.*) \(.*\$/\0/')
+        \\  local theme_list=$(ghostty +list-themes | sed -E 's/^(.*) \(.*$/\1/')
         \\  local themes=(${(f)theme_list})
         \\  _describe -t themes 'themes' themes
         \\}
@@ -101,13 +101,13 @@ fn writeZshCompletions(writer: anytype) !void {
         \\_ghostty() {
         \\  typeset -A opt_args
         \\  local context state line
-        \\  local opt=('--help' '--version')
+        \\  local opt=('-e' '--help' '--version')
         \\
         \\  _arguments -C \
         \\    '1:actions:->actions' \
         \\    '*:: :->rest' \
         \\
-        \\  if [[ "$line[1]" == "--help" || "$line[1]" == "--version" ]]; then
+        \\  if [[ "$line[1]" == "--help" || "$line[1]" == "--version" || "$line[1]" == "-e" ]]; then
         \\    return
         \\  fi
         \\
@@ -127,6 +127,9 @@ fn writeZshCompletions(writer: anytype) !void {
         var count: usize = 0;
         const padding = "        ";
         for (@typeInfo(Action).Enum.fields) |field| {
+            if (std.mem.eql(u8, "help", field.name)) continue;
+            if (std.mem.eql(u8, "version", field.name)) continue;
+
             try writer.writeAll(padding ++ "'+");
             try writer.writeAll(field.name);
             try writer.writeAll("'\n");


### PR DESCRIPTION
Adds -e handling to both completions. Updates eval overhead on fish to avoid similar adjustments made in #2962. Fixes improperly escaped sed expression for generating theme names in completions.

I agree to re-license these commits as MIT