### PR TITLE
Add keybind action `copy_url_to_clipboard`

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3936,6 +3936,33 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             return false;
         },
 
+        .copy_url_to_clipboard => {
+            // If the mouse isn't over a link, nothing we can do.
+            if (!self.mouse.over_link) return false;
+
+            const pos = try self.rt_surface.getCursorPos();
+            if (try self.linkAtPos(pos)) |link_info| {
+                // Get the URL text from selection
+                const url_text = (self.io.terminal.screen.selectionString(self.alloc, .{
+                    .sel = link_info[1],
+                    .trim = self.config.clipboard_trim_trailing_spaces,
+                })) catch |err| {
+                    log.err("error reading url string err={}", .{err});
+                    return false;
+                };
+                defer self.alloc.free(url_text);
+
+                self.rt_surface.setClipboardString(url_text, .standard, false) catch |err| {
+                    log.err("error copying url to clipboard err={}", .{err});
+                    return true;
+                };
+
+                return true;
+            }
+
+            return false;
+        },
+
         .paste_from_clipboard => try self.startClipboardRequest(
             .standard,
             .{ .paste = {} },

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -259,6 +259,10 @@ pub const Action = union(enum) {
     paste_from_clipboard: void,
     paste_from_selection: void,
 
+    /// Copy the URL under the cursor to the clipboard. If there is no
+    /// URL under the cursor, this does nothing.
+    copy_url_to_clipboard: void,
+
     /// Increase/decrease the font size by a certain amount.
     increase_font_size: f32,
     decrease_font_size: f32,
@@ -711,6 +715,7 @@ pub const Action = union(enum) {
             .cursor_key,
             .reset,
             .copy_to_clipboard,
+            .copy_url_to_clipboard,
             .paste_from_clipboard,
             .paste_from_selection,
             .increase_font_size,


### PR DESCRIPTION
## Description

This PR implements the `copy_url_to_clipboard` keybind action. This action allows users to copy URLs directly to the clipboard without needing to select them first.

### Features

- Works with both regex-matched URLs and OSC8 hyperlinks
- Copies only the URL portion, not the surrounding text
- Respects the `clipboard_trim_trailing_spaces` configuration
- Provides clear error feedback
- Follows the same patterns as other clipboard operations

https://github.com/user-attachments/assets/c9c82e3d-dfc5-4171-b367-d6799305d87f

Resolves https://github.com/ghostty-org/ghostty/issues/4633