### PR TITLE
gtk: fix non-notebook separator colors

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -99,6 +99,7 @@ pub fn init(self: *Window, app: *App) !void {
     self.window = gtk_window;
     c.gtk_window_set_title(gtk_window, "Ghostty");
     c.gtk_window_set_default_size(gtk_window, 1000, 600);
+    c.gtk_widget_add_css_class(@ptrCast(gtk_window), "terminal-window");
 
     // GTK4 grabs F10 input by default to focus the menubar icon. We want
     // to disable this so that terminal programs can capture F10 (such as htop)

--- a/src/apprt/gtk/notebook_adw.zig
+++ b/src/apprt/gtk/notebook_adw.zig
@@ -23,6 +23,7 @@ pub const NotebookAdw = struct {
         assert(adwaita.enabled(&app.config));
 
         const tab_view: *c.AdwTabView = c.adw_tab_view_new().?;
+        c.gtk_widget_add_css_class(@ptrCast(@alignCast(tab_view)), "notebook");
 
         if (comptime adwaita.versionAtLeast(1, 2, 0) and adwaita.versionAtLeast(1, 2, 0)) {
             // Adwaita enables all of the shortcuts by default.

--- a/src/apprt/gtk/notebook_gtk.zig
+++ b/src/apprt/gtk/notebook_gtk.zig
@@ -20,6 +20,8 @@ pub const NotebookGtk = struct {
 
         // Create a notebook to hold our tabs.
         const notebook_widget: *c.GtkWidget = c.gtk_notebook_new();
+        c.gtk_widget_add_css_class(notebook_widget, "notebook");
+
         const gtk_notebook: *c.GtkNotebook = @ptrCast(notebook_widget);
         const notebook_tab_pos: c_uint = switch (app.config.@"gtk-tabs-location") {
             .top, .hidden => c.GTK_POS_TOP,

--- a/src/apprt/gtk/style-dark.css
+++ b/src/apprt/gtk/style-dark.css
@@ -2,7 +2,7 @@
   background-color: transparent;
 }
 
-separator {
+.terminal-window .notebook separator {
   background-color: rgba(36, 36, 36, 1);
   background-clip: content-box;
 }

--- a/src/apprt/gtk/style.css
+++ b/src/apprt/gtk/style.css
@@ -41,7 +41,7 @@ window.without-window-decoration-and-with-titlebar {
   background-color: transparent;
 }
 
-separator {
+.terminal-window .notebook separator {
   background-color: rgba(250, 250, 250, 1);
   background-clip: content-box;
 }


### PR DESCRIPTION
Before: 
![Screenshot From 2025-01-02 12-25-55](https://github.com/user-attachments/assets/62c3f15b-e717-499b-963f-c72ec8988f25)
After:
![Screenshot From 2025-01-02 12-28-02](https://github.com/user-attachments/assets/9e04b249-2414-4cae-8ea2-94c86bba5be6)
