### PR TITLE
gtk(wayland): respect compositor SSD preferences

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -1881,16 +1881,14 @@ fn initContextMenu(self: *App) void {
         c.g_menu_append(section, "Terminal Inspector", "win.toggle_inspector");
     }
 
-    if (!self.config.@"window-decoration".isCSD()) {
-        const section = c.g_menu_new();
-        defer c.g_object_unref(section);
-        const submenu = c.g_menu_new();
-        defer c.g_object_unref(submenu);
+    const section = c.g_menu_new();
+    defer c.g_object_unref(section);
+    const submenu = c.g_menu_new();
+    defer c.g_object_unref(submenu);
 
-        initMenuContent(@ptrCast(submenu));
-        c.g_menu_append_submenu(section, "Menu", @ptrCast(@alignCast(submenu)));
-        c.g_menu_append_section(menu, null, @ptrCast(@alignCast(section)));
-    }
+    initMenuContent(@ptrCast(submenu));
+    c.g_menu_append_submenu(section, "Menu", @ptrCast(@alignCast(submenu)));
+    c.g_menu_append_section(menu, null, @ptrCast(@alignCast(section)));
 
     self.context_menu = menu;
 }

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -584,8 +584,8 @@ pub fn toggleFullscreen(self: *Window) void {
 /// Toggle the window decorations for this window.
 pub fn toggleWindowDecorations(self: *Window) void {
     self.app.config.@"window-decoration" = switch (self.app.config.@"window-decoration") {
-        .client, .server => .none,
-        .none => .server,
+        .auto, .client, .server => .none,
+        .none => .client,
     };
     self.updateConfig(&self.app.config) catch {};
 }

--- a/src/apprt/gtk/winproto/x11.zig
+++ b/src/apprt/gtk/winproto/x11.zig
@@ -168,7 +168,7 @@ pub const Window = struct {
                 .blur = config.@"background-blur-radius".enabled(),
                 .has_decoration = switch (config.@"window-decoration") {
                     .none => false,
-                    .client, .server => true,
+                    .auto, .client, .server => true,
                 },
             };
         }


### PR DESCRIPTION
Compositors can actually tell us whether they want to use CSD or SSD!

(Ignore the context menu changes — they will most likely be unified after #4952 anyway)