### PR TITLE
cli: allow renaming config fields to maintain backwards compatibility

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -339,7 +339,7 @@ extension Ghostty {
         var backgroundBlurRadius: Int {
             guard let config = self.config else { return 1 }
             var v: Int = 0
-            let key = "background-blur-radius"
+            let key = "background-blur"
             _ = ghostty_config_get(config, &v, key, UInt(key.count))
             return v;
         }

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1958,7 +1958,7 @@ pub const CAPI = struct {
         _ = CGSSetWindowBackgroundBlurRadius(
             CGSDefaultConnectionForThread(),
             nswindow.msgSend(usize, objc.sel("windowNumber"), .{}),
-            @intCast(config.@"background-blur-radius".cval()),
+            @intCast(config.@"background-blur".cval()),
         );
     }
 

--- a/src/apprt/gtk/winproto/wayland.zig
+++ b/src/apprt/gtk/winproto/wayland.zig
@@ -176,7 +176,7 @@ pub const Window = struct {
 
         pub fn init(config: *const Config) DerivedConfig {
             return .{
-                .blur = config.@"background-blur-radius".enabled(),
+                .blur = config.@"background-blur".enabled(),
                 .window_decoration = config.@"window-decoration",
             };
         }

--- a/src/apprt/gtk/winproto/x11.zig
+++ b/src/apprt/gtk/winproto/x11.zig
@@ -165,7 +165,7 @@ pub const Window = struct {
 
         pub fn init(config: *const Config) DerivedConfig {
             return .{
-                .blur = config.@"background-blur-radius".enabled(),
+                .blur = config.@"background-blur".enabled(),
                 .has_decoration = switch (config.@"window-decoration") {
                     .none => false,
                     .auto, .client, .server => true,

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -42,6 +42,15 @@ const c = @cImport({
     @cInclude("unistd.h");
 });
 
+/// Renamed fields, used by cli.parse
+pub const renamed = std.StaticStringMap([]const u8).initComptime(&.{
+    // Ghostty 1.1 introduced background-blur support for Linux which
+    // doesn't support a specific radius value. The renaming is to let
+    // one field be used for both platforms (macOS retained the ability
+    // to set a radius).
+    .{ "background-blur-radius", "background-blur" },
+});
+
 /// The font families to use.
 ///
 /// You can generate the list of valid values using the CLI:
@@ -649,7 +658,7 @@ palette: Palette = .{},
 /// need to set environment-specific settings and/or install third-party plugins
 /// in order to support background blur, as there isn't a unified interface for
 /// doing so.
-@"background-blur-radius": BackgroundBlur = .false,
+@"background-blur": BackgroundBlur = .false,
 
 /// The opacity level (opposite of transparency) of an unfocused split.
 /// Unfocused splits by default are slightly faded out to make it easier to see
@@ -5854,7 +5863,7 @@ pub const AutoUpdate = enum {
     download,
 };
 
-/// See background-blur-radius
+/// See background-blur
 pub const BackgroundBlur = union(enum) {
     false,
     true,

--- a/src/config/c_get.zig
+++ b/src/config/c_get.zig
@@ -192,21 +192,21 @@ test "c_get: background-blur" {
     defer c.deinit();
 
     {
-        c.@"background-blur-radius" = .false;
+        c.@"background-blur" = .false;
         var cval: u8 = undefined;
-        try testing.expect(get(&c, .@"background-blur-radius", @ptrCast(&cval)));
+        try testing.expect(get(&c, .@"background-blur", @ptrCast(&cval)));
         try testing.expectEqual(0, cval);
     }
     {
-        c.@"background-blur-radius" = .true;
+        c.@"background-blur" = .true;
         var cval: u8 = undefined;
-        try testing.expect(get(&c, .@"background-blur-radius", @ptrCast(&cval)));
+        try testing.expect(get(&c, .@"background-blur", @ptrCast(&cval)));
         try testing.expectEqual(20, cval);
     }
     {
-        c.@"background-blur-radius" = .{ .radius = 42 };
+        c.@"background-blur" = .{ .radius = 42 };
         var cval: u8 = undefined;
-        try testing.expect(get(&c, .@"background-blur-radius", @ptrCast(&cval)));
+        try testing.expect(get(&c, .@"background-blur", @ptrCast(&cval)));
         try testing.expectEqual(42, cval);
     }
 }


### PR DESCRIPTION
Fixes #4631

This introduces a mechanism by which parsed config fields can be renamed to maintain backwards compatibility. This already has a use case -- implemented in this commit -- for `background-blur-radius` to be renamed to `background-blur`.

The remapping is comptime-known which lets us do some comptime validation. The remap check isn't done unless no fields match which means for well-formed config files, there's no overhead.

For future improvements:

- We should update our config help generator to note renamed fields.
- We could offer automatic migration of config files be rewriting them.
- We can enrich the value type with more metadata to help with config gen or other tooling.