### PR TITLE
correct default keybinding cmd+backspace for macOS

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2603,7 +2603,7 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
         try result.keybind.set.put(
             alloc,
             .{ .key = .{ .translated = .backspace }, .mods = .{ .super = true } },
-            .{ .esc = "\x15" },
+            .{ .text = "\\x15" },
         );
         try result.keybind.set.put(
             alloc,


### PR DESCRIPTION
This produces the following keybind, which I believe was intended.
> keybind = cmd+backspace=text:\x15

Matches the cmd+left and cmd+right which are a few lines up.

#3679 
#3646