### PR TITLE
Right click to copy support

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1465,7 +1465,7 @@ fn setSelection(self: *Surface, sel_: ?terminal.Selection) !void {
     // If copy on select is false then exit early.
     if (self.config.copy_on_select == .false) return;
 
-    // clear the clipboard. If the selection is set, we only set the clipboard
+    // Clear the clipboard. If the selection is set, we only set the clipboard
     // again if it changed, since setting the clipboard can be an expensive
     // operation.
     const sel = sel_ orelse return;
@@ -3109,8 +3109,10 @@ pub fn mouseButtonCallback(
         // If we already have a selection and the selection contains
         // where we clicked then we don't want to modify the selection.
         if (self.io.terminal.screen.selection) |prev_sel| {
-            try self.copyOnMouseAction(prev_sel, self.config.copy_on_right_click);
-            if (prev_sel.contains(screen, pin)) break :sel;
+            if (prev_sel.contains(screen, pin)) {
+                try self.copyOnMouseAction(prev_sel, self.config.copy_on_right_click);
+                break :sel;
+            }
             // The selection doesn't contain our pin, so we create a new
             // word selection where we clicked.
         }

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1464,7 +1464,7 @@ fn gtkMouseDown(
     // If a right click isn't consumed, mouseButtonCallback selects the hovered
     // word and returns false. We can use this to handle the context menu
     // opening under normal scenarios.
-    if (!consumed and button == .right) {
+    if (!consumed and button == .right and self.app.config.@"copy-on-right-click" == .false) {
         self.showContextMenu(@floatCast(x), @floatCast(y));
     }
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -15,7 +15,7 @@ pub const formatEntry = formatter.formatEntry;
 // Field types
 pub const ClipboardAccess = Config.ClipboardAccess;
 pub const ConfirmCloseSurface = Config.ConfirmCloseSurface;
-pub const CopyOnSelect = Config.CopyOnSelect;
+pub const CopyOnMouseAction = Config.CopyOnMouseAction;
 pub const CustomShaderAnimation = Config.CustomShaderAnimation;
 pub const FontSyntheticStyle = Config.FontSyntheticStyle;
 pub const FontStyle = Config.FontStyle;

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1512,6 +1512,20 @@ keybind: Keybinds = .{},
     else => .false,
 },
 
+/// Whether to copy selected text to the clipboard on right mouse click. `true`
+/// will prefer to copy to the selection clipboard, otherwise it will copy to
+/// the system clipboard.
+///
+/// The value `clipboard` will always copy text to the selection clipboard
+/// as well as the system clipboard.
+///
+/// Middle-click paste will always use the selection clipboard. Middle-click
+/// paste is always enabled even if this is `false`.
+///
+/// The default value is false for all systems.
+///
+/// At present this will only disable the context menu on Linux in the future
+/// this shoul also disable the context menu on macOS
 @"copy-on-right-click": CopyOnMouseAction = .false,
 
 /// The time in milliseconds between clicks to consider a click a repeat

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1525,7 +1525,7 @@ keybind: Keybinds = .{},
 /// The default value is false for all systems.
 ///
 /// At present this will only disable the context menu on Linux in the future
-/// this shoul also disable the context menu on macOS
+/// this should also disable the context menu on macOS
 @"copy-on-right-click": CopyOnMouseAction = .false,
 
 /// The time in milliseconds between clicks to consider a click a repeat

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1513,8 +1513,8 @@ keybind: Keybinds = .{},
 },
 
 @"copy-on-right-click": CopyOnMouseAction = switch (builtin.os.tag) {
-    .linux => .true,
-    .macos => .true,
+    .linux => .false,
+    .macos => .false,
     else => .false,
 },
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1512,11 +1512,7 @@ keybind: Keybinds = .{},
     else => .false,
 },
 
-@"copy-on-right-click": CopyOnMouseAction = switch (builtin.os.tag) {
-    .linux => .false,
-    .macos => .false,
-    else => .false,
-},
+@"copy-on-right-click": CopyOnMouseAction = .false,
 
 /// The time in milliseconds between clicks to consider a click a repeat
 /// (double, triple, etc.) or an entirely new single click. A value of zero will

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1506,7 +1506,13 @@ keybind: Keybinds = .{},
 /// paste is always enabled even if this is `false`.
 ///
 /// The default value is true on Linux and macOS.
-@"copy-on-select": CopyOnSelect = switch (builtin.os.tag) {
+@"copy-on-select": CopyOnMouseAction = switch (builtin.os.tag) {
+    .linux => .true,
+    .macos => .true,
+    else => .false,
+},
+
+@"copy-on-right-click": CopyOnMouseAction = switch (builtin.os.tag) {
     .linux => .true,
     .macos => .true,
     else => .false,
@@ -5754,7 +5760,7 @@ pub const RepeatableLink = struct {
 };
 
 /// Options for copy on select behavior.
-pub const CopyOnSelect = enum {
+pub const CopyOnMouseAction = enum {
     /// Disables copy on select entirely.
     false,
 


### PR DESCRIPTION
Adds right click to copy support to ghostty.

Only gtk context menu is currently being disabled.

Issue [4404](https://github.com/ghostty-org/ghostty/issues/4404)