### PR TITLE
input: performable bindings aren't part of the reverse mapping

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1015,6 +1015,12 @@ class: ?[:0]const u8 = null,
 ///     performable (acting identically to not having a keybind set at
 ///     all).
 ///
+///     Performable keybinds will not appear as menu shortcuts in the
+///     application menu. This is because the menu shortcuts force the
+///     action to be performed regardless of the state of the terminal.
+///     Performable keybinds will still work, they just won't appear as
+///     a shortcut label in the menu.
+///
 /// Keybind triggers are not unique per prefix combination. For example,
 /// `ctrl+a` and `global:ctrl+a` are not two separate keybinds. The keybind
 /// set later will overwrite the keybind set earlier. In this case, the


### PR DESCRIPTION
Fixes #4522

This is a bit of a hammer-meets-nail solution, but it's a simple solution to the problem. The reverse mapping is used to find the binding that an action is bound to, and it's used by apprt's to populate the accelerator label in the UI.

The problem is that accelerators in GTK are handled early in the event handling process and its difficult to get that event mapping to a specific surface. Therefore, the "performable" prefix was not working. On macOS, this issue didn't exist because there exists an OS mechanism to install an event handler earlier than the menu system.

This commit changes the reverse mapping to only include bindings that are not performable. This way, the keybind always reaches the surface and can be handled by `Surface.keyCallback` which processes `performable`.

The caveat is that performable bindings will not show up in the UI for menu items. This is documented in this commit now. They still work, its just a UI issue.