### PR TITLE
ci: release workflows build a dmg for macOS

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -199,7 +199,18 @@ jobs:
           # Codesign the app bundle
           /usr/bin/codesign --verbose -f -s "$MACOS_CERTIFICATE_NAME" -o runtime --entitlements "macos/Ghostty.entitlements" macos/build/Release/Ghostty.app
 
-      - name: "Notarize app bundle"
+      - name: Create DMG
+        env:
+          MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
+        run: |
+          npm install --global create-dmg
+          create-dmg \
+            --identity="$MACOS_CERTIFICATE_NAME" \
+            ./macos/build/Release/Ghostty.app \
+            ./
+          mv ./Ghostty*.dmg ./Ghostty.dmg
+
+      - name: "Notarize DMG"
         env:
           PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
           PROD_MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}
@@ -210,22 +221,18 @@ jobs:
           echo "Create keychain profile"
           xcrun notarytool store-credentials "notarytool-profile" --apple-id "$PROD_MACOS_NOTARIZATION_APPLE_ID" --team-id "$PROD_MACOS_NOTARIZATION_TEAM_ID" --password "$PROD_MACOS_NOTARIZATION_PWD"
 
-          # We can't notarize an app bundle directly, but we need to compress it as an archive.
-          # Therefore, we create a zip file containing our app bundle, so that we can send it to the
-          # notarization service
-          echo "Creating temp notarization archive"
-          ditto -c -k --keepParent "macos/build/Release/Ghostty.app" "notarization.zip"
-
           # Here we send the notarization request to the Apple's Notarization service, waiting for the result.
           # This typically takes a few seconds inside a CI environment, but it might take more depending on the App
           # characteristics. Visit the Notarization docs for more information and strategies on how to optimize it if
           # you're curious
-          echo "Notarize app"
-          xcrun notarytool submit "notarization.zip" --keychain-profile "notarytool-profile" --wait
+          echo "Notarize dmg"
+          xcrun notarytool submit "Ghostty.dmg" --keychain-profile "notarytool-profile" --wait
 
           # Finally, we need to "attach the staple" to our executable, which will allow our app to be
-          # validated by macOS even when an internet connection is not available.
+          # validated by macOS even when an internet connection is not available. We do this to
+          # both the app and the dmg
           echo "Attach staple"
+          xcrun stapler staple "Ghostty.dmg"
           xcrun stapler staple "macos/build/Release/Ghostty.app"
 
       # Zip up the app and symbols
@@ -240,6 +247,7 @@ jobs:
         with:
           name: macos
           path: |-
+            Ghostty.dmg
             ghostty-macos-universal.zip
             ghostty-macos-universal-dsym.zip
 
@@ -299,7 +307,7 @@ jobs:
           echo "GHOSTTY_COMMIT_LONG=$GHOSTTY_COMMIT_LONG"
 
           echo $SPARKLE_KEY > signing.key
-          sign_update -f signing.key ghostty-macos-universal.zip > sign_update.txt
+          sign_update -f signing.key Ghostty.dmg > sign_update.txt
           curl -L https://release.files.ghostty.org/appcast.xml > appcast.xml
           python3 ./dist/macos/update_appcast_tag.py
           test -f appcast_new.xml
@@ -348,6 +356,7 @@ jobs:
           mv ghostty-source.tar.gz.minisig blob/${GHOSTTY_VERSION}/ghostty-source.tar.gz.minisig
           mv ghostty-macos-universal.zip blob/${GHOSTTY_VERSION}/ghostty-macos-universal.zip
           mv ghostty-macos-universal-dsym.zip blob/${GHOSTTY_VERSION}/ghostty-macos-universal-dsym.zip
+          mv Ghostty.dmg blob/${GHOSTTY_VERSION}/Ghostty.dmg
       - name: Upload to R2
         uses: ryand56/r2-upload-action@latest
         with:

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -239,7 +239,18 @@ jobs:
           # Codesign the app bundle
           /usr/bin/codesign --verbose -f -s "$MACOS_CERTIFICATE_NAME" -o runtime --entitlements "macos/Ghostty.entitlements" macos/build/Release/Ghostty.app
 
-      - name: "Notarize app bundle"
+      - name: Create DMG
+        env:
+          MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
+        run: |
+          npm install --global create-dmg
+          create-dmg \
+            --identity="$MACOS_CERTIFICATE_NAME" \
+            ./macos/build/Release/Ghostty.app \
+            ./
+          mv ./Ghostty*.dmg ./Ghostty.dmg
+
+      - name: "Notarize DMG"
         env:
           PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
           PROD_MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}
