### PR TITLE
Use \w instead of $PWD for title bar

### DIFF
--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -141,7 +141,7 @@ function __ghostty_precmd() {
         # Command and working directory
         # shellcheck disable=SC2016
         PS0=$PS0'$(__ghostty_get_current_command)'
-        PS1=$PS1'\[\e]2;$PWD\a\]'
+        PS1=$PS1'\[\e]2;\w\a\]'
       fi
     fi
 


### PR DESCRIPTION
The `PS1=` variable in the bash integration for the title bar could use [`\w`](https://www.man7.org/linux/man-pages//man1/bash.1.html#PROMPTING) rather than `$PWD` to indicate the working directory.

The effect is to replace any leading instance of `$HOME` with a tilde, so `/Users/patrick/code` becomes `~/code`.  It also respects [`$PROMPT_DIRTRIM`](https://www.man7.org/linux/man-pages//man1/bash.1.html#PARAMETERS), if any.  It looks cleaner to me, especially if there are multiple tabs open.

Implements #4643 (cc discussion #4601).