### PR TITLE
Mention macOS' `open` in the CLI help messages

### DIFF
--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -51,7 +51,9 @@ pub fn run(alloc: Allocator) !u8 {
         \\`ghostty -e top` will run the `top` command inside the terminal.
         \\
         \\On macOS, launching the terminal emulator from the CLI is not
-        \\supported and only actions are supported.
+        \\supported and only actions are supported. Use `open -na Ghostty.app`
+        \\instead, or `open -na ghostty.app --args --foo=bar --baz=quz` to pass
+        \\arguments.
         \\
         \\Available actions:
         \\

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -84,6 +84,9 @@ pub fn main() !MainReturn {
             \\(i.e. Ghostty.app on macOS). This CLI can be used to perform various
             \\actions such as inspecting the version, listing fonts, etc.
             \\
+            \\On macOS, the terminal can also be launched using `open -na Ghostty.app`,
+            \\or `open -na Ghostty.app --args --foo=bar --baz=qux` to pass arguments.
+            \\
             \\We don't have proper help output yet, sorry! Please refer to the
             \\source code or Discord community for help for now. We'll fix this in time.
             \\


### PR DESCRIPTION
> 3. If you want to live dangerously, open a pull request and hope for the best.

Sure, why not!

---

This is a *super common* ask in both the GitHub Discussions and on Discord; I thus decided to add a small(ish) note to the help output directing users to try the open command.  I did not include a note to check the man page, as the text was already getting a bit long, but I can change that if requested.  Strings open for bike-shedding, of course.

Of course, feel free to close this if this is not a desirable change for the project; I would appreciate a note about that though, rather than a random unexpected close without any reason, as that would prevent any future PRs about this from others.

As I do not use macOS, I was unable to test the appearance of the string I edited in `main_ghostty.zig`.

On a slightly related note: are there any plans to translate the CLI's strings?  I assume they're in the same boat as the configuration parsing errors which were [discussed in #maintainers] on [the Ghostty Discord].

[discussed in #maintainers]: https://discord.com/channels/1005603569187160125/1337443701403815999/1352390511553417327
[the Ghostty Discord]: https://discord.org/ghostty