### PR TITLE
gtk/GlobalShortcuts: don't request session with no shortcuts

### DIFF
--- a/src/apprt/gtk/GlobalShortcuts.zig
+++ b/src/apprt/gtk/GlobalShortcuts.zig
@@ -117,7 +117,9 @@ pub fn refreshSession(self: *GlobalShortcuts, app: *App) !void {
         );
     }
 
-    try self.request(.create_session);
+    if (self.map.count() > 0) {
+        try self.request(.create_session);
+    }
 }
 
 fn shortcutActivated(


### PR DESCRIPTION
There aren't any reasons to pay the D-Bus tax if you don't use global shortcuts.

Fixes https://github.com/ghostty-org/ghostty/discussions/7509