### PR TITLE
apprt/gtk: color popovers when window-theme=ghostty

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -988,6 +988,8 @@ fn loadRuntimeCss(
                 \\  --headerbar-fg-color: rgb({d},{d},{d});
                 \\  --headerbar-bg-color: rgb({d},{d},{d});
                 \\  --headerbar-backdrop-color: oklab(from var(--headerbar-bg-color) calc(l * 0.9) a b / alpha);
+                \\  --popover-fg-color: rgb({d},{d},{d});
+                \\  --popover-bg-color: rgb({d},{d},{d});
                 \\}}
                 \\windowhandle {{
                 \\  background-color: var(--headerbar-bg-color);
@@ -997,6 +999,12 @@ fn loadRuntimeCss(
                 \\ background-color: var(--headerbar-backdrop-color);
                 \\}}
             , .{
+                headerbar_foreground.r,
+                headerbar_foreground.g,
+                headerbar_foreground.b,
+                headerbar_background.r,
+                headerbar_background.g,
+                headerbar_background.b,
                 headerbar_foreground.r,
                 headerbar_foreground.g,
                 headerbar_foreground.b,


### PR DESCRIPTION
This looks better than the regular dark color. It also happens to match what Ptyxis does. It does not support non-libadwaita builds.

Before:
![image](https://github.com/user-attachments/assets/8c400bdf-05b3-4629-925d-fd8ce9554ae7)

After:
![image](https://github.com/user-attachments/assets/d958eb6a-102d-4d91-970b-fcaca7f2386c)

It will look even better whenever we fix the separator colors :smile: 