### PR TITLE
Add sv_SE Swedish locale

### DIFF
--- a/po/sv_SE.po
+++ b/po/sv_SE.po
@@ -196,7 +196,7 @@ msgstr "Visa öppna flikar"
 msgid ""
 "⚠️ You're running a debug build of Ghostty! Performance will be degraded."
 msgstr ""
-"⚠️ Du kör en felsökningsversion av Ghostty! Prestanda kommer att försämras."
+"⚠️ Du använder en felsökningsversion av Ghostty! Prestanda kommer att försämras."
 
 #: src/apprt/gtk/Window.zig:681
 msgid "Reloaded the configuration"

--- a/po/sv_SE.po
+++ b/po/sv_SE.po
@@ -18,223 +18,221 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:5
-msgid "Ändra terminaltitel"
-msgstr ""
+msgid "Change Terminal Title"
+msgstr "Ändra terminaltitel"
 
 #: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:6
-msgid "Lämna tomt för att återställa titeln till standardinställningarna."
-msgstr ""
+msgid "Leave blank to restore the default title."
+msgstr "Lämna tomt för att återställa titeln till standardinställningarna."
 
 #: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:9
 #: src/apprt/gtk/ui/1.5/ccw-paste.blp:10 src/apprt/gtk/CloseDialog.zig:44
-msgid "Avbryt"
-msgstr ""
+msgid "Cancel"
+msgstr "Avbryt"
 
 #: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:10
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:6
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:6
-msgid "Kopiera"
-msgstr ""
+msgid "Copy"
+msgstr "Kopiera"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:11
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:11
 #: src/apprt/gtk/ui/1.5/ccw-paste.blp:11
-msgid "Klistra in"
-msgstr ""
+msgid "Paste"
+msgstr "Klistra in"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:18
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:73
-msgid "Rensa"
-msgstr ""
+msgid "Clear"
+msgstr "Rensa"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:23
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:78
-msgid "Återställ"
-msgstr ""
+msgid "Reset"
+msgstr "Återställ"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:30
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:42
-msgid "Dela"
-msgstr ""
+msgid "Split"
+msgstr "Dela"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:33
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:45
-msgid "Ändra titel…"
-msgstr ""
+msgid "Change Title…"
+msgstr "Ändra titel…"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:38
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:50
-msgid "Dela uppåt"
-msgstr ""
+msgid "Split Up"
+msgstr "Dela uppåt"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:43
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:55
-msgid "Dela nedåt"
-msgstr ""
+msgid "Split Down"
+msgstr "Dela nedåt"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:48
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:60
-msgid "Dela åt vänster"
-msgstr ""
+msgid "Split Left"
+msgstr "Dela åt vänster"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:53
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:65
-msgid "Dela åt höger"
-msgstr ""
+msgid "Split Right"
+msgstr "Dela åt höger"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:59
-msgid "Flik"
-msgstr ""
+msgid "Tab"
+msgstr "Flik"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:62
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:30
 #: src/apprt/gtk/Window.zig:246
-msgid "Ny flik"
-msgstr ""
+msgid "New Tab"
+msgstr "Ny flik"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:67
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:35
-msgid "Stäng flik"
-msgstr ""
+msgid "Close Tab"
+msgstr "Stäng flik"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:73
-msgid "Fönster"
-msgstr ""
+msgid "Window"
+msgstr "Fönster"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:76
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:18
-msgid "Nytt fönster"
-msgstr ""
+msgid "New Window"
+msgstr "Nytt fönster"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:81
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:23
-msgid "Stäng fönster"
-msgstr ""
+msgid "Close Window"
+msgstr "Stäng fönster"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:89
-msgid "Konfiguration"
-msgstr ""
+msgid "Config"
+msgstr "Konfiguration"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:92
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:90
-msgid "Öpnna konfiguration"
-msgstr ""
+msgid "Open Configuration"
+msgstr "Öpnna konfiguration"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:97
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:95
-msgid "Ladda om configuration"
-msgstr ""
+msgid "Reload Configuration"
+msgstr "Ladda om configuration"
 
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:85
-msgid "Inspektera terminalen"
-msgstr ""
+msgid "Terminal Inspector"
+msgstr "Inspektera terminalen"
 
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:102
 #: src/apprt/gtk/Window.zig:933
