### PR TITLE
PageList.zig: Allow a Pin's x to be a column or negative to allow full line select when mouse is dragging left of the terminal

### DIFF
--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1563,7 +1563,7 @@ fn gtkMouseMotion(
     const scaled = self.scaledCoordinates(x, y);
 
     const pos: apprt.CursorPos = .{
-        .x = @floatCast(@max(0, scaled.x)),
+        .x = @floatCast(scaled.x),
         .y = @floatCast(scaled.y),
     };
 

--- a/src/font/shaper/run.zig
+++ b/src/font/shaper/run.zig
@@ -89,8 +89,8 @@ pub const RunIterator = struct {
             if (self.selection) |unordered_sel| {
                 if (j > self.i) {
                     const sel = unordered_sel.ordered(self.screen, .forward);
-                    const start_x = sel.start().x;
-                    const end_x = sel.end().x;
+                    const start_x = sel.start().xInt();
+                    const end_x = sel.end().xInt();
 
                     if (start_x > 0 and
                         j == start_x) break;

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -1035,7 +1035,7 @@ fn prepKittyVirtualPlacement(
     try self.prepKittyImage(&image);
     try self.image_placements.append(self.alloc, .{
         .image_id = image.id,
-        .x = @intCast(rp.top_left.x),
+        .x = @intCast(rp.top_left.x.col),
         .y = @intCast(viewport.viewport.y),
         .z = -1,
         .width = rp.dest_width,
@@ -1097,7 +1097,7 @@ fn prepKittyPlacement(
     if (dest_size.width > 0 and dest_size.height > 0) {
         try self.image_placements.append(self.alloc, .{
             .image_id = image.id,
-            .x = @intCast(rect.top_left.x),
+            .x = @intCast(rect.top_left.x.col),
             .y = y_pos,
             .z = p.z,
             .width = dest_size.width,
@@ -1366,28 +1366,28 @@ pub fn rebuildCells(
                     // Try to read the cells from the shaping cache if we can.
                     self.font_shaper_cache.get(run) orelse
                     cache: {
-                        // Otherwise we have to shape them.
-                        const cells = try self.font_shaper.shape(run);
+                    // Otherwise we have to shape them.
+                    const cells = try self.font_shaper.shape(run);
 
-                        // Try to cache them. If caching fails for any reason we
-                        // continue because it is just a performance optimization,
-                        // not a correctness issue.
-                        self.font_shaper_cache.put(
-                            self.alloc,
-                            run,
-                            cells,
-                        ) catch |err| {
-                            log.warn(
-                                "error caching font shaping results err={}",
-                                .{err},
-                            );
-                        };
-
-                        // The cells we get from direct shaping are always owned
-                        // by the shaper and valid until the next shaping call so
-                        // we can safely use them.
-                        break :cache cells;
+                    // Try to cache them. If caching fails for any reason we
+                    // continue because it is just a performance optimization,
+                    // not a correctness issue.
+                    self.font_shaper_cache.put(
+                        self.alloc,
+                        run,
+                        cells,
+                    ) catch |err| {
+                        log.warn(
+                            "error caching font shaping results err={}",
+                            .{err},
+                        );
                     };
+
+                    // The cells we get from direct shaping are always owned
+                    // by the shaper and valid until the next shaping call so
+                    // we can safely use them.
+                    break :cache cells;
+                };
 
                 // Advance our index until we reach or pass
                 // our current x position in the shaper cells.
@@ -1402,7 +1402,7 @@ pub fn rebuildCells(
 
             const cell_pin: terminal.Pin = cell: {
                 var copy = row;
-                copy.x = @intCast(x);
+                copy.x = .{ .col = @intCast(x) };
                 break :cell copy;
             };
 
@@ -1411,14 +1411,16 @@ pub fn rebuildCells(
                 sel.contains(screen, .{
                     .node = row.node,
                     .y = row.y,
-                    .x = @intCast(
-                        // Spacer tails should show the selection
-                        // state of the wide cell they belong to.
-                        if (wide == .spacer_tail)
-                            x -| 1
-                        else
-                            x,
-                    ),
+                    .x = .{
+                        .col = @intCast(
+                            // Spacer tails should show the selection
+                            // state of the wide cell they belong to.
+                            if (wide == .spacer_tail)
+                                x -| 1
+                            else
+                                x,
+                        ),
+                    },
                 })
             else
                 false;
@@ -1611,28 +1613,28 @@ pub fn rebuildCells(
                     // Try to read the cells from the shaping cache if we can.
                     self.font_shaper_cache.get(run) orelse
                     cache: {
-                        // Otherwise we have to shape them.
-                        const cells = try self.font_shaper.shape(run);
+                    // Otherwise we have to shape them.
+                    const cells = try self.font_shaper.shape(run);
 
-                        // Try to cache them. If caching fails for any reason we
-                        // continue because it is just a performance optimization,
-                        // not a correctness issue.
-                        self.font_shaper_cache.put(
-                            self.alloc,
-                            run,
-                            cells,
-                        ) catch |err| {
-                            log.warn(
-                                "error caching font shaping results err={}",
-                                .{err},
-                            );
-                        };
-
-                        // The cells we get from direct shaping are always owned
-                        // by the shaper and valid until the next shaping call so
-                        // we can safely use them.
-                        break :cache cells;
+                    // Try to cache them. If caching fails for any reason we
+                    // continue because it is just a performance optimization,
+                    // not a correctness issue.
+                    self.font_shaper_cache.put(
+                        self.alloc,
+                        run,
+                        cells,
+                    ) catch |err| {
+                        log.warn(
+                            "error caching font shaping results err={}",
+                            .{err},
+                        );
                     };
+
+                    // The cells we get from direct shaping are always owned
+                    // by the shaper and valid until the next shaping call so
+                    // we can safely use them.
+                    break :cache cells;
+                };
 
                 const cells = shaper_cells orelse break :glyphs;
 

--- a/src/renderer/cell.zig
+++ b/src/renderer/cell.zig
@@ -70,16 +70,16 @@ pub fn fgMode(
             }
 
             // If we are at the end of the screen its definitely constrained
-            if (cell_pin.x == cell_pin.node.data.size.cols - 1) break :text .constrained;
+            if (cell_pin.xInt() == cell_pin.node.data.size.cols - 1) break :text .constrained;
 
             // If we have a previous cell and it was PUA then we need to
             // also constrain. This is so that multiple PUA glyphs align.
             // As an exception, we ignore powerline glyphs since they are
             // used for box drawing and we consider them whitespace.
-            if (cell_pin.x > 0) prev: {
+            if (cell_pin.xInt() > 0) prev: {
                 const prev_cp = prev_cp: {
                     var copy = cell_pin;
-                    copy.x -= 1;
+                    copy.x.col -= 1;
                     const prev_cell = copy.rowAndCell().cell;
                     break :prev_cp prev_cell.codepoint();
                 };
@@ -96,7 +96,7 @@ pub fn fgMode(
             // full glyph size.
             const next_cp = next_cp: {
                 var copy = cell_pin;
-                copy.x += 1;
+                copy.x = .{ .col = copy.xInt() + 1 };
                 const next_cell = copy.rowAndCell().cell;
                 break :next_cp next_cell.codepoint();
             };

--- a/src/terminal/Selection.zig
+++ b/src/terminal/Selection.zig
@@ -217,7 +217,7 @@ pub fn order(self: Selection, s: *const Screen) Order {
 
     if (start_pt.y < end_pt.y) return .forward;
     if (start_pt.y > end_pt.y) return .reverse;
-    if (start_pt.x <= end_pt.x) return .forward;
+    if (self.start().x.lessEq(self.end().x)) return .forward;
     return .reverse;
 }
 
@@ -266,13 +266,13 @@ pub fn contains(self: Selection, s: *const Screen, pin: Pin) bool {
     // If tl/br are same line
     if (tl.y == br.y) return p.y == tl.y and
         p.x >= tl.x and
-        p.x <= br.x;
+        pin.x.lessEq(br_pin.x);
 
     // If on top line, just has to be left of X
-    if (p.y == tl.y) return p.x >= tl.x;
+    if (p.y == tl.y) return tl_pin.x.lessEq(pin.x);
 
     // If on bottom line, just has to be right of X
-    if (p.y == br.y) return p.x <= br.x;
+    if (p.y == br.y) return pin.x.lessEq(br_pin.x);
 
     // If between the top/bottom, always good.
     return p.y > tl.y and p.y < br.y;
@@ -437,15 +437,15 @@ pub fn adjust(
                 const cells = next.node.data.getCells(rac.row);
                 if (page.Cell.hasTextAny(cells)) {
                     end_pin.* = next;
-                    end_pin.x = @intCast(cells.len - 1);
+                    end_pin.x = .{ .col = @intCast(cells.len - 1) };
                     break;
                 }
             }
         },
 
-        .beginning_of_line => end_pin.x = 0,
+        .beginning_of_line => end_pin.x = .{ .col = 0 },
 
-        .end_of_line => end_pin.x = end_pin.node.data.size.cols - 1,
+        .end_of_line => end_pin.x = .{ .col = end_pin.node.data.size.cols - 1 },
     }
 }
 

--- a/src/terminal/kitty/graphics_exec.zig
+++ b/src/terminal/kitty/graphics_exec.zig
@@ -272,7 +272,7 @@ fn display(
 
                 terminal.setCursorPos(
                     terminal.screen.cursor.y,
-                    pin.x + size.cols + 1,
+                    pin.x.col + size.cols + 1,
                 );
             },
         },

--- a/src/terminal/kitty/graphics_storage.zig
+++ b/src/terminal/kitty/graphics_storage.zig
@@ -331,7 +331,7 @@ pub const ImageStorage = struct {
                 while (it.next()) |entry| {
                     const img = self.imageById(entry.key_ptr.image_id) orelse continue;
                     const rect = entry.value_ptr.rect(img, t) orelse continue;
-                    if (rect.top_left.x <= x and rect.bottom_right.x >= x) {
+                    if (rect.top_left.x.col <= x and rect.bottom_right.x.col >= x) {
                         entry.value_ptr.deinit(&t.screen);
                         self.placements.removeByPtr(entry.key_ptr);
                         if (v.delete) self.deleteIfUnused(alloc, img.id);
@@ -790,13 +790,13 @@ pub const ImageStorage = struct {
                 .offset => |v| v,
                 .overflow => |v| v.end,
             };
-            br.x = @min(
+            br.x = .{ .col = @min(
                 // We need to sub one here because the x value is
                 // one width already. So if the image is width "1"
                 // then we add zero to X because X itself is width 1.
-                pin.x + (grid_size.cols - 1),
+                pin.x.col + (grid_size.cols - 1),
                 t.cols - 1,
-            );
+            ) };
 
             return .{
                 .top_left = pin.*,

--- a/src/terminal/kitty/graphics_unicode.zig
+++ b/src/terminal/kitty/graphics_unicode.zig
@@ -48,12 +48,12 @@ pub const PlacementIterator = struct {
 
             // Iterate over our remaining cells and find one with a placeholder.
             const cells = row.cells(.right);
-            for (cells, row.x..) |*cell, x| {
+            for (cells, row.xInt()..) |*cell, x| {
                 // "row" now points to the top-left pin of the placement.
                 // We need this temporary state to build our incomplete
                 // placement.
                 assert(@intFromPtr(row) == @intFromPtr(&self.row));
-                row.x = @intCast(x);
+                row.x = .{ .col = @intCast(x) };
 
                 // If this cell doesn't have the placeholder, then we
                 // complete the run if we have it otherwise we just move

--- a/src/terminal/search.zig
+++ b/src/terminal/search.zig
@@ -397,7 +397,7 @@ const SlidingWindow = struct {
             return .{
                 .node = meta.node,
                 .y = map.y,
-                .x = map.x,
+                .x = .{ .col = map.x },
             };
         }
 


### PR DESCRIPTION
I looked at a few ways to solve this problem. The core idea is that PageList.zig:Pin needs to be able to represent being off the left side of the terminal. Historically that's been impossible as the x coordinate is a u16 and an x value of 0 in the selection end means the character at column 0 is included in the selection.

Alternatives considered:
- Change Pin.x to signed int. A value in the 40,000 range was required to fit into the x value somewhere in the code base, so that would mean i32 could be a decent type to choose. However, this led to many casts when converting to/from or comparing to u16.
- Shift the meaning of Pin.x by 1, so that 0 means off the left side, 1 means the first column is included, etc. This results in a lot of "+ 1" being added to the code, which seems error prone.

The approach taken was to change x to a tagged union, either a column which is u16 as before, with (mostly) all the same behavior as before, or it's a void type indicating it's negative, meaning off to the left.

The vast majority of the change is mechanically changing code to handle this type change without having a behavior change, other than the intended one.

Fixes https://github.com/ghostty-org/ghostty/discussions/5058

Feedback welcome! Thank you to the amazing devs here!