### PR TITLE
Use foreground color in macOS tab titles

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -247,8 +247,6 @@ class TerminalController: BaseTerminalController {
 
         window.hasShadow = surfaceConfig.macosWindowShadow
 
-        guard window.hasStyledTabs else { return }
-
         updateWindowTitleColors(surfaceConfig)
     }
 
@@ -645,6 +643,7 @@ class TerminalController: BaseTerminalController {
 
     private func updateWindowTitleColors(_ surfaceConfig: Ghostty.SurfaceView.DerivedConfig) {
         guard let window = self.window as? TerminalWindow else { return }
+        guard window.hasStyledTabs else { return }
 
         // Our background color depends on if our focused surface borders the top or not.
         // If it does, we match the focused surface. If it doesn't, we use the app

--- a/macos/Sources/Features/Terminal/TerminalToolbar.swift
+++ b/macos/Sources/Features/Terminal/TerminalToolbar.swift
@@ -25,6 +25,16 @@ class TerminalToolbar: NSToolbar, NSToolbarDelegate {
         }
     }
 
+    var titleColor: NSColor? {
+        get {
+            titleTextField.textColor
+        }
+
+        set {
+            titleTextField.textColor = newValue
+        }
+    }
+
     override init(identifier: NSToolbar.Identifier) {
         super.init(identifier: identifier)
 

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -350,6 +350,26 @@ extension Ghostty {
             return v;
         }
 
+        var foregroundColor: Color {
+            var color: ghostty_config_color_s = .init();
+            let bg_key = "foreground"
+            if (!ghostty_config_get(config, &color, bg_key, UInt(bg_key.count))) {
+#if os(macOS)
+                return Color(NSColor.labelColor)
+#elseif os(iOS)
+                return Color(UIColor.label)
+#else
+#error("unsupported")
+#endif
+            }
+
+            return .init(
+                red: Double(color.r) / 255,
+                green: Double(color.g) / 255,
+                blue: Double(color.b) / 255
+            )
+        }
+
         var unfocusedSplitOpacity: Double {
             guard let config = self.config else { return 1 }
             var opacity: Double = 0.85

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -55,6 +55,10 @@ extension Ghostty {
         /// dynamically updated. Otherwise, the background color is the default background color.
         @Published private(set) var backgroundColor: Color? = nil
 
+        /// The foreground color within the color palette of the surface. This is only set if it is
+        /// dynamically updated. Otherwise, the background color is the default background color.
+        @Published private(set) var foregroundColor: Color? = nil
+
         // An initial size to request for a window. This will only affect
         // then the view is moved to a new window.
         var initialSize: NSSize? = nil
@@ -442,6 +446,11 @@ extension Ghostty {
             case .background:
                 DispatchQueue.main.async { [weak self] in
                     self?.backgroundColor = change.color
+                }
+                self.backgroundColor = change.color
+            case .foreground:
+                DispatchQueue.main.async { [weak self] in
+                    self?.foregroundColor = change.color
                 }
 
             default:
@@ -1209,6 +1218,7 @@ extension Ghostty {
         struct DerivedConfig {
             let backgroundColor: Color
             let backgroundOpacity: Double
+            let foregroundColor: Color
             let macosWindowShadow: Bool
             let windowTitleFontFamily: String?
             let windowAppearance: NSAppearance?
@@ -1216,6 +1226,7 @@ extension Ghostty {
             init() {
                 self.backgroundColor = Color(NSColor.windowBackgroundColor)
                 self.backgroundOpacity = 1
+                self.foregroundColor = Color(NSColor.labelColor)
                 self.macosWindowShadow = true
                 self.windowTitleFontFamily = nil
                 self.windowAppearance = nil
@@ -1224,6 +1235,7 @@ extension Ghostty {
             init(_ config: Ghostty.Config) {
                 self.backgroundColor = config.backgroundColor
                 self.backgroundOpacity = config.backgroundOpacity
+                self.foregroundColor = config.foregroundColor
                 self.macosWindowShadow = config.macosWindowShadow
                 self.windowTitleFontFamily = config.windowTitleFontFamily
                 self.windowAppearance = .init(ghosttyConfig: config)


### PR DESCRIPTION
I'm not a Zig or a Swift/macOS developer but I've been really liking GhostTTY and wanted to open this PR to either contribute back, or at least share the progress/learnings when tackling https://github.com/ghostty-org/ghostty/issues/2764 (which I think this should close, if this is a valid approach). I have a vimscript that syncs the terminal colors with my vim theme, so I was pretty motivated to implement this feature.

This change was relatively straightforward (but required a lot of learning). In general it:

- Tracks `foregroundColor` in the SurfaceView. It's pre-populated with the config defined foreground color. It is also updated via the color change events (which I added foreground support to)
- Adds a new `titleForegroundColor` property to use in `TerminalWindow` titles so the colors can be updated dynamically.
- Updates each window's tab foreground color when `syncAppearance` is called. (I'm honestly not sure if this is the best approach, but it's the solution I found. happy to update if there's a better approach)
- Calls `syncAppearance` when a window becomes the key window to sync the colors across each tab.
- Updates some fonts to use 11pt sizes instead of `systemFontSize` to match the existing behavior/size of tabs (happy to provide screenshots to elaborate)

Here's a quick screencap of the new behavior:

https://github.com/user-attachments/assets/ba97432e-193a-4afd-95cd-faf23694530a


<details>
  <summary>I also quickly validated that this works with `macos-titlebar-style=transparent` in addition to `tabs`</summary>

<img width="912" alt="Screenshot 2024-12-28 at 10 01 24 PM" src="https://github.com/user-attachments/assets/42447da7-3661-418c-8cd5-7e41430c9591" />
</details>

<details>
  <summary>and just for completions sake, bg transparency:</summary>
  <img width="819" alt="Screenshot 2024-12-28 at 10 04 20 PM" src="https://github.com/user-attachments/assets/293e1041-79ff-4a3c-9d52-47f24e0880d4" />
</details>

