### PR TITLE
Handle execveZ failures in `Command.zig`

### DIFF
--- a/src/Command.zig
+++ b/src/Command.zig
@@ -588,8 +588,8 @@ test "createNullDelimitedEnvMap" {
 test "Command: pre exec" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
     var cmd: Command = .{
-        .path = "/usr/bin/env",
-        .args = &.{ "/usr/bin/env", "-v" },
+        .path = "/bin/sh",
+        .args = &.{ "/bin/sh", "--help" },
         .pre_exec = (struct {
             fn do(_: *Command) void {
                 // This runs in the child, so we can exit and it won't
@@ -630,8 +630,8 @@ test "Command: redirect stdout to file" {
         .args = &.{"C:\\Windows\\System32\\whoami.exe"},
         .stdout = stdout,
     } else .{
-        .path = "/usr/bin/env",
-        .args = &.{ "/usr/bin/env", "-v" },
+        .path = "/bin/sh",
+        .args = &.{ "/bin/sh", "-c", "echo hello" },
         .stdout = stdout,
     };
 
@@ -664,8 +664,8 @@ test "Command: custom env vars" {
         .stdout = stdout,
         .env = &env,
     } else .{
-        .path = "/usr/bin/env",
-        .args = &.{ "/usr/bin/env", "sh", "-c", "echo $VALUE" },
+        .path = "/bin/sh",
+        .args = &.{ "/bin/sh", "-c", "echo $VALUE" },
         .stdout = stdout,
         .env = &env,
     };
@@ -700,10 +700,10 @@ test "Command: custom working directory" {
         .stdout = stdout,
         .cwd = "C:\\Windows\\System32",
     } else .{
-        .path = "/usr/bin/env",
-        .args = &.{ "/usr/bin/env", "sh", "-c", "pwd" },
+        .path = "/bin/sh",
+        .args = &.{ "/bin/sh", "-c", "pwd" },
         .stdout = stdout,
-        .cwd = "/usr/bin",
+        .cwd = "/bin",
     };
 
     try cmd.start(testing.allocator);

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -182,9 +182,10 @@ fn startPosix(self: *Command, arena: Allocator) !void {
     _ = posix.execveZ(pathZ, argsZ, envp) catch null;
 
     // If we are executing this code, the exec failed. In that scenario,
-    // we return a very specific error that can be detected to determine
-    // we're in the child.
-    return error.ExecFailedInChild;
+    // terminate so we don't duplicate the original process
+    // note: returning to test code from this point would run 2 copies of the test suite
+    std.debug.print("failed to execveZ as child process, terminating", .{});
+    std.process.exit(1);
 }
 
 fn startWindows(self: *Command, arena: Allocator) !void {
@@ -719,6 +720,35 @@ test "Command: custom working directory" {
     if (builtin.os.tag == .windows) {
         try testing.expectEqualStrings("C:\\Windows\\System32\r\n", contents);
     } else {
-        try testing.expectEqualStrings("/usr/bin\n", contents);
+        try testing.expectEqualStrings("/bin\n", contents);
     }
+}
+
+// Duplicating a test process via fork does unexepected things.
+// zig build test will hang
+// test binary created via -Demit-test-exe will run 2 copies of the test suite
+//
+// This test relys on cmd.start -> posix.start terminating the child process rather
+// than returning to avoid those two strange behaviours
+test "Command: posix fork handles execveZ failure" {
+    if (builtin.os.tag == .windows) {
+        return error.SkipZigTest;
+    }
+    var td = try TempDir.init();
+    defer td.deinit();
+    var stdout = try createTestStdout(td.dir);
+    defer stdout.close();
+
+    var cmd: Command = .{
+        .path = "/not/a/binary",
+        .args = &.{ "/not/a/binary", "" },
+        .stdout = stdout,
+        .cwd = "/bin",
+    };
+
+    try cmd.start(testing.allocator);
+    try testing.expect(cmd.pid != null);
+    const exit = try cmd.wait(true);
+    try testing.expect(exit == .Exited);
+    try testing.expect(exit.Exited == 1);
 }

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -182,10 +182,9 @@ fn startPosix(self: *Command, arena: Allocator) !void {
     _ = posix.execveZ(pathZ, argsZ, envp) catch null;
 
     // If we are executing this code, the exec failed. In that scenario,
-    // terminate so we don't duplicate the original process
-    // note: returning to test code from this point would run 2 copies of the test suite
-    std.debug.print("failed to execveZ as child process, terminating", .{});
-    std.process.exit(1);
+    // we return a very specific error that can be detected to determine
+    // we're in the child.
+    return error.ExecFailedInChild;
 }
 
 fn startWindows(self: *Command, arena: Allocator) !void {
@@ -599,7 +598,7 @@ test "Command: pre exec" {
         }).do,
     };
 
-    try cmd.start(testing.allocator);
+    try cmd.testingStart();
     try testing.expect(cmd.pid != null);
     const exit = try cmd.wait(true);
     try testing.expect(exit == .Exited);
@@ -635,7 +634,7 @@ test "Command: redirect stdout to file" {
         .stdout = stdout,
     };
 
-    try cmd.start(testing.allocator);
+    try cmd.testingStart();
     try testing.expect(cmd.pid != null);
     const exit = try cmd.wait(true);
     try testing.expect(exit == .Exited);
@@ -670,7 +669,7 @@ test "Command: custom env vars" {
         .env = &env,
     };
 
-    try cmd.start(testing.allocator);
+    try cmd.testingStart();
     try testing.expect(cmd.pid != null);
     const exit = try cmd.wait(true);
     try testing.expect(exit == .Exited);
@@ -706,7 +705,7 @@ test "Command: custom working directory" {
         .cwd = "/bin",
     };
 
-    try cmd.start(testing.allocator);
+    try cmd.testingStart();
     try testing.expect(cmd.pid != null);
     const exit = try cmd.wait(true);
     try testing.expect(exit == .Exited);
@@ -724,12 +723,12 @@ test "Command: custom working directory" {
     }
 }
 
-// Duplicating a test process via fork does unexepected things.
+// Test validate an execveZ failure correctly terminates when error.ExecFailedInChild is correctly handled
+//
+// Incorrectly handling an error.ExecFailedInChild results in a second copy of the test process running.
+// Duplicating the test process leads to weird behavior
 // zig build test will hang
 // test binary created via -Demit-test-exe will run 2 copies of the test suite
-//
-// This test relys on cmd.start -> posix.start terminating the child process rather
-// than returning to avoid those two strange behaviours
 test "Command: posix fork handles execveZ failure" {
     if (builtin.os.tag == .windows) {
         return error.SkipZigTest;
@@ -746,9 +745,22 @@ test "Command: posix fork handles execveZ failure" {
         .cwd = "/bin",
     };
 
-    try cmd.start(testing.allocator);
+    try cmd.testingStart();
     try testing.expect(cmd.pid != null);
     const exit = try cmd.wait(true);
     try testing.expect(exit == .Exited);
     try testing.expect(exit.Exited == 1);
+}
+
+// If cmd.start fails with error.ExecFailedInChild it's the _child_ process that is running. If it does not
+// terminate in response to that error both the parent and child will continue as if they _are_ the test suite
+// process.
+fn testingStart(self: *Command) !void {
+    self.start(testing.allocator) catch |err| {
+        if (err == error.ExecFailedInChild) {
+            // I am a child process, I must not get confused and continue running the rest of the test suite.
+            posix.exit(1);
+        }
+        return err;
+    };
 }


### PR DESCRIPTION
Bit of a rabbit hole came up while trying to package ghostty for nixos. `zig build test` would just hang when run as part of `checkPhase` in a nix build. (rather than the `nix develop ...` command run in CI).

Here's what I understand so far:

`/usr/bin/env` does not exist in a nix build sandbox. This only works as a test binary when running in `nix develop` as it shares its environment with the user where this compatibility crutch exists.
When executing `Command.zig` tests that reference `/usr/bin/env` the eventual call to fork+execevZ will duplicate the running test process as execevZ _returns_ rather than dissapearing into the new exec'd process. Duplicating a test process via fork does unexepected things. `zig build test` will hang for <reasons?>. A test binary created via `-Demit-test-exe` will run two copies of the test suite producing two different failure outputs for the same test. (or ~4 copies of the test framework, one extra for each test that fails this way)

`/bin/sh` can be used and an alternative test target. It isn't amazing as it's relying on stdenv creating `/bin/sh` and it just existing on user systems. Other alternatives I can think of would require build flags or some sort of contract with packaging around what binary will exist for the `Command.zig` tests.

This is ~probably right, either way leave it until after release. I agree to re-license my commits as MIT.