### PR TITLE
Change default key bindings to capture full screen contents (`write_screen_file`)

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2370,13 +2370,13 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
     try result.keybind.set.put(
         alloc,
         .{ .key = .{ .translated = .j }, .mods = inputpkg.ctrlOrSuper(.{ .shift = true }) },
-        .{ .write_scrollback_file = .paste },
+        .{ .write_screen_file = .paste },
     );
 
     try result.keybind.set.put(
         alloc,
         .{ .key = .{ .translated = .j }, .mods = inputpkg.ctrlOrSuper(.{ .shift = true, .alt = true }) },
-        .{ .write_scrollback_file = .open },
+        .{ .write_screen_file = .open },
     );
 
     // Expand Selection


### PR DESCRIPTION
The current default keybinding on `Ctrl-Shift-J`/`Cmd-Shift-J` utilize [`write_scrollback_file`](https://ghostty.org/docs/config/keybind/reference#write_scrollback_file) which only captures text that's scrolled off-screen. This can be confusing, as I would expect it to capture everything on and off-screen.

Per the docs, [`write_screen_file`](https://ghostty.org/docs/config/keybind/reference#write_screen_file) is the "Same as `write_scrollback_file` but writes the full screen contents" which is perfect to solve this problem and aligns exactly with the expected behavior.

This change addresses the friction that people have reported in the discussions below and specifically coming from the [search scrollback feature discussion](https://github.com/ghostty-org/ghostty/issues/189), where `Ctrl-Shift-J`/`Cmd-Shift-J` is one of the interim decent workarounds but then you also have to figure out the extra intricacy to use `write_screen_file` instead of `write_scrollback_file`.

Previous discussions:

 - https://github.com/ghostty-org/ghostty/discussions/3652
 - https://github.com/ghostty-org/ghostty/issues/3496
 - https://github.com/ghostty-org/ghostty/discussions/4911
 - https://github.com/ghostty-org/ghostty/discussions/4390
 - https://github.com/ghostty-org/ghostty/discussions/2363#discussioncomment-11735957
 - https://github.com/ghostty-org/ghostty/issues/189#issuecomment-2564719973
 - https://github.com/ghostty-org/ghostty/pull/2040
 
### Workaround

Before this PR is merged, you can achieve the same result by updating your Ghostty config:

`.config/ghostty`
```sh
# So we have more scrollback history (the size of the scrollback buffer in bytes)
scrollback-limit = 100000000

# The default keybindings use `write_scrollback_file` but that only includes what is
# offscreen. `write_screen_file` includes what's on screen and offscreen.
keybind = ctrl+shift+j=write_screen_file:paste
keybind = ctrl+shift+alt+j=write_screen_file:open
```