### PR TITLE
add option to strip build regardless of optimization

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -161,7 +161,7 @@ pub fn build(b: *std.Build) !void {
     const strip = b.option(
         bool,
         "strip",
-        "Build the website data for the website.",
+        "Strip the final executable. Default true for fast and small releases",
     ) orelse null;
 
     const conformance = b.option(

--- a/build.zig
+++ b/build.zig
@@ -162,7 +162,11 @@ pub fn build(b: *std.Build) !void {
         bool,
         "strip",
         "Strip the final executable. Default true for fast and small releases",
-    ) orelse null;
+    ) orelse switch (optimize) {
+        .Debug => false,
+        .ReleaseSafe => false,
+        .ReleaseFast, .ReleaseSmall => true,
+    };
 
     const conformance = b.option(
         []const u8,
@@ -348,11 +352,7 @@ pub fn build(b: *std.Build) !void {
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
-        .strip = strip orelse switch (optimize) {
-            .Debug => false,
-            .ReleaseSafe => false,
-            .ReleaseFast, .ReleaseSmall => true,
-        },
+        .strip = strip,
     }) else null;
 
     // Exe

--- a/build.zig
+++ b/build.zig
@@ -158,6 +158,12 @@ pub fn build(b: *std.Build) !void {
         "Build a Position Independent Executable. Default true for system packages.",
     ) orelse system_package;
 
+    const strip = b.option(
+        bool,
+        "strip",
+        "Build the website data for the website.",
+    ) orelse null;
+
     const conformance = b.option(
         []const u8,
         "conformance",
@@ -342,7 +348,7 @@ pub fn build(b: *std.Build) !void {
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
-        .strip = switch (optimize) {
+        .strip = strip orelse switch (optimize) {
             .Debug => false,
             .ReleaseSafe => false,
             .ReleaseFast, .ReleaseSmall => true,

--- a/build.zig
+++ b/build.zig
@@ -690,6 +690,7 @@ pub fn build(b: *std.Build) !void {
                 .root_source_file = b.path("src/main_c.zig"),
                 .optimize = optimize,
                 .target = target,
+                .strip = strip,
             });
             _ = try addDeps(b, lib, config);
 
@@ -707,6 +708,7 @@ pub fn build(b: *std.Build) !void {
                 .root_source_file = b.path("src/main_c.zig"),
                 .optimize = optimize,
                 .target = target,
+                .strip = strip,
             });
             _ = try addDeps(b, lib, config);
 


### PR DESCRIPTION
adds the option "strip" which can be used to override the default strip setting, which is based on the optimization mode.

Useful for a distro setting where you want a release build but still keep symbols.

Also reuses the option for the shared and static library