### PR TITLE
`zig build dist` and `distcheck` for source tarballs

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -77,8 +77,17 @@ jobs:
     needs: [setup]
     env:
       GHOSTTY_VERSION: ${{ needs.setup.outputs.version }}
+      ZIG_LOCAL_CACHE_DIR: /zig/local-cache
+      ZIG_GLOBAL_CACHE_DIR: /zig/global-cache
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup Cache
+        uses: namespacelabs/nscloud-cache-action@v1.2.0
+        with:
+          path: |
+            /nix
+            /zig
 
       - uses: cachix/install-nix-action@v30
         with:
@@ -91,8 +100,8 @@ jobs:
 
       - name: Create Tarball
         run: |
-          git archive --format=tgz --prefix="ghostty-${GHOSTTY_VERSION}/" -o "ghostty-${GHOSTTY_VERSION}.tar.gz" HEAD
-          git archive --format=tgz --prefix=ghostty-source/ -o ghostty-source.tar.gz HEAD
+          nix develop -c zig build distcheck
+          cp zig-out/dist/ghostty-${GHOSTTY_VERSION}.tar.gz .
 
       - name: Sign Tarball
         run: |
@@ -108,8 +117,6 @@ jobs:
           path: |-
             ghostty-${{ env.GHOSTTY_VERSION }}.tar.gz
             ghostty-${{ env.GHOSTTY_VERSION }}.tar.gz.minisig
-            ghostty-source.tar.gz
-            ghostty-source.tar.gz.minisig
 
   build-macos:
     needs: [setup]

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -101,8 +101,17 @@ jobs:
         )
       }}
     runs-on: namespace-profile-ghostty-md
+    env:
+      ZIG_LOCAL_CACHE_DIR: /zig/local-cache
+      ZIG_GLOBAL_CACHE_DIR: /zig/global-cache
     steps:
       - uses: actions/checkout@v4
