### PR TITLE
ci: separate publish and release workflows

### DIFF
--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -1,0 +1,74 @@
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to deploy (format: vX.Y.Z)"
+        required: true
+
+name: Publish Tagged Release
+
+# We must only run one release workflow at a time to prevent corrupting
+# our release artifacts.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  setup:
+    runs-on: namespace-profile-ghostty-sm
+    outputs:
+      version: ${{ steps.extract_version.outputs.version }}
+    steps:
+      - name: Validate Version Input
+        run: |
+          if [[ ! "${{ github.event.inputs.version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Version must follow the format vX.Y.Z (e.g., v1.0.0)."
+            exit 1
+          fi
+
+          echo "Version is valid: ${{ github.event.inputs.version }}"
+
+      - name: Exract the Version
+        id: extract_version
+        run: |
+          VERSION=${{ github.event.inputs.version }}
+          VERSION=${VERSION#v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+  upload:
+    needs: [setup]
+    runs-on: namespace-profile-ghostty-sm
+    env:
+      GHOSTTY_VERSION: ${{ needs.setup.outputs.version }}
+    steps:
+      - name: Validate Release Files
+        run: |
+          BASE="https://release.files.ghostty.org/${GHOSTTY_VERSION}"
+          curl -I -s -o /dev/null -w "%{http_code}" "${BASE}/ghostty-${GHOSTTY_VERSION}.tar.gz" | grep -q "^200$" || exit 1
+          curl -I -s -o /dev/null -w "%{http_code}" "${BASE}/ghostty-${GHOSTTY_VERSION}.tar.gz.minisig" | grep -q "^200$" || exit 1
+          curl -I -s -o /dev/null -w "%{http_code}" "${BASE}/ghostty-source.tar.gz" | grep -q "^200$" || exit 1
+          curl -I -s -o /dev/null -w "%{http_code}" "${BASE}/ghostty-source.tar.gz.minisig" | grep -q "^200$" || exit 1
+          curl -I -s -o /dev/null -w "%{http_code}" "${BASE}/ghostty-macos-universal.zip" | grep -q "^200$" || exit 1
+          curl -I -s -o /dev/null -w "%{http_code}" "${BASE}/ghostty-macos-universal-dsym.zip" | grep -q "^200$" || exit 1
+          curl -I -s -o /dev/null -w "%{http_code}" "${BASE}/Ghostty.dmg" | grep -q "^200$" || exit 1
+          curl -I -s -o /dev/null -w "%{http_code}" "${BASE}/appcast-staged.xml" | grep -q "^200$" || exit 1
+
+      - name: Download Staged Appcast
+        run: |
+          curl -L https://release.files.ghostty.org/${GHOSTTY_VERSION}/appcast-staged.xml
+          mv appcast-staged.xml appcast.xml
+
+      - name: Upload Appcast
+        run: |
+          rm -rf blob
+          mkdir blob
+          mv appcast.xml blob/appcast.xml
+      - name: Upload Appcast to R2
+        uses: ryand56/r2-upload-action@latest
+        with:
+          r2-account-id: ${{ secrets.CF_R2_RELEASE_ACCOUNT_ID }}
+          r2-access-key-id: ${{ secrets.CF_R2_RELEASE_AWS_KEY }}
+          r2-secret-access-key: ${{ secrets.CF_R2_RELEASE_SECRET_KEY }}
+          r2-bucket: ghostty-release
+          source-dir: blob
+          destination-dir: ./

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -7,6 +7,7 @@ on:
       upload:
         description: "Upload final artifacts to R2"
         default: false
+
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
@@ -367,22 +368,8 @@ jobs:
           mv ghostty-macos-universal.zip blob/${GHOSTTY_VERSION}/ghostty-macos-universal.zip
           mv ghostty-macos-universal-dsym.zip blob/${GHOSTTY_VERSION}/ghostty-macos-universal-dsym.zip
           mv Ghostty.dmg blob/${GHOSTTY_VERSION}/Ghostty.dmg
+          mv appcast.xml blob/${GHOSTTY_VERSION}/appcast-staged.xml
       - name: Upload to R2
-        uses: ryand56/r2-upload-action@latest
-        with:
-          r2-account-id: ${{ secrets.CF_R2_RELEASE_ACCOUNT_ID }}
-          r2-access-key-id: ${{ secrets.CF_R2_RELEASE_AWS_KEY }}
-          r2-secret-access-key: ${{ secrets.CF_R2_RELEASE_SECRET_KEY }}
-          r2-bucket: ghostty-release
-          source-dir: blob
-          destination-dir: ./
-
-      - name: Prep Appcast
-        run: |
-          rm -rf blob
-          mkdir blob
-          mv appcast.xml blob/appcast.xml
-      - name: Upload Appcast to R2
         uses: ryand56/r2-upload-action@latest
         with:
           r2-account-id: ${{ secrets.CF_R2_RELEASE_ACCOUNT_ID }}


### PR DESCRIPTION
Fixes #4218 

This now requires a separate manually triggered `publish` workflow to be run after the release completes in order to transition the release to the `published` state.

Practically today this only means that the release will be published to the macOS auto-updater, but in the future we could add additional steps such as creating a GH release or some other notifications.

Importantly, this lets us verify the release in the uploaded location before general users are notified of the update.