### PR TITLE
Add background image support for Metal

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -30,10 +30,11 @@ pub const RepeatableFontVariation = Config.RepeatableFontVariation;
 pub const RepeatableString = Config.RepeatableString;
 pub const RepeatableStringMap = @import("config/RepeatableStringMap.zig");
 pub const RepeatablePath = Config.RepeatablePath;
-pub const SinglePath = Config.SinglePath;
+pub const Path = Config.Path;
 pub const ShellIntegrationFeatures = Config.ShellIntegrationFeatures;
 pub const WindowPaddingColor = Config.WindowPaddingColor;
 pub const BackgroundImageMode = Config.BackgroundImageMode;
+pub const BackgroundImagePosition = Config.BackgroundImagePosition;
 
 // Alternate APIs
 pub const CAPI = @import("config/CAPI.zig");

--- a/src/config.zig
+++ b/src/config.zig
@@ -30,8 +30,10 @@ pub const RepeatableFontVariation = Config.RepeatableFontVariation;
 pub const RepeatableString = Config.RepeatableString;
 pub const RepeatableStringMap = @import("config/RepeatableStringMap.zig");
 pub const RepeatablePath = Config.RepeatablePath;
+pub const SinglePath = Config.SinglePath;
 pub const ShellIntegrationFeatures = Config.ShellIntegrationFeatures;
 pub const WindowPaddingColor = Config.WindowPaddingColor;
+pub const BackgroundImageMode = Config.BackgroundImageMode;
 
 // Alternate APIs
 pub const CAPI = @import("config/CAPI.zig");

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -460,7 +460,7 @@ background: Color = .{ .r = 0x28, .g = 0x2C, .b = 0x34 },
 foreground: Color = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF },
 
 /// Background image for the window.
-@"background-image": SinglePath = .{},
+@"background-image": ?Path = null,
 
 /// Background image opacity
 @"background-image-opacity": f32 = 1.0,
@@ -469,23 +469,30 @@ foreground: Color = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF },
 ///
 /// Valid values are:
 ///
-///   * `zoomed` - Image is scaled to fit the window, preserving aspect ratio.
-///   * `stretched` - Image is stretched to fill the window, not preserving aspect ratio.
-///   * `cropped` - Image is centered in the window, preserving the aspect ratio
+///   * `contain` - Image is scaled to fit the window, preserving aspect ratio.
+///   * `fill` - Image is stretched to fill the window, not preserving aspect ratio.
+///   * `cover` - Image is centered in the window, preserving the aspect ratio
 ///     but cropping the image to fill the window, as needed.
 ///   * `tiled` - Image is repeated horizontally and vertically to fill the window.
-///   * `centered` - Image is centered in the window and displayed 1-to-1 pixel
-///     scale, preserving both the aspect ratio and the image size.
-///   * `upper-left` - Image is anchored to the upper left corner of the window,
-///     preserving the aspect ratio.
-///   * `upper-right` - Image is anchored to the upper right corner of the window,
-///     preserving the aspect ratio.
-///   * `lower-left` - Image is anchored to the lower left corner of the window,
-///     preserving the aspect ratio.
-///   * `lower-right` - Image is anchored to the lower right corner of the window,
-///     preserving the aspect ratio.
+///   * `none` - Image is displayed 1-to-1 pixel scale, preserving both the aspect
+///     ratio and the image size.
 ///
-@"background-image-mode": BackgroundImageMode = .zoomed,
+@"background-image-mode": BackgroundImageMode = .none,
+
+/// Background image position.
+///
+/// Valid values are:
+///   * `top-left`
+///   * `top-center`
+///   * `top-right`
+///   * `center-left`
+///   * `center`
+///   * `center-right`
+///   * `bottom-left`
+///   * `bottom-center`
+///   * `bottom-right`
+///
+@"background-image-position": BackgroundImagePosition = .center,
 
 /// The foreground and background color for selection. If this is not set, then
 /// the selection color is just the inverted window background and foreground
@@ -3003,95 +3010,27 @@ fn expandPaths(self: *Config, base: []const u8) !void {
     );
 
     // Expand all of our paths