@@ -250,22 +261,18 @@ jobs:
           echo "Create keychain profile"
           xcrun notarytool store-credentials "notarytool-profile" --apple-id "$PROD_MACOS_NOTARIZATION_APPLE_ID" --team-id "$PROD_MACOS_NOTARIZATION_TEAM_ID" --password "$PROD_MACOS_NOTARIZATION_PWD"
 
-          # We can't notarize an app bundle directly, but we need to compress it as an archive.
-          # Therefore, we create a zip file containing our app bundle, so that we can send it to the
-          # notarization service
-          echo "Creating temp notarization archive"
-          ditto -c -k --keepParent "macos/build/Release/Ghostty.app" "notarization.zip"
-
           # Here we send the notarization request to the Apple's Notarization service, waiting for the result.
           # This typically takes a few seconds inside a CI environment, but it might take more depending on the App
           # characteristics. Visit the Notarization docs for more information and strategies on how to optimize it if
           # you're curious
-          echo "Notarize app"
-          xcrun notarytool submit "notarization.zip" --keychain-profile "notarytool-profile" --wait
+          echo "Notarize dmg"
+          xcrun notarytool submit "Ghostty.dmg" --keychain-profile "notarytool-profile" --wait
 
           # Finally, we need to "attach the staple" to our executable, which will allow our app to be
-          # validated by macOS even when an internet connection is not available.
+          # validated by macOS even when an internet connection is not available. We do this to
+          # both the app and the dmg
           echo "Attach staple"
+          xcrun stapler staple "Ghostty.dmg"
           xcrun stapler staple "macos/build/Release/Ghostty.app"
 
       # Zip up the app and symbols
@@ -283,7 +290,9 @@ jobs:
           prerelease: true
           tag_name: tip
           target_commitish: ${{ github.sha }}
-          files: ghostty-macos-universal.zip
+          files: |
+            ghostty-macos-universal.zip
+            Ghostty.dmg
           token: ${{ secrets.GH_RELEASE_TOKEN }}
 
       # Create our appcast for Sparkle
@@ -292,7 +301,7 @@ jobs:
           SPARKLE_KEY: ${{ secrets.PROD_MACOS_SPARKLE_KEY }}
         run: |
           echo $SPARKLE_KEY > signing.key
-          sign_update -f signing.key ghostty-macos-universal.zip > sign_update.txt
+          sign_update -f signing.key Ghostty.dmg > sign_update.txt
           curl -L https://tip.files.ghostty.org/appcast.xml > appcast.xml
           python3 ./dist/macos/update_appcast_tip.py
           test -f appcast_new.xml
@@ -304,6 +313,7 @@ jobs:
           mkdir -p blob/${GHOSTTY_COMMIT_LONG}
           cp ghostty-macos-universal.zip blob/${GHOSTTY_COMMIT_LONG}/ghostty-macos-universal.zip
           cp ghostty-macos-universal-dsym.zip blob/${GHOSTTY_COMMIT_LONG}/ghostty-macos-universal-dsym.zip
+          cp Ghostty.dmg blob/${GHOSTTY_COMMIT_LONG}/Ghostty.dmg
 
       - name: Upload to R2
         uses: ryand56/r2-upload-action@latest

--- a/dist/macos/update_appcast_tag.py
+++ b/dist/macos/update_appcast_tag.py
@@ -96,7 +96,7 @@ the <a href="https://ghostty.org">Ghostty website</a>.
 </p>
 """
 elem = ET.SubElement(item, "enclosure")
-elem.set("url", f"https://release.files.ghostty.org/{version}/ghostty-macos-universal.zip")
+elem.set("url", f"https://release.files.ghostty.org/{version}/Ghostty.dmg")
 elem.set("type", "application/octet-stream")
 for key, value in attrs.items():
     elem.set(key, value)

--- a/dist/macos/update_appcast_tip.py
+++ b/dist/macos/update_appcast_tip.py
@@ -94,7 +94,7 @@ commit history <a href="{repo}">on GitHub</a> for all changes.
 </p>
 """
 elem = ET.SubElement(item, "enclosure")
-elem.set("url", f"https://tip.files.ghostty.org/{commit_long}/ghostty-macos-universal.zip")
+elem.set("url", f"https://tip.files.ghostty.org/{commit_long}/Ghostty.dmg")
 elem.set("type", "application/octet-stream")
 for key, value in attrs.items():
     elem.set(key, value)


### PR DESCRIPTION
We've used a zip for the duration of the private beta but macOS users expect a dmg. This commit changes both of our release workflows to begin building a dmg instead of a zip.

![CleanShot 2024-12-20 at 21 26 53@2x](https://github.com/user-attachments/assets/2873854d-7849-4c53-9b58-e636ef8e2899)
