### PR TITLE
macos: reset the last command key state when keyDown event

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -884,6 +884,11 @@ extension Ghostty {
                 nil
             }
 
+            // If we are in a keyDown then we don't need to redispatch a command-modded
+            // key event (see docs for this field) so reset this to nil because
+            // `interpretKeyEvents` may dispach it.
+            self.lastCommandEvent = nil
+
             self.interpretKeyEvents([translationEvent])
 
             // If our keyboard changed from this we just assume an input method


### PR DESCRIPTION
Fixes a regression from #6909
See #6887

In certain scenarios, the last command key state would linger around (I could only see this happen with global keybinds for unknown reasons yet). This state is only meant to have an effect within the cycle of a single keybind and only so we can ensure an event reaches keyDown so it should be reset if keyDown is ever sent (since, by definition at that point, keyDown has been reached).

I'm still not happy that this is necessary and I suspect there is a better root cause to resolve, but I'd rather get this fix in now and figure out the root cause later.