### PR TITLE
gtk: update menus to use popovers and builder ui files

### DIFF
--- a/src/apprt/gtk/Builder.zig
+++ b/src/apprt/gtk/Builder.zig
@@ -56,7 +56,7 @@ pub fn setWidgetClassTemplate(self: *const Builder, class: *gtk.WidgetClass) voi
     class.setTemplateFromResource(self.resource_name);
 }
 
-pub fn getObject(self: *Builder, name: [:0]const u8) ?*gobject.Object {
+pub fn getObject(self: *Builder, comptime T: type, name: [:0]const u8) ?*T {
     const builder = builder: {
         if (self.builder) |builder| break :builder builder;
         const builder = gtk.Builder.newFromResource(self.resource_name);
@@ -64,7 +64,7 @@ pub fn getObject(self: *Builder, name: [:0]const u8) ?*gobject.Object {
         break :builder builder;
     };
 
-    return builder.getObject(name);
+    return gobject.ext.cast(T, builder.getObject(name) orelse return null);
 }
 
 pub fn deinit(self: *const Builder) void {

--- a/src/apprt/gtk/Tab.zig
+++ b/src/apprt/gtk/Tab.zig
@@ -108,8 +108,8 @@ pub fn replaceElem(self: *Tab, elem: Surface.Container.Elem) void {
     self.elem = elem;
 }
 
-pub fn setLabelText(self: *Tab, title: [:0]const u8) void {
-    self.window.notebook.setTabLabel(self, title);
+pub fn setTitleText(self: *Tab, title: [:0]const u8) void {
+    self.window.notebook.setTabTitle(self, title);
 }
 
 pub fn setTooltipText(self: *Tab, tooltip: [:0]const u8) void {

--- a/src/apprt/gtk/TabView.zig
+++ b/src/apprt/gtk/TabView.zig
@@ -165,7 +165,7 @@ pub fn reorderPage(self: *TabView, tab: *Tab, position: c_int) void {
     _ = self.tab_view.reorderPage(page, position);
 }
 
-pub fn setTabLabel(self: *TabView, tab: *Tab, title: [:0]const u8) void {
+pub fn setTabTitle(self: *TabView, tab: *Tab, title: [:0]const u8) void {
     const page = self.tab_view.getPage(@ptrCast(tab.box));
     page.setTitle(title.ptr);
 }
@@ -188,7 +188,7 @@ pub fn addTab(self: *TabView, tab: *Tab, title: [:0]const u8) void {
     const position = self.newTabInsertPosition(tab);
     const box_widget: *gtk.Widget = @ptrCast(tab.box);
     const page = self.tab_view.insert(box_widget, position);
-    self.setTabLabel(tab, title);
+    self.setTabTitle(tab, title);
     self.tab_view.setSelectedPage(page);
 }
 

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -1083,6 +1083,8 @@ fn gtkTitlebarMenuActivate(
     _: *c.GParamSpec,
     ud: ?*anyopaque,
 ) callconv(.C) void {
+    // debian 12 is stuck on GTK 4.8
+    if (!version.atLeast(4, 10, 0)) return;
     const active = c.gtk_menu_button_get_active(btn) != 0;
     const self = userdataSelf(ud orelse return);
     if (active) {

--- a/src/apprt/gtk/gresource.zig
+++ b/src/apprt/gtk/gresource.zig
@@ -53,7 +53,10 @@ const icons = [_]struct {
     },
 };
 
-pub const ui_files = [_][]const u8{};
+pub const ui_files = [_][]const u8{
+    "menu-window-titlebar_menu",
+    "menu-surface-context_menu",
+};
 pub const blueprint_files = [_][]const u8{};
 
 pub fn main() !void {

--- a/src/apprt/gtk/menu.zig
+++ b/src/apprt/gtk/menu.zig
@@ -1,0 +1,135 @@
+const std = @import("std");
+
+const gtk = @import("gtk");
+const gdk = @import("gdk");
+const gio = @import("gio");
+const gobject = @import("gobject");
+
+const apprt = @import("../../apprt.zig");
+const App = @import("App.zig");
+const Window = @import("Window.zig");
+const Surface = @import("Surface.zig");
+const Builder = @import("Builder.zig");
+
+/// Abstract GTK menus to take advantage of machinery for buildtime/comptime
+/// error checking.
+pub fn Menu(
+    /// GTK apprt type that the menu is "for". Window and Surface are supported
+    /// right now.
+    comptime T: type,
+    /// Name of the menu. Along with the apprt type, this is used to look up the
+    /// builder ui definitions of the menu.
+    comptime menu_name: []const u8,
+    /// Should the popup have a pointer pointing to the location that it's
+    /// attached to.
+    comptime arrow: bool,
+) type {
+    return struct {
+        const Self = @This();
+
+        /// parent apprt object
+        parent: *T,
+
+        /// our widget
+        menu_widget: *gtk.PopoverMenu,
+
+        /// initialize the menu
+        pub fn init(self: *Self, parent: *T) void {
+            const object_type = switch (T) {
+                Window => "window",
+                Surface => "surface",
+                else => unreachable,
+            };
+
+            var builder = Builder.init("menu-" ++ object_type ++ "-" ++ menu_name, .ui);
+            defer builder.deinit();
+
+            const menu_model = builder.getObject(gio.MenuModel, "menu").?;
+
+            const menu_widget = gtk.PopoverMenu.newFromModelFull(menu_model, .{ .nested = true });
+            menu_widget.as(gtk.Popover).setHasArrow(@intFromBool(arrow));
+            _ = gtk.Popover.signals.closed.connect(
+                menu_widget,
+                *Self,
+                gtkRefocusTerm,
+                self,
+                .{},
+            );
+
+            self.* = .{
+                .parent = parent,
+                .menu_widget = menu_widget,
+            };
+        }
+
+        pub fn setParent(self: *const Self, widget: *gtk.Widget) void {
+            self.menu_widget.as(gtk.Widget).setParent(widget);
+        }
+
+        pub fn asWidget(self: *const Self) *gtk.Widget {
+            return self.menu_widget.as(gtk.Widget);
+        }
+
+        pub fn isVisible(self: *const Self) bool {
+            return self.menu_widget.as(gtk.Widget).getVisible() != 0;
+        }
+
+        pub fn setVisible(self: *const Self, visible: bool) void {
+            self.menu_widget.as(gtk.Widget).setVisible(@intFromBool(visible));
+        }
+
+        /// Refresh the menu. Right now that means enabling/disabling the "Copy"
+        /// menu item based on whether there is an active selection or not, but
+        /// that may change in the future.
+        pub fn refresh(self: *const Self) void {
+            const window: *gtk.Window, const has_selection: bool = switch (T) {
+                Window => window: {
+                    const core_surface = self.parent.actionSurface() orelse break :window .{
+                        @ptrCast(@alignCast(self.parent.window)),
+                        false,
+                    };
+                    const has_selection = core_surface.hasSelection();
+                    break :window .{ @ptrCast(@alignCast(self.parent.window)), has_selection };
+                },
+                Surface => surface: {
+                    const window = self.parent.container.window() orelse return;
+                    const has_selection = self.parent.core_surface.hasSelection();
+                    break :surface .{ @ptrCast(@alignCast(window.window)), has_selection };
+                },
+                else => unreachable,
+            };
+
+            const action_map: *gio.ActionMap = gobject.ext.cast(gio.ActionMap, window) orelse return;
+            const action: *gio.SimpleAction = gobject.ext.cast(
+                gio.SimpleAction,
+                action_map.lookupAction("copy") orelse return,
+            ) orelse return;
+            action.setEnabled(@intFromBool(has_selection));
+        }
+
+        /// Pop up the menu at the given coordinates
+        pub fn popupAt(self: *const Self, x: c_int, y: c_int) void {
+            const rect: gdk.Rectangle = .{
+                .f_x = x,
+                .f_y = y,
+                .f_width = 1,
+                .f_height = 1,
+            };
+            const popover = self.menu_widget.as(gtk.Popover);
+            popover.setPointingTo(&rect);
+            self.refresh();
+            popover.popup();
+        }
+
+        /// Refocus tab that lost focus because of the popover menu
+        fn gtkRefocusTerm(_: *gtk.PopoverMenu, self: *Self) callconv(.C) void {
+            const window: *Window = switch (T) {
+                Window => self.parent,
+                Surface => self.parent.container.window() orelse return,
+                else => unreachable,
+            };
+
+            window.focusCurrentTab();
+        }
+    };
+}

--- a/src/apprt/gtk/ui/menu-surface-context_menu.ui
+++ b/src/apprt/gtk/ui/menu-surface-context_menu.ui
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface domain="com.mitchellh.ghostty">
+  <requires lib="gtk" version="4.0"/>
+  <menu id="menu">
+    <section>
+      <item>
+        <attribute name="label" translatable="yes">Copy</attribute>
+        <attribute name="action">win.copy</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">Paste</attribute>
+        <attribute name="action">win.paste</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
+        <attribute name="label" translatable="yes">Clear</attribute>
+        <attribute name="action">win.clear</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">Reset</attribute>
+        <attribute name="action">win.reset</attribute>
+      </item>
+    </section>
+    <section>
+      <submenu>
+        <attribute name="label">Split</attribute>
+        <section>
+          <item>
+            <attribute name="label" translatable="yes">Split Up</attribute>
+            <attribute name="action">win.split-up</attribute>
+          </item>
+          <item>
+            <attribute name="label" translatable="yes">Split Down</attribute>
+            <attribute name="action">win.split-down</attribute>
+          </item>
+          <item>
+            <attribute name="label" translatable="yes">Split Left</attribute>
+            <attribute name="action">win.split-left</attribute>
+          </item>
+          <item>
+            <attribute name="label" translatable="yes">Split Right</attribute>
+            <attribute name="action">win.split-right</attribute>
+          </item>
+        </section>
+      </submenu>
+      <submenu>
+        <attribute name="label">Tab</attribute>
+        <section>
+          <item>
+            <attribute name="label" translatable="yes">New Tab</attribute>
+            <attribute name="action">win.new-tab</attribute>
+          </item>
+          <item>
+            <attribute name="label" translatable="yes">Close Tab</attribute>
+            <attribute name="action">win.close-tab</attribute>
+          </item>
+        </section>
+      </submenu>
+      <submenu>
+        <attribute name="label">Window</attribute>
+        <section>
+          <item>
+            <attribute name="label" translatable="yes">New Window</attribute>
+            <attribute name="action">win.new-window</attribute>
+          </item>
+          <item>
+            <attribute name="label" translatable="yes">Close Window</attribute>
+            <attribute name="action">win.close</attribute>
+          </item>
+        </section>
+      </submenu>
+    </section>
+    <section>
+      <submenu>
+        <attribute name="label">Config</attribute>
+        <section>
+          <item>
+            <attribute name="label" translatable="yes">Open Configuration</attribute>
+            <attribute name="action">app.open-config</attribute>
+          </item>
+          <item>
+            <attribute name="label" translatable="yes">Reload Configuration</attribute>
+            <attribute name="action">app.reload-config</attribute>
+          </item>
+        </section>
+      </submenu>
+    </section>
+  </menu>
+</interface>

--- a/src/apprt/gtk/ui/menu-window-titlebar_menu.ui
+++ b/src/apprt/gtk/ui/menu-window-titlebar_menu.ui
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface domain="com.mitchellh.ghostty">
+  <requires lib="gtk" version="4.0"/>
+  <menu id="menu">
+    <section>
+      <item>
+        <attribute name="label" translatable="yes">Copy</attribute>
+        <attribute name="action">win.copy</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">Paste</attribute>
+        <attribute name="action">win.paste</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
+        <attribute name="label" translatable="yes">New Window</attribute>
+        <attribute name="action">win.new-window</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">Close Window</attribute>
+        <attribute name="action">win.close</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
+        <attribute name="label" translatable="yes">New Tab</attribute>
+        <attribute name="action">win.new-tab</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">Close Tab</attribute>
+        <attribute name="action">win.close-tab</attribute>
+      </item>
+    </section>
+    <section>
+      <submenu>
+        <attribute name="label">Split</attribute>
+        <section>
+          <item>
+            <attribute name="label" translatable="yes">Split Up</attribute>
+            <attribute name="action">win.split-up</attribute>
+          </item>
+          <item>
+            <attribute name="label" translatable="yes">Split Down</attribute>
+            <attribute name="action">win.split-down</attribute>
+          </item>
+          <item>
+            <attribute name="label" translatable="yes">Split Left</attribute>
+            <attribute name="action">win.split-left</attribute>
+          </item>
+          <item>
+            <attribute name="label" translatable="yes">Split Right</attribute>
+            <attribute name="action">win.split-right</attribute>
+          </item>
+        </section>
+      </submenu>
+    </section>
+    <section>
+      <item>
+        <attribute name="label" translatable="yes">Clear</attribute>
+        <attribute name="action">win.clear</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">Reset</attribute>
+        <attribute name="action">win.reset</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
+        <attribute name="label" translatable="yes">Terminal Inspector</attribute>
+        <attribute name="action">win.toggle-inspector</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">Open Configuration</attribute>
+        <attribute name="action">app.open-config</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">Reload Configuration</attribute>
+        <attribute name="action">app.reload-config</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
+        <attribute name="label" translatable="yes">About Ghostty</attribute>
+        <attribute name="action">win.about</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">Quit</attribute>
+        <attribute name="action">app.quit</attribute>
+      </item>
+    </section>
+  </menu>
+</interface>

--- a/src/build/docker/debian/Dockerfile
+++ b/src/build/docker/debian/Dockerfile
@@ -10,6 +10,7 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get -qq update && \
     libonig-dev \
     lintian \
     lsb-release \
+    libxml2-utils \
     pandoc \
     wget \
     # Ghostty Dependencies


### PR DESCRIPTION
Menus (context menus and the window hamburger menu) now use popovers and are defined using GTK builder UI files. This is a bit more "modern" and reduces the amount of code to define menus.