### PR TITLE
macos: simplify some ServiceProvider code

### DIFF
--- a/macos/Sources/Features/Services/ServiceProvider.swift
+++ b/macos/Sources/Features/Services/ServiceProvider.swift
@@ -5,7 +5,7 @@ class ServiceProvider: NSObject {
     static private let errorNoString = NSString(string: "Could not load any text from the clipboard.")
 
     /// The target for an open operation
-    enum OpenTarget {
+    private enum OpenTarget {
         case tab
         case window
     }
@@ -15,7 +15,7 @@ class ServiceProvider: NSObject {
         userData: String?,
         error: AutoreleasingUnsafeMutablePointer<NSString>
     ) {
-        openTerminalFromPasteboard(pasteboard: pasteboard, target: .tab, error: error)
+        openTerminal(from: pasteboard, target: .tab, error: error)
     }
 
     @objc func openWindow(
@@ -23,40 +23,33 @@ class ServiceProvider: NSObject {
         userData: String?,
         error: AutoreleasingUnsafeMutablePointer<NSString>
     ) {
-        openTerminalFromPasteboard(pasteboard: pasteboard, target: .window, error: error)
+        openTerminal(from: pasteboard, target: .window, error: error)
     }
 
-    @inline(__always)
-    private func openTerminalFromPasteboard(
-        pasteboard: NSPasteboard,
+    private func openTerminal(
+        from pasteboard: NSPasteboard,
         target: OpenTarget,
         error: AutoreleasingUnsafeMutablePointer<NSString>
     ) {
-        guard let objs = pasteboard.readObjects(forClasses: [NSURL.self]) as? [NSURL] else {
+        guard let delegate = NSApp.delegate as? AppDelegate else { return }
+        let terminalManager = delegate.terminalManager
+
+        guard let pathURLs = pasteboard.readObjects(forClasses: [NSURL.self]) as? [URL] else {
             error.pointee = Self.errorNoString
             return
         }
-        let urlObjects = objs.map { $0 as URL }
 
-        openTerminal(urlObjects, target: target)
-    }
-
-    private func openTerminal(_ urls: [URL], target: OpenTarget) {
-        guard let delegateRaw = NSApp.delegate else { return }
-        guard let delegate = delegateRaw as? AppDelegate else { return }
-        let terminalManager = delegate.terminalManager
-
-        let uniqueCwds: Set<URL> = Set(
-            urls.map { url -> URL in
-                // We only open in directories.
+        // Build a set of unique directory URLs to open. File paths are truncated
+        // to their directories because that's the only thing we can open.
+        let directoryURLs = Set(
+            pathURLs.map { url -> URL in
                 url.hasDirectoryPath ? url : url.deletingLastPathComponent()
             }
         )
 
-        for cwd in uniqueCwds {
-            // Build our config
+        for url in directoryURLs {
             var config = Ghostty.SurfaceConfiguration()
-            config.workingDirectory = cwd.path(percentEncoded: false)
+            config.workingDirectory = url.path(percentEncoded: false)
 
             switch (target) {
             case .window:


### PR DESCRIPTION
First, remove the always-inlined openTerminalFromPasteboard code and combine it with openTerminal. Now that we're doing a bit of work inside openTerminal, there's little better to having an intermediate, inlined function.

Second, combine some type-casting operations (saving a .map() call).

Lastly, adjust some variable names because a generic `objs` or `urls` was a little ambiguous now that we're all in one function scope.