### PR TITLE
build: update zig-wayland to use new LazyPath API

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -34,8 +34,8 @@
             .hash = "12207831bce7d4abce57b5a98e8f3635811cfefd160bca022eb91fe905d36a02cf25",
         },
         .zig_wayland = .{
-            .url = "https://codeberg.org/ifreund/zig-wayland/archive/a5e2e9b6a6d7fba638ace4d4b24a3b576a02685b.tar.gz",
-            .hash = "1220d41b23ae70e93355bb29dac1c07aa6aeb92427a2dffc4375e94b4de18111248c",
+            .url = "https://codeberg.org/ifreund/zig-wayland/archive/0823d9116b80d65ecfad48a2efbca166c7b03497.tar.gz",
+            .hash = "12205e05d4db71ef30aeb3517727382c12d294968e541090a762689acbb9038826a1",
         },
         .zf = .{
             .url = "git+https://github.com/natecraddock/zf/?ref=main#ed99ca18b02dda052e20ba467e90b623c04690dd",

--- a/nix/zigCacheHash.nix
+++ b/nix/zigCacheHash.nix
@@ -1,3 +1,3 @@
 # This file is auto-generated! check build-support/check-zig-cache-hash.sh for
 # more details.
-"sha256-PnfSy793kcVt85q47kWR0xkivXoMOZAAmuUyKO9vqAI="
+"sha256-MeSJiiSDDWZ7vUgY56t9aPSLPTgIKb4jexoHmDhJOGM="

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -435,15 +435,13 @@ pub fn add(
                 if (self.config.x11) step.linkSystemLibrary2("X11", dynamic_link_opts);
 
                 if (self.config.wayland) {
-                    const scanner = Scanner.create(b, .{
+                    const scanner = Scanner.create(b.dependency("zig_wayland", .{}), .{
                         // We shouldn't be using getPath but we need to for now
                         // https://codeberg.org/ifreund/zig-wayland/issues/66
-                        .wayland_xml_path = b.dependency("wayland", .{})
-                            .path("protocol/wayland.xml")
-                            .getPath(b),
-                        .wayland_protocols_path = b.dependency("wayland_protocols", .{})
-                            .path("")
-                            .getPath(b),
+                        .wayland_xml = b.dependency("wayland", .{})
+                            .path("protocol/wayland.xml"),
+                        .wayland_protocols = b.dependency("wayland_protocols", .{})
+                            .path(""),
                     });
 
                     const wayland = b.createModule(.{ .root_source_file = scanner.result });


### PR DESCRIPTION
This is a more idiomatic way to handle build paths in Zig 0.13 and later.