### PR TITLE
Fix certain paths in the docs containing spaces when the shouldn't

### DIFF
--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -73,11 +73,11 @@ const ThemeListElement = struct {
 ///
 /// The second directory is the `themes` subdirectory of the Ghostty resources
 /// directory. Ghostty ships with a multitude of themes that will be installed
-/// into this directory. On macOS, this directory is the `Ghostty.app/Contents/
-/// Resources/ghostty/themes`. On Linux, this directory is the `share/ghostty/
-/// themes` (wherever you installed the Ghostty "share" directory). If you're
-/// running Ghostty from the source, this is the `zig-out/share/ghostty/themes`
-/// directory.
+/// into this directory. On macOS, this directory is the
+/// `Ghostty.app/Contents/Resources/ghostty/themes`. On Linux, this directory
+/// is the `share/ghostty/themes` (wherever you installed the Ghostty "share"
+/// directory). If you're running Ghostty from the source, this is the
+/// `zig-out/share/ghostty/themes` directory.
 ///
 /// You can also set the `GHOSTTY_RESOURCES_DIR` environment variable to point
 /// to the resources directory.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -351,10 +351,10 @@ const c = @cImport({
 ///
 /// The second directory is the `themes` subdirectory of the Ghostty resources
 /// directory. Ghostty ships with a multitude of themes that will be installed
-/// into this directory. On macOS, this list is in the `Ghostty.app/Contents/
-/// Resources/ghostty/themes` directory. On Linux, this list is in the `share/
-/// ghostty/themes` directory (wherever you installed the Ghostty "share"
-/// directory.
+/// into this directory. On macOS, this list is in the
+/// `Ghostty.app/Contents/Resources/ghostty/themes` directory. On Linux, this
+/// list is in the `share/ghostty/themes` directory (wherever you installed the
+/// Ghostty "share" directory.
 ///
 /// To see a list of available themes, run `ghostty +list-themes`.
 ///


### PR DESCRIPTION
This addresses issue #3275
