### PR TITLE
keybindings: improve sort to include key value 1,2,3,4...

### DIFF
--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -185,10 +185,29 @@ pub fn lessThan(_: void, lhs: Binding, rhs: Binding) bool {
         if (rhs.trigger.mods.alt) count += 1;
         break :blk count;
     };
-    if (lhs_count == rhs_count)
+
+    if (lhs_count != rhs_count)
+        return lhs_count > rhs_count;
+
+    if (lhs.trigger.mods.int() != rhs.trigger.mods.int())
         return lhs.trigger.mods.int() > rhs.trigger.mods.int();
 
-    return lhs_count > rhs_count;
+    const lhs_key: c_int = blk: {
+        switch (lhs.trigger.key) {
+            .translated => break :blk @intFromEnum(lhs.trigger.key.translated),
+            .physical => break :blk @intFromEnum(lhs.trigger.key.physical),
+            .unicode => break :blk @intCast(lhs.trigger.key.unicode),
+        }
+    };
+    const rhs_key: c_int = blk: {
+        switch (rhs.trigger.key) {
+            .translated => break :blk @intFromEnum(rhs.trigger.key.translated),
+            .physical => break :blk @intFromEnum(rhs.trigger.key.physical),
+            .unicode => break :blk @intCast(rhs.trigger.key.unicode),
+        }
+    };
+
+    return lhs_key < rhs_key;
 }
 
 /// The set of actions that a keybinding can take.


### PR DESCRIPTION
Current sort used by `+list-keybinds` doesn't include the value of the key:
```
ctrl  + shift + v                      paste_from_clipboard
ctrl  + shift + a                      select_all
...
ctrl  + shift + q                      quit
ctrl  + shift + n                      new_window
...
alt   + five                           goto_tab:5
alt   + eight                          goto_tab:8
...
alt   + six                            goto_tab:6
alt   + seven                          goto_tab:7
```
adding the key value improves the sort order

```
ctrl  + shift + a                      select_all
ctrl  + shift + c                      copy_to_clipboard
...
ctrl  + shift + n                      new_window
ctrl  + shift + o                      new_split:right
ctrl  + shift + q                      quit
...
alt   + one                            goto_tab:1
alt   + two                            goto_tab:2
alt   + three                          goto_tab:3
...
alt   + eight                          goto_tab:8
alt   + nine                           last_tab
alt   + f4                             close_window