### PR TITLE
feat: open files without `file://` protocol

### DIFF
--- a/src/config/url.zig
+++ b/src/config/url.zig
@@ -24,7 +24,7 @@ const oni = @import("oniguruma");
 /// handling them well requires a non-regex approach.
 pub const regex =
     "(?:" ++ url_schemes ++
-    \\)(?:[\w\-.~:/?#@!$&*+,;=%]+(?:[\(\[]\w*[\)\]])?)+(?<![,.])
+    \\)(?:[\w\-.~:/?#@!$&*+,;=%]+(?:[\(\[]\w*[\)\]])?)+(?<![,.])|(?:\.\.\/|\.\/*|\/)[\w\-.~:\/?#@!$&*+,;=%]+(?:\/[\w\-.~:\/?#@!$&*+,;=%]*)*
 ;
 const url_schemes =
     \\https?://|mailto:|ftp://|file:|ssh:|git://|ssh://|tel:|magnet:|ipfs://|ipns://|gemini://|gopher://|news:
@@ -165,6 +165,34 @@ test "url regex" {
         .{
             .input = "match news:comp.infosystems.www.servers.unix news links",
             .expect = "news:comp.infosystems.www.servers.unix",
+        },
+        .{
+            .input = "/Users/ghostty.user/code/example.py",
+            .expect = "/Users/ghostty.user/code/example.py",
+        },
+        .{
+            .input = "/Users/ghostty.user/code/../example.py",
+            .expect = "/Users/ghostty.user/code/../example.py",
+        },
+        .{
+            .input = "/Users/ghostty.user/code/../example.py hello world",
+            .expect = "/Users/ghostty.user/code/../example.py",
+        },
+        .{
+            .input = "../example.py",
+            .expect = "../example.py",
+        },
+        .{
+            .input = "../example.py ",
+            .expect = "../example.py",
+        },
+        .{
+            .input = "first time ../example.py contributor ",
+            .expect = "../example.py",
+        },
+        .{
+            .input = "[link](/home/user/ghostty.user/example)",
+            .expect = "/home/user/ghostty.user/example",
         },
     };
 


### PR DESCRIPTION
**Overview**: add support for file paths starts with `../` `./` and `/`

To implement this I extended the existing regex variable in the `src/config` dir. In a few test cases, extra space is added intentionally to verify we don't include space in the URL as it looks & feels odd.

Here is the text file content used for testing
```console
➜  ~ cat test.txt
https://google.com
file:///Users/ABC/oss/ghostty/build.zig
file:///Users/ABC/oss/ghostty/debug.sh


/Users/ABC/oss/ghostty/src/../debug.sh
../../Applications/Zed.app/Contents/Info.plist
[link](/home/user/ghostty.user/example) -- non-existent
[link](/Users/ABC/oss/ghostty/src/../debug.sh)
first time ../../Applications/Zed.app/Contents/Info.plist contributor
➜  ~
```

Here is the screen recording of the changes.
[![Screencast](https://img.youtube.com/vi/Q8qdwdBVbWk/0.jpg)](https://www.youtube.com/watch?v=Q8qdwdBVbWk)

