### PR TITLE
Allow startup with $HOME read-only

### DIFF
--- a/src/crash/sentry.zig
+++ b/src/crash/sentry.zig
@@ -81,7 +81,11 @@ fn initThread(gpa: Allocator) !void {
     const alloc = arena.allocator();
 
     const transport = sentry.Transport.init(&Transport.send);
-    errdefer transport.deinit();
+    // This will crash if the transport was never used so we avoid
+    // that for now. This probably leaks some memory but it'd be very
+    // small and a one time cost. Once this is fixed upstream we can
+    // remove this.
+    //errdefer transport.deinit();
 
     const opts = sentry.c.sentry_options_new();
     errdefer sentry.c.sentry_options_free(opts);

--- a/src/global.zig
+++ b/src/global.zig
@@ -127,7 +127,12 @@ pub const GlobalState = struct {
         internal_os.fixMaxFiles();
 
         // Initialize our crash reporting.
-        try crash.init(self.alloc);
+        crash.init(self.alloc) catch |err| {
+            std.log.warn(
+                "sentry init failed, no crash capture available err={}",
+                .{err},
+            );
+        };
 
         // const sentrylib = @import("sentry");
         // if (sentrylib.captureEvent(sentrylib.Value.initMessageEvent(


### PR DESCRIPTION
Fixes #3202

Two changes to get here:

1. Do not fail startup if crash reporting initialization fails. This is a non-critical feature and should not prevent the terminal from starting.

2. Avoid freeing Sentry transport on error path. This segfaults. Upstream issue will be reported separately.