### PR TITLE
macOS: Set LANGUAGE env var based on macOS preferred language list

### DIFF
--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -52,3 +52,7 @@ pub const OpenType = openpkg.Type;
 pub const pipe = pipepkg.pipe;
 pub const resourcesDir = resourcesdir.resourcesDir;
 pub const ShellEscapeWriter = shell.ShellEscapeWriter;
+
+test {
+    _ = i18n;
+}


### PR DESCRIPTION
Sets the LANGUAGE environment variable based on the preferred languages as reported by NSLocale. 

macOS has a concept of preferred languages separate from the system locale. The set of preferred languages is a list in priority order of what translations the user prefers. A user can have, for example, "fr_FR" as their locale but "en" as their preferred language. This would mean that they want to use French units, date formats, etc. but they prefer English translations.

gettext uses the LANGUAGE environment variable to override only translations and a priority order can be specified by separating the languages with colons. For example, "en:fr" would mean that English translations are preferred but if they are not available then French translations should be used.

To further complicate things, Apple reports the languages in BCP-47 format which is not compatible with gettext's POSIX locale format so we have to canonicalize them. To canonicalize the languages we use an internal function from libintl. This isn't normally available but since we compile from source on macOS we can use it. This isn't necessary for other platforms.

This logic is only run if the user didn't explicitly request a specific locale, so it should really only affect macOS app launches. From the CLI the environment will have a locale unless the user really explicitly clears it out.