### PR TITLE
apprt initial_size is sent whenever the grid size changes

### DIFF
--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -140,9 +140,16 @@ pub const Action = union(Key) {
     /// Sets a size limit (in pixels) for the target terminal.
     size_limit: SizeLimit,
 
-    /// Specifies the initial size of the target terminal. This will be
-    /// sent only during the initialization of a surface. If it is received
-    /// after the surface is initialized it should be ignored.
+    /// Specifies the initial size of the target terminal.
+    ///
+    /// This may be sent once during the initialization of a surface
+    /// (as part of the init call) to indicate the initial size requested
+    /// for the window if it is not maximized or fullscreen.
+    ///
+    /// This may also be sent at any time after the surface is initialized
+    /// to note the new "default size" of the window. This should in general
+    /// be ignored, but may be useful if the apprt wants to support
+    /// a "return to default size" action.
     initial_size: InitialSize,
 
     /// The cell size has changed to the given dimensions in pixels.

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -897,6 +897,13 @@ pub fn getSize(self: *const Surface) !apprt.SurfaceSize {
 }
 
 pub fn setInitialWindowSize(self: *const Surface, width: u32, height: u32) !void {
+    // If we've already become realized once then we ignore this
+    // request. The apprt initial_size action should only modify
+    // the physical size of the window during initialization.
+    // Subsequent actions are only informative in case we want to
+    // implement a "return to default size" action later.
+    if (self.realized) return;
+
     // If we are within a split, do not set the size.
     if (self.container.split() != null) return;
 


### PR DESCRIPTION
As noted in the comments, this is so that apprt's can always know what the default size of a window would be so they can utilize this for "return to default size" actions.

The initial size shouldn't be treated as a "resize" event and was already documented as such. Prior to this commit the docs already noted that the initial size may be sent multiple times but only the first time during initialization should be used as a resize.

Therefore, this shouldn't impact prior behavior. I've verified this with the apprts.