### PR TITLE
ci: lint zig code with ZLint

### DIFF
--- a/.github/workflows/zlint.yml
+++ b/.github/workflows/zlint.yml
@@ -1,0 +1,23 @@
+name: ZLint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  zlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Lint with ZLint
+        uses: DonIsaac/zlint-action@v0
+        with:
+          # When true (the default value), only files changed in a
+          # PR get linted. Has no effect on pushes.
+          diff-only: false


### PR DESCRIPTION
## What This PR Does

Adds a CI workflow to lint Zig source code with [zlint](https://github.com/DonIsaac/zlint).

ZLint checks for:
- Compiler errors that are never emitted because they occur in dead code
- Potentially unsafe logic
- More idiomatic ways to do the same thing (e.g. `foo() catch |e| return e` -> `try foo()`
- Dead code

This workflow can be configured to only check files changed in a pull request. I have turned this off for demonstration purposes. Please let me know if you would like it re-enabled.

Here's some sample output from `zlint --quiet`
<img width="878" alt="image" src="https://github.com/user-attachments/assets/5c49e297-f257-4e3e-b90f-140930af4bd5" />
