### PR TITLE
renderer/Metal: improve linear blending correction

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -259,7 +259,8 @@ pub const renamed = std.StaticStringMap([]const u8).initComptime(&.{
 
 /// What color space to use when performing alpha blending.
 ///
-/// This affects how text looks for different background/foreground color pairs.
+/// This affects the appearance of text and of any images with transparency.
+/// Additionally, custom shaders will receive colors in the configured space.
 ///
 /// Valid values:
 ///
@@ -276,11 +277,7 @@ pub const renamed = std.StaticStringMap([]const u8).initComptime(&.{
 /// * `linear-corrected` - Same as `linear`, but with a correction step applied
 ///   for text that makes it look nearly or completely identical to `native`,
 ///   but without any of the darkening artifacts.
-///
-/// Note: This setting affects more than just text, images will also be blended
-/// in the selected color space, and custom shaders will receive colors in that
-/// color space as well.
-@"text-blending": TextBlending = .native,
+@"alpha-blending": AlphaBlending = .native,
 
 /// All of the configurations behavior adjust various metrics determined by the
 /// font. The values can be integers (1, -1, etc.) or a percentage (20%, -15%,
@@ -1220,12 +1217,16 @@ keybind: Keybinds = .{},
 /// This is currently only supported on macOS and Linux.
 @"window-theme": WindowTheme = .auto,
 
-/// The colorspace to use for the terminal window. The default is `srgb` but
-/// this can also be set to `display-p3` to use the Display P3 colorspace.
+/// The color space to use when interpreting terminal colors. "Terminal colors"
+/// refers to colors specified in your configuration and colors produced by
+/// direct-color SGR sequences.
 ///
-/// Changing this value at runtime will only affect new windows.
+/// Valid values:
 ///
-/// This setting is only supported on macOS.
+///   * `srgb` - Interpret colors in the sRGB color space. This is the default.
+///   * `display-p3` - Interpret colors in the Display P3 color space.
+///
+/// This setting is currently only supported on macOS.
 @"window-colorspace": WindowColorspace = .srgb,
 
 /// The initial window size. This size is in terminal grid cells by default.
@@ -5825,13 +5826,13 @@ pub const GraphemeWidthMethod = enum {
     unicode,
 };
 
-/// See text-blending
-pub const TextBlending = enum {
+/// See alpha-blending
+pub const AlphaBlending = enum {
     native,
     linear,
     @"linear-corrected",
 
-    pub fn isLinear(self: TextBlending) bool {
+    pub fn isLinear(self: AlphaBlending) bool {
         return switch (self) {
             .native => false,
             .linear, .@"linear-corrected" => true,

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -273,10 +273,9 @@ pub const renamed = std.StaticStringMap([]const u8).initComptime(&.{
 ///   This is also sometimes known as "gamma correction".
 ///   (Currently only supported on macOS. Has no effect on Linux.)
 ///
-/// * `linear-corrected` - Corrects the thinning/thickening effect of linear
-///   by applying a correction curve to the text alpha depending on its
-///   brightness. This compensates for the thinning and makes the weight of
-///   most text appear very similar to when it's blended non-linearly.
+/// * `linear-corrected` - Same as `linear`, but with a correction step applied
+///   for text that makes it look nearly or completely identical to `native`,
+///   but without any of the darkening artifacts.
 ///
 /// Note: This setting affects more than just text, images will also be blended
 /// in the selected color space, and custom shaders will receive colors in that

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -391,7 +391,7 @@ pub const DerivedConfig = struct {
     links: link.Set,
     vsync: bool,
     colorspace: configpkg.Config.WindowColorspace,
-    blending: configpkg.Config.TextBlending,
+    blending: configpkg.Config.AlphaBlending,
 
     pub fn init(
         alloc_gpa: Allocator,
@@ -463,7 +463,7 @@ pub const DerivedConfig = struct {
             .links = links,
             .vsync = config.@"window-vsync",
             .colorspace = config.@"window-colorspace",
-            .blending = config.@"text-blending",
+            .blending = config.@"alpha-blending",
             .arena = arena,
         };
     }

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -667,7 +667,7 @@ pub fn init(alloc: Allocator, options: renderer.Options) !Metal {
             .cursor_wide = false,
             .use_display_p3 = options.config.colorspace == .@"display-p3",
             .use_linear_blending = options.config.blending.isLinear(),
-            .use_experimental_linear_correction = options.config.blending == .@"linear-corrected",
+            .use_linear_correction = options.config.blending == .@"linear-corrected",
         },
 
         // Fonts
@@ -2099,7 +2099,7 @@ pub fn changeConfig(self: *Metal, config: *DerivedConfig) !void {
     // Set our new color space and blending
     self.uniforms.use_display_p3 = config.colorspace == .@"display-p3";
     self.uniforms.use_linear_blending = config.blending.isLinear();
-    self.uniforms.use_experimental_linear_correction = config.blending == .@"linear-corrected";
+    self.uniforms.use_linear_correction = config.blending == .@"linear-corrected";
 
     // Set our new colors
     self.default_background_color = config.background;
@@ -2242,7 +2242,7 @@ pub fn setScreenSize(
         .cursor_wide = old.cursor_wide,
         .use_display_p3 = old.use_display_p3,
         .use_linear_blending = old.use_linear_blending,
-        .use_experimental_linear_correction = old.use_experimental_linear_correction,
+        .use_linear_correction = old.use_linear_correction,
     };
 
     // Reset our cell contents if our grid size has changed.

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -158,7 +158,7 @@ pub const Uniforms = extern struct {
     /// Enables a weight correction step that makes text rendered
     /// with linear alpha blending have a similar apparent weight
     /// (thickness) to gamma-incorrect blending.
-    use_experimental_linear_correction: bool align(1) = false,
+    use_linear_correction: bool align(1) = false,
 
     const PaddingExtend = packed struct(u8) {
         left: bool = false,

--- a/src/renderer/shaders/cell.metal
+++ b/src/renderer/shaders/cell.metal
@@ -473,7 +473,11 @@ vertex CellTextVertexOut cell_text_vertex(
     ) &&
     in.grid_pos.y == uniforms.cursor_pos.y
   ) {
-    out.color = float4(uniforms.cursor_color) / 255.0f;
+    out.color = load_color(
+      uniforms.cursor_color,
+      uniforms.use_display_p3,
+      false
+    );
   }
 
   return out;


### PR DESCRIPTION
While I actually do personally prefer the previous style's appearance, I have a feeling this version will be much more popular, since it essentially replicates the appearance of non-linear blending but without any fringing artifacts. Details are explained in the comments and commit messages.

<details>
<summary>
<h3>Screenshots for comparison</h3>
</summary>

*(open images in separate tabs and make sure they're at 100% scale for proper comparison)*

|blending|screenshot|
|-|-|
|`native`|![native](https://github.com/user-attachments/assets/295bbab3-60a7-4915-93d9-a938082fa309)|
|`linear`|![linear](https://github.com/user-attachments/assets/a9a5a5ea-cf57-4730-8ac6-3ce1dc29c5f8)|
|`linear-corrected` (old)|![linear-corrected_old](https://github.com/user-attachments/assets/4fd9510d-b798-4900-8c31-00e3f67fd806)|
|`linear-corrected` (new)|![linear-corrected_new](https://github.com/user-attachments/assets/a379f307-db8a-4335-aa11-3ac71d01470e)|
</details>