### PR TITLE
feat: add support for middle position quick terminal

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalPosition.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalPosition.swift
@@ -5,6 +5,7 @@ enum QuickTerminalPosition : String {
     case bottom
     case left
     case right
+    case middle
 
     /// Set the loaded state for a window.
     func setLoaded(_ window: NSWindow) {
@@ -24,6 +25,14 @@ enum QuickTerminalPosition : String {
                 size: .init(
                     width: screen.frame.width / 4,
                     height: screen.frame.height)
+            ), display: false)
+
+        case .middle:
+            window.setFrame(.init(
+                origin: window.frame.origin,
+                size: .init(
+                    width: screen.frame.width / 2,
+                    height: screen.frame.height / 3)
             ), display: false)
         }
     }
@@ -61,6 +70,10 @@ enum QuickTerminalPosition : String {
 
         case .left, .right:
             finalSize.height = screen.frame.height
+
+        case .middle:
+            finalSize.width = screen.frame.width / 2
+            finalSize.height = screen.frame.height / 3
         }
 
         return finalSize
@@ -80,6 +93,9 @@ enum QuickTerminalPosition : String {
 
         case .right:
             return .init(x: screen.frame.maxX, y: 0)
+
+        case .middle:
+            return .init(x: (screen.visibleFrame.maxX - window.frame.width) / 2, y: screen.visibleFrame.maxY - window.frame.width)
         }
     }
 
@@ -97,6 +113,9 @@ enum QuickTerminalPosition : String {
 
         case .right:
             return .init(x: screen.visibleFrame.maxX - window.frame.width, y: window.frame.origin.y)
+
+        case .middle:
+            return .init(x: (screen.visibleFrame.maxX - window.frame.width) / 2, y: (screen.visibleFrame.maxY - window.frame.height) / 2)
         }
     }
 }

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalPosition.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalPosition.swift
@@ -5,7 +5,7 @@ enum QuickTerminalPosition : String {
     case bottom
     case left
     case right
-    case middle
+    case center
 
     /// Set the loaded state for a window.
     func setLoaded(_ window: NSWindow) {
@@ -27,7 +27,7 @@ enum QuickTerminalPosition : String {
                     height: screen.frame.height)
             ), display: false)
 
-        case .middle:
+        case .center:
             window.setFrame(.init(
                 origin: window.frame.origin,
                 size: .init(
@@ -71,7 +71,7 @@ enum QuickTerminalPosition : String {
         case .left, .right:
             finalSize.height = screen.frame.height
 
-        case .middle:
+        case .center:
             finalSize.width = screen.frame.width / 2
             finalSize.height = screen.frame.height / 3
         }
@@ -94,7 +94,7 @@ enum QuickTerminalPosition : String {
         case .right:
             return .init(x: screen.frame.maxX, y: 0)
 
-        case .middle:
+        case .center:
             return .init(x: (screen.visibleFrame.maxX - window.frame.width) / 2, y: screen.visibleFrame.maxY - window.frame.width)
         }
     }
@@ -114,7 +114,7 @@ enum QuickTerminalPosition : String {
         case .right:
             return .init(x: screen.visibleFrame.maxX - window.frame.width, y: window.frame.origin.y)
 
-        case .middle:
+        case .center:
             return .init(x: (screen.visibleFrame.maxX - window.frame.width) / 2, y: (screen.visibleFrame.maxY - window.frame.height) / 2)
         }
     }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -5257,6 +5257,7 @@ pub const QuickTerminalPosition = enum {
     bottom,
     left,
     right,
+    middle,
 };
 
 /// See quick-terminal-screen

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1377,6 +1377,7 @@ keybind: Keybinds = .{},
 ///   * `bottom` - Terminal appears at the bottom of the screen.
 ///   * `left` - Terminal appears at the left of the screen.
 ///   * `right` - Terminal appears at the right of the screen.
+///   * `center` - Terminal appears at the center of the screen.
 ///
 /// Changing this configuration requires restarting Ghostty completely.
 @"quick-terminal-position": QuickTerminalPosition = .top,
@@ -5257,7 +5258,7 @@ pub const QuickTerminalPosition = enum {
     bottom,
     left,
     right,
-    middle,
+    center,
 };
 
 /// See quick-terminal-screen


### PR DESCRIPTION
# Description

This commit introduces the ability to launch the quick terminal in the middle position.

![Screen Recording 2024-12-24 at 14 59 46](https://github.com/user-attachments/assets/6c733caf-34c7-4e80-ba16-24b41f98d2f0)

## Note to reviewer
- The quick terminal is currently centered. Should we consider adding a top offset to better align with the screenshot in [the issue](#2494 )? Should it be configurable?
- On large monitors, half the visible frame might be excessively large. To mitigate, I am planning to implement #2384 but we should probably agree on a good default maximum width/height in middle position.
- I also figured out, reloading the configuration does not update the quick terminal configuration. That is also an issue I will try to fix.

Resolves #2494

I agree to relicense my commit to MIT.