### PR TITLE
vim compiler plugin for ghostty filetype

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -615,6 +615,7 @@ pub fn build(b: *std.Build) !void {
         _ = wf.add("syntax/ghostty.vim", config_vim.syntax);
         _ = wf.add("ftdetect/ghostty.vim", config_vim.ftdetect);
         _ = wf.add("ftplugin/ghostty.vim", config_vim.ftplugin);
+        _ = wf.add("compiler/ghostty.vim", config_vim.compiler);
         b.installDirectory(.{
             .source_dir = wf.getDirectory(),
             .install_dir = .prefix,
@@ -631,6 +632,7 @@ pub fn build(b: *std.Build) !void {
         _ = wf.add("syntax/ghostty.vim", config_vim.syntax);
         _ = wf.add("ftdetect/ghostty.vim", config_vim.ftdetect);
         _ = wf.add("ftplugin/ghostty.vim", config_vim.ftplugin);
+        _ = wf.add("compiler/ghostty.vim", config_vim.compiler);
         b.installDirectory(.{
             .source_dir = wf.getDirectory(),
             .install_dir = .prefix,

--- a/src/config/vim.zig
+++ b/src/config/vim.zig
@@ -26,7 +26,7 @@ pub const ftplugin =
     \\
     \\if !exists('current_compiler')
     \\  compiler ghostty
-    \\  let b:undo_ftplugin .= "| compiler make"
+    \\  let b:undo_ftplugin .= " makeprg< errorformat<"
     \\endif
     \\
 ;

--- a/src/config/vim.zig
+++ b/src/config/vim.zig
@@ -24,6 +24,21 @@ pub const ftplugin =
     \\
     \\let b:undo_ftplugin = 'setl cms< isk< ofu<'
     \\
+    \\if !exists('current_compiler')
+    \\  compiler ghostty
+    \\  let b:undo_ftplugin .= "| compiler make"
+    \\endif
+    \\
+;
+pub const compiler =
+    \\if exists("current_compiler")
+    \\  finish
+    \\endif
+    \\let current_compiler = "ghostty"
+    \\
+    \\CompilerSet makeprg=ghostty\ +validate-config
+    \\CompilerSet errorformat=%f:%l:%m
+    \\
 ;
 
 /// Generates the syntax file at comptime.


### PR DESCRIPTION
Basically integrates `ghostty +validate-config` with vim's compiler feature. This allows validating the config from vim and navigating to errors e.g. with the quickfix list.