### PR TITLE
Hopefully fix weird bug for Intel Mac users

### DIFF
--- a/src/renderer/shaders/cell.metal
+++ b/src/renderer/shaders/cell.metal
@@ -487,13 +487,6 @@ vertex CellTextVertexOut cell_text_vertex(
     );
   }
 
-  // Don't bother rendering if the bg and fg colors are identical, just return
-  // the same point which will be culled because it makes the quad zero sized.
-  // However, we should still render if this is the cursor position
-  if (all(out.color == out.bg_color) && !is_cursor_pos) {
-    out.position = float4(0.0);
-  }
-
   return out;
 }
 


### PR DESCRIPTION
I don't have a machine locally that can reproduce the issue in #5597 but have been working with @paperlib over Discord to try to narrow down the cause. My fix in #5625 didn't fix the problem, so I'm *really* hoping this patch does.

The problem presents as any text that matches the default bg color not being rendered, regardless of the cell's bg color. The best I can figure is that either we have some sort of accidental UB or there's a driver bug (perhaps related to the addition of the `[[flat]]` interpolation qualifier to the vertex out structure?), but I don't have a system locally to iterate on to narrow it down.

The optimization represented by the code which is commented out by this PR is marginal anyway, and if it fixes what can be a really bad bug for those who experience it then it's worth it to remove.