### PR TITLE
fix: update zig version regex in windows build workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -247,10 +247,10 @@ jobs:
         run: |
           # Get the zig version from build.zig so that it only needs to be updated
           $fileContent = Get-Content -Path "build.zig" -Raw
-          $pattern = 'buildpkg\.requireZig\("(.*?)"\)'
+          $pattern = 'buildpkg\.requireZig\("(.*?)"\);'
           $zigVersion = [regex]::Match($fileContent, $pattern).Groups[1].Value
-          Write-Output $version
           $version = "zig-windows-x86_64-$zigVersion"
+          Write-Output $version
           $uri = "https://ziglang.org/download/$zigVersion/$version.zip"
           Invoke-WebRequest -Uri "$uri" -OutFile ".\zig-windows.zip"
           Expand-Archive -Path ".\zig-windows.zip" -DestinationPath ".\" -Force

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -247,7 +247,7 @@ jobs:
         run: |
           # Get the zig version from build.zig so that it only needs to be updated
           $fileContent = Get-Content -Path "build.zig" -Raw
-          $pattern = 'const required_zig = "(.*?)";'
+          $pattern = 'buildpkg\.requireZig\("(.*?)"\)'
           $zigVersion = [regex]::Match($fileContent, $pattern).Groups[1].Value
           Write-Output $version
           $version = "zig-windows-x86_64-$zigVersion"


### PR DESCRIPTION

The [Windows build job in the test workflow was failing](https://github.com/ghostty-org/ghostty/actions/runs/12679651693/job/35339885415) because it couldn't extract
the Zig version from _build.zig_. This was caused by a recent refactor that changed
[how the Zig version is specified](https://github.com/ghostty-org/ghostty/commit/eb40cce45e6593a4065a32681d27c75c4ca3a9c9#diff-f87bb3596894756629bc39d595fb18d479dc4edf168d93a911cadcb060f10fccR6) in _build.zig_.