### PR TITLE
doc: add background-opacity needs restart

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -560,6 +560,7 @@ palette: Palette = .{},
 /// On macOS, background opacity is disabled when the terminal enters native
 /// fullscreen. This is because the background becomes gray and it can cause
 /// widgets to show through which isn't generally desirable.
+/// On macOs, this setting cannot be reloaded and needs a restart
 @"background-opacity": f64 = 1.0,
 
 /// A positive value enables blurring of the background when background-opacity

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -560,7 +560,7 @@ palette: Palette = .{},
 /// On macOS, background opacity is disabled when the terminal enters native
 /// fullscreen. This is because the background becomes gray and it can cause
 /// widgets to show through which isn't generally desirable.
-/// On macOs, this setting cannot be reloaded and needs a restart
+/// On macOS, changing this configuration requires restarting Ghostty completely.
 @"background-opacity": f64 = 1.0,
 
 /// A positive value enables blurring of the background when background-opacity


### PR DESCRIPTION
The section informing that some configs need a restart points that the specific config should have details about this. This adds the information that `background-opacity` on MacOS needs a restart
 
> Some configuration options cannot be reloaded at runtime; others may only apply to newly created terminals. See the specific configuration option for details.

_PS: lovin ghostty_