### PR TITLE
optimize `Style` hashing to be single-shot

### DIFF
--- a/src/terminal/color.zig
+++ b/src/terminal/color.zig
@@ -95,7 +95,7 @@ pub const Name = enum(u8) {
 };
 
 /// RGB
-pub const RGB = struct {
+pub const RGB = packed struct(u24) {
     r: u8 = 0,
     g: u8 = 0,
     b: u8 = 0,
@@ -155,9 +155,9 @@ pub const RGB = struct {
         return 0.299 * (r_f64 / 255) + 0.587 * (g_f64 / 255) + 0.114 * (b_f64 / 255);
     }
 
-    test "size" {
-        try std.testing.expectEqual(@as(usize, 24), @bitSizeOf(RGB));
-        try std.testing.expectEqual(@as(usize, 3), @sizeOf(RGB));
+    comptime {
+        assert(@bitSizeOf(RGB) == 24);
+        assert(@sizeOf(RGB) == 4);
     }
 
     /// Parse a color from a floating point intensity value.

--- a/src/terminal/style.zig
+++ b/src/terminal/style.zig
@@ -239,6 +239,14 @@ pub const Style = struct {
         _ = try writer.write(" }");
     }
 
+    /// `PackedStyle` represents the same data as `Style` but without padding,
+    /// which is necassary for hashing via re-interpretation of the underlying bytes.
+    ///
+    /// `Style` is still prefered for everything else as it has type-safety when using
+    /// the `Color` tagged union.
+    ///
+    /// Empirical testing shows that storing all of the tags first and then the datas
+    /// provides a better layout for serializing into and is faster on benchmarks.
     const PackedStyle = packed struct(u128) {
         tags: packed struct {
             fg: Color.Tag,
@@ -253,6 +261,10 @@ pub const Style = struct {
         flags: Flags,
         _padding: u16 = 0,
 
+        /// After https://github.com/ziglang/zig/issues/19754 is implemented, it
+        /// will be an compiler-error to have packed union fields of differing size.
+        ///
+        /// For now we just need to be careful not to accidentally introduce padding.
         const Data = packed union {
             none: u24,
             palette: packed struct(u24) {

--- a/src/terminal/style.zig
+++ b/src/terminal/style.zig
@@ -240,13 +240,15 @@ pub const Style = struct {
     }
 
     /// `PackedStyle` represents the same data as `Style` but without padding,
-    /// which is necassary for hashing via re-interpretation of the underlying bytes.
+    /// which is necessary for hashing via re-interpretation of the underlying
+    /// bytes.
     ///
-    /// `Style` is still prefered for everything else as it has type-safety when using
-    /// the `Color` tagged union.
+    /// `Style` is still preferred for everything else as it has type-safety
+    /// when using the `Color` tagged union.
     ///
-    /// Empirical testing shows that storing all of the tags first and then the datas
-    /// provides a better layout for serializing into and is faster on benchmarks.
+    /// Empirical testing shows that storing all of the tags first and then the
+    /// data provides a better layout for serializing into and is faster on
+    /// benchmarks.
     const PackedStyle = packed struct(u128) {
         tags: packed struct {
             fg: Color.Tag,
@@ -261,10 +263,12 @@ pub const Style = struct {
         flags: Flags,
         _padding: u16 = 0,
 
-        /// After https://github.com/ziglang/zig/issues/19754 is implemented, it
-        /// will be an compiler-error to have packed union fields of differing size.
+        /// After https://github.com/ziglang/zig/issues/19754 is implemented,
+        /// it will be an compiler-error to have packed union fields of
+        /// differing size.
         ///
-        /// For now we just need to be careful not to accidentally introduce padding.
+        /// For now we just need to be careful not to accidentally introduce
+        /// padding.
         const Data = packed union {
             none: u24,
             palette: packed struct(u24) {


### PR DESCRIPTION
The idea is to serialize `Style` into a packed format as quickly as possible. 
Following an SOA pattern here yields the best result.

Using the Doom-Fire benchmark, 
New: 780FPS
Old (f46a6769): 627FPS

Memory usage isn't affected as the layout changes cancel each other out.