### PR TITLE
nix: vms for testing ghostty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/cases/**/*.actual.png
 glad.zip
 /Box_test.ppm
 /Box_test_diff.ppm
+/ghostty.qcow2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ software can be installed by using standard Nix mechanisms like `nix run nixpkgs
 
 ### Contributing new VM definitions
 
-#### Acceptance Criteria
+#### VM Acceptance Criteria
 
 We welcome the contribution of new VM definitions, as long as they meet the following criteria:
 
@@ -130,5 +130,5 @@ We welcome the contribution of new VM definitions, as long as they meet the foll
 1. VMs should be as minimal as possible so that they build and launch quickly.
    Additional software can be added at runtime with a command like `nix run nixpkgs#<package name>`.
 2. VMs should not expose any services to the network, or run any remote access
-   software like SSH, VNC or RDP.
+   software like SSH daemons, VNC or RDP.
 3. VMs should auto-login using the "ghostty" user.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ Several Nix virtual machine definitions are provided by the project for testing
 and developing Ghostty against multiple different Linux desktop environments.
 
 Running these requires a working Nix installation, either Nix on your
-favorite Linux distribution, NixOS, or macOS with nix-darwin installed. Futher
+favorite Linux distribution, NixOS, or macOS with nix-darwin installed. Further
 requirements for macOS are detailed below.
 
 VMs should only be run on your local desktop and then powered off when not in
@@ -128,7 +128,7 @@ We welcome the contribution of new VM definitions, as long as they meet the foll
 #### VM Definition Criteria
 
 1. VMs should be as minimal as possible so that they build and launch quickly.
-   Additonal software can be added at runtime with a command like `nix run nixpkgs#<package name>`.
+   Additional software can be added at runtime with a command like `nix run nixpkgs#<package name>`.
 2. VMs should not expose any services to the network, or run any remote access
    software like SSH, VNC or RDP.
 3. VMs should auto-login using the "ghostty" user.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,3 +77,58 @@ pull request will be accepted with a high degree of certainty.
 > **Pull requests are NOT a place to discuss feature design.** Please do
 > not open a WIP pull request to discuss a feature. Instead, use a discussion
 > and link to your branch.
+
+## Nix Virtual Machines
+
+Several Nix virtual machine definitions are provided by the project for testing
+and developing Ghostty against multiple different Linux desktop environments.
+
+Running these requires a working Nix installation, either Nix on your
+favorite Linux distribution, NixOS, or macOS with nix-darwin installed. Futher
+requirements for macOS are detailed below.
+
+VMs should only be run on your local desktop and then powered off when not in
+use, which will discard any changes to the VM.
+
+The VM definitions provide minimal software "out of the box" but additional
+software can be installed by using standard Nix mechanisms like `nix run nixpkgs#<package>`.
+
+### Linux
+
+1. Check out the Ghostty source and change to the directory.
+2. Run `nix run .#<vmtype>`. `<vmtype>` can be any of the VMs defined in the
+   `nix/vm` directory (without the `.nix` suffix) excluding any file prefixed
+   with `common`.
+3. The VM will build and then launch. Depending on the speed of your system, this
+   can take a while, but eventually you should get a new VM window.
+4. The Ghostty source directory should be mounted to `/tmp/shared` in the VM. Depending
+   on what UID and GID of the user that you launched the VM as, `/tmp/shared` _may_ be
+   writable by the VM user, so be careful!
+
+### macOS
+
+1. To run the VMs on macOS you will need to enable the Linux builder in your `nix-darwin`
+   config. This _should_ be as simple as adding `nix.linux-builder.enable=true` to your
+   configuration and then rebuilding. See [this](https://nixcademy.com/posts/macos-linux-builder/)
+   blog post for more information about the Linux builder and how to tune the performance.
+2. Once the Linux builder has been enabled, you should be able to follow the Linux instructions
+   above to launch a VM.
+
+### Contributing new VM definitions
+
+#### Acceptance Criteria
+
+We welcome the contribution of new VM definitions, as long as they meet the following criteria:
+
+1. The should be different enough from existing VM definitions that they represent a distinct
+   user (and developer) experience.
+2. There's a significant Ghostty user population that uses a similar environment.
+3. The VMs can be built using only packages from the current stable NixOS release.
+
+#### VM Definition Criteria
+
+1. VMs should be as minimal as possible so that they build and launch quickly.
+   Additonal software can be added at runtime with a command like `nix run nixpkgs#<package name>`.
+2. VMs should not expose any services to the network, or run any remote access
+   software like SSH, VNC or RDP.
+3. VMs should auto-login using the "ghostty" user.

--- a/flake.nix
+++ b/flake.nix
@@ -79,8 +79,12 @@
                 }
             );
           in {
+            "wayland-cinnamon-${system}" = makeVM ./nix/vm/wayland-cinnamon.nix;
             "wayland-gnome-${system}" = makeVM ./nix/vm/wayland-gnome.nix;
+            "wayland-plasma6-${system}" = makeVM ./nix/vm/wayland-plasma6.nix;
+            "x11-cinnamon-${system}" = makeVM ./nix/vm/x11-cinnamon.nix;
             "x11-gnome-${system}" = makeVM ./nix/vm/x11-gnome.nix;
+            "x11-plasma6-${system}" = makeVM ./nix/vm/x11-plasma6.nix;
           };
 
           apps.${system} = let
