### PR TITLE
Docs: update goto_split documentation

### DIFF
--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -341,7 +341,7 @@ pub const Action = union(enum) {
     /// the direction given. For example `new_split:up`. Valid values are left, right, up, down and auto.
     new_split: SplitDirection,
 
-    /// Focus on a split in a given direction. For example `goto_split:top`. Valid values are top, bottom, left, right, previous and next.
+    /// Focus on a split in a given direction. For example `goto_split:up`. Valid values are left, right, up, down, previous and next.
     goto_split: SplitFocusDirection,
 
     /// zoom/unzoom the current split.


### PR DESCRIPTION
In #4388, documentation was added for goto_split but in #3427 this documentation was made outdated but not updated. This makes the documentation up to date and brings the ordering in line with new_split