### PR TITLE
macOS: weak self for event monitor to avoid retain cycle for controllers

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -111,8 +111,8 @@ class BaseTerminalController: NSWindowController,
         // Listen for local events that we need to know of outside of
         // single surface handlers.
         self.eventMonitor = NSEvent.addLocalMonitorForEvents(
-            matching: [.flagsChanged],
-            handler: localEventHandler)
+            matching: [.flagsChanged]
+        ) { [weak self] event in self?.localEventHandler(event) }
     }
 
     deinit {
@@ -160,7 +160,7 @@ class BaseTerminalController: NSWindowController,
     }
 
     // MARK: Notifications
-    
+
     @objc private func didChangeScreenParametersNotification(_ notification: Notification) {
         // If we have a window that is visible and it is outside the bounds of the
         // screen then we clamp it back to within the screen.


### PR DESCRIPTION
Fixes #3219

We were holding a reference cycle to the base terminal controller. This was preventing the window from ever being fully deallocated.