### PR TITLE
fix: copy_url_to_clipboard copies full OSC8 URL instead of single cha…

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3712,17 +3712,18 @@ fn linkAtPos(
     for (self.config.links) |link| {
         switch (link.highlight) {
             .always, .hover => {},
-            .always_mods, .hover_mods => |v| {
-                // Special case: if the expected mods are "ctrl or super" (like the default URL config),
-                // then we should match if the user pressed either ctrl or super, just like OSC8 links.
-                const is_ctrl_or_super_expected = (v.ctrl and !v.super and !v.shift and !v.alt) or
-                    (v.super and !v.ctrl and !v.shift and !v.alt);
-                if (is_ctrl_or_super_expected) {
-                    if (!(mouse_mods.ctrl or mouse_mods.super)) continue;
-                } else {
-                    if (!v.equal(mouse_mods)) continue;
-                }
-            },
+            .always_mods, .hover_mods => |v| if (!v.equal(mouse_mods)) continue,
+            // .always_mods, .hover_mods => |_| {
+            //     // Special case: if the expected mods are "ctrl or super" (like the default URL config),
+            //     // then we should match if the user pressed either ctrl or super, just like OSC8 links.
+            //     // const is_ctrl_or_super_expected = (v.ctrl and !v.super and !v.shift and !v.alt) or
+            //     //     (v.super and !v.ctrl and !v.shift and !v.alt);
+            //     // if (is_ctrl_or_super_expected) {
+            //     //     if (!(mouse_mods.ctrl or mouse_mods.super)) continue;
+            //     // } else {
+            //     //     if (!v.equal(mouse_mods)) continue;
+            //     // }
+            // },
         }
 
         var it = strmap.searchIterator(link.regex);

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3712,7 +3712,17 @@ fn linkAtPos(
     for (self.config.links) |link| {
         switch (link.highlight) {
             .always, .hover => {},
-            .always_mods, .hover_mods => |v| if (!v.equal(mouse_mods)) continue,
+            .always_mods, .hover_mods => |v| {
+                // Special case: if the expected mods are "ctrl or super" (like the default URL config),
+                // then we should match if the user pressed either ctrl or super, just like OSC8 links.
+                const is_ctrl_or_super_expected = (v.ctrl and !v.super and !v.shift and !v.alt) or
+                    (v.super and !v.ctrl and !v.shift and !v.alt);
+                if (is_ctrl_or_super_expected) {
+                    if (!(mouse_mods.ctrl or mouse_mods.super)) continue;
+                } else {
+                    if (!v.equal(mouse_mods)) continue;
+                }
+            },
         }
 
         var it = strmap.searchIterator(link.regex);

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3713,17 +3713,6 @@ fn linkAtPos(
         switch (link.highlight) {
             .always, .hover => {},
             .always_mods, .hover_mods => |v| if (!v.equal(mouse_mods)) continue,
-            // .always_mods, .hover_mods => |_| {
-            //     // Special case: if the expected mods are "ctrl or super" (like the default URL config),
-            //     // then we should match if the user pressed either ctrl or super, just like OSC8 links.
-            //     // const is_ctrl_or_super_expected = (v.ctrl and !v.super and !v.shift and !v.alt) or
-            //     //     (v.super and !v.ctrl and !v.shift and !v.alt);
-            //     // if (is_ctrl_or_super_expected) {
-            //     //     if (!(mouse_mods.ctrl or mouse_mods.super)) continue;
-            //     // } else {
-            //     //     if (!v.equal(mouse_mods)) continue;
-            //     // }
-            // },
         }
 
         var it = strmap.searchIterator(link.regex);


### PR DESCRIPTION
fix: copy_url_to_clipboard for OSC8 hyperlinks

OSC8 links were only detected when exact platform-specific modifiers were held (Cmd on macOS, Ctrl on Linux), but copy_url_to_clipboard should work with either. Additionally, OSC8 links were using selectionString() which gets visible text instead of the actual URI. Now we use osc8URI() for OSC8 links and fall back to selectionString() for regex-detected links.

Fixes #7499