### PR TITLE
Fix clipboard confirmation window typo

### DIFF
--- a/src/apprt/gtk/ClipboardConfirmationWindow.zig
+++ b/src/apprt/gtk/ClipboardConfirmationWindow.zig
@@ -238,7 +238,7 @@ fn promptText(req: apprt.ClipboardRequest) [:0]const u8 {
         \\Pasting this text into the terminal may be dangerous as it looks like some commands may be executed.
         ,
         .osc_52_read =>
-        \\An appliclication is attempting to read from the clipboard.
+        \\An application is attempting to read from the clipboard.
         \\The current clipboard contents are shown below.
         ,
         .osc_52_write =>


### PR DESCRIPTION
uh just fixes a typo of appliclication instead of application for an osc_52_read request