### PR TITLE
fix(window): ensure last_tab action on linux navigates to last tab

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -497,9 +497,9 @@ pub fn moveTab(self: *Window, surface: *Surface, position: c_int) void {
     self.notebook.moveTab(tab, position);
 }
 
-/// Go to the next tab for a surface.
+/// Go to the last tab for a surface.
 pub fn gotoLastTab(self: *Window) void {
-    const max = self.notebook.nPages() -| 1;
+    const max = self.notebook.nPages();
     self.gotoTab(@intCast(max));
 }
 


### PR DESCRIPTION
Previously, the logic navigated to the second-to-last tab instead of the last tab due to an off-by-one error. This updates the implementation so that the index calculation to accurately target the last tab. In the `gotoLastTab` method there was a decrement in the number of max number of tabs and another increment in the `goToTab` method to get the actual tab index.