### PR TITLE
avoid asserting working directory is absolute

### DIFF
--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1135,7 +1135,7 @@ const Subprocess = struct {
         // This is important because our cwd can be set by the shell (OSC 7)
         // and we don't want to break new windows.
         const cwd: ?[]const u8 = if (self.cwd) |proposed| cwd: {
-            if (std.fs.accessAbsolute(proposed, .{})) {
+            if (std.fs.cwd().access(proposed, .{})) {
                 break :cwd proposed;
             } else |err| {
                 log.warn("cannot access cwd, ignoring: {}", .{err});


### PR DESCRIPTION
`std.fs.accessAbsolute` asserts if the user proposed path is absolute, which we are seemingly passing as-is with no validating that it is.

When running with safety checks on, passing non-absolute path to --working-directory will make ghostty crash.

I changed it to use `Dir.access`, which is just `accessAbsolute` without the check.

This has the side effect of also allowing relative working directory.