### PR TITLE
Fix unfocused split color balance

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -355,7 +355,7 @@ extension Ghostty {
             }
 
             return .init(
-                red: Double(color.r),
+                red: Double(color.r) / 255,
                 green: Double(color.g) / 255,
                 blue: Double(color.b) / 255
             )


### PR DESCRIPTION
After upgrading Ghostty to the latest release, b92fb2d9, the unfocused split color was quite different:

<img width="931" alt="image" src="https://github.com/user-attachments/assets/9ff21db8-0280-416f-8119-2b0d1f08efc4" />

This was surprising because I don't set `unfocused-split-fill` so it should use the background color.

I traced this to 298d6194f4c4de6727b6391b631d4d7f54d7f6b1 where the blue and green components are divided by 255 but not the red.

Although I'm sure this should be easy to reproduce, the relevant bits of my configuration file are included below:

```
theme = catppuccin-frappe

unfocused-split-opacity = 0.95
```

This fixes #3065.