### PR TITLE
fix: properly intialize key event in GlobalEventTap

### DIFF
--- a/macos/Sources/Features/Global Keybinds/GlobalEventTap.swift
+++ b/macos/Sources/Features/Global Keybinds/GlobalEventTap.swift
@@ -141,12 +141,7 @@ fileprivate func cgEventFlagsChangedHandler(
     guard let event: NSEvent = .init(cgEvent: cgEvent) else { return result }
 
     // Build our event input and call ghostty
-    var key_ev = ghostty_input_key_s()
-    key_ev.action = GHOSTTY_ACTION_PRESS
-    key_ev.mods = Ghostty.ghosttyMods(event.modifierFlags)
-    key_ev.keycode = UInt32(event.keyCode)
-    key_ev.text = nil
-    key_ev.composing = false
+    var key_ev = event.ghosttyKeyEvent(GHOSTTY_ACTION_PRESS)
     if (ghostty_app_key(ghostty, key_ev)) {
         GlobalEventTap.logger.info("global key event handled event=\(event)")
         return nil


### PR DESCRIPTION
Fixes #7215. The issue was that `GlobalEventTap` didn't fully initialize the key event before passing it to `ghostty_app_key`. In particular, it didn't set the `unshifted_codepoint` field, which is needed to find a match when calling `keybind.set.getEvent`, because `keybind.set` stores bindings by codepoint, not physical key (i.e., the trigger to match is `ctrl+p`, not `ctrl+key_p`, et cetera).

The fix was to make `GlobalEventTap` initialize the key event using `event.ghosttyKeyEvent`, like it's done in `SurfaceView.keyAction` and `AppDelegate.localEventKeyDown`.

This is my first time touching either Zig or Swift, so I'm a bit green. In particular, I don't know if it's possible to write a test covering this, and if so, how and where to put it. Please edit or request changes as you see fit.