### PR TITLE
Fix passing EnvMap for Flatpak builds

### DIFF
--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1105,7 +1105,7 @@ const Subprocess = struct {
             // Flatpak command must have a stable pointer.
             self.flatpak_command = .{
                 .argv = self.args,
-                .env = &self.env,
+                .env = if (self.env) |*env| env else null,
                 .stdin = pty.slave,
                 .stdout = pty.slave,
                 .stderr = pty.slave,


### PR DESCRIPTION
When using -Dflatpak=true the EnvMap was passed as the incorrect type.