### PR TITLE
renderer/metal: blend rendered text in linear RGB space (aka. Gamma Correction)

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -2861,7 +2861,7 @@ fn addGlyph(
         .powerline => .fg_powerline,
     };
 
-    // TOOD: Could convert from sRGB color to linear here, possibly using a LUT.
+    // TODO: Could convert from sRGB color to linear here, possibly using a LUT.
     try self.cells.add(self.alloc, .text, .{
         .mode = mode,
         .grid_pos = .{ @intCast(x), @intCast(y) },

--- a/src/renderer/metal/api.zig
+++ b/src/renderer/metal/api.zig
@@ -74,6 +74,7 @@ pub const MTLPixelFormat = enum(c_ulong) {
     rgba8unorm = 70,
     rgba8uint = 73,
     bgra8unorm = 80,
+    bgra8unorm_srgb = 81,
 };
 
 /// https://developer.apple.com/documentation/metal/mtlpurgeablestate?language=objc

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -427,8 +427,12 @@ fn initCellTextPipeline(device: objc.Object, library: objc.Object) !objc.Object 
             .{@as(c_ulong, 0)},
         );
 
-        // Value is MTLPixelFormatBGRA8Unorm
-        attachment.setProperty("pixelFormat", @as(c_ulong, 80));
+        // Setting this to a sRGB pixel format means a) that Metal will encode
+        // the result of alpha blending (in linear RGB space) back into sRGB
+        // space, and b) that the destination color (aka background color in
+        // case we're rendering text on a background) is decoded to linear
+        // before alpha blending.
+        attachment.setProperty("pixelFormat", @as(c_ulong, @intFromEnum(mtl.MTLPixelFormat.bgra8unorm_srgb)));
 
         // Blending. This is required so that our text we render on top
         // of our drawable properly blends into the bg.

--- a/src/renderer/shaders/cell.metal
+++ b/src/renderer/shaders/cell.metal
@@ -365,6 +365,12 @@ fragment float4 cell_text_fragment(
 
       // Then premult the texture color
       float a = textureGrayscale.sample(textureSampler, in.tex_coord).r;
+
+      // Demonstrate how we can thicken fonts by applying some "gain" to the
+      // alpha we get from the texture.
+      //
+      // We could make this a configurable knob.
+      a = pow(a, 1 / 3.0f);
       premult = premult * a;
       return premult;
 


### PR DESCRIPTION
Touches #2125

Before, we were blending rendered text onto the background in sRGB
space, which is linear in perceived color/brightness but _not_ linear in
physical terms.

Correct alpha blending requires decoding from sRGB space into linear RGB
space, performing the blending, and then encoding back to sRGB space for
presenting. See here for a very good article on the whole topic of gamma
and how it relates to sRGB and text rendering:
https://blog.johnnovak.net/2016/09/21/what-every-coder-should-know-about-gamma/#antialiasing

In this demonstation, I do the decoding "by hand" in the shader, and
rely on Metal do re-encode as sRGB, by setting the right pixelFormat on
the colorAttachment.

One thing to note is that correct alpha blending in linear space makes
the rendered fonts look even thinner than they already are. When Kitty
introduced alpha blending in linear space, they introduced a
configuration that allows adjusting the gamma/contrast, which will
thicken up the fonts again. Fonts being thinner when doing correct
blending is also something that the article linked above explains, and
you can confirm this behavior for youself by running through an example
alpha blending calculation by hand, on pen and paper, say.

Just letting you know, I'm not at all wedded to this PR. 🕊️  I got interested in the topic because font rendering on Ghostty looked somewhat "flimsy" to me, so I dug down into the rabbit hole of sRGB, gamma correction, etc. If you have other plans or someone is already working on this I can close the PR. _If_ you're keen to help me shepherd this in, though, I'd be very happy to respond to any comments/suggestions!

TODO/Notes before merging:

 - Add config that allows thickening fonts
 - Check performance, maybe introduce a LUT for doing the
   conversions/decode. **Which benchmarks should I be running?**
 - Follow up: I've only looked at Metal, but the Linux/OpenGL renderer
   might have the same issues. I could work on that one next.

## Screenshots

You might have to zoom in/pixel peep on these.

This shows how fonts look even thinner now, as the above article also describes:
<img width="989" alt="Screenshot 2025-01-06 at 14 49 48" src="https://github.com/user-attachments/assets/bc5325ce-f255-4a51-af79-a3668f7487bc" />

We can see there's no more dark color artifacts around the edged:
<img width="974" alt="Screenshot 2025-01-06 at 14 49 10" src="https://github.com/user-attachments/assets/ef4057e6-1817-4fe3-8f5b-fda98b5a8d0b" />

And here I demonstrate how we could thicken the fonts again by adding adjustable "gain" (name totally TBD) to the rendered font's alpha:
<img width="1028" alt="Screenshot 2025-01-06 at 14 54 22" src="https://github.com/user-attachments/assets/a0f97773-757d-458c-a98a-625eed191322" />

Here's a yet more thorough comparison. We have browsers up top (Firefox, Safari, Chrome), of which I'd say Firefox does _not_ blend in linear space but Safari and Chrome _do_. And I'd say Safari looks best to my eyes. In the bottom row we have Ghostty main and Terminal, which blend in sRGB space (without gamma correction), and then Kitty and this branch on the bottom right which _do_ blend in linear space (with gamma correction). Here it also really helps to click through to the screenshot and zoom in. But the changes are most obvious when going in there with Digital Colour Meter.
<img width="1565" alt="Screenshot 2025-01-07 at 13 52 19" src="https://github.com/user-attachments/assets/9418ae00-8bb8-457d-b90a-90cb0d3ab25f" />