-    inline for (@typeInfo(Config).Struct.fields) |field| {
-        if (field.type == RepeatablePath) {
-            try @field(self, field.name).expand(
-                arena_alloc,
-                base,
-                &self._diagnostics,
-            );
+    inline for (@typeInfo(Config).@"struct".fields) |field| {
+        switch (field.type) {
+            RepeatablePath, Path => {
+                try @field(self, field.name).expand(
+                    arena_alloc,
+                    base,
+                    &self._diagnostics,
+                );
+            },
+            ?Path => {
+                if (@field(self, field.name)) |*path| {
+                    try path.expand(
+                        arena_alloc,
+                        base,
+                        &self._diagnostics,
+                    );
+                }
+            },
+            else => {},
         }
     }
-}
-
-/// Expand a relative path to an absolute path. This function is used by
-/// the RepeatablePath and SinglePath to expand the paths they store.
-fn expandPath(
-    alloc: Allocator,
-    base: []const u8,
-    path: []const u8,
-    diags: *cli.DiagnosticList,
-) ![]const u8 {
-    assert(std.fs.path.isAbsolute(base));
-    var dir = try std.fs.cwd().openDir(base, .{});
-    defer dir.close();
-
-    // If it is already absolute we can just return it
-    if (path.len == 0 or std.fs.path.isAbsolute(path)) return path;
-
-    // If it isn't absolute, we need to make it absolute relative
-    // to the base.
-    var buf: [std.fs.max_path_bytes]u8 = undefined;
-
-    // Check if the path starts with a tilde and expand it to the
-    // home directory on Linux/macOS. We explicitly look for "~/"
-    // because we don't support alternate users such as "~alice/"
-    if (std.mem.startsWith(u8, path, "~/")) expand: {
-        // Windows isn't supported yet
-        if (comptime builtin.os.tag == .windows) break :expand;
-
-        const expanded: []const u8 = internal_os.expandHome(
-            path,
-            &buf,
-        ) catch |err| {
-            try diags.append(alloc, .{
-                .message = try std.fmt.allocPrintZ(
-                    alloc,
-                    "error expanding home directory for path {s}: {}",
-                    .{ path, err },
-                ),
-            });
-
-            // We can't expand this path so return an empty string
-            return "";
-        };
-
-        log.debug(
-            "expanding file path from home directory: path={s}",
-            .{expanded},
-        );
-
-        return expanded;
-    }
-
-    const abs = dir.realpath(path, &buf) catch |err| abs: {
-        if (err == error.FileNotFound) {
-            // The file doesn't exist. Try to resolve the relative path
-            // another way.
-            const resolved = try std.fs.path.resolve(alloc, &.{ base, path });
-            defer alloc.free(resolved);
-            @memcpy(buf[0..resolved.len], resolved);
-            break :abs buf[0..resolved.len];
-        }
-
-        try diags.append(alloc, .{
-            .message = try std.fmt.allocPrintZ(
-                alloc,
-                "error resolving file path {s}: {}",
-                .{ path, err },
-            ),
-        });
-
-        // We can't expand this path so return an empty string
-        return "";
-    };
-
-    log.debug(
-        "expanding file path relative={s} abs={s}",
-        .{ path, abs },
-    );
-
-    return abs;
 }
 
 fn loadTheme(self: *Config, theme: Theme) !void {
@@ -4272,63 +4211,6 @@ pub const Palette = struct {
     }
 };
 
-/// SinglePath is a path to a single file. When loading the configuration
-/// file, always the last one will be kept and be automatically expanded
-/// relative to the path of the config file.
-pub const SinglePath = struct {
-    const Self = @This();
-
-    /// The actual value that is updated as we parse.
-    value: ?[]const u8 = null,
-
-    /// Parse a single path.
-    pub fn parseCLI(self: *Self, alloc: Allocator, input: ?[]const u8) !void {
-        const value = input orelse return error.ValueRequired;
-        // If the value is empty, we set the value to null
-        if (value.len == 0) {
-            self.value = null;
-            return;
-        }
-        const copy = try alloc.dupe(u8, value);
-        self.value = copy;
-    }
-
-    /// Deep copy of the struct. Required by Config.
-    pub fn clone(self: Self, alloc: Allocator) Allocator.Error!Self {
-        const value = self.value orelse return .{};
-
-        const copy_path = try alloc.dupe(u8, value);
-        return .{
-            .value = copy_path,
-        };
-    }
-
-    /// Used by Formatter
-    pub fn formatEntry(self: Self, formatter: anytype) !void {
-        const value = self.value orelse return;
-        try formatter.formatEntry([]const u8, value);
-    }
-
-    /// Expand all the paths relative to the base directory.
-    pub fn expand(
-        self: *Self,
-        alloc: Allocator,
-        base: []const u8,
-        diags: *cli.DiagnosticList,
-    ) !void {
-        // Try expanding path relative to the base.
-        const path = self.value orelse return;
-        const abs = try expandPath(alloc, base, path, diags);
-
-        if (abs.len == 0) {
-            // Blank this path so that we don't attempt to resolve it again
-            self.value = null;
-            return;
-        }
-        self.value = try alloc.dupeZ(u8, abs);
-    }
-};
-
 /// RepeatableString is a string value that can be repeated to accumulate
 /// a list of strings. This isn't called "StringList" because I find that
 /// sometimes leads to confusion that it _accepts_ a list such as
@@ -4482,272 +4364,6 @@ pub const RepeatableString = struct {
         try list.parseCLI(alloc, "B");
         try list.formatEntry(formatterpkg.entryFormatter("a", buf.writer()));
         try std.testing.expectEqualSlices(u8, "a = A\na = B\n", buf.items);
-    }
-};
-
-/// RepeatablePath is like repeatable string but represents a path value.
-/// The difference is that when loading the configuration any values for
-/// this will be automatically expanded relative to the path of the config
-/// file.
-pub const RepeatablePath = struct {
-    const Self = @This();
-
-    const Path = union(enum) {
-        /// No error if the file does not exist.
-        optional: [:0]const u8,
-
-        /// The file is required to exist.
-        required: [:0]const u8,
-    };
-
-    value: std.ArrayListUnmanaged(Path) = .{},
-
-    pub fn parseCLI(self: *Self, alloc: Allocator, input: ?[]const u8) !void {
-        const value, const optional = if (input) |value| blk: {
-            if (value.len == 0) {
-                self.value.clearRetainingCapacity();
-                return;
-            }
-
-            break :blk if (value[0] == '?')
-                .{ value[1..], true }
-            else if (value.len >= 2 and value[0] == '"' and value[value.len - 1] == '"')
-                .{ value[1 .. value.len - 1], false }
-            else
-                .{ value, false };
-        } else return error.ValueRequired;
-
-        if (value.len == 0) {
-            // This handles the case of zero length paths after removing any ?
-            // prefixes or surrounding quotes. In this case, we don't reset the
-            // list.
-            return;
-        }
-
-        const item: Path = if (optional)
-            .{ .optional = try alloc.dupeZ(u8, value) }
-        else
-            .{ .required = try alloc.dupeZ(u8, value) };
-
-        try self.value.append(alloc, item);
-    }
-
-    /// Deep copy of the struct. Required by Config.
-    pub fn clone(self: *const Self, alloc: Allocator) Allocator.Error!Self {
-        const value = try self.value.clone(alloc);
-        for (value.items) |*item| {
-            switch (item.*) {
-                .optional, .required => |*path| path.* = try alloc.dupeZ(u8, path.*),
-            }
-        }
-
-        return .{
-            .value = value,
-        };
-    }
-
-    /// Compare if two of our value are requal. Required by Config.
-    pub fn equal(self: Self, other: Self) bool {
-        if (self.value.items.len != other.value.items.len) return false;
-        for (self.value.items, other.value.items) |a, b| {
-            if (!std.meta.eql(a, b)) return false;
-        }
-
-        return true;
-    }
-
-    /// Used by Formatter
-    pub fn formatEntry(self: Self, formatter: anytype) !void {
-        if (self.value.items.len == 0) {
-            try formatter.formatEntry(void, {});
-            return;
-        }
-
-        var buf: [std.fs.max_path_bytes + 1]u8 = undefined;
-        for (self.value.items) |item| {
-            const value = switch (item) {
-                .optional => |path| std.fmt.bufPrint(
-                    &buf,
-                    "?{s}",
-                    .{path},
-                ) catch |err| switch (err) {
-                    // Required for builds on Linux where NoSpaceLeft
-                    // isn't an allowed error for fmt.
-                    error.NoSpaceLeft => return error.OutOfMemory,
-                },
-                .required => |path| path,
-            };
-
-            try formatter.formatEntry([]const u8, value);
-        }
-    }
-
-    /// Expand all the paths relative to the base directory.
-    pub fn expand(
-        self: *Self,
-        alloc: Allocator,
-        base: []const u8,
-        diags: *cli.DiagnosticList,
-    ) !void {
-        assert(std.fs.path.isAbsolute(base));
-        var dir = try std.fs.cwd().openDir(base, .{});
-        defer dir.close();
-
-        for (0..self.value.items.len) |i| {
-            const path = switch (self.value.items[i]) {
-                .optional, .required => |path| path,
-            };
-
-            // If it is already absolute we can ignore it.
-            if (path.len == 0 or std.fs.path.isAbsolute(path)) continue;
-
-            // If it isn't absolute, we need to make it absolute relative
-            // to the base.
-            var buf: [std.fs.max_path_bytes]u8 = undefined;
-
-            // Check if the path starts with a tilde and expand it to the
-            // home directory on Linux/macOS. We explicitly look for "~/"
-            // because we don't support alternate users such as "~alice/"
-            if (std.mem.startsWith(u8, path, "~/")) expand: {
-                // Windows isn't supported yet
-                if (comptime builtin.os.tag == .windows) break :expand;
-
-                const expanded: []const u8 = internal_os.expandHome(
-                    path,
-                    &buf,
-                ) catch |err| {
-                    try diags.append(alloc, .{
-                        .message = try std.fmt.allocPrintZ(
-                            alloc,
-                            "error expanding home directory for path {s}: {}",
-                            .{ path, err },
-                        ),
-                    });
-
-                    // Blank this path so that we don't attempt to resolve it
-                    // again
-                    self.value.items[i] = .{ .required = "" };
-
-                    continue;
-                };
-
-                log.debug(
-                    "expanding file path from home directory: path={s}",
-                    .{expanded},
-                );
-
-                switch (self.value.items[i]) {
-                    .optional, .required => |*p| p.* = try alloc.dupeZ(u8, expanded),
-                }
-
-                continue;
-            }
-
-            const abs = dir.realpath(path, &buf) catch |err| abs: {
-                if (err == error.FileNotFound) {
-                    // The file doesn't exist. Try to resolve the relative path
-                    // another way.
-                    const resolved = try std.fs.path.resolve(alloc, &.{ base, path });
-                    defer alloc.free(resolved);
-                    @memcpy(buf[0..resolved.len], resolved);
-                    break :abs buf[0..resolved.len];
-                }
-
-                try diags.append(alloc, .{
-                    .message = try std.fmt.allocPrintZ(
-                        alloc,
-                        "error resolving file path {s}: {}",
-                        .{ path, err },
-                    ),
-                });
-
-                // Blank this path so that we don't attempt to resolve it again
-                self.value.items[i] = .{ .required = "" };
-
-                continue;
-            };
-
-            log.debug(
-                "expanding file path relative={s} abs={s}",
-                .{ path, abs },
-            );
-
-            switch (self.value.items[i]) {
-                .optional, .required => |*p| p.* = try alloc.dupeZ(u8, abs),
-            }
-        }
-    }
-
-    test "parseCLI" {
-        const testing = std.testing;
-        var arena = ArenaAllocator.init(testing.allocator);
-        defer arena.deinit();
-        const alloc = arena.allocator();
-
-        var list: Self = .{};
-        try list.parseCLI(alloc, "config.1");
-        try list.parseCLI(alloc, "?config.2");
-        try list.parseCLI(alloc, "\"?config.3\"");
-
-        // Zero-length values, ignored
-        try list.parseCLI(alloc, "?");
-        try list.parseCLI(alloc, "\"\"");
-
-        try testing.expectEqual(@as(usize, 3), list.value.items.len);
-
-        const Tag = std.meta.Tag(Path);
-        try testing.expectEqual(Tag.required, @as(Tag, list.value.items[0]));
-        try testing.expectEqualStrings("config.1", list.value.items[0].required);
-
-        try testing.expectEqual(Tag.optional, @as(Tag, list.value.items[1]));
-        try testing.expectEqualStrings("config.2", list.value.items[1].optional);
-
-        try testing.expectEqual(Tag.required, @as(Tag, list.value.items[2]));
-        try testing.expectEqualStrings("?config.3", list.value.items[2].required);
-
-        try list.parseCLI(alloc, "");
-        try testing.expectEqual(@as(usize, 0), list.value.items.len);
-    }
-
-    test "formatConfig empty" {
-        const testing = std.testing;
-        var buf = std.ArrayList(u8).init(testing.allocator);
-        defer buf.deinit();
-
-        var list: Self = .{};
-        try list.formatEntry(formatterpkg.entryFormatter("a", buf.writer()));
-        try std.testing.expectEqualSlices(u8, "a = \n", buf.items);
-    }
-
-    test "formatConfig single item" {
-        const testing = std.testing;
-        var buf = std.ArrayList(u8).init(testing.allocator);
-        defer buf.deinit();
-
-        var arena = ArenaAllocator.init(testing.allocator);
-        defer arena.deinit();
-        const alloc = arena.allocator();
-
-        var list: Self = .{};
-        try list.parseCLI(alloc, "A");
-        try list.formatEntry(formatterpkg.entryFormatter("a", buf.writer()));
-        try std.testing.expectEqualSlices(u8, "a = A\n", buf.items);
-    }
-
-    test "formatConfig multiple items" {
-        const testing = std.testing;
-        var buf = std.ArrayList(u8).init(testing.allocator);
-        defer buf.deinit();
-
-        var arena = ArenaAllocator.init(testing.allocator);
-        defer arena.deinit();
-        const alloc = arena.allocator();
-
-        var list: Self = .{};
-        try list.parseCLI(alloc, "A");
-        try list.parseCLI(alloc, "?B");
-        try list.formatEntry(formatterpkg.entryFormatter("a", buf.writer()));
-        try std.testing.expectEqualSlices(u8, "a = A\na = ?B\n", buf.items);
     }
 };
 
