### PR TITLE
macos: toggle_visibility fullscreen check requires active app

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -709,13 +709,13 @@ class AppDelegate: NSObject,
 
     /// Toggles visibility of all Ghosty Terminal windows. When hidden, activates Ghostty as the frontmost application
     @IBAction func toggleVisibility(_ sender: Any) {
-        // Toggle visibility doesn't do anything if the focused window is native
-        // fullscreen.
-        guard let keyWindow = NSApp.keyWindow,
-              !keyWindow.styleMask.contains(.fullScreen) else { return }
-
         // If we have focus, then we hide all windows.
         if NSApp.isActive {
+            // Toggle visibility doesn't do anything if the focused window is native
+            // fullscreen. This is only relevant if Ghostty is active.
+            guard let keyWindow = NSApp.keyWindow,
+                  !keyWindow.styleMask.contains(.fullScreen) else { return }
+
             // We need to keep track of the windows that were visible because we only
             // want to bring back these windows if we remove the toggle.
             //


### PR DESCRIPTION
This fixes a regression from #5472. The fullscreen check must check if the app is active otherwise the guard statement fails and we can't bring the macOS app back from the background.

This regression never hit a versioned release, only tip.