### PR TITLE
Feat: Add ability to toggle zsh-integration title change

### DIFF
--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -196,10 +196,30 @@ _ghostty_deferred_init() {
 
     if [[ "$GHOSTTY_SHELL_INTEGRATION_NO_TITLE" != 1 ]]; then
       # Enable terminal title changes.
+
+      # Heredoc assignment to variable without cat from https://stackoverflow.com/a/1655389
+
+      read -r -d '' _ghostty_precmd_title_epilogue <<'END'
+          if [[ "$GHOSTTY_SHELL_INTEGRATION_TOGGLE_TITLE_OFF" != 1 ]]; then
+              builtin print -rnu $_ghostty_fd $'\e]2;'"${(%):-%(4~|…/%3~|%~)}"$'\a'
+          fi
+END
+
+      read -r -d '' _ghostty_preexec_title_epilogue <<'END'
+          if [[ "$GHOSTTY_SHELL_INTEGRATION_TOGGLE_TITLE_OFF" != 1 ]]; then
+              builtin print -rnu $_ghostty_fd $'\e]2;'"${(V)1}"$'\a'
+          fi
+END
+
       functions[_ghostty_precmd]+="
-          builtin print -rnu $_ghostty_fd \$'\\e]2;'\"\${(%):-%(4~|…/%3~|%~)}\"\$'\\a'"
+        ${_ghostty_precmd_title_epilogue}"
+
       functions[_ghostty_preexec]+="
-          builtin print -rnu $_ghostty_fd \$'\\e]2;'\"\${(V)1}\"\$'\\a'"
+        ${_ghostty_preexec_title_epilogue}"
+
+      unset _ghostty_precmd_title_epilogue
+      unset _ghostty_preexec_title_epilogue
+
     fi
 
     if [[ "$GHOSTTY_SHELL_INTEGRATION_NO_CURSOR" != 1 ]]; then


### PR DESCRIPTION
When changing the current surface's title via ANSI escape escape sequences (`\e]0;My Custom Title Here\a` or `\e]2;My Custom Title Here\a`), the zsh shell integration's `_ghostty_precmd` and `_ghostty_preexec` functions automatically overwrite it (I spent the better part of today tearing my head out and searching through the code thinking this was a bug in the terminal itself). This functionality can be disabled, however it must be disabled _before_ the shell finishes loading and cannot be re-enabled (or disabled) at a later point.

To work around this, a new environment variable has been added (only to the zsh integration for now): `GHOSTTY_SHELL_INTEGRATION_TOGGLE_TITLE_OFF`. This is settable by scripts and commands to disable the zsh integration's overwriting of the title and can be unset to re-enable the functionality.

To take advantage of this, I have the following functions enabled in my .zshrc:

```zsh
function unset_title() {
    echo -ne "\x1b]0;\x07"
    if [[ $TERM == "xterm-ghostty" ]]; then
        unset GHOSTTY_SHELL_INTEGRATION_TOGGLE_TITLE_OFF
    fi
}

function set_title() {
    if [ $# -eq 0 -o ${#1} -eq 0 ]; then
        # If the title isn't provided or is an empty string, reset the title to factory settings
        unset_title
    else
        echo -ne "\x1b]0;${1}\x07"
        if [[ $TERM == "xterm-ghostty" ]]; then
            GHOSTTY_SHELL_INTEGRATION_TOGGLE_TITLE_OFF=1
        fi
    fi
}
```

After taking a cursory look at the bash I don't believe this same method will be possible there (as it works by setting $PS0 and $PS1 to send the escape sequences).

For elvish I don't know enough to add the desired functionality.

If someone wants to add the code for the other supported shells, or suggest how I might go about fixing them I would be more than happy to include / create it.