### PR TITLE
termio: revise macOS-specific .hushlogin note

### DIFF
--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -971,12 +971,12 @@ const Subprocess = struct {
                 // which we may not want. If we specify "-l" then we can avoid
                 // this behavior but now the shell isn't a login shell.
                 //
-                // There is another issue: `login(1)` only checks for ".hushlogin"
-                // in the working directory. This means that if we specify "-l"
-                // then we won't get hushlogin honored if its in the home
-                // directory (which is standard). To get around this, we
-                // check for hushlogin ourselves and if present specify the
-                // "-q" flag to login(1).
+                // There is another issue: `login(1)` on macOS 14.3 and earlier
+                // checked for ".hushlogin" in the working directory. This means
+                // that if we specify "-l" then we won't get hushlogin honored
+                // if its in the home directory (which is standard). To get
+                // around this, we check for hushlogin ourselves and if present
+                // specify the "-q" flag to login(1).
                 //
                 // So to get all the behaviors we want, we specify "-l" but
                 // execute "bash" (which is built-in to macOS). We then use


### PR DESCRIPTION
login(1)'s .hushlogin logic was "fixed" in macOS Sonoma 14.4, so this
comment (and our workaround) is only relevant for versions earlier than
that.

The relevant change to login/login.c is part of system_cmds-979.100.8.

> login.c: look for .hushlogin in home directory (112854361)

- https://github.com/apple-oss-distributions/system_cmds/commit/1bca46ecc5b76432f42eb23ec39fe63e8159f251
- https://github.com/apple-oss-distributions/distribution-macOS/tree/macos-144