-msgid "Om Ghostty"
-msgstr ""
+msgid "About Ghostty"
+msgstr "Om Ghostty"
 
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:107
-msgid "Avsluta"
-msgstr ""
+msgid "Quit"
+msgstr "Avsluta"
 
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:6
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:6
-msgid "Tillåt åtkomst till urklipp"
-msgstr ""
+msgid "Authorize Clipboard Access"
+msgstr "Tillåt åtkomst till urklipp"
 
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:7
 msgid ""
-"Ett program försöker läsa från urklipp. Det aktuella "
-"innehållet visas nedan."
-msgstr ""
+"An application is attempting to read from the clipboard. The current "
+"clipboard contents are shown below."
 
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:10
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:10
-msgid "Neka"
-msgstr ""
+msgid "Deny"
+msgstr "Neka"
 
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:11
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:11
-msgid "Tillåt"
-msgstr ""
+msgid "Allow"
+msgstr "Tillåt"
 
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:7
 msgid ""
-"Ett program försöker skriva till urklipp. Det aktuella "
-"innehållet visas nedan."
-msgstr ""
+"An application is attempting to write to the clipboard. The current "
+"clipboard contents are shown below."
 
 #: src/apprt/gtk/ui/1.5/ccw-paste.blp:6
-msgid "Varning: Potentiellt osäker infogning"
-msgstr ""
+msgid "Warning: Potentially Unsafe Paste"
+msgstr "Varning: Potentiellt osäker infogning"
 
 #: src/apprt/gtk/ui/1.5/ccw-paste.blp:7
 msgid ""
-"Att klistra in den här texten i terminalen kan vara farligt eftersom det ser ut som "
-"att kommandon kan utföras."
-msgstr ""
+"Pasting this text into the terminal may be dangerous as it looks like some "
+"commands may be executed."
 
 #: src/apprt/gtk/Window.zig:199
-msgid "Huvudmeny"
-msgstr ""
+msgid "View Open Tabs"
+msgstr "Huvudmeny"
 
 #: src/apprt/gtk/Window.zig:219
-msgid "Visa öppna flikar"
-msgstr ""
+msgid "View Open Tabs"
+msgstr "Visa öppna flikar"
 
 #: src/apprt/gtk/Window.zig:265
 msgid ""
-"⚠️ Du kör en felsökningsversion av Ghostty! Prestanda kommer att försämras."
+"⚠️ You're running a debug build of Ghostty! Performance will be degraded."
 msgstr ""
+"⚠️ Du kör en felsökningsversion av Ghostty! Prestanda kommer att försämras."
 
 #: src/apprt/gtk/Window.zig:681
-msgid "Laddade om konfigurationen"
-msgstr ""
+msgid "Reloaded the configuration"
+msgstr "Laddade om konfigurationen"
 
 #: src/apprt/gtk/Window.zig:914
-msgid "Ghostty-utvecklare"
-msgstr ""
+msgid "Ghostty Developers"
+msgstr "Ghostty-utvecklare"
 
 #: src/apprt/gtk/CloseDialog.zig:47
-msgid "Stäng"
-msgstr ""
+msgid "Close"
+msgstr "Stäng"
 
 #: src/apprt/gtk/CloseDialog.zig:87
-msgid "Vill du avsluta Ghostty?"
-msgstr ""
+msgid "Quit Ghostty?"
+msgstr "Vill du avsluta Ghostty?"
 
 #: src/apprt/gtk/CloseDialog.zig:88
-msgid "Vill du stänga fönstret?"
-msgstr ""
+msgid "Close Window?"
+msgstr "Vill du stänga fönstret?"
 
 #: src/apprt/gtk/CloseDialog.zig:89
-msgid "Vill du stänga fliken?"
-msgstr ""
+msgid "Close Tab?"
+msgstr "Vill du stänga fliken?"
 
 #: src/apprt/gtk/CloseDialog.zig:90
-msgid "Stäng uppdelning?"
-msgstr ""
+msgid "Close Split?"
+msgstr "Vill du stänga uppdelat fönster?"
 
 #: src/apprt/gtk/CloseDialog.zig:96
