### PR TITLE
macos: always have terminal fullscreen style

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -309,11 +309,11 @@ class BaseTerminalController: NSWindowController,
             // We consider our mode changed if the types change (obvious) but
             // also if its nil (not obvious) because nil means that the style has
             // likely changed but we don't support it.
-            if newStyle == nil || type(of: newStyle) != type(of: oldStyle) {
+            if newStyle == nil || type(of: newStyle!) != type(of: oldStyle) {
                 // Our mode changed. Exit fullscreen (since we're toggling anyways)
-                // and then unset the style so that we replace it next time.
+                // and then set the new style for future use
                 oldStyle.exit()
-                self.fullscreenStyle = nil
+                self.fullscreenStyle = newStyle
 
                 // We're done
                 return


### PR DESCRIPTION
~~When processing toggle_fullscreen actions, multiple FullscreenStyle derived objects would register observers on the same window and subsequently remove them when the old style was deinited.~~

~~This change passes ownership of the fullscreenNotification observers to TerminalController while still allowing FullscreenStyles access to the window for style specific actions.~~

We need to have at least one fullscreen style (even if it is not being used) to make sure that observers for fullscreen state changes are set up. An alternative approach would be the first version of this PR (for which my reasoning was wrong but the end change was correct) which registers the fullscreen observers at either the TerminalController or BaseTerminalController level.

Fixes #3553