### PR TITLE
apprt: add window-titlebar-{background,foreground} config options

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -966,8 +966,8 @@ fn loadRuntimeCss(
     const config: *const Config = &self.config;
     const window_theme = config.@"window-theme";
     const unfocused_fill: Config.Color = config.@"unfocused-split-fill" orelse config.background;
-    const headerbar_background = config.background;
-    const headerbar_foreground = config.foreground;
+    const headerbar_background = config.@"window-titlebar-background" orelse config.background;
+    const headerbar_foreground = config.@"window-titlebar-foreground" orelse config.foreground;
 
     try writer.print(
         \\widget.unfocused-split {{

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1149,6 +1149,16 @@ keybind: Keybinds = .{},
 ///   * `end` - Insert the new tab at the end of the tab list.
 @"window-new-tab-position": WindowNewTabPosition = .current,
 
+/// Background color for the window titlebar. This only takes effect if
+/// window-theme is set to ghostty. Currently only supported in the GTK app
+/// runtime.
+@"window-titlebar-background": ?Color = null,
+
+/// Foreground color for the window titlebar. This only takes effect if
+/// window-theme is set to ghostty. Currently only supported in the GTK app
+/// runtime.
+@"window-titlebar-foreground": ?Color = null,
+
 /// This controls when resize overlays are shown. Resize overlays are a
 /// transient popup that shows the size of the terminal while the surfaces are
 /// being resized. The possible options are:


### PR DESCRIPTION
This gives people finer-grained control over the coloring of their titlebars. Currently only implemented for GTK.