### PR TITLE
updated logic for grouping actions

### DIFF
--- a/src/build/webgen/main_actions.zig
+++ b/src/build/webgen/main_actions.zig
@@ -22,8 +22,17 @@ pub fn genKeybindActions(writer: anytype) !void {
 
     @setEvalBranchQuota(5_000);
     const fields = @typeInfo(KeybindAction).Union.fields;
+
+    var buffer = std.ArrayList(u8).init(std.heap.page_allocator);
     inline for (fields) |field| {
         if (field.name[0] == '_') continue;
+
+        if (@hasDecl(help_strings.KeybindAction, field.name)) {
+            try writer.writeAll(buffer.items);
+            try writer.writeAll("\n");
+
+            buffer.clearRetainingCapacity();
+        }
 
         // Write the field name.
         try writer.writeAll("## `");
@@ -37,10 +46,9 @@ pub fn genKeybindActions(writer: anytype) !void {
                 '\n',
             );
             while (iter.next()) |s| {
-                try writer.writeAll(s);
-                try writer.writeAll("\n");
+                try buffer.appendSlice(s);
+                try buffer.appendSlice("\n");
             }
-            try writer.writeAll("\n\n");
         }
     }
 }

--- a/src/build/webgen/main_actions.zig
+++ b/src/build/webgen/main_actions.zig
@@ -27,6 +27,7 @@ pub fn genKeybindActions(writer: anytype) !void {
     inline for (fields) |field| {
         if (field.name[0] == '_') continue;
 
+        // Write previously stored doc comment below all related actions
         if (@hasDecl(help_strings.KeybindAction, field.name)) {
             try writer.writeAll(buffer.items);
             try writer.writeAll("\n");


### PR DESCRIPTION
Update logic for generating `webgen_actions`. 

Before the change, the following grouping was produced:
```md
## `copy_to_clipboard`
Copy and paste.


## `paste_from_clipboard`
## `paste_from_selection`
## `increase_font_size`
Increase/decrease the font size by a certain amount.
```

After the change, the following grouping is being produced
```md
## `copy_to_clipboard`
## `paste_from_clipboard`
## `paste_from_selection`
Copy and paste.

## `increase_font_size`
## `decrease_font_size`
Increase/decrease the font size by a certain amount.
```

Please note that this is my first time ever writing zig, so forgive me violating zig best practices and feel free to make suggestions

Successor of [this](https://github.com/ghostty-org/website/pull/147) pr in the website repo