### PR TITLE
bash: prefer $HOME over tilde notation

### DIFF
--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -47,7 +47,7 @@ if [ -n "$GHOSTTY_BASH_INJECT" ]; then
     if builtin shopt -q login_shell; then
       if [[ $__ghostty_bash_flags != *"--noprofile"* ]]; then
         [ -r /etc/profile ] && builtin source "/etc/profile"
-        for rcfile in ~/.bash_profile ~/.bash_login ~/.profile; do
+        for rcfile in "$HOME/.bash_profile" "$HOME/.bash_login" "$HOME/.profile"; do
           [ -r "$rcfile" ] && { builtin source "$rcfile"; break; }
         done
       fi
@@ -62,7 +62,7 @@ if [ -n "$GHOSTTY_BASH_INJECT" ]; then
         for rcfile in /etc/bash.bashrc /etc/bash/bashrc /etc/bashrc; do
           [ -r "$rcfile" ] && { builtin source "$rcfile"; break; }
         done
-        if [[ -z "$GHOSTTY_BASH_RCFILE" ]]; then GHOSTTY_BASH_RCFILE=~/.bashrc; fi
+        if [[ -z "$GHOSTTY_BASH_RCFILE" ]]; then GHOSTTY_BASH_RCFILE="$HOME/.bashrc"; fi
         [ -r "$GHOSTTY_BASH_RCFILE" ] && builtin source "$GHOSTTY_BASH_RCFILE"
       fi
     fi


### PR DESCRIPTION
This reverts part of #5075. While the ~ notation is more concise, I think the consensus is that using $HOME is more explicit, so prefer it.

We've also seen reports (#5169) that something about #5075 breaks the startup sequence in some environments. Reverting this part of the change will help us narrow that down.

Fixes #5206