### PR TITLE
build: allow CLI actions to have enum option values

### DIFF
--- a/src/build/bash_completions.zig
+++ b/src/build/bash_completions.zig
@@ -181,11 +181,28 @@ fn writeBashCompletions(writer: anytype) !void {
                 .Bool => try writer.writeAll("return ;;"),
                 .Enum => |info| {
                     try writer.writeAll(compgenPrefix);
-                    for (info.opts, 0..) |f, i| {
+                    for (info.fields, 0..) |f, i| {
                         if (i > 0) try writer.writeAll(" ");
                         try writer.writeAll(f.name);
                     }
                     try writer.writeAll(compgenSuffix);
+                },
+                .Optional => |optional| {
+                    switch (@typeInfo(optional.child)) {
+                        .Enum => |info| {
+                            try writer.writeAll(compgenPrefix);
+                            for (info.fields, 0..) |f, i| {
+                                if (i > 0) try writer.writeAll(" ");
+                                try writer.writeAll(f.name);
+                            }
+                            try writer.writeAll(compgenSuffix);
+                        },
+                        else => {
+                            if (std.mem.eql(u8, "config-file", opt.name)) {
+                                try writer.writeAll("return ;;");
+                            } else try writer.writeAll("return;;");
+                        },
+                    }
                 },
                 else => {
                     if (std.mem.eql(u8, "config-file", opt.name)) {

--- a/src/build/fish_completions.zig
+++ b/src/build/fish_completions.zig
@@ -117,11 +117,24 @@ fn writeFishCompletions(writer: anytype) !void {
                 .Bool => try writer.writeAll(" -a \"true false\""),
                 .Enum => |info| {
                     try writer.writeAll(" -a \"");
-                    for (info.opts, 0..) |f, i| {
+                    for (info.fields, 0..) |f, i| {
                         if (i > 0) try writer.writeAll(" ");
                         try writer.writeAll(f.name);
                     }
                     try writer.writeAll("\"");
+                },
+                .Optional => |optional| {
+                    switch (@typeInfo(optional.child)) {
+                        .Enum => |info| {
+                            try writer.writeAll(" -a \"");
+                            for (info.fields, 0..) |f, i| {
+                                if (i > 0) try writer.writeAll(" ");
+                                try writer.writeAll(f.name);
+                            }
+                            try writer.writeAll("\"");
+                        },
+                        else => {},
+                    }
                 },
                 else => {},
             }

--- a/src/build/zsh_completions.zig
+++ b/src/build/zsh_completions.zig
@@ -175,11 +175,28 @@ fn writeZshCompletions(writer: anytype) !void {
                     .Bool => try writer.writeAll("(true false)"),
                     .Enum => |info| {
                         try writer.writeAll("(");
-                        for (info.opts, 0..) |f, i| {
+                        for (info.fields, 0..) |f, i| {
                             if (i > 0) try writer.writeAll(" ");
                             try writer.writeAll(f.name);
                         }
                         try writer.writeAll(")");
+                    },
+                    .Optional => |optional| {
+                        switch (@typeInfo(optional.child)) {
+                            .Enum => |info| {
+                                try writer.writeAll("(");
+                                for (info.fields, 0..) |f, i| {
+                                    if (i > 0) try writer.writeAll(" ");
+                                    try writer.writeAll(f.name);
+                                }
+                                try writer.writeAll(")");
+                            },
+                            else => {
+                                if (std.mem.eql(u8, "config-file", opt.name)) {
+                                    try writer.writeAll("_files");
+                                } else try writer.writeAll("( )");
+                            },
+                        }
                     },
                     else => {
                         if (std.mem.eql(u8, "config-file", opt.name)) {


### PR DESCRIPTION
A typo in the fish completions (that was likely copied to the zsh and bash completions) prevented CLI actions from using enums as option values because the completions tried to access non-existent fields from type introspection. This doesn't cause any problems _now_ because no CLI action uses an enum as an option value. However as soon as you try and add one the completions fail to compile.

This patch fixes the incorrect field reference. It also adds the ability to have _optional_ enums as option values.

cc @jparise @anund @anmolw 