### PR TITLE
core: update zig2nix to use explicit Zig version from Nix

### DIFF
--- a/build.zig.zon.nix
+++ b/build.zig.zon.nix
@@ -5,7 +5,7 @@
   fetchurl,
   fetchgit,
   runCommandLocal,
-  zig,
+  zig_0_13,
   name ? "zig-packages",
 }:
 with builtins;
@@ -16,7 +16,7 @@ with lib; let
   }:
     runCommandLocal name
     {
-      nativeBuildInputs = [zig];
+      nativeBuildInputs = [zig_0_13];
     }
     ''
       hash="$(zig fetch --global-cache-dir "$TMPDIR" ${artifact})"

--- a/flake.lock
+++ b/flake.lock
@@ -125,16 +125,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1738263917,
-        "narHash": "sha256-j/3fwe2pEOquHabP/puljOKwAZFjIE9gXZqA91sC48M=",
+        "lastModified": 1741368279,
+        "narHash": "sha256-WTaC8HmnIq6O71iK0g9as404BbmS+YyEP5qS85m2JBY=",
         "owner": "jcollie",
         "repo": "zig2nix",
-        "rev": "c311d8e77a6ee0d995f40a6e10a89a3a4ab04f9a",
+        "rev": "672971b5b6911de21446ad4fc76dee677922eda0",
         "type": "github"
       },
       "original": {
         "owner": "jcollie",
-        "ref": "c311d8e77a6ee0d995f40a6e10a89a3a4ab04f9a",
+        "ref": "672971b5b6911de21446ad4fc76dee677922eda0",
         "repo": "zig2nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
     };
 
     zig2nix = {
-      url = "github:jcollie/zig2nix?ref=c311d8e77a6ee0d995f40a6e10a89a3a4ab04f9a";
+      url = "github:jcollie/zig2nix?ref=672971b5b6911de21446ad4fc76dee677922eda0";
       inputs = {
         nixpkgs.follows = "nixpkgs-stable";
         flake-utils.follows = "flake-utils";


### PR DESCRIPTION
This will avoid build breakage in the near future as Zig 0.14 is coming to Nix.