### PR TITLE
Partially fix issue #1938, fix issue #3412, by enabling the vulkan-based ngl renderer in GTK

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -100,40 +100,10 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
         c.gtk_get_micro_version(),
     });
 
-    // Disabling Vulkan can improve startup times by hundreds of
-    // milliseconds on some systems. We don't use Vulkan so we can just
-    // disable it.
-    if (version.atLeast(4, 16, 0)) {
-        // From gtk 4.16, GDK_DEBUG is split into GDK_DEBUG and GDK_DISABLE.
-        // For the remainder of "why" see the 4.14 comment below.
-        _ = internal_os.setenv("GDK_DISABLE", "gles-api,vulkan");
-        _ = internal_os.setenv("GDK_DEBUG", "opengl");
-    } else if (version.atLeast(4, 14, 0)) {
-        // We need to export GDK_DEBUG to run on Wayland after GTK 4.14.
-        // Older versions of GTK do not support these values so it is safe
-        // to always set this. Forwards versions are uncertain so we'll have to
-        // reassess...
-        //
-        // Upstream issue: https://gitlab.gnome.org/GNOME/gtk/-/issues/6589
-        //
-        // Specific details about values:
-        //   - "opengl" - output OpenGL debug information
-        //   - "gl-disable-gles" - disable GLES, Ghostty can't use GLES
-        //   - "vulkan-disable" - disable Vulkan, Ghostty can't use Vulkan
-        //     and initializing a Vulkan context was causing a longer delay
-        //     on some systems.
-        _ = internal_os.setenv("GDK_DEBUG", "opengl,gl-disable-gles,vulkan-disable");
-    } else {
-        // Versions prior to 4.14 are a bit of an unknown for Ghostty. It
-        // is an environment that isn't tested well and we don't have a
-        // good understanding of what we may need to do.
-        _ = internal_os.setenv("GDK_DEBUG", "vulkan-disable");
-    }
-
     if (version.atLeast(4, 14, 0)) {
         // We need to export GSK_RENDERER to opengl because GTK uses ngl by
         // default after 4.14
-        _ = internal_os.setenv("GSK_RENDERER", "opengl");
+        _ = internal_os.setenv("GSK_RENDERER", "ngl");
     }
 
     // Load our configuration


### PR DESCRIPTION
## Summary of this change
In this draft pull request, I try changing the GSK renderer to the newer, Vulkan-based `ngl` renderer in the GTK build.

## Context
The motivation behind this PR stemmed from issue #1938 and #3412. Currently, Ghostty has several issues when running on a Wayland desktop with fractional scaling enabled, such as graphical artifacts and blurry font rendering.

## Scope
This change interests source file `src/apprt/gtk/App.zig` and it should only affect Linux systems, for builds compiled with GTK support enabled.

## Implementation details
This is admittedly a pretty quick and dirty attempt that needs more polish. I am open to trying my best to improve it. In the context of the GTK App initialization, I removed the code that disables Vulkan and I switched the `GSK_RENDERER` from `opengl` to `ngl`.

What this does is switch the GSK renderer from the old `gl` renderer to [the new Ngl renderer](https://docs.gtk.org/gsk4/class.NglRenderer.html).

## Impact
This new renderer greatly improves positioning and anti-aliasing in hi-dpi setups with fractional scaling, as better documented in the article [New renderers for GTK](https://blog.gtk.org/2024/01/28/new-renderers-for-gtk/) from the GNOME blog. Several other Libadwaita-based applications are migrating to this new renderer.

There are some immediate benefits to this change.

* I am no longer able to reproduce issue #3412 and there are no more graphical artifacts. Even the window now tiles perfectly, with no gaps.
* It greatly improves font rendering in the GTK interface (title bar and menus). The fonts go from fuzzy to very crisp. This is an improvement for #1938 


## Examples
This is how the fonts on the main menu and title bar look with the `opengl` renderer:
![image](https://github.com/user-attachments/assets/c1f5360d-0c40-4079-b5a9-f56a7cc5727f)

![image](https://github.com/user-attachments/assets/bef64d65-f5e1-4cc2-ac8d-038d66621357)
There is a fuzzy halo around the fonts.

Here is the same thing with `ngl`:
![image](https://github.com/user-attachments/assets/35876199-5470-4cb6-9779-c0a20276f38f)
![image](https://github.com/user-attachments/assets/a5c6f708-81c5-4c72-98dd-7f8cc5b2a812)


Here is how the "About Ghostty" dialog compares:

![image](https://github.com/user-attachments/assets/a8d89598-6e1a-494c-a469-d34a94d7408c)

![image](https://github.com/user-attachments/assets/b24ed7e9-9fa9-43ea-b54c-9938c59fd32f)

However, I am not sure this change impacts the contents of the terminal window as of now. I left a screenshot to help validate that. Left: stock build. Right: build from this PR. Below: output from `zig build -Dapp-runtime=glfw run`. Note that the latter `glfw` build runs through the XWayland socket, so it does not have access to the native resolution framebuffer as GTK under Wayland can as per [Wayland fractional-scale-v1 protocol](https://wayland.app/protocols/fractional-scale-v1), but rather it uses a supersampling trick which makes rendering different.

![image](https://github.com/user-attachments/assets/33df59fb-9152-49e6-b994-3916a133eb7b)

All of this is being tested on a machine running Fedora Workstation 41, `gnome-shell` 47.2, `mutter` 47.3,  `gtk4` 4.16.5 with a Wayland session and fractional scaling set to 175%. Base build is from commit a8e5eef.