### PR TITLE
docs: use Command instead of super for macOS

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -826,7 +826,7 @@ env: RepeatableStringMap = .{},
 link: RepeatableLink = .{},
 
 /// Enable URL matching. URLs are matched on hover with control (Linux) or
-/// super (macOS) pressed and open using the default system application for
+/// command (macOS) pressed and open using the default system application for
 /// the linked URL.
 ///
 /// The URL matcher is always lowest priority of any configured links (see


### PR DESCRIPTION
Command is the name Apple uses for this key and that's printed on the keyboard 😉