### PR TITLE
Toggling visibility is now ignored when in fullscreen mode.

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -709,11 +709,21 @@ class AppDelegate: NSObject,
 
     /// Toggles visibility of all Ghosty Terminal windows. When hidden, activates Ghostty as the frontmost application
     @IBAction func toggleVisibility(_ sender: Any) {
+        // Toggle visibility doesn't do anything if the focused window is native
+        // fullscreen.
+        guard let keyWindow = NSApp.keyWindow,
+              !keyWindow.styleMask.contains(.fullScreen) else { return }
+
         // If we have focus, then we hide all windows.
         if NSApp.isActive {
             // We need to keep track of the windows that were visible because we only
             // want to bring back these windows if we remove the toggle.
-            self.hiddenWindows = NSApp.windows.filter { $0.isVisible }.map { Weak($0) }
+            //
+            // We also ignore fullscreen windows because they don't hide anyways.
+            self.hiddenWindows = NSApp.windows.filter {
+                $0.isVisible &&
+                !$0.styleMask.contains(.fullScreen)
+            }.map { Weak($0) }
             NSApp.hide(nil)
             return
         }

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -470,6 +470,8 @@ pub const Action = union(enum) {
     /// Ghostty becomes focused. When hiding all windows, focus is yielded
     /// to the next application as determined by the OS.
     ///
+    /// Note: When the focused surface is fullscreen, this method does nothing.
+    ///
     /// This currently only works on macOS.
     toggle_visibility: void,
 


### PR DESCRIPTION
This PR ensures visibility toggling is ignored when the currently focused surface is fullscreen. This includes the following:

- Show/Hide All Terminals is ignored
- Using a binding to toggle is ignored

This ensures Ghostty doesn't unexpectedly lose focus or disappear and is the expected behavior on macOS.