### PR TITLE
input: "ignore" binding action are still be processed by the OS/GUI

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2069,12 +2069,18 @@ fn maybeHandleBinding(
         break :performed try self.performBindingAction(action);
     };
 
-    // If we performed an action and it was a closing action,
-    // our "self" pointer is not safe to use anymore so we need to
-    // just exit immediately.
-    if (performed and closingAction(action)) {
-        log.debug("key binding is a closing binding, halting key event processing", .{});
-        return .closed;
+    if (performed) {
+        // If we performed an action and it was a closing action,
+        // our "self" pointer is not safe to use anymore so we need to
+        // just exit immediately.
+        if (closingAction(action)) {
+            log.debug("key binding is a closing binding, halting key event processing", .{});
+            return .closed;
+        }
+
+        // If our action was "ignore" then we return the special input
+        // effect of "ignored".
+        if (action == .ignore) return .ignored;
     }
 
     // If we have the performable flag and the action was not performed,

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -222,13 +222,20 @@ pub fn lessThan(_: void, lhs: Binding, rhs: Binding) bool {
 
 /// The set of actions that a keybinding can take.
 pub const Action = union(enum) {
-    /// Ignore this key combination, don't send it to the child process, just
-    /// black hole it.
+    /// Ignore this key combination, don't send it to the child process,
+    /// pretend that it never happened at the Ghostty level. The key
+    /// combination may still be processed by the OS or other
+    /// applications.
     ignore,
 
     /// This action is used to flag that the binding should be removed from
     /// the set. This should never exist in an active set and `set.put` has an
     /// assertion to verify this.
+    ///
+    /// This is only able to unbind bindings that were previously
+    /// bound to Ghostty. This cannot unbind bindings that were not
+    /// bound by Ghostty (e.g. bindings set by the OS or some other
+    /// application).
     unbind,
 
     /// Send a CSI sequence. The value should be the CSI sequence without the


### PR DESCRIPTION
Related to #7468

This changes the behavior of "ignore". Previously, Ghostty would consider "ignore" actions consumed but do nothing. They were like a black hole. Now, Ghostty returns `ignored` which lets the apprt forward the event to the OS/GUI.

This enables keys that would otherwise be pty-encoded to be processed later, such as for GTK to show the GTK inspector.