### PR TITLE
gtk: implement sensitive content reveal on paste confirmation

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -502,12 +502,12 @@ pub fn performAction(
         .quit_timer => self.quitTimer(value),
         .prompt_title => try self.promptTitle(target),
         .toggle_quick_terminal => return try self.toggleQuickTerminal(),
+        .secure_input => self.setSecureInput(target, value),
 
         // Unimplemented
         .close_all_windows,
         .toggle_visibility,
         .cell_size,
-        .secure_input,
         .key_sequence,
         .render_inspector,
         .renderer_health,
@@ -1407,6 +1407,15 @@ fn newWindow(self: *App, parent_: ?*CoreSurface) !void {
 
     // Show the new window
     window.present();
+}
+
+fn setSecureInput(_: *App, target: apprt.Target, value: apprt.action.SecureInput) void {
+    switch (target) {
+        .app => {},
+        .surface => |surface| {
+            surface.rt_surface.setSecureInput(value);
+        },
+    }
 }
 
 fn quit(self: *App) void {

--- a/src/apprt/gtk/ClipboardConfirmationWindow.zig
+++ b/src/apprt/gtk/ClipboardConfirmationWindow.zig
@@ -27,8 +27,8 @@ core_surface: *CoreSurface,
 pending_req: apprt.ClipboardRequest,
 text_view: *gtk.TextView,
 text_view_scroll: *gtk.ScrolledWindow,
-reveal_button_widget: *gtk.Widget,
-hide_button_widget: *gtk.Widget,
+reveal_button: *gtk.Button,
+hide_button: *gtk.Button,
 
 pub fn create(
     app: *App,
@@ -101,8 +101,8 @@ fn init(
         .pending_req = request,
         .text_view = text_view,
         .text_view_scroll = text_view_scroll,
-        .reveal_button_widget = gobject.ext.cast(gtk.Widget, reveal_button).?,
-        .hide_button_widget = gobject.ext.cast(gtk.Widget, hide_button).?,
+        .reveal_button = reveal_button,
+        .hide_button = hide_button,
     };
 
     const buffer = gtk.TextBuffer.new(null);
@@ -111,10 +111,10 @@ fn init(
     text_view.setBuffer(buffer);
 
     if (is_secure_input) {
-        gobject.ext.as(gtk.Widget, text_view_scroll).setSensitive(@intFromBool(false));
-        gobject.ext.as(gtk.Widget, self.text_view).addCssClass("blurred");
+        text_view_scroll.as(gtk.Widget).setSensitive(@intFromBool(false));
+        self.text_view.as(gtk.Widget).addCssClass("blurred");
 
-        self.reveal_button_widget.setVisible(@intFromBool(true));
+        self.reveal_button.as(gtk.Widget).setVisible(@intFromBool(true));
 
         _ = gtk.Button.signals.clicked.connect(
             reveal_button,
@@ -189,17 +189,17 @@ fn gtkResponse(_: *DialogType, response: [*:0]u8, self: *ClipboardConfirmation) 
 }
 
 fn gtkRevealButtonClicked(_: *gtk.Button, self: *ClipboardConfirmation) callconv(.C) void {
-    gobject.ext.as(gtk.Widget, self.text_view_scroll).setSensitive(@intFromBool(true));
-    gobject.ext.as(gtk.Widget, self.text_view).removeCssClass("blurred");
+    self.text_view_scroll.as(gtk.Widget).setSensitive(@intFromBool(true));
+    self.text_view.as(gtk.Widget).removeCssClass("blurred");
 
-    self.hide_button_widget.setVisible(@intFromBool(true));
-    self.reveal_button_widget.setVisible(@intFromBool(false));
+    self.hide_button.as(gtk.Widget).setVisible(@intFromBool(true));
+    self.reveal_button.as(gtk.Widget).setVisible(@intFromBool(false));
 }
 
 fn gtkHideButtonClicked(_: *gtk.Button, self: *ClipboardConfirmation) callconv(.C) void {
-    gobject.ext.as(gtk.Widget, self.text_view_scroll).setSensitive(@intFromBool(false));
-    gobject.ext.as(gtk.Widget, self.text_view).addCssClass("blurred");
+    self.text_view_scroll.as(gtk.Widget).setSensitive(@intFromBool(false));
+    self.text_view.as(gtk.Widget).addCssClass("blurred");
 
-    self.hide_button_widget.setVisible(@intFromBool(false));
-    self.reveal_button_widget.setVisible(@intFromBool(true));
+    self.hide_button.as(gtk.Widget).setVisible(@intFromBool(false));
+    self.reveal_button.as(gtk.Widget).setVisible(@intFromBool(true));
 }

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1209,7 +1209,13 @@ fn gtkClipboardRead(
         error.UnauthorizedPaste,
         => {
             // Create a dialog and ask the user if they want to paste anyway.
-            ClipboardConfirmationWindow.create(self.app, str, &self.core_surface, req.state, self.is_secure_input) catch |window_err| {
+            ClipboardConfirmationWindow.create(
+                self.app,
+                str,
+                &self.core_surface,
+                req.state,
+                self.is_secure_input,
+            ) catch |window_err| {
                 log.err("failed to create clipboard confirmation window err={}", .{window_err});
             };
             return;
@@ -2224,7 +2230,13 @@ fn doPaste(self: *Surface, data: [:0]const u8) void {
         error.UnsafePaste,
         error.UnauthorizedPaste,
         => {
-            ClipboardConfirmationWindow.create(self.app, data, &self.core_surface, .paste, self.is_secure_input) catch |window_err| {
+            ClipboardConfirmationWindow.create(
+                self.app,
+                data,
+                &self.core_surface,
+                .paste,
+                self.is_secure_input,
+            ) catch |window_err| {
                 log.err("failed to create clipboard confirmation window err={}", .{window_err});
             };
         },

--- a/src/apprt/gtk/style.css
+++ b/src/apprt/gtk/style.css
@@ -63,3 +63,13 @@ window.ssd.no-border-radius {
   margin: 0;
   padding: 0;
 }
+
+.clipboard-content-view {
+  filter: blur(0px);
+  transition: filter 0.3s ease;
+}
+
+.clipboard-content-view.blurred {
+  filter: blur(5px);
+  transition: filter 0.3s ease;
+}

--- a/src/apprt/gtk/ui/1.2/ccw-osc-52-read.blp
+++ b/src/apprt/gtk/ui/1.2/ccw-osc-52-read.blp
@@ -14,18 +14,58 @@ Adw.MessageDialog clipboard_confirmation_window {
   default-response: "cancel";
   close-response: "cancel";
 
-  extra-child: ScrolledWindow {
-    width-request: 500;
-    height-request: 250;
+  extra-child: Overlay {
+    styles [
+      "osd"
+    ]
 
-    TextView text_view {
-      cursor-visible: false;
-      editable: false;
-      monospace: true;
-      top-margin: 8;
-      left-margin: 8;
-      bottom-margin: 8;
-      right-margin: 8;
+    ScrolledWindow text_view_scroll {
+      width-request: 500;
+      height-request: 250;
+
+      TextView text_view {
+        cursor-visible: false;
+        editable: false;
+        monospace: true;
+        top-margin: 8;
+        left-margin: 8;
+        bottom-margin: 8;
+        right-margin: 8;
+
+        styles [
+          "clipboard-content-view"
+        ]
+      }
+    }
+
+    [overlay]
+    Button reveal_button {
+      visible: false;
+      halign: end;
+      valign: start;
+      margin-end: 12;
+      margin-top: 12;
+
+      Image {
+        icon-name: "view-reveal-symbolic";
+      }
+    }
+
+    [overlay]
+    Button hide_button {
+      visible: false;
+      halign: end;
+      valign: start;
+      margin-end: 12;
+      margin-top: 12;
+
+      styles [
+        "opaque"
+      ]
+
+      Image {
+        icon-name: "view-conceal-symbolic";
+      }
     }
   };
 }

--- a/src/apprt/gtk/ui/1.2/ccw-osc-52-read.ui
+++ b/src/apprt/gtk/ui/1.2/ccw-osc-52-read.ui
@@ -7,27 +7,68 @@ corresponding .blp file and regenerate this file with blueprint-compiler.
 <interface domain="com.mitchellh.ghostty">
   <requires lib="gtk" version="4.0"/>
   <object class="AdwMessageDialog" id="clipboard_confirmation_window">
-    <property name="heading" translatable="yes">Authorize Clipboard Access</property>
-    <property name="body" translatable="yes">An application is attempting to read from the clipboard. The current clipboard contents are shown below.</property>
+    <property name="heading" translatable="true">Authorize Clipboard Access</property>
+    <property name="body" translatable="true">An application is attempting to read from the clipboard. The current clipboard contents are shown below.</property>
     <responses>
-      <response id="cancel" translatable="yes" appearance="suggested">Deny</response>
-      <response id="ok" translatable="yes" appearance="destructive">Allow</response>
+      <response id="cancel" translatable="true" appearance="suggested">Deny</response>
+      <response id="ok" translatable="true" appearance="destructive">Allow</response>
     </responses>
     <property name="default-response">cancel</property>
     <property name="close-response">cancel</property>
     <property name="extra-child">
-      <object class="GtkScrolledWindow">
-        <property name="width-request">500</property>
-        <property name="height-request">250</property>
+      <object class="GtkOverlay">
+        <style>
+          <class name="osd"/>
+        </style>
         <child>
-          <object class="GtkTextView" id="text_view">
-            <property name="cursor-visible">false</property>
-            <property name="editable">false</property>
-            <property name="monospace">true</property>
-            <property name="top-margin">8</property>
-            <property name="left-margin">8</property>
-            <property name="bottom-margin">8</property>
-            <property name="right-margin">8</property>
+          <object class="GtkScrolledWindow" id="text_view_scroll">
+            <property name="width-request">500</property>
+            <property name="height-request">250</property>
+            <child>
+              <object class="GtkTextView" id="text_view">
+                <property name="cursor-visible">false</property>
+                <property name="editable">false</property>
+                <property name="monospace">true</property>
+                <property name="top-margin">8</property>
+                <property name="left-margin">8</property>
+                <property name="bottom-margin">8</property>
+                <property name="right-margin">8</property>
+                <style>
+                  <class name="clipboard-content-view"/>
+                </style>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child type="overlay">
+          <object class="GtkButton" id="reveal_button">
+            <property name="visible">false</property>
+            <property name="halign">2</property>
+            <property name="valign">1</property>
+            <property name="margin-end">12</property>
+            <property name="margin-top">12</property>
+            <child>
+              <object class="GtkImage">
+                <property name="icon-name">view-reveal-symbolic</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child type="overlay">
+          <object class="GtkButton" id="hide_button">
+            <property name="visible">false</property>
+            <property name="halign">2</property>
+            <property name="valign">1</property>
+            <property name="margin-end">12</property>
+            <property name="margin-top">12</property>
+            <style>
+              <class name="opaque"/>
+            </style>
+            <child>
+              <object class="GtkImage">
+                <property name="icon-name">view-conceal-symbolic</property>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/src/apprt/gtk/ui/1.2/ccw-osc-52-write.blp
+++ b/src/apprt/gtk/ui/1.2/ccw-osc-52-write.blp
@@ -14,18 +14,58 @@ Adw.MessageDialog clipboard_confirmation_window {
   default-response: "cancel";
   close-response: "cancel";
 
-  extra-child: ScrolledWindow {
-    width-request: 500;
-    height-request: 250;
+  extra-child: Overlay {
+    styles [
+      "osd"
+    ]
 
-    TextView text_view {
-      cursor-visible: false;
-      editable: false;
-      monospace: true;
-      top-margin: 8;
-      left-margin: 8;
-      bottom-margin: 8;
-      right-margin: 8;
+    ScrolledWindow text_view_scroll {
+      width-request: 500;
+      height-request: 250;
+
+      TextView text_view {
+        cursor-visible: false;
+        editable: false;
+        monospace: true;
+        top-margin: 8;
+        left-margin: 8;
+        bottom-margin: 8;
+        right-margin: 8;
+
+        styles [
+          "clipboard-content-view"
+        ]
+      }
+    }
+
+    [overlay]
+    Button reveal_button {
+      visible: false;
+      halign: end;
+      valign: start;
+      margin-end: 12;
+      margin-top: 12;
+
+      Image {
+        icon-name: "view-reveal-symbolic";
+      }
+    }
+
+    [overlay]
+    Button hide_button {
+      visible: false;
+      halign: end;
+      valign: start;
+      margin-end: 12;
+      margin-top: 12;
+
+      styles [
+        "opaque"
+      ]
+
+      Image {
+        icon-name: "view-conceal-symbolic";
+      }
     }
   };
 }

--- a/src/apprt/gtk/ui/1.2/ccw-osc-52-write.ui
+++ b/src/apprt/gtk/ui/1.2/ccw-osc-52-write.ui
@@ -7,27 +7,68 @@ corresponding .blp file and regenerate this file with blueprint-compiler.
 <interface domain="com.mitchellh.ghostty">
   <requires lib="gtk" version="4.0"/>
   <object class="AdwMessageDialog" id="clipboard_confirmation_window">
-    <property name="heading" translatable="yes">Authorize Clipboard Access</property>
-    <property name="body" translatable="yes">An application is attempting to write to the clipboard. The current clipboard contents are shown below.</property>
+    <property name="heading" translatable="true">Authorize Clipboard Access</property>
+    <property name="body" translatable="true">An application is attempting to write to the clipboard. The current clipboard contents are shown below.</property>
     <responses>
-      <response id="cancel" translatable="yes" appearance="suggested">Deny</response>
-      <response id="ok" translatable="yes" appearance="destructive">Allow</response>
+      <response id="cancel" translatable="true" appearance="suggested">Deny</response>
+      <response id="ok" translatable="true" appearance="destructive">Allow</response>
     </responses>
     <property name="default-response">cancel</property>
     <property name="close-response">cancel</property>
     <property name="extra-child">
-      <object class="GtkScrolledWindow">
-        <property name="width-request">500</property>
-        <property name="height-request">250</property>
+      <object class="GtkOverlay">
+        <style>
+          <class name="osd"/>
+        </style>
         <child>
-          <object class="GtkTextView" id="text_view">
-            <property name="cursor-visible">false</property>
-            <property name="editable">false</property>
-            <property name="monospace">true</property>
-            <property name="top-margin">8</property>
-            <property name="left-margin">8</property>
-            <property name="bottom-margin">8</property>
-            <property name="right-margin">8</property>
+          <object class="GtkScrolledWindow" id="text_view_scroll">
+            <property name="width-request">500</property>
+            <property name="height-request">250</property>
+            <child>
+              <object class="GtkTextView" id="text_view">
+                <property name="cursor-visible">false</property>
+                <property name="editable">false</property>
+                <property name="monospace">true</property>
+                <property name="top-margin">8</property>
+                <property name="left-margin">8</property>
+                <property name="bottom-margin">8</property>
+                <property name="right-margin">8</property>
+                <style>
+                  <class name="clipboard-content-view"/>
+                </style>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child type="overlay">
+          <object class="GtkButton" id="reveal_button">
+            <property name="visible">false</property>
+            <property name="halign">2</property>
+            <property name="valign">1</property>
+            <property name="margin-end">12</property>
+            <property name="margin-top">12</property>
+            <child>
+              <object class="GtkImage">
+                <property name="icon-name">view-reveal-symbolic</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child type="overlay">
+          <object class="GtkButton" id="hide_button">
+            <property name="visible">false</property>
+            <property name="halign">2</property>
+            <property name="valign">1</property>
+            <property name="margin-end">12</property>
+            <property name="margin-top">12</property>
+            <style>
+              <class name="opaque"/>
+            </style>
+            <child>
+              <object class="GtkImage">
+                <property name="icon-name">view-conceal-symbolic</property>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/src/apprt/gtk/ui/1.2/ccw-paste.blp
+++ b/src/apprt/gtk/ui/1.2/ccw-paste.blp
@@ -14,18 +14,58 @@ Adw.MessageDialog clipboard_confirmation_window {
   default-response: "cancel";
   close-response: "cancel";
 
-  extra-child: ScrolledWindow {
-    width-request: 500;
-    height-request: 250;
+  extra-child: Overlay {
+    styles [
+      "osd"
+    ]
 
-    TextView text_view {
-      cursor-visible: false;
-      editable: false;
-      monospace: true;
-      top-margin: 8;
-      left-margin: 8;
-      bottom-margin: 8;
-      right-margin: 8;
+    ScrolledWindow text_view_scroll {
+      width-request: 500;
+      height-request: 250;
+
+      TextView text_view {
+        cursor-visible: false;
+        editable: false;
+        monospace: true;
+        top-margin: 8;
+        left-margin: 8;
+        bottom-margin: 8;
+        right-margin: 8;
+
+        styles [
+          "clipboard-content-view"
+        ]
+      }
+    }
+
+    [overlay]
+    Button reveal_button {
+      visible: false;
+      halign: end;
+      valign: start;
+      margin-end: 12;
+      margin-top: 12;
+
+      Image {
+        icon-name: "view-reveal-symbolic";
+      }
+    }
+
+    [overlay]
+    Button hide_button {
+      visible: false;
+      halign: end;
+      valign: start;
+      margin-end: 12;
+      margin-top: 12;
+
+      styles [
+        "opaque"
+      ]
+
+      Image {
+        icon-name: "view-conceal-symbolic";
+      }
     }
   };
 }

--- a/src/apprt/gtk/ui/1.2/ccw-paste.ui
+++ b/src/apprt/gtk/ui/1.2/ccw-paste.ui
@@ -7,27 +7,68 @@ corresponding .blp file and regenerate this file with blueprint-compiler.
 <interface domain="com.mitchellh.ghostty">
   <requires lib="gtk" version="4.0"/>
   <object class="AdwMessageDialog" id="clipboard_confirmation_window">
-    <property name="heading" translatable="yes">Warning: Potentially Unsafe Paste</property>
-    <property name="body" translatable="yes">Pasting this text into the terminal may be dangerous as it looks like some commands may be executed.</property>
+    <property name="heading" translatable="true">Warning: Potentially Unsafe Paste</property>
+    <property name="body" translatable="true">Pasting this text into the terminal may be dangerous as it looks like some commands may be executed.</property>
     <responses>
-      <response id="cancel" translatable="yes" appearance="suggested">Cancel</response>
-      <response id="ok" translatable="yes" appearance="destructive">Paste</response>
+      <response id="cancel" translatable="true" appearance="suggested">Cancel</response>
+      <response id="ok" translatable="true" appearance="destructive">Paste</response>
     </responses>
     <property name="default-response">cancel</property>
     <property name="close-response">cancel</property>
     <property name="extra-child">
-      <object class="GtkScrolledWindow">
-        <property name="width-request">500</property>
-        <property name="height-request">250</property>
+      <object class="GtkOverlay">
+        <style>
+          <class name="osd"/>
+        </style>
         <child>
-          <object class="GtkTextView" id="text_view">
-            <property name="cursor-visible">false</property>
-            <property name="editable">false</property>
-            <property name="monospace">true</property>
-            <property name="top-margin">8</property>
-            <property name="left-margin">8</property>
-            <property name="bottom-margin">8</property>
-            <property name="right-margin">8</property>
+          <object class="GtkScrolledWindow" id="text_view_scroll">
+            <property name="width-request">500</property>
+            <property name="height-request">250</property>
+            <child>
+              <object class="GtkTextView" id="text_view">
+                <property name="cursor-visible">false</property>
+                <property name="editable">false</property>
+                <property name="monospace">true</property>
+                <property name="top-margin">8</property>
+                <property name="left-margin">8</property>
+                <property name="bottom-margin">8</property>
+                <property name="right-margin">8</property>
+                <style>
+                  <class name="clipboard-content-view"/>
+                </style>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child type="overlay">
+          <object class="GtkButton" id="reveal_button">
+            <property name="visible">false</property>
+            <property name="halign">2</property>
+            <property name="valign">1</property>
+            <property name="margin-end">12</property>
+            <property name="margin-top">12</property>
+            <child>
+              <object class="GtkImage">
+                <property name="icon-name">view-reveal-symbolic</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child type="overlay">
+          <object class="GtkButton" id="hide_button">
+            <property name="visible">false</property>
+            <property name="halign">2</property>
+            <property name="valign">1</property>
+            <property name="margin-end">12</property>
+            <property name="margin-top">12</property>
+            <style>
+              <class name="opaque"/>
+            </style>
+            <child>
+              <object class="GtkImage">
+                <property name="icon-name">view-conceal-symbolic</property>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp
+++ b/src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp
@@ -15,6 +15,10 @@ Adw.AlertDialog clipboard_confirmation_window {
   close-response: "cancel";
 
   extra-child: Overlay {
+    styles [
+      "osd"
+    ]
+
     ScrolledWindow text_view_scroll {
       width-request: 500;
       height-request: 250;
@@ -42,10 +46,6 @@ Adw.AlertDialog clipboard_confirmation_window {
       margin-end: 12;
       margin-top: 12;
 
-      styles [
-        "destructive-action",
-      ]
-
       Image {
         icon-name: "view-reveal-symbolic";
       }
@@ -60,7 +60,7 @@ Adw.AlertDialog clipboard_confirmation_window {
       margin-top: 12;
 
       styles [
-        "suggested-action",
+        "opaque"
       ]
 
       Image {

--- a/src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp
+++ b/src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp
@@ -14,28 +14,7 @@ Adw.AlertDialog clipboard_confirmation_window {
   default-response: "cancel";
   close-response: "cancel";
 
-  extra-child: Box {
-    orientation: vertical;
-    spacing: 12;
-
-    Button reveal_button {
-      visible: false;
-
-      styles [
-        "destructive-action"
-      ]
-
-      Adw.ButtonContent {
-        label: _("Reveal Potentially Sensitive Content");
-        icon-name: "dialog-warning-symbolic";
-      }
-    }
-
-    Button hide_button {
-      visible: false;
-      label: _("Hide Potentially Sensitive Content");
-    }
-
+  extra-child: Overlay {
     ScrolledWindow text_view_scroll {
       width-request: 500;
       height-request: 250;
@@ -52,6 +31,40 @@ Adw.AlertDialog clipboard_confirmation_window {
         styles [
           "clipboard-content-view"
         ]
+      }
+    }
+
+    [overlay]
+    Button reveal_button {
+      visible: false;
+      halign: end;
+      valign: start;
+      margin-end: 12;
+      margin-top: 12;
+
+      styles [
+        "destructive-action",
+      ]
+
+      Image {
+        icon-name: "view-reveal-symbolic";
+      }
+    }
+
+    [overlay]
+    Button hide_button {
+      visible: false;
+      halign: end;
+      valign: start;
+      margin-end: 12;
+      margin-top: 12;
+
+      styles [
+        "suggested-action",
+      ]
+
+      Image {
+        icon-name: "view-conceal-symbolic";
       }
     }
   };

--- a/src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp
+++ b/src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp
@@ -36,23 +36,22 @@ Adw.AlertDialog clipboard_confirmation_window {
       label: _("Hide Potentially Sensitive Content");
     }
 
-    Revealer content_revealer {
-      reveal-child: true;
-      transition-type: slide_down;
+    ScrolledWindow text_view_scroll {
+      width-request: 500;
+      height-request: 250;
 
-      ScrolledWindow {
-        width-request: 500;
-        height-request: 250;
+      TextView text_view {
+        cursor-visible: false;
+        editable: false;
+        monospace: true;
+        top-margin: 8;
+        left-margin: 8;
+        bottom-margin: 8;
+        right-margin: 8;
 
-        TextView text_view {
-          cursor-visible: false;
-          editable: false;
-          monospace: true;
-          top-margin: 8;
-          left-margin: 8;
-          bottom-margin: 8;
-          right-margin: 8;
-        }
+        styles [
+          "clipboard-content-view"
+        ]
       }
     }
   };

--- a/src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp
+++ b/src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp
@@ -14,18 +14,46 @@ Adw.AlertDialog clipboard_confirmation_window {
   default-response: "cancel";
   close-response: "cancel";
 
-  extra-child: ScrolledWindow {
-    width-request: 500;
-    height-request: 250;
+  extra-child: Box {
+    orientation: vertical;
+    spacing: 12;
 
-    TextView text_view {
-      cursor-visible: false;
-      editable: false;
-      monospace: true;
-      top-margin: 8;
-      left-margin: 8;
-      bottom-margin: 8;
-      right-margin: 8;
+    Button reveal_button {
+      visible: false;
+
+      styles [
+        "destructive-action"
+      ]
+
+      Adw.ButtonContent {
+        label: _("Reveal Potentially Sensitive Content");
+        icon-name: "dialog-warning-symbolic";
+      }
+    }
+
+    Button hide_button {
+      visible: false;
+      label: _("Hide Potentially Sensitive Content");
+    }
+
+    Revealer content_revealer {
+      reveal-child: true;
+      transition-type: slide_down;
+
+      ScrolledWindow {
+        width-request: 500;
+        height-request: 250;
+
+        TextView text_view {
+          cursor-visible: false;
+          editable: false;
+          monospace: true;
+          top-margin: 8;
+          left-margin: 8;
+          bottom-margin: 8;
+          right-margin: 8;
+        }
+      }
     }
   };
 }

--- a/src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp
+++ b/src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp
@@ -15,6 +15,10 @@ Adw.AlertDialog clipboard_confirmation_window {
   close-response: "cancel";
 
   extra-child: Overlay {
+    styles [
+      "osd"
+    ]
+
     ScrolledWindow text_view_scroll {
       width-request: 500;
       height-request: 250;
@@ -42,10 +46,6 @@ Adw.AlertDialog clipboard_confirmation_window {
       margin-end: 12;
       margin-top: 12;
 
-      styles [
-        "destructive-action",
-      ]
-
       Image {
         icon-name: "view-reveal-symbolic";
       }
@@ -60,7 +60,7 @@ Adw.AlertDialog clipboard_confirmation_window {
       margin-top: 12;
 
       styles [
-        "suggested-action",
+        "opaque"
       ]
 
       Image {

--- a/src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp
+++ b/src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp
@@ -14,28 +14,7 @@ Adw.AlertDialog clipboard_confirmation_window {
   default-response: "cancel";
   close-response: "cancel";
 
-  extra-child: Box {
-    orientation: vertical;
-    spacing: 12;
-
-    Button reveal_button {
-      visible: false;
-
-      styles [
-        "destructive-action"
-      ]
-
-      Adw.ButtonContent {
-        label: _("Reveal Potentially Sensitive Content");
-        icon-name: "dialog-warning-symbolic";
-      }
-    }
-
-    Button hide_button {
-      visible: false;
-      label: _("Hide Potentially Sensitive Content");
-    }
-
+  extra-child: Overlay {
     ScrolledWindow text_view_scroll {
       width-request: 500;
       height-request: 250;
@@ -52,6 +31,40 @@ Adw.AlertDialog clipboard_confirmation_window {
         styles [
           "clipboard-content-view"
         ]
+      }
+    }
+
+    [overlay]
+    Button reveal_button {
+      visible: false;
+      halign: end;
+      valign: start;
+      margin-end: 12;
+      margin-top: 12;
+
+      styles [
+        "destructive-action",
+      ]
+
+      Image {
+        icon-name: "view-reveal-symbolic";
+      }
+    }
+
+    [overlay]
+    Button hide_button {
+      visible: false;
+      halign: end;
+      valign: start;
+      margin-end: 12;
+      margin-top: 12;
+
+      styles [
+        "suggested-action",
+      ]
+
+      Image {
+        icon-name: "view-conceal-symbolic";
       }
     }
   };

--- a/src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp
+++ b/src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp
@@ -36,23 +36,22 @@ Adw.AlertDialog clipboard_confirmation_window {
       label: _("Hide Potentially Sensitive Content");
     }
 
-    Revealer content_revealer {
-      reveal-child: true;
-      transition-type: slide_down;
+    ScrolledWindow text_view_scroll {
+      width-request: 500;
+      height-request: 250;
 
-      ScrolledWindow {
-        width-request: 500;
-        height-request: 250;
+      TextView text_view {
+        cursor-visible: false;
+        editable: false;
+        monospace: true;
+        top-margin: 8;
+        left-margin: 8;
+        bottom-margin: 8;
+        right-margin: 8;
 
-        TextView text_view {
-          cursor-visible: false;
-          editable: false;
-          monospace: true;
-          top-margin: 8;
-          left-margin: 8;
-          bottom-margin: 8;
-          right-margin: 8;
-        }
+        styles [
+          "clipboard-content-view"
+        ]
       }
     }
   };

--- a/src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp
+++ b/src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp
@@ -14,18 +14,46 @@ Adw.AlertDialog clipboard_confirmation_window {
   default-response: "cancel";
   close-response: "cancel";
 
-  extra-child: ScrolledWindow {
-    width-request: 500;
-    height-request: 250;
+  extra-child: Box {
+    orientation: vertical;
+    spacing: 12;
 
-    TextView text_view {
-      cursor-visible: false;
-      editable: false;
-      monospace: true;
-      top-margin: 8;
-      left-margin: 8;
-      bottom-margin: 8;
-      right-margin: 8;
+    Button reveal_button {
+      visible: false;
+
+      styles [
+        "destructive-action"
+      ]
+
+      Adw.ButtonContent {
+        label: _("Reveal Potentially Sensitive Content");
+        icon-name: "dialog-warning-symbolic";
+      }
+    }
+
+    Button hide_button {
+      visible: false;
+      label: _("Hide Potentially Sensitive Content");
+    }
+
+    Revealer content_revealer {
+      reveal-child: true;
+      transition-type: slide_down;
+
+      ScrolledWindow {
+        width-request: 500;
+        height-request: 250;
+
+        TextView text_view {
+          cursor-visible: false;
+          editable: false;
+          monospace: true;
+          top-margin: 8;
+          left-margin: 8;
+          bottom-margin: 8;
+          right-margin: 8;
+        }
+      }
     }
   };
 }

--- a/src/apprt/gtk/ui/1.5/ccw-paste.blp
+++ b/src/apprt/gtk/ui/1.5/ccw-paste.blp
@@ -15,6 +15,10 @@ Adw.AlertDialog clipboard_confirmation_window {
   close-response: "cancel";
 
   extra-child: Overlay {
+    styles [
+      "osd"
+    ]
+
     ScrolledWindow text_view_scroll {
       width-request: 500;
       height-request: 250;
@@ -42,10 +46,6 @@ Adw.AlertDialog clipboard_confirmation_window {
       margin-end: 12;
       margin-top: 12;
 
-      styles [
-        "destructive-action",
-      ]
-
       Image {
         icon-name: "view-reveal-symbolic";
       }
@@ -60,7 +60,7 @@ Adw.AlertDialog clipboard_confirmation_window {
       margin-top: 12;
 
       styles [
-        "suggested-action",
+        "opaque"
       ]
 
       Image {

--- a/src/apprt/gtk/ui/1.5/ccw-paste.blp
+++ b/src/apprt/gtk/ui/1.5/ccw-paste.blp
@@ -14,28 +14,7 @@ Adw.AlertDialog clipboard_confirmation_window {
   default-response: "cancel";
   close-response: "cancel";
 
-  extra-child: Box {
-    orientation: vertical;
-    spacing: 12;
-
-    Button reveal_button {
-      visible: false;
-
-      styles [
-        "destructive-action"
-      ]
-
-      Adw.ButtonContent {
-        label: _("Reveal Potentially Sensitive Content");
-        icon-name: "dialog-warning-symbolic";
-      }
-    }
-
-    Button hide_button {
-      visible: false;
-      label: _("Hide Potentially Sensitive Content");
-    }
-
+  extra-child: Overlay {
     ScrolledWindow text_view_scroll {
       width-request: 500;
       height-request: 250;
@@ -52,6 +31,40 @@ Adw.AlertDialog clipboard_confirmation_window {
         styles [
           "clipboard-content-view"
         ]
+      }
+    }
+
+    [overlay]
+    Button reveal_button {
+      visible: false;
+      halign: end;
+      valign: start;
+      margin-end: 12;
+      margin-top: 12;
+
+      styles [
+        "destructive-action",
+      ]
+
+      Image {
+        icon-name: "view-reveal-symbolic";
+      }
+    }
+
+    [overlay]
+    Button hide_button {
+      visible: false;
+      halign: end;
+      valign: start;
+      margin-end: 12;
+      margin-top: 12;
+
+      styles [
+        "suggested-action",
+      ]
+
+      Image {
+        icon-name: "view-conceal-symbolic";
       }
     }
   };

--- a/src/apprt/gtk/ui/1.5/ccw-paste.blp
+++ b/src/apprt/gtk/ui/1.5/ccw-paste.blp
@@ -36,23 +36,22 @@ Adw.AlertDialog clipboard_confirmation_window {
       label: _("Hide Potentially Sensitive Content");
     }
 
-    Revealer content_revealer {
-      reveal-child: true;
-      transition-type: slide_down;
+    ScrolledWindow text_view_scroll {
+      width-request: 500;
+      height-request: 250;
 
-      ScrolledWindow {
-        width-request: 500;
-        height-request: 250;
+      TextView text_view {
+        cursor-visible: false;
+        editable: false;
+        monospace: true;
+        top-margin: 8;
+        left-margin: 8;
+        bottom-margin: 8;
+        right-margin: 8;
 
-        TextView text_view {
-          cursor-visible: false;
-          editable: false;
-          monospace: true;
-          top-margin: 8;
-          left-margin: 8;
-          bottom-margin: 8;
-          right-margin: 8;
-        }
+        styles [
+          "clipboard-content-view"
+        ]
       }
     }
   };

--- a/src/apprt/gtk/ui/1.5/ccw-paste.blp
+++ b/src/apprt/gtk/ui/1.5/ccw-paste.blp
@@ -10,22 +10,50 @@ Adw.AlertDialog clipboard_confirmation_window {
     cancel: _("Cancel") suggested,
     ok: _("Paste") destructive
   ]
-  
+
   default-response: "cancel";
   close-response: "cancel";
-  
-  extra-child: ScrolledWindow {
-    width-request: 500;
-    height-request: 250;
 
-    TextView text_view {
-      cursor-visible: false;
-      editable: false;
-      monospace: true;
-      top-margin: 8;
-      left-margin: 8;
-      bottom-margin: 8;
-      right-margin: 8;
+  extra-child: Box {
+    orientation: vertical;
+    spacing: 12;
+
+    Button reveal_button {
+      visible: false;
+
+      styles [
+        "destructive-action"
+      ]
+
+      Adw.ButtonContent {
+        label: _("Reveal Potentially Sensitive Content");
+        icon-name: "dialog-warning-symbolic";
+      }
+    }
+
+    Button hide_button {
+      visible: false;
+      label: _("Hide Potentially Sensitive Content");
+    }
+
+    Revealer content_revealer {
+      reveal-child: true;
+      transition-type: slide_down;
+
+      ScrolledWindow {
+        width-request: 500;
+        height-request: 250;
+
+        TextView text_view {
+          cursor-visible: false;
+          editable: false;
+          monospace: true;
+          top-margin: 8;
+          left-margin: 8;
+          bottom-margin: 8;
+          right-margin: 8;
+        }
+      }
     }
   };
 }


### PR DESCRIPTION
Fixes https://github.com/ghostty-org/ghostty/issues/4947 for gtk
This PR implements the senstive content hiding when displaying the paste confirmation dialog in secure input mode.

Following changes are implemented:
- in the blueprint for each dialog add a show/hide button that is not visible by default, and a Revealer that is revealed by default
- save the `secure_input` action value for each surface in the GTK apprt
- pass the value when initializing the paste confirmation dialog
- in the dialog code, alter the visibility of the content and reveal/hide buttons based on secure input flag value

Demo:

https://github.com/user-attachments/assets/c91cbd3d-ed3b-464d-b4cf-e51fe7aa23b7

I feel like this is already a nearly full implementation, but I'm leaving this as a draft for now, since i need to look into blueprints for Adwaita 1.2, and verify if it behaves properly when the dialog is in not-sensitive input mode and in OSC52 mode.
