### PR TITLE
elvish: use kitty-shell-cwd:// to report pwd

### DIFF
--- a/src/shell-integration/elvish/lib/ghostty-integration.elv
+++ b/src/shell-integration/elvish/lib/ghostty-integration.elv
@@ -76,7 +76,7 @@
 
   fn report-pwd {
     use platform
-    printf "\e]7;file://%s%s\a" platform:hostname $pwd
+    printf "\e]7;kitty-shell-cwd://%s%s\a" platform:hostname $pwd
   }
 
   fn sudo-with-terminfo {|@args|

--- a/src/shell-integration/elvish/lib/ghostty-integration.elv
+++ b/src/shell-integration/elvish/lib/ghostty-integration.elv
@@ -76,7 +76,7 @@
 
   fn report-pwd {
     use platform
-    printf "\e]7;kitty-shell-cwd://%s%s\a" platform:hostname $pwd
+    printf "\e]7;kitty-shell-cwd://%s%s\a" (platform:hostname) $pwd
   }
 
   fn sudo-with-terminfo {|@args|


### PR DESCRIPTION
OSC 7's standard body is a percent-encoded file:// URL. There isn't an
easy way for us to percent-encode the path ($pwd) component here without
implementing a custom function.

Instead, switch to the kitty-shell-cwd:// scheme, which Kitty introduced
to ease this implementation challenge in shell scripts. It accepts the
path string verbatim, without an encoding.

In Ghostty, we accept both the file:// and kitty-shell-cwd:// schemes,
and we attempt to URI-decode them both, so in practice this is more
about the "correctness" of this protocol than a functional change. It's
also possible we might decide to treat these schemes differently in the
runtime, like Kitty does.

Also, fix the `platform:hostname` function call syntax.