### PR TITLE
[macOS] Improve split and tab navigation behavior

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.SplitNode.swift
+++ b/macos/Sources/Ghostty/Ghostty.SplitNode.swift
@@ -130,6 +130,15 @@ extension Ghostty {
             }
         }
 
+        /// Returns true if the view is in a split (not a single leaf)
+        func isViewInSplit(_ view: SurfaceView) -> Bool {
+            if case .split = self {
+                return contains(view: view)
+            }
+            return false
+        }
+
+
         /// Find a surface view by UUID.
         func findUUID(uuid: UUID) -> SurfaceView? {
             switch (self) {


### PR DESCRIPTION
This PR improves the split and tab navigation experience by making `gotoSplit` actions (next/previous) automatically fall back to `gotoTab` actions (next/previous)  when no splits exist in the current window, providing more intuitive navigation between splits and tabs.

The implementation is currently macOS-only as I don't have access to Linux hardware for testing.

cc @shinoxzu - Would you mind giving it a try? Any feedback would be appreciated!

Partially fixes #5552