### PR TITLE
macOS: use file parent dir for `openTerminal` service cwd (#7286)

### DIFF
--- a/macos/Sources/Features/Services/ServiceProvider.swift
+++ b/macos/Sources/Features/Services/ServiceProvider.swift
@@ -36,30 +36,27 @@ class ServiceProvider: NSObject {
             error.pointee = Self.errorNoString
             return
         }
-        let filePaths = objs.map { $0.path }.compactMap { $0 }
+        let urlObjects = objs.map { $0 as URL }
 
-        openTerminal(filePaths, target: target)
+        openTerminal(urlObjects, target: target)
     }
 
-    private func openTerminal(_ paths: [String], target: OpenTarget) {
+    private func openTerminal(_ urls: [URL], target: OpenTarget) {
         guard let delegateRaw = NSApp.delegate else { return }
         guard let delegate = delegateRaw as? AppDelegate else { return }
         let terminalManager = delegate.terminalManager
 
-        for path in paths {
-            // We only open in directories.
-            var isDirectory = ObjCBool(true)
-            guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) else { continue }
-
-            var workingDirectory = path
-            if !isDirectory.boolValue {
-                workingDirectory = (path as NSString).deletingLastPathComponent
-                guard FileManager.default.fileExists(atPath: workingDirectory, isDirectory: &isDirectory), isDirectory.boolValue else { continue }
+        let uniqueCwds: Set<URL> = Set(
+            urls.map { url -> URL in
+                // We only open in directories.
+                url.hasDirectoryPath ? url : url.deletingLastPathComponent()
             }
+        )
 
+        for cwd in uniqueCwds {
             // Build our config
             var config = Ghostty.SurfaceConfiguration()
-            config.workingDirectory = workingDirectory
+            config.workingDirectory = cwd.path(percentEncoded: false)
 
             switch (target) {
             case .window:

--- a/macos/Sources/Features/Services/ServiceProvider.swift
+++ b/macos/Sources/Features/Services/ServiceProvider.swift
@@ -47,29 +47,19 @@ class ServiceProvider: NSObject {
         let terminalManager = delegate.terminalManager
 
         for path in paths {
-            // Check if the path exists and determine if it's a directory
-            var isDirectory = ObjCBool(false)
+            // We only open in directories.
+            var isDirectory = ObjCBool(true)
             guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) else { continue }
 
-            let targetDirectoryPath: String
-
-            if isDirectory.boolValue {
-                // Path is already a directory, use it directly
-                targetDirectoryPath = path
-            } else {
-                // Path is a file, get its parent directory
-                let parentDirectoryPath = (path as NSString).deletingLastPathComponent
-                var isParentPathDirectory = ObjCBool(true)
-                guard FileManager.default.fileExists(atPath: parentDirectoryPath, isDirectory: &isParentPathDirectory),
-                    isParentPathDirectory.boolValue else {
-                    continue
-                }
-                targetDirectoryPath = parentDirectoryPath
+            var workingDirectory = path
+            if !isDirectory.boolValue {
+                workingDirectory = (path as NSString).deletingLastPathComponent
+                guard FileManager.default.fileExists(atPath: workingDirectory, isDirectory: &isDirectory), isDirectory.boolValue else { continue }
             }
 
             // Build our config
             var config = Ghostty.SurfaceConfiguration()
-            config.workingDirectory = targetDirectoryPath
+            config.workingDirectory = workingDirectory
 
             switch (target) {
             case .window:

--- a/macos/Sources/Features/Services/ServiceProvider.swift
+++ b/macos/Sources/Features/Services/ServiceProvider.swift
@@ -47,14 +47,29 @@ class ServiceProvider: NSObject {
         let terminalManager = delegate.terminalManager
 
         for path in paths {
-            // We only open in directories.
-            var isDirectory = ObjCBool(true)
+            // Check if the path exists and determine if it's a directory
+            var isDirectory = ObjCBool(false)
             guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) else { continue }
-            guard isDirectory.boolValue else { continue }
+
+            let targetDirectoryPath: String
+
+            if isDirectory.boolValue {
+                // Path is already a directory, use it directly
+                targetDirectoryPath = path
+            } else {
+                // Path is a file, get its parent directory
+                let parentDirectoryPath = (path as NSString).deletingLastPathComponent
+                var isParentPathDirectory = ObjCBool(true)
+                guard FileManager.default.fileExists(atPath: parentDirectoryPath, isDirectory: &isParentPathDirectory),
+                    isParentPathDirectory.boolValue else {
+                    continue
+                }
+                targetDirectoryPath = parentDirectoryPath
+            }
 
             // Build our config
             var config = Ghostty.SurfaceConfiguration()
-            config.workingDirectory = path
+            config.workingDirectory = targetDirectoryPath
 
             switch (target) {
             case .window:


### PR DESCRIPTION
Fixes #7286

Previously, when using the "New Ghostty Window/Tab Here" macOS service on a file, the new terminal window/tab would incorrectly open in the user's home directory. This was because the service handler only expected directory paths.

This commit updates the service handler to check if the provided path is a file. If it is, the handler now uses the file's parent
directory as the working directory for the new Ghostty window or tab, aligning with user expectations. If the path is a directory, it's used directly as before.