### PR TITLE
fix(macos): prevent performing newTab shortcut on QuickTerminalWindow…

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -442,7 +442,7 @@ class QuickTerminalController: BaseTerminalController {
         }
     }
 
-    func showNoNewTabAlert() {
+    private func showNoNewTabAlert() {
         guard let window else { return }
         let alert = NSAlert()
         alert.messageText = "Cannot Create New Tab"

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -59,6 +59,11 @@ class QuickTerminalController: BaseTerminalController {
             selector: #selector(ghosttyConfigDidChange(_:)),
             name: .ghosttyConfigDidChange,
             object: nil)
+        center.addObserver(
+            self,
+            selector: #selector(onNewTab),
+            name: Ghostty.Notification.ghosttyNewTab,
+            object: nil)
     }
 
     required init?(coder: NSCoder) {
@@ -494,6 +499,14 @@ class QuickTerminalController: BaseTerminalController {
         self.derivedConfig = DerivedConfig(config)
 
         syncAppearance()
+    }
+
+    @objc private func onNewTab(notification: SwiftUI.Notification) {
+        guard let surfaceView = notification.object as? Ghostty.SurfaceView else { return }
+        guard let window = surfaceView.window else { return }
+        guard window.windowController is QuickTerminalController else { return }
+        // Tabs aren't supported with Quick Terminals or derivatives
+        showNoNewTabAlert()
     }
 
     private struct DerivedConfig {

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -437,6 +437,16 @@ class QuickTerminalController: BaseTerminalController {
         }
     }
 
+    func showNoNewTabAlert() {
+        guard let window else { return }
+        let alert = NSAlert()
+        alert.messageText = "Cannot Create New Tab"
+        alert.informativeText = "Tabs aren't supported in the Quick Terminal."
+        alert.addButton(withTitle: "OK")
+        alert.alertStyle = .warning
+        alert.beginSheetModal(for: window)
+    }
+
     // MARK: First Responder
 
     @IBAction override func closeWindow(_ sender: Any) {
@@ -445,13 +455,7 @@ class QuickTerminalController: BaseTerminalController {
     }
 
     @IBAction func newTab(_ sender: Any?) {
-        guard let window else { return }
-        let alert = NSAlert()
-        alert.messageText = "Cannot Create New Tab"
-        alert.informativeText = "Tabs aren't supported in the Quick Terminal."
-        alert.addButton(withTitle: "OK")
-        alert.alertStyle = .warning
-        alert.beginSheetModal(for: window)
+        showNoNewTabAlert()
     }
 
     @IBAction func toggleGhosttyFullScreen(_ sender: Any) {

--- a/macos/Sources/Features/Terminal/TerminalManager.swift
+++ b/macos/Sources/Features/Terminal/TerminalManager.swift
@@ -125,6 +125,12 @@ class TerminalManager {
     }
 
     private func newTab(to parent: NSWindow, withBaseConfig base: Ghostty.SurfaceConfiguration?) {
+        // If the parent window is a QuickTerminalWindow, we early return with an alert.
+        if let controller = parent.windowController as? QuickTerminalController {
+            controller.showNoNewTabAlert()
+            return
+        }
+
         // If our parent is in non-native fullscreen, then new tabs do not work.
         // See: https://github.com/mitchellh/ghostty/issues/392
         if let controller = parent.windowController as? TerminalController,

--- a/macos/Sources/Features/Terminal/TerminalManager.swift
+++ b/macos/Sources/Features/Terminal/TerminalManager.swift
@@ -125,11 +125,8 @@ class TerminalManager {
     }
 
     private func newTab(to parent: NSWindow, withBaseConfig base: Ghostty.SurfaceConfiguration?) {
-        // If the parent window is a QuickTerminalWindow, we early return with an alert.
-        if let controller = parent.windowController as? QuickTerminalController {
-            controller.showNoNewTabAlert()
-            return
-        }
+        // Making sure that we're dealing with a TerminalController
+        guard parent.windowController is TerminalController else { return }
 
         // If our parent is in non-native fullscreen, then new tabs do not work.
         // See: https://github.com/mitchellh/ghostty/issues/392


### PR DESCRIPTION
Fixes #5939 