### PR TITLE
Fix UB in style hashing by using autoHash, but keep XxHash3

### DIFF
--- a/src/terminal/style.zig
+++ b/src/terminal/style.zig
@@ -9,6 +9,7 @@ const OffsetBuf = size.OffsetBuf;
 const RefCountedSet = @import("ref_counted_set.zig").RefCountedSet;
 
 const XxHash3 = std.hash.XxHash3;
+const autoHash = std.hash.autoHash;
 
 /// The unique identifier for a style. This is at most the number of cells
 /// that can fit into a terminal page.
@@ -229,13 +230,10 @@ pub const Style = struct {
         _ = try writer.write(" }");
     }
 
-    /// Hash the raw bytes of the struct with XxHash3
-    ///
-    /// NOTE: Because the struct does not have a guaranteed in-memory layout
-    ///       this hash is NOT suitable for serialization. If used for a hash
-    ///       table that is then serialized, it MUST be re-hashed when read.
     pub fn hash(self: *const Style) u64 {
-        return XxHash3.hash(0, @as(*const [@sizeOf(Style)]u8, @ptrCast(self)));
+        var hasher = XxHash3.init(0);
+        autoHash(&hasher, self.*);
+        return hasher.final();
     }
 
     test {


### PR DESCRIPTION
Back out "perf(styles): greatly improve style.hash performance" This backs out commit 3bfe4cd25ca7a5ae4d4084818b86ada9236b3bb5, but keeps the hash algorithm as XxHash3 which showed improvements in performance.