### PR TITLE
macos: dismiss notifications on focus, application exit

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -316,6 +316,13 @@ class AppDelegate: NSObject,
         }
     }
 
+    func applicationWillTerminate(_ notification: Notification) {
+        // We have no notifications we want to persist after death,
+        // so remove them all now. In the future we may want to be
+        // more selective and only remove surface-targeted notifications.
+        UNUserNotificationCenter.current().removeAllDeliveredNotifications()
+    }
+
     /// This is called when the application is already open and someone double-clicks the icon
     /// or clicks the dock icon.
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {


### PR DESCRIPTION
I've only recently been using programs that use user notifications heavily and this commit addresses a number of annoyances I've encountered.

  1. Notifications dispatched while the source terminal surface is focused are now only shown for a short time (3 seconds hardcoded) and then automatically dismiss.

  2. Notifications are dismissed when the target surface becomes focused from an unfocused state. This dismissal happens immediately (no delay).

  3. Notifications are dismissed when the application exits.

  4. This fixes a bug where notification callbacks were modifying view
     state, but the notification center doesn't guarantee that the
     callback is called on the main thread. We now ensure that
     the callback is always called on the main thread.