### PR TITLE
termio, flatpak: implement process watcher with xev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: namespace-profile-ghostty-sm
     needs:
       - build-bench
+      - build-flatpak
       - build-linux
       - build-linux-libghostty
       - build-nix
@@ -78,6 +79,40 @@ jobs:
 
       - name: Build Benchmarks
         run: nix develop -c zig build -Dapp-runtime=glfw -Demit-bench
+
+  build-flatpak:
+    strategy:
+      fail-fast: false
+    runs-on: namespace-profile-ghostty-sm
+    needs: test
+    env:
+      ZIG_LOCAL_CACHE_DIR: /zig/local-cache
+      ZIG_GLOBAL_CACHE_DIR: /zig/global-cache
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Cache
+        uses: namespacelabs/nscloud-cache-action@v1.2.0
+        with:
+          path: |
+            /nix
+            /zig
+
+      # Install Nix and use that to run our tests so our environment matches exactly.
+      - uses: cachix/install-nix-action@v30
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ghostty
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: Build with Flatpak
+        run: |
+          nix develop -c \
+            zig build \
+            -Dflatpak=true
 
   build-linux:
     strategy:


### PR DESCRIPTION
This allows `termio.Exec` to track processes spawned via `FlatpakHostCommand`, finally allowing Ghostty to function as a Flatpak.

Alongside this is a few bug fixes:

* Don't add ghostty to PATH when running in flatpak mode since it's unreachable.
* Correctly handle exit status returned by Flatpak. Previously this was not processed and contains extra status bits.
* Use correct type for PID returned by Flatpak.