### PR TITLE
Add Custom Shader Uniforms for Cursor Effects

### DIFF
--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -1951,7 +1951,7 @@ fn addCursor(
         .glyph_offset_y = render.glyph.offset_y,
     });
 
-    //Update cursor uniforms only when custom shaders are loaded
+    // Update cursor uniforms only when custom shaders are loaded
     if (self.gl_state) |*gl_state| {
         if (gl_state.custom) |*custom_state| {
             custom_state.addCursor(self.size, screen.cursor, cursor_style, render.glyph);

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -1951,6 +1951,13 @@ fn addCursor(
         .glyph_offset_y = render.glyph.offset_y,
     });
 
+    //Update cursor uniforms only when custom shaders are loaded
+    if (self.gl_state) |*gl_state| {
+        if (gl_state.custom) |*custom_state| {
+            custom_state.addCursor(self.size, screen.cursor, cursor_style, render.glyph);
+        }
+    }
+
     return &self.cells.items[self.cells.items.len - 1];
 }
 

--- a/src/renderer/opengl/custom.zig
+++ b/src/renderer/opengl/custom.zig
@@ -185,8 +185,8 @@ pub const State = struct {
     
     // Update the cursor related uniforms
     pub fn addCursor(self: *State, size: Size, cursor: Screen.Cursor, cursor_style: CursorStyle, glyph: Glyph) void {
-        const current_x: f32 = @as(f32, @floatFromInt(cursor.x * size.cell.width)) + @as(f32, @floatFromInt(glyph.offset_x));
-        const current_y: f32 = @as(f32, @floatFromInt(size.screen.height - (cursor.y + 1) * size.cell.height)) + @as(f32, @floatFromInt(glyph.offset_y));
+        const current_x: f32 = @as(f32, @floatFromInt(cursor.x * size.cell.width + size.padding.left)) + @as(f32, @floatFromInt(glyph.offset_x));
+        const current_y: f32 = @as(f32, @floatFromInt(size.screen.height - size.padding.top - (cursor.y + 1) * size.cell.height)) + @as(f32, @floatFromInt(glyph.offset_y));
 
         const cursor_width: f32 = if (cursor_style == .bar) 1.0 else @floatFromInt(glyph.width);
         const cursor_height: f32 = @floatFromInt(glyph.height);

--- a/src/renderer/opengl/custom.zig
+++ b/src/renderer/opengl/custom.zig
@@ -22,6 +22,9 @@ pub const Uniforms = extern struct {
     mouse: [4]f32 align(16) = .{ 0, 0, 0, 0 },
     date: [4]f32 align(16) = .{ 0, 0, 0, 0 },
     sample_rate: f32 align(4) = 1,
+    current_cursor: [4]f32 align(16) = .{ 0, 0, 0, 0 }, 
+    previous_cursor: [4]f32 align(16) = .{ 0, 0, 0, 0 }, 
+    cursor_change_time: f32 align(4) = 1 
 };
 
 /// The state associated with custom shaders. This should only be initialized

--- a/src/renderer/shaders/shadertoy_prefix.glsl
+++ b/src/renderer/shaders/shadertoy_prefix.glsl
@@ -11,6 +11,9 @@ layout(binding = 0) uniform Globals {
     uniform vec4	iMouse;
     uniform vec4	iDate;
     uniform float	iSampleRate;
+    uniform vec4	iCurrentCursor;
+    uniform vec4	iPreviousCursor;
+    uniform float	iTimeCursorChange;
 };
 
 layout(binding = 0) uniform sampler2D	iChannel0;


### PR DESCRIPTION
Hi,
As requested, this is a pull request for discussion #6901. It adds cursor position data to the uniforms for custom shaders, enabling more dynamic and interactive effects.

Let me know if any adjustments are needed. Thanks!


https://github.com/user-attachments/assets/e24d6641-b458-4a25-8fc3-eb854931db54

