### PR TITLE
Adding default.nix for flake-compat

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,13 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    nodeName = lock.nodes.root.inputs.flake-compat;
+  in
+    fetchTarball {
+      url =
+        lock.nodes.${nodeName}.locked.url
+        or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
+      sha256 = lock.nodes.${nodeName}.locked.narHash;
+    }
+) {src = ./.;})
+.defaultNix


### PR DESCRIPTION
This way non-flake users can access packages with niv or npins easily, and as flake-compat is already a dependency, this is just a "glue". Copy-pasted from [here](https://github.com/edolstra/flake-compat/tree/ff81ac966bb2cae68946d5ed5fc4994f96d0ffec?tab=readme-ov-file#usage).

An example with npins would be:
`npins add github ghostty-org ghostty`

and then in the config:
```nix
{pkgs, ...}: let
    sources = import ./npins;
    ghostty = import sources.ghostty;
in {
    environment.systemPackages = [ ghostty.packages.${pkgs.system}.default ];
}
```