### PR TITLE
Fixed documentation generation in `list-actions --docs` command

### DIFF
--- a/src/build/webgen/main_actions.zig
+++ b/src/build/webgen/main_actions.zig
@@ -50,9 +50,16 @@ pub fn genKeybindActions(writer: anytype) !void {
                 '\n',
             );
             while (iter.next()) |s| {
+                // If it is the last line and empty, then skip it.
+                if (iter.peek() == null and s.len == 0) continue;
                 try buffer.appendSlice(s);
                 try buffer.appendSlice("\n");
             }
         }
+    }
+
+    // Write any remaining buffered documentation
+    if (buffer.items.len > 0) {
+        try writer.writeAll(buffer.items);
     }
 }

--- a/src/build/webgen/main_actions.zig
+++ b/src/build/webgen/main_actions.zig
@@ -1,65 +1,8 @@
 const std = @import("std");
 const help_strings = @import("help_strings");
-const KeybindAction = @import("../../input/Binding.zig").Action;
+const helpgen_actions = @import("../../helpgen_actions.zig");
 
 pub fn main() !void {
     const output = std.io.getStdOut().writer();
-    try genKeybindActions(output);
-}
-
-pub fn genKeybindActions(writer: anytype) !void {
-    // Write the header
-    try writer.writeAll(
-        \\---
-        \\title: Keybinding Action Reference
-        \\description: Reference of all Ghostty keybinding actions.
-        \\editOnGithubLink: https://github.com/ghostty-org/ghostty/edit/main/src/input/Binding.zig
-        \\---
-        \\
-        \\This is a reference of all Ghostty keybinding actions.
-        \\
-        \\
-    );
-
-    @setEvalBranchQuota(5_000);
-
-    var buffer = std.ArrayList(u8).init(std.heap.page_allocator);
-    defer buffer.deinit();
-
-    const fields = @typeInfo(KeybindAction).Union.fields;
-    inline for (fields) |field| {
-        if (field.name[0] == '_') continue;
-
-        // Write previously stored doc comment below all related actions
-        if (@hasDecl(help_strings.KeybindAction, field.name)) {
-            try writer.writeAll(buffer.items);
-            try writer.writeAll("\n");
-
-            buffer.clearRetainingCapacity();
-        }
-
-        // Write the field name.
-        try writer.writeAll("## `");
-        try writer.writeAll(field.name);
-        try writer.writeAll("`\n");
-
-        if (@hasDecl(help_strings.KeybindAction, field.name)) {
-            var iter = std.mem.splitScalar(
-                u8,
-                @field(help_strings.KeybindAction, field.name),
-                '\n',
-            );
-            while (iter.next()) |s| {
-                // If it is the last line and empty, then skip it.
-                if (iter.peek() == null and s.len == 0) continue;
-                try buffer.appendSlice(s);
-                try buffer.appendSlice("\n");
-            }
-        }
-    }
-
-    // Write any remaining buffered documentation
-    if (buffer.items.len > 0) {
-        try writer.writeAll(buffer.items);
-    }
+    try helpgen_actions.generate(output, .markdown, std.heap.page_allocator);
 }

--- a/src/helpgen.zig
+++ b/src/helpgen.zig
@@ -115,38 +115,6 @@ fn genActions(alloc: std.mem.Allocator, writer: anytype) !void {
     try writer.writeAll("};\n");
 }
 
-fn genKeybindField(
-    alloc: std.mem.Allocator,
-    writer: anytype,
-    ast: std.zig.Ast,
-    comptime field: []const u8,
-) !void {
-    const tokens = ast.tokens.items(.tag);
-
-    // Find the field and check if it has doc comments
-    for (tokens, 0..) |token, i| {
-        if (token != .identifier) continue;
-        const name = ast.tokenSlice(@intCast(i));
-        if (!std.mem.eql(u8, name, field)) continue;
-
-        try writer.writeAll("pub const ");
-        try writer.writeAll(name);
-        try writer.writeAll(": [:0]const u8 = \n");
-
-        // If it has doc comments, use them
-        if (i > 0 and tokens[i - 1] == .doc_comment) {
-            const comment = try extractDocComments(alloc, ast, @intCast(i - 1), tokens);
-            try writer.writeAll(comment);
-        } else {
-            // Otherwise use default documentation
-            try writer.writeAll("    \\\\This action is currently undocumented.\n");
-            try writer.writeAll("    \\\\Please refer to the source code or contribute documentation.\n");
-            try writer.writeAll(";\n");
-        }
-        break;
-    }
-}
-
 fn genKeybindActions(alloc: std.mem.Allocator, writer: anytype) !void {
     var ast = try std.zig.Ast.parse(alloc, @embedFile("input/Binding.zig"), .zig);
     defer ast.deinit(alloc);
@@ -160,7 +128,7 @@ fn genKeybindActions(alloc: std.mem.Allocator, writer: anytype) !void {
 
     inline for (@typeInfo(KeybindAction).Union.fields) |field| {
         if (field.name[0] == '_') continue;
-        try genKeybindField(alloc, writer, ast, field.name);
+        try genConfigField(alloc, writer, ast, field.name);
     }
 
     try writer.writeAll("};\n");

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -236,9 +236,9 @@ pub const Action = union(enum) {
     /// Send an `ESC` sequence.
     esc: []const u8,
 
-    // Send the given text. Uses Zig string literal syntax. This is currently
-    // not validated. If the text is invalid (i.e. contains an invalid escape
-    // sequence), the error will currently only show up in logs.
+    /// Send the given text. Uses Zig string literal syntax. This is currently
+    /// not validated. If the text is invalid (i.e. contains an invalid escape
+    /// sequence), the error will currently only show up in logs.
     text: []const u8,
 
     /// Send data to the pty depending on whether cursor key mode is enabled

--- a/src/input/helpgen_actions.zig
+++ b/src/input/helpgen_actions.zig
@@ -1,0 +1,107 @@
+//! This module is a help generator for keybind actions documentation.
+//! It can generate documentation in different formats (plaintext for CLI,
+//! markdown for website) while maintaining consistent content.
+
+const std = @import("std");
+const KeybindAction = @import("Binding.zig").Action;
+const help_strings = @import("help_strings");
+
+/// Format options for generating keybind actions documentation
+pub const Format = enum {
+    /// Plain text output with indentation
+    plaintext,
+    /// Markdown formatted output
+    markdown,
+
+    fn formatFieldName(self: Format, writer: anytype, field_name: []const u8) !void {
+        switch (self) {
+            .plaintext => {
+                try writer.writeAll(field_name);
+                try writer.writeAll(":\n");
+            },
+            .markdown => {
+                try writer.writeAll("## `");
+                try writer.writeAll(field_name);
+                try writer.writeAll("`\n");
+            },
+        }
+    }
+
+    fn formatDocLine(self: Format, writer: anytype, line: []const u8) !void {
+        switch (self) {
+            .plaintext => {
+                try writer.appendSlice("  ");
+                try writer.appendSlice(line);
+                try writer.appendSlice("\n");
+            },
+            .markdown => {
+                try writer.appendSlice(line);
+                try writer.appendSlice("\n");
+            },
+        }
+    }
+
+    fn header(self: Format) ?[]const u8 {
+        return switch (self) {
+            .plaintext => null,
+            .markdown =>
+            \\---
+            \\title: Keybinding Action Reference
+            \\description: Reference of all Ghostty keybinding actions.
+            \\editOnGithubLink: https://github.com/ghostty-org/ghostty/edit/main/src/input/Binding.zig
+            \\---
+            \\
+            \\This is a reference of all Ghostty keybinding actions.
+            \\
+            \\
+            ,
+        };
+    }
+};
+
+/// Generate keybind actions documentation with the specified format
+pub fn generate(
+    writer: anytype,
+    format: Format,
+    page_allocator: std.mem.Allocator,
+) !void {
+    if (format.header()) |header| {
+        try writer.writeAll(header);
+    }
+
+    var buffer = std.ArrayList(u8).init(page_allocator);
+    defer buffer.deinit();
+
+    const fields = @typeInfo(KeybindAction).Union.fields;
+    inline for (fields) |field| {
+        if (field.name[0] == '_') continue;
+
+        // Write previously stored doc comment below all related actions
+        if (@hasDecl(help_strings.KeybindAction, field.name)) {
+            try writer.writeAll(buffer.items);
+            try writer.writeAll("\n");
+
+            buffer.clearRetainingCapacity();
+        }
+
+        try format.formatFieldName(writer, field.name);
+
+        if (@hasDecl(help_strings.KeybindAction, field.name)) {
+            var iter = std.mem.splitScalar(
+                u8,
+                @field(help_strings.KeybindAction, field.name),
+                '\n',
+            );
+            while (iter.next()) |s| {
+                // If it is the last line and empty, then skip it.
+                if (iter.peek() == null and s.len == 0) continue;
+                try format.formatDocLine(&buffer, s);
+            }
+        }
+    }
+
+    // Write any remaining buffered documentation
+    if (buffer.items.len > 0) {
+        try writer.writeAll(buffer.items);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/ghostty-org/ghostty/issues/4958

## Changes

1. Fixed documentation generation in `actions.mdx`:

   - Fixed an issue where the last action's documentation was [not properly generated](https://github.com/ghostty-org/website/blob/fe6c69263cdf2779e72014160970c3be31cbf1a2/docs/config/keybind/reference.mdx#crash)
   
   - Ensured all actions' documentation is correctly included in the output

2. Improved `ghostty +list-actions --docs` command output formatting:

   - Grouped related actions together with shared documentation
   
   - Added proper spacing between action groups
  
<details> 
    <summary>ghostty-dev +list-actions --docs</summary>

```
ignore:
  Ignore this key combination, don't send it to the child process, just
  black hole it.

unbind:
  This action is used to flag that the binding should be removed from
  the set. This should never exist in an active set and `set.put` has an
  assertion to verify this.

csi:
  Send a CSI sequence. The value should be the CSI sequence without the
  CSI header (`ESC [` or `\x1b[`).

esc:
  Send an `ESC` sequence.

text:
  Send the given text. Uses Zig string literal syntax. This is currently
  not validated. If the text is invalid (i.e. contains an invalid escape
  sequence), the error will currently only show up in logs.

cursor_key:
  Send data to the pty depending on whether cursor key mode is enabled
  (`application`) or disabled (`normal`).

reset:
  Reset the terminal. This can fix a lot of issues when a running
  program puts the terminal into a broken state. This is equivalent to
  when you type "reset" and press enter.

  If you do this while in a TUI program such as vim, this may break
  the program. If you do this while in a shell, you may have to press
  enter after to get a new prompt.

copy_to_clipboard:
paste_from_clipboard:
paste_from_selection:
  Copy and paste.

copy_url_to_clipboard:
  Copy the URL under the cursor to the clipboard. If there is no
  URL under the cursor, this does nothing.

increase_font_size:
decrease_font_size:
  Increase/decrease the font size by a certain amount.

reset_font_size:
  Reset the font size to the original configured size.

clear_screen:
  Clear the screen. This also clears all scrollback.

select_all:
  Select all text on the screen.

scroll_to_top:
scroll_to_bottom:
scroll_page_up:
scroll_page_down:
scroll_page_fractional:
scroll_page_lines:
  Scroll the screen varying amounts.

adjust_selection:
  Adjust an existing selection in a given direction. This action
  does nothing if there is no active selection.

jump_to_prompt:
  Jump the viewport forward or back by prompt. Positive number is the
  number of prompts to jump forward, negative is backwards.

write_scrollback_file:
  Write the entire scrollback into a temporary file. The action
  determines what to do with the filepath. Valid values are:

    - "paste": Paste the file path into the terminal.
    - "open": Open the file in the default OS editor for text files.
      The default OS editor is determined by using `open` on macOS
      and `xdg-open` on Linux.

write_screen_file:
  Same as write_scrollback_file but writes the full screen contents.
  See write_scrollback_file for available values.

write_selection_file:
  Same as write_scrollback_file but writes the selected text.
  If there is no selected text this does nothing (it doesn't
  even create an empty file). See write_scrollback_file for
  available values.

new_window:
  Open a new window. If the application isn't currently focused,
  this will bring it to the front.

new_tab:
  Open a new tab.

previous_tab:
  Go to the previous tab.

next_tab:
  Go to the next tab.

last_tab:
  Go to the last tab (the one with the highest index)

goto_tab:
  Go to the tab with the specific number, 1-indexed. If the tab number
  is higher than the number of tabs, this will go to the last tab.

move_tab:
  Moves a tab by a relative offset.
  Adjusts the tab position based on `offset`. For example `move_tab:-1` for left, `move_tab:1` for right.
  If the new position is out of bounds, it wraps around cyclically within the tab range.

toggle_tab_overview:
  Toggle the tab overview.
  This only works with libadwaita enabled currently.

new_split:
  Create a new split in the given direction. The new split will appear in
  the direction given. For example `new_split:up`. Valid values are left, right, up, down and auto.

goto_split:
  Focus on a split in a given direction. For example `goto_split:up`.
  Valid values are left, right, up, down, previous and next.

toggle_split_zoom:
  zoom/unzoom the current split.

resize_split:
  Resize the current split by moving the split divider in the given
  direction. For example `resize_split:left,10`. The valid directions are up, down, left and right.

equalize_splits:
  Equalize all splits in the current window

inspector:
  Show, hide, or toggle the terminal inspector for the currently focused
  terminal.

open_config:
  Open the configuration file in the default OS editor. If your default OS
  editor isn't configured then this will fail. Currently, any failures to
  open the configuration will show up only in the logs.

reload_config:
  Reload the configuration. The exact meaning depends on the app runtime
  in use but this usually involves re-reading the configuration file
  and applying any changes. Note that not all changes can be applied at
  runtime.

close_surface:
  Close the current "surface", whether that is a window, tab, split, etc.
  This only closes ONE surface. This will trigger close confirmation as
  configured.

close_tab:
  Close the current tab, regardless of how many splits there may be.
  This will trigger close confirmation as configured.

close_window:
  Close the window, regardless of how many tabs or splits there may be.
  This will trigger close confirmation as configured.

close_all_windows:
  Close all windows. This will trigger close confirmation as configured.
  This only works for macOS currently.

toggle_fullscreen:
  Toggle fullscreen mode of window.

toggle_window_decorations:
  Toggle window decorations on and off. This only works on Linux.

toggle_secure_input:
  Toggle secure input mode on or off. This is used to prevent apps
  that monitor input from seeing what you type. This is useful for
  entering passwords or other sensitive information.

  This applies to the entire application, not just the focused
  terminal. You must toggle it off to disable it, or quit Ghostty.

  This only works on macOS, since this is a system API on macOS.

toggle_quick_terminal:
  Toggle the "quick" terminal. The quick terminal is a terminal that
  appears on demand from a keybinding, often sliding in from a screen
  edge such as the top. This is useful for quick access to a terminal
  without having to open a new window or tab.

  When the quick terminal loses focus, it disappears. The terminal state
  is preserved between appearances, so you can always press the keybinding
  to bring it back up.

  To enable the quick terminally globally so that Ghostty doesn't
  have to be focused, prefix your keybind with `global`. Example:

  \```ini
  keybind = global:cmd+grave_accent=toggle_quick_terminal
  \```

  The quick terminal has some limitations:

    - It is a singleton; only one instance can exist at a time.
    - It does not support tabs, but it does support splits.
    - It will not be restored when the application is restarted
      (for systems that support window restoration).
    - It supports fullscreen, but fullscreen will always be a non-native
      fullscreen (macos-non-native-fullscreen = true). This only applies
      to the quick terminal window. This is a requirement due to how
      the quick terminal is rendered.

  See the various configurations for the quick terminal in the
  configuration file to customize its behavior.

  This currently only works on macOS.

toggle_visibility:
  Show/hide all windows. If all windows become shown, we also ensure
  Ghostty becomes focused. When hiding all windows, focus is yielded
  to the next application as determined by the OS.

  This currently only works on macOS.

quit:
  Quit ghostty.

crash:
  Crash ghostty in the desired thread for the focused surface.

  WARNING: This is a hard crash (panic) and data can be lost.

  The purpose of this action is to test crash handling. For some
  users, it may be useful to test crash reporting functionality in
  order to determine if it all works as expected.

  The value determines the crash location:

    - "main" - crash on the main (GUI) thread.
    - "io" - crash on the IO thread for the focused surface.
    - "render" - crash on the render thread for the focused surface.

```
</details>

## Testing

- Run `ghostty-dev +list-actions --docs` to verify the new output format

- Check generated _zig-out/share/ghostty/webdata/actions.mdx_ to ensure all actions are properly documented
