### PR TITLE
fix: quick terminal hidden by macos menu bar

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalPosition.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalPosition.swift
@@ -69,7 +69,7 @@ enum QuickTerminalPosition : String {
             finalSize.width = screen.frame.width
 
         case .left, .right:
-            finalSize.height = screen.frame.height
+            finalSize.height = screen.visibleFrame.height
 
         case .center:
             finalSize.width = screen.frame.width / 2


### PR DESCRIPTION
ghostty#5000 changed the window level from `.popupMenu` to `.floating` to improve IME support. However, this introduced a side effect which render the Quick Terminal (QT) below the macOS menu bar, whereas previously it would cover it.

When positioned on `right` and `left`, the top of the QT becomes partially hidden. This PR adjust the size of the QT to ensure it remains fully visible and stays below the menu bar.

Before #5000:
![Screen Recording 2025-01-19 at 11 14 48](https://github.com/user-attachments/assets/70565c28-783f-4a2a-a8c9-a2eb16ea50e9)
With #5000:
![Screen Recording 2025-01-19 at 11 13 27](https://github.com/user-attachments/assets/184a1205-0a68-4fa0-a0d8-cc37701529af)
This branch:
![Screen Recording 2025-01-19 at 11 17 32](https://github.com/user-attachments/assets/f589d9e1-c5a0-4ed1-9f9b-651f3cb22f58)
