### PR TITLE
Follow-up to #7462: `var` -> `let`

### DIFF
--- a/macos/Sources/Features/Global Keybinds/GlobalEventTap.swift
+++ b/macos/Sources/Features/Global Keybinds/GlobalEventTap.swift
@@ -141,7 +141,7 @@ fileprivate func cgEventFlagsChangedHandler(
     guard let event: NSEvent = .init(cgEvent: cgEvent) else { return result }
 
     // Build our event input and call ghostty
-    var key_ev = event.ghosttyKeyEvent(GHOSTTY_ACTION_PRESS)
+    let key_ev = event.ghosttyKeyEvent(GHOSTTY_ACTION_PRESS)
     if (ghostty_app_key(ghostty, key_ev)) {
         GlobalEventTap.logger.info("global key event handled event=\(event)")
         return nil


### PR DESCRIPTION
Just a quick follow-up to #7462: I noticed Swift was admonishing me about a `var` that could be a `let`, and realized that it was I who had failed to make that change. Apologies for the noise.