### PR TITLE
[macOS] fix: Closing tab with running process while in Stage Manager no longer causes focus to be lost

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -449,6 +449,7 @@ class BaseTerminalController: NSWindowController,
         alert.addButton(withTitle: "Cancel")
         alert.alertStyle = .warning
         alert.beginSheetModal(for: window, completionHandler: { response in
+            self.alert = nil
             switch (response) {
             case .alertFirstButtonReturn:
                 alert.window.orderOut(nil)

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -449,9 +449,9 @@ class BaseTerminalController: NSWindowController,
         alert.addButton(withTitle: "Cancel")
         alert.alertStyle = .warning
         alert.beginSheetModal(for: window, completionHandler: { response in
-            self.alert = nil
             switch (response) {
             case .alertFirstButtonReturn:
+                alert.window.orderOut(nil)
                 window.close()
 
             default:

--- a/macos/Sources/Ghostty/Ghostty.TerminalSplit.swift
+++ b/macos/Sources/Ghostty/Ghostty.TerminalSplit.swift
@@ -205,6 +205,7 @@ extension Ghostty {
             alert.beginSheetModal(for: window, completionHandler: { response in
                 switch (response) {
                 case .alertFirstButtonReturn:
+                    alert.window.orderOut(nil)
                     node = nil
 
                 default:


### PR DESCRIPTION
Resolves #5108 

Reproduction: While Stage Manager is activated, create a new tab in Ghostty, run `sleep 500` in that tab, and try and close it. Make sure to try both closing the tab with cmd-w and clicking the x; also try accepting the modal with a mouse click and pressing enter. 

Relevant AppKit documentation: [NSAlert beginSheetModal](https://developer.apple.com/documentation/appkit/nsalert/beginsheetmodal(for:completionhandler:))

What I believe is happening is that the alert modal ("there is still a process running") is closed automatically after the completion handler is run, which closes the window on which the alert is attached. Something seems to go wrong in Stage Manager at this point; perhaps it detects the alert closing as a "full" window closing and moves focus to a different window. 

The fix I've identified is to manually call the `orderOut` function to dismiss the alert _before_ the code that closes the window is run.