### PR TITLE
terminal: parse ConEmu progress OSC 9

### DIFF
--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -1447,6 +1447,10 @@ pub fn Stream(comptime Handler: type) type {
                         return;
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
+
+                .progress => {
+                    log.warn("unimplemented OSC callback: {}", .{cmd});
+                },
             }
 
             // Fall through for when we don't have a handler.


### PR DESCRIPTION
Fixes #3119
Supersedes #3099 

ConEmu and iTerm2 both use OSC 9 to implement different things. iTerm2 uses it to implement desktop notifications, while ConEmu uses it to implement various OS commands.

Ghostty has supported iTerm2 OSC 9 for a while, but it didn't (and doesn't) support ConEmu OSC 9. This means that if a program tries to send a ConEmu OSC 9 to Ghostty, it will turn into a desktop notification.

This commit adds parsing for ConEmu OSC 9 progress reports. This means that these specific syntaxes can never be desktop notifications, but they're quite strange to be desktop notifications anyway so this should be an okay tradeoff.

This doesn't actually _do anything with the progress reports_, it just parses them so that they don't turn into desktop notifications.

cc @Jan200101 