### PR TITLE
gtk: implement dropping files and strings

### DIFF
--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -21,6 +21,7 @@ pub const passwd = @import("passwd.zig");
 pub const xdg = @import("xdg.zig");
 pub const windows = @import("windows.zig");
 pub const macos = @import("macos.zig");
+pub const shell = @import("shell.zig");
 
 // Functions and types
 pub const CFReleaseThread = @import("cf_release_thread.zig");
@@ -48,3 +49,4 @@ pub const open = openpkg.open;
 pub const OpenType = openpkg.Type;
 pub const pipe = pipepkg.pipe;
 pub const resourcesDir = resourcesdir.resourcesDir;
+pub const ShellEscapeWriter = shell.ShellEscapeWriter;

--- a/src/os/shell.zig
+++ b/src/os/shell.zig
@@ -1,0 +1,90 @@
+const std = @import("std");
+const testing = std.testing;
+
+pub fn ShellEscapeWriter(comptime T: type) type {
+    return struct {
+        child_writer: T,
+
+        fn write(self: *ShellEscapeWriter(T), data: []const u8) error{Error}!usize {
+            var count: usize = 0;
+            for (data) |byte| {
+                const buf = switch (byte) {
+                    '\\',
+                    '"',
+                    '\'',
+                    '$',
+                    '`',
+                    '*',
+                    '?',
+                    ' ',
+                    '|',
+                    => &[_]u8{ '\\', byte },
+                    else => &[_]u8{byte},
+                };
+                self.child_writer.writeAll(buf) catch return error.Error;
+                count += 1;
+            }
+            return count;
+        }
+
+        const Writer = std.io.Writer(*ShellEscapeWriter(T), error{Error}, write);
+
+        pub fn writer(self: *ShellEscapeWriter(T)) Writer {
+            return .{ .context = self };
+        }
+    };
+}
+
+test "shell escape 1" {
+    var buf: [128]u8 = undefined;
+    var fmt = std.io.fixedBufferStream(&buf);
+    var shell: ShellEscapeWriter(@TypeOf(fmt).Writer) = .{ .child_writer = fmt.writer() };
+    const writer = shell.writer();
+    try writer.writeAll("abc");
+    try testing.expectEqualStrings("abc", fmt.getWritten());
+}
+
+test "shell escape 2" {
+    var buf: [128]u8 = undefined;
+    var fmt = std.io.fixedBufferStream(&buf);
+    var shell: ShellEscapeWriter(@TypeOf(fmt).Writer) = .{ .child_writer = fmt.writer() };
+    const writer = shell.writer();
+    try writer.writeAll("a c");
+    try testing.expectEqualStrings("a\\ c", fmt.getWritten());
+}
+
+test "shell escape 3" {
+    var buf: [128]u8 = undefined;
+    var fmt = std.io.fixedBufferStream(&buf);
+    var shell: ShellEscapeWriter(@TypeOf(fmt).Writer) = .{ .child_writer = fmt.writer() };
+    const writer = shell.writer();
+    try writer.writeAll("a?c");
+    try testing.expectEqualStrings("a\\?c", fmt.getWritten());
+}
+
+test "shell escape 4" {
+    var buf: [128]u8 = undefined;
+    var fmt = std.io.fixedBufferStream(&buf);
+    var shell: ShellEscapeWriter(@TypeOf(fmt).Writer) = .{ .child_writer = fmt.writer() };
+    const writer = shell.writer();
+    try writer.writeAll("a\\c");
+    try testing.expectEqualStrings("a\\\\c", fmt.getWritten());
+}
+
+test "shell escape 5" {
+    var buf: [128]u8 = undefined;
+    var fmt = std.io.fixedBufferStream(&buf);
+    var shell: ShellEscapeWriter(@TypeOf(fmt).Writer) = .{ .child_writer = fmt.writer() };
+    const writer = shell.writer();
+    try writer.writeAll("a|c");
+    try testing.expectEqualStrings("a\\|c", fmt.getWritten());
+}
+
+test "shell escape 6" {
+    var buf: [128]u8 = undefined;
+    var fmt = std.io.fixedBufferStream(&buf);
+    var shell: ShellEscapeWriter(@TypeOf(fmt).Writer) = .{ .child_writer = fmt.writer() };
+    const writer = shell.writer();
+    try writer.writeAll("a\"c");
+    try testing.expectEqualStrings("a\\\"c", fmt.getWritten());
+}

--- a/src/os/shell.zig
+++ b/src/os/shell.zig
@@ -1,6 +1,11 @@
 const std = @import("std");
 const testing = std.testing;
 
+/// Writer that escapes characters that shells treat specially to reduce the
+/// risk of injection attacks or other such weirdness. Specifically excludes
+/// linefeeds so that they can be used to delineate lists of file paths.
+///
+/// T should be a Zig type that follows the `std.io.Writer` interface.
 pub fn ShellEscapeWriter(comptime T: type) type {
     return struct {
         child_writer: T,


### PR DESCRIPTION
This allows dropping files and strings onto Ghostty in the GTK apprt. If you drop files onto Ghostty it will be pasted as a list of shell-escaped paths separated by newlines. If you drop a string onto Ghostty it will paste the string. Normal rules for pasting (bracketed pasts, unsafe pastes) apply.