### PR TITLE
Fix markdown formatting for (blank) in docs

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -485,7 +485,7 @@ palette: Palette = .{},
 ///
 /// Valid values are:
 ///
-///   * `` (blank)
+///   * ` ` (blank)
 ///   * `true`
 ///   * `false`
 ///


### PR DESCRIPTION
I realize I'm rolling the dice by opening a PR without a pre-approved issue, but I'll take that chance. Feel free to close if this isn't desired; no hard feelings!

Currently, the docs for `cursor-style-blink` have two backticks side by side in the docs, which end up rendering as actual backticks rather than a code-formatted blank space:

<img width="721" alt="Screenshot 2024-12-28 at 11 19 02 PM" src="https://github.com/user-attachments/assets/295369d6-624f-4efe-a7ea-495c9fd216bb" />

This change puts a space between the backticks so they render as a code-formatted space.