### PR TITLE
Allow whitespace in ColorList values

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -4338,7 +4338,9 @@ pub const ColorList = struct {
             count += 1;
             if (count > 64) return error.InvalidValue;
 
-            const color = try Color.parseCLI(raw);
+            // Trim whitespace from each color value
+            const trimmed = std.mem.trim(u8, raw, " \t");
+            const color = try Color.parseCLI(trimmed);
             try self.colors.append(alloc, color);
             try self.colors_c.append(alloc, color.cval());
         }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -4409,6 +4409,14 @@ pub const ColorList = struct {
         try p.parseCLI(alloc, "black,white");
         try testing.expectEqual(2, p.colors.items.len);
 
+        // Test whitespace handling
+        try p.parseCLI(alloc, "black, white"); // space after comma
+        try testing.expectEqual(2, p.colors.items.len);
+        try p.parseCLI(alloc, "black , white"); // spaces around comma
+        try testing.expectEqual(2, p.colors.items.len);
+        try p.parseCLI(alloc, " black , white "); // extra spaces at ends
+        try testing.expectEqual(2, p.colors.items.len);
+
         // Error cases
         try testing.expectError(error.ValueRequired, p.parseCLI(alloc, null));
         try testing.expectError(error.InvalidValue, p.parseCLI(alloc, " "));


### PR DESCRIPTION
The following formats are now all valid:

```zig
macos-icon-screen-color = #00FF00,#FF1000,#00FFFF
macos-icon-screen-color = #00FF00, #FF1000, #00FFFF
macos-icon-screen-color = #00FF00 ,#FF1000 ,#00FFFF
macos-icon-screen-color =  #00FF00 , #FF1000  , #00FFFF
```

Fixes #5918
