### PR TITLE
Add IPv6 URL pattern support with comprehensive test cases

### DIFF
--- a/src/config/url.zig
+++ b/src/config/url.zig
@@ -24,10 +24,16 @@ const oni = @import("oniguruma");
 /// handling them well requires a non-regex approach.
 pub const regex =
     "(?:" ++ url_schemes ++
-    \\)(?:[\w\-.~:/?#@!$&*+,;=%]+(?:[\(\[]\w*[\)\]])?)+(?<![,.])|(?:\.\.\/|\.\/*|\/)[\w\-.~:\/?#@!$&*+,;=%]+(?:\/[\w\-.~:\/?#@!$&*+,;=%]*)*
+    \\)(?:
+++ ipv6_url_pattern ++
+    \\|[\w\-.~:/?#@!$&*+,;=%]+(?:[\(\[]\w*[\)\]])?)+(?<![,.])|(?:\.\.\/|\.\/*|\/)[\w\-.~:\/?#@!$&*+,;=%]+(?:\/[\w\-.~:\/?#@!$&*+,;=%]*)*
 ;
 const url_schemes =
     \\https?://|mailto:|ftp://|file:|ssh:|git://|ssh://|tel:|magnet:|ipfs://|ipns://|gemini://|gopher://|news:
+;
+
+const ipv6_url_pattern =
+    \\(?:\[[:0-9a-fA-F]+(?:[:0-9a-fA-F]*)+\](?::[0-9]+)?)
 ;
 
 test "url regex" {
@@ -193,6 +199,55 @@ test "url regex" {
         .{
             .input = "[link](/home/user/ghostty.user/example)",
             .expect = "/home/user/ghostty.user/example",
+        },
+        // IPv6 URL tests - Basic tests
+        .{
+            .input = "Serving HTTP on :: port 8000 (http://[::]:8000/)",
+            .expect = "http://[::]:8000/",
+        },
+        .{
+            .input = "IPv6 address https://[2001:db8::1]:8080/path",
+            .expect = "https://[2001:db8::1]:8080/path",
+        },
+        .{
+            .input = "IPv6 localhost http://[::1]:3000",
+            .expect = "http://[::1]:3000",
+        },
+        .{
+            .input = "Complex IPv6 https://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443/",
+            .expect = "https://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443/",
+        },
+        // IPv6 URL tests - URLs with paths and query parameters
+        .{
+            .input = "IPv6 with path https://[2001:db8::1]/path/to/resource",
+            .expect = "https://[2001:db8::1]/path/to/resource",
+        },
+        .{
+            .input = "IPv6 with query https://[2001:db8::1]:8080/api?param=value&other=123",
+            .expect = "https://[2001:db8::1]:8080/api?param=value&other=123",
+        },
+        // IPv6 URL tests - Compressed forms
+        .{
+            .input = "IPv6 compressed http://[2001:db8::]:80/",
+            .expect = "http://[2001:db8::]:80/",
+        },
+        .{
+            .input = "IPv6 multiple zeros http://[2001:0:0:0:0:0:0:1]",
+            .expect = "http://[2001:0:0:0:0:0:0:1]",
+        },
+        // IPv6 URL tests - Special cases
+        .{
+            .input = "IPv6 link-local https://[fe80::1234:5678:9abc]",
+            .expect = "https://[fe80::1234:5678:9abc]",
+        },
+        .{
+            .input = "IPv6 multicast http://[ff02::1]/stream",
+            .expect = "http://[ff02::1]/stream",
+        },
+        // IPv6 URL tests - Mixed scenarios
+        .{
+            .input = "IPv6 in markdown [link](http://[2001:db8::1]/docs)",
+            .expect = "http://[2001:db8::1]/docs",
         },
     };
 


### PR DESCRIPTION
## Description

This PR adds support for IPv6 URL detection in terminal output, addressing issue #4743. The implementation enhances URL detection to properly handle IPv6 addresses in URLs, including various formats and use cases.

## Changes

- Added dedicated IPv6 URL pattern matching

- Integrated IPv6 pattern with existing URL regex

- Added comprehensive test suite for IPv6 URL scenarios

## Test Cases
The implementation includes test cases for:
- Basic IPv6 URLs (e.g., `http://[::]:8000/`)
- Full IPv6 addresses with ports
- Compressed IPv6 forms
- URLs with paths and query parameters
- Special cases (link-local, multicast)
- Context-specific scenarios (markdown)

## Related Issues

Resolves #4743 