### PR TITLE
license: update copyright notices to include contributors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Mitchell Hashimoto
+Copyright (c) 2024 Mitchell Hashimoto, Ghostty contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -12,7 +12,7 @@ paste them into your project.
 the Ghostty project. This license does not apply to the rest of the
 Ghostty project.**
 
-Copyright © 2024 Mitchell Hashimoto
+Copyright © 2024 Mitchell Hashimoto, Ghostty contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the “Software”), to deal in

--- a/pkg/glfw/LICENSE
+++ b/pkg/glfw/LICENSE
@@ -1,5 +1,5 @@
 Copyright (c) 2021 Hexops Contributors (given via the Git commit history).
-Copyright (c) 2025 Mitchell Hashimoto
+Copyright (c) 2025 Mitchell Hashimoto, Ghostty contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/po/ca_ES.UTF-8.po
+++ b/po/ca_ES.UTF-8.po
@@ -1,5 +1,5 @@
 # Catalan translations for com.mitchellh.ghostty package.
-# Copyright (C) 2025 Mitchell Hashimoto
+# Copyright (C) 2025 Mitchell Hashimoto, Ghostty contributors
 # This file is distributed under the same license as the com.mitchellh.ghostty package.
 # Francesc Arpi <francesc.arpi@gmail.com>, 2025.
 #

--- a/po/com.mitchellh.ghostty.pot
+++ b/po/com.mitchellh.ghostty.pot
@@ -1,5 +1,5 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR Mitchell Hashimoto
+# Copyright (C) YEAR Mitchell Hashimoto, Ghostty contributors
 # This file is distributed under the same license as the com.mitchellh.ghostty package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #

--- a/po/de_DE.UTF-8.po
+++ b/po/de_DE.UTF-8.po
@@ -1,6 +1,6 @@
 # German translations for com.mitchellh.ghostty package
 # German translation for com.mitchellh.ghostty.
-# Copyright (C) 2025 Mitchell Hashimoto
+# Copyright (C) 2025 Mitchell Hashimoto, Ghostty contributors
 # This file is distributed under the same license as the com.mitchellh.ghostty package.
 # Robin Pfäffle <r@rpfaeffle.com>, 2025.
 #

--- a/po/es_BO.UTF-8.po
+++ b/po/es_BO.UTF-8.po
@@ -1,5 +1,5 @@
 # Spanish translations for com.mitchellh.ghostty package.
-# Copyright (C) 2025 Mitchell Hashimoto
+# Copyright (C) 2025 Mitchell Hashimoto, Ghostty contributors
 # This file is distributed under the same license as the com.mitchellh.ghostty package.
 # Miguel Peredo <miguelp@quientienemail.com>, 2025.
 #

--- a/po/fr_FR.UTF-8.po
+++ b/po/fr_FR.UTF-8.po
@@ -1,5 +1,5 @@
 # French translations for com.mitchellh.ghostty package.
-# Copyright (C) 2025 Mitchell Hashimoto
+# Copyright (C) 2025 Mitchell Hashimoto, Ghostty contributors
 # This file is distributed under the same license as the com.mitchellh.ghostty package.
 # Kirwiisp <swiip__@hotmail.com>, 2025.
 #

--- a/po/id_ID.UTF-8.po
+++ b/po/id_ID.UTF-8.po
@@ -1,5 +1,5 @@
 # Indonesian translations for com.mitchellh.ghostty package.
-# Copyright (C) 2025 Mitchell Hashimoto
+# Copyright (C) 2025 Mitchell Hashimoto, Ghostty contributors
 # This file is distributed under the same license as the com.mitchellh.ghostty package.
 # Satrio Bayu Aji <halosatrio@gmail.com>, 2025.
 #

--- a/po/ja_JP.UTF-8.po
+++ b/po/ja_JP.UTF-8.po
@@ -1,6 +1,6 @@
 # Japanese translations for com.mitchellh.ghostty package
 # com.mitchellh.ghostty パッケージに対する和訳.
-# Copyright (C) 2025 Mitchell Hashimoto
+# Copyright (C) 2025 Mitchell Hashimoto, Ghostty contributors
 # This file is distributed under the same license as the com.mitchellh.ghostty package.
 # Lon Sagisawa <lon@sagisawa.me>, 2025.
 #

--- a/po/mk_MK.UTF-8.po
+++ b/po/mk_MK.UTF-8.po
@@ -1,5 +1,5 @@
 # Macedonian translations for com.mitchellh.ghostty package.
-# Copyright (C) 2025 Mitchell Hashimoto
+# Copyright (C) 2025 Mitchell Hashimoto, Ghostty contributors
 # This file is distributed under the same license as the com.mitchellh.ghostty package.
 # Andrej Daskalov <andrej.daskalov@gmail.com>, 2025.
 #

--- a/po/nb_NO.UTF-8.po
+++ b/po/nb_NO.UTF-8.po
@@ -1,5 +1,5 @@
 # Norwegian Bokmal translations for com.mitchellh.ghostty package.
-# Copyright (C) 2025 Mitchell Hashimoto
+# Copyright (C) 2025 Mitchell Hashimoto, Ghostty contributors
 # This file is distributed under the same license as the com.mitchellh.ghostty package.
 # Hanna Rose <hanna@hanna.lol>, 2025.
 # Uzair Aftab <uzaaft@outlook.com>, 2025.

--- a/po/nl_NL.UTF-8.po
+++ b/po/nl_NL.UTF-8.po
@@ -1,5 +1,5 @@
 # Dutch translations for com.mitchellh.ghostty package.
