### PR TITLE
update zig-wayland

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -34,8 +34,8 @@
             .hash = "12207831bce7d4abce57b5a98e8f3635811cfefd160bca022eb91fe905d36a02cf25",
         },
         .zig_wayland = .{
-            .url = "https://codeberg.org/ifreund/zig-wayland/archive/fbfe3b4ac0b472a27b1f1a67405436c58cbee12d.tar.gz",
-            .hash = "12209ca054cb1919fa276e328967f10b253f7537c4136eb48f3332b0f7cf661cad38",
+            .url = "https://deps.files.ghostty.org/zig-wayland-a507358764d209627e6a555104099b0825d8934c.tar.gz",
+            .hash = "12204339bf0ea439f92ad54e220be6d42f15431f3d1cd107fb272d0b19a43d98ab17",
         },
         .zf = .{
             .url = "git+https://github.com/natecraddock/zf/?ref=main#ed99ca18b02dda052e20ba467e90b623c04690dd",

--- a/nix/zigCacheHash.nix
+++ b/nix/zigCacheHash.nix
@@ -1,3 +1,3 @@
 # This file is auto-generated! check build-support/check-zig-cache-hash.sh for
 # more details.
-"sha256-Bjy31evaKgpRX1mGwAFkai44eiiorTV1gW3VdP9Ins8="
+"sha256-MAE8r0YvF2tQZ7KakXUAANHhGt7kjRhUcrk2Xax/Caw="

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -435,7 +435,7 @@ pub fn add(
                 if (self.config.x11) step.linkSystemLibrary2("X11", dynamic_link_opts);
 
                 if (self.config.wayland) {
-                    const scanner = Scanner.create(b.dependency("zig_wayland", .{}), .{
+                    const scanner = Scanner.create(b, .{
                         // We shouldn't be using getPath but we need to for now
                         // https://codeberg.org/ifreund/zig-wayland/issues/66
                         .wayland_xml = b.dependency("wayland", .{})


### PR DESCRIPTION
This fixes a somewhat jank workaround they had to do. No functional changes. I also took this time to cache it in our mirror. The content hash always matches upstream so you can verify it yourself.