### PR TITLE
apprt/gtk: Move most version checks to runtime

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -111,12 +111,12 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
     // Disabling Vulkan can improve startup times by hundreds of
     // milliseconds on some systems. We don't use Vulkan so we can just
     // disable it.
-    if (version.atLeast(4, 16, 0)) {
+    if (version.runtimeAtLeast(4, 16, 0)) {
         // From gtk 4.16, GDK_DEBUG is split into GDK_DEBUG and GDK_DISABLE.
         // For the remainder of "why" see the 4.14 comment below.
         _ = internal_os.setenv("GDK_DISABLE", "gles-api,vulkan");
         _ = internal_os.setenv("GDK_DEBUG", "opengl,gl-no-fractional");
-    } else if (version.atLeast(4, 14, 0)) {
+    } else if (version.runtimeAtLeast(4, 14, 0)) {
         // We need to export GDK_DEBUG to run on Wayland after GTK 4.14.
         // Older versions of GTK do not support these values so it is safe
         // to always set this. Forwards versions are uncertain so we'll have to
@@ -138,7 +138,7 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
         _ = internal_os.setenv("GDK_DEBUG", "vulkan-disable");
     }
 
-    if (version.atLeast(4, 14, 0)) {
+    if (version.runtimeAtLeast(4, 14, 0)) {
         // We need to export GSK_RENDERER to opengl because GTK uses ngl by
         // default after 4.14
         _ = internal_os.setenv("GSK_RENDERER", "opengl");
@@ -1028,7 +1028,7 @@ fn loadRuntimeCss(
         , .{ .font_family = font_family });
     }
 
-    if (version.atLeast(4, 16, 0)) {
+    if (version.runtimeAtLeast(4, 16, 0)) {
         switch (window_theme) {
             .ghostty => try writer.print(
                 \\:root {{

--- a/src/apprt/gtk/version.zig
+++ b/src/apprt/gtk/version.zig
@@ -7,6 +7,11 @@ const c = @import("c.zig").c;
 /// in the headers. If it is run in a runtime context, it will
 /// check the actual version of the library we are linked against.
 ///
+/// This function should be used in cases where the version check
+/// would affect code generation, such as using symbols that are
+/// only available beyond a certain version. For checks which only
+/// depend on GTK's runtime behavior, use `runtimeAtLeast`.
+///
 /// This is inlined so that the comptime checks will disable the
 /// runtime checks if the comptime checks fail.
 pub inline fn atLeast(
@@ -26,6 +31,20 @@ pub inline fn atLeast(
     // If we're in comptime then we can't check the runtime version.
     if (@inComptime()) return true;
 
+    return runtimeAtLeast(major, minor, micro);
+}
+
+/// Verifies that the GTK version at runtime is at least the given
+/// version.
+///
+/// This function should be used in cases where the only the runtime
+/// behavior is affected by the version check. For checks which would
+/// affect code generation, use `atLeast`.
+pub inline fn runtimeAtLeast(
+    comptime major: u16,
+    comptime minor: u16,
+    comptime micro: u16,
+) bool {
     // We use the functions instead of the constants such as
     // c.GTK_MINOR_VERSION because the function gets the actual
     // runtime version.
@@ -44,15 +63,18 @@ test "atLeast" {
     const std = @import("std");
     const testing = std.testing;
 
-    try testing.expect(atLeast(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION));
+    const funs = &.{ atLeast, runtimeAtLeast };
+    inline for (funs) |fun| {
+        try testing.expect(fun(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION));
 
-    try testing.expect(!atLeast(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION + 1));
-    try testing.expect(!atLeast(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION + 1, c.GTK_MICRO_VERSION));
-    try testing.expect(!atLeast(c.GTK_MAJOR_VERSION + 1, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION));
+        try testing.expect(!fun(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION + 1));
+        try testing.expect(!fun(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION + 1, c.GTK_MICRO_VERSION));
+        try testing.expect(!fun(c.GTK_MAJOR_VERSION + 1, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION));
 
-    try testing.expect(atLeast(c.GTK_MAJOR_VERSION - 1, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION));
-    try testing.expect(atLeast(c.GTK_MAJOR_VERSION - 1, c.GTK_MINOR_VERSION + 1, c.GTK_MICRO_VERSION));
-    try testing.expect(atLeast(c.GTK_MAJOR_VERSION - 1, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION + 1));
+        try testing.expect(fun(c.GTK_MAJOR_VERSION - 1, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION));
+        try testing.expect(fun(c.GTK_MAJOR_VERSION - 1, c.GTK_MINOR_VERSION + 1, c.GTK_MICRO_VERSION));
+        try testing.expect(fun(c.GTK_MAJOR_VERSION - 1, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION + 1));
 
-    try testing.expect(atLeast(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION - 1, c.GTK_MICRO_VERSION + 1));
+        try testing.expect(fun(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION - 1, c.GTK_MICRO_VERSION + 1));
+    }
 }


### PR DESCRIPTION
### apprt/gtk: Add version.runtimeAtLeast

This will be used for version checks that are independent of the version
of GTK we built against.

### apprt/gtk: Move most version checks to runtime

Unless we are guarding against symbols added in new versions we now
check against the runtime version of GTK to handle them even when we
didn't build against that version.