### PR TITLE
don't error when gtk4 could not be found via pkg-config

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -143,7 +143,7 @@ pub fn build(b: *std.Build) !void {
                     break :x11 false;
                 }
                 std.log.warn("pkg-config: {s} with code {d}", .{ @tagName(term), code });
-                return error.Unexpected;
+                break :x11 false;
             },
             inline else => |code| {
                 std.log.warn("pkg-config: {s} with code {d}", .{ @tagName(term), code });


### PR DESCRIPTION
running `zig build --help` was crashing for some people, I narrowed it down to gtk4 not being installed however that shouldn't make the help message nor should it block glfw builds