### PR TITLE
fix: use `open -t` to open text editor

### DIFF
--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -12,7 +12,7 @@ pub fn open(alloc: Allocator, url: []const u8) !void {
     // the process to exit to collect stderr.
     const argv, const wait = switch (builtin.os.tag) {
         .linux => .{ &.{ "xdg-open", url }, false },
-        .macos => .{ &.{ "open", url }, true },
+        .macos => .{ &.{ "open -t", url }, true },
         .windows => .{ &.{ "rundll32", "url.dll,FileProtocolHandler", url }, false },
         .ios => return error.Unimplemented,
         else => @compileError("unsupported OS"),


### PR DESCRIPTION
This fixes #3284 