### PR TITLE
docs: fix referenced toggle window decorations action name

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1003,7 +1003,7 @@ keybind: Keybinds = .{},
 ///   * `false` - windows won't have native decorations, i.e. titlebar and
 ///      borders. On macOS this also disables tabs and tab overview.
 ///
-/// The "toggle_window_decoration" keybind action can be used to create
+/// The "toggle_window_decorations" keybind action can be used to create
 /// a keybinding to toggle this setting at runtime.
 ///
 /// Changing this configuration in your configuration and reloading will


### PR DESCRIPTION
I tried adding a key binding as the docs suggested, but it seems like the referenced action has since been renamed from `toggle_window_decoration` to `toggle_window_decorations`.

Since I saw questions in other small PRs: I am fine with this being relicensed under the MIT license.