### PR TITLE
build: script to download deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ glad.zip
 /Box_test.ppm
 /Box_test_diff.ppm
 /ghostty.qcow2
-/build.zig.zon2json-lock
+/deps

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -14,11 +14,11 @@
             .lazy = true,
         },
         .vaxis = .{
-            .url = "git+https://github.com/rockorager/libvaxis/?ref=main#6d729a2dc3b934818dffe06d2ba3ce02841ed74b",
+            .url = "https://github.com/rockorager/libvaxis/archive/6d729a2dc3b934818dffe06d2ba3ce02841ed74b.tar.gz",
             .hash = "12200df4ebeaed45de26cb2c9f3b6f3746d8013b604e035dae658f86f586c8c91d2f",
         },
         .z2d = .{
-            .url = "git+https://github.com/vancluever/z2d?ref=v0.4.0#4638bb02a9dc41cc2fb811f092811f6a951c752a",
+            .url = "https://github.com/vancluever/z2d/archive/4638bb02a9dc41cc2fb811f092811f6a951c752a.tar.gz",
             .hash = "12201f0d542e7541cf492a001d4d0d0155c92f58212fbcb0d224e95edeba06b5416a",
         },
         .zig_objc = .{
@@ -38,7 +38,7 @@
             .hash = "12209ca054cb1919fa276e328967f10b253f7537c4136eb48f3332b0f7cf661cad38",
         },
         .zf = .{
-            .url = "git+https://github.com/natecraddock/zf/?ref=main#ed99ca18b02dda052e20ba467e90b623c04690dd",
+            .url = "https://github.com/natecraddock/zf/archive/ed99ca18b02dda052e20ba467e90b623c04690dd.tar.gz",
             .hash = "1220edc3b8d8bedbb50555947987e5e8e2f93871ca3c8e8d4cc8f1377c15b5dd35e8",
         },
         .gobject = .{
@@ -76,7 +76,7 @@
             .hash = "12201a57c6ce0001aa034fa80fba3e1cd2253c560a45748f4f4dd21ff23b491cddef",
         },
         .plasma_wayland_protocols = .{
-            .url = "git+https://github.com/KDE/plasma-wayland-protocols?ref=main#db525e8f9da548cffa2ac77618dd0fbe7f511b86",
+            .url = "https://github.com/KDE/plasma-wayland-protocols/archive/db525e8f9da548cffa2ac77618dd0fbe7f511b86.tar.gz",
             .hash = "12207e0851c12acdeee0991e893e0132fc87bb763969a585dc16ecca33e88334c566",
         },
 

