### PR TITLE
macos: make auto-update optional

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -486,15 +486,16 @@ class AppDelegate: NSObject,
 
         // Sync our auto-update settings. If SUEnableAutomaticChecks (in our Info.plist) is
         // explicitly false (NO), auto-updates are disabled. Otherwise, we use the behavior
-        // defined by our "auto-update" configuration.
-        if Bundle.main.infoDictionary?["SUEnableAutomaticChecks"] as? Bool != false {
-            updaterController.updater.automaticallyChecksForUpdates =
-                config.autoUpdate == .check || config.autoUpdate == .download
-            updaterController.updater.automaticallyDownloadsUpdates =
-                config.autoUpdate == .download
-        } else {
+        // defined by our "auto-update" configuration (if set) or fall back to Sparkle
+        // user-based defaults.
+        if Bundle.main.infoDictionary?["SUEnableAutomaticChecks"] as? Bool == false {
             updaterController.updater.automaticallyChecksForUpdates = false
             updaterController.updater.automaticallyDownloadsUpdates = false
+        } else if let autoUpdate = config.autoUpdate {
+            updaterController.updater.automaticallyChecksForUpdates =
+                autoUpdate == .check || autoUpdate == .download
+            updaterController.updater.automaticallyDownloadsUpdates =
+                autoUpdate == .download
         }
 
         // Config could change keybindings, so update everything that depends on that

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -437,15 +437,14 @@ extension Ghostty {
             return v;
         }
 
-        var autoUpdate: AutoUpdate {
-            let defaultValue = AutoUpdate.check
-            guard let config = self.config else { return defaultValue }
+        var autoUpdate: AutoUpdate? {
+            guard let config = self.config else { return nil }
             var v: UnsafePointer<Int8>? = nil
             let key = "auto-update"
-            guard ghostty_config_get(config, &v, key, UInt(key.count)) else { return defaultValue }
-            guard let ptr = v else { return defaultValue }
+            guard ghostty_config_get(config, &v, key, UInt(key.count)) else { return nil }
+            guard let ptr = v else { return nil }
             let str = String(cString: ptr)
-            return AutoUpdate(rawValue: str) ?? defaultValue
+            return AutoUpdate(rawValue: str)
         }
 
         var autoUpdateChannel: AutoUpdateChannel {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1967,10 +1967,11 @@ term: []const u8 = "xterm-ghostty",
 ///  * `download` - Check for updates, automatically download the update,
 ///    notify the user, but do not automatically install the update.
 ///
-/// The default value is `check`.
+/// If unset, we defer to Sparkle's default behavior, which respects the
+/// preference stored in the standard user defaults (`defaults(1)`).
 ///
 /// Changing this value at runtime works after a small delay.
-@"auto-update": AutoUpdate = .check,
+@"auto-update": ?AutoUpdate = null,
 
 /// The release channel to use for auto-updates.
 ///


### PR DESCRIPTION
When unset, we use Sparkle's default behavior, which is based on the user's preference stored in the standard user defaults.

The rest of the previous behavior is preserved:
- When SUEnableAutomaticChecks is explicitly false, auto-updates are disabled.
- When 'auto-update' is set, use its value to set Sparkle's auto-update behavior.

Fixes #4433