### PR TITLE
Fix triple clicking empty line and dragging

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3563,17 +3563,15 @@ fn dragLeftClickTriple(
     const screen = &self.io.terminal.screen;
     const click_pin = self.mouse.left_click_pin.?.*;
 
-    // Get the line selection under our current drag point. If there isn't a line, do nothing.
+    // Get the line selection under our current drag point. If there isn't a
+    // line, do nothing.
     const line = screen.selectLine(.{ .pin = drag_pin }) orelse return;
 
-    // get the selection under our click point.
-    var sel_ = screen.selectLine(.{ .pin = click_pin });
-
-    // We may not have a selection if we started our triple-click in an area
-    // that had no data, in this case recall selectLine with allow_empty_lines.
-    if (sel_ == null) {
-        sel_ = screen.selectLine(.{ .pin = click_pin, .allow_empty_lines = true });
-    }
+    // Get the selection under our click point. We first try to trim
+    // whitespace if we've selected a word. But if no word exists then
+    // we select the blank line.
+    const sel_ = screen.selectLine(.{ .pin = click_pin }) orelse
+        screen.selectLine(.{ .pin = click_pin, .whitespace = null });
 
     var sel = sel_ orelse return;
     if (drag_pin.before(click_pin)) {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3563,22 +3563,23 @@ fn dragLeftClickTriple(
     const screen = &self.io.terminal.screen;
     const click_pin = self.mouse.left_click_pin.?.*;
 
-    // Get the word under our current point. If there isn't a word, do nothing.
-    const word = screen.selectLine(.{ .pin = drag_pin }) orelse return;
+    // Get the line selection under our current drag point. If there isn't a line, do nothing.
+    const line = screen.selectLine(.{ .pin = drag_pin }) orelse return;
 
-    // Get our selection to grow it. If we don't have a selection, start it now.
-    // We may not have a selection if we started our dbl-click in an area
-    // that had no data, then we dragged our mouse into an area with data.
-    var sel = screen.selectLine(.{ .pin = click_pin }) orelse {
-        try self.setSelection(word);
-        return;
-    };
+    // get the selection under our click point.
+    var sel_ = screen.selectLine(.{ .pin = click_pin });
 
-    // Grow our selection
+    // We may not have a selection if we started our triple-click in an area
+    // that had no data, in this case recall selectLine with allow_empty_lines.
+    if (sel_ == null) {
+        sel_ = screen.selectLine(.{ .pin = click_pin, .allow_empty_lines = true });
+    }
+
+    var sel = sel_ orelse return;
     if (drag_pin.before(click_pin)) {
-        sel.startPtr().* = word.start();
+        sel.startPtr().* = line.start();
     } else {
-        sel.endPtr().* = word.end();
+        sel.endPtr().* = line.end();
     }
     try self.setSelection(sel);
 }

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -2215,7 +2215,6 @@ pub const SelectLine = struct {
     /// state changing a boundary. State changing is ANY state
     /// change.
     semantic_prompt_boundary: bool = true,
-    allow_empty_lines: bool = false,
 };
 
 /// Select the line under the given point. This will select across soft-wrapped
@@ -2292,11 +2291,6 @@ pub fn selectLine(self: *const Screen, opts: SelectLine) ?Selection {
 
         return null;
     };
-
-    // If we allow empty lines, we don't need to do any further checks.
-    if (opts.allow_empty_lines) {
-        return Selection.init(start_pin, end_pin, false);
-    }
 
     // Go forward from the start to find the first non-whitespace character.
     const start: Pin = start: {

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -2215,6 +2215,7 @@ pub const SelectLine = struct {
     /// state changing a boundary. State changing is ANY state
     /// change.
     semantic_prompt_boundary: bool = true,
+    allow_empty_lines: bool = false,
 };
 
 /// Select the line under the given point. This will select across soft-wrapped
@@ -2291,6 +2292,11 @@ pub fn selectLine(self: *const Screen, opts: SelectLine) ?Selection {
 
         return null;
     };
+
+    // If we allow empty lines, we don't need to do any further checks.
+    if (opts.allow_empty_lines) {
+        return Selection.init(start_pin, end_pin, false);
+    }
 
     // Go forward from the start to find the first non-whitespace character.
     const start: Pin = start: {


### PR DESCRIPTION
Fixes core issue #4957. Adds a bool to `SelectLine` allowing the `selectLine` function to select lines that are empty. When starting a triple selection on an empty line the initial `selectLine` returns null because we don't see any characters, in this case we rerun `selectLine` but short circuit with the `allow_empty_lines`. We need to run `selectLine` with out allowing empty lines once because if there are characters on the line we don't want to select empty space.

