### PR TITLE
config: `unbind` keybind triggers unbinds both translated and physical

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -914,7 +914,9 @@ class: ?[:0]const u8 = null,
 ///
 ///   * `unbind` - Remove the binding. This makes it so the previous action
 ///     is removed, and the key will be sent through to the child command
-///     if it is printable.
+///     if it is printable. Unbind will remove any matching trigger,
+///     including `physical:`-prefixed triggers without specifying the
+///     prefix.
 ///
 ///   * `csi:text` - Send a CSI sequence. i.e. `csi:A` sends "cursor up".
 ///


### PR DESCRIPTION
Fixes #4703

This changes `unbind` so it always removes all keybinds with the given trigger pattern regardless of if it is translated or physical.

The previous behavior was technically correct, but this implements the pattern of least surprise. I can't think of a scenario where you really want to be exact about what key you're unbinding. And if that scenario does exist, you can always fix it by rebinding after unbind.