### PR TITLE
feat(GTK): show menu in context menu if titlebar is disabled

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -1835,9 +1835,8 @@ fn initContextMenu(self: *App) void {
         defer c.g_object_unref(section);
         const submenu = c.g_menu_new();
         defer c.g_object_unref(submenu);
-        initMenuContent(@ptrCast(submenu));
 
-        // Just append the submenu to the menu structure
+        initMenuContent(@ptrCast(submenu));
         c.g_menu_append_submenu(section, "Menu", @ptrCast(@alignCast(submenu)));
         c.g_menu_append_section(menu, null, @ptrCast(@alignCast(section)));
     }

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -270,7 +270,7 @@ pub fn init(self: *Window, app: *App) !void {
     }
 
     self.context_menu = c.gtk_popover_menu_new_from_model(@ptrCast(@alignCast(self.app.context_menu)));
-    c.gtk_widget_set_parent(self.context_menu, window);
+    c.gtk_widget_set_parent(self.context_menu, box);
     c.gtk_popover_set_has_arrow(@ptrCast(@alignCast(self.context_menu)), 0);
     c.gtk_widget_set_halign(self.context_menu, c.GTK_ALIGN_START);
 


### PR DESCRIPTION
This PR addresses https://github.com/ghostty-org/ghostty/issues/4732.

While @tristan957 suggested alternative approaches, this implementation provides a straightforward way to make the menu accessible when the window decoration is disabled. It follows patterns seen in other GTK apps for handling submenus, though not strictly in the context menu format truth be told.

If there’s a better way to approach this or further refinements needed, I’m happy to discuss and iterate. This has been a minor issue I’ve encountered personally, and I’d like to help improve the experience for others as well.

Small video of how it looks:

https://github.com/user-attachments/assets/59548fef-f11c-421f-b05b-be81eab6ce06

