### PR TITLE
fix(gtk): add close confirmation for tabs

### DIFF
--- a/src/apprt/gtk/Tab.zig
+++ b/src/apprt/gtk/Tab.zig
@@ -122,14 +122,12 @@ pub fn remove(self: *Tab) void {
 }
 
 /// Helper function to check if any surface in the split hierarchy needs close confirmation
-const needsConfirm = struct {
-    fn check(elem: Surface.Container.Elem) bool {
-        return switch (elem) {
-            .surface => |s| s.core_surface.needsConfirmQuit(),
-            .split => |s| check(s.top_left) or check(s.bottom_right),
-        };
-    }
-}.check;
+fn needsConfirm(elem: Surface.Container.Elem) bool {
+    return switch (elem) {
+        .surface => |s| s.core_surface.needsConfirmQuit(),
+        .split => |s| needsConfirm(s.top_left) or needsConfirm(s.bottom_right),
+    };
+}
 
 /// Close the tab, asking for confirmation if any surface requests it.
 fn closeWithConfirmation(tab: *Tab) void {

--- a/src/apprt/gtk/notebook_gtk.zig
+++ b/src/apprt/gtk/notebook_gtk.zig
@@ -157,8 +157,8 @@ pub const NotebookGtk = struct {
         c.gtk_gesture_single_set_button(@ptrCast(gesture_tab_click), 0);
         c.gtk_widget_add_controller(label_box_widget, @ptrCast(gesture_tab_click));
 
-        _ = c.g_signal_connect_data(label_close, "clicked", c.G_CALLBACK(&Tab.gtkTabCloseClick), tab, null, c.G_CONNECT_DEFAULT);
-        _ = c.g_signal_connect_data(gesture_tab_click, "pressed", c.G_CALLBACK(&Tab.gtkTabClick), tab, null, c.G_CONNECT_DEFAULT);
+        _ = c.g_signal_connect_data(label_close, "clicked", c.G_CALLBACK(&gtkTabCloseClick), tab, null, c.G_CONNECT_DEFAULT);
+        _ = c.g_signal_connect_data(gesture_tab_click, "pressed", c.G_CALLBACK(&gtkTabClick), tab, null, c.G_CONNECT_DEFAULT);
 
         // Tab settings
         c.gtk_notebook_set_tab_reorderable(self.notebook, box_widget, 1);
@@ -282,4 +282,23 @@ fn gtkNotebookCreateWindow(
     tab.window = newWindow;
 
     return newWindow.notebook.gtk.notebook;
+}
+
+fn gtkTabCloseClick(_: *c.GtkButton, ud: ?*anyopaque) callconv(.C) void {
+    const tab: *Tab = @ptrCast(@alignCast(ud));
+    tab.closeWithConfirmation();
+}
+
+fn gtkTabClick(
+    gesture: *c.GtkGestureClick,
+    _: c.gint,
+    _: c.gdouble,
+    _: c.gdouble,
+    ud: ?*anyopaque,
+) callconv(.C) void {
+    const self: *Tab = @ptrCast(@alignCast(ud));
+    const gtk_button = c.gtk_gesture_single_get_current_button(@ptrCast(gesture));
+    if (gtk_button == c.GDK_BUTTON_MIDDLE) {
+        self.closeWithConfirmation();
+    }
 }


### PR DESCRIPTION
On the discord this bit of feedback came up from [here](https://ncurses.scripts.mit.edu/?p=ncurses.git;a=blob;f=misc/terminfo.src;h=ccd4c32099cf740d331eeaa3955f48f177435878;hb=a28a11d84d969cfdc876e158deae7870e8948a24#l8323)
```
8323 # - ghostty has tabs (imitating gnome-terminal); when closing a tab with a
8324 #   running process (e.g., a hung vttest), ghostty does not prompt about the 
8325 #   process to be killed.
```

This PR adds confirmation to the places where tabs are closed directly 

Fixes: https://github.com/ghostty-org/ghostty/issues/4234