@@ -6634,15 +6250,29 @@ pub const AlphaBlending = enum {
 /// in sync with the values in the vertex shader used to render the
 /// background image (`bgimage`).
 pub const BackgroundImageMode = enum(u8) {
-    zoomed = 0,
-    stretched = 1,
-    cropped = 2,
+    contain = 0,
+    fill = 1,
+    cover = 2,
     tiled = 3,
-    centered = 4,
-    upper_left = 5,
-    upper_right = 6,
-    lower_left = 7,
-    lower_right = 8,
+    none = 4,
+};
+
+/// See background-image-position
+///
+/// This enum is used to set the background image position. The shader expects
+/// a `uint`, so we use `u8` here. The values for each position should be kept
+/// in sync with the values in the vertex shader used to render the
+/// background image (`bgimage`).
+pub const BackgroundImagePosition = enum(u8) {
+    @"top-left" = 0,
+    @"top-center" = 1,
+    @"top-right" = 2,
+    @"center-left" = 3,
+    center = 4,
+    @"center-right" = 5,
+    @"bottom-left" = 6,
+    @"bottom-center" = 7,
+    @"bottom-right" = 8,
 };
 
 /// See freetype-load-flag

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -470,7 +470,9 @@ foreground: Color = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF },
 /// Valid values are:
 ///
 ///   * `zoomed` - Image is scaled to fit the window, preserving aspect ratio.
