### PR TITLE
Regenerate translations to fix CI

### DIFF
--- a/po/com.mitchellh.ghostty.pot
+++ b/po/com.mitchellh.ghostty.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-03-18 11:48+0100\n"
+"POT-Creation-Date: 2025-03-19 08:28-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -148,7 +148,7 @@ msgid "Terminal Inspector"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:102
-#: src/apprt/gtk/Window.zig:958
+#: src/apprt/gtk/Window.zig:960
 msgid "About Ghostty"
 msgstr ""
 
@@ -193,29 +193,12 @@ msgid ""
 "commands may be executed."
 msgstr ""
 
-#: src/apprt/gtk/Window.zig:200
-msgid "Main Menu"
-msgstr ""
-
-#: src/apprt/gtk/Window.zig:221
-msgid "View Open Tabs"
-msgstr ""
-
-#: src/apprt/gtk/Window.zig:295
-msgid ""
-"⚠️ You're running a debug build of Ghostty! Performance will be degraded."
-msgstr ""
-
-#: src/apprt/gtk/Window.zig:725
-msgid "Reloaded the configuration"
-msgstr ""
-
-#: src/apprt/gtk/Window.zig:939
-msgid "Ghostty Developers"
-msgstr ""
-
 #: src/apprt/gtk/inspector.zig:144
 msgid "Ghostty: Terminal Inspector"
+msgstr ""
+
+#: src/apprt/gtk/Surface.zig:1243
+msgid "Copied to clipboard"
 msgstr ""
 
 #: src/apprt/gtk/CloseDialog.zig:47
@@ -254,6 +237,23 @@ msgstr ""
 msgid "The currently running process in this split will be terminated."
 msgstr ""
 
-#: src/apprt/gtk/Surface.zig:1242
-msgid "Copied to clipboard"
+#: src/apprt/gtk/Window.zig:200
+msgid "Main Menu"
+msgstr ""
+
+#: src/apprt/gtk/Window.zig:221
+msgid "View Open Tabs"
+msgstr ""
+
+#: src/apprt/gtk/Window.zig:295
+msgid ""
+"⚠️ You're running a debug build of Ghostty! Performance will be degraded."
+msgstr ""
+
+#: src/apprt/gtk/Window.zig:725
+msgid "Reloaded the configuration"
+msgstr ""
+
+#: src/apprt/gtk/Window.zig:941
+msgid "Ghostty Developers"
 msgstr ""

--- a/po/de_DE.UTF-8.po
+++ b/po/de_DE.UTF-8.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-03-18 11:48+0100\n"
+"POT-Creation-Date: 2025-03-19 08:28-0700\n"
 "PO-Revision-Date: 2025-03-06 14:57+0100\n"
 "Last-Translator: Robin <r@rpfaeffle.com>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
@@ -149,7 +149,7 @@ msgid "Terminal Inspector"
 msgstr "Terminalinspektor"
 
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:102
-#: src/apprt/gtk/Window.zig:958
+#: src/apprt/gtk/Window.zig:960
 msgid "About Ghostty"
 msgstr "Über Ghostty"
 
@@ -200,32 +200,13 @@ msgstr ""
 "Diesen Text in das Terminal einzufügen könnte möglicherweise gefährlich "
 "sein. Es scheint, dass Anweisungen ausgeführt werden könnten."
 
-#: src/apprt/gtk/Window.zig:200
-msgid "Main Menu"
-msgstr "Hauptmenü"
-
-#: src/apprt/gtk/Window.zig:221
-msgid "View Open Tabs"
-msgstr "Offene Tabs einblenden"
-
-#: src/apprt/gtk/Window.zig:295
-msgid ""
-"⚠️ You're running a debug build of Ghostty! Performance will be degraded."
-msgstr ""
-"⚠️ Du verwendest einen Debug Build von Ghostty! Die Leistung wird reduziert "
-"sein."
-
-#: src/apprt/gtk/Window.zig:725
-msgid "Reloaded the configuration"
-msgstr "Konfiguration wurde neu geladen"
-
-#: src/apprt/gtk/Window.zig:939
-msgid "Ghostty Developers"
-msgstr "Ghostty-Entwickler"
-
 #: src/apprt/gtk/inspector.zig:144
 msgid "Ghostty: Terminal Inspector"
 msgstr ""
+
+#: src/apprt/gtk/Surface.zig:1243
+msgid "Copied to clipboard"
+msgstr "In die Zwischenablage kopiert"
 
 #: src/apprt/gtk/CloseDialog.zig:47
 msgid "Close"
@@ -263,6 +244,25 @@ msgstr "Alle Terminalsitzungen in diesem Tab werden beendet."
 msgid "The currently running process in this split will be terminated."
 msgstr "Der aktuell laufende Prozess in diesem geteilten Fenster wird beendet."
 
