### PR TITLE
nix: support `programs.vim.plugins = [ ghostty.vim ]`

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -157,7 +157,7 @@ in
       chmod u+rwX -R $ZIG_GLOBAL_CACHE_DIR
     '';
 
-    outputs = ["out" "terminfo" "shell_integration"];
+    outputs = ["out" "terminfo" "shell_integration" "vim"];
 
     postInstall = ''
       terminfo_src=${
@@ -177,6 +177,8 @@ in
       mv "$out/share/ghostty/shell-integration" "$shell_integration/shell-integration"
       ln -sf "$shell_integration/shell-integration" "$out/share/ghostty/shell-integration"
       echo "$shell_integration" >> "$out/nix-support/propagated-user-env-packages"
+
+      cp -r $out/share/vim/vimfiles "$vim"
     '';
 
     postFixup = ''


### PR DESCRIPTION
nixos vim module expects vim plugins to have their code organized as top level directories. eg: `/ftdetect` rather than `/share/vim/vimfiles/ftdetect`. Adding a separate output seems like a convenient way to reference the plugin files in `programs.vim.plugins ...`. Interestingly neovim will find the plugin via directory traversal making `ghostty.vim` and `ghostty` the same for `programs.neovim.plugins`

I agree to re-license my commits to MIT