### PR TITLE
input: add backwards compatible alias for `plus` to `+`

### DIFF
--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -1218,6 +1218,7 @@ pub const Trigger = struct {
         .{ "seven", Key{ .unicode = '7' } },
         .{ "eight", Key{ .unicode = '8' } },
         .{ "nine", Key{ .unicode = '9' } },
+        .{ "plus", Key{ .unicode = '+' } },
         .{ "apostrophe", Key{ .unicode = '\'' } },
         .{ "grave_accent", Key{ .physical = .backquote } },
         .{ "left_bracket", Key{ .physical = .bracket_left } },


### PR DESCRIPTION
From #7320
Discussion #7340

There isn't a `physical` alias because there is no physical plus key defined for the W3C keycode spec.