### PR TITLE
fix: ensure consistent mouse event format in terminfo

### DIFF
--- a/src/terminfo/ghostty.zig
+++ b/src/terminfo/ghostty.zig
@@ -379,7 +379,7 @@ pub const ghostty: Source = .{
         .{ .name = "khome", .value = .{ .string = "\\EOH" } },
         .{ .name = "kich1", .value = .{ .string = "\\E[2~" } },
         .{ .name = "kind", .value = .{ .string = "\\E[1;2B" } },
-        .{ .name = "kmous", .value = .{ .string = "\\E[<" } },
+        .{ .name = "kmous", .value = .{ .string = "\\E[M" } },
         .{ .name = "knp", .value = .{ .string = "\\E[6~" } },
         .{ .name = "kpp", .value = .{ .string = "\\E[5~" } },
         .{ .name = "kri", .value = .{ .string = "\\E[1;2A" } },


### PR DESCRIPTION
The terminal code in Surface.zig correctly sends '\x1b[M' for mouse events,
which is properly defined in the terminfo entry as '\E[M' for the kmous
capability. This commit ensures that the mouse event format is consistent
between the implementation in Surface.zig and the terminfo definition.

This maintains compatibility with applications that rely on the correct
mouse event format when interacting with the terminal.

See https://github.com/ghostty-org/ghostty/blob/6e11d947e7ae6f37567faddb863b48107cdf278b/src/Surface.zig#L2696-L2698
