### PR TITLE
fix: cmd+triple-click select all command output when first line wraps

### DIFF
--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -2596,6 +2596,15 @@ pub fn selectOutput(self: *Screen, pin: Pin) ?Selection {
         while (it.next()) |p| {
             it_prev = p;
             const row = p.rowAndCell().row;
+            switch (row.semantic_prompt) {
+                .command => break,
+
+                .unknown,
+                .prompt,
+                .prompt_continuation,
+                .input,
+                => {},
+            }
             if (row.semantic_prompt == .command) {
                 break;
             }
@@ -2606,8 +2615,14 @@ pub fn selectOutput(self: *Screen, pin: Pin) ?Selection {
         // yield the previous row.
         while (it.next()) |p| {
             const row = p.rowAndCell().row;
-            if (row.semantic_prompt != .command) {
-                break :boundary it_prev;
+            switch (row.semantic_prompt) {
+                .command => {},
+
+                .unknown,
+                .prompt,
+                .prompt_continuation,
+                .input,
+                => break :boundary it_prev,
             }
             it_prev = p;
         }


### PR DESCRIPTION
I found this bug was easily reproduced with any command that wrapped to multiple rows on the first line of its output. The cause is that we stop searching for rows once we reach the first one where `row.semantic_prompt = .command`, which means that we reach the bottom line of wrapped output and stop there.

This PR makes it so that we continue iterating until we reach a row where `semantic_prompt != .command` and then return the previous one (or the last one if we run out of rows).

I also updated the test cases to include this.

I considered that this bug would also be avoided if we didn't propagate the `command` semantic prompt to additional rows on wrapped lines, but I don't know enough about the shell integration to make a call on that.

Closes #4693 