### PR TITLE
linux: ensure that group dir fd is closed

### DIFF
--- a/src/os/cgroup.zig
+++ b/src/os/cgroup.zig
@@ -102,6 +102,7 @@ pub fn cloneInto(cgroup: []const u8) !posix.pid_t {
         }
     };
     assert(fd >= 0);
+    defer _ = linux.close(fd);
 
     const args: extern struct {
         flags: u64,


### PR DESCRIPTION
The CLOEXEC flag on the fd will ensure that the directory is closed on the child, but also need to close the fd in the parent.