### PR TITLE
gtk: implement quick-terminal-size

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -82,6 +82,7 @@ pub const DerivedConfig = struct {
     gtk_toolbar_style: configpkg.Config.GtkToolbarStyle,
 
     quick_terminal_position: configpkg.Config.QuickTerminalPosition,
+    quick_terminal_size: configpkg.Config.QuickTerminalSize,
     quick_terminal_autohide: bool,
 
     maximize: bool,
@@ -100,6 +101,7 @@ pub const DerivedConfig = struct {
             .gtk_toolbar_style = config.@"gtk-toolbar-style",
 
             .quick_terminal_position = config.@"quick-terminal-position",
+            .quick_terminal_size = config.@"quick-terminal-size",
             .quick_terminal_autohide = config.@"quick-terminal-autohide",
 
             .maximize = config.maximize,


### PR DESCRIPTION
Fixes #2384 on GTK

I'm not exactly sure how to deal with centered quick terminals so I opted to make them similar to either top/bottom or left/right quick terminals based on the monitor's orientation (portrait/landscape). This may not be the right approach, so I'd like to hear more thoughts about this.