### PR TITLE
CI: Add --prefix option to `git archive`

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -87,7 +87,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Create Tarball
-        run: git archive --format=tgz -o ghostty-source.tar.gz HEAD
+        run: git archive --format=tgz --prefix=ghostty-source/ -o ghostty-source.tar.gz HEAD
 
       - name: Sign Tarball
         run: |

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -111,7 +111,7 @@ jobs:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Create Tarball
-        run: git archive --format=tgz -o ghostty-source.tar.gz HEAD
+        run: git archive --format=tgz --prefix=ghostty-source/ -o ghostty-source.tar.gz HEAD
       - name: Sign Tarball
         run: |
           echo -n "${{ secrets.MINISIGN_KEY }}" > minisign.key


### PR DESCRIPTION
Without a prefix option, the result of extracting the archive is the repository being laid out flat
which requires an extra step of making a directory and changing into it.
`  tar -xvf "${SOURCE_TAR}" -C "$BUILD_NAME"`, Change into the directory first, then perform extraction.
Running a plain `tar -xvf ghostty-source.tar.gz` on results in the following structures
```
 .
├── build.zig
├── build.zig.zon
├── com.mitchellh.ghostty.yml
├── conformance
├── CONTRIBUTING.md
├── dist
├── example
├── flake.lock
├── flake.nix
├── ghostty-source.tar.gz
├── images
├── include
├── macos
├── Makefile
├── nix
├── PACKAGING.md
├── pkg
├── README.md
├── README_TESTERS.md
├── shell.nix
├── src
├── test
├── TODO.md
├── typos.toml
└── vendor
```
With a prefix, extracted contents are kept under a top-level directory
```
.
├── ghostty-source
│   ├── build.zig
│   ├── build.zig.zon
│   ├── com.mitchellh.ghostty.yml
│   ├── conformance
│   ├── CONTRIBUTING.md
│   ├── dist
│   ├── example
│   ├── flake.lock
│   ├── flake.nix
│   ├── images
│   ├── include
│   ├── macos
│   ├── Makefile
│   ├── nix
│   ├── PACKAGING.md
│   ├── pkg
│   ├── README.md
│   ├── README_TESTERS.md
│   ├── shell.nix
│   ├── src
│   ├── test
│   ├── TODO.md
│   ├── typos.toml
│   └── vendor
└── ghostty-source.tar.gz
```
This would be a breaking change for scripts depending on the current archive format but it I think  is easier to work with and a change that should be made before 1.0.