### PR TITLE
gtk: switch to vulkan as the default renderer

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -189,7 +189,7 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
             // From gtk 4.16, GDK_DEBUG is split into GDK_DEBUG and GDK_DISABLE.
             // For the remainder of "why" see the 4.14 comment below.
             gdk_disable.@"gles-api" = true;
-            gdk_disable.vulkan = true;
+            gdk_disable.vulkan = config.@"gtk-gsk-renderer" != .vulkan;
             gdk_debug.@"gl-no-fractional" = true;
             break :environment;
         }
@@ -202,13 +202,13 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
             // Upstream issue: https://gitlab.gnome.org/GNOME/gtk/-/issues/6589
             gdk_debug.@"gl-disable-gles" = true;
             gdk_debug.@"gl-no-fractional" = true;
-            gdk_debug.@"vulkan-disable" = true;
+            gdk_debug.@"vulkan-disable" = config.@"gtk-gsk-renderer" != .vulkan;
             break :environment;
         }
         // Versions prior to 4.14 are a bit of an unknown for Ghostty. It
         // is an environment that isn't tested well and we don't have a
         // good understanding of what we may need to do.
-        gdk_debug.@"vulkan-disable" = true;
+        gdk_debug.@"vulkan-disable" = config.@"gtk-gsk-renderer" != .vulkan;
     }
 
     {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2192,7 +2192,7 @@ keybind: Keybinds = .{},
 /// default GSK renderer, or set the GSK_RENDERER environment variable to your
 /// renderer of choice before launching Ghostty. This setting has no effect when
 /// using versions of GTK earlier than 4.14.0.
-@"gtk-gsk-renderer": GtkGskRenderer = .opengl,
+@"gtk-gsk-renderer": GtkGskRenderer = .vulkan,
 
 /// If `true`, the Ghostty GTK application will run in single-instance mode:
 /// each new `ghostty` process launched will result in a new window if there is
@@ -6503,6 +6503,7 @@ pub const WindowPadding = struct {
 pub const GtkGskRenderer = enum {
     default,
     opengl,
+    vulkan,
 };
 
 test "parse duration" {


### PR DESCRIPTION
Potential fix for #6872. Probably will need to change the defaults for older GTK versions, but this works on my GTK 4.16 system. I can't test on anything newer or older right now.