### PR TITLE
Change to F3 legacy encoding with modifiers

### DIFF
--- a/src/input/KeyEncoder.zig
+++ b/src/input/KeyEncoder.zig
@@ -2067,7 +2067,7 @@ test "legacy: f1" {
     {
         enc.event.key = .f3;
         const actual = try enc.legacy(&buf);
-        try testing.expectEqualStrings("\x1b[1;5R", actual);
+        try testing.expectEqualStrings("\x1b[13;5~", actual);
     }
 
     // F4

--- a/src/input/function_keys.zig
+++ b/src/input/function_keys.zig
@@ -89,7 +89,7 @@ pub const keys = keys: {
     // Function Keys. todo: f13-f35 but we need to add to input.Key
     result.set(.f1, pcStyle("\x1b[1;{}P") ++ .{.{ .sequence = "\x1BOP" }});
     result.set(.f2, pcStyle("\x1b[1;{}Q") ++ .{.{ .sequence = "\x1BOQ" }});
-    result.set(.f3, pcStyle("\x1b[1;{}R") ++ .{.{ .sequence = "\x1BOR" }});
+    result.set(.f3, pcStyle("\x1b[13;{}~") ++ .{.{ .sequence = "\x1BOR" }});
     result.set(.f4, pcStyle("\x1b[1;{}S") ++ .{.{ .sequence = "\x1BOS" }});
     result.set(.f5, pcStyle("\x1b[15;{}~") ++ .{.{ .sequence = "\x1B[15~" }});
     result.set(.f6, pcStyle("\x1b[17;{}~") ++ .{.{ .sequence = "\x1B[17~" }});


### PR DESCRIPTION
The [fixterms](http://www.leonerd.org.uk/hacks/fixterms/) "Really Special Keypresses" section suggests using CSI 1 ; Ps R for F3, but this is also a valid cursor position report.  The intention was to make back-compatible changes, so this is fairly considered a specification bug.

This changes F3 in legacy mode to send CSI 13 ; Ps ~ instead, this is a variant listed in fixterms, is what kitty protocol uses, and lacks the problematic overlap with cursor positions.

The KeyEncoder.zig unit test has been changed accordingly, and all tests pass on my machine.