### PR TITLE
GTK: propagate config updates to the GTK apprt surfaces

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -892,6 +892,9 @@ fn configChange(
 ) void {
     switch (target) {
         .surface => |surface| surface: {
+            surface.rt_surface.updateConfig(new_config) catch |err| {
+                log.err("unable to update surface config: {}", .{err});
+            };
             const window = surface.rt_surface.container.window() orelse break :surface;
             window.updateConfig(new_config) catch |err| {
                 log.warn("error updating config for window err={}", .{err});

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -682,6 +682,12 @@ pub fn deinit(self: *Surface) void {
     self.resize_overlay.deinit();
 }
 
+/// Update our local copy of any configuration that we use.
+pub fn updateConfig(self: *Surface, config: *const configpkg.Config) !void {
+    _ = self;
+    _ = config;
+}
+
 // unref removes the long-held reference to the gl_area and kicks off the
 // deinit/destroy process for this surface.
 pub fn unref(self: *Surface) void {

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -361,7 +361,7 @@ pub fn updateConfig(
     config: *const configpkg.Config,
 ) !void {
     // avoid multiple reconfigs when we have many surfaces contained in this
-    // surface using the integer value of config as a simple marker to know if
+    // window using the integer value of config as a simple marker to know if
     // we've "seen" this particular config before
     const this_config = @intFromPtr(config);
     if (self.last_config == this_config) return;

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -31,6 +31,10 @@ const log = std.log.scoped(.gtk);
 
 app: *App,
 
+/// Used to deduplicate updateConfig invocations
+last_config: usize,
+
+/// Local copy of any configuration
 config: DerivedConfig,
 
 /// Our window
@@ -107,6 +111,7 @@ pub fn init(self: *Window, app: *App) !void {
     // Set up our own state
     self.* = .{
         .app = app,
+        .last_config = @intFromPtr(&app.config),
         .config = DerivedConfig.init(&app.config),
         .window = undefined,
         .headerbar = undefined,
@@ -355,6 +360,13 @@ pub fn updateConfig(
     self: *Window,
     config: *const configpkg.Config,
 ) !void {
+    // avoid multiple reconfigs when we have many surfaces contained in this
+    // surface using the integer value of config as a simple marker to know if
+    // we've "seen" this particular config before
+    const this_config = @intFromPtr(config);
+    if (self.last_config == this_config) return;
+    self.last_config = this_config;
+
     self.config = DerivedConfig.init(config);
 
     // We always resync our appearance whenever the config changes.


### PR DESCRIPTION
This will be needed to the convert GTK apprt surfaces to a DerivedConfig model rather than accessing the global config stored in the app. It's a no-op for now, but I have a PR in the works to update the resize overlay that will take advantage of this.