### PR TITLE
gtk: fix closing window when last tab is closed

### DIFF
--- a/src/apprt/gtk/TabView.zig
+++ b/src/apprt/gtk/TabView.zig
@@ -193,6 +193,10 @@ pub fn addTab(self: *TabView, tab: *Tab, title: [:0]const u8) void {
 }
 
 pub fn closeTab(self: *TabView, tab: *Tab) void {
+    // Save a pointer to the GTK window in case we need it later. It may be
+    // impossible to access later due to how resources are cleaned up.
+    const window: *gtk.Window = @ptrCast(@alignCast(self.window.window));
+
     // closeTab always expects to close unconditionally so we mark this
     // as true so that the close_page call below doesn't request
     // confirmation.
@@ -220,6 +224,8 @@ pub fn closeTab(self: *TabView, tab: *Tab) void {
             const box: *gtk.Box = @ptrCast(@alignCast(tab.box));
             box.as(gobject.Object).unref();
         }
+
+        window.destroy();
     }
 }
 


### PR DESCRIPTION
Causes windows to not close and leave behind a "corpse" if they are not the last window or we are running in single instance mode.
![image](https://github.com/user-attachments/assets/5f6860c2-7807-4ff1-9cad-d32dd4bc348b)


