### PR TITLE
macos: disable auto-updates for local builds

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -110,6 +110,7 @@ jobs:
 
           # Updater
           /usr/libexec/PlistBuddy -c "Set :SUPublicEDKey $SPARKLE_KEY_PUB" "macos/build/Release/Ghostty.app/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Delete :SUEnableAutomaticChecks" "macos/build/Release/Ghostty.app/Contents/Info.plist"
 
       - name: Codesign app bundle
         env:
@@ -261,6 +262,7 @@ jobs:
 
           # Updater
           /usr/libexec/PlistBuddy -c "Set :SUPublicEDKey $SPARKLE_KEY_PUB" "macos/build/Release/Ghostty.app/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Delete :SUEnableAutomaticChecks" "macos/build/Release/Ghostty.app/Contents/Info.plist"
 
       - name: Codesign app bundle
         env:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -165,6 +165,7 @@ jobs:
 
           # Updater
           /usr/libexec/PlistBuddy -c "Set :SUPublicEDKey $SPARKLE_KEY_PUB" "macos/build/Release/Ghostty.app/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Delete :SUEnableAutomaticChecks" "macos/build/Release/Ghostty.app/Contents/Info.plist"
 
       - name: Codesign app bundle
         env:

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -205,6 +205,7 @@ jobs:
 
           # Updater
           /usr/libexec/PlistBuddy -c "Set :SUPublicEDKey $SPARKLE_KEY_PUB" "macos/build/Release/Ghostty.app/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Delete :SUEnableAutomaticChecks" "macos/build/Release/Ghostty.app/Contents/Info.plist"
 
       - name: Codesign app bundle
         env:
@@ -419,6 +420,7 @@ jobs:
 
           # Updater
           /usr/libexec/PlistBuddy -c "Set :SUPublicEDKey $SPARKLE_KEY_PUB" "macos/build/Release/Ghostty.app/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Delete :SUEnableAutomaticChecks" "macos/build/Release/Ghostty.app/Contents/Info.plist"
 
       - name: Codesign app bundle
         env:
@@ -593,6 +595,7 @@ jobs:
 
           # Updater
           /usr/libexec/PlistBuddy -c "Set :SUPublicEDKey $SPARKLE_KEY_PUB" "macos/build/Release/Ghostty.app/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Delete :SUEnableAutomaticChecks" "macos/build/Release/Ghostty.app/Contents/Info.plist"
 
       - name: Codesign app bundle
         env:

--- a/macos/Ghostty-Info.plist
+++ b/macos/Ghostty-Info.plist
@@ -96,6 +96,8 @@
 			</array>
 		</dict>
 	</array>
+	<key>SUEnableAutomaticChecks</key>
+	<false/>
 	<key>SUPublicEDKey</key>
 	<string>wsNcGf5hirwtdXMVnYoxRIX/SqZQLMOsYlD3q3imeok=</string>
 </dict>

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -484,11 +484,18 @@ class AppDelegate: NSObject,
         default: UserDefaults.standard.removeObject(forKey: "NSQuitAlwaysKeepsWindows")
         }
 
-        // Sync our auto-update settings
-        updaterController.updater.automaticallyChecksForUpdates =
-            config.autoUpdate == .check || config.autoUpdate == .download
-        updaterController.updater.automaticallyDownloadsUpdates =
-            config.autoUpdate == .download
+        // Sync our auto-update settings. If SUEnableAutomaticChecks (in our Info.plist) is
+        // explicitly false (NO), auto-updates are disabled. Otherwise, we use the behavior
+        // defined by our "auto-update" configuration.
+        if Bundle.main.infoDictionary?["SUEnableAutomaticChecks"] as? Bool != false {
+            updaterController.updater.automaticallyChecksForUpdates =
+                config.autoUpdate == .check || config.autoUpdate == .download
+            updaterController.updater.automaticallyDownloadsUpdates =
+                config.autoUpdate == .download
+        } else {
+            updaterController.updater.automaticallyChecksForUpdates = false
+            updaterController.updater.automaticallyDownloadsUpdates = false
+        }
 
         // Config could change keybindings, so update everything that depends on that
         syncMenuShortcuts(config)


### PR DESCRIPTION
The auto-update prompt isn't useful for local (source) builds. Disable it by default by setting Sparkle's SUEnableAutomaticChecks Info.plist key to NO (false) for all build configurations.

We then selectively re-enable it by deleting that Info.plist key from our release workflows. We delete the key instead of setting its value to YES (true) to give us Sparkle's default behavior of prompting the user to enable update checks on the second application launch. (YES tells Sparkle to skip that prompt and silently enable update checks.)

See also: https://sparkle-project.org/documentation/customization/

(This is a safer alternative to #3273.)

Fixes: #3179