### PR TITLE
gtk: work around oversized drag handle for GtkPaned

### DIFF
--- a/src/apprt/gtk/style.css
+++ b/src/apprt/gtk/style.css
@@ -48,4 +48,18 @@ window.ssd.no-border-radius {
 .terminal-window .notebook paned > separator {
   background-color: rgba(250, 250, 250, 1);
   background-clip: content-box;
+
+  /* This works around the oversized drag area for the right side of GtkPaned.
+   *
+   * Upstream Gtk issue:
+   * https://gitlab.gnome.org/GNOME/gtk/-/issues/4484#note_2362002
+   *
+   * Ghostty issue:
+   * https://github.com/ghostty-org/ghostty/issues/3020
+   *
+   * Without this, it's not possible to select the first character on the
+   * right-hand side of a split.
+   */
+  margin: 0;
+  padding: 0;
 }


### PR DESCRIPTION
Improves #3020.

Based on recommendation from upstream Gtk issue:
https://gitlab.gnome.org/GNOME/gtk/-/issues/4484#note_2362002

Without this, it's not possible to select the first character on the right-hand side of a split.