### PR TITLE
fix(gtk): confirm tab close on close_tab action

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -579,7 +579,7 @@ fn closeTab(_: *App, target: apprt.Target) !void {
                 return;
             };
 
-            tab.window.closeTab(tab);
+            tab.closeWithConfirmation();
         },
     }
 }


### PR DESCRIPTION
#4033 introduced a `ctrl-shift-w` binding to close a tab, but it doesn't respect the `confirm-close-surface` option. Now `ctrl-shift-w` will ask for confirmation exactly the same as clicking the close button with the mouse.