### PR TITLE
macOS/libghostty: rework keyboard input handling 

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -254,8 +254,10 @@ typedef enum {
 typedef struct {
   ghostty_input_action_e action;
   ghostty_input_mods_e mods;
+  ghostty_input_mods_e consumed_mods;
   uint32_t keycode;
   const char* text;
+  uint32_t unshifted_codepoint;
   bool composing;
 } ghostty_input_key_s;
 
@@ -725,6 +727,7 @@ ghostty_input_mods_e ghostty_surface_key_translation_mods(ghostty_surface_t,
 bool ghostty_surface_key(ghostty_surface_t, ghostty_input_key_s);
 bool ghostty_surface_key_is_binding(ghostty_surface_t, ghostty_input_key_s);
 void ghostty_surface_text(ghostty_surface_t, const char*, uintptr_t);
+void ghostty_surface_preedit(ghostty_surface_t, const char*, uintptr_t);
 bool ghostty_surface_mouse_captured(ghostty_surface_t);
 bool ghostty_surface_mouse_button(ghostty_surface_t,
                                   ghostty_input_mouse_state_e,

--- a/macos/Sources/Ghostty/NSEvent+Extension.swift
+++ b/macos/Sources/Ghostty/NSEvent+Extension.swift
@@ -3,13 +3,56 @@ import GhosttyKit
 
 extension NSEvent {
     /// Create a Ghostty key event for a given keyboard action.
+    ///
+    /// This will not set the "text" or "composing" fields since these can't safely be set
+    /// with the information or lifetimes given.
     func ghosttyKeyEvent(_ action: ghostty_input_action_e) -> ghostty_input_key_s {
-        var key_ev = ghostty_input_key_s()
+        var key_ev: ghostty_input_key_s = .init()
         key_ev.action = action
-        key_ev.mods = Ghostty.ghosttyMods(modifierFlags)
         key_ev.keycode = UInt32(keyCode)
+
+        // We can't infer or set these safely from this method. Since text is
+        // a cString, we can't use self.characters because of garbage collection.
+        // We have to let the caller handle this.
         key_ev.text = nil
         key_ev.composing = false
+
+        // macOS provides no easy way to determine the consumed modifiers for
+        // producing text. We apply a simple heuristic here that has worked for years
+        // so far: control and command never contribute to the translation of text,
+        // assume everything else did.
+        key_ev.mods = Ghostty.ghosttyMods(modifierFlags)
+        key_ev.consumed_mods = Ghostty.ghosttyMods(modifierFlags.subtracting([.control, .command]))
+
+        // Our unshifted codepoint is the codepoint with no modifiers. We
+        // ignore multi-codepoint values.
+        key_ev.unshifted_codepoint = 0
+        if let charactersIgnoringModifiers,
+           let codepoint = charactersIgnoringModifiers.unicodeScalars.first
+        {
+            key_ev.unshifted_codepoint = codepoint.value
+        }
+
         return key_ev
+    }
+
+    /// Returns the text to set for a key event for Ghostty.
+    ///
+    /// This namely contains logic to avoid control characters, since we handle control character
+    /// mapping manually within Ghostty.
+    var ghosttyCharacters: String? {
+        // If we have no characters associated with this event we do nothing.
+        guard let characters else { return nil }
+
+        // If we have a single control character, then we return the characters
+        // without control pressed. We do this because we handle control character
+        // encoding directly within Ghostty's KeyEncoder.
+        if characters.count == 1,
+            let scalar = characters.unicodeScalars.first,
+            scalar.value < 0x20 {
+            return self.characters(byApplyingModifiers: modifierFlags.subtracting(.control))
+        }
+
+        return nil
     }
 }


### PR DESCRIPTION
This is a large refactor of the keyboard input handling code in
libghostty and macOS. Previously, libghostty did a lot of things that
felt out of scope or was repeated work due to lacking context. For
example, libghostty would do full key translation from key event to
character (including unshifted translation) as well as managing dead key
states and setting the proper preedit text.

This is all information the apprt can and should have on its own.
NSEvent on macOS already provides us with all of this information,
there's no need to redo the work. The reason we did in the first place
is mostly historical: libghostty powered our initial macOS port years
ago when we didn't have an AppKit runtime yet.

This cruft has already practically been the source of numerous issues, e.g.
https://github.com/ghostty-org/ghostty/issues/5558, but many other hacks along the way, too.

This commit pushes all preedit (e.g. dead key) handling and key translation
including unshifted keys up into the caller of libghostty.

Besides code cleanup, a practical benefit of this is that key event
handling on macOS is now about 10x faster on average. That's because
we're avoiding repeated key translations as well as other unnecessary
work. This should have a meaningful impact on input latency but I didn't
measure the full end-to-end latency.

A scarier part of this commit is that key handling is not well tested
since its a GUI component. I suspect we'll have some fallout for certain
keyboard layouts or input methods, but I did my best to run through
everything I could think of.

This also fixes one bug where preedit state didn't properly clear when
changing keyboard layouts. This now does and matches the behavior
of native apps like TextEdit and Terminal.app