### PR TITLE
surface: add timer-based scrolling during selection

### DIFF
--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -79,8 +79,12 @@ pub const Message = union(enum) {
         color: terminal.color.RGB,
     },
 
-    // Tell the surface to perform selection scrolling.
-    selection_scroll: bool,
+    /// Notifies the surface that a tick of the timer that is timing
+    /// out selection scrolling has occurred. "selection scrolling"
+    /// is when the user has clicked and dragged the mouse outside
+    /// the viewport of the terminal and the terminal is scrolling
+    /// the viewport to follow the mouse cursor.
+    selection_scroll_tick: bool,
 
     /// The terminal has reported a change in the working directory.
     pwd_change: WriteReq,

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -79,6 +79,9 @@ pub const Message = union(enum) {
         color: terminal.color.RGB,
     },
 
+    // Tell the surface to perform selection scrolling.
+    selection_scroll: bool,
+
     /// The terminal has reported a change in the working directory.
     pwd_change: WriteReq,
 

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -124,6 +124,9 @@ flags: packed struct {
     /// to true based on termios state.
     password_input: bool = false,
 
+    /// True if the terminal should perform selection scrolling.
+    selection_scroll: bool = false,
+
     /// Dirty flags for the renderer.
     dirty: Dirty = .{},
 } = .{},

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -37,6 +37,9 @@ const Coalesce = struct {
 /// if the running program hasn't already.
 const sync_reset_ms = 1000;
 
+/// The number of milliseconds between each movement during selection scrolling.
+const selection_scroll_ms = 15;
+
 /// Allocator used for some state
 alloc: std.mem.Allocator,
 
@@ -52,6 +55,11 @@ wakeup_c: xev.Completion = .{},
 /// This can be used to stop the thread on the next loop iteration.
 stop: xev.Async,
 stop_c: xev.Completion = .{},
+
+/// This is used for timer-based selection scrolling.
+scroll: xev.Timer,
+scroll_c: xev.Completion = .{},
+scroll_active: bool = false,
 
 /// This is used to coalesce resize events.
 coalesce: xev.Timer,
@@ -92,6 +100,10 @@ pub fn init(
     var stop_h = try xev.Async.init();
     errdefer stop_h.deinit();
 
+    // This timer is used for selection scrolling.
+    var scroll_h = try xev.Timer.init();
+    errdefer scroll_h.deinit();
+
     // This timer is used to coalesce resize events.
     var coalesce_h = try xev.Timer.init();
     errdefer coalesce_h.deinit();
@@ -104,6 +116,7 @@ pub fn init(
         .alloc = alloc,
         .loop = loop,
         .stop = stop_h,
+        .scroll = scroll_h,
         .coalesce = coalesce_h,
         .sync_reset = sync_reset_h,
     };
@@ -112,6 +125,7 @@ pub fn init(
 /// Clean up the thread. This is only safe to call once the thread
 /// completes executing; the caller must join prior to this.
 pub fn deinit(self: *Thread) void {
+    self.scroll.deinit();
     self.coalesce.deinit();
     self.sync_reset.deinit();
     self.stop.deinit();
@@ -308,6 +322,13 @@ fn drainMailbox(
             .size_report => |v| try io.sizeReport(data, v),
             .clear_screen => |v| try io.clearScreen(data, v.history),
             .scroll_viewport => |v| try io.scrollViewport(v),
+            .selection_scroll => |v| {
+                if (v) {
+                    self.startScrollTimer(cb);
+                } else {
+                    self.stopScrollTimer();
+                }
+            },
             .jump_to_prompt => |v| try io.jumpToPrompt(v),
             .start_synchronized_output => self.startSynchronizedOutput(cb),
             .linefeed_mode => |v| self.flags.linefeed_mode = v,
@@ -444,5 +465,50 @@ fn stopCallback(
 ) xev.CallbackAction {
     _ = r catch unreachable;
     cb_.?.self.loop.stop();
+    return .disarm;
+}
+
+fn startScrollTimer(self: *Thread, cb: *CallbackData) void {
+    self.scroll_active = true;
+
+    // Start the timer which loops
+    self.scroll.run(&self.loop, &self.scroll_c, selection_scroll_ms, CallbackData, cb, selectionScrollCallback);
+}
+
+fn stopScrollTimer(self: *Thread) void {
+    // This will stop the scrolling on the next iteration.
+    self.scroll_active = false;
+}
+
+fn selectionScrollCallback(
+    cb_: ?*CallbackData,
+    _: *xev.Loop,
+    _: *xev.Completion,
+    r: xev.Timer.RunError!void,
+) xev.CallbackAction {
+    _ = r catch |err| switch (err) {
+        error.Canceled => {},
+        else => {
+            log.warn("error during selection scroll callback err={}", .{err});
+            return .disarm;
+        },
+    };
+
+    const cb = cb_ orelse return .disarm;
+    const surface = cb.io.surface_mailbox.surface;
+    const pos = try surface.rt_surface.getCursorPos();
+    const delta: isize = if (pos.y < 0) -1 else 1;
+
+    try cb.io.terminal.scrollViewport(.{ .delta = delta });
+
+    // Notify the renderer that it should repaint immediately after scrolling
+    cb.io.renderer_wakeup.notify() catch {};
+
+    const self = cb.self;
+
+    if (self.scroll_active) {
+        self.scroll.run(&self.loop, &self.scroll_c, selection_scroll_ms, CallbackData, cb, selectionScrollCallback);
+    }
+
     return .disarm;
 }

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -495,16 +495,12 @@ fn selectionScrollCallback(
     };
 
     const cb = cb_ orelse return .disarm;
-    const surface = cb.io.surface_mailbox.surface;
-    const pos = try surface.rt_surface.getCursorPos();
-    const delta: isize = if (pos.y < 0) -1 else 1;
+    const self = cb.self;
 
-    try cb.io.terminal.scrollViewport(.{ .delta = delta });
+    _ = cb.io.surface_mailbox.push(.{ .selection_scroll = self.scroll_active }, .{ .instant = {} });
 
     // Notify the renderer that it should repaint immediately after scrolling
     cb.io.renderer_wakeup.notify() catch {};
-
-    const self = cb.self;
 
     if (self.scroll_active) {
         self.scroll.run(&self.loop, &self.scroll_c, selection_scroll_ms, CallbackData, cb, selectionScrollCallback);

--- a/src/termio/message.zig
+++ b/src/termio/message.zig
@@ -48,6 +48,9 @@ pub const Message = union(enum) {
     /// Scroll the viewport
     scroll_viewport: terminal.Terminal.ScrollViewport,
 
+    /// Selection scrolling
+    selection_scroll: bool,
+
     /// Jump forward/backward n prompts.
     jump_to_prompt: isize,
 

--- a/src/termio/message.zig
+++ b/src/termio/message.zig
@@ -48,7 +48,10 @@ pub const Message = union(enum) {
     /// Scroll the viewport
     scroll_viewport: terminal.Terminal.ScrollViewport,
 
-    /// Selection scrolling
+    /// Selection scrolling. If this is set to true then the termio
+    /// thread starts a timer that will trigger a `selection_scroll_tick`
+    /// message back to the surface. This ping/pong is because the
+    /// surface thread doesn't have access to an event loop from libghostty.
     selection_scroll: bool,
 
     /// Jump forward/backward n prompts.


### PR DESCRIPTION
Adds a timer to continuously scroll during selection when outside the viewport, 15ms per line.

Currently the scrolling behavior requires you to jiggle the mouse to continuously scroll upwards/downwards when selecting text.


### Before

https://github.com/user-attachments/assets/18e6c547-ed04-4098-88b4-35360f8c8c3c

### After

https://github.com/user-attachments/assets/46d5a6fc-b38e-46cf-b00f-52c8bc289f52
