### PR TITLE
Remove note about default from bell-features→system's description

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1866,7 +1866,7 @@ keybind: Keybinds = .{},
 ///
 /// Valid values are:
 ///
-///  * `system` (default)
+///  * `system`
 ///
 ///    Instructs the system to notify the user using built-in system functions.
 ///    This could result in an audiovisual effect, a notification, or something


### PR DESCRIPTION
It's no longer the default since https://github.com/ghostty-org/ghostty/pull/7087#discussion_r2042452771.