### PR TITLE
code style: use `@splat` where possible

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -160,7 +160,7 @@ pub const InputEffect = enum {
 /// Mouse state for the surface.
 const Mouse = struct {
     /// The last tracked mouse button state by button.
-    click_state: [input.MouseButton.max]input.MouseButtonState = .{.release} ** input.MouseButton.max,
+    click_state: [input.MouseButton.max]input.MouseButtonState = @splat(.release),
 
     /// The last mods state when the last mouse button (whatever it was) was
     /// pressed or release.

--- a/src/datastruct/cache_table.zig
+++ b/src/datastruct/cache_table.zig
@@ -70,7 +70,7 @@ pub fn CacheTable(
         /// become a pointless check, but hopefully branch prediction picks
         /// up on it at that point. The memory cost isn't too bad since it's
         /// just bytes, so should be a fraction the size of the main table.
-        lengths: [bucket_count]u8 = [_]u8{0} ** bucket_count,
+        lengths: [bucket_count]u8 = @splat(0),
 
         /// An instance of the context structure.
         /// Must be initialized before calling any operations.

--- a/src/font/SharedGridSet.zig
+++ b/src/font/SharedGridSet.zig
@@ -498,7 +498,7 @@ pub const Key = struct {
     /// each style. For example, bold is from
     /// offsets[@intFromEnum(.bold) - 1] to
     /// offsets[@intFromEnum(.bold)].
-    style_offsets: StyleOffsets = .{0} ** style_offsets_len,
+    style_offsets: StyleOffsets = @splat(0),
 
     /// The codepoint map configuration.
     codepoint_map: CodepointMap = .{},

--- a/src/font/sprite/Box.zig
+++ b/src/font/sprite/Box.zig
@@ -2517,7 +2517,7 @@ fn draw_octant(self: Box, canvas: *font.sprite.Canvas, cp: u32) void {
     const octants: [octants_len]Octant = comptime octants: {
         @setEvalBranchQuota(10_000);
 
-        var result: [octants_len]Octant = .{Octant{}} ** octants_len;
+        var result: [octants_len]Octant = @splat(.{});
         var i: usize = 0;
 
         const data = @embedFile("octants.txt");

--- a/src/terminal/Tabstops.zig
+++ b/src/terminal/Tabstops.zig
@@ -44,7 +44,7 @@ const masks = blk: {
 cols: usize = 0,
 
 /// Preallocated tab stops.
-prealloc_stops: [prealloc_count]Unit = [1]Unit{0} ** prealloc_count,
+prealloc_stops: [prealloc_count]Unit = @splat(0),
 
 /// Dynamically expanded stops above prealloc stops.
 dynamic_stops: []Unit = &[0]Unit{},

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -2329,7 +2329,7 @@ pub fn printAttributes(self: *Terminal, buf: []u8) ![]const u8 {
     try writer.writeByte('0');
 
     const pen = self.screen.cursor.style;
-    var attrs = [_]u8{0} ** 8;
+    var attrs: [8]u8 = @splat(0);
     var i: usize = 0;
 
     if (pen.flags.bold) {

--- a/src/terminal/kitty/key.zig
+++ b/src/terminal/kitty/key.zig
@@ -8,7 +8,7 @@ const std = @import("std");
 pub const FlagStack = struct {
     const len = 8;
 
-    flags: [len]Flags = .{Flags{}} ** len,
+    flags: [len]Flags = @splat(.{}),
     idx: u3 = 0,
 
     /// Return the current stack value
@@ -51,7 +51,7 @@ pub const FlagStack = struct {
         // could send a huge number of pop commands to waste cpu.
         if (n >= self.flags.len) {
             self.idx = 0;
-            self.flags = .{Flags{}} ** len;
+            self.flags = @splat(.{});
             return;
         }
 

--- a/src/terminal/ref_counted_set.zig
+++ b/src/terminal/ref_counted_set.zig
@@ -115,7 +115,7 @@ pub fn RefCountedSet(
         /// input. We handle this gracefully by returning an error
         /// anywhere where we're about to insert if there's any
         /// item with a PSL in the last slot of the stats array.
-        psl_stats: [32]Id = [_]Id{0} ** 32,
+        psl_stats: [32]Id = @splat(0),
 
         /// The backing store of items
         items: Offset(Item),
@@ -663,7 +663,7 @@ pub fn RefCountedSet(
                 const table = self.table.ptr(base);
                 const items = self.items.ptr(base);
 
-                var psl_stats: [32]Id = [_]Id{0} ** 32;
+                var psl_stats: [32]Id = @splat(0);
 
                 for (items[0..self.layout.cap], 0..) |item, id| {
                     if (item.meta.bucket < std.math.maxInt(Id)) {
@@ -676,7 +676,7 @@ pub fn RefCountedSet(
 
                 assert(std.mem.eql(Id, &psl_stats, &self.psl_stats));
 
-                psl_stats = [_]Id{0} ** 32;
+                psl_stats = @splat(0);
 
                 for (table[0..self.layout.table_cap], 0..) |id, bucket| {
                     const item = items[id];

--- a/src/terminfo/Source.zig
+++ b/src/terminfo/Source.zig
@@ -74,7 +74,7 @@ pub fn xtgettcapMap(comptime self: Source) std.StaticStringMap([]const u8) {
     // We have all of our capabilities plus To, TN, and RGB which aren't
     // in the capabilities list but are query-able.
     const len = self.capabilities.len + 3;
-    var kvs: [len]KV = .{.{ "", "" }} ** len;
+    var kvs: [len]KV = @splat(.{ "", "" });
 
     // We first build all of our entries with raw K=V pairs.
     kvs[0] = .{ "TN", self.names[0] };


### PR DESCRIPTION
As of Zig 0.14.0, `@splat` can be used for array types, which eliminates a lot of redundant syntax and makes things generally cleaner.

I've explicitly avoided applying this change in the renderer files for now since it would just create rebasing conflicts in my renderer rework branch which I'll be PR-ing pretty soon.