### PR TITLE
macOS: remove "r" & "c" from resize overlay

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -329,7 +329,7 @@ extension Ghostty {
                         Spacer()
                     }
 
-                    Text(verbatim: "\(size.columns)c ⨯ \(size.rows)r")
+                    Text(verbatim: "\(size.columns) ⨯ \(size.rows)")
                         .padding(.init(top: padding, leading: padding, bottom: padding, trailing: padding))
                         .background(
                             RoundedRectangle(cornerRadius: 4)


### PR DESCRIPTION
as per [#6013](https://github.com/ghostty-org/ghostty/pull/6013) and [#6040](https://github.com/ghostty-org/ghostty/pull/6040) but for macOS