### PR TITLE
bash: remove sed dependency for history processing

### DIFF
--- a/src/shell-integration/bash/bash-preexec.sh
+++ b/src/shell-integration/bash/bash-preexec.sh
@@ -250,10 +250,8 @@ __bp_preexec_invoke_exec() {
     fi
 
     local this_command
-    this_command=$(
-        export LC_ALL=C
-        HISTTIMEFORMAT='' builtin history 1 | sed '1 s/^ *[0-9][0-9]*[* ] //'
-    )
+    this_command=$(LC_ALL=C HISTTIMEFORMAT='' builtin history 1)
+    this_command="${this_command#*[[:digit:]][* ] }"
 
     # Sanity check to make sure we have something to invoke our function with.
     if [[ -z "$this_command" ]]; then


### PR DESCRIPTION
We post-process history 1's output to extract the current command. This processing needs to strip the leading history number, an optional * character indicating whether the entry was modified (or a space), and then a space separating character.

We were previously using sed(1) for this, but we can implement an equivalent transformation using bash's native parameter expansion syntax.

This also results in ~4x reduction in per-prompt command overhead.

Upstream: https://github.com/rcaloras/bash-preexec/pull/167