### PR TITLE
make target specific dependencies lazy

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1210,11 +1210,11 @@ fn addDeps(
     }
 
     // Wasm we do manually since it is such a different build.
-    if (step.rootModuleTarget().cpu.arch == .wasm32) {
-        const js_dep = b.dependency("zig_js", .{
+    if (step.rootModuleTarget().cpu.arch == .wasm32) wasm: {
+        const js_dep = b.lazyDependency("zig_js", .{
             .target = target,
             .optimize = optimize,
-        });
+        }) orelse break :wasm;
         step.root_module.addImport("zig-js", js_dep.module("zig-js"));
 
         return static_libs;
@@ -1306,15 +1306,15 @@ fn addDeps(
     }).module("zf"));
 
     // Mac Stuff
-    if (step.rootModuleTarget().isDarwin()) {
-        const objc_dep = b.dependency("zig_objc", .{
+    if (step.rootModuleTarget().isDarwin()) darwin: {
+        const objc_dep = b.lazyDependency("zig_objc", .{
             .target = target,
             .optimize = optimize,
-        });
-        const macos_dep = b.dependency("macos", .{
+        }) orelse break: darwin;
+        const macos_dep = b.lazyDependency("macos", .{
             .target = target,
             .optimize = optimize,
-        });
+        }) orelse break: darwin;
 
         step.root_module.addImport("objc", objc_dep.module("objc"));
         step.root_module.addImport("macos", macos_dep.module("macos"));

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -16,10 +16,12 @@
         .zig_objc = .{
             .url = "https://github.com/mitchellh/zig-objc/archive/9b8ba849b0f58fe207ecd6ab7c147af55b17556e.tar.gz",
             .hash = "1220e17e64ef0ef561b3e4b9f3a96a2494285f2ec31c097721bf8c8677ec4415c634",
+            .lazy = true,
         },
         .zig_js = .{
             .url = "https://github.com/mitchellh/zig-js/archive/d0b8b0a57c52fbc89f9d9fecba75ca29da7dd7d1.tar.gz",
             .hash = "12205a66d423259567764fa0fc60c82be35365c21aeb76c5a7dc99698401f4f6fefc",
+            .lazy = true,
         },
         .ziglyph = .{
             .url = "https://deps.files.ghostty.org/ziglyph-b89d43d1e3fb01b6074bc1f7fc980324b04d26a5.tar.gz",


### PR DESCRIPTION
spiritual follow-up to #1447

turns zig_objc and zig_js into lazy dependencies so they aren't required when building for different targets using the system package mode 

I don't have a mac to test this so I'm at the mercy of someone else doing that for me