### PR TITLE
Prevent hyperlink hover state when mouse is outside viewport

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1041,6 +1041,9 @@ fn mouseRefreshLinks(
     pos_vp: terminal.point.Coordinate,
     over_link: bool,
 ) !void {
+    // If the position is outside our viewport, do nothing
+    if (pos.x < 0 or pos.y < 0) return;
+
     self.mouse.link_point = pos_vp;
 
     if (try self.linkAtPos(pos)) |link| {

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -638,7 +638,7 @@ pub const Surface = struct {
                 .y = @floatCast(opts.scale_factor),
             },
             .size = .{ .width = 800, .height = 600 },
-            .cursor_pos = .{ .x = 0, .y = 0 },
+            .cursor_pos = .{ .x = -1, .y = -1 },
             .keymap_state = .{},
         };
 

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -560,7 +560,7 @@ pub fn init(self: *Surface, app: *App, opts: Options) !void {
         .font_size = font_size,
         .init_config = init_config,
         .size = .{ .width = 800, .height = 600 },
-        .cursor_pos = .{ .x = 0, .y = 0 },
+        .cursor_pos = .{ .x = -1, .y = -1 },
         .im_context = im_context,
         .cgroup_path = cgroup_path,
     };


### PR DESCRIPTION
## Description

Fixed an issue where hyperlinks would maintain their hover state when the mouse is outside the viewport while holding the Cmd key. This created inconsistent behavior with the window's standard hover state clearing logic.

## Changes

- Added viewport boundary check in `mouseRefreshLinks` function to prevent link processing when cursor is outside the window

## Testing

To reproduce and verify the fix:

1. Run `fd --hyperlink "\.zig$" src/apprt` to create hyperlinks

2. Move mouse over a hyperlink (it should highlight)

3. Move mouse outside window

4. Hold Cmd key

	- Before: Link would show hover state

	- After: Link remains in non-hover state

Fixes #5252

@rrotter Could you please try this to see if it solves your issue?