### PR TITLE
CI: Add checks for blueprint compiler / Nix refactors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
       - alejandra
       - typos
       - translations
+      - blueprint-compiler
       - test-pkg-linux
       - test-debian-12
     steps:
@@ -701,6 +702,35 @@ jobs:
             # Ignore untranslated entries
             msgcmp --use-untranslated "$f" po/com.mitchellh.ghostty.pot;
           done
+
+  blueprint-compiler:
+    if: github.repository == 'ghostty-org/ghostty'
+    runs-on: namespace-profile-ghostty-sm
+    timeout-minutes: 60
+    env:
+      ZIG_LOCAL_CACHE_DIR: /zig/local-cache
+      ZIG_GLOBAL_CACHE_DIR: /zig/global-cache
+    steps:
+      - uses: actions/checkout@v4 # Check out repo so we can lint it
+      - name: Setup Cache
+        uses: namespacelabs/nscloud-cache-action@v1.2.0
+        with:
+          path: |
+            /nix
+            /zig
+      - uses: cachix/install-nix-action@v30
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ghostty
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          skipPush: true
+          useDaemon: false # sometimes fails on short jobs
+      - name: check blueprints
+        run: nix develop -c ./nix/build-support/check-blueprints.sh
+      - name: check unchanged
+        run: git diff --exit-code
 
   test-pkg-linux:
     strategy:

--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,8 @@
           devShell.${system} = pkgs-stable.callPackage ./nix/devShell.nix {
             zig = zig.packages.${system}."0.14.0";
             wraptest = pkgs-stable.callPackage ./nix/wraptest.nix {};
+            # remove once blueprint-compiler 0.16.0 is in the stable nixpkgs
+            blueprint-compiler = pkgs-unstable.blueprint-compiler;
             zon2nix = zon2nix;
           };
 

--- a/nix/build-support/build-inputs.nix
+++ b/nix/build-support/build-inputs.nix
@@ -1,0 +1,43 @@
+{
+  pkgs,
+  lib,
+  stdenv,
+  enableX11 ? true,
+  enableWayland ? true,
+}:
+[
+  pkgs.libGL
+]
+++ lib.optionals stdenv.hostPlatform.isLinux [
+  pkgs.bzip2
+  pkgs.expat
+  pkgs.fontconfig
+  pkgs.freetype
+  pkgs.harfbuzz
+  pkgs.libpng
+  pkgs.libxml2
+  pkgs.oniguruma
+  pkgs.simdutf
+  pkgs.zlib
+
+  pkgs.glslang
+  pkgs.spirv-cross
+
+  pkgs.libxkbcommon
+
+  pkgs.glib
+  pkgs.gobject-introspection
+  pkgs.gsettings-desktop-schemas
+  pkgs.gtk4
+  pkgs.libadwaita
+]
+++ lib.optionals (stdenv.hostPlatform.isLinux && enableX11) [
+  pkgs.xorg.libX11
+  pkgs.xorg.libXcursor
+  pkgs.xorg.libXi
+  pkgs.xorg.libXrandr
+]
+++ lib.optionals (stdenv.hostPlatform.isLinux && enableWayland) [
+  pkgs.gtk4-layer-shell
+  pkgs.wayland
+]

--- a/nix/build-support/check-blueprints.sh
+++ b/nix/build-support/check-blueprints.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -o nounset -o pipefail -o errexit
+
+find src -name \*.blp -exec blueprint-compiler format {} \+
+find src -name \*.blp -exec blueprint-compiler compile --output=/dev/null {} \;

--- a/nix/build-support/gi-typelib-path.nix
+++ b/nix/build-support/gi-typelib-path.nix
@@ -1,0 +1,17 @@
+{
+  pkgs,
+  lib,
+  stdenv,
+}:
+lib.makeSearchPath "lib/girepository-1.0" (map (lib.getOutput "lib") (lib.optionals stdenv.hostPlatform.isLinux [
+  pkgs.cairo
+  pkgs.gdk-pixbuf
+  pkgs.glib
+  pkgs.gobject-introspection
+  pkgs.graphene
+  pkgs.gtk4
+  pkgs.gtk4-layer-shell
+  pkgs.harfbuzz
+  pkgs.libadwaita
+  pkgs.pango
+]))

