### PR TITLE
macOS: get proper unshifted codepoint with ctrl pressed

### DIFF
--- a/macos/Sources/Ghostty/NSEvent+Extension.swift
+++ b/macos/Sources/Ghostty/NSEvent+Extension.swift
@@ -33,11 +33,13 @@ extension NSEvent {
                 .subtracting([.control, .command]))
 
         // Our unshifted codepoint is the codepoint with no modifiers. We
-        // ignore multi-codepoint values.
+        // ignore multi-codepoint values. We have to use `byApplyingModifiers`
+        // instead of `charactersIgnoringModifiers` because the latter changes
+        // behavior with ctrl pressed and we don't want any of that.
         key_ev.unshifted_codepoint = 0
         if type == .keyDown || type == .keyUp {
-            if let charactersIgnoringModifiers,
-               let codepoint = charactersIgnoringModifiers.unicodeScalars.first
+            if let chars = characters(byApplyingModifiers: []),
+               let codepoint = chars.unicodeScalars.first
             {
                 key_ev.unshifted_codepoint = codepoint.value
             }


### PR DESCRIPTION
Fixes a regression where `C-S-c` stopped working properly in both legacy and Kitty modes (although the Kitty mode side only affected alternates and not the key itself so it probably worked fine in most programs).

The issue is that `charactersIgnoringModifiers` changes behavior if `control` is pressed, so it doesn't really ignore all modifiers. We have to use `characters(byApplyingModifiers:)` to get the proper unshifted codepoint when `control` is pressed.