### PR TITLE
Equalize Splits invalid keybind

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2622,7 +2622,7 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
         );
         try result.keybind.set.put(
             alloc,
-            .{ .key = .{ .translated = .equal }, .mods = .{ .super = true, .ctrl = true, .shift = true } },
+            .{ .key = .{ .translated = .plus }, .mods = .{ .super = true, .ctrl = true, .shift = true } },
             .{ .equalize_splits = {} },
         );
 


### PR DESCRIPTION
refer to #4007

there are also quite a few posts about this in the discord help section

Basically for some reason for the equal key shift is not a typical modifier where it would be the original key + shift modifier but it actually just changes equal to respond as the plus key this is the only key on the keyboard I can see exhibit this behavior

it seems all 3 major operating systems report the key this way (mac, linux, and windows) 