### PR TITLE
macos: fix window borders on dark mode

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -244,7 +244,9 @@ class TerminalController: BaseTerminalController {
         let backgroundColor: OSColor
         if let surfaceTree {
             if let focusedSurface, surfaceTree.doesBorderTop(view: focusedSurface) {
-                backgroundColor = OSColor(focusedSurface.backgroundColor ?? surfaceConfig.backgroundColor).withAlphaComponent(0.0)
+                // Similar to above, an alpha component of "0" causes compositor issues, so
+                // we use 0.001. See: https://github.com/ghostty-org/ghostty/pull/4308
+                backgroundColor = OSColor(focusedSurface.backgroundColor ?? surfaceConfig.backgroundColor).withAlphaComponent(0.001)
             } else {
                 // We don't have a focused surface or our surface doesn't border the
                 // top. We choose to match the color of the top-left most surface.


### PR DESCRIPTION
After updating to 1.0.1 I noticed something different in the terminal, which turned out being the window borders - it appeared as if Ghostty was using light-mode style borders (dark/black outline with a thin light stroke at the top) instead of the entire light outline from before:

| 1.0.0 | 1.0.1 |
| - | - |
| <img width="308" alt="Screenshot 2025-01-01 at 2 28 12 PM" src="https://github.com/user-attachments/assets/d8bc5bdd-c3b2-401c-a8ed-9da0b768cb3d" /> | <img width="308" alt="Screenshot 2025-01-01 at 2 29 07 PM" src="https://github.com/user-attachments/assets/fd710bed-1756-4f66-8402-bfbdd25218ab" /> |

After digging a bit, I found #3834, which fixes fullscreen background colors through alpha channels by appending a `withAlphaComponent(0.0)` to `backgroundColor` - for reasons I may be entirely unaware of (since I'm not a Swift developer), this seems to cause the dark-mode border style to go away.

Some lines above that, I noticed the `.clear` callout from line 266, which talks about matching Terminal.app's styles, and it _also_ has a `withAlphaComponent` but set to `0.001` - if I understand correctly, and the fix from #3834 works by setting the alpha component to a _practically_ zero value, then I thought perhaps a really small number like `0.001` could do the trick as well. This ended up working and bringing back the right borders again.

Not sure again if this may make a difference anywhere else in the app or bring any undesired behavior, but if anyone who is well-versed in Swift would like chime in with more details or perhaps a better approach, I'd greatly appreciate it!