### PR TITLE
sextants: always properly scale the middle

### DIFF
--- a/src/font/sprite/Box.zig
+++ b/src/font/sprite/Box.zig
@@ -2495,7 +2495,7 @@ fn yThirds(self: Box) [2]u32 {
     return switch (@mod(self.metrics.cell_height, 3)) {
         0 => .{ self.metrics.cell_height / 3, 2 * self.metrics.cell_height / 3 },
         1 => .{ self.metrics.cell_height / 3, 2 * self.metrics.cell_height / 3 + 1 },
-        2 => .{ self.metrics.cell_height / 3 + 1, 2 * self.metrics.cell_height / 3 },
+        2 => .{ self.metrics.cell_height / 3 + 1, 2 * self.metrics.cell_height / 3 + 1 },
         else => unreachable,
     };
 }


### PR DESCRIPTION
what's going on here is we're saying if there's a single extra row in the cell to be distributed, put it on the center, and if there are two, put them on the top and bottom (we get the bottom without specification because we use the cell geometry
directly there). in the mod 2 case, we still want to draw the middle one line past its natural position, to account for the extra line from above. otherwise your bottom third is one larger than your top, and two larger than your middle, which no one wants.

if you have 11, you want

 [0..3] 3 + 1
 [4..6] 3
 [7..10] 3 + 1

but the current breakdown gives you

 [0..3] 3 + 1
 [4..5] 2
 [6..10] 3 + 2

and there is much gnashing and wailing of teeth. but perhaps i'm misunderstanding things.