### PR TITLE
cgroup: change suffix to .scope

### DIFF
--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -507,7 +507,7 @@ pub fn init(self: *Surface, app: *App, opts: Options) !void {
         var buf: [256]u8 = undefined;
         const name = std.fmt.bufPrint(
             &buf,
-            "surfaces/{X}.service",
+            "surfaces/{X}.scope",
             .{@intFromPtr(self)},
         ) catch unreachable;
 


### PR DESCRIPTION
I think it's more consistent with the name convention used by systemd and other terminal emulators (e.g. gnome-terminal).

See also: https://systemd.io/CGROUP_DELEGATION/#systemds-unit-types