### PR TITLE
gtk: apply all window appearance changes in syncAppearance

### DIFF
--- a/src/apprt/gtk/winproto.zig
+++ b/src/apprt/gtk/winproto.zig
@@ -5,6 +5,7 @@ const c = @import("c.zig").c;
 const Config = @import("../../config.zig").Config;
 const input = @import("../../input.zig");
 const key = @import("key.zig");
+const ApprtWindow = @import("Window.zig");
 
 pub const noop = @import("winproto/noop.zig");
 pub const x11 = @import("winproto/x11.zig");
@@ -74,8 +75,7 @@ pub const Window = union(Protocol) {
     pub fn init(
         alloc: Allocator,
         app: *App,
-        window: *c.GtkWindow,
-        config: *const Config,
+        apprt_window: *ApprtWindow,
     ) !Window {
         return switch (app.*) {
             inline else => |*v, tag| {
@@ -90,8 +90,7 @@ pub const Window = union(Protocol) {
                         try field.type.init(
                             alloc,
                             v,
-                            window,
-                            config,
+                            apprt_window,
                         ),
                     );
                 }
@@ -108,15 +107,6 @@ pub const Window = union(Protocol) {
     pub fn resizeEvent(self: *Window) !void {
         switch (self.*) {
             inline else => |*v| try v.resizeEvent(),
-        }
-    }
-
-    pub fn updateConfigEvent(
-        self: *Window,
-        config: *const Config,
-    ) !void {
-        switch (self.*) {
-            inline else => |*v| try v.updateConfigEvent(config),
         }
     }
 

--- a/src/apprt/gtk/winproto/noop.zig
+++ b/src/apprt/gtk/winproto/noop.zig
@@ -3,6 +3,7 @@ const Allocator = std.mem.Allocator;
 const c = @import("../c.zig").c;
 const Config = @import("../../../config.zig").Config;
 const input = @import("../../../input.zig");
+const ApprtWindow = @import("../Window.zig");
 
 const log = std.log.scoped(.winproto_noop);
 
@@ -34,8 +35,7 @@ pub const Window = struct {
     pub fn init(
         _: Allocator,
         _: *App,
-        _: *c.GtkWindow,
-        _: *const Config,
+        _: *ApprtWindow,
     ) !Window {
         return .{};
     }
@@ -47,7 +47,7 @@ pub const Window = struct {
 
     pub fn updateConfigEvent(
         _: *Window,
-        _: *const Config,
+        _: *const ApprtWindow.DerivedConfig,
     ) !void {}
 
     pub fn resizeEvent(_: *Window) !void {}

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1212,12 +1212,7 @@ keybind: Keybinds = .{},
 /// Windows).
 ///
 /// The "toggle_window_decorations" keybind action can be used to create
-/// a keybinding to toggle this setting at runtime. This will always toggle
-/// back to "auto" if the current value is "none" (this is an issue
-/// that will be fixed in the future).
-///
-/// Changing this configuration in your configuration and reloading will
-/// only affect new windows. Existing windows will not be affected.
+/// a keybinding to toggle this setting at runtime.
 ///
 /// macOS: To hide the titlebar without removing the native window borders
 ///        or rounded corners, use `macos-titlebar-style = hidden` instead.
@@ -1323,8 +1318,8 @@ keybind: Keybinds = .{},
 /// window will be placed below the menu bar.
 ///
 /// Note: this is only supported on macOS and Linux GLFW builds. The GTK
-/// runtime does not support setting the window position (this is a limitation
-/// of GTK 4.0).
+/// runtime does not support setting the window position, as windows are
+/// only allowed position themselves in X11 and not Wayland.
 @"window-position-x": ?i16 = null,
 @"window-position-y": ?i16 = null,
 
@@ -2180,9 +2175,6 @@ keybind: Keybinds = .{},
 ///
 /// This option does nothing when `window-decoration` is false or when running
 /// under macOS.
-///
-/// Changing this value at runtime and reloading the configuration will only
-/// affect new windows.
 @"gtk-titlebar": bool = true,
 
 /// Determines the side of the screen that the GTK tab bar will stick to.
@@ -2207,8 +2199,6 @@ keybind: Keybinds = .{},
 ///  * `raised` - Top and bottom bars cast a shadow on the terminal area.
 ///  * `raised-border` - Similar to `raised` but the shadow is replaced with a
 ///    more subtle border.
-///
-/// Changing this value at runtime will only affect new windows.
 @"gtk-toolbar-style": GtkToolbarStyle = .raised,
 
 /// If `true` (default), then the Ghostty GTK tabs will be "wide." Wide tabs


### PR DESCRIPTION
The GTK side of appearance code is kind of a mess with several different functions all having the responsibility of interacting with each other and setting the appropriate window appearance. It should solely be the responsibility of the `syncAppearance` function to apply appearance changes, with other callbacks/functions calling it instead: much like what we already do for the macOS apprt.

~~I also took the time to refactor the libadwaita version checks since calling `versionAtLeast(0, 0, 0)` does get old after a while. Now almost all checks are given human-readable names and contributors need not memorize what the relevant version checks all are.~~ Moved to another PR