### PR TITLE
gtk(x11): set `WINDOWID` env var for subprocesses

### DIFF
--- a/src/apprt/glfw.zig
+++ b/src/apprt/glfw.zig
@@ -874,6 +874,11 @@ pub const Surface = struct {
         };
     }
 
+    pub fn defaultTermioEnv(self: *Surface) !?std.process.EnvMap {
+        _ = self;
+        return null;
+    }
+
     fn sizeCallback(window: glfw.Window, width: i32, height: i32) void {
         _ = width;
         _ = height;

--- a/src/apprt/gtk/winproto.zig
+++ b/src/apprt/gtk/winproto.zig
@@ -131,4 +131,10 @@ pub const Window = union(Protocol) {
             inline else => |v| v.clientSideDecorationEnabled(),
         };
     }
+
+    pub fn addSubprocessEnv(self: *Window, env: *std.process.EnvMap) !void {
+        switch (self.*) {
+            inline else => |*v| try v.addSubprocessEnv(env),
+        }
+    }
 };

--- a/src/apprt/gtk/winproto/noop.zig
+++ b/src/apprt/gtk/winproto/noop.zig
@@ -61,4 +61,6 @@ pub const Window = struct {
         _ = self;
         return true;
     }
+
+    pub fn addSubprocessEnv(_: *Window, _: *std.process.EnvMap) !void {}
 };

--- a/src/apprt/gtk/winproto/wayland.zig
+++ b/src/apprt/gtk/winproto/wayland.zig
@@ -262,6 +262,11 @@ pub const Window = struct {
         };
     }
 
+    pub fn addSubprocessEnv(self: *Window, env: *std.process.EnvMap) !void {
+        _ = self;
+        _ = env;
+    }
+
     /// Update the blur state of the window.
     fn syncBlur(self: *Window) !void {
         const manager = self.app_context.kde_blur_manager orelse return;

--- a/src/apprt/gtk/winproto/x11.zig
+++ b/src/apprt/gtk/winproto/x11.zig
@@ -314,6 +314,13 @@ pub const Window = struct {
         );
     }
 
+    pub fn addSubprocessEnv(self: *Window, env: *std.process.EnvMap) !void {
+        var buf: [64]u8 = undefined;
+        const window_id = try std.fmt.bufPrint(&buf, "{}", .{self.window});
+
+        try env.put("WINDOWID", window_id);
+    }
+
     fn getWindowProperty(
         self: *Window,
         comptime T: type,

--- a/src/os/env.zig
+++ b/src/os/env.zig
@@ -2,8 +2,17 @@ const std = @import("std");
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const posix = std.posix;
+const isFlatpak = @import("flatpak.zig").isFlatpak;
 
 pub const Error = Allocator.Error;
+
+/// Get the environment map.
+pub fn getEnvMap(alloc: Allocator) !std.process.EnvMap {
+    return if (isFlatpak())
+        std.process.EnvMap.init(alloc)
+    else
+        try std.process.getEnvMap(alloc);
+}
 
 /// Append a value to an environment variable such as PATH.
 /// The returned value is always allocated so it must be freed.

--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -26,6 +26,7 @@ pub const shell = @import("shell.zig");
 // Functions and types
 pub const CFReleaseThread = @import("cf_release_thread.zig");
 pub const TempDir = @import("TempDir.zig");
+pub const getEnvMap = env.getEnvMap;
 pub const appendEnv = env.appendEnv;
 pub const appendEnvAlways = env.appendEnvAlways;
 pub const prependEnv = env.prependEnv;


### PR DESCRIPTION
`WINDOWID` is the conventional environment variable for scripts that want to know the X11 window ID of the terminal, so that it may call tools like `xprop` or `xdotool`. We already know the window ID for window protocol handling, so we might as well throw this in for convenience.

Originally suggested by #4299