### PR TITLE
macOS: Do not send control characters as UTF8 keyboard text

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -1169,7 +1169,12 @@ extension Ghostty {
 
             var key_ev = event.ghosttyKeyEvent(action, translationMods: translationEvent?.modifierFlags)
             key_ev.composing = composing
-            if let text {
+
+            // For text, we only encode UTF8 if we don't have a single control
+            // character. Control characters are encoded by Ghostty itself.
+            // Without this, `ctrl+enter` does the wrong thing.
+            if let text, text.count > 0,
+               let codepoint = text.utf8.first, codepoint >= 0x20 {
                 return text.withCString { ptr in
                     key_ev.text = ptr
                     return ghostty_surface_key(surface, key_ev)

--- a/src/input/KeyEncoder.zig
+++ b/src/input/KeyEncoder.zig
@@ -35,7 +35,7 @@ pub fn encode(
     self: *const KeyEncoder,
     buf: []u8,
 ) ![]const u8 {
-    // log.warn("KEYENCODER self={}", .{self.j});
+    // log.warn("KEYENCODER self={}", .{self.*});
     if (self.kitty_flags.int() != 0) return try self.kitty(buf);
     return try self.legacy(buf);
 }


### PR DESCRIPTION
Fixes a regression where `ctrl+enter` was not encoding properly since our input stack changes.