### PR TITLE
translations: add German translation

### DIFF
--- a/po/de_DE.UTF-8.po
+++ b/po/de_DE.UTF-8.po
@@ -24,7 +24,7 @@ msgstr "Terminal-Titel bearbeiten"
 
 #: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:6
 msgid "Leave blank to restore the default title."
-msgstr "Leer lassen, um den Standardtitel wiederherzustellen"
+msgstr "Leer lassen, um den Standardtitel wiederherzustellen."
 
 #: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:9
 #: src/apprt/gtk/ui/1.5/ccw-paste.blp:10
@@ -209,4 +209,4 @@ msgstr "Ghostty-Entwickler"
 
 #: src/apprt/gtk/Surface.zig:1236
 msgid "Copied to clipboard"
-msgstr "In die Zwischenablage kopiert."
+msgstr "In die Zwischenablage kopiert"

--- a/po/de_DE.UTF-8.po
+++ b/po/de_DE.UTF-8.po
@@ -197,7 +197,7 @@ msgstr "Offene Tabs einblenden"
 msgid ""
 "⚠️ You're running a debug build of Ghostty! Performance will be degraded."
 msgstr ""
-"  Du verwendest einen Debug Build von Ghostty! Die Leistung wird reduziert sein."
+"⚠️ Du verwendest einen Debug Build von Ghostty! Die Leistung wird reduziert sein."
 
 #: src/apprt/gtk/Window.zig:660
 msgid "Reloaded the configuration"

--- a/po/de_DE.UTF-8.po
+++ b/po/de_DE.UTF-8.po
@@ -1,0 +1,212 @@
+# German translations for com.mitchellh.ghostty package
+# German translation for com.mitchellh.ghostty.
+# Copyright (C) 2025 Mitchell Hashimoto
+# This file is distributed under the same license as the com.mitchellh.ghostty package.
+# Robin Pfäffle <r@rpfaeffle.com>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: com.mitchellh.ghostty\n"
+"Report-Msgid-Bugs-To: m@mitchellh.com\n"
+"POT-Creation-Date: 2025-02-28 22:12+0100\n"
+"PO-Revision-Date: 2025-03-06 14:57+0100\n"
+"Last-Translator: Robin <r@rpfaeffle.com>\n"
+"Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:5
+msgid "Change Terminal Title"
+msgstr "Terminal-Titel bearbeiten"
+
+#: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:6
+msgid "Leave blank to restore the default title."
+msgstr "Leer lassen, um den Standardtitel wiederherzustellen"
+
+#: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:9
+#: src/apprt/gtk/ui/1.5/ccw-paste.blp:10
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:10
+msgid "OK"
+msgstr "OK"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:6
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:6
+msgid "Copy"
+msgstr "Kopieren"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:11
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:11
+#: src/apprt/gtk/ui/1.5/ccw-paste.blp:11
+msgid "Paste"
+msgstr "Einfügen"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:18
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:73
+msgid "Clear"
+msgstr "Leeren"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:23
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:78
+msgid "Reset"
+msgstr "Zurücksetzen"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:30
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:42
+msgid "Split"
+msgstr "Fenster teilen"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:33
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:45
+msgid "Change Title…"
+msgstr "Titel bearbeiten…"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:38
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:50
+msgid "Split Up"
+msgstr "Fenster nach oben teilen"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:43
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:55
+msgid "Split Down"
+msgstr "Fenster nach unten teilen"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:48
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:60
+msgid "Split Left"
+msgstr "Fenter nach links teilen"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:53
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:65
+msgid "Split Right"
+msgstr "Fenster nach rechts teilen"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:59
+msgid "Tab"
+msgstr "Tab"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:62
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:30
+#: src/apprt/gtk/Window.zig:239
+msgid "New Tab"
+msgstr "Neuer Tab"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:67
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:35
+msgid "Close Tab"
+msgstr "Tab schließen"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:73
+msgid "Window"
+msgstr "Fenster"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:76
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:18
+msgid "New Window"
+msgstr "Neues Fenster"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:81
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:23
+msgid "Close Window"
+msgstr "Fenster schließen"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:89
+msgid "Config"
+msgstr "Konfiguration"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:92
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:90
+msgid "Open Configuration"
+msgstr "Konfiguration öffnen"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:97
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:95
+msgid "Reload Configuration"
+msgstr "Konfiguration neu laden"
+
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:85
+msgid "Terminal Inspector"
+msgstr "Terminalinspektor"
+
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:102
+#: src/apprt/gtk/Window.zig:923
+msgid "About Ghostty"
+msgstr "Über Ghostty"
+
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:107
+msgid "Quit"
+msgstr "Beenden"
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:6
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:6
+msgid "Authorize Clipboard Access"
+msgstr "Zugriff auf die Zwischenablage gewähren"
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:7
+msgid ""
+"An application is attempting to read from the clipboard. The current "
+"clipboard contents are shown below."
+msgstr ""
+"Eine Anwendung versucht von der Zwischenablage zu lesen. Der aktuelle "
+"Inhalt der Zwischenablage wird unten angezeigt."
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:10
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:10
+msgid "Deny"
+msgstr "Nicht erlauben"
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:11
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:11
+msgid "Allow"
+msgstr "Erlauben"
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:7
+msgid ""
+"An application is attempting to write to the clipboard. The current "
+"clipboard contents are shown below."
+msgstr ""
+"Eine Anwendung versucht in die Zwischenablage zu schreiben. Der aktuelle "
+"Inhalt der Zwischenablage wird unten angezeigt."
+
+#: src/apprt/gtk/ui/1.5/ccw-paste.blp:6
+msgid "Warning: Potentially Unsafe Paste"
+msgstr "Achtung: Möglicherweise unsicheres Einfügen"
+
+#: src/apprt/gtk/ui/1.5/ccw-paste.blp:7
+msgid ""
+"Pasting this text into the terminal may be dangerous as it looks like some "
+"commands may be executed."
+msgstr ""
+"Diesen Text in das Terminal einzufügen könnte möglicherweise gefährlich sein. "
+"Es scheint, dass Anweisungen ausgeführt werden könnten."
+
+#: src/apprt/gtk/Window.zig:192
+msgid "Main Menu"
+msgstr "Hauptmenü"
+
+#: src/apprt/gtk/Window.zig:212
+msgid "View Open Tabs"
+msgstr "Offene Tabs einblenden"
+
+#: src/apprt/gtk/Window.zig:257
+msgid ""
+"⚠️ You're running a debug build of Ghostty! Performance will be degraded."
+msgstr ""
+"  Du verwendest einen Debug Build von Ghostty! Die Leistung wird reduziert sein."
+
+#: src/apprt/gtk/Window.zig:660
+msgid "Reloaded the configuration"
+msgstr "Konfiguration wurde neu geladen"
+
+#: src/apprt/gtk/Window.zig:904
+msgid "Ghostty Developers"
+msgstr "Ghostty-Entwickler"
+
+#: src/apprt/gtk/Surface.zig:1236
+msgid "Copied to clipboard"
+msgstr "In die Zwischenablage kopiert."

