### PR TITLE
bash: revert automatic shell integration changes

### DIFF
--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -41,37 +41,31 @@ if [ -n "$GHOSTTY_BASH_INJECT" ]; then
 
   # Manually source the startup files. See INVOCATION in bash(1) and
   # run_startup_files() in shell.c in the Bash source code.
-  function __ghostty_bash_startup() {
-    builtin local rcfile
-
-    if builtin shopt -q login_shell; then
-      if [[ $__ghostty_bash_flags != *"--noprofile"* ]]; then
-        [ -r /etc/profile ] && builtin source "/etc/profile"
-        for rcfile in ~/.bash_profile ~/.bash_login ~/.profile; do
-          [ -r "$rcfile" ] && { builtin source "$rcfile"; break; }
-        done
-      fi
-    else
-      if [[ $__ghostty_bash_flags != *"--norc"* ]]; then
-        # The location of the system bashrc is determined at bash build
-        # time via -DSYS_BASHRC and can therefore vary across distros:
-        #  Arch, Debian, Ubuntu use /etc/bash.bashrc
-        #  Fedora uses /etc/bashrc sourced from ~/.bashrc instead of SYS_BASHRC
-        #  Void Linux uses /etc/bash/bashrc
-        #  Nixos uses /etc/bashrc
-        for rcfile in /etc/bash.bashrc /etc/bash/bashrc /etc/bashrc; do
-          [ -r "$rcfile" ] && { builtin source "$rcfile"; break; }
-        done
-        if [[ -z "$GHOSTTY_BASH_RCFILE" ]]; then GHOSTTY_BASH_RCFILE=~/.bashrc; fi
-        [ -r "$GHOSTTY_BASH_RCFILE" ] && builtin source "$GHOSTTY_BASH_RCFILE"
-      fi
+  if builtin shopt -q login_shell; then
+    if [[ $__ghostty_bash_flags != *"--noprofile"* ]]; then
+      [ -r /etc/profile ] && builtin source "/etc/profile"
+      for __ghostty_rcfile in "$HOME/.bash_profile" "$HOME/.bash_login" "$HOME/.profile"; do
+        [ -r "$__ghostty_rcfile" ] && { builtin source "$__ghostty_rcfile"; break; }
+      done
     fi
-  }
+  else
+    if [[ $__ghostty_bash_flags != *"--norc"* ]]; then
+      # The location of the system bashrc is determined at bash build
+      # time via -DSYS_BASHRC and can therefore vary across distros:
+      #  Arch, Debian, Ubuntu use /etc/bash.bashrc
+      #  Fedora uses /etc/bashrc sourced from ~/.bashrc instead of SYS_BASHRC
+      #  Void Linux uses /etc/bash/bashrc
+      #  Nixos uses /etc/bashrc
+      for __ghostty_rcfile in /etc/bash.bashrc /etc/bash/bashrc /etc/bashrc; do
+        [ -r "$__ghostty_rcfile" ] && { builtin source "$__ghostty_rcfile"; break; }
+      done
+      if [[ -z "$GHOSTTY_BASH_RCFILE" ]]; then GHOSTTY_BASH_RCFILE="$HOME/.bashrc"; fi
+      [ -r "$GHOSTTY_BASH_RCFILE" ] && builtin source "$GHOSTTY_BASH_RCFILE"
+    fi
+  fi
 
-  __ghostty_bash_startup
-
-  builtin unset -f __ghostty_bash_startup
-  builtin unset -v __ghostty_bash_flags
+  builtin unset __ghostty_rcfile
+  builtin unset __ghostty_bash_flags
   builtin unset GHOSTTY_BASH_RCFILE
 fi
 


### PR DESCRIPTION
The intention of #5075 was to create a less intrusive, more hermetic environment in which to source the bash startup files. This caused problems for multiple people, and I believe that's because the general expectation is that these files are sourced at global (not function) scope.

For example, when a file is sourced from within a function scope, any variables that weren't explicitly exported into the global environment won't be available outside of the scope of the function. Most system and personal startup files aren't written with that constraint because it's not how bash itself loads these files.

As a small improvement over the original code, `rcfile` has been renamed to `__ghostty_rcfile`. Avoiding leaking this variable while sourcing these files was a goal of #5075, and prefixing it make it much less of a potential issue.

This change also reverts the $HOME -> ~/ change. While the ~/ notation is more concise, using $HOME is more common and easier to implement safely with regard to quoting.

Fixes #5206