### PR TITLE
fix typo: CSI header

### DIFF
--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -230,7 +230,7 @@ pub const Action = union(enum) {
     unbind: void,
 
     /// Send a CSI sequence. The value should be the CSI sequence without the
-    /// CSI header (`ESC ]` or `\x1b]`).
+    /// CSI header (`ESC [` or `\x1b[`).
     csi: []const u8,
 
     /// Send an `ESC` sequence.


### PR DESCRIPTION
Fixes a typo in the keybindings documentation comments.
Originally opened on the website repo at https://github.com/ghostty-org/website/pull/259 