### PR TITLE
macos: add id to SplitTreeView to detect tree structural changes

### DIFF
--- a/macos/Sources/Features/Splits/TerminalSplitTreeView.swift
+++ b/macos/Sources/Features/Splits/TerminalSplitTreeView.swift
@@ -10,6 +10,11 @@ struct TerminalSplitTreeView: View {
                 node: node,
                 isRoot: node == tree.root,
                 onResize: onResize)
+            // This is necessary because we can't rely on SwiftUI's implicit
+            // structural identity to detect changes to this view. Due to
+            // the tree structure of splits it could result in bad beaviors.
+            // See: https://github.com/ghostty-org/ghostty/issues/7546
+            .id(node.structuralIdentity)
         }
     }
 }


### PR DESCRIPTION
Fixes #7546

The comments explain what was going on here.