### PR TITLE
Clarify how to read logs on macOS

### DIFF
--- a/src/build/mdgen/ghostty_5_header.md
+++ b/src/build/mdgen/ghostty_5_header.md
@@ -71,7 +71,7 @@ If your configuration file has any errors, Ghostty does its best to ignore
 them and move on. Configuration errors currently show up in the log. The log
 is written directly to stderr, so it is up to you to figure out how to access
 that for your system (for now). On macOS, you can also use the system `log` CLI
-utility. See the Mac App section for more information.
+utility with `log stream --level debug --predicate 'subsystem=="com.mitchellh.ghostty"'`.
 
 ## Debugging Configuration
 


### PR DESCRIPTION
I removed the sentence `See the Mac App section for more information.` because I cannot find the relevant information. It would be great to have a separate log file and indicate its location in the document.

For the record, I just spent 15 minute searching for the location of a log file in the document, which is painful because the website does not have a search button. Eventually I gave up and looked into the source file, and finally found the following comment (btw do we really need `sudo`?):

https://github.com/ghostty-org/ghostty/blob/ca7c9547129cb156417f7aa50cb390edecb685d7/src/main_ghostty.zig#L129-L132

Hopefully, this commit can make other new users' lives easier!