### PR TITLE
terminal: remove redundant assertIntegrity from clearPrompt

### DIFF
--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1373,7 +1373,6 @@ pub fn clearPrompt(self: *Screen) void {
         while (clear_it.next()) |p| {
             const row = p.rowAndCell().row;
             p.node.data.clearCells(row, 0, p.node.data.size.cols);
-            p.node.data.assertIntegrity();
         }
     }
 }


### PR DESCRIPTION
clearCells() always asserts its page's integrity after finishing its work (via a `defer`). We don't need to re-assert the page's integrity immediately thereafter.