### PR TITLE
fix: wait-after-command confirmation set

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -907,12 +907,7 @@ pub fn handleMessage(self: *Surface, msg: Message) !void {
         },
 
         .close => self.close(),
-
-        // Close without confirmation.
-        .child_exited => {
-            self.child_exited = true;
-            self.close();
-        },
+        .child_exited => self.child_exited = true,
 
         .desktop_notification => |notification| {
             if (!self.config.desktop_notifications) {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -418,6 +418,11 @@ fn processExitCommon(td: *termio.Termio.ThreadData, exit_code: u32) void {
         return;
     }
 
+    // Notify our surface that the child process has exited
+    _ = td.surface_mailbox.push(.{
+        .child_exited = {},
+    }, .{ .forever = {} });
+
     // We output a message so that the user knows whats going on and
     // doesn't think their terminal just froze. We show this unconditionally
     // on close even if `wait_after_command` is false and the surface closes
@@ -442,7 +447,7 @@ fn processExitCommon(td: *termio.Termio.ThreadData, exit_code: u32) void {
 
     // Notify our surface we want to close
     _ = td.surface_mailbox.push(.{
-        .child_exited = {},
+        .close = {},
     }, .{ .forever = {} });
 }
 
@@ -568,6 +573,9 @@ pub fn queueWrite(
     if (exec.exited) {
         _ = td.surface_mailbox.push(.{
             .child_exited = {},
+        }, .{ .forever = {} });
+        _ = td.surface_mailbox.push(.{
+            .close = {},
         }, .{ .forever = {} });
         return;
     }


### PR DESCRIPTION
A fix for issue https://github.com/ghostty-org/ghostty/issues/7500: 

This is my first contribution to this project so bear with me. It seemed that the reason why wait-after-command was incorrectly requiring a confirmation message was because the "child_exited" value on the surface was not properly being set to true when the child actually exited. This was because the message that was supposed to be sent to the surface notifying that the child exited was never sent until after the user clicks a key, which would simultaneously close the program.

I've refactored the "child_exited" message to simply set the child_exited flag to true, and made it so elsewhere in the code where that message is sent, the close message is also sent soon after. I'm new to the codebase, so I'm not sure if this would be the best way to handle this kind of message, but from my testing it seems to be working. 

I've only tested this on Linux with GTK. Unfortunately, I don't own a Mac so I'm not really able to test on there.  