### PR TITLE
Add back quotes for variables in the zsh shell integration to improve compatibility

### DIFF
--- a/src/shell-integration/README.md
+++ b/src/shell-integration/README.md
@@ -73,6 +73,6 @@ sequence occurs.
 
 ```bash
 if [[ -n $GHOSTTY_RESOURCES_DIR ]]; then
-  source $GHOSTTY_RESOURCES_DIR/shell-integration/zsh/ghostty-integration
+  source "$GHOSTTY_RESOURCES_DIR"/shell-integration/zsh/ghostty-integration
 fi
 ```


### PR DESCRIPTION
https://github.com/ghostty-org/ghostty/pull/3332#issuecomment-2564526118
According to this comment, using variables without quoting may not work with `setopt SH_WORD_SPLIT`.

We don't need to quote variables in `[[ ]]` because it works differently.