### PR TITLE
apprt/gtk: support dark window decorations with GtkWindow

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -221,6 +221,9 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
                 switch (config.@"window-theme") {
                     .system, .light => {},
                     .dark => {
+                        const settings = c.gtk_settings_get_default();
+                        c.g_object_set(@ptrCast(@alignCast(settings)), "gtk-application-prefer-dark-theme", true, @as([*c]const u8, null));
+
                         c.gtk_css_provider_load_from_resource(
                             provider,
                             "/com/mitchellh/ghostty/style-dark.css",
@@ -234,6 +237,9 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
                     .auto, .ghostty => {
                         const lum = config.background.toTerminalRGB().perceivedLuminance();
                         if (lum <= 0.5) {
+                            const settings = c.gtk_settings_get_default();
+                            c.g_object_set(@ptrCast(@alignCast(settings)), "gtk-application-prefer-dark-theme", true, @as([*c]const u8, null));
+
                             c.gtk_css_provider_load_from_resource(
                                 provider,
                                 "/com/mitchellh/ghostty/style-dark.css",


### PR DESCRIPTION
While builds with libawdaita support light and dark window decorations, builds without libadwaita are always light. This PR adds support for the dark GtkWindow variant when `window-theme` is `dark` or `auto`. 

Before (window-theme=auto): 
![before](https://github.com/user-attachments/assets/619988e5-1a7e-4f8f-8533-3b376f896c24)

After (window-theme=auto):
![after](https://github.com/user-attachments/assets/bb1d172b-d14e-42fd-90bd-84bf058bb5fc)

Note: `window-theme = ghostty` is broken with GtkWindow and not fixed in this PR.