-#: src/apprt/gtk/Surface.zig:1242
-msgid "Copied to clipboard"
-msgstr "In die Zwischenablage kopiert"
+#: src/apprt/gtk/Window.zig:200
+msgid "Main Menu"
+msgstr "Hauptmenü"
+
+#: src/apprt/gtk/Window.zig:221
+msgid "View Open Tabs"
+msgstr "Offene Tabs einblenden"
+
+#: src/apprt/gtk/Window.zig:295
+msgid ""
+"⚠️ You're running a debug build of Ghostty! Performance will be degraded."
+msgstr ""
+"⚠️ Du verwendest einen Debug Build von Ghostty! Die Leistung wird reduziert "
+"sein."
+
+#: src/apprt/gtk/Window.zig:725
+msgid "Reloaded the configuration"
+msgstr "Konfiguration wurde neu geladen"
+
+#: src/apprt/gtk/Window.zig:941
+msgid "Ghostty Developers"
+msgstr "Ghostty-Entwickler"

--- a/po/nb_NO.UTF-8.po
+++ b/po/nb_NO.UTF-8.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-03-06 20:10+0100\n"
+"POT-Creation-Date: 2025-03-19 08:28-0700\n"
 "PO-Revision-Date: 2025-03-14 20:41-0400\n"
 "Last-Translator: Hanna Rose <hanna@hanna.lol>\n"
 "Language-Team: Norwegian Bokmal <l10n-no@lister.huftis.org>\n"
@@ -34,6 +34,26 @@ msgstr "Avbryt"
 #: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:10
 msgid "OK"
 msgstr "OK"
+
+#: src/apprt/gtk/ui/1.5/config-errors-dialog.blp:5
+msgid "Configuration Errors"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.5/config-errors-dialog.blp:6
+msgid ""
+"One or more configuration errors were found. Please review the errors below, "
+"and either reload your configuration or ignore these errors."
+msgstr ""
+
+#: src/apprt/gtk/ui/1.5/config-errors-dialog.blp:9
+msgid "Ignore"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.5/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:97
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:95
+msgid "Reload Configuration"
+msgstr "Last konfigurasjon på nytt"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:6
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:6
@@ -124,17 +144,12 @@ msgstr "Konfigurasjon"
 msgid "Open Configuration"
 msgstr "Åpne konfigurasjon"
 
-#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:97
-#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:95
-msgid "Reload Configuration"
-msgstr "Last konfigurasjon på nytt"
-
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:85
 msgid "Terminal Inspector"
 msgstr "Terminalinspektør"
 
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:102
-#: src/apprt/gtk/Window.zig:933
+#: src/apprt/gtk/Window.zig:960
 msgid "About Ghostty"
 msgstr "Om Ghostty"
 
@@ -182,30 +197,16 @@ msgid ""
 "Pasting this text into the terminal may be dangerous as it looks like some "
 "commands may be executed."
 msgstr ""
-"Det ser ut som at kommandoer vil bli kjørt hvis du limer inn dette, "
-"vurder om du mener det er trygt."
+"Det ser ut som at kommandoer vil bli kjørt hvis du limer inn dette, vurder "
+"om du mener det er trygt."
 
-#: src/apprt/gtk/Window.zig:199
-msgid "Main Menu"
-msgstr "Hovedmeny"
-
-#: src/apprt/gtk/Window.zig:219
-msgid "View Open Tabs"
-msgstr "Se åpen faner"
-
-#: src/apprt/gtk/Window.zig:265
-msgid ""
-"⚠️ You're running a debug build of Ghostty! Performance will be degraded."
+#: src/apprt/gtk/inspector.zig:144
+msgid "Ghostty: Terminal Inspector"
 msgstr ""
-"⚠️ Du kjører en debug-bygg av Ghostty. Debug-bygg har redusert ytelse."
 
-#: src/apprt/gtk/Window.zig:681
-msgid "Reloaded the configuration"
-msgstr "Konfigurasjon ble lastet på nytt"
-
-#: src/apprt/gtk/Window.zig:914
-msgid "Ghostty Developers"
-msgstr "Ghostty utviklere"
+#: src/apprt/gtk/Surface.zig:1243
+msgid "Copied to clipboard"
+msgstr "Kopiert til utklippstavle"
 
 #: src/apprt/gtk/CloseDialog.zig:47
 msgid "Close"
@@ -243,6 +244,23 @@ msgstr "Alle terminaløkter i denne fanen vil bli avsluttet."
 msgid "The currently running process in this split will be terminated."
 msgstr "Kjørende prosess for denne splitten vil bli avsluttet."
 
