### PR TITLE
apprt/gtk: any preedit change should note a composing state

### DIFF
--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1969,6 +1969,14 @@ fn gtkInputPreeditChanged(
     ctx: *gtk.IMMulticontext,
     self: *Surface,
 ) callconv(.C) void {
+    // Any preedit change should mark that we're composing. Its possible this
+    // is false using fcitx5-hangul and typing "dkssud<space>" ("안녕"). The
+    // second "s" results in a "commit" for "안" which sets composing to false,
+    // but then immediately sends a preedit change for the next symbol. With
+    // composing set to false we won't commit this text. Therefore, we must
+    // ensure it is set here.
+    self.im_composing = true;
+
     // Get our pre-edit string that we'll use to show the user.
     var buf: [*:0]u8 = undefined;
     ctx.as(gtk.IMContext).getPreeditString(&buf, null, null);


### PR DESCRIPTION
Fixes #6772

When typing Korean with the fcitx5-hangful input method, moving between graphemes does not trigger a preedit end/start cycle and instead just clears the preexisting preedit and reuses the started state.

Every other input method we've tested up until now doesn't do this. We need to mark composing set to "false" in "commit" because some input methods on the contrary fail to ever call END.

What is the point of start/end events if they are just ignored depending on the whim of the input method? Nothing. That's what. Its all a mess that GTK should be protecting us from but it doesn't and now its the app developer's problem. I'm frustrated because I feel like the point of an app framework is to mask this kind of complexity from the app developer and I'm playing whack-a-mole with input methods.

Well, here's another whack. Let's see if it works.