### PR TITLE
Add `close_tab` keybinding action for macOS

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -30,6 +30,7 @@ class AppDelegate: NSObject,
     @IBOutlet private var menuSplitRight: NSMenuItem?
     @IBOutlet private var menuSplitDown: NSMenuItem?
     @IBOutlet private var menuClose: NSMenuItem?
+    @IBOutlet private var menuCloseTab: NSMenuItem?
     @IBOutlet private var menuCloseWindow: NSMenuItem?
     @IBOutlet private var menuCloseAllWindows: NSMenuItem?
 
@@ -347,6 +348,7 @@ class AppDelegate: NSObject,
         syncMenuShortcut(config, action: "new_window", menuItem: self.menuNewWindow)
         syncMenuShortcut(config, action: "new_tab", menuItem: self.menuNewTab)
         syncMenuShortcut(config, action: "close_surface", menuItem: self.menuClose)
+        syncMenuShortcut(config, action: "close_tab", menuItem: self.menuCloseTab)
         syncMenuShortcut(config, action: "close_window", menuItem: self.menuCloseWindow)
         syncMenuShortcut(config, action: "close_all_windows", menuItem: self.menuCloseAllWindows)
         syncMenuShortcut(config, action: "new_split:right", menuItem: self.menuSplitRight)

--- a/macos/Sources/App/macOS/MainMenu.xib
+++ b/macos/Sources/App/macOS/MainMenu.xib
@@ -17,6 +17,7 @@
                 <outlet property="menuCheckForUpdates" destination="GEA-5y-yzH" id="0nV-Tf-nJQ"/>
                 <outlet property="menuClose" destination="DVo-aG-piG" id="R3t-0C-aSU"/>
                 <outlet property="menuCloseAllWindows" destination="yKr-Vi-Yqw" id="Zet-Ir-zbm"/>
+                <outlet property="menuCloseTab" destination="Obb-Mk-j8J" id="Gda-L0-gdz"/>
                 <outlet property="menuCloseWindow" destination="W5w-UZ-crk" id="6ff-BT-ENV"/>
                 <outlet property="menuCopy" destination="Jqf-pv-Zcu" id="bKd-1C-oy9"/>
                 <outlet property="menuDecreaseFontSize" destination="kzb-SZ-dOA" id="Y1B-Vh-6Z2"/>
@@ -153,6 +154,12 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="close:" target="-1" id="tTZ-2b-Mbm"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Close Tab" id="Obb-Mk-j8J">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="closeTab:" target="-1" id="UBb-Bd-nkj"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Close Window" id="W5w-UZ-crk">

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -448,6 +448,9 @@ extension Ghostty {
             case GHOSTTY_ACTION_NEW_SPLIT:
                 newSplit(app, target: target, direction: action.action.new_split)
 
+            case GHOSTTY_ACTION_CLOSE_TAB:
+                closeTab(app, target: target)
+
             case GHOSTTY_ACTION_TOGGLE_FULLSCREEN:
                 toggleFullscreen(app, target: target, mode: action.action.toggle_fullscreen)
 
@@ -643,6 +646,27 @@ extension Ghostty {
                         "direction": direction,
                         Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: ghostty_surface_inherited_config(surface)),
                     ]
+                )
+
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        private static func closeTab(_ app: ghostty_app_t, target: ghostty_target_s) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                Ghostty.logger.warning("close tab does nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+
+                NotificationCenter.default.post(
+                    name: .ghosttyCloseTab,
+                    object: surfaceView
                 )
 
 

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -236,6 +236,9 @@ extension Notification.Name {
     /// Goto tab. Has tab index in the userinfo.
     static let ghosttyMoveTab = Notification.Name("com.mitchellh.ghostty.moveTab")
     static let GhosttyMoveTabKey = ghosttyMoveTab.rawValue
+
+    /// Close tab
+    static let ghosttyCloseTab = Notification.Name("com.mitchellh.ghostty.closeTab")
 }
 
 // NOTE: I am moving all of these to Notification.Name extensions over time. This

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4266,6 +4266,7 @@ fn closingAction(action: input.Binding.Action) bool {
     return switch (action) {
         .close_surface,
         .close_window,
+        .close_tab,
         => true,
 
         else => false,

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -375,6 +375,10 @@ pub const Action = union(enum) {
     /// configured.
     close_surface: void,
 
+    /// Close the current tab, regardless of how many splits there may be.
+    /// This will trigger close confirmation as configured.
+    close_tab: void,
+
     /// Close the window, regardless of how many tabs or splits there may be.
     /// This will trigger close confirmation as configured.
     close_window: void,
@@ -382,9 +386,6 @@ pub const Action = union(enum) {
     /// Close all windows. This will trigger close confirmation as configured.
     /// This only works for macOS currently.
     close_all_windows: void,
-
-    /// Closes the tab belonging to the currently focused split.
-    close_tab: void,
 
     /// Toggle fullscreen mode of window.
     toggle_fullscreen: void,
@@ -729,6 +730,7 @@ pub const Action = union(enum) {
             .write_screen_file,
             .write_selection_file,
             .close_surface,
+            .close_tab,
             .close_window,
             .toggle_fullscreen,
             .toggle_window_decorations,
@@ -753,7 +755,6 @@ pub const Action = union(enum) {
             .resize_split,
             .equalize_splits,
             .inspector,
-            .close_tab,
             => .surface,
         };
     }


### PR DESCRIPTION
This PR adds support for a dedicated `close_tab` keybinding action, allowing users to bind specific keys for closing tabs. The implementation:

- Adds `close_tab` as a new keybinding action
- Preserves all existing confirmation dialogs for running processes
- Works seamlessly with macOS native tab system

### Testing
- [x] Tested with single tabs
- [x] Tested with multiple tabs
- [x] Tested with running processes (confirmation dialog)
- [x] Tested with splits within tabs

<img width="797" alt="image" src="https://github.com/user-attachments/assets/8e09eea3-1f71-40a3-a835-76de14013a29" />

https://github.com/user-attachments/assets/155210f7-20fe-4a96-8800-6969df214871

Partially resolved #4331