### PR TITLE
apprt/gtk: fix typo

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -1058,7 +1058,7 @@ fn gtkActionSplitUp(
     _: ?*glib.Variant,
     self: *Window,
 ) callconv(.C) void {
-    self.performBindingAction(.{ .new_split = .right });
+    self.performBindingAction(.{ .new_split = .up });
 }
 
 fn gtkActionToggleInspector(


### PR DESCRIPTION
I had a copy-paste error when I used right instead of up.