### PR TITLE
core: add build option to disable sentry

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -376,6 +376,66 @@ jobs:
             -Dgtk-adwaita=${{ matrix.adwaita }} \
             -Dgtk-x11=${{ matrix.x11 }}
 
+  test-sentry-linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        sentry: ["true", "false"]
+    name: Build -Dsentry=${{ matrix.sentry }} on Linux
+    runs-on: namespace-profile-ghostty-sm
+    needs: test
+    env:
+      ZIG_LOCAL_CACHE_DIR: /zig/local-cache
+      ZIG_GLOBAL_CACHE_DIR: /zig/global-cache
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Cache
+        uses: namespacelabs/nscloud-cache-action@v1.2.0
+        with:
+          path: |
+            /nix
+            /zig
+
+      # Install Nix and use that to run our tests so our environment matches exactly.
+      - uses: cachix/install-nix-action@v30
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ghostty
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: Test Sentry Build
+        run: |
+          nix develop -c zig build -Dsentry=${{ matrix.sentry }}
+
+  test-sentry-macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        sentry: ["true", "false"]
+    name: Build -Dsentry=${{ matrix.sentry }} on macOS
+    runs-on: namespace-profile-ghostty-macos
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Install Nix and use that to run our tests so our environment matches exactly.
+      - uses: cachix/install-nix-action@v30
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ghostty
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: Test Sentry Build
+        run: |
+          nix develop -c zig build -Dsentry=${{ matrix.sentry }}
+
   test-macos:
     runs-on: namespace-profile-ghostty-macos
     needs: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -381,7 +381,7 @@ jobs:
       fail-fast: false
       matrix:
         sentry: ["true", "false"]
-    name: Build -Dsentry=${{ matrix.sentry }} on Linux
+    name: Build -Dsentry=${{ matrix.sentry }}
     runs-on: namespace-profile-ghostty-sm
     needs: test
     env:
@@ -397,31 +397,6 @@ jobs:
           path: |
             /nix
             /zig
-
-      # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@v15
-        with:
-          name: ghostty
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-
-      - name: Test Sentry Build
-        run: |
-          nix develop -c zig build -Dsentry=${{ matrix.sentry }}
-
-  test-sentry-macos:
-    strategy:
-      fail-fast: false
-      matrix:
-        sentry: ["true", "false"]
-    name: Build -Dsentry=${{ matrix.sentry }} on macOS
-    runs-on: namespace-profile-ghostty-macos
-    needs: test
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
 
       # Install Nix and use that to run our tests so our environment matches exactly.
       - uses: cachix/install-nix-action@v30

--- a/build.zig
+++ b/build.zig
@@ -159,6 +159,9 @@ pub fn build(b: *std.Build) !void {
     ) orelse sentry: {
         switch (target.result.os.tag) {
             .macos, .ios => break :sentry true,
+
+            // Note its false for linux because the crash reports on Linux
+            // don't have much useful information.
             else => break :sentry false,
         }
     };
@@ -1256,9 +1259,7 @@ fn addDeps(
     }
 
     // Sentry
-    if (config.sentry) sentry: {
-        if (target.result.os.tag == .windows) break :sentry;
-
+    if (config.sentry) {
         const sentry_dep = b.dependency("sentry", .{
             .target = target,
             .optimize = optimize,

--- a/src/build_config.zig
+++ b/src/build_config.zig
@@ -23,6 +23,7 @@ pub const BuildConfig = struct {
     flatpak: bool = false,
     adwaita: bool = false,
     x11: bool = false,
+    sentry: bool = true,
     app_runtime: apprt.Runtime = .none,
     renderer: rendererpkg.Impl = .opengl,
     font_backend: font.Backend = .freetype,
@@ -43,6 +44,7 @@ pub const BuildConfig = struct {
         step.addOption(bool, "flatpak", self.flatpak);
         step.addOption(bool, "adwaita", self.adwaita);
         step.addOption(bool, "x11", self.x11);
+        step.addOption(bool, "sentry", self.sentry);
         step.addOption(apprt.Runtime, "app_runtime", self.app_runtime);
         step.addOption(font.Backend, "font_backend", self.font_backend);
         step.addOption(rendererpkg.Impl, "renderer", self.renderer);


### PR DESCRIPTION
This disables compiling/linking Sentry automatically on platforms other than macOS, which removes a potential blocker for getting Ghostty running on *BSD or other systems.

This is also useful for the security paranoid that don't want any chance that sensitive information could be captured in a crash dump.