-///   * `scaled` - Image is scaled to fill the window, not preserving aspect ratio.
+///   * `stretched` - Image is stretched to fill the window, not preserving aspect ratio.
+///   * `cropped` - Image is centered in the window, preserving the aspect ratio
+///     but cropping the image to fill the window, as needed.
 ///   * `tiled` - Image is repeated horizontally and vertically to fill the window.
 ///   * `centered` - Image is centered in the window and displayed 1-to-1 pixel
 ///     scale, preserving both the aspect ratio and the image size.
@@ -6634,12 +6636,13 @@ pub const AlphaBlending = enum {
 pub const BackgroundImageMode = enum(u8) {
     zoomed = 0,
     stretched = 1,
-    tiled = 2,
-    centered = 3,
-    upper_left = 4,
-    upper_right = 5,
-    lower_left = 6,
-    lower_right = 7,
+    cropped = 2,
+    tiled = 3,
+    centered = 4,
+    upper_left = 5,
+    upper_right = 6,
+    lower_left = 7,
+    lower_right = 8,
 };
 
 /// See freetype-load-flag

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -2958,7 +2958,7 @@ fn rebuildCells(
                 const bg_alpha: u8 = bg_alpha: {
                     const default: u8 = 255;
 
-                    if (self.current_background_image == null and self.config.background_opacity >= 1) break :bg_alpha default;
+                    if (self.config.background_opacity >= 1) break :bg_alpha default;
 
                     // Cells that are selected should be fully opaque.
                     if (selected) break :bg_alpha default;
@@ -2969,11 +2969,6 @@ fn rebuildCells(
                     // Cells that have an explicit bg color should be fully opaque.
                     if (bg_style != null) {
                         break :bg_alpha default;
-                    }
-
-                    // If we have a background image, use the configured background image opacity.
-                    if (self.current_background_image != null) {
-                        break :bg_alpha @intFromFloat(@round((1 - self.config.background_image_opacity) * 255.0));
                     }
 
                     // Otherwise, we use the configured background opacity.

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -117,6 +117,7 @@ pub const Image = extern struct {
 pub const BgImage = extern struct {
     terminal_size: [2]f32,
     mode: configpkg.BackgroundImageMode,
+    position_index: configpkg.BackgroundImagePosition,
 };
 
 /// The uniforms that are passed to the terminal cell shader.

--- a/src/renderer/shaders/cell.metal
+++ b/src/renderer/shaders/cell.metal
@@ -262,12 +262,12 @@ fragment float4 cell_bg_fragment(
   int2 grid_pos = int2(floor((in.position.xy - uniforms.grid_padding.wx) / uniforms.cell_size));
 
   float4 bg = float4(0.0);
-  // If we have any background transparency then we render bg-colored cells as
-  // fully transparent, since the background is handled by the layer bg color
-  // and we don't want to double up our bg color, but if our bg color is fully
-  // opaque then our layer is opaque and can't handle transparency, so we need
-  // to return the bg color directly instead.
-  if (uniforms.bg_color.a == 255) {
+  // If we have any background transparency or a background image, then we
+  // render bg-colored cells as fully transparent, since the background is
+  // handled by the layer bg color and we don't want to double up our bg color.
+  // But if our bg color is fully opaque, then our layer is opaque and can't
+  // handle transparency, so we need to return the bg color directly instead.
+  if (uniforms.bg_color.a == 255 && !uniforms.has_bg_image) {
     bg = in.bg_color;
   }
 

--- a/src/renderer/shaders/cell.metal
+++ b/src/renderer/shaders/cell.metal
@@ -239,14 +239,9 @@ vertex CellBgVertexOut cell_bg_vertex(
   position.zw = 1.0;
   out.position = position;
 
-  uchar4 bg_color = uniforms.bg_color;
-  if (uniforms.has_bg_image) {
-    bg_color.a = uchar((1.0f - uniforms.bg_image_opacity) * 255);
-  }
-
   // Convert the background color to Display P3
   out.bg_color = load_color(
-    bg_color,
+    uniforms.bg_color,
     uniforms.use_display_p3,
     uniforms.use_linear_blending
   );


### PR DESCRIPTION
- Implements #3645 for Metal.
- Uses foundation / logic from the OpenGL counterpart (https://github.com/ghostty-org/ghostty/pull/4226) making changes only when necessary