### PR TITLE
gtk: add `split-separator-color` config

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -996,6 +996,21 @@ fn loadRuntimeCss(
         unfocused_fill.b,
     });
 
+    if (config.@"split-divider-color") |color| {
+        try writer.print(
+            \\.terminal-window .notebook separator {{
+            \\  color: rgb({[r]d},{[g]d},{[b]d});
+            \\  background: rgb({[r]d},{[g]d},{[b]d});
+            \\}}
+        ,
+            .{
+                .r = color.r,
+                .g = color.g,
+                .b = color.b,
+            },
+        );
+    }
+
     if (version.atLeast(4, 16, 0)) {
         switch (window_theme) {
             .ghostty => try writer.print(

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -610,6 +610,10 @@ palette: Palette = .{},
 /// Specified as either hex (`#RRGGBB` or `RRGGBB`) or a named X11 color.
 @"unfocused-split-fill": ?Color = null,
 
+/// The color of the divider between splits. If unset the default system color
+/// will be used. GTK only.
+@"split-divider-color": ?Color = null,
+
 /// The command to run, usually a shell. If this is not an absolute path, it'll
 /// be looked up in the `PATH`. If this is not set, a default will be looked up
 /// from your system. The rules for the default lookup are:


### PR DESCRIPTION
Fixes #4326

![image](https://github.com/user-attachments/assets/eaf5280b-be08-4927-9536-19b96d206ad6)
