### PR TITLE
fix: Ensure file paths are properly escaped during pasteboard paste operations

### DIFF
--- a/macos/Sources/Helpers/NSPasteboard+Extension.swift
+++ b/macos/Sources/Helpers/NSPasteboard+Extension.swift
@@ -9,14 +9,14 @@ extension NSPasteboard {
 
     /// Gets the contents of the pasteboard as a string following a specific set of semantics.
     /// Does these things in order:
-    /// - Tries to get the absolute filesystem path of the file in the pasteboard if there is one.
+    /// - Tries to get the absolute filesystem path of the file in the pasteboard if there is one and ensures the file path is properly escaped.
     /// - Tries to get any string from the pasteboard.
     /// If all of the above fail, returns None.
     func getOpinionatedStringContents() -> String? {
         if let urls = readObjects(forClasses: [NSURL.self]) as? [URL],
            urls.count > 0 {
             return urls
-                .map { $0.isFileURL ? $0.path : $0.absoluteString }
+                .map { $0.isFileURL ? Ghostty.Shell.escape($0.path) : $0.absoluteString }
                 .joined(separator: " ")
         }
 


### PR DESCRIPTION
This PR ensures file paths derived from pasteboard operations are properly escaped:

## Before fix:
Attempting to cd into these paths rendered the following error: `cd: too many arguments` because the directory name includes spaces or special characters, which need to be handled correctly when running the cd command.

https://github.com/user-attachments/assets/4d03a94a-fa14-4ac8-9c1e-1ad8b0b939a7

## Afer fix

File paths are now properly escaped and we can correctly `cd` into these paths.

https://github.com/user-attachments/assets/72e794c0-31e4-43b8-bebf-76c161924bd1

This change ensures Ghostty has the same behaviour as Iterm2.

