### PR TITLE
macOS: Cmd + Shift + Plus should increase font size too

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2091,7 +2091,7 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
     // set the expected keybind for the menu.
     try result.keybind.set.put(
         alloc,
-        .{ .key = .{ .translated = .plus }, .mods = inputpkg.ctrlOrSuper(.{}) },
+        .{ .key = .{ .translated = .plus }, .mods = inputpkg.ctrlOrSuper(.{ .shift = true }) },
         .{ .increase_font_size = 1 },
     );
     try result.keybind.set.put(


### PR DESCRIPTION
Addresses [#3899](https://github.com/ghostty-org/ghostty/issues/3899).

It looks like `Command + Shift + minus` is a mac built-in keybinding while `Command + Shit + plus` is not. In my testing, the combos work (Command + minus, Command + Shift + minus, Command + plus, Command + Shift + plus)

From: [Mac keyboard shortcuts](https://support.apple.com/en-ca/102650)

> Shift–Command–Minus sign (-): Decrease the size of the selected item.
>
> Shift–Command–Plus sign (+): Increase the size of the selected item. Command–Equal sign (=) performs the same function.```

(Note: I'm trying to find where iTerm2 does it in their code)