### PR TITLE
GTK: do not check for terminal area focus when setting window title

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -653,6 +653,10 @@ pub fn focusCurrentTab(self: *Window) void {
     const surface = tab.focus_child orelse return;
     const gl_area = @as(*c.GtkWidget, @ptrCast(surface.gl_area));
     _ = c.gtk_widget_grab_focus(gl_area);
+
+    if (surface.getTitle()) |title| {
+        self.setTitle(title);
+    }
 }
 
 pub fn onConfigReloaded(self: *Window) void {


### PR DESCRIPTION
Fixes https://github.com/ghostty-org/ghostty/issues/5940
The mentioned problem occurs because when creating a new tab through the tab overview we do not have focus on the terminal area widget, it does not matter if we have a custom title set or not.
I think it is just safe to remove this check from the code. I've tested the change and I don't really see a valid use case in which we would not want to set the window title even if we don't have focus on the terminal area.