### PR TITLE
feat: beautify macOS command palette

### DIFF
--- a/macos/Sources/Features/Command Palette/CommandPalette.swift
+++ b/macos/Sources/Features/Command Palette/CommandPalette.swift
@@ -18,6 +18,7 @@ struct CommandOption: Identifiable, Hashable {
 
 struct CommandPaletteView: View {
     @Binding var isPresented: Bool
+    var backgroundColor: Color = Color(nsColor: .windowBackgroundColor)
     var options: [CommandOption]
     @State private var query = ""
     @State private var selectedIndex: UInt?
@@ -43,6 +44,12 @@ struct CommandPaletteView: View {
     }
 
     var body: some View {
+        @State var scheme: ColorScheme = if OSColor(backgroundColor).isLightColor {
+            .light
+        } else {
+            .dark
+        }
+
         VStack(alignment: .leading, spacing: 0) {
             CommandPaletteQuery(query: $query) { event in
                 switch (event) {
@@ -98,7 +105,16 @@ struct CommandPaletteView: View {
             }
         }
         .frame(maxWidth: 500)
-        .background(BackgroundVisualEffectView())
+        .background(
+            ZStack {
+                Rectangle()
+                    .fill(.ultraThinMaterial)
+                Rectangle()
+                    .fill(backgroundColor)
+                    .blendMode(.color)
+            }
+                .compositingGroup()
+        )
         .clipShape(RoundedRectangle(cornerRadius: 10))
         .overlay(
             RoundedRectangle(cornerRadius: 10)
@@ -106,6 +122,7 @@ struct CommandPaletteView: View {
         )
         .shadow(radius: 32, x: 0, y: 12)
         .padding()
+        .environment(\.colorScheme, scheme)
     }
 }
 
@@ -241,23 +258,6 @@ fileprivate struct CommandRow: View {
         .onHover { hovering in
             hoveredID = hovering ? option.id : nil
         }
-    }
-}
-
-/// A view that creates a semi-transparent blurry background.
-fileprivate struct BackgroundVisualEffectView: NSViewRepresentable {
-    func makeNSView(context: Context) -> NSVisualEffectView {
-        let view = NSVisualEffectView()
-
-        view.blendingMode = .withinWindow
-        view.state = .active
-        view.material = .sidebar
-
-        return view
-    }
-
-    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {
-        //
     }
 }
 

--- a/macos/Sources/Features/Command Palette/CommandPalette.swift
+++ b/macos/Sources/Features/Command Palette/CommandPalette.swift
@@ -44,7 +44,7 @@ struct CommandPaletteView: View {
     }
 
     var body: some View {
-        @State var scheme: ColorScheme = if OSColor(backgroundColor).isLightColor {
+        let scheme: ColorScheme = if OSColor(backgroundColor).isLightColor {
             .light
         } else {
             .dark

--- a/macos/Sources/Features/Command Palette/TerminalCommandPalette.swift
+++ b/macos/Sources/Features/Command Palette/TerminalCommandPalette.swift
@@ -59,6 +59,7 @@ struct TerminalCommandPaletteView: View {
 
                         CommandPaletteView(
                             isPresented: $isPresented,
+                            backgroundColor: ghosttyConfig.backgroundColor,
                             options: commandOptions
                         )
                         .transition(

--- a/macos/Sources/Features/Command Palette/TerminalCommandPalette.swift
+++ b/macos/Sources/Features/Command Palette/TerminalCommandPalette.swift
@@ -40,7 +40,7 @@ struct TerminalCommandPaletteView: View {
             return CommandOption(
                 title: String(cString: c.title),
                 description: String(cString: c.description),
-                shortcut: ghosttyConfig.keyboardShortcut(for: action)?.description
+                symbols: ghosttyConfig.keyboardShortcut(for: action)?.keyList
             ) {
                 onAction(action)
             }
@@ -59,7 +59,6 @@ struct TerminalCommandPaletteView: View {
 
                         CommandPaletteView(
                             isPresented: $isPresented,
-                            backgroundColor: ghosttyConfig.backgroundColor,
                             options: commandOptions
                         )
                         .transition(

--- a/macos/Sources/Helpers/KeyboardShortcut+Extension.swift
+++ b/macos/Sources/Helpers/KeyboardShortcut+Extension.swift
@@ -1,12 +1,9 @@
 import SwiftUI
 
 extension KeyboardShortcut: @retroactive CustomStringConvertible {
-    public var description: String {
-        var result = ""
+    public var keyList: [String] {
+        var result: [String] = []
 
-        if modifiers.contains(.command) {
-            result.append("⌘")
-        }
         if modifiers.contains(.control) {
             result.append("⌃")
         }
@@ -16,6 +13,9 @@ extension KeyboardShortcut: @retroactive CustomStringConvertible {
         if modifiers.contains(.shift) {
             result.append("⇧")
         }
+        if modifiers.contains(.command) {
+            result.append("⌘")
+        }
 
         let keyString: String
         switch key {
@@ -24,20 +24,24 @@ extension KeyboardShortcut: @retroactive CustomStringConvertible {
         case .delete: keyString = "⌫"
         case .space: keyString = "␣"
         case .tab: keyString = "⇥"
-        case .upArrow: keyString = "↑"
-        case .downArrow: keyString = "↓"
-        case .leftArrow: keyString = "←"
-        case .rightArrow: keyString = "→"
-        case .pageUp: keyString = "PgUp"
-        case .pageDown: keyString = "PgDown"
-        case .end: keyString = "End"
-        case .home: keyString = "Home"
+        case .upArrow: keyString = "▲"
+        case .downArrow: keyString = "▼"
+        case .leftArrow: keyString = "◀"
+        case .rightArrow: keyString = "▶"
+        case .pageUp: keyString = "↑"
+        case .pageDown: keyString = "↓"
+        case .home: keyString = "⤒"
+        case .end: keyString = "⤓"
         default:
             keyString = String(key.character.uppercased())
         }
 
         result.append(keyString)
         return result
+    }
+
+    public var description: String {
+        return self.keyList.joined()
     }
 }
 


### PR DESCRIPTION
Resolve 1. of #7173
<img width="1126" alt="image" src="https://github.com/user-attachments/assets/8904b09f-42f6-4f26-a722-c92dad8e2933" />

Changes made:
1. Change shortcut from `String` to `[String]` so its easier to iterate over it.
2. Overlay background color on top of an `ultraThinMaterial` for better aesthetic.
3. Reorganize and beautify the spacings and paddings.
4. Unhide the scrollbar.
5. Reorder the modifier keys to Control, Option, Shift and then Command. <https://leancrew.com/all-this/2017/11/modifier-key-order/>
6. Style shortcut keys to resemble macOS menu bar items, using corresponding symbols and fixed-width for alignment.