### PR TITLE
feat: add new noop action for key bindings (#4680)

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -437,6 +437,7 @@ pub fn performAction(
     switch (action) {
         .unbind => unreachable,
         .ignore => {},
+        .noop => {},
         .quit => try rt_app.performAction(.app, .quit, {}),
         .new_window => try self.newWindow(rt_app, .{ .parent = null }),
         .open_config => try rt_app.performAction(.app, .open_config, {}),
@@ -581,3 +582,4 @@ pub const Wasm = if (!builtin.target.isWasm()) struct {} else struct {
     //     }
     // }
 };
+

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1968,7 +1968,10 @@ fn maybeHandleBinding(
 
     // If we have the performable flag and the action was not performed,
     // then we act as though a binding didn't exist.
-    if (leaf.flags.performable and !performed) {
+    if (leaf.flags.performable and !performed or switch (action) {
+        .noop => true,
+        else => false,
+    }) {
         // If we're in a sequence, we treat this as if we pressed a key
         // that doesn't exist in the sequence. Reset our sequence and flush
         // any queued events.
@@ -4643,3 +4646,4 @@ fn presentSurface(self: *Surface) !void {
         {},
     );
 }
+

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -229,6 +229,11 @@ pub const Action = union(enum) {
     /// assertion to verify this.
     unbind: void,
 
+    /// This action is similar to `unbind` but it is used to flag that the
+    /// binding should be removed from the set and the key should be unbound
+    /// from the system.
+    noop: void,
+
     /// Send a CSI sequence. The value should be the CSI sequence without the
     /// CSI header (`ESC [` or `\x1b[`).
     csi: []const u8,
@@ -685,6 +690,7 @@ pub const Action = union(enum) {
             // Doesn't really matter, so we'll see app.
             .ignore,
             .unbind,
+            .noop,
             => .app,
 
             // Obviously app actions.


### PR DESCRIPTION
Introduces a “noop” action for key bindings, allowing shortcuts to be defined without triggering any action, while still passing the key event to the pseudoterminal (pty).

- Unlike “ignore,” it does not block the key event from reaching the pty.
- Unlike “unbind,” it overrides OS-level shortcuts, effectively disabling the default OS-level action.