### PR TITLE
Fix typo in list-themes browser

### DIFF
--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -1102,7 +1102,7 @@ const Preview = struct {
                         },
 
                         .{
-                            .text = "ziggzag.zig",
+                            .text = "ziggzagg.zig",
                             .style = bold,
                         },
                     },


### PR DESCRIPTION
This is a small PR to fix a tiny continuity typo I noticed in the list-themes viewer.

#### Before and After

![image](https://github.com/user-attachments/assets/c95b23bb-01ad-4e82-8f9b-0b8559d006ba)
