### PR TITLE
gtk: add config entry to hide titlebar when the window is maximized

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -204,6 +204,7 @@ pub fn init(self: *Window, app: *App) !void {
     }
 
     _ = c.g_signal_connect_data(gtk_window, "notify::decorated", c.G_CALLBACK(&gtkWindowNotifyDecorated), self, null, c.G_CONNECT_DEFAULT);
+    _ = c.g_signal_connect_data(gtk_window, "notify::maximized", c.G_CALLBACK(&gtkWindowNotifyMaximized), self, null, c.G_CONNECT_DEFAULT);
     _ = c.g_signal_connect_data(gtk_window, "notify::fullscreened", c.G_CALLBACK(&gtkWindowNotifyFullscreened), self, null, c.G_CONNECT_DEFAULT);
 
     // If we are disabling decorations then disable them right away.
@@ -599,6 +600,22 @@ fn gtkRealize(v: *c.GtkWindow, ud: ?*anyopaque) callconv(.C) bool {
     };
 
     return true;
+}
+
+fn gtkWindowNotifyMaximized(
+    _: *c.GObject,
+    _: *c.GParamSpec,
+    ud: ?*anyopaque,
+) callconv(.C) void {
+    const self = userdataSelf(ud orelse return);
+    const maximized = c.gtk_window_is_maximized(self.window) != 0;
+    if (!maximized) {
+        self.headerbar.setVisible(true);
+        return;
+    }
+    if (self.app.config.@"gtk-titlebar-hide-when-maximized") {
+        self.headerbar.setVisible(false);
+    }
 }
 
 fn gtkWindowNotifyDecorated(

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2032,6 +2032,10 @@ keybind: Keybinds = .{},
 /// title bar, or you can switch tabs with keybinds.
 @"gtk-tabs-location": GtkTabsLocation = .top,
 
+/// If this is `true`, the titlebar will be hidden when the window is maximized,
+/// and shown when the titlebar is unmaximized. GTK only.
+@"gtk-titlebar-hide-when-maximized": bool = false,
+
 /// Determines the appearance of the top and bottom bars when using the
 /// Adwaita tab bar. This requires `gtk-adwaita` to be enabled (it is
 /// by default).


### PR DESCRIPTION
Fixes #3381

Note that #4936 will need to be merged or you'll need to rely on Gnome's default keybinding for unmaximizing a window (super+down).