### PR TITLE
gtk: fix copy keybinds

### DIFF
--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1080,6 +1080,13 @@ pub fn setClipboardString(
     if (!confirm) {
         const clipboard = getClipboard(@ptrCast(self.gl_area), clipboard_type);
         c.gdk_clipboard_set_text(clipboard, val.ptr);
+        // We only toast if we are copying to the standard clipboard.
+        if (clipboard_type == .standard and
+            self.app.config.@"adw-toast".@"clipboard-copy")
+        {
+            if (self.container.window()) |window|
+                window.sendToast("Copied to clipboard");
+        }
         return;
     }
 

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -543,7 +543,7 @@ pub fn onConfigReloaded(self: *Window) void {
     self.sendToast("Reloaded the configuration");
 }
 
-fn sendToast(self: *Window, title: [:0]const u8) void {
+pub fn sendToast(self: *Window, title: [:0]const u8) void {
     if (comptime !adwaita.versionAtLeast(0, 0, 0)) return;
     const toast_overlay = self.toast_overlay orelse return;
     const toast = c.adw_toast_new(title);
@@ -895,10 +895,6 @@ fn gtkActionCopy(
         log.warn("error performing binding action error={}", .{err});
         return;
     };
-
-    if (self.app.config.@"adw-toast".@"clipboard-copy") {
-        self.sendToast("Copied to clipboard");
-    }
 }
 
 fn gtkActionPaste(

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2165,6 +2165,25 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
     );
 
     {
+        // On non-MacOS desktop envs (Windows, KDE, Gnome, Xfce), ctrl+insert is an
+        // alt keybinding for Copy and shift+ins is an alt keybinding for Paste
+        //
+        // The order of these blocks is important. The *last* added keybind for a given action is
+        // what will display in the menu. We want the more typical keybinds after this block to be
+        // the standard
+        if (!builtin.target.isDarwin()) {
+            try result.keybind.set.put(
+                alloc,
+                .{ .key = .{ .translated = .insert }, .mods = .{ .ctrl = true } },
+                .{ .copy_to_clipboard = {} },
+            );
+            try result.keybind.set.put(
+                alloc,
+                .{ .key = .{ .translated = .insert }, .mods = .{ .shift = true } },
+                .{ .paste_from_clipboard = {} },
+            );
+        }
+
         // On macOS we default to super but Linux ctrl+shift since
         // ctrl+c is to kill the process.
         const mods: inputpkg.Mods = if (builtin.target.isDarwin())
@@ -2182,20 +2201,6 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
             .{ .key = .{ .translated = .v }, .mods = mods },
             .{ .paste_from_clipboard = {} },
         );
-        // On non-MacOS desktop envs (Windows, KDE, Gnome, Xfce), ctrl+insert is an
-        // alt keybinding for Copy and shift+ins is an alt keybinding for Paste
-        if (!builtin.target.isDarwin()) {
-            try result.keybind.set.put(
-                alloc,
-                .{ .key = .{ .translated = .insert }, .mods = .{ .ctrl = true } },
-                .{ .copy_to_clipboard = {} },
-            );
-            try result.keybind.set.put(
-                alloc,
-                .{ .key = .{ .translated = .insert }, .mods = .{ .shift = true } },
-                .{ .paste_from_clipboard = {} },
-            );
-        }
     }
 
     // Increase font size mapping for keyboards with dedicated plus keys (like german)


### PR DESCRIPTION

- **gtk: send copy_to_clipboard toast from Surface**

    Move the toast we send when copying to the clipboard to the Surface
    implementation. Previously, we only called this from the gtk accelerator
    callback which we only call when the *last set* keybind is activated.

    We also only send a toast if we have copied to the standard clipboard,
    as opposed to the selection clipboard. By default, we have
    copy-to-clipboard true for linux, which sets the selection keyboard on
    any select. This becomes *very* noisy.

- **config: rearrange default copy_to_clipboard keybinds**

    Move the newly added *+insert keybinds to before the ctrl+shift+*
    keybinds. This is needed to have the ctrl+shift keybinds be the ones
    that show up in the menu.
