### PR TITLE
build: add nix script to make cache tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ glad.zip
 /Box_test_diff.ppm
 /ghostty.qcow2
 /build.zig.zon2json-lock
+/blob

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -23,6 +23,7 @@
   pkg-config,
   zig_0_13,
   pandoc,
+  version,
   revision ? "dirty",
   optimize ? "Debug",
   enableX11 ? true,
@@ -48,7 +49,7 @@
 in
   stdenv.mkDerivation (finalAttrs: {
     pname = "ghostty";
-    version = "1.1.1";
+    inherit version;
 
     # We limit source like this to try and reduce the amount of rebuilds as possible
     # thus we only provide the source that is needed for the build


### PR DESCRIPTION
Run `nix run .#make-cache` to create a directory `blob/` with a tarball of the Zig deps. Potentially suitable for uploading to R2 to make getting the Zig deps easier for people with bad connectivity to certain sites or for packagers.