### PR TITLE
gtk: implement quick terminal

### DIFF
--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -31,6 +31,7 @@
   glib,
   glslang,
   gtk4,
+  gtk4-layer-shell,
   gobject-introspection,
   libadwaita,
   blueprint-compiler,
@@ -88,6 +89,7 @@
 
       libadwaita
       gtk4
+      gtk4-layer-shell
       glib
       gobject-introspection
       wayland
@@ -167,6 +169,7 @@ in
         blueprint-compiler
         libadwaita
         gtk4
+        gtk4-layer-shell
         glib
         gobject-introspection
         wayland

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -13,6 +13,7 @@
   libGL,
   glib,
   gtk4,
+  gtk4-layer-shell,
   gobject-introspection,
   libadwaita,
   blueprint-compiler,
@@ -118,6 +119,7 @@ in
         libXrandr
       ]
       ++ lib.optionals enableWayland [
+        gtk4-layer-shell
         wayland
       ];
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -73,6 +73,8 @@ parts:
       - blueprint-compiler
       - libgtk-4-dev
       - libadwaita-1-dev
+      # TODO: Add when the Snap is updated to Ubuntu 24.10+
+      # - gtk4-layer-shell
       - libxml2-utils
       - git
       - patchelf

--- a/src/apprt/gtk/TabView.zig
+++ b/src/apprt/gtk/TabView.zig
@@ -193,10 +193,6 @@ pub fn addTab(self: *TabView, tab: *Tab, title: [:0]const u8) void {
 }
 
 pub fn closeTab(self: *TabView, tab: *Tab) void {
-    // Save a pointer to the GTK window in case we need it later. It may be
-    // impossible to access later due to how resources are cleaned up.
-    const window: *gtk.Window = @ptrCast(@alignCast(self.window.window));
-
     // closeTab always expects to close unconditionally so we mark this
     // as true so that the close_page call below doesn't request
     // confirmation.
@@ -225,7 +221,7 @@ pub fn closeTab(self: *TabView, tab: *Tab) void {
             box.as(gobject.Object).unref();
         }
 
-        window.destroy();
+        self.window.close();
     }
 }
 
@@ -234,7 +230,9 @@ pub fn createWindow(currentWindow: *Window) !*Window {
     const app = currentWindow.app;
 
     // Create a new window
-    return Window.create(alloc, app);
+    const window = try Window.create(alloc, app);
+    window.present();
+    return window;
 }
 
 fn adwPageAttached(_: *adw.TabView, page: *adw.TabPage, _: c_int, self: *TabView) callconv(.C) void {

--- a/src/apprt/gtk/c.zig
+++ b/src/apprt/gtk/c.zig
@@ -15,6 +15,7 @@ pub const c = @cImport({
         @cInclude("X11/XKBlib.h");
     }
     if (build_options.wayland) {
+        if (build_options.layer_shell) @cInclude("gtk4-layer-shell/gtk4-layer-shell.h");
         @cInclude("gdk/wayland/gdkwayland.h");
     }
 

--- a/src/apprt/gtk/winproto.zig
+++ b/src/apprt/gtk/winproto.zig
@@ -59,6 +59,23 @@ pub const App = union(Protocol) {
             inline else => |*v| v.eventMods(device, gtk_mods),
         } orelse key.translateMods(gtk_mods);
     }
+
+    pub fn supportsQuickTerminal(self: App) bool {
+        return switch (self) {
+            inline else => |v| v.supportsQuickTerminal(),
+        };
+    }
+
+    /// Set up necessary support for the quick terminal that must occur
+    /// *before* the window-level winproto object is created.
+    ///
+    /// Only has an effect on the Wayland backend, where the gtk4-layer-shell
+    /// library is initialized.
+    pub fn initQuickTerminal(self: *App, apprt_window: *ApprtWindow) !void {
+        switch (self.*) {
+            inline else => |*v| try v.initQuickTerminal(apprt_window),
+        }
+    }
 };
 
 /// Per-Window state for the underlying windowing protocol.
