### PR TITLE
Prevent window title reset when command palette opens

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.TerminalSplit.swift
+++ b/macos/Sources/Ghostty/Ghostty.TerminalSplit.swift
@@ -77,7 +77,6 @@ extension Ghostty {
                         .onReceive(pubZoom) { onZoom(notification: $0) }
                     }
                 }
-                .navigationTitle(surfaceTitle ?? "Ghostty")
                 .id(node) // Needed for change detection on node
             } else {
                 // On these events we want to reset the split state and call it.

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -13,7 +13,6 @@ extension Ghostty {
                 SurfaceForApp(app) { surfaceView in
                     SurfaceWrapper(surfaceView: surfaceView)
                 }
-                .navigationTitle(surfaceTitle ?? "Ghostty")
             }
         }
     }


### PR DESCRIPTION
Fixes #7236

When the command palette is opened, the terminal view loses focus, causing the `@FocusedValue` for the surface title and PWD to become `nil`. 

Previously, this led to the window title reverting to a default value (`👻`) and the PWD icon disappearing.

This PR implements manual state management for the title and PWD URL within `TerminalView`. It preserves the last known valid values and only updates the window state via the `TerminalViewDelegate` when these values genuinely change, ignoring temporary `nil` states caused by focus loss.

Associated `.navigationTitle` modifiers were removed to prevent conflicts.

This change should resolve the title flicker issue noted during the review of PR #5790.

https://github.com/user-attachments/assets/0b45602b-5131-4d66-9864-356a49a51d6c

