### PR TITLE
Add baseline implementation of Automatic Termination

### DIFF
--- a/macos/Ghostty-Info.plist
+++ b/macos/Ghostty-Info.plist
@@ -53,6 +53,8 @@
 	</dict>
 	<key>MDItemKeywords</key>
 	<string>Terminal</string>
+	<key>NSSupportsAutomaticTermination</key>
+	<true/>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSServices</key>

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -234,6 +234,11 @@ extension Ghostty {
 
             // The UTTypes that can be dragged onto this view.
             registerForDraggedTypes(Array(Self.dropTypes))
+
+            // Disable Automatic Termination while we have a surface open,
+            // since an open surface means there’s state the user cares about
+            // that can’t be restored.
+            ProcessInfo.processInfo.disableAutomaticTermination("surface created")
         }
 
         required init?(coder: NSCoder) {
@@ -261,6 +266,11 @@ extension Ghostty {
 
             guard let surface = self.surface else { return }
             ghostty_surface_free(surface)
+
+            // Re-enable Automatic Termination once we know this surface is
+            // gone, since that means we have nothing to lose if macOS decides
+            // to kill us.
+            ProcessInfo.processInfo.enableAutomaticTermination("surface freed")
         }
 
         /// Close the surface early. This will free the associated Ghostty surface and the view will
@@ -275,6 +285,9 @@ extension Ghostty {
             guard let surface = self.surface else { return }
             ghostty_surface_free(surface)
             self.surface = nil
+
+            // Same as the other call to this function in deinit
+            ProcessInfo.processInfo.enableAutomaticTermination("surface freed")
         }
 
         func focusDidChange(_ focused: Bool) {


### PR DESCRIPTION
### Explanation of Automatic Termination in case you’re not familiar with the concept – skip to below the divider if you already know what it is :)

Traditionally, open apps have a process associated with them and closed apps don’t have one. Automatic Termination brings an iOS-like process model to the Mac:

- open applications can have no associated process (app processes can be asked to silently terminate by the system, while the system keeps screenshots of the app’s windows around to create the illusion that the process never went away; if the user interacts with the screenshots, the process is relaunched and the screenshots are swapped out for real windows)
- closed applications can actually have a process (the system keeps the process around after the app appears to close so that future relaunches are instant; these background processes are terminated if the machine starts to run out of memory)

While Automatic Termination is enabled, the system can at any time ask an app to quit through the usual `NSApp.terminate()`.

If the app is performing work which cannot be paused when it’s quit and then resumed once it’s launched again, then it should temporarily disable Automatic Termination until that work is complete. (Note that enabling and disabling Automatic Termination works in a manner similar to reference counting, so you can call the enable or disable methods as many times as you like as long as the calls are balanced.)

---

This PR adds Automatic Termination to Ghostty in a very limited form.

Ideally Ghostty would have scrollback restoration: if this were the case, we’d leave Automatic Termination enabled all the time except for when a shell is running commands, enabling it again once it’s back at the prompt. If a surface is at the prompt, then that means it can be closed and later restored with full fidelity, and the user would be none the wiser.

Unfortunately Ghostty doesn’t have scrollback restoration, meaning Automatic Termination needs to be disabled as long as a surface is open. Open surfaces have scrollback which can’t be restored should the OS decide to terminate us, so we need to disable Automatic Termination while there are open surfaces.

Although this may make supporting Automatic Termination seem pointless, it does gain us two nice features: instant reopen, and automatic close when no windows are open. You can observe this behavior in TextEdit, Preview, QuickTime Player, Pages, Keynote, etc. Here’s a small demonstration:

https://github.com/user-attachments/assets/8f01592d-6219-4cff-80aa-0283e13ef43e

And here’s a demonstration of how this PR interacts with the quick terminal:

https://github.com/user-attachments/assets/0d578cd0-9aeb-4d8a-b114-b6418076b750

Note that I never actually invoked Quit in either of these videos.

I’m not sure whether it’s necessary to implement a setting to disable Automatic Termination in Ghostty, since it’s standard behavior on macOS across a wide range of apps and there’s a built-in way to turn it off (`defaults write -g NSDisableAutomaticTermination -bool YES`). In case you think there should be a dedicated setting for this in Ghostty, the setting should be distinct from `quit-after-last-window-closed`, since Automatic Termination is wider in scope than just making the app appear to close once its last window is gone.

Let me know if you have any thoughts or questions :D