### PR TITLE
Fix macOS shortcut binding for `close_window` action

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -91,6 +91,12 @@ class TerminalController: BaseTerminalController {
             name: Ghostty.Notification.didEqualizeSplits,
             object: nil
         )
+        center.addObserver(
+            self,
+            selector: #selector(onCloseWindow),
+            name: .ghosttyCloseWindow,
+            object: nil
+        )
     }
 
     required init?(coder: NSCoder) {
@@ -840,6 +846,12 @@ class TerminalController: BaseTerminalController {
         guard let target = notification.object as? Ghostty.SurfaceView else { return }
         guard surfaceTree?.contains(view: target) ?? false else { return }
         closeTab(self)
+    }
+
+    @objc private func onCloseWindow(notification: SwiftUI.Notification) {
+        guard let target = notification.object as? Ghostty.SurfaceView else { return }
+        guard surfaceTree?.contains(view: target) ?? false else { return }
+        closeWindow(self)
     }
 
     @objc private func onResetWindowSize(notification: SwiftUI.Notification) {

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -107,7 +107,7 @@ extension Ghostty {
         deinit {
             // This will force the didSet callbacks to run which free.
             self.app = nil
-            
+
 #if os(macOS)
             NotificationCenter.default.removeObserver(self)
 #endif
@@ -451,6 +451,9 @@ extension Ghostty {
             case GHOSTTY_ACTION_CLOSE_TAB:
                 closeTab(app, target: target)
 
+            case GHOSTTY_ACTION_CLOSE_WINDOW:
+                closeWindow(app, target: target)
+
             case GHOSTTY_ACTION_TOGGLE_FULLSCREEN:
                 toggleFullscreen(app, target: target, mode: action.action.toggle_fullscreen)
 
@@ -680,6 +683,26 @@ extension Ghostty {
                     object: surfaceView
                 )
 
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        private static func closeWindow(_ app: ghostty_app_t, target: ghostty_target_s) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                Ghostty.logger.warning("close window does nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+
+                NotificationCenter.default.post(
+                    name: .ghosttyCloseWindow,
+                    object: surfaceView
+                )
 
             default:
                 assertionFailure()

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -248,6 +248,9 @@ extension Notification.Name {
     /// Close tab
     static let ghosttyCloseTab = Notification.Name("com.mitchellh.ghostty.closeTab")
 
+    /// Close window
+    static let ghosttyCloseWindow = Notification.Name("com.mitchellh.ghostty.closeWindow")
+
     /// Resize the window to a default size.
     static let ghosttyResetWindowSize = Notification.Name("com.mitchellh.ghostty.resetWindowSize")
 }


### PR DESCRIPTION
Fixes #7003