### PR TITLE
Add "Scroll to Selection" command

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4119,6 +4119,14 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             }, .unlocked);
         },
 
+        .scroll_to_selection => {
+            self.renderer_state.mutex.lock();
+            defer self.renderer_state.mutex.unlock();
+            const sel = self.io.terminal.screen.selection orelse return false;
+            const tl = sel.topLeft(&self.io.terminal.screen);
+            self.io.terminal.screen.scroll(.{ .pin = tl });
+        },
+
         .scroll_page_up => {
             const rows: isize = @intCast(self.size.grid().rows);
             self.io.queueMessage(.{

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -279,6 +279,7 @@ pub const Action = union(enum) {
     /// Scroll the screen varying amounts.
     scroll_to_top,
     scroll_to_bottom,
+    scroll_to_selection,
     scroll_page_up,
     scroll_page_down,
     scroll_page_fractional: f32,
@@ -789,6 +790,7 @@ pub const Action = union(enum) {
             .select_all,
             .scroll_to_top,
             .scroll_to_bottom,
+            .scroll_to_selection,
             .scroll_page_up,
             .scroll_page_down,
             .scroll_page_fractional,

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -170,6 +170,12 @@ fn actionCommands(action: Action.Key) []const Command {
             .description = "Scroll to the bottom of the screen.",
         }},
 
+        .scroll_to_selection => comptime &.{.{
+            .action = .scroll_to_selection,
+            .title = "Scroll to Selection",
+            .description = "Scroll to the selected text.",
+        }},
+
         .scroll_page_up => comptime &.{.{
             .action = .scroll_page_up,
             .title = "Scroll Page Up",


### PR DESCRIPTION
This is mostly intended for implementing the "Jump to Selection" (<kbd>⌘</kbd> <kbd>J</kbd>) command on macOS (but as per the TODO, the pin still needs to be centered)

Demo: (Selected text is "10")

<table><tr>
<td><img width="965" alt="Screenshot 2025-05-03 at 9 21 55 AM" src="https://github.com/user-attachments/assets/c37ba0b7-f622-48d2-b598-4151e85377ef" /></td>
<td><img width="965" alt="Screenshot 2025-05-03 at 9 21 58 AM" src="https://github.com/user-attachments/assets/650f44f9-3125-4a2a-b264-a6e8476e4fcb" /></td>
</tr></table>