### PR TITLE
ansi: Add support blinking text

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -478,6 +478,41 @@ foreground: Color = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF },
 /// This value does not apply to Emoji or images.
 @"minimum-contrast": f64 = 1,
 
+/// The amount of time it takes for blinking text and cursors to toggle between
+/// being invisible and visible.
+/// Any cell on the screen could be set to blink by setting SGR attribute 5,
+/// while cursor blinking is controlled by the `cursor-style-blink` setting.
+///
+/// The interval is specified as a series of numbers followed by time units.
+/// Whitespace is allowed between numbers and units. Each number and unit will
+/// be added together to form the total interval.
+///
+/// Blinking is disabled when the interval is set to zero.
+///
+/// The allowed time units are as follows:
+///
+///   * `y` - 365 SI days, or 8760 hours, or 31536000 seconds. No adjustments
+///     are made for leap years or leap seconds.
+///   * `d` - one SI day, or 86400 seconds.
+///   * `h` - one hour, or 3600 seconds.
+///   * `m` - one minute, or 60 seconds.
+///   * `s` - one second.
+///   * `ms` - one millisecond, or 0.001 second.
+///   * `us` or `µs` - one microsecond, or 0.000001 second.
+///   * `ns` - one nanosecond, or 0.000000001 second.
+///
+/// Examples:
+///   * `1h30m`
+///   * `45s`
+///
+/// Units can be repeated and will be added together. This means that
+/// `1h1h` is equivalent to `2h`. This is confusing and should be avoided.
+/// A future update may disallow this.
+///
+/// The maximum value is `584y 49w 23h 34m 33s 709ms 551µs 615ns`. Any
+/// value larger than this will be clamped to the maximum value.
+@"blink-interval": Duration = .{ .duration = 600 * std.time.ns_per_ms },
+
 /// Color palette for the 256 color form that many terminal applications use.
 /// The syntax of this configuration is `N=COLOR` where `N` is 0 to 255 (for
 /// the 256 colors in the terminal color table) and `COLOR` is a typical RGB

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -92,6 +92,7 @@ pub const Shaper = struct {
         grid: *SharedGrid,
         screen: *const terminal.Screen,
         row: terminal.Pin,
+        text_blink_visible: bool,
         selection: ?terminal.Selection,
         cursor_x: ?usize,
     ) font.shape.RunIterator {
@@ -100,6 +101,7 @@ pub const Shaper = struct {
             .grid = grid,
             .screen = screen,
             .row = row,
+            .text_blink_visible = text_blink_visible,
             .selection = selection,
             .cursor_x = cursor_x,
         };
@@ -229,6 +231,7 @@ test "run iterator" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             null,
             null,
         );
@@ -248,6 +251,7 @@ test "run iterator" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             null,
             null,
         );
@@ -268,6 +272,7 @@ test "run iterator" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             null,
             null,
         );
@@ -320,6 +325,7 @@ test "run iterator: empty cells with background set" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             null,
             null,
         );
@@ -357,6 +363,7 @@ test "shape" {
         testdata.grid,
         &screen,
         screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+        true,
         null,
         null,
     );
@@ -386,6 +393,7 @@ test "shape inconsolata ligs" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             null,
             null,
         );
@@ -411,6 +419,7 @@ test "shape inconsolata ligs" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             null,
             null,
         );
@@ -444,6 +453,7 @@ test "shape monaspace ligs" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             null,
             null,
         );
@@ -480,6 +490,7 @@ test "shape arabic forced LTR" {
         testdata.grid,
         &screen,
         screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+        true,
         null,
         null,
     );
@@ -517,6 +528,7 @@ test "shape emoji width" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             null,
             null,
         );
@@ -559,6 +571,7 @@ test "shape emoji width long" {
         testdata.grid,
         &screen,
         screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+        true,
         null,
         null,
     );
@@ -597,6 +610,7 @@ test "shape variation selector VS15" {
         testdata.grid,
         &screen,
         screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+        true,
         null,
         null,
     );
@@ -634,6 +648,7 @@ test "shape variation selector VS16" {
         testdata.grid,
         &screen,
         screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+        true,
         null,
         null,
     );
@@ -668,6 +683,7 @@ test "shape with empty cells in between" {
         testdata.grid,
         &screen,
         screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+        true,
         null,
         null,
     );
@@ -706,6 +722,7 @@ test "shape Chinese characters" {
         testdata.grid,
         &screen,
         screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+        true,
         null,
         null,
     );
@@ -746,6 +763,7 @@ test "shape box glyphs" {
         testdata.grid,
         &screen,
         screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+        true,
         null,
         null,
     );
