### PR TITLE
improvements to the Issue Triage Discussion template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -26,7 +26,7 @@ body:
         > - **Renderer issues:** (Linux) include your OpenGL version, graphics card, driver version.
         > - **Crashes:** (macOS) include the [Sentry UUID](https://github.com/ghostty-org/ghostty?tab=readme-ov-file#crash-reports); (Linux) try to reproduce using a debug build and provide the stack trace.
       placeholder: |
-        Example: When using SSH to connect to my remote Linux machine from my local macOS device in Ghostty, I try to run `clear`, and the screen does not clear.  Instead, I see the following error message printed to the terminal: `Error opening terminal: xterm-ghostty.`
+        When using SSH to connect to my remote Linux machine from my local macOS device in Ghostty, I try to run `clear`, and the screen does not clear.  Instead, I see the following error message printed to the terminal: `Error opening terminal: xterm-ghostty.`
     validations:
       required: true
   - type: textarea
@@ -35,7 +35,7 @@ body:
       description: |
         Provide a summary of how you expect Ghostty to behave in this situation.  Include any relevant documentation links.
       placeholder: |
-        Example: When I run `clear`, I expect the screen to be cleared and the prompt to be redrawn at the top of the window.
+        The screen to be cleared and the prompt is redrawn at the top of the window.
       render: text
     validations:
       required: true
@@ -45,7 +45,7 @@ body:
       description: |
         Provide a summary of how Ghostty actually behaves in this situation.  If it is not immediately obvious how the actual behavior differs from the expected behavior described above, please be sure to mention the deviation specifically.
       placeholder: |
-        Example: When I run `clear`, the screen is not cleared, and an error is printed: `Error opening terminal: xterm-ghostty.`
+        The screen is not cleared, and an error is printed: `Error opening terminal: xterm-ghostty`.
       render: text
     validations:
       required: true

--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -157,5 +157,5 @@ body:
           required: true
         - label: I have searched the Ghostty repository (both open and closed Discussions and Issues) and confirm this is not a duplicate of an existing issue or discussion.
           required: true
-        - label:  I have checked the “Preview” tab on all text fields to ensure that everything looks right, and have wrapped all configuration and code in code blocks with a group of three backticks (```) on separate lines.
+        - label: I have checked the “Preview” tab on all text fields to ensure that everything looks right, and have wrapped all configuration and code in code blocks with a group of three backticks (```) on separate lines.
           required: true

--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -118,7 +118,7 @@ body:
     attributes:
       label: Minimal Ghostty Configuration
       description: |
-        Please provide the **minimum** configuration needed to reproduce this issue.  If you cannot determine this, paste the contents of your Ghostty configuration file here.
+        Please provide the **minimum** configuration needed to reproduce this issue.  If you can still reproduce the issue with one of the lines removed, do not include that line.  If and **only** if you are not able to determine this, paste the contents of your Ghostty configuration file here.
       placeholder: |
         font-family = CommitMono Nerd Font
         font-family-bold = CommitMono Nerd Font

--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Expected Behavior
       description: |
-        Provide a summary of how you expect Ghostty to behave in this situation.  Include any relevant documentation links.
+        Describe how you expect Ghostty to behave in this situation.  Include any relevant documentation links.
       placeholder: |
         The screen is cleared and the prompt is redrawn at the top of the window.
     validations:
@@ -42,7 +42,7 @@ body:
     attributes:
       label: Actual Behavior
       description: |
-        Provide a summary of how Ghostty actually behaves in this situation.  If it is not immediately obvious how the actual behavior differs from the expected behavior described above, please be sure to mention the deviation specifically.
+        Describe how Ghostty actually behaves in this situation.  If it is not immediately obvious how the actual behavior differs from the expected behavior described above, please be sure to mention the deviation specifically.
       placeholder: |
         The screen is not cleared, and an error is printed: `Error opening terminal: xterm-ghostty`.
     validations:

--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -157,5 +157,5 @@ body:
           required: true
         - label: I have searched the Ghostty repository (both open and closed Discussions and Issues) and confirm this is not a duplicate of an existing issue or discussion.
           required: true
-        - label: I have checked the “Preview” tab on all text fields to ensure that everything looks right, and have wrapped all configuration and code in code blocks with a group of three backticks (```) on separate lines.
+        - label: I have checked the “Preview” tab on all text fields to ensure that everything looks right, and have wrapped all configuration and code in code blocks with a group of three backticks (` ``` `) on separate lines.
           required: true

--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -35,7 +35,7 @@ body:
       description: |
         Provide a summary of how you expect Ghostty to behave in this situation.  Include any relevant documentation links.
       placeholder: |
-        The screen to be cleared and the prompt is redrawn at the top of the window.
+        The screen is cleared and the prompt is redrawn at the top of the window.
       render: text
     validations:
       required: true

--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -157,5 +157,5 @@ body:
           required: true
         - label: I have searched the Ghostty repository (both open and closed Discussions and Issues) and confirm this is not a duplicate of an existing issue or discussion.
           required: true
-        - label: I have checked the “Preview” tab on all text fields to ensure that everything looks right, and have wrapped all configuration and code in code blocks with a group of three backticks (` ``` `) on separate lines.
+        - label: I have checked the "Preview" tab on all text fields to ensure that everything looks right, and have wrapped all configuration and code in code blocks with a group of three backticks (` ``` `) on separate lines.
           required: true

--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -22,7 +22,7 @@ body:
         >[!TIP]
         > **Not sure what information to include?**
         > Here are some recommendations:
-        > - **Input issues:** include your keyboard layout, a screenshot of the terminal inspector's logged keystrokes from the Terminal Inspector's "Keyboard" tab (Linux: <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>i</kbd>; MacOS: <kbd>cmd</kbd>+<kbd>alt</kbd>+<kbd>i</kbd>), input method, Linux input method engine (IBus, Fcitx 5, or none) and its version.
+        > - **Input issues:** include your keyboard layout, a screenshot of logged keystrokes from the Terminal Inspector's "Keyboard" tab (Linux: <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>i</kbd>; MacOS: <kbd>cmd</kbd>+<kbd>alt</kbd>+<kbd>i</kbd>), input method, Linux input method engine (IBus, Fcitx 5, or none) and its version.
         > - **Font issues:** include the problematic character(s), the output of `ghostty +show-face` for these character(s), and if they work in other applications.
         > - **Terminal emulation issues (including image rendering issues):** attach an [asciinema](https://docs.asciinema.org/getting-started/) cast file, shell script, or text file for reproduction.
         > - **Renderer issues:** (Linux) include your OpenGL version, graphics card, driver version.

--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -24,7 +24,7 @@ body:
         > Here are some recommendations:
         > - **Input issues:** include your keyboard layout, a screenshot of the terminal inspector's logged keystrokes from the Terminal Inspector's "Keyboard" tab (Linux: <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>i</kbd>; MacOS: <kbd>cmd</kbd>+<kbd>alt</kbd>+<kbd>i</kbd>), input method, Linux input method engine (IBus, Fcitx 5, or none) and its version.
         > - **Font issues:** include the problematic character(s), the output of `ghostty +show-face` for these character(s), and if they work in other applications.
-        > - **VT issues (including image rendering issues):** attach an [asciinema](https://docs.asciinema.org/getting-started/) cast file, shell script, or text file for reproduction.
+        > - **Terminal emulation issues (including image rendering issues):** attach an [asciinema](https://docs.asciinema.org/getting-started/) cast file, shell script, or text file for reproduction.
         > - **Renderer issues:** (Linux) include your OpenGL version, graphics card, driver version.
         > - **Crashes:** (macOS) include the [Sentry UUID](https://github.com/ghostty-org/ghostty?tab=readme-ov-file#crash-reports); (Linux) try to reproduce using a debug build and provide the stack trace.
       placeholder: |

--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -116,7 +116,7 @@ body:
       required: false
   - type: textarea
     attributes:
-      label: Ghostty Configuration (Minimal)
+      label: Minimal Ghostty Configuration
       description: |
         Please provide the **minimum** configuration needed to reproduce this issue.  If you cannot determine this, paste the contents of your Ghostty configuration file here.
       placeholder: |

--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -33,12 +33,6 @@ body:
       required: true
   - type: textarea
     attributes:
-      label: Ghostty Logs
-      description: |
-        Provide any captured Ghostty logs or stacktraces during your issue reproduction in this field.  For macOS users, logs can be viewed with `sudo log stream --level debug --predicate 'subsystem=="com.mitchellh.ghostty"'`.
-      render: text
-  - type: textarea
-    attributes:
       label: Reproduction Steps
       description: |
         Provide a detailed set of step-by-step instructions for reproducing this issue.
@@ -49,6 +43,12 @@ body:
         4. Observe `xterm-ghostty` error message above.
     validations:
       required: true
+  - type: textarea
+    attributes:
+      label: Ghostty Logs
+      description: |
+        Provide any captured Ghostty logs or stacktraces during your issue reproduction in this field.  For macOS users, logs can be viewed with `sudo log stream --level debug --predicate 'subsystem=="com.mitchellh.ghostty"'`.
+      render: text
   - type: textarea
     attributes:
       label: Ghostty Version

--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -36,7 +36,6 @@ body:
         Provide a summary of how you expect Ghostty to behave in this situation.  Include any relevant documentation links.
       placeholder: |
         The screen is cleared and the prompt is redrawn at the top of the window.
-      render: text
     validations:
       required: true
   - type: textarea
@@ -46,7 +45,6 @@ body:
         Provide a summary of how Ghostty actually behaves in this situation.  If it is not immediately obvious how the actual behavior differs from the expected behavior described above, please be sure to mention the deviation specifically.
       placeholder: |
         The screen is not cleared, and an error is printed: `Error opening terminal: xterm-ghostty`.
-      render: text
     validations:
       required: true
   - type: textarea
@@ -143,7 +141,6 @@ body:
         set-option -sa terminal-overrides ",xterm*:Tc"
         set  -g base-index      1
         setw -g pane-base-index 1
-      render: text
     validations:
       required: false
   - type: markdown

--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -135,7 +135,7 @@ body:
       description: |
         If your issue involves other programs, tools, or applications in addition to Ghostty (e.g. Neovim, tmux, Zellij, etc.), please provide the minimum configuration and versions needed for all relevant programs to reproduce the issue here.  If you use custom CSS or shaders for Ghostty, also include them here, if applicable to your issue.
       placeholder: |
-        `tmux.conf` (tmux 3.5a)
+        #### `tmux.conf` (tmux 3.5a)
         ---
         set  -g default-terminal "tmux-256color"
         set-option -sa terminal-overrides ",xterm*:Tc"

--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -35,7 +35,7 @@ body:
     attributes:
       label: Ghostty Logs
       description: |
-        Provide any captured Ghostty logs or stacktraces during your issue reproduction in this field.  For macOS users, logs can be found via the command provided in [#7194](https://github.com/ghostty-org/ghostty/discussions/7194)
+        Provide any captured Ghostty logs or stacktraces during your issue reproduction in this field.  For macOS users, logs can be viewed with `sudo log stream --level debug --predicate 'subsystem=="com.mitchellh.ghostty"'`.
       render: text
   - type: textarea
     attributes:

--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -16,22 +16,26 @@ body:
         - The feature or configuration option you encounter the issue with.
         - The expected behavior.
         - The actual behavior (and how it deviates from the expected behavior, if it is not immediately obvious).
-        - Relevant Ghostty logs or other stacktraces.
-        - Relevant screenshots, screen recordings, or other supporting media (as needed).
+        - Screenshots, screen recordings, or other supporting media (as needed).
         - If this is a regression of an existing issue that was closed or resolved, please include the previous item reference (Discussion, Issue, PR, commit) in your description.
 
         >[!TIP]
         > **Not sure what information to include?**
         > Here are some recommendations:
-        > - **Input issues:** include your keyboard layout, a screenshot of the terminal inspector's logged keystrokes (Linux: <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>i</kbd>; MacOS: <kbd>cmd</kbd>+<kbd>alt</kbd>+<kbd>i</kbd>), input method, Linux input method engine (IBus, Fcitx 5, or none) and its version.
+        > - **Input issues:** include your keyboard layout, a screenshot of the terminal inspector's logged keystrokes from the Terminal Inspector's "Keyboard" tab (Linux: <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>i</kbd>; MacOS: <kbd>cmd</kbd>+<kbd>alt</kbd>+<kbd>i</kbd>), input method, Linux input method engine (IBus, Fcitx 5, or none) and its version.
         > - **Font issues:** include the problematic character(s), the output of `ghostty +show-face` for these character(s), and if they work in other applications.
         > - **VT issues (including image rendering issues):** attach an [asciinema](https://docs.asciinema.org/getting-started/) cast file, shell script, or text file for reproduction.
         > - **Renderer issues:** (Linux) include your OpenGL version, graphics card, driver version.
-
+        > - **Crashes:** (macOS) include the [Sentry UUID](https://github.com/ghostty-org/ghostty?tab=readme-ov-file#crash-reports); (Linux) try to reproduce using a debug build and provide the stack trace.
       placeholder: |
         Example: When using SSH to connect to my remote Linux machine from my local macOS device in Ghostty, I try to run `clear`, and the screen does not clear.  Instead, I see the following error message printed to the terminal: `Error opening terminal: xterm-ghostty.`
     validations:
       required: true
+  - type: textarea
+    attributes:
+      label: Ghostty Logs
+      description: |
+        Provide any captured Ghostty logs or stacktraces during your issue reproduction in this field.  For macOS users, logs can be found via the command provided in [#7194](https://github.com/ghostty-org/ghostty/discussions/7194)
   - type: textarea
     attributes:
       label: Reproduction Steps
@@ -93,9 +97,9 @@ body:
       required: false
   - type: textarea
     attributes:
-      label: Ghostty Configuration
+      label: Ghostty Configuration (Minimal)
       description: |
-        Please provide the minimum configuration needed to reproduce this issue.  If you cannot determine this, paste the output of `ghostty +show-config` here.
+        Please provide the **minimum** configuration needed to reproduce this issue.  If you cannot determine this, paste the contents of your Ghostty configuration file here.
       placeholder: |
         font-family = CommitMono Nerd Font
         font-family-bold = CommitMono Nerd Font
@@ -112,9 +116,9 @@ body:
     attributes:
       label: Additional Relevant Configuration
       description: |
-        If your issue involves other programs, tools, or applications in addition to Ghostty (e.g. Neovim, tmux, Zellij, etc.), please provide the minimum configuration needed for all relevant programs to reproduce the issue here.  If you use custom CSS or shaders for Ghostty, also include them here, if applicable to your issue.
+        If your issue involves other programs, tools, or applications in addition to Ghostty (e.g. Neovim, tmux, Zellij, etc.), please provide the minimum configuration and versions needed for all relevant programs to reproduce the issue here.  If you use custom CSS or shaders for Ghostty, also include them here, if applicable to your issue.
       placeholder: |
-        `tmux.conf`
+        `tmux.conf` (tmux 3.5a)
         ---
         set  -g default-terminal "tmux-256color"
         set-option -sa terminal-overrides ",xterm*:Tc"

--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -17,7 +17,7 @@ body:
         - Screenshots, screen recordings, or other supporting media (as needed).
         - If this is a regression of an existing issue that was closed or resolved, please include the previous item reference (Discussion, Issue, PR, commit) in your description.
 
-        >[!TIP]
+        > [!TIP]
         > **Not sure what information to include?**
         > Here are some recommendations:
         > - **Input issues:** include your keyboard layout, a screenshot of logged keystrokes from the terminal inspector's "Keyboard" tab (Linux: <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>i</kbd>; MacOS: <kbd>cmd</kbd>+<kbd>alt</kbd>+<kbd>i</kbd>), input method, Linux input method engine (IBus, Fcitx 5, or none) and its version.

--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -20,7 +20,7 @@ body:
         >[!TIP]
         > **Not sure what information to include?**
         > Here are some recommendations:
-        > - **Input issues:** include your keyboard layout, a screenshot of logged keystrokes from the Terminal Inspector's "Keyboard" tab (Linux: <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>i</kbd>; MacOS: <kbd>cmd</kbd>+<kbd>alt</kbd>+<kbd>i</kbd>), input method, Linux input method engine (IBus, Fcitx 5, or none) and its version.
+        > - **Input issues:** include your keyboard layout, a screenshot of logged keystrokes from the terminal inspector's "Keyboard" tab (Linux: <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>i</kbd>; MacOS: <kbd>cmd</kbd>+<kbd>alt</kbd>+<kbd>i</kbd>), input method, Linux input method engine (IBus, Fcitx 5, or none) and its version.
         > - **Font issues:** include the problematic character(s), the output of `ghostty +show-face` for these character(s), and if they work in other applications.
         > - **Terminal emulation issues (including image rendering issues):** attach an [asciinema](https://docs.asciinema.org/getting-started/) cast file, shell script, or text file for reproduction.
         > - **Renderer issues:** (Linux) include your OpenGL version, graphics card, driver version.

--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -36,6 +36,7 @@ body:
       label: Ghostty Logs
       description: |
         Provide any captured Ghostty logs or stacktraces during your issue reproduction in this field.  For macOS users, logs can be found via the command provided in [#7194](https://github.com/ghostty-org/ghostty/discussions/7194)
+      render: text
   - type: textarea
     attributes:
       label: Reproduction Steps

--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -136,11 +136,12 @@ body:
         If your issue involves other programs, tools, or applications in addition to Ghostty (e.g. Neovim, tmux, Zellij, etc.), please provide the minimum configuration and versions needed for all relevant programs to reproduce the issue here.  If you use custom CSS or shaders for Ghostty, also include them here, if applicable to your issue.
       placeholder: |
         #### `tmux.conf` (tmux 3.5a)
-        ---
+        ```
         set  -g default-terminal "tmux-256color"
         set-option -sa terminal-overrides ",xterm*:Tc"
         set  -g base-index      1
         setw -g pane-base-index 1
+        ```
     validations:
       required: false
   - type: markdown

--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -157,3 +157,5 @@ body:
           required: true
         - label: I have searched the Ghostty repository (both open and closed Discussions and Issues) and confirm this is not a duplicate of an existing issue or discussion.
           required: true
+        - label:  I have checked the “Preview” tab on all text fields to ensure that everything looks right, and have wrapped all configuration and code in code blocks with a group of three backticks (```) on separate lines.
+          required: true

--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -14,8 +14,6 @@ body:
       description: |
         Provide a detailed description of the issue.  Include relevant information, such as:
         - The feature or configuration option you encounter the issue with.
-        - The expected behavior.
-        - The actual behavior (and how it deviates from the expected behavior, if it is not immediately obvious).
         - Screenshots, screen recordings, or other supporting media (as needed).
         - If this is a regression of an existing issue that was closed or resolved, please include the previous item reference (Discussion, Issue, PR, commit) in your description.
 
@@ -29,6 +27,26 @@ body:
         > - **Crashes:** (macOS) include the [Sentry UUID](https://github.com/ghostty-org/ghostty?tab=readme-ov-file#crash-reports); (Linux) try to reproduce using a debug build and provide the stack trace.
       placeholder: |
         Example: When using SSH to connect to my remote Linux machine from my local macOS device in Ghostty, I try to run `clear`, and the screen does not clear.  Instead, I see the following error message printed to the terminal: `Error opening terminal: xterm-ghostty.`
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: |
+        Provide a summary of how you expect Ghostty to behave in this situation.  Include any relevant documentation links.
+      placeholder: |
+        Example: When I run `clear`, I expect the screen to be cleared and the prompt to be redrawn at the top of the window.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Actual Behavior
+      description: |
+        Provide a summary of how Ghostty actually behaves in this situation.  If it is not immediately obvious how the actual behavior differs from the expected behavior described above, please be sure to mention the deviation specifically.
+      placeholder: |
+        Example: When I run `clear`, the screen is not cleared, and an error is printed: `Error opening terminal: xterm-ghostty.`
+      render: text
     validations:
       required: true
   - type: textarea

--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -47,7 +47,7 @@ body:
     attributes:
       label: Ghostty Logs
       description: |
-        Provide any captured Ghostty logs or stacktraces during your issue reproduction in this field.  For macOS users, logs can be viewed with `sudo log stream --level debug --predicate 'subsystem=="com.mitchellh.ghostty"'`.
+        Provide any captured Ghostty logs or stacktraces during your issue reproduction in this field.  On Linux, logs can be found by running `ghostty` from the command-line; on macOS, logs can be viewed with `sudo log stream --level debug --predicate 'subsystem=="com.mitchellh.ghostty"'` from another terminal emulator.
       render: text
   - type: textarea
     attributes:

--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -1,4 +1,4 @@
-labels: ["needs confirmation"]
+labels: ["needs-confirmation"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
After some time with the initial template and Discussions being created, there are some improvements we should make to the Issue Triage template.

Most of these changes were discussed in #7012 and among helpers in the Discord.

~~I've marked this as a Draft for now as I work with the helpers to confirm how we want to approach a few of the outstanding changes, mostly minor updates.~~

As always, you can test these out by [opening an Issue Triage Discussion post on my fork](https://github.com/taylrfnt/ghostty/discussions/new?category=issue-triage).