### PR TITLE
termio: use modified backend

### DIFF
--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -220,7 +220,7 @@ pub fn init(self: *Termio, alloc: Allocator, opts: termio.Options) !void {
         .renderer_mailbox = opts.renderer_mailbox,
         .surface_mailbox = opts.surface_mailbox,
         .size = opts.size,
-        .backend = opts.backend,
+        .backend = backend,
         .mailbox = opts.mailbox,
         .terminal_stream = .{
             .handler = handler,


### PR DESCRIPTION
In Termio.init, we make a copy of backend and modify it by calling
initTerminal. However, we used the original in the struct definition.
This lead to the pty being opened with a size 0,0.
