### PR TITLE
Fix the format string of font size in points in the inspector

### DIFF
--- a/src/inspector/Inspector.zig
+++ b/src/inspector/Inspector.zig
@@ -724,7 +724,7 @@ fn renderSizeWindow(self: *Inspector) void {
             {
                 _ = cimgui.c.igTableSetColumnIndex(1);
                 cimgui.c.igText(
-                    "%d pt",
+                    "%.2f pt",
                     self.surface.font_size.points,
                 );
             }


### PR DESCRIPTION
It's an `f32` which was previously formatted with `%d`.

Credits to @gabydd who found this over at https://discord.com/channels/1005603569187160125/1324249888514506752/1324275061380874250.