### PR TITLE
Eliminate tab content flickering during tab movement on macOS

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -709,13 +709,21 @@ class TerminalController: BaseTerminalController {
         // If our index is the same we do nothing
         guard finalIndex != selectedIndex else { return }
 
-        // Get our parent
-        let parent = tabbedWindows[finalIndex]
+        // Get our target window
+        let targetWindow = tabbedWindows[finalIndex]
 
-        // Move our current selected window to the proper index
+        // Begin a group of window operations to minimize visual updates
+        NSAnimationContext.beginGrouping()
+        NSAnimationContext.current.duration = 0
+
+        // Remove and re-add the window in the correct position
         tabGroup.removeWindow(selectedWindow)
-        parent.addTabbedWindow(selectedWindow, ordered: action.amount < 0 ? .below : .above)
-        selectedWindow.makeKeyAndOrderFront(nil)
+        targetWindow.addTabbedWindow(selectedWindow, ordered: action.amount < 0 ? .below : .above)
+
+        // Ensure our window remains selected
+        selectedWindow.makeKey()
+
+        NSAnimationContext.endGrouping()
     }
 
     @objc private func onGotoTab(notification: SwiftUI.Notification) {


### PR DESCRIPTION
Fixes https://github.com/ghostty-org/ghostty/issues/5689

The flickering was caused by uncontrolled visual updates during tab reordering. The fix uses `NSAnimationContext` to batch all visual changes together and simplifies window focus handling to prevent unnecessary redraws.

https://github.com/user-attachments/assets/2a6525cd-8a97-418b-8442-18dab6b4636d


