### PR TITLE
Linux: Syscall errno handle

### DIFF
--- a/src/os/cgroup.zig
+++ b/src/os/cgroup.zig
@@ -130,6 +130,7 @@ pub fn cloneInto(cgroup: []const u8) !posix.pid_t {
     };
 
     const rc = linux.syscall2(linux.SYS.clone3, @intFromPtr(&args), @sizeOf(@TypeOf(args)));
+    // do not use posix.errno, when linking libc it will use the libc errno which will not be set when making the syscall directly
     return switch (std.os.linux.E.init(rc)) {
         .SUCCESS => @as(posix.pid_t, @intCast(rc)),
         else => |errno| err: {

--- a/src/os/cgroup.zig
+++ b/src/os/cgroup.zig
@@ -130,7 +130,7 @@ pub fn cloneInto(cgroup: []const u8) !posix.pid_t {
     };
 
     const rc = linux.syscall2(linux.SYS.clone3, @intFromPtr(&args), @sizeOf(@TypeOf(args)));
-    return switch (posix.errno(rc)) {
+    return switch (std.os.linux.E.init(rc)) {
         .SUCCESS => @as(posix.pid_t, @intCast(rc)),
         else => |errno| err: {
             log.err("unable to clone: {}", .{errno});


### PR DESCRIPTION
When trying to run valgrind this incorrectly results in a correct result, this is because `posix.errno` will use libc errno when linking libc which ghostty does. 

https://github.com/ziglang/zig/blob/cf90dfd3098bef5b3c22d5ab026173b3c357f2dd/lib/std/posix.zig#L219-L221

Since we are making the syscall directly  we should not use this function but rather use the return code directly on the enum, name from this function seems odd to me (no zig experience) but it is the suggested answer from zig (refer to issue below)
https://github.com/ziglang/zig/issues/22718

Note this definitely isnt much better than what we were doing before in the case of running in valgrind

```text
error(linux-cgroup): unable to clone: os.linux.E__enum_81093.NOSYS
debug(io_thread): IO thread exited
warning(io_thread): error in io thread err=error.CloneError
warning(io_thread): abrupt io thread exit detected, starting xev to drain mailbox
debug(io_thread): io thread fully exiting after abnormal failure
```

opening a new tab shows
```
error starting IO thread: error.CloneError

The underlying shell or command was unable to be started.
This error is usually due to exhausting a system resource.
If this looks like a bug, please report it.

This terminal is non-functional. Please close it and try again.
```

this did not show on the original surface only on the new tab


