### PR TITLE
apprt/gtk: use a subtitle to mark the current working directory

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -453,6 +453,22 @@ pub fn deinit(self: *Window) void {
     }
 }
 
+/// Set the title of the window.
+pub fn setTitle(self: *Window, title: [:0]const u8) void {
+    if ((comptime adwaita.versionAtLeast(1, 4, 0)) and adwaita.versionAtLeast(1, 4, 0) and adwaita.enabled(&self.app.config) and self.app.config.@"gtk-titlebar") {
+        if (self.header) |header| header.setTitle(title);
+    } else {
+        c.gtk_window_set_title(self.window, title);
+    }
+}
+
+/// Set the subtitle of the window if it has one.
+pub fn setSubtitle(self: *Window, subtitle: [:0]const u8) void {
+    if ((comptime adwaita.versionAtLeast(1, 4, 0)) and adwaita.versionAtLeast(1, 4, 0) and adwaita.enabled(&self.app.config) and self.app.config.@"gtk-titlebar") {
+        if (self.header) |header| header.setSubtitle(subtitle);
+    }
+}
+
 /// Add a new tab to this window.
 pub fn newTab(self: *Window, parent: ?*CoreSurface) !void {
     const alloc = self.app.core_app.alloc;

--- a/src/apprt/gtk/notebook_adw.zig
+++ b/src/apprt/gtk/notebook_adw.zig
@@ -159,5 +159,5 @@ fn adwSelectPage(_: *c.GObject, _: *c.GParamSpec, ud: ?*anyopaque) void {
     const window: *Window = @ptrCast(@alignCast(ud.?));
     const page = c.adw_tab_view_get_selected_page(window.notebook.adw.tab_view) orelse return;
     const title = c.adw_tab_page_get_title(page);
-    c.gtk_window_set_title(window.window, title);
+    window.setTitle(std.mem.span(title));
 }

--- a/src/apprt/gtk/notebook_gtk.zig
+++ b/src/apprt/gtk/notebook_gtk.zig
@@ -259,7 +259,7 @@ fn gtkSwitchPage(_: *c.GtkNotebook, page: *c.GtkWidget, _: usize, ud: ?*anyopaqu
     const gtk_label_box = @as(*c.GtkWidget, @ptrCast(c.gtk_notebook_get_tab_label(self.notebook, page)));
     const gtk_label = @as(*c.GtkLabel, @ptrCast(c.gtk_widget_get_first_child(gtk_label_box)));
     const label_text = c.gtk_label_get_text(gtk_label);
-    c.gtk_window_set_title(window.window, label_text);
+    window.setTitle(std.mem.span(label_text));
 }
 
 fn gtkNotebookCreateWindow(

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1118,6 +1118,15 @@ keybind: Keybinds = .{},
 /// required to be a fixed-width font.
 @"window-title-font-family": ?[:0]const u8 = null,
 
+/// The text that will be displayed in the subtitle of the window. Valid values:
+///
+///   * `false` - Disable the subtitle.
+///   * `working-directory` - Set the subtitle to the working directory of the
+///      surface.
+///
+/// This feature is only supported on GTK with Adwaita enabled.
+@"window-subtitle": WindowSubtitle = .false,
+
 /// The theme to use for the windows. Valid values:
 ///
 ///   * `auto` - Determine the theme based on the configured terminal
@@ -3966,6 +3975,11 @@ pub const WindowPaddingColor = enum {
     background,
     extend,
     @"extend-always",
+};
+
+pub const WindowSubtitle = enum {
+    false,
+    @"working-directory",
 };
 
 /// Color represents a color using RGB.


### PR DESCRIPTION
If the title is already the current working directory, hide the subtitle. Otherwise show the current working directory, like if a command is running for instance.

This is a re-opening of my original PR because I had to delete my fork and re-fork it.