### PR TITLE
build: change object storage domain to ghostty.org

### DIFF
--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -293,7 +293,7 @@ jobs:
         run: |
           echo $SPARKLE_KEY > signing.key
           sign_update -f signing.key ghostty-macos-universal.zip > sign_update.txt
-          curl -L https://tip.files.ghostty.dev/appcast.xml > appcast.xml
+          curl -L https://tip.files.ghostty.org/appcast.xml > appcast.xml
           python3 ./dist/macos/update_appcast_tip.py
           test -f appcast_new.xml
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -22,7 +22,7 @@
             .hash = "12205a66d423259567764fa0fc60c82be35365c21aeb76c5a7dc99698401f4f6fefc",
         },
         .ziglyph = .{
-            .url = "https://deps.files.ghostty.dev/ziglyph-b89d43d1e3fb01b6074bc1f7fc980324b04d26a5.tar.gz",
+            .url = "https://deps.files.ghostty.org/ziglyph-b89d43d1e3fb01b6074bc1f7fc980324b04d26a5.tar.gz",
             .hash = "12207831bce7d4abce57b5a98e8f3635811cfefd160bca022eb91fe905d36a02cf25",
         },
 

--- a/dist/macos/update_appcast_tip.py
+++ b/dist/macos/update_appcast_tip.py
@@ -94,7 +94,7 @@ commit history <a href="{repo}">on GitHub</a> for all changes.
 </p>
 """
 elem = ET.SubElement(item, "enclosure")
-elem.set("url", f"https://tip.files.ghostty.dev/{commit_long}/ghostty-macos-universal.zip")
+elem.set("url", f"https://tip.files.ghostty.org/{commit_long}/ghostty-macos-universal.zip")
 elem.set("type", "application/octet-stream")
 for key, value in attrs.items():
     elem.set(key, value)

--- a/macos/Sources/Features/Update/UpdateDelegate.swift
+++ b/macos/Sources/Features/Update/UpdateDelegate.swift
@@ -7,7 +7,7 @@ class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
         // channels but we probably don't want some appcasts in the same file (i.e.
         // tip) so this would be the place to change that. For now, we hardcode the
         // tip appcast URL since it is all we support.
-        return "https://tip.files.ghostty.dev/appcast.xml"
+        return "https://tip.files.ghostty.org/appcast.xml"
     }
 
     func updaterWillRelaunchApplication(_ updater: SPUUpdater) {

--- a/pkg/fontconfig/build.zig.zon
+++ b/pkg/fontconfig/build.zig.zon
@@ -3,7 +3,7 @@
     .version = "2.14.2",
     .dependencies = .{
         .fontconfig = .{
-            .url = "https://deps.files.ghostty.dev/fontconfig-2.14.2.tar.gz",
+            .url = "https://deps.files.ghostty.org/fontconfig-2.14.2.tar.gz",
             .hash = "12201149afb3326c56c05bb0a577f54f76ac20deece63aa2f5cd6ff31a4fa4fcb3b7",
         },
 


### PR DESCRIPTION
DNS and TLS are up to date so this should all work. I want to start rolling this out now so I can phase out the `.dev` before the 1.0 release.