### PR TITLE
core: fixup callconv(.C) -> callconv(.c)

### DIFF
--- a/pkg/cimgui/main.zig
+++ b/pkg/cimgui/main.zig
@@ -1,20 +1,20 @@
 pub const c = @import("c.zig").c;
 
 // OpenGL
-pub extern fn ImGui_ImplOpenGL3_Init(?[*:0]const u8) callconv(.C) bool;
-pub extern fn ImGui_ImplOpenGL3_Shutdown() callconv(.C) void;
-pub extern fn ImGui_ImplOpenGL3_NewFrame() callconv(.C) void;
-pub extern fn ImGui_ImplOpenGL3_RenderDrawData(*c.ImDrawData) callconv(.C) void;
+pub extern fn ImGui_ImplOpenGL3_Init(?[*:0]const u8) callconv(.c) bool;
+pub extern fn ImGui_ImplOpenGL3_Shutdown() callconv(.c) void;
+pub extern fn ImGui_ImplOpenGL3_NewFrame() callconv(.c) void;
+pub extern fn ImGui_ImplOpenGL3_RenderDrawData(*c.ImDrawData) callconv(.c) void;
 
 // Metal
-pub extern fn ImGui_ImplMetal_Init(*anyopaque) callconv(.C) bool;
-pub extern fn ImGui_ImplMetal_Shutdown() callconv(.C) void;
-pub extern fn ImGui_ImplMetal_NewFrame(*anyopaque) callconv(.C) void;
-pub extern fn ImGui_ImplMetal_RenderDrawData(*c.ImDrawData, *anyopaque, *anyopaque) callconv(.C) void;
+pub extern fn ImGui_ImplMetal_Init(*anyopaque) callconv(.c) bool;
+pub extern fn ImGui_ImplMetal_Shutdown() callconv(.c) void;
+pub extern fn ImGui_ImplMetal_NewFrame(*anyopaque) callconv(.c) void;
+pub extern fn ImGui_ImplMetal_RenderDrawData(*c.ImDrawData, *anyopaque, *anyopaque) callconv(.c) void;
 
 // OSX
-pub extern fn ImGui_ImplOSX_Init(*anyopaque) callconv(.C) bool;
-pub extern fn ImGui_ImplOSX_Shutdown() callconv(.C) void;
-pub extern fn ImGui_ImplOSX_NewFrame(*anyopaque) callconv(.C) void;
+pub extern fn ImGui_ImplOSX_Init(*anyopaque) callconv(.c) bool;
+pub extern fn ImGui_ImplOSX_Shutdown() callconv(.c) void;
+pub extern fn ImGui_ImplOSX_NewFrame(*anyopaque) callconv(.c) void;
 
 test {}

