### PR TITLE
chore: replace adwaita-1 to libadwaita-1 for better pkg-config handling

### DIFF
--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -431,7 +431,7 @@ pub fn add(
 
             .gtk => {
                 step.linkSystemLibrary2("gtk4", dynamic_link_opts);
-                if (self.config.adwaita) step.linkSystemLibrary2("adwaita-1", dynamic_link_opts);
+                if (self.config.adwaita) step.linkSystemLibrary2("libadwaita-1", dynamic_link_opts);
                 if (self.config.x11) step.linkSystemLibrary2("X11", dynamic_link_opts);
 
                 if (self.config.wayland) {


### PR DESCRIPTION
The reasoning for this PR is discussed at https://github.com/ghostty-org/ghostty/discussions/3667

But in short, `pkg-config` queries `libadwaita-1` successfully, but not for `adwaita-1`, hence renaming it would result in better integration with pkg-config.