### PR TITLE
bash: re-enable automatic bash shell detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,12 @@ function fine within Ghostty with the above mentioned shell integration features
 inoperative. **If you want to disable automatic shell integration,** set
 `shell-integration = none` in your configuration file.
 
-Automatic `bash` shell integration requires Bash version 4 or later and must be
-explicitly enabled by setting `shell-integration = bash`.
+> [!NOTE]
+>
+> The version of Bash distributed with macOS (`/bin/bash`) does not support
+> automatic shell integration. You'll need to manually source the shell
+> integration script (as shown below). You can also install a standard
+> version of Bash from Homebrew or elsewhere and set it as your shell.
 
 **For the automatic shell integration to work,** Ghostty must either be run
 from the macOS app bundle or be installed in a location where the contents of

--- a/src/shell-integration/README.md
+++ b/src/shell-integration/README.md
@@ -18,9 +18,6 @@ our integration script (`bash/ghostty.bash`). This prevents Bash from loading
 its normal startup files, which becomes our script's responsibility (along with
 disabling POSIX mode).
 
-Because automatic Bash shell integration requires Bash version 4 or later, it
-must be explicitly enabled (`shell-integration = bash`).
-
 Bash shell integration can also be sourced manually from `bash/ghostty.bash`.
 This also works for older versions of Bash.
 
@@ -30,6 +27,13 @@ if [ -n "${GHOSTTY_RESOURCES_DIR}" ]; then
     builtin source "${GHOSTTY_RESOURCES_DIR}/shell-integration/bash/ghostty.bash"
 fi
 ```
+
+> [!NOTE]
+>
+> The version of Bash distributed with macOS (`/bin/bash`) does not support
+> automatic shell integration. You'll need to manually source the shell
+> integration script (as shown above). You can also install a standard
+> version of Bash from Homebrew or elsewhere and set it as your shell.
 
 ### Elvish
 


### PR DESCRIPTION
Bash shell detection was originally disabled in #1823 due to problems with /bin/bash on macOS.

Apple distributes their own patched version of Bash 3.2 on macOS that disables the POSIX-style $ENV-based startup path:

https://github.com/apple-oss-distributions/bash/blob/e5397a7e74633a4e84194a6c6b609e04077da6f8/bash-3.2/shell.c#L1112-L1114

This means we're unable to perform our automatic shell integration sequence in this specific environment. Standard Bash 3.2 works fine.

Knowing this, we can re-enable bash shell detection by default unless we're running "/bin/bash" on Darwin. We can safely assume that's the unsupported Bash executable because /bin is non-writable on modern macOS installations due to System Integrity Protection.

macOS users can either manually source our shell integration script (which otherwise works fine with Apple's Bash) or install a standard version of Bash from Homebrew or elsewhere.