### PR TITLE
macOS: Fix new window focus when created from quick terminal

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalManager.swift
+++ b/macos/Sources/Features/Terminal/TerminalManager.swift
@@ -95,11 +95,8 @@ class TerminalManager {
             }
         }
 
-        // If our app isn't active, we make it active. All new_window actions
-        // force our app to be active.
-        if !NSApp.isActive {
-            NSApp.activate(ignoringOtherApps: true)
-        }
+        // All new_window actions force our app to be active.
+        NSApp.activate(ignoringOtherApps: true)
 
         // We're dispatching this async because otherwise the lastCascadePoint doesn't
         // take effect. Our best theory is there is some next-event-loop-tick logic


### PR DESCRIPTION
## Root Cause

The issue has two aspects:

1. The window creation process didn't explicitly force focus on the new window after showing it.
2. More fundamentally, we were relying on `NSApp.isActive` to determine whether to activate the application, which is problematic because:
   - When creating a window from quick terminal, the application is already "active" but this active state is owned by the quick terminal
   - The [`NSApp.isActive` check](https://github.com/ghostty-org/ghostty/blob/4cfe5522db9f073cef9695e9edb1d71f02f2edb1/macos/Sources/Features/Terminal/TerminalManager.swift#L100) doesn't accurately reflect our intent - creating a new window is an explicit user action that should always result in that window gaining focus

## Solution

Removing the `NSApp.isActive` check.

```swift
// Before
if !NSApp.isActive {
    NSApp.activate(ignoringOtherApps: true)
}

// After
NSApp.activate(ignoringOtherApps: true)
```

Fixes #5688

