### PR TITLE
pwd: fix hostname resolution on macos

### DIFF
--- a/src/os/hostname.zig
+++ b/src/os/hostname.zig
@@ -199,6 +199,40 @@ test parseUrl {
     try std.testing.expectEqualStrings("ab:cd:ef:ab:cd:ef", uri.host.?.percent_encoded);
     try std.testing.expectEqualStrings("/home/test/", uri.path.percent_encoded);
     try std.testing.expect(uri.port == null);
+
+    // 3. Hostnames that are mac addresses with no path.
+
+    // Numerical mac addresses.
+
+    uri = try parseUrl("file://12:34:56:78:90:12");
+
+    try std.testing.expectEqualStrings("file", uri.scheme);
+    try std.testing.expectEqualStrings("12:34:56:78:90", uri.host.?.percent_encoded);
+    try std.testing.expectEqualStrings("", uri.path.percent_encoded);
+    try std.testing.expect(uri.port == 12);
+
+    uri = try parseUrl("kitty-shell-cwd://12:34:56:78:90:12");
+
+    try std.testing.expectEqualStrings("kitty-shell-cwd", uri.scheme);
+    try std.testing.expectEqualStrings("12:34:56:78:90", uri.host.?.percent_encoded);
+    try std.testing.expectEqualStrings("", uri.path.percent_encoded);
+    try std.testing.expect(uri.port == 12);
+
+    // Alphabetical mac addresses.
+
+    uri = try parseUrl("file://ab:cd:ef:ab:cd:ef");
+
+    try std.testing.expectEqualStrings("file", uri.scheme);
+    try std.testing.expectEqualStrings("ab:cd:ef:ab:cd:ef", uri.host.?.percent_encoded);
+    try std.testing.expectEqualStrings("", uri.path.percent_encoded);
+    try std.testing.expect(uri.port == null);
+
+    uri = try parseUrl("kitty-shell-cwd://ab:cd:ef:ab:cd:ef");
+
+    try std.testing.expectEqualStrings("kitty-shell-cwd", uri.scheme);
+    try std.testing.expectEqualStrings("ab:cd:ef:ab:cd:ef", uri.host.?.percent_encoded);
+    try std.testing.expectEqualStrings("", uri.path.percent_encoded);
+    try std.testing.expect(uri.port == null);
 }
 
 test "parseUrl succeeds even if path component is missing" {

--- a/src/os/hostname.zig
+++ b/src/os/hostname.zig
@@ -19,9 +19,7 @@ fn isValidMacAddress(mac_address: []const u8) bool {
         return false;
     }
 
-    for (0..mac_address.len) |i| {
-        const c = mac_address[i];
-
+    for (mac_address, 0..) |c, i| {
         if ((i + 1) % 3 == 0) {
             if (c != ':') {
                 return false;

--- a/src/os/hostname.zig
+++ b/src/os/hostname.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const posix = std.posix;
 
 pub const HostnameParsingError = error{
@@ -40,6 +41,10 @@ fn isValidMacAddress(mac_address: []const u8) bool {
 /// correctly.
 pub fn parseUrl(url: []const u8) !std.Uri {
     return std.Uri.parse(url) catch |e| {
+        // The mac-address-as-hostname issue is specific to macOS so we just return an error if we
+        // hit it on other platforms.
+        comptime if (builtin.os.tag != .macos) return e;
+
         // It's possible this is a mac address on macOS where the last 2 characters in the
         // address are non-digits, e.g. 'ff', and thus an invalid port.
         //

--- a/src/os/hostname.zig
+++ b/src/os/hostname.zig
@@ -48,7 +48,7 @@ pub fn parseUrl(url: []const u8) UrlParsingError!std.Uri {
     return std.Uri.parse(url) catch |e| {
         // The mac-address-as-hostname issue is specific to macOS so we just return an error if we
         // hit it on other platforms.
-        comptime if (builtin.os.tag != .macos) return e;
+        if (comptime builtin.os.tag != .macos) return e;
 
         // It's possible this is a mac address on macOS where the last 2 characters in the
         // address are non-digits, e.g. 'ff', and thus an invalid port.

--- a/src/os/hostname.zig
+++ b/src/os/hostname.zig
@@ -12,6 +12,8 @@ pub const UrlParsingError = std.Uri.ParseError || error{
     NoSchemeProvided,
 };
 
+const mac_address_length = 17;
+
 fn isUriPathSeparator(c: u8) bool {
     return switch (c) {
         '?', '#' => true,
@@ -65,7 +67,6 @@ pub fn parseUrl(url: []const u8) UrlParsingError!std.Uri {
         // The first '/' after the scheme marks the end of the hostname. If the first '/'
         // following the end of the scheme is not at the right position this is not a
         // valid mac address.
-        const mac_address_length = 17;
         if (url_without_scheme.len != mac_address_length and
             std.mem.indexOfScalarPos(u8, url_without_scheme, 0, '/') != mac_address_length)
         {

--- a/src/os/hostname.zig
+++ b/src/os/hostname.zig
@@ -55,20 +55,21 @@ pub fn parseUrl(url: []const u8) !std.Uri {
         // The first '/' after the scheme marks the end of the hostname. If the first '/'
         // following the end of the scheme is not at the right position this is not a
         // valid mac address.
-        if (url_without_scheme.len != 17 and
-            std.mem.indexOfScalarPos(u8, url_without_scheme, 0, '/') != 17)
+        const mac_address_length = 17;
+        if (url_without_scheme.len != mac_address_length and
+            std.mem.indexOfScalarPos(u8, url_without_scheme, 0, '/') != mac_address_length)
         {
             return error.HostnameIsNotMacAddress;
         }
 
         // At this point we may have a mac address as the hostname.
-        const mac_address = url_without_scheme[0..17];
+        const mac_address = url_without_scheme[0..mac_address_length];
 
         if (!isValidMacAddress(mac_address)) {
             return error.HostnameIsNotMacAddress;
         }
 
-        var uri_path_end_idx: usize = 17;
+        var uri_path_end_idx: usize = mac_address_length;
         while (uri_path_end_idx < url_without_scheme.len and
             !isUriPathSeparator(url_without_scheme[uri_path_end_idx]))
         {
@@ -80,7 +81,9 @@ pub fn parseUrl(url: []const u8) !std.Uri {
         return .{
             .scheme = scheme,
             .host = .{ .percent_encoded = mac_address },
-            .path = .{ .percent_encoded = url_without_scheme[17..uri_path_end_idx] },
+            .path = .{
+                .percent_encoded = url_without_scheme[mac_address_length..uri_path_end_idx],
+            },
         };
     };
 }

--- a/src/os/hostname.zig
+++ b/src/os/hostname.zig
@@ -32,10 +32,8 @@ fn isValidMacAddress(mac_address: []const u8) bool {
             if (c != ':') {
                 return false;
             }
-        } else {
-            if (!std.mem.containsAtLeastScalar(u8, "0123456789ABCDEFabcdef", 1, c)) {
-                return false;
-            }
+        } else if (!std.mem.containsAtLeastScalar(u8, "0123456789ABCDEFabcdef", 1, c)) {
+            return false;
         }
     }
 

--- a/src/os/hostname.zig
+++ b/src/os/hostname.zig
@@ -7,12 +7,9 @@ pub const HostnameParsingError = error{
     NoSpaceLeft,
 };
 
-pub const UrlParsingError = error{
+pub const UrlParsingError = std.Uri.ParseError || error{
     HostnameIsNotMacAddress,
-    InvalidFormat,
-    InvalidPort,
     NoSchemeProvided,
-    UnexpectedCharacter,
 };
 
 fn isUriPathSeparator(c: u8) bool {

--- a/src/os/hostname.zig
+++ b/src/os/hostname.zig
@@ -46,15 +46,11 @@ pub fn parseUrl(url: []const u8) !std.Uri {
         // Example: file://12:34:56:78:90:12/path/to/file
         if (e != error.InvalidPort) return e;
 
-        const scheme, const url_without_scheme = url: {
-            if (std.mem.startsWith(u8, url, "file://")) break :url .{ "file", url[7..] };
-            if (std.mem.startsWith(u8, url, "kitty-shell-cwd://")) break :url .{
-                "kitty-shell-cwd",
-                url[18..],
-            };
-
-            return error.UnsupportedScheme;
+        const url_without_scheme_start = std.mem.indexOf(u8, url, "://") orelse {
+            return error.InvalidScheme;
         };
+        const scheme = url[0..url_without_scheme_start];
+        const url_without_scheme = url[url_without_scheme_start + 3 ..];
 
         // The first '/' after the scheme marks the end of the hostname. If the first '/'
         // following the end of the scheme is not at the right position this is not a

--- a/src/os/hostname.zig
+++ b/src/os/hostname.zig
@@ -7,6 +7,14 @@ pub const HostnameParsingError = error{
     NoSpaceLeft,
 };
 
+pub const UrlParsingError = error{
+    HostnameIsNotMacAddress,
+    InvalidFormat,
+    InvalidPort,
+    NoSchemeProvided,
+    UnexpectedCharacter,
+};
+
 fn isUriPathSeparator(c: u8) bool {
     return switch (c) {
         '?', '#' => true,
@@ -39,7 +47,7 @@ fn isValidMacAddress(mac_address: []const u8) bool {
 /// path information for Ghostty's PWD reporting functionality. Takes into account that on macOS
 /// the url passed to this function might have a mac address as its hostname and parses it
 /// correctly.
-pub fn parseUrl(url: []const u8) !std.Uri {
+pub fn parseUrl(url: []const u8) UrlParsingError!std.Uri {
     return std.Uri.parse(url) catch |e| {
         // The mac-address-as-hostname issue is specific to macOS so we just return an error if we
         // hit it on other platforms.
@@ -52,7 +60,7 @@ pub fn parseUrl(url: []const u8) !std.Uri {
         if (e != error.InvalidPort) return e;
 
         const url_without_scheme_start = std.mem.indexOf(u8, url, "://") orelse {
-            return error.InvalidScheme;
+            return error.NoSchemeProvided;
         };
         const scheme = url[0..url_without_scheme_start];
         const url_without_scheme = url[url_without_scheme_start + 3 ..];

--- a/src/os/hostname.zig
+++ b/src/os/hostname.zig
@@ -55,8 +55,8 @@ pub fn parseUrl(url: []const u8) !std.Uri {
         // The first '/' after the scheme marks the end of the hostname. If the first '/'
         // following the end of the scheme is not at the right position this is not a
         // valid mac address.
-        if (std.mem.indexOfScalarPos(u8, url_without_scheme, 0, '/') != 17 and
-            url_without_scheme.len != 17)
+        if (url_without_scheme.len != 17 and
+            std.mem.indexOfScalarPos(u8, url_without_scheme, 0, '/') != 17)
         {
             return error.HostnameIsNotMacAddress;
         }

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1082,17 +1082,18 @@ pub const StreamHandler = struct {
                 // address are non-digits, e.g. 'ff', and thus an invalid port.
                 //
                 // Example: file://12:34:56:78:90:12/path/to/file
+                if (e != error.InvalidPort) return;
 
                 // Insufficient length to have a mac address in the hostname.
                 if (url.len < 24) {
-                    log.warn("invalid url in OSC 7: {}", .{e});
+                    log.warn("invalid MAC address in OSC 7: insufficient length", .{});
                     return;
                 }
 
                 // The first '/' after the scheme marks the end of the hostname. If the hostname is
                 // not 17 characters, it's not a mac address.
                 if (std.mem.indexOfScalarPos(u8, url, 7, '/') != 24) {
-                    log.warn("invalid url in OSC 7: {}", .{e});
+                    log.warn("invalid MAC address in OSC 7: invalid scheme", .{});
                     return;
                 }
 
@@ -1102,14 +1103,14 @@ pub const StreamHandler = struct {
                 for (0..mac_address.len) |i| {
                     const c = mac_address[i];
 
-                    if (i + 1 % 3 == 0) {
+                    if ((i + 1) % 3 == 0) {
                         if (c != ':') {
-                            log.warn("invalid url in OSC 7: {}", .{e});
+                            log.warn("invalid MAC address in OSC 7: missing colon", .{});
                             return;
                         }
                     } else {
-                        if (!std.mem.containsAtLeastScalar(u8, "0123456789abcdef", 1, mac_address[i])) {
-                            log.warn("invalid url in OSC 7: {}", .{e});
+                        if (!std.mem.containsAtLeastScalar(u8, "0123456789ABCDEFabcdef", 1, mac_address[i])) {
+                            log.warn("invalid MAC address in OSC 7: invalid character '{c}' at position '{d}'", .{ mac_address[i], i });
                             return;
                         }
                     }
@@ -1125,7 +1126,7 @@ pub const StreamHandler = struct {
                 // Same compliance factor as std.Uri.parse(), i.e. not at all compliant with the URI
                 // spec.
                 break :uri .{
-                    .scheme = "file://",
+                    .scheme = "file",
                     .host = .{ .percent_encoded = mac_address },
                     .path = .{ .percent_encoded = url[24..uri_path_end_idx] },
                 };

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1041,82 +1041,6 @@ pub const StreamHandler = struct {
         self.terminal.markSemanticPrompt(.command);
     }
 
-    fn isUriPathSeparator(c: u8) bool {
-        return switch (c) {
-            '?', '#' => true,
-            else => false,
-        };
-    }
-
-    fn isValidMacAddress(mac_address: []const u8) bool {
-        // A valid mac address has 6 two-character components with 5 colons, e.g. 12:34:56:ab:cd:ef.
-        if (mac_address.len != 17) {
-            return false;
-        }
-
-        for (0..mac_address.len) |i| {
-            const c = mac_address[i];
-
-            if ((i + 1) % 3 == 0) {
-                if (c != ':') {
-                    return false;
-                }
-            } else {
-                if (!std.mem.containsAtLeastScalar(u8, "0123456789ABCDEFabcdef", 1, c)) {
-                    return false;
-                }
-            }
-        }
-
-        return true;
-    }
-
-    fn parseUrl(url: []const u8) !std.Uri {
-        return std.Uri.parse(url) catch |e| {
-            // It's possible this is a mac address on macOS where the last 2 characters in the
-            // address are non-digits, e.g. 'ff', and thus an invalid port.
-            //
-            // Example: file://12:34:56:78:90:12/path/to/file
-            if (e != error.InvalidPort) return e;
-
-            const url_without_scheme = url: {
-                if (std.mem.startsWith(u8, url, "file://")) break :url url[7..];
-                if (std.mem.startsWith(u8, url, "kitty-shell-cwd://")) break :url url[18..];
-
-                return error.UnsupportedScheme;
-            };
-
-            // The first '/' after the scheme marks the end of the hostname. If the first '/'
-            // following the end of the scheme is not at the right position this is not a
-            // valid mac address.
-            if (std.mem.indexOfScalarPos(u8, url_without_scheme, 0, '/') != 17) {
-                return error.HostnameIsNotMacAddress;
-            }
-
-            // At this point we may have a mac address as the hostname.
-            const mac_address = url_without_scheme[0..17];
-
-            if (!isValidMacAddress(mac_address)) {
-                return error.HostnameIsNotMacAddress;
-            }
-
-            var uri_path_end_idx: usize = 17;
-            while (uri_path_end_idx < url_without_scheme.len and
-                !isUriPathSeparator(url_without_scheme[uri_path_end_idx]))
-            {
-                uri_path_end_idx += 1;
-            }
-
-            // Same compliance factor as std.Uri.parse(), i.e. not at all compliant with the URI
-            // spec.
-            return .{
-                .scheme = "file",
-                .host = .{ .percent_encoded = mac_address },
-                .path = .{ .percent_encoded = url_without_scheme[17..uri_path_end_idx] },
-            };
-        };
-    }
-
     pub fn reportPwd(self: *StreamHandler, url: []const u8) !void {
         // Special handling for the empty URL. We treat the empty URL
         // as resetting the pwd as if we never saw a pwd. I can't find any
@@ -1145,7 +1069,7 @@ pub const StreamHandler = struct {
             return;
         }
 
-        const uri: std.Uri = parseUrl(url) catch |e| {
+        const uri: std.Uri = internal_os.hostname.parseUrl(url) catch |e| {
             log.warn("invalid url in OSC 7: {}", .{e});
             return;
         };


### PR DESCRIPTION
## Description

Yet another edge case in #2484 

When macOS's "Private WiFi address" feature is enabled it'll change the hostname to a mac address. Mac addresses look like URIs with a hostname and port component, e.g. `12:34:56:78:90:12` where `:12` looks like port `12`. However, mac addresses use hex numbers and as such can also contain letters `a` through `f`. So, a mac address like `ab:cd:ef:ab:cd:ef` is valid, but will not be parsed as a URI, because `:ef` is not a valid port.

This commit attempts to fix that by checking if the hostname is a valid mac address when `std.Uri.parse()` fails and constructing a new `std.Uri` struct using that information.

It's not perfect, but is equally compliant with the URI spec as `std.Uri` currently is. Meaning not at all compliant 😅 

## Testing instructions

### Unit tests

> [!IMPORTANT]
> I don't know if these tests are run in CI or if they're picked up by `zig build test`. I get an unrelated crash that mentions `minidump` and an invalid OSC command when I try to run `zig build test` on my mac.

1. Make sure `zig test src/os/hostname.zig` is passing.

### Manual testing instructions

#### Setup - Enable the "Private WiFi address" setting

> [!IMPORTANT]
> You must be connected to WiFi to be able to test this.

1. Open your mac's "System Settings".
2. Go to Network &rarr; Wi-Fi &rarr; Details.

<img width="710" alt="image" src="https://github.com/user-attachments/assets/fe30cfe7-8e77-4421-8b36-2f7aab0918dd" />

3. Set the "Private Wi-Fi address" setting to `Rotating`.

<img width="710" alt="image" src="https://github.com/user-attachments/assets/bd695c20-106c-46bd-8862-cbdce55fed6f" />

> [!IMPORTANT]
> Now you wait. The private Wi-Fi address will eventually rotate to a mac address that ends with a non-digit, e.g. `0a`, `ff`, `e2`, etc. You'll notice this when your shell integration stops working, e.g. you open a new tab in Ghostty and the shell is in your home directory instead of whichever directory you had open in your previous tab.

#### Testing the changes

1. Open Ghostty.
3. `cd` to any directory that isn't the default (usually `$HOME`) directory, e.g. `cd Documents`.
4. Open a new tab (<kbd>Cmd+T</kbd>) or split (<kbd>Cmd+D</kbd>).
5. Assuming the setup steps have been followed you should:
    * On `main`:  land in `$HOME` in the new tab or split.
    * On this branch: land in the same working directory as the original tab or split.