--- a/build.zig.zon.nix
+++ b/build.zig.zon.nix
@@ -232,7 +232,7 @@ in
       path = fetchZigArtifact {
         name = "wayland";
         url = "https://deps.files.ghostty.org/wayland-9cb3d7aa9dc995ffafdbdef7ab86a949d0fb0e7d.tar.gz";
-        hash = "sha256-m9G72jdG30KH2yQhNBcBJ46OnekzuX0i2uIOyczkpLk=";
+        hash = "sha256-6kGR1o5DdnflHzqs3ieCmBAUTpMdOXoyfcYDXiw5xQ0=";
       };
     }
     {
@@ -367,8 +367,8 @@ in
       name = "12207ff340169c7d40c570b4b6a97db614fe47e0d83b5801a932dcd44917424c8806";
       path = fetchZigArtifact {
         name = "pixels";
-        url = "https://github.com/make-github-pseudonymous-again/pixels/d843c2714d32e15b48b8d7eeb480295af537f877.tar.gz";
-        hash = "sha256-ABnfxLMtY8E5KqJkrtIlPB4ML7CSFvjizCabv7i7SbU=";
+        url = "https://github.com/make-github-pseudonymous-again/pixels/archive/d843c2714d32e15b48b8d7eeb480295af537f877.tar.gz";
+        hash = "sha256-Veg7FtCRCCUCvxSb9FfzH0IJLFmCZQ4/+657SIcb8Ro=";
       };
     }
     {

--- a/build.zig.zon.nix
+++ b/build.zig.zon.nix
@@ -143,8 +143,8 @@ in
       name = "12200df4ebeaed45de26cb2c9f3b6f3746d8013b604e035dae658f86f586c8c91d2f";
       path = fetchZigArtifact {
         name = "vaxis";
-        url = "git+https://github.com/rockorager/libvaxis/?ref=main#6d729a2dc3b934818dffe06d2ba3ce02841ed74b";
-        hash = "sha256-fFf79fCy4QQFVNcN722tSMjB6FyVEzCB36oH1olk9JQ=";
+        url = "https://github.com/rockorager/libvaxis/archive/6d729a2dc3b934818dffe06d2ba3ce02841ed74b.tar.gz";
+        hash = "sha256-OCNs6Gl2ruq5dBm4uIxs93hoXw/+n+x1+bIDfQGDx3s=";
       };
     }
     {
@@ -167,8 +167,8 @@ in
       name = "12201f0d542e7541cf492a001d4d0d0155c92f58212fbcb0d224e95edeba06b5416a";
       path = fetchZigArtifact {
         name = "z2d";
-        url = "git+https://github.com/vancluever/z2d?ref=v0.4.0#4638bb02a9dc41cc2fb811f092811f6a951c752a";
-        hash = "sha256-YpWXn1J3JKQSCrWB25mAfzd1/T56QstEZnhPzBwxgoM=";
+        url = "https://github.com/vancluever/z2d/archive/4638bb02a9dc41cc2fb811f092811f6a951c752a.tar.gz";
+        hash = "sha256-P0UJ54RO/vVyDa+UkBl+QEOjzoMMEFSOTexQP/uBXfc=";
       };
     }
     {
@@ -207,8 +207,8 @@ in
       name = "1220edc3b8d8bedbb50555947987e5e8e2f93871ca3c8e8d4cc8f1377c15b5dd35e8";
       path = fetchZigArtifact {
         name = "zf";
-        url = "git+https://github.com/natecraddock/zf/?ref=main#ed99ca18b02dda052e20ba467e90b623c04690dd";
-        hash = "sha256-t6QNrEJZ4GZZsYixjYvpdrYoCmNbG8TTUmGs2MFa4sU=";
+        url = "https://github.com/natecraddock/zf/archive/ed99ca18b02dda052e20ba467e90b623c04690dd.tar.gz";
+        hash = "sha256-/oLryY3VQfjbtQi+UP+n6FJTVA/YxIetjO+6Ovrh6/E=";
       };
     }
     {
@@ -247,8 +247,8 @@ in
       name = "12207e0851c12acdeee0991e893e0132fc87bb763969a585dc16ecca33e88334c566";
       path = fetchZigArtifact {
         name = "plasma_wayland_protocols";
-        url = "git+https://github.com/KDE/plasma-wayland-protocols?ref=main#db525e8f9da548cffa2ac77618dd0fbe7f511b86";
-        hash = "sha256-iWRv3+OfmHxmeCJ8m0ChjgZX6mwXlcFmK8P/Vt8gDj4=";
+        url = "https://github.com/KDE/plasma-wayland-protocols/archive/db525e8f9da548cffa2ac77618dd0fbe7f511b86.tar.gz";
+        hash = "sha256-XFi6IUrNjmvKNCbcCLAixGqN2Zeymhs+KLrfccIN9EE=";
       };
     }
     {
@@ -367,8 +367,8 @@ in
       name = "12207ff340169c7d40c570b4b6a97db614fe47e0d83b5801a932dcd44917424c8806";
       path = fetchZigArtifact {
         name = "pixels";
-        url = "git+https://github.com/make-github-pseudonymous-again/pixels?ref=main#d843c2714d32e15b48b8d7eeb480295af537f877";
-        hash = "sha256-kXYGO0qn2PfyOYCrRA49BHIgTzdmKhI8SNO1ZKfUYEE=";
+        url = "https://github.com/make-github-pseudonymous-again/pixels/d843c2714d32e15b48b8d7eeb480295af537f877.tar.gz";
+        hash = "sha256-ABnfxLMtY8E5KqJkrtIlPB4ML7CSFvjizCabv7i7SbU=";
       };
     }
     {

--- a/build.zig.zon2json-lock
+++ b/build.zig.zon2json-lock
@@ -1,0 +1,192 @@
+{
+  "1220ebf88622c4d502dc59e71347e4d28c47e033f11b59aff774ae5787565c40999c": {
+    "name": "libxev",
+    "url": "https://github.com/mitchellh/libxev/archive/31eed4e337fed7b0149319e5cdbb62b848c24fbd.tar.gz",
+    "hash": "sha256-VHP90NTytIZ8UZsYRKOOxN490/I6yv6ec40sP8y5MJ8="
+  },
+  "12206ed982e709e565d536ce930701a8c07edfd2cfdce428683f3f2a601d37696a62": {
+    "name": "mach_glfw",
+    "url": "https://github.com/mitchellh/mach-glfw/archive/37c2995f31abcf7e8378fba68ddcf4a3faa02de0.tar.gz",
+    "hash": "sha256-HhXIvWUS8/CHWY4VXPG2ZEo+we8XOn3o5rYJCQ1n8Nk="
+  },
+  "1220736fa4ba211162c7a0e46cc8fe04d95921927688bff64ab5da7420d098a7272d": {
+    "name": "glfw",
+    "url": "https://github.com/mitchellh/glfw/archive/b552c6ec47326b94015feddb36058ea567b87159.tar.gz",
+    "hash": "sha256-IeBVAOQmtyFqVxzuXPek1onuPwIamcOyYtxqKpPEQjU="
+  },
+  "12202adbfecdad671d585c9a5bfcbd5cdf821726779430047742ce1bf94ad67d19cb": {
+    "name": "xcode_frameworks",
+    "url": "https://github.com/mitchellh/xcode-frameworks/archive/69801c154c39d7ae6129ea1ba8fe1afe00585fc8.tar.gz",
+    "hash": "sha256-mP/I2coL57UJm/3+4Q8sPAgQwk8V4zM+S4VBBTrX2To="
+  },
+  "122004bfd4c519dadfb8e6281a42fc34fd1aa15aea654ea8a492839046f9894fa2cf": {
+    "name": "vulkan_headers",
+    "url": "https://github.com/mitchellh/vulkan-headers/archive/04c8a0389d5a0236a96312988017cd4ce27d8041.tar.gz",
+    "hash": "sha256-K+zrRudgHFukOM6En1StRYRMNYkeRk+qHTXvrXaG+FU="
+  },
+  "1220b3164434d2ec9db146a40bf3a30f490590d68fa8529776a3138074f0da2c11ca": {
+    "name": "wayland_headers",
+    "url": "https://github.com/mitchellh/wayland-headers/archive/5f991515a29f994d87b908115a2ab0b899474bd1.tar.gz",
+    "hash": "sha256-uFilLZinKkZt6RdVTV3lUmJpzpswDdFva22FvwU/XQI="
+  },
+  "122089c326186c84aa2fd034b16abc38f3ebf4862d9ae106dc1847ac44f557b36465": {
+    "name": "x11_headers",
+    "url": "https://github.com/mitchellh/x11-headers/archive/2ffbd62d82ff73ec929dd8de802bc95effa0ef88.tar.gz",
+    "hash": "sha256-EhV2bmTY/OMYN1wEul35gD0hQgS/Al262jO3pVr0O+c="
+  },
+  "12200df4ebeaed45de26cb2c9f3b6f3746d8013b604e035dae658f86f586c8c91d2f": {
+    "name": "vaxis",
+    "url": "https://github.com/rockorager/libvaxis/archive/6d729a2dc3b934818dffe06d2ba3ce02841ed74b.tar.gz",
+    "hash": "sha256-OCNs6Gl2ruq5dBm4uIxs93hoXw/+n+x1+bIDfQGDx3s="
+  },
+  "1220dd654ef941fc76fd96f9ec6adadf83f69b9887a0d3f4ee5ac0a1a3e11be35cf5": {
+    "name": "zigimg",
+    "url": "git+https://github.com/zigimg/zigimg#3a667bdb3d7f0955a5a51c8468eac83210c1439e",
+    "hash": "sha256-oLf3YH3yeg4ikVO/GahMCDRMTU31AHkfSnF4rt7xTKo="
+  },
+  "122055beff332830a391e9895c044d33b15ea21063779557024b46169fb1984c6e40": {
+    "name": "zg",
+    "url": "https://codeberg.org/atman/zg/archive/v0.13.2.tar.gz",
+    "hash": "sha256-2x9hT7bYq9KJYWLVOf21a+QvTG/F7HWT+YK15IMRzNY="
+  },
+  "12201f0d542e7541cf492a001d4d0d0155c92f58212fbcb0d224e95edeba06b5416a": {
+    "name": "z2d",
+    "url": "https://github.com/vancluever/z2d/archive/4638bb02a9dc41cc2fb811f092811f6a951c752a.tar.gz",
+    "hash": "sha256-P0UJ54RO/vVyDa+UkBl+QEOjzoMMEFSOTexQP/uBXfc="
+  },
+  "1220e17e64ef0ef561b3e4b9f3a96a2494285f2ec31c097721bf8c8677ec4415c634": {
+    "name": "zig_objc",
+    "url": "https://github.com/mitchellh/zig-objc/archive/9b8ba849b0f58fe207ecd6ab7c147af55b17556e.tar.gz",
+    "hash": "sha256-H+HIbh2T23uzrsg9/1/vl9Ir1HCAa2pzeTx6zktJH9Q="
+  },
+  "12205a66d423259567764fa0fc60c82be35365c21aeb76c5a7dc99698401f4f6fefc": {
+    "name": "zig_js",
+    "url": "https://github.com/mitchellh/zig-js/archive/d0b8b0a57c52fbc89f9d9fecba75ca29da7dd7d1.tar.gz",
+    "hash": "sha256-fyNeCVbC9UAaKJY6JhAZlT0A479M/AKYMPIWEZbDWD0="
+  },
+  "12207831bce7d4abce57b5a98e8f3635811cfefd160bca022eb91fe905d36a02cf25": {
+    "name": "ziglyph",
+    "url": "https://deps.files.ghostty.org/ziglyph-b89d43d1e3fb01b6074bc1f7fc980324b04d26a5.tar.gz",
+    "hash": "sha256-cse98+Ft8QUjX+P88yyYfaxJOJGQ9M7Ymw7jFxDz89k="
+  },
+  "12209ca054cb1919fa276e328967f10b253f7537c4136eb48f3332b0f7cf661cad38": {
+    "name": "zig_wayland",
+    "url": "https://deps.files.ghostty.org/zig-wayland-fbfe3b4ac0b472a27b1f1a67405436c58cbee12d.tar.gz",
+    "hash": "sha256-RtAystqK/GRYIquTK1KfD7rRSCrfuzAvCD1Z9DE1ldc="
+  },
+  "1220edc3b8d8bedbb50555947987e5e8e2f93871ca3c8e8d4cc8f1377c15b5dd35e8": {
+    "name": "zf",
+    "url": "https://github.com/natecraddock/zf/archive/ed99ca18b02dda052e20ba467e90b623c04690dd.tar.gz",
+    "hash": "sha256-/oLryY3VQfjbtQi+UP+n6FJTVA/YxIetjO+6Ovrh6/E="
+  },
+  "1220c72c1697dd9008461ead702997a15d8a1c5810247f02e7983b9f74c6c6e4c087": {
+    "name": "vaxis",
+    "url": "git+https://github.com/rockorager/libvaxis/?ref=main#dc0a228a5544988d4a920cfb40be9cd28db41423",
+    "hash": "sha256-QWN4jOrA91KlbqmeEHHJ4HTnCC9nmfxt8DHUXJpAzLI="
+  },
+  "12208d70ee791d7ef7e16e1c3c9c1127b57f1ed066a24f87d57fc9f730c5dc394b9d": {
+    "name": "gobject",
+    "url": "https://github.com/ianprime0509/zig-gobject/releases/download/v0.2.2/bindings-gnome47.tar.zst",
+    "hash": "sha256-UU97kNv/bZzQPKz1djhEDLapLguvfBpFfWVb6FthtcI="
+  },
+  "12202cdac858abc52413a6c6711d5026d2d3c8e13f95ca2c327eade0736298bb021f": {
+    "name": "wayland",
+    "url": "https://deps.files.ghostty.org/wayland-9cb3d7aa9dc995ffafdbdef7ab86a949d0fb0e7d.tar.gz",
+    "hash": "sha256-m9G72jdG30KH2yQhNBcBJ46OnekzuX0i2uIOyczkpLk="
+  },
+  "12201a57c6ce0001aa034fa80fba3e1cd2253c560a45748f4f4dd21ff23b491cddef": {
+    "name": "wayland_protocols",
+    "url": "https://deps.files.ghostty.org/wayland-protocols-258d8f88f2c8c25a830c6316f87d23ce1a0f12d9.tar.gz",
+    "hash": "sha256-XO3K3egbdeYPI+XoO13SuOtO+5+Peb16NH0UiusFMPg="
+  },
+  "12207e0851c12acdeee0991e893e0132fc87bb763969a585dc16ecca33e88334c566": {
+    "name": "plasma_wayland_protocols",
+    "url": "https://github.com/KDE/plasma-wayland-protocols/archive/db525e8f9da548cffa2ac77618dd0fbe7f511b86.tar.gz",
+    "hash": "sha256-XFi6IUrNjmvKNCbcCLAixGqN2Zeymhs+KLrfccIN9EE="
+  },
+  "12203d2647e5daf36a9c85b969e03f422540786ce9ea624eb4c26d204fe1f46218f3": {
+    "name": "iterm2_themes",
+    "url": "https://github.com/mbadolato/iTerm2-Color-Schemes/archive/db227d159adc265818f2e898da0f70ef8d7b580e.tar.gz",
+    "hash": "sha256-Iyf7U4rpvNkPX4AOEbYSYGte5+SjRwsWD2luOn1Hz8U="
+  },
+  "1220bc6b9daceaf7c8c60f3c3998058045ba0c5c5f48ae255ff97776d9cd8bfc6402": {
+    "name": "imgui",
+    "url": "https://github.com/ocornut/imgui/archive/e391fe2e66eb1c96b1624ae8444dc64c23146ef4.tar.gz",
+    "hash": "sha256-oF/QHgTPEat4Hig4fGIdLkIPHmBEyOJ6JeYD6pnveGA="
+  },
+  "1220b81f6ecfb3fd222f76cf9106fecfa6554ab07ec7fdc4124b9bb063ae2adf969d": {
+    "name": "freetype",
+    "url": "https://github.com/freetype/freetype/archive/refs/tags/VER-2-13-2.tar.gz",
+    "hash": "sha256-QnIB9dUVFnDQXB9bRb713aHy592XHvVPD+qqf/0quQw="
+  },
+  "1220aa013f0c83da3fb64ea6d327f9173fa008d10e28bc9349eac3463457723b1c66": {
+    "name": "libpng",
+    "url": "https://github.com/glennrp/libpng/archive/refs/tags/v1.6.43.tar.gz",
+    "hash": "sha256-/syVtGzwXo4/yKQUdQ4LparQDYnp/fF16U/wQcrxoDo="
+  },
+  "1220fed0c74e1019b3ee29edae2051788b080cd96e90d56836eea857b0b966742efb": {
+    "name": "zlib",
+    "url": "https://github.com/madler/zlib/archive/refs/tags/v1.3.1.tar.gz",
+    "hash": "sha256-F+iIY/NgBnKrSRgvIXKBtvxNPHYr3jYZNeQ2qVIU0Fw="
+  },
+  "12201149afb3326c56c05bb0a577f54f76ac20deece63aa2f5cd6ff31a4fa4fcb3b7": {
+    "name": "fontconfig",
+    "url": "https://deps.files.ghostty.org/fontconfig-2.14.2.tar.gz",
+    "hash": "sha256-O6LdkhWHGKzsXKrxpxYEO1qgVcJ7CB2RSvPMtA3OilU="
+  },
+  "122032442d95c3b428ae8e526017fad881e7dc78eab4d558e9a58a80bfbd65a64f7d": {
+    "name": "libxml2",
+    "url": "https://github.com/GNOME/libxml2/archive/refs/tags/v2.11.5.tar.gz",
+    "hash": "sha256-bCgFni4+60K1tLFkieORamNGwQladP7jvGXNxdiaYhU="
+  },
+  "1220b8588f106c996af10249bfa092c6fb2f35fbacb1505ef477a0b04a7dd1063122": {
+    "name": "harfbuzz",
+    "url": "https://github.com/harfbuzz/harfbuzz/archive/refs/tags/8.4.0.tar.gz",
+    "hash": "sha256-nxygiYE7BZRK0c6MfgGCEwJtNdybq0gKIeuHaDg5ZVY="
+  },
+  "12205c83b8311a24b1d5ae6d21640df04f4b0726e314337c043cde1432758cbe165b": {
+    "name": "highway",
+    "url": "https://github.com/google/highway/archive/refs/tags/1.1.0.tar.gz",
+    "hash": "sha256-NUqLRTm1iOcLmOxwhEJz4/J0EwLEw3e8xOgbPRhm98k="
+  },
+  "1220c15e72eadd0d9085a8af134904d9a0f5dfcbed5f606ad60edc60ebeccd9706bb": {
+    "name": "oniguruma",
+    "url": "https://github.com/kkos/oniguruma/archive/refs/tags/v6.9.9.tar.gz",
+    "hash": "sha256-ABqhIC54RI9MC/GkjHblVodrNvFtks4yB+zP1h2Z8qA="
+  },
+  "1220446be831adcca918167647c06c7b825849fa3fba5f22da394667974537a9c77e": {
+    "name": "sentry",
+    "url": "https://github.com/getsentry/sentry-native/archive/refs/tags/0.7.8.tar.gz",
+    "hash": "sha256-KsZJfMjWGo0xCT5HrduMmyxFsWsHBbszSoNbZCPDGN8="
+  },
+  "12207fd37bb8251919c112dcdd8f616a491857b34a451f7e4486490077206dc2a1ea": {
+    "name": "breakpad",
+    "url": "https://github.com/getsentry/breakpad/archive/b99f444ba5f6b98cac261cbb391d8766b34a5918.tar.gz",
+    "hash": "sha256-bMqYlD0amQdmzvYQd8Ca/1k4Bj/heh7+EijlQSttatk="
+  },
+  "1220d4d18426ca72fc2b7e56ce47273149815501d0d2395c2a98c726b31ba931e641": {
+    "name": "utfcpp",
+    "url": "https://github.com/nemtrif/utfcpp/archive/refs/tags/v4.0.5.tar.gz",
+    "hash": "sha256-/8ZooxDndgfTk/PBizJxXyI9oerExNbgV5oR345rWc8="
+  },
+  "122037b39d577ec2db3fd7b2130e7b69ef6cc1807d68607a7c232c958315d381b5cd": {
+    "name": "wuffs",
+    "url": "https://github.com/google/wuffs/archive/refs/tags/v0.4.0-alpha.9.tar.gz",
+    "hash": "sha256-nkzSCr6W5sTG7enDBXEIhgEm574uLD41UVR2wlC+HBM="
+  },
+  "12207ff340169c7d40c570b4b6a97db614fe47e0d83b5801a932dcd44917424c8806": {
+    "name": "pixels",
+    "url": "https://github.com/make-github-pseudonymous-again/pixels/d843c2714d32e15b48b8d7eeb480295af537f877.tar.gz",
+    "hash": "sha256-ABnfxLMtY8E5KqJkrtIlPB4ML7CSFvjizCabv7i7SbU="
+  },
+  "12201278a1a05c0ce0b6eb6026c65cd3e9247aa041b1c260324bf29cee559dd23ba1": {
+    "name": "glslang",
+    "url": "https://github.com/KhronosGroup/glslang/archive/refs/tags/14.2.0.tar.gz",
+    "hash": "sha256-FKLtu1Ccs+UamlPj9eQ12/WXFgS0uDPmPmB26MCpl7U="
+  },
+  "1220fb3b5586e8be67bc3feb34cbe749cf42a60d628d2953632c2f8141302748c8da": {
+    "name": "spirv_cross",
+    "url": "https://github.com/KhronosGroup/SPIRV-Cross/archive/476f384eb7d9e48613c45179e502a15ab95b6b49.tar.gz",
+    "hash": "sha256-tStvz8Ref6abHwahNiwVVHNETizAmZVVaxVsU7pmV+M="
+  }
+}

--- a/build.zig.zon2json-lock
+++ b/build.zig.zon2json-lock
@@ -92,7 +92,7 @@
   "12202cdac858abc52413a6c6711d5026d2d3c8e13f95ca2c327eade0736298bb021f": {
     "name": "wayland",
     "url": "https://deps.files.ghostty.org/wayland-9cb3d7aa9dc995ffafdbdef7ab86a949d0fb0e7d.tar.gz",
-    "hash": "sha256-m9G72jdG30KH2yQhNBcBJ46OnekzuX0i2uIOyczkpLk="
+    "hash": "sha256-6kGR1o5DdnflHzqs3ieCmBAUTpMdOXoyfcYDXiw5xQ0="
   },
   "12201a57c6ce0001aa034fa80fba3e1cd2253c560a45748f4f4dd21ff23b491cddef": {
     "name": "wayland_protocols",
@@ -176,8 +176,8 @@
   },
   "12207ff340169c7d40c570b4b6a97db614fe47e0d83b5801a932dcd44917424c8806": {
     "name": "pixels",
-    "url": "https://github.com/make-github-pseudonymous-again/pixels/d843c2714d32e15b48b8d7eeb480295af537f877.tar.gz",
-    "hash": "sha256-ABnfxLMtY8E5KqJkrtIlPB4ML7CSFvjizCabv7i7SbU="
+    "url": "https://github.com/make-github-pseudonymous-again/pixels/archive/d843c2714d32e15b48b8d7eeb480295af537f877.tar.gz",
+    "hash": "sha256-Veg7FtCRCCUCvxSb9FfzH0IJLFmCZQ4/+657SIcb8Ro="
   },
   "12201278a1a05c0ce0b6eb6026c65cd3e9247aa041b1c260324bf29cee559dd23ba1": {
     "name": "glslang",

--- a/nix/build-support/check-zig-cache.sh
+++ b/nix/build-support/check-zig-cache.sh
@@ -42,7 +42,6 @@ fi
 rm -f "$BUILD_ZIG_ZON_LOCK"
 zon2nix "$BUILD_ZIG_ZON" > "$WORK_DIR/build.zig.zon.nix"
 alejandra --quiet "$WORK_DIR/build.zig.zon.nix"
-rm -f "$BUILD_ZIG_ZON_LOCK"
 
 NEW_HASH=$(sha512sum "$WORK_DIR/build.zig.zon.nix" | awk '{print $1}')
 

--- a/pkg/wuffs/build.zig.zon
+++ b/pkg/wuffs/build.zig.zon
@@ -8,7 +8,7 @@
         },
 
         .pixels = .{
-            .url = "git+https://github.com/make-github-pseudonymous-again/pixels?ref=main#d843c2714d32e15b48b8d7eeb480295af537f877",
+            .url = "https://github.com/make-github-pseudonymous-again/pixels/d843c2714d32e15b48b8d7eeb480295af537f877.tar.gz",
             .hash = "12207ff340169c7d40c570b4b6a97db614fe47e0d83b5801a932dcd44917424c8806",
         },
 

--- a/pkg/wuffs/build.zig.zon
+++ b/pkg/wuffs/build.zig.zon
@@ -8,7 +8,7 @@
         },
 
         .pixels = .{
-            .url = "https://github.com/make-github-pseudonymous-again/pixels/d843c2714d32e15b48b8d7eeb480295af537f877.tar.gz",
+            .url = "https://github.com/make-github-pseudonymous-again/pixels/archive/d843c2714d32e15b48b8d7eeb480295af537f877.tar.gz",
             .hash = "12207ff340169c7d40c570b4b6a97db614fe47e0d83b5801a932dcd44917424c8806",
         },
 

