### PR TITLE
feat: support selection foreground being cell foreground

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -62,6 +62,13 @@ pub const compatibility = std.StaticStringMap(
     // Ghostty 1.2 removed the `hidden` value from `gtk-tabs-location` and
     // moved it to `window-show-tab-bar`.
     .{ "gtk-tabs-location", compatGtkTabsLocation },
+
+    // Ghostty 1.2 lets you set `cell-foreground` and `cell-background`
+    // to match the cell foreground and background colors, respectively.
+    // This can be used with `cursor-color` and `cursor-text` to recreate
+    // this behavior. This applies to selection too.
+    .{ "cursor-invert-fg-bg", compatCursorInvertFgBg },
+    .{ "selection-invert-fg-bg", compatSelectionInvertFgBg },
 });
 
 /// The font families to use.
@@ -597,18 +604,6 @@ foreground: Color = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF },
 @"selection-foreground": ?DynamicColor = null,
 @"selection-background": ?DynamicColor = null,
 
-/// Swap the foreground and background colors of cells for selection. This
-/// option overrides the `selection-foreground` and `selection-background`
-/// options.
-///
-/// If you select across cells with differing foregrounds and backgrounds, the
-/// selection color will vary across the selection.
-///
-/// Warning: This option has been deprecated as of version 1.2.0. Instead,
-/// users should set `selection-foreground` and `selection-background` to
-/// `cell-background` and `cell-foreground`, respectively.
-@"selection-invert-fg-bg": bool = false,
-
 /// Whether to clear selected text when typing. This defaults to `true`.
 /// This is typical behavior for most terminal emulators as well as
 /// text input fields. If you set this to `false`, then the selected text
@@ -651,19 +646,20 @@ foreground: Color = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF },
 palette: Palette = .{},
 
 /// The color of the cursor. If this is not set, a default will be chosen.
-/// Specified as either hex (`#RRGGBB` or `RRGGBB`) or a named X11 color.
-/// Since version 1.2.0, this can also be set to `cell-foreground` to match
-/// the cell foreground color, or `cell-background` to match the cell
-/// background color.
-@"cursor-color": ?DynamicColor = null,
-
-/// Swap the foreground and background colors of the cell under the cursor. This
-/// option overrides the `cursor-color` and `cursor-text` options.
 ///
-/// Warning: This option has been deprecated as of version 1.2.0. Instead,
-/// users should set `cursor-color` and `cursor-text` to `cell-foreground` and
-/// `cell-background`, respectively.
-@"cursor-invert-fg-bg": bool = false,
+/// Direct colors can be specified as either hex (`#RRGGBB` or `RRGGBB`)
+/// or a named X11 color.
+///
+/// Additionally, special values can be used to set the color to match
+/// other colors at runtime:
+///
+///   * `cell-foreground` - Match the cell foreground color.
+///     (Available since version 1.2.0)
+///
+///   * `cell-background` - Match the cell background color.
+///     (Available since version 1.2.0)
+///
+@"cursor-color": ?DynamicColor = null,
 
 /// The opacity level (opposite of transparency) of the cursor. A value of 1
 /// is fully opaque and a value of 0 is fully transparent. A value less than 0
@@ -3843,10 +3839,6 @@ pub fn parseManuallyHook(
     return true;
 }
 
