### PR TITLE
config: overhaul help string generation

### DIFF
--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -8,6 +8,7 @@ const builtin = @import("builtin");
 const apprt = @import("../apprt.zig");
 const font = @import("../font/main.zig");
 const renderer = @import("../renderer.zig");
+const configpkg = @import("../config.zig");
 const Command = @import("../Command.zig");
 const WasmTarget = @import("../os/wasm/target.zig").Target;
 
@@ -396,7 +397,7 @@ pub fn addOptions(self: *const Config, step: *std.Build.Step.Options) !void {
         .{self.version},
     ));
     step.addOption(
-        ReleaseChannel,
+        configpkg.Config.ReleaseChannel,
         "release_channel",
         channel: {
             const pre = self.version.pre orelse break :channel .stable;
@@ -491,13 +492,4 @@ pub const ExeEntrypoint = enum {
     bench_codepoint_width,
     bench_grapheme_break,
     bench_page_init,
-};
-
-/// The release channel for the build.
-pub const ReleaseChannel = enum {
-    /// Unstable builds on every commit.
-    tip,
-
-    /// Stable tagged releases.
-    stable,
 };

--- a/src/build/mdgen/mdgen.zig
+++ b/src/build/mdgen/mdgen.zig
@@ -34,6 +34,7 @@ pub fn genConfig(writer: anytype, cli: bool) !void {
         if (cli) try writer.writeAll("--");
         try writer.writeAll(field.name);
         try writer.writeAll("`**\n\n");
+
         if (@hasDecl(help_strings.Config, field.name)) {
             var iter = std.mem.splitScalar(u8, @field(help_strings.Config, field.name), '\n');
             var first = true;

--- a/src/build_config.zig
+++ b/src/build_config.zig
@@ -11,15 +11,14 @@ const font = @import("font/main.zig");
 const rendererpkg = @import("renderer.zig");
 const WasmTarget = @import("os/wasm/target.zig").Target;
 const BuildConfig = @import("build/Config.zig");
-
-pub const ReleaseChannel = BuildConfig.ReleaseChannel;
+const Config = @import("config/Config.zig");
 
 /// The semantic version of this build.
 pub const version = options.app_version;
 pub const version_string = options.app_version_string;
 
 /// The release channel for this build.
-pub const release_channel = std.meta.stringToEnum(ReleaseChannel, @tagName(options.release_channel)).?;
+pub const release_channel = std.meta.stringToEnum(Config.ReleaseChannel, @tagName(options.release_channel)).?;
 
 /// The optimization mode as a string.
 pub const mode_string = mode: {

--- a/src/cli/action.zig
+++ b/src/cli/action.zig
@@ -121,12 +121,12 @@ pub const Action = enum {
                     // for all commands by just changing this one place.
 
                     if (std.mem.eql(u8, field.name, @tagName(self))) {
-                        const stdout = std.io.getStdOut().writer();
-                        const text = @field(help_strings.Action, field.name) ++ "\n";
-                        stdout.writeAll(text) catch |write_err| {
-                            std.log.warn("failed to write help text: {}\n", .{write_err});
-                            break :err 1;
-                        };
+                        // const stdout = std.io.getStdOut().writer();
+                        // const text = @field(help_strings.Action, field.name) ++ "\n";
+                        // stdout.writeAll(text) catch |write_err| {
+                        //     std.log.warn("failed to write help text: {}\n", .{write_err});
+                        //     break :err 1;
+                        // };
 
                         break :err 0;
                     }

--- a/src/cli/list_actions.zig
+++ b/src/cli/list_actions.zig
@@ -41,10 +41,10 @@ pub fn run(alloc: Allocator) !u8 {
         try stdout.print("{s}", .{field.name});
         if (opts.docs) {
             try stdout.print(":\n", .{});
-            var iter = std.mem.splitScalar(u8, std.mem.trimRight(u8, @field(help_strings.KeybindAction, field.name), &std.ascii.whitespace), '\n');
-            while (iter.next()) |line| {
-                try stdout.print("  {s}\n", .{line});
-            }
+            // var iter = std.mem.splitScalar(u8, std.mem.trimRight(u8, @field(help_strings.KeybindAction, field.name), &std.ascii.whitespace), '\n');
+            // while (iter.next()) |line| {
+            //     try stdout.print("  {s}\n", .{line});
+            // }
         } else {
             try stdout.print("\n", .{});
         }

--- a/src/helpgen.zig
+++ b/src/helpgen.zig
@@ -27,46 +27,15 @@ fn genConfig(alloc: std.mem.Allocator, writer: anytype) !void {
     var ast = try std.zig.Ast.parse(alloc, @embedFile("config/Config.zig"), .zig);
     defer ast.deinit(alloc);
 
-    try writer.writeAll(
-        \\/// Configuration help
-        \\pub const Config = struct {
-        \\
-        \\
+    try genStringsStruct(
+        alloc,
+        writer,
+        ast,
+        "Config",
+        0,
+        ast.rootDecls(),
+        0,
     );
-
-    inline for (@typeInfo(Config).Struct.fields) |field| {
-        if (field.name[0] == '_') continue;
-        try genConfigField(alloc, writer, ast, field.name);
-    }
-
-    try writer.writeAll("};\n");
-}
-
-fn genConfigField(
-    alloc: std.mem.Allocator,
-    writer: anytype,
-    ast: std.zig.Ast,
-    comptime field: []const u8,
-) !void {
-    const tokens = ast.tokens.items(.tag);
-    for (tokens, 0..) |token, i| {
-        // We only care about identifiers that are preceded by doc comments.
-        if (token != .identifier) continue;
-        if (tokens[i - 1] != .doc_comment) continue;
-
-        // Identifier may have @"" so we strip that.
-        const name = ast.tokenSlice(@intCast(i));
-        const key = if (name[0] == '@') name[2 .. name.len - 1] else name;
-        if (!std.mem.eql(u8, key, field)) continue;
-
-        const comment = try extractDocComments(alloc, ast, @intCast(i - 1), tokens);
-        try writer.writeAll("pub const ");
-        try writer.writeAll(name);
-        try writer.writeAll(": [:0]const u8 = \n");
-        try writer.writeAll(comment);
-        try writer.writeAll("\n");
-        break;
-    }
 }
 
 fn genActions(alloc: std.mem.Allocator, writer: anytype) !void {
@@ -86,6 +55,7 @@ fn genActions(alloc: std.mem.Allocator, writer: anytype) !void {
 
         var ast = try std.zig.Ast.parse(alloc, @embedFile(action_file), .zig);
         defer ast.deinit(alloc);
+
         const tokens: []std.zig.Token.Tag = ast.tokens.items(.tag);
 
         for (tokens, 0..) |token, i| {
@@ -102,12 +72,18 @@ fn genActions(alloc: std.mem.Allocator, writer: anytype) !void {
                 std.process.exit(1);
             }
 
-            const comment = try extractDocComments(alloc, ast, @intCast(i - 2), tokens);
+            const comment = try extractDocComments(
+                alloc,
+                ast,
+                @intCast(i - 2),
+                0,
+            ) orelse continue;
+
             try writer.writeAll("pub const @\"");
             try writer.writeAll(field.name);
             try writer.writeAll("\" = \n");
             try writer.writeAll(comment);
-            try writer.writeAll("\n\n");
+            try writer.writeAll(";\n\n");
             break;
         }
     }
@@ -120,26 +96,337 @@ fn genKeybindActions(alloc: std.mem.Allocator, writer: anytype) !void {
     defer ast.deinit(alloc);
 
     try writer.writeAll(
-        \\/// keybind actions help
         \\pub const KeybindAction = struct {
         \\
+        \\};
+    );
+
+    // for (ast.rootDecls()) |decl| {
+    //     if (ast.fullVarDecl(decl)) |var_decl| {
+    //         var buf: [2]std.zig.Ast.TokenIndex = undefined;
+    //         const decl_container = ast.fullContainerDecl(&buf, var_decl.ast.init_node) orelse continue;
+    //         const name = ast.tokenSlice(var_decl.ast.mut_token + 1);
+
+    //         if (!std.mem.eql(u8, name, "Action")) continue;
+
+    //         _ = decl_container;
+    //         _ = writer;
+
+    // try genStringsStruct(
+    //     alloc,
+    //     writer,
+    //     ast,
+    //     "KeybindAction",
+    //     decl_container.ast.members,
+    //     var_decl.firstToken() - 1,
+    // );
+
+    //         return;
+    //     }
+    // }
+}
+
+fn genStringsStruct(
+    alloc: std.mem.Allocator,
+    writer: anytype,
+    ast: std.zig.Ast,
+    name: []const u8,
+    main_token: std.zig.Ast.TokenIndex,
+    members: []const std.zig.Ast.Node.Index,
+    doc_comment_token: ?std.zig.Ast.TokenIndex,
+) !void {
+    var fields: std.ArrayListUnmanaged(std.zig.Ast.full.ContainerField) = .{};
+    defer fields.deinit(alloc);
+
+    var decls: std.ArrayListUnmanaged(std.zig.Ast.full.VarDecl) = .{};
+    defer decls.deinit(alloc);
+
+    try writer.print("pub const {s} = struct {{\n", .{name});
+
+    for (members) |member| {
+        if (ast.fullContainerField(member)) |field| {
+            try fields.append(alloc, field);
+        } else if (ast.fullVarDecl(member)) |var_decl| {
+            // Is it defining a subtype?
+            try decls.append(alloc, var_decl);
+        }
+    }
+
+    for (fields.items) |field| {
+        try genConfigField(alloc, writer, ast, field, decls.items);
+    }
+
+    for (decls.items) |var_decl| {
+        var buf: [2]std.zig.Ast.TokenIndex = undefined;
+        const decl_container = ast.fullContainerDecl(&buf, var_decl.ast.init_node) orelse continue;
+
+        try genStringsStruct(
+            alloc,
+            writer,
+            ast,
+            ast.tokenSlice(var_decl.ast.mut_token + 1),
+            decl_container.ast.main_token,
+            decl_container.ast.members,
+            var_decl.firstToken() - 1,
+        );
+    }
+
+    try writer.writeAll(
+        \\pub const @"DOC-COMMENT": []const u8 =
         \\
     );
 
-    inline for (@typeInfo(KeybindAction).Union.fields) |field| {
-        if (field.name[0] == '_') continue;
-        try genConfigField(alloc, writer, ast, field.name);
+    if (doc_comment_token) |token| {
+        if (try extractDocComments(
+            alloc,
+            ast,
+            @intCast(token),
+            0,
+        )) |comment| {
+            try writer.writeAll(comment);
+        }
     }
 
-    try writer.writeAll("};\n");
+    try genValidValues(
+        alloc,
+        writer,
+        ast,
+        main_token,
+        members,
+    );
+
+    try writer.writeAll(
+        \\    \\
+        \\;
+        \\};
+    );
+}
+
+fn genValidValues(
+    alloc: std.mem.Allocator,
+    writer: anytype,
+    ast: std.zig.Ast,
+    main_token: std.zig.Ast.TokenIndex,
+    members: []const std.zig.Ast.Node.Index,
+) !void {
+    const token_tags = ast.tokens.items(.tag);
+
+    const ContainerType = enum {
+        @"enum",
+        @"union",
+        bitfield,
+    };
+
+    const container_type: ContainerType = switch (token_tags[main_token]) {
+        .keyword_enum => .@"enum",
+        .keyword_union => .@"union",
+        .keyword_struct => switch (token_tags[main_token - 1]) {
+            .keyword_packed => .bitfield,
+            else => return,
+        },
+        else => return,
+    };
+
+    try writer.writeAll(
+        \\\\
+        \\\\Valid values:
+        \\\\
+        \\
+    );
+
+    for (members) |member| {
+        const field = ast.fullContainerField(member) orelse continue;
+        var field_name = ast.tokenSlice(field.ast.main_token);
+
+        if (std.mem.startsWith(u8, field_name, "@\"")) {
+            field_name = field_name[2..][0 .. field_name.len - 3];
+        }
+
+        try writer.writeAll(
+            \\\\ -
+        );
+
+        switch (container_type) {
+            .@"enum" => try writer.print(" `{s}`\n", .{field_name}),
+            .@"union" => {
+                const field_type = ast.getNodeSource(field.ast.type_expr);
+
+                // Only generate the field name if the field is "enum-variant-like":
+                // type is void or nonexistent.
+                if (field.ast.main_token == ast.firstToken(field.ast.type_expr) or
+                    std.mem.eql(u8, field_type, "void"))
+                {
+                    try writer.print(" `{s}`\n", .{field_name});
+                }
+            },
+            .bitfield => {
+                const default_value = ast.tokenSlice(ast.firstToken(field.ast.value_expr));
+                const is_default = std.mem.eql(u8, default_value, "true");
+
+                if (is_default) {
+                    try writer.print(" [x] `{s}` (Enabled by default)\n", .{field_name});
+                } else {
+                    try writer.print(" [ ] `{s}`\n", .{field_name});
+                }
+            },
+        }
+
+        try writer.writeAll(
+            \\\\
+            \\
+        );
+
+        if (try extractDocComments(
+            alloc,
+            ast,
+            field.firstToken() - 1,
+            3, // 4 indents would be an indented code block
+        )) |comment| {
+            try writer.writeAll(comment);
+            try writer.writeAll(
+                \\\\
+                \\
+            );
+        }
+    }
+}
+
+fn genConfigField(
+    alloc: std.mem.Allocator,
+    writer: anytype,
+    ast: std.zig.Ast,
+    field: std.zig.Ast.full.ContainerField,
+    decls: []std.zig.Ast.full.VarDecl,
+) !void {
+    const name = ast.tokenSlice(field.ast.main_token);
+    if (name[0] == '_') return;
+
+    // Escape special identifiers that are valid as enum variants but not as field names
+    const special_identifiers = &[_][]const u8{ "true", "false", "null" };
+
+    const is_special = for (special_identifiers) |special| {
+        if (std.mem.eql(u8, name, special)) break true;
+    } else false;
+
+    const comment = try extractDocComments(
+        alloc,
+        ast,
+        field.firstToken() - 1,
+        0,
+    ) orelse return;
+
+    try writer.writeAll("pub const ");
+    if (is_special) try writer.writeAll("@\"");
+    try writer.writeAll(name);
+    if (is_special) try writer.writeAll("\"");
+    try writer.writeAll(": [:0]const u8 = \n");
+    try writer.writeAll(comment);
+
+    const type_name = ast.tokenSlice(ast.lastToken(field.ast.type_expr));
+
+    for (decls) |decl| {
+        if (std.mem.eql(u8, type_name, ast.tokenSlice(decl.ast.mut_token + 1))) {
+            try writer.writeAll(
+                \\\\
+                \\\\
+                \\++
+                \\
+            );
+            try writer.writeAll(type_name);
+            try writer.writeAll(
+                \\.@"DOC-COMMENT"
+                \\
+            );
+        }
+    }
+
+    try genDefaultValue(writer, ast, field);
+
+    try writer.writeAll(";\n");
+}
+
+fn genDefaultValue(
+    writer: anytype,
+    ast: std.zig.Ast,
+    field: std.zig.Ast.full.ContainerField,
+) !void {
+    const value = ast.nodes.get(field.ast.value_expr);
+
+    switch (value.tag) {
+        .number_literal, .string_literal => {
+            try writer.writeAll(
+                \\++
+                \\\\
+                \\\\Defaults to `{s}`.
+            , ast.getNodeSource(field.ast.value_expr));
+        },
+        .identifier, .number_literal, .string_literal, .enum_literal => {
+            try writer.writeAll(
+                \\++
+                \\\\
+                \\\\
+                \\\\
+            );
+
+            const default = switch (value.tag) {
+                .enum_literal, .identifier => id: {
+                    // Escape @"blah"
+                    const slice = ast.tokenSlice(value.main_token);
+                    break :id if (std.mem.startsWith(u8, slice, "@\""))
+                        slice[2..][0 .. slice.len - 3]
+                    else
+                        slice;
+                },
+                .number_literal => ast.tokenSlice(value.main_token),
+                // We really don't know. Guess.
+                else => ast.getNodeSource(field.ast.value_expr),
+            };
+
+            // var default = ast.getNodeSource(field.ast.value_expr);
+            // if (default[0] == '.') {
+            //     default = default[1..];
+            // }
+
+            if (std.mem.eql(u8, default, "null")) {
+                try writer.writeAll("Unset by default.\n");
+                return;
+            }
+
+            const default_type_node = ast.nodes.get(field.ast.type_expr);
+            // ?bool is still semantically boolean
+            const default_type = if (default_type_node.tag == .optional_type)
+                ast.getNodeSource(default_type_node.data.lhs)
+            else
+                ast.getNodeSource(field.ast.type_expr);
+
+            // There are some enums/tagged unions with variants called `true`
+            // or `false`, and it's not accurate to call them enabled or
+            // disabled in some circumstances.
+            // Thus we only consider booleans here.
+            if (std.mem.eql(u8, default_type, "bool")) {
+                if (std.mem.eql(u8, default, "true")) {
+                    try writer.writeAll("Enabled by default.\n");
+                } else if (std.mem.eql(u8, default, "false")) {
+                    try writer.writeAll("Disabled by default.\n");
+                }
+                return;
+            }
+
+            try writer.print("Defaults to `{s}`.\n", .{default});
+        },
+        else => {},
+    }
 }
 
 fn extractDocComments(
     alloc: std.mem.Allocator,
     ast: std.zig.Ast,
     index: std.zig.Ast.TokenIndex,
-    tokens: []std.zig.Token.Tag,
-) ![]const u8 {
+    comptime indent: usize,
+) !?[]const u8 {
+    if (index == 0) return null;
+    const tokens = ast.tokens.items(.tag);
+
     // Find the first index of the doc comments. The doc comments are
     // always stacked on top of each other so we can just go backwards.
     const start_idx: usize = start_idx: for (0..index) |i| {
@@ -161,14 +448,15 @@ fn extractDocComments(
     var buffer = std.ArrayList(u8).init(alloc);
     const writer = buffer.writer();
     const prefix = findCommonPrefix(lines);
+
+    if (lines.items.len == 0) return null;
     for (lines.items) |line| {
-        try writer.writeAll("    \\\\");
+        try writer.writeAll("    \\\\" ++ " " ** indent);
         try writer.writeAll(line[@min(prefix, line.len)..]);
         try writer.writeAll("\n");
     }
-    try writer.writeAll(";\n");
 
-    return buffer.toOwnedSlice();
+    return try buffer.toOwnedSlice();
 }
 
 fn findCommonPrefix(lines: std.ArrayList([]const u8)) usize {


### PR DESCRIPTION
Overhauls the way help strings are generated by also generating documentation for the possible values allowed for each type, adds the default value of each key, and deduplicating type-specific documentation (e.g. `Color` and `Duration`).

Still WIP: Webgen works but other forms of documentation are untested. Action and KeybindAction also likely have to be rewritten.