### PR TITLE
Use built-in functions for elvish

### DIFF
--- a/src/shell-integration/elvish/lib/ghostty-integration.elv
+++ b/src/shell-integration/elvish/lib/ghostty-integration.elv
@@ -75,7 +75,8 @@
   }
 
   fn report-pwd {
-    printf "\e]7;file://%s%s\a" (hostname) (pwd)
+    use platform
+    printf "\e]7;file://%s%s\a" (platform:hostname) ($pwd)
   }
 
   fn sudo-with-terminfo {|@args|
@@ -109,7 +110,7 @@
   var features = [(str:split ',' $E:GHOSTTY_SHELL_FEATURES)]
 
   if (has-value $features title) {
-    set after-chdir = (conj $after-chdir {|_| report-pwd })
+    set after-chdir = (conj $after-chdir {|_| report- })
   }
   if (has-value $features cursor) {
     fn beam  { printf "\e[5 q" }

--- a/src/shell-integration/elvish/lib/ghostty-integration.elv
+++ b/src/shell-integration/elvish/lib/ghostty-integration.elv
@@ -110,7 +110,7 @@
   var features = [(str:split ',' $E:GHOSTTY_SHELL_FEATURES)]
 
   if (has-value $features title) {
-    set after-chdir = (conj $after-chdir {|_| report- })
+    set after-chdir = (conj $after-chdir {|_| report-pwd })
   }
   if (has-value $features cursor) {
     fn beam  { printf "\e[5 q" }

--- a/src/shell-integration/elvish/lib/ghostty-integration.elv
+++ b/src/shell-integration/elvish/lib/ghostty-integration.elv
@@ -76,7 +76,7 @@
 
   fn report-pwd {
     use platform
-    printf "\e]7;file://%s%s\a" (platform:hostname) ($pwd)
+    printf "\e]7;file://%s%s\a" platform:hostname $pwd
   }
 
   fn sudo-with-terminfo {|@args|


### PR DESCRIPTION
Currently the elvish shell integration uses the `hostname` command, this may not exist on all systems and is somewhat redundant to rely on when elvish has an [`platform:hostname`](https://elv.sh/ref/platform.html#platform:hostname) function that can be used and will work across platform regardless of command availability. On top of this instead of directly calling the `pwd` function we can simply use the built-in [`$pwd`](https://elv.sh/ref/builtin.html#$pwd) variable that elvish gives us. This should prevent the shell integration from breaking due to external function availability.