### PR TITLE
Added bold-color option

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -14,6 +14,7 @@ pub const entryFormatter = formatter.entryFormatter;
 pub const formatEntry = formatter.formatEntry;
 
 // Field types
+pub const BoldColor = Config.BoldColor;
 pub const ClipboardAccess = Config.ClipboardAccess;
 pub const Command = Config.Command;
 pub const ConfirmCloseSurface = Config.ConfirmCloseSurface;


### PR DESCRIPTION
As discussed in https://github.com/ghostty-org/ghostty/discussions/3134

To allow for the option to render bold text in a different colour for better visibility as an extension of `bold-is-bright`.

This is a feature that is available in other terminals.