### PR TITLE
libghostty: Action CValue should be untagged extern union

### DIFF
--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -311,7 +311,7 @@ pub const Action = union(Key) {
 
         break :cvalue @Type(.{ .@"union" = .{
             .layout = .@"extern",
-            .tag_type = Key,
+            .tag_type = null,
             .fields = &union_fields,
             .decls = &.{},
         } });
@@ -322,6 +322,13 @@ pub const Action = union(Key) {
         key: Key,
         value: CValue,
     };
+
+    comptime {
+        // For ABI compatibility, we expect that this is our union size.
+        // At the time of writing, we don't promise ABI compatibility
+        // so we can change this but I want to be aware of it.
+        assert(@sizeOf(CValue) == 16);
+    }
 
     /// Returns the value type for the given key.
     pub fn Value(comptime key: Key) type {


### PR DESCRIPTION
Fixes #6962

I believe this is an upstream bug
(https://github.com/ziglang/zig/issues/23454), where Zig is allowing extern unions to be tagged when created via type reification. This results in a CValue that has an extra trailing byte (the tag).

This wasn't causing any noticeable issues for Ghostty for some reason but others using our pattern were seeing issues. And I did confirm that our CValue was indeed tagged and was the wrong byte size. I assume Swift was just ignoring it because it was extra data. I don't know, but we should fix this in general for libghostty.