-msgid "Alla terminalsessioner kommer att avslutas."
-msgstr ""
+msgid "All terminal sessions will be terminated."
+msgstr "Alla terminalsessioner kommer att avslutas."
 
 #: src/apprt/gtk/CloseDialog.zig:97
-msgid "Alla terminalsessioner i detta fönster kommer att avslutas."
-msgstr ""
+msgid "All terminal sessions in this window will be terminated."
+msgstr "Alla terminalsessioner i detta fönster kommer att avslutas."
 
 #: src/apprt/gtk/CloseDialog.zig:98
-msgid "Alla terminalsessioner på den här fliken kommer att avslutas."
-msgstr ""
+msgid "All terminal sessions in this tab will be terminated."
+msgstr "Alla terminalsessioner på den här fliken kommer att avslutas."
 
 #: src/apprt/gtk/CloseDialog.zig:99
-msgid "Den för närvarande pågående processen i denna uppdelning kommer att avslutas."
-msgstr ""
+msgid "The currently running process in this split will be terminated."
+msgstr "Den för närvarande pågående processen i denna uppdelning kommer att avslutas."
 
 #: src/apprt/gtk/Surface.zig:1128
-msgid "Sparat i urklipp"
-msgstr ""
+msgid "Copied to clipboard"
+msgstr "Sparat i urklipp"

--- a/po/sv_SE.po
+++ b/po/sv_SE.po
@@ -174,7 +174,7 @@ msgstr ""
 
 #: src/apprt/gtk/ui/1.5/ccw-paste.blp:6
 msgid "Warning: Potentially Unsafe Paste"
-msgstr "Varning: Potentiellt osäker infogning"
+msgstr "Varning: Potentiellt osäker inklistring"
 
 #: src/apprt/gtk/ui/1.5/ccw-paste.blp:7
 msgid ""