--- a/pkg/glfw/Joystick.zig
+++ b/pkg/glfw/Joystick.zig
@@ -333,7 +333,7 @@ pub inline fn setCallback(comptime callback: ?fn (joystick: Joystick, event: Eve
 
     if (callback) |user_callback| {
         const CWrapper = struct {
-            pub fn joystickCallbackWrapper(jid: c_int, event: c_int) callconv(.C) void {
+            pub fn joystickCallbackWrapper(jid: c_int, event: c_int) callconv(.c) void {
                 @call(.always_inline, user_callback, .{
                     Joystick{ .jid = @as(Joystick.Id, @enumFromInt(jid)) },
                     @as(Event, @enumFromInt(event)),

--- a/pkg/glfw/Monitor.zig
+++ b/pkg/glfw/Monitor.zig
@@ -389,7 +389,7 @@ pub inline fn setCallback(comptime callback: ?fn (monitor: Monitor, event: Event
 
     if (callback) |user_callback| {
         const CWrapper = struct {
-            pub fn monitorCallbackWrapper(monitor: ?*c.GLFWmonitor, event: c_int) callconv(.C) void {
+            pub fn monitorCallbackWrapper(monitor: ?*c.GLFWmonitor, event: c_int) callconv(.c) void {
                 @call(.always_inline, user_callback, .{
                     Monitor{ .handle = monitor.? },
                     @as(Event, @enumFromInt(event)),

--- a/pkg/glfw/Window.zig
+++ b/pkg/glfw/Window.zig
@@ -1230,7 +1230,7 @@ pub inline fn setPosCallback(self: Window, comptime callback: ?fn (window: Windo
 
     if (callback) |user_callback| {
         const CWrapper = struct {
-            pub fn posCallbackWrapper(handle: ?*c.GLFWwindow, xpos: c_int, ypos: c_int) callconv(.C) void {
+            pub fn posCallbackWrapper(handle: ?*c.GLFWwindow, xpos: c_int, ypos: c_int) callconv(.c) void {
                 @call(.always_inline, user_callback, .{
                     from(handle.?),
                     @as(i32, @intCast(xpos)),
@@ -1263,7 +1263,7 @@ pub inline fn setSizeCallback(self: Window, comptime callback: ?fn (window: Wind
 
     if (callback) |user_callback| {
         const CWrapper = struct {
-            pub fn sizeCallbackWrapper(handle: ?*c.GLFWwindow, width: c_int, height: c_int) callconv(.C) void {
+            pub fn sizeCallbackWrapper(handle: ?*c.GLFWwindow, width: c_int, height: c_int) callconv(.c) void {
                 @call(.always_inline, user_callback, .{
                     from(handle.?),
                     @as(i32, @intCast(width)),
@@ -1304,7 +1304,7 @@ pub inline fn setCloseCallback(self: Window, comptime callback: ?fn (window: Win
 
     if (callback) |user_callback| {
         const CWrapper = struct {
-            pub fn closeCallbackWrapper(handle: ?*c.GLFWwindow) callconv(.C) void {
+            pub fn closeCallbackWrapper(handle: ?*c.GLFWwindow) callconv(.c) void {
                 @call(.always_inline, user_callback, .{
                     from(handle.?),
                 });
@@ -1341,7 +1341,7 @@ pub inline fn setRefreshCallback(self: Window, comptime callback: ?fn (window: W
 
     if (callback) |user_callback| {
         const CWrapper = struct {
-            pub fn refreshCallbackWrapper(handle: ?*c.GLFWwindow) callconv(.C) void {
+            pub fn refreshCallbackWrapper(handle: ?*c.GLFWwindow) callconv(.c) void {
                 @call(.always_inline, user_callback, .{
                     from(handle.?),
                 });
@@ -1379,7 +1379,7 @@ pub inline fn setFocusCallback(self: Window, comptime callback: ?fn (window: Win
 
     if (callback) |user_callback| {
         const CWrapper = struct {
-            pub fn focusCallbackWrapper(handle: ?*c.GLFWwindow, focused: c_int) callconv(.C) void {
+            pub fn focusCallbackWrapper(handle: ?*c.GLFWwindow, focused: c_int) callconv(.c) void {
                 @call(.always_inline, user_callback, .{
                     from(handle.?),
                     focused == c.GLFW_TRUE,
@@ -1413,7 +1413,7 @@ pub inline fn setIconifyCallback(self: Window, comptime callback: ?fn (window: W
 
     if (callback) |user_callback| {
         const CWrapper = struct {
-            pub fn iconifyCallbackWrapper(handle: ?*c.GLFWwindow, iconified: c_int) callconv(.C) void {
+            pub fn iconifyCallbackWrapper(handle: ?*c.GLFWwindow, iconified: c_int) callconv(.c) void {
                 @call(.always_inline, user_callback, .{
                     from(handle.?),
                     iconified == c.GLFW_TRUE,
@@ -1448,7 +1448,7 @@ pub inline fn setMaximizeCallback(self: Window, comptime callback: ?fn (window: 
 
     if (callback) |user_callback| {
         const CWrapper = struct {
-            pub fn maximizeCallbackWrapper(handle: ?*c.GLFWwindow, maximized: c_int) callconv(.C) void {
+            pub fn maximizeCallbackWrapper(handle: ?*c.GLFWwindow, maximized: c_int) callconv(.c) void {
                 @call(.always_inline, user_callback, .{
                     from(handle.?),
                     maximized == c.GLFW_TRUE,
@@ -1483,7 +1483,7 @@ pub inline fn setFramebufferSizeCallback(self: Window, comptime callback: ?fn (w
 
     if (callback) |user_callback| {
         const CWrapper = struct {
-            pub fn framebufferSizeCallbackWrapper(handle: ?*c.GLFWwindow, width: c_int, height: c_int) callconv(.C) void {
+            pub fn framebufferSizeCallbackWrapper(handle: ?*c.GLFWwindow, width: c_int, height: c_int) callconv(.c) void {
                 @call(.always_inline, user_callback, .{
                     from(handle.?),
                     @as(u32, @intCast(width)),
@@ -1519,7 +1519,7 @@ pub inline fn setContentScaleCallback(self: Window, comptime callback: ?fn (wind
 
     if (callback) |user_callback| {
         const CWrapper = struct {
-            pub fn windowScaleCallbackWrapper(handle: ?*c.GLFWwindow, xscale: f32, yscale: f32) callconv(.C) void {
+            pub fn windowScaleCallbackWrapper(handle: ?*c.GLFWwindow, xscale: f32, yscale: f32) callconv(.c) void {
                 @call(.always_inline, user_callback, .{
                     from(handle.?),
                     xscale,
@@ -1871,7 +1871,7 @@ pub inline fn setKeyCallback(self: Window, comptime callback: ?fn (window: Windo
 
     if (callback) |user_callback| {
         const CWrapper = struct {
-            pub fn keyCallbackWrapper(handle: ?*c.GLFWwindow, key: c_int, scancode: c_int, action: c_int, mods: c_int) callconv(.C) void {
+            pub fn keyCallbackWrapper(handle: ?*c.GLFWwindow, key: c_int, scancode: c_int, action: c_int, mods: c_int) callconv(.c) void {
                 @call(.always_inline, user_callback, .{
                     from(handle.?),
                     @as(Key, @enumFromInt(key)),
@@ -1917,7 +1917,7 @@ pub inline fn setCharCallback(self: Window, comptime callback: ?fn (window: Wind
 
     if (callback) |user_callback| {
         const CWrapper = struct {
-            pub fn charCallbackWrapper(handle: ?*c.GLFWwindow, codepoint: c_uint) callconv(.C) void {
+            pub fn charCallbackWrapper(handle: ?*c.GLFWwindow, codepoint: c_uint) callconv(.c) void {
                 @call(.always_inline, user_callback, .{
                     from(handle.?),
                     @as(u21, @intCast(codepoint)),
@@ -1958,7 +1958,7 @@ pub inline fn setMouseButtonCallback(self: Window, comptime callback: ?fn (windo
 
     if (callback) |user_callback| {
         const CWrapper = struct {
-            pub fn mouseButtonCallbackWrapper(handle: ?*c.GLFWwindow, button: c_int, action: c_int, mods: c_int) callconv(.C) void {
+            pub fn mouseButtonCallbackWrapper(handle: ?*c.GLFWwindow, button: c_int, action: c_int, mods: c_int) callconv(.c) void {
                 @call(.always_inline, user_callback, .{
                     from(handle.?),
                     @as(MouseButton, @enumFromInt(button)),
@@ -1996,7 +1996,7 @@ pub inline fn setCursorPosCallback(self: Window, comptime callback: ?fn (window:
 
     if (callback) |user_callback| {
         const CWrapper = struct {
-            pub fn cursorPosCallbackWrapper(handle: ?*c.GLFWwindow, xpos: f64, ypos: f64) callconv(.C) void {
+            pub fn cursorPosCallbackWrapper(handle: ?*c.GLFWwindow, xpos: f64, ypos: f64) callconv(.c) void {
                 @call(.always_inline, user_callback, .{
                     from(handle.?),
                     xpos,
@@ -2030,7 +2030,7 @@ pub inline fn setCursorEnterCallback(self: Window, comptime callback: ?fn (windo
 
     if (callback) |user_callback| {
         const CWrapper = struct {
-            pub fn cursorEnterCallbackWrapper(handle: ?*c.GLFWwindow, entered: c_int) callconv(.C) void {
+            pub fn cursorEnterCallbackWrapper(handle: ?*c.GLFWwindow, entered: c_int) callconv(.c) void {
                 @call(.always_inline, user_callback, .{
                     from(handle.?),
                     entered == c.GLFW_TRUE,
@@ -2067,7 +2067,7 @@ pub inline fn setScrollCallback(self: Window, comptime callback: ?fn (window: Wi
 
     if (callback) |user_callback| {
         const CWrapper = struct {
-            pub fn scrollCallbackWrapper(handle: ?*c.GLFWwindow, xoffset: f64, yoffset: f64) callconv(.C) void {
+            pub fn scrollCallbackWrapper(handle: ?*c.GLFWwindow, xoffset: f64, yoffset: f64) callconv(.c) void {
                 @call(.always_inline, user_callback, .{
                     from(handle.?),
                     xoffset,
@@ -2110,7 +2110,7 @@ pub inline fn setDropCallback(self: Window, comptime callback: ?fn (window: Wind
 
     if (callback) |user_callback| {
         const CWrapper = struct {
-            pub fn dropCallbackWrapper(handle: ?*c.GLFWwindow, path_count: c_int, paths: [*c][*c]const u8) callconv(.C) void {
+            pub fn dropCallbackWrapper(handle: ?*c.GLFWwindow, path_count: c_int, paths: [*c][*c]const u8) callconv(.c) void {
                 @call(.always_inline, user_callback, .{
                     from(handle.?),
                     @as([*][*:0]const u8, @ptrCast(paths))[0..@as(u32, @intCast(path_count))],

--- a/pkg/glfw/errors.zig
+++ b/pkg/glfw/errors.zig
@@ -300,7 +300,7 @@ pub inline fn mustGetErrorString() [:0]const u8 {
 pub fn setErrorCallback(comptime callback: ?fn (error_code: ErrorCode, description: [:0]const u8) void) void {
     if (callback) |user_callback| {
         const CWrapper = struct {
-            pub fn errorCallbackWrapper(err_int: c_int, c_description: [*c]const u8) callconv(.C) void {
+            pub fn errorCallbackWrapper(err_int: c_int, c_description: [*c]const u8) callconv(.c) void {
                 convertError(err_int) catch |error_code| {
                     user_callback(error_code, mem.sliceTo(c_description, 0));
                 };

--- a/pkg/glfw/opengl.zig
+++ b/pkg/glfw/opengl.zig
@@ -161,7 +161,7 @@ pub const GLProc = *const fn () callconv(if (builtin.os.tag == .windows and buil
 /// @thread_safety This function may be called from any thread.
 ///
 /// see also: context_glext, glfwExtensionSupported
-pub fn getProcAddress(proc_name: [*:0]const u8) callconv(.C) ?GLProc {
+pub fn getProcAddress(proc_name: [*:0]const u8) callconv(.c) ?GLProc {
     internal_debug.assertInitialized();
     if (c.glfwGetProcAddress(proc_name)) |proc_address| return @ptrCast(proc_address);
     return null;

--- a/pkg/glfw/vulkan.zig
+++ b/pkg/glfw/vulkan.zig
@@ -33,7 +33,7 @@ pub fn initVulkanLoader(loader_function: ?VKGetInstanceProcAddr) void {
     c.glfwInitVulkanLoader(loader_function orelse null);
 }
 
-pub const VKGetInstanceProcAddr = *const fn (vk_instance: c.VkInstance, name: [*c]const u8) callconv(.C) ?VKProc;
+pub const VKGetInstanceProcAddr = *const fn (vk_instance: c.VkInstance, name: [*c]const u8) callconv(.c) ?VKProc;
 
 /// Returns whether the Vulkan loader and an ICD have been found.
 ///
@@ -127,7 +127,7 @@ pub const VKProc = *const fn () callconv(if (builtin.os.tag == .windows and buil
 /// @pointer_lifetime The returned function pointer is valid until the library is terminated.
 ///
 /// @thread_safety This function may be called from any thread.
-pub fn getInstanceProcAddress(vk_instance: ?*anyopaque, proc_name: [*:0]const u8) callconv(.C) ?VKProc {
+pub fn getInstanceProcAddress(vk_instance: ?*anyopaque, proc_name: [*:0]const u8) callconv(.c) ?VKProc {
     internal_debug.assertInitialized();
     if (c.glfwGetInstanceProcAddress(if (vk_instance) |v| @as(c.VkInstance, @ptrCast(v)) else null, proc_name)) |proc_address| return proc_address;
     return null;

--- a/pkg/harfbuzz/blob.zig
+++ b/pkg/harfbuzz/blob.zig
@@ -77,11 +77,11 @@ pub const Blob = struct {
         comptime T: type,
         key: ?*anyopaque,
         ptr: ?*T,
-        comptime destroycb: ?*const fn (?*T) callconv(.C) void,
+        comptime destroycb: ?*const fn (?*T) callconv(.c) void,
         replace: bool,
     ) bool {
         const Callback = struct {
-            pub fn callback(data: ?*anyopaque) callconv(.C) void {
+            pub fn callback(data: ?*anyopaque) callconv(.c) void {
                 @call(.{ .modifier = .always_inline }, destroycb, .{
                     @as(?*T, @ptrCast(@alignCast(data))),
                 });

--- a/pkg/macos/foundation/array.zig
+++ b/pkg/macos/foundation/array.zig
@@ -84,7 +84,7 @@ pub const MutableArray = opaque {
             a: *const Elem,
             b: *const Elem,
             context: ?*Context,
-        ) callconv(.C) ComparisonResult,
+        ) callconv(.c) ComparisonResult,
     ) void {
         CFArraySortValues(
             self,
@@ -155,7 +155,7 @@ test "array sorting" {
         void,
         null,
         struct {
-            fn compare(a: *const u8, b: *const u8, _: ?*void) callconv(.C) ComparisonResult {
+            fn compare(a: *const u8, b: *const u8, _: ?*void) callconv(.c) ComparisonResult {
                 if (a.* > b.*) return .greater;
                 if (a.* == b.*) return .equal;
                 return .less;

--- a/pkg/macos/video/display_link.zig
+++ b/pkg/macos/video/display_link.zig
@@ -66,7 +66,7 @@ pub const DisplayLink = opaque {
                     flagsIn: c.CVOptionFlags,
                     flagsOut: *c.CVOptionFlags,
                     inner_userinfo: ?*anyopaque,
-                ) callconv(.C) c.CVReturn {
+                ) callconv(.c) c.CVReturn {
                     _ = inNow;
                     _ = inOutputTime;
                     _ = flagsIn;

--- a/pkg/opengl/glad.zig
+++ b/pkg/opengl/glad.zig
@@ -13,8 +13,8 @@ pub threadlocal var context: Context = undefined;
 /// The getProcAddress param is an anytype so that we can accept multiple
 /// forms of the function depending on what we're interfacing with.
 pub fn load(getProcAddress: anytype) !c_int {
-    const GlProc = *const fn () callconv(.C) void;
-    const GlfwFn = *const fn ([*:0]const u8) callconv(.C) ?GlProc;
+    const GlProc = *const fn () callconv(.c) void;
+    const GlfwFn = *const fn ([*:0]const u8) callconv(.c) ?GlProc;
 
     const res = switch (@TypeOf(getProcAddress)) {
         // glfw

--- a/pkg/sentry/transport.zig
+++ b/pkg/sentry/transport.zig
@@ -5,8 +5,8 @@ const Envelope = @import("envelope.zig").Envelope;
 
 /// sentry_transport_t
 pub const Transport = opaque {
-    pub const SendFunc = *const fn (envelope: *Envelope, state: ?*anyopaque) callconv(.C) void;
-    pub const FreeFunc = *const fn (state: ?*anyopaque) callconv(.C) void;
+    pub const SendFunc = *const fn (envelope: *Envelope, state: ?*anyopaque) callconv(.c) void;
+    pub const FreeFunc = *const fn (state: ?*anyopaque) callconv(.c) void;
 
     pub fn init(f: SendFunc) *Transport {
         return @ptrCast(c.sentry_transport_new(@ptrCast(f)).?);

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -43,15 +43,15 @@ pub const App = struct {
 
         /// Callback called to wakeup the event loop. This should trigger
         /// a full tick of the app loop.
-        wakeup: *const fn (AppUD) callconv(.C) void,
+        wakeup: *const fn (AppUD) callconv(.c) void,
 
         /// Callback called to handle an action.
-        action: *const fn (*App, apprt.Target.C, apprt.Action.C) callconv(.C) bool,
+        action: *const fn (*App, apprt.Target.C, apprt.Action.C) callconv(.c) bool,
 
         /// Read the clipboard value. The return value must be preserved
         /// by the host until the next call. If there is no valid clipboard
         /// value then this should return null.
-        read_clipboard: *const fn (SurfaceUD, c_int, *apprt.ClipboardRequest) callconv(.C) void,
+        read_clipboard: *const fn (SurfaceUD, c_int, *apprt.ClipboardRequest) callconv(.c) void,
 
         /// This may be called after a read clipboard call to request
         /// confirmation that the clipboard value is safe to read. The embedder
@@ -61,13 +61,13 @@ pub const App = struct {
             [*:0]const u8,
             *apprt.ClipboardRequest,
             apprt.ClipboardRequestType,
-        ) callconv(.C) void,
+        ) callconv(.c) void,
 
         /// Write the clipboard value.
-        write_clipboard: *const fn (SurfaceUD, [*:0]const u8, c_int, bool) callconv(.C) void,
+        write_clipboard: *const fn (SurfaceUD, [*:0]const u8, c_int, bool) callconv(.c) void,
 
         /// Close the current surface given by this function.
-        close_surface: ?*const fn (SurfaceUD, bool) callconv(.C) void = null,
+        close_surface: ?*const fn (SurfaceUD, bool) callconv(.c) void = null,
     };
 
     /// This is the key event sent for ghostty_surface_key and

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -1527,7 +1527,7 @@ fn adwNotifyDark(
     style_manager: *adw.StyleManager,
     _: *gobject.ParamSpec,
     self: *App,
-) callconv(.C) void {
+) callconv(.c) void {
     const color_scheme: apprt.ColorScheme = if (style_manager.getDark() == 0)
         .light
     else

--- a/src/apprt/gtk/ClipboardConfirmationWindow.zig
+++ b/src/apprt/gtk/ClipboardConfirmationWindow.zig
@@ -152,7 +152,7 @@ fn init(
     }
 }
 
-fn gtkResponse(_: *DialogType, response: [*:0]u8, self: *ClipboardConfirmation) callconv(.C) void {
+fn gtkResponse(_: *DialogType, response: [*:0]u8, self: *ClipboardConfirmation) callconv(.c) void {
     if (std.mem.orderZ(u8, response, "ok") == .eq) {
         self.core_surface.completeClipboardRequest(
             self.pending_req,
@@ -165,7 +165,7 @@ fn gtkResponse(_: *DialogType, response: [*:0]u8, self: *ClipboardConfirmation) 
     self.destroy();
 }
 
-fn gtkRevealButtonClicked(_: *gtk.Button, self: *ClipboardConfirmation) callconv(.C) void {
+fn gtkRevealButtonClicked(_: *gtk.Button, self: *ClipboardConfirmation) callconv(.c) void {
     self.text_view_scroll.as(gtk.Widget).setSensitive(@intFromBool(true));
     self.text_view.as(gtk.Widget).removeCssClass("blurred");
 
@@ -173,7 +173,7 @@ fn gtkRevealButtonClicked(_: *gtk.Button, self: *ClipboardConfirmation) callconv
     self.reveal_button.as(gtk.Widget).setVisible(@intFromBool(false));
 }
 
-fn gtkHideButtonClicked(_: *gtk.Button, self: *ClipboardConfirmation) callconv(.C) void {
+fn gtkHideButtonClicked(_: *gtk.Button, self: *ClipboardConfirmation) callconv(.c) void {
     self.text_view_scroll.as(gtk.Widget).setSensitive(@intFromBool(false));
     self.text_view.as(gtk.Widget).addCssClass("blurred");
 

--- a/src/apprt/gtk/CloseDialog.zig
+++ b/src/apprt/gtk/CloseDialog.zig
@@ -64,7 +64,7 @@ fn responseCallback(
     _: *DialogType,
     response: [*:0]const u8,
     target: *Target,
-) callconv(.C) void {
+) callconv(.c) void {
     const alloc = target.allocator();
     defer alloc.destroy(target);
 
@@ -141,7 +141,7 @@ pub const Target = union(enum) {
     }
 };
 
-fn findActiveWindow(data: ?*const anyopaque, _: ?*const anyopaque) callconv(.C) c_int {
+fn findActiveWindow(data: ?*const anyopaque, _: ?*const anyopaque) callconv(.c) c_int {
     const window: *gtk.Window = @ptrCast(@alignCast(@constCast(data orelse return -1)));
 
     // Confusingly, `isActive` returns 1 when active,

--- a/src/apprt/gtk/ConfigErrorsDialog.zig
+++ b/src/apprt/gtk/ConfigErrorsDialog.zig
@@ -67,7 +67,7 @@ pub fn maybePresent(app: *App, window: ?*Window) void {
     }
 }
 
-fn onResponse(_: *DialogType, response: [*:0]const u8, app: *App) callconv(.C) void {
+fn onResponse(_: *DialogType, response: [*:0]const u8, app: *App) callconv(.c) void {
     if (std.mem.orderZ(u8, response, "reload") == .eq) {
         app.reloadConfig(.app, .{}) catch |err| {
             log.warn("error reloading config error={}", .{err});

--- a/src/apprt/gtk/ImguiWidget.zig
+++ b/src/apprt/gtk/ImguiWidget.zig
@@ -221,12 +221,12 @@ fn translateMouseButton(button: c_uint) ?c_int {
     };
 }
 
-fn gtkDestroy(_: *gtk.GLArea, self: *ImguiWidget) callconv(.C) void {
+fn gtkDestroy(_: *gtk.GLArea, self: *ImguiWidget) callconv(.c) void {
     log.debug("imgui widget destroy", .{});
     self.deinit();
 }
 
-fn gtkRealize(area: *gtk.GLArea, self: *ImguiWidget) callconv(.C) void {
+fn gtkRealize(area: *gtk.GLArea, self: *ImguiWidget) callconv(.c) void {
     log.debug("gl surface realized", .{});
 
     // We need to make the context current so we can call GL functions.
@@ -242,7 +242,7 @@ fn gtkRealize(area: *gtk.GLArea, self: *ImguiWidget) callconv(.C) void {
     _ = cimgui.ImGui_ImplOpenGL3_Init(null);
 }
 
-fn gtkUnrealize(area: *gtk.GLArea, self: *ImguiWidget) callconv(.C) void {
+fn gtkUnrealize(area: *gtk.GLArea, self: *ImguiWidget) callconv(.c) void {
     _ = area;
     log.debug("gl surface unrealized", .{});
 
@@ -250,7 +250,7 @@ fn gtkUnrealize(area: *gtk.GLArea, self: *ImguiWidget) callconv(.C) void {
     cimgui.ImGui_ImplOpenGL3_Shutdown();
 }
 
-fn gtkResize(area: *gtk.GLArea, width: c_int, height: c_int, self: *ImguiWidget) callconv(.C) void {
+fn gtkResize(area: *gtk.GLArea, width: c_int, height: c_int, self: *ImguiWidget) callconv(.c) void {
     cimgui.c.igSetCurrentContext(self.ig_ctx);
     const io: *cimgui.c.ImGuiIO = cimgui.c.igGetIO();
     const scale_factor = area.as(gtk.Widget).getScaleFactor();
@@ -273,7 +273,7 @@ fn gtkResize(area: *gtk.GLArea, width: c_int, height: c_int, self: *ImguiWidget)
     active_style.* = style.*;
 }
 
-fn gtkRender(_: *gtk.GLArea, _: *gdk.GLContext, self: *ImguiWidget) callconv(.C) c_int {
+fn gtkRender(_: *gtk.GLArea, _: *gdk.GLContext, self: *ImguiWidget) callconv(.c) c_int {
     cimgui.c.igSetCurrentContext(self.ig_ctx);
 
     // Setup our frame. We render twice because some ImGui behaviors
@@ -307,7 +307,7 @@ fn gtkMouseMotion(
     x: f64,
     y: f64,
     self: *ImguiWidget,
-) callconv(.C) void {
+) callconv(.c) void {
     cimgui.c.igSetCurrentContext(self.ig_ctx);
     const io: *cimgui.c.ImGuiIO = cimgui.c.igGetIO();
     const scale_factor: f64 = @floatFromInt(self.gl_area.as(gtk.Widget).getScaleFactor());
@@ -325,7 +325,7 @@ fn gtkMouseDown(
     _: f64,
     _: f64,
     self: *ImguiWidget,
-) callconv(.C) void {
+) callconv(.c) void {
     self.queueRender();
 
     cimgui.c.igSetCurrentContext(self.ig_ctx);
@@ -343,7 +343,7 @@ fn gtkMouseUp(
     _: f64,
     _: f64,
     self: *ImguiWidget,
-) callconv(.C) void {
+) callconv(.c) void {
     self.queueRender();
 
     cimgui.c.igSetCurrentContext(self.ig_ctx);
@@ -359,7 +359,7 @@ fn gtkMouseScroll(
     x: f64,
     y: f64,
     self: *ImguiWidget,
-) callconv(.C) c_int {
+) callconv(.c) c_int {
     self.queueRender();
 
     cimgui.c.igSetCurrentContext(self.ig_ctx);
@@ -373,7 +373,7 @@ fn gtkMouseScroll(
     return @intFromBool(true);
 }
 
-fn gtkFocusEnter(_: *gtk.EventControllerFocus, self: *ImguiWidget) callconv(.C) void {
+fn gtkFocusEnter(_: *gtk.EventControllerFocus, self: *ImguiWidget) callconv(.c) void {
     self.queueRender();
 
     cimgui.c.igSetCurrentContext(self.ig_ctx);
@@ -381,7 +381,7 @@ fn gtkFocusEnter(_: *gtk.EventControllerFocus, self: *ImguiWidget) callconv(.C) 
     cimgui.c.ImGuiIO_AddFocusEvent(io, true);
 }
 
-fn gtkFocusLeave(_: *gtk.EventControllerFocus, self: *ImguiWidget) callconv(.C) void {
+fn gtkFocusLeave(_: *gtk.EventControllerFocus, self: *ImguiWidget) callconv(.c) void {
     self.queueRender();
 
     cimgui.c.igSetCurrentContext(self.ig_ctx);
@@ -393,7 +393,7 @@ fn gtkInputCommit(
     _: *gtk.IMMulticontext,
     bytes: [*:0]u8,
     self: *ImguiWidget,
-) callconv(.C) void {
+) callconv(.c) void {
     self.queueRender();
 
     cimgui.c.igSetCurrentContext(self.ig_ctx);
@@ -407,7 +407,7 @@ fn gtkKeyPressed(
     keycode: c_uint,
     gtk_mods: gdk.ModifierType,
     self: *ImguiWidget,
-) callconv(.C) c_int {
+) callconv(.c) c_int {
     return @intFromBool(self.keyEvent(
         .press,
         ec_key,
@@ -423,7 +423,7 @@ fn gtkKeyReleased(
     keycode: c_uint,
     gtk_mods: gdk.ModifierType,
     self: *ImguiWidget,
-) callconv(.C) void {
+) callconv(.c) void {
     _ = self.keyEvent(
         .release,
         ec_key,

--- a/src/apprt/gtk/ResizeOverlay.zig
+++ b/src/apprt/gtk/ResizeOverlay.zig
@@ -104,7 +104,7 @@ pub fn maybeShow(self: *ResizeOverlay) void {
 
 /// Actually update the overlay widget. This should only be called from a GTK
 /// idle handler.
-fn gtkUpdate(ud: ?*anyopaque) callconv(.C) c_int {
+fn gtkUpdate(ud: ?*anyopaque) callconv(.c) c_int {
     const self: *ResizeOverlay = @ptrCast(@alignCast(ud orelse return 0));
 
     // No matter what our idler is complete with this callback
@@ -198,7 +198,7 @@ fn setPosition(label: *gtk.Label, config: *DerivedConfig) void {
 
 /// If this fires, it means that the delay period has expired and the resize
 /// overlay widget should be hidden.
-fn gtkTimerExpired(ud: ?*anyopaque) callconv(.C) c_int {
+fn gtkTimerExpired(ud: ?*anyopaque) callconv(.c) c_int {
     const self: *ResizeOverlay = @ptrCast(@alignCast(ud orelse return 0));
     self.timer = null;
     if (self.label) |label| hide(label);

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1025,7 +1025,7 @@ pub fn setTitle(self: *Surface, slice: [:0]const u8, source: SetTitleSource) !vo
     self.update_title_timer = glib.timeoutAdd(75, updateTitleTimerExpired, self);
 }
 
-fn updateTitleTimerExpired(ud: ?*anyopaque) callconv(.C) c_int {
+fn updateTitleTimerExpired(ud: ?*anyopaque) callconv(.c) c_int {
     const self: *Surface = @ptrCast(@alignCast(ud.?));
 
     self.updateTitleLabels();
@@ -1265,7 +1265,7 @@ fn gtkClipboardRead(
     source: ?*gobject.Object,
     res: *gio.AsyncResult,
     ud: ?*anyopaque,
-) callconv(.C) void {
+) callconv(.c) void {
     const clipboard = gobject.ext.cast(gdk.Clipboard, source orelse return) orelse return;
     const req: *ClipboardRequest = @ptrCast(@alignCast(ud orelse return));
     const self = req.self;
@@ -1349,7 +1349,7 @@ pub fn showDesktopNotification(
     app.sendNotification(body.ptr, notification);
 }
 
-fn gtkRealize(gl_area: *gtk.GLArea, self: *Surface) callconv(.C) void {
+fn gtkRealize(gl_area: *gtk.GLArea, self: *Surface) callconv(.c) void {
     log.debug("gl surface realized", .{});
 
     // We need to make the context current so we can call GL functions.
@@ -1377,7 +1377,7 @@ fn gtkRealize(gl_area: *gtk.GLArea, self: *Surface) callconv(.C) void {
 
 /// This is called when the underlying OpenGL resources must be released.
 /// This is usually due to the OpenGL area changing GDK surfaces.
-fn gtkUnrealize(gl_area: *gtk.GLArea, self: *Surface) callconv(.C) void {
+fn gtkUnrealize(gl_area: *gtk.GLArea, self: *Surface) callconv(.c) void {
     log.debug("gl surface unrealized", .{});
 
     // See gtkRealize for why we do this here.
@@ -1405,7 +1405,7 @@ fn gtkUnrealize(gl_area: *gtk.GLArea, self: *Surface) callconv(.C) void {
 }
 
 /// render signal
-fn gtkRender(_: *gtk.GLArea, _: *gdk.GLContext, self: *Surface) callconv(.C) c_int {
+fn gtkRender(_: *gtk.GLArea, _: *gdk.GLContext, self: *Surface) callconv(.c) c_int {
     self.render() catch |err| {
         log.err("surface failed to render: {}", .{err});
         return 0;
@@ -1415,7 +1415,7 @@ fn gtkRender(_: *gtk.GLArea, _: *gdk.GLContext, self: *Surface) callconv(.C) c_i
 }
 
 /// resize signal
-fn gtkResize(gl_area: *gtk.GLArea, width: c_int, height: c_int, self: *Surface) callconv(.C) void {
+fn gtkResize(gl_area: *gtk.GLArea, width: c_int, height: c_int, self: *Surface) callconv(.c) void {
     // Some debug output to help understand what GTK is telling us.
     {
         const scale_factor = scale: {
@@ -1471,7 +1471,7 @@ fn gtkResize(gl_area: *gtk.GLArea, width: c_int, height: c_int, self: *Surface) 
 }
 
 /// "destroy" signal for surface
-fn gtkDestroy(_: *gtk.GLArea, self: *Surface) callconv(.C) void {
+fn gtkDestroy(_: *gtk.GLArea, self: *Surface) callconv(.c) void {
     log.debug("gl destroy", .{});
 
     const alloc = self.app.core_app.alloc;
@@ -1505,7 +1505,7 @@ fn gtkMouseDown(
     x: f64,
     y: f64,
     self: *Surface,
-) callconv(.C) void {
+) callconv(.c) void {
     const event = gesture.as(gtk.EventController).getCurrentEvent() orelse return;
 
     const gtk_mods = event.getModifierState();
@@ -1538,7 +1538,7 @@ fn gtkMouseUp(
     _: f64,
     _: f64,
     self: *Surface,
-) callconv(.C) void {
+) callconv(.c) void {
     const event = gesture.as(gtk.EventController).getCurrentEvent() orelse return;
 
     const gtk_mods = event.getModifierState();
@@ -1557,7 +1557,7 @@ fn gtkMouseMotion(
     x: f64,
     y: f64,
     self: *Surface,
-) callconv(.C) void {
+) callconv(.c) void {
     const event = ec.as(gtk.EventController).getCurrentEvent() orelse return;
 
     const scaled = self.scaledCoordinates(x, y);
@@ -1603,7 +1603,7 @@ fn gtkMouseMotion(
 fn gtkMouseLeave(
     ec_motion: *gtk.EventControllerMotion,
     self: *Surface,
-) callconv(.C) void {
+) callconv(.c) void {
     const event = ec_motion.as(gtk.EventController).getCurrentEvent() orelse return;
 
     // Get our modifiers
@@ -1618,14 +1618,14 @@ fn gtkMouseLeave(
 fn gtkMouseScrollPrecisionBegin(
     _: *gtk.EventControllerScroll,
     self: *Surface,
-) callconv(.C) void {
+) callconv(.c) void {
     self.precision_scroll = true;
 }
 
 fn gtkMouseScrollPrecisionEnd(
     _: *gtk.EventControllerScroll,
     self: *Surface,
-) callconv(.C) void {
+) callconv(.c) void {
     self.precision_scroll = false;
 }
 
@@ -1634,7 +1634,7 @@ fn gtkMouseScroll(
     x: f64,
     y: f64,
     self: *Surface,
-) callconv(.C) c_int {
+) callconv(.c) c_int {
     const scaled = self.scaledCoordinates(x, y);
 
     // GTK doesn't support any of the scroll mods.
@@ -1664,7 +1664,7 @@ fn gtkKeyPressed(
     keycode: c_uint,
     gtk_mods: gdk.ModifierType,
     self: *Surface,
-) callconv(.C) c_int {
+) callconv(.c) c_int {
     return @intFromBool(self.keyEvent(
         .press,
         ec_key,
@@ -1680,7 +1680,7 @@ fn gtkKeyReleased(
     keycode: c_uint,
     state: gdk.ModifierType,
     self: *Surface,
-) callconv(.C) void {
+) callconv(.c) void {
     _ = self.keyEvent(
         .release,
         ec_key,
@@ -1971,7 +1971,7 @@ pub fn keyEvent(
 fn gtkInputPreeditStart(
     _: *gtk.IMMulticontext,
     self: *Surface,
-) callconv(.C) void {
+) callconv(.c) void {
     // log.warn("GTKIM: preedit start", .{});
 
     // Start our composing state for the input method and reset our
@@ -1983,7 +1983,7 @@ fn gtkInputPreeditStart(
 fn gtkInputPreeditChanged(
     ctx: *gtk.IMMulticontext,
     self: *Surface,
-) callconv(.C) void {
+) callconv(.c) void {
     // Any preedit change should mark that we're composing. Its possible this
     // is false using fcitx5-hangul and typing "dkssud<space>" ("안녕"). The
     // second "s" results in a "commit" for "안" which sets composing to false,
@@ -2009,7 +2009,7 @@ fn gtkInputPreeditChanged(
 fn gtkInputPreeditEnd(
     _: *gtk.IMMulticontext,
     self: *Surface,
-) callconv(.C) void {
+) callconv(.c) void {
     // log.warn("GTKIM: preedit end", .{});
 
     // End our composing state for GTK, allowing us to commit the text.
@@ -2025,7 +2025,7 @@ fn gtkInputCommit(
     _: *gtk.IMMulticontext,
     bytes: [*:0]u8,
     self: *Surface,
-) callconv(.C) void {
+) callconv(.c) void {
     const str = std.mem.sliceTo(bytes, 0);
 
     // log.debug("GTKIM: input commit composing={} keyevent={} str={s}", .{
@@ -2100,7 +2100,7 @@ fn gtkInputCommit(
     };
 }
 
-fn gtkFocusEnter(_: *gtk.EventControllerFocus, self: *Surface) callconv(.C) void {
+fn gtkFocusEnter(_: *gtk.EventControllerFocus, self: *Surface) callconv(.c) void {
     if (!self.realized) return;
 
     // Notify our IM context
@@ -2125,7 +2125,7 @@ fn gtkFocusEnter(_: *gtk.EventControllerFocus, self: *Surface) callconv(.C) void
     };
 }
 
-fn gtkFocusLeave(_: *gtk.EventControllerFocus, self: *Surface) callconv(.C) void {
+fn gtkFocusLeave(_: *gtk.EventControllerFocus, self: *Surface) callconv(.c) void {
     if (!self.realized) return;
 
     // Notify our IM context
@@ -2243,7 +2243,7 @@ fn gtkDrop(
     _: f64,
     _: f64,
     self: *Surface,
-) callconv(.C) c_int {
+) callconv(.c) c_int {
     const alloc = self.app.core_app.alloc;
 
     if (g_value_holds(value, gdk.FileList.getGObjectType())) {
@@ -2395,7 +2395,7 @@ fn g_value_holds(value_: ?*gobject.Value, g_type: gobject.Type) bool {
     return false;
 }
 
-fn gtkPromptTitleResponse(source_object: ?*gobject.Object, result: *gio.AsyncResult, ud: ?*anyopaque) callconv(.C) void {
+fn gtkPromptTitleResponse(source_object: ?*gobject.Object, result: *gio.AsyncResult, ud: ?*anyopaque) callconv(.c) void {
     if (!adw_version.supportsDialogs()) return;
     const dialog = gobject.ext.cast(adw.AlertDialog, source_object.?).?;
     const self: *Surface = @ptrCast(@alignCast(ud));

--- a/src/apprt/gtk/Tab.zig
+++ b/src/apprt/gtk/Tab.zig
@@ -161,7 +161,7 @@ pub fn closeWithConfirmation(tab: *Tab) void {
     }
 }
 
-fn gtkDestroy(_: *gtk.Box, self: *Tab) callconv(.C) void {
+fn gtkDestroy(_: *gtk.Box, self: *Tab) callconv(.c) void {
     log.debug("tab box destroy", .{});
 
     const alloc = self.window.app.core_app.alloc;

--- a/src/apprt/gtk/TabView.zig
+++ b/src/apprt/gtk/TabView.zig
@@ -227,7 +227,7 @@ pub fn createWindow(window: *Window) !*Window {
     return new_window;
 }
 
-fn adwPageAttached(_: *adw.TabView, page: *adw.TabPage, _: c_int, self: *TabView) callconv(.C) void {
+fn adwPageAttached(_: *adw.TabView, page: *adw.TabPage, _: c_int, self: *TabView) callconv(.c) void {
     const child = page.getChild().as(gobject.Object);
     const tab: *Tab = @ptrCast(@alignCast(child.getData(Tab.GHOSTTY_TAB) orelse return));
     tab.window = self.window;
@@ -239,7 +239,7 @@ fn adwClosePage(
     _: *adw.TabView,
     page: *adw.TabPage,
     self: *TabView,
-) callconv(.C) c_int {
+) callconv(.c) c_int {
     const child = page.getChild().as(gobject.Object);
     const tab: *Tab = @ptrCast(@alignCast(child.getData(Tab.GHOSTTY_TAB) orelse return 0));
     self.tab_view.closePageFinish(page, @intFromBool(self.forcing_close));
@@ -251,7 +251,7 @@ fn adwClosePage(
 fn adwTabViewCreateWindow(
     _: *adw.TabView,
     self: *TabView,
-) callconv(.C) ?*adw.TabView {
+) callconv(.c) ?*adw.TabView {
     const window = createWindow(self.window) catch |err| {
         log.warn("error creating new window error={}", .{err});
         return null;
@@ -259,7 +259,7 @@ fn adwTabViewCreateWindow(
     return window.notebook.tab_view;
 }
 
-fn adwSelectPage(_: *adw.TabView, _: *gobject.ParamSpec, self: *TabView) callconv(.C) void {
+fn adwSelectPage(_: *adw.TabView, _: *gobject.ParamSpec, self: *TabView) callconv(.c) void {
     const page = self.tab_view.getSelectedPage() orelse return;
 
     // If the tab was previously marked as needing attention

--- a/src/apprt/gtk/URLWidget.zig
+++ b/src/apprt/gtk/URLWidget.zig
@@ -101,7 +101,7 @@ fn gtkLeftEnter(
     _: f64,
     _: f64,
     right: *gtk.Label,
-) callconv(.C) void {
+) callconv(.c) void {
     right.as(gtk.Widget).removeCssClass("hidden");
 }
 
@@ -110,6 +110,6 @@ fn gtkLeftEnter(
 fn gtkLeftLeave(
     _: *gtk.EventControllerMotion,
     right: *gtk.Label,
-) callconv(.C) void {
+) callconv(.c) void {
     right.as(gtk.Widget).addCssClass("hidden");
 }

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -792,7 +792,7 @@ fn gtkWindowNotifyIsActive(
     _: *adw.ApplicationWindow,
     _: *gobject.ParamSpec,
     self: *Window,
-) callconv(.C) void {
+) callconv(.c) void {
     if (!self.isQuickTerminal()) return;
 
     // Hide when we're unfocused
@@ -883,7 +883,7 @@ fn adwTabOverviewOpen(
 
 fn adwTabOverviewFocusTimer(
     ud: ?*anyopaque,
-) callconv(.C) c_int {
+) callconv(.c) c_int {
     if (!adw_version.supportsTabOverview()) unreachable;
     const self: *Window = @ptrCast(@alignCast(ud orelse return 0));
     self.adw_tab_overview_focus_timer = null;
@@ -970,7 +970,7 @@ fn gtkActionAbout(
     _: *gio.SimpleAction,
     _: ?*glib.Variant,
     self: *Window,
-) callconv(.C) void {
+) callconv(.c) void {
     const name = "Ghostty";
     const icon = "com.mitchellh.ghostty";
     const website = "https://ghostty.org";
@@ -1014,7 +1014,7 @@ fn gtkActionClose(
     _: *gio.SimpleAction,
     _: ?*glib.Variant,
     self: *Window,
-) callconv(.C) void {
+) callconv(.c) void {
     self.closeWithConfirmation();
 }
 
@@ -1022,7 +1022,7 @@ fn gtkActionNewWindow(
     _: *gio.SimpleAction,
     _: ?*glib.Variant,
     self: *Window,
-) callconv(.C) void {
+) callconv(.c) void {
     self.performBindingAction(.{ .new_window = {} });
 }
 
@@ -1030,7 +1030,7 @@ fn gtkActionNewTab(
     _: *gio.SimpleAction,
     _: ?*glib.Variant,
     self: *Window,
-) callconv(.C) void {
+) callconv(.c) void {
     self.performBindingAction(.{ .new_tab = {} });
 }
 
@@ -1038,7 +1038,7 @@ fn gtkActionCloseTab(
     _: *gio.SimpleAction,
     _: ?*glib.Variant,
     self: *Window,
-) callconv(.C) void {
+) callconv(.c) void {
     self.performBindingAction(.{ .close_tab = {} });
 }
 
@@ -1046,7 +1046,7 @@ fn gtkActionSplitRight(
     _: *gio.SimpleAction,
     _: ?*glib.Variant,
     self: *Window,
-) callconv(.C) void {
+) callconv(.c) void {
     self.performBindingAction(.{ .new_split = .right });
 }
 
@@ -1054,7 +1054,7 @@ fn gtkActionSplitDown(
     _: *gio.SimpleAction,
     _: ?*glib.Variant,
     self: *Window,
-) callconv(.C) void {
+) callconv(.c) void {
     self.performBindingAction(.{ .new_split = .down });
 }
 
@@ -1062,7 +1062,7 @@ fn gtkActionSplitLeft(
     _: *gio.SimpleAction,
     _: ?*glib.Variant,
     self: *Window,
-) callconv(.C) void {
+) callconv(.c) void {
     self.performBindingAction(.{ .new_split = .left });
 }
 
@@ -1070,7 +1070,7 @@ fn gtkActionSplitUp(
     _: *gio.SimpleAction,
     _: ?*glib.Variant,
     self: *Window,
-) callconv(.C) void {
+) callconv(.c) void {
     self.performBindingAction(.{ .new_split = .up });
 }
 
@@ -1078,7 +1078,7 @@ fn gtkActionToggleInspector(
     _: *gio.SimpleAction,
     _: ?*glib.Variant,
     self: *Window,
-) callconv(.C) void {
+) callconv(.c) void {
     self.performBindingAction(.{ .inspector = .toggle });
 }
 
@@ -1086,7 +1086,7 @@ fn gtkActionCopy(
     _: *gio.SimpleAction,
     _: ?*glib.Variant,
     self: *Window,
-) callconv(.C) void {
+) callconv(.c) void {
     self.performBindingAction(.{ .copy_to_clipboard = {} });
 }
 
@@ -1094,7 +1094,7 @@ fn gtkActionPaste(
     _: *gio.SimpleAction,
     _: ?*glib.Variant,
     self: *Window,
-) callconv(.C) void {
+) callconv(.c) void {
     self.performBindingAction(.{ .paste_from_clipboard = {} });
 }
 
@@ -1102,7 +1102,7 @@ fn gtkActionReset(
     _: *gio.SimpleAction,
     _: ?*glib.Variant,
     self: *Window,
-) callconv(.C) void {
+) callconv(.c) void {
     self.performBindingAction(.{ .reset = {} });
 }
 
@@ -1110,7 +1110,7 @@ fn gtkActionClear(
     _: *gio.SimpleAction,
     _: ?*glib.Variant,
     self: *Window,
-) callconv(.C) void {
+) callconv(.c) void {
     self.performBindingAction(.{ .clear_screen = {} });
 }
 
@@ -1118,7 +1118,7 @@ fn gtkActionPromptTitle(
     _: *gio.SimpleAction,
     _: ?*glib.Variant,
     self: *Window,
-) callconv(.C) void {
+) callconv(.c) void {
     self.performBindingAction(.{ .prompt_surface_title = {} });
 }
 
@@ -1133,7 +1133,7 @@ fn gtkTitlebarMenuActivate(
     btn: *gtk.MenuButton,
     _: *gobject.ParamSpec,
     self: *Window,
-) callconv(.C) void {
+) callconv(.c) void {
     // debian 12 is stuck on GTK 4.8
     if (!gtk_version.atLeast(4, 10, 0)) return;
     const active = btn.getActive() != 0;

--- a/src/apprt/gtk/inspector.zig
+++ b/src/apprt/gtk/inspector.zig
@@ -177,7 +177,7 @@ const Window = struct {
     }
 
     /// "destroy" signal for the window
-    fn gtkDestroy(_: *gtk.ApplicationWindow, self: *Window) callconv(.C) void {
+    fn gtkDestroy(_: *gtk.ApplicationWindow, self: *Window) callconv(.c) void {
         log.debug("window destroy", .{});
         self.deinit();
     }

--- a/src/apprt/gtk/menu.zig
+++ b/src/apprt/gtk/menu.zig
@@ -130,7 +130,7 @@ pub fn Menu(
         }
 
         /// Refocus tab that lost focus because of the popover menu
-        fn gtkRefocusTerm(_: *gtk.PopoverMenu, self: *Self) callconv(.C) void {
+        fn gtkRefocusTerm(_: *gtk.PopoverMenu, self: *Self) callconv(.c) void {
             const window: *Window = switch (T) {
                 Window => self.parent,
                 Surface => self.parent.container.window() orelse return,

--- a/src/apprt/gtk/winproto/wayland.zig
+++ b/src/apprt/gtk/winproto/wayland.zig
@@ -410,7 +410,7 @@ pub const Window = struct {
         _: *gdk.Surface,
         monitor: *gdk.Monitor,
         apprt_window: *ApprtWindow,
-    ) callconv(.C) void {
+    ) callconv(.c) void {
         const window = apprt_window.window.as(gtk.Window);
         const size = apprt_window.config.quick_terminal_size;
         const position = apprt_window.config.quick_terminal_position;

--- a/src/crash/sentry.zig
+++ b/src/crash/sentry.zig
@@ -166,7 +166,7 @@ fn beforeSend(
     event_val: sentry.c.sentry_value_t,
     _: ?*anyopaque,
     _: ?*anyopaque,
-) callconv(.C) sentry.c.sentry_value_t {
+) callconv(.c) sentry.c.sentry_value_t {
     // The native SDK at the time of writing doesn't support thread-local
     // scopes. The full SDK has one global scope. So we use the beforeSend
     // handler to set thread-specific data such as window size, grid size,
@@ -237,7 +237,7 @@ fn beforeSend(
 }
 
 pub const Transport = struct {
-    pub fn send(envelope: *sentry.Envelope, ud: ?*anyopaque) callconv(.C) void {
+    pub fn send(envelope: *sentry.Envelope, ud: ?*anyopaque) callconv(.c) void {
         _ = ud;
         defer envelope.deinit();
 

--- a/src/os/flatpak.zig
+++ b/src/os/flatpak.zig
@@ -444,7 +444,7 @@ pub const FlatpakHostCommand = struct {
         _: [*c]const u8,
         params: ?*c.GVariant,
         ud: ?*anyopaque,
-    ) callconv(.C) void {
+    ) callconv(.c) void {
         const self = @as(*FlatpakHostCommand, @ptrCast(@alignCast(ud)));
         const state = state: {
             self.state_mutex.lock();

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -1524,7 +1524,7 @@ const CompletionBlock = objc.Block(struct { self: *Metal }, .{
 fn bufferCompleted(
     block: *const CompletionBlock.Context,
     buffer_id: objc.c.id,
-) callconv(.C) void {
+) callconv(.c) void {
     const self = block.self;
     const buffer = objc.Object.fromId(buffer_id);
 

--- a/src/renderer/shadertoy.zig
+++ b/src/renderer/shadertoy.zig
@@ -250,7 +250,7 @@ fn spvCross(
     // It would be better to get this out into an output parameter to
     // show users but for now we can just log it.
     c.spvc_context_set_error_callback(ctx, @ptrCast(&(struct {
-        fn callback(_: ?*anyopaque, msg_ptr: [*c]const u8) callconv(.C) void {
+        fn callback(_: ?*anyopaque, msg_ptr: [*c]const u8) callconv(.c) void {
             const msg = std.mem.sliceTo(msg_ptr, 0);
             std.log.warn("spirv-cross error message={s}", .{msg});
         }


### PR DESCRIPTION
https://ziglang.org/download/0.14.0/release-notes.html#Calling-Convention-Enhancements-and-setAlignStack-Replaced