### PR TITLE
flatpak: Add --device=all permission

### DIFF
--- a/flatpak/com.mitchellh.ghostty.Devel.yml
+++ b/flatpak/com.mitchellh.ghostty.Devel.yml
@@ -14,6 +14,8 @@ desktop-file-name-suffix: " (Devel)"
 finish-args:
   # 3D rendering
   - --device=dri
+  # use host PTS namespace
+  - --device=all
   # Windowing
   - --share=ipc
   - --socket=fallback-x11

--- a/flatpak/com.mitchellh.ghostty.yml
+++ b/flatpak/com.mitchellh.ghostty.yml
@@ -9,6 +9,8 @@ command: ghostty
 finish-args:
   # 3D rendering
   - --device=dri
+  # use host PTS namespace
+  - --device=all
   # Windowing
   - --share=ipc
   - --socket=fallback-x11


### PR DESCRIPTION
Without --device=all, the sandbox gets a dedicated PTY namespace. Commands run on the host via the HostCommand D-Bus interface receive the file descriptors from the namespaced PTY but cannot determine its path via ttyname(3). This breaks commands like tty(1), ps(1) and emacsclient(1).

Add --device=all so the host PTY namespace is used when allocating TTYs. Applications with access to org.freedesktop.Flatpak can already give themselves arbitrary permissions, so the sandboxing benefits of restricted device access are limited. For terminal emulators, the consistency provided by a cross-distribution runtime and ability to distribute directly to users is the primary benefit of shipping as a Flatpak rather than sandboxing.