--- a/po/de_DE.UTF-8.po
+++ b/po/de_DE.UTF-8.po
@@ -209,22 +209,18 @@ msgid "Ghostty Developers"
 msgstr "Ghostty-Entwickler"
 
 #: src/apprt/gtk/CloseDialog.zig:47
-#, fuzzy
 msgid "Close"
 msgstr "Schließen"
 
 #: src/apprt/gtk/CloseDialog.zig:87
-#, fuzzy
 msgid "Quit Ghostty?"
-msgstr "Über Ghostty?"
+msgstr "Ghostty schließen?"
 
 #: src/apprt/gtk/CloseDialog.zig:88
-#, fuzzy
 msgid "Close Window?"
 msgstr "Fenster schließen?"
 
 #: src/apprt/gtk/CloseDialog.zig:89
-#, fuzzy
 msgid "Close Tab?"
 msgstr "Tab schließen?"
 

--- a/po/de_DE.UTF-8.po
+++ b/po/de_DE.UTF-8.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-02-28 22:12+0100\n"
+"POT-Creation-Date: 2025-03-06 20:10+0100\n"
 "PO-Revision-Date: 2025-03-06 14:57+0100\n"
 "Last-Translator: Robin <r@rpfaeffle.com>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
@@ -27,7 +27,7 @@ msgid "Leave blank to restore the default title."
 msgstr "Leer lassen, um den Standardtitel wiederherzustellen."
 
 #: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:9
-#: src/apprt/gtk/ui/1.5/ccw-paste.blp:10
+#: src/apprt/gtk/ui/1.5/ccw-paste.blp:10 src/apprt/gtk/CloseDialog.zig:44
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -92,7 +92,7 @@ msgstr "Tab"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:62
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:30
-#: src/apprt/gtk/Window.zig:239
+#: src/apprt/gtk/Window.zig:246
 msgid "New Tab"
 msgstr "Neuer Tab"
 
@@ -134,7 +134,7 @@ msgid "Terminal Inspector"
 msgstr "Terminalinspektor"
 
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:102
-#: src/apprt/gtk/Window.zig:923
+#: src/apprt/gtk/Window.zig:933
 msgid "About Ghostty"
 msgstr "Über Ghostty"
 
@@ -152,8 +152,8 @@ msgid ""
 "An application is attempting to read from the clipboard. The current "
 "clipboard contents are shown below."
 msgstr ""
