### PR TITLE
ci: switch to Determinate Nix installer

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -41,10 +41,7 @@ jobs:
           path: |
             /nix
             /zig
-      - name: Setup Nix
-        uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -57,9 +57,7 @@ jobs:
           fetch-depth: 0
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty
@@ -209,9 +207,7 @@ jobs:
           fetch-depth: 0
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -89,9 +89,7 @@ jobs:
             /nix
             /zig
 
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
 
       - uses: cachix/cachix-action@v15
         with:
@@ -130,9 +128,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -112,9 +112,7 @@ jobs:
           path: |
             /nix
             /zig
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty
@@ -164,9 +162,7 @@ jobs:
           fetch-depth: 0
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty
@@ -379,9 +375,7 @@ jobs:
           fetch-depth: 0
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty
@@ -554,9 +548,7 @@ jobs:
           fetch-depth: 0
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,9 +74,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty
@@ -105,9 +103,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty
@@ -141,9 +137,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty
@@ -170,9 +164,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty
@@ -203,9 +195,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty
@@ -247,9 +237,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty
@@ -276,9 +264,7 @@ jobs:
         uses: actions/checkout@v4
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty
@@ -316,9 +302,7 @@ jobs:
         uses: actions/checkout@v4
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty
@@ -499,9 +483,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty
@@ -530,9 +512,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty
@@ -575,9 +555,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty
@@ -614,9 +592,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty
@@ -634,9 +610,7 @@ jobs:
         uses: actions/checkout@v4
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty
@@ -667,9 +641,7 @@ jobs:
           path: |
             /nix
             /zig
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty
@@ -694,9 +666,7 @@ jobs:
           path: |
             /nix
             /zig
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty
@@ -721,9 +691,7 @@ jobs:
           path: |
             /nix
             /zig
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty
@@ -748,9 +716,7 @@ jobs:
           path: |
             /nix
             /zig
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty
@@ -775,9 +741,7 @@ jobs:
           path: |
             /nix
             /zig
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty
@@ -802,9 +766,7 @@ jobs:
           path: |
             /nix
             /zig
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty
@@ -839,9 +801,7 @@ jobs:
             /zig
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty
@@ -895,10 +855,7 @@ jobs:
           path: |
             /nix
             /zig
-      - name: Setup Nix
-        uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty

--- a/.github/workflows/update-colorschemes.yml
+++ b/.github/workflows/update-colorschemes.yml
@@ -28,10 +28,7 @@ jobs:
             /nix
             /zig
 
-      - name: Setup Nix
-        uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/nix-installer-action@v17
       - uses: cachix/cachix-action@v15
         with:
           name: ghostty


### PR DESCRIPTION
In testing, it's slower but generally more reliable (the installer, not Nix). I've emailed Determinate with my concerns about speed and I hope they can address those. We are still using upstream Nix (not Determinate Nix), this just changes our installer.