### PR TITLE
gtk: always set the title on the underlying window when using adwaita

### DIFF
--- a/src/apprt/gtk/headerbar_adw.zig
+++ b/src/apprt/gtk/headerbar_adw.zig
@@ -65,6 +65,7 @@ pub fn packStart(self: HeaderBarAdw, widget: *c.GtkWidget) void {
 }
 
 pub fn setTitle(self: HeaderBarAdw, title: [:0]const u8) void {
+    c.gtk_window_set_title(self.window.window, title);
     if (comptime adwaita.versionAtLeast(0, 0, 0)) {
         c.adw_window_title_set_title(self.title, title);
     }


### PR DESCRIPTION
Fixes #5140 