### PR TITLE
fix: building on systems with older adwaita

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -410,7 +410,7 @@ pub fn syncAppearance(self: *Window, config: *const configpkg.Config) !void {
     // Disable the title buttons (close, maximize, minimize, ...)
     // *inside* the tab overview if CSDs are disabled.
     // We do spare the search button, though.
-    if ((comptime adwaita.versionAtLeast(0, 0, 0)) and
+    if ((comptime adwaita.versionAtLeast(1, 4, 0)) and
         adwaita.enabled(&self.app.config))
     {
         if (self.tab_overview) |tab_overview| {


### PR DESCRIPTION
3cdb9a7 made ghostty unable to compile on my debian system (adwaita 1.2.2) due to `adw_tab_overview_set_show_start_title_buttons` and `adw_tab_overview_set_show_end_title_buttons` which are since 1.3.0. I increased the comptime check to 1.4.0, this is fine since the assignment of `tab_overview` is [already comptime guarded by 1.4.0](https://github.com/ghostty-org/ghostty/blob/3cdb9a7dfe59fa46dde27b5ada5932bbe42094b8/src/apprt/gtk/Window.zig#L130)