### PR TITLE
Fix typo in config docs

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -628,7 +628,7 @@ command: ?[]const u8 = null,
 ///     (i.e. by wrapping your command in a shell, setting env vars, etc.).
 ///     This is a safety measure to prevent unexpected behavior. If you want
 ///     shell integration with a `-e`-executed command, you must either
-///     name your binary appopriately or source the shell integration script
+///     name your binary appropriately or source the shell integration script
 ///     manually.
 ///
 @"initial-command": ?[]const u8 = null,


### PR DESCRIPTION
This was originally fixed in ghostty-org/website#152, but was accidentally reverted in [ghostty-org/website#99795d7882a5ee47437454c7c106c2874e0406dc](https://github.com/ghostty-org/website/commit/99795d7882a5ee47437454c7c106c2874e0406dc).

P.S., you might want an PR template to discourage folks from making unsolicited PRs like this :)
P.P.S., you can write issue templates as yaml files to stop folks from ignoring them (required fields)