### PR TITLE
Fix shell-integration-features being ignored with manual shell integration

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1670,7 +1670,9 @@ keybind: Keybinds = .{},
 /// The default value is `detect`.
 @"shell-integration": ShellIntegration = .detect,
 
-/// Shell integration features to enable if shell integration itself is enabled.
+/// Shell integration features to enable. These require our shell integration
+/// to be loaded, either automatically via shell-integration or manually.
+///
 /// The format of this is a list of features to enable separated by commas. If
 /// you prefix a feature with `no-` then it is disabled. If you omit a feature,
 /// its default value is used, so you must explicitly disable features you don't

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -875,7 +875,11 @@ const Subprocess = struct {
             };
 
             const force: ?shell_integration.Shell = switch (cfg.shell_integration) {
-                .none => break :shell .{ null, default_shell_command },
+                .none => {
+                    // Even if shell integration is none, we still want to set up the feature env vars
+                    try shell_integration.setupFeatures(&env, cfg.shell_integration_features);
+                    break :shell .{ null, default_shell_command };
+                },
                 .detect => null,
                 .bash => .bash,
                 .elvish => .elvish,

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -114,9 +114,7 @@ pub fn setup(
     };
 
     // Setup our feature env vars
-    if (!features.cursor) try env.put("GHOSTTY_SHELL_INTEGRATION_NO_CURSOR", "1");
-    if (!features.sudo) try env.put("GHOSTTY_SHELL_INTEGRATION_NO_SUDO", "1");
-    if (!features.title) try env.put("GHOSTTY_SHELL_INTEGRATION_NO_TITLE", "1");
+    try setupFeatures(env, features);
 
     return result;
 }
@@ -136,6 +134,17 @@ test "force shell" {
         const result = try setup(alloc, ".", "sh", &env, shell, .{});
         try testing.expectEqual(shell, result.?.shell);
     }
+}
+
+/// Setup shell integration feature environment variables without
+/// performing full shell integration setup.
+pub fn setupFeatures(
+    env: *EnvMap,
+    features: config.ShellIntegrationFeatures,
+) !void {
+    if (!features.cursor) try env.put("GHOSTTY_SHELL_INTEGRATION_NO_CURSOR", "1");
+    if (!features.sudo) try env.put("GHOSTTY_SHELL_INTEGRATION_NO_SUDO", "1");
+    if (!features.title) try env.put("GHOSTTY_SHELL_INTEGRATION_NO_TITLE", "1");
 }
 
 /// Setup the bash automatic shell integration. This works by


### PR DESCRIPTION
## Descriptions

The code was short-circuiting the shell integration setup when `shell-integration = none`, which prevented the feature environment variables from being set. These environment variables are needed even for manual shell integration to work properly.

## Changes

- Extracted feature environment variables setup into a separate `setup_features` function

- Modified the shell integration initialization to ensure features are set up even when `shell-integration = none`

<img width="1126" alt="image" src="https://github.com/user-attachments/assets/ceeb33f5-26ee-4a3b-a6d5-eed57848c96c" />


Fixes https://github.com/ghostty-org/ghostty/issues/5046
