### PR TITLE
macOS: handle scenario cgWindowId is nil

### DIFF
--- a/macos/Sources/Helpers/Fullscreen.swift
+++ b/macos/Sources/Helpers/Fullscreen.swift
@@ -355,16 +355,23 @@ class NonNativeFullscreen: FullscreenBase, FullscreenStyle {
             self.styleMask = window.styleMask
             self.dock = window.screen?.hasDock ?? false
 
-            // We hide the menu only if this window is not on any fullscreen
-            // spaces. We do this because fullscreen spaces already hide the
-            // menu and if we insert/remove this presentation option we get
-            // issues (see #7075)
-            let activeSpace = CGSSpace.active()
-            let spaces = CGSSpace.list(for: window.cgWindowId)
-            if spaces.contains(activeSpace) {
-                self.menu = activeSpace.type != .fullscreen
+            if let cgWindowId = window.cgWindowId {
+                // We hide the menu only if this window is not on any fullscreen
+                // spaces. We do this because fullscreen spaces already hide the
+                // menu and if we insert/remove this presentation option we get
+                // issues (see #7075)
+                let activeSpace = CGSSpace.active()
+                let spaces = CGSSpace.list(for: cgWindowId)
+                if spaces.contains(activeSpace) {
+                    self.menu = activeSpace.type != .fullscreen
+                } else {
+                    self.menu = spaces.allSatisfy { $0.type != .fullscreen }
+                }
             } else {
-                self.menu = spaces.allSatisfy { $0.type != .fullscreen }
+                // Window doesn't have a window device, its not visible or something.
+                // In this case, we assume we can hide the menu. We may want to do
+                // something more sophisticated but this works for now.
+                self.menu = true
             }
         }
     }

--- a/macos/Sources/Helpers/NSWindow+Extension.swift
+++ b/macos/Sources/Helpers/NSWindow+Extension.swift
@@ -2,7 +2,11 @@ import AppKit
 
 extension NSWindow {
     /// Get the CGWindowID type for the window (used for low level CoreGraphics APIs).
-    var cgWindowId: CGWindowID {
-        CGWindowID(windowNumber)
+    var cgWindowId: CGWindowID? {
+        // "If the window doesn’t have a window device, the value of this
+        // property is equal to or less than 0." - Docs. In practice I've
+        // found this is true if a window is not visible.
+        guard windowNumber > 0 else { return nil }
+        return CGWindowID(windowNumber)
     }
 }


### PR DESCRIPTION
Fixes #7114
Supercedes #7271

This fixes a crash that could occur with non-native fullscreen and `fullscreen = true` set at once.

The "windowNumber" can be `<= 0` if the window "doesn't have a window device." I don't fully know all the scenarios this is true but it is true when the window is not visible, at least.