### PR TITLE
Add default keybinds for move_tab

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2427,6 +2427,16 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
         );
         try result.keybind.set.put(
             alloc,
+            .{ .key = .{ .translated = .left_bracket }, .mods = .{ .ctrl = true, .shift = true } },
+            .{ .move_tab = -1 },
+        );
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .{ .translated = .right_bracket }, .mods = .{ .ctrl = true, .shift = true } },
+            .{ .move_tab = 1 },
+        );
+        try result.keybind.set.put(
+            alloc,
             .{ .key = .{ .translated = .o }, .mods = .{ .ctrl = true, .shift = true } },
             .{ .new_split = .right },
         );
@@ -2699,6 +2709,16 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
             alloc,
             .{ .key = .{ .translated = .right_bracket }, .mods = .{ .super = true, .shift = true } },
             .{ .next_tab = {} },
+        );
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .{ .translated = .left_bracket }, .mods = .{ .ctrl = true, .shift = true } },
+            .{ .move_tab = -1 },
+        );
+        try result.keybind.set.put(
+            alloc,
+            .{ .key = .{ .translated = .right_bracket }, .mods = .{ .ctrl = true, .shift = true } },
+            .{ .move_tab = 1 },
         );
         try result.keybind.set.put(
             alloc,


### PR DESCRIPTION
Adds default keybinds for the `move_tab` action. I went with `ctrl+shift+{left,right}_bracket` since page_up/page_down is already bound to `jump_to_prompt`. Quick note, although the original issue is tagged for linux, this pr also handles macOS.

Closes https://github.com/ghostty-org/ghostty/issues/4998