### PR TITLE
gtk: use the standard path for including Adwaita header file

### DIFF
--- a/src/apprt/gtk/c.zig
+++ b/src/apprt/gtk/c.zig
@@ -4,7 +4,7 @@ const build_options = @import("build_options");
 pub const c = @cImport({
     @cInclude("gtk/gtk.h");
     if (build_options.adwaita) {
-        @cInclude("libadwaita-1/adwaita.h");
+        @cInclude("adwaita.h");
     }
 
     if (build_options.x11) {


### PR DESCRIPTION
As pointed out by @tristan957 the standard path for including the Adwaita header file is simply "adwaita.h". While it may have been necessary in the past to use a non-standard include path, that no longer appears to be the case.