### PR TITLE
Fix building with -Dflatpak=true

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -604,11 +604,7 @@ pub fn build(b: *std.Build) !void {
         // https://developer.gnome.org/documentation/guidelines/maintainer/integrating.html
 
         // Desktop file so that we have an icon and other metadata
-        if (config.flatpak) {
-            b.installFile("dist/linux/app-flatpak.desktop", "share/applications/com.mitchellh.ghostty.desktop");
-        } else {
-            b.installFile("dist/linux/app.desktop", "share/applications/com.mitchellh.ghostty.desktop");
-        }
+        b.installFile("dist/linux/app.desktop", "share/applications/com.mitchellh.ghostty.desktop");
 
         // Right click menu action for Plasma desktop
         b.installFile("dist/linux/ghostty_dolphin.desktop", "share/kio/servicemenus/com.mitchellh.ghostty.desktop");

--- a/src/os/flatpak.zig
+++ b/src/os/flatpak.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const builtin = @import("builtin");
+const posix = std.posix;
 
 const log = std.log.scoped(.flatpak);
 
@@ -26,7 +27,7 @@ pub fn isFlatpak() bool {
 ///
 /// Requires GIO, GLib to be available and linked.
 pub const FlatpakHostCommand = struct {
-    const fd_t = std.os.fd_t;
+    const fd_t = posix.fd_t;
     const EnvMap = std.process.EnvMap;
     const c = @cImport({
         @cInclude("gio/gio.h");

--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -36,6 +36,7 @@ pub const fixMaxFiles = file.fixMaxFiles;
 pub const allocTmpDir = file.allocTmpDir;
 pub const freeTmpDir = file.freeTmpDir;
 pub const isFlatpak = flatpak.isFlatpak;
+pub const FlatpakHostCommand = flatpak.FlatpakHostCommand;
 pub const home = homedir.home;
 pub const ensureLocale = locale.ensureLocale;
 pub const clickInterval = mouse.clickInterval;

--- a/src/os/passwd.zig
+++ b/src/os/passwd.zig
@@ -4,6 +4,7 @@ const internal_os = @import("main.zig");
 const build_config = @import("../build_config.zig");
 const Allocator = std.mem.Allocator;
 const ArenaAllocator = std.heap.ArenaAllocator;
+const posix = std.posix;
 
 const log = std.log.scoped(.passwd);
 
@@ -88,13 +89,13 @@ pub fn get(alloc: Allocator) !Entry {
         // Once started, we can close the child side. We do this after
         // wait right now but that is fine too. This lets us read the
         // parent and detect EOF.
-        _ = std.os.close(pty.slave);
+        _ = posix.close(pty.slave);
 
         // Read all of our output
         const output = output: {
             var output: std.ArrayListUnmanaged(u8) = .{};
             while (true) {
-                const n = std.os.read(pty.master, &buf) catch |err| {
+                const n = posix.read(pty.master, &buf) catch |err| {
                     switch (err) {
                         // EIO is triggered at the end since we closed our
                         // child side. This is just EOF for this. I'm not sure


### PR DESCRIPTION
While running a Ghostty instance built with this option currently crashes under Flatpak, at least it ensures we're able to build it again.