### PR TITLE
Clarify CLI vs. Keybind Actions documentation

### DIFF
--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -63,7 +63,7 @@ pub fn run(alloc: Allocator) !u8 {
     try stdout.writeAll(
         \\
         \\Specify `+<action> --help` to see the help for a specific action,
-        \\where `<action>` is one of actions listed below.
+        \\where `<action>` is one of actions listed above.
         \\
     );
 

--- a/src/cli/list_actions.zig
+++ b/src/cli/list_actions.zig
@@ -20,8 +20,9 @@ pub const Options = struct {
     }
 };
 
-/// The `list-actions` command is used to list all the available keybind actions
-/// for Ghostty.
+/// The `list-actions` command is used to list all the available keybind
+/// actions for Ghostty. These are distinct from the CLI Actions which can
+/// be listed via `+help`
 ///
 /// The `--docs` argument will print out the documentation for each action.
 pub fn run(alloc: Allocator) !u8 {

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -49,7 +49,8 @@ pub fn main() !MainReturn {
 
             error.InvalidAction => try stderr.print(
                 "Error: unknown CLI action specified. CLI actions are specified with\n" ++
-                    "the '+' character.\n",
+                    "the '+' character.\n\n" ++
+                    "All valid CLI actions can be listed with `ghostty +help`\n",
                 .{},
             ),
 


### PR DESCRIPTION
https://github.com/ghostty-org/ghostty/discussions/4107#discussioncomment-11699228

I was confused about not being able to run `ghostty +new_window` since I hadn't read the docs closely enough to understand the distinction between Keybind Actions and CLI Actions.

I think if the error messages I've modified here would have read this way to begin with I would've had a better chance of discovering this distinction on my own.

I did read the Contributing guidelines but I avoided opening an Issue since the changes here are minimal enough that I felt it would just add noise. If that's a mistake then I'm happy to close this out and return to the original discussion and/or create a new Issue.