### PR TITLE
Update Adwaita version check for Box unref

### DIFF
--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -370,6 +370,7 @@ pub fn init(self: *Surface, app: *App, opts: Options) !void {
 
     // Create an overlay so we can layer the GL area with other widgets.
     const overlay = gtk.Overlay.new();
+    errdefer overlay.unref();
     const overlay_widget = overlay.as(gtk.Widget);
     overlay.setChild(gl_area_widget);
 

--- a/src/apprt/gtk/Tab.zig
+++ b/src/apprt/gtk/Tab.zig
@@ -64,6 +64,7 @@ pub fn init(self: *Tab, window: *Window, parent_: ?*CoreSurface) !void {
     // box makes it easier to maintain the tab contents because we never need to
     // change the root widget of the notebook page (tab).
     const box = gtk.Box.new(.vertical, 0);
+    errdefer box.unref();
     const box_widget = box.as(gtk.Widget);
     box_widget.setHexpand(1);
     box_widget.setVexpand(1);

--- a/src/apprt/gtk/TabView.zig
+++ b/src/apprt/gtk/TabView.zig
@@ -209,14 +209,11 @@ pub fn closeTab(self: *TabView, tab: *Tab) void {
 
     // If we have no more tabs we close the window
     if (self.nPages() == 0) {
-        // libadw versions <= 1.3.x leak the final page view
+        // libadw versions < 1.5.1 leak the final page view
         // which causes our surface to not properly cleanup. We
         // unref to force the cleanup. This will trigger a critical
         // warning from GTK, but I don't know any other workaround.
-        // Note: I'm not actually sure if 1.4.0 contains the fix,
-        // I just know that 1.3.x is broken and 1.5.1 is fixed.
-        // If we know that 1.4.0 is fixed, we can change this.
-        if (!adwaita.versionAtLeast(1, 4, 0)) {
+        if (!adwaita.versionAtLeast(1, 5, 1)) {
             const box: *gtk.Box = @ptrCast(@alignCast(tab.box));
             box.as(gobject.Object).unref();
         }


### PR DESCRIPTION
As of Adwaita 1.5.0, the GTK Box is not being properly unref'd when the parent window is closed. Update the conditional to account for this.

Also add a couple of missing unref()s in errdefers.

This fixes an issue where Ghostty would not properly quit after closing the last surface.

Resolves: https://github.com/ghostty-org/ghostty/discussions/3807