### PR TITLE
Fix tilde path handling in terminal links

### DIFF
--- a/src/config/url.zig
+++ b/src/config/url.zig
@@ -26,7 +26,7 @@ pub const regex =
     "(?:" ++ url_schemes ++
     \\)(?:
 ++ ipv6_url_pattern ++
-    \\|[\w\-.~:/?#@!$&*+,;=%]+(?:[\(\[]\w*[\)\]])?)+(?<![,.])|(?:\.\.\/|\.\/*|\/)[\w\-.~:\/?#@!$&*+,;=%]+(?:\/[\w\-.~:\/?#@!$&*+,;=%]*)*
+    \\|[\w\-.~:/?#@!$&*+,;=%]+(?:[\(\[]\w*[\)\]])?)+(?<![,.])|(?:~|~/|\.\.\/|\.\/*|\/)[\w\-.~:\/?#@!$&*+,;=%]*(?:\/[\w\-.~:\/?#@!$&*+,;=%]*)*
 ;
 const url_schemes =
     \\https?://|mailto:|ftp://|file:|ssh:|git://|ssh://|tel:|magnet:|ipfs://|ipns://|gemini://|gopher://|news:
@@ -199,6 +199,21 @@ test "url regex" {
         .{
             .input = "[link](/home/user/ghostty.user/example)",
             .expect = "/home/user/ghostty.user/example",
+        },
+        // Test standalone tilde
+        .{
+            .input = "~",
+            .expect = "~",
+        },
+        // Test tilde with path
+        .{
+            .input = "~/Documents/example.txt",
+            .expect = "~/Documents/example.txt",
+        },
+        // Test tilde in text context
+        .{
+            .input = "cd ~ to go home",
+            .expect = "~",
         },
         // IPv6 URL tests - Basic tests
         .{


### PR DESCRIPTION
This PR improves the handling of tilde (`~`) in clickable paths within the terminal, making it more consistent with standard terminal behavior.

Related to issue #1972 and PR #5801

## Changes

### Core Functionality
- Enhance path handling in `Surface.zig` to properly expand tilde paths
- Update URL regex pattern in `config/url.zig` to recognize standalone tilde
- Clean up path processing in `renderer/link.zig` for better maintainability

### Test Coverage
Added comprehensive test cases in `url.zig` to verify:
- Standalone tilde (`~`) detection and expansion
- Tilde with path (`~/path`) handling
- Tilde in text context (`cd ~ to go home`)

## Impact
These changes ensure:
1. Clicking on a standalone `~` opens the home directory
2. Paths starting with `~/` correctly expand to the full home directory path
3. Existing path patterns and URL detection remain unaffected