### PR TITLE
gtk: only allow one config error dialog at a time

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -74,6 +74,9 @@ cursor_none: ?*gdk.Cursor,
 /// The clipboard confirmation window, if it is currently open.
 clipboard_confirmation_window: ?*ClipboardConfirmationWindow = null,
 
+/// The config errors dialog, if it is currently open.
+config_errors_dialog: ?ConfigErrorsDialog = null,
+
 /// The window containing the quick terminal.
 /// Null when never initialized.
 quick_terminal: ?*Window = null,

--- a/src/apprt/gtk/ConfigErrorsDialog.zig
+++ b/src/apprt/gtk/ConfigErrorsDialog.zig
@@ -37,7 +37,6 @@ pub fn maybePresent(app: *App, window: ?*Window) void {
             adw.MessageDialog => Builder.init("config-errors-dialog", 1, 2),
             else => unreachable,
         };
-        // defer builder.deinit();
 
         const dialog = builder.getObject(DialogType, "config_errors_dialog").?;
         const error_message = builder.getObject(gtk.TextBuffer, "error_message").?;


### PR DESCRIPTION
This fixes a problem introduced by #7241 that would cause multiple error dialogs to be shown.