### PR TITLE
don't build freetype2 when system integration is enabled

### DIFF
--- a/pkg/fontconfig/build.zig
+++ b/pkg/fontconfig/build.zig
@@ -56,7 +56,7 @@ pub fn build(b: *std.Build) !void {
     }
 }
 
-pub fn buildLib(b: *std.Build, module: *std.Build.Module, options: anytype) !*std.Build.Step.Compile {
+fn buildLib(b: *std.Build, module: *std.Build.Module, options: anytype) !*std.Build.Step.Compile {
     const target = options.target;
     const optimize = options.optimize;
 

--- a/pkg/fontconfig/build.zig
+++ b/pkg/fontconfig/build.zig
@@ -186,7 +186,7 @@ pub fn buildLib(b: *std.Build, module: *std.Build.Module, options: anytype) !*st
     _ = b.systemIntegrationOption("freetype", .{}); // So it shows up in help
     if (freetype_enabled) {
         if (b.systemIntegrationOption("freetype", .{})) {
-            lib.linkSystemLibrary2("freetype", dynamic_link_opts);
+            lib.linkSystemLibrary2("freetype2", dynamic_link_opts);
         } else {
             const freetype_dep = b.dependency(
                 "freetype",

--- a/pkg/harfbuzz/build.zig
+++ b/pkg/harfbuzz/build.zig
@@ -71,7 +71,7 @@ pub fn build(b: *std.Build) !void {
     }
 }
 
-pub fn buildLib(b: *std.Build, module: *std.Build.Module, options: anytype) !*std.Build.Step.Compile {
+fn buildLib(b: *std.Build, module: *std.Build.Module, options: anytype) !*std.Build.Step.Compile {
     const target = options.target;
     const optimize = options.optimize;
 

--- a/pkg/harfbuzz/build.zig
+++ b/pkg/harfbuzz/build.zig
@@ -43,7 +43,11 @@ pub fn build(b: *std.Build) !void {
     {
         var it = module.import_table.iterator();
         while (it.next()) |entry| test_exe.root_module.addImport(entry.key_ptr.*, entry.value_ptr.*);
-        test_exe.linkLibrary(freetype.artifact("freetype"));
+        if (b.systemIntegrationOption("freetype", .{})) {
+            test_exe.linkSystemLibrary2("freetype2", dynamic_link_opts);
+        } else {
+            test_exe.linkLibrary(freetype.artifact("freetype"));
+        }
         const tests_run = b.addRunArtifact(test_exe);
         const test_step = b.step("test", "Run tests");
         test_step.dependOn(&tests_run.step);

--- a/pkg/oniguruma/build.zig
+++ b/pkg/oniguruma/build.zig
@@ -53,7 +53,7 @@ pub fn build(b: *std.Build) !void {
     }
 }
 
-pub fn buildLib(b: *std.Build, module: *std.Build.Module, options: anytype) !*std.Build.Step.Compile {
+fn buildLib(b: *std.Build, module: *std.Build.Module, options: anytype) !*std.Build.Step.Compile {
     const target = options.target;
     const optimize = options.optimize;
 


### PR DESCRIPTION
yet another follow up to #4534

some notes:
- different parts of the build system link against freetype2 or freetype with freetype2 being the name for the pkg-config file. Because of the include path in freetype-zig.h the pkg-config is needed otherwise it would be unable to find the headers. The change isn't technically needed for the harfbuzz and fontconfig modules however I think its best to keep them all consistent since otherwise it might cause build errors in non standard setups
- looking back, I initially modelled buildLib after the build function and kept the pub, none of them need to be public so I've gone ahead and removed all of that

test logic was kept just as they were before with a setup exact like it was done for oniguruma

the main program and the testsall seem to work just fine both with and without system integration