### PR TITLE
macOS: add link to release notes on appcast

### DIFF
--- a/dist/macos/update_appcast_tag.py
+++ b/dist/macos/update_appcast_tag.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone
 
 now = datetime.now(timezone.utc)
 version = os.environ["GHOSTTY_VERSION"]
+version_dash = version.replace('.', '-')
 build = os.environ["GHOSTTY_BUILD"]
 commit = os.environ["GHOSTTY_COMMIT"]
 commit_long = os.environ["GHOSTTY_COMMIT_LONG"]
@@ -82,18 +83,20 @@ elem = ET.SubElement(item, "sparkle:shortVersionString")
 elem.text = f"{version}"
 elem = ET.SubElement(item, "sparkle:minimumSystemVersion")
 elem.text = "13.0.0"
+elem = ET.SubElement(item, "sparkle:fullReleaseNotesLink")
+elem.text = f"https://ghostty.org/docs/install/release-notes/{version_dash}"
 elem = ET.SubElement(item, "description")
 elem.text = f"""
-<h1>Ghostty v{version}</h1>
+<![CDATA[<h1>Ghostty v{version}</h1>
 <p>
 This release was built from commit <code><a href="{repo}/commits/{commit_long}">{commit}</a></code>
 on {now.strftime('%Y-%m-%d')}.
 </p>
 <p>
 We don't currently generate release notes for auto-updates.
-You can view the complete changelog and release notes on
-the <a href="https://ghostty.org">Ghostty website</a>.
-</p>
+You can view the complete changelog and release notes
+at <a href="https://ghostty.org/docs/install/release-notes/{version_dash}">ghostty.org/docs/install/release-notes/{version_dash}</a>.
+</p>]]>
 """
 elem = ET.SubElement(item, "enclosure")
 elem.set("url", f"https://release.files.ghostty.org/{version}/Ghostty.dmg")

--- a/dist/macos/update_appcast_tip.py
+++ b/dist/macos/update_appcast_tip.py
@@ -83,7 +83,7 @@ elem = ET.SubElement(item, "sparkle:minimumSystemVersion")
 elem.text = "13.0.0"
 elem = ET.SubElement(item, "description")
 elem.text = f"""
-<p>
+<![CDATA[<p>
 Automated build from commit <code><a href="{repo}/commits/{commit_long}">{commit}</a></code>
 on {now.strftime('%Y-%m-%d')}.
 </p>
@@ -91,7 +91,7 @@ on {now.strftime('%Y-%m-%d')}.
 These are automatic per-commit builds generated from the main Git branch.
 We do not generate any release notes for these builds. You can view the full
 commit history <a href="{repo}">on GitHub</a> for all changes.
-</p>
+</p>]]>
 """
 elem = ET.SubElement(item, "enclosure")
 elem.set("url", f"https://tip.files.ghostty.org/{commit_long}/Ghostty.dmg")


### PR DESCRIPTION
Resolves #4730

I opted to link directly to the release notes of the updated version in the `<description>` body, i.e. in the future it would link directly v1.0.2's release notes at https://ghostty.org/docs/install/release-notes/1-0-2. This thereby implements the second option mentioned in the issue. It wasn't that much harder than the third option, but if there's any particular reason _not to_ link directly to a version's changelog page, I'll be more than happy to modify this PR and implement the third option instead - in any case, I had opened https://github.com/ghostty-org/website/pull/277 so that https://ghostty.org/docs/install/release-notes is a valid page.

I also wrapped the current text `<![CDATA[ ... ]]>` just in case, as I noticed this is a pretty standard practice in other apps that use `<description>` to embed their release notes when using Sparkle - [Sparkle's documentation](https://sparkle-project.org/documentation/publishing/#embedded-release-notes) says to do this so you can use unescaped HTML.