### PR TITLE
parse ConEmu OSC9;3

### DIFF
--- a/src/inspector/termio.zig
+++ b/src/inspector/termio.zig
@@ -208,6 +208,20 @@ pub const VTEvent = struct {
                     );
                 },
 
+                .Union => |info| {
+                    const Tag = info.tag_type orelse @compileError("Unions must have a tag");
+                    const tag_name = @tagName(@as(Tag, v));
+                    inline for (info.fields) |field| {
+                        if (std.mem.eql(u8, field.name, tag_name)) {
+                            if (field.type == void) {
+                                break try md.put("data", tag_name);
+                            } else {
+                                break try encodeMetadataSingle(alloc, md, tag_name, @field(v, field.name));
+                            }
+                        }
+                    }
+                },
+
                 else => {
                     @compileLog(T);
                     @compileError("unsupported type, see log");

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -1605,7 +1605,7 @@ pub fn Stream(comptime Handler: type) type {
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
 
-                .progress, .show_message_box => {
+                .progress, .show_message_box, .change_conemu_tab_title => {
                     log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
             }


### PR DESCRIPTION
This PR implements support for the [ConEmu OSC9;3 escape sequence](https://conemu.github.io/en/AnsiEscapeCodes.html#OSC_Operating_system_commands).

| Sequence | Description |
| - | - |
ESC ] 9 ; 3 ; ”txt“ ST | Change ConEmu Tab to txt. Set empty string to return original Tab text

#3125