@@ -98,8 +102,12 @@
               }
             );
           in {
+            wayland-cinnamon = wrapVM "wayland-cinnamon";
             wayland-gnome = wrapVM "wayland-gnome";
+            wayland-plasma6 = wrapVM "wayland-plasma6";
+            x11-cinnamon = wrapVM "x11-cinnamon";
             x11-gnome = wrapVM "x11-gnome";
+            x11-plasma6 = wrapVM "x11-plasma6";
           };
         }
         # Our supported systems are the same supported systems as the Zig binaries.

--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,7 @@
                   modules = [
                     {
                       nixpkgs.overlays = [
-                        self.overlays.debug
+                        self.overlays.releasefast
                       ];
                     }
                     ./nix/vm/common.nix

--- a/flake.nix
+++ b/flake.nix
@@ -63,9 +63,12 @@
             makeVM = (
               path:
                 nixpkgs-stable.lib.nixosSystem {
-                  inherit system;
+                  system = builtins.replaceStrings ["darwin"] ["linux"] system;
                   modules = [
                     {
+                      virtualisation.vmVariant = {
+                        virtualisation.host.pkgs = pkgs-stable;
+                      };
                       nixpkgs.overlays = [
                         self.overlays.releasefast
                       ];

--- a/flake.nix
+++ b/flake.nix
@@ -85,6 +85,7 @@
             x11-cinnamon = runVM ./nix/vm/x11-cinnamon.nix;
             x11-gnome = runVM ./nix/vm/x11-gnome.nix;
             x11-plasma6 = runVM ./nix/vm/x11-plasma6.nix;
+            x11-xfce = runVM ./nix/vm/x11-xfce.nix;
           };
         }
         # Our supported systems are the same supported systems as the Zig binaries.
@@ -104,6 +105,7 @@
       create-cinnamon-vm = import ./nix/vm/create-cinnamon.nix;
       create-gnome-vm = import ./nix/vm/create-gnome.nix;
       create-plasma6-vm = import ./nix/vm/create-plasma6.nix;
+      create-xfce-vm = import ./nix/vm/create-xfce.nix;
     };
 
   nixConfig = {

--- a/flake.nix
+++ b/flake.nix
@@ -61,9 +61,9 @@
 
           apps.${system} = let
             runVM = (
-              path: let
+              module: let
                 vm = import ./nix/vm/create.nix {
-                  inherit system path;
+                  inherit system module;
                   nixpkgs = nixpkgs-stable;
                   overlay = self.overlays.debug;
                 };
@@ -71,7 +71,7 @@
                   SHARED_DIR=$(pwd)
                   export SHARED_DIR
 
-                  ${vm.config.system.build.vm}/bin/run-ghostty-vm
+                  ${pkgs-stable.lib.getExe vm.config.system.build.vm} "$@"
                 '';
               in {
                 type = "app";

--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,7 @@
             );
           in {
             "wayland-gnome-${system}" = makeVM ./nix/vm/wayland-gnome.nix;
+            "x11-gnome-${system}" = makeVM ./nix/vm/x11-gnome.nix;
           };
 
           apps.${system} = let
@@ -98,6 +99,7 @@
             );
           in {
             wayland-gnome = wrapVM "wayland-gnome";
+            x11-gnome = wrapVM "x11-gnome";
           };
         }
         # Our supported systems are the same supported systems as the Zig binaries.

--- a/nix/vm/common-cinnamon.nix
+++ b/nix/vm/common-cinnamon.nix
@@ -1,0 +1,14 @@
+{...}: {
+  services.xserver = {
+    displayManager = {
+      lightdm = {
+        enable = true;
+      };
+    };
+    desktopManager = {
+      cinnamon = {
+        enable = true;
+      };
+    };
+  };
+}

--- a/nix/vm/common-cinnamon.nix
+++ b/nix/vm/common-cinnamon.nix
@@ -1,4 +1,8 @@
 {...}: {
+  imports = [
+    ./common.nix
+  ];
+
   services.xserver = {
     displayManager = {
       lightdm = {

--- a/nix/vm/common-gnome.nix
+++ b/nix/vm/common-gnome.nix
@@ -63,32 +63,6 @@
     yelp
   ];
 
-  services.gnome = {
-    gnome-browser-connector.enable = false;
-    gnome-initial-setup.enable = false;
-    gnome-online-accounts.enable = false;
-    gnome-remote-desktop.enable = false;
-    rygel.enable = false;
-  };
-
-  system.activationScripts = {
-    face = {
-      text = ''
-        mkdir -p /var/lib/AccountsService/{icons,users}
-
-        cp ${pkgs.ghostty}/share/icons/hicolor/1024x1024/apps/com.mitchellh.ghostty.png /var/lib/AccountsService/icons/ghostty
-
-        echo -e "[User]\nIcon=/var/lib/AccountsService/icons/ghostty\n" > /var/lib/AccountsService/users/ghostty
-
-        chown root:root /var/lib/AccountsService/users/ghostty
-        chmod 0600 /var/lib/AccountsService/users/ghostty
-
-        chown root:root /var/lib/AccountsService/icons/ghostty
-        chmod 0444 /var/lib/AccountsService/icons/ghostty
-      '';
-    };
-  };
-
   programs.dconf = {
     enable = true;
     profiles.user.databases = [
@@ -129,4 +103,30 @@
   };
 
   programs.geary.enable = false;
+
+  services.gnome = {
+    gnome-browser-connector.enable = false;
+    gnome-initial-setup.enable = false;
+    gnome-online-accounts.enable = false;
+    gnome-remote-desktop.enable = false;
+    rygel.enable = false;
+  };
+
+  system.activationScripts = {
+    face = {
+      text = ''
+        mkdir -p /var/lib/AccountsService/{icons,users}
+
+        cp ${pkgs.ghostty}/share/icons/hicolor/1024x1024/apps/com.mitchellh.ghostty.png /var/lib/AccountsService/icons/ghostty
+
+        echo -e "[User]\nIcon=/var/lib/AccountsService/icons/ghostty\n" > /var/lib/AccountsService/users/ghostty
+
+        chown root:root /var/lib/AccountsService/users/ghostty
+        chmod 0600 /var/lib/AccountsService/users/ghostty
+
+        chown root:root /var/lib/AccountsService/icons/ghostty
+        chmod 0444 /var/lib/AccountsService/icons/ghostty
+      '';
+    };
+  };
 }

--- a/nix/vm/common-gnome.nix
+++ b/nix/vm/common-gnome.nix
@@ -4,6 +4,10 @@
   pkgs,
   ...
 }: {
+  imports = [
+    ./common.nix
+  ];
+
   services.xserver = {
     displayManager = {
       gdm = {

--- a/nix/vm/common-gnome.nix
+++ b/nix/vm/common-gnome.nix
@@ -1,0 +1,133 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: {
+  services.xserver = {
+    enable = true;
+    displayManager = {
+      gdm = {
+        enable = true;
+        autoSuspend = false;
+      };
+    };
+    desktopManager = {
+      gnome = {
+        enable = true;
+      };
+    };
+  };
+
+  environment.systemPackages = [
+    pkgs.gnomeExtensions.no-overview
+  ];
+
+  environment.gnome.excludePackages = with pkgs; [
+    atomix
+    baobab
+    cheese
+    epiphany
+    evince
+    file-roller
+    geary
+    gnome-backgrounds
+    gnome-calculator
+    gnome-calendar
+    gnome-clocks
+    gnome-connections
+    gnome-contacts
+    gnome-disk-utility
+    gnome-extension-manager
+    gnome-logs
+    gnome-maps
+    gnome-music
+    gnome-photos
+    gnome-software
+    gnome-system-monitor
+    gnome-text-editor
+    gnome-themes-extra
+    gnome-tour
+    gnome-user-docs
+    gnome-weather
+    hitori
+    iagno
+    loupe
+    nautilus
+    orca
+    seahorse
+    simple-scan
+    snapshot
+    sushi
+    tali
+    totem
+    yelp
+  ];
+
+  services.gnome = {
+    gnome-browser-connector.enable = false;
+    gnome-initial-setup.enable = false;
+    gnome-online-accounts.enable = false;
+    gnome-remote-desktop.enable = false;
+    rygel.enable = false;
+  };
+
+  system.activationScripts = {
+    face = {
+      text = ''
+        mkdir -p /var/lib/AccountsService/{icons,users}
+
+        cp ${pkgs.ghostty}/share/icons/hicolor/1024x1024/apps/com.mitchellh.ghostty.png /var/lib/AccountsService/icons/ghostty
+
+        echo -e "[User]\nIcon=/var/lib/AccountsService/icons/ghostty\n" > /var/lib/AccountsService/users/ghostty
+
+        chown root:root /var/lib/AccountsService/users/ghostty
+        chmod 0600 /var/lib/AccountsService/users/ghostty
+
+        chown root:root /var/lib/AccountsService/icons/ghostty
+        chmod 0444 /var/lib/AccountsService/icons/ghostty
+      '';
+    };
+  };
+
+  programs.dconf = {
+    enable = true;
+    profiles.user.databases = [
+      {
+        settings = with lib.gvariant; {
+          "org/gnome/desktop/background" = {
+            picture-uri = "file://${pkgs.ghostty}/share/icons/hicolor/512x512/apps/com.mitchellh.ghostty.png";
+            picture-uri-dark = "file://${pkgs.ghostty}/share/icons/hicolor/512x512/apps/com.mitchellh.ghostty.png";
+            picture-options = "centered";
+            primary-color = "#000000000000";
+            secondary-color = "#000000000000";
+          };
+          "org/gnome/desktop/interface" = {
+            color-scheme = "prefer-dark";
+          };
+          "org/gnome/desktop/notifications" = {
+            show-in-lock-screen = false;
+          };
+          "org/gnome/desktop/screensaver" = {
+            lock-enabled = false;
+            picture-uri = "file://${pkgs.ghostty}/share/icons/hicolor/512x512/apps/com.mitchellh.ghostty.png";
+            picture-options = "centered";
+            primary-color = "#000000000000";
+            secondary-color = "#000000000000";
+          };
+          "org/gnome/desktop/session" = {
+            idle-delay = mkUint32 0;
+          };
+          "org/gnome/shell" = {
+            disable-user-extensions = false;
+            enabled-extensions = builtins.map (x: x.extensionUuid) (
+              lib.filter (p: p ? extensionUuid) config.environment.systemPackages
+            );
+          };
+        };
+      }
+    ];
+  };
+
+  programs.geary.enable = false;
+}

--- a/nix/vm/common-gnome.nix
+++ b/nix/vm/common-gnome.nix
@@ -5,7 +5,6 @@
   ...
 }: {
   services.xserver = {
-    enable = true;
     displayManager = {
       gdm = {
         enable = true;

--- a/nix/vm/common-plasma6.nix
+++ b/nix/vm/common-plasma6.nix
@@ -1,4 +1,8 @@
 {...}: {
+  imports = [
+    ./common.nix
+  ];
+
   services = {
     displayManager = {
       sddm = {

--- a/nix/vm/common-plasma6.nix
+++ b/nix/vm/common-plasma6.nix
@@ -1,0 +1,17 @@
+{...}: {
+  services = {
+    displayManager = {
+      sddm = {
+        enable = true;
+        wayland = {
+          enable = true;
+        };
+      };
+    };
+    desktopManager = {
+      plasma6 = {
+        enable = true;
+      };
+    };
+  };
+}

--- a/nix/vm/common-xfce.nix
+++ b/nix/vm/common-xfce.nix
@@ -1,0 +1,18 @@
+{...}: {
+  imports = [
+    ./common.nix
+  ];
+
+  services.xserver = {
+    displayManager = {
+      lightdm = {
+        enable = true;
+      };
+    };
+    desktopManager = {
+      xfce = {
+        enable = true;
+      };
+    };
+  };
+}

--- a/nix/vm/common.nix
+++ b/nix/vm/common.nix
@@ -47,13 +47,35 @@
   environment.systemPackages = [
     pkgs.kitty
     pkgs.ghostty
+    pkgs.helix
+    pkgs.neovim
     pkgs.zig_0_13
   ];
+
+  security.polkit = {
+    enable = true;
+  };
+
+  services.dbus = {
+    enable = true;
+  };
 
   services.displayManager = {
     autoLogin = {
       user = "ghostty";
     };
+  };
+
+  services.libinput = {
+    enable = true;
+  };
+
+  services.qemuGuest = {
+    enable = true;
+  };
+
+  services.spice-vdagentd = {
+    enable = true;
   };
 
   services.xserver = {

--- a/nix/vm/common.nix
+++ b/nix/vm/common.nix
@@ -11,6 +11,18 @@
     virtualisation.memorySize = 2048;
   };
 
+  nix = {
+    settings = {
+      trusted-users = [
+        "root"
+        "ghostty"
+      ];
+    };
+    extraOptions = ''
+      experimental-features = nix-command flakes
+    '';
+  };
+
   users.mutableUsers = true;
 
   users.groups.ghostty = {
@@ -26,10 +38,27 @@
     initialPassword = "ghostty";
   };
 
+  environment.etc = {
+    "xdg/autostart/com.mitchellh.ghostty.desktop" = {
+      source = "${pkgs.ghostty}/share/applications/com.mitchellh.ghostty.desktop";
+    };
+  };
+
   environment.systemPackages = [
     pkgs.kitty
     pkgs.ghostty
+    pkgs.zig_0_13
   ];
+
+  services.displayManager = {
+    autoLogin = {
+      user = "ghostty";
+    };
+  };
+
+  services.xserver = {
+    enable = true;
+  };
 
   system.stateVersion = "24.11";
 }

--- a/nix/vm/common.nix
+++ b/nix/vm/common.nix
@@ -23,7 +23,7 @@
     '';
   };
 
-  users.mutableUsers = true;
+  users.mutableUsers = false;
 
   users.groups.ghostty = {};
 
@@ -43,11 +43,12 @@
 
   environment.systemPackages = [
     pkgs.kitty
+    pkgs.fish
     pkgs.ghostty
     pkgs.helix
     pkgs.neovim
     pkgs.xterm
-    pkgs.zig_0_13
+    pkgs.zsh
   ];
 
   security.polkit = {

--- a/nix/vm/common.nix
+++ b/nix/vm/common.nix
@@ -1,0 +1,33 @@
+{pkgs, ...}: {
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+
+  networking.hostName = "ghostty";
+  networking.domain = "mitchellh.com";
+
+  virtualisation.vmVariant = {
+    virtualisation.memorySize = 2048;
+  };
+
+  users.mutableUsers = true;
+
+  users.groups.ghostty = {
+    gid = 1000;
+  };
+
+  users.users.ghostty = {
+    description = "Ghostty";
+    uid = 1000;
+    group = "ghostty";
+    extraGroups = ["wheel"];
+    isNormalUser = true;
+    initialPassword = "ghostty";
+  };
+
+  environment.systemPackages = [
+    pkgs.kitty
+    pkgs.ghostty
+  ];
+
+  system.stateVersion = "24.11";
+}

--- a/nix/vm/common.nix
+++ b/nix/vm/common.nix
@@ -25,13 +25,10 @@
 
   users.mutableUsers = true;
 
-  users.groups.ghostty = {
-    gid = 1000;
-  };
+  users.groups.ghostty = {};
 
   users.users.ghostty = {
     description = "Ghostty";
-    uid = 1000;
     group = "ghostty";
     extraGroups = ["wheel"];
     isNormalUser = true;
@@ -49,6 +46,7 @@
     pkgs.ghostty
     pkgs.helix
     pkgs.neovim
+    pkgs.xterm
     pkgs.zig_0_13
   ];
 
@@ -81,6 +79,4 @@
   services.xserver = {
     enable = true;
   };
-
-  system.stateVersion = "24.11";
 }

--- a/nix/vm/common.nix
+++ b/nix/vm/common.nix
@@ -2,6 +2,8 @@
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
+  documentation.nixos.enable = false;
+
   networking.hostName = "ghostty";
   networking.domain = "mitchellh.com";
 

--- a/nix/vm/create-cinnamon.nix
+++ b/nix/vm/create-cinnamon.nix
@@ -1,0 +1,12 @@
+{
+  system,
+  nixpkgs,
+  overlay,
+  path,
+  uid ? 1000,
+  gid ? 1000,
+}:
+import ./create.nix {
+  inherit system nixpkgs overlay path uid gid;
+  common = ./common-cinnamon.nix;
+}

--- a/nix/vm/create-cinnamon.nix
+++ b/nix/vm/create-cinnamon.nix
@@ -2,11 +2,11 @@
   system,
   nixpkgs,
   overlay,
-  path,
+  module,
   uid ? 1000,
   gid ? 1000,
 }:
 import ./create.nix {
-  inherit system nixpkgs overlay path uid gid;
+  inherit system nixpkgs overlay module uid gid;
   common = ./common-cinnamon.nix;
 }

--- a/nix/vm/create-gnome.nix
+++ b/nix/vm/create-gnome.nix
@@ -1,0 +1,12 @@
+{
+  system,
+  nixpkgs,
+  overlay,
+  path,
+  uid ? 1000,
+  gid ? 1000,
+}:
+import ./create.nix {
+  inherit system nixpkgs overlay path uid gid;
+  common = ./common-gnome.nix;
+}

--- a/nix/vm/create-gnome.nix
+++ b/nix/vm/create-gnome.nix
@@ -2,11 +2,11 @@
   system,
   nixpkgs,
   overlay,
-  path,
+  module,
   uid ? 1000,
   gid ? 1000,
 }:
 import ./create.nix {
-  inherit system nixpkgs overlay path uid gid;
+  inherit system nixpkgs overlay module uid gid;
   common = ./common-gnome.nix;
 }

--- a/nix/vm/create-plasma6.nix
+++ b/nix/vm/create-plasma6.nix
@@ -2,11 +2,11 @@
   system,
   nixpkgs,
   overlay,
-  path,
+  module,
   uid ? 1000,
   gid ? 1000,
 }:
 import ./create.nix {
-  inherit system nixpkgs overlay path uid gid;
+  inherit system nixpkgs overlay module uid gid;
   common = ./common-plasma6.nix;
 }

--- a/nix/vm/create-plasma6.nix
+++ b/nix/vm/create-plasma6.nix
@@ -1,0 +1,12 @@
+{
+  system,
+  nixpkgs,
+  overlay,
+  path,
+  uid ? 1000,
+  gid ? 1000,
+}:
+import ./create.nix {
+  inherit system nixpkgs overlay path uid gid;
+  common = ./common-plasma6.nix;
+}

--- a/nix/vm/create-xfce.nix
+++ b/nix/vm/create-xfce.nix
@@ -1,0 +1,12 @@
+{
+  system,
+  nixpkgs,
+  overlay,
+  module,
+  uid ? 1000,
+  gid ? 1000,
+}:
+import ./create.nix {
+  inherit system nixpkgs overlay module uid gid;
+  common = ./common-xfce.nix;
+}

--- a/nix/vm/create.nix
+++ b/nix/vm/create.nix
@@ -2,7 +2,7 @@
   system,
   nixpkgs,
   overlay,
-  path,
+  module,
   common ? ./common.nix,
   uid ? 1000,
   gid ? 1000,
@@ -37,6 +37,6 @@ in
         system.stateVersion = nixpkgs.lib.trivial.release;
       }
       common
-      path
+      module
     ];
   }

--- a/nix/vm/create.nix
+++ b/nix/vm/create.nix
@@ -3,6 +3,7 @@
   nixpkgs,
   overlay,
   path,
+  common ? ./common.nix,
   uid ? 1000,
   gid ? 1000,
 }: let
@@ -33,9 +34,9 @@ in
           uid = uid;
         };
 
-        system.stateVersion = "24.11";
+        system.stateVersion = nixpkgs.lib.trivial.release;
       }
-      ./common.nix
+      common
       path
     ];
   }

--- a/nix/vm/create.nix
+++ b/nix/vm/create.nix
@@ -1,0 +1,41 @@
+{
+  system,
+  nixpkgs,
+  overlay,
+  path,
+  uid ? 1000,
+  gid ? 1000,
+}: let
+  pkgs = import nixpkgs {
+    inherit system;
+    overlays = [
+      overlay
+    ];
+  };
+in
+  nixpkgs.lib.nixosSystem {
+    system = builtins.replaceStrings ["darwin"] ["linux"] system;
+    modules = [
+      {
+        virtualisation.vmVariant = {
+          virtualisation.host.pkgs = pkgs;
+        };
+
+        nixpkgs.overlays = [
+          overlay
+        ];
+
+        users.groups.ghostty = {
+          gid = gid;
+        };
+
+        users.users.ghostty = {
+          uid = uid;
+        };
+
+        system.stateVersion = "24.11";
+      }
+      ./common.nix
+      path
+    ];
+  }

--- a/nix/vm/wayland-cinnamon.nix
+++ b/nix/vm/wayland-cinnamon.nix
@@ -1,0 +1,7 @@
+{...}: {
+  imports = [
+    ./common-cinnamon.nix
+  ];
+
+  services.displayManager.defaultSession = "cinnamon-wayland";
+}

--- a/nix/vm/wayland-gnome.nix
+++ b/nix/vm/wayland-gnome.nix
@@ -1,0 +1,107 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: {
+  services.displayManager = {
+    autoLogin = {
+      user = "ghostty";
+    };
+  };
+
+  services.xserver = {
+    enable = true;
+    displayManager = {
+      gdm = {
+        enable = true;
+        autoSuspend = false;
+      };
+    };
+    desktopManager = {
+      gnome = {
+        enable = true;
+      };
+    };
+  };
+
+  environment.etc = {
+    "xdg/autostart/com.mitchellh.ghostty.desktop" = {
+      source = "${pkgs.ghostty}/share/applications/com.mitchellh.ghostty.desktop";
+    };
+  };
+
+  environment.systemPackages = [
+    pkgs.gnomeExtensions.no-overview
+  ];
+
+  environment.gnome.excludePackages = with pkgs; [
+    atomix
+    cheese
+    epiphany
+    geary
+    gnome-music
+    gnome-photos
+    gnome-tour
+    hitori
+    iagno
+    tali
+  ];
+
+  system.activationScripts = {
+    face = {
+      text = ''
+        mkdir -p /var/lib/AccountsService/{icons,users}
+
+        cp ${pkgs.ghostty}/share/icons/hicolor/1024x1024/apps/com.mitchellh.ghostty.png /var/lib/AccountsService/icons/ghostty
+
+        echo -e "[User]\nIcon=/var/lib/AccountsService/icons/ghostty\n" > /var/lib/AccountsService/users/ghostty
+
+        chown root:root /var/lib/AccountsService/users/ghostty
+        chmod 0600 /var/lib/AccountsService/users/ghostty
+
+        chown root:root /var/lib/AccountsService/icons/ghostty
+        chmod 0444 /var/lib/AccountsService/icons/ghostty
+      '';
+    };
+  };
+
+  programs.dconf = {
+    enable = true;
+    profiles.user.databases = [
+      {
+        settings = with lib.gvariant; {
+          "org/gnome/desktop/background" = {
+            picture-uri = "file://${pkgs.ghostty}/share/icons/hicolor/512x512/apps/com.mitchellh.ghostty.png";
+            picture-uri-dark = "file://${pkgs.ghostty}/share/icons/hicolor/512x512/apps/com.mitchellh.ghostty.png";
+            picture-options = "centered";
+            primary-color = "#000000000000";
+            secondary-color = "#000000000000";
+          };
+          "org/gnome/desktop/desktop" = {
+            interface = "prefer-dark";
+          };
+          "org/gnome/desktop/notifications" = {
+            show-in-lock-screen = false;
+          };
+          "org/gnome/desktop/screensaver" = {
+            lock-enabled = false;
+            picture-uri = "file://${pkgs.ghostty}/share/icons/hicolor/512x512/apps/com.mitchellh.ghostty.png";
+            picture-options = "centered";
+            primary-color = "#000000000000";
+            secondary-color = "#000000000000";
+          };
+          "org/gnome/desktop/session" = {
+            idle-delay = mkUint32 0;
+          };
+          "org/gnome/shell" = {
+            disable-user-extensions = false;
+            enabled-extensions = builtins.map (x: x.extensionUuid) (
+              lib.filter (p: p ? extensionUuid) config.environment.systemPackages
+            );
+          };
+        };
+      }
+    ];
+  };
+}

--- a/nix/vm/wayland-gnome.nix
+++ b/nix/vm/wayland-gnome.nix
@@ -78,8 +78,8 @@
             primary-color = "#000000000000";
             secondary-color = "#000000000000";
           };
-          "org/gnome/desktop/desktop" = {
-            interface = "prefer-dark";
+          "org/gnome/desktop/interface" = {
+            color-scheme = "prefer-dark";
           };
           "org/gnome/desktop/notifications" = {
             show-in-lock-screen = false;

--- a/nix/vm/wayland-gnome.nix
+++ b/nix/vm/wayland-gnome.nix
@@ -104,4 +104,6 @@
       }
     ];
   };
