### PR TITLE
bash: remove dependency on $GHOSTTY_RESOURCES_DIR

### DIFF
--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -15,10 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# We need to be in interactive mode and we need to have the Ghostty
-# resources dir set which also tells us we're running in Ghostty.
+# We need to be in interactive mode to proceed.
 if [[ "$-" != *i* ]] ; then builtin return; fi
-if [ -z "$GHOSTTY_RESOURCES_DIR" ]; then builtin return; fi
 
 # When automatic shell integration is active, we were started in POSIX
 # mode and need to manually recreate the bash startup sequence.
@@ -98,7 +96,7 @@ if [[ "$GHOSTTY_SHELL_FEATURES" == *"sudo"* && -n "$TERMINFO" ]]; then
 fi
 
 # Import bash-preexec, safe to do multiple times
-builtin source "$GHOSTTY_RESOURCES_DIR/shell-integration/bash/bash-preexec.sh"
+builtin source "$(dirname -- "${BASH_SOURCE[0]}")/bash-preexec.sh"
 
 # This is set to 1 when we're executing a command so that we don't
 # send prompt marks multiple times.


### PR DESCRIPTION
We were depending on $GHOSTTY_RESOURCES_DIR for two reasons:

1. To locate our script-adjacent bash-preexec.sh script
2. To restrict our script's execution to environments in which $GHOSTTY_RESOURCES_DIR is available (i.e. Ghostty-only shells)

For (1), we can instead determine our directory using $BASH_SOURCE[0]. This is slightly differently than our previous behavior, where we'd always load bash-preexec.sh from the $GHOSTTY_RESOURCES_DIR hierarchy, even if ghostty.bash from source from somewhere else on the file system ... but we never relied on that behavior, even in development.

For (2), there's no harm in source'ing this script outside of Ghostty, and if that does become a concern, we can restore this condition or use something more targeted based on those specific cases.

Historically, I believe (2) was in place to enable (1), so addressing (1) removes the need for (2).

And lastly, none of the other shell integration scripts depend on $GHOSTTY_RESOURCES_DIR.