### PR TITLE
Bash complex completions

### DIFF
--- a/src/build/bash_completions.zig
+++ b/src/build/bash_completions.zig
@@ -37,12 +37,47 @@ fn writeBashCompletions(writer: anytype) !void {
     const pad4 = pad3 ++ pad1;
 
     try writer.writeAll(
+        \\
         \\# -o nospace requires we add back a space when a completion is finished
         \\# and not part of a --key= completion
         \\addSpaces() {
         \\  for idx in "${!COMPREPLY[@]}"; do
         \\    [ -n "${COMPREPLY[idx]}" ] && COMPREPLY[idx]="${COMPREPLY[idx]} ";
         \\  done
+        \\}
+        \\
+        \\_fonts() {
+        \\  local IFS=$'\n'
+        \\  mapfile -t COMPREPLY < <( compgen -P '"' -S '"' -W "$($ghostty +list-fonts | grep '^[A-Z]' )" -- "$cur")
+        \\}
+        \\
+        \\_themes() {
+        \\  local IFS=$'\n'
+        \\  mapfile -t COMPREPLY < <( compgen -P '"' -S '"' -W "$($ghostty +list-themes | sed -E 's/^(.*) \(.*$/\1/')" -- "$cur")
+        \\}
+        \\
+        \\_files() {
+        \\  mapfile -t COMPREPLY < <( compgen -o filenames -f -- "$cur" )
+        \\  for i in "${!COMPREPLY[@]}"; do
+        \\    if [[ -d "${COMPREPLY[i]}" ]]; then
+        \\      COMPREPLY[i]="${COMPREPLY[i]}/";
+        \\    fi
+        \\    if [[ -f "${COMPREPLY[i]}" ]]; then
+        \\      COMPREPLY[i]="${COMPREPLY[i]} ";
+        \\    fi
+        \\  done
+        \\}
+        \\
+        \\_dirs() {
+        \\  mapfile -t COMPREPLY < <( compgen -o dirnames -d -- "$cur" )
+        \\  for i in "${!COMPREPLY[@]}"; do
+        \\    if [[ -d "${COMPREPLY[i]}" ]]; then
+        \\      COMPREPLY[i]="${COMPREPLY[i]}/";
+        \\    fi
+        \\  done
+        \\  if [[ "${#COMPREPLY[@]}" == 0 && -d "$cur" ]]; then
+        \\    COMPREPLY=( "$cur " )
+        \\  fi
         \\}
         \\
         \\config="--help"
@@ -70,13 +105,13 @@ fn writeBashCompletions(writer: anytype) !void {
         try writer.writeAll(pad2 ++ "--" ++ field.name ++ ") ");
 
         if (std.mem.startsWith(u8, field.name, "font-family"))
-            try writer.writeAll("return ;;")
+            try writer.writeAll("_fonts ;;")
         else if (std.mem.eql(u8, "theme", field.name))
-            try writer.writeAll("return ;;")
+            try writer.writeAll("_themes ;;")
         else if (std.mem.eql(u8, "working-directory", field.name))
-            try writer.writeAll("return ;;")
+            try writer.writeAll("_dirs ;;")
         else if (field.type == Config.RepeatablePath)
-            try writer.writeAll("return ;;")
+            try writer.writeAll("_files ;;")
         else {
             const compgenPrefix = "mapfile -t COMPREPLY < <( compgen -W \"";
             const compgenSuffix = "\" -- \"$cur\" ); addSpaces ;;";
@@ -206,7 +241,7 @@ fn writeBashCompletions(writer: anytype) !void {
                 },
                 else => {
                     if (std.mem.eql(u8, "config-file", opt.name)) {
-                        try writer.writeAll("return ;;");
+                        try writer.writeAll("_files ;;");
                     } else try writer.writeAll("return;;");
                 },
             }
@@ -254,6 +289,12 @@ fn writeBashCompletions(writer: anytype) !void {
         \\  else                    prev="${COMP_WORDS[COMP_CWORD-1]}"
         \\  fi
         \\
+        \\  # current completion is double quoted add a space so the curor progresses
+        \\  if [[ "$2" == \"*\" ]]; then
+        \\    COMPREPLY=( "$cur " );
+        \\    return;
+        \\  fi
+        \\
         \\  case "$COMP_CWORD" in
         \\    1)
         \\      case "${COMP_WORDS[1]}" in
@@ -266,6 +307,12 @@ fn writeBashCompletions(writer: anytype) !void {
         \\      case "$prev" in
         \\        -e | --help | --version) return 0 ;;
         \\        *)
+        \\          if [[ "=" != "${COMP_WORDS[COMP_CWORD]}" && $prevWasEq != true ]]; then
+        \\            # must be completing with a space after the key eg: '--<key> '
+        \\            # clear out prev so we don't run any of the key specific completions
+        \\            prev=""
+        \\          fi
+        \\        
         \\          case "${COMP_WORDS[1]}" in
         \\            --*) _handleConfig ;;
         \\            +*) _handleActions ;;

--- a/src/build/bash_completions.zig
+++ b/src/build/bash_completions.zig
@@ -37,7 +37,6 @@ fn writeBashCompletions(writer: anytype) !void {
     const pad4 = pad3 ++ pad1;
 
     try writer.writeAll(
-        \\
         \\# -o nospace requires we add back a space when a completion is finished
         \\# and not part of a --key= completion
         \\addSpaces() {
@@ -280,6 +279,11 @@ fn writeBashCompletions(writer: anytype) !void {
         \\_ghostty() {
         \\  cur=""; prev=""; prevWasEq=false; COMPREPLY=()
         \\  ghostty="$1"
+        \\
+        \\  # script assumes default COMP_WORDBREAKS of roughly $' \t\n"\'><=;|&(:'
+        \\  # if = is missing this script will degrade to matching on keys only.
+        \\  # eg: --key=
+        \\  # this can be improved if needed see: https://github.com/ghostty-org/ghostty/discussions/2994
         \\
         \\  if [ "$2" = "=" ]; then cur=""
         \\  else                    cur="$2"


### PR DESCRIPTION
Given https://github.com/ghostty-org/ghostty/discussions/2994 revert https://github.com/ghostty-org/ghostty/pull/2963/commits/f1728f594a681941b85a8d2fa8a136d625d9b633. Add documentation to help point people towards the discussion and needed changes to handle `COMP_WORDBREAKS` not including expected characters. 

We know macOS and nixos defaults to including `=` so explicit handling to change behaviour should only be required if it turns out some systematically used tool brings in a completion function that changes `COMP_WORDBREAKS` away from the default. (something they should not be doing)

If necessary I can create a issue to track handling unexpected word breaks usage. This change improves the current completions.

I agree to re-license my commits to MIT