-"Eine Anwendung versucht von der Zwischenablage zu lesen. Der aktuelle "
-"Inhalt der Zwischenablage wird unten angezeigt."
+"Eine Anwendung versucht von der Zwischenablage zu lesen. Der aktuelle Inhalt "
+"der Zwischenablage wird unten angezeigt."
 
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:10
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:10
@@ -182,31 +182,72 @@ msgid ""
 "Pasting this text into the terminal may be dangerous as it looks like some "
 "commands may be executed."
 msgstr ""
-"Diesen Text in das Terminal einzufügen könnte möglicherweise gefährlich sein. "
-"Es scheint, dass Anweisungen ausgeführt werden könnten."
+"Diesen Text in das Terminal einzufügen könnte möglicherweise gefährlich "
+"sein. Es scheint, dass Anweisungen ausgeführt werden könnten."
 
-#: src/apprt/gtk/Window.zig:192
+#: src/apprt/gtk/Window.zig:199
 msgid "Main Menu"
 msgstr "Hauptmenü"
 
-#: src/apprt/gtk/Window.zig:212
+#: src/apprt/gtk/Window.zig:219
 msgid "View Open Tabs"
 msgstr "Offene Tabs einblenden"
 
-#: src/apprt/gtk/Window.zig:257
+#: src/apprt/gtk/Window.zig:265
 msgid ""
 "⚠️ You're running a debug build of Ghostty! Performance will be degraded."
 msgstr ""
-"⚠️ Du verwendest einen Debug Build von Ghostty! Die Leistung wird reduziert sein."
+"⚠️ Du verwendest einen Debug Build von Ghostty! Die Leistung wird reduziert "
+"sein."
 
-#: src/apprt/gtk/Window.zig:660
+#: src/apprt/gtk/Window.zig:681
 msgid "Reloaded the configuration"
 msgstr "Konfiguration wurde neu geladen"
 
-#: src/apprt/gtk/Window.zig:904
+#: src/apprt/gtk/Window.zig:914
 msgid "Ghostty Developers"
 msgstr "Ghostty-Entwickler"
 
-#: src/apprt/gtk/Surface.zig:1236
+#: src/apprt/gtk/CloseDialog.zig:47
+#, fuzzy
+msgid "Close"
+msgstr "Schließen"
+
+#: src/apprt/gtk/CloseDialog.zig:87
+#, fuzzy
+msgid "Quit Ghostty?"
+msgstr "Über Ghostty?"
+
+#: src/apprt/gtk/CloseDialog.zig:88
+#, fuzzy
+msgid "Close Window?"
+msgstr "Fenster schließen?"
+
+#: src/apprt/gtk/CloseDialog.zig:89
+#, fuzzy
+msgid "Close Tab?"
+msgstr "Tab schließen?"
+
+#: src/apprt/gtk/CloseDialog.zig:90
+msgid "Close Split?"
+msgstr "Geteiltes Fenster schließen?"
+
+#: src/apprt/gtk/CloseDialog.zig:96
+msgid "All terminal sessions will be terminated."
+msgstr "Alle Terminalsitzungen werden beendet."
+
+#: src/apprt/gtk/CloseDialog.zig:97
+msgid "All terminal sessions in this window will be terminated."
+msgstr "Alle Terminalsitzungen in diesem Fenster werden beendet."
+
+#: src/apprt/gtk/CloseDialog.zig:98
+msgid "All terminal sessions in this tab will be terminated."
+msgstr "Alle Terminalsitzungen in diesem Tab werden beendet."
+
+#: src/apprt/gtk/CloseDialog.zig:99
+msgid "The currently running process in this split will be terminated."
+msgstr "Der aktuell laufende Prozess in diesem geteilten Fenster wird beendet."
+
+#: src/apprt/gtk/Surface.zig:1128
 msgid "Copied to clipboard"
 msgstr "In die Zwischenablage kopiert"

--- a/src/os/i18n.zig
+++ b/src/os/i18n.zig
@@ -24,6 +24,7 @@ const log = std.log.scoped(.i18n);
 ///   3. Most preferred locale for a language without a country code.
 ///
 pub const locales = [_][:0]const u8{
+    "de_DE.UTF-8",
     "zh_CN.UTF-8",
 };
 

--- a/typos.toml
+++ b/typos.toml
@@ -45,5 +45,9 @@ greyscale = "grayscale"
 DECID = "DECID"
 flate = "flate"
 
+[type.po]
+extend-glob = ["*.po"]
+check-file = false
+
 [type.swift.extend-words]
 inout = "inout"


### PR DESCRIPTION
This PR adds a translation for German `de_DE`.

Additionally it excludes all `*.po` files from the typos CI action.

Some comments on the decisions I made (open to discuss them):

- I choosed to use `du` instead of `Sie` as this seems appropriate
  to me.
- I added `Window` (`Fenster` in German) to all split commands
  as it appears more naturally to me.
