### PR TITLE
parse ConEmu OSC9;5

### DIFF
--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -1605,7 +1605,7 @@ pub fn Stream(comptime Handler: type) type {
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
 
-                .progress, .sleep, .show_message_box, .change_conemu_tab_title => {
+                .progress, .sleep, .show_message_box, .change_conemu_tab_title, .wait_input => {
                     log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
             }


### PR DESCRIPTION
| Sequence | Description |
| - | - |
ESC ] 9 ; 5 ST | Wait for Enter/Space/Esc. Set environment variable “ConEmuWaitKey” to “ENTER”/”SPACE”/”ESC” on exit.

Source: https://conemu.github.io/en/AnsiEscapeCodes.html#OSC_Operating_system_commands

#3125 