### PR TITLE
apprt/gtk: make window-decoration=false with gtk-titlebar=true look better

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -972,6 +972,9 @@ fn loadRuntimeCss(
     const headerbar_foreground = config.@"window-titlebar-foreground" orelse config.foreground;
 
     try writer.print(
+        \\window.without-window-decoration-and-with-titlebar {{
+        \\  border-radius: 0 0;
+        \\}}
         \\widget.unfocused-split {{
         \\ opacity: {d:.2};
         \\ background-color: rgb({d},{d},{d});

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -209,6 +209,11 @@ pub fn init(self: *Window, app: *App) !void {
     // If we are disabling decorations then disable them right away.
     if (!app.config.@"window-decoration") {
         c.gtk_window_set_decorated(gtk_window, 0);
+
+        // Fix any artifacting that may occur in window corners.
+        if (app.config.@"gtk-titlebar") {
+            c.gtk_widget_add_css_class(window, "without-window-decoration-and-with-titlebar");
+        }
     }
 
     // In debug we show a warning and apply the 'devel' class to the window.


### PR DESCRIPTION
Before this change, there seemed to be some artifacting in the window corners due to the window border no longer outlining the content properly. By detecting the situation, we can turn the window border radius off.