### PR TITLE
fix(gtk): fix segfault on ctrl-d on older adw

### DIFF
--- a/src/apprt/gtk/notebook_adw.zig
+++ b/src/apprt/gtk/notebook_adw.zig
@@ -137,6 +137,8 @@ pub const NotebookAdw = struct {
 
         // If we have no more tabs we close the window
         if (self.nPages() == 0) {
+            const window = tab.window.window;
+
             // libadw versions <= 1.3.x leak the final page view
             // which causes our surface to not properly cleanup. We
             // unref to force the cleanup. This will trigger a critical
@@ -150,7 +152,7 @@ pub const NotebookAdw = struct {
 
             // `self` will become invalid after this call because it will have
             // been freed up as part of the process of closing the window.
-            c.gtk_window_destroy(tab.window.window);
+            c.gtk_window_destroy(window);
         }
     }
 };


### PR DESCRIPTION
Ghostty with libadwaita older than 1.4.0 (in my case, that of debian bookworm) will segfault when you exit ghostty with ctrl+d. This was already fixed by #3694 but it re-appeared during a refactor. The fix simply uses a reference to `tab.window.window` to call `gtk_window_destroy`, because `tab.window` has already been [destroyed by a signal handler](https://github.com/ghostty-org/ghostty/blob/6cbd69da7839260508466f9dfb2bc0c0fbb43991/src/apprt/gtk/Tab.zig#L130-L137) triggered in the old libadwaita path.

Original issue: #3135