### PR TITLE
pkg/macos: clean up for Zig 0.14, consolidate C imports into one decl

### DIFF
--- a/pkg/macos/animation/c.zig
+++ b/pkg/macos/animation/c.zig
@@ -1,3 +1,1 @@
-pub const c = @cImport({
-    @cInclude("QuartzCore/CALayer.h");
-});
+pub const c = @import("../main.zig").c;

--- a/pkg/macos/build.zig.zon
+++ b/pkg/macos/build.zig.zon
@@ -1,6 +1,7 @@
 .{
-    .name = "macos",
+    .name = .macos,
     .version = "0.1.0",
+    .fingerprint = 0x45e2f6107d5b2b2c,
     .paths = .{""},
     .dependencies = .{
         .apple_sdk = .{ .path = "../apple-sdk" },

--- a/pkg/macos/carbon/c.zig
+++ b/pkg/macos/carbon/c.zig
@@ -1,3 +1,1 @@
-pub const c = @cImport({
-    @cInclude("Carbon/Carbon.h");
-});
+pub const c = @import("../main.zig").c;

--- a/pkg/macos/dispatch/c.zig
+++ b/pkg/macos/dispatch/c.zig
@@ -1,3 +1,1 @@
-pub const c = @cImport({
-    @cInclude("dispatch/dispatch.h");
-});
+pub const c = @import("../main.zig").c;

--- a/pkg/macos/foundation/attributed_string.zig
+++ b/pkg/macos/foundation/attributed_string.zig
@@ -67,7 +67,7 @@ pub const MutableAttributedString = opaque {
     ) void {
         const T = @TypeOf(key);
         const info = @typeInfo(T);
-        const Key = if (info != .Pointer) T else info.Pointer.child;
+        const Key = if (info != .pointer) T else info.pointer.child;
         const key_arg = if (@hasDecl(Key, "key"))
             key.key()
         else

--- a/pkg/macos/foundation/c.zig
+++ b/pkg/macos/foundation/c.zig
@@ -1,3 +1,1 @@
-pub const c = @cImport({
-    @cInclude("CoreFoundation/CoreFoundation.h");
-});
+pub const c = @import("../main.zig").c;

--- a/pkg/macos/graphics/bitmap_context.zig
+++ b/pkg/macos/graphics/bitmap_context.zig
@@ -38,13 +38,13 @@ test {
     const cs = try graphics.ColorSpace.createDeviceGray();
     defer cs.release();
     const ctx = try BitmapContext.create(null, 80, 80, 8, 80, cs, 0);
-    defer ctx.release();
-
-    ctx.setShouldAntialias(true);
-    ctx.setShouldSmoothFonts(false);
-    ctx.setGrayFillColor(1, 1);
-    ctx.setGrayStrokeColor(1, 1);
-    ctx.setTextDrawingMode(.fill);
-    ctx.setTextMatrix(graphics.AffineTransform.identity());
-    ctx.setTextPosition(0, 0);
+    const context = BitmapContext.context;
+    defer context.release(ctx);
+    context.setShouldAntialias(ctx, true);
+    context.setShouldSmoothFonts(ctx, false);
+    context.setGrayFillColor(ctx, 1, 1);
+    context.setGrayStrokeColor(ctx, 1, 1);
+    context.setTextDrawingMode(ctx, .fill);
+    context.setTextMatrix(ctx, graphics.AffineTransform.identity());
+    context.setTextPosition(ctx, 0, 0);
 }

--- a/pkg/macos/graphics/c.zig
+++ b/pkg/macos/graphics/c.zig
@@ -1,3 +1,1 @@
-pub const c = @cImport({
-    @cInclude("CoreGraphics/CoreGraphics.h");
-});
+pub const c = @import("../main.zig").c;

--- a/pkg/macos/graphics/path.zig
+++ b/pkg/macos/graphics/path.zig
@@ -3,7 +3,7 @@ const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const foundation = @import("../foundation.zig");
 const graphics = @import("../graphics.zig");
-const c = @import("c.zig");
+const c = @import("c.zig").c;
 
 pub const Path = opaque {
     pub fn createWithRect(

--- a/pkg/macos/main.zig
+++ b/pkg/macos/main.zig
@@ -1,3 +1,5 @@
+const builtin = @import("builtin");
+
 pub const carbon = @import("carbon.zig");
 pub const foundation = @import("foundation.zig");
 pub const animation = @import("animation.zig");
@@ -6,6 +8,23 @@ pub const graphics = @import("graphics.zig");
 pub const os = @import("os.zig");
 pub const text = @import("text.zig");
 pub const video = @import("video.zig");
+
+// All of our C imports consolidated into one place. We used to
+// import them one by one in each package but Zig 0.14 has some
+// kind of issue with that I wasn't able to minimize.
+pub const c = @cImport({
+    @cInclude("CoreFoundation/CoreFoundation.h");
+    @cInclude("CoreGraphics/CoreGraphics.h");
+    @cInclude("CoreText/CoreText.h");
+    @cInclude("CoreVideo/CoreVideo.h");
+    @cInclude("QuartzCore/CALayer.h");
+    @cInclude("dispatch/dispatch.h");
+    @cInclude("os/log.h");
+
+    if (builtin.os.tag == .macos) {
+        @cInclude("Carbon/Carbon.h");
+    }
+});
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/pkg/macos/os/c.zig
+++ b/pkg/macos/os/c.zig
@@ -1,3 +1,1 @@
-pub const c = @cImport({
-    @cInclude("os/log.h");
-});
+pub const c = @import("../main.zig").c;

--- a/pkg/macos/text/c.zig
+++ b/pkg/macos/text/c.zig
@@ -1,3 +1,1 @@
-pub const c = @cImport({
-    @cInclude("CoreText/CoreText.h");
-});
+pub const c = @import("../main.zig").c;

--- a/pkg/macos/text/font.zig
+++ b/pkg/macos/text/font.zig
@@ -280,7 +280,8 @@ test {
         const cs = try graphics.ColorSpace.createDeviceGray();
         defer cs.release();
         const ctx = try graphics.BitmapContext.create(null, 80, 80, 8, 80, cs, 0);
-        defer ctx.release();
+        const context = graphics.BitmapContext.context;
+        defer context.release(ctx);
 
         var pos = [_]graphics.Point{.{ .x = 0, .y = 0 }};
         font.drawGlyphs(

--- a/pkg/macos/text/font_descriptor.zig
+++ b/pkg/macos/text/font_descriptor.zig
@@ -276,7 +276,7 @@ test "descriptor" {
     const v = try FontDescriptor.createWithNameAndSize(name, 12);
     defer v.release();
 
-    const copy_name = v.copyAttribute(.name);
+    const copy_name = v.copyAttribute(.name).?;
     defer copy_name.release();
 
     {

--- a/pkg/macos/video/c.zig
+++ b/pkg/macos/video/c.zig
@@ -1,3 +1,1 @@
-pub const c = @cImport({
-    @cInclude("CoreVideo/CoreVideo.h");
-});
+pub const c = @import("../main.zig").c;


### PR DESCRIPTION
Fixes #6727

The major change in this commit is to consolidate all the C imports in a single decl in main.zig. This is required for Zig 0.14. Without it, the problem in #6727 will happen. I was never able to minimize why this happens in order to open a Zig bug.

Beyond this, I fixed the build.zig and build.zig.zon to work with Zig 0.14 so that we can test building `pkg/macos` in isolation. There are no downstream impacting changes in the build.zig files.