### PR TITLE
Fix bash script without conditional function

### DIFF
--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -6,6 +6,26 @@
 # my simple bash usage this is working. If a bash expert wants to
 # improve this please do!
 
+sudo_function() {
+  builtin local sudo_has_sudoedit_flags="no"
+  for arg in "$@"; do
+    # Check if argument is '-e' or '--edit' (sudoedit flags)
+    if [[ "$arg" == "-e" || $arg == "--edit" ]]; then
+      sudo_has_sudoedit_flags="yes"
+      builtin break
+    fi
+    # Check if argument is neither an option nor a key-value pair
+    if [[ "$arg" != -* && "$arg" != *=* ]]; then
+      builtin break
+    fi
+  done
+  if [[ "$sudo_has_sudoedit_flags" == "yes" ]]; then
+    builtin command sudo "$@";
+  else
+    builtin command sudo TERMINFO="$TERMINFO" "$@";
+  fi
+}
+
 # We need to be in interactive mode and we need to have the Ghostty
 # resources dir set which also tells us we're running in Ghostty.
 if [[ "$-" != *i* ]] ; then builtin return; fi
@@ -117,25 +137,7 @@ function __ghostty_precmd() {
       if [[ "$GHOSTTY_SHELL_INTEGRATION_NO_SUDO" != "1" ]] && [[ -n "$TERMINFO" ]]; then
         # Wrap `sudo` command to ensure Ghostty terminfo is preserved
         # shellcheck disable=SC2317
-        sudo() {
-          builtin local sudo_has_sudoedit_flags="no"
-          for arg in "$@"; do
-            # Check if argument is '-e' or '--edit' (sudoedit flags)
-            if [[ "$arg" == "-e" || $arg == "--edit" ]]; then
-              sudo_has_sudoedit_flags="yes"
-              builtin break
-            fi
-            # Check if argument is neither an option nor a key-value pair
-            if [[ "$arg" != -* && "$arg" != *=* ]]; then
-              builtin break
-            fi
-          done
-          if [[ "$sudo_has_sudoedit_flags" == "yes" ]]; then
-            builtin command sudo "$@";
-          else
-            builtin command sudo TERMINFO="$TERMINFO" "$@";
-          fi
-        }
+        alias sudo="sudo_function"
       fi
 
       if [[ "$GHOSTTY_SHELL_INTEGRATION_NO_TITLE" != 1 ]]; then


### PR DESCRIPTION
This is a compatibility improvement

The bash script that runs when ghostty is launched produces the following error:
```
bash: /home/dan/git/ghostty/zig-out/share/ghostty/shell-integration/bash/ghostty.bash: line 120: syntax error near unexpected token `('
bash: /home/dan/git/ghostty/zig-out/share/ghostty/shell-integration/bash/ghostty.bash: line 120: `        sudo() {'
```

This change should alleviate that by defining the original sudo function outside and aliasing sudo to that function. This should allow ghostty to work without issues on systems with sudo already aliased.