### PR TITLE
docs: add guide for setting quick terminal toggle keybind

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1380,6 +1380,9 @@ keybind: Keybinds = .{},
 ///   * `center` - Terminal appears at the center of the screen.
 ///
 /// Changing this configuration requires restarting Ghostty completely.
+///
+/// Note: There is no default keybind for toggling the quick terminal.
+/// To enable this feature, bind the `toggle_quick_terminal` action to a key.
 @"quick-terminal-position": QuickTerminalPosition = .top,
 
 /// The screen where the quick terminal should show up.

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -380,10 +380,17 @@ pub const Action = union(enum) {
     /// is preserved between appearances, so you can always press the keybinding
     /// to bring it back up.
     ///
+    /// To enable the quick terminally globally so that Ghostty doesn't
+    /// have to be focused, prefix your keybind with `global`. Example:
+    ///
+    /// ```ini
+    /// keybind = global:cmd+grave_accent=toggle_quick_terminal
+    /// ```
+    ///
     /// The quick terminal has some limitations:
     ///
     ///   - It is a singleton; only one instance can exist at a time.
-    ///   - It does not support tabs.
+    ///   - It does not support tabs, but it does support splits.
     ///   - It will not be restored when the application is restarted
     ///     (for systems that support window restoration).
     ///   - It supports fullscreen, but fullscreen will always be a non-native


### PR DESCRIPTION
Added documentation to guide users on configuring a keybind to toggle the quick terminal. By default there is no keybind and there is no reference in docs also on how to set a keybind.

Related: https://github.com/ghostty-org/website/pull/193#issuecomment-2564164801