### PR TITLE
Docs change: Note instead of simple text and Removing two times showing info.

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2060,15 +2060,15 @@ keybind: Keybinds = .{},
 ///  * `plastic` - A glossy, dark plastic frame.
 ///  * `chrome` - A shiny chrome frame.
 ///
-/// This only has an effect when `macos-icon` is set to `custom-style`.
+/// Note: This configuration is required when `macos-icon` is set to
+/// `custom-style`.
+///
 @"macos-icon-frame": MacAppIconFrame = .aluminum,
 
 /// The color of the ghost in the macOS app icon.
 ///
 /// Note: This configuration is required when `macos-icon` is set to
 /// `custom-style`.
-///
-/// This only has an effect when `macos-icon` is set to `custom-style`.
 ///
 /// Specified as either hex (`#RRGGBB` or `RRGGBB`) or a named X11 color.
 @"macos-icon-ghost-color": ?Color = null,
@@ -2082,7 +2082,6 @@ keybind: Keybinds = .{},
 /// Note: This configuration is required when `macos-icon` is set to
 /// `custom-style`.
 ///
-/// This only has an effect when `macos-icon` is set to `custom-style`.
 @"macos-icon-screen-color": ?ColorList = null,
 
 /// Put every surface (tab, split, window) into a dedicated Linux cgroup.


### PR DESCRIPTION
In docs option reference, for macos-icon info. It is showing two times similar thing. And Note looks good instead of just text because it wont work without `custom-style`. So a Big Note is a good highlight.