### PR TITLE
add macos default config path to manpages

### DIFF
--- a/src/build/mdgen/ghostty_1_footer.md
+++ b/src/build/mdgen/ghostty_1_footer.md
@@ -4,6 +4,10 @@ _\$XDG_CONFIG_HOME/ghostty/config_
 
 : Location of the default configuration file.
 
+_\$HOME/Library/Application Support/com.mitchellh.ghostty/config_
+
+: **On macOS**, location of the default configuration file.
+
 _\$LOCALAPPDATA/ghostty/config_
 
 : **On Windows**, if _\$XDG_CONFIG_HOME_ is not set, _\$LOCALAPPDATA_ will be searched
@@ -22,6 +26,10 @@ for configuration files.
 **XDG_CONFIG_HOME**
 
 : Default location for configuration files.
+
+**$HOME/Library/Application Support/com.mitchellh.ghostty**
+
+: **MACOS ONLY** default location for configuration files.
 
 **LOCALAPPDATA**
 

--- a/src/build/mdgen/ghostty_1_footer.md
+++ b/src/build/mdgen/ghostty_1_footer.md
@@ -30,7 +30,8 @@ for configuration files.
 
 **$HOME/Library/Application Support/com.mitchellh.ghostty**
 
-: **MACOS ONLY** default location for configuration files.
+: **MACOS ONLY** default location for configuration files. This location takes
+precedence over the XDG environment locations.
 
 **LOCALAPPDATA**
 

--- a/src/build/mdgen/ghostty_1_footer.md
+++ b/src/build/mdgen/ghostty_1_footer.md
@@ -6,7 +6,8 @@ _\$XDG_CONFIG_HOME/ghostty/config_
 
 _\$HOME/Library/Application Support/com.mitchellh.ghostty/config_
 
-: **On macOS**, location of the default configuration file.
+: **On macOS**, location of the default configuration file. This location takes
+precedence over the XDG environment locations.
 
 _\$LOCALAPPDATA/ghostty/config_
 

--- a/src/build/mdgen/ghostty_5_footer.md
+++ b/src/build/mdgen/ghostty_5_footer.md
@@ -4,6 +4,10 @@ _\$XDG_CONFIG_HOME/ghostty/config_
 
 : Location of the default configuration file.
 
+_\$HOME/Library/Application Support/com.mitchellh.ghostty/config_
+
+: **On macOS**, location of the default configuration file.
+
 _\$LOCALAPPDATA/ghostty/config_
 
 : **On Windows**, if _\$XDG_CONFIG_HOME_ is not set, _\$LOCALAPPDATA_ will be searched
@@ -14,6 +18,10 @@ for configuration files.
 **XDG_CONFIG_HOME**
 
 : Default location for configuration files.
+
+**$HOME/Library/Application Support/com.mitchellh.ghostty**
+
+: **MACOS ONLY** default location for configuration files.
 
 **LOCALAPPDATA**
 

--- a/src/build/mdgen/ghostty_5_footer.md
+++ b/src/build/mdgen/ghostty_5_footer.md
@@ -6,7 +6,8 @@ _\$XDG_CONFIG_HOME/ghostty/config_
 
 _\$HOME/Library/Application Support/com.mitchellh.ghostty/config_
 
-: **On macOS**, location of the default configuration file.
+: **On macOS**, location of the default configuration file. This location takes
+precedence over the XDG environment locations.
 
 _\$LOCALAPPDATA/ghostty/config_
 

--- a/src/build/mdgen/ghostty_5_footer.md
+++ b/src/build/mdgen/ghostty_5_footer.md
@@ -22,7 +22,8 @@ for configuration files.
 
 **$HOME/Library/Application Support/com.mitchellh.ghostty**
 
-: **MACOS ONLY** default location for configuration files.
+: **MACOS ONLY** default location for configuration files. This location takes
+precedence over the XDG environment locations.
 
 **LOCALAPPDATA**
 

--- a/src/build/mdgen/ghostty_5_header.md
+++ b/src/build/mdgen/ghostty_5_header.md
@@ -11,6 +11,11 @@ is on the roadmap but not yet supported. The configuration file must be placed
 at `$XDG_CONFIG_HOME/ghostty/config`, which defaults to `~/.config/ghostty/config`
 if the [XDG environment is not set](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
 
+**If you are using macOS, the configuration file can also be placed at
+`$HOME/Library/Application Support/com.mitchellh.ghostty/config`.** This is the
+default configuration location for macOS. It will be searched before any of the
+XDG environment locations listed above.
+
 The file format is documented below as an example:
 
     # The syntax is "key = value". The whitespace around the equals doesn't matter.


### PR DESCRIPTION
This should resolve #5938.

I tested this locally using `zig build -D=emit-docs=true` and confirmed that the mdgen process provided the new manpages in `zig-out/share/man/man*`, respectively.

Let me know if this needs any changes, I tried to keep this as similar as possible to the existing manpages (both format and content).