### PR TITLE
Add note to configuration that some settings might require a restart

### DIFF
--- a/src/config/config-template
+++ b/src/config/config-template
@@ -14,6 +14,12 @@
 #
 # Additionally, each config option is also explained in detail
 # on Ghostty's website, at https://ghostty.org/docs/config.
+#
+# Ghostty can reload the configuration while running by using the menu
+# options or the bound key (default: Command + Shift + comma on macOS and
+# Control + Shift + comma on other platforms). Not all config options can be
+# reloaded while running; some only apply to new windows and others may require
+# a full restart to take effect.
 
 # Config syntax crash course
 # ==========================


### PR DESCRIPTION
This adds a note in the default config to note that may require a restart.  Also adds a note with the window-padding-x and window-padding-y to indicate a restart will be required to update existing windows.

I ran into this while updating one of the existing values in the default config file. `window-padding-x` The value defaulted to 2 so figured it was safe to assume and just uncomment it and try reloading the config.  

Doing that doesn't work only restarting will make it take effect for the main window ( or of course more tricky opening new windows and killing off the old one )

https://github.com/ghostty-org/ghostty/discussions/6022