-/// parseFieldManuallyFallback is a fallback called only when
-/// parsing the field directly failed. It can be used to implement
-/// backward compatibility. Since this is only called when parsing
-/// fails, it doesn't impact happy-path performance.
 fn compatGtkTabsLocation(
     self: *Config,
     alloc: Allocator,
@@ -3862,6 +3854,51 @@ fn compatGtkTabsLocation(
     }
 
     return false;
+}
+
+fn compatCursorInvertFgBg(
+    self: *Config,
+    alloc: Allocator,
+    key: []const u8,
+    value_: ?[]const u8,
+) bool {
+    _ = alloc;
+    assert(std.mem.eql(u8, key, "cursor-invert-fg-bg"));
+
+    // We don't do anything if the value is unset, which is technically
+    // not EXACTLY the same as prior behavior since it would fallback
+    // to doing whatever cursor-color/cursor-text were set to, but
+    // I don't want to store what that is separately so this is close
+    // enough.
+    //
+    // Realistically, these fields were mutually exclusive so anyone
+    // relying on that behavior should just upgrade to the new
+    // cursor-color/cursor-text fields.
+    const set = cli.args.parseBool(value_ orelse "t") catch return false;
+    if (set) {
+        self.@"cursor-color" = .@"cell-foreground";
+        self.@"cursor-text" = .@"cell-background";
+    }
+
+    return true;
+}
+
+fn compatSelectionInvertFgBg(
+    self: *Config,
+    alloc: Allocator,
+    key: []const u8,
+    value_: ?[]const u8,
+) bool {
+    _ = alloc;
+    assert(std.mem.eql(u8, key, "selection-invert-fg-bg"));
+
+    const set = cli.args.parseBool(value_ orelse "t") catch return false;
+    if (set) {
+        self.@"selection-foreground" = .@"cell-background";
+        self.@"selection-background" = .@"cell-foreground";
+    }
+
+    return true;
 }
 
 /// Create a shallow copy of this config. This will share all the memory
@@ -4437,28 +4474,41 @@ pub const DynamicColor = union(enum) {
 
     pub fn parseCLI(input_: ?[]const u8) !DynamicColor {
         const input = input_ orelse return error.ValueRequired;
-
         if (std.mem.eql(u8, input, "cell-foreground")) return .@"cell-foreground";
         if (std.mem.eql(u8, input, "cell-background")) return .@"cell-background";
-
-        return DynamicColor{ .color = try Color.parseCLI(input) };
+        return .{ .color = try Color.parseCLI(input) };
     }
 
     /// Used by Formatter
     pub fn formatEntry(self: DynamicColor, formatter: anytype) !void {
         switch (self) {
             .color => try self.color.formatEntry(formatter),
-            .@"cell-foreground", .@"cell-background" => try formatter.formatEntry([:0]const u8, @tagName(self)),
+
+            .@"cell-foreground",
+            .@"cell-background",
+            => try formatter.formatEntry([:0]const u8, @tagName(self)),
         }
     }
 
     test "parseCLI" {
         const testing = std.testing;
 
-        try testing.expectEqual(DynamicColor{ .color = Color{ .r = 78, .g = 42, .b = 132 } }, try DynamicColor.parseCLI("#4e2a84"));
-        try testing.expectEqual(DynamicColor{ .color = Color{ .r = 0, .g = 0, .b = 0 } }, try DynamicColor.parseCLI("black"));
-        try testing.expectEqual(DynamicColor{.@"cell-foreground"}, try DynamicColor.parseCLI("cell-foreground"));
-        try testing.expectEqual(DynamicColor{.@"cell-background"}, try DynamicColor.parseCLI("cell-background"));
+        try testing.expectEqual(
+            DynamicColor{ .color = Color{ .r = 78, .g = 42, .b = 132 } },
+            try DynamicColor.parseCLI("#4e2a84"),
+        );
+        try testing.expectEqual(
+            DynamicColor{ .color = Color{ .r = 0, .g = 0, .b = 0 } },
+            try DynamicColor.parseCLI("black"),
+        );
+        try testing.expectEqual(
+            DynamicColor{.@"cell-foreground"},
+            try DynamicColor.parseCLI("cell-foreground"),
+        );
+        try testing.expectEqual(
+            DynamicColor{.@"cell-background"},
+            try DynamicColor.parseCLI("cell-background"),
+        );
 
         try testing.expectError(error.InvalidValue, DynamicColor.parseCLI("a"));
     }
@@ -8105,5 +8155,53 @@ test "theme specifying light/dark sets theme usage in conditional state" {
 
         try testing.expect(cfg.@"window-theme" == .system);
         try testing.expect(cfg._conditional_set.contains(.theme));
+    }
+}
+
+test "compatibility: removed cursor-invert-fg-bg" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    {
+        var cfg = try Config.default(alloc);
+        defer cfg.deinit();
+        var it: TestIterator = .{ .data = &.{
+            "--cursor-invert-fg-bg",
+        } };
+        try cfg.loadIter(alloc, &it);
+        try cfg.finalize();
+
+        try testing.expectEqual(
+            DynamicColor.@"cell-foreground",
+            cfg.@"cursor-color",
+        );
+        try testing.expectEqual(
+            DynamicColor.@"cell-background",
+            cfg.@"cursor-text",
+        );
+    }
+}
+
+test "compatibility: removed selection-invert-fg-bg" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    {
+        var cfg = try Config.default(alloc);
+        defer cfg.deinit();
+        var it: TestIterator = .{ .data = &.{
+            "--selection-invert-fg-bg",
+        } };
+        try cfg.loadIter(alloc, &it);
+        try cfg.finalize();
+
+        try testing.expectEqual(
+            DynamicColor.@"cell-background",
+            cfg.@"selection-foreground",
+        );
+        try testing.expectEqual(
+            DynamicColor.@"cell-foreground",
+            cfg.@"selection-background",
+        );
     }
 }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -591,7 +591,7 @@ foreground: Color = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF },
 /// the selection color is just the inverted window background and foreground
 /// (note: not to be confused with the cell bg/fg).
 /// Specified as either hex (`#RRGGBB` or `RRGGBB`) or a named X11 color.
