### PR TITLE
Correct comptime GTK atLeast() version comparison

### DIFF
--- a/src/apprt/gtk/version.zig
+++ b/src/apprt/gtk/version.zig
@@ -44,15 +44,15 @@ test "atLeast" {
     const std = @import("std");
     const testing = std.testing;
 
-    try testing.expectEqual(true, atLeast(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION));
+    try testing.expect(atLeast(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION));
 
-    try testing.expectEqual(false, atLeast(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION + 1));
-    try testing.expectEqual(false, atLeast(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION + 1, c.GTK_MICRO_VERSION));
-    try testing.expectEqual(false, atLeast(c.GTK_MAJOR_VERSION + 1, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION));
+    try testing.expect(!atLeast(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION + 1));
+    try testing.expect(!atLeast(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION + 1, c.GTK_MICRO_VERSION));
+    try testing.expect(!atLeast(c.GTK_MAJOR_VERSION + 1, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION));
 
-    try testing.expectEqual(true, atLeast(c.GTK_MAJOR_VERSION - 1, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION));
-    try testing.expectEqual(true, atLeast(c.GTK_MAJOR_VERSION - 1, c.GTK_MINOR_VERSION + 1, c.GTK_MICRO_VERSION));
-    try testing.expectEqual(true, atLeast(c.GTK_MAJOR_VERSION - 1, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION + 1));
+    try testing.expect(atLeast(c.GTK_MAJOR_VERSION - 1, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION));
+    try testing.expect(atLeast(c.GTK_MAJOR_VERSION - 1, c.GTK_MINOR_VERSION + 1, c.GTK_MICRO_VERSION));
+    try testing.expect(atLeast(c.GTK_MAJOR_VERSION - 1, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION + 1));
 
-    try testing.expectEqual(true, atLeast(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION - 1, c.GTK_MICRO_VERSION + 1));
+    try testing.expect(atLeast(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION - 1, c.GTK_MICRO_VERSION + 1));
 }

--- a/src/apprt/gtk/version.zig
+++ b/src/apprt/gtk/version.zig
@@ -39,3 +39,20 @@ pub inline fn atLeast(
 
     return false;
 }
+
+test "atLeast" {
+    const std = @import("std");
+    const testing = std.testing;
+
+    try testing.expectEqual(true, atLeast(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION));
+
+    try testing.expectEqual(false, atLeast(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION + 1));
+    try testing.expectEqual(false, atLeast(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION + 1, c.GTK_MICRO_VERSION));
+    try testing.expectEqual(false, atLeast(c.GTK_MAJOR_VERSION + 1, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION));
+
+    try testing.expectEqual(true, atLeast(c.GTK_MAJOR_VERSION - 1, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION));
+    try testing.expectEqual(true, atLeast(c.GTK_MAJOR_VERSION - 1, c.GTK_MINOR_VERSION + 1, c.GTK_MICRO_VERSION));
+    try testing.expectEqual(true, atLeast(c.GTK_MAJOR_VERSION - 1, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION + 1));
+
+    try testing.expectEqual(true, atLeast(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION - 1, c.GTK_MICRO_VERSION + 1));
+}

--- a/src/apprt/gtk/version.zig
+++ b/src/apprt/gtk/version.zig
@@ -19,8 +19,9 @@ pub inline fn atLeast(
     // compiling against unknown symbols and makes runtime checks
     // very slightly faster.
     if (comptime c.GTK_MAJOR_VERSION < major or
-        c.GTK_MINOR_VERSION < minor or
-        c.GTK_MICRO_VERSION < micro) return false;
+        (c.GTK_MAJOR_VERSION == major and c.GTK_MINOR_VERSION < minor) or
+        (c.GTK_MAJOR_VERSION == major and c.GTK_MINOR_VERSION == minor and c.GTK_MICRO_VERSION < micro))
+        return false;
 
     // If we're in comptime then we can't check the runtime version.
     if (@inComptime()) return true;


### PR DESCRIPTION
The comptime path of the GTK `atLeast()` version function fails to take the proceeding portion of the version into account. For example version 5.1.0 is incorrectly marked as less than 4.16.7 due to the minor version (1) being less than the minor we are comparing against (16).

This update required that the major versions be equal when comparing minor versions and the major and minor versions be equal when comparing micro versions.

For example, building against GTK 4.17.1:
Before: version.atLeast(4,16,2) -> false
After:  version.atLeast(4,16,2) -> true