### PR TITLE
[GTK4] Disallow tab bar focussing

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -294,6 +294,10 @@ pub fn init(self: *Window, app: *App) !void {
             const tab_bar = c.adw_tab_bar_new();
             c.adw_tab_bar_set_view(tab_bar, self.notebook.adw.tab_view);
 
+            if (!app.config.@"gtk-tabs-can-focus") {
+                c.gtk_widget_set_can_focus(@ptrCast(@alignCast(tab_bar)), 0);
+            }
+
             if (!app.config.@"gtk-wide-tabs") c.adw_tab_bar_set_expand_tabs(tab_bar, 0);
 
             const tab_bar_widget: *c.GtkWidget = @ptrCast(@alignCast(tab_bar));
@@ -347,6 +351,10 @@ pub fn init(self: *Window, app: *App) !void {
                     .hidden => unreachable,
                 }
                 c.adw_tab_bar_set_view(tab_bar, adw.tab_view);
+
+                if (!app.config.@"gtk-tabs-can-focus") {
+                    c.gtk_widget_set_can_focus(@ptrCast(@alignCast(tab_bar)), 0);
+                }
 
                 if (!app.config.@"gtk-wide-tabs") c.adw_tab_bar_set_expand_tabs(tab_bar, 0);
             },

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -294,9 +294,7 @@ pub fn init(self: *Window, app: *App) !void {
             const tab_bar = c.adw_tab_bar_new();
             c.adw_tab_bar_set_view(tab_bar, self.notebook.adw.tab_view);
 
-            if (!app.config.@"gtk-tabs-can-focus") {
-                c.gtk_widget_set_can_focus(@ptrCast(@alignCast(tab_bar)), 0);
-            }
+            c.gtk_widget_set_can_focus(@ptrCast(@alignCast(tab_bar)), 0);
 
             if (!app.config.@"gtk-wide-tabs") c.adw_tab_bar_set_expand_tabs(tab_bar, 0);
 
@@ -352,9 +350,7 @@ pub fn init(self: *Window, app: *App) !void {
                 }
                 c.adw_tab_bar_set_view(tab_bar, adw.tab_view);
 
-                if (!app.config.@"gtk-tabs-can-focus") {
-                    c.gtk_widget_set_can_focus(@ptrCast(@alignCast(tab_bar)), 0);
-                }
+                c.gtk_widget_set_can_focus(@ptrCast(@alignCast(tab_bar)), 0);
 
                 if (!app.config.@"gtk-wide-tabs") c.adw_tab_bar_set_expand_tabs(tab_bar, 0);
             },

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2132,6 +2132,16 @@ keybind: Keybinds = .{},
 /// and shown when the titlebar is unmaximized. GTK only.
 @"gtk-titlebar-hide-when-maximized": bool = false,
 
+/// Determines whether or not we allow the tabs in the tab bar to be focussed.
+///
+/// If true (the default), users can focus tabs in the tab bar by clicking them,
+/// and then use arrow keys to navigate, but focus in the main surface will be
+/// lost, requiring the user to change focus back in order to use the terminal.
+///
+/// If false, the tab bar will never take focus, keeping the focus on the main
+/// window surface.
+@"gtk-tabs-can-focus": bool = true,
+
 /// Determines the appearance of the top and bottom bars when using the
 /// Adwaita tab bar. This requires `gtk-adwaita` to be enabled (it is
 /// by default).

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2132,16 +2132,6 @@ keybind: Keybinds = .{},
 /// and shown when the titlebar is unmaximized. GTK only.
 @"gtk-titlebar-hide-when-maximized": bool = false,
 
-/// Determines whether or not we allow the tabs in the tab bar to be focussed.
-///
-/// If true (the default), users can focus tabs in the tab bar by clicking them,
-/// and then use arrow keys to navigate, but focus in the main surface will be
-/// lost, requiring the user to change focus back in order to use the terminal.
-///
-/// If false, the tab bar will never take focus, keeping the focus on the main
-/// window surface.
-@"gtk-tabs-can-focus": bool = true,
-
 /// Determines the appearance of the top and bottom bars when using the
 /// Adwaita tab bar. This requires `gtk-adwaita` to be enabled (it is
 /// by default).


### PR DESCRIPTION
~Adds configuration to allow/~Disallow the Adwaita tab bar from gaining focus with an additional click. This is the default behaviour of the tab bar, and it allows users to use the arrow keys to navigate the tabs and then the tab key to move to the window surface.

Personally, I hate when this happens and don't ever want my tabs focussed by accident, so I thought it might make sense to add ~a configuration option~ functionality to prevent this from happening.

Works great with adwaita 1.5 (Ubuntu 24.04) and adwaita 1.1 (Ubuntu 22.04). Tab bars in 22.04 are showing up above the window title bar, but ~~I'm not sure if that's related to this change~~ ~~that seems to be unrelated to this change~~ that is resolved separately in #5410.