### PR TITLE
Add config color palette C bindings

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -357,6 +357,11 @@ typedef struct {
   size_t len;
 } ghostty_config_color_list_s;
 
+// config.Palette
+typedef struct {
+  ghostty_config_color_s colors[256];
+} ghostty_config_palette_s;
+
 // apprt.Target.Key
 typedef enum {
   GHOSTTY_TARGET_APP,

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3930,6 +3930,24 @@ pub const Palette = struct {
     /// The actual value that is updated as we parse.
     value: terminal.color.Palette = terminal.color.default,
 
+    /// ghostty_config_palette_s
+    pub const C = extern struct {
+        colors: [265]Color.C,
+    };
+
+    pub fn cval(self: Self) Palette.C {
+        var result: Palette.C = undefined;
+        for (self.value, 0..) |color, i| {
+            result.colors[i] = Color.C{
+                .r = color.r,
+                .g = color.g,
+                .b = color.b,
+            };
+        }
+
+        return result;
+    }
+
     pub fn parseCLI(
         self: *Self,
         input: ?[]const u8,


### PR DESCRIPTION
C bindings to expose the color palette to Swift for macOS. Returns the full 256 colors from the current color scheme. After fetching the palette with `ghostty_config_get`, you can access the desired color by its index in the list.

### Usage

Here is one way to get the palette in Swift.

```swift
import GhosttyKit

private(set) var config: ghostty_config_t? = nil {
    didSet {
        // Free the old value whenever we change
        guard let old = oldValue else { return }
        ghostty_config_free(old)
    }
}

var paletteColors: [Color] {
    var paletteList: ghostty_config_palette_s = .init()
    let key = "palette"
    
    if (!ghostty_config_get(config, &paletteList, key, UInt(key.count))) {
        return []
    }
    
    var colors: [Color] = []
    let mirror = Mirror(reflecting: paletteList.colors)
    
    for (_, element) in mirror.children {
        if let color = element as? ghostty_config_color_s {
            colors.append(Color(
                red: Double(color.r) / 255,
                green: Double(color.g) / 255,
                blue: Double(color.b) / 255
            ))
        }
    }
    
    print("Palette Colors: ", colors)
    return colors
}
```
Result (GruvboxDarkHard theme)
![CleanShot 2025-04-25 at 14 21 39](https://github.com/user-attachments/assets/a282fd8d-3e5e-4281-819c-dff00b84318f)

