### PR TITLE
GTK: disable color management

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -146,14 +146,14 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
 
     var gdk_disable: struct {
         @"gles-api": bool = false,
-        /// current gtk implementation for color management is not good enough. 
-        /// see: https://bugs.kde.org/show_bug.cgi?id=495647
-        @"color-mgmt": bool = true,
+        @"color-mgmt": bool,
         /// Disabling Vulkan can improve startup times by hundreds of
         /// milliseconds on some systems. We don't use Vulkan so we can just
         /// disable it.
         vulkan: bool = false,
-    } = .{};
+    } = .{
+        .@"color-mgmt" = config.@"disable-gtk-color-mgmt",
+    };
 
     environment: {
         if (version.runtimeAtLeast(4, 16, 0)) {

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -148,16 +148,18 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
         @"gles-api": bool = false,
         /// current gtk implementation for color management is not good enough.
         /// see: https://bugs.kde.org/show_bug.cgi?id=495647
-        @"color-mgmt": bool,
+        @"color-mgmt": bool = true,
         /// Disabling Vulkan can improve startup times by hundreds of
         /// milliseconds on some systems. We don't use Vulkan so we can just
         /// disable it.
         vulkan: bool = false,
-    } = .{
-        .@"color-mgmt" = config.@"gtk-gdk-disable-color-mgmt",
-    };
+    } = .{};
 
     environment: {
+        if (version.runtimeAtLeast(4, 17, 0)) {
+            gdk_disable.@"color-mgmt" = false;
+        }
+
         if (version.runtimeAtLeast(4, 16, 0)) {
             // From gtk 4.16, GDK_DEBUG is split into GDK_DEBUG and GDK_DISABLE.
             // For the remainder of "why" see the 4.14 comment below.

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -148,6 +148,7 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
         @"gles-api": bool = false,
         /// current gtk implementation for color management is not good enough.
         /// see: https://bugs.kde.org/show_bug.cgi?id=495647
+        /// gtk issue: https://gitlab.gnome.org/GNOME/gtk/-/issues/6864
         @"color-mgmt": bool = true,
         /// Disabling Vulkan can improve startup times by hundreds of
         /// milliseconds on some systems. We don't use Vulkan so we can just

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -146,6 +146,9 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
 
     var gdk_disable: struct {
         @"gles-api": bool = false,
+        /// current gtk implementation for color management is not good enough. 
+        /// see: https://bugs.kde.org/show_bug.cgi?id=495647
+        @"color-mgmt": bool = true,
         /// Disabling Vulkan can improve startup times by hundreds of
         /// milliseconds on some systems. We don't use Vulkan so we can just
         /// disable it.

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -146,13 +146,15 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
 
     var gdk_disable: struct {
         @"gles-api": bool = false,
+        /// current gtk implementation for color management is not good enough.
+        /// see: https://bugs.kde.org/show_bug.cgi?id=495647
         @"color-mgmt": bool,
         /// Disabling Vulkan can improve startup times by hundreds of
         /// milliseconds on some systems. We don't use Vulkan so we can just
         /// disable it.
         vulkan: bool = false,
     } = .{
-        .@"color-mgmt" = config.@"disable-gtk-color-mgmt",
+        .@"color-mgmt" = config.@"gtk-gdk-disable-color-mgmt",
     };
 
     environment: {

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -157,7 +157,7 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
     } = .{};
 
     environment: {
-        if (version.runtimeAtLeast(4, 17, 0)) {
+        if (version.runtimeAtLeast(4, 18, 0)) {
             gdk_disable.@"color-mgmt" = false;
         }
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1350,19 +1350,6 @@ keybind: Keybinds = .{},
 /// Specified as either hex (`#RRGGBB` or `RRGGBB`) or a named X11 color.
 @"window-titlebar-foreground": ?Color = null,
 
-/// Controls whether to disable GDK color management in GTK applications.
-///
-/// By default this is set to `false`, meaning color management is enabled.
-/// You may want to enable this setting (set to `true`) if you experience:
-/// - Incorrect or washed out colors in your terminal
-/// - Color inconsistencies between GTK applications
-/// - Performance issues related to color management
-///
-/// This is a workaround for known issues with GTK's color management implementation,
-/// particularly affecting applications running under Wayland.
-/// See: https://bugs.kde.org/show_bug.cgi?id=495647
-@"gtk-gdk-disable-color-mgmt": bool = false,
-
 /// This controls when resize overlays are shown. Resize overlays are a
 /// transient popup that shows the size of the terminal while the surfaces are
 /// being resized. The possible options are:

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1350,6 +1350,10 @@ keybind: Keybinds = .{},
 /// Specified as either hex (`#RRGGBB` or `RRGGBB`) or a named X11 color.
 @"window-titlebar-foreground": ?Color = null,
 
+/// current gtk implementation for color management is not good enough.
+/// see: https://bugs.kde.org/show_bug.cgi?id=495647
+@"disable-gtk-color-mgmt": bool = false,
+
 /// This controls when resize overlays are shown. Resize overlays are a
 /// transient popup that shows the size of the terminal while the surfaces are
 /// being resized. The possible options are:

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1350,9 +1350,18 @@ keybind: Keybinds = .{},
 /// Specified as either hex (`#RRGGBB` or `RRGGBB`) or a named X11 color.
 @"window-titlebar-foreground": ?Color = null,
 
-/// current gtk implementation for color management is not good enough.
-/// see: https://bugs.kde.org/show_bug.cgi?id=495647
-@"disable-gtk-color-mgmt": bool = false,
+/// Controls whether to disable GDK color management in GTK applications.
+///
+/// By default this is set to `false`, meaning color management is enabled.
+/// You may want to enable this setting (set to `true`) if you experience:
+/// - Incorrect or washed out colors in your terminal
+/// - Color inconsistencies between GTK applications
+/// - Performance issues related to color management
+///
+/// This is a workaround for known issues with GTK's color management implementation,
+/// particularly affecting applications running under Wayland.
+/// See: https://bugs.kde.org/show_bug.cgi?id=495647
+@"gtk-gdk-disable-color-mgmt": bool = false,
 
 /// This controls when resize overlays are shown. Resize overlays are a
 /// transient popup that shows the size of the terminal while the surfaces are


### PR DESCRIPTION
fixes: https://github.com/ghostty-org/ghostty/discussions/4976

Before: 
![image](https://github.com/user-attachments/assets/169c29b5-b52a-44cd-aea8-43c2cfd8e411)

After:
![image](https://github.com/user-attachments/assets/80468ae2-7d75-464f-a2b0-37da48fdf61d)