### PR TITLE
Fix zsh shell integration docs

### DIFF
--- a/src/shell-integration/README.md
+++ b/src/shell-integration/README.md
@@ -73,6 +73,6 @@ sequence occurs.
 
 ```bash
 if [[ -n $GHOSTTY_RESOURCES_DIR ]]; then
-  "$GHOSTTY_RESOURCES_DIR"/shell-integration/zsh/ghostty-integration
+  source $GHOSTTY_RESOURCES_DIR/shell-integration/zsh/ghostty-integration
 fi
 ```


### PR DESCRIPTION
- There is no need to quote variables in zsh.
- The shell integration file is not executable; we should `source` it instead.