### PR TITLE
Implement a size-limit function for GTK

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -493,6 +493,7 @@ pub fn performAction(
         .pwd => try self.setPwd(target, value),
         .present_terminal => self.presentTerminal(target),
         .initial_size => try self.setInitialSize(target, value),
+        .size_limit => try self.setSizeLimit(target, value),
         .mouse_visibility => self.setMouseVisibility(target, value),
         .mouse_shape => try self.setMouseShape(target, value),
         .mouse_over_link => self.setMouseOverLink(target, value),
@@ -505,7 +506,6 @@ pub fn performAction(
         .close_all_windows,
         .toggle_quick_terminal,
         .toggle_visibility,
-        .size_limit,
         .cell_size,
         .secure_input,
         .key_sequence,
@@ -820,6 +820,23 @@ fn setInitialSize(
             value.width,
             value.height,
         ),
+    }
+}
+
+fn setSizeLimit(
+    _: *App,
+    target: apprt.Target,
+    value: apprt.action.SizeLimit,
+) !void {
+    switch (target) {
+        .app => {},
+        .surface => |v| try v.rt_surface.setSizeLimits(.{
+                    .width = value.min_width,
+                    .height = value.min_height,
+                }, if (value.max_width > 0) .{
+                    .width = value.max_width,
+                    .height = value.max_height,
+                } else null),
     }
 }
 

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -858,6 +858,28 @@ pub fn setInitialWindowSize(self: *const Surface, width: u32, height: u32) !void
     );
 }
 
+pub fn setSizeLimits(self: *const Surface, min: apprt.SurfaceSize, max_: ?apprt.SurfaceSize) !void {
+
+    // There's no support for setting max size at the moment.
+    _ = max_;
+
+    // If we are within a split, do not set the size.
+    if (self.container.split() != null) return;
+
+    // This operation only makes sense if we're within a window view
+    // hierarchy and we're the first tab in the window.
+    const window = self.container.window() orelse return;
+    if (window.notebook.nPages() > 1) return;
+
+    // Note: this doesn't properly take into account the window decorations.
+    // I'm not currently sure how to do that.
+    c.gtk_widget_set_size_request(
+        @ptrCast(window.window),
+        @intCast(min.width),
+        @intCast(min.height),
+    );
+}
+
 pub fn grabFocus(self: *Surface) void {
     if (self.container.tab()) |tab| {
         // If any other surface was focused and zoomed in, set it to non zoomed in


### PR DESCRIPTION
A "size-limit" function has been implemented for GTK which calls
gtk_widget_set_size_request() to set the minimum widget/window size. Without
this function, it's left to GTK to set the minimum size which is usually
a lot larger than the documented 10x4 cell minimum size.  This doesn't fix the
issue completely as GTK retains the final say in how small a window can be
but it gets closer.

Resolves: #4836
