### PR TITLE
apprt/gtk: move new tab button to start of header bar

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -200,7 +200,7 @@ pub fn init(self: *Window, app: *App) !void {
             const btn = c.gtk_button_new_from_icon_name("tab-new-symbolic");
             c.gtk_widget_set_tooltip_text(btn, "New Tab");
             _ = c.g_signal_connect_data(btn, "clicked", c.G_CALLBACK(&gtkTabNewClick), self, null, c.G_CONNECT_DEFAULT);
-            header.packEnd(btn);
+            header.packStart(btn);
         }
 
         self.header = header;


### PR DESCRIPTION
According to the GNOME human interface guidelines, buttons for the main user actions, such as new, add, open, and back should be placed at the start of the header bar. (https://developer.gnome.org/hig/patterns/containers/header-bars.html#header-bar-buttons)

Moving the new tab button to the start of the header bar brings Ghostty in line with other GNOME applications such as gedit and gnome-terminal.