@@ -113,6 +130,12 @@ pub const Window = union(Protocol) {
     pub fn syncAppearance(self: *Window) !void {
         switch (self.*) {
             inline else => |*v| try v.syncAppearance(),
+        }
+    }
+
+    pub fn syncQuickTerminal(self: *Window) !void {
+        switch (self.*) {
+            inline else => |*v| try v.syncQuickTerminal(),
         }
     }
 

--- a/src/apprt/gtk/winproto/noop.zig
+++ b/src/apprt/gtk/winproto/noop.zig
@@ -29,6 +29,11 @@ pub const App = struct {
     ) ?input.Mods {
         return null;
     }
+
+    pub fn supportsQuickTerminal(_: App) bool {
+        return false;
+    }
+    pub fn initQuickTerminal(_: *App, _: *ApprtWindow) !void {}
 };
 
 pub const Window = struct {
@@ -53,6 +58,8 @@ pub const Window = struct {
     pub fn resizeEvent(_: *Window) !void {}
 
     pub fn syncAppearance(_: *Window) !void {}
+
+    pub fn syncQuickTerminal(_: *Window) !void {}
 
     /// This returns true if CSD is enabled for this window. This
     /// should be the actual present state of the window, not the

--- a/src/apprt/gtk/winproto/x11.zig
+++ b/src/apprt/gtk/winproto/x11.zig
@@ -148,6 +148,12 @@ pub const App = struct {
 
         return mods;
     }
+
+    pub fn supportsQuickTerminal(_: App) bool {
+        return false;
+    }
+
+    pub fn initQuickTerminal(_: *App, _: *ApprtWindow) !void {}
 };
 
 pub const Window = struct {
@@ -221,6 +227,8 @@ pub const Window = struct {
             log.err("failed to synchronize decorations={}", .{err});
         };
     }
+
+    pub fn syncQuickTerminal(_: *Window) !void {}
 
     pub fn clientSideDecorationEnabled(self: Window) bool {
         return switch (self.config.window_decoration) {

--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -34,6 +34,7 @@ font_backend: font.Backend = .freetype,
 /// Feature flags
 x11: bool = false,
 wayland: bool = false,
+layer_shell: bool = false,
 sentry: bool = true,
 wasm_shared: bool = true,
 
@@ -109,7 +110,6 @@ pub fn init(b: *std.Build) !Config {
 
     //---------------------------------------------------------------
     // Comptime Interfaces
-
     config.font_backend = b.option(
         font.Backend,
         "font-backend",
@@ -162,6 +162,12 @@ pub fn init(b: *std.Build) !Config {
         "gtk-x11",
         "Enables linking against X11 libraries when using the GTK rendering backend.",
     ) orelse gtk_targets.x11;
+
+    config.layer_shell = b.option(
+        bool,
+        "gtk-layer-shell",
+        "Enables linking against the gtk4-layer-shell library for quick terminal support. Requires Wayland.",
+    ) orelse gtk_targets.layer_shell;
 
     //---------------------------------------------------------------
     // Ghostty Exe Properties
@@ -392,6 +398,7 @@ pub fn addOptions(self: *const Config, step: *std.Build.Step.Options) !void {
     step.addOption(bool, "flatpak", self.flatpak);
     step.addOption(bool, "x11", self.x11);
     step.addOption(bool, "wayland", self.wayland);
+    step.addOption(bool, "layer_shell", self.layer_shell);
     step.addOption(bool, "sentry", self.sentry);
     step.addOption(apprt.Runtime, "app_runtime", self.app_runtime);
     step.addOption(font.Backend, "font_backend", self.font_backend);

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -460,12 +460,8 @@ pub fn add(
 
                 if (self.config.wayland) {
                     const scanner = Scanner.create(b.dependency("zig_wayland", .{}), .{
-                        // We shouldn't be using getPath but we need to for now
-                        // https://codeberg.org/ifreund/zig-wayland/issues/66
-                        .wayland_xml = b.dependency("wayland", .{})
-                            .path("protocol/wayland.xml"),
-                        .wayland_protocols = b.dependency("wayland_protocols", .{})
-                            .path(""),
+                        .wayland_xml = b.dependency("wayland", .{}).path("protocol/wayland.xml"),
+                        .wayland_protocols = b.dependency("wayland_protocols", .{}).path(""),
                     });
 
                     const wayland = b.createModule(.{ .root_source_file = scanner.result });
@@ -485,6 +481,8 @@ pub fn add(
 
                     step.root_module.addImport("wayland", wayland);
                     step.root_module.addImport("gdk_wayland", gobject.module("gdkwayland4"));
+
+                    if (self.config.layer_shell) step.linkSystemLibrary2("gtk4-layer-shell", dynamic_link_opts);
                     step.linkSystemLibrary2("wayland-client", dynamic_link_opts);
                 }
 

--- a/src/build/docker/debian/Dockerfile
+++ b/src/build/docker/debian/Dockerfile
@@ -18,6 +18,8 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get -qq update && \
     # Ghostty Dependencies
     libadwaita-1-dev \
     libgtk-4-dev && \
+    # TODO: Add when this is updated to Debian 13++
+    # gtk4-layer-shell
     # Clean up for better caching
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Using `gtk4-layer-shell` still seems like the path of least resistance, and to my delight it pretty much Just Works. Hurrah!

This implementation could do with some further polish (e.g. animations, which can be implemented via libadwaita's animations API, and global shortcuts), but as a MVP it works well enough.

It even supports tabs!

Fixes #4624.