### PR TITLE
gtk: request initial color scheme asynchronously

### DIFF
--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -633,9 +633,6 @@ fn realize(self: *Surface) !void {
         try self.core_surface.setFontSize(size);
     }
 
-    // Set the initial color scheme
-    try self.core_surface.colorSchemeCallback(self.app.getColorScheme());
-
     // Note we're realized
     self.realized = true;
 }


### PR DESCRIPTION
Requesting the initial color scheme on systems where the D-Bus interface is nonexistent would delay Ghostty startup by 1-2 minutes. That's not acceptable. Our color scheme events are already async-friendly anyway.

Fixes #4632