### PR TITLE
Fix URL handling in pasteboard operations

### DIFF
--- a/macos/Sources/Helpers/NSPasteboard+Extension.swift
+++ b/macos/Sources/Helpers/NSPasteboard+Extension.swift
@@ -15,7 +15,9 @@ extension NSPasteboard {
     func getOpinionatedStringContents() -> String? {
         if let urls = readObjects(forClasses: [NSURL.self]) as? [URL],
            urls.count > 0 {
-            return urls.map { $0.path }.joined(separator: " ")
+            return urls
+                .map { $0.isFileURL ? $0.path : $0.absoluteString }
+                .joined(separator: " ")
         }
 
         return self.string(forType: .string)


### PR DESCRIPTION
## Description
When pasting URLs from clipboard, the behavior varies based on the source:

1. From browser address bar:

   - Pasteboard types: ["public.utf8-plain-text", "NSStringPboardType"]
   
   - Handled as plain text, resulting in correct full URL paste

2. From clipboard history tools, such as Raycast clipboard history:
   
   - Pasteboard types include "public.url" and related URL types
   
   - URL was being processed through NSURL, which only extracted the path component
   
   - This resulted in incomplete URLs

## Changes

- Modified `getOpinionatedStringContents()` to differentiate URL types:

  - For file URLs (`file://`): preserve existing behavior, return path only
  
  - For web URLs (`http://`, `https://`): return full URL string via `absoluteString`
  
  - For non-URL content: maintain existing plain text handling

## Related Issues

Fixes #5026

@caarlos0 Could you please help check if this resolves the issue you were encountering?