### PR TITLE
optimize `Style.eql` using `PackedStyle`

### DIFF
--- a/src/terminal/style.zig
+++ b/src/terminal/style.zig
@@ -87,7 +87,10 @@ pub const Style = struct {
 
     /// True if the style is equal to another style.
     pub fn eql(self: Style, other: Style) bool {
-        return std.meta.eql(self, other);
+        const packed_self = PackedStyle.fromStyle(self);
+        const packed_other = PackedStyle.fromStyle(other);
+        // TODO: in Zig 0.14, equating packed structs is allowed. Remove this work around.
+        return @as(u128, @bitCast(packed_self)) == @as(u128, @bitCast(packed_other));
     }
 
     /// Returns the bg color for a cell with this style given the cell


### PR DESCRIPTION
A follow-up on #3103, the `Style.eql` function can also benefit from `PackedStyle`.

Using the same DFZ benchmark,
New: 795 FPS
Old (fddedd7c): 765 FPS

FPS is a bit different due to differing background system loads, but the increase in FPS is consistent across benchmarks.