### PR TITLE
terminal: fix crash when reflowing grapheme with a spacer head

### DIFF
--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -1316,7 +1316,12 @@ pub const Page = struct {
 
     /// Set the graphemes for the given cell. This asserts that the cell
     /// has no graphemes set, and only contains a single codepoint.
-    pub fn setGraphemes(self: *Page, row: *Row, cell: *Cell, cps: []u21) GraphemeError!void {
+    pub fn setGraphemes(
+        self: *Page,
+        row: *Row,
+        cell: *Cell,
+        cps: []const u21,
+    ) GraphemeError!void {
         defer self.assertIntegrity();
 
         assert(cell.codepoint() > 0);


### PR DESCRIPTION
Fixes #7536

When we're reflowing a row and we need to insert a spacer head, we must move to the next row to insert it. Previously, we were setting a spacer head and then copying data into that spacer head, which could lead to corrupt data and an eventual crash.

In debug builds this triggers assertion failures but in release builds this would lead to silent corruption and a crash later on.

The unit test shows the issue clearly but effectively you need a multi-codepoint grapheme such as `👨‍👨‍👦‍👦` to wrap across a row by changing the columns.