### PR TITLE
apprt/gtk: fix window colors when window-theme=ghostty

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -1041,6 +1041,8 @@ fn loadRuntimeCss(
                 \\  --overview-bg-color: var(--ghostty-bg);
                 \\  --popover-fg-color: var(--ghostty-fg);
                 \\  --popover-bg-color: var(--ghostty-bg);
+                \\  --window-fg-color: var(--ghostty-fg);
+                \\  --window-bg-color: var(--ghostty-bg);
                 \\}}
                 \\windowhandle {{
                 \\  background-color: var(--headerbar-bg-color);


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/53819255-40a6-41f3-bdce-0e37c69b4d77)

After:
![image](https://github.com/user-attachments/assets/e2041832-7dd4-4adc-b0b2-093b4d18ed9b)
