### PR TITLE
macOS: Basic Read-Only Accessibility Integration

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -355,6 +355,27 @@ typedef struct {
   double tl_px_y;
   uint32_t offset_start;
   uint32_t offset_len;
+  const char* text;
+  uintptr_t text_len;
+} ghostty_text_s;
+
+typedef enum {
+  GHOSTTY_POINT_ACTIVE,
+  GHOSTTY_POINT_VIEWPORT,
+  GHOSTTY_POINT_SCREEN,
+  GHOSTTY_POINT_SURFACE,
+} ghostty_point_tag_e;
+
+typedef struct {
+  ghostty_point_tag_e tag;
+  uint32_t x;
+  uint32_t y;
+} ghostty_point_s;
+
+typedef struct {
+  ghostty_point_s top_left;
+  ghostty_point_s bottom_right;
+  bool rectangle;
 } ghostty_selection_s;
 
 typedef struct {
@@ -832,16 +853,16 @@ void ghostty_surface_complete_clipboard_request(ghostty_surface_t,
                                                 void*,
                                                 bool);
 bool ghostty_surface_has_selection(ghostty_surface_t);
-uintptr_t ghostty_surface_selection(ghostty_surface_t, char*, uintptr_t);
+bool ghostty_surface_read_selection(ghostty_surface_t, ghostty_text_s*);
+bool ghostty_surface_read_text(ghostty_surface_t,
+                               ghostty_selection_s,
+                               ghostty_text_s*);
+void ghostty_surface_free_text(ghostty_surface_t, ghostty_text_s*);
 
 #ifdef __APPLE__
 void ghostty_surface_set_display_id(ghostty_surface_t, uint32_t);
 void* ghostty_surface_quicklook_font(ghostty_surface_t);
-uintptr_t ghostty_surface_quicklook_word(ghostty_surface_t,
-                                         char*,
-                                         uintptr_t,
-                                         ghostty_selection_s*);
-bool ghostty_surface_selection_info(ghostty_surface_t, ghostty_selection_s*);
+bool ghostty_surface_quicklook_word(ghostty_surface_t, ghostty_text_s*);
 #endif
 
 ghostty_inspector_t ghostty_surface_inspector(ghostty_surface_t);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -366,8 +366,15 @@ typedef enum {
   GHOSTTY_POINT_SURFACE,
 } ghostty_point_tag_e;
 
+typedef enum {
+  GHOSTTY_POINT_COORD_EXACT,
+  GHOSTTY_POINT_COORD_TOP_LEFT,
+  GHOSTTY_POINT_COORD_BOTTOM_RIGHT,
+} ghostty_point_coord_e;
+
 typedef struct {
   ghostty_point_tag_e tag;
+  ghostty_point_coord_e coord;
   uint32_t x;
   uint32_t y;
 } ghostty_point_s;

--- a/macos/Sources/Features/Splits/SplitView.Divider.swift
+++ b/macos/Sources/Features/Splits/SplitView.Divider.swift
@@ -7,6 +7,7 @@ extension SplitView {
         let visibleSize: CGFloat
         let invisibleSize: CGFloat
         let color: Color
+        @Binding var split: CGFloat
 
         private var visibleWidth: CGFloat? {
             switch (direction) {
@@ -78,6 +79,40 @@ extension SplitView {
                 } else {
                     NSCursor.pop()
                 }
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(axLabel)
+            .accessibilityValue("\(Int(split * 100))%")
+            .accessibilityHint(axHint)
+            .accessibilityAddTraits(.isButton)
+            .accessibilityAdjustableAction { direction in
+                let adjustment: CGFloat = 0.025
+                switch direction {
+                case .increment:
+                    split = min(split + adjustment, 0.9)
+                case .decrement:
+                    split = max(split - adjustment, 0.1)
+                @unknown default:
+                    break
+                }
+            }
+        }
+
+        private var axLabel: String {
+            switch direction {
+            case .horizontal:
+                return "Horizontal split divider"
+            case .vertical:
+                return "Vertical split divider"
+            }
+        }
+
+        private var axHint: String {
+            switch direction {
+            case .horizontal:
+                return "Drag to resize the left and right panes"
+            case .vertical:
+                return "Drag to resize the top and bottom panes"
             }
         }
     }

--- a/macos/Sources/Features/Splits/SplitView.swift
+++ b/macos/Sources/Features/Splits/SplitView.swift
@@ -42,16 +42,23 @@ struct SplitView<L: View, R: View>: View {
                 left
                     .frame(width: leftRect.size.width, height: leftRect.size.height)
                     .offset(x: leftRect.origin.x, y: leftRect.origin.y)
+                    .accessibilityElement(children: .contain)
+                    .accessibilityLabel(leftPaneLabel)
                 right
                     .frame(width: rightRect.size.width, height: rightRect.size.height)
                     .offset(x: rightRect.origin.x, y: rightRect.origin.y)
+                    .accessibilityElement(children: .contain)
+                    .accessibilityLabel(rightPaneLabel)
                 Divider(direction: direction,
                         visibleSize: splitterVisibleSize,
                         invisibleSize: splitterInvisibleSize,
-                        color: dividerColor)
+                        color: dividerColor,
+                        split: $split)
                     .position(splitterPoint)
                     .gesture(dragGesture(geo.size, splitterPoint: splitterPoint))
             }
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel(splitViewLabel)
         }
     }
 
