### PR TITLE
Linux: stop flickering and stretching on resize

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1635,6 +1635,9 @@ fn resize(self: *Surface, size: rendererpkg.ScreenSize) !void {
     self.size.screen = size;
     self.balancePaddingIfNeeded();
 
+    // Update renderer with latest size
+    self.renderer.setTrueSize(size);
+
     // Recalculate our grid size. Because Ghostty supports fluid resizing,
     // its possible the grid doesn't change at all even if the screen size changes.
     // We have to update the IO thread no matter what because we send

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1286,6 +1286,8 @@ pub fn updateFrame(
     }
 }
 
+pub fn setTrueSize(_: *Metal, _: renderer.ScreenSize) void {}
+
 /// Draw the frame to the screen.
 pub fn drawFrame(self: *Metal, surface: *apprt.Surface) !void {
     _ = surface;

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -2201,12 +2201,6 @@ pub fn setScreenSize(
     if (single_threaded_draw) self.draw_mutex.lock();
     defer if (single_threaded_draw) self.draw_mutex.unlock();
 
-    // Reset our buffer sizes so that we free memory when the screen shrinks.
-    // This could be made more clever by only doing this when the screen
-    // shrinks but the performance cost really isn't that much.
-    self.cells.clearAndFree(self.alloc);
-    self.cells_bg.clearAndFree(self.alloc);
-
     // Store our screen size
     self.size = size;
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -1784,6 +1784,15 @@ pub fn rebuildCells(
         }
     }
 
+    // Free up memory, generally in case where surface has shrunk.
+    // If more than half of the capacity is unused, remove all unused capacity.
+    if (self.cells.items.len * 2 < self.cells.capacity) {
+        self.cells.shrinkAndFree(self.alloc, self.cells.items.len);
+    }
+    if (self.cells_bg.items.len * 2 < self.cells_bg.capacity) {
+        self.cells_bg.shrinkAndFree(self.alloc, self.cells_bg.items.len);
+    }
+
     // Some debug mode safety checks
     if (std.debug.runtime_safety) {
         for (self.cells_bg.items) |cell| assert(cell.mode == .bg);


### PR DESCRIPTION
A few commits to address the concerns of flickering and content stretching on https://github.com/ghostty-org/ghostty/issues/2446

First, tell OpenGL the true size it has at the time drawFrame is called, so that it's not using an older size and thus stretching content.

Second, revert a patch that freed up memory from unused cell capacity in the OpenGL renderer, and replace it with a new patch that frees up the memory. The problem with the earlier patch was it was freeing the cells fully, then OpenGL would display content (which was blank!) and then rendering would complete and cells would be set again. This was leading to occasional blank frames during render. The new change keeps memory down, as was the goal with the earlier patch, but keeps the old cells around a bit longer in case they are needed to paint.

This is my first change on this codebase and in the Zig language; any advice is welcome!

NOTE: I am hoping CI will test that this doesn't break macOS. I don't have a mac handy to test.