### PR TITLE
Fix elvish sudo integration and update documentation

### DIFF
--- a/src/shell-integration/README.md
+++ b/src/shell-integration/README.md
@@ -47,7 +47,19 @@ made available for use as modules by way of `use <filename>`.
 Ghostty launches Elvish, passing the environment with `XDG_DATA_DIRS`prepended
 with `$GHOSTTY_RESOURCES_DIR/src/shell-integration`. It contains
 `./elvish/lib/ghostty-integration.elv`. The user can then import it
-by `use ghostty-integration`, which will run the integration routines.
+by `use ghostty-integration` every time after shell startup or
+autostart integration in `$XDG_CONFIG_HOME/elvish/rc.elv`,
+which will run the integration routines.
+
+If you decide to autostart `ghostty-integration` with `rc.elv`, you should
+detect whether the terminal is Ghostty or not. To do this, add this to the end
+of your `rc.elv` file:
+
+```elvish
+if (eq $E:TERM "xterm-ghostty") {
+  use ghostty-integration
+}
+```
 
 The [Elvish](https://elv.sh) shell integration is supported by
 the community and is not officially supported by Ghostty. We distribute

--- a/src/shell-integration/elvish/lib/ghostty-integration.elv
+++ b/src/shell-integration/elvish/lib/ghostty-integration.elv
@@ -92,7 +92,7 @@
     }
 
     if (not $sudoedit) { set args = [ TERMINFO=$E:TERMINFO $@args ] }
-    command sudo $@args
+    (external sudo) $@args
   }
 
   defer {


### PR DESCRIPTION
Elvish integration is broken when running `sudo`, because the function `sudo-with-terminfo` uses `command` command, which is not implemented in Elvish. Changing it to `external` command should fix possible error when bypassing aliases, functions and builtins, like `command` does in Bash.
Discussion about this issue: #5979 

Also I updated documentation about Elvish integration to provide fix when using `use ghostty-integration` outside of Ghostty with `rc.elv`.