### PR TITLE
pkg(gtk4-layer-shell): Enable using system-installed headers for dynamic linking

### DIFF
--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -506,7 +506,7 @@ pub fn add(
                     // IMPORTANT: gtk4-layer-shell must be linked BEFORE
                     // wayland-client, as it relies on shimming libwayland's APIs.
                     if (b.systemIntegrationOption("gtk4-layer-shell", .{})) {
-                        step.linkSystemLibrary2("gtk4-layer-shell", dynamic_link_opts);
+                        step.linkSystemLibrary2("gtk4-layer-shell-0", dynamic_link_opts);
                     } else {
                         // gtk4-layer-shell *must* be dynamically linked,
                         // so we don't add it as a static library


### PR DESCRIPTION
I noticed we weren't doing system-integration against the pkgconfig for gtk4-layer-shell. This behaviour differed from how we handled system integration for existing deps in `pkg/` (oniguruma, fontconfig).

Refactored `pkg/gtk4-layer-shell/build.zig` referencing `pkg/oniguruma/build.zig` to use pkgconfig names in system integration. Previously we used to libname `libgtk4-layer-shell.so` (`gtk4-layer-shell`) instead of pkgconfig name `gtk4-layer-shell-0.pc` which meant system integration still relied on fetching the C-headers via `zig fetch` instead of system C-headers. 

I've tested this with a `--system` build where the relevant `.zig-cache/p/<hash of gtk4-layer-shell>` is stubbed to an empty directory and `pkgconfig(gtk4-layer-shell-0)` is installed instead on fedora linux.

 