### PR TITLE
CI: Update release-tag.yml to include the version in the source archive and prefix within

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -87,21 +87,21 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Create Tarball
-        run: git archive --format=tgz --prefix=ghostty-source/ -o ghostty-source.tar.gz HEAD
+        run: git archive --format=tgz --prefix="ghostty-${GHOSTTY_VERSION}/" -o "ghostty-${GHOSTTY_VERSION}.tar.gz" HEAD
 
       - name: Sign Tarball
         run: |
           echo -n "${{ secrets.MINISIGN_KEY }}" > minisign.key
           echo -n "${{ secrets.MINISIGN_PASSWORD }}" > minisign.password
-          nix develop -c minisign -S -m ghostty-source.tar.gz -s minisign.key < minisign.password
+          nix develop -c minisign -S -m "ghostty-${GHOSTTY_VERSION}.tar.gz" -s minisign.key < minisign.password
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: source-tarball
           path: |-
-            ghostty-source.tar.gz
-            ghostty-source.tar.gz.minisig
+            "ghostty-${GHOSTTY_VERSION}.tar.gz"
+            "ghostty-${GHOSTTY_VERSION}.tar.gz.minisig"
 
   build-macos:
     needs: [setup]
@@ -352,8 +352,8 @@ jobs:
         run: |
           mkdir blob
           mkdir -p blob/${GHOSTTY_VERSION}
-          mv ghostty-source.tar.gz blob/${GHOSTTY_VERSION}/ghostty-source.tar.gz
-          mv ghostty-source.tar.gz.minisig blob/${GHOSTTY_VERSION}/ghostty-source.tar.gz.minisig
+          mv "ghostty-${GHOSTTY_VERSION}.tar.gz blob/${GHOSTTY_VERSION}/ghostty-${GHOSTTY_VERSION}.tar.gz"
+          mv ghostty-${GHOSTTY_VERSION}.tar.gz.minisig blob/${GHOSTTY_VERSION}/ghostty-${GHOSTTY_VERSION}.tar.gz.minisig
           mv ghostty-macos-universal.zip blob/${GHOSTTY_VERSION}/ghostty-macos-universal.zip
           mv ghostty-macos-universal-dsym.zip blob/${GHOSTTY_VERSION}/ghostty-macos-universal-dsym.zip
           mv Ghostty.dmg blob/${GHOSTTY_VERSION}/Ghostty.dmg

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -89,13 +89,16 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Create Tarball
-        run: git archive --format=tgz --prefix="ghostty-${GHOSTTY_VERSION}/" -o "ghostty-${GHOSTTY_VERSION}.tar.gz" HEAD
+        run: |
+          git archive --format=tgz --prefix="ghostty-${GHOSTTY_VERSION}/" -o "ghostty-${GHOSTTY_VERSION}.tar.gz" HEAD
+          git archive --format=tgz --prefix=ghostty-source/ -o ghostty-source.tar.gz HEAD
 
       - name: Sign Tarball
         run: |
           echo -n "${{ secrets.MINISIGN_KEY }}" > minisign.key
           echo -n "${{ secrets.MINISIGN_PASSWORD }}" > minisign.password
           nix develop -c minisign -S -m "ghostty-${GHOSTTY_VERSION}.tar.gz" -s minisign.key < minisign.password
+          nix develop -c minisign -S -m "ghostty-source.tar.gz" -s minisign.key < minisign.password
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -104,6 +107,8 @@ jobs:
           path: |-
             "ghostty-${{ env.GHOSTTY_VERSION }}.tar.gz"
             "ghostty-${{ env.GHOSTTY_VERSION }}.tar.gz.minisig"
+            ghostty-source.tar.gz
+            ghostty-source.tar.gz.minisig
 
   build-macos:
     needs: [setup]
@@ -356,6 +361,8 @@ jobs:
           mkdir -p blob/${GHOSTTY_VERSION}
           mv "ghostty-${GHOSTTY_VERSION}.tar.gz blob/${GHOSTTY_VERSION}/ghostty-${GHOSTTY_VERSION}.tar.gz"
           mv ghostty-${GHOSTTY_VERSION}.tar.gz.minisig blob/${GHOSTTY_VERSION}/ghostty-${GHOSTTY_VERSION}.tar.gz.minisig
+          mv ghostty-source.tar.gz blob/${GHOSTTY_VERSION}/ghostty-source.tar.gz
+          mv ghostty-source.tar.gz.minisig blob/${GHOSTTY_VERSION}/ghostty-source.tar.gz.minisig
           mv ghostty-macos-universal.zip blob/${GHOSTTY_VERSION}/ghostty-macos-universal.zip
           mv ghostty-macos-universal-dsym.zip blob/${GHOSTTY_VERSION}/ghostty-macos-universal-dsym.zip
           mv Ghostty.dmg blob/${GHOSTTY_VERSION}/Ghostty.dmg

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -74,6 +74,8 @@ jobs:
   source-tarball:
     runs-on: namespace-profile-ghostty-md
     needs: [setup]
+    env:
+      GHOSTTY_VERSION: ${{ needs.setup.outputs.version }}
     steps:
       - uses: actions/checkout@v4
 
@@ -100,8 +102,8 @@ jobs:
         with:
           name: source-tarball
           path: |-
-            "ghostty-${GHOSTTY_VERSION}.tar.gz"
-            "ghostty-${GHOSTTY_VERSION}.tar.gz.minisig"
+            "ghostty-${{ env.GHOSTTY_VERSION }}.tar.gz"
+            "ghostty-${{ env.GHOSTTY_VERSION }}.tar.gz.minisig"
 
   build-macos:
     needs: [setup]

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -19,8 +19,8 @@ at `release.files.ghostty.org` in the following URL format where
 `VERSION` is the version number with no prefix such as `1.0.0`:
 
 ```
-https://release.files.ghostty.org/VERSION/ghostty-source.tar.gz
-https://release.files.ghostty.org/VERSION/ghostty-source.tar.gz.minisig
+https://release.files.ghostty.org/VERSION/ghostty-VERSION.tar.gz
+https://release.files.ghostty.org/VERSION/ghostty-VERSION.tar.gz.minisig
 ```
 
 Signature files are signed with


### PR DESCRIPTION
Continuing from #3043 I agree that it seems idiomatic to have an archive with format <name>-<version>.tar.gz and matching prefix for packaging, RPM and Debian packaging guides seem to assume this format and the automated extract tooling assumes it too.

# Testing
I haven't tested running this workflow,  and am unsure about the yaml substitution at lines 105-106

# Breaking changes
This would break existing packaging scripts, not sure how we want to version it
 