### PR TITLE
Change default log level to warning.

### DIFF
--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -119,6 +119,12 @@ fn logFn(
     comptime format: []const u8,
     args: anytype,
 ) void {
+
+    // If we're not logging messages at this level, we can just stop now.
+    if (@intFromEnum(level) > @intFromEnum(state.log_level)) {
+        return;
+    }
+
     // Stuff we can do before the lock
     const level_txt = comptime level.asText();
     const prefix = if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
@@ -147,15 +153,9 @@ fn logFn(
         logger.log(std.heap.c_allocator, mac_level, format, args);
     }
 
-    switch (state.logging) {
-        .disabled => {},
-
-        .stderr => {
-            // Always try default to send to stderr
-            const stderr = std.io.getStdErr().writer();
-            nosuspend stderr.print(level_txt ++ prefix ++ format ++ "\n", args) catch return;
-        },
-    }
+    // Always try default to send to stderr
+    const stderr = std.io.getStdErr().writer();
+    nosuspend stderr.print(level_txt ++ prefix ++ format ++ "\n", args) catch return;
 }
 
 pub const std_options: std.Options = .{


### PR DESCRIPTION
Ghostty's default log level is now "warning" unless one of the following
conditions is met...
* A "+action" is being run in which case it's "error".
* There's no app_runtime (lib mode) in which case it's "error".
* The GHOSTTY_LOG environment variable isn't empty in which case it's "info".
* Ghostty was started from a desktop/launcher icon in which case it's "info".
* A debug build is being run in which case it's "debug".

The conditons are evaluated from top to bottom and the last one met wins.
