### PR TITLE
declare `StartupWMClass` in .desktop

### DIFF
--- a/dist/linux/app.desktop
+++ b/dist/linux/app.desktop
@@ -7,6 +7,7 @@ Icon=com.mitchellh.ghostty
 Categories=System;TerminalEmulator;
 Keywords=terminal;tty;pty;
 StartupNotify=true
+StartupWMClass=com.mitchellh.ghostty
 Terminal=false
 Actions=new-window;
 X-GNOME-UsesNotifications=true


### PR DESCRIPTION
This allows the app to be pinned in the dock/task manager in several common desktop environments. 

When not set this happens when you open the pinned application: 

![image](https://github.com/user-attachments/assets/81316c9c-4cd4-4a7c-ba3e-74b9a7abc1fa)
