### PR TITLE
Fix example of using ZSH integration manually

### DIFF
--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -25,7 +25,7 @@
 # Ghostty in all shells should add the following lines to their .zshrc:
 #
 #   if [[ -n $GHOSTTY_RESOURCES_DIR ]]; then
-#     "$GHOSTTY_RESOURCES_DIR"/shell-integration/zsh/ghostty-integration
+#     source "$GHOSTTY_RESOURCES_DIR"/shell-integration/zsh/ghostty-integration
 #   fi
 #
 # Implementation note: We can assume that alias expansion is disabled in this


### PR DESCRIPTION
The ZSH integration file should be sourced so it's read into the current process, rather than executed in a separate ZSH process, in which case it doesn't have any impact on the current ZSH process.