### PR TITLE
surface: don't early return when clearing hyperlinks

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3298,9 +3298,10 @@ pub fn cursorPosCallback(
 
         // No mouse point so we don't highlight links
         self.renderer_state.mouse.point = null;
-        self.renderer_state.terminal.screen.dirty.hyperlink_hover = true;
 
-        return;
+        // Mark the link's row as dirty, but continue with updating the
+        // mouse state below so we can scroll when our position is negative.
+        self.renderer_state.terminal.screen.dirty.hyperlink_hover = true;
     }
 
     // Always show the mouse again if it is hidden


### PR DESCRIPTION
When outside the viewport, other actions such as scrolling might be happening, and doing an early return when clearing hyperlinks prevents scrolling upwards.

We reposition the check, and do not early return so we can process scrolling when it happens.

This fixes #2645, restoring the ability to scroll upwards while retaining the behavior of hyperlinks when outside the viewport.

(and, yes I still permit my commits to be relicensed to MIT)

## Before
[Screen Recording 2024-12-21 at 01.36.02.webm](https://github.com/user-attachments/assets/bf144455-ff26-4d4e-9eff-c3d632c02c17)

## After
[Screen Recording 2024-12-21 at 01.36.44.webm](https://github.com/user-attachments/assets/308a795f-971d-4807-b4ba-91bd3685c185)
