### PR TITLE
fix: gtk titlebar being restored if it shouldn't be

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -675,7 +675,13 @@ fn gtkWindowNotifyFullscreened(
     ud: ?*anyopaque,
 ) callconv(.C) void {
     const self = userdataSelf(ud orelse return);
-    self.headerbar.setVisible(c.gtk_window_is_fullscreen(@ptrCast(object)) == 0);
+    const fullscreened = c.gtk_window_is_fullscreen(@ptrCast(object)) != 0;
+    if (!fullscreened) {
+        self.headerbar.setVisible(self.app.config.@"gtk-titlebar");
+        return;
+    }
+
+    self.headerbar.setVisible(false);
 }
 
 // Note: we MUST NOT use the GtkButton parameter because gtkActionNewTab

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -646,7 +646,7 @@ fn gtkWindowNotifyMaximized(
     if (!self.winproto.clientSideDecorationEnabled()) return;
 
     if (!maximized) {
-        self.headerbar.setVisible(true);
+        self.headerbar.setVisible(self.app.config.@"gtk-titlebar");
         return;
     }
     if (self.app.config.@"gtk-titlebar-hide-when-maximized") {


### PR DESCRIPTION
I feel like we should be respecting the value of `gtk-titlebar` in the `gtkWindowNotifyMaximized` callback as mentioned in discord (https://discord.com/channels/1005603569187160125/1005603569711452192/1328976978094723163)

Would close https://github.com/ghostty-org/ghostty/issues/5262