### PR TITLE
Fix older adwaita tab bars appearing above the title bar

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -335,10 +335,7 @@ pub fn init(self: *Window, app: *App) !void {
                     .top,
                     .left,
                     .right,
-                    => c.gtk_box_prepend(
-                        @ptrCast(box),
-                        @ptrCast(@alignCast(tab_bar)),
-                    ),
+                    => c.gtk_box_insert_child_after(@ptrCast(box), @ptrCast(@alignCast(tab_bar)), @ptrCast(@alignCast(self.headerbar.asWidget()))),
 
                     .bottom => c.gtk_box_append(
                         @ptrCast(box),


### PR DESCRIPTION
When setting up the GTK window with older Adwaita versions, we need to explicitly create and add a tab bar. The previous code simply prepended the tab bar into the GtkBox, which resulted in it being the very first element (ahead of the title bar).

Instead, we grab a reference to the GTK title bar widget and call `gtk_box_insert_child_after()` to explicitly insert our tab bar into the hierarchy just after the title bar.