### PR TITLE
gtk(x11): update blur region upon syncAppearance

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -661,8 +661,9 @@ fn gtkWindowNotifyMaximized(
 fn gtkWindowNotifyDecorated(
     object: *c.GObject,
     _: *c.GParamSpec,
-    _: ?*anyopaque,
+    ud: ?*anyopaque,
 ) callconv(.C) void {
+    const self = userdataSelf(ud orelse return);
     const is_decorated = c.gtk_window_get_decorated(@ptrCast(object)) == 1;
 
     // Fix any artifacting that may occur in window corners. The .ssd CSS
@@ -671,6 +672,11 @@ fn gtkWindowNotifyDecorated(
     // for .ssd is provided by GTK and Adwaita.
     toggleCssClass(@ptrCast(object), "ssd", !is_decorated);
     toggleCssClass(@ptrCast(object), "no-border-radius", !is_decorated);
+
+    // FIXME: This is to update the blur region offset on X11.
+    // Remove this when we move everything related to window appearance
+    // to `syncAppearance` for Ghostty 1.2.
+    self.winproto.syncAppearance() catch {};
 }
 
 fn gtkWindowNotifyFullscreened(


### PR DESCRIPTION
Fixes a bug where the blur region offset used to accomodate CSDs are applied even when CSDs are disabled.