### PR TITLE
[macOS] feat: Add setting to hide icon from dock/cmd-tab

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -533,6 +533,15 @@ class AppDelegate: NSObject,
         // AppKit mutex on the appearance.
         DispatchQueue.main.async { self.syncAppearance(config: config) }
 
+        // Decide whether to hide/unhide app from dock and app switcher
+        switch (config.macosHidden) {
+        case .never:
+            NSApp.setActivationPolicy(.regular)
+
+        case .always:
+            NSApp.setActivationPolicy(.accessory)
+        }
+
         // If we have configuration errors, we need to show them.
         let c = ConfigurationErrorsController.sharedInstance
         c.errors = config.errors

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -302,6 +302,16 @@ extension Ghostty {
             return buffer.map { .init(ghostty: $0) }
         }
 
+        var macosHidden: MacHidden {
+            guard let config = self.config else { return .never }
+            var v: UnsafePointer<Int8>? = nil
+            let key = "macos-hidden"
+            guard ghostty_config_get(config, &v, key, UInt(key.count)) else { return .never }
+            guard let ptr = v else { return .never }
+            let str = String(cString: ptr)
+            return MacHidden(rawValue: str) ?? .never
+        }
+
         var focusFollowsMouse : Bool {
             guard let config = self.config else { return false }
             var v = false;
@@ -514,6 +524,11 @@ extension Ghostty.Config {
         case off
         case check
         case download
+    }
+
+    enum MacHidden : String {
+        case never
+        case always
     }
 
     enum ResizeOverlay : String {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1974,6 +1974,26 @@ keybind: Keybinds = .{},
 /// find false more visually appealing.
 @"macos-window-shadow": bool = true,
 
+/// If true, the macOS icon in the dock and app switcher will be hidden. This is
+/// mainly intended for those primarily using the quick-terminal mode.
+///
+/// Note that setting this to true means that keyboard layout changes
+/// will no longer be automatic.
+///
+/// Control whether macOS app is excluded from the dock and app switcher,
+/// a "hidden" state. This is mainly intended for those primarily using
+/// quick-terminal mode, but is a general configuration for any use
+/// case.
+///
+/// Available values:
+///
+///   * `never` - The macOS app is never hidden.
+///   * `always` - The macOS app is always hidden.
+///
+/// Note: When the macOS application is hidden, keyboard layout changes
+/// will no longer be automatic. This is a limitation of macOS.
+@"macos-hidden": MacHidden = .never,
+
 /// If true, Ghostty on macOS will automatically enable the "Secure Input"
 /// feature when it detects that a password prompt is being displayed.
 ///
@@ -5736,6 +5756,12 @@ pub const MacTitlebarStyle = enum {
 pub const MacTitlebarProxyIcon = enum {
     visible,
     hidden,
+};
+
+/// See macos-hidden
+pub const MacHidden = enum {
+    never,
+    always,
 };
 
 /// See macos-icon


### PR DESCRIPTION
Resolves #4538 

Adds boolean configuration option `macos-hidden` which toggles the NSApp's activation policy appropriately on config change. 