### PR TITLE
gtk: introduce Zig bindings for GTK/GObject

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -41,6 +41,10 @@
             .url = "git+https://github.com/natecraddock/zf/?ref=main#ed99ca18b02dda052e20ba467e90b623c04690dd",
             .hash = "1220edc3b8d8bedbb50555947987e5e8e2f93871ca3c8e8d4cc8f1377c15b5dd35e8",
         },
+        .gobject = .{
+            .url = "https://github.com/ianprime0509/zig-gobject/releases/download/v0.2.2/bindings-gnome47.tar.zst",
+            .hash = "12208d70ee791d7ef7e16e1c3c9c1127b57f1ed066a24f87d57fc9f730c5dc394b9d",
+        },
 
         // C libs
         .cimgui = .{ .path = "./pkg/cimgui" },

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -30,6 +30,7 @@
   glib,
   glslang,
   gtk4,
+  gobject-introspection,
   libadwaita,
   adwaita-icon-theme,
   hicolor-icon-theme,
@@ -83,6 +84,7 @@
       libadwaita
       gtk4
       glib
+      gobject-introspection
       wayland
     ];
 in
@@ -157,6 +159,7 @@ in
         libadwaita
         gtk4
         glib
+        gobject-introspection
         wayland
         wayland-scanner
         wayland-protocols

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -12,6 +12,7 @@
   libGL,
   glib,
   gtk4,
+  gobject-introspection,
   libadwaita,
   wrapGAppsHook4,
   gsettings-desktop-schemas,
@@ -124,6 +125,7 @@ in
         pandoc
         pkg-config
         zig_hook
+        gobject-introspection
         wrapGAppsHook4
       ]
       ++ lib.optionals enableWayland [

--- a/nix/zigCacheHash.nix
+++ b/nix/zigCacheHash.nix
@@ -1,3 +1,3 @@
 # This file is auto-generated! check build-support/check-zig-cache-hash.sh for
 # more details.
-"sha256-I7uuv0MkaW3gWAw6NHci+II42OfM7NdtKh2Npw2pTis="
+"sha256-+Ag900R3lDV7iEeRFGe2HWJDtquW3I9GFvHGle+U3k0="


### PR DESCRIPTION
`zig-gobject` is a set of GObject bindings that allow us to write GTK-facing code in Zig instead of getting hands dirty with C. It's been tested and refined in real-life applications and several GTK contributors agree that it is a marked improvement over using the C API directly, such as allowing method call syntax and avoiding many manual `@ptrCast`s.

This PR doesn't actually contain any changes to our preexisting GTK code — the migration process is intended to begin in chunks, firstly in self-contained components (e.g. the header bar, overlays, etc.), and then full-scale migration can begin when we remove non-Adwaita GTK builds for 1.2. (After all, why port code that you'll remove later either way?)