### PR TITLE
Fix quick terminal fullscreen toggle in front of fullscreen window

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -33,9 +33,6 @@ class QuickTerminalController: BaseTerminalController {
     /// The configuration derived from the Ghostty config so we don't need to rely on references.
     private var derivedConfig: DerivedConfig
 
-    /// Storage for the window frame before entering fullscreen mode
-    private var savedWindowFrame: NSRect? = nil
-
     init(_ ghostty: Ghostty.App,
          position: QuickTerminalPosition = .top,
          baseConfig base: Ghostty.SurfaceConfiguration? = nil,
@@ -488,16 +485,9 @@ class QuickTerminalController: BaseTerminalController {
     @objc private func onToggleFullscreen(notification: SwiftUI.Notification) {
         guard let target = notification.object as? Ghostty.SurfaceView else { return }
         guard target == self.focusedSurface else { return }
-        guard let window = self.window else { return }
-        guard let screen = window.screen ?? NSScreen.main else { return }
 
-        if let originalFrame = savedWindowFrame {
-            window.setFrame(originalFrame, display: true)
-            savedWindowFrame = nil
-        } else {
-            savedWindowFrame = window.frame
-            window.setFrame(screen.frame, display: true)
-        }
+        // We ignore the requested mode and always use non-native for the quick terminal
+        toggleFullscreen(mode: .nonNative)
     }
 
     @objc private func ghosttyConfigDidChange(_ notification: Notification) {


### PR DESCRIPTION
Fixes #7070 

The root issue occurs when the quick terminal has already entered fullscreen state and the main window is also in fullscreen mode. When attempting to toggle fullscreen again, the state detection fails due to interference from the main window's fullscreen state.

In the original code, `toggleFullscreen(mode: .nonNative)` attempts to toggle fullscreen based on the current state, but the detection is confused by the main window's fullscreen state.