### PR TITLE
fix(Metal): force a full rebuild in `setFontGrid`

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1019,6 +1019,10 @@ pub fn setFontGrid(self: *Metal, grid: *font.SharedGrid) void {
         // out a better way to handle this.
         log.err("error resizing cells buffer err={}", .{err});
     };
+
+    // Reset our viewport to force a rebuild, since `setScreenSize` only
+    // does this when the number of cells changes, which isn't guaranteed.
+    self.cells_viewport = null;
 }
 
 /// Update the frame data.


### PR DESCRIPTION
This was causing garbled text due to a non-rebuilt rows referencing an outdated atlas when the DPI changed but not the grid dimensions, which could be caused by a variety of things such as the quick terminal slide-in, dpi scaling changes on sleep/wake, moving windows between displays because of closing/opening the laptop lid, etc.

Fixes #2731 