### PR TITLE
Implement configuration option split-divider-color for macOS

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -375,8 +375,6 @@ extension Ghostty {
             )
         }
 
-        // This isn't actually a configurable value currently but it could be done day.
-        // We put it here because it is a color that changes depending on the configuration.
         var splitDividerColor: Color {
             let backgroundColor = OSColor(backgroundColor)
             let isLightBackground = backgroundColor.isLightColor

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -381,7 +381,20 @@ extension Ghostty {
             let backgroundColor = OSColor(backgroundColor)
             let isLightBackground = backgroundColor.isLightColor
             let newColor = isLightBackground ? backgroundColor.darken(by: 0.08) : backgroundColor.darken(by: 0.4)
-            return Color(newColor)
+
+            guard let config = self.config else { return Color(newColor) }
+
+            var color: ghostty_config_color_s = .init();
+            let key = "split-divider-color"
+            if (!ghostty_config_get(config, &color, key, UInt(key.count))) {
+                return Color(newColor)
+            }
+
+            return .init(
+                red: Double(color.r) / 255,
+                green: Double(color.g) / 255,
+                blue: Double(color.b) / 255
+            )
         }
 
         #if canImport(AppKit)

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -610,8 +610,8 @@ palette: Palette = .{},
 /// Specified as either hex (`#RRGGBB` or `RRGGBB`) or a named X11 color.
 @"unfocused-split-fill": ?Color = null,
 
-/// The color of the divider between splits. If unset the default system color
-/// will be used. GTK only.
+/// The color of the split divider. If this is not set, a default will be chosen.
+/// Specified as either hex (`#RRGGBB` or `RRGGBB`) or a named X11 color.
 @"split-divider-color": ?Color = null,
 
 /// The command to run, usually a shell. If this is not an absolute path, it'll


### PR DESCRIPTION
Addresses #4326 for macOS only, should be easy to combine PR #4593 doing the same for GTK