### PR TITLE
Add support for buffer switching with CSI ? 47 h/l

### DIFF
--- a/src/terminal/modes.zig
+++ b/src/terminal/modes.zig
@@ -206,6 +206,7 @@ const entries: []const ModeEntry = &.{
     .{ .name = "cursor_visible", .value = 25, .default = true },
     .{ .name = "enable_mode_3", .value = 40 },
     .{ .name = "reverse_wrap", .value = 45 },
+    .{ .name = "alt_screen_legacy", .value = 47 },
     .{ .name = "keypad_keys", .value = 66 },
     .{ .name = "enable_left_and_right_margin", .value = 69 },
     .{ .name = "mouse_event_normal", .value = 1000 },

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -582,6 +582,16 @@ pub const StreamHandler = struct {
                 self.terminal.scrolling_region.right = self.terminal.cols - 1;
             },
 
+            .alt_screen_legacy => {
+                if (enabled)
+                    self.terminal.alternateScreen(.{})
+                else
+                    self.terminal.primaryScreen(.{});
+
+                // Schedule a render since we changed screens
+                try self.queueRender();
+            },
+
             .alt_screen => {
                 const opts: terminal.Terminal.AlternateScreenOptions = .{
                     .cursor_save = false,


### PR DESCRIPTION
This PR adds support for handling the escape sequences CSI ? 47 h/l, which are related to alternate screen buffer switching. This is in response to the issue reported in [ghostty-org/ghostty#7386](https://github.com/ghostty-org/ghostty/issues/7386).

I'm unsure where to add tests for this change. Would it make sense to add visual tests for this behavior, or is there a preferred approach or location for testing such functionality? I tested it locally using the following commands:
```bash
echo -e "\e[?47h"
echo "Printed on the alt screen"
echo -e "\e[?47l"
```