### PR TITLE
Correct `$XDG_CONFIG_DIR` to `$XDG_CONFIG_HOME`

### DIFF
--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -77,7 +77,7 @@ const ThemeListElement = struct {
 /// Two different directories will be searched for themes.
 ///
 /// The first directory is the `themes` subdirectory of your Ghostty
-/// configuration directory. This is `$XDG_CONFIG_DIR/ghostty/themes` or
+/// configuration directory. This is `$XDG_CONFIG_HOME/ghostty/themes` or
 /// `~/.config/ghostty/themes`.
 ///
 /// The second directory is the `themes` subdirectory of the Ghostty resources

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -410,7 +410,7 @@ pub const renamed = std.StaticStringMap([]const u8).initComptime(&.{
 /// include path separators unless it is an absolute pathname.
 ///
 /// The first directory is the `themes` subdirectory of your Ghostty
-/// configuration directory. This is `$XDG_CONFIG_DIR/ghostty/themes` or
+/// configuration directory. This is `$XDG_CONFIG_HOME/ghostty/themes` or
 /// `~/.config/ghostty/themes`.
 ///
 /// The second directory is the `themes` subdirectory of the Ghostty resources


### PR DESCRIPTION
Ghostty doesn't support `$XDG_CONFIG_DIR`, it only supports `$XDG_CONFIG_HOME`, so the documentation was incorrect.  Not to be confused with `$XDG_CONFIG_DIRS` nor `$XDG_RUNTIME_DIR` (very consistent…).

Furthermore, `$XDG_CONFIG_HOME` is the correct XDG path:

> <ins>$XDG_CONFIG_HOME</ins> defines the base directory relative to which user-specific configuration files should be stored. If <ins>$XDG_CONFIG_HOME</ins> is either not set or empty, a default equal to <ins>$HOME</ins>/.config should be used.
> […]
> <ins>$XDG_CONFIG_DIRS</ins> defines the preference-ordered set of base directories to search for configuration files in addition to the <ins>$XDG_CONFIG_HOME</ins> base directory. The directories in <ins>$XDG_CONFIG_DIRS</ins> should be separated with a colon ':'.

— [XDG Base Directory Specification § Environment variables][xdgvars]

Cross-reference: https://github.com/ghostty-org/ghostty/discussions/7431#discussioncomment-13283139.

[xdgvars]: https://specifications.freedesktop.org/basedir-spec/latest#variables