### PR TITLE
flatpak: update GNOME runtime to 48

### DIFF
--- a/flatpak/com.mitchellh.ghostty.Devel.yml
+++ b/flatpak/com.mitchellh.ghostty.Devel.yml
@@ -1,6 +1,6 @@
 app-id: com.mitchellh.ghostty.Devel
 runtime: org.gnome.Platform
-runtime-version: "47"
+runtime-version: "48"
 sdk: org.gnome.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.ziglang

--- a/flatpak/com.mitchellh.ghostty.yml
+++ b/flatpak/com.mitchellh.ghostty.yml
@@ -1,6 +1,6 @@
 app-id: com.mitchellh.ghostty
 runtime: org.gnome.Platform
-runtime-version: "47"
+runtime-version: "48"
 sdk: org.gnome.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.ziglang


### PR DESCRIPTION
Notable dependencies updates:

- GTK 4.16.13 -> 4.18.4
- Libadwaita 1.6.6 -> 1.7.2