### PR TITLE
gtk: Use wide handle for GtkPaned

### DIFF
--- a/src/apprt/gtk/Split.zig
+++ b/src/apprt/gtk/Split.zig
@@ -111,6 +111,12 @@ pub fn init(
     // Keep a long-lived reference, which we unref in destroy.
     _ = c.g_object_ref(paned);
 
+    // Ensure that the drag handle for split panes never overlaps
+    // pane content. (#3020)
+    // See recommendation in upstream Gtk issue:
+    // https://gitlab.gnome.org/GNOME/gtk/-/issues/4484#note_2362002
+    c.gtk_paned_set_wide_handle(@ptrCast(paned), @intFromBool(true));
+
     // Update all of our containers to point to the right place.
     // The split has to point to where the sibling pointed to because
     // we're inheriting its parent. The sibling points to its location
@@ -370,7 +376,6 @@ fn directionRight(self: *const Split, from: Side) ?*Surface {
         ),
     }
 }
-
 
 fn directionPrevious(self: *const Split, from: Side) ?struct {
     surface: *Surface,

--- a/src/apprt/gtk/style.css
+++ b/src/apprt/gtk/style.css
@@ -41,6 +41,22 @@ window.ssd.no-border-radius {
   border-radius: 0 0;
 }
 
+paned > separator {
+  /* This works around the oversized drag area for the right side of GtkPaned.
+   *
+   * Upstream Gtk issue:
+   * https://gitlab.gnome.org/GNOME/gtk/-/issues/4484#note_2362002
+   *
+   * Ghostty issue:
+   * https://github.com/ghostty-org/ghostty/issues/3020
+   *
+   * Without this, it's not possible to select the first character on the
+   * right-hand side of a split.
+   */
+    margin: 0;
+    padding: 0;
+}
+
 .transparent {
   background-color: transparent;
 }


### PR DESCRIPTION
Improves #3020.

Ensures that the drag handle for the pane separator never overlaps pane content.

See recommendation in upstream Gtk issue:
https://gitlab.gnome.org/GNOME/gtk/-/issues/4484#note_2362002

**Note**: This is a more experimental / invasive alternative to #6000, as it changes the appearance and width of the split pane separator.

However, it is also more functional, as it is no longer possible to accidentally drag the pane handle when you intended to select text.

This should perhaps be a setting, but I'm not sure how to do that.

On reflection, a nicer approach would just be to include a small `6px` margin to the right of the split separator. (This is what WezTerm appears to do.) This maintains the nice appearance of a single split divider, and the usability of keeping the content away from the drag handle.