### PR TITLE
Update docs generators to include proper edit on github links

### DIFF
--- a/src/build/webgen/main_actions.zig
+++ b/src/build/webgen/main_actions.zig
@@ -13,6 +13,7 @@ pub fn genKeybindActions(writer: anytype) !void {
         \\---
         \\title: Keybinding Action Reference
         \\description: Reference of all Ghostty keybinding actions.
+        \\editOnGithubLink: https://github.com/ghostty-org/ghostty/edit/main/src/input/Binding.zig
         \\---
         \\
         \\This is a reference of all Ghostty keybinding actions.

--- a/src/build/webgen/main_config.zig
+++ b/src/build/webgen/main_config.zig
@@ -13,6 +13,7 @@ pub fn genConfig(writer: anytype) !void {
         \\---
         \\title: Reference
         \\description: Reference of all Ghostty configuration options.
+        \\editOnGithubLink: https://github.com/ghostty-org/ghostty/edit/main/src/config/Config.zig
         \\---
         \\
         \\This is a reference of all Ghostty configuration options. These


### PR DESCRIPTION
Ref: https://github.com/ghostty-org/website/pull/197

The "Edit on Github" links currently on [ghostty.org](https://ghostty.org/) link to the downstream MDX files. This has lead to multiple folks editing the downstream MDX files.

Preview:
https://website-git-edit-on-github-link-override-ghostty.vercel.app/docs/config/reference#auto-update-channel