--- a/po/sv_SE.po
+++ b/po/sv_SE.po
@@ -1,0 +1,240 @@
+# Swedish translations for com.mitchellh.ghostty package.
+# Copyright (C) 2025 Mitchell Hashimoto
+# This file is distributed under the same license as the com.mitchellh.ghostty package.
+# Adrian von Gegerfelt <adrian@designbyadrian.com>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: com.mitchellh.ghostty\n"
+"Report-Msgid-Bugs-To: m@mitchellh.com\n"
+"POT-Creation-Date: 2025-03-06 20:10+0100\n"
+"PO-Revision-Date: 2025-03-18 11:33+0100\n"
+"Last-Translator: Adrian von Gegerfelt <adrian@designbyadrian.com>\n"
+"Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:5
+msgid "Change Terminal Title"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:6
+msgid "Leave blank to restore the default title."
+msgstr ""
+
+#: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:9
+#: src/apprt/gtk/ui/1.5/ccw-paste.blp:10 src/apprt/gtk/CloseDialog.zig:44
+msgid "Cancel"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:10
+msgid "OK"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:6
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:6
+msgid "Copy"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:11
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:11
+#: src/apprt/gtk/ui/1.5/ccw-paste.blp:11
+msgid "Paste"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:18
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:73
+msgid "Clear"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:23
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:78
+msgid "Reset"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:30
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:42
+msgid "Split"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:33
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:45
+msgid "Change Title…"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:38
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:50
+msgid "Split Up"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:43
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:55
+msgid "Split Down"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:48
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:60
+msgid "Split Left"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:53
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:65
+msgid "Split Right"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:59
+msgid "Tab"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:62
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:30
+#: src/apprt/gtk/Window.zig:246
+msgid "New Tab"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:67
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:35
+msgid "Close Tab"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:73
+msgid "Window"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:76
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:18
+msgid "New Window"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:81
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:23
+msgid "Close Window"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:89
+msgid "Config"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:92
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:90
+msgid "Open Configuration"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:97
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:95
+msgid "Reload Configuration"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:85
+msgid "Terminal Inspector"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:102
+#: src/apprt/gtk/Window.zig:933
+msgid "About Ghostty"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:107
+msgid "Quit"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:6
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:6
+msgid "Authorize Clipboard Access"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:7
+msgid ""
+"An application is attempting to read from the clipboard. The current "
+"clipboard contents are shown below."
+msgstr ""
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:10
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:10
+msgid "Deny"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:11
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:11
+msgid "Allow"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:7
+msgid ""
+"An application is attempting to write to the clipboard. The current "
+"clipboard contents are shown below."
+msgstr ""
+
+#: src/apprt/gtk/ui/1.5/ccw-paste.blp:6
+msgid "Warning: Potentially Unsafe Paste"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.5/ccw-paste.blp:7
+msgid ""
+"Pasting this text into the terminal may be dangerous as it looks like some "
+"commands may be executed."
+msgstr ""
+
+#: src/apprt/gtk/Window.zig:199
+msgid "Main Menu"
+msgstr ""
+
+#: src/apprt/gtk/Window.zig:219
+msgid "View Open Tabs"
+msgstr ""
+
+#: src/apprt/gtk/Window.zig:265
+msgid ""
+"⚠️ You're running a debug build of Ghostty! Performance will be degraded."
+msgstr ""
+
+#: src/apprt/gtk/Window.zig:681
+msgid "Reloaded the configuration"
+msgstr ""
+
+#: src/apprt/gtk/Window.zig:914
+msgid "Ghostty Developers"
+msgstr ""
+
+#: src/apprt/gtk/CloseDialog.zig:47
+msgid "Close"
+msgstr ""
+
+#: src/apprt/gtk/CloseDialog.zig:87
+msgid "Quit Ghostty?"
+msgstr ""
+
+#: src/apprt/gtk/CloseDialog.zig:88
+msgid "Close Window?"
+msgstr ""
+
+#: src/apprt/gtk/CloseDialog.zig:89
+msgid "Close Tab?"
+msgstr ""
+
+#: src/apprt/gtk/CloseDialog.zig:90
+msgid "Close Split?"
+msgstr ""
+
+#: src/apprt/gtk/CloseDialog.zig:96
+msgid "All terminal sessions will be terminated."
+msgstr ""
+
+#: src/apprt/gtk/CloseDialog.zig:97
+msgid "All terminal sessions in this window will be terminated."
+msgstr ""
+
+#: src/apprt/gtk/CloseDialog.zig:98
+msgid "All terminal sessions in this tab will be terminated."
+msgstr ""
+
+#: src/apprt/gtk/CloseDialog.zig:99
+msgid "The currently running process in this split will be terminated."
+msgstr ""
+
+#: src/apprt/gtk/Surface.zig:1128
+msgid "Copied to clipboard"
+msgstr ""

--- a/po/sv_SE.po
+++ b/po/sv_SE.po
@@ -130,7 +130,7 @@ msgstr "Ladda om konfiguration"
 
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:85
 msgid "Terminal Inspector"
-msgstr "Terminalinspektören"
+msgstr "Terminalinspektör"
 
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:102
 #: src/apprt/gtk/Window.zig:933

--- a/po/sv_SE.po
+++ b/po/sv_SE.po
@@ -48,7 +48,7 @@ msgstr "Klistra in"
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:18
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:73
 msgid "Clear"
-msgstr "Rensa"
+msgstr "Töm"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:23
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:78

--- a/po/sv_SE.po
+++ b/po/sv_SE.po
@@ -228,7 +228,7 @@ msgstr "Vill du stänga uppdelat fönster?"
 
 #: src/apprt/gtk/CloseDialog.zig:96
 msgid "All terminal sessions will be terminated."
-msgstr "Alla terminalsessioner kommer att avslutas."
+msgstr "Alla terminalsessioner kommer avslutas."
 
 #: src/apprt/gtk/CloseDialog.zig:97
 msgid "All terminal sessions in this window will be terminated."

--- a/po/sv_SE.po
+++ b/po/sv_SE.po
@@ -58,7 +58,7 @@ msgstr "Återställ"
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:30
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:42
 msgid "Split"
-msgstr "Dela"
+msgstr "Dela fönster"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:33
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:45
@@ -126,11 +126,11 @@ msgstr "Öpnna konfiguration"
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:97
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:95
 msgid "Reload Configuration"
-msgstr "Ladda om configuration"
+msgstr "Ladda om konfiguration"
 
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:85
 msgid "Terminal Inspector"
