### PR TITLE
fix: `config-file` diagnostics when theme is set

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3207,6 +3207,11 @@ fn loadTheme(self: *Config, theme: Theme) !void {
     var new_config = try self.cloneEmpty(alloc_gpa);
     errdefer new_config.deinit();
 
+    // Clone our diagnostics if any.
+    if (!self._diagnostics.empty()) {
+        new_config._diagnostics = try self._diagnostics.clone(alloc_gpa);
+    }
+
     // Load our theme
     var buf_reader = std.io.bufferedReader(file.reader());
     const reader = buf_reader.reader();


### PR DESCRIPTION
Fix a bug when diagnostics are lost when a theme is loaded.

### The issue
When a them is loaded, it initializes a new empty `Config`, apply the theme, then replays the user configuration on top of it. This behaviour is explained in detail here:

https://github.com/ghostty-org/ghostty/blob/8f5f432ab61fa73b77cb61239c0cff34250f77bb/src/config/Config.zig#L3192-L3205

The issue is because the `loadTheme` function overwrites the existing `Config` with its internal state, including diagnostics. As a result, previously generated diagnostics from [LoadRecursiveFiles](https://github.com/ghostty-org/ghostty/blob/8f5f432ab61fa73b77cb61239c0cff34250f77bb/src/config/Config.zig#L2991) are lost.

NOTE: This is one solution among others and may not be the most optimal approach.

Fixes #4509