### PR TITLE
Update doc inform toggle_quick_terminal macOS only

### DIFF
--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -393,6 +393,8 @@ pub const Action = union(enum) {
     ///
     /// See the various configurations for the quick terminal in the
     /// configuration file to customize its behavior.
+    ///
+    /// This currently only works on macOS.
     toggle_quick_terminal: void,
 
     /// Show/hide all windows. If all windows become shown, we also ensure


### PR DESCRIPTION
From the 'CONTRIBUTING.md':
"Pull requests should be associated with a previously accepted issue. If you open a pull request for something that wasn't previously discussed, it may be closed or remain stale for an indefinite period of time. I'm not saying it will never be accepted, but the odds are stacked against you."

I understand this, and I make a PR without an issue because I feel like this is actually binary.

On discord I've been informed the quick terminal is macOS only, and in the documentation I don't think this is expressed, please correct me if wrong and close this.

If it's correct and the documentation should contain it, then here's my PR adding that information on the bottom of the section.
If the location of the added information does not fit the style guidelines I can change it.