@@ -135,6 +142,35 @@ struct SplitView<L: View, R: View>: View {
 
         case .vertical:
             return CGPoint(x: size.width / 2, y: leftRect.size.height)
+        }
+    }
+    
+    // MARK: Accessibility
+    
+    private var splitViewLabel: String {
+        switch direction {
+        case .horizontal:
+            return "Horizontal split view"
+        case .vertical:
+            return "Vertical split view"
+        }
+    }
+    
+    private var leftPaneLabel: String {
+        switch direction {
+        case .horizontal:
+            return "Left pane"
+        case .vertical:
+            return "Top pane"
+        }
+    }
+    
+    private var rightPaneLabel: String {
+        switch direction {
+        case .horizontal:
+            return "Right pane"
+        case .vertical:
+            return "Bottom pane"
         }
     }
 }

--- a/macos/Sources/Features/Splits/TerminalSplitTreeView.swift
+++ b/macos/Sources/Features/Splits/TerminalSplitTreeView.swift
@@ -32,6 +32,8 @@ struct TerminalSplitSubtreeView: View {
             Ghostty.InspectableSurface(
                 surfaceView: leafView,
                 isSplit: !isRoot)
+                .accessibilityElement(children: .contain)
+                .accessibilityLabel("Terminal pane")
 
         case .split(let split):
             let splitViewDirection: SplitViewDirection = switch (split.direction) {

--- a/macos/Sources/Features/Terminal/TerminalView.swift
+++ b/macos/Sources/Features/Terminal/TerminalView.swift
@@ -139,6 +139,10 @@ struct DebugBuildWarningView: View {
         }
         .background(Color(.windowBackgroundColor))
         .frame(maxWidth: .infinity)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Debug build warning")
+        .accessibilityValue("Debug builds of Ghostty are very slow and you may experience performance problems. Debug builds are only recommended during development.")
+        .accessibilityAddTraits(.isStaticText)
         .onTapGesture {
             isPopover = true
         }

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -1844,3 +1844,26 @@ extension Ghostty.SurfaceView {
         return false
     }
 }
+
+// MARK: Accessibility
+
+extension Ghostty.SurfaceView {
+    /// Indicates that this view should be exposed to accessibility tools like VoiceOver.
+    /// By returning true, we make the terminal surface accessible to screen readers
+    /// and other assistive technologies.
+    override func isAccessibilityElement() -> Bool {
+         return true
+     }
+
+    /// Defines the accessibility role for this view, which helps assistive technologies
+    /// understand what kind of content this view contains and how users can interact with it.
+    override func accessibilityRole() -> NSAccessibility.Role? {
+        /// We use .textArea because the terminal surface is essentially an editable text area
+        /// where users can input commands and view output.
+        return .textArea
+    }
+
+    override func accessibilityHelp() -> String? {
+        return "Terminal content area"
+    }
+}

--- a/src/terminal/main.zig
+++ b/src/terminal/main.zig
@@ -35,6 +35,7 @@ pub const Page = page.Page;
 pub const PageList = @import("PageList.zig");
 pub const Parser = @import("Parser.zig");
 pub const Pin = PageList.Pin;
+pub const Point = point.Point;
 pub const Screen = @import("Screen.zig");
 pub const ScreenType = Terminal.ScreenType;
 pub const Selection = @import("Selection.zig");


### PR DESCRIPTION
This integrates with macOS accessibility APIs to expose Ghostty terminal structure and content.

This is a very, very bare implementation and the terminal contents currently reported are the _full screen and scrollback_ which is way too much for realistic human accessibility use. The target use case for this PR is to enable automated tooling (namely, AI screen readers). However, this is all groundwork we'll need to iterate and improve the accessibility work anyways.

To make this work, I also replatformed some of our hacky C APIs onto a more robust `ghostty_surface_read_text` API that can now read arbitrary ranges of the screen into C strings for consumers to use. This will be useful in more places going forward (hint hint).

## Before

Accessibility tooling can't read anything, Ghostty has no attributes, no contents, just shows up as a square.

![CleanShot 2025-06-15 at 14 06 55@2x](https://github.com/user-attachments/assets/55eba1b4-6fd4-4d78-9434-5d672f374c67)

## After

A lot of metadata, including the screen contents as text.

![CleanShot 2025-06-15 at 14 07 25@2x](https://github.com/user-attachments/assets/e14cb7df-e4e2-4cc4-a214-004a8459f353)

Also, split hierarchies are navigable:


https://github.com/user-attachments/assets/a7b2ffb7-dbeb-41b2-8705-9c3200812c4d

