### PR TITLE
font(freetype): constrain emoji to cell width

### DIFF
--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -1392,28 +1392,28 @@ pub fn rebuildCells(
                     // Try to read the cells from the shaping cache if we can.
                     self.font_shaper_cache.get(run) orelse
                     cache: {
-                    // Otherwise we have to shape them.
-                    const cells = try self.font_shaper.shape(run);
+                        // Otherwise we have to shape them.
+                        const cells = try self.font_shaper.shape(run);
 
-                    // Try to cache them. If caching fails for any reason we
-                    // continue because it is just a performance optimization,
-                    // not a correctness issue.
-                    self.font_shaper_cache.put(
-                        self.alloc,
-                        run,
-                        cells,
-                    ) catch |err| {
-                        log.warn(
-                            "error caching font shaping results err={}",
-                            .{err},
-                        );
+                        // Try to cache them. If caching fails for any reason we
+                        // continue because it is just a performance optimization,
+                        // not a correctness issue.
+                        self.font_shaper_cache.put(
+                            self.alloc,
+                            run,
+                            cells,
+                        ) catch |err| {
+                            log.warn(
+                                "error caching font shaping results err={}",
+                                .{err},
+                            );
+                        };
+
+                        // The cells we get from direct shaping are always owned
+                        // by the shaper and valid until the next shaping call so
+                        // we can safely use them.
+                        break :cache cells;
                     };
-
-                    // The cells we get from direct shaping are always owned
-                    // by the shaper and valid until the next shaping call so
-                    // we can safely use them.
-                    break :cache cells;
-                };
 
                 // Advance our index until we reach or pass
                 // our current x position in the shaper cells.
@@ -1637,28 +1637,28 @@ pub fn rebuildCells(
                     // Try to read the cells from the shaping cache if we can.
                     self.font_shaper_cache.get(run) orelse
                     cache: {
-                    // Otherwise we have to shape them.
-                    const cells = try self.font_shaper.shape(run);
+                        // Otherwise we have to shape them.
+                        const cells = try self.font_shaper.shape(run);
 
-                    // Try to cache them. If caching fails for any reason we
-                    // continue because it is just a performance optimization,
-                    // not a correctness issue.
-                    self.font_shaper_cache.put(
-                        self.alloc,
-                        run,
-                        cells,
-                    ) catch |err| {
-                        log.warn(
-                            "error caching font shaping results err={}",
-                            .{err},
-                        );
+                        // Try to cache them. If caching fails for any reason we
+                        // continue because it is just a performance optimization,
+                        // not a correctness issue.
+                        self.font_shaper_cache.put(
+                            self.alloc,
+                            run,
+                            cells,
+                        ) catch |err| {
+                            log.warn(
+                                "error caching font shaping results err={}",
+                                .{err},
+                            );
+                        };
+
+                        // The cells we get from direct shaping are always owned
+                        // by the shaper and valid until the next shaping call so
+                        // we can safely use them.
+                        break :cache cells;
                     };
-
-                    // The cells we get from direct shaping are always owned
-                    // by the shaper and valid until the next shaping call so
-                    // we can safely use them.
-                    break :cache cells;
-                };
 
                 const cells = shaper_cells orelse break :glyphs;
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -2105,6 +2105,7 @@ fn addGlyph(
         shaper_run.font_index,
         shaper_cell.glyph_index,
         .{
+            .cell_width = if (cell.wide == .wide) 2 else 1,
             .grid_metrics = self.grid_metrics,
             .thicken = self.config.font_thicken,
             .thicken_strength = self.config.font_thicken_strength,


### PR DESCRIPTION
When scaling emoji (with freetype), we would unilaterally scale the bitmap to fit within the `cell_height`. For narrow fonts, this would result in a horizontal overflow:

![image](https://github.com/user-attachments/assets/87b9f952-6f12-40b2-bbed-5bfe948f45b4)

Modify the glyph rendering such that we scale to fit within the cell width. After doing so, the above image looks like:

![image](https://github.com/user-attachments/assets/c75bfa51-4730-4179-b032-c3afa7840d65)

The emoji glyph is noticeably smaller because we have constrained the height further than before, but fits perfectly within two cells. I am using Victor Mono as my font, which is pretty narrow. The effect would be even more pronounced on something like Iosevka.