### PR TITLE
fix: Disable quick terminal on linux when gtk4-layer-shell version is incompatible

### DIFF
--- a/pkg/gtk4-layer-shell/src/main.zig
+++ b/pkg/gtk4-layer-shell/src/main.zig
@@ -38,7 +38,7 @@ pub fn getProtocolVersion() c_uint {
 
 /// Returns the runtime version of the GTK Layer Shell library
 pub fn getRuntimeVersion() std.SemanticVersion {
-    return std.SemanticVersion{
+    return .{
         .major = c.gtk_layer_get_major_version(),
         .minor = c.gtk_layer_get_minor_version(),
         .patch = c.gtk_layer_get_micro_version(),

--- a/pkg/gtk4-layer-shell/src/main.zig
+++ b/pkg/gtk4-layer-shell/src/main.zig
@@ -1,6 +1,7 @@
 const c = @cImport({
     @cInclude("gtk4-layer-shell.h");
 });
+const std = @import("std");
 const gtk = @import("gtk");
 
 pub const ShellLayer = enum(c_uint) {
@@ -23,12 +24,25 @@ pub const KeyboardMode = enum(c_uint) {
     on_demand = c.GTK_LAYER_SHELL_KEYBOARD_MODE_ON_DEMAND,
 };
 
+/// Returns True if the platform is Wayland and Wayland compositor supports the
+/// zwlr_layer_shell_v1 protocol.
 pub fn isProtocolSupported() bool {
     return c.gtk_layer_is_supported() != 0;
 }
 
+/// Returns the version of the zwlr_layer_shell_v1 protocol supported by the
+/// compositor or 0 if the protocol is not supported.
 pub fn getProtocolVersion() c_uint {
     return c.gtk_layer_get_protocol_version();
+}
+
+/// Returns the runtime version of the GTK Layer Shell library
+pub fn getRuntimeVersion() std.SemanticVersion {
+    return std.SemanticVersion{
+        .major = c.gtk_layer_get_major_version(),
+        .minor = c.gtk_layer_get_minor_version(),
+        .patch = c.gtk_layer_get_micro_version(),
+    };
 }
 
 pub fn initForWindow(window: *gtk.Window) void {

--- a/pkg/gtk4-layer-shell/src/main.zig
+++ b/pkg/gtk4-layer-shell/src/main.zig
@@ -23,7 +23,7 @@ pub const KeyboardMode = enum(c_uint) {
     on_demand = c.GTK_LAYER_SHELL_KEYBOARD_MODE_ON_DEMAND,
 };
 
-pub fn isSupported() bool {
+pub fn isProtocolSupported() bool {
     return c.gtk_layer_is_supported() != 0;
 }
 

--- a/src/apprt/gtk/adw_version.zig
+++ b/src/apprt/gtk/adw_version.zig
@@ -27,13 +27,16 @@ pub fn getRuntimeVersion() std.SemanticVersion {
     };
 }
 
-const AdwaitaVersion = VersionChecked("libadwaita", std.log.scoped(.gtk), getRuntimeVersion, comptime_version);
+const AdwaitaVersion = VersionChecked("libadwaita", getRuntimeVersion, comptime_version);
 
 pub const atLeast = AdwaitaVersion.atLeast;
 pub const until = AdwaitaVersion.until;
 pub const runtimeAtLeast = AdwaitaVersion.runtimeAtLeast;
 pub const runtimeUntil = AdwaitaVersion.runtimeUntil;
-pub const logVersion = AdwaitaVersion.logVersion;
+
+pub fn logVersion() void {
+    log.info("{s}", .{AdwaitaVersion.logFormat()});
+}
 
 // Whether AdwDialog, AdwAlertDialog, etc. are supported (1.5+)
 pub inline fn supportsDialogs() bool {

--- a/src/apprt/gtk/adw_version.zig
+++ b/src/apprt/gtk/adw_version.zig
@@ -9,6 +9,7 @@ const c = @cImport({
 });
 
 const adw = @import("adw");
+const VersionChecked = @import("version.zig").VersionChecked;
 
 const log = std.log.scoped(.gtk);
 
@@ -26,79 +27,13 @@ pub fn getRuntimeVersion() std.SemanticVersion {
     };
 }
 
-pub fn logVersion() void {
-    log.info("libadwaita version build={} runtime={}", .{
-        comptime_version,
-        getRuntimeVersion(),
-    });
-}
+const AdwaitaVersion = VersionChecked("libadwaita", std.log.scoped(.gtk), getRuntimeVersion, comptime_version);
 
-/// Verifies that the running libadwaita version is at least the given
-/// version. This will return false if Ghostty is configured to not build with
-/// libadwaita.
-///
-/// This can be run in both a comptime and runtime context. If it is run in a
-/// comptime context, it will only check the version in the headers. If it is
-/// run in a runtime context, it will check the actual version of the library we
-/// are linked against. So generally  you probably want to do both checks!
-///
-/// This is inlined so that the comptime checks will disable the runtime checks
-/// if the comptime checks fail.
-pub inline fn atLeast(
-    comptime major: u16,
-    comptime minor: u16,
-    comptime micro: u16,
-) bool {
-    // If our header has lower versions than the given version, we can return
-    // false immediately. This prevents us from compiling against unknown
-    // symbols and makes runtime checks very slightly faster.
-    if (comptime comptime_version.order(.{
-        .major = major,
-        .minor = minor,
-        .patch = micro,
-    }) == .lt) return false;
-
-    // If we're in comptime then we can't check the runtime version.
-    if (@inComptime()) return true;
-
-    return runtimeAtLeast(major, minor, micro);
-}
-
-/// Verifies that the libadwaita version at runtime is at least the given version.
-///
-/// This function should be used in cases where the only the runtime behavior
-/// is affected by the version check. For checks which would affect code
-/// generation, use `atLeast`.
-pub inline fn runtimeAtLeast(
-    comptime major: u16,
-    comptime minor: u16,
-    comptime micro: u16,
-) bool {
-    // We use the functions instead of the constants such as c.GTK_MINOR_VERSION
-    // because the function gets the actual runtime version.
-    const runtime_version = getRuntimeVersion();
-    return runtime_version.order(.{
-        .major = major,
-        .minor = minor,
-        .patch = micro,
-    }) != .lt;
-}
-
-test "versionAtLeast" {
-    const testing = std.testing;
-
-    const funs = &.{ atLeast, runtimeAtLeast };
-    inline for (funs) |fun| {
-        try testing.expect(fun(c.ADW_MAJOR_VERSION, c.ADW_MINOR_VERSION, c.ADW_MICRO_VERSION));
-        try testing.expect(!fun(c.ADW_MAJOR_VERSION, c.ADW_MINOR_VERSION, c.ADW_MICRO_VERSION + 1));
-        try testing.expect(!fun(c.ADW_MAJOR_VERSION, c.ADW_MINOR_VERSION + 1, c.ADW_MICRO_VERSION));
-        try testing.expect(!fun(c.ADW_MAJOR_VERSION + 1, c.ADW_MINOR_VERSION, c.ADW_MICRO_VERSION));
-        try testing.expect(fun(c.ADW_MAJOR_VERSION - 1, c.ADW_MINOR_VERSION, c.ADW_MICRO_VERSION));
-        try testing.expect(fun(c.ADW_MAJOR_VERSION - 1, c.ADW_MINOR_VERSION + 1, c.ADW_MICRO_VERSION));
-        try testing.expect(fun(c.ADW_MAJOR_VERSION - 1, c.ADW_MINOR_VERSION, c.ADW_MICRO_VERSION + 1));
-        try testing.expect(fun(c.ADW_MAJOR_VERSION, c.ADW_MINOR_VERSION - 1, c.ADW_MICRO_VERSION + 1));
-    }
-}
+pub const atLeast = AdwaitaVersion.atLeast;
+pub const until = AdwaitaVersion.until;
+pub const runtimeAtLeast = AdwaitaVersion.runtimeAtLeast;
+pub const runtimeUntil = AdwaitaVersion.runtimeUntil;
+pub const logVersion = AdwaitaVersion.logVersion;
 
 // Whether AdwDialog, AdwAlertDialog, etc. are supported (1.5+)
 pub inline fn supportsDialogs() bool {

--- a/src/apprt/gtk/gtk_layer_version.zig
+++ b/src/apprt/gtk/gtk_layer_version.zig
@@ -1,10 +1,16 @@
 const std = @import("std");
 const gtk4_layer_shell = @import("gtk4-layer-shell");
 const VersionChecked = @import("version.zig").VersionChecked;
+const log = std.log.scoped(.gtk);
 
 pub const getRuntimeVersion = gtk4_layer_shell.getRuntimeVersion;
-const LayerShellVersion = VersionChecked("gtk4-layer-shell", std.log.scoped(.gtk), getRuntimeVersion, null);
+const LayerShellVersion = VersionChecked("gtk4-layer-shell", getRuntimeVersion, null);
 
 pub const atLeast = LayerShellVersion.atLeast;
+pub const until = LayerShellVersion.until;
 pub const runtimeAtLeast = LayerShellVersion.runtimeAtLeast;
-pub const logVersion = LayerShellVersion.logVersion;
+pub const runtimeUntil = LayerShellVersion.until;
+
+pub fn logVersion() void {
+    log.info("{s}", .{LayerShellVersion.logFormat()});
+}

--- a/src/apprt/gtk/gtk_layer_version.zig
+++ b/src/apprt/gtk/gtk_layer_version.zig
@@ -1,0 +1,10 @@
+const std = @import("std");
+const gtk4_layer_shell = @import("gtk4-layer-shell");
+const VersionChecked = @import("version.zig").VersionChecked;
+
+pub const getRuntimeVersion = gtk4_layer_shell.getRuntimeVersion;
+const LayerShellVersion = VersionChecked("gtk4-layer-shell", std.log.scoped(.gtk), getRuntimeVersion, null);
+
+pub const atLeast = LayerShellVersion.atLeast;
+pub const runtimeAtLeast = LayerShellVersion.runtimeAtLeast;
+pub const logVersion = LayerShellVersion.logVersion;

--- a/src/apprt/gtk/gtk_version.zig
+++ b/src/apprt/gtk/gtk_version.zig
@@ -9,6 +9,7 @@ const c = @cImport({
 
 const gtk = @import("gtk");
 const VersionChecked = @import("version.zig").VersionChecked;
+const log = std.log.scoped(.gtk);
 
 pub const comptime_version: std.SemanticVersion = .{
     .major = c.GTK_MAJOR_VERSION,
@@ -24,10 +25,13 @@ pub fn getRuntimeVersion() std.SemanticVersion {
     };
 }
 
-const GTKVersion = VersionChecked("GTK", std.log.scoped(.gtk), getRuntimeVersion, comptime_version);
+const GTKVersion = VersionChecked("GTK", getRuntimeVersion, comptime_version);
 
 pub const atLeast = GTKVersion.atLeast;
 pub const until = GTKVersion.until;
 pub const runtimeAtLeast = GTKVersion.runtimeAtLeast;
 pub const runtimeUntil = GTKVersion.runtimeUntil;
-pub const logVersion = GTKVersion.logVersion;
+
+pub fn logVersion() void {
+    log.info("{s}", .{GTKVersion.logFormat()});
+}

--- a/src/apprt/gtk/gtk_version.zig
+++ b/src/apprt/gtk/gtk_version.zig
@@ -8,8 +8,7 @@ const c = @cImport({
 });
 
 const gtk = @import("gtk");
-
-const log = std.log.scoped(.gtk);
+const VersionChecked = @import("version.zig").VersionChecked;
 
 pub const comptime_version: std.SemanticVersion = .{
     .major = c.GTK_MAJOR_VERSION,
@@ -25,96 +24,10 @@ pub fn getRuntimeVersion() std.SemanticVersion {
     };
 }
 
-pub fn logVersion() void {
-    log.info("GTK version build={} runtime={}", .{
-        comptime_version,
-        getRuntimeVersion(),
-    });
-}
+const GTKVersion = VersionChecked("GTK", std.log.scoped(.gtk), getRuntimeVersion, comptime_version);
 
-/// Verifies that the GTK version is at least the given version.
-///
-/// This can be run in both a comptime and runtime context. If it is run in a
-/// comptime context, it will only check the version in the headers. If it is
-/// run in a runtime context, it will check the actual version of the library we
-/// are linked against.
-///
-/// This function should be used in cases where the version check would affect
-/// code generation, such as using symbols that are only available beyond a
-/// certain version. For checks which only depend on GTK's runtime behavior,
-/// use `runtimeAtLeast`.
-///
-/// This is inlined so that the comptime checks will disable the runtime checks
-/// if the comptime checks fail.
-pub inline fn atLeast(
-    comptime major: u16,
-    comptime minor: u16,
-    comptime micro: u16,
-) bool {
-    // If our header has lower versions than the given version,
-    // we can return false immediately. This prevents us from
-    // compiling against unknown symbols and makes runtime checks
-    // very slightly faster.
-    if (comptime comptime_version.order(.{
-        .major = major,
-        .minor = minor,
-        .patch = micro,
-    }) == .lt) return false;
-
-    // If we're in comptime then we can't check the runtime version.
-    if (@inComptime()) return true;
-
-    return runtimeAtLeast(major, minor, micro);
-}
-
-/// Verifies that the GTK version at runtime is at least the given version.
-///
-/// This function should be used in cases where the only the runtime behavior
-/// is affected by the version check. For checks which would affect code
-/// generation, use `atLeast`.
-pub inline fn runtimeAtLeast(
-    comptime major: u16,
-    comptime minor: u16,
-    comptime micro: u16,
-) bool {
-    // We use the functions instead of the constants such as c.GTK_MINOR_VERSION
-    // because the function gets the actual runtime version.
-    const runtime_version = getRuntimeVersion();
-    return runtime_version.order(.{
-        .major = major,
-        .minor = minor,
-        .patch = micro,
-    }) != .lt;
-}
-
-pub inline fn runtimeUntil(
-    comptime major: u16,
-    comptime minor: u16,
-    comptime micro: u16,
-) bool {
-    const runtime_version = getRuntimeVersion();
-    return runtime_version.order(.{
-        .major = major,
-        .minor = minor,
-        .patch = micro,
-    }) == .lt;
-}
-
-test "atLeast" {
-    const testing = std.testing;
-
-    const funs = &.{ atLeast, runtimeAtLeast, runtimeUntil };
-    inline for (funs) |fun| {
-        try testing.expect(fun(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION));
-
-        try testing.expect(!fun(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION + 1));
-        try testing.expect(!fun(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION + 1, c.GTK_MICRO_VERSION));
-        try testing.expect(!fun(c.GTK_MAJOR_VERSION + 1, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION));
-
-        try testing.expect(fun(c.GTK_MAJOR_VERSION - 1, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION));
-        try testing.expect(fun(c.GTK_MAJOR_VERSION - 1, c.GTK_MINOR_VERSION + 1, c.GTK_MICRO_VERSION));
-        try testing.expect(fun(c.GTK_MAJOR_VERSION - 1, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION + 1));
-
-        try testing.expect(fun(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION - 1, c.GTK_MICRO_VERSION + 1));
-    }
-}
+pub const atLeast = GTKVersion.atLeast;
+pub const until = GTKVersion.until;
+pub const runtimeAtLeast = GTKVersion.runtimeAtLeast;
+pub const runtimeUntil = GTKVersion.runtimeUntil;
+pub const logVersion = GTKVersion.logVersion;

--- a/src/apprt/gtk/version.zig
+++ b/src/apprt/gtk/version.zig
@@ -1,0 +1,149 @@
+const std = @import("std");
+
+/// A generic way to dispatch version checks of a runtime dependency.
+///
+/// The runtimeVersion function is expected to be created from the library we link against.
+/// The comptime_version is optional
+pub fn VersionChecked(
+    comptime dependency_name: []const u8,
+    comptime log_scope: @TypeOf(std.log.scoped(.enum_literal)),
+    comptime getRuntimeVersion: fn () std.SemanticVersion,
+    comptime comptime_version_: ?std.SemanticVersion,
+) type {
+    return struct {
+        const Self = @This();
+        const name = dependency_name;
+        const log = log_scope;
+        const comptime_version = comptime_version_;
+
+        /// Verifies that the running dependency version is at least the given
+        /// version.
+        ///
+        /// This can be run in both a comptime and runtime context. If it is run in a
+        /// comptime context, it will only check the version in the headers. If it is
+        /// run in a runtime context, it will check the actual version of the library we
+        /// are linked against. So generally  you probably want to do both checks!
+        ///
+        /// This is inlined so that the comptime checks will disable the runtime checks
+        /// if the comptime checks fail.
+        pub inline fn atLeast(
+            comptime major: u16,
+            comptime minor: u16,
+            comptime micro: u16,
+        ) bool {
+
+            // If no comptime version is known or our header has lower versions than the
+            // given version, we can return false immediately. This prevents us from compiling
+            // against unknown symbols and makes runtime checks very slightly faster.
+            comptime if (Self.comptime_version) |version| {
+                if (version.order(.{
+                    .major = major,
+                    .minor = minor,
+                    .patch = micro,
+                }) == .lt) return false;
+            };
+
+            // If we're in comptime then we can't check the runtime version.
+            if (@inComptime()) return true;
+
+            return Self.runtimeAtLeast(major, minor, micro);
+        }
+
+        pub inline fn until(
+            comptime major: u16,
+            comptime minor: u16,
+            comptime micro: u16,
+        ) bool {
+
+            // If no comptime version is known or our header has lower versions than the
+            // given version, we can return false immediately. This prevents us from compiling
+            // against unknown symbols and makes runtime checks very slightly faster.
+            comptime if (Self.comptime_version) |version| {
+                if (version.order(.{
+                    .major = major,
+                    .minor = minor,
+                    .patch = micro,
+                }) == .lt) return true;
+            };
+
+            // If we're in comptime then we can't check the runtime version.
+            if (@inComptime()) return false;
+
+            return Self.runtimeUntil(major, minor, micro);
+        }
+
+        /// Verifies that the dependency version at runtime is at least the given version.
+        ///
+        /// This function should be used in cases where only the runtime behavior
+        /// is affected by the version check. For checks which would affect code
+        /// generation, use `atLeast`.
+        pub inline fn runtimeAtLeast(
+            comptime major: u16,
+            comptime minor: u16,
+            comptime micro: u16,
+        ) bool {
+            // We use the functions instead of the constants such as c.GTK_MINOR_VERSION
+            // because the function gets the actual runtime version.
+            const runtime_version = getRuntimeVersion();
+            return runtime_version.order(.{
+                .major = major,
+                .minor = minor,
+                .patch = micro,
+            }) != .lt;
+        }
+
+        /// Verifies that the dependency version is less than the given version.
+        ///
+        /// This function should be used when only the runtime version matters.
+        /// Instead use the `until` function to perform a comptime check for
+        /// the version being built against matters for code generation while falling
+        /// back to the runtime check.
+        pub inline fn runtimeUntil(
+            comptime major: u16,
+            comptime minor: u16,
+            comptime micro: u16,
+        ) bool {
+            const runtime_version = getRuntimeVersion();
+            return runtime_version.order(.{
+                .major = major,
+                .minor = minor,
+                .patch = micro,
+            }) == .lt;
+        }
+
+        pub fn logVersion() void {
+            if (Self.comptime_version) |comptime_version__| {
+                Self.log.info("{s} version build={} runtime={}", .{
+                    Self.name,
+                    comptime_version__,
+                    getRuntimeVersion(),
+                });
+            } else {
+                Self.log.info("{s} version runtime={}", .{
+                    Self.name,
+                    getRuntimeVersion(),
+                });
+            }
+        }
+
+        test "atLeast" {
+            const testing = std.testing;
+            const version = Self.comptime_version orelse std.SemanticVersion{ 1, 1, 1 };
+
+            const funs = &.{ atLeast, runtimeAtLeast, runtimeUntil };
+            inline for (funs) |fun| {
+                try testing.expect(fun(version.major, version.minor, version.patch));
+
+                try testing.expect(!fun(version.major, version.minor, version.patch + 1));
+                try testing.expect(!fun(version.major, version.minor + 1, version.patch));
+                try testing.expect(!fun(version.major + 1, version.minor, version.patch));
+
+                try testing.expect(fun(version.major - 1, version.minor, version.patch));
+                try testing.expect(fun(version.major - 1, version.minor + 1, version.patch));
+                try testing.expect(fun(version.major - 1, version.minor, version.patch + 1));
+
+                try testing.expect(fun(version.major, version.minor - 1, version.patch + 1));
+            }
+        }
+    };
+}

--- a/src/apprt/gtk/winproto/wayland.zig
+++ b/src/apprt/gtk/winproto/wayland.zig
@@ -105,11 +105,11 @@ pub const App = struct {
         }
         // GTK4 >= 4.16.0 uses xdg_wm_dialog protocol if available which breaks gtk_layer_shell < 1.0.4
         // See: https://github.com/wmww/gtk4-layer-shell/issues/50
-        if (self.context.xdg_wm_dialog) |_| {
-            if (gtk_version.atLeast(4, 16, 0) and !gtk_layer_version.atLeast(1, 0, 4)) {
-                log.warn("Your gtk4-layer-shell version is too old for your compositor and gtk4 version; disabling quick terminal", .{});
-                return false;
-            }
+        if (self.context.xdg_wm_dialog != null and
+            gtk_version.atLeast(4, 16, 0) and !gtk_layer_version.atLeast(1, 0, 4))
+        {
+            log.warn("Your gtk4-layer-shell version is defective, update to 1.0.4 or later (and contact distro maintainers if this is latest); disabling quick terminal", .{});
+            return false;
         }
         return true;
     }

--- a/src/apprt/gtk/winproto/wayland.zig
+++ b/src/apprt/gtk/winproto/wayland.zig
@@ -96,7 +96,7 @@ pub const App = struct {
     }
 
     pub fn supportsQuickTerminal(_: App) bool {
-        if (!layer_shell.isSupported()) {
+        if (!layer_shell.isProtocolSupported()) {
             log.warn("your compositor does not support the wlr-layer-shell protocol; disabling quick terminal", .{});
             return false;
         }

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -619,7 +619,7 @@ fn addGTK(
         scanner.addCustomProtocol(
             plasma_wayland_protocols_dep.path("src/protocols/slide.xml"),
         );
-        scanner.addSystemProtocol("staging/xdg-activation/xdg-activation-v1.xml");
+        scanner.addCustomProtocol(wayland_protocols_dep.path("staging/xdg-activation/xdg-activation-v1.xml"));
         scanner.addCustomProtocol(wayland_protocols_dep.path("staging/xdg-dialog/xdg-dialog-v1.xml"));
         scanner.addCustomProtocol(wayland_protocols_dep.path("stable/xdg-shell/xdg-shell.xml"));
 

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -620,12 +620,15 @@ fn addGTK(
             plasma_wayland_protocols_dep.path("src/protocols/slide.xml"),
         );
         scanner.addSystemProtocol("staging/xdg-activation/xdg-activation-v1.xml");
+        scanner.addCustomProtocol(wayland_protocols_dep.path("staging/xdg-dialog/xdg-dialog-v1.xml"));
+        scanner.addCustomProtocol(wayland_protocols_dep.path("stable/xdg-shell/xdg-shell.xml"));
 
         scanner.generate("wl_compositor", 1);
         scanner.generate("org_kde_kwin_blur_manager", 1);
         scanner.generate("org_kde_kwin_server_decoration_manager", 1);
         scanner.generate("org_kde_kwin_slide_manager", 1);
         scanner.generate("xdg_activation_v1", 1);
+        scanner.generate("xdg_wm_dialog_v1", 1);
 
         step.root_module.addImport("wayland", b.createModule(.{
             .root_source_file = scanner.result,


### PR DESCRIPTION
On Fedora 41 using Hyprland, using `gtk4-layer-shell = 1.0.3` with `gtk4 >= 4.16.0` and wayland protocol`xdg_wm_dialog_v1` attempting to open the quick terminal will forcibly quit. This is fixed with `gtk4-layer-shell >= 1.0.4`.
The upstream issue is https://github.com/wmww/gtk4-layer-shell/issues/50.
This PR also refactors how we implement `<library>.atLeast(major, minor, patch)` checks to duplicate less code but preserve the existing callsites.

We setup the `xdg_wm_dialog_v1` to check it's presence but otherwise do not use it, this is provided within the existing `wayland_protocols` dependency.