--- a/nix/build-support/ld-library-path.nix
+++ b/nix/build-support/ld-library-path.nix
@@ -1,0 +1,10 @@
+{
+  pkgs,
+  lib,
+  stdenv,
+  enableX11 ? true,
+  enableWayland ? true,
+}:
+lib.makeLibraryPath (import ./build-inputs.nix {
+  inherit pkgs lib stdenv enableX11 enableWayland;
+})

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -40,7 +40,6 @@
   hicolor-icon-theme,
   harfbuzz,
   libpng,
-  libGL,
   libxkbcommon,
   libX11,
   libXcursor,
@@ -63,44 +62,18 @@
   wayland-protocols,
   zon2nix,
   system,
+  pkgs,
 }: let
   # See package.nix. Keep in sync.
-  rpathLibs =
-    [
-      libGL
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [
-      bzip2
-      expat
-      fontconfig
-      freetype
-      harfbuzz
-      libpng
-      libxml2
-      oniguruma
-      simdutf
-      zlib
-
-      glslang
-      spirv-cross
-
-      libxkbcommon
-      libX11
-      libXcursor
-      libXi
-      libXrandr
-
-      libadwaita
-      gtk4
-      gtk4-layer-shell
-      glib
-      gobject-introspection
-      wayland
-    ];
+  ld_library_path = import ./build-support/ld-library-path.nix {
+    inherit pkgs lib stdenv;
+  };
+  gi_typelib_path = import ./build-support/gi-typelib-path.nix {
+    inherit pkgs lib stdenv;
+  };
 in
   mkShell {
     name = "ghostty";
-
     packages =
       [
         # For builds
@@ -186,7 +159,8 @@ in
 
     # This should be set onto the rpath of the ghostty binary if you want
     # it to be "portable" across the system.
-    LD_LIBRARY_PATH = lib.makeLibraryPath rpathLibs;
+    LD_LIBRARY_PATH = ld_library_path;
+    GI_TYPELIB_PATH = gi_typelib_path;
 
     shellHook =
       (lib.optionalString stdenv.hostPlatform.isLinux ''

--- a/src/apprt/gtk/ui/1.2/ccw-osc-52-read.blp
+++ b/src/apprt/gtk/ui/1.2/ccw-osc-52-read.blp
@@ -8,7 +8,7 @@ Adw.MessageDialog clipboard_confirmation_window {
 
   responses [
     cancel: _("Deny") suggested,
-    ok: _("Allow") destructive
+    ok: _("Allow") destructive,
   ]
 
   default-response: "cancel";
@@ -16,7 +16,7 @@ Adw.MessageDialog clipboard_confirmation_window {
 
   extra-child: Overlay {
     styles [
-      "osd"
+      "osd",
     ]
 
     ScrolledWindow text_view_scroll {
@@ -33,7 +33,7 @@ Adw.MessageDialog clipboard_confirmation_window {
         right-margin: 8;
 
         styles [
-          "clipboard-content-view"
+          "clipboard-content-view",
         ]
       }
     }
@@ -60,7 +60,7 @@ Adw.MessageDialog clipboard_confirmation_window {
       margin-top: 12;
 
       styles [
-        "opaque"
+        "opaque",
       ]
 
       Image {

--- a/src/apprt/gtk/ui/1.2/ccw-osc-52-write.blp
+++ b/src/apprt/gtk/ui/1.2/ccw-osc-52-write.blp
@@ -8,7 +8,7 @@ Adw.MessageDialog clipboard_confirmation_window {
 
   responses [
     cancel: _("Deny") suggested,
-    ok: _("Allow") destructive
+    ok: _("Allow") destructive,
   ]
 
   default-response: "cancel";
@@ -16,7 +16,7 @@ Adw.MessageDialog clipboard_confirmation_window {
 
   extra-child: Overlay {
     styles [
-      "osd"
+      "osd",
     ]
 
     ScrolledWindow text_view_scroll {
@@ -33,7 +33,7 @@ Adw.MessageDialog clipboard_confirmation_window {
         right-margin: 8;
 
         styles [
-          "clipboard-content-view"
+          "clipboard-content-view",
         ]
       }
     }
@@ -60,7 +60,7 @@ Adw.MessageDialog clipboard_confirmation_window {
       margin-top: 12;
 
       styles [
-        "opaque"
+        "opaque",
       ]
 
       Image {

--- a/src/apprt/gtk/ui/1.2/ccw-paste.blp
+++ b/src/apprt/gtk/ui/1.2/ccw-paste.blp
@@ -8,7 +8,7 @@ Adw.MessageDialog clipboard_confirmation_window {
 
   responses [
     cancel: _("Cancel") suggested,
-    ok: _("Paste") destructive
+    ok: _("Paste") destructive,
   ]
 
   default-response: "cancel";
@@ -16,7 +16,7 @@ Adw.MessageDialog clipboard_confirmation_window {
 
   extra-child: Overlay {
     styles [
-      "osd"
+      "osd",
     ]
 
     ScrolledWindow text_view_scroll {
@@ -33,7 +33,7 @@ Adw.MessageDialog clipboard_confirmation_window {
         right-margin: 8;
 
         styles [
-          "clipboard-content-view"
+          "clipboard-content-view",
         ]
       }
     }
@@ -60,7 +60,7 @@ Adw.MessageDialog clipboard_confirmation_window {
       margin-top: 12;
 
       styles [
-        "opaque"
+        "opaque",
       ]
 
       Image {

--- a/src/apprt/gtk/ui/1.2/config-errors-dialog.blp
+++ b/src/apprt/gtk/ui/1.2/config-errors-dialog.blp
@@ -2,27 +2,27 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.MessageDialog config_errors_dialog {
-    heading: _("Configuration Errors");
-    body: _("One or more configuration errors were found. Please review the errors below, and either reload your configuration or ignore these errors.");
+  heading: _("Configuration Errors");
+  body: _("One or more configuration errors were found. Please review the errors below, and either reload your configuration or ignore these errors.");
 
-    responses [
-        ignore: _("Ignore"),
-        reload: _("Reload Configuration") suggested,
-    ]
+  responses [
+    ignore: _("Ignore"),
+    reload: _("Reload Configuration") suggested,
+  ]
 
-    extra-child: ScrolledWindow {
-        min-content-width: 500;
-        min-content-height: 100;
-        
-        TextView {
-            editable: false;
-            cursor-visible: false;
-            top-margin: 8;
-            bottom-margin: 8;
-            left-margin: 8;
-            right-margin: 8;
+  extra-child: ScrolledWindow {
+    min-content-width: 500;
+    min-content-height: 100;
 
-            buffer: TextBuffer error_message { };
-        }
-    };
+    TextView {
+      editable: false;
+      cursor-visible: false;
+      top-margin: 8;
+      bottom-margin: 8;
+      left-margin: 8;
+      right-margin: 8;
+
+      buffer: TextBuffer error_message {};
+    }
+  };
 }

--- a/src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp
+++ b/src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp
@@ -8,7 +8,7 @@ Adw.AlertDialog clipboard_confirmation_window {
 
   responses [
     cancel: _("Deny") suggested,
-    ok: _("Allow") destructive
+    ok: _("Allow") destructive,
   ]
 
   default-response: "cancel";
@@ -16,7 +16,7 @@ Adw.AlertDialog clipboard_confirmation_window {
 
   extra-child: Overlay {
     styles [
-      "osd"
+      "osd",
     ]
 
     ScrolledWindow text_view_scroll {
@@ -33,7 +33,7 @@ Adw.AlertDialog clipboard_confirmation_window {
         right-margin: 8;
 
         styles [
-          "clipboard-content-view"
+          "clipboard-content-view",
         ]
       }
     }
@@ -60,7 +60,7 @@ Adw.AlertDialog clipboard_confirmation_window {
       margin-top: 12;
 
       styles [
-        "opaque"
+        "opaque",
       ]
 
       Image {

--- a/src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp
+++ b/src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp
@@ -8,7 +8,7 @@ Adw.AlertDialog clipboard_confirmation_window {
 
   responses [
     cancel: _("Deny") suggested,
-    ok: _("Allow") destructive
+    ok: _("Allow") destructive,
   ]
 
   default-response: "cancel";
@@ -16,7 +16,7 @@ Adw.AlertDialog clipboard_confirmation_window {
 
   extra-child: Overlay {
     styles [
-      "osd"
+      "osd",
     ]
 
     ScrolledWindow text_view_scroll {
@@ -33,7 +33,7 @@ Adw.AlertDialog clipboard_confirmation_window {
         right-margin: 8;
 
         styles [
-          "clipboard-content-view"
+          "clipboard-content-view",
         ]
       }
     }
@@ -60,7 +60,7 @@ Adw.AlertDialog clipboard_confirmation_window {
       margin-top: 12;
 
       styles [
-        "opaque"
+        "opaque",
       ]
 
       Image {

--- a/src/apprt/gtk/ui/1.5/ccw-paste.blp
+++ b/src/apprt/gtk/ui/1.5/ccw-paste.blp
@@ -8,7 +8,7 @@ Adw.AlertDialog clipboard_confirmation_window {
 
   responses [
     cancel: _("Cancel") suggested,
-    ok: _("Paste") destructive
+    ok: _("Paste") destructive,
   ]
 
   default-response: "cancel";
@@ -16,7 +16,7 @@ Adw.AlertDialog clipboard_confirmation_window {
 
   extra-child: Overlay {
     styles [
-      "osd"
+      "osd",
     ]
 
     ScrolledWindow text_view_scroll {
@@ -33,7 +33,7 @@ Adw.AlertDialog clipboard_confirmation_window {
         right-margin: 8;
 
         styles [
-          "clipboard-content-view"
+          "clipboard-content-view",
         ]
       }
     }
@@ -60,7 +60,7 @@ Adw.AlertDialog clipboard_confirmation_window {
       margin-top: 12;
 
       styles [
-        "opaque"
+        "opaque",
       ]
 
       Image {

--- a/src/apprt/gtk/ui/1.5/config-errors-dialog.blp
+++ b/src/apprt/gtk/ui/1.5/config-errors-dialog.blp
@@ -2,27 +2,27 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.AlertDialog config_errors_dialog {
-    heading: _("Configuration Errors");
-    body: _("One or more configuration errors were found. Please review the errors below, and either reload your configuration or ignore these errors.");
+  heading: _("Configuration Errors");
+  body: _("One or more configuration errors were found. Please review the errors below, and either reload your configuration or ignore these errors.");
 
-    responses [
-        ignore: _("Ignore"),
-        reload: _("Reload Configuration") suggested,
-    ]
+  responses [
+    ignore: _("Ignore"),
+    reload: _("Reload Configuration") suggested,
+  ]
 
-    extra-child: ScrolledWindow {
-        min-content-width: 500;
-        min-content-height: 100;
-        
-        TextView {
-            editable: false;
-            cursor-visible: false;
-            top-margin: 8;
-            bottom-margin: 8;
-            left-margin: 8;
-            right-margin: 8;
+  extra-child: ScrolledWindow {
+    min-content-width: 500;
+    min-content-height: 100;
 
-            buffer: TextBuffer error_message { };
-        }
-    };
+    TextView {
+      editable: false;
+      cursor-visible: false;
+      top-margin: 8;
+      bottom-margin: 8;
+      left-margin: 8;
+      right-margin: 8;
+
+      buffer: TextBuffer error_message {};
+    }
+  };
 }

--- a/src/apprt/gtk/ui/1.5/prompt-title-dialog.blp
+++ b/src/apprt/gtk/ui/1.5/prompt-title-dialog.blp
@@ -7,7 +7,7 @@ Adw.AlertDialog prompt_title_dialog {
 
   responses [
     cancel: _("Cancel") suggested,
-    ok: _("OK") destructive
+    ok: _("OK") destructive,
   ]
 
   focus-widget: title_entry;


### PR DESCRIPTION
1. Refactored Nix devshell/package to make it easier to keep LD_LIBRARY_PATH & buildInputs in sync (plus make it easier to re-use in other Nix environment).
2. Added a CI job to ensure that Blueprints are formatted correctly and that they will compile using `blueprint-compiler` 0.16.0.
3. Reformatted all Blueprints with `blueprint-compiler format`.