### PR TITLE
gtk: fix context menu computed location

### DIFF
--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1284,8 +1284,8 @@ fn showContextMenu(self: *Surface, x: f32, y: f32) void {
     const rect: c.GdkRectangle = .{
         .x = @intFromFloat(point.x),
         .y = @intFromFloat(point.y),
-        .width = 0,
-        .height = 0,
+        .width = 1,
+        .height = 1,
     };
 
     c.gtk_popover_set_pointing_to(@ptrCast(@alignCast(window.context_menu)), &rect);

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1270,10 +1270,12 @@ fn showContextMenu(self: *Surface, x: f32, y: f32) void {
         return;
     };
 
+    // Convert surface coordinate into coordinate space of the
+    // context menu's parent
     var point: c.graphene_point_t = .{ .x = x, .y = y };
     if (c.gtk_widget_compute_point(
         self.primaryWidget(),
-        @ptrCast(window.window),
+        c.gtk_widget_get_parent(@ptrCast(window.context_menu)),
         &c.GRAPHENE_POINT_INIT(point.x, point.y),
         @ptrCast(&point),
     ) == 0) {

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1284,8 +1284,8 @@ fn showContextMenu(self: *Surface, x: f32, y: f32) void {
     const rect: c.GdkRectangle = .{
         .x = @intFromFloat(point.x),
         .y = @intFromFloat(point.y),
-        .width = 1,
-        .height = 1,
+        .width = 0,
+        .height = 0,
     };
 
     c.gtk_popover_set_pointing_to(@ptrCast(@alignCast(window.context_menu)), &rect);


### PR DESCRIPTION
When a tab bar is displayed, the context menu opened with right click is offset from the cursor.

This was due to using the incorrect coordinate space for describing where to draw the context menu.

[gtk_popover_set_pointing_to](https://docs.gtk.org/gtk4/method.Popover.set_pointing_to.html) uses the coordinate space of the popover's parent, however we used the active window's coordinate space which was noticeably different when the tab bar is visible.

Before:
![Screenshot_12-Feb_22-39-07_com mitchellh ghostty](https://github.com/user-attachments/assets/5263dd9d-f3ab-44f6-baf2-7208d3d3bd01)
After:
![Screenshot_12-Feb_22-41-41_com mitchellh ghostty-debug](https://github.com/user-attachments/assets/8d3e8bbd-af4e-43a6-a52d-6601a0b66ece)