@@ -783,6 +801,7 @@ test "shape selection boundary" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             terminal.Selection.init(
                 screen.pages.pin(.{ .active = .{ .x = 0, .y = 0 } }).?,
                 screen.pages.pin(.{ .active = .{ .x = screen.pages.cols - 1, .y = 0 } }).?,
@@ -806,6 +825,7 @@ test "shape selection boundary" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             terminal.Selection.init(
                 screen.pages.pin(.{ .active = .{ .x = 2, .y = 0 } }).?,
                 screen.pages.pin(.{ .active = .{ .x = screen.pages.cols - 1, .y = 0 } }).?,
@@ -829,6 +849,7 @@ test "shape selection boundary" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             terminal.Selection.init(
                 screen.pages.pin(.{ .active = .{ .x = 0, .y = 0 } }).?,
                 screen.pages.pin(.{ .active = .{ .x = 3, .y = 0 } }).?,
@@ -852,6 +873,7 @@ test "shape selection boundary" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             terminal.Selection.init(
                 screen.pages.pin(.{ .active = .{ .x = 1, .y = 0 } }).?,
                 screen.pages.pin(.{ .active = .{ .x = 3, .y = 0 } }).?,
@@ -875,6 +897,7 @@ test "shape selection boundary" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             terminal.Selection.init(
                 screen.pages.pin(.{ .active = .{ .x = 1, .y = 0 } }).?,
                 screen.pages.pin(.{ .active = .{ .x = 1, .y = 0 } }).?,
@@ -911,6 +934,7 @@ test "shape cursor boundary" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             null,
             null,
         );
@@ -930,6 +954,7 @@ test "shape cursor boundary" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             null,
             0,
         );
@@ -949,6 +974,7 @@ test "shape cursor boundary" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             null,
             1,
         );
@@ -968,6 +994,7 @@ test "shape cursor boundary" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             null,
             9,
         );
@@ -1000,6 +1027,7 @@ test "shape cursor boundary and colored emoji" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             null,
             null,
         );
@@ -1019,6 +1047,7 @@ test "shape cursor boundary and colored emoji" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             null,
             0,
         );
@@ -1036,6 +1065,7 @@ test "shape cursor boundary and colored emoji" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             null,
             1,
         );
@@ -1066,6 +1096,7 @@ test "shape cell attribute change" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             null,
             null,
         );
@@ -1090,6 +1121,7 @@ test "shape cell attribute change" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             null,
             null,
         );
@@ -1115,6 +1147,7 @@ test "shape cell attribute change" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             null,
             null,
         );
@@ -1140,6 +1173,7 @@ test "shape cell attribute change" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             null,
             null,
         );
@@ -1164,6 +1198,7 @@ test "shape cell attribute change" {
             testdata.grid,
             &screen,
             screen.pages.pin(.{ .screen = .{ .y = 0 } }).?,
+            true,
             null,
             null,
         );

