### PR TITLE
fix: [snap] Don't set GDK_PIXBUF_MODULE_FILE, it causes the icon loader

### DIFF
--- a/snap/local/launcher
+++ b/snap/local/launcher
@@ -33,7 +33,6 @@ export DRIRC_CONFIGDIR=${SNAP}/usr/share/drirc.d
 export VK_LAYER_PATH=${VK_LAYER_PATH:+$VK_LAYER_PATH:}${SNAP}/usr/share/vulkan/implicit_layer.d/:${SNAP}/usr/share/vulkan/explicit_layer.d/
 export XDG_DATA_DIRS=${XDG_DATA_DIRS:+$XDG_DATA_DIRS:}${SNAP}/usr/share
 export XLOCALEDIR="${SNAP}/usr/share/X11/locale"
-export GDK_PIXBUF_MODULE_FILE="$XDG_CACHE_HOME/gdk-pixbuf-loaders.cache"
 export GDK_PIXBUF_MODULEDIR="$SNAP/usr/lib/$ARCH/gdk-pixbuf-2.0/2.10.0/loaders"
 export GTK_PATH="$SNAP/usr/lib/$ARCH/gtk-4.0"
 

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -2277,7 +2277,6 @@ pub fn defaultTermioEnv(self: *Surface) !std.process.EnvMap {
         env.remove("VK_LAYER_PATH");
         env.remove("XLOCALEDIR");
         env.remove("GDK_PIXBUF_MODULEDIR");
-        env.remove("GDK_PIXBUF_MODULE_FILE");
         env.remove("GTK_PATH");
     }
 


### PR DESCRIPTION
This fixes loading the tab-new-symbolic icon in the snap package