### PR TITLE
fix: focus lost when closing tab when using stage manager on macOS

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -452,6 +452,12 @@ class BaseTerminalController: NSWindowController,
             self.alert = nil
             switch (response) {
             case .alertFirstButtonReturn:
+                if let windows = window.tabGroup?.windows, windows.count > 1 {
+                    let secondLastWindow = windows[windows.count - 2]
+                    secondLastWindow.makeKeyAndOrderFront(nil)
+                    secondLastWindow.makeFirstResponder(nil)
+                    window.close()
+                }
                 window.close()
 
             default:


### PR DESCRIPTION
This PR addresses an issue on macOS where the application loses focus and gets moved to the recently used apps list after closing a terminal window tab when Stage Manager is enabled. The fix ensures the application remains focused when closing tabs as is expected.

# Demo


https://github.com/user-attachments/assets/6f2bae65-acd0-4250-90e1-5c1971dfe397




Resolves #5108