### PR TITLE
apprt/gtk: make GL context current in unrealize

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -247,19 +247,6 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
         _ = internal_os.setenv("GDK_DISABLE", value[0 .. value.len - 1 :0]);
     }
 
-    if (gtk_version.runtimeAtLeast(4, 14, 0)) {
-        switch (config.@"gtk-gsk-renderer") {
-            .default => {},
-            else => |renderer| {
-                // Force the GSK renderer to a specific value. After GTK 4.14 the
-                // `ngl` renderer is used by default which causes artifacts when
-                // used with Ghostty so it should be avoided.
-                log.warn("setting GSK_RENDERER={s}", .{@tagName(renderer)});
-                _ = internal_os.setenv("GSK_RENDERER", @tagName(renderer));
-            },
-        }
-    }
-
     adw.init();
 
     const display: *gdk.Display = gdk.Display.getDefault() orelse {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2186,14 +2186,6 @@ keybind: Keybinds = .{},
 /// debug builds, `false` for all others.
 @"gtk-opengl-debug": bool = builtin.mode == .Debug,
 
-/// After GTK 4.14.0, we need to force the GSK renderer to OpenGL as the default
-/// GSK renderer is broken on some systems. If you would like to override
-/// that bekavior, set `gtk-gsk-renderer=default` and either use your system's
-/// default GSK renderer, or set the GSK_RENDERER environment variable to your
-/// renderer of choice before launching Ghostty. This setting has no effect when
-/// using versions of GTK earlier than 4.14.0.
-@"gtk-gsk-renderer": GtkGskRenderer = .opengl,
-
 /// If `true`, the Ghostty GTK application will run in single-instance mode:
 /// each new `ghostty` process launched will result in a new window if there is
 /// already a running process.
@@ -6497,12 +6489,6 @@ pub const WindowPadding = struct {
         try testing.expectError(error.InvalidValue, WindowPadding.parseCLI(""));
         try testing.expectError(error.InvalidValue, WindowPadding.parseCLI("a"));
     }
-};
-
-/// See the `gtk-gsk-renderer` config.
-pub const GtkGskRenderer = enum {
-    default,
-    opengl,
 };
 
 test "parse duration" {


### PR DESCRIPTION
Fixes #6872

This commit explicitly acquires the GL context in the `unrealize` signal handler of the GTK Surface prior to cleaning up GPU resources.

A GLArea only guarantees that the associated GdkContext is current for the `render` signal (see the docs[1]). This is why our OpenGL renderer "defers" various operations such as resize, font grid changing, etc. (see the `deferred_`-prefix fields in `renderer/OpenGL.zig`). However, we missed a spot.

The `gtk-widget::unrealize` signal is emitted when the widget is destroyed, and it is the last chance we have to clean up our GPU resources. But it is not guaranteed that the GL context is current at that point, and we weren't making it current. On the NGL GTK renderer, this was freeing GPU resources we didn't own.

As best I can understand, the old GL renderer only ever used a handful of GL resources that were early in the ID space, so by coincidence we were probably freeing nothing and everything was fine. But with the new NGL renderer uses a LOT more GL resources (make a few splits and the ID space is already in the thousands, from GTK!), so we were freeing real resources that we didn't own, which caused rendering issues. :)

I suspect the above also resulted in VRAM memory leaks (which would be RAM memory leaks for unified memory GPUs). This potentially relates to #5491.

The fix is to explicitly make the GL context current in the `unrealize` handler.

[1]: https://docs.gtk.org/gtk4/method.GLArea.make_current.html