### PR TITLE
terminal: implement support for ConEmu OSC 9 progress report

### DIFF
--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -1447,6 +1447,10 @@ pub fn Stream(comptime Handler: type) type {
                         return;
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
+
+                .progress => {
+                    log.warn("unimplemented OSC callback: {}", .{cmd});
+                },
             }
 
             // Fall through for when we don't have a handler.


### PR DESCRIPTION
ConTerm and iTerm2 have both taken OSC 9 to implement different things: iTerm2 uses it to implement desktop notifications
ConTerm uses it to implement lots of different instructions

Terminals such as Kitty or GhosTTY have implemented OSC 9 like iTerm2 did meanwhile other projects such as Windows Terminal, systemd and flatpak have decided to use OSC 9;4 to report the progress state

https://conemu.github.io/en/AnsiEscapeCodes.html#ConEmu_specific_OSC
https://iterm2.com/documentation-escape-codes.html

For this PR I've implemented support for the OSC 9;4 command by ConEmu with a fallback to desktop notification if anything doesn't match what is expected
