### PR TITLE
ci: workaround broken lxd start with snap builder

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -374,6 +374,11 @@ jobs:
             /zig
       - run: sudo apt install -y udev
       - run: sudo systemctl start systemd-udevd
+      # Workaround until this is fixed: https://github.com/canonical/lxd-pkg-snap/pull/789
+      - run: |
+          _LXD_SNAP_DEVCGROUP_CONFIG="/var/lib/snapd/cgroup/snap.lxd.device"
+          sudo mkdir -p /var/lib/snapd/cgroup
+          echo 'self-managed=true' | sudo tee  "${_LXD_SNAP_DEVCGROUP_CONFIG}"
       - uses: snapcore/action-build@v1
         with:
           path: dist


### PR DESCRIPTION
https://discourse.ubuntu.com/t/lxd-doesn-t-start-snap-lxd-device-directory-nonexistent/59785 https://github.com/canonical/lxd-pkg-snap/pull/789

This is required until Namespace or further upstream fixes are made.