--- a/src/build/deps.py
+++ b/src/build/deps.py
@@ -1,7 +1,59 @@
 import json
 import pathlib
+import subprocess
+import tempfile
 import urllib.parse
 import urllib.request
+
+
+def clone(deps: pathlib.Path, name: str, url: urllib.parse.ParseResult) -> pathlib.Path:
+    repo = urllib.parse.ParseResult(
+        scheme=url.scheme.removeprefix("git+"),
+        netloc=url.netloc,
+        path=url.path,
+        params="",
+        query="",
+        fragment="",
+    )
+    file = deps / f"{name}-{url.fragment}.tar.gz"
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpdir = pathlib.Path(tmp)
+        archivedir = tmpdir / f"{name}-{url.fragment}"
+        archivedir.mkdir()
+        subprocess.run(
+            ["git", "init"],
+            cwd=str(archivedir),
+            check=True,
+        )
+        subprocess.run(
+            ["git", "remote", "add", "origin", repo.geturl()],
+            cwd=str(archivedir),
+            check=True,
+        )
+        subprocess.run(
+            ["git", "fetch", "origin", "--depth=1", url.fragment],
+            cwd=str(archivedir),
+            check=True,
+        )
+        subprocess.run(
+            ["git", "checkout", "FETCH_HEAD"],
+            cwd=str(archivedir),
+            check=True,
+        )
+        subprocess.run(
+            [
+                "tar",
+                "--create",
+                "--file",
+                str(file.resolve()),
+                "--exclude",
+                ".git",
+                f"{name}-{url.fragment}",
+            ],
+            cwd=str(tmpdir),
+            check=True,
+        )
+    return file
 
 
 def main() -> None:
