### PR TITLE
macOS: add descriptions for PgUp, PgDown, End, and Home keys

### DIFF
--- a/macos/Sources/Helpers/KeyboardShortcut+Extension.swift
+++ b/macos/Sources/Helpers/KeyboardShortcut+Extension.swift
@@ -28,6 +28,10 @@ extension KeyboardShortcut: @retroactive CustomStringConvertible {
         case .downArrow: keyString = "↓"
         case .leftArrow: keyString = "←"
         case .rightArrow: keyString = "→"
+        case .pageUp: keyString = "PgUp"
+        case .pageDown: keyString = "PgDown"
+        case .end: keyString = "End"
+        case .home: keyString = "Home"
         default:
             keyString = String(key.character.uppercased())
         }


### PR DESCRIPTION
Resolves #7174. The PgUp, PgDown, End, and Home keys were not being assigned a description in the `KeyboardShortcut` extension. 