### PR TITLE
gtk: don't modify horizontal alignment on menus that have arrows

### DIFF
--- a/src/apprt/gtk/menu.zig
+++ b/src/apprt/gtk/menu.zig
@@ -47,8 +47,15 @@ pub fn Menu(
             const menu_model = builder.getObject(gio.MenuModel, "menu").?;
 
             const menu_widget = gtk.PopoverMenu.newFromModelFull(menu_model, .{ .nested = true });
-            menu_widget.as(gtk.Widget).setHalign(.start);
+
+            // If this menu has an arrow, don't modify the horizontal alignment
+            // or you get visual anomalies. See PR #6087. Otherwise set the
+            // horizontal alignment to `start` so that the top left corner of
+            // the menu aligns with the point that the menu is popped up at.
+            if (!arrow) menu_widget.as(gtk.Widget).setHalign(.start);
+
             menu_widget.as(gtk.Popover).setHasArrow(@intFromBool(arrow));
+
             _ = gtk.Popover.signals.closed.connect(
                 menu_widget,
                 *Self,


### PR DESCRIPTION
Setting the horizontal alignment to start on popover menus that have arrows results in visual anomalies:

![image](https://github.com/user-attachments/assets/fef279a3-73cf-4717-9b32-605ccd48c934)

From Discord:

https://discord.com/channels/1005603569187160125/1346819853612482571