--- a/src/font/shaper/noop.zig
+++ b/src/font/shaper/noop.zig
@@ -73,6 +73,7 @@ pub const Shaper = struct {
         grid: *SharedGrid,
         screen: *const terminal.Screen,
         row: terminal.Pin,
+        text_blink_visible: bool,
         selection: ?terminal.Selection,
         cursor_x: ?usize,
     ) font.shape.RunIterator {
@@ -81,6 +82,7 @@ pub const Shaper = struct {
             .grid = grid,
             .screen = screen,
             .row = row,
+            .text_blink_visible = text_blink_visible,
             .selection = selection,
             .cursor_x = cursor_x,
         };

--- a/src/font/shaper/run.zig
+++ b/src/font/shaper/run.zig
@@ -38,6 +38,7 @@ pub const RunIterator = struct {
     grid: *font.SharedGrid,
     screen: *const terminal.Screen,
     row: terminal.Pin,
+    text_blink_visible: bool,
     selection: ?terminal.Selection = null,
     cursor_x: ?usize = null,
     i: usize = 0,
@@ -58,7 +59,8 @@ pub const RunIterator = struct {
         // Invisible cells don't have any glyphs rendered,
         // so we explicitly skip them in the shaping process.
         while (self.i < max and
-            self.row.style(&cells[self.i]).flags.invisible)
+            (self.row.style(&cells[self.i]).flags.invisible or
+            (self.row.style(&cells[self.i]).flags.blink and !self.text_blink_visible)))
         {
             self.i += 1;
         }

--- a/src/font/shaper/web_canvas.zig
+++ b/src/font/shaper/web_canvas.zig
@@ -63,6 +63,7 @@ pub const Shaper = struct {
         self: *Shaper,
         group: *font.GroupCache,
         row: terminal.Screen.Row,
+        text_blink_visible: bool,
         selection: ?terminal.Selection,
         cursor_x: ?usize,
     ) font.shape.RunIterator {
@@ -70,6 +71,7 @@ pub const Shaper = struct {
             .hooks = .{ .shaper = self },
             .group = group,
             .row = row,
+            .text_blink_visible = text_blink_visible,
             .selection = selection,
             .cursor_x = cursor_x,
         };
@@ -295,7 +297,7 @@ pub const Wasm = struct {
         while (rowIter.next()) |row| {
             defer y += 1;
 
-            var iter = self.runIterator(group, row, null, null);
+            var iter = self.runIterator(group, row, true, null, null);
             while (try iter.next(alloc)) |run| {
                 const cells = try self.shape(run);
                 log.info("y={} run={d} shape={any} idx={}", .{

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -2377,6 +2377,7 @@ fn rebuildCells(
     preedit: ?renderer.State.Preedit,
     cursor_style_: ?renderer.CursorStyle,
     color_palette: *const terminal.color.Palette,
+    text_blink_visible: bool,
 ) !void {
     // const start = try std.time.Instant.now();
     // const start_micro = std.time.microTimestamp();
@@ -2495,6 +2496,7 @@ fn rebuildCells(
             screen,
             row,
             row_selection,
+            text_blink_visible,
             if (shape_cursor) screen.cursor.x else null,
         );
         var shaper_run: ?font.shape.TextRun = try run_iter.next(self.alloc);
@@ -2694,7 +2696,7 @@ fn rebuildCells(
             // emulators, e.g. Alacritty, still render text decorations
             // and only make the text itself invisible. The decision
             // has been made here to match xterm's behavior for this.
-            if (style.flags.invisible) {
+            if (style.flags.invisible or style.flags.blink) {
                 continue;
             }
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -689,6 +689,7 @@ pub fn updateFrame(
     surface: *apprt.Surface,
     state: *renderer.State,
     cursor_blink_visible: bool,
+    text_blink_visible: bool,
 ) !void {
     _ = surface;
 
@@ -702,6 +703,7 @@ pub fn updateFrame(
         preedit: ?renderer.State.Preedit,
         cursor_style: ?renderer.CursorStyle,
         color_palette: terminal.color.Palette,
+        text_blink_visible: bool,
     };
 
     // Update all our data as tightly as possible within the mutex.
@@ -863,6 +865,7 @@ pub fn updateFrame(
             .preedit = preedit,
             .cursor_style = cursor_style,
             .color_palette = state.terminal.color_palette.colors,
+            .text_blink_visible = text_blink_visible,
         };
     };
     defer {
@@ -887,6 +890,7 @@ pub fn updateFrame(
             critical.preedit,
             critical.cursor_style,
             &critical.color_palette,
+            critical.text_blink_visible,
         );
 
         // Notify our shaper we're done for the frame. For some shapers like
@@ -1217,6 +1221,7 @@ pub fn rebuildCells(
     preedit: ?renderer.State.Preedit,
     cursor_style_: ?renderer.CursorStyle,
     color_palette: *const terminal.color.Palette,
+    text_blink_visible: bool,
 ) !void {
     _ = screen_type;
 
@@ -1349,6 +1354,7 @@ pub fn rebuildCells(
             self.font_grid,
             screen,
             row,
+            text_blink_visible,
             row_selection,
             if (shape_cursor) screen.cursor.x else null,
         );
@@ -1576,7 +1582,7 @@ pub fn rebuildCells(
             // emulators, e.g. Alacritty, still render text decorations
             // and only make the text itself invisible. The decision
             // has been made here to match xterm's behavior for this.
-            if (style.flags.invisible) {
+            if (style.flags.invisible or (style.flags.blink and !text_blink_visible)) {
                 continue;
             }
 


### PR DESCRIPTION
Add support for the blinking text ansi character. Both "slow" (code 5) and "fast" (code 6) blink at the same interval as the cursor, as it seems implementations often do this.

Blinking of text stops when the screen loses focus, same as the cursor. To keep blinking of text and cursor in sync, typing a character no longer resets the cursor blinking timer. Instead of reseting the timer, the cursor is immediately set to visible and will stay visible for at least the length of one interval to ensure that blinking does not happen while the user is actively typing. This has the side-effect that at startup, it takes two intervals until the first cursor blink happens when ghostty is launched.

Also introduce a config "blink-interval" which can set the blinking speed of the cursor and text to an arbitrary time. This config code was originally written by @pluiedev.

Discussion in: https://github.com/ghostty-org/ghostty/discussions/4258#discussion-7767836