+
+  programs.geary.enable = false;
 }

--- a/nix/vm/wayland-gnome.nix
+++ b/nix/vm/wayland-gnome.nix
@@ -37,16 +37,52 @@
 
   environment.gnome.excludePackages = with pkgs; [
     atomix
+    baobab
     cheese
     epiphany
+    evince
+    file-roller
     geary
+    gnome-backgrounds
+    gnome-calculator
+    gnome-calendar
+    gnome-clocks
+    gnome-connections
+    gnome-contacts
+    gnome-disk-utility
+    gnome-extension-manager
+    gnome-logs
+    gnome-maps
     gnome-music
     gnome-photos
+    gnome-software
+    gnome-system-monitor
+    gnome-text-editor
+    gnome-themes-extra
     gnome-tour
+    gnome-user-docs
+    gnome-weather
     hitori
     iagno
+    loupe
+    nautilus
+    orca
+    seahorse
+    simple-scan
+    snapshot
+    sushi
     tali
+    totem
+    yelp
   ];
+
+  services.gnome = {
+    gnome-browser-connector.enable = false;
+    gnome-initial-setup.enable = false;
+    gnome-online-accounts.enable = false;
+    gnome-remote-desktop.enable = false;
+    rygel.enable = false;
+  };
 
   system.activationScripts = {
     face = {

--- a/nix/vm/wayland-plasma6.nix
+++ b/nix/vm/wayland-plasma6.nix
@@ -1,0 +1,6 @@
+{...}: {
+  imports = [
+    ./common-plasma6.nix
+  ];
+  services.displayManager.defaultSession = "plasma";
+}

--- a/nix/vm/x11-cinnamon.nix
+++ b/nix/vm/x11-cinnamon.nix
@@ -1,0 +1,7 @@
+{...}: {
+  imports = [
+    ./common-cinnamon.nix
+  ];
+
+  services.displayManager.defaultSession = "cinnamon";
+}

--- a/nix/vm/x11-gnome.nix
+++ b/nix/vm/x11-gnome.nix
@@ -4,6 +4,6 @@
   ];
 
   services.displayManager = {
-    defaultSession = "gnome";
+    defaultSession = "gnome-xorg";
   };
 }

