### PR TITLE
[macOS] feat: Add "quick-terminal" option to "macos-hidden" config

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -403,6 +403,12 @@ class AppDelegate: NSObject,
         reloadDockMenu()
     }
 
+    func applicationDidUpdate(_ notification: Notification) {
+        guard derivedConfig.shouldSwitchBetweenActivationPolicies else { return }
+        // Are we presenting any regular windows ?
+        NSApp.setActivationPolicy(NSApp.visibleRegularWindows.isEmpty ? .accessory : .regular)
+    }
+
     /// Syncs a single menu shortcut for the given action. The action string is the same
     /// action string used for the Ghostty configuration.
     private func syncMenuShortcut(_ config: Ghostty.Config, action: String, menuItem: NSMenuItem?) {
@@ -540,6 +546,9 @@ class AppDelegate: NSObject,
 
         case .always:
             NSApp.setActivationPolicy(.accessory)
+
+        case .quick_terminal:
+            NSApp.setActivationPolicy(NSApp.visibleRegularWindows.isEmpty ? .accessory : .regular)
         }
 
         // If we have configuration errors, we need to show them.
@@ -786,17 +795,20 @@ class AppDelegate: NSObject,
         let initialWindow: Bool
         let shouldQuitAfterLastWindowClosed: Bool
         let quickTerminalPosition: QuickTerminalPosition
+        let shouldSwitchBetweenActivationPolicies: Bool
 
         init() {
             self.initialWindow = true
             self.shouldQuitAfterLastWindowClosed = false
             self.quickTerminalPosition = .top
+            self.shouldSwitchBetweenActivationPolicies = false
         }
 
         init(_ config: Ghostty.Config) {
             self.initialWindow = config.initialWindow
             self.shouldQuitAfterLastWindowClosed = config.shouldQuitAfterLastWindowClosed
             self.quickTerminalPosition = config.quickTerminalPosition
+            self.shouldSwitchBetweenActivationPolicies = config.macosHidden == .quick_terminal
         }
     }
 

--- a/macos/Sources/Features/Terminal/TerminalManager.swift
+++ b/macos/Sources/Features/Terminal/TerminalManager.swift
@@ -17,7 +17,13 @@ class TerminalManager {
     var focusedSurface: Ghostty.SurfaceView? { mainWindow?.controller.focusedSurface }
 
     /// The set of windows we currently have.
-    var windows: [Window] = []
+    private(set) var windows: [Window] = [] {
+        didSet {
+            let userInfo = [Notification.Name.GhosttyWindowsChangedKey: windows.count]
+            NotificationCenter.default
+                .post(name: .ghosttyWindowsChanged, object: nil, userInfo: userInfo)
+        }
+    }
 
     // Keep track of the last point that our window was launched at so that new
     // windows "cascade" over each other and don't just launch directly on top

--- a/macos/Sources/Features/Terminal/TerminalManager.swift
+++ b/macos/Sources/Features/Terminal/TerminalManager.swift
@@ -17,13 +17,7 @@ class TerminalManager {
     var focusedSurface: Ghostty.SurfaceView? { mainWindow?.controller.focusedSurface }
 
     /// The set of windows we currently have.
-    private(set) var windows: [Window] = [] {
-        didSet {
-            let userInfo = [Notification.Name.GhosttyWindowsChangedKey: windows.count]
-            NotificationCenter.default
-                .post(name: .ghosttyWindowsChanged, object: nil, userInfo: userInfo)
-        }
-    }
+    private(set) var windows: [Window] = []
 
     // Keep track of the last point that our window was launched at so that new
     // windows "cascade" over each other and don't just launch directly on top

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -529,6 +529,7 @@ extension Ghostty.Config {
     enum MacHidden : String {
         case never
         case always
+        case quick_terminal = "quick-terminal"
     }
 
     enum ResizeOverlay : String {

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -247,6 +247,10 @@ extension Notification.Name {
 
     /// Close tab
     static let ghosttyCloseTab = Notification.Name("com.mitchellh.ghostty.closeTab")
+
+    /// Managed windows did change.
+    static let ghosttyWindowsChanged = Notification.Name("com.mitchellh.ghostty.windowsChanged")
+    static let GhosttyWindowsChangedKey = ghosttyWindowsChanged.rawValue
 }
 
 // NOTE: I am moving all of these to Notification.Name extensions over time. This

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -247,10 +247,6 @@ extension Notification.Name {
 
     /// Close tab
     static let ghosttyCloseTab = Notification.Name("com.mitchellh.ghostty.closeTab")
-
-    /// Managed windows did change.
-    static let ghosttyWindowsChanged = Notification.Name("com.mitchellh.ghostty.windowsChanged")
-    static let GhosttyWindowsChangedKey = ghosttyWindowsChanged.rawValue
 }
 
 // NOTE: I am moving all of these to Notification.Name extensions over time. This

--- a/macos/Sources/Helpers/NSApplication+Extension.swift
+++ b/macos/Sources/Helpers/NSApplication+Extension.swift
@@ -24,6 +24,21 @@ extension NSApplication {
     }
 }
 
+extension NSApplication {
+    private static let nonRegularWindowsClassNames: [String] = [
+        "NSStatusBarWindow",
+        "_NSPopoverWindow",
+        "TUINSWindow"
+    ]
+
+    /// Windows that are visible and regular (such as terminal & update windows)
+    var visibleRegularWindows: [NSWindow] {
+        NSApp.windows
+            .filter { !Self.nonRegularWindowsClassNames.contains($0.className) }
+            .filter { $0.isVisible }
+    }
+}
+
 extension NSApplication.PresentationOptions.Element: @retroactive Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(rawValue)

--- a/macos/Sources/Helpers/NSApplication+Extension.swift
+++ b/macos/Sources/Helpers/NSApplication+Extension.swift
@@ -31,9 +31,11 @@ extension NSApplication {
         "TUINSWindow"
     ]
 
-    /// Windows that are visible and regular (such as terminal & update windows)
+    /// Windows that are visible and regular (such as terminal & update windows).
+    /// `QuickTerminalWindow` instances are omitted from this collection.
     var visibleRegularWindows: [NSWindow] {
         NSApp.windows
+            .filter { !($0 is QuickTerminalWindow) }
             .filter { !Self.nonRegularWindowsClassNames.contains($0.className) }
             .filter { $0.isVisible }
     }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1989,6 +1989,7 @@ keybind: Keybinds = .{},
 ///
 ///   * `never` - The macOS app is never hidden.
 ///   * `always` - The macOS app is always hidden.
+///   * `quick-terminal` - The macOS app is hidden only if no windows are shown.
 ///
 /// Note: When the macOS application is hidden, keyboard layout changes
 /// will no longer be automatic. This is a limitation of macOS.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -5762,6 +5762,7 @@ pub const MacTitlebarProxyIcon = enum {
 pub const MacHidden = enum {
     never,
     always,
+    @"quick-terminal",
 };
 
 /// See macos-icon


### PR DESCRIPTION
Fixes #5784

I started with a notification for listening to Ghostty terminal windows but then I saw the remark about update windows so I implemented `applicationDidUpdate` which is called whenever a window is added/removed.

Tell me if if you want me to remove the notification for Ghostty terminals!