### PR TITLE
gtk: Always read gtk-xft-dpi for font scaling

### DIFF
--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -794,10 +794,11 @@ pub fn getContentScale(self: *const Surface) !apprt.ContentScale {
     // can support fractional scaling.
     const gtk_scale: f32 = @floatFromInt(c.gtk_widget_get_scale_factor(@ptrCast(self.gl_area)));
 
-    // If we are on X11, we also have to scale using Xft.dpi
-    const xft_dpi_scale = if (!x11.is_current_display_server()) 1.0 else xft_scale: {
-        // Here we use GTK to retrieve gtk-xft-dpi, which is Xft.dpi multiplied
-        // by 1024. See https://docs.gtk.org/gtk4/property.Settings.gtk-xft-dpi.html
+    // Also scale using font-specific DPI, which is often exposed to the user
+    // via DE accessibility settings (see https://docs.gtk.org/gtk4/class.Settings.html).
+    const xft_dpi_scale = xft_scale: {
+        // gtk-xft-dpi is font DPI multiplied by 1024. See
+        // https://docs.gtk.org/gtk4/property.Settings.gtk-xft-dpi.html
         const settings = c.gtk_settings_get_default();
 
         var value: c.GValue = std.mem.zeroes(c.GValue);
@@ -806,10 +807,9 @@ pub fn getContentScale(self: *const Surface) !apprt.ContentScale {
         c.g_object_get_property(@ptrCast(@alignCast(settings)), "gtk-xft-dpi", &value);
         const gtk_xft_dpi = c.g_value_get_int(&value);
 
-        // As noted above Xft.dpi is multiplied by 1024, so we divide by 1024,
-        // then divide by the default value of Xft.dpi (96) to derive a scale.
-        // Note that gtk-xft-dpi can be fractional, so we use floating point
-        // math here.
+        // As noted above gtk-xft-dpi is multiplied by 1024, so we divide by
+        // 1024, then divide by the default value (96) to derive a scale. Note
+        // gtk-xft-dpi can be fractional, so we use floating point math here.
         const xft_dpi: f32 = @as(f32, @floatFromInt(gtk_xft_dpi)) / 1024;
         break :xft_scale xft_dpi / 96;
     };

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -177,6 +177,10 @@ const c = @cImport({
 /// depending on your `window-inherit-font-size` setting. If that setting is
 /// true, only the first window will be affected by this change since all
 /// subsequent windows will inherit the font size of the previous window.
+///
+/// On Linux with GTK, font size is scaled according to both display-wide and
+/// text-specific scaling factors, which are often managed by your desktop
+/// environment (e.g. the GNOME display scale and large text settings).
 @"font-size": f32 = switch (builtin.os.tag) {
     // On macOS we default a little bigger since this tends to look better. This
     // is purely subjective but this is easy to modify.


### PR DESCRIPTION
Commit ad503b8c4fa7 ("linux: consider Xft.dpi to scale the content") introduced reading gtk-xft-dpi when the X11 build option is enabled.

While the name suggests it is X11-specific (perhaps it was at one point), gtk-xft-dpi is a GTK setting that can be modified regardless of GDK backend. GNOME’s Large Text accessibility setting ultimately modifies it. Outside of desktop environments, it can be set via GTK configuration files.

Remove the conditional gating the code on X11, since none of the code is actually X11-specific. While we’re here, document scaling behaviors under Config.font-size.

Fixes: ad503b8c4fa7 ("linux: consider Xft.dpi to scale the content")
Fixes: https://github.com/ghostty-org/ghostty/issues/4338
Link: https://docs.gtk.org/gtk4/class.Settings.html
Link: https://docs.gtk.org/gtk4/property.Settings.gtk-xft-dpi.html