### PR TITLE
Fix Terminal Inspector option turns inactive if toggled in the Quick Terminal

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -459,6 +459,11 @@ class QuickTerminalController: BaseTerminalController {
         ghostty.toggleFullscreen(surface: surface)
     }
 
+    @IBAction func toggleTerminalInspector(_ sender: Any?) {
+        guard let surface = focusedSurface?.surface else { return }
+        ghostty.toggleTerminalInspector(surface: surface)
+    }
+
     // MARK: Notifications
 
     @objc private func applicationWillTerminate(_ notification: Notification) {


### PR DESCRIPTION
Fixed: [2475](https://github.com/ghostty-org/ghostty/issues/2475)

The problem actually existed because of the responder chain, as previously pointed out in the report (thanks to @mitchellh).

When we first click on Toggle Terminal Inspector:
* the responder chain goes to _toggleTerminalInspector_ (_SurfaceView_AppKit_ implementation). 
When we click the second toggleTerminalInspector:
* it tries to find the next responder, but the one available is _TerminalController_. (if we remove this method from there, the bug will reproduce even without quick mode)

**Problem**:
TerminalController not available during quick terminal, so there's no way to toggle inspector
**Solution**:
We add toggleTerminalInspector to the _QuickTerminalController_: selector, as we did with other similar methods.