### PR TITLE
macos: fix hasWindowButtons logic (#7504 follow-up)

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/TerminalWindow.swift
@@ -45,15 +45,14 @@ class TerminalWindow: NSWindow {
         },
     ]
 
+    // false if all three traffic lights are missing/hidden, otherwise true
     private var hasWindowButtons: Bool {
         get {
-            if let close = standardWindowButton(.closeButton),
-                  let miniaturize = standardWindowButton(.miniaturizeButton),
-                  let zoom = standardWindowButton(.zoomButton) {
-                return !(close.isHidden && miniaturize.isHidden && zoom.isHidden)
-            } else {
-                return false
-            }
+            // if standardWindowButton(.theButton) == nil, the button isn't there, so coalesce to true
+            let closeIsHidden = standardWindowButton(.closeButton)?.isHiddenOrHasHiddenAncestor ?? true
+            let miniaturizeIsHidden = standardWindowButton(.miniaturizeButton)?.isHiddenOrHasHiddenAncestor ?? true
+            let zoomIsHidden = standardWindowButton(.zoomButton)?.isHiddenOrHasHiddenAncestor ?? true
+            return !(closeIsHidden && miniaturizeIsHidden && zoomIsHidden)
         }
     }
 
@@ -78,7 +77,7 @@ class TerminalWindow: NSWindow {
 		if titlebarTabs {
 			generateToolbar()
 		}
-        
+
         level = UserDefaults.standard.value(forKey: Self.defaultLevelKey) as? NSWindow.Level ?? .normal
     }
 


### PR DESCRIPTION
Took another look through #7504 after the merge and realized that the logic behind the `hasWindowButtons` property wasn't quite sound. It would return `false` if either _at least one_ button were missing in the `standardWindowButton(.theButton) == nil` sense, or if _all_ buttons were hidden in the `isHidden` sense.

With this PR, the logic is rectified: `false` if _all_ buttons are missing or hidden in any sense, otherwise `true`.

In practice, I suppose Ghostty won't ever instantiate a `TerminalWindow` where `standardWindowButton(.theButton) == nil`, but might as well get it right and sleep better at night.