### PR TITLE
fix elvish integration: remove erroneous call to "type"

### DIFF
--- a/src/shell-integration/elvish/lib/ghostty-integration.elv
+++ b/src/shell-integration/elvish/lib/ghostty-integration.elv
@@ -117,7 +117,7 @@
     set edit:before-readline = (conj $edit:before-readline $beam~)
     set edit:after-readline  = (conj $edit:after-readline {|_| block })
   }
-  if (and (not $no-sudo) (not-eq "" $E:TERMINFO) (eq file (type -t sudo))) {
+  if (and (not $no-sudo) (not-eq "" $E:TERMINFO) (has-external sudo)) {
     edit:add-var sudo~ $sudo-with-terminfo~
   }
 }


### PR DESCRIPTION
An exception is raised from the elvish integration module when `TERMINFO` is set:

```
Exception: exec: "type": executable file not found in $PATH
  ghostty-integration.elv:120:60-71:   if (and (not $no-sudo) (not-eq "" $E:TERMINFO) (eq file (type -t sudo))) {
  ghostty-integration.elv:38:1-123:1:
```

`type` is a builtin in bash and [in fish](https://fishshell.com/docs/current/cmds/type.html) but it does not exist in elvish.  I suspect it is here as an accidental copy/paste from the ghostty [fish integration](https://github.com/ghostty-org/ghostty/blob/main/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish#L71).

Maybe we can use the elvish [`has-external`](https://elv.sh/ref/builtin.html#has-external) function instead (or we could remove that check altogether).

Edit: I think this is in a merge-able state (and it would fix that error!), but I have just converted this PR to a draft since I can see other problems with the script. I'll give it a more thorough treatment later and amend this PR (or also happy to merge this and do other fixes in separate PRs).