### PR TITLE
macOS: change default keybinds for equalize splits, jump to prompt -1/+1

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2503,8 +2503,20 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
         );
         try result.keybind.set.put(
             alloc,
-            .{ .key = .{ .translated = .equal }, .mods = .{ .shift = true, .alt = true } },
+            .{ .key = .{ .translated = .equal }, .mods = .{ .super = true, .ctrl = true } },
             .{ .equalize_splits = {} },
+        );
+
+        // Jump to prompt, matches Terminal.app
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .{ .translated = .up }, .mods = .{ .super = true } },
+            .{ .jump_to_prompt = -1 },
+        );
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .{ .translated = .down }, .mods = .{ .super = true } },
+            .{ .jump_to_prompt = 1 },
         );
 
         // Inspector, matching Chromium


### PR DESCRIPTION
From: https://github.com/ghostty-org/ghostty/discussions/2363#discussioncomment-11645228

The justification there makes sense to me and I think it would be a good change to make. Copied here:

> There are a few bindings that feel a little weird on macOS. My suggestions:
>
> (1) Equalize Splits
> ```
> keybind = shift+opt+equal=unbind
> keybind = ctrl+cmd+equal=equalize_splits
> ```
> The default hijacks the `±` character on US keyboards. Believe it or not, I do use ± in the terminal. Ctrl+cmd+equal matches the arrow key bindings in the Window > Resize Split menu and thus looks more elegant and is easier to memorize.
>
> (2) Jump to Prompt
> ```
> keybind = cmd+up=jump_to_prompt:-1
> keybind = cmd+down=jump_to_prompt:1
> ```
> These are the bindings in Terminal.app. The default shift-cmd-up/down is usually associated with extending a selection. Cmd-up/down are available (they currently act as simple up/down). I bind them additionally to the defaults.