### PR TITLE
ci: add required checks jobs

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,6 +1,15 @@
 on: [push, pull_request]
 name: Nix
 jobs:
+  required:
+    name: Required Checks
+    runs-on: namespace-profile-ghostty-sm
+    needs:
+      - check-zig-cache-hash
+    steps:
+      - name: Noop
+        run: echo "Required Checks Met"
+
   check-zig-cache-hash:
     if: github.repository == 'ghostty-org/ghostty'
     runs-on: namespace-profile-ghostty-sm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,29 @@ on:
 name: Test
 
 jobs:
+  required:
+    name: Required Checks
+    runs-on: namespace-profile-ghostty-sm
+    needs:
+      - build
+      - build-bench
+      - build-linux-libghostty
+      - build-nix
+      - build-macos
+      - build-macos-matrix
+      - build-windows
+      - test
+      - test-gtk
+      - test-sentry-linux
+      - test-macos
+      - prettier
+      - alejandra
+      - typos
+      - test-pkg-linux
+    steps:
+      - name: Noop
+        run: echo "Required Checks Met"
+
   build:
     strategy:
       fail-fast: false


### PR DESCRIPTION
This is a hack to make it easier for our GitHub branching rules to require a single check to pass before merging. This lets us describe the required checks in code rather than via the GH UI.