### PR TITLE
don't error if gtk4 pkg-config configuration could not be found

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -145,7 +145,6 @@ pub fn build(b: *std.Build) !void {
                     if (std.mem.indexOf(u8, stdout.items, "wayland")) |_| wayland = true;
                 } else {
                     std.log.warn("pkg-config: {s} with code {d}", .{ @tagName(term), code });
-                    return error.Unexpected;
                 }
             },
             inline else => |code| {


### PR DESCRIPTION
this prevents issues with people running `zig build --help` without gtk4 development stuff installed

same as #4546