### PR TITLE
gtk: use updated blueprint compiler for needed new features

### DIFF
--- a/nix/blueprint-compiler.nix
+++ b/nix/blueprint-compiler.nix
@@ -1,0 +1,83 @@
+{
+  dbus,
+  fetchFromGitLab,
+  gobject-introspection,
+  lib,
+  libadwaita,
+  meson,
+  ninja,
+  python3,
+  stdenv,
+  testers,
+  xvfb-run,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "blueprint-compiler";
+  version = "0.16.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "jwestman";
+    repo = "blueprint-compiler";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-FnMQtqy+uejWn3tDeaj92h2x9TzyiK5KdlRm55ObgPg=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+  ];
+
+  postPatch = ''
+    patchShebangs docs/collect-sections.py
+  '';
+
+  buildInputs = [
+    libadwaita
+    (python3.withPackages (
+      ps:
+        with ps; [
+          pygobject3
+        ]
+    ))
+  ];
+
+  propagatedBuildInputs = [
+    # For setup hook, so that the compiler can find typelib files
+    gobject-introspection
+  ];
+
+  nativeCheckInputs = [
+    dbus
+    xvfb-run
+  ];
+
+  # requires xvfb-run
+  doCheck = !stdenv.hostPlatform.isDarwin && false; # tests time out
+
+  checkPhase = ''
+    runHook preCheck
+
+    xvfb-run dbus-run-session \
+      --config-file=${dbus}/share/dbus-1/session.conf \
+      meson test --no-rebuild --print-errorlogs
+
+    runHook postCheck
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+  };
+
+  meta = with lib; {
+    description = "Markup language for GTK user interface files";
+    mainProgram = "blueprint-compiler";
+    homepage = "https://gitlab.gnome.org/jwestman/blueprint-compiler";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [
+      benediktbroich
+      ranfdev
+    ];
+    platforms = platforms.unix;
+  };
+})

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -2,6 +2,7 @@
   mkShell,
   lib,
   stdenv,
+  callPackage,
   bashInteractive,
   gdb,
   #, glxinfo # unused
@@ -34,7 +35,7 @@
   gtk4-layer-shell,
   gobject-introspection,
   libadwaita,
-  blueprint-compiler,
+  # blueprint-compiler,
   adwaita-icon-theme,
   hicolor-icon-theme,
   harfbuzz,
@@ -62,6 +63,7 @@
   zig2nix,
   system,
 }: let
+  blueprint-compiler = callPackage ./blueprint-compiler.nix {};
   # See package.nix. Keep in sync.
   rpathLibs =
     [

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -16,7 +16,7 @@
   gtk4-layer-shell,
   gobject-introspection,
   libadwaita,
-  blueprint-compiler,
+  # blueprint-compiler,
   libxml2,
   wrapGAppsHook4,
   gsettings-desktop-schemas,
@@ -47,6 +47,7 @@
   zig_hook = zig_0_13.hook.overrideAttrs {
     zig_default_flags = "-Dcpu=baseline -Doptimize=${optimize} --color off";
   };
+  blueprint-compiler = callPackage ./blueprint-compiler.nix {};
 in
   stdenv.mkDerivation (finalAttrs: {
     pname = "ghostty";


### PR DESCRIPTION
This should be reverted once NixOS stable has a new enough version. Note that this won't yet help those building on non-Nix systems but it should help unblock development.