### PR TITLE
Fix large OSC 8 links causing memory corruption

### DIFF
--- a/src/terminal/hyperlink.zig
+++ b/src/terminal/hyperlink.zig
@@ -194,14 +194,24 @@ pub const Set = RefCountedSet(
     Id,
     size.CellCountInt,
     struct {
+        /// The page which holds the strings for items in this set.
         page: ?*Page = null,
 
+        /// The page which holds the strings for items
+        /// looked up with, e.g., `add` or `lookup`,
+        /// if different from the destination page.
+        src_page: ?*const Page = null,
+
         pub fn hash(self: *const @This(), link: PageEntry) u64 {
-            return link.hash(self.page.?.memory);
+            return link.hash((self.src_page orelse self.page.?).memory);
         }
 
         pub fn eql(self: *const @This(), a: PageEntry, b: PageEntry) bool {
-            return a.eql(self.page.?.memory, &b, self.page.?.memory);
+            return a.eql(
+                (self.src_page orelse self.page.?).memory,
+                &b,
+                self.page.?.memory,
+            );
         }
 
         pub fn deleted(self: *const @This(), link: PageEntry) void {

--- a/src/terminal/osc.zig
+++ b/src/terminal/osc.zig
@@ -1660,10 +1660,11 @@ test "OSC: longer than buffer" {
 
     var p: Parser = .{};
 
-    const input = "a" ** (Parser.MAX_BUF + 2);
+    const input = "0;" ++ "a" ** (Parser.MAX_BUF + 2);
     for (input) |ch| p.next(ch);
 
     try testing.expect(p.end(null) == null);
+    try testing.expect(p.complete == false);
 }
 
 test "OSC: report default foreground color" {

--- a/src/terminal/osc.zig
+++ b/src/terminal/osc.zig
@@ -272,6 +272,9 @@ pub const Parser = struct {
     // Maximum length of a single OSC command. This is the full OSC command
     // sequence length (excluding ESC ]). This is arbitrary, I couldn't find
     // any definitive resource on how long this should be.
+    //
+    // NOTE: This does mean certain OSC sequences such as OSC 8 (hyperlinks)
+    //       won't work if their parameters are larger than fit in the buffer.
     const MAX_BUF = 2048;
 
     pub const State = enum {
@@ -425,9 +428,23 @@ pub const Parser = struct {
 
     /// Consume the next character c and advance the parser state.
     pub fn next(self: *Parser, c: u8) void {
-        // If our buffer is full then we're invalid.
+        // If our buffer is full then we're invalid, so we set our state
+        // accordingly and indicate the sequence is incomplete so that we
+        // don't accidentally issue a command when ending.
         if (self.buf_idx >= self.buf.len) {
+            if (self.state != .invalid) {
+                log.warn(
+                    "OSC sequence too long (> {d}), ignoring. state={}",
+                    .{ self.buf.len, self.state },
+                );
+            }
+
             self.state = .invalid;
+
+            // We have to do this here because it will never reach the
+            // switch statement below, since our buf_idx will always be
+            // too high after this.
+            self.complete = false;
             return;
         }
 

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -821,11 +821,7 @@ pub const Page = struct {
                         if (self.hyperlink_set.lookupContext(
                             self.memory,
                             other_link.*,
-
-                            // `lookupContext` uses the context for hashing, and
-                            // that doesn't write to the page, so this constCast
-                            // is completely safe.
-                            .{ .page = @constCast(other) },
+                            .{ .page = self, .src_page = @constCast(other) },
                         )) |i| {
                             self.hyperlink_set.use(self.memory, i);
                             break :dst_id i;

--- a/src/terminal/ref_counted_set.zig
+++ b/src/terminal/ref_counted_set.zig
@@ -38,8 +38,14 @@ const fastmem = @import("../fastmem.zig");
 ///
 /// `Context`
 ///   A type containing methods to define behaviors.
+///
 ///   - `fn hash(*Context, T) u64`    - Return a hash for an item.
+///
 ///   - `fn eql(*Context, T, T) bool` - Check two items for equality.
+///     The first of the two items passed in is guaranteed to be from
+///     a value passed in to an `add` or `lookup` function, the second
+///     is guaranteed to be a value already resident in the set.
+///
 ///   - `fn deleted(*Context, T) void` - [OPTIONAL] Deletion callback.
 ///     If present, called whenever an item is finally deleted.
 ///     Useful if the item has memory that needs to be freed.


### PR DESCRIPTION
Fixes #5635

### Changes:
- Added handling to `Screen.adjustCapacity` which properly returns an error if there's no room for the cursor hyperlink. Note the TODO, in the future we should probably make it handle this by increasing the capacity further.

- Added handling to `Screen.cursorSetHyperlink` which ensures there will be sufficient capacity to add the redundant cursor hyperlink to the string alloc after adjusting the capacity.

  ***Future work:** Aside from separating the cursor's managed memory from the page memory, which is a big thing we desperately need, we should probably also make the page string alloc intern the strings it gets to deduplicate.*
  
- Fixed a slight bug in the OSC parser which was causing the hyperlink command to be issued with an empty (0-length) URI when the buffer capacity was exceeded during an OSC 8 sequence.

  ***Future work:** We should consider increasing the `MAX_BUF` since some specs call for a max size of 4096 (such as various Kitty protocols) -- otherwise we should switch all the OSCs that can take arbitrary data like this to use the allocator instead of the fixed buffer.*
  
- Fixed a problem where when cloning content across pages (as happened every time we had to adjust page capacities) hyperlinks would not be properly looked up, often leading to many many redundant copies of a given URI being stored, exploding string memory.