### PR TITLE
macOS: fix invalid kitty keyboard encoding of control characters

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -849,28 +849,8 @@ extension Ghostty {
             var handled: Bool = false
             if let list = keyTextAccumulator, list.count > 0 {
                 handled = true
-
-                // This is a hack. libghostty on macOS treats ctrl input as not having
-                // text because some keyboard layouts generate bogus characters for
-                // ctrl+key. libghostty can't tell this is from an IM keyboard giving
-                // us direct values. So, we just remove control.
-                var modifierFlags = event.modifierFlags
-                modifierFlags.remove(.control)
-                if let keyTextEvent = NSEvent.keyEvent(
-                    with: .keyDown,
-                    location: event.locationInWindow,
-                    modifierFlags: modifierFlags,
-                    timestamp: event.timestamp,
-                    windowNumber: event.windowNumber,
-                    context: nil,
-                    characters: event.characters ?? "",
-                    charactersIgnoringModifiers: event.charactersIgnoringModifiers ?? "",
-                    isARepeat: event.isARepeat,
-                    keyCode: event.keyCode
-                ) {
-                    for text in list {
-                        _ = keyAction(action, event: keyTextEvent, text: text)
-                    }
+                for text in list {
+                    _ = keyAction(action, event: event, text: text)
                 }
             }
 

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -849,8 +849,28 @@ extension Ghostty {
             var handled: Bool = false
             if let list = keyTextAccumulator, list.count > 0 {
                 handled = true
-                for text in list {
-                    _ = keyAction(action, event: event, text: text)
+
+                // This is a hack. libghostty on macOS treats ctrl input as not having
+                // text because some keyboard layouts generate bogus characters for
+                // ctrl+key. libghostty can't tell this is from an IM keyboard giving
+                // us direct values. So, we just remove control.
+                var modifierFlags = event.modifierFlags
+                modifierFlags.remove(.control)
+                if let keyTextEvent = NSEvent.keyEvent(
+                    with: .keyDown,
+                    location: event.locationInWindow,
+                    modifierFlags: modifierFlags,
+                    timestamp: event.timestamp,
+                    windowNumber: event.windowNumber,
+                    context: nil,
+                    characters: event.characters ?? "",
+                    charactersIgnoringModifiers: event.charactersIgnoringModifiers ?? "",
+                    isARepeat: event.isARepeat,
+                    keyCode: event.keyCode
+                ) {
+                    for text in list {
+                        _ = keyAction(action, event: keyTextEvent, text: text)
+                    }
                 }
             }
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -182,14 +182,9 @@ pub const App = struct {
                 if (strip) translate_mods.alt = false;
             }
 
-            // On macOS we strip ctrl because UCKeyTranslate
-            // converts to the masked values (i.e. ctrl+c becomes 3)
-            // and we don't want that behavior.
-            //
-            // We also strip super because its not used for translation
-            // on macos and it results in a bad translation.
+            // We strip super on macOS because its not used for translation
+            // it results in a bad translation.
             if (comptime builtin.target.isDarwin()) {
-                translate_mods.ctrl = false;
                 translate_mods.super = false;
             }
 
@@ -229,6 +224,7 @@ pub const App = struct {
             const result: input.Keymap.Translation = if (event_text) |text| .{
                 .text = text,
                 .composing = event.composing,
+                .mods = translate_mods,
             } else try self.keymap.translate(
                 &buf,
                 switch (target) {
@@ -273,16 +269,12 @@ pub const App = struct {
                 // then we clear the text. We handle non-printables in the
                 // key encoder manual (such as tab, ctrl+c, etc.)
                 if (result.text.len == 1 and result.text[0] < 0x20) {
-                    break :translate .{ .composing = false, .text = "" };
+                    break :translate .{};
                 }
             }
 
             break :translate result;
-        } else .{ .composing = false, .text = "" };
-
-        // UCKeyTranslate always consumes all mods, so if we have any output
-        // then we've consumed our translate mods.
-        const consumed_mods: input.Mods = if (result.text.len > 0) translate_mods else .{};
+        } else .{};
 
         // We need to always do a translation with no modifiers at all in
         // order to get the "unshifted_codepoint" for the key event.
@@ -354,7 +346,7 @@ pub const App = struct {
             .key = key,
             .physical_key = physical_key,
             .mods = mods,
-            .consumed_mods = consumed_mods,
+            .consumed_mods = result.mods,
             .composing = result.composing,
             .utf8 = result.text,
             .unshifted_codepoint = unshifted_codepoint,

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -182,9 +182,14 @@ pub const App = struct {
                 if (strip) translate_mods.alt = false;
             }
 
-            // We strip super on macOS because its not used for translation
-            // it results in a bad translation.
+            // On macOS we strip ctrl because UCKeyTranslate
+            // converts to the masked values (i.e. ctrl+c becomes 3)
+            // and we don't want that behavior.
+            //
+            // We also strip super because its not used for translation
+            // on macos and it results in a bad translation.
             if (comptime builtin.target.isDarwin()) {
+                translate_mods.ctrl = false;
                 translate_mods.super = false;
             }
 
@@ -231,14 +236,7 @@ pub const App = struct {
                     .surface => |surface| &surface.keymap_state,
                 },
                 @intCast(keycode),
-                if (comptime builtin.target.isDarwin()) mods: {
-                    // On macOS we strip ctrl because UCKeyTranslate
-                    // converts to the masked values (i.e. ctrl+c becomes 3)
-                    // and we don't want that behavior.
-                    var v = translate_mods;
-                    v.ctrl = false;
-                    break :mods v;
-                } else translate_mods,
+                translate_mods,
             );
 
             // TODO(mitchellh): I think we can get rid of the above keymap

--- a/src/input/KeymapNoop.zig
+++ b/src/input/KeymapNoop.zig
@@ -6,8 +6,9 @@ const Mods = @import("key.zig").Mods;
 
 pub const State = struct {};
 pub const Translation = struct {
-    text: []const u8,
-    composing: bool,
+    text: []const u8 = "",
+    composing: bool = false,
+    mods: Mods = .{},
 };
 
 pub fn init() !KeymapNoop {


### PR DESCRIPTION
Fixes #5743 

This fixes a terrible regression where by fixing one issue we introduced another, and the other is that ctrl keys didn't work with programs with Kitty keyboard protocol. 

The problem is that our fix blindly assumed control was always consumed for translation, which is obviously wrong but I didn't think there'd be downstream effects. The reality is that we need to be more accurate.

This PR makes it so that:

  * If macOS provides us with UTF-8 text, we assume all mods were involved except super
  * If macOS does not provide us with UTF-8 text, we use whatever UCKeyTranslate consumed
  * We never allow UCKeyTranslate to consume control because it turns it into the masked ASCII value and we don't want that.

The only _new_ behavior which fixes the bug is point 2 above. 

Tested:

  1. Dvorak Ctrl characters
  2. Ergo-L Ctrl characters
  3. US standard Ctrl characters
  4. Japanese IME input Ctrl input to modify IME state
  5. Ctrl keybindings with Kitty keyboard protocol in both Kitty and Neovim