### PR TITLE
macOS: fix crosshair verticalText and contextMenu pointerStyles

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -360,14 +360,14 @@ extension Ghostty {
                 pointerStyle = .resizeLeftRight
 
             case GHOSTTY_MOUSE_SHAPE_VERTICAL_TEXT:
-                pointerStyle = .default
+                pointerStyle = .verticalText
 
-            // These are not yet supported. We should support them by constructing a
-            // PointerStyle from an NSCursor.
-            case GHOSTTY_MOUSE_SHAPE_CONTEXT_MENU:
-                fallthrough
             case GHOSTTY_MOUSE_SHAPE_CROSSHAIR:
-                fallthrough
+                pointerStyle = .crosshair
+                
+            case GHOSTTY_MOUSE_SHAPE_CONTEXT_MENU:
+                pointerStyle = .contextMenu
+                
             case GHOSTTY_MOUSE_SHAPE_NOT_ALLOWED:
                 pointerStyle = .default
 

--- a/macos/Sources/Helpers/Backport.swift
+++ b/macos/Sources/Helpers/Backport.swift
@@ -61,6 +61,8 @@ enum BackportVisibility {
 
 enum BackportPointerStyle {
     case `default`
+    case contextMenu
+    case crosshair
     case grabIdle
     case grabActive
     case horizontalText
@@ -78,6 +80,8 @@ enum BackportPointerStyle {
     var official: PointerStyle {
         switch self {
         case .default: return .default
+        case .contextMenu: return .image(Image(nsImage: NSCursor.contextualMenu.image), hotSpot: UnitPoint(x: 0, y: 0))  
+        case .crosshair: return .rectSelection
         case .grabIdle: return .grabIdle
         case .grabActive: return .grabActive
         case .horizontalText: return .horizontalText


### PR DESCRIPTION
fixes three mouse pointer styles that weren't working on macOS.