### PR TITLE
cli(list_themes): ignore .DS_Store

### DIFF
--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -127,6 +127,8 @@ pub fn run(gpa_alloc: std.mem.Allocator) !u8 {
         while (try walker.next()) |entry| {
             switch (entry.kind) {
                 .file, .sym_link => {
+                    if (std.mem.eql(u8, entry.name, ".DS_Store"))
+                        continue;
                     count += 1;
                     try themes.append(.{
                         .location = loc.location,


### PR DESCRIPTION
macOS will create `.DS_Store` files in any directory it opens in Finder.
The `+list_themes` command would then list this file as a theme, and
attempt to preview it. `.DS_Store` is a binary file, and is silently
failing in the theme preview...I am on Linux and when I put a small
binary file in my user themes directory, I get a segfault. There is
something about the specific contents in `.DS_Store` that does not cause
this segfault, but lets us silently fail. We should investigate this
further - the issue is in `Config.loadFile` I believe.

In either case, we need to ignore `.DS_Store` so that it is not listed
as a theme.
