### PR TITLE
Add default Nix overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,12 @@
       formatter.${system} = pkgs-stable.alejandra;
 
       # Our supported systems are the same supported systems as the Zig binaries.
-    }) (builtins.attrNames zig.packages));
+    }) (builtins.attrNames zig.packages))
+    // {
+      overlays.default = final: prev: {
+        ghostty = self.packages.${prev.system}.default;
+      };
+    };
 
   nixConfig = {
     extra-substituters = ["https://ghostty.cachix.org"];


### PR DESCRIPTION
Adding an overlay allows to easily change the version of `ghostty` provided by `nixpkgs`:

```nix
pkgs = import nixpkgs {
  inherit system;
  overlays = [ ghostty.overlays.default ];
}
```

Then, all references to `pkgs.ghostty` would refer to this project's package definition.