-msgstr "Inspektera terminalen"
+msgstr "Terminalinspektören"
 
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:102
 #: src/apprt/gtk/Window.zig:933
@@ -150,6 +150,9 @@ msgstr "Tillåt åtkomst till urklipp"
 msgid ""
 "An application is attempting to read from the clipboard. The current "
 "clipboard contents are shown below."
+msgstr ""
+"Ett program försöker läsa från urklipp. Det aktuella "
+"innehållet visas nedan."
 
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:10
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:10
@@ -165,6 +168,9 @@ msgstr "Tillåt"
 msgid ""
 "An application is attempting to write to the clipboard. The current "
 "clipboard contents are shown below."
+msgstr ""
+"Ett program försöker skriva till urklipp. Det aktuella "
+"innehållet visas nedan."
 
 #: src/apprt/gtk/ui/1.5/ccw-paste.blp:6
 msgid "Warning: Potentially Unsafe Paste"
@@ -174,6 +180,9 @@ msgstr "Varning: Potentiellt osäker infogning"
 msgid ""
 "Pasting this text into the terminal may be dangerous as it looks like some "
 "commands may be executed."
+msgstr ""
+"Att klistra in den här texten i terminalen kan vara farligt eftersom det ser ut som "
+"att kommandon kan utföras."
 
 #: src/apprt/gtk/Window.zig:199
 msgid "View Open Tabs"

--- a/po/sv_SE.po
+++ b/po/sv_SE.po
@@ -18,16 +18,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:5
-msgid "Change Terminal Title"
+msgid "Ändra terminaltitel"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:6
-msgid "Leave blank to restore the default title."
+msgid "Lämna tomt för att återställa titeln till standardinställningarna."
 msgstr ""
 
 #: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:9
 #: src/apprt/gtk/ui/1.5/ccw-paste.blp:10 src/apprt/gtk/CloseDialog.zig:44
-msgid "Cancel"
+msgid "Avbryt"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:10
@@ -36,205 +36,205 @@ msgstr ""
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:6
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:6
-msgid "Copy"
+msgid "Kopiera"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:11
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:11
 #: src/apprt/gtk/ui/1.5/ccw-paste.blp:11
-msgid "Paste"
+msgid "Klistra in"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:18
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:73
-msgid "Clear"
+msgid "Rensa"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:23
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:78
-msgid "Reset"
+msgid "Återställ"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:30
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:42
-msgid "Split"
+msgid "Dela"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:33
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:45
-msgid "Change Title…"
+msgid "Ändra titel…"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:38
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:50
-msgid "Split Up"
+msgid "Dela uppåt"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:43
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:55
-msgid "Split Down"
+msgid "Dela nedåt"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:48
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:60
-msgid "Split Left"
+msgid "Dela åt vänster"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:53
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:65
-msgid "Split Right"
+msgid "Dela åt höger"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:59
-msgid "Tab"
+msgid "Flik"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:62
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:30
 #: src/apprt/gtk/Window.zig:246
-msgid "New Tab"
+msgid "Ny flik"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:67
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:35
-msgid "Close Tab"
+msgid "Stäng flik"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:73
-msgid "Window"
+msgid "Fönster"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:76
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:18
-msgid "New Window"
+msgid "Nytt fönster"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:81
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:23
-msgid "Close Window"
+msgid "Stäng fönster"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:89
-msgid "Config"
+msgid "Konfiguration"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:92
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:90
-msgid "Open Configuration"
+msgid "Öpnna konfiguration"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:97
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:95
-msgid "Reload Configuration"
+msgid "Ladda om configuration"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:85
-msgid "Terminal Inspector"
+msgid "Inspektera terminalen"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:102
 #: src/apprt/gtk/Window.zig:933
-msgid "About Ghostty"
+msgid "Om Ghostty"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:107
-msgid "Quit"
+msgid "Avsluta"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:6
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:6
-msgid "Authorize Clipboard Access"
+msgid "Tillåt åtkomst till urklipp"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:7
 msgid ""