--- a/nix/vm/x11-plasma6.nix
+++ b/nix/vm/x11-plasma6.nix
@@ -1,0 +1,6 @@
+{...}: {
+  imports = [
+    ./common-plasma6.nix
+  ];
+  services.displayManager.defaultSession = "plasmax11";
+}

--- a/nix/vm/x11-xfce.nix
+++ b/nix/vm/x11-xfce.nix
@@ -1,0 +1,7 @@
+{...}: {
+  imports = [
+    ./common-xfce.nix
+  ];
+
+  services.displayManager.defaultSession = "xfce";
+}


### PR DESCRIPTION
Adds a Nix VM configuration to run Gnome/Wayland. The primary purpose will be testing Ghostty in a "clean" environment. I'm going to continue to experiment with running this in CI to see if we can do some basic testing of GTK since it's difficult to unit test that code.

To use, run `nix run .#wayland-gnome` in the Ghostty source directory. I have no idea if this works on macOS. There's probably a lot of extra stuff that can be trimmed to slim it down.

Whatever directory you run this from will be mounted at `/tmp/shared` in the VM. The `ghostty` user runs as uid/gid 1000/1000 so that may affect your ability to read/write that directory if your host system user runs as a different uid/gid.

If this is something that we'd like to keep, we should add VM definitions for KDE Plasma and maybe one tiling window manager.

https://github.com/user-attachments/assets/57190913-f338-4383-93aa-90c9e351543d

