### PR TITLE
build: add unwind tables and frame pointers to debug/test builds

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -110,9 +110,15 @@ pub fn build(b: *std.Build) !void {
 
         const test_exe = b.addTest(.{
             .name = "ghostty-test",
-            .root_source_file = b.path("src/main.zig"),
-            .target = config.target,
-            .filter = test_filter,
+            .filters = if (test_filter) |v| &.{v} else &.{},
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/main.zig"),
+                .target = config.target,
+                .optimize = .Debug,
+                .strip = false,
+                .omit_frame_pointer = false,
+                .unwind_tables = .sync,
+            }),
         });
 
         {

--- a/src/apprt/gtk/key.zig
+++ b/src/apprt/gtk/key.zig
@@ -246,7 +246,7 @@ test "xdgShortcutFromTrigger" {
 
     try testing.expectEqualStrings("LOGO+q", (try xdgShortcutFromTrigger(&buf, .{
         .mods = .{ .super = true },
-        .key = .{ .translated = .q },
+        .key = .{ .unicode = 'q' },
     })).?);
 
     try testing.expectEqualStrings("SHIFT+CTRL+ALT+LOGO+backslash", (try xdgShortcutFromTrigger(&buf, .{

--- a/src/build/GhosttyBench.zig
+++ b/src/build/GhosttyBench.zig
@@ -36,11 +36,13 @@ pub fn init(
         const bin_name = try std.fmt.allocPrint(b.allocator, "bench-{s}", .{name});
         const c_exe = b.addExecutable(.{
             .name = bin_name,
-            .root_source_file = b.path("src/main.zig"),
-            .target = deps.config.target,
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/main.zig"),
+                .target = deps.config.target,
 
-            // We always want our benchmarks to be in release mode.
-            .optimize = .ReleaseFast,
+                // We always want our benchmarks to be in release mode.
+                .optimize = .ReleaseFast,
+            }),
         });
         c_exe.linkLibC();
 

--- a/src/build/GhosttyDocs.zig
+++ b/src/build/GhosttyDocs.zig
@@ -26,8 +26,13 @@ pub fn init(
     inline for (manpages) |manpage| {
         const generate_markdown = b.addExecutable(.{
             .name = "mdgen_" ++ manpage.name ++ "_" ++ manpage.section,
-            .root_source_file = b.path("src/main.zig"),
-            .target = b.graph.host,
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/main.zig"),
+                .target = b.graph.host,
+                .strip = false,
+                .omit_frame_pointer = false,
+                .unwind_tables = .sync,
+            }),
         });
         deps.help_strings.addImport(generate_markdown);
 

--- a/src/build/GhosttyExe.zig
+++ b/src/build/GhosttyExe.zig
@@ -13,10 +13,14 @@ install_step: *std.Build.Step.InstallArtifact,
 pub fn init(b: *std.Build, cfg: *const Config, deps: *const SharedDeps) !Ghostty {
     const exe: *std.Build.Step.Compile = b.addExecutable(.{
         .name = "ghostty",
-        .root_source_file = b.path("src/main.zig"),
-        .target = cfg.target,
-        .optimize = cfg.optimize,
-        .strip = cfg.strip,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = cfg.target,
+            .optimize = cfg.optimize,
+            .strip = cfg.strip,
+            .omit_frame_pointer = cfg.strip,
+            .unwind_tables = if (cfg.strip) .none else .sync,
+        }),
     });
     const install_step = b.addInstallArtifact(exe, .{});
 

--- a/src/build/GhosttyFrameData.zig
+++ b/src/build/GhosttyFrameData.zig
@@ -15,8 +15,13 @@ output: std.Build.LazyPath,
 pub fn init(b: *std.Build) !GhosttyFrameData {
     const exe = b.addExecutable(.{
         .name = "framegen",
-        .root_source_file = b.path("src/build/framegen/main.zig"),
-        .target = b.graph.host,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/build/framegen/main.zig"),
+            .target = b.graph.host,
+            .strip = false,
+            .omit_frame_pointer = false,
+            .unwind_tables = .sync,
+        }),
     });
 
     const run = b.addRunArtifact(exe);

--- a/src/build/GhosttyWebdata.zig
+++ b/src/build/GhosttyWebdata.zig
@@ -18,8 +18,13 @@ pub fn init(
     {
         const webgen_config = b.addExecutable(.{
             .name = "webgen_config",
-            .root_source_file = b.path("src/main.zig"),
-            .target = b.graph.host,
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/main.zig"),
+                .target = b.graph.host,
+                .strip = false,
+                .omit_frame_pointer = false,
+                .unwind_tables = .sync,
+            }),
         });
         deps.help_strings.addImport(webgen_config);
 

--- a/src/build/HelpStrings.zig
+++ b/src/build/HelpStrings.zig
@@ -12,8 +12,13 @@ output: std.Build.LazyPath,
 pub fn init(b: *std.Build, cfg: *const Config) !HelpStrings {
     const exe = b.addExecutable(.{
         .name = "helpgen",
-        .root_source_file = b.path("src/helpgen.zig"),
-        .target = b.graph.host,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/helpgen.zig"),
+            .target = b.graph.host,
+            .strip = false,
+            .omit_frame_pointer = false,
+            .unwind_tables = .sync,
+        }),
     });
 
     const help_config = config: {

--- a/src/build/UnicodeTables.zig
+++ b/src/build/UnicodeTables.zig
@@ -12,8 +12,13 @@ output: std.Build.LazyPath,
 pub fn init(b: *std.Build) !UnicodeTables {
     const exe = b.addExecutable(.{
         .name = "unigen",
-        .root_source_file = b.path("src/unicode/props.zig"),
-        .target = b.graph.host,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/unicode/props.zig"),
+            .target = b.graph.host,
+            .strip = false,
+            .omit_frame_pointer = false,
+            .unwind_tables = .sync,
+        }),
     });
 
     if (b.lazyDependency("ziglyph", .{


### PR DESCRIPTION
This fixes an issue where stack traces were unreliable on some platforms (namely aarch64-linux in a MacOS VM). I'm unsure if this is a bug in Zig (defaults should be changed?) or what, because this isn't necessary on other platforms, but this works around the issue.

I've unconditionally enabled this for all platforms, depending on build mode (debug/test) and not the target. This is because I don't think there is a downside for other platforms but if thats wrong we can fix that quickly.

Some binaries have this unconditionally enabled regardless of build mode (e.g. the Unicode tables generator) because having symbols in those cases is always useful.

Some unrelated GTK test fix is also included here. I'm not sure why CI didn't catch this (perhaps we only run tests for none-runtime) but all tests pass locally and we can look into that elsewhere.

I also updated all our build API calls to be non-deprecated fields.