### PR TITLE
Metal: fix crunchy constrained glyphs

### DIFF
--- a/src/renderer/shaders/cell.metal
+++ b/src/renderer/shaders/cell.metal
@@ -425,11 +425,19 @@ vertex CellTextVertexOut cell_text_vertex(
   // If we're constrained then we need to scale the glyph.
   if (in.mode == MODE_TEXT_CONSTRAINED) {
     float max_width = uniforms.cell_size.x * in.constraint_width;
+    // If this glyph is wider than the constraint width,
+    // fit it to the width and remove its horizontal offset.
     if (size.x > max_width) {
       float new_y = size.y * (max_width / size.x);
       offset.y += (size.y - new_y) / 2;
+      offset.x = 0;
       size.y = new_y;
       size.x = max_width;
+    } else if (max_width - size.x > offset.x) {
+      // However, if it does fit in the constraint width, make
+      // sure the offset is small enough to not push it over the
+      // right edge of the constraint width.
+      offset.x = max_width - size.x;
     }
   }
 

--- a/src/renderer/shaders/cell.metal
+++ b/src/renderer/shaders/cell.metal
@@ -499,7 +499,11 @@ fragment float4 cell_text_fragment(
   constexpr sampler textureSampler(
     coord::pixel,
     address::clamp_to_edge,
-    filter::nearest
+    // TODO(qwerasd): This can be changed back to filter::nearest when
+    //                we move the constraint logic out of the GPU code
+    //                which should once again guarantee pixel perfect
+    //                sizing.
+    filter::linear
   );
 
   switch (in.mode) {


### PR DESCRIPTION
Fixes problem pointed out in discussion #6895, as well as adjusting the constraint logic to account for the offset, since I noticed it was wrong; the constraint logic now accounts for the x offset, so that the glyph does not exceed the right edge of the constraint width when the offset is added, and the offset is zeroed if the glyph is resized down to fit the constraint width.

|**Before**|**After**|
|-|-|
|<img width="84" alt="image" src="https://github.com/user-attachments/assets/9561ca40-cfa0-4aed-b192-ee15042d8cbb" />|<img width="82" alt="image" src="https://github.com/user-attachments/assets/9a77ac61-f46d-41de-a859-2b394024f7bc" />|

<sup>Zoom in to images for detail if you can't see the crunchiness.</sup>

> [!NOTE]
> It may be an issue that that glyph is rendered with the constrained text mode in the first place - Kitty doesn't seem to apply constraint logic to it, and it seems a little over-eager to do so on our part. This is something to look in to.