### PR TITLE
macOS: Fix window-decoration=none regression on Tahoe

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -11,6 +11,13 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
 
         guard let appDelegate = NSApp.delegate as? AppDelegate else { return defaultValue }
         let config = appDelegate.ghostty.config
+
+        // If we have no window decorations, there's no reason to do anything but
+        // the default titlebar (because there will be no titlebar).
+        if !config.windowDecorations {
+            return defaultValue
+        }
+
         let nib = switch config.macosTitlebarStyle {
         case "native": "Terminal"
         case "hidden": "TerminalHiddenTitlebar"

--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -58,16 +58,19 @@ class TerminalWindow: NSWindow {
             hideWindowButtons()
         }
 
-        // Create our reset zoom titlebar accessory.
-        resetZoomAccessory.layoutAttribute = .right
-        resetZoomAccessory.view = NSHostingView(rootView: ResetZoomAccessoryView(
-            viewModel: viewModel,
-            action: { [weak self] in
-                guard let self else { return }
-                self.terminalController?.splitZoom(self)
-            }))
-        addTitlebarAccessoryViewController(resetZoomAccessory)
-        resetZoomAccessory.view.translatesAutoresizingMaskIntoConstraints = false
+        // Create our reset zoom titlebar accessory. We have to have a title
+        // to do this or AppKit triggers an assertion.
+        if styleMask.contains(.titled) {
+            resetZoomAccessory.layoutAttribute = .right
+            resetZoomAccessory.view = NSHostingView(rootView: ResetZoomAccessoryView(
+                viewModel: viewModel,
+                action: { [weak self] in
+                    guard let self else { return }
+                    self.terminalController?.splitZoom(self)
+                }))
+            addTitlebarAccessoryViewController(resetZoomAccessory)
+            resetZoomAccessory.view.translatesAutoresizingMaskIntoConstraints = false
+        }
 
         // Setup the accessory view for tabs that shows our keyboard shortcuts,
         // zoomed state, etc. Note I tried to use SwiftUI here but ran into issues


### PR DESCRIPTION
This regression may have existed on Sequoia too, but I only saw it on Tahoe.

The issue is that we should not be setting up titlebar accessory views when there is no titlebar. This was triggering an AppKit assertion.

To further simplify things, I always use the basic window styling if window decorations are off, too.