### PR TITLE
macOS: move window title handling fully to AppKit, fix command palette losing title

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalView.swift
+++ b/macos/Sources/Features/Terminal/TerminalView.swift
@@ -8,9 +8,6 @@ protocol TerminalViewDelegate: AnyObject {
     /// Called when the currently focused surface changed. This can be nil.
     func focusedSurfaceDidChange(to: Ghostty.SurfaceView?)
 
-    /// The title of the terminal should change.
-    func titleDidChange(to: String)
-
     /// The URL of the pwd should change.
     func pwdDidChange(to: URL?)
 
@@ -59,18 +56,9 @@ struct TerminalView<ViewModel: TerminalViewModel>: View {
 
     // Various state values sent back up from the currently focused terminals.
     @FocusedValue(\.ghosttySurfaceView) private var focusedSurface
-    @FocusedValue(\.ghosttySurfaceTitle) private var surfaceTitle
     @FocusedValue(\.ghosttySurfacePwd) private var surfacePwd
     @FocusedValue(\.ghosttySurfaceZoomed) private var zoomedSplit
     @FocusedValue(\.ghosttySurfaceCellSize) private var cellSize
-
-    // The title for our window
-    private var title: String {
-        if let surfaceTitle, !surfaceTitle.isEmpty {
-            return surfaceTitle
-        }
-        return "👻"
-    }
 
     // The pwd of the focused surface as a URL
     private var pwdURL: URL? {
@@ -104,9 +92,6 @@ struct TerminalView<ViewModel: TerminalViewModel>: View {
                                 lastFocusedSurface = .init(newValue)
                                 self.delegate?.focusedSurfaceDidChange(to: newValue)
                             }
-                        }
-                        .onChange(of: title) { newValue in
-                            self.delegate?.titleDidChange(to: newValue)
                         }
                         .onChange(of: pwdURL) { newValue in
                             self.delegate?.pwdDidChange(to: newValue)

--- a/macos/Sources/Ghostty/Ghostty.TerminalSplit.swift
+++ b/macos/Sources/Ghostty/Ghostty.TerminalSplit.swift
@@ -45,8 +45,6 @@ extension Ghostty {
         /// this one.
         @Binding var zoomedSurface: SurfaceView?
 
-        @FocusedValue(\.ghosttySurfaceTitle) private var surfaceTitle: String?
-
         var body: some View {
             let center = NotificationCenter.default
             let pubZoom = center.publisher(for: Notification.didToggleSplitZoom)
@@ -77,7 +75,6 @@ extension Ghostty {
                         .onReceive(pubZoom) { onZoom(notification: $0) }
                     }
                 }
-                .navigationTitle(surfaceTitle ?? "Ghostty")
                 .id(node) // Needed for change detection on node
             } else {
                 // On these events we want to reset the split state and call it.

--- a/macos/Sources/Ghostty/InspectorView.swift
+++ b/macos/Sources/Ghostty/InspectorView.swift
@@ -31,7 +31,6 @@ extension Ghostty {
                     }, right: {
                         InspectorViewRepresentable(surfaceView: surfaceView)
                             .focused($inspectorFocus)
-                            .focusedValue(\.ghosttySurfaceTitle, surfaceView.title)
                             .focusedValue(\.ghosttySurfaceView, surfaceView)
                     })
                 }

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -6,14 +6,12 @@ extension Ghostty {
     /// Render a terminal for the active app in the environment.
     struct Terminal: View {
         @EnvironmentObject private var ghostty: Ghostty.App
-        @FocusedValue(\.ghosttySurfaceTitle) private var surfaceTitle: String?
 
         var body: some View {
             if let app = self.ghostty.app {
                 SurfaceForApp(app) { surfaceView in
                     SurfaceWrapper(surfaceView: surfaceView)
                 }
-                .navigationTitle(surfaceTitle ?? "Ghostty")
             }
         }
     }
@@ -83,7 +81,6 @@ extension Ghostty {
 
                     Surface(view: surfaceView, size: geo.size)
                         .focused($surfaceFocus)
-                        .focusedValue(\.ghosttySurfaceTitle, title)
                         .focusedValue(\.ghosttySurfacePwd, surfaceView.pwd)
                         .focusedValue(\.ghosttySurfaceView, surfaceView)
                         .focusedValue(\.ghosttySurfaceCellSize, surfaceView.cellSize)
@@ -494,15 +491,6 @@ extension FocusedValues {
 
     struct FocusedGhosttySurface: FocusedValueKey {
         typealias Value = Ghostty.SurfaceView
-    }
-
-    var ghosttySurfaceTitle: String? {
-        get { self[FocusedGhosttySurfaceTitle.self] }
-        set { self[FocusedGhosttySurfaceTitle.self] = newValue }
-    }
-
-    struct FocusedGhosttySurfaceTitle: FocusedValueKey {
-        typealias Value = String
     }
 
     var ghosttySurfacePwd: String? {


### PR DESCRIPTION
Fixes #7236
Supersedes #7249

This removes all of our `focusedValue`-based tracking of the surface title and moves it completely to the window controller. The window controller now sets up event listeners (via Combine) when the focused surface changes and updates the window title accordingly.

There is some complicated logic here to handle when we lose focus to something other than a surface. In this case, we want our title to be the last focused surface so long as it exists.

The prior `focusedValue`-based code was a relic of when Ghostty was a full SwiftUI app. Now that we have AppKit in the mix (and have for a couple years), we shouldn't bolt on fixes to that cruft if we can help it.