### PR TITLE
flatpak: rename .Devel variant to .ghostty-debug

### DIFF
--- a/flatpak/com.mitchellh.ghostty-debug.yml
+++ b/flatpak/com.mitchellh.ghostty-debug.yml
@@ -1,4 +1,4 @@
-app-id: com.mitchellh.ghostty.Devel
+app-id: com.mitchellh.ghostty-debug
 runtime: org.gnome.Platform
 runtime-version: "48"
 sdk: org.gnome.Sdk
@@ -10,7 +10,7 @@ command: ghostty
 rename-desktop-file: com.mitchellh.ghostty.desktop
 rename-appdata-file: com.mitchellh.ghostty.metainfo.xml
 rename-icon: com.mitchellh.ghostty
-desktop-file-name-suffix: " (Devel)"
+desktop-file-name-suffix: " (Debug)"
 finish-args:
   # 3D rendering
   - --device=dri


### PR DESCRIPTION
This is done to match against the default application id when Ghostty is built using debug configuration, preparing the Flatpak version for D-Bus activation support (#7433).