### PR TITLE
pkg(highway): Enable system-integration

### DIFF
--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -40,6 +40,7 @@
   hicolor-icon-theme,
   harfbuzz,
   libpng,
+  libhwy,
   libxkbcommon,
   libX11,
   libXcursor,
@@ -141,6 +142,7 @@ in
         zlib
 
         glslang
+        libhwy
         spirv-cross
 
         libxkbcommon

--- a/pkg/highway/build.zig.zon
+++ b/pkg/highway/build.zig.zon
@@ -8,6 +8,7 @@
         .highway = .{
             .url = "https://deps.files.ghostty.org/highway-66486a10623fa0d72fe91260f96c892e41aceb06.tar.gz",
             .hash = "N-V-__8AAGmZhABbsPJLfbqrh6JTHsXhY6qCaLAQyx25e0XE",
+            .lazy = true,
         },
 
         .apple_sdk = .{ .path = "../apple-sdk" },

--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -355,13 +355,13 @@ pub fn init(b: *std.Build) !Config {
         // generally want a fat binary. This can be overridden with the
         // `-fsys` flag.
         for (&[_][]const u8{
-            "freetype",
-            "harfbuzz",
             "fontconfig",
-            "libpng",
-            "zlib",
-            "oniguruma",
+            "freetype",
             "gtk4-layer-shell",
+            "harfbuzz",
+            "libpng",
+            "oniguruma",
+            "zlib",
         }) |dep| {
             _ = b.systemIntegrationOption(
                 dep,
@@ -379,6 +379,13 @@ pub fn init(b: *std.Build) !Config {
             "glslang",
             "spirv-cross",
             "simdutf",
+
+            // This is mostly header-only in release builds and the API
+            // isn't totally stable so this package either doesn't typically
+            // exist OR is a common source of build issues. Packagers who
+            // feel strongly about not building this from source can explicitly
+            // enable fsys on this.
+            "highway",
 
             // This is default false because it is used for testing
             // primarily and not official packaging. The packaging

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -485,8 +485,13 @@ pub fn add(
         .target = target,
         .optimize = optimize,
     })) |highway_dep| {
-        step.linkLibrary(highway_dep.artifact("highway"));
-        try static_libs.append(highway_dep.artifact("highway").getEmittedBin());
+        step.root_module.addImport("highway", highway_dep.module("highway"));
+        if (b.systemIntegrationOption("highway", .{})) {
+            step.linkSystemLibrary2("libhwy", dynamic_link_opts);
+        } else {
+            step.linkLibrary(highway_dep.artifact("highway"));
+            try static_libs.append(highway_dep.artifact("highway").getEmittedBin());
+        }
     }
 
     // utfcpp - This is used as a dependency on our hand-written C++ code


### PR DESCRIPTION
Move bridge.cpp to being a module cSourceFile instead of part of the staticlib Dynamic link against highway with pkg-config name 'libhwy.pc' when system-integrated

Some concerns:
- Running `ldd zig-out/bin/ghostty` after building with `zig build -Doptimize=ReleaseFast` does not show `libhwy.so` but is included in debug optimize.
  *  The staticlib variant also compiles without source files in release mode but not in debug due to missing symbols `hwy::Abort()`. 
  * Would look into how highway works more to understand this, it looks to extensively use templates and template-specialisations which results in little shared object code?

- We configure a few optimization related flags (vectorization, constants), ran a quick DOOM-fire and cats and it seems okay
- There's a few macro defines for predefined macros (__DATE__, __TIMESTAMP__, __TIME__) that are overrided in the static lib. The comment seems to imply that they are for reproducible binaries so I think it shouldn't change runtime behaviour.

