### PR TITLE
font/freetype: introduce mutexes to ensure thread safety of Library and Face

### DIFF
--- a/src/font/CodepointResolver.zig
+++ b/src/font/CodepointResolver.zig
@@ -380,7 +380,7 @@ test getIndex {
     const testEmoji = font.embedded.emoji;
     const testEmojiText = font.embedded.emoji_text;
 
-    var lib = try Library.init();
+    var lib = try Library.init(alloc);
     defer lib.deinit();
 
     var c = Collection.init();
@@ -461,7 +461,7 @@ test "getIndex disabled font style" {
     var atlas_grayscale = try font.Atlas.init(alloc, 512, .grayscale);
     defer atlas_grayscale.deinit(alloc);
 
-    var lib = try Library.init();
+    var lib = try Library.init(alloc);
     defer lib.deinit();
 
     var c = Collection.init();
@@ -513,7 +513,7 @@ test "getIndex box glyph" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
-    var lib = try Library.init();
+    var lib = try Library.init(alloc);
     defer lib.deinit();
 
     const c = Collection.init();

--- a/src/font/Collection.zig
+++ b/src/font/Collection.zig
@@ -714,15 +714,18 @@ test "add full" {
         ) });
     }
 
-    try testing.expectError(error.CollectionFull, c.add(
-        alloc,
-        .regular,
-        .{ .loaded = try Face.init(
-            lib,
-            testFont,
-            .{ .size = .{ .points = 12 } },
-        ) },
-    ));
+    var face = try Face.init(
+        lib,
+        testFont,
+        .{ .size = .{ .points = 12 } },
+    );
+    // We have to deinit it manually since the
+    // collection doesn't do it if adding fails.
+    defer face.deinit();
+    try testing.expectError(
+        error.CollectionFull,
+        c.add(alloc, .regular, .{ .loaded = face }),
+    );
 }
 
 test "add deferred without loading options" {

--- a/src/font/Collection.zig
+++ b/src/font/Collection.zig
@@ -78,8 +78,8 @@ pub const AddError = Allocator.Error || error{
 /// next in priority if others exist already, i.e. it'll be the _last_ to be
 /// searched for a glyph in that list.
 ///
-/// The collection takes ownership of the face. The face will be deallocated
-/// when the collection is deallocated.
+/// If no error is encountered then the collection takes ownership of the face,
+/// in which case face will be deallocated when the collection is deallocated.
 ///
 /// If a loaded face is added to the collection, it should be the same
 /// size as all the other faces in the collection. This function will not
@@ -700,7 +700,7 @@ test "add full" {
     const alloc = testing.allocator;
     const testFont = font.embedded.regular;
 
-    var lib = try Library.init();
+    var lib = try Library.init(alloc);
     defer lib.deinit();
 
     var c = init();
@@ -746,7 +746,7 @@ test getFace {
     const alloc = testing.allocator;
     const testFont = font.embedded.regular;
 
-    var lib = try Library.init();
+    var lib = try Library.init(alloc);
     defer lib.deinit();
 
     var c = init();
@@ -770,7 +770,7 @@ test getIndex {
     const alloc = testing.allocator;
     const testFont = font.embedded.regular;
 
-    var lib = try Library.init();
+    var lib = try Library.init(alloc);
     defer lib.deinit();
 
     var c = init();
@@ -801,7 +801,7 @@ test completeStyles {
     const alloc = testing.allocator;
     const testFont = font.embedded.regular;
 
-    var lib = try Library.init();
+    var lib = try Library.init(alloc);
     defer lib.deinit();
 
     var c = init();
@@ -828,7 +828,7 @@ test setSize {
     const alloc = testing.allocator;
     const testFont = font.embedded.regular;
 
-    var lib = try Library.init();
+    var lib = try Library.init(alloc);
     defer lib.deinit();
 
     var c = init();
@@ -851,7 +851,7 @@ test hasCodepoint {
     const alloc = testing.allocator;
     const testFont = font.embedded.regular;
 
-    var lib = try Library.init();
+    var lib = try Library.init(alloc);
     defer lib.deinit();
 
     var c = init();
@@ -875,7 +875,7 @@ test "hasCodepoint emoji default graphical" {
     const alloc = testing.allocator;
     const testEmoji = font.embedded.emoji;
 
-    var lib = try Library.init();
+    var lib = try Library.init(alloc);
     defer lib.deinit();
 
     var c = init();
@@ -898,7 +898,7 @@ test "metrics" {
     const alloc = testing.allocator;
     const testFont = font.embedded.inconsolata;
 
-    var lib = try Library.init();
+    var lib = try Library.init(alloc);
     defer lib.deinit();
 
     var c = init();

--- a/src/font/DeferredFace.zig
+++ b/src/font/DeferredFace.zig
@@ -407,7 +407,7 @@ test "fontconfig" {
     const alloc = testing.allocator;
 
     // Load freetype
-    var lib = try Library.init();
+    var lib = try Library.init(alloc);
     defer lib.deinit();
 
     // Get a deferred face from fontconfig
@@ -437,7 +437,7 @@ test "coretext" {
     const alloc = testing.allocator;
 
     // Load freetype
-    var lib = try Library.init();
+    var lib = try Library.init(alloc);
     defer lib.deinit();
 
     // Get a deferred face from fontconfig

--- a/src/font/DeferredFace.zig
+++ b/src/font/DeferredFace.zig
@@ -425,7 +425,8 @@ test "fontconfig" {
     try testing.expect(n.len > 0);
 
     // Load it and verify it works
-    const face = try def.load(lib, .{ .size = .{ .points = 12 } });
+    var face = try def.load(lib, .{ .size = .{ .points = 12 } });
+    defer face.deinit();
     try testing.expect(face.glyphIndex(' ') != null);
 }
 
@@ -456,6 +457,7 @@ test "coretext" {
     try testing.expect(n.len > 0);
 
     // Load it and verify it works
-    const face = try def.load(lib, .{ .size = .{ .points = 12 } });
+    var face = try def.load(lib, .{ .size = .{ .points = 12 } });
+    defer face.deinit();
     try testing.expect(face.glyphIndex(' ') != null);
 }

--- a/src/font/SharedGrid.zig
+++ b/src/font/SharedGrid.zig
@@ -338,7 +338,7 @@ test getIndex {
     const alloc = testing.allocator;
     // const testEmoji = @import("test.zig").fontEmoji;
 
-    var lib = try Library.init();
+    var lib = try Library.init(alloc);
     defer lib.deinit();
 
     var grid = try testGrid(.normal, alloc, lib);

--- a/src/font/SharedGridSet.zig
+++ b/src/font/SharedGridSet.zig
@@ -50,7 +50,7 @@ pub const InitError = Library.InitError;
 
 /// Initialize a new SharedGridSet.
 pub fn init(alloc: Allocator) InitError!SharedGridSet {
-    var font_lib = try Library.init();
+    var font_lib = try Library.init(alloc);
     errdefer font_lib.deinit();
 
     return .{

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -46,7 +46,11 @@ pub const Face = struct {
     };
 
     /// Initialize a CoreText-based font from a TTF/TTC in memory.
-    pub fn init(lib: font.Library, source: [:0]const u8, opts: font.face.Options) !Face {
+    pub fn init(
+        lib: font.Library,
+        source: [:0]const u8,
+        opts: font.face.Options,
+    ) !Face {
         _ = lib;
 
         const data = try macos.foundation.Data.createWithBytesNoCopy(source);
@@ -914,7 +918,7 @@ test "in-memory" {
     var atlas = try font.Atlas.init(alloc, 512, .grayscale);
     defer atlas.deinit(alloc);
 
-    var lib = try font.Library.init();
+    var lib = try font.Library.init(alloc);
     defer lib.deinit();
 
     var face = try Face.init(lib, testFont, .{ .size = .{ .points = 12 } });
@@ -941,7 +945,7 @@ test "variable" {
     var atlas = try font.Atlas.init(alloc, 512, .grayscale);
     defer atlas.deinit(alloc);
 
-    var lib = try font.Library.init();
+    var lib = try font.Library.init(alloc);
     defer lib.deinit();
 
     var face = try Face.init(lib, testFont, .{ .size = .{ .points = 12 } });
@@ -968,7 +972,7 @@ test "variable set variation" {
     var atlas = try font.Atlas.init(alloc, 512, .grayscale);
     defer atlas.deinit(alloc);
 
-    var lib = try font.Library.init();
+    var lib = try font.Library.init(alloc);
     defer lib.deinit();
 
     var face = try Face.init(lib, testFont, .{ .size = .{ .points = 12 } });
@@ -996,7 +1000,7 @@ test "svg font table" {
     const alloc = testing.allocator;
     const testFont = font.embedded.julia_mono;
 
-    var lib = try font.Library.init();
+    var lib = try font.Library.init(alloc);
     defer lib.deinit();
 
     var face = try Face.init(lib, testFont, .{ .size = .{ .points = 12 } });
@@ -1010,9 +1014,10 @@ test "svg font table" {
 
 test "glyphIndex colored vs text" {
     const testing = std.testing;
+    const alloc = testing.allocator;
     const testFont = font.embedded.julia_mono;
 
-    var lib = try font.Library.init();
+    var lib = try font.Library.init(alloc);
     defer lib.deinit();
 
     var face = try Face.init(lib, testFont, .{ .size = .{ .points = 12 } });

--- a/src/font/opentype/svg.zig
+++ b/src/font/opentype/svg.zig
@@ -99,7 +99,7 @@ test "SVG" {
     const alloc = testing.allocator;
     const testFont = font.embedded.julia_mono;
 
-    var lib = try font.Library.init();
+    var lib = try font.Library.init(alloc);
     defer lib.deinit();
 
     var face = try font.Face.init(lib, testFont, .{ .size = .{ .points = 12 } });

--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -1761,7 +1761,7 @@ fn testShaperWithFont(alloc: Allocator, font_req: TestFont) !TestShaper {
         .nerd_font => font.embedded.nerd_font,
     };
 
-    var lib = try Library.init();
+    var lib = try Library.init(alloc);
     errdefer lib.deinit();
 
     var c = Collection.init();

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -1220,7 +1220,7 @@ fn testShaperWithFont(alloc: Allocator, font_req: TestFont) !TestShaper {
         .arabic => font.embedded.arabic,
     };
 
-    var lib = try Library.init();
+    var lib = try Library.init(alloc);
     errdefer lib.deinit();
 
     var c = Collection.init();


### PR DESCRIPTION
tl;dr: FT_New_Face and FT_Done_Face require the Library to be locked for thread safety, and FT_Load_Glyph and FT_Render_Glyph and friends need the face to be locked for thread safety, since we're sharing faces across threads.

For details see comments and FreeType docs @
- https://freetype.org/freetype2/docs/reference/ft2-library_setup.html#ft_library
- https://freetype.org/freetype2/docs/reference/ft2-face_creation.html#ft_face

---

This might resolve the issue discussed in #7016 but I wasn't able to reliably reproduce it in a way I could debug, so someone who was experiencing it should probably test this PR.

Additionally I can still semi-reliably produce a crash with the GTK apprt by setting an `all:` keybind to adjust font sizes and changing the font size rapidly with many surfaces open with emojis on them. Unfortunately I can't really tell what the root cause is because the debug info is broken in QEMU.

However, I do think this is a good idea for us to be thread safe with this stuff even if it isn't related to that problem.