### PR TITLE
bash: set the title command in preexec

### DIFF
--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -105,15 +105,6 @@ builtin source "$GHOSTTY_RESOURCES_DIR/shell-integration/bash/bash-preexec.sh"
 _ghostty_executing=""
 _ghostty_last_reported_cwd=""
 
-function __ghostty_get_current_command() {
-    builtin local last_cmd
-    # shellcheck disable=SC1007
-    last_cmd=$(HISTTIMEFORMAT= builtin history 1)
-    last_cmd="${last_cmd#*[[:digit:]]*[[:space:]]}"  # remove leading history number
-    last_cmd="${last_cmd#"${last_cmd%%[![:space:]]*}"}"  # remove remaining leading whitespace
-    builtin printf "\e]2;%s\a" "${last_cmd//[[:cntrl:]]}"  # remove any control characters
-}
-
 function __ghostty_precmd() {
     local ret="$?"
     if test "$_ghostty_executing" != "0"; then
@@ -138,10 +129,8 @@ function __ghostty_precmd() {
         PS0=$PS0'\[\e[0 q\]'
       fi
 
+      # Title (working directory)
       if [[ "$GHOSTTY_SHELL_INTEGRATION_NO_TITLE" != 1 ]]; then
-        # Command and working directory
-        # shellcheck disable=SC2016
-        PS0=$PS0'$(__ghostty_get_current_command)'
         PS1=$PS1'\[\e]2;\w\a\]'
       fi
     fi
@@ -165,9 +154,18 @@ function __ghostty_precmd() {
 }
 
 function __ghostty_preexec() {
+    builtin local cmd="$1"
+
     PS0="$_GHOSTTY_SAVE_PS0"
     PS1="$_GHOSTTY_SAVE_PS1"
     PS2="$_GHOSTTY_SAVE_PS2"
+
+    # Title (current command)
+    if [[ -n $cmd && "$GHOSTTY_SHELL_INTEGRATION_NO_TITLE" != 1 ]]; then
+      builtin printf "\e]2;%s\a" "${cmd//[[:cntrl:]]}"
+    fi
+
+    # End of input, start of output.
     builtin printf "\e]133;C;\a"
     _ghostty_executing=1
 }


### PR DESCRIPTION
PS0 is evaluated after a command is read but before it is executed. The 'preexec' hook (from bash-preexec) is equivalent for our title-updating purposes and conveniently provides the current command as an argument (from its own `history 1` call).