### PR TITLE
fix: respect notch in MacOS non-native fullscreen mode

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -333,7 +333,15 @@ class BaseTerminalController: NSWindowController,
         }
     }
 
-    func fullscreenDidChange() {
+    func fullscreenDidChange(mode: FullscreenMode, enabled: Bool) {
+        NotificationCenter.default.post(
+            name: Ghostty.Notification.ghosttyDidToggleFullscreen,
+            object: self.window,
+            userInfo: [
+                Ghostty.Notification.FullscreenEnabledKey: enabled,
+                Ghostty.Notification.FullscreenModeKey: mode,
+            ]
+        )
         // For some reason focus can get lost when we change fullscreen. Regardless of
         // mode above we just move it back.
         if let focusedSurface {

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -95,8 +95,8 @@ class TerminalController: BaseTerminalController {
     }
 
 
-    override func fullscreenDidChange() {
-        super.fullscreenDidChange()
+    override func fullscreenDidChange(mode: FullscreenMode, enabled: Bool) {
+        super.fullscreenDidChange(mode: mode, enabled: enabled)
 
         // When our fullscreen state changes, we resync our appearance because some
         // properties change when fullscreen or not.

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -269,6 +269,10 @@ extension Ghostty.Notification {
     static let ghosttyToggleFullscreen = Notification.Name("com.mitchellh.ghostty.toggleFullscreen")
     static let FullscreenModeKey = ghosttyToggleFullscreen.rawValue
 
+    /// Toggle fullscreen of current window
+    static let ghosttyDidToggleFullscreen = Notification.Name("com.mitchellh.ghostty.didToggleFullscreen")
+    static let FullscreenEnabledKey = ghosttyDidToggleFullscreen.rawValue + ".bool"
+
     /// Notification sent to toggle split maximize/unmaximize.
     static let didToggleSplitZoom = Notification.Name("com.mitchellh.ghostty.didToggleSplitZoom")
 

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -49,7 +49,7 @@ extension Ghostty {
         // Maintain whether our window has focus (is key) or not
         @State private var windowFocus: Bool = true
 
-        // Maintain whether our window is fullscreen or not
+        // Top padding for macOS notch in non-native fullscreen mode.
         @State private var paddingTop: CGFloat = 0
 
         // True if we're hovering over the left URL view, so we can show it on the right.

--- a/macos/Sources/Helpers/Fullscreen.swift
+++ b/macos/Sources/Helpers/Fullscreen.swift
@@ -38,11 +38,11 @@ protocol FullscreenStyle {
 protocol FullscreenDelegate: AnyObject {
     /// Called whenever the fullscreen state changed. You can call isFullscreen to see
     /// the current state.
-    func fullscreenDidChange()
+    func fullscreenDidChange(mode: FullscreenMode, enabled: Bool)
 }
 
 extension FullscreenDelegate {
-    func fullscreenDidChange() {}
+    func fullscreenDidChange(mode: FullscreenMode, enabled: Bool) {}
 }
 
 /// The base class for fullscreen implementations, cannot be used as a FullscreenStyle on its own.
@@ -74,11 +74,11 @@ class FullscreenBase {
     }
 
     @objc private func didEnterFullScreenNotification(_ notification: Notification) {
-        delegate?.fullscreenDidChange()
+        delegate?.fullscreenDidChange(mode: FullscreenMode.native, enabled: true)
     }
 
     @objc private func didExitFullScreenNotification(_ notification: Notification) {
-        delegate?.fullscreenDidChange()
+        delegate?.fullscreenDidChange(mode: FullscreenMode.native, enabled: false)
     }
 }
 
@@ -202,7 +202,7 @@ class NonNativeFullscreen: FullscreenBase, FullscreenStyle {
         // https://github.com/ghostty-org/ghostty/issues/1996
         DispatchQueue.main.async {
             self.window.setFrame(self.fullscreenFrame(screen), display: true)
-            self.delegate?.fullscreenDidChange()
+            self.delegate?.fullscreenDidChange(mode: FullscreenMode.nonNative, enabled: true)
         }
     }
 
@@ -258,7 +258,7 @@ class NonNativeFullscreen: FullscreenBase, FullscreenStyle {
         window.makeKeyAndOrderFront(nil)
 
         // Notify the delegate
-        self.delegate?.fullscreenDidChange()
+        self.delegate?.fullscreenDidChange(mode: FullscreenMode.nonNative, enabled: false)
     }
 
     private func fullscreenFrame(_ screen: NSScreen) -> NSRect {


### PR DESCRIPTION
This patch adds notch padding to respect macOS notch in non-native fullscreen mode.

I do not have any experience with swift & swiftui, so please let me know if there's a better way to implement this!

References #378