### PR TITLE
`write_*_file` actions default to mode 0600

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4242,7 +4242,7 @@ fn writeScreenFile(
     const filename = try std.fmt.bufPrint(&filename_buf, "{s}.txt", .{@tagName(loc)});
 
     // Open our scrollback file
-    var file = try tmp_dir.dir.createFile(filename, .{});
+    var file = try tmp_dir.dir.createFile(filename, .{ .mode = 0o600 });
     defer file.close();
 
     // Screen.dumpString writes byte-by-byte, so buffer it


### PR DESCRIPTION
This commit changes the default filemode for the write actions so that it is only readable and writable by the user running Ghostty.