### PR TITLE
apprt/gtk: continue cleanup of window-decoration code

### DIFF
--- a/src/apprt/gtk/style.css
+++ b/src/apprt/gtk/style.css
@@ -33,7 +33,11 @@ label.size-overlay.hidden {
   opacity: 0;
 }
 
-window.without-window-decoration-and-with-titlebar {
+window.ssd.no-border-radius {
+  /* Without clearing the border radius, at least on Mutter with
+   * gtk-titlebar=true and gtk-adwaita=false, there is some window artifacting
+   * that this will mitigate.
+   */
   border-radius: 0 0;
 }
 


### PR DESCRIPTION
Remove all window corner artifacting. Now we also respond to changes when the window becomes decorated or not.