### PR TITLE
Fix: Correct version strings for simdutf and cimgui to match vendored files

### DIFF
--- a/pkg/cimgui/build.zig.zon
+++ b/pkg/cimgui/build.zig.zon
@@ -1,10 +1,10 @@
 .{
     .name = "cimgui",
-    .version = "1.89.9",
+    .version = "1.90.6", // -docking branch
     .paths = .{""},
     .dependencies = .{
         // This should be kept in sync with the submodule in the cimgui source
-        // code to be safe that they're compatible.
+        // code in ./vendor/ to be safe that they're compatible.
         .imgui = .{
             .url = "https://github.com/ocornut/imgui/archive/e391fe2e66eb1c96b1624ae8444dc64c23146ef4.tar.gz",
             .hash = "1220bc6b9daceaf7c8c60f3c3998058045ba0c5c5f48ae255ff97776d9cd8bfc6402",

--- a/pkg/simdutf/build.zig.zon
+++ b/pkg/simdutf/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "simdutf",
-    .version = "4.0.9",
+    .version = "5.2.8",
     .paths = .{""},
     .dependencies = .{
         .apple_sdk = .{ .path = "../apple-sdk" },


### PR DESCRIPTION
The cimgui version listed does not match the upstream commit or the vendored cimgui files 
Checking the upstream `git log` the commit corresponds to `commit e391fe2e66eb1c96b1624ae8444dc64c23146ef4 (tag: v1.90.6-docking)` however the `build.zig.zon` is outdated.
The vendored cimgui files also contain the header
```cpp
// This file is automatically generated by generator.lua from
// https://github.com/cimgui/cimgui based on imgui.h file version "1.90.6" 19060
// from Dear ImGui https://github.com/ocornut/imgui with imgui_internal.h api
// docking branch
```

I wasn't too clear with what the comment meant:
```
// This should be kept in sync with the submodule in the cimgui source
// code to be safe that they're compatible.
```
and assumed it was referring to the vendored cimgui files, added a comment pointing out where to find the cimgui source mentioned.