### PR TITLE
snap: build from source tarball

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -353,15 +353,19 @@ jobs:
         os:
           [namespace-profile-ghostty-snap, namespace-profile-ghostty-snap-arm64]
     runs-on: ${{ matrix.os }}
-    needs: test
+    needs: [test, build-dist]
     env:
       ZIG_LOCAL_CACHE_DIR: /zig/local-cache
       ZIG_GLOBAL_CACHE_DIR: /zig/global-cache
     steps:
-      - uses: actions/checkout@v4
+      - name: Download Source Tarball Artifacts
+        uses: actions/download-artifact@v4
         with:
-          fetch-depth: 0
-          fetch-tags: true
+          name: source-tarball
+      - name: Extract tarball
+        run: |
+          mkdir dist
+          tar --verbose --extract --strip-components 1 --directory dist --file ghostty-source.tar.gz
       - name: Setup Cache
         uses: namespacelabs/nscloud-cache-action@v1.2.0
         with:
@@ -371,6 +375,8 @@ jobs:
       - run: sudo apt install -y udev
       - run: sudo systemctl start systemd-udevd
       - uses: snapcore/action-build@v1
+        with:
+          path: dist
 
   build-windows:
     runs-on: windows-2022

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -70,7 +70,6 @@ parts:
     plugin: nil
     build-attributes: [enable-patchelf]
     build-packages:
-      - blueprint-compiler
       - libgtk-4-dev
       - libadwaita-1-dev
       # TODO: Add when the Snap is updated to Ubuntu 24.10+
@@ -80,7 +79,7 @@ parts:
       - patchelf
       - gettext
     override-build: |
-      craftctl set version=$(git describe --abbrev=8)
+      craftctl set version=$(cat VERSION)
       $CRAFT_PART_SRC/../../zig/src/zig build -Dpatch-rpath=\$ORIGIN/../usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:/snap/core24/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR -Doptimize=ReleaseFast
       cp -rp zig-out/* $CRAFT_PART_INSTALL/
       sed -i 's|Icon=com.mitchellh.ghostty|Icon=/snap/ghostty/current/share/icons/hicolor/512x512/apps/com.mitchellh.ghostty.png|g' $CRAFT_PART_INSTALL/share/applications/com.mitchellh.ghostty.desktop

--- a/src/build/GhosttyDist.zig
+++ b/src/build/GhosttyDist.zig
@@ -36,6 +36,17 @@ pub fn init(b: *std.Build, cfg: *const Config) !GhosttyDist {
         "--format=tgz",
     });
 
+    // embed the Ghostty version in the tarball
+    {
+        const version = b.addWriteFiles().add("VERSION", b.fmt("{}", .{cfg.version}));
+        // --add-file uses the most recent --prefix to determine the path
+        // in the archive to copy the file (the directory only).
+        git_archive.addArg(b.fmt("--prefix=ghostty-{}/", .{
+            cfg.version,
+        }));
+        git_archive.addPrefixedFileArg("--add-file=", version);
+    }
+
     // Add all of our resources into the tarball.
     for (resources.items) |resource| {
         // Our dist path basename may not match our generated file basename,


### PR DESCRIPTION
Eliminates the need for `blueprint-compiler`, which isn't quite new enough on the snap builder.