### PR TITLE
terminal: increase CSI max params to 24 to accept Kakoune sequence

### DIFF
--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -932,7 +932,7 @@ pub fn Stream(comptime Handler: type) type {
                 // SGR - Select Graphic Rendition
                 'm' => switch (input.intermediates.len) {
                     0 => if (@hasDecl(T, "setAttribute")) {
-                        // log.info("parse SGR params={any}", .{action.params});
+                        // log.info("parse SGR params={any}", .{input.params});
                         var p: sgr.Parser = .{
                             .params = input.params,
                             .params_sep = input.params_sep,


### PR DESCRIPTION
See #5930

Kakoune sends a real SGR sequence with 17 parameters. Our previous max was 16 so we threw away the entire sequence. This commit increases the max rather than fundamentally addressing limitations.

Practically, it took us this long to witness a real world sequence that exceeded our previous limit. We may need to revisit this in the future, but this is an easy fix for now.

In the future, as the comment states in this diff, we should probably look into a rare slow path where we heap allocate to accept up to some larger size (but still would need a cap to avoid DoS). For now, increasing to 24 slightly increases our memory usage but shouldn't result in any real world issues.