### PR TITLE
Use premultiplied alpha for renderer clearColor

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1186,9 +1186,9 @@ pub fn drawFrame(self: *Metal, surface: *apprt.Surface) !void {
                 attachment.setProperty("storeAction", @intFromEnum(mtl.MTLStoreAction.store));
                 attachment.setProperty("texture", screen_texture.value);
                 attachment.setProperty("clearColor", mtl.MTLClearColor{
-                    .red = @as(f32, @floatFromInt(self.current_background_color.r)) / 255,
-                    .green = @as(f32, @floatFromInt(self.current_background_color.g)) / 255,
-                    .blue = @as(f32, @floatFromInt(self.current_background_color.b)) / 255,
+                    .red = @as(f32, @floatFromInt(self.current_background_color.r)) / 255 * self.config.background_opacity,
+                    .green = @as(f32, @floatFromInt(self.current_background_color.g)) / 255 * self.config.background_opacity,
+                    .blue = @as(f32, @floatFromInt(self.current_background_color.b)) / 255 * self.config.background_opacity,
                     .alpha = self.config.background_opacity,
                 });
             }

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -2344,9 +2344,9 @@ fn drawCellProgram(
 
     // Clear the surface
     gl.clearColor(
-        @as(f32, @floatFromInt(self.draw_background.r)) / 255,
-        @as(f32, @floatFromInt(self.draw_background.g)) / 255,
-        @as(f32, @floatFromInt(self.draw_background.b)) / 255,
+        @as(f32, @floatFromInt(self.draw_background.r)) / 255 * self.config.background_opacity,
+        @as(f32, @floatFromInt(self.draw_background.g)) / 255 * self.config.background_opacity,
+        @as(f32, @floatFromInt(self.draw_background.b)) / 255 * self.config.background_opacity,
         @floatCast(self.config.background_opacity),
     );
     gl.clear(gl.c.GL_COLOR_BUFFER_BIT);

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -2344,9 +2344,9 @@ fn drawCellProgram(
 
     // Clear the surface
     gl.clearColor(
-        @as(f32, @floatFromInt(self.draw_background.r)) / 255 * self.config.background_opacity,
-        @as(f32, @floatFromInt(self.draw_background.g)) / 255 * self.config.background_opacity,
-        @as(f32, @floatFromInt(self.draw_background.b)) / 255 * self.config.background_opacity,
+        @floatCast(@as(f32, @floatFromInt(self.draw_background.r)) / 255 * self.config.background_opacity),
+        @floatCast(@as(f32, @floatFromInt(self.draw_background.g)) / 255 * self.config.background_opacity),
+        @floatCast(@as(f32, @floatFromInt(self.draw_background.b)) / 255 * self.config.background_opacity),
         @floatCast(self.config.background_opacity),
     );
     gl.clear(gl.c.GL_COLOR_BUFFER_BIT);


### PR DESCRIPTION
Fixes #3324

---

I haven't tested it on Linux yet, but I believe it has the similar problem and could be fixed by this PR as well.