### PR TITLE
gtk: use language-neutral arrows for resize overlays

### DIFF
--- a/src/apprt/gtk/ResizeOverlay.zig
+++ b/src/apprt/gtk/ResizeOverlay.zig
@@ -114,7 +114,7 @@ fn gtkUpdate(ud: ?*anyopaque) callconv(.C) c_int {
     var buf: [32]u8 = undefined;
     const text = std.fmt.bufPrintZ(
         &buf,
-        "{d}c ⨯ {d}r",
+        "{d} ↔ ⨯ {d} ↕",
         .{
             grid_size.columns,
             grid_size.rows,


### PR DESCRIPTION
The meaning of "c" and "r" can be somewhat cryptic to non-native English speakers as it may not be immediately obvious that "c" stands for "columns", and "r" stands for "rows". I propose replacing them with left-right and up-down double-headed arrows that convey the same meaning, but in a truly language-neutral manner.

Related to #2357