### PR TITLE
iOS: Fix crash on device

### DIFF
--- a/src/renderer/metal/api.zig
+++ b/src/renderer/metal/api.zig
@@ -175,4 +175,8 @@ pub const MTLSize = extern struct {
     depth: c_ulong,
 };
 
+/// https://developer.apple.com/documentation/metal/1433367-mtlcopyalldevices
 pub extern "c" fn MTLCopyAllDevices() ?*anyopaque;
+
+/// https://developer.apple.com/documentation/metal/1433401-mtlcreatesystemdefaultdevice
+pub extern "c" fn MTLCreateSystemDefaultDevice() ?*anyopaque;


### PR DESCRIPTION
Currently causes a crash on launch in iOS devices (not Simulators) since [isHeadless](https://developer.apple.com/documentation/metal/mtldevice/1433377-isheadless), [isRemovable](https://developer.apple.com/documentation/metal/mtldevice/2889851-isremovable) and [isLowPower](https://developer.apple.com/documentation/metal/mtldevice/1433409-islowpower) are only available on macOS (raises `[AGXG16GDevice isHeadless]: unrecognized selector sent to instance ... `).

The [preferred method](https://developer.apple.com/documentation/metal/gpu_devices_and_work_submission/getting_the_default_gpu) in iOS is to access the single GPU device by attempting to create a default one.

Fixes #4685.