### PR TITLE
don't build fontconfig when system integration is enabled

### DIFF
--- a/pkg/fontconfig/build.zig
+++ b/pkg/fontconfig/build.zig
@@ -13,7 +13,56 @@ pub fn build(b: *std.Build) !void {
     ) orelse (target.result.os.tag != .windows);
     const freetype_enabled = b.option(bool, "enable-freetype", "Build freetype") orelse true;
 
-    const module = b.addModule("fontconfig", .{ .root_source_file = b.path("main.zig") });
+    const module = b.addModule("fontconfig", .{
+        .root_source_file = b.path("main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // For dynamic linking, we prefer dynamic linking and to search by
+    // mode first. Mode first will search all paths for a dynamic library
+    // before falling back to static.
+    const dynamic_link_opts: std.Build.Module.LinkSystemLibraryOptions = .{
+        .preferred_link_mode = .dynamic,
+        .search_strategy = .mode_first,
+    };
+
+    const test_exe = b.addTest(.{
+        .name = "test",
+        .root_source_file = b.path("main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const tests_run = b.addRunArtifact(test_exe);
+    const test_step = b.step("test", "Run tests");
+    test_step.dependOn(&tests_run.step);
+
+    if (b.systemIntegrationOption("fontconfig", .{})) {
+        module.linkSystemLibrary("fontconfig", dynamic_link_opts);
+        test_exe.linkSystemLibrary2("fontconfig", dynamic_link_opts);
+    } else {
+        const lib = try buildLib(b, module, .{
+            .target = target,
+            .optimize = optimize,
+
+            .libxml2_enabled = libxml2_enabled,
+            .libxml2_iconv_enabled = libxml2_iconv_enabled,
+            .freetype_enabled = freetype_enabled,
+
+            .dynamic_link_opts = dynamic_link_opts,
+        });
+
+        test_exe.linkLibrary(lib);
+    }
+}
+
+pub fn buildLib(b: *std.Build, module: *std.Build.Module, options: anytype) !*std.Build.Step.Compile {
+    const target = options.target;
+    const optimize = options.optimize;
+
+    const libxml2_enabled = options.libxml2_enabled;
+    const libxml2_iconv_enabled = options.libxml2_iconv_enabled;
+    const freetype_enabled = options.freetype_enabled;
 
     const upstream = b.dependency("fontconfig", .{});
     const lib = b.addStaticLibrary(.{
@@ -131,13 +180,7 @@ pub fn build(b: *std.Build) !void {
         }
     }
 
-    // For dynamic linking, we prefer dynamic linking and to search by
-    // mode first. Mode first will search all paths for a dynamic library
-    // before falling back to static.
-    const dynamic_link_opts: std.Build.Module.LinkSystemLibraryOptions = .{
-        .preferred_link_mode = .dynamic,
-        .search_strategy = .mode_first,
-    };
+    const dynamic_link_opts = options.dynamic_link_opts;
 
     // Freetype2
     _ = b.systemIntegrationOption("freetype", .{}); // So it shows up in help
@@ -194,16 +237,7 @@ pub fn build(b: *std.Build) !void {
 
     b.installArtifact(lib);
 
-    const test_exe = b.addTest(.{
-        .name = "test",
-        .root_source_file = b.path("main.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
-    test_exe.linkLibrary(lib);
-    const tests_run = b.addRunArtifact(test_exe);
-    const test_step = b.step("test", "Run tests");
-    test_step.dependOn(&tests_run.step);
+    return lib;
 }
 
 const headers = &.{


### PR DESCRIPTION
same as #4205 but for fontconfig

it follows the same pattern with one addition:
the module needs a known target to be able to link a system library
I don't think this will affect anything 

ghostty and all tests appear to run on my system both with and without system integration