### PR TITLE
Fix removed GDK_DEBUG  `gl-no-fractional`

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -190,7 +190,6 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
             // For the remainder of "why" see the 4.14 comment below.
             gdk_disable.@"gles-api" = true;
             gdk_disable.vulkan = true;
-            gdk_debug.@"gl-no-fractional" = true;
             break :environment;
         }
         if (gtk_version.runtimeAtLeast(4, 14, 0)) {
@@ -201,8 +200,11 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
             //
             // Upstream issue: https://gitlab.gnome.org/GNOME/gtk/-/issues/6589
             gdk_debug.@"gl-disable-gles" = true;
-            gdk_debug.@"gl-no-fractional" = true;
             gdk_debug.@"vulkan-disable" = true;
+
+            if (gtk_version.runtimeUntil(4, 17, 5)) {
+                gdk_debug.@"gl-no-fractional" = true;
+            }
             break :environment;
         }
         // Versions prior to 4.14 are a bit of an unknown for Ghostty. It

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -159,6 +159,7 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
         opengl: bool = false,
         /// disable GLES, Ghostty can't use GLES
         @"gl-disable-gles": bool = false,
+        // GTK's new renderer can cause blurry font when using fractional scaling.
         @"gl-no-fractional": bool = false,
         /// Disabling Vulkan can improve startup times by hundreds of
         /// milliseconds on some systems. We don't use Vulkan so we can just
@@ -203,6 +204,7 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
             gdk_debug.@"vulkan-disable" = true;
 
             if (gtk_version.runtimeUntil(4, 17, 5)) {
+                // Removed at GTK v4.17.5
                 gdk_debug.@"gl-no-fractional" = true;
             }
             break :environment;

--- a/src/apprt/gtk/gtk_version.zig
+++ b/src/apprt/gtk/gtk_version.zig
@@ -87,10 +87,23 @@ pub inline fn runtimeAtLeast(
     }) != .lt;
 }
 
+pub inline fn runtimeUntil(
+    comptime major: u16,
+    comptime minor: u16,
+    comptime micro: u16,
+) bool {
+    const runtime_version = getRuntimeVersion();
+    return runtime_version.order(.{
+        .major = major,
+        .minor = minor,
+        .patch = micro,
+    }) == .lt;
+}
+
 test "atLeast" {
     const testing = std.testing;
 
-    const funs = &.{ atLeast, runtimeAtLeast };
+    const funs = &.{ atLeast, runtimeAtLeast, runtimeUntil };
     inline for (funs) |fun| {
         try testing.expect(fun(c.GTK_MAJOR_VERSION, c.GTK_MINOR_VERSION, c.GTK_MICRO_VERSION));
 


### PR DESCRIPTION
`gl-no-fractional` is removed from GTK v4.17.5