### PR TITLE
Add `NSCalibratedRGBColorSpace` support.

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -322,6 +322,8 @@ class QuickTerminalController: BaseTerminalController {
         switch (self.derivedConfig.windowColorspace) {
         case "display-p3":
             window.colorSpace = .displayP3
+        case "generic-rgb":
+            window.colorSpace = .genericRGB
         case "srgb":
             fallthrough
         default:

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -301,6 +301,8 @@ class TerminalController: BaseTerminalController {
         switch (config.windowColorspace) {
         case "display-p3":
             window.colorSpace = .displayP3
+        case "generic-rgb":
+            window.colorSpace = .genericRGB
         case "srgb":
             fallthrough
         default:

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1067,7 +1067,8 @@ keybind: Keybinds = .{},
 @"window-theme": WindowTheme = .auto,
 
 /// The colorspace to use for the terminal window. The default is `srgb` but
-/// this can also be set to `display-p3` to use the Display P3 colorspace.
+/// this can also be set to `display-p3` to use the Display P3 colorspace or
+/// `generic-rgb` to use the Calibrated RGB colorspace.
 ///
 /// Changing this value at runtime will only affect new windows.
 ///

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -5291,6 +5291,7 @@ pub const WindowTheme = enum {
 pub const WindowColorspace = enum {
     srgb,
     @"display-p3",
+    @"generic-rgb",
 };
 
 /// See macos-titlebar-style


### PR DESCRIPTION
**Problem**

Ghostty is using sRGB by default, optionally Display P3 color space. However neither color space matches to the color space that the regular macOS apps are using.
That is `NSCalibratedRGBColorSpace`, seems called "Generic RGB" from initializer API name.

Because of this, colors has same hex value are slightly stronger on Ghostty compare to Terminal.app, for example.
> **Example:** A window in front is Ghostty without this patch, a window behind is Terminal.app
> ![Screen capture](https://github.com/user-attachments/assets/b705257a-14cb-4b9c-9088-8a3396ca48b2)

**Solution**

Add `generic-rgb` to `WindowColorspace`, therefore users can set `window-colorspace` to `generic-rgb` in config to have similar colors with the other macOS apps.