### PR TITLE
Correct typos and update typos.toml

### DIFF
--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -146,7 +146,7 @@ image_bg_end: u32 = 0,
 image_text_end: u32 = 0,
 image_virtual: bool = false,
 
-/// Defererred OpenGL operation to update the screen size.
+/// Deferred OpenGL operation to update the screen size.
 const SetScreenSize = struct {
     size: renderer.Size,
 

--- a/typos.toml
+++ b/typos.toml
@@ -42,6 +42,7 @@ wdth = "wdth"
 Strat = "Strat"
 grey = "gray"
 greyscale = "grayscale"
+DECID = "DECID"
 
 [type.swift.extend-words]
 inout = "inout"


### PR DESCRIPTION
I noticed that the version of `typos` in nixpkgs is still at [1.28.4](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ty/typos/package.nix#L12) (as of [2 weeks ago](https://github.com/crate-ci/typos/releases/tag/v1.28.4)), while the latest version is [1.29.3](https://github.com/crate-ci/typos/releases/tag/v1.29.3). For tools like this where the dictionary is constantly being updated, we might want to consider using `uses: crate-ci/typos@master` directly in our CI workflow instead of the version from nixpkgs.

I understand the current setup using `devShell.nix` helps maintain consistency between local development and CI environments. However, I found some typos that can be detected by the new version of typos, but were missed by the old version of typos on nixpkgs.

<img width="690" alt="image" src="https://github.com/user-attachments/assets/d9e7f45a-8980-4acd-a093-a1e45521a28d" />

## Proposal:

1. Use `crate-ci/typos` action in CI while keeping nixpkgs version for local development (catching more typos in CI but introducing some inconsistency)
