### PR TITLE
render consecutive shaders to the fbo (opengl)

### DIFF
--- a/src/renderer/opengl/custom.zig
+++ b/src/renderer/opengl/custom.zig
@@ -251,7 +251,6 @@ pub const Program = struct {
         const program = try gl.Program.createVF(
             @embedFile("../shaders/custom.v.glsl"),
             src,
-            //@embedFile("../shaders/temp.f.glsl"),
         );
         errdefer program.destroy();
 


### PR DESCRIPTION
fixes #4729

allows the shaders to sample each other via the fbo texture.

also, a better example would use the full screen e.g.:
"behind.glsl"
```glsl
void mainImage( out vec4 fragColor, in vec2 fragCoord )
{
    fragColor = vec4(fragCoord/iResolution.xy, 0.0, 1.0);
}
```

"infront.glsl"
```glsl
void mainImage( out vec4 fragColor, in vec2 fragCoord )
{
    fragColor = texture(iChannel0, fragCoord/iResolution.xy);
}
```
`ghostty --custom-shader=behind.glsl --custom-shader=infront.glsl`
|before|after|
|-|-|
| ![image](https://github.com/user-attachments/assets/d96cc8f1-7d87-4346-963a-a1fb27b81cba) | ![image](https://github.com/user-attachments/assets/203c3827-9574-4739-9d54-430dc4a47dcc)|
