### PR TITLE
Install icons during postInstall phase of Nix flake

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -188,6 +188,9 @@ in
       mv $out/share/vim/vimfiles "$vim"
       ln -sf "$vim" "$out/share/vim/vimfiles"
       echo "$vim" >> "$out/nix-support/propagated-user-env-packages"
+
+      install -Dt $out/share/applications dist/linux/app.desktop
+      install -Dt $out/share/icons/com.mitchellh.ghostty.png images/icons/icon_512.png
     '';
 
     meta = {


### PR DESCRIPTION
Small fix for Nix packaging that installs the app icon and desktop file (icon_512 by default) during postInstall phase. There was no issue for this, but I'm not really sure it was large enough to warrant a full triage. 

Before:

![image](https://github.com/user-attachments/assets/4bea17cd-070c-43ce-90b7-9fe57bff0a92)

After: 

![image](https://github.com/user-attachments/assets/cb8884e6-75a6-4212-aef2-81925a7e5e97)