-"An application is attempting to read from the clipboard. The current "
-"clipboard contents are shown below."
+"Ett program försöker läsa från urklipp. Det aktuella "
+"innehållet visas nedan."
 msgstr ""
 
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:10
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:10
-msgid "Deny"
+msgid "Neka"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:11
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:11
-msgid "Allow"
+msgid "Tillåt"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:7
 msgid ""
-"An application is attempting to write to the clipboard. The current "
-"clipboard contents are shown below."
+"Ett program försöker skriva till urklipp. Det aktuella "
+"innehållet visas nedan."
 msgstr ""
 
 #: src/apprt/gtk/ui/1.5/ccw-paste.blp:6
-msgid "Warning: Potentially Unsafe Paste"
+msgid "Varning: Potentiellt osäker infogning"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.5/ccw-paste.blp:7
 msgid ""
-"Pasting this text into the terminal may be dangerous as it looks like some "
-"commands may be executed."
+"Att klistra in den här texten i terminalen kan vara farligt eftersom det ser ut som "
+"att kommandon kan utföras."
 msgstr ""
 
 #: src/apprt/gtk/Window.zig:199
-msgid "Main Menu"
+msgid "Huvudmeny"
 msgstr ""
 
 #: src/apprt/gtk/Window.zig:219
-msgid "View Open Tabs"
+msgid "Visa öppna flikar"
 msgstr ""
 
 #: src/apprt/gtk/Window.zig:265
 msgid ""
-"⚠️ You're running a debug build of Ghostty! Performance will be degraded."
+"⚠️ Du kör en felsökningsversion av Ghostty! Prestanda kommer att försämras."
 msgstr ""
 
 #: src/apprt/gtk/Window.zig:681
-msgid "Reloaded the configuration"
+msgid "Laddade om konfigurationen"
 msgstr ""
 
 #: src/apprt/gtk/Window.zig:914
-msgid "Ghostty Developers"
+msgid "Ghostty-utvecklare"
 msgstr ""
 
 #: src/apprt/gtk/CloseDialog.zig:47
-msgid "Close"
+msgid "Stäng"
 msgstr ""
 
 #: src/apprt/gtk/CloseDialog.zig:87
-msgid "Quit Ghostty?"
+msgid "Vill du avsluta Ghostty?"
 msgstr ""
 
 #: src/apprt/gtk/CloseDialog.zig:88
-msgid "Close Window?"
+msgid "Vill du stänga fönstret?"
 msgstr ""
 
 #: src/apprt/gtk/CloseDialog.zig:89
-msgid "Close Tab?"
+msgid "Vill du stänga fliken?"
 msgstr ""
 
 #: src/apprt/gtk/CloseDialog.zig:90
-msgid "Close Split?"
+msgid "Stäng uppdelning?"
 msgstr ""
 
 #: src/apprt/gtk/CloseDialog.zig:96
-msgid "All terminal sessions will be terminated."
+msgid "Alla terminalsessioner kommer att avslutas."
 msgstr ""
 
 #: src/apprt/gtk/CloseDialog.zig:97
-msgid "All terminal sessions in this window will be terminated."
+msgid "Alla terminalsessioner i detta fönster kommer att avslutas."
 msgstr ""
 
 #: src/apprt/gtk/CloseDialog.zig:98
-msgid "All terminal sessions in this tab will be terminated."
+msgid "Alla terminalsessioner på den här fliken kommer att avslutas."
 msgstr ""
 
 #: src/apprt/gtk/CloseDialog.zig:99
-msgid "The currently running process in this split will be terminated."
+msgid "Den för närvarande pågående processen i denna uppdelning kommer att avslutas."
 msgstr ""
 
 #: src/apprt/gtk/Surface.zig:1128
-msgid "Copied to clipboard"
+msgid "Sparat i urklipp"
 msgstr ""

--- a/src/os/i18n.zig
+++ b/src/os/i18n.zig
@@ -25,6 +25,7 @@ const log = std.log.scoped(.i18n);
 ///
 pub const locales = [_][:0]const u8{
     "de_DE.UTF-8",
+    "sv_SE.UTF-8",
     "zh_CN.UTF-8",
 };
 


### PR DESCRIPTION
Po files added for Swedish.

No amendments for the macOS version due to localisation on macOS being in progress, according to Ghostty devs.