### PR TITLE
Inspector: support monitor DPI for font scaling

### DIFF
--- a/src/inspector/Inspector.zig
+++ b/src/inspector/Inspector.zig
@@ -745,6 +745,35 @@ fn renderSizeWindow(self: *Inspector) void {
                 );
             }
         }
+
+        {
+            cimgui.c.igTableNextRow(cimgui.c.ImGuiTableRowFlags_None, 0);
+
+            {
+                _ = cimgui.c.igTableSetColumnIndex(0);
+                cimgui.c.igText("X (Dpi)");
+            }
+            {
+                _ = cimgui.c.igTableSetColumnIndex(1);
+                cimgui.c.igText(
+                    "%d dpi",
+                    self.surface.font_size.xdpi,
+                );
+            }
+
+            cimgui.c.igTableNextRow(cimgui.c.ImGuiTableRowFlags_None, 0);
+            {
+                _ = cimgui.c.igTableSetColumnIndex(0);
+                cimgui.c.igText("Y (Dpi)");
+            }
+            {
+                _ = cimgui.c.igTableSetColumnIndex(1);
+                cimgui.c.igText(
+                    "%d dpi",
+                    self.surface.font_size.ydpi,
+                );
+            }
+        }
     }
 
     cimgui.c.igSeparatorText("Mouse");


### PR DESCRIPTION
This is my first contribution to the project. This pull request should solve the #814: linux/macos: support monitor DPI for font scaling. I am not an expert in terminals nor fonts, but after researching and reading ghostty's source code, I saw that the current font dpi was already stored in surface.font_size struct. 

After that it was just a matter of updating the imgui to add the two more rows to show the dpi. At least, this is what I understood by the request "support monitor DPI for font scaling". If I am wrong it would be great to have some more guidance, on what to do.

Thanks in advance!
