### PR TITLE
macOS: only emit a mouse exited position if we're not dragging

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -743,6 +743,13 @@ extension Ghostty {
         override func mouseExited(with event: NSEvent) {
             guard let surface = self.surface else { return }
 
+            // If the mouse is being dragged then we don't have to emit
+            // this because we get mouse drag events even if we've already
+            // exited the viewport (i.e. mouseDragged)
+            if NSEvent.pressedMouseButtons != 0 {
+                return
+            }
+
             // Negative values indicate cursor has left the viewport
             let mods = Ghostty.ghosttyMods(event.modifierFlags)
             ghostty_surface_mouse_pos(surface, -1, -1, mods)


### PR DESCRIPTION
Fixes #7071

When the mouse is being actively dragged, AppKit continues to emit mouseDragged events which will update our position appropriately. The mouseExit event we were sending sends a synthetic (-1, -1) position which was causing a scroll up.