### PR TITLE
apprt/gtk: when text is committed, end the preedit state

### DIFF
--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1961,6 +1961,12 @@ fn gtkInputCommit(
     // Committing ends composing state
     self.im_composing = false;
 
+    // End our preedit state. Well-behaved input methods do this for us
+    // by triggering a preedit-end event but some do not (ibus 1.5.29).
+    self.core_surface.preeditCallback(null) catch |err| {
+        log.err("error in preedit callback err={}", .{err});
+    };
+
     // Send the text to the core surface, associated with no key (an
     // invalid key, which should produce no PTY encoding).
     _ = self.core_surface.keyCallback(.{


### PR DESCRIPTION
Fixes #3567

ibus 1.5.29 doesn't trigger a preedit end state when text is committed. This is fixed in ibus 1.5.30, but we need to handle this case for older versions which are shipped on LTS distributions such as Ubuntu.

Every other input method engine I've tried thus far also triggers a preedit end state when text is committed, and none would expect preedit to continue after text is committed. So I think it's safe to assume that this is the expected behavior.