### PR TITLE
termio/exec: call waitpid in process exit callback

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .dependencies = .{
         // Zig libs
         .libxev = .{
-            .url = "https://github.com/mitchellh/libxev/archive/aceef3d11efacd9d237c91632f930ed13a2834bf.tar.gz",
-            .hash = "12205b2b47fe61a4cde3a45ee4b9cddee75897739dbc196d6396e117cb1ce28e1ad0",
+            .url = "https://github.com/mitchellh/libxev/archive/31eed4e337fed7b0149319e5cdbb62b848c24fbd.tar.gz",
+            .hash = "1220ebf88622c4d502dc59e71347e4d28c47e033f11b59aff774ae5787565c40999c",
         },
         .mach_glfw = .{
             .url = "https://github.com/mitchellh/mach-glfw/archive/37c2995f31abcf7e8378fba68ddcf4a3faa02de0.tar.gz",

--- a/nix/zigCacheHash.nix
+++ b/nix/zigCacheHash.nix
@@ -1,3 +1,3 @@
 # This file is auto-generated! check build-support/check-zig-cache-hash.sh for
 # more details.
-"sha256-AvfYl8vLxxsRnf/ERpw5jQIro5rVd98q63hwFsgQOvo="
+"sha256-Bjy31evaKgpRX1mGwAFkai44eiiorTV1gW3VdP9Ins8="


### PR DESCRIPTION
Fixes #4554

When a process exited on its own (we didn't kill it), we were not calling waitpid. This commit adds a waitpid call in the event loop process exit notification.

This happened because when an external exit happened we could call `subprocess.externalExit` which tells our subprocess manager to NOT kill the process (since its already dead). Unfortunately in this case it means we also didn't call waitpid.