### PR TITLE
gtk(wayland): add support for background blur on KDE Plasma

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1479,7 +1479,14 @@ fn addDeps(
 
                     const wayland = b.createModule(.{ .root_source_file = scanner.result });
 
+                    const plasma_wayland_protocols = b.dependency("plasma_wayland_protocols", .{
+                        .target = target,
+                        .optimize = optimize,
+                    });
+                    scanner.addCustomProtocol(plasma_wayland_protocols.path("src/protocols/blur.xml"));
+
                     scanner.generate("wl_compositor", 1);
+                    scanner.generate("org_kde_kwin_blur_manager", 1);
 
                     step.root_module.addImport("wayland", wayland);
                     step.linkSystemLibrary2("wayland-client", dynamic_link_opts);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -25,6 +25,10 @@
             .url = "https://deps.files.ghostty.org/ziglyph-b89d43d1e3fb01b6074bc1f7fc980324b04d26a5.tar.gz",
             .hash = "12207831bce7d4abce57b5a98e8f3635811cfefd160bca022eb91fe905d36a02cf25",
         },
+        .zig_wayland = .{
+            .url = "https://codeberg.org/ifreund/zig-wayland/archive/a5e2e9b6a6d7fba638ace4d4b24a3b576a02685b.tar.gz",
+            .hash = "1220d41b23ae70e93355bb29dac1c07aa6aeb92427a2dffc4375e94b4de18111248c",
+        },
 
         // C libs
         .cimgui = .{ .path = "./pkg/cimgui" },
@@ -63,6 +67,10 @@
         .z2d = .{
             .url = "git+https://github.com/vancluever/z2d?ref=v0.4.0#4638bb02a9dc41cc2fb811f092811f6a951c752a",
             .hash = "12201f0d542e7541cf492a001d4d0d0155c92f58212fbcb0d224e95edeba06b5416a",
+        },
+        .plasma_wayland_protocols = .{
+            .url = "git+https://invent.kde.org/libraries/plasma-wayland-protocols.git?ref=master#db525e8f9da548cffa2ac77618dd0fbe7f511b86",
+            .hash = "12207e0851c12acdeee0991e893e0132fc87bb763969a585dc16ecca33e88334c566",
         },
     },
 }

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -51,6 +51,9 @@
   pandoc,
   hyperfine,
   typos,
+  wayland,
+  wayland-scanner,
+  wayland-protocols,
 }: let
   # See package.nix. Keep in sync.
   rpathLibs =
@@ -80,6 +83,7 @@
       libadwaita
       gtk4
       glib
+      wayland
     ];
 in
   mkShell {
@@ -153,6 +157,9 @@ in
         libadwaita
         gtk4
         glib
+        wayland
+        wayland-scanner
+        wayland-protocols
       ];
 
     # This should be set onto the rpath of the ghostty binary if you want

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -10,10 +10,6 @@
   oniguruma,
   zlib,
   libGL,
-  libX11,
-  libXcursor,
-  libXi,
-  libXrandr,
   glib,
   gtk4,
   libadwaita,
@@ -26,7 +22,17 @@
   pandoc,
   revision ? "dirty",
   optimize ? "Debug",
-  x11 ? true,
+
+  enableX11 ? true,
+  libX11,
+  libXcursor,
+  libXi,
+  libXrandr,
+
+  enableWayland ? true,
+  wayland,
+  wayland-protocols,
+  wayland-scanner,
 }: let
   # The Zig hook has no way to select the release type without actual
   # overriding of the default flags.
@@ -114,14 +120,19 @@ in
     version = "1.0.2";
     inherit src;
 
-    nativeBuildInputs = [
-      git
-      ncurses
-      pandoc
-      pkg-config
-      zig_hook
-      wrapGAppsHook4
-    ];
+    nativeBuildInputs =
+      [
+        git
+        ncurses
+        pandoc
+        pkg-config
+        zig_hook
+        wrapGAppsHook4
+      ]
+      ++ lib.optionals enableWayland [
+        wayland-scanner
+        wayland-protocols
+      ];
 
     buildInputs =
       [
@@ -142,16 +153,19 @@ in
         glib
         gsettings-desktop-schemas
       ]
-      ++ lib.optionals x11 [
+      ++ lib.optionals enableX11 [
         libX11
         libXcursor
         libXi
         libXrandr
+      ]
+      ++ lib.optionals enableWayland [
+        wayland
       ];
 
     dontConfigure = true;
 
-    zigBuildFlags = "-Dversion-string=${finalAttrs.version}-${revision}-nix -Dgtk-x11=${lib.boolToString x11}";
+    zigBuildFlags = "-Dversion-string=${finalAttrs.version}-${revision}-nix -Dgtk-x11=${lib.boolToString enableX11} -Dgtk-wayland=${lib.boolToString enableWayland}";
 
     preBuild = ''
       rm -rf $ZIG_GLOBAL_CACHE_DIR

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -22,13 +22,11 @@
   pandoc,
   revision ? "dirty",
   optimize ? "Debug",
-
   enableX11 ? true,
   libX11,
   libXcursor,
   libXi,
   libXrandr,
-
   enableWayland ? true,
   wayland,
   wayland-protocols,

--- a/nix/zigCacheHash.nix
+++ b/nix/zigCacheHash.nix
@@ -1,3 +1,3 @@
 # This file is auto-generated! check build-support/check-zig-cache-hash.sh for
 # more details.
-"sha256-l+tZVL18qhm8BoBsQVbKfYmXQVObD0QMzQe6VBM/8Oo="
+"sha256-eUY6MS3//r6pA/w9b+E4+YqmqUbzpUfL3afJJlnMhLY="

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1953,7 +1953,7 @@ pub const CAPI = struct {
         _ = CGSSetWindowBackgroundBlurRadius(
             CGSDefaultConnectionForThread(),
             nswindow.msgSend(usize, objc.sel("windowNumber"), .{}),
-            @intCast(config.@"background-blur-radius"),
+            @intCast(config.@"background-blur-radius".cval()),
         );
     }
 

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -847,9 +847,11 @@ fn configChange(
     new_config: *const Config,
 ) void {
     switch (target) {
-        // We don't do anything for surface config change events. There
-        // is nothing to sync with regards to a surface today.
-        .surface => {},
+        .surface => |surface| {
+            if (surface.rt_surface.container.window()) |window| window.syncAppearance(new_config) catch |err| {
+                log.warn("error syncing appearance changes to window err={}", .{err});
+            };
+        },
 
         .app => {
             // We clone (to take ownership) and update our configuration.

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -403,7 +403,7 @@ pub fn syncAppearance(self: *Window, config: *const configpkg.Config) !void {
         const blurred = switch (config.@"background-blur-radius") {
             .false => false,
             .true => true,
-            .value => |v| v > 0,
+            .radius => |v| v > 0,
         };
         try wl.setBlur(blurred);
     }

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -119,11 +119,6 @@ pub fn init(self: *Window, app: *App) !void {
         c.gtk_widget_add_css_class(@ptrCast(gtk_window), "window-theme-ghostty");
     }
 
-    // Remove the window's background if any of the widgets need to be transparent
-    if (app.config.@"background-opacity" < 1) {
-        c.gtk_widget_remove_css_class(@ptrCast(window), "background");
-    }
-
     // Create our box which will hold our widgets in the main content area.
     const box = c.gtk_box_new(c.GTK_ORIENTATION_VERTICAL, 0);
 
@@ -398,6 +393,12 @@ pub fn init(self: *Window, app: *App) !void {
 /// TODO: Many of the initial style settings in `create` could possibly be made
 /// reactive by moving them here.
 pub fn syncAppearance(self: *Window, config: *const configpkg.Config) !void {
+    if (config.@"background-opacity" < 1) {
+        c.gtk_widget_remove_css_class(@ptrCast(self.window), "background");
+    } else {
+        c.gtk_widget_add_css_class(@ptrCast(self.window), "background");
+    }
+
     if (self.wayland) |*wl| {
         try wl.setBlur(config.@"background-blur-radius" > 0);
     }

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -400,7 +400,12 @@ pub fn syncAppearance(self: *Window, config: *const configpkg.Config) !void {
     }
 
     if (self.wayland) |*wl| {
-        try wl.setBlur(config.@"background-blur-radius" > 0);
+        const blurred = switch (config.@"background-blur-radius") {
+            .false => false,
+            .true => true,
+            .value => |v| v > 0,
+        };
+        try wl.setBlur(blurred);
     }
 }
 

--- a/src/apprt/gtk/c.zig
+++ b/src/apprt/gtk/c.zig
@@ -14,6 +14,9 @@ pub const c = @cImport({
         // Xkb for X11 state handling
         @cInclude("X11/XKBlib.h");
     }
+    if (build_options.wayland) {
+        @cInclude("gdk/wayland/gdkwayland.h");
+    }
 
     // generated header files
     @cInclude("ghostty_resources.h");

--- a/src/apprt/gtk/wayland.zig
+++ b/src/apprt/gtk/wayland.zig
@@ -1,0 +1,90 @@
+const std = @import("std");
+const c = @import("c.zig").c;
+const wayland = @import("wayland");
+const wl = wayland.client.wl;
+const build_options = @import("build_options");
+
+const log = std.log.scoped(.gtk_wayland);
+
+/// Wayland state that contains application-wide Wayland objects (e.g. wl_display).
+pub const AppState = struct {
+    display: *wl.Display,
+
+    pub fn init(display: ?*c.GdkDisplay) ?AppState {
+        if (comptime !build_options.wayland) return null;
+
+        // It should really never be null
+        const display_ = display orelse return null;
+
+        // Check if we're actually on Wayland
+        if (c.g_type_check_instance_is_a(
+            @ptrCast(@alignCast(display_)),
+            c.gdk_wayland_display_get_type(),
+        ) == 0)
+            return null;
+
+        const wl_display: *wl.Display = @ptrCast(c.gdk_wayland_display_get_wl_display(display_) orelse return null);
+
+        return .{
+            .display = wl_display,
+        };
+    }
+
+    pub fn register(self: *AppState) !void {
+        const registry = try self.display.getRegistry();
+
+        registry.setListener(*AppState, registryListener, self);
+        if (self.display.roundtrip() != .SUCCESS) return error.RoundtripFailed;
+
+        log.debug("app wayland init={}", .{self});
+    }
+};
+
+/// Wayland state that contains Wayland objects associated with a window (e.g. wl_surface).
+pub const SurfaceState = struct {
+    app_state: *AppState,
+    surface: *wl.Surface,
+
+    pub fn init(window: *c.GtkWindow, app_state: *AppState) ?SurfaceState {
+        if (comptime !build_options.wayland) return null;
+
+        const surface = c.gtk_native_get_surface(@ptrCast(window)) orelse return null;
+
+        // Check if we're actually on Wayland
+        if (c.g_type_check_instance_is_a(
+            @ptrCast(@alignCast(surface)),
+            c.gdk_wayland_surface_get_type(),
+        ) == 0)
+            return null;
+
+        const wl_surface: *wl.Surface = @ptrCast(c.gdk_wayland_surface_get_wl_surface(surface) orelse return null);
+
+        return .{
+            .app_state = app_state,
+            .surface = wl_surface,
+        };
+    }
+
+    pub fn deinit(self: *SurfaceState) void {
+    }
+};
+
+fn registryListener(registry: *wl.Registry, event: wl.Registry.Event, state: *AppState) void {
+    switch (event) {
+        .global => |global| {
+            log.debug("got global interface={s}", .{global.interface});
+        },
+        .global_remove => {},
+    }
+}
+
+fn bindInterface(comptime T: type, registry: *wl.Registry, global: anytype, version: u32) ?*T {
+    if (std.mem.orderZ(u8, global.interface, T.interface.name) == .eq) {
+        return registry.bind(global.name, T, version) catch |err| {
+            log.warn("encountered error={} while binding interface {s}", .{ err, global.interface });
+            return null;
+        };
+    } else {
+        return null;
+    }
+}

--- a/src/build_config.zig
+++ b/src/build_config.zig
@@ -23,6 +23,7 @@ pub const BuildConfig = struct {
     flatpak: bool = false,
     adwaita: bool = false,
     x11: bool = false,
+    wayland: bool = false,
     sentry: bool = true,
     app_runtime: apprt.Runtime = .none,
     renderer: rendererpkg.Impl = .opengl,
@@ -44,6 +45,7 @@ pub const BuildConfig = struct {
         step.addOption(bool, "flatpak", self.flatpak);
         step.addOption(bool, "adwaita", self.adwaita);
         step.addOption(bool, "x11", self.x11);
+        step.addOption(bool, "wayland", self.wayland);
         step.addOption(bool, "sentry", self.sentry);
         step.addOption(apprt.Runtime, "app_runtime", self.app_runtime);
         step.addOption(font.Backend, "font_backend", self.font_backend);

--- a/src/cli/args.zig
+++ b/src/cli/args.zig
@@ -533,7 +533,7 @@ fn parsePackedStruct(comptime T: type, v: []const u8) !T {
     return result;
 }
 
-fn parseBool(v: []const u8) !bool {
+pub fn parseBool(v: []const u8) !bool {
     const t = &[_][]const u8{ "1", "t", "T", "true" };
     const f = &[_][]const u8{ "0", "f", "F", "false" };
 

--- a/src/cli/version.zig
+++ b/src/cli/version.zig
@@ -68,6 +68,14 @@ pub fn run(alloc: Allocator) !u8 {
         } else {
             try stdout.print("  - libX11     : disabled\n", .{});
         }
+
+        // We say `libwayland` since it is possible to build Ghostty without
+        // Wayland integration but with Wayland-enabled GTK
+        if (comptime build_options.wayland) {
+            try stdout.print("  - libwayland : enabled\n", .{});
+        } else {
+            try stdout.print("  - libwayland : disabled\n", .{});
+        }
     }
     return 0;
 }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -5666,7 +5666,7 @@ pub const AutoUpdate = enum {
 pub const BackgroundBlur = union(enum) {
     false,
     true,
-    value: u8,
+    radius: u8,
 
     pub fn parseCLI(self: *BackgroundBlur, input: ?[]const u8) !void {
         const input_ = input orelse {
@@ -5675,19 +5675,21 @@ pub const BackgroundBlur = union(enum) {
             return;
         };
 
-        if (cli.args.parseBool(input_)) |b| {
-            self.* = if (b) .true else .false;
-        } else |_| {
-            const value = std.fmt.parseInt(u8, input_, 0) catch return error.InvalidValue;
-            self.* = .{ .value = value };
-        }
+        self.* = if (cli.args.parseBool(input_)) |b|
+            if (b) .true else .false
+        else |_|
+            .{ .radius = std.fmt.parseInt(
+                u8,
+                input_,
+                0,
+            ) catch return error.InvalidValue };
     }
 
     pub fn cval(self: BackgroundBlur) u8 {
         return switch (self) {
             .false => 0,
             .true => 20,
-            .value => |v| v,
+            .radius => |v| v,
         };
     }
 
@@ -5698,7 +5700,7 @@ pub const BackgroundBlur = union(enum) {
         switch (self) {
             .false => try formatter.formatEntry(bool, false),
             .true => try formatter.formatEntry(bool, true),
-            .value => |v| try formatter.formatEntry(u8, v),
+            .radius => |v| try formatter.formatEntry(u8, v),
         }
     }
 
@@ -5716,7 +5718,7 @@ pub const BackgroundBlur = union(enum) {
         try testing.expectEqual(.false, v);
 
         try v.parseCLI("42");
-        try testing.expectEqual(42, v.value);
+        try testing.expectEqual(42, v.radius);
 
         try testing.expectError(error.InvalidValue, v.parseCLI(""));
         try testing.expectError(error.InvalidValue, v.parseCLI("aaaa"));

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -583,11 +583,27 @@ palette: Palette = .{},
 @"background-opacity": f64 = 1.0,
 
 /// A positive value enables blurring of the background when background-opacity
-/// is less than 1. The value is the blur radius to apply. A value of 20
+/// is less than 1.
+///
+/// On macOS, the value is the blur radius to apply. A value of 20
 /// is reasonable for a good looking blur. Higher values will cause strange
 /// rendering issues as well as performance issues.
 ///
-/// This is only supported on macOS.
+/// On KDE Plasma under Wayland, the exact value is _ignored_ —  the reason is
+/// that KWin, the window compositor powering Plasma, only has one global blur
+/// setting and does not allow applications to have individual blur settings.
+///
+/// To configure KWin's global blur setting, open System Settings and go to
+/// "Apps & Windows" > "Window Management" > "Desktop Effects" and select the
+/// "Blur" plugin. If disabled, enable it by ticking the checkbox to the left.
+/// Then click on the "Configure" button and there will be two sliders that
+/// allow you to set background blur and noise strengths for all apps,
+/// including Ghostty.
+///
+/// All other Linux desktop environments are as of now unsupported. Users may
+/// need to set environment-specific settings and/or install third-party plugins
+/// in order to support background blur, as there isn't a unified interface for
+/// doing so.
 @"background-blur-radius": u8 = 0,
 
 /// The opacity level (opposite of transparency) of an unfocused split.

--- a/src/config/c_get.zig
+++ b/src/config/c_get.zig
@@ -204,7 +204,7 @@ test "c_get: background-blur" {
         try testing.expectEqual(20, cval);
     }
     {
-        c.@"background-blur-radius" = .{ .value = 42 };
+        c.@"background-blur-radius" = .{ .radius = 42 };
         var cval: u8 = undefined;
         try testing.expect(get(&c, .@"background-blur-radius", @ptrCast(&cval)));
         try testing.expectEqual(42, cval);

--- a/src/config/c_get.zig
+++ b/src/config/c_get.zig
@@ -84,6 +84,17 @@ fn getValue(ptr_raw: *anyopaque, value: anytype) bool {
                 ptr.* = @intCast(@as(Backing, @bitCast(value)));
             },
 
+            .Union => |_| {
+                if (@hasDecl(T, "cval")) {
+                    const PtrT = @typeInfo(@TypeOf(T.cval)).Fn.return_type.?;
+                    const ptr: *PtrT = @ptrCast(@alignCast(ptr_raw));
+                    ptr.* = value.cval();
+                    return true;
+                }
+
+                return false;
+            },
+
             else => return false,
         },
     }
@@ -170,5 +181,32 @@ test "c_get: optional" {
         try testing.expectEqual(255, cval.r);
         try testing.expectEqual(0, cval.g);
         try testing.expectEqual(0, cval.b);
+    }
+}
+
+test "c_get: background-blur" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var c = try Config.default(alloc);
+    defer c.deinit();
+
+    {
+        c.@"background-blur-radius" = .false;
+        var cval: u8 = undefined;
+        try testing.expect(get(&c, .@"background-blur-radius", @ptrCast(&cval)));
+        try testing.expectEqual(0, cval);
+    }
+    {
+        c.@"background-blur-radius" = .true;
+        var cval: u8 = undefined;
+        try testing.expect(get(&c, .@"background-blur-radius", @ptrCast(&cval)));
+        try testing.expectEqual(20, cval);
+    }
+    {
+        c.@"background-blur-radius" = .{ .value = 42 };
+        var cval: u8 = undefined;
+        try testing.expect(get(&c, .@"background-blur-radius", @ptrCast(&cval)));
+        try testing.expectEqual(42, cval);
     }
 }


### PR DESCRIPTION
Also establishes a foundation for Wayland support and fixes a minor bug (GTK windows remaining opaque when `background-opacity` is set to 1 on startup and later updated to less than 1 with a config reload)

Can't update the Zig cache hash myself since I'm currently in China and my proxy's broken for some reason :(

See also #4361, part of #4626