### PR TITLE
gtk: fix the alignment of the context menu

### DIFF
--- a/src/apprt/gtk/menu.zig
+++ b/src/apprt/gtk/menu.zig
@@ -47,6 +47,7 @@ pub fn Menu(
             const menu_model = builder.getObject(gio.MenuModel, "menu").?;
 
             const menu_widget = gtk.PopoverMenu.newFromModelFull(menu_model, .{ .nested = true });
+            menu_widget.as(gtk.Widget).setHalign(.start);
             menu_widget.as(gtk.Popover).setHasArrow(@intFromBool(arrow));
             _ = gtk.Popover.signals.closed.connect(
                 menu_widget,


### PR DESCRIPTION
This aligns the top left of the context menu with the right-click location, rather than the top center.

@tristan957 @mitchellh @pluiedev 