### PR TITLE
macos: add +list-mac-app-icons cli action

### DIFF
--- a/src/cli/action.zig
+++ b/src/cli/action.zig
@@ -9,6 +9,7 @@ const list_keybinds = @import("list_keybinds.zig");
 const list_themes = @import("list_themes.zig");
 const list_colors = @import("list_colors.zig");
 const list_actions = @import("list_actions.zig");
+const list_mac_app_icons = @import("list_mac_app_icons.zig");
 const show_config = @import("show_config.zig");
 const validate_config = @import("validate_config.zig");
 const crash_report = @import("crash_report.zig");
@@ -39,6 +40,9 @@ pub const Action = enum {
 
     /// List keybind actions
     @"list-actions",
+
+    /// List available macOS app icons
+    @"list-mac-app-icons",
 
     /// Dump the config to stdout
     @"show-config",
@@ -151,6 +155,7 @@ pub const Action = enum {
             .@"list-themes" => try list_themes.run(alloc),
             .@"list-colors" => try list_colors.run(alloc),
             .@"list-actions" => try list_actions.run(alloc),
+            .@"list-mac-app-icons" => try list_mac_app_icons.run(alloc),
             .@"show-config" => try show_config.run(alloc),
             .@"validate-config" => try validate_config.run(alloc),
             .@"crash-report" => try crash_report.run(alloc),
@@ -187,6 +192,7 @@ pub const Action = enum {
                 .@"list-themes" => list_themes.Options,
                 .@"list-colors" => list_colors.Options,
                 .@"list-actions" => list_actions.Options,
+                .@"list-mac-app-icons" => list_mac_app_icons.Options,
                 .@"show-config" => show_config.Options,
                 .@"validate-config" => validate_config.Options,
                 .@"crash-report" => crash_report.Options,

--- a/src/cli/list_mac_app_icons.zig
+++ b/src/cli/list_mac_app_icons.zig
@@ -1,0 +1,44 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const Action = @import("action.zig").Action;
+const args = @import("args.zig");
+const Config = @import("../config/Config.zig");
+
+pub const Options = struct {
+    pub fn deinit(self: Options) void {
+        _ = self;
+    }
+
+    /// Enables "-h" and "--help" to work.
+    pub fn help(self: Options) !void {
+        _ = self;
+        return Action.help_error;
+    }
+};
+
+/// The `list-mac-app-icons` command is used to list all available macOS app icons
+/// that can be used with the `macos-icon` configuration option in Ghostty.
+pub fn run(alloc: std.mem.Allocator) !u8 {
+    if (comptime !builtin.target.isDarwin()) {
+        const stderr = std.io.getStdErr().writer();
+        try stderr.writeAll("This command is only supported on macOS\n");
+        return 1;
+    }
+
+    var opts: Options = .{};
+    defer opts.deinit();
+
+    {
+        var iter = try args.argsIterator(alloc);
+        defer iter.deinit();
+        try args.parse(Options, alloc, &opts, &iter);
+    }
+
+    const stdout = std.io.getStdOut().writer();
+
+    inline for (@typeInfo(Config.MacAppIcon).Enum.fields) |field| {
+        try stdout.print("{s}\n", .{field.name});
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This adds a new CLI command `+list-mac-app-icons` that lists all available macOS app icons added in #5696 which can be used with the `macos-icon` configuration option.

## Details
- Adds new `list-mac-app-icons` command to list available macOS app icons
- Only available on macOS and returns an error message on other platforms
- Follows existing CLI command patterns and code structure

## Example Usage
```sh
Ghostty.app/Contents/MacOS/ghostty +list-mac-app-icons
official
blueprint
chalkboard
microchip
...
```

## Testing
- Tested on macOS: successfully lists available icons
- Tested on Linux: displays appropriate "only supported on macOS" message
- Verified help text functionality works as expected