### PR TITLE
misc: add desktop entry fields to support xdg-terminal-exec

### DIFF
--- a/dist/linux/app.desktop
+++ b/dist/linux/app.desktop
@@ -10,6 +10,11 @@ StartupNotify=true
 Terminal=false
 Actions=new-window;
 X-GNOME-UsesNotifications=true
+X-TerminalArgExec=-e
+X-TerminalArgTitle=--title=
+X-TerminalArgAppId=--class=
+X-TerminalArgDir=--working-directory=
+X-TerminalArgHold=--wait-after-command
 
 [Desktop Action new-window]
 Name=New Window


### PR DESCRIPTION
This PR adds fields to desktop entry that are standardized in [Proposal for XDG Default Terminal Execution Specification (xdg-terminal-exec)](https://github.com/Vladimir-csp/xdg-terminal-exec).