### PR TITLE
config: quick terminal auto hide

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -107,7 +107,9 @@ class QuickTerminalController: BaseTerminalController {
             self.previousApp = nil
         }
 
-        animateOut()
+        if (derivedConfig.quickTerminalAutoHide) {
+            animateOut()
+        }
     }
 
     func windowWillResize(_ sender: NSWindow, to frameSize: NSSize) -> NSSize {
@@ -395,15 +397,18 @@ class QuickTerminalController: BaseTerminalController {
     private struct DerivedConfig {
         let quickTerminalScreen: QuickTerminalScreen
         let quickTerminalAnimationDuration: Double
+        let quickTerminalAutoHide: Bool
 
         init() {
             self.quickTerminalScreen = .main
             self.quickTerminalAnimationDuration = 0.2
+            self.quickTerminalAutoHide = true
         }
 
         init(_ config: Ghostty.Config) {
             self.quickTerminalScreen = config.quickTerminalScreen
             self.quickTerminalAnimationDuration = config.quickTerminalAnimationDuration
+            self.quickTerminalAutoHide = config.quickTerminalAutoHide
         }
     }
 }

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -232,7 +232,7 @@ extension Ghostty {
             guard let ptr = v else { return defaultValue }
             return String(cString: ptr)
         }
-        
+
         var macosTitlebarProxyIcon: MacOSTitlebarProxyIcon {
             let defaultValue = MacOSTitlebarProxyIcon.visible
             guard let config = self.config else { return defaultValue }
@@ -363,6 +363,14 @@ extension Ghostty {
             guard let config = self.config else { return 0.2 }
             var v: Double = 0.2
             let key = "quick-terminal-animation-duration"
+            _ = ghostty_config_get(config, &v, key, UInt(key.count))
+            return v
+        }
+
+        var quickTerminalAutoHide: Bool {
+            guard let config = self.config else { return true }
+            var v = true
+            let key = "quick-terminal-autohide"
             _ = ghostty_config_get(config, &v, key, UInt(key.count))
             return v
         }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1404,6 +1404,10 @@ keybind: Keybinds = .{},
 /// runtime.
 @"quick-terminal-animation-duration": f64 = 0.2,
 
+/// Automatically hide the quick terminal when focus shifts to another window.
+/// Set it to false for the quick terminal to remain open even when it loses focus.
+@"quick-terminal-autohide": bool = true,
+
 /// Whether to enable shell integration auto-injection or not. Shell integration
 /// greatly enhances the terminal experience by enabling a number of features:
 ///


### PR DESCRIPTION
## Description

Introduce a setting allowing to customize the behavior of the quick terminal when it loses focus. By default, the quick terminal will automatically hide. However, you can now configure it to remain open by setting `quick-terminal-autohide: false`.

Resolves #2558