### PR TITLE
pkg/harfbuzz: update 8.4 => 11.0

### DIFF
--- a/build.zig.zon.json
+++ b/build.zig.zon.json
@@ -39,10 +39,10 @@
     "url": "https://deps.files.ghostty.org/gtk4-layer-shell-1.1.0.tar.gz",
     "hash": "sha256-mChCgSYKXu9bT2OlXxbEv2p4ihAgptsDfssPcfozaYg="
   },
-  "N-V-__8AAKa0rgW4WI8QbJlq8QJJv6CSxvsvNfussVBe9Heg": {
+  "N-V-__8AAG02ugUcWec-Ndp-i7JTsJ0dgF8nnJRUInkGLG7G": {
     "name": "harfbuzz",
-    "url": "https://deps.files.ghostty.org/harfbuzz-1220b8588f106c996af10249bfa092c6fb2f35fbacb1505ef477a0b04a7dd1063122.tar.gz",
-    "hash": "sha256-nxygiYE7BZRK0c6MfgGCEwJtNdybq0gKIeuHaDg5ZVY="
+    "url": "https://deps.files.ghostty.org/harfbuzz-11.0.0.tar.xz",
+    "hash": "sha256-8WNRuv4hRyX+LB1bWfDZPkmQWkskeJn7kNcM/5U6K5s="
   },
   "N-V-__8AAGmZhABbsPJLfbqrh6JTHsXhY6qCaLAQyx25e0XE": {
     "name": "highway",

--- a/build.zig.zon.nix
+++ b/build.zig.zon.nix
@@ -146,11 +146,11 @@ in
       };
     }
     {
-      name = "N-V-__8AAKa0rgW4WI8QbJlq8QJJv6CSxvsvNfussVBe9Heg";
+      name = "N-V-__8AAG02ugUcWec-Ndp-i7JTsJ0dgF8nnJRUInkGLG7G";
       path = fetchZigArtifact {
         name = "harfbuzz";
-        url = "https://deps.files.ghostty.org/harfbuzz-1220b8588f106c996af10249bfa092c6fb2f35fbacb1505ef477a0b04a7dd1063122.tar.gz";
-        hash = "sha256-nxygiYE7BZRK0c6MfgGCEwJtNdybq0gKIeuHaDg5ZVY=";
+        url = "https://deps.files.ghostty.org/harfbuzz-11.0.0.tar.xz";
+        hash = "sha256-8WNRuv4hRyX+LB1bWfDZPkmQWkskeJn7kNcM/5U6K5s=";
       };
     }
     {

--- a/build.zig.zon.txt
+++ b/build.zig.zon.txt
@@ -8,7 +8,7 @@ https://deps.files.ghostty.org/freetype-1220b81f6ecfb3fd222f76cf9106fecfa6554ab0
 https://deps.files.ghostty.org/gettext-0.24.tar.gz
 https://deps.files.ghostty.org/glslang-12201278a1a05c0ce0b6eb6026c65cd3e9247aa041b1c260324bf29cee559dd23ba1.tar.gz
 https://deps.files.ghostty.org/gtk4-layer-shell-1.1.0.tar.gz
-https://deps.files.ghostty.org/harfbuzz-1220b8588f106c996af10249bfa092c6fb2f35fbacb1505ef477a0b04a7dd1063122.tar.gz
+https://deps.files.ghostty.org/harfbuzz-11.0.0.tar.xz
 https://deps.files.ghostty.org/highway-66486a10623fa0d72fe91260f96c892e41aceb06.tar.gz
 https://deps.files.ghostty.org/imgui-1220bc6b9daceaf7c8c60f3c3998058045ba0c5c5f48ae255ff97776d9cd8bfc6402.tar.gz
 https://deps.files.ghostty.org/libpng-1220aa013f0c83da3fb64ea6d327f9173fa008d10e28bc9349eac3463457723b1c66.tar.gz

--- a/pkg/harfbuzz/build.zig.zon
+++ b/pkg/harfbuzz/build.zig.zon
@@ -1,13 +1,13 @@
 .{
     .name = .harfbuzz,
-    .version = "8.4.0",
+    .version = "11.0.0",
     .fingerprint = 0xbd60917cd18865d8,
     .paths = .{""},
     .dependencies = .{
         // harfbuzz/harfbuzz
         .harfbuzz = .{
-            .url = "https://deps.files.ghostty.org/harfbuzz-1220b8588f106c996af10249bfa092c6fb2f35fbacb1505ef477a0b04a7dd1063122.tar.gz",
-            .hash = "N-V-__8AAKa0rgW4WI8QbJlq8QJJv6CSxvsvNfussVBe9Heg",
+            .url = "https://deps.files.ghostty.org/harfbuzz-11.0.0.tar.xz",
+            .hash = "N-V-__8AAG02ugUcWec-Ndp-i7JTsJ0dgF8nnJRUInkGLG7G",
             .lazy = true,
         },
 


### PR DESCRIPTION
This updates our bundled Harfbuzz from 8.4 to 11.0. The changes from 8 to 11 include a number of correctness and performance improvements. Packaged releases tend to dynamically link so this won't affect existing users, but build-from-source users hopefully get an improvement.