### PR TITLE
gtk: update ResizeOverlay for zig-gobject

### DIFF
--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -273,8 +273,8 @@ pub const URLWidget = struct {
         );
 
         // Show it
-        c.gtk_overlay_add_overlay(@ptrCast(surface.overlay), left);
-        c.gtk_overlay_add_overlay(@ptrCast(surface.overlay), right);
+        c.gtk_overlay_add_overlay(surface.overlay, left);
+        c.gtk_overlay_add_overlay(surface.overlay, right);
 
         return .{
             .left = left,
@@ -283,8 +283,8 @@ pub const URLWidget = struct {
     }
 
     pub fn deinit(self: *URLWidget, overlay: *c.GtkOverlay) void {
-        c.gtk_overlay_remove_overlay(@ptrCast(overlay), @ptrCast(self.left));
-        c.gtk_overlay_remove_overlay(@ptrCast(overlay), @ptrCast(self.right));
+        c.gtk_overlay_remove_overlay(overlay, @ptrCast(self.left));
+        c.gtk_overlay_remove_overlay(overlay, @ptrCast(self.right));
     }
 
     pub fn setText(self: *const URLWidget, str: [:0]const u8) void {
@@ -336,7 +336,7 @@ gl_area: *c.GtkGLArea,
 url_widget: ?URLWidget = null,
 
 /// The overlay that shows resizing information.
-resize_overlay: ResizeOverlay = .{},
+resize_overlay: ResizeOverlay = undefined,
 
 /// Whether or not the current surface is zoomed in (see `toggle_split_zoom`).
 zoomed_in: bool = false,
@@ -583,7 +583,7 @@ pub fn init(self: *Surface, app: *App, opts: Options) !void {
         .container = .{ .none = {} },
         .overlay = @ptrCast(overlay),
         .gl_area = @ptrCast(gl_area),
-        .resize_overlay = ResizeOverlay.init(self),
+        .resize_overlay = undefined,
         .title_text = null,
         .core_surface = undefined,
         .font_size = font_size,
@@ -599,6 +599,9 @@ pub fn init(self: *Surface, app: *App, opts: Options) !void {
     // initialize the context menu
     self.context_menu.init(self);
     self.context_menu.setParent(@ptrCast(@alignCast(overlay)));
+
+    // initialize the resize overlay
+    self.resize_overlay.init(self, &app.config);
 
     // Set our default mouse shape
     try self.setMouseShape(.text);
@@ -706,8 +709,7 @@ pub fn deinit(self: *Surface) void {
 
 /// Update our local copy of any configuration that we use.
 pub fn updateConfig(self: *Surface, config: *const configpkg.Config) !void {
-    _ = self;
-    _ = config;
+    self.resize_overlay.updateConfig(config);
 }
 
 // unref removes the long-held reference to the gl_area and kicks off the


### PR DESCRIPTION
Also switch to a "DerivedConfig" model so that we aren't referring to a global copy of the config.