### PR TITLE
Correct `change_title_prompt` → `prompt_surface_title`

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -398,7 +398,7 @@ class AppDelegate: NSObject,
         syncMenuShortcut(config, action: "increase_font_size:1", menuItem: self.menuIncreaseFontSize)
         syncMenuShortcut(config, action: "decrease_font_size:1", menuItem: self.menuDecreaseFontSize)
         syncMenuShortcut(config, action: "reset_font_size", menuItem: self.menuResetFontSize)
-        syncMenuShortcut(config, action: "change_title_prompt", menuItem: self.menuChangeTitle)
+        syncMenuShortcut(config, action: "prompt_surface_title", menuItem: self.menuChangeTitle)
         syncMenuShortcut(config, action: "toggle_quick_terminal", menuItem: self.menuQuickTerminal)
         syncMenuShortcut(config, action: "toggle_visibility", menuItem: self.menuToggleVisibility)
         syncMenuShortcut(config, action: "inspector:toggle", menuItem: self.menuTerminalInspector)


### PR DESCRIPTION
This was changed pretty late at https://github.com/ghostty-org/ghostty/pull/4217#issuecomment-2660307923, and I don't think anybody saw my comment at https://github.com/ghostty-org/ghostty/pull/4217#discussion_r2045783050; I have no idea if this change is correct and have no way to test it either as I don't use macOS, but I'm quite suspicious of that line having not been changed.