### PR TITLE
feature: option to start Ghostty maximized on Linux

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -265,10 +265,12 @@ pub fn init(self: *Window, app: *App) !void {
     c.gtk_popover_set_has_arrow(@ptrCast(@alignCast(self.context_menu)), 0);
     c.gtk_widget_set_halign(self.context_menu, c.GTK_ALIGN_START);
 
-    if (app.config.@"gtk-maximize") c.gtk_window_maximize(self.window);
-
-    // If we are in fullscreen mode, new windows start fullscreen.
-    if (app.config.fullscreen) c.gtk_window_fullscreen(self.window);
+    // Set window mode based on the config
+    if (app.config.fullscreen) {
+        c.gtk_window_fullscreen(self.window);
+    } else if (app.config.maximize) {
+        c.gtk_window_maximize(self.window);
+    }
 
     // We register a key event controller with the window so
     // we can catch key events when our surface may not be

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -265,6 +265,8 @@ pub fn init(self: *Window, app: *App) !void {
     c.gtk_popover_set_has_arrow(@ptrCast(@alignCast(self.context_menu)), 0);
     c.gtk_widget_set_halign(self.context_menu, c.GTK_ALIGN_START);
 
+    if (app.config.@"gtk-maximize") c.gtk_window_maximize(self.window);
+
     // If we are in fullscreen mode, new windows start fullscreen.
     if (app.config.fullscreen) c.gtk_window_fullscreen(self.window);
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1855,8 +1855,9 @@ keybind: Keybinds = .{},
 /// does not apply to tabs, splits, etc. However, this setting will apply to all
 /// new windows, not just the first one.
 ///
-/// This setting is overwritten by `fullscreen` option.
-@"gtk-maximize": bool = false,
+/// This setting will be ignored if `fullscreen = true`.
+/// Note: This only works on Linux.
+maximize: bool = false,
 
 /// If `true`, the Ghostty GTK application will run in single-instance mode:
 /// each new `ghostty` process launched will result in a new window if there is
@@ -3282,6 +3283,10 @@ pub fn finalize(self: *Config) !void {
                 .{duration},
             );
         }
+    }
+
+    if (self.maximize and self.fullscreen) {
+        log.warn("'fullscreen' and 'maximize' cannot be used at the same time, 'maximize' will be ignored.", .{});
     }
 
     // We can't set this as a struct default because our config is

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1851,6 +1851,13 @@ keybind: Keybinds = .{},
 /// must always be able to move themselves into an isolated cgroup.
 @"linux-cgroup-hard-fail": bool = false,
 
+/// Start new windows maximized. This setting applies to new windows and
+/// does not apply to tabs, splits, etc. However, this setting will apply to all
+/// new windows, not just the first one.
+///
+/// This setting is overwritten by `fullscreen` option.
+@"gtk-maximize": bool = false,
+
 /// If `true`, the Ghostty GTK application will run in single-instance mode:
 /// each new `ghostty` process launched will result in a new window if there is
 /// already a running process.


### PR DESCRIPTION
This PR is related to #4302 adding the option to start Ghostty maximized in linux systems adding a new flag in config.