### PR TITLE
Fuzzer fixes

### DIFF
--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -244,6 +244,7 @@ pub fn init(
 
     // We always track our viewport pin to ensure this is never an allocation
     const viewport_pin = try pool.pins.create();
+    viewport_pin.* = .{ .node = page_list.first.? };
     var tracked_pins: PinSet = .{};
     errdefer tracked_pins.deinit(pool.alloc);
     try tracked_pins.putNoClobber(pool.alloc, viewport_pin, {});

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -878,7 +878,7 @@ pub fn cursorScrollAbove(self: *Screen) !void {
 }
 
 fn cursorScrollAboveRotate(self: *Screen) !void {
-    self.cursor.page_pin.* = self.cursor.page_pin.down(1).?;
+    self.cursorChangePin(self.cursor.page_pin.down(1).?);
 
     // Go through each of the pages following our pin, shift all rows
     // down by one, and copy the last row of the previous page.

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -620,7 +620,7 @@ pub fn cursorAbsolute(self: *Screen, x: size.CellCountInt, y: size.CellCountInt)
     self.cursor.x = x; // Must be set before cursorChangePin
     self.cursor.y = y;
     self.cursorChangePin(page_pin);
-    const page_rac = page_pin.rowAndCell();
+    const page_rac = self.cursor.page_pin.rowAndCell();
     self.cursor.page_row = page_rac.row;
     self.cursor.page_cell = page_rac.cell;
 }

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1774,18 +1774,11 @@ pub fn manualStyleUpdate(self: *Screen) !void {
     // Release our previous style if it was not default.
     if (self.cursor.style_id != style.default_id) {
         page.styles.release(page.memory, self.cursor.style_id);
-    }
-
-    // If our new style is the default, just reset to that
-    if (self.cursor.style.default()) {
         self.cursor.style_id = style.default_id;
-        return;
     }
 
-    // Clear the cursor style ID to prevent weird things from happening
-    // if the page capacity has to be adjusted which would end up calling
-    // manualStyleUpdate again.
-    self.cursor.style_id = style.default_id;
+    // If our new style is the default, then we're done.
+    if (self.cursor.style.default()) return;
 
     // After setting the style, we need to update our style map.
     // Note that we COULD lazily do this in print. We should look into


### PR DESCRIPTION
I fuzzed things a little bit with integrity tests enabled and found 2 bugs which I fixed (I think one of them is responsible for the crash reported in #2497 after it was closed) and 1 other potential bug in a similar vein.

I also found a violation of the LTR shaping assertion in the Metal renderer and a style ref mismatch (off by 1) integrity violation in `Terminal.index` -> `PageList.eraseRowBounded` -> `Page.clonePartialRowFrom`, neither of which I've had time to fix.

I didn't have time to make tests for the fixed issues, but they shouldn't be *too* hard to make? Hopefully.

While fixing a test failure I found a bug, revealed by my `cursorReload` fix, where during reflow tracked pins could be lost. I fixed that, but there's still some test failures remaining, specifically for `Screen.cursorScrollAbove` - because my fix to `cursorScrollAboveRotate` changed the dirtying behavior (`cursorChangePin` unconditionally dirties the source and destination row for the cursor, because cursor position can change shaping). I took a look and it seems like what's being tested for that behavior is incorrect.

I don't have enough time to investigate more thoroughly tonight, I might have a little time tomorrow, but I'm opening the PR in case you want to take a look.