### PR TITLE
gtk/x11: link directly to libX11, no more dlopen

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1427,6 +1427,7 @@ fn addDeps(
             .gtk => {
                 step.linkSystemLibrary2("gtk4", dynamic_link_opts);
                 if (config.adwaita) step.linkSystemLibrary2("adwaita-1", dynamic_link_opts);
+                if (config.x11) step.linkSystemLibrary2("X11", dynamic_link_opts);
 
                 {
                     const gresource = @import("src/apprt/gtk/gresource.zig");

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -26,7 +26,7 @@
   pandoc,
   revision ? "dirty",
   optimize ? "Debug",
-  x11 ? false,
+  x11 ? true,
 }: let
   # The Zig hook has no way to select the release type without actual
   # overriding of the default flags.
@@ -151,7 +151,7 @@ in
 
     dontConfigure = true;
 
-    zigBuildFlags = "-Dversion-string=${finalAttrs.version}-${revision}-nix";
+    zigBuildFlags = "-Dversion-string=${finalAttrs.version}-${revision}-nix -Dgtk-x11=${lib.boolToString x11}";
 
     preBuild = ''
       rm -rf $ZIG_GLOBAL_CACHE_DIR
@@ -188,10 +188,6 @@ in
       mv $out/share/vim/vimfiles "$vim"
       ln -sf "$vim" "$out/share/vim/vimfiles"
       echo "$vim" >> "$out/nix-support/propagated-user-env-packages"
-    '';
-
-    postFixup = lib.optionalString x11 ''
-      patchelf --add-rpath "${lib.makeLibraryPath [libX11]}" "$out/bin/.ghostty-wrapped"
     '';
 
     meta = {


### PR DESCRIPTION
As a follow-up to #3477 and #3748, this eliminates the use of dlopen to access `libX11` functions by directly linking `libX11` if X11 is enabled. This should also fix problems with systems like NixOS and Void Linux that have reported problems using Ghostty on X11 when using the distribution packages.