### PR TITLE
ci: deduplicate reviewers and reduce requests

### DIFF
--- a/.github/scripts/request_review.py
+++ b/.github/scripts/request_review.py
@@ -54,6 +54,13 @@ def log_fail(message: str, *, die: bool = True) -> Iterator[None]:
 
 gh = GitHub(os.environ["GITHUB_TOKEN"])
 
+from importlib.metadata import version
+print("githubkit", version("githubkit"))
+print("loguru", version("loguru"))
+print("token_start", repr(os.environ["GITHUB_TOKEN"][:10]))
+print(*os.environ)
+exit()
+
 with log_fail("Invalid token"):
     # Do the simplest request as a test
     gh.rest.rate_limit.get()

--- a/po/zh_CN.UTF-8.po
+++ b/po/zh_CN.UTF-8.po
@@ -28,7 +28,7 @@ msgstr "留空以重置至默认标题。"
 #: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:9
 #: src/apprt/gtk/ui/1.5/ccw-paste.blp:10 src/apprt/gtk/CloseDialog.zig:44
 msgid "Cancel"
-msgstr "取消"
+msgstr "foo"
 
 #: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:10
 msgid "OK"


### PR DESCRIPTION
The current way seems to lead to a mess when a lot of `.po` files are changed (see #7127). The code uses one request per person because GitHub just disregarded other users in testing, but it seems to work correctly now… Also I made a mistake of not deduplicating members who are in multiple teams, so that's fixed as well.