### PR TITLE
apprt/gtk: revert pull request ghostty-org#2242 to correct menu separator colour

### DIFF
--- a/src/apprt/gtk/style-dark.css
+++ b/src/apprt/gtk/style-dark.css
@@ -1,8 +1,3 @@
 .transparent {
   background-color: transparent;
 }
-
-separator {
-  background-color: rgba(36, 36, 36, 1);
-  background-clip: content-box;
-}

--- a/src/apprt/gtk/style.css
+++ b/src/apprt/gtk/style.css
@@ -36,8 +36,3 @@ label.size-overlay.hidden {
 .transparent {
   background-color: transparent;
 }
-
-separator {
-  background-color: rgba(250, 250, 250, 1);
-  background-clip: content-box;
-}


### PR DESCRIPTION
ghostty-org#2242 was intended to correct the separator colour between panes but also sets the menu separator colour. Backing out this change corrects the menu separator colour for the GTK and Adwaita window implementations without causing the split separator to become transparent.

### Before: 

GtkWindow:
![before_gtkwindow](https://github.com/user-attachments/assets/a476a455-3999-4454-9869-94313bd4a288)

Adwaita Light:
![before_adwaita_light](https://github.com/user-attachments/assets/bf7c494c-3056-4ee7-8aaf-11a9b4232745)

Adwaita Dark:
![before_adwaita_dark](https://github.com/user-attachments/assets/db6c340d-7a73-4556-8a11-814e251d7079)

### After:

GtkWindow:
![after_gtkwindow](https://github.com/user-attachments/assets/2d7e5eba-480d-40c3-91d0-6329b9f8ff0b)

Adwaita Light:
![after_adwaita_light](https://github.com/user-attachments/assets/a7a0cd48-db27-4445-862e-d5d2525e78a6)

Adwaita Dark:
![after_adwaita_dark](https://github.com/user-attachments/assets/0ecd7253-ebd7-4b42-a61f-62f71028fe4c)


