### PR TITLE
macOS: only set LANGUAGE for app bundle, do not inherit in termio env

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1039,6 +1039,13 @@ pub const Surface = struct {
 
             // Remove this so that running `ghostty` within Ghostty works.
             env.remove("GHOSTTY_MAC_APP");
+
+            // If we were launched from the desktop then we want to
+            // remove the LANGUAGE env var so that we don't inherit
+            // our translation settings for Ghostty. If we aren't from
+            // the desktop then we didn't set our LANGUAGE var so we
+            // don't need to remove it.
+            if (internal_os.launchedFromDesktop()) env.remove("LANGUAGE");
         }
 
         return env;


### PR DESCRIPTION
Fixes #6633

For macOS, we set LANGUAGE to the priority list of preferred languages for the app bundle, using the GNU gettext priority list format (colon separated list of language codes).

This previously was inherited by the termio env. At first, this was by design, but this has inherent flaws. Namely, the priority list format is a GNU gettext specific format, and programs that use alternate gettext implementations (like musl or Python) do not understand it and actually do the wrong thing (not their fault!).

This change removes the inheritance of LANGUAGE in the termio env. To make it extra safe, we only do set and unset LANGUAGE when we know we launch from an app bundle. That was always the desired behavior but this makes it more explicit.