-# Copyright (C) 2025 Mitchell Hashimoto
+# Copyright (C) 2025 Mitchell Hashimoto, Ghostty contributors
 # This file is distributed under the same license as the com.mitchellh.ghostty package.
 # Nico Geesink <geesinknico@gmail.com>, 2025.
 #

--- a/po/pl_PL.UTF-8.po
+++ b/po/pl_PL.UTF-8.po
@@ -1,6 +1,6 @@
 # Polish translations for com.mitchellh.ghostty package
 # Polskie tłumaczenia dla pakietu com.mitchellh.ghostty.
-# Copyright (C) 2025 Mitchell Hashimoto
+# Copyright (C) 2025 Mitchell Hashimoto, Ghostty contributors
 # This file is distributed under the same license as the com.mitchellh.ghostty package.
 # Bartosz Sokorski <b.sokorski@gmail.com>, 2025.
 #

--- a/po/pt_BR.UTF-8.po
+++ b/po/pt_BR.UTF-8.po
@@ -1,6 +1,6 @@
 # Portuguese translations for com.mitchellh.ghostty package
 # Traduções em português brasileiro para o pacote com.mitchellh.ghostty.
-# Copyright (C) 2025 Mitchell Hashimoto
+# Copyright (C) 2025 Mitchell Hashimoto, Ghostty contributors
 # This file is distributed under the same license as the com.mitchellh.ghostty package.
 # Gustavo Peres <gsodevel@gmail.com>, 2025.
 #

--- a/po/ru_RU.UTF-8.po
+++ b/po/ru_RU.UTF-8.po
@@ -1,6 +1,6 @@
 # Russian translations for com.mitchellh.ghostty package
 # Русские переводы для пакета com.mitchellh.ghostty.
-# Copyright (C) 2025 Mitchell Hashimoto
+# Copyright (C) 2025 Mitchell Hashimoto, Ghostty contributors
 # This file is distributed under the same license as the com.mitchellh.ghostty package.
 # blackzeshi <sergey_zhuzhgov@mail.ru>, 2025.
 #

--- a/po/tr_TR.UTF-8.po
+++ b/po/tr_TR.UTF-8.po
@@ -1,5 +1,5 @@
 # Turkish translations for com.mitchellh.ghostty package.
-# Copyright (C) 2025 Mitchell Hashimoto
+# Copyright (C) 2025 Mitchell Hashimoto, Ghostty contributors
 # This file is distributed under the same license as the com.mitchellh.ghostty package.
 # Emir SARI <emir_sari@icloud.com>, 2025.
 #

--- a/po/uk_UA.UTF-8.po
+++ b/po/uk_UA.UTF-8.po
@@ -1,5 +1,5 @@
 # Ukrainian translations for com.mitchellh.ghostty package.
-# Copyright (C) 2025 Mitchell Hashimoto
+# Copyright (C) 2025 Mitchell Hashimoto, Ghostty contributors
 # This file is distributed under the same license as the com.mitchellh.ghostty package.
 # Danylo Zalizchuk <danilmail0110@gmail.com>, 2025.
 #

--- a/po/zh_CN.UTF-8.po
+++ b/po/zh_CN.UTF-8.po
@@ -1,6 +1,6 @@
 # Chinese translations for com.mitchellh.ghostty package
 # com.mitchellh.ghostty 软件包的简体中文翻译.
-# Copyright (C) 2025 Mitchell Hashimoto
+# Copyright (C) 2025 Mitchell Hashimoto, Ghostty contributors
 # This file is distributed under the same license as the com.mitchellh.ghostty package.
 # Leah <hi@pluie.me>, 2025.
 #

--- a/src/build/GhosttyI18n.zig
+++ b/src/build/GhosttyI18n.zig
@@ -54,7 +54,7 @@ fn createUpdateStep(b: *std.Build) !*std.Build.Step {
         "--keyword=C_:1c,2",
         "--package-name=" ++ domain,
         "--msgid-bugs-address=m@mitchellh.com",
-        "--copyright-holder=Mitchell Hashimoto",
+        "--copyright-holder=\"Mitchell Hashimoto, Ghostty contributors\"",
         "-o",
         "-",
     });

--- a/src/build/mdgen/ghostty_1_footer.md
+++ b/src/build/mdgen/ghostty_1_footer.md
@@ -44,6 +44,7 @@ See GitHub issues: <https://github.com/ghostty-org/ghostty/issues>
 # AUTHOR
 
 Mitchell Hashimoto <m@mitchellh.com>
+Ghostty contributors <https://github.com/ghostty-org/ghostty/graphs/contributors>
 
 # SEE ALSO
 

--- a/src/build/mdgen/ghostty_5_footer.md
+++ b/src/build/mdgen/ghostty_5_footer.md
@@ -36,6 +36,7 @@ See GitHub issues: <https://github.com/ghostty-org/ghostty/issues>
 # AUTHOR
 
 Mitchell Hashimoto <m@mitchellh.com>
+Ghostty contributors <https://github.com/ghostty-org/ghostty/graphs/contributors>
 
 # SEE ALSO
 


### PR DESCRIPTION
Updates all copyright notices to include "Ghostty contributors" to reflect the fact that Mitchell is not the sole copyright owner.

Also adds "Ghostty contributors" to the author section in the manpages, linking https://github.com/ghostty-org/ghostty/graphs/contributors for proper credit.

This change was discussed in the Discord.