-#: src/apprt/gtk/Surface.zig:1128
-msgid "Copied to clipboard"
-msgstr "Kopiert til utklippstavle"
+#: src/apprt/gtk/Window.zig:200
+msgid "Main Menu"
+msgstr "Hovedmeny"
+
+#: src/apprt/gtk/Window.zig:221
+msgid "View Open Tabs"
+msgstr "Se åpen faner"
+
+#: src/apprt/gtk/Window.zig:295
+msgid ""
+"⚠️ You're running a debug build of Ghostty! Performance will be degraded."
+msgstr "⚠️ Du kjører en debug-bygg av Ghostty. Debug-bygg har redusert ytelse."
+
+#: src/apprt/gtk/Window.zig:725
+msgid "Reloaded the configuration"
+msgstr "Konfigurasjon ble lastet på nytt"
+
+#: src/apprt/gtk/Window.zig:941
+msgid "Ghostty Developers"
+msgstr "Ghostty utviklere"

--- a/po/zh_CN.UTF-8.po
+++ b/po/zh_CN.UTF-8.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-03-18 11:48+0100\n"
+"POT-Creation-Date: 2025-03-19 08:28-0700\n"
 "PO-Revision-Date: 2025-02-27 09:16+0100\n"
 "Last-Translator: Leah <hi@pluie.me>\n"
 "Language-Team: Chinese (simplified) <i18n-zh@googlegroups.com>\n"
@@ -43,8 +43,7 @@ msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
 msgstr ""
-"加载设置时发现了以下错误。请仔细阅读错误信息，"
-"并选择忽略或重新加载设置文件。"
+"加载设置时发现了以下错误。请仔细阅读错误信息，并选择忽略或重新加载设置文件。"
 
 #: src/apprt/gtk/ui/1.5/config-errors-dialog.blp:9
 msgid "Ignore"
@@ -150,7 +149,7 @@ msgid "Terminal Inspector"
 msgstr "终端检视器"
 
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:102
-#: src/apprt/gtk/Window.zig:958
+#: src/apprt/gtk/Window.zig:960
 msgid "About Ghostty"
 msgstr "关于 Ghostty"
 
@@ -195,30 +194,13 @@ msgid ""
 "commands may be executed."
 msgstr "将以下内容粘贴至终端内将可能执行有害命令。"
 
-#: src/apprt/gtk/Window.zig:200
-msgid "Main Menu"
-msgstr "主菜单"
-
-#: src/apprt/gtk/Window.zig:221
-msgid "View Open Tabs"
-msgstr "浏览标签页"
-
-#: src/apprt/gtk/Window.zig:295
-msgid ""
-"⚠️ You're running a debug build of Ghostty! Performance will be degraded."
-msgstr "⚠️ Ghostty 正在以调试模式运行！性能将大打折扣。"
-
-#: src/apprt/gtk/Window.zig:725
-msgid "Reloaded the configuration"
-msgstr "已重新加载设置"
-
-#: src/apprt/gtk/Window.zig:939
-msgid "Ghostty Developers"
-msgstr "Ghostty 开发团队"
-
 #: src/apprt/gtk/inspector.zig:144
 msgid "Ghostty: Terminal Inspector"
 msgstr "Ghostty 终端检视器"
+
+#: src/apprt/gtk/Surface.zig:1243
+msgid "Copied to clipboard"
+msgstr "已复制至剪切板"
 
 #: src/apprt/gtk/CloseDialog.zig:47
 msgid "Close"
@@ -256,6 +238,23 @@ msgstr "标签页内所有运行中的进程将被终止。"
 msgid "The currently running process in this split will be terminated."
 msgstr "分屏内正在运行中的进程将被终止。"
 
-#: src/apprt/gtk/Surface.zig:1242
-msgid "Copied to clipboard"
-msgstr "已复制至剪切板"
+#: src/apprt/gtk/Window.zig:200
+msgid "Main Menu"
+msgstr "主菜单"
+
+#: src/apprt/gtk/Window.zig:221
+msgid "View Open Tabs"
+msgstr "浏览标签页"
+
+#: src/apprt/gtk/Window.zig:295
+msgid ""
+"⚠️ You're running a debug build of Ghostty! Performance will be degraded."
+msgstr "⚠️ Ghostty 正在以调试模式运行！性能将大打折扣。"
+
+#: src/apprt/gtk/Window.zig:725
+msgid "Reloaded the configuration"
+msgstr "已重新加载设置"
+
+#: src/apprt/gtk/Window.zig:941
+msgid "Ghostty Developers"
+msgstr "Ghostty 开发团队"


### PR DESCRIPTION
I don't see any actual changes here, just reordering. It's using the Nix environment so I'm not sure why this happened but it seemed to stem from the Norwegian work originally. Fixing it back.