### PR TITLE
GTK: crash reports notice

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -44,6 +44,9 @@ const log = std.log.scoped(.gtk);
 
 pub const Options = struct {};
 
+/// A global variable indicating if user has dismissed the notice about existing crash reports
+pub var crash_reports_notice_dismissed = false;
+
 core_app: *CoreApp,
 config: Config,
 

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -44,8 +44,6 @@ const log = std.log.scoped(.gtk);
 
 pub const Options = struct {};
 
-/// A global variable indicating if user has dismissed the notice about existing crash reports
-pub var crash_reports_notice_dismissed = false;
 
 core_app: *CoreApp,
 config: Config,
@@ -55,6 +53,9 @@ ctx: *c.GMainContext,
 
 /// True if the app was launched with single instance mode.
 single_instance: bool,
+
+/// A flag indicating if user has dismissed the notice about existing crash reports
+crash_reports_notice_dismissed: bool = false,
 
 /// The "none" cursor. We use one that is shared across the entire app.
 cursor_none: ?*c.GdkCursor,

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -44,7 +44,6 @@ const log = std.log.scoped(.gtk);
 
 pub const Options = struct {};
 
-
 core_app: *CoreApp,
 config: Config,
 

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -280,16 +280,10 @@ pub fn init(self: *Window, app: *App) !void {
                 c.adw_banner_set_use_markup(@ptrCast(banner), 1);
 
                 c.adw_banner_set_button_label(@ptrCast(banner), "Dismiss");
-                const close_banner_callback = struct {
-                    fn callback(_: ?*c.GtkWidget, data: ?*anyopaque) callconv(.C) void {
-                        const widget: *c.AdwBanner = @ptrCast(data);
-                        c.adw_banner_set_revealed(widget, c.FALSE);
-                    }
-                }.callback;
                 _ = c.g_signal_connect_data(
                     banner,
                     "button-clicked",
-                    c.G_CALLBACK(&close_banner_callback),
+                    c.G_CALLBACK(&adwHideBanner),
                     banner,
                     null,
                     c.G_CONNECT_DEFAULT,
@@ -311,16 +305,10 @@ pub fn init(self: *Window, app: *App) !void {
                 c.gtk_widget_set_margin_top(@ptrCast(close_button), 10);
                 c.gtk_widget_set_margin_bottom(@ptrCast(close_button), 10);
                 c.gtk_widget_set_margin_end(@ptrCast(close_button), 10);
-                const close_warning_callback = struct {
-                    fn callback(_: ?*c.GtkWidget, data: ?*anyopaque) callconv(.C) void {
-                        const widget: *c.GtkWidget = @ptrCast(@alignCast(data));
-                        c.gtk_widget_set_visible(widget, c.FALSE);
-                    }
-                }.callback;
                 _ = c.g_signal_connect_data(
                     close_button,
                     "clicked",
-                    c.G_CALLBACK(&close_warning_callback),
+                    c.G_CALLBACK(&gtkHideWidget),
                     warning_box,
                     null,
                     0
@@ -1046,6 +1034,16 @@ fn gtkActionReset(
         log.warn("error performing binding action error={}", .{err});
         return;
     };
+}
+
+fn gtkHideWidget(_: ?*c.GtkWidget, data: ?*anyopaque) void {
+    const widget: *c.GtkWidget = @ptrCast(@alignCast(data));
+    c.gtk_widget_set_visible(widget, c.FALSE);
+}
+
+fn adwHideBanner(_: ?*c.GtkWidget, data: ?*anyopaque) void {
+    const banner: *c.AdwBanner = @ptrCast(data);
+    c.adw_banner_set_revealed(banner, c.FALSE);
 }
 
 /// Returns the surface to use for an action.

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -297,21 +297,20 @@ pub fn init(self: *Window, app: *App) !void {
 
                 c.gtk_box_append(@ptrCast(warning_box), @ptrCast(banner));
             } else {
-                const hbox = c.gtk_box_new(c.GTK_ORIENTATION_HORIZONTAL, 5);
-                c.gtk_widget_set_halign(@ptrCast(hbox), c.GTK_ALIGN_CENTER);
+                const center_box = c.gtk_center_box_new();
 
                 const message = c.gtk_label_new(null);
                 c.gtk_label_set_markup(@ptrCast(message), warning_text.ptr);
                 c.gtk_label_set_use_markup(@ptrCast(message), 1);
+                c.gtk_label_set_justify(@ptrCast(message), c.GTK_JUSTIFY_CENTER);
+                c.gtk_label_set_xalign(@ptrCast(message), 0.5);
                 c.gtk_widget_set_margin_top(@ptrCast(message), 10);
                 c.gtk_widget_set_margin_bottom(@ptrCast(message), 10);
-
-                c.gtk_box_append(@ptrCast(hbox), message);
 
                 const close_button = c.gtk_button_new_from_icon_name("window-close-symbolic");
                 c.gtk_widget_set_margin_top(@ptrCast(close_button), 10);
                 c.gtk_widget_set_margin_bottom(@ptrCast(close_button), 10);
-
+                c.gtk_widget_set_margin_end(@ptrCast(close_button), 10);
                 const close_warning_callback = struct {
                     fn callback(_: ?*c.GtkWidget, data: ?*anyopaque) callconv(.C) void {
                         const widget: *c.GtkWidget = @ptrCast(@alignCast(data));
@@ -327,8 +326,10 @@ pub fn init(self: *Window, app: *App) !void {
                     0
                 );
 
-                c.gtk_box_append(@ptrCast(hbox), close_button);
-                c.gtk_box_append(@ptrCast(warning_box), @ptrCast(hbox));
+                c.gtk_center_box_set_center_widget(@ptrCast(center_box), message);
+                c.gtk_center_box_set_end_widget(@ptrCast(center_box), close_button);
+
+                c.gtk_box_append(@ptrCast(warning_box), @ptrCast(center_box));
             }
 
             c.gtk_widget_add_css_class(@ptrCast(warning_box), "background");

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -263,7 +263,7 @@ pub fn init(self: *Window, app: *App) !void {
         if (try it.next()) |_| {
             const warning_text = try std.fmt.allocPrintZ(
                 self.app.core_app.alloc,
-            \\ There are existing crash reports located at <a href="file://{s}">{s}</a>.
+            \\ ⚠️ There are existing crash reports located at <a href="file://{s}">{s}</a>.
                  \\ If possible, <a href="https://github.com/ghostty-org/ghostty?tab=readme-ov-file#crash-reports">report them to the developers</a> to help improve the application.
                     ,
                 .{crash_dir.path, crash_dir.path}

--- a/src/apprt/gtk/style.css
+++ b/src/apprt/gtk/style.css
@@ -47,5 +47,5 @@ window.without-window-decoration-and-with-titlebar {
 }
 
 .banner-box:not(:first-child) {
-    border-top: 1px solid alpha(@borders, 0.2);
+  border-top: 1px solid alpha(@borders, 0.2);
 }

--- a/src/apprt/gtk/style.css
+++ b/src/apprt/gtk/style.css
@@ -45,3 +45,7 @@ window.without-window-decoration-and-with-titlebar {
   background-color: rgba(250, 250, 250, 1);
   background-clip: content-box;
 }
+
+.banner-box:not(:first-child) {
+    border-top: 1px solid alpha(@borders, 0.2);
+}

--- a/src/crash/dir.zig
+++ b/src/crash/dir.zig
@@ -38,7 +38,7 @@ pub const ReportIterator = struct {
     it: std.fs.Dir.Iterator = undefined,
 
     pub fn deinit(self: *ReportIterator) void {
-        if (self.dir) |dir| dir.close();
+        if (self.dir) |*dir| dir.close();
     }
 
     pub fn next(self: *ReportIterator) !?Report {


### PR DESCRIPTION
This pr implements the GUI notice informing about existing crash reports in the GTK application, and partially resolves https://github.com/ghostty-org/ghostty/issues/2183.

As proposed in https://github.com/ghostty-org/ghostty/issues/2183#issuecomment-2325155949 I implemented a banner similiar to the debug mode notice.
The message embeds clickable links leading to the reports directory and reporting instructions.


`gtk-adwaita=true`:
![image](https://github.com/user-attachments/assets/835159e7-6d66-42f0-96ed-0605751cbcff)
`gtk-adwaita=false`:
![image](https://github.com/user-attachments/assets/ba1a3288-dd21-4eaf-9749-77e15d96385f)
