### PR TITLE
build: options to enable/disable terminfo & termcap install

### DIFF
--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -55,6 +55,8 @@ emit_helpgen: bool = false,
 emit_docs: bool = false,
 emit_webdata: bool = false,
 emit_xcframework: bool = false,
+emit_terminfo: bool = false,
+emit_termcap: bool = false,
 
 /// Environmental properties
 env: std.process.EnvMap,
@@ -306,11 +308,32 @@ pub fn init(b: *std.Build) !Config {
         break :emit_docs path != null;
     };
 
+    config.emit_terminfo = b.option(
+        bool,
+        "emit-terminfo",
+        "Install Ghostty terminfo source file",
+    ) orelse switch (target.result.os.tag) {
+        .windows => true,
+        else => switch (optimize) {
+            .Debug => true,
+            .ReleaseSafe, .ReleaseFast, .ReleaseSmall => false,
+        },
+    };
+
+    config.emit_termcap = b.option(
+        bool,
+        "emit-termcap",
+        "Install Ghostty termcap file",
+    ) orelse false;
+
     config.emit_webdata = b.option(
         bool,
         "emit-webdata",
         "Build the website data for the website.",
-    ) orelse false;
+    ) orelse switch (optimize) {
+        .Debug => true,
+        .ReleaseSafe, .ReleaseFast, .ReleaseSmall => false,
+    };
 
     config.emit_xcframework = b.option(
         bool,

--- a/src/build/GhosttyResources.zig
+++ b/src/build/GhosttyResources.zig
@@ -23,9 +23,12 @@ pub fn init(b: *std.Build, cfg: *const Config) !GhosttyResources {
 
         // Write it
         var wf = b.addWriteFiles();
-        const src_source = wf.add("share/terminfo/ghostty.terminfo", str.items);
-        const src_install = b.addInstallFile(src_source, "share/terminfo/ghostty.terminfo");
-        try steps.append(&src_install.step);
+        const source = wf.add("ghostty.terminfo", str.items);
+
+        if (cfg.emit_terminfo) {
+            const source_install = b.addInstallFile(source, "share/terminfo/ghostty.terminfo");
+            try steps.append(&source_install.step);
+        }
 
         // Windows doesn't have the binaries below.
         if (cfg.target.result.os.tag == .windows) break :terminfo;
@@ -33,10 +36,10 @@ pub fn init(b: *std.Build, cfg: *const Config) !GhosttyResources {
         // Convert to termcap source format if thats helpful to people and
         // install it. The resulting value here is the termcap source in case
         // that is used for other commands.
-        {
+        if (cfg.emit_termcap) {
             const run_step = RunStep.create(b, "infotocap");
-            run_step.addArg("infotocap");
-            run_step.addFileArg(src_source);
+            run_step.addArgs(&.{ "infotocap", "-" });
+            run_step.setStdIn(.{ .lazy_path = source });
             const out_source = run_step.captureStdOut();
             _ = run_step.captureStdErr(); // so we don't see stderr
 
@@ -48,24 +51,21 @@ pub fn init(b: *std.Build, cfg: *const Config) !GhosttyResources {
         {
             const run_step = RunStep.create(b, "tic");
             run_step.addArgs(&.{ "tic", "-x", "-o" });
-            const path = run_step.addOutputFileArg("terminfo");
-            run_step.addFileArg(src_source);
+            const path = run_step.addOutputDirectoryArg("share/terminfo");
+            run_step.addArg("-");
+            run_step.setStdIn(.{ .lazy_path = source });
             _ = run_step.captureStdErr(); // so we don't see stderr
 
-            // Depend on the terminfo source install step so that Zig build
-            // creates the "share" directory for us.
-            run_step.step.dependOn(&src_install.step);
+            try steps.append(&run_step.step);
 
-            {
-                // Use cp -R instead of Step.InstallDir because we need to preserve
-                // symlinks in the terminfo database. Zig's InstallDir step doesn't
-                // handle symlinks correctly yet.
-                const copy_step = RunStep.create(b, "copy terminfo db");
-                copy_step.addArgs(&.{ "cp", "-R" });
-                copy_step.addFileArg(path);
-                copy_step.addArg(b.fmt("{s}/share", .{b.install_path}));
-                try steps.append(&copy_step.step);
-            }
+            // Use cp -R instead of Step.InstallDir because we need to preserve
+            // symlinks in the terminfo database. Zig's InstallDir step doesn't
+            // handle symlinks correctly yet.
+            const copy_step = RunStep.create(b, "copy terminfo db");
+            copy_step.addArgs(&.{ "cp", "-R" });
+            copy_step.addFileArg(path);
+            copy_step.addArg(b.fmt("{s}/share", .{b.install_path}));
+            try steps.append(&copy_step.step);
         }
     }
 

--- a/src/os/resourcesdir.zig
+++ b/src/os/resourcesdir.zig
@@ -21,7 +21,10 @@ pub fn resourcesDir(alloc: std.mem.Allocator) !?[]const u8 {
 
     // This is the sentinel value we look for in the path to know
     // we've found the resources directory.
-    const sentinel = "terminfo/ghostty.termcap";
+    const sentinel = switch (comptime builtin.target.os.tag) {
+        .windows => "terminfo/ghostty.terminfo",
+        else => "terminfo/x/xterm-ghostty",
+    };
 
     // Get the path to our running binary
     var exe_buf: [std.fs.max_path_bytes]u8 = undefined;


### PR DESCRIPTION
Fixes #5253

Add `-Demit-terminfo` and `-Demit-termcap` build options to enable/disable installtion of source terminfo and termcap files.