### PR TITLE
New editor action for write_screen_file

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4326,15 +4326,7 @@ fn openScreenFile(
         return error.EnvironmentVariableNotFound;
     };
 
-    const command_buf = try self.alloc.alloc(u8, editor.len + file_path.len + 2);
-    // This is quite ugly sending the message to the mailbox and executing it on behalf of the user
-    // Spawing a process doesn't render the command in the main surface.
-    const command = try std.fmt.bufPrint(
-        command_buf,
-        "{s} {s}\n",
-        .{ editor, file_path },
-    );
-
+    const command = try std.fmt.allocPrint(self.alloc, "{s} {s}\n", .{ editor, file_path });
     self.io.queueMessage(try termio.Message.writeReq(
         self.alloc,
         command,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -16,7 +16,6 @@ pub const Mailbox = apprt.surface.Mailbox;
 pub const Message = apprt.surface.Message;
 
 const std = @import("std");
-const process = std.process;
 const builtin = @import("builtin");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4325,10 +4325,8 @@ fn openScreenFile(
         std.log.debug("EDITOR environment variable not set", .{});
         return error.EnvironmentVariableNotFound;
     };
-    const allocator = std.heap.page_allocator;
-    const command_buf = try allocator.alloc(u8, editor.len + file_path.len + 2);
-    errdefer allocator.free(command_buf);
-    defer allocator.free(command_buf);
+
+    const command_buf = try self.alloc.alloc(u8, editor.len + file_path.len + 2);
     // This is quite ugly sending the message to the mailbox and executing it on behalf of the user
     // Spawing a process doesn't render the command in the main surface.
     const command = try std.fmt.bufPrint(
@@ -4338,7 +4336,7 @@ fn openScreenFile(
     );
 
     self.io.queueMessage(try termio.Message.writeReq(
-        allocator,
+        self.alloc,
         command,
     ), .unlocked);
 }

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4322,7 +4322,7 @@ fn openScreenFile(
     file_path: []const u8,
 ) !void {
     const editor = std.posix.getenv("EDITOR") orelse {
-        std.log.err("EDITOR environment variable not set", .{});
+        std.log.debug("EDITOR environment variable not set", .{});
         return error.EnvironmentVariableNotFound;
     };
     const allocator = std.heap.page_allocator;
@@ -4720,4 +4720,18 @@ fn presentSurface(self: *Surface) !void {
         .present_terminal,
         {},
     );
+}
+
+test "openScreenFile - no EDITOR" {
+    const testing = std.testing;
+    const unsetenv = @import("os/env.zig").unsetenv;
+    const allocator = testing.allocator;
+
+    var surface = Surface{ .alloc = allocator, .size = undefined, .app = undefined, .rt_app = undefined, .rt_surface = undefined, .font_grid_key = undefined, .font_size = undefined, .font_metrics = undefined, .renderer = undefined, .renderer_state = undefined, .renderer_thr = undefined, .renderer_thread = undefined, .mouse = undefined, .keyboard = undefined, .io = undefined, .io_thr = undefined, .io_thread = undefined, .config = undefined, .config_conditional_state = undefined };
+    const file_path = "test.txt";
+
+    _ = unsetenv("EDITOR");
+
+    const err = surface.openScreenFile(file_path);
+    try testing.expectError(error.EnvironmentVariableNotFound, err);
 }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2395,6 +2395,12 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
 
     try result.keybind.set.put(
         alloc,
+        .{ .key = .{ .translated = .f }, .mods = inputpkg.ctrlOrSuper(.{ .shift = true }) },
+        .{ .write_screen_file = .editor },
+    );
+
+    try result.keybind.set.put(
+        alloc,
         .{ .key = .{ .translated = .j }, .mods = inputpkg.ctrlOrSuper(.{ .shift = true, .alt = true }) },
         .{ .write_screen_file = .open },
     );

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -592,6 +592,7 @@ pub const Action = union(enum) {
     pub const WriteScreenAction = enum {
         paste,
         open,
+        editor,
     };
 
     // Extern because it is used in the embedded runtime ABI.


### PR DESCRIPTION
This PR adds an additional option to open write_screen_file in your defined terminal `EDITOR` instead of the desktop environments default with `xdg-open` or `open`

[Screencast From 2025-02-02 15-22-56.webm](https://github.com/user-attachments/assets/5b184372-1fb6-4f95-9b6f-bd69e6ee0134)
