### PR TITLE
vim: fix syntax highlight on scratch buffer

### DIFF
--- a/src/config/vim.zig
+++ b/src/config/vim.zig
@@ -88,6 +88,7 @@ fn writeSyntax(writer: anytype) !void {
         \\let s:cpo_save = &cpo
         \\set cpo&vim
         \\
+        \\syn iskeyword @,48-57,-
         \\syn keyword ghosttyConfigKeyword
     );
 


### PR DESCRIPTION
Sometimes we need detect ghostty filetype on scratch buffer.
In this case `set iskeyword` in ftplugin is not loaded.

Screenshot: https://github.com/ibhagwan/fzf-lua/pull/1913#issuecomment-2813289819.

e.g.
```sh
nvim +'0r ~/.config/ghostty/config' +'se syntax=ghostty'
```
