### PR TITLE
gtk: build gtk4-layer-shell ourselves

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -60,6 +60,7 @@
         .cimgui = .{ .path = "./pkg/cimgui" },
         .fontconfig = .{ .path = "./pkg/fontconfig" },
         .freetype = .{ .path = "./pkg/freetype" },
+        .gtk4_layer_shell = .{ .path = "./pkg/gtk4-layer-shell" },
         .harfbuzz = .{ .path = "./pkg/harfbuzz" },
         .highway = .{ .path = "./pkg/highway" },
         .libpng = .{ .path = "./pkg/libpng" },

--- a/build.zig.zon.nix
+++ b/build.zig.zon.nix
@@ -308,6 +308,14 @@ in
       };
     }
     {
+      name = "12203eff4829ad8afdd828eb323d48e5ba8dbb44d224e9e314d4ab1533c2bec20f4b";
+      path = fetchZigArtifact {
+        name = "gtk4_layer_shell";
+        url = "https://github.com/wmww/gtk4-layer-shell/archive/refs/tags/v1.1.0.tar.gz";
+        hash = "sha256-mChCgSYKXu9bT2OlXxbEv2p4ihAgptsDfssPcfozaYg=";
+      };
+    }
+    {
       name = "1220b8588f106c996af10249bfa092c6fb2f35fbacb1505ef477a0b04a7dd1063122";
       path = fetchZigArtifact {
         name = "harfbuzz";

--- a/build.zig.zon.txt
+++ b/build.zig.zon.txt
@@ -22,13 +22,13 @@ https://deps.files.ghostty.org/wayland-protocols-258d8f88f2c8c25a830c6316f87d23c
 https://deps.files.ghostty.org/wuffs-122037b39d577ec2db3fd7b2130e7b69ef6cc1807d68607a7c232c958315d381b5cd.tar.gz
 https://deps.files.ghostty.org/z2d-12201f0d542e7541cf492a001d4d0d0155c92f58212fbcb0d224e95edeba06b5416a.tar.gz
 https://deps.files.ghostty.org/zf-1220edc3b8d8bedbb50555947987e5e8e2f93871ca3c8e8d4cc8f1377c15b5dd35e8.tar.gz
-https://deps.files.ghostty.org/zig-wayland-fbfe3b4ac0b472a27b1f1a67405436c58cbee12d.tar.gz
 https://deps.files.ghostty.org/zig_js-12205a66d423259567764fa0fc60c82be35365c21aeb76c5a7dc99698401f4f6fefc.tar.gz
-https://deps.files.ghostty.org/zig_objc-1220e17e64ef0ef561b3e4b9f3a96a2494285f2ec31c097721bf8c8677ec4415c634.tar.gz
 https://deps.files.ghostty.org/ziglyph-b89d43d1e3fb01b6074bc1f7fc980324b04d26a5.tar.gz
+https://deps.files.ghostty.org/zig_objc-1220e17e64ef0ef561b3e4b9f3a96a2494285f2ec31c097721bf8c8677ec4415c634.tar.gz
+https://deps.files.ghostty.org/zig-wayland-fbfe3b4ac0b472a27b1f1a67405436c58cbee12d.tar.gz
 https://deps.files.ghostty.org/zlib-1220fed0c74e1019b3ee29edae2051788b080cd96e90d56836eea857b0b966742efb.tar.gz
-https://github.com/GNOME/libxml2/archive/refs/tags/v2.11.5.tar.gz
 https://github.com/getsentry/breakpad/archive/b99f444ba5f6b98cac261cbb391d8766b34a5918.tar.gz
+https://github.com/GNOME/libxml2/archive/refs/tags/v2.11.5.tar.gz
 https://github.com/mbadolato/iTerm2-Color-Schemes/archive/e21d5ffd19605741d0e3e19d7c5a8c6c25648673.tar.gz
 https://github.com/mitchellh/glfw/archive/b552c6ec47326b94015feddb36058ea567b87159.tar.gz
 https://github.com/mitchellh/libxev/archive/8943932a668f338cb2c500f6e1a7396bacd8b55d.tar.gz
@@ -36,3 +36,4 @@ https://github.com/mitchellh/vulkan-headers/archive/04c8a0389d5a0236a96312988017
 https://github.com/mitchellh/wayland-headers/archive/5f991515a29f994d87b908115a2ab0b899474bd1.tar.gz
 https://github.com/mitchellh/x11-headers/archive/2ffbd62d82ff73ec929dd8de802bc95effa0ef88.tar.gz
 https://github.com/mitchellh/xcode-frameworks/archive/69801c154c39d7ae6129ea1ba8fe1afe00585fc8.tar.gz
+https://github.com/wmww/gtk4-layer-shell/archive/refs/tags/v1.1.0.tar.gz

--- a/build.zig.zon2json-lock
+++ b/build.zig.zon2json-lock
@@ -139,6 +139,11 @@
     "url": "https://github.com/GNOME/libxml2/archive/refs/tags/v2.11.5.tar.gz",
     "hash": "sha256-bCgFni4+60K1tLFkieORamNGwQladP7jvGXNxdiaYhU="
   },
+  "12203eff4829ad8afdd828eb323d48e5ba8dbb44d224e9e314d4ab1533c2bec20f4b": {
+    "name": "gtk4_layer_shell",
+    "url": "https://github.com/wmww/gtk4-layer-shell/archive/refs/tags/v1.1.0.tar.gz",
+    "hash": "sha256-mChCgSYKXu9bT2OlXxbEv2p4ihAgptsDfssPcfozaYg="
+  },
   "1220b8588f106c996af10249bfa092c6fb2f35fbacb1505ef477a0b04a7dd1063122": {
     "name": "harfbuzz",
     "url": "https://deps.files.ghostty.org/harfbuzz-1220b8588f106c996af10249bfa092c6fb2f35fbacb1505ef477a0b04a7dd1063122.tar.gz",

--- a/pkg/gtk4-layer-shell/build.zig
+++ b/pkg/gtk4-layer-shell/build.zig
@@ -1,0 +1,106 @@
+const std = @import("std");
+
+// TODO: Import this from build.zig.zon when possible
+const version: std.SemanticVersion = .{ .major = 1, .minor = 1, .patch = 0 };
+
+pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const upstream = b.dependency("gtk4_layer_shell", .{});
+    const wayland_protocols = b.dependency("wayland_protocols", .{});
+
+    // Zig API
+    const module = b.addModule("gtk4-layer-shell", .{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    module.addIncludePath(upstream.path("include"));
+    // Needs the gtk.h header
+    module.linkSystemLibrary("gtk4", dynamic_link_opts);
+
+    // Shared library
+    const lib = b.addSharedLibrary(.{
+        .name = "gtk4-layer-shell",
+        .target = target,
+        .optimize = optimize,
+    });
+    lib.linkLibC();
+    lib.addIncludePath(upstream.path("include"));
+    lib.addIncludePath(upstream.path("src"));
+
+    // GTK
+    lib.linkSystemLibrary2("gtk4", dynamic_link_opts);
+
+    // Wayland headers and source files
+    {
+        const protocols = [_]struct { []const u8, std.Build.LazyPath }{
+            .{
+                "wlr-layer-shell-unstable-v1",
+                upstream.path("protocol/wlr-layer-shell-unstable-v1.xml"),
+            },
+            .{
+                "xdg-shell",
+                wayland_protocols.path("stable/xdg-shell/xdg-shell.xml"),
+            },
+            // Even though we don't use session lock, we still need its headers
+            .{
+                "ext-session-lock-v1",
+                wayland_protocols.path("staging/ext-session-lock/ext-session-lock-v1.xml"),
+            },
+        };
+
+        const wf = b.addWriteFiles();
+        for (protocols) |protocol| {
+            const name, const xml = protocol;
+
+            const header_scanner = b.addSystemCommand(&.{ "wayland-scanner", "client-header" });
+            header_scanner.addFileArg(xml);
+            _ = wf.addCopyFile(
+                header_scanner.addOutputFileArg(name),
+                b.fmt("{s}-client.h", .{name}),
+            );
+
+            const source_scanner = b.addSystemCommand(&.{ "wayland-scanner", "private-code" });
+            source_scanner.addFileArg(xml);
+            const source = source_scanner.addOutputFileArg(b.fmt("{s}.c", .{name}));
+            lib.addCSourceFile(.{ .file = source });
+        }
+        lib.addIncludePath(wf.getDirectory());
+    }
+
+    lib.installHeadersDirectory(
+        upstream.path("include"),
+        "",
+        .{ .include_extensions = &.{".h"} },
+    );
+
+    lib.addCSourceFiles(.{
+        .root = upstream.path("src"),
+        .files = srcs,
+        .flags = &.{
+            b.fmt("-DGTK_LAYER_SHELL_MAJOR={}", .{version.major}),
+            b.fmt("-DGTK_LAYER_SHELL_MINOR={}", .{version.minor}),
+            b.fmt("-DGTK_LAYER_SHELL_MICRO={}", .{version.patch}),
+        },
+    });
+
+    b.installArtifact(lib);
+}
+
+// Certain files relating to session lock were removed as we don't use them
+const srcs: []const []const u8 = &.{
+    "gtk4-layer-shell.c",
+    "layer-surface.c",
+    "libwayland-shim.c",
+    "registry.c",
+    "stolen-from-libwayland.c",
+    "stubbed-surface.c",
+    "xdg-surface-server.c",
+};
+
+const dynamic_link_opts: std.Build.Module.LinkSystemLibraryOptions = .{
+    .preferred_link_mode = .dynamic,
+    .search_strategy = .mode_first,
+};

--- a/pkg/gtk4-layer-shell/build.zig.zon
+++ b/pkg/gtk4-layer-shell/build.zig.zon
@@ -1,0 +1,15 @@
+.{
+    .name = "gtk4-layer-shell",
+    .version = "1.1.0",
+    .paths = .{""},
+    .dependencies = .{
+        .gtk4_layer_shell = .{
+            .url = "https://github.com/wmww/gtk4-layer-shell/archive/refs/tags/v1.1.0.tar.gz",
+            .hash = "12203eff4829ad8afdd828eb323d48e5ba8dbb44d224e9e314d4ab1533c2bec20f4b",
+        },
+        .wayland_protocols = .{
+            .url = "https://deps.files.ghostty.org/wayland-protocols-258d8f88f2c8c25a830c6316f87d23ce1a0f12d9.tar.gz",
+            .hash = "12201a57c6ce0001aa034fa80fba3e1cd2253c560a45748f4f4dd21ff23b491cddef",
+        },
+    },
+}

--- a/pkg/gtk4-layer-shell/src/main.zig
+++ b/pkg/gtk4-layer-shell/src/main.zig
@@ -1,0 +1,48 @@
+const c = @cImport({
+    @cInclude("gtk4-layer-shell.h");
+});
+const gtk = @import("gtk");
+
+pub const ShellLayer = enum(c_uint) {
+    background = c.GTK_LAYER_SHELL_LAYER_BACKGROUND,
+    bottom = c.GTK_LAYER_SHELL_LAYER_BOTTOM,
+    top = c.GTK_LAYER_SHELL_LAYER_TOP,
+    overlay = c.GTK_LAYER_SHELL_LAYER_OVERLAY,
+};
+
+pub const ShellEdge = enum(c_uint) {
+    left = c.GTK_LAYER_SHELL_EDGE_LEFT,
+    right = c.GTK_LAYER_SHELL_EDGE_RIGHT,
+    top = c.GTK_LAYER_SHELL_EDGE_TOP,
+    bottom = c.GTK_LAYER_SHELL_EDGE_BOTTOM,
+};
+
+pub const KeyboardMode = enum(c_uint) {
+    none = c.GTK_LAYER_SHELL_KEYBOARD_MODE_NONE,
+    exclusive = c.GTK_LAYER_SHELL_KEYBOARD_MODE_EXCLUSIVE,
+    on_demand = c.GTK_LAYER_SHELL_KEYBOARD_MODE_ON_DEMAND,
+};
+
+pub fn isSupported() bool {
+    return c.gtk_layer_is_supported() != 0;
+}
+
+pub fn initForWindow(window: *gtk.Window) void {
+    c.gtk_layer_init_for_window(@ptrCast(window));
+}
+
+pub fn setLayer(window: *gtk.Window, layer: ShellLayer) void {
+    c.gtk_layer_set_layer(@ptrCast(window), @intFromEnum(layer));
+}
+
+pub fn setAnchor(window: *gtk.Window, edge: ShellEdge, anchor_to_edge: bool) void {
+    c.gtk_layer_set_anchor(@ptrCast(window), @intFromEnum(edge), @intFromBool(anchor_to_edge));
+}
+
+pub fn setMargin(window: *gtk.Window, edge: ShellEdge, margin_size: c_int) void {
+    c.gtk_layer_set_margin(@ptrCast(window), @intFromEnum(edge), margin_size);
+}
+
+pub fn setKeyboardMode(window: *gtk.Window, mode: KeyboardMode) void {
+    c.gtk_layer_set_keyboard_mode(@ptrCast(window), @intFromEnum(mode));
+}

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -781,10 +781,7 @@ fn toggleQuickTerminal(self: *App) !bool {
         return true;
     }
 
-    if (!self.winproto.supportsQuickTerminal()) {
-        log.err("quick terminal not supported on current platform", .{});
-        return false;
-    }
+    if (!self.winproto.supportsQuickTerminal()) return false;
 
     const qt = Window.create(self.core_app.alloc, self) catch |err| {
         log.err("failed to initialize quick terminal={}", .{err});

--- a/src/apprt/gtk/c.zig
+++ b/src/apprt/gtk/c.zig
@@ -15,7 +15,6 @@ pub const c = @cImport({
         @cInclude("X11/XKBlib.h");
     }
     if (build_options.wayland) {
-        if (build_options.layer_shell) @cInclude("gtk4-layer-shell/gtk4-layer-shell.h");
         @cInclude("gdk/wayland/gdkwayland.h");
     }
 

--- a/src/apprt/gtk/winproto/x11.zig
+++ b/src/apprt/gtk/winproto/x11.zig
@@ -150,6 +150,7 @@ pub const App = struct {
     }
 
     pub fn supportsQuickTerminal(_: App) bool {
+        log.warn("quick terminal is not yet supported on X11", .{});
         return false;
     }
 

--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -34,7 +34,6 @@ font_backend: font.Backend = .freetype,
 /// Feature flags
 x11: bool = false,
 wayland: bool = false,
-layer_shell: bool = false,
 sentry: bool = true,
 wasm_shared: bool = true,
 
@@ -162,12 +161,6 @@ pub fn init(b: *std.Build) !Config {
         "gtk-x11",
         "Enables linking against X11 libraries when using the GTK rendering backend.",
     ) orelse gtk_targets.x11;
-
-    config.layer_shell = b.option(
-        bool,
-        "gtk-layer-shell",
-        "Enables linking against the gtk4-layer-shell library for quick terminal support. Requires Wayland.",
-    ) orelse gtk_targets.layer_shell;
 
     //---------------------------------------------------------------
     // Ghostty Exe Properties
@@ -366,6 +359,7 @@ pub fn init(b: *std.Build) !Config {
             "libpng",
             "zlib",
             "oniguruma",
+            "gtk4-layer-shell",
         }) |dep| {
             _ = b.systemIntegrationOption(
                 dep,
@@ -398,7 +392,6 @@ pub fn addOptions(self: *const Config, step: *std.Build.Step.Options) !void {
     step.addOption(bool, "flatpak", self.flatpak);
     step.addOption(bool, "x11", self.x11);
     step.addOption(bool, "wayland", self.wayland);
-    step.addOption(bool, "layer_shell", self.layer_shell);
     step.addOption(bool, "sentry", self.sentry);
     step.addOption(apprt.Runtime, "app_runtime", self.app_runtime);
     step.addOption(font.Backend, "font_backend", self.font_backend);

--- a/src/build/docker/debian/Dockerfile
+++ b/src/build/docker/debian/Dockerfile
@@ -51,5 +51,6 @@ RUN ZIG_GLOBAL_CACHE_DIR=/zig/global-cache ./nix/build-support/fetch-zig-cache.s
 
 COPY ./src /src/src
 
-RUN zig build -Doptimize=Debug -Dcpu=baseline -Dapp-runtime=gtk --system /zig/global-cache/p
+# Debian 12 doesn't have gtk4-layer-shell, so we have to manually compile it ourselves
+RUN zig build -Doptimize=Debug -Dcpu=baseline -Dapp-runtime=gtk -fno-sys=gtk4-layer-shell --system /zig/global-cache/p
 

--- a/src/build/gtk.zig
+++ b/src/build/gtk.zig
@@ -3,7 +3,6 @@ const std = @import("std");
 pub const Targets = packed struct {
     x11: bool = false,
     wayland: bool = false,
-    layer_shell: bool = false,
 };
 
 /// Returns the targets that GTK4 was compiled with.
@@ -21,21 +20,8 @@ pub fn targets(b: *std.Build) Targets {
     const x11 = std.mem.indexOf(u8, output, "x11") != null;
     const wayland = std.mem.indexOf(u8, output, "wayland") != null;
 
-    const layer_shell = layer_shell: {
-        if (!wayland) break :layer_shell false;
-
-        _ = b.runAllowFail(
-            &.{ "pkg-config", "--exists", "gtk4-layer-shell-0" },
-            &code,
-            .Ignore,
-        ) catch break :layer_shell false;
-
-        break :layer_shell true;
-    };
-
     return .{
         .x11 = x11,
         .wayland = wayland,
-        .layer_shell = layer_shell,
     };
 }


### PR DESCRIPTION
As of now `gtk4-layer-shell` is unavailable on recent, stable releases of many distros (Debian 12, Ubuntu 24.04, openSUSE Leap & Tumbleweed, etc.) and outdated on many others (Nixpkgs 24.11/unstable, Fedora 41, etc.) This is inconvenient for our users and severely limits where the quick terminal can be used. As a result we then build gtk4-layer-shell ourselves by default unless `--system` or `-fsys=gtk4-layer-shell` are specified. This also allows me to add an idiomatic Zig API on top of the library and avoiding adding even more raw C code in the GTK apprt.

Since we now build gtk4-layer-shell it should be theoretically available on all Linux systems we target. As such, the `-Dgtk-layer-shell` build option has been removed. This is somewhat of an experimental change as I don't know if gtk4-layer-shell works perfectly across all distros, and we can always add the option back if need be.