### PR TITLE
bash: improve clearing of multiline prompts

### DIFF
--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -100,15 +100,11 @@ function __ghostty_precmd() {
       PS1=$PS1'\[\e]133;B\a\]'
       PS2=$PS2'\[\e]133;B\a\]'
 
+      # bash doesn't redraw the leading lines in a multiline prompt so
+      # mark the last line as a secondary prompt (k=s) to prevent the
+      # preceding lines from being erased by ghostty after a resize.
       if [[ "${PS1}" == *"\n"* || "${PS1}" == *$'\n'* ]]; then
-        # bash doesn't redraw the leading lines in a multiline prompt so
-        # mark the last line as a secondary prompt (k=s) to prevent the
-        # preceding lines from being erased by ghostty after a resize.
-        builtin local oldval
-        oldval=$(builtin shopt -p extglob)
-        builtin shopt -s extglob
-        PS1=${PS1%@('\n'|$'\n')*}'\n\[\e]133;A;k=s\a\]'${PS1##*@('\n'|$'\n')}
-        builtin eval "$oldval"
+        PS1=$PS1'\[\e]133;A;k=s\a\]'
       fi
 
       # Cursor


### PR DESCRIPTION
Bash doesn't redraw the leading lines in a multiline prompt so we mark the last line as a secondary prompt (k=s) to prevent the preceding lines from being erased by Ghostty after a resize.

Our previously attempt at this (#1973) was flawed. Instead, we now just re-issue the OSC "133;A" command with a 'k=s' (secondary) kind at the end of our prompt string.

This isn't a great solution because it stomps on the prompt's "133;B" command (end of prompt and start of user input), but it's sufficient for now and only applies in the multiline prompt case.

Going forward, we should revisit our semantic prompt implementation. Our row-based approach is too limiting; lines can have multiple markers, and markers should be recorded with their full coordinates so they can form ranges.

See: https://per.bothner.com/blog/2019/shell-integration-proposal/

Fixes: #1961