### PR TITLE
unigen: Remove libc dependency, use ArenaAllocator

### DIFF
--- a/src/build/UnicodeTables.zig
+++ b/src/build/UnicodeTables.zig
@@ -15,7 +15,6 @@ pub fn init(b: *std.Build) !UnicodeTables {
         .root_source_file = b.path("src/unicode/props.zig"),
         .target = b.host,
     });
-    exe.linkLibC();
 
     const ziglyph_dep = b.dependency("ziglyph", .{
         .target = b.host,

--- a/src/unicode/props.zig
+++ b/src/unicode/props.zig
@@ -131,7 +131,9 @@ pub fn get(cp: u21) Properties {
 
 /// Runnable binary to generate the lookup tables and output to stdout.
 pub fn main() !void {
-    const alloc = std.heap.c_allocator;
+    var arena_state = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_state.deinit();
+    const alloc = arena_state.allocator();
 
     const gen: lut.Generator(
         Properties,


### PR DESCRIPTION
Not linking libc avoids potential problems when compiling from/for certain targets (see https://github.com/ghostty-org/ghostty/discussions/3218), and using an ArenaAllocator makes unigen run just as fast (in both release and debug modes) while also taking less memory.

```
Benchmark 1 (3 runs): ./zig-out/bin/unigen-release-c
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          1.75s  ± 15.8ms    1.73s  … 1.76s           0 ( 0%)        0%
  peak_rss           2.23MB ±    0      2.23MB … 2.23MB          0 ( 0%)        0%
  cpu_cycles         7.22G  ± 62.8M     7.16G  … 7.29G           0 ( 0%)        0%
  instructions       11.5G  ± 16.0      11.5G  … 11.5G           0 ( 0%)        0%
  cache_references    436M  ± 6.54M      430M  …  443M           0 ( 0%)        0%
  cache_misses        310K  ±  203K      134K  …  532K           0 ( 0%)        0%
  branch_misses      1.03M  ± 29.9K      997K  … 1.06M           0 ( 0%)        0%
Benchmark 2 (3 runs): ./zig-out/bin/unigen-release-arena
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          1.73s  ± 6.40ms    1.72s  … 1.73s           0 ( 0%)          -  1.0% ±  1.6%
  peak_rss           1.27MB ± 75.7KB    1.18MB … 1.31MB          0 ( 0%)        ⚡- 43.1% ±  5.4%
  cpu_cycles         7.16G  ± 26.5M     7.13G  … 7.18G           0 ( 0%)          -  0.9% ±  1.5%
  instructions       11.4G  ± 28.2      11.4G  … 11.4G           0 ( 0%)          -  0.8% ±  0.0%
  cache_references    441M  ± 2.89M      439M  …  444M           0 ( 0%)          +  1.2% ±  2.6%
  cache_misses        152K  ±  102K     35.2K  …  220K           0 ( 0%)          - 50.8% ± 117.8%
  branch_misses      1.05M  ± 13.4K     1.04M  … 1.06M           0 ( 0%)          +  2.0% ±  5.1%
```

```
Benchmark 1 (3 runs): ./zig-out/bin/unigen-debug-c
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          1.75s  ± 32.4ms    1.71s  … 1.77s           0 ( 0%)        0%
  peak_rss           2.23MB ±    0      2.23MB … 2.23MB          0 ( 0%)        0%
  cpu_cycles         7.23G  ±  136M     7.08G  … 7.34G           0 ( 0%)        0%
  instructions       11.5G  ± 37.9      11.5G  … 11.5G           0 ( 0%)        0%
  cache_references    448M  ± 1.03M      447M  …  449M           0 ( 0%)        0%
  cache_misses        148K  ± 42.6K     99.3K  …  180K           0 ( 0%)        0%
  branch_misses       987K  ± 5.27K      983K  …  993K           0 ( 0%)        0%
Benchmark 2 (3 runs): ./zig-out/bin/unigen-debug-arena
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          1.76s  ± 4.12ms    1.76s  … 1.76s           0 ( 0%)          +  0.4% ±  3.0%
  peak_rss           1.22MB ± 75.7KB    1.18MB … 1.31MB          0 ( 0%)        ⚡- 45.1% ±  5.4%
  cpu_cycles         7.27G  ± 17.1M     7.26G  … 7.29G           0 ( 0%)          +  0.6% ±  3.0%
  instructions       11.4G  ± 3.79      11.4G  … 11.4G           0 ( 0%)          -  0.8% ±  0.0%
  cache_references    440M  ± 4.52M      435M  …  444M           0 ( 0%)          -  1.7% ±  1.7%
  cache_misses       43.6K  ± 19.2K     26.5K  … 64.3K           0 ( 0%)        ⚡- 70.5% ± 50.8%
  branch_misses      1.04M  ± 2.25K     1.04M  … 1.05M           0 ( 0%)        💩+  5.8% ±  0.9%
```