### PR TITLE
Rework mouse selection logic

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3827,7 +3827,7 @@ fn mouseSelection(
     // TODO: Clamp selection to the screen area, don't
     //       let it extend past the last written row.
 
-    return terminal.Selection.init(
+    return .init(
         start_pin,
         end_pin,
         rectangle_selection,

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -1563,7 +1563,7 @@ fn gtkMouseMotion(
     const scaled = self.scaledCoordinates(x, y);
 
     const pos: apprt.CursorPos = .{
-        .x = @floatCast(@max(0, scaled.x)),
+        .x = @floatCast(scaled.x),
         .y = @floatCast(scaled.y),
     };
 

--- a/src/terminal/point.zig
+++ b/src/terminal/point.zig
@@ -3,10 +3,12 @@ const Allocator = std.mem.Allocator;
 const assert = std.debug.assert;
 const size = @import("size.zig");
 
-/// The possible reference locations for a point. When someone says "(42, 80)" in the context of a terminal, that could mean multiple
-/// things: it is in the current visible viewport? the current active
-/// area of the screen where the cursor is? the entire scrollback history?
-/// etc. This tag is used to differentiate those cases.
+/// The possible reference locations for a point. When someone says "(42, 80)"
+/// in the context of a terminal, that could mean multiple things: it is in the
+/// current visible viewport? the current active area of the screen where the
+/// cursor is? the entire scrollback history? etc.
+///
+/// This tag is used to differentiate those cases.
 pub const Tag = enum {
     /// Top-left is part of the active area where a running program can
     /// jump the cursor and make changes. The active area is the "editable"


### PR DESCRIPTION
This PR fixes the problem discussed in #5058 and #7434 by reworking the selection logic in a way that better handles edge cases as well as being generally cleaner.

This rework does change how selection behaves slightly, especially rectangular selection, but the new behavior of rectangular selection is more in line with other terminals I tested (Terminal.app, Kitty).

There are some TODO comments for adding unit tests- I ran out of steam tonight, but if this PR is still open tomorrow I'll go ahead and add them.