### PR TITLE
macOS: Command Pallete Improvements

### DIFF
--- a/macos/Sources/Features/Command Palette/CommandPalette.swift
+++ b/macos/Sources/Features/Command Palette/CommandPalette.swift
@@ -177,11 +177,8 @@ fileprivate struct CommandTable: View {
                 .frame(maxHeight: 200)
                 .onChange(of: selectedIndex) { _ in
                     guard selectedIndex < options.count else { return }
-                    withAnimation {
-                        proxy.scrollTo(
-                            options[Int(selectedIndex)].id,
-                            anchor: .center)
-                    }
+                    proxy.scrollTo(
+                        options[Int(selectedIndex)].id)
                 }
             }
         }


### PR DESCRIPTION
As discussed in #7165, this PR resolves two issues with the command pallete on macOS. 
1. The flashing of a command passing out of view was caused by the `withAnimation` function. Removing this closure resolved this issue.
2. The current implementation kept the selected command anchored to the middle of the pallete. However, most command pallates allow you to key through the visible options, only scrolling when your selection hits the boundary. I resolved this by removing the `anchor: .center` parameter for the `scrollTo` command.