### PR TITLE
Vertically center title when `macos-titlebar-style = tabs`

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalToolbar.swift
+++ b/macos/Sources/Features/Terminal/TerminalToolbar.swift
@@ -95,6 +95,23 @@ fileprivate class CenteredDynamicLabel: NSTextField {
         setContentHuggingPriority(.defaultLow, for: .horizontal)
         setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
     }
+
+    // Vertically center the text
+    override func draw(_ dirtyRect: NSRect) {
+        guard let attributedString = self.attributedStringValue.mutableCopy() as? NSMutableAttributedString else {
+            super.draw(dirtyRect)
+            return
+        }
+        
+        let textSize = attributedString.size()
+        
+        let yOffset = (self.bounds.height - textSize.height) / 2 - 1 // -1 to center it better
+        
+        let centeredRect = NSRect(x: self.bounds.origin.x, y: self.bounds.origin.y + yOffset,
+                                  width: self.bounds.width, height: textSize.height)
+        
+        attributedString.draw(in: centeredRect)
+    }
 }
 
 extension NSToolbarItem.Identifier {


### PR DESCRIPTION
Fix #3868 
<img width="812" alt="Frame 14" src="https://github.com/user-attachments/assets/1fe78a13-ed8f-46e5-b4d4-69ecefdbdc22" />
