### PR TITLE
macos: quick terminal can equalize splits

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -124,6 +124,11 @@ class BaseTerminalController: NSWindowController,
             selector: #selector(ghosttyMaximizeDidToggle(_:)),
             name: .ghosttyMaximizeDidToggle,
             object: nil)
+        center.addObserver(
+            self,
+            selector: #selector(ghosttyDidEqualizeSplits(_:)),
+            name: Ghostty.Notification.didEqualizeSplits,
+            object: nil)
 
         // Listen for local events that we need to know of outside of
         // single surface handlers.
@@ -248,6 +253,17 @@ class BaseTerminalController: NSWindowController,
         guard let surfaceView = notification.object as? Ghostty.SurfaceView else { return }
         guard surfaceTree?.contains(view: surfaceView) ?? false else { return }
         window.zoom(nil)
+    }
+    
+    @objc private func ghosttyDidEqualizeSplits(_ notification: Notification) {
+        guard let target = notification.object as? Ghostty.SurfaceView else { return }
+        
+        // Check if target surface is in current controller's tree
+        guard surfaceTree?.contains(view: target) ?? false else { return }
+        
+        if case .split(let container) = surfaceTree {
+            _ = container.equalize()
+        }
     }
 
     // MARK: Local Events

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -87,12 +87,6 @@ class TerminalController: BaseTerminalController {
             object: nil)
         center.addObserver(
             self,
-            selector: #selector(onEqualizeSplits),
-            name: Ghostty.Notification.didEqualizeSplits,
-            object: nil
-        )
-        center.addObserver(
-            self,
             selector: #selector(onCloseWindow),
             name: .ghosttyCloseWindow,
             object: nil
@@ -875,16 +869,6 @@ class TerminalController: BaseTerminalController {
         toggleFullscreen(mode: fullscreenMode)
     }
 
-    @objc private func onEqualizeSplits(_ notification: Notification) {
-        guard let target = notification.object as? Ghostty.SurfaceView else { return }
-
-        // Check if target surface is in current controller's tree
-        guard surfaceTree?.contains(view: target) ?? false else { return }
-
-        if case .split(let container) = surfaceTree {
-            _ = container.equalize()
-        }
-    }
 
     struct DerivedConfig {
         let backgroundColor: Color


### PR DESCRIPTION
Fixes #7480

I regret to inform the haters that an AI agent did this while I was out getting a coffee. I only had to follow up once to ask it rename the method to be more idiomatic. I absolutely didn't need AI to do this, but I was leaving the office _anyways_ and figured why not. Got back and it was done. What a time to be alive.