### PR TITLE
bash: narrow the scope of GHOSTTY_BASH_ENV

### DIFF
--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -24,6 +24,7 @@ if [ -n "$GHOSTTY_BASH_INJECT" ]; then
       builtin source "$GHOSTTY_BASH_ENV"
       builtin export ENV="$GHOSTTY_BASH_ENV"
     fi
+    builtin unset GHOSTTY_BASH_ENV
   else
     # Restore bash's default 'posix' behavior. Also reset 'inherit_errexit',
     # which doesn't happen as part of the 'posix' reset.
@@ -64,7 +65,7 @@ if [ -n "$GHOSTTY_BASH_INJECT" ]; then
     fi
   fi
 
-  builtin unset GHOSTTY_BASH_ENV GHOSTTY_BASH_RCFILE
+  builtin unset GHOSTTY_BASH_RCFILE
   builtin unset ghostty_bash_inject rcfile
 fi
 


### PR DESCRIPTION
GHOSTTY_BASH_ENV is only set in the '--posix' path. This change is a code organization improvement and doesn't change the script's behavior.