### PR TITLE
contributing: fix link to Translator's Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,10 @@ pull request will be accepted with a high degree of certainty.
 > working on Ghostty.** If you're a user reporting an issue, you can
 > ignore the rest of this document.
 
+## Including and Updating Translations
+
+See the [Contributor's Guide](po/README_CONTRIBUTORS.md) for more details.
+
 ## Input Stack Testing
 
 The input stack is the part of the codebase that starts with a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,11 +23,11 @@ friendly to new contributors are tagged with "contributor friendly".
 
 **I'd like to translate Ghostty to my language!**
 
-We have written a [Translator's Guide](po/README_CONTRIBUTORS.md) for
+We have written a [Translator's Guide](po/README_TRANSLATORS.md) for
 everyone interested in contributing translations to Ghostty.
 Translations usually do not need to go through the process of issue triage
 and you can submit pull requests directly, although please make sure that
-our [Style Guide](po/README_CONTRIBUTORS.md#style-guide) is followed before
+our [Style Guide](po/README_TRANSLATORS.md#style-guide) is followed before
 submission.
 
 **I have a bug!**


### PR DESCRIPTION
For some reason it pointed to the Contributor's Guide instead...