### PR TITLE
Set the paste preview text in GTK4 to monospace

### DIFF
--- a/src/apprt/gtk/ClipboardConfirmationWindow.zig
+++ b/src/apprt/gtk/ClipboardConfirmationWindow.zig
@@ -131,6 +131,7 @@ const PrimaryView = struct {
         c.gtk_text_view_set_bottom_margin(@ptrCast(text), 8);
         c.gtk_text_view_set_left_margin(@ptrCast(text), 8);
         c.gtk_text_view_set_right_margin(@ptrCast(text), 8);
+        c.gtk_text_view_set_monospace(@ptrCast(text), 1);
 
         return .{ .root = view.root, .text = @ptrCast(text) };
     }


### PR DESCRIPTION
A simple change to make the text preview in the paste confirmation dialog monospace; this feels like something that most users would want, or at least very few users would dislike.

We just call `gtk_text_view_set_monospace` and let GTK use whatever default monospace font it wants to use. Theoretically we could probably tell it to use whatever font the user has configured, but this should be sufficient for most users.
