### PR TITLE
macos: send a cursor position event on mouseEnter

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -575,6 +575,20 @@ extension Ghostty {
             super.rightMouseUp(with: event)
         }
 
+        override func mouseEntered(with event: NSEvent) {
+            super.mouseEntered(with: event)
+
+            guard let surface = self.surface else { return }
+
+            // On mouse enter we need to reset our cursor position. This is
+            // super important because we set it to -1/-1 on mouseExit and
+            // lots of mouse logic (i.e. whether to send mouse reports) depend
+            // on the position being in the viewport if it is.
+            let pos = self.convert(event.locationInWindow, from: nil)
+            let mods = Ghostty.ghosttyMods(event.modifierFlags)
+            ghostty_surface_mouse_pos(surface, pos.x, frame.height - pos.y, mods)
+        }
+
         override func mouseExited(with event: NSEvent) {
             guard let surface = self.surface else { return }
 


### PR DESCRIPTION
Fixes #3117

On mouseExit we sent a cursor position event with (-1, -1). Negative values are meant to indicate that the cursor is not on the surface. The magnitude of the values are irrelevant. However, we never reset the cursor position on mouseEnter.

This has the effect of the previous cursor position being stuck outside the viewport which makes certain things such as `button` mouse reporting not report until the mouse is moved.

This commit sends the correct cursor position event on mouseEnter.