### PR TITLE
Modify cmd+9 behaviour

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2303,18 +2303,18 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
         );
     }
     {
+        // On macOS we default to super but everywhere else
+        // is alt.
+        const mods: inputpkg.Mods = if (builtin.target.isDarwin())
+            .{ .super = true }
+        else
+            .{ .alt = true };
+
         // Cmd+N for goto tab N
         const start = @intFromEnum(inputpkg.Key.one);
-        const end = @intFromEnum(inputpkg.Key.nine);
+        const end = @intFromEnum(inputpkg.Key.eight);
         var i: usize = start;
         while (i <= end) : (i += 1) {
-            // On macOS we default to super but everywhere else
-            // is alt.
-            const mods: inputpkg.Mods = if (builtin.target.isDarwin())
-                .{ .super = true }
-            else
-                .{ .alt = true };
-
             try result.keybind.set.put(
                 alloc,
                 .{
@@ -2333,6 +2333,17 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
                 .{ .goto_tab = (i - start) + 1 },
             );
         }
+        try result.keybind.set.put(
+            alloc,
+            .{
+                .key = if (comptime builtin.target.isDarwin())
+                    .{ .physical = .nine }
+                else
+                    .{ .translated = .nine },
+                .mods = mods,
+            },
+            .{ .last_tab = {} },
+        );
     }
 
     // Toggle fullscreen
@@ -2436,11 +2447,6 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
             alloc,
             .{ .key = .{ .translated = .right_bracket }, .mods = .{ .super = true, .shift = true } },
             .{ .next_tab = {} },
-        );
-        try result.keybind.set.put(
-            alloc,
-            .{ .key = .{ .physical = inputpkg.Key.zero }, .mods = .{ .super = true } },
-            .{ .last_tab = {} },
         );
         try result.keybind.set.put(
             alloc,


### PR DESCRIPTION
Fixes #3528 

**Note:**
Not sure if this is what OP requested regarding displaying user defined shortcuts as hints, but we currently relabel all tabs, but only consider labels for tabs from 1 to 9. Applying this simple patch should allow for displaying shortcut hints for tabs beyond 9
<details><summary>Patch</summary>

```diff
diff --git a/macos/Sources/Features/Terminal/TerminalController.swift b/macos/Sources/Features/Terminal/TerminalController.swift
index 7fd1802d..242e5711 100644
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -155,13 +155,6 @@ class TerminalController: BaseTerminalController {
         tabListenForFrame = windows.count > 1
 
         for (tab, window) in zip(1..., windows) {
-            // We need to clear any windows beyond this because they have had
-            // a keyEquivalent set previously.
-            guard tab <= 9 else {
-                window.keyEquivalent = ""
-                continue
-            }
-
             let action = "goto_tab:\(tab)"
             if let equiv = ghostty.config.keyEquivalent(for: action) {
                 window.keyEquivalent = "\(equiv)"
```

</details> 