### PR TITLE
deps: Default gtk4-layer-shell system integration to true

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -81,9 +81,6 @@ parts:
       craftctl set version=$(cat VERSION)
       $CRAFT_PART_SRC/../../zig/src/zig build -Dpatch-rpath=\$ORIGIN/../usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:/snap/core24/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR -Doptimize=ReleaseFast -Dcpu=baseline -fno-sys=gtk4-layer-shell
       cp -rp zig-out/* $CRAFT_PART_INSTALL/
-      # Install libgtk4-layer-shell.so
-      mkdir -p $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
-      cp .zig-cache/*/*/libgtk4-layer-shell.so $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/
       sed -i 's|Icon=com.mitchellh.ghostty|Icon=${SNAP}/share/icons/hicolor/512x512/apps/com.mitchellh.ghostty.png|g' $CRAFT_PART_INSTALL/share/applications/com.mitchellh.ghostty.desktop
 
   libs:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -76,9 +76,10 @@ parts:
       - git
       - patchelf
       - gettext
+    # TODO: Remove -fno-sys=gtk4-layer-shell when we upgrade to a version that packages it Ubuntu 24.10+
     override-build: |
       craftctl set version=$(cat VERSION)
-      $CRAFT_PART_SRC/../../zig/src/zig build -Dpatch-rpath=\$ORIGIN/../usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:/snap/core24/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR -Doptimize=ReleaseFast -Dcpu=baseline
+      $CRAFT_PART_SRC/../../zig/src/zig build -Dpatch-rpath=\$ORIGIN/../usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:/snap/core24/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR -Doptimize=ReleaseFast -Dcpu=baseline -fno-sys=gtk4-layer-shell
       cp -rp zig-out/* $CRAFT_PART_INSTALL/
       # Install libgtk4-layer-shell.so
       mkdir -p $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR

--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -361,7 +361,6 @@ pub fn init(b: *std.Build) !Config {
             "libpng",
             "zlib",
             "oniguruma",
-            "gtk4-layer-shell",
         }) |dep| {
             _ = b.systemIntegrationOption(
                 dep,
@@ -386,6 +385,15 @@ pub fn init(b: *std.Build) !Config {
             "glfw3",
         }) |dep| {
             _ = b.systemIntegrationOption(dep, .{ .default = false });
+        }
+
+        // These are dynamic libraries we default to true, preferring
+        // to use system packages over building and installing libs
+        // as they require additional ldconfig of library paths or
+        // patching the rpath of the program to discover the dynamic library
+        // at runtime
+        for (&[_][]const u8{"gtk4-layer-shell"}) |dep| {
+            _ = b.systemIntegrationOption(dep, .{ .default = true });
         }
     }
 

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -652,14 +652,13 @@ fn addGTK(
             // IMPORTANT: gtk4-layer-shell must be linked BEFORE
             // wayland-client, as it relies on shimming libwayland's APIs.
             if (b.systemIntegrationOption("gtk4-layer-shell", .{})) {
-                step.linkSystemLibrary2(
-                    "gtk4-layer-shell-0",
-                    dynamic_link_opts,
-                );
+                step.linkSystemLibrary2("gtk4-layer-shell-0", dynamic_link_opts);
             } else {
                 // gtk4-layer-shell *must* be dynamically linked,
                 // so we don't add it as a static library
-                step.linkLibrary(gtk4_layer_shell.artifact("gtk4-layer-shell"));
+                const shared_lib = gtk4_layer_shell.artifact("gtk4-layer-shell");
+                b.installArtifact(shared_lib);
+                step.linkLibrary(shared_lib);
             }
         }
 


### PR DESCRIPTION
Closes #6632 
When compiling the dynamic lib and linking, the rpath resolves to the compile cache location instead of the install location for the lib. This resulted in loading the dylib failing when the compile cache was removed or the install location is changed.

Based on https://github.com/ziglang/zig/issues/5827 , we specify the rpath to search relative to the executable.
Previous state:
- dynamic lib was not installed to the output directory -> now appears in `$OUT/lib/libgtk4-layer-shell.so`
- rpath only included the compile cache location, not the install location. 
Before:
```sh
$ patchelf --print-rpath zig-out/bin/ghostty
/home/anthony/dev/ghostty-pure/.zig-cache/o/0254fb4753185c5429180337a720248d
$ ldd zig-out/bin/ghostty
        ...
        libgtk4-layer-shell.so => /home/anthony/dev/ghostty-pure/.zig-cache/o/0254fb4753185c5429180337a720248d/libgtk4-layer-shell.so (0x00007f7975468000)
        ...
$  ldd zig-out/bin/ghostty
        ...
        libgtk4-layer-shell.so => not found
        ...
```

After:

```sh
$ zig build
$ patchelf --print-rpath zig-out/bin/ghostty
/home/anthony/dev/ghostty/.zig-cache/o/f45360ddde653cb3bc70966c326dd96d:$ORIGIN/../lib/
$ ldd zig-out/bin/ghostty
        ...
        libgtk4-layer-shell.so => /home/anthony/dev/ghostty/.zig-cache/o/f45360ddde653cb3bc70966c326dd96d/libgtk4-layer-shell.so (0x00007fbf81ad8000)
        ...
 $ rm -r .zig-cache/
 $ ldd zig-out/bin/ghostty
        ...
        libgtk4-layer-shell.so => /home/anthony/dev/ghostty/zig-out/bin/../lib/libgtk4-layer-shell.so (0x00007f60dc087000)
        ...
```
