### PR TITLE
apprt/gtk: remove non-ascii characters from resize overlay

### DIFF
--- a/src/apprt/gtk/ResizeOverlay.zig
+++ b/src/apprt/gtk/ResizeOverlay.zig
@@ -114,7 +114,7 @@ fn gtkUpdate(ud: ?*anyopaque) callconv(.C) c_int {
     var buf: [32]u8 = undefined;
     const text = std.fmt.bufPrintZ(
         &buf,
-        "{d} ↔ ⨯ {d} ↕",
+        "{d} x {d}",
         .{
             grid_size.columns,
             grid_size.rows,


### PR DESCRIPTION
It is possible that fonts people are using don't contain these characters as evidenced by users in the Discord.