### PR TITLE
config: use escaped encoding for macOS cmd+left/right

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2542,12 +2542,12 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
         try result.keybind.set.put(
             alloc,
             .{ .key = .{ .translated = .right }, .mods = .{ .super = true } },
-            .{ .text = "\x05" },
+            .{ .text = "\\x05" },
         );
         try result.keybind.set.put(
             alloc,
             .{ .key = .{ .translated = .left }, .mods = .{ .super = true } },
-            .{ .text = "\x01" },
+            .{ .text = "\\x01" },
         );
         try result.keybind.set.put(
             alloc,


### PR DESCRIPTION
Fixes #3114

I forgot that the format gets parsed as a Zig string so putting it in already parsed made `+list-keybinds` incorrect. It worked either way but this fixes the `+list-keybinds` CLI action.