### PR TITLE
gtk: improve app id validation

### DIFF
--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -288,7 +288,7 @@ pub fn init(core_app: *CoreApp, opts: Options) !App {
     // can develop Ghostty in Ghostty.
     const app_id: [:0]const u8 = app_id: {
         if (config.class) |class| {
-            if (isValidAppId(class)) {
+            if (gio.Application.idIsValid(class) != 0) {
                 break :app_id class;
             } else {
                 log.warn("invalid 'class' in config, ignoring", .{});
@@ -1687,36 +1687,4 @@ fn initActions(self: *App) void {
         const action_map = self.app.as(gio.ActionMap);
         action_map.addAction(action.as(gio.Action));
     }
-}
-
-fn isValidAppId(app_id: [:0]const u8) bool {
-    if (app_id.len > 255) return false;
-
-    var hasSep = false;
-    var lastWasSep = true;
-    for (app_id) |char| {
-        switch (char) {
-            'a'...'z', 'A'...'Z', '_', '-' => {},
-            '0'...'9', '.' => if (lastWasSep) return false,
-            else => return false,
-        }
-        lastWasSep = char == '.';
-        hasSep = hasSep or lastWasSep;
-    }
-    return hasSep and !lastWasSep;
-}
-
-test "isValidAppId" {
-    try testing.expect(isValidAppId("foo.bar"));
-    try testing.expect(isValidAppId("foo.bar.baz"));
-    try testing.expect(isValidAppId("f00.bar"));
-    try testing.expect(isValidAppId("foo-bar._baz"));
-    try testing.expect(!isValidAppId("foo"));
-    try testing.expect(!isValidAppId("foo.bar?"));
-    try testing.expect(!isValidAppId("foo."));
-    try testing.expect(!isValidAppId(".foo"));
-    try testing.expect(!isValidAppId(""));
-    try testing.expect(!isValidAppId("foo" ** 86));
-    try testing.expect(!isValidAppId("foo..bar"));
-    try testing.expect(!isValidAppId("0foo.bar"));
 }

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -1690,30 +1690,33 @@ fn initActions(self: *App) void {
 }
 
 fn isValidAppId(app_id: [:0]const u8) bool {
-    if (app_id.len > 255 or app_id.len == 0) return false;
-    if (app_id[0] == '.') return false;
-    if (app_id[app_id.len - 1] == '.') return false;
+    if (app_id.len > 255) return false;
 
-    var hasDot = false;
+    var hasSep = false;
+    var lastWasSep = true;
     for (app_id) |char| {
         switch (char) {
-            'a'...'z', 'A'...'Z', '0'...'9', '_', '-' => {},
-            '.' => hasDot = true,
+            'a'...'z', 'A'...'Z', '_', '-' => {},
+            '0'...'9', '.' => if (lastWasSep) return false,
             else => return false,
         }
+        lastWasSep = char == '.';
+        hasSep = hasSep or lastWasSep;
     }
-    if (!hasDot) return false;
-
-    return true;
+    return hasSep and !lastWasSep;
 }
 
 test "isValidAppId" {
     try testing.expect(isValidAppId("foo.bar"));
     try testing.expect(isValidAppId("foo.bar.baz"));
+    try testing.expect(isValidAppId("f00.bar"));
+    try testing.expect(isValidAppId("foo-bar._baz"));
     try testing.expect(!isValidAppId("foo"));
     try testing.expect(!isValidAppId("foo.bar?"));
     try testing.expect(!isValidAppId("foo."));
     try testing.expect(!isValidAppId(".foo"));
     try testing.expect(!isValidAppId(""));
     try testing.expect(!isValidAppId("foo" ** 86));
+    try testing.expect(!isValidAppId("foo..bar"));
+    try testing.expect(!isValidAppId("0foo.bar"));
 }


### PR DESCRIPTION
'g_application_id_is_valid' doesn't allow empty elements or elements that start with digits.
This commit updates 'isValidAppId' to be more consistant with 'g_application_id_is_valid' avoiding the app id defaulting to 'GTK Application' for app ids like '0foo.bar' or 'foo..bar'.