### PR TITLE
terminal: keep track of colon vs semicolon state in CSI params

### DIFF
--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -253,15 +253,11 @@ pub fn Stream(comptime Handler: type) type {
                     // A parameter separator:
                     ':', ';' => if (self.parser.params_idx < 16) {
                         self.parser.params[self.parser.params_idx] = self.parser.param_acc;
+                        if (c == ':') self.parser.params_sep.set(self.parser.params_idx);
                         self.parser.params_idx += 1;
 
                         self.parser.param_acc = 0;
                         self.parser.param_acc_idx = 0;
-
-                        // Keep track of separator state.
-                        const sep: Parser.ParamSepState = @enumFromInt(c);
-                        if (self.parser.params_idx == 1) self.parser.params_sep = sep;
-                        if (self.parser.params_sep != sep) self.parser.params_sep = .mixed;
                     },
                     // Explicitly ignored:
                     0x7F => {},
@@ -937,7 +933,10 @@ pub fn Stream(comptime Handler: type) type {
                 'm' => switch (input.intermediates.len) {
                     0 => if (@hasDecl(T, "setAttribute")) {
                         // log.info("parse SGR params={any}", .{action.params});
-                        var p: sgr.Parser = .{ .params = input.params, .colon = input.sep == .colon };
+                        var p: sgr.Parser = .{
+                            .params = input.params,
+                            .params_sep = input.params_sep,
+                        };
                         while (p.next()) |attr| {
                             // log.info("SGR attribute: {}", .{attr});
                             try self.handler.setAttribute(attr);


### PR DESCRIPTION
Fixes #5022

The CSI SGR sequence (CSI m) is unique in that its the only CSI sequence that allows colons as delimiters between some parameters, and the colon vs. semicolon changes the semantics of the parameters.

Previously, Ghostty assumed that an SGR sequence was either all colons or all semicolons, and would change its behavior based on the first delimiter it encountered.

This is incorrect. It is perfectly valid for an SGR sequence to have both colons and semicolons as delimiters. For example, Kakoune sends the following:

    ;4:3;38;2;175;175;215;58:2::190:80:70m

This is equivalent to:

  - unset (0)
  - curly underline (4:3)
  - foreground color (38;2;175;175;215)
  - underline color (58:2::190:80:70)

This commit changes the behavior of Ghostty to track the delimiter per parameter, rather than per sequence. It also updates the SGR parser to be more robust and handle the various edge cases that can occur. Tests were added for the new cases.