@@ -13,18 +65,22 @@ def main() -> None:
             continue
         url = urllib.parse.urlparse(data["url"])
         if url.scheme.startswith("git+"):
-            continue
-        path = pathlib.Path(url.path)
-        basename = path.parts[-1]
-        if not basename.startswith(f"{data["name"]}-"):
-            file = deps / f"{data["name"]}-{basename}"
+            file = clone(deps, data["name"], url)
+            print(f"{data["url"]} -> {file}")
         else:
-            file = deps / basename
-        req = urllib.request.Request(data["url"], headers={"User-Agent": "ghostty/1.0"})
-        with urllib.request.urlopen(req) as response:
-            body = response.read()
-            file.write_bytes(body)
-        print(f"{data["url"]} -> https://deps.files.ghostty.org/{file.parts[-1]}")
+            path = pathlib.Path(url.path)
+            basename = path.parts[-1]
+            if not basename.startswith(f"{data["name"]}-"):
+                file = deps / f"{data["name"]}-{basename}"
+            else:
+                file = deps / basename
+            req = urllib.request.Request(
+                data["url"], headers={"User-Agent": "ghostty-downloader/1.0"}
+            )
+            with urllib.request.urlopen(req) as response:
+                body = response.read()
+                file.write_bytes(body)
+            print(f"{data["url"]} -> {file}")
 
 
 if __name__ == "__main__":

--- a/src/build/deps.py
+++ b/src/build/deps.py
@@ -1,0 +1,31 @@
+import json
+import pathlib
+import urllib.parse
+import urllib.request
+
+
+def main() -> None:
+    deps = pathlib.Path("deps")
+    deps.mkdir(exist_ok=True)
+    build = json.load(open("build.zig.zon2json-lock"))
+    for data in build.values():
+        if "url" not in data:
+            continue
+        url = urllib.parse.urlparse(data["url"])
+        if url.scheme.startswith("git+"):
+            continue
+        path = pathlib.Path(url.path)
+        basename = path.parts[-1]
+        if not basename.startswith(f"{data["name"]}-"):
+            file = deps / f"{data["name"]}-{basename}"
+        else:
+            file = deps / basename
+        req = urllib.request.Request(data["url"], headers={"User-Agent": "ghostty/1.0"})
+        with urllib.request.urlopen(req) as response:
+            body = response.read()
+            file.write_bytes(body)
+        print(f"{data["url"]} -> https://deps.files.ghostty.org/{file.parts[-1]}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Run `python src/build/deps.py`. That will create a directory `deps` that contain tarballs of all the Zig deps that don't use `git+https`. Suitable for uploading to R2.