### PR TITLE
macos: restore 0 blur-radius when reloading config

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1891,9 +1891,6 @@ pub const CAPI = struct {
         // Do nothing if we don't have background transparency enabled
         if (config.@"background-opacity" >= 1.0) return;
 
-        // Do nothing if our blur value is zero
-        if (config.@"background-blur-radius" == 0) return;
-
         const nswindow = objc.Object.fromId(window);
         _ = CGSSetWindowBackgroundBlurRadius(
             CGSDefaultConnectionForThread(),


### PR DESCRIPTION
If a blur radius config value was previously set but then removed or set to 0, the new blur radius would not take effect on config reload due to the early return clause.