### PR TITLE
Fix leaked zombie processes when closing surfaces

### DIFF
--- a/src/Command.zig
+++ b/src/Command.zig
@@ -306,6 +306,7 @@ fn setupFd(src: File.Handle, target: i32) !void {
 }
 
 /// Wait for the command to exit and return information about how it exited.
+/// "block" is currently not respected on Windows.
 pub fn wait(self: Command, block: bool) i32 {
     if (comptime builtin.os.tag == .windows) {
         // Block until the process exits. This returns immediately if the

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -22,7 +22,6 @@ const inputpkg = @import("../input.zig");
 const terminal = @import("../terminal/main.zig");
 const internal_os = @import("../os/main.zig");
 const cli = @import("../cli.zig");
-const Command = @import("../Command.zig");
 
 const conditional = @import("conditional.zig");
 const Conditional = conditional.Conditional;

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1297,13 +1297,10 @@ const Subprocess = struct {
                             },
                         }
 
-                        // See Command.zig wait for why we specify WNOHANG.
-                        // The gist is that it lets us detect when children
-                        // are still alive without blocking so that we can
-                        // kill them again.
-                        const res = posix.waitpid(pid, std.c.W.NOHANG);
-                        log.debug("waitpid result={}", .{res.pid});
-                        if (res.pid != 0) break;
+                        const ret = command.wait(false);
+                        log.debug("wait result={}", .{ret});
+                        // 0 means the process is still running
+                        if (ret != 0) break;
                         std.time.sleep(10 * std.time.ns_per_ms);
                     }
                 },

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1203,6 +1203,10 @@ const Subprocess = struct {
     /// Called to notify that we exited externally so we can unset our
     /// running state.
     pub fn externalExit(self: *Subprocess) void {
+        if (self.command) |*cmd| {
+            _ = cmd.wait(false) catch |err|
+                log.err("error waiting on subprocess: {}", .{err});
+        }
         self.command = null;
     }
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1200,8 +1200,8 @@ const Subprocess = struct {
         try self.pty.?.childPreExec();
     }
 
-    /// Called to notify that we exited externally so we can unset our
-    /// running state.
+    /// Called to notify that we exited externally so we can call wait on the
+    /// process and unset our running state.
     pub fn externalExit(self: *Subprocess) void {
         if (self.command) |*cmd| {
             _ = cmd.wait(false) catch |err|

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1204,8 +1204,8 @@ const Subprocess = struct {
     /// process and unset our running state.
     pub fn externalExit(self: *Subprocess) void {
         if (self.command) |*cmd| {
-            _ = cmd.wait(false) catch |err|
-                log.err("error waiting on subprocess: {}", .{err});
+            const ret = cmd.wait(false);
+            log.debug("wait result={}", .{ret});
         }
         self.command = null;
     }

--- a/src/termio/Options.zig
+++ b/src/termio/Options.zig
@@ -4,7 +4,6 @@ const builtin = @import("builtin");
 const xev = @import("xev");
 const apprt = @import("../apprt.zig");
 const renderer = @import("../renderer.zig");
-const Command = @import("../Command.zig");
 const Config = @import("../config.zig").Config;
 const termio = @import("../termio.zig");
 

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -13,7 +13,6 @@ const ArenaAllocator = std.heap.ArenaAllocator;
 const EnvMap = std.process.EnvMap;
 const posix = std.posix;
 const termio = @import("../termio.zig");
-const Command = @import("../Command.zig");
 const Pty = @import("../pty.zig").Pty;
 const StreamHandler = @import("stream_handler.zig").StreamHandler;
 const terminal = @import("../terminal/main.zig");

--- a/src/termio/backend.zig
+++ b/src/termio/backend.zig
@@ -11,7 +11,6 @@ const renderer = @import("../renderer.zig");
 const shell_integration = @import("shell_integration.zig");
 const terminal = @import("../terminal/main.zig");
 const termio = @import("../termio.zig");
-const Command = @import("../Command.zig");
 const Pty = @import("../pty.zig").Pty;
 
 // The preallocation size for the write request pool. This should be big


### PR DESCRIPTION
Issue description can be found at #4554, which this fixes.

I'm not thrilled about this solution, but it's the pragmatic option. I reached my wits' end trying to figure out why things weren't quite the same on linux, and we'd need to revisit that if we want to solve this in a different way.

Some notes:
- we were failing to call `waitpid` on subprocesses that exit independently of ghostty (i.e. they terminate, rather than us terminating them by e.g. closing a tab)
- `std.posix.waitpid` [panics](https://github.com/ziglang/zig/blob/0.13.0/lib/std/posix.zig#L4254) if `waitpid` returned `ECHILD`, which happens if the process has already been reaped when we call `waitpid`
- on linux, something mysterious is causing the subprocesses to be reaped without us calling `waitpid`, and so adding in a call to `waitpid` caused the IO thread to panic (this is what @slovdahl was seeing below with an older version of my fix, I believe)

Details of the fix:
- to enable us to always be sure to call `waitpid`, but to avoid panicking on linux, I switched us over to using `std.c.waitpid` instead of `std.posix.waitpid`
- to make this change easier, I reviewed our use of the `Command.wait` method, and discovered we could simplify it a bit
- this also provided an opportunity to de-duplicate some of the looping logic around non-blocking calls to `waitpid` that had been introduced

The only other option (other than getting to the bottom of the linux reaping mystery, which may still be worth doing), is to introduce a comptime check around the additional call to `waitpid` so that it happens on MacOS only. Would be happy to switch to that approach if it's preferred.

I definitely would understand if you don't want to merge this as is and would prefer to really get to the bottom of what's happening on linux. I just don't have more time to dedicate to that right now. I could look more next week, but would probably benefit from a second pair of eyes to ensure I'm not missing something obvious.