### PR TITLE
gtk: fix building on Debian 12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -628,11 +628,7 @@ jobs:
           nix develop -c sh -c "cd pkg/${{ matrix.pkg }} ; zig build test"
 
   test-debian-12:
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: ["linux/amd64", "linux/arm64"]
-    name: Test build on Debian 12 ${{ matrix.platform }}
+    name: Test build on Debian 12
     runs-on: namespace-profile-ghostty-sm
     needs: test
     steps:
@@ -651,4 +647,3 @@ jobs:
           context: .
           file: src/build/docker/debian/Dockerfile
           build-args: DISTRO_VERSION=12
-          platform: ${{ matrix.platform }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -647,4 +647,4 @@ jobs:
         with:
           context: .
           file: src/build/docker/debian/Dockerfile
-          build-args: DISTRO_VERSION=12
+          build-args: DISTRO_VERSION=12,ZIG_VERSION=0.13.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -626,3 +626,29 @@ jobs:
       - name: Test ${{ matrix.pkg }} Build
         run: |
           nix develop -c sh -c "cd pkg/${{ matrix.pkg }} ; zig build test"
+
+  test-debian-12:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ["linux/amd64", "linux/arm64"]
+    name: Test build on Debian 12 ${{ matrix.platform }}
+    runs-on: namespace-profile-ghostty-sm
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install and configure Namespace CLI
+        uses: namespacelabs/nscloud-setup@v0
+
+      - name: Configure Namespace powered Buildx
+        uses: namespacelabs/nscloud-setup-buildx-action@v0
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: src/build/docker/debian/Dockerfile
+          build-args: DISTRO_VERSION=12
+          platform: ${{ matrix.platform }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -647,4 +647,6 @@ jobs:
         with:
           context: .
           file: src/build/docker/debian/Dockerfile
-          build-args: DISTRO_VERSION=12,ZIG_VERSION=0.13.0
+          build-args: |
+            DISTRO_VERSION=12
+            ZIG_VERSION=0.13.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
       - alejandra
       - typos
       - test-pkg-linux
+      - test-debian-12
     steps:
       - id: status
         name: Determine status

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -152,7 +152,7 @@ pub fn init(self: *Window, app: *App) !void {
 
     // If we're using an AdwWindow then we can support the tab overview.
     if (self.tab_overview) |tab_overview| {
-        assert(adwaita.versionAtLeast(1, 4, 0));
+        if (!adwaita.versionAtLeast(1, 4, 0)) unreachable;
         const btn = switch (app.config.@"gtk-tabs-location") {
             .top, .bottom => btn: {
                 const btn = c.gtk_toggle_button_new();
@@ -228,6 +228,7 @@ pub fn init(self: *Window, app: *App) !void {
 
     // If we have a tab overview then we can set it on our notebook.
     if (self.tab_overview) |tab_overview| {
+        if (!adwaita.versionAtLeast(1, 4, 0)) unreachable;
         c.adw_tab_overview_set_view(@ptrCast(tab_overview), self.notebook.tab_view);
     }
 
@@ -364,7 +365,7 @@ pub fn syncAppearance(self: *Window, config: *const configpkg.Config) !void {
     // *inside* the tab overview if CSDs are disabled.
     // We do spare the search button, though.
     if (self.tab_overview) |tab_overview| {
-        assert(adwaita.versionAtLeast(1, 4, 0));
+        if (!adwaita.versionAtLeast(1, 4, 0)) unreachable;
         c.adw_tab_overview_set_show_start_title_buttons(
             @ptrCast(tab_overview),
             @intFromBool(csd_enabled),
@@ -509,7 +510,7 @@ pub fn gotoTab(self: *Window, n: usize) bool {
 /// Toggle tab overview (if present)
 pub fn toggleTabOverview(self: *Window) void {
     if (self.tab_overview) |tab_overview_widget| {
-        assert(adwaita.versionAtLeast(1, 4, 0));
+        if (!adwaita.versionAtLeast(1, 4, 0)) unreachable;
         const tab_overview: *c.AdwTabOverview = @ptrCast(@alignCast(tab_overview_widget));
         c.adw_tab_overview_set_open(tab_overview, 1 - c.adw_tab_overview_get_open(tab_overview));
     }

--- a/src/build/docker/debian/Dockerfile
+++ b/src/build/docker/debian/Dockerfile
@@ -1,0 +1,49 @@
+ARG DISTRO_VERSION="12"
+FROM docker.io/library/debian:${DISTRO_VERSION}
+
+# Install Dependencies
+RUN DEBIAN_FRONTEND="noninteractive" apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install \
+    # Build Tools
+    build-essential \
+    libbz2-dev \
+    libonig-dev \
+    lintian \
+    lsb-release \
+    pandoc \
+    wget \
+    # Ghostty Dependencies
+    libadwaita-1-dev \
+    libgtk-4-dev && \
+    # Clean up for better caching
+    rm -rf /var/lib/apt/lists/*
+
+# work around the fact that Debian 12 doesn't ship a pkg-config file for bzip2
+RUN . /etc/os-release; if [ $VERSION_ID -le 12 ]; then ln -s libbz2.so /usr/lib/$(gcc -dumpmachine)/libbzip2.so; fi
+
+# Install zig
+# https://ziglang.org/download/
+ARG ZIG_VERSION="0.13.0"
+RUN wget -q "https://ziglang.org/download/$ZIG_VERSION/zig-linux-$(uname -m)-$ZIG_VERSION.tar.xz" && \
+    tar -xf "zig-linux-$(uname -m)-$ZIG_VERSION.tar.xz" -C /opt && \
+    rm zig-linux-* && \
+    ln -s "/opt/zig-linux-$(uname -m)-$ZIG_VERSION/zig" /usr/local/bin/zig
+
+WORKDIR /src
+
+COPY ./dist/linux /src/dist/linux
+COPY ./images /src/images
+COPY ./include /src/include
+COPY ./pkg /src/pkg
+COPY ./nix /src/nix
+COPY ./vendor /src/vendor
+COPY ./build.zig /src/build.zig
+COPY ./build.zig.zon /src/build.zig.zon
+COPY ./build.zig.zon.txt /src/build.zig.zon.txt
+
+RUN ZIG_GLOBAL_CACHE_DIR=/zig/global-cache ./nix/build-support/fetch-zig-cache.sh
+
+COPY ./src /src/src
+
+RUN zig build -Doptimize=Debug -Dcpu=baseline -Dapp-runtime=gtk --system /zig/global-cache/p
+


### PR DESCRIPTION
`std.debug.assert(x)` _is not_ the same as `if (!x) unreachable` because the function call is not `inline`. Since it's not inline the Zig compiler will try to compile any code that might otherwise be unreachable.

Also, added a CI test that compiles Ghostty in a Debian 12 container to ensure that regressions do not happen.