+      - name: Setup Cache
+        uses: namespacelabs/nscloud-cache-action@v1.2.0
+        with:
+          path: |
+            /nix
+            /zig
       - uses: cachix/install-nix-action@v30
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -111,12 +120,17 @@ jobs:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Create Tarball
-        run: git archive --format=tgz --prefix=ghostty-source/ -o ghostty-source.tar.gz HEAD
+        run: |
+          rm -rf zig-out/dist
+          nix develop -c zig build distcheck
+          cp zig-out/dist/*.tar.gz ghostty-source.tar.gz
+
       - name: Sign Tarball
         run: |
           echo -n "${{ secrets.MINISIGN_KEY }}" > minisign.key
           echo -n "${{ secrets.MINISIGN_PASSWORD }}" > minisign.password
           nix develop -c minisign -S -m ghostty-source.tar.gz -s minisign.key < minisign.password
+
       - name: Update Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: namespace-profile-ghostty-sm
     needs:
       - build-bench
+      - build-dist
       - build-flatpak
       - build-linux
       - build-linux-libghostty
@@ -208,6 +209,35 @@ jobs:
 
       - name: Test NixOS package build
         run: nix build .#ghostty
+
+  build-dist:
+    runs-on: namespace-profile-ghostty-md
+    needs: test
+    env:
+      ZIG_LOCAL_CACHE_DIR: /zig/local-cache
+      ZIG_GLOBAL_CACHE_DIR: /zig/global-cache
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Cache
+        uses: namespacelabs/nscloud-cache-action@v1.2.0
+        with:
+          path: |
+            /nix
+            /zig
+
+      # Install Nix and use that to run our tests so our environment matches exactly.
+      - uses: cachix/install-nix-action@v30
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ghostty
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: Build and Check Source Tarball
+        run: nix develop -c zig build distcheck
 
   build-macos:
     runs-on: namespace-profile-ghostty-macos

--- a/src/build/GhosttyDist.zig
+++ b/src/build/GhosttyDist.zig
@@ -1,0 +1,87 @@
+const GhosttyDist = @This();
+
+const std = @import("std");
+const Config = @import("Config.zig");
+const SharedDeps = @import("SharedDeps.zig");
+
+/// The final source tarball.
+archive: std.Build.LazyPath,
+
+/// The step to install the tarball.
+install_step: *std.Build.Step,
+
+/// The step to depend on
+archive_step: *std.Build.Step,
+
+/// The step to depend on for checking the dist
+check_step: *std.Build.Step,
+
+pub fn init(b: *std.Build, cfg: *const Config) !GhosttyDist {
+    // git archive to create the final tarball. "git archive" is the
+    // easiest way I can find to create a tarball that ignores stuff
+    // from gitignore and also supports adding files as well as removing
+    // dist-only files (the "export-ignore" git attribute).
+    const git_archive = b.addSystemCommand(&.{
+        "git",
+        "archive",
+        "--format=tgz",
+
+        // This is important. Standard source tarballs extract into
+        // a directory named `project-version`. This is expected by
+        // standard tooling such as debhelper and rpmbuild.
+        b.fmt("--prefix=ghostty-{}/", .{cfg.version}),
+
+        "-o",
+    });
+    const output = git_archive.addOutputFileArg(b.fmt(
+        "ghostty-{}.tar.gz",
+        .{cfg.version},
+    ));
+    git_archive.addArg("HEAD");
+
+    // The install step to put the dist into the build directory.
+    const install = b.addInstallFile(
+        output,
+        b.fmt("dist/ghostty-{}.tar.gz", .{cfg.version}),
+    );
+
+    // The check step to ensure the archive works.
+    const check = b.addSystemCommand(&.{ "tar", "xvzf" });
+    check.addFileArg(output);
+    check.addArg("-C");
+
+    // This is the root Ghostty source dir of the extracted source tarball.
+    // i.e. this is way `build.zig` is.
+    const extract_dir = check
+        .addOutputDirectoryArg("ghostty")
+        .path(b, b.fmt("ghostty-{}", .{cfg.version}));
+
+    // Check that tests pass within the extracted directory. This isn't
+    // a fully hermetic test because we're sharing the Zig cache. In
+    // the future we could add an option to use a totally new cache but
+    // in the interest of speed we don't do that for now and hope other
+    // CI catches any issues.
+    const check_test = step: {
+        const step = b.addSystemCommand(&.{ "zig", "build", "test" });
+        step.setCwd(extract_dir);
+
+        // Must be set so that Zig knows that this command doesn't
+        // have side effects and is being run for its exit code check.
+        // Zig will cache depending on its extract dir.
+        step.expectExitCode(0);
+
+        // Capture stderr so it doesn't spew into the parent build.
+        // On the flip side, if the test fails we won't know why so
+        // that sucks but we should have already ran tests at this point.
+        _ = step.captureStdErr();
+
+        break :step step;
+    };
+
+    return .{
+        .archive = output,
+        .install_step = &install.step,
+        .archive_step = &git_archive.step,
+        .check_step = &check_test.step,
+    };
+}

--- a/src/build/main.zig
+++ b/src/build/main.zig
@@ -8,6 +8,7 @@ pub const GitVersion = @import("GitVersion.zig");
 
 // Artifacts
 pub const GhosttyBench = @import("GhosttyBench.zig");
+pub const GhosttyDist = @import("GhosttyDist.zig");
 pub const GhosttyDocs = @import("GhosttyDocs.zig");
 pub const GhosttyExe = @import("GhosttyExe.zig");
 pub const GhosttyFrameData = @import("GhosttyFrameData.zig");


### PR DESCRIPTION
This moves the source tarball creation process into the Zig build system and follows the autotools-standard naming conventions of `dist` and `distcheck`.

This doesn't change any of our build process otherwise. This is the foundation for #6760 along with other source tarball tasks I have planned (i.e. gobject bindings too). 

The `dist` target creates a source tarball in the `PREFIX/dist` directory. The tarball is named `ghostty-VERSION.tar.gz` as expected by standard source tarball conventions.

The `distcheck` target does the same as `dist`, but also takes the resulting tarball, extracts it, and runs tests on the extracted source to verify the source tarball works as expected. Distcheck currently only runs `zig build test` but in the future we can add additional checks to run. 

This commit also updates CI:

  1. Tagged releases now use the new `zig build distcheck` command.
  2. Tip releases now use the new `zig build dist` command.
  3. A new test build tests that source tarball generation works on every commit.