### PR TITLE
macos 15 regression: transparent style shouldn't draw border

### DIFF
--- a/macos/Sources/Features/Terminal/Window Styles/TransparentTitlebarTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TransparentTitlebarTerminalWindow.swift
@@ -96,9 +96,16 @@ class TransparentTitlebarTerminalWindow: TerminalWindow {
     @available(macOS 13.0, *)
     private func syncAppearanceVentura(_ surfaceConfig: Ghostty.SurfaceView.DerivedConfig) {
         guard let titlebarContainer else { return }
+        
+        // Setup the titlebar background color to match ours
         titlebarContainer.wantsLayer = true
         titlebarContainer.layer?.backgroundColor = preferredBackgroundColor?.cgColor
+        
+        // See the docs for the function that sets this to true on why
         effectViewIsHidden = false
+        
+        // Necessary to not draw the border around the title
+        titlebarAppearsTransparent = true
     }
 
     // MARK: View Finders


### PR DESCRIPTION
This fixes a regression from our Tahoe window styling changes on earlier, stable versions of macOS. We need to set  "titlebarAppearsTransparent" to true in order to hide the bottom border.