### PR TITLE
fix probable typo in Config.zig

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1191,7 +1191,7 @@ keybind: Keybinds = .{},
 
 /// If true, when there are multiple split panes, the mouse selects the pane
 /// that is focused. This only applies to the currently focused window; i.e.
-/// mousing over a split in an unfocused window will now focus that split
+/// mousing over a split in an unfocused window will not focus that split
 /// and bring the window to front.
 ///
 /// Default is false.


### PR DESCRIPTION
Based on both context and interaction with ghostty, "now" was intended to be "not" in the paragraph describing the behavior of `focus-follows-mouse` is set to `true`.