### PR TITLE
snap: vendor libgtk4-layer-shell.so

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -72,8 +72,6 @@ parts:
     build-packages:
       - libgtk-4-dev
       - libadwaita-1-dev
-      # TODO: Add when the Snap is updated to Ubuntu 24.10+
-      # - gtk4-layer-shell
       - libxml2-utils
       - git
       - patchelf
@@ -82,7 +80,10 @@ parts:
       craftctl set version=$(cat VERSION)
       $CRAFT_PART_SRC/../../zig/src/zig build -Dpatch-rpath=\$ORIGIN/../usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:/snap/core24/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR -Doptimize=ReleaseFast -Dcpu=baseline
       cp -rp zig-out/* $CRAFT_PART_INSTALL/
-      sed -i 's|Icon=com.mitchellh.ghostty|Icon=/snap/ghostty/current/share/icons/hicolor/512x512/apps/com.mitchellh.ghostty.png|g' $CRAFT_PART_INSTALL/share/applications/com.mitchellh.ghostty.desktop
+      # Install libgtk4-layer-shell.so
+      mkdir -p $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
+      cp .zig-cache/*/*/libgtk4-layer-shell.so $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/
+      sed -i 's|Icon=com.mitchellh.ghostty|Icon=${SNAP}/share/icons/hicolor/512x512/apps/com.mitchellh.ghostty.png|g' $CRAFT_PART_INSTALL/share/applications/com.mitchellh.ghostty.desktop
 
   libs:
     plugin: nil


### PR DESCRIPTION
vendor libgtk4-layer-shell.so to ensure it's available at runtime regardless of host system.