### PR TITLE
i18n: fixed the translation for Russian

### DIFF
--- a/po/ru_RU.UTF-8.po
+++ b/po/ru_RU.UTF-8.po
@@ -45,7 +45,7 @@ msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
 msgstr ""
-"Конфигурация содержит ошибки. Проверьте их ниже, а затемлибо перезагрузите "
+"Конфигурация содержит ошибки. Проверьте их ниже, а затем либо перезагрузите "
 "конфигурацию, либо проигнорируйте ошибки."
 
 #: src/apprt/gtk/ui/1.5/config-errors-dialog.blp:9


### PR DESCRIPTION
The problem was highlighted in https://github.com/ghostty-org/ghostty/pull/7127#discussion_r2051223171

In Russian, the words [`затем`](https://ru.wiktionary.org/wiki/%D0%B7%D0%B0%D1%82%D0%B5%D0%BC) and [`либо`](https://ru.wiktionary.org/wiki/%D0%BB%D0%B8%D0%B1%D0%BE) are written separately.

@zeshi09 @TicClick take a look?