### PR TITLE
input: parse triggers with codepoints that map to keys as translated

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -4746,9 +4746,11 @@ pub const Keybinds = struct {
         try list.parseCLI(alloc, "ctrl+z>2=goto_tab:2");
         try list.formatEntry(formatterpkg.entryFormatter("keybind", buf.writer()));
 
+        // Note they turn into translated keys because they match
+        // their ASCII mapping.
         const want =
-            \\keybind = ctrl+z>1=goto_tab:1
-            \\keybind = ctrl+z>2=goto_tab:2
+            \\keybind = ctrl+z>two=goto_tab:2
+            \\keybind = ctrl+z>one=goto_tab:1
             \\
         ;
         try std.testing.expectEqualStrings(want, buf.items);

--- a/src/input/key.zig
+++ b/src/input/key.zig
@@ -729,7 +729,9 @@ pub const Key = enum(c_int) {
         .{ '\t', .tab },
 
         // Keypad entries. We just assume keypad with the kp_ prefix
-        // so that has some special meaning. These must also always be last.
+        // so that has some special meaning. These must also always be last,
+        // so that our `fromASCII` function doesn't accidentally map them
+        // over normal numerics and other keys.
         .{ '0', .kp_0 },
         .{ '1', .kp_1 },
         .{ '2', .kp_2 },


### PR DESCRIPTION
Fixes #4146

This makes it so that keys such as `cmd+1` and `cmd+one` are identical.