### PR TITLE
config: revert cmd/alt+left/right to legacy encoding on macOS by default

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2532,6 +2532,32 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
             .{ .key = .{ .translated = .f }, .mods = .{ .super = true, .ctrl = true } },
             .{ .toggle_fullscreen = {} },
         );
+
+        // "Natural text editing" keybinds. This forces these keys to go back
+        // to legacy encoding (not fixterms). It seems macOS users more than
+        // others are used to these keys so we set them as defaults. If
+        // people want to get back to the fixterm encoding they can set
+        // the keybinds to `unbind`.
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .{ .translated = .right }, .mods = .{ .super = true } },
+            .{ .text = "\x05" },
+        );
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .{ .translated = .left }, .mods = .{ .super = true } },
+            .{ .text = "\x01" },
+        );
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .{ .translated = .left }, .mods = .{ .alt = true } },
+            .{ .esc = "b" },
+        );
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .{ .translated = .right }, .mods = .{ .alt = true } },
+            .{ .esc = "f" },
+        );
     }
 
     // Add our default link for URL detection


### PR DESCRIPTION
Fixes #3106
Related to #2838
Discussion in #2363

This breaks fixterms encodings for these specific keys so that shells and other programs that rely on the legacy encoding for these keys will work by default.

This only does this for macOS because for whatever reason during the large beta period, only macOS users found this as lacking.

If users want to restore fixterms behaviors, they can rebind these keys as `unbind`.