### PR TITLE
GTK: refactor headerbar into separate Adwaita & GTK structs

### DIFF
--- a/src/apprt/gtk/headerbar.zig
+++ b/src/apprt/gtk/headerbar.zig
@@ -4,93 +4,58 @@ const c = @import("c.zig").c;
 const Window = @import("Window.zig");
 const adwaita = @import("adwaita.zig");
 
-const AdwHeaderBar = if (adwaita.versionAtLeast(0, 0, 0)) c.AdwHeaderBar else void;
+const HeaderBarAdw = @import("headerbar_adw.zig");
+const HeaderBarGtk = @import("headerbar_gtk.zig");
 
 pub const HeaderBar = union(enum) {
-    adw: *AdwHeaderBar,
-    gtk: *c.GtkHeaderBar,
+    adw: HeaderBarAdw,
+    gtk: HeaderBarGtk,
 
-    pub fn init(window: *Window) HeaderBar {
-        if ((comptime adwaita.versionAtLeast(1, 4, 0)) and
-            adwaita.enabled(&window.app.config))
-        {
-            return initAdw(window);
+    pub fn init(self: *HeaderBar) void {
+        const window: *Window = @fieldParentPtr("headerbar", self);
+        if ((comptime adwaita.versionAtLeast(1, 4, 0)) and adwaita.enabled(&window.app.config)) {
+            HeaderBarAdw.init(self);
+        } else {
+            HeaderBarGtk.init(self);
         }
 
-        return initGtk();
-    }
-
-    fn initAdw(window: *Window) HeaderBar {
-        const headerbar = c.adw_header_bar_new();
-        c.adw_header_bar_set_title_widget(@ptrCast(headerbar), @ptrCast(c.adw_window_title_new(c.gtk_window_get_title(window.window) orelse "Ghostty", null)));
-        return .{ .adw = @ptrCast(headerbar) };
-    }
-
-    fn initGtk() HeaderBar {
-        const headerbar = c.gtk_header_bar_new();
-        return .{ .gtk = @ptrCast(headerbar) };
+        if (!window.app.config.@"gtk-titlebar" or !window.app.config.@"window-decoration")
+            self.setVisible(false);
     }
 
     pub fn setVisible(self: HeaderBar, visible: bool) void {
-        c.gtk_widget_set_visible(self.asWidget(), @intFromBool(visible));
+        switch (self) {
+            inline else => |v| v.setVisible(visible),
+        }
     }
 
     pub fn asWidget(self: HeaderBar) *c.GtkWidget {
         return switch (self) {
-            .adw => |headerbar| @ptrCast(@alignCast(headerbar)),
-            .gtk => |headerbar| @ptrCast(@alignCast(headerbar)),
+            inline else => |v| v.asWidget(),
         };
     }
 
     pub fn packEnd(self: HeaderBar, widget: *c.GtkWidget) void {
         switch (self) {
-            .adw => |headerbar| if (comptime adwaita.versionAtLeast(0, 0, 0)) {
-                c.adw_header_bar_pack_end(
-                    @ptrCast(@alignCast(headerbar)),
-                    widget,
-                );
-            },
-            .gtk => |headerbar| c.gtk_header_bar_pack_end(
-                @ptrCast(@alignCast(headerbar)),
-                widget,
-            ),
+            inline else => |v| v.packEnd(widget),
         }
     }
 
     pub fn packStart(self: HeaderBar, widget: *c.GtkWidget) void {
         switch (self) {
-            .adw => |headerbar| if (comptime adwaita.versionAtLeast(0, 0, 0)) {
-                c.adw_header_bar_pack_start(
-                    @ptrCast(@alignCast(headerbar)),
-                    widget,
-                );
-            },
-            .gtk => |headerbar| c.gtk_header_bar_pack_start(
-                @ptrCast(@alignCast(headerbar)),
-                widget,
-            ),
+            inline else => |v| v.packStart(widget),
         }
     }
 
     pub fn setTitle(self: HeaderBar, title: [:0]const u8) void {
         switch (self) {
-            .adw => |headerbar| if (comptime adwaita.versionAtLeast(0, 0, 0)) {
-                const window_title: *c.AdwWindowTitle = @ptrCast(c.adw_header_bar_get_title_widget(@ptrCast(headerbar)));
-                c.adw_window_title_set_title(window_title, title);
-            },
-            // The title is owned by the window when not using Adwaita
-            .gtk => unreachable,
+            inline else => |v| v.setTitle(title),
         }
     }
 
     pub fn setSubtitle(self: HeaderBar, subtitle: [:0]const u8) void {
         switch (self) {
-            .adw => |headerbar| if (comptime adwaita.versionAtLeast(0, 0, 0)) {
-                const window_title: *c.AdwWindowTitle = @ptrCast(c.adw_header_bar_get_title_widget(@ptrCast(headerbar)));
-                c.adw_window_title_set_subtitle(window_title, subtitle);
-            },
-            // There is no subtitle unless Adwaita is used
-            .gtk => unreachable,
+            inline else => |v| v.setSubtitle(subtitle),
         }
     }
 };

--- a/src/apprt/gtk/headerbar_adw.zig
+++ b/src/apprt/gtk/headerbar_adw.zig
@@ -1,0 +1,77 @@
+const HeaderBarAdw = @This();
+
+const std = @import("std");
+const c = @import("c.zig").c;
+
+const Window = @import("Window.zig");
+const adwaita = @import("adwaita.zig");
+
+const HeaderBar = @import("headerbar.zig").HeaderBar;
+
+const AdwHeaderBar = if (adwaita.versionAtLeast(0, 0, 0)) c.AdwHeaderBar else anyopaque;
+const AdwWindowTitle = if (adwaita.versionAtLeast(0, 0, 0)) c.AdwWindowTitle else anyopaque;
+
+/// the window that this headerbar is attached to
+window: *Window,
+/// the Adwaita headerbar widget
+headerbar: *AdwHeaderBar,
+/// the Adwaita window title widget
+title: *AdwWindowTitle,
+
+pub fn init(headerbar: *HeaderBar) void {
+    if (!adwaita.versionAtLeast(0, 0, 0)) return;
+
+    const window: *Window = @fieldParentPtr("headerbar", headerbar);
+    headerbar.* = .{
+        .adw = .{
+            .window = window,
+            .headerbar = @ptrCast(@alignCast(c.adw_header_bar_new())),
+            .title = @ptrCast(@alignCast(c.adw_window_title_new(
+                c.gtk_window_get_title(window.window) orelse "Ghostty",
+                null,
+            ))),
+        },
+    };
+    c.adw_header_bar_set_title_widget(
+        headerbar.adw.headerbar,
+        @ptrCast(@alignCast(headerbar.adw.title)),
+    );
+}
+
+pub fn setVisible(self: HeaderBarAdw, visible: bool) void {
+    c.gtk_widget_set_visible(self.asWidget(), @intFromBool(visible));
+}
+
+pub fn asWidget(self: HeaderBarAdw) *c.GtkWidget {
+    return @ptrCast(@alignCast(self.headerbar));
+}
+
+pub fn packEnd(self: HeaderBarAdw, widget: *c.GtkWidget) void {
+    if (comptime adwaita.versionAtLeast(0, 0, 0)) {
+        c.adw_header_bar_pack_end(
+            @ptrCast(@alignCast(self.headerbar)),
+            widget,
+        );
+    }
+}
+
+pub fn packStart(self: HeaderBarAdw, widget: *c.GtkWidget) void {
+    if (comptime adwaita.versionAtLeast(0, 0, 0)) {
+        c.adw_header_bar_pack_start(
+            @ptrCast(@alignCast(self.headerbar)),
+            widget,
+        );
+    }
+}
+
+pub fn setTitle(self: HeaderBarAdw, title: [:0]const u8) void {
+    if (comptime adwaita.versionAtLeast(0, 0, 0)) {
+        c.adw_window_title_set_title(self.title, title);
+    }
+}
+
+pub fn setSubtitle(self: HeaderBarAdw, subtitle: [:0]const u8) void {
+    if (comptime adwaita.versionAtLeast(0, 0, 0)) {
+        c.adw_window_title_set_subtitle(self.title, subtitle);
+    }
+}

--- a/src/apprt/gtk/headerbar_gtk.zig
+++ b/src/apprt/gtk/headerbar_gtk.zig
@@ -1,0 +1,52 @@
+const HeaderBarGtk = @This();
+
+const std = @import("std");
+const c = @import("c.zig").c;
+
+const Window = @import("Window.zig");
+const adwaita = @import("adwaita.zig");
+
+const HeaderBar = @import("headerbar.zig").HeaderBar;
+
+/// the window that this headarbar is attached to
+window: *Window,
+/// the GTK headerbar widget
+headerbar: *c.GtkHeaderBar,
+
+pub fn init(headerbar: *HeaderBar) void {
+    const window: *Window = @fieldParentPtr("headerbar", headerbar);
+    headerbar.* = .{
+        .gtk = .{
+            .window = window,
+            .headerbar = @ptrCast(c.gtk_header_bar_new()),
+        },
+    };
+}
+
+pub fn setVisible(self: HeaderBarGtk, visible: bool) void {
+    c.gtk_widget_set_visible(self.asWidget(), @intFromBool(visible));
+}
+
+pub fn asWidget(self: HeaderBarGtk) *c.GtkWidget {
+    return @ptrCast(@alignCast(self.headerbar));
+}
+
+pub fn packEnd(self: HeaderBarGtk, widget: *c.GtkWidget) void {
+    c.gtk_header_bar_pack_end(
+        @ptrCast(@alignCast(self.headerbar)),
+        widget,
+    );
+}
+
+pub fn packStart(self: HeaderBarGtk, widget: *c.GtkWidget) void {
+    c.gtk_header_bar_pack_start(
+        @ptrCast(@alignCast(self.headerbar)),
+        widget,
+    );
+}
+
+pub fn setTitle(self: HeaderBarGtk, title: [:0]const u8) void {
+    c.gtk_window_set_title(self.window.window, title);
+}
+
+pub fn setSubtitle(_: HeaderBarGtk, _: [:0]const u8) void {}


### PR DESCRIPTION
There's one behavioral change here. Before this patch, if `gtk-titlebar=false` we _never_ created a headerbar. This explicitly contradicted the comments in the source, and the documentation for `gtk-titlebar` imply that if a window starts out without a titlebar it can be brought back later with the `toggle_window_decorations` keybind action.

After this patch, a headerbar is always created, but if `gtk-titlebar=false` or `window-decoration=false` it's immediately hidden.

I'm not sure how this interacts with the current SSD/CSD detection that seems to happen when running Ghostty on non-Gnome DEs so it'll be important to get #4724 merged (plus any follow ups) to enable more explicit control of SSD/CSD.