### PR TITLE
Use `source` in the example for sourcing Zsh shell integration

### DIFF
--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -25,7 +25,7 @@
 # Ghostty in all shells should add the following lines to their .zshrc:
 #
 #   if [[ -n $GHOSTTY_RESOURCES_DIR ]]; then
-#     "$GHOSTTY_RESOURCES_DIR"/shell-integration/zsh/ghostty-integration
+#     source "$GHOSTTY_RESOURCES_DIR"/shell-integration/zsh/ghostty-integration
 #   fi
 #
 # Implementation note: We can assume that alias expansion is disabled in this


### PR DESCRIPTION
A few people were copying that snippet and were facing issues such as "permission denied", and (after a subsequent `chmod`) "syntax error".

-----
From the [CONTRIBUTING.md]:

> Pull requests should be associated with a previously accepted issue.

I decided to ignore this for a single-word change, since creating a discussion then waiting for it to be promoted to an issue seemed pointless for such a minor change.

[CONTRIBUTING.md]: https://github.com/ghostty-org/ghostty/blob/main/CONTRIBUTING.md#pull-requests-implement-an-issue