### PR TITLE
apprt/embedded: utf8 encoding buffer lifetime must extend beyond call

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1727,7 +1727,7 @@ pub fn keyCallback(
     self: *Surface,
     event: input.KeyEvent,
 ) !InputEffect {
-    // log.debug("text keyCallback event={}", .{event});
+    // log.warn("text keyCallback event={}", .{event});
 
     // Crash metadata in case we crash in here
     crash.sentry.thread_state = self.crashThreadState();

--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -72,7 +72,7 @@ pub fn init(b: *std.Build) !Config {
         if (result.result.os.tag == .macos and
             builtin.target.os.tag.isDarwin())
         {
-            result = genericMacOSTarget(b, null);
+            result = genericMacOSTarget(b, result.query.cpu_arch);
         }
 
         // If we have no minimum OS version, we set the default based on


### PR DESCRIPTION
Fixes #6821

UTF8 translation using KeymapDarwin requires a buffer and the buffer was stack allocated in the coreKeyEvent call and returned from the function. We need the buffer to live longer than this.

Long term, we're removing KeymapDarwin (there is a whole TODO comment in there about how to do it), but this fixes a real problem today.