-/// Since version 1.1.1, this can also be set to `cell-foreground` to match
+/// Since version 1.2.0, this can also be set to `cell-foreground` to match
 /// the cell foreground color, or `cell-background` to match the cell
 /// background color.
 @"selection-foreground": ?DynamicColor = null,
@@ -604,7 +604,7 @@ foreground: Color = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF },
 /// If you select across cells with differing foregrounds and backgrounds, the
 /// selection color will vary across the selection.
 ///
-/// Warning: This option has been deprecated as of version 1.1.1. Instead,
+/// Warning: This option has been deprecated as of version 1.2.0. Instead,
 /// users should set `selection-foreground` and `selection-background` to
 /// `cell-background` and `cell-foreground`, respectively.
 @"selection-invert-fg-bg": bool = false,
@@ -652,7 +652,7 @@ palette: Palette = .{},
 
 /// The color of the cursor. If this is not set, a default will be chosen.
 /// Specified as either hex (`#RRGGBB` or `RRGGBB`) or a named X11 color.
-/// Since version 1.1.1, this can also be set to `cell-foreground` to match
+/// Since version 1.2.0, this can also be set to `cell-foreground` to match
 /// the cell foreground color, or `cell-background` to match the cell
 /// background color.
 @"cursor-color": ?DynamicColor = null,
@@ -660,7 +660,7 @@ palette: Palette = .{},
 /// Swap the foreground and background colors of the cell under the cursor. This
 /// option overrides the `cursor-color` and `cursor-text` options.
 ///
-/// Warning: This option has been deprecated as of version 1.1.1. Instead,
+/// Warning: This option has been deprecated as of version 1.2.0. Instead,
 /// users should set `cursor-color` and `cursor-text` to `cell-foreground` and
 /// `cell-background`, respectively.
 @"cursor-invert-fg-bg": bool = false,
@@ -713,7 +713,7 @@ palette: Palette = .{},
 /// The color of the text under the cursor. If this is not set, a default will
 /// be chosen.
 /// Specified as either hex (`#RRGGBB` or `RRGGBB`) or a named X11 color.
-/// Since version 1.1.1, this can also be set to `cell-foreground` to match
+/// Since version 1.2.0, this can also be set to `cell-foreground` to match
 /// the cell foreground color, or `cell-background` to match the cell
 /// background color.
 @"cursor-text": ?DynamicColor = null,

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -4500,11 +4500,11 @@ pub const TerminalColor = union(enum) {
             try TerminalColor.parseCLI("black"),
         );
         try testing.expectEqual(
-            TerminalColor{.@"cell-foreground"},
+            TerminalColor.@"cell-foreground",
             try TerminalColor.parseCLI("cell-foreground"),
         );
         try testing.expectEqual(
-            TerminalColor{.@"cell-background"},
+            TerminalColor.@"cell-background",
             try TerminalColor.parseCLI("cell-background"),
         );
 
@@ -4516,7 +4516,7 @@ pub const TerminalColor = union(enum) {
         var buf = std.ArrayList(u8).init(testing.allocator);
         defer buf.deinit();
 
-        var sc: TerminalColor = .{.@"cell-foreground"};
+        var sc: TerminalColor = .@"cell-foreground";
         try sc.formatEntry(formatterpkg.entryFormatter("a", buf.writer()));
         try testing.expectEqualSlices(u8, "a = cell-foreground\n", buf.items);
     }

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -133,12 +133,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// This is cursor color as set in the user's config, if any. If no cursor color
         /// is set in the user's config, then the cursor color is determined by the
         /// current foreground color.
-        default_cursor_color: ?terminal.color.RGB,
-
-        /// When `cursor_color` is null, swap the foreground and background colors of
-        /// the cell under the cursor for the cursor color. Otherwise, use the default
-        /// foreground color as the cursor color.
-        cursor_invert: bool,
+        default_cursor_color: ?configpkg.Config.DynamicColor,
 
         /// The current set of cells to render. This is rebuilt on every frame
         /// but we keep this around so that we don't reallocate. Each set of
@@ -514,16 +509,14 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             font_features: std.ArrayListUnmanaged([:0]const u8),
             font_styles: font.CodepointResolver.StyleStatus,
             font_shaping_break: configpkg.FontShapingBreak,
-            cursor_color: ?terminal.color.RGB,
-            cursor_invert: bool,
+            cursor_color: ?configpkg.Config.DynamicColor,
             cursor_opacity: f64,
-            cursor_text: ?terminal.color.RGB,
+            cursor_text: ?configpkg.Config.DynamicColor,
             background: terminal.color.RGB,
             background_opacity: f64,
             foreground: terminal.color.RGB,
-            selection_background: ?terminal.color.RGB,
-            selection_foreground: ?terminal.color.RGB,
-            invert_selection_fg_bg: bool,
+            selection_background: ?configpkg.Config.DynamicColor,
+            selection_foreground: ?configpkg.Config.DynamicColor,
             bold_is_bright: bool,
             min_contrast: f32,
             padding_color: configpkg.WindowPaddingColor,
@@ -571,8 +564,6 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     config.link.links.items,
                 );
 
-                const cursor_invert = config.@"cursor-invert-fg-bg";
-
                 return .{
                     .background_opacity = @max(0, @min(1, config.@"background-opacity")),
                     .font_thicken = config.@"font-thicken",
@@ -581,36 +572,18 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     .font_styles = font_styles,
                     .font_shaping_break = config.@"font-shaping-break",
 
-                    .cursor_color = if (!cursor_invert and config.@"cursor-color" != null)
-                        config.@"cursor-color".?.toTerminalRGB()
-                    else
-                        null,
-
-                    .cursor_invert = cursor_invert,
-
-                    .cursor_text = if (config.@"cursor-text") |txt|
-                        txt.toTerminalRGB()
-                    else
-                        null,
-
+                    .cursor_color = config.@"cursor-color",
+                    .cursor_text = config.@"cursor-text",
                     .cursor_opacity = @max(0, @min(1, config.@"cursor-opacity")),
 
                     .background = config.background.toTerminalRGB(),
                     .foreground = config.foreground.toTerminalRGB(),
-                    .invert_selection_fg_bg = config.@"selection-invert-fg-bg",
                     .bold_is_bright = config.@"bold-is-bright",
                     .min_contrast = @floatCast(config.@"minimum-contrast"),
                     .padding_color = config.@"window-padding-color",
 
-                    .selection_background = if (config.@"selection-background") |bg|
-                        bg.toTerminalRGB()
-                    else
-                        null,
-
-                    .selection_foreground = if (config.@"selection-foreground") |bg|
-                        bg.toTerminalRGB()
-                    else
-                        null,
+                    .selection_background = config.@"selection-background",
+                    .selection_foreground = config.@"selection-foreground",
 
                     .custom_shaders = custom_shaders,
                     .bg_image = bg_image,
@@ -703,7 +676,6 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 .default_background_color = options.config.background,
                 .cursor_color = null,
                 .default_cursor_color = options.config.cursor_color,
-                .cursor_invert = options.config.cursor_invert,
 
                 // Render state
                 .cells = .{},
@@ -2079,8 +2051,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // Set our new colors
             self.default_background_color = config.background;
             self.default_foreground_color = config.foreground;
-            self.default_cursor_color = if (!config.cursor_invert) config.cursor_color else null;
-            self.cursor_invert = config.cursor_invert;
+            self.default_cursor_color = config.cursor_color;
 
             const bg_image_config_changed =
                 self.config.bg_image_fit != config.bg_image_fit or
@@ -2583,22 +2554,15 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     // The final background color for the cell.
                     const bg = bg: {
                         if (selected) {
-                            break :bg if (self.config.invert_selection_fg_bg)
-                                if (style.flags.inverse)
-                                    // Cell is selected with invert selection fg/bg
-                                    // enabled, and the cell has the inverse style
-                                    // flag, so they cancel out and we get the normal
-                                    // bg color.
-                                    bg_style
-                                else
-                                    // If it doesn't have the inverse style
-                                    // flag then we use the fg color instead.
-                                    fg_style
+                            break :bg if (self.config.selection_background) |selection_color|
+                                // Use the selection background if set, otherwise the default fg color.
+                                switch (selection_color) {
+                                    .color => selection_color.color.toTerminalRGB(),
+                                    .@"cell-foreground" => if (style.flags.inverse) bg_style else fg_style,
+                                    .@"cell-background" => if (style.flags.inverse) fg_style else bg_style,
+                                }
                             else
-                                // If we don't have invert selection fg/bg set then we
-                                // just use the selection background if set, otherwise
-                                // the default fg color.
-                                break :bg self.config.selection_background orelse self.foreground_color orelse self.default_foreground_color;
+                                self.foreground_color orelse self.default_foreground_color;
                         }
 
                         // Not selected
@@ -2618,20 +2582,26 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     };
 
                     const fg = fg: {
-                        if (selected and !self.config.invert_selection_fg_bg) {
-                            // If we don't have invert selection fg/bg set
-                            // then we just use the selection foreground if
-                            // set, otherwise the default bg color.
-                            break :fg self.config.selection_foreground orelse self.background_color orelse self.default_background_color;
-                        }
+                        const final_bg = bg_style orelse self.background_color orelse self.default_background_color;
 
                         // Whether we need to use the bg color as our fg color:
+                        // - Cell is selected, inverted, and set to cell-foreground
+                        // - Cell is selected, not inverted, and set to cell-background
                         // - Cell is inverted and not selected
-                        // - Cell is selected and not inverted
-                        //    Note: if selected then invert sel fg / bg must be
-                        //    false since we separately handle it if true above.
-                        break :fg if (style.flags.inverse != selected)
-                            bg_style orelse self.background_color orelse self.default_background_color
+                        if (selected) {
+                            // Use the selection foreground if set, otherwise the default bg color.
+                            break :fg if (self.config.selection_foreground) |selection_color|
+                                switch (selection_color) {
+                                    .color => selection_color.color.toTerminalRGB(),
+                                    .@"cell-foreground" => if (style.flags.inverse) final_bg else fg_style,
+                                    .@"cell-background" => if (style.flags.inverse) fg_style else final_bg,
+                                }
+                            else
+                                self.background_color orelse self.default_background_color;
+                        }
+
+                        break :fg if (style.flags.inverse)
+                            final_bg
                         else
                             fg_style;
                     };
@@ -2817,19 +2787,25 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
                 // Prepare the cursor cell contents.
                 const style = cursor_style_ orelse break :cursor;
-                const cursor_color = self.cursor_color orelse self.default_cursor_color orelse color: {
-                    if (self.cursor_invert) {
-                        // Use the foreground color from the cell under the cursor, if any.
-                        const sty = screen.cursor.page_pin.style(screen.cursor.page_cell);
-                        break :color if (sty.flags.inverse)
-                            // If the cell is reversed, use background color instead.
-                            (sty.bg(screen.cursor.page_cell, color_palette) orelse self.background_color orelse self.default_background_color)
-                        else
-                            (sty.fg(color_palette, self.config.bold_is_bright) orelse self.foreground_color orelse self.default_foreground_color);
-                    } else {
-                        break :color self.foreground_color orelse self.default_foreground_color;
+                const cursor_color = self.cursor_color orelse if (self.default_cursor_color) |color| color: {
+                    // If cursor-color is set, then compute the correct color.
+                    // Otherwise, use the foreground color
+                    if (color == .color) {
+                        // Use the color set by cursor-color, if any.
+                        break :color color.color.toTerminalRGB();
                     }
-                };
+
+                    const sty = screen.cursor.page_pin.style(screen.cursor.page_cell);
+                    const fg_style = sty.fg(color_palette, self.config.bold_is_bright) orelse self.foreground_color orelse self.default_foreground_color;
+                    const bg_style = sty.bg(screen.cursor.page_cell, color_palette) orelse self.background_color orelse self.default_background_color;
+
+                    break :color switch (color) {
+                        // If the cell is reversed, use the opposite cell color instead.
+                        .@"cell-foreground" => if (sty.flags.inverse) bg_style else fg_style,
+                        .@"cell-background" => if (sty.flags.inverse) fg_style else bg_style,
+                        else => unreachable,
+                    };
+                } else self.foreground_color orelse self.default_foreground_color;
 
                 self.addCursor(screen, style, cursor_color);
 
@@ -2853,18 +2829,25 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                         .wide, .spacer_tail => true,
                     };
 
-                    const uniform_color = if (self.cursor_invert) blk: {
-                        // Use the background color from the cell under the cursor, if any.
+                    const uniform_color = if (self.config.cursor_text) |txt| blk: {
+                        // If cursor-text is set, then compute the correct color.
+                        // Otherwise, use the background color.
+                        if (txt == .color) {
+                            // Use the color set by cursor-text, if any.
+                            break :blk txt.color.toTerminalRGB();
+                        }
+
                         const sty = screen.cursor.page_pin.style(screen.cursor.page_cell);
-                        break :blk if (sty.flags.inverse)
-                            // If the cell is reversed, use foreground color instead.
-                            (sty.fg(color_palette, self.config.bold_is_bright) orelse self.foreground_color orelse self.default_foreground_color)
-                        else
-                            (sty.bg(screen.cursor.page_cell, color_palette) orelse self.background_color orelse self.default_background_color);
-                    } else if (self.config.cursor_text) |txt|
-                        txt
-                    else
-                        self.background_color orelse self.default_background_color;
+                        const fg_style = sty.fg(color_palette, self.config.bold_is_bright) orelse self.foreground_color orelse self.default_foreground_color;
+                        const bg_style = sty.bg(screen.cursor.page_cell, color_palette) orelse self.background_color orelse self.default_background_color;
+
+                        break :blk switch (txt) {
+                            // If the cell is reversed, use the opposite cell color instead.
+                            .@"cell-foreground" => if (sty.flags.inverse) bg_style else fg_style,
+                            .@"cell-background" => if (sty.flags.inverse) fg_style else bg_style,
+                            else => unreachable,
+                        };
+                    } else self.background_color orelse self.default_background_color;
 
                     self.uniforms.cursor_color = .{
                         uniform_color.r,

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -163,8 +163,7 @@ pub const DerivedConfig = struct {
     image_storage_limit: usize,
     cursor_style: terminalpkg.CursorStyle,
     cursor_blink: ?bool,
-    cursor_color: ?configpkg.Config.Color,
-    cursor_invert: bool,
+    cursor_color: ?configpkg.Config.DynamicColor,
     foreground: configpkg.Config.Color,
     background: configpkg.Config.Color,
     osc_color_report_format: configpkg.Config.OSCColorReportFormat,
@@ -185,7 +184,6 @@ pub const DerivedConfig = struct {
             .cursor_style = config.@"cursor-style",
             .cursor_blink = config.@"cursor-style-blink",
             .cursor_color = config.@"cursor-color",
-            .cursor_invert = config.@"cursor-invert-fg-bg",
             .foreground = config.foreground,
             .background = config.background,
             .osc_color_report_format = config.@"osc-color-report-format",
@@ -265,8 +263,11 @@ pub fn init(self: *Termio, alloc: Allocator, opts: termio.Options) !void {
     // Create our stream handler. This points to memory in self so it
     // isn't safe to use until self.* is set.
     const handler: StreamHandler = handler: {
-        const default_cursor_color = if (!opts.config.cursor_invert and opts.config.cursor_color != null)
-            opts.config.cursor_color.?.toTerminalRGB()
+        const default_cursor_color = if (opts.config.cursor_color) |color|
+            switch (color) {
+                .color => color.color.toTerminalRGB(),
+                else => null,
+            }
         else
             null;
 

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -163,7 +163,7 @@ pub const DerivedConfig = struct {
     image_storage_limit: usize,
     cursor_style: terminalpkg.CursorStyle,
     cursor_blink: ?bool,
-    cursor_color: ?configpkg.Config.DynamicColor,
+    cursor_color: ?configpkg.Config.TerminalColor,
     foreground: configpkg.Config.Color,
     background: configpkg.Config.Color,
     osc_color_report_format: configpkg.Config.OSCColorReportFormat,
@@ -263,13 +263,16 @@ pub fn init(self: *Termio, alloc: Allocator, opts: termio.Options) !void {
     // Create our stream handler. This points to memory in self so it
     // isn't safe to use until self.* is set.
     const handler: StreamHandler = handler: {
-        const default_cursor_color = if (opts.config.cursor_color) |color|
-            switch (color) {
-                .color => color.color.toTerminalRGB(),
-                else => null,
-            }
-        else
-            null;
+        const default_cursor_color: ?terminalpkg.color.RGB = color: {
+            if (opts.config.cursor_color) |color| switch (color) {
+                .color => break :color color.color.toTerminalRGB(),
+                .@"cell-foreground",
+                .@"cell-background",
+                => {},
+            };
+
+            break :color null;
+        };
 
         break :handler .{
             .alloc = alloc,

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -121,8 +121,11 @@ pub const StreamHandler = struct {
         self.default_background_color = config.background.toTerminalRGB();
         self.default_cursor_style = config.cursor_style;
         self.default_cursor_blink = config.cursor_blink;
-        self.default_cursor_color = if (!config.cursor_invert and config.cursor_color != null)
-            config.cursor_color.?.toTerminalRGB()
+        self.default_cursor_color = if (config.cursor_color) |color|
+            switch (color) {
+                .color => color.color.toTerminalRGB(),
+                else => null,
+            }
         else
             null;
 

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -121,13 +121,16 @@ pub const StreamHandler = struct {
         self.default_background_color = config.background.toTerminalRGB();
         self.default_cursor_style = config.cursor_style;
         self.default_cursor_blink = config.cursor_blink;
-        self.default_cursor_color = if (config.cursor_color) |color|
-            switch (color) {
-                .color => color.color.toTerminalRGB(),
-                else => null,
-            }
-        else
-            null;
+        self.default_cursor_color = color: {
+            if (config.cursor_color) |color| switch (color) {
+                .color => break :color color.color.toTerminalRGB(),
+                .@"cell-foreground",
+                .@"cell-background",
+                => {},
+            };
+
+            break :color null;
+        };
 
         // If our cursor is the default, then we update it immediately.
         if (self.default_cursor) self.setCursorStyle(.default) catch |err| {


### PR DESCRIPTION
This resolves #2685.

## Changes

* Created `SelectionColor` tagged union that can take a `Color`, `cell-foreground`, or `cell-background`
* Used the new union to implement the feature for Metal and OpenGL
* Removed the use of `invert_selection_fg_bg` during rendering as suggested in the issue

## Demo

macOS:

https://github.com/user-attachments/assets/b5b2db83-bb62-4929-8e3c-870a1e1a7a5c

Ubuntu:

https://github.com/user-attachments/assets/259dd707-d9d9-4590-8f3c-a67ccdef34bc


Any feedback would be helpful, I'm sure there's a lot of room for improvement here.

