### PR TITLE
build: Use correct SDK for iOS Simulator shader build

### DIFF
--- a/src/build/MetallibStep.zig
+++ b/src/build/MetallibStep.zig
@@ -24,8 +24,19 @@ output: LazyPath,
 pub fn create(b: *std.Build, opts: Options) ?*MetallibStep {
     const sdk = switch (opts.target.result.os.tag) {
         .macos => "macosx",
-        .ios => "iphoneos",
+        .ios => switch (opts.target.result.abi) {
+            .simulator => "iphonesimulator",
+            else => "iphoneos",
+        },
         else => return null,
+    };
+    const platform_version_arg = switch (opts.target.result.os.tag) {
+        .macos => "-mmacos-version-min",
+        .ios => switch (opts.target.result.abi) {
+            .simulator => "-mios-simulator-version-min",
+            else => "-mios-version-min",
+        },
+        else => null,
     };
 
     const self = b.allocator.create(MetallibStep) catch @panic("OOM");
@@ -46,16 +57,11 @@ pub fn create(b: *std.Build, opts: Options) ?*MetallibStep {
     const output_ir = run_ir.addOutputFileArg(b.fmt("{s}.ir", .{opts.name}));
     run_ir.addArgs(&.{"-c"});
     for (opts.sources) |source| run_ir.addFileArg(source);
-    switch (opts.target.result.os.tag) {
-        .ios => run_ir.addArgs(&.{b.fmt(
-            "-mios-version-min={s}",
-            .{min_version},
-        )}),
-        .macos => run_ir.addArgs(&.{b.fmt(
-            "-mmacos-version-min={s}",
-            .{min_version},
-        )}),
-        else => {},
+    if (platform_version_arg) |arg| {
+        run_ir.addArgs(&.{b.fmt(
+            "{s}={s}",
+            .{ arg, min_version },
+        )});
     }
 
     const run_lib = RunStep.create(


### PR DESCRIPTION
This PR makes the build script use the correct SDK and version flag for the iOS Simulator.

Without this PR, the terminal fails to initialize on the iOS Simulator:

```
Compiler failed to build request
metal error=Target OS is incompatible: library was not compiled for the simulator
error initializing surface err=error.MetalFailed
```


<details>
<summary>With the PR</summary>

![image](https://github.com/user-attachments/assets/13735334-1321-42d5-8f01-4d5f6a7660ba)
</details>

Fixes #7635.

