### PR TITLE
core!: modify scroll behavior

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2432,6 +2432,12 @@ pub fn scrollCallback(
             try self.setSelection(null);
         }
 
+        // We never use a multiplier for precision scrolls.
+        const multiplier: f64 = if (scroll_mods.precision)
+            1.0
+        else
+            self.config.mouse_scroll_multiplier;
+
         // If we're in alternate screen with alternate scroll enabled, then
         // we convert to cursor keys. This only happens if we're:
         // (1) alt screen (2) no explicit mouse reporting and (3) alt
@@ -2459,7 +2465,7 @@ pub fn scrollCallback(
                     };
                 };
                 // We multiple by the scroll multiplier when reporting arrows
-                const multiplied = y.multiplied(self.config.mouse_scroll_multiplier);
+                const multiplied = y.multiplied(multiplier);
                 for (0..multiplied.magnitude()) |_| {
                     self.io.queueMessage(.{ .write_stable = seq }, .locked);
                 }
@@ -2497,7 +2503,7 @@ pub fn scrollCallback(
 
         if (y.delta != 0) {
             // We multiply by the multiplier when scrolling the viewport
-            const multiplied = y.multiplied(self.config.mouse_scroll_multiplier);
+            const multiplied = y.multiplied(multiplier);
             // Modify our viewport, this requires a lock since it affects
             // rendering. We have to switch signs here because our delta
             // is negative down but our viewport is positive down.

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2348,22 +2348,12 @@ pub fn scrollCallback(
     if (self.mouse.hidden) self.showMouse();
 
     const y: ScrollAmount = if (yoff == 0) .{} else y: {
-        // Non-precision scrolling is easy to calculate. We don't use
-        // the given offset at all and instead just treat a positive
-        // as a scroll up and a negative as a scroll down and scroll in
-        // steps.
+        // Non-precision scrolls don't accumulate. We cast that raw yoff to an isize and interpret
+        // it as the number of lines to scroll.
         if (!scroll_mods.precision) {
-            // Calculate our magnitude of scroll. This is constant (not
-            // dependent on yoff).
-            const grid_size = self.size.grid();
-            const grid_rows_f64: f64 = @floatFromInt(grid_size.rows);
-            const y_delta_f64: f64 = @round((grid_rows_f64 * self.config.mouse_scroll_multiplier) / 15.0);
-            const y_delta_usize: usize = @max(1, @as(usize, @intFromFloat(y_delta_f64)));
-
-            // Calculate our direction of scroll based on the sign of yoff.
-            const y_sign: isize = if (yoff >= 0) 1 else -1;
-            const y_delta_isize: isize = y_sign * @as(isize, @intCast(y_delta_usize));
-
+            // Calculate our magnitude of scroll. This is a direct multiple of yoff
+            const y_delta_f64: f64 = @round(yoff * self.config.mouse_scroll_multiplier);
+            const y_delta_isize: isize = @intFromFloat(y_delta_f64);
             break :y .{ .delta = y_delta_isize };
         }
 
@@ -2404,10 +2394,8 @@ pub fn scrollCallback(
     // For detailed comments see the y calculation above.
     const x: ScrollAmount = if (xoff == 0) .{} else x: {
         if (!scroll_mods.precision) {
-            const x_delta_f64: f64 = @round(1 * self.config.mouse_scroll_multiplier);
-            const x_delta_usize: usize = @max(1, @as(usize, @intFromFloat(x_delta_f64)));
-            const x_sign: isize = if (xoff >= 0) 1 else -1;
-            const x_delta_isize: isize = x_sign * @as(isize, @intCast(x_delta_usize));
+            const x_delta_f64: f64 = @round(xoff * self.config.mouse_scroll_multiplier);
+            const x_delta_isize: isize = @intFromFloat(x_delta_f64);
             break :x .{ .delta = x_delta_isize };
         }
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2325,6 +2325,13 @@ const ScrollAmount = struct {
     pub fn magnitude(self: ScrollAmount) usize {
         return @abs(self.delta);
     }
+
+    pub fn multiplied(self: ScrollAmount, multiplier: f64) ScrollAmount {
+        const delta_f64: f64 = @floatFromInt(self.delta);
+        const delta_adjusted: f64 = delta_f64 * multiplier;
+        const delta_isize: isize = @intFromFloat(@round(delta_adjusted));
+        return .{ .delta = delta_isize };
+    }
 };
 
 /// Mouse scroll event. Negative is down, left. Positive is up, right.
@@ -2352,8 +2359,7 @@ pub fn scrollCallback(
         // it as the number of lines to scroll.
         if (!scroll_mods.precision) {
             // Calculate our magnitude of scroll. This is a direct multiple of yoff
-            const y_delta_f64: f64 = @round(yoff * self.config.mouse_scroll_multiplier);
-            const y_delta_isize: isize = @intFromFloat(y_delta_f64);
+            const y_delta_isize: isize = @intFromFloat(@round(yoff));
             break :y .{ .delta = y_delta_isize };
         }
 
@@ -2362,7 +2368,7 @@ pub fn scrollCallback(
         // tiny amount so that we can scroll by a full row when we have enough.
 
         // Adjust our offset by the multiplier
-        const yoff_adjusted: f64 = yoff * self.config.mouse_scroll_multiplier;
+        const yoff_adjusted: f64 = yoff;
 
         // Add our previously saved pending amount to the offset to get the
         // new offset value. The signs of the pending and yoff should match
@@ -2394,13 +2400,11 @@ pub fn scrollCallback(
     // For detailed comments see the y calculation above.
     const x: ScrollAmount = if (xoff == 0) .{} else x: {
         if (!scroll_mods.precision) {
-            const x_delta_f64: f64 = @round(xoff * self.config.mouse_scroll_multiplier);
-            const x_delta_isize: isize = @intFromFloat(x_delta_f64);
+            const x_delta_isize: isize = @intFromFloat(@round(xoff));
             break :x .{ .delta = x_delta_isize };
         }
 
-        const xoff_adjusted: f64 = xoff * self.config.mouse_scroll_multiplier;
-        const poff: f64 = self.mouse.pending_scroll_x + xoff_adjusted;
+        const poff: f64 = self.mouse.pending_scroll_x + xoff;
         const cell_size: f64 = @floatFromInt(self.size.cell.width);
         if (@abs(poff) < cell_size) {
             self.mouse.pending_scroll_x = poff;
@@ -2454,7 +2458,9 @@ pub fn scrollCallback(
                         .down_left => "\x1b[B",
                     };
                 };
-                for (0..y.magnitude()) |_| {
+                // We multiple by the scroll multiplier when reporting arrows
+                const multiplied = y.multiplied(self.config.mouse_scroll_multiplier);
+                for (0..multiplied.magnitude()) |_| {
                     self.io.queueMessage(.{ .write_stable = seq }, .locked);
                 }
             }
@@ -2490,10 +2496,12 @@ pub fn scrollCallback(
         }
 
         if (y.delta != 0) {
+            // We multiply by the multiplier when scrolling the viewport
+            const multiplied = y.multiplied(self.config.mouse_scroll_multiplier);
             // Modify our viewport, this requires a lock since it affects
             // rendering. We have to switch signs here because our delta
             // is negative down but our viewport is positive down.
-            try self.io.terminal.scrollViewport(.{ .delta = y.delta * -1 });
+            try self.io.terminal.scrollViewport(.{ .delta = multiplied.delta * -1 });
         }
     }
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -612,7 +612,7 @@ palette: Palette = .{},
 /// A value of "1" (default) scrolls the default amount. A value of "2" scrolls
 /// double the default amount. A value of "0.5" scrolls half the default amount.
 /// Et cetera.
-@"mouse-scroll-multiplier": f64 = 1.0,
+@"mouse-scroll-multiplier": f64 = 3.0,
 
 /// The opacity level (opposite of transparency) of the background. A value of
 /// 1 is fully opaque and a value of 0 is fully transparent. A value less than 0

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -609,9 +609,7 @@ palette: Palette = .{},
 /// than 0.01 or greater than 10,000 will be clamped to the nearest valid
 /// value.
 ///
-/// A value of "1" (default) scrolls the default amount. A value of "2" scrolls
-/// double the default amount. A value of "0.5" scrolls half the default amount.
-/// Et cetera.
+/// A value of "3" (default) scrolls 3 lines per tick.
 @"mouse-scroll-multiplier": f64 = 3.0,
 
 /// The opacity level (opposite of transparency) of the background. A value of


### PR DESCRIPTION
Modify the scroll behavior to better match other terminals, as well as provide a
better overall experience. Before this PR, ghostty would scale non-precision
scroll events dependent on the screen size. This is in line with kitty, but no
other terminal. Ghostty also was the only terminal to send *more than one* wheel
event.

```
 # 50% Screen height
| terminal   | arrows keys sent| wheels events sent|
|------------|-----------------|-------------------|
| alacritty  |        3        |          1        |
| foot       |        3        |          1        |
| xterm      |        5        |          1        |
| kitty      |        3        |          1        |
| ghostty    |        2        |          2        |

 # 100% Screen height
| terminal   | arrows keys sent| wheels events sent|
|------------|-----------------|-------------------|
| alacritty  |        3        |          1        |
| foot       |        3        |          1        |
| xterm      |        5        |          1        |
| kitty      |        5        |          1        |
| ghostty    |        3        |          3        |
```

This PR modifies Ghostty to behave like foot and alacritty.

For an improved user experience, we only use the configured multiplier for
non-precision scrolls. This multiplier now *only applies* to viewport scrolling
and alternate scroll mode. The default value has been updated to 3.0.

GTK also now supports precision scrolling.
