### PR TITLE
core: add context menu key

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -240,6 +240,9 @@ typedef enum {
   GHOSTTY_KEY_KP_DELETE,
   GHOSTTY_KEY_KP_BEGIN,
 
+  // special keys
+  GHOSTTY_KEY_CONTEXT_MENU,
+
   // modifiers
   GHOSTTY_KEY_LEFT_SHIFT,
   GHOSTTY_KEY_LEFT_CONTROL,

--- a/src/input/key.zig
+++ b/src/input/key.zig
@@ -401,7 +401,8 @@ pub const Key = enum(c_int) {
     kp_delete,
     kp_begin,
 
-    // TODO: media keys
+    // special keys
+    context_menu,
 
     // modifiers
     left_shift,
@@ -579,6 +580,7 @@ pub const Key = enum(c_int) {
             .backspace => cimgui.c.ImGuiKey_Backspace,
             .print_screen => cimgui.c.ImGuiKey_PrintScreen,
             .pause => cimgui.c.ImGuiKey_Pause,
+            .context_menu => cimgui.c.ImGuiKey_Menu,
 
             .f1 => cimgui.c.ImGuiKey_F1,
             .f2 => cimgui.c.ImGuiKey_F2,

--- a/src/input/keycodes.zig
+++ b/src/input/keycodes.zig
@@ -153,6 +153,7 @@ const code_to_key = code_to_key: {
         .{ "Numpad0", .kp_0 },
         .{ "NumpadDecimal", .kp_decimal },
         .{ "NumpadEqual", .kp_equal },
+        .{ "ContextMenu", .context_menu },
         .{ "ControlLeft", .left_control },
         .{ "ShiftLeft", .left_shift },
         .{ "AltLeft", .left_alt },


### PR DESCRIPTION
I have this key on a cheap Lenovo keyboard at work and would like to put it to some use.