### PR TITLE
Ignore SIGPIPE

### DIFF
--- a/src/pty.zig
+++ b/src/pty.zig
@@ -201,6 +201,7 @@ const PosixPty = struct {
         try posix.sigaction(posix.SIG.HUP, &sa, null);
         try posix.sigaction(posix.SIG.ILL, &sa, null);
         try posix.sigaction(posix.SIG.INT, &sa, null);
+        try posix.sigaction(posix.SIG.PIPE, &sa, null);
         try posix.sigaction(posix.SIG.SEGV, &sa, null);
         try posix.sigaction(posix.SIG.TRAP, &sa, null);
         try posix.sigaction(posix.SIG.TERM, &sa, null);


### PR DESCRIPTION
Fixes #5359

The comments explain what's going on. Longer term we should adjust our termio/exec to avoid the SIGPIPE but its still possible (i.e. that thread crashes) to happen so we should be robust to it.