### PR TITLE
os: add prependEnv(), like appendEnv()

### DIFF
--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -27,6 +27,7 @@ pub const CFReleaseThread = @import("cf_release_thread.zig");
 pub const TempDir = @import("TempDir.zig");
 pub const appendEnv = env.appendEnv;
 pub const appendEnvAlways = env.appendEnvAlways;
+pub const prependEnv = env.prependEnv;
 pub const getenv = env.getenv;
 pub const setenv = env.setenv;
 pub const unsetenv = env.unsetenv;


### PR DESCRIPTION
We can use this function in setupXdgDataDirs() to simplify the XDG_DATA_DIRS environment variable code in a more standardized way.