### PR TITLE
apprt/gtk: ensure configuration is loaded on startup

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -1291,6 +1291,13 @@ pub fn run(self: *App) !void {
     // Setup our actions
     self.initActions();
 
+    // On startup, we want to check for configuration errors right away
+    // so we can show our error window. We also need to setup other initial
+    // state.
+    self.syncConfigChanges(null) catch |err| {
+        log.warn("error handling configuration changes err={}", .{err});
+    };
+
     while (self.running) {
         _ = glib.MainContext.iteration(self.ctx, 1);
 


### PR DESCRIPTION
Restores the app configuration code removed in
https://github.com/ghostty-org/ghostty/pull/6792.

The was unnoticed due to `colorSchemeEvent` triggering a configuration reload if `window-theme` deviates from the default (i.e. dark mode is used).

Fixes https://github.com/ghostty-org/ghostty/discussions/7206