### PR TITLE
fix: remove extraneous if check after change to exhaustive switch

### DIFF
--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -2605,9 +2605,6 @@ pub fn selectOutput(self: *Screen, pin: Pin) ?Selection {
                 .input,
                 => {},
             }
-            if (row.semantic_prompt == .command) {
-                break;
-            }
         }
 
         // Because the first line of command output may span multiple visual rows we must now


### PR DESCRIPTION
This came out of cmd+triple-click fix in PR #5373