### PR TITLE
Fix `DESTDIR` handling for terminfo installation

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -481,19 +481,25 @@ pub fn build(b: *std.Build) !void {
             run_step.step.dependOn(&src_install.step);
 
             {
+                // Use cp -R instead of Step.InstallDir because we need to preserve
+                // symlinks in the terminfo database. Zig's InstallDir step doesn't
+                // handle symlinks correctly yet.
                 const copy_step = RunStep.create(b, "copy terminfo db");
                 copy_step.addArgs(&.{ "cp", "-R" });
                 copy_step.addFileArg(path);
-                copy_step.addArg(b.fmt("{s}/share", .{b.install_prefix}));
+                copy_step.addArg(b.fmt("{s}/share", .{b.install_path}));
                 b.getInstallStep().dependOn(&copy_step.step);
             }
 
             if (target.result.os.tag == .macos and exe_ != null) {
+                // Use cp -R instead of Step.InstallDir because we need to preserve
+                // symlinks in the terminfo database. Zig's InstallDir step doesn't
+                // handle symlinks correctly yet.
                 const copy_step = RunStep.create(b, "copy terminfo db");
                 copy_step.addArgs(&.{ "cp", "-R" });
                 copy_step.addFileArg(path);
                 copy_step.addArg(
-                    b.fmt("{s}/Ghostty.app/Contents/Resources", .{b.install_prefix}),
+                    b.fmt("{s}/Ghostty.app/Contents/Resources", .{b.install_path}),
                 );
                 b.getInstallStep().dependOn(&copy_step.step);
             }


### PR DESCRIPTION
## Description:

Fix `DESTDIR` handling when installing terminfo database files by using `install_path` instead of `install_prefix`. This ensures files are correctly installed under `$DESTDIR/$prefix` during packaging.

## Changes:

- Replace `b.install_prefix` with `b.install_path` for terminfo database installation paths

- This change properly respects the `DESTDIR` environment variable during installation

## Testing:

I've verified this fix by:

1. Setting `DESTDIR=/tmp/ghostty`

2. Building with: 
```bash
DESTDIR=/tmp/ghostty \
zig build \
  --prefix /usr \
  --system /tmp/offline-cache/p \
  -Doptimize=ReleaseFast \
  -Dcpu=baseline
```

3. Confirming files are correctly installed to:

```
/tmp/ghostty/usr/share/terminfo/ghostty.terminfo
/tmp/ghostty/usr/share/terminfo/ghostty.termcap
```

The files are now properly installed under `$DESTDIR/$prefix` path structure as expected.

cc @BratishkaErik - Since you suggested this fix in #3152, would you mind reviewing this implementation?

Fixes #3152