### PR TITLE
Set alpha component for fullscreen background colour

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -247,7 +247,7 @@ class TerminalController: BaseTerminalController {
         let backgroundColor: OSColor
         if let surfaceTree {
             if let focusedSurface, surfaceTree.doesBorderTop(view: focusedSurface) {
-                backgroundColor = OSColor(focusedSurface.backgroundColor ?? surfaceConfig.backgroundColor)
+                backgroundColor = OSColor(focusedSurface.backgroundColor ?? surfaceConfig.backgroundColor).withAlphaComponent(0.0)
             } else {
                 // We don't have a focused surface or our surface doesn't border the
                 // top. We choose to match the color of the top-left most surface.


### PR DESCRIPTION
This fixes a bug in the fullscreen behaviour on MacOS.

As per discussion #2840 native fullscreen on MacOS should set the background to be opaque. Colours are incorrectly set due to the alpha channel.

## Original behaviour:
When windowed:
<img width="810" alt="Screenshot 2024-12-28 at 9 02 09 PM" src="https://github.com/user-attachments/assets/59bd4380-2744-42e6-99c7-6d7b19919206" />

When fullscreened:
<img width="1470" alt="Screenshot 2024-12-28 at 9 01 46 PM" src="https://github.com/user-attachments/assets/a18f82ea-8cce-4d9b-8bb2-c279e2a753f0" />

## After the fix:
When fullscreened:
<img width="1470" alt="Screenshot 2024-12-28 at 9 13 17 PM" src="https://github.com/user-attachments/assets/6c3f31ae-c206-4234-8bde-1886ce16c837" />
