### PR TITLE
Replace the alert dialog for tab title editing with popover

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -1171,8 +1171,15 @@ extension Ghostty {
             menu.addItem(.separator())
             menu.addItem(withTitle: "Reset Terminal", action: #selector(resetTerminal(_:)), keyEquivalent: "")
             menu.addItem(withTitle: "Toggle Terminal Inspector", action: #selector(toggleTerminalInspector(_:)), keyEquivalent: "")
-            menu.addItem(.separator())
-            menu.addItem(withTitle: "Change Title...", action: #selector(changeTitle(_:)), keyEquivalent: "")
+
+            // Only show Change Title menu item if we have a title bar
+            if let window = self.window,
+               !window.styleMask.contains(.fullScreen),
+               let appDelegate = NSApplication.shared.delegate as? AppDelegate,
+               appDelegate.ghostty.config.windowDecorations {
+                menu.addItem(.separator())
+                menu.addItem(withTitle: "Change Title...", action: #selector(changeTitle(_:)), keyEquivalent: "")
+            }
 
             return menu
         }
@@ -1547,6 +1554,11 @@ extension Ghostty.SurfaceView: NSMenuItemValidation {
             let pb = NSPasteboard.ghosttySelection
             guard let str = pb.getOpinionatedStringContents() else { return false }
             return !str.isEmpty
+
+        case #selector(changeTitle):
+            guard let window = self.window,
+                  let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return false }
+            return !window.styleMask.contains(.fullScreen) && appDelegate.ghostty.config.windowDecorations
 
         default:
             return true


### PR DESCRIPTION
Resolves #5768

https://github.com/user-attachments/assets/08d78c3e-5fb3-475e-a5b8-c29ff79ba7e9

During testing, it was found when `window-decoration` is set to `none`, the "Change Title..." in both the context menu and menu bar doesn't have any effect since there's no title bar to display or modify. Perhaps in this case we should hide this feature to avoid confusion.