### PR TITLE
Fix RefCountedSet issue(s)

### DIFF
--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1763,9 +1763,14 @@ pub fn manualStyleUpdate(self: *Screen) !void {
 
     // If our new style is the default, just reset to that
     if (self.cursor.style.default()) {
-        self.cursor.style_id = 0;
+        self.cursor.style_id = style.default_id;
         return;
     }
+
+    // Clear the cursor style ID to prevent weird things from happening
+    // if the page capacity has to be adjusted which would end up calling
+    // manualStyleUpdate again.
+    self.cursor.style_id = style.default_id;
 
     // After setting the style, we need to update our style map.
     // Note that we COULD lazily do this in print. We should look into


### PR DESCRIPTION
Fixes #2497 

While investigating the issue I added an integrity check that found a problem hiding in the insert logic that was unrelated- in fixing that I greatly simplified the insert logic.

It turns out that #2497 is ultimately just a case of bad luck, pathological inputs that result in very non-uniform hashes so the clustering overwhelms things. The solution was just to add a check and claim we're out of memory.

I tried adding an entropy folding function to fix the hash a little but it had a measurable negative impact on performance and isn't necessary so I've not included it here. Currently there's an open PR to Zig to [add RapidHash](https://github.com/ziglang/zig/pull/22085),  which is the successor to Wyhash and apparently has much better statistical characteristics on top of being faster. I imagine it will land in time for 0.14 so whenever we update to 0.14 we should probably switch our standard hash function to RapidHash, which I imagine should yield improvements across the board.

Using the AutoHasher may also be not the best idea, I may explore ways to improve how we generate our style hashes in the future.