### PR TITLE
feat: implement mode 1048 for saving/restoring cursor position

### DIFF
--- a/src/terminal/modes.zig
+++ b/src/terminal/modes.zig
@@ -223,6 +223,7 @@ const entries: []const ModeEntry = &.{
     .{ .name = "alt_sends_escape", .value = 1039 },
     .{ .name = "reverse_wrap_extended", .value = 1045 },
     .{ .name = "alt_screen", .value = 1047 },
+    .{ .name = "save_cursor", .value = 1048 },
     .{ .name = "alt_screen_save_cursor_clear_enter", .value = 1049 },
     .{ .name = "bracketed_paste", .value = 2004 },
     .{ .name = "synchronized_output", .value = 2026 },

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -597,6 +597,18 @@ pub const StreamHandler = struct {
                 try self.queueRender();
             },
 
+            // Mode 1048 is xterm's conditional save cursor depending
+            // on if alt screen is enabled or not (at the terminal emulator
+            // level). Alt screen is always enabled for us so this just
+            // does a save/restore cursor.
+            .save_cursor => {
+                if (enabled) {
+                    self.terminal.saveCursor();
+                } else {
+                    try self.terminal.restoreCursor();
+                }
+            },
+
             // Force resize back to the window size
             .enable_mode_3 => {
                 const grid_size = self.size.grid();


### PR DESCRIPTION
Implements mode 1048 for saving/restoring cursor position.

This is the same as mode 1049 but only saves cursor position without touching the alternate screen.

**save/restore cursor position:**
- `ESC[?1048h` - save cursor position  
- `ESC[?1048l` - restore cursor position

**Quick test:**
```bash
printf '\e[5;10H[SAVED HERE]'
printf '\e[?1048h'                # save position
printf '\e[15;1HMoved somewhere else...'
printf '\e[?1048l'                # restore 
printf ' RESTORED!'           # should appear next to [SAVED HERE]
```

Fixes #7473