### PR TITLE
bash: avoid accidents on macos when /bin/bash is being used

### DIFF
--- a/src/build/bash_completions.zig
+++ b/src/build/bash_completions.zig
@@ -261,7 +261,12 @@ fn writeBashCompletions(writer: anytype) !void {
         \\  return 0
         \\}
         \\
-        \\complete -o nospace -o bashdefault -F _ghostty ghostty
+        \\if ! command -v mapfile 2>&1 >/dev/null
+        \\then
+        \\  echo "mapfile could not be found. ghostty autocomplete requires bash >=4.0"
+        \\else
+        \\  complete -o nospace -o bashdefault -F _ghostty ghostty
+        \\fi
         \\
     );
 }


### PR DESCRIPTION
If completions are sourced under bash missing `mapfile` (macos default /bin/bash) users get an error rather than a completion suggestion. Move the error to point of source rather than point of use. It is possible to write these completions to support bash without mapfile if someone is so inclined.

I agree to re-license my commits to MIT