### PR TITLE
chore: fix typos

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -548,7 +548,7 @@ palette: Palette = .{},
 /// than 0.01 or greater than 10,000 will be clamped to the nearest valid
 /// value.
 ///
-/// A value of "1" (default) scrolls te default amount. A value of "2" scrolls
+/// A value of "1" (default) scrolls the default amount. A value of "2" scrolls
 /// double the default amount. A value of "0.5" scrolls half the default amount.
 /// Et cetera.
 @"mouse-scroll-multiplier": f64 = 1.0,
@@ -724,7 +724,7 @@ fullscreen: bool = false,
 /// This configuration can be reloaded at runtime. If it is set, the title
 /// will update for all windows. If it is unset, the next title change escape
 /// sequence will be honored but previous changes will not retroactively
-/// be set. This latter case may require you restart programs such as neovim
+/// be set. This latter case may require you to restart programs such as Neovim
 /// to get the new title.
 title: ?[:0]const u8 = null,
 


### PR DESCRIPTION
Fixes:

- te -> the
- require you restart -> require you to restart
- neovim -> Neovim