### PR TITLE
feat: parse ConEmu OSC9;2

### DIFF
--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -1605,7 +1605,7 @@ pub fn Stream(comptime Handler: type) type {
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
 
-                .progress => {
+                .progress, .show_message_box => {
                     log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
             }


### PR DESCRIPTION
This PR implements support for the [ConEmu OSC9;2 escape sequence](https://conemu.github.io/en/AnsiEscapeCodes.html#OSC_Operating_system_commands).

| Sequence | Description |
| - | - |
ESC ] 9 ; 2 ; ”txt“ ST | Show GUI MessageBox ( txt ) for any purposes.

#3125 