### PR TITLE
fix(wuffs): don't premul alpha when loading png

### DIFF
--- a/pkg/wuffs/src/jpeg.zig
+++ b/pkg/wuffs/src/jpeg.zig
@@ -55,7 +55,7 @@ pub fn decode(alloc: Allocator, data: []const u8) Error!ImageData {
 
     c.wuffs_base__pixel_config__set(
         &image_config.pixcfg,
-        c.WUFFS_BASE__PIXEL_FORMAT__RGBA_PREMUL,
+        c.WUFFS_BASE__PIXEL_FORMAT__RGBA_NONPREMUL,
         c.WUFFS_BASE__PIXEL_SUBSAMPLING__NONE,
         width,
         height,
@@ -91,16 +91,6 @@ pub fn decode(alloc: Allocator, data: []const u8) Error!ImageData {
             &pixel_buffer,
             &image_config.pixcfg,
             c.wuffs_base__make_slice_u8(destination.ptr, destination.len),
-        );
-        try check(log, &status);
-    }
-
-    var frame_config: c.wuffs_base__frame_config = undefined;
-    {
-        const status = c.wuffs_jpeg__decoder__decode_frame_config(
-            decoder,
-            &frame_config,
-            &source_buffer,
         );
         try check(log, &status);
     }

--- a/pkg/wuffs/src/png.zig
+++ b/pkg/wuffs/src/png.zig
@@ -55,7 +55,7 @@ pub fn decode(alloc: Allocator, data: []const u8) Error!ImageData {
 
     c.wuffs_base__pixel_config__set(
         &image_config.pixcfg,
-        c.WUFFS_BASE__PIXEL_FORMAT__RGBA_PREMUL,
+        c.WUFFS_BASE__PIXEL_FORMAT__RGBA_NONPREMUL,
         c.WUFFS_BASE__PIXEL_SUBSAMPLING__NONE,
         width,
         height,
@@ -91,16 +91,6 @@ pub fn decode(alloc: Allocator, data: []const u8) Error!ImageData {
             &pixel_buffer,
             &image_config.pixcfg,
             c.wuffs_base__make_slice_u8(destination.ptr, destination.len),
-        );
-        try check(log, &status);
-    }
-
-    var frame_config: c.wuffs_base__frame_config = undefined;
-    {
-        const status = c.wuffs_png__decoder__decode_frame_config(
-            decoder,
-            &frame_config,
-            &source_buffer,
         );
         try check(log, &status);
     }


### PR DESCRIPTION
This was causing excessively faint/dark areas anywhere there was transparency, since our image shaders for both Metal and OpenGL assume the image data has straight alpha (which, I think should be the case for data transmitted directly with kitty graphics protocol rather than png-encoded), and do an additional multiplication.

After this change, our image blending looks *like most other apps*, even though it's still technically wrong since it "should" be done in linear space. Kitty, for example, does do linear blending for images, which is *more correct* even though it doesn't look like most apps. On macOS if `text-blending` is set to `linear` we do get linear blending, and match Kitty exactly with this change.

In order to have linear blending of images while maintaining non-linear blending of text for a "native" look on macOS we'd have to use swap textures with different pixel formats (`*_srgb` / not `*_srgb`) or else the API validator yells at us (even though it *does* work correctly...) -- either that or perform our blending in a shader instead of relying on Metal, which is my plan ultimately whenever I get around to making the deferred render pipeline.