### PR TITLE
macos: only set quick terminal level to popUpMenu during animation

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -230,6 +230,11 @@ class QuickTerminalController: BaseTerminalController {
         // Move our window off screen to the top
         position.setInitial(in: window, on: screen)
 
+        // We need to set our window level to a high value. In testing, only
+        // popUpMenu and above do what we want. This gets it above the menu bar
+        // and lets us render off screen.
+        window.level = .popUpMenu
+
         // Move it to the visible position since animation requires this
         DispatchQueue.main.async {
             window.makeKeyAndOrderFront(nil)
@@ -247,6 +252,11 @@ class QuickTerminalController: BaseTerminalController {
             DispatchQueue.main.async {
                 // If we canceled our animation in we do nothing
                 guard self.visible else { return }
+
+                // After animating in, we reset the window level to a value that
+                // is above other windows but not as high as popUpMenu. This allows
+                // things like IME dropdowns to appear properly.
+                window.level = .floating
 
                 // Now that the window is visible, sync our appearance. This function
                 // requires the window is visible.
@@ -338,6 +348,11 @@ class QuickTerminalController: BaseTerminalController {
                 _ = previousApp.activate(options: [])
             }
         }
+
+        // We need to set our window level to a high value. In testing, only
+        // popUpMenu and above do what we want. This gets it above the menu bar
+        // and lets us render off screen.
+        window.level = .popUpMenu
 
         NSAnimationContext.runAnimationGroup({ context in
             context.duration = derivedConfig.quickTerminalAnimationDuration

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalWindow.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalWindow.swift
@@ -28,23 +28,5 @@ class QuickTerminalWindow: NSPanel {
 
         // We don't want to activate the owning app when quick terminal is triggered.
         self.styleMask.insert(.nonactivatingPanel)
-
-        // We need to set our window level to a high value. In testing, only
-        // popUpMenu and above do what we want. This gets it above the menu bar
-        // and lets us render off screen.
-        self.level = .popUpMenu
-
-        // This plus the level above was what was needed for the animation to work,
-        // because it gets the window off screen properly. Plus we add some fields
-        // we just want the behavior of.
-        self.collectionBehavior = [
-            // We want this to be part of every space because it is a singleton.
-            .canJoinAllSpaces,
-
-            // We don't want to be part of command-tilde
-            .ignoresCycle,
-
-            // We want to show the window on another space if it is visible
-            .fullScreenAuxiliary]
     }
 }


### PR DESCRIPTION
Fixes #4999

We need to set the level to popUpMenu so that we can move the window offscreen and animate it over the main menu, but we must reset it back to floating after the animation is complete so that other higher-level windows can be shown on top of it such as IME windows.