### PR TITLE
config: Add the option `toast_on_clipboard_copy`

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -894,7 +894,9 @@ fn gtkActionCopy(
         return;
     };
 
-    self.sendToast("Copied to clipboard");
+    if (self.app.config.@"toast-on-clipboard-copy") {
+        self.sendToast("Copied to clipboard");
+    }
 }
 
 fn gtkActionPaste(

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -894,7 +894,7 @@ fn gtkActionCopy(
         return;
     };
 
-    if (self.app.config.@"toast-on-clipboard-copy") {
+    if (self.app.config.@"adw-toast".@"clipboard-copy") {
         self.sendToast("Copied to clipboard");
     }
 }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1276,9 +1276,6 @@ keybind: Keybinds = .{},
 @"clipboard-read": ClipboardAccess = .ask,
 @"clipboard-write": ClipboardAccess = .allow,
 
-/// Enables or disables the toast message on a clipboard copy action.
-@"toast-on-clipboard-copy": bool = true,
-
 /// Trims trailing whitespace on data that is copied to the clipboard. This does
 /// not affect data sent to the clipboard via `clipboard-write`.
 @"clipboard-trim-trailing-spaces": bool = true,
@@ -1944,6 +1941,22 @@ keybind: Keybinds = .{},
 ///
 /// Changing this value at runtime will only affect new windows.
 @"adw-toolbar-style": AdwToolbarStyle = .raised,
+
+/// Control the toasts that Ghostty shows. Toasts are small notifications
+/// that appear overlaid on top of the terminal window. They are used to
+/// show information that is not critical but may be important.
+///
+/// Valid values are:
+///
+///   - `clipboard-copy` (default: true) - Show a toast when text is copied
+///     to the clipboard.
+///
+/// You can prefix any value with `no-` to disable it. For example,
+/// `no-clipboard-copy` will disable the clipboard copy toast. Multiple
+/// values can be set by separating them with commas.
+///
+/// This configuration only applies to GTK with Adwaita enabled.
+@"adw-toast": AdwToast = .{},
 
 /// If `true` (default), then the Ghostty GTK tabs will be "wide." Wide tabs
 /// are the new typical Gnome style where tabs fill their available space.
@@ -5443,6 +5456,11 @@ pub const AdwToolbarStyle = enum {
     flat,
     raised,
     @"raised-border",
+};
+
+/// See adw-toast
+pub const AdwToast = packed struct {
+    @"clipboard-copy": bool = true,
 };
 
 /// See mouse-shift-capture

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1276,6 +1276,9 @@ keybind: Keybinds = .{},
 @"clipboard-read": ClipboardAccess = .ask,
 @"clipboard-write": ClipboardAccess = .allow,
 
+/// Enables or disables the toast message on a clipboard copy action.
+@"toast-on-clipboard-copy": bool = true,
+
 /// Trims trailing whitespace on data that is copied to the clipboard. This does
 /// not affect data sent to the clipboard via `clipboard-write`.
 @"clipboard-trim-trailing-spaces": bool = true,


### PR DESCRIPTION
Add a config option to enable/disable the toast shown on clipboard copy

Also suggested in https://github.com/ghostty-org/ghostty/discussions/4165
