### PR TITLE
i18n: Add Irish (ga_IE) translation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -173,6 +173,7 @@
 /po/tr_TR.UTF-8.po @ghostty-org/tr_TR
 /po/uk_UA.UTF-8.po @ghostty-org/uk_UA
 /po/zh_CN.UTF-8.po @ghostty-org/zh_CN
+/po/ga_IE.UTF-8.po @ghostty-org/ga_IE
 
 # Packaging - Snap
 /snap/ @ghostty-org/snap

--- a/po/ga_IE.UTF-8.po
+++ b/po/ga_IE.UTF-8.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
 "POT-Creation-Date: 2025-04-23 16:58+0800\n"
-"PO-Revision-Date: 2025-06-24 12:42+0100\n"
+"PO-Revision-Date: 2025-06-29 21:15+0100\n"
 "Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@gmail.com>\n"
 "Language-Team: Irish <gaeilge-gnulinux@lists.sourceforge.net>\n"
 "Language: ga\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n==2 ? 1 : 2;\n"
-"X-Generator: Poedit 3.4.2\n"
+"X-Generator: Poedit 3.4.4\n"
 
 #: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:5
 msgid "Change Terminal Title"
@@ -212,7 +212,7 @@ msgid ""
 "commands may be executed."
 msgstr ""
 "D’fhéadfadh sé a bheith contúirteach an téacs seo a ghreamú isteach sa "
-"chríochfort mar is cosúil go bhféadfaí roinnt orduithe a fhorghníomhú."
+"teirminéal, toisc go d'fhéadfadh roinnt orduithe a fhorghníomhú."
 
 #: src/apprt/gtk/Window.zig:208
 msgid "Main Menu"
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/apprt/gtk/Window.zig:765
 msgid "Reloaded the configuration"
-msgstr "Athluchtaigh an chumraíocht"
+msgstr "Tá an chumraíocht athlódáilte"
 
 #: src/apprt/gtk/Window.zig:1005
 msgid "Ghostty Developers"

--- a/po/ga_IE.UTF-8.po
+++ b/po/ga_IE.UTF-8.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
 "POT-Creation-Date: 2025-04-23 16:58+0800\n"
-"PO-Revision-Date: 2025-06-23 09:00+0100\n"
+"PO-Revision-Date: 2025-06-24 09:21+0100\n"
 "Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@gmail.com>\n"
 "Language-Team: Irish <gaeilge-gnulinux@lists.sourceforge.net>\n"
 "Language: ga\n"
@@ -156,7 +156,7 @@ msgstr "Oscail cumraíocht"
 
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:85
 msgid "Command Palette"
-msgstr "Pailéad ordú"
+msgstr "Pailéad ordaithe"
 
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:90
 msgid "Terminal Inspector"

--- a/po/ga_IE.UTF-8.po
+++ b/po/ga_IE.UTF-8.po
@@ -1,0 +1,286 @@
+# Irish translations for com.mitchellh.ghostty package.
+# Copyright (C) 2025 Mitchell Hashimoto, Ghostty contributors
+# This file is distributed under the same license as the com.mitchellh.ghostty package.
+# Aindriú Mac Giolla Eoin <aindriu80@gmail.com>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: com.mitchellh.ghostty\n"
+"Report-Msgid-Bugs-To: m@mitchellh.com\n"
+"POT-Creation-Date: 2025-04-23 16:58+0800\n"
+"PO-Revision-Date: 2025-06-22 19:43+0100\n"
+"Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@gmail.com>\n"
+"Language-Team: Irish <gaeilge-gnulinux@lists.sourceforge.net>\n"
+"Language: ga\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n==2 ? 1 : 2;\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:5
+msgid "Change Terminal Title"
+msgstr "Athraigh Teideal Teirminéil"
+
+#: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:6
+msgid "Leave blank to restore the default title."
+msgstr "Fág bán chun an teideal réamhshocraithe a athbhunú."
+
+#: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:9
+#: src/apprt/gtk/ui/1.5/ccw-paste.blp:10 src/apprt/gtk/CloseDialog.zig:44
+msgid "Cancel"
+msgstr "Cealaigh"
+
+#: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:10
+msgid "OK"
+msgstr "Ceart go leor"
+
+#: src/apprt/gtk/ui/1.5/config-errors-dialog.blp:5
+msgid "Configuration Errors"
+msgstr "Earráidí Cumraíochta"
+
+#: src/apprt/gtk/ui/1.5/config-errors-dialog.blp:6
+msgid ""
+"One or more configuration errors were found. Please review the errors below, "
+"and either reload your configuration or ignore these errors."
+msgstr ""
+"Fuarthas earráid chumraíochta amháin nó níos mó. Athbhreithnigh na hearráidí "
+"thíos, agus athlódáil do chumraíocht nó déan neamhaird de na hearráidí seo."
+
+#: src/apprt/gtk/ui/1.5/config-errors-dialog.blp:9
+msgid "Ignore"
+msgstr "Déan neamhaird de"
+
+#: src/apprt/gtk/ui/1.5/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:97
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:100
+msgid "Reload Configuration"
+msgstr "Athlódáil Cumraíocht"
+
+#: src/apprt/gtk/ui/1.0/menu-headerbar-split_menu.blp:6
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:38
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:50
+msgid "Split Up"
+msgstr "Scoilt Suas"
+
+#: src/apprt/gtk/ui/1.0/menu-headerbar-split_menu.blp:11
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:43
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:55
+msgid "Split Down"
+msgstr "Scoilt Síos"
+
+#: src/apprt/gtk/ui/1.0/menu-headerbar-split_menu.blp:16
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:48
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:60
+msgid "Split Left"
+msgstr "Scoilt ar Chlé"
+
+#: src/apprt/gtk/ui/1.0/menu-headerbar-split_menu.blp:21
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:53
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:65
+msgid "Split Right"
+msgstr "Scoilt ar Dheis"
+
+#: src/apprt/gtk/ui/1.5/command-palette.blp:16
+msgid "Execute a command…"
+msgstr "Rith ordú…"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:6
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:6
+msgid "Copy"
+msgstr "Cóipeáil"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:11
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:11
+#: src/apprt/gtk/ui/1.5/ccw-paste.blp:11
+msgid "Paste"
+msgstr "Greamaigh"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:18
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:73
+msgid "Clear"
+msgstr "Glan"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:23
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:78
+msgid "Reset"
+msgstr "Athshocraigh"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:30
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:42
+msgid "Split"
+msgstr "Scoilt"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:33
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:45
+msgid "Change Title…"
+msgstr "Athraigh Teideal…"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:59
+msgid "Tab"
+msgstr "Cluaisín"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:62
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:30
+#: src/apprt/gtk/Window.zig:255
+msgid "New Tab"
+msgstr "Cluaisín Nua"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:67
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:35
+msgid "Close Tab"
+msgstr "Dún Cluaisín"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:73
+msgid "Window"
+msgstr "Fuinneog"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:76
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:18
+msgid "New Window"
+msgstr "Fuinneog Nua"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:81
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:23
+msgid "Close Window"
+msgstr "Dún Fuinneog"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:89
+msgid "Config"
+msgstr "Cumraíocht"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:92
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:95
+msgid "Open Configuration"
+msgstr "Oscail Cumraíocht"
+
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:85
+msgid "Command Palette"
+msgstr "Pailéad Ordú"
+
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:90
+msgid "Terminal Inspector"
+msgstr "Cigire Teirminéil"
+
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:107
+#: src/apprt/gtk/Window.zig:1024
+msgid "About Ghostty"
+msgstr "Maidir le Ghostty"
+
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:112
+msgid "Quit"
+msgstr "Scoir"
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:6
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:6
+msgid "Authorize Clipboard Access"
+msgstr "Údarú Rochtain ar an nGearrthaisce"
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:7
+msgid ""
+"An application is attempting to read from the clipboard. The current "
+"clipboard contents are shown below."
+msgstr ""
+"Tá feidhmchlár ag iarraidh léamh ón ngearrthaisce. Taispeántar ábhar reatha "
+"an ghearrthaisce thíos."
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:10
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:10
+msgid "Deny"
+msgstr "Diúltaigh"
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:11
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:11
+msgid "Allow"
+msgstr "Ceadaigh"
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:7
+msgid ""
+"An application is attempting to write to the clipboard. The current "
+"clipboard contents are shown below."
+msgstr ""
+"Tá feidhmchlár ag iarraidh scríobh chuig an ngearrthaisce. Taispeántar ábhar "
+"reatha an ghearrthaisce thíos."
+
+#: src/apprt/gtk/ui/1.5/ccw-paste.blp:6
+msgid "Warning: Potentially Unsafe Paste"
+msgstr "Rabhadh: Greamaigh a d'fhéadfadh a bheith neamhshábháilte"
+
+#: src/apprt/gtk/ui/1.5/ccw-paste.blp:7
+msgid ""
+"Pasting this text into the terminal may be dangerous as it looks like some "
+"commands may be executed."
+msgstr ""
+"D’fhéadfadh sé a bheith contúirteach an téacs seo a ghreamú isteach sa "
+"chríochfort mar is cosúil go bhféadfaí roinnt orduithe a fhorghníomhú."
+
+#: src/apprt/gtk/Window.zig:208
+msgid "Main Menu"
+msgstr "Príomh-Roghchlár"
+
+#: src/apprt/gtk/Window.zig:229
+msgid "View Open Tabs"
+msgstr "Féach ar na Cluaisíní Oscailte"
+
+#: src/apprt/gtk/Window.zig:256
+msgid "New Split"
+msgstr "Scoilt Nua"
+
+#: src/apprt/gtk/Window.zig:319
+msgid ""
+"⚠️ You're running a debug build of Ghostty! Performance will be degraded."
+msgstr ""
+"⚠️ Tá leagan dífhabhtaithe de Ghostty á rith agat! Laghdófar an fheidhmíocht."
+
+#: src/apprt/gtk/Window.zig:765
+msgid "Reloaded the configuration"
+msgstr "Athluchtaigh an chumraíocht"
+
+#: src/apprt/gtk/Window.zig:1005
+msgid "Ghostty Developers"
+msgstr "Forbróirí Ghostty"
+
+#: src/apprt/gtk/inspector.zig:144
+msgid "Ghostty: Terminal Inspector"
+msgstr "Ghostty: Cigire Teirminéil"
+
+#: src/apprt/gtk/CloseDialog.zig:47
+msgid "Close"
+msgstr "Dún"
+
+#: src/apprt/gtk/CloseDialog.zig:87
+msgid "Quit Ghostty?"
+msgstr "Scoir Ghostty?"
+
+#: src/apprt/gtk/CloseDialog.zig:88
+msgid "Close Window?"
+msgstr "Dún Fuinneog?"
+
+#: src/apprt/gtk/CloseDialog.zig:89
+msgid "Close Tab?"
+msgstr "Dún Cluaisín?"
+
+#: src/apprt/gtk/CloseDialog.zig:90
+msgid "Close Split?"
+msgstr "Dún an Scoilt?"
+
+#: src/apprt/gtk/CloseDialog.zig:96
+msgid "All terminal sessions will be terminated."
+msgstr "Cuirfear deireadh le gach seisiún teirminéil."
+
+#: src/apprt/gtk/CloseDialog.zig:97
+msgid "All terminal sessions in this window will be terminated."
+msgstr "Cuirfear deireadh le gach seisiún teirminéil san fhuinneog seo."
+
+#: src/apprt/gtk/CloseDialog.zig:98
+msgid "All terminal sessions in this tab will be terminated."
+msgstr "Cuirfear deireadh le gach seisiún críochfoirt sa chluaisín seo."
+
+#: src/apprt/gtk/CloseDialog.zig:99
+msgid "The currently running process in this split will be terminated."
+msgstr ""
+"Cuirfear deireadh leis an bpróiseas atá ar siúl faoi láthair sa scoilt seo."
+
+#: src/apprt/gtk/Surface.zig:1243
+msgid "Copied to clipboard"
+msgstr "Cóipeáilte chuig an ghearrthaisce"

--- a/po/ga_IE.UTF-8.po
+++ b/po/ga_IE.UTF-8.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
 "POT-Creation-Date: 2025-04-23 16:58+0800\n"
-"PO-Revision-Date: 2025-06-22 19:43+0100\n"
+"PO-Revision-Date: 2025-06-23 09:00+0100\n"
 "Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@gmail.com>\n"
 "Language-Team: Irish <gaeilge-gnulinux@lists.sourceforge.net>\n"
 "Language: ga\n"
@@ -20,7 +20,7 @@ msgstr ""
 
 #: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:5
 msgid "Change Terminal Title"
-msgstr "Athraigh Teideal Teirminéil"
+msgstr "Athraigh teideal teirminéil"
 
 #: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:6
 msgid "Leave blank to restore the default title."
@@ -37,7 +37,7 @@ msgstr "Ceart go leor"
 
 #: src/apprt/gtk/ui/1.5/config-errors-dialog.blp:5
 msgid "Configuration Errors"
-msgstr "Earráidí Cumraíochta"
+msgstr "Earráidí cumraíochta"
 
 #: src/apprt/gtk/ui/1.5/config-errors-dialog.blp:6
 msgid ""
@@ -55,31 +55,31 @@ msgstr "Déan neamhaird de"
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:97
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:100
 msgid "Reload Configuration"
-msgstr "Athlódáil Cumraíocht"
+msgstr "Athlódáil cumraíocht"
 
 #: src/apprt/gtk/ui/1.0/menu-headerbar-split_menu.blp:6
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:38
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:50
 msgid "Split Up"
-msgstr "Scoilt Suas"
+msgstr "Scoilt suas"
 
 #: src/apprt/gtk/ui/1.0/menu-headerbar-split_menu.blp:11
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:43
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:55
 msgid "Split Down"
-msgstr "Scoilt Síos"
+msgstr "Scoilt síos"
 
 #: src/apprt/gtk/ui/1.0/menu-headerbar-split_menu.blp:16
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:48
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:60
 msgid "Split Left"
-msgstr "Scoilt ar Chlé"
+msgstr "Scoilt ar chlé"
 
 #: src/apprt/gtk/ui/1.0/menu-headerbar-split_menu.blp:21
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:53
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:65
 msgid "Split Right"
-msgstr "Scoilt ar Dheis"
+msgstr "Scoilt ar dheis"
 
 #: src/apprt/gtk/ui/1.5/command-palette.blp:16
 msgid "Execute a command…"
@@ -114,7 +114,7 @@ msgstr "Scoilt"
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:33
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:45
 msgid "Change Title…"
-msgstr "Athraigh Teideal…"
+msgstr "Athraigh teideal…"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:59
 msgid "Tab"
@@ -124,12 +124,12 @@ msgstr "Cluaisín"
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:30
 #: src/apprt/gtk/Window.zig:255
 msgid "New Tab"
-msgstr "Cluaisín Nua"
+msgstr "Cluaisín nua"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:67
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:35
 msgid "Close Tab"
-msgstr "Dún Cluaisín"
+msgstr "Dún cluaisín"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:73
 msgid "Window"
@@ -138,12 +138,12 @@ msgstr "Fuinneog"
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:76
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:18
 msgid "New Window"
-msgstr "Fuinneog Nua"
+msgstr "Fuinneog nua"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:81
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:23
 msgid "Close Window"
-msgstr "Dún Fuinneog"
+msgstr "Dún fuinneog"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:89
 msgid "Config"
@@ -152,15 +152,15 @@ msgstr "Cumraíocht"
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:92
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:95
 msgid "Open Configuration"
-msgstr "Oscail Cumraíocht"
+msgstr "Oscail cumraíocht"
 
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:85
 msgid "Command Palette"
-msgstr "Pailéad Ordú"
+msgstr "Pailéad ordú"
 
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:90
 msgid "Terminal Inspector"
-msgstr "Cigire Teirminéil"
+msgstr "Cigire teirminéil"
 
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:107
 #: src/apprt/gtk/Window.zig:1024
@@ -174,7 +174,7 @@ msgstr "Scoir"
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:6
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:6
 msgid "Authorize Clipboard Access"
-msgstr "Údarú Rochtain ar an nGearrthaisce"
+msgstr "Údarú rochtain ar an ngearrthaisce"
 
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:7
 msgid ""
@@ -220,11 +220,11 @@ msgstr "Príomh-Roghchlár"
 
 #: src/apprt/gtk/Window.zig:229
 msgid "View Open Tabs"
-msgstr "Féach ar na Cluaisíní Oscailte"
+msgstr "Féach ar na cluaisíní oscailte"
 
 #: src/apprt/gtk/Window.zig:256
 msgid "New Split"
-msgstr "Scoilt Nua"
+msgstr "Scoilt nua"
 
 #: src/apprt/gtk/Window.zig:319
 msgid ""
@@ -242,7 +242,7 @@ msgstr "Forbróirí Ghostty"
 
 #: src/apprt/gtk/inspector.zig:144
 msgid "Ghostty: Terminal Inspector"
-msgstr "Ghostty: Cigire Teirminéil"
+msgstr "Ghostty: Cigire teirminéil"
 
 #: src/apprt/gtk/CloseDialog.zig:47
 msgid "Close"
@@ -254,15 +254,15 @@ msgstr "Scoir Ghostty?"
 
 #: src/apprt/gtk/CloseDialog.zig:88
 msgid "Close Window?"
-msgstr "Dún Fuinneog?"
+msgstr "Dún fuinneog?"
 
 #: src/apprt/gtk/CloseDialog.zig:89
 msgid "Close Tab?"
-msgstr "Dún Cluaisín?"
+msgstr "Dún cluaisín?"
 
 #: src/apprt/gtk/CloseDialog.zig:90
 msgid "Close Split?"
-msgstr "Dún an Scoilt?"
+msgstr "Dún an scoilt?"
 
 #: src/apprt/gtk/CloseDialog.zig:96
 msgid "All terminal sessions will be terminated."

--- a/po/ga_IE.UTF-8.po
+++ b/po/ga_IE.UTF-8.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
 "POT-Creation-Date: 2025-04-23 16:58+0800\n"
-"PO-Revision-Date: 2025-06-24 09:21+0100\n"
+"PO-Revision-Date: 2025-06-24 12:42+0100\n"
 "Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@gmail.com>\n"
 "Language-Team: Irish <gaeilge-gnulinux@lists.sourceforge.net>\n"
 "Language: ga\n"
@@ -118,18 +118,18 @@ msgstr "Athraigh teideal…"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:59
 msgid "Tab"
-msgstr "Cluaisín"
+msgstr "Táb"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:62
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:30
 #: src/apprt/gtk/Window.zig:255
 msgid "New Tab"
-msgstr "Cluaisín nua"
+msgstr "Táb nua"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:67
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:35
 msgid "Close Tab"
-msgstr "Dún cluaisín"
+msgstr "Dún táb"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:73
 msgid "Window"
@@ -220,7 +220,7 @@ msgstr "Príomh-Roghchlár"
 
 #: src/apprt/gtk/Window.zig:229
 msgid "View Open Tabs"
-msgstr "Féach ar na cluaisíní oscailte"
+msgstr "Féach ar na táib oscailte"
 
 #: src/apprt/gtk/Window.zig:256
 msgid "New Split"
@@ -258,7 +258,7 @@ msgstr "Dún fuinneog?"
 
 #: src/apprt/gtk/CloseDialog.zig:89
 msgid "Close Tab?"
-msgstr "Dún cluaisín?"
+msgstr "Dún táb?"
 
 #: src/apprt/gtk/CloseDialog.zig:90
 msgid "Close Split?"
@@ -274,7 +274,7 @@ msgstr "Cuirfear deireadh le gach seisiún teirminéil san fhuinneog seo."
 
 #: src/apprt/gtk/CloseDialog.zig:98
 msgid "All terminal sessions in this tab will be terminated."
-msgstr "Cuirfear deireadh le gach seisiún críochfoirt sa chluaisín seo."
+msgstr "Cuirfear deireadh le gach seisiún teirminéil sa táb seo."
 
 #: src/apprt/gtk/CloseDialog.zig:99
 msgid "The currently running process in this split will be terminated."

--- a/src/os/i18n.zig
+++ b/src/os/i18n.zig
@@ -45,6 +45,7 @@ pub const locales = [_][:0]const u8{
     "es_BO.UTF-8",
     "pt_BR.UTF-8",
     "ca_ES.UTF-8",
+    "ga_IE.UTF-8",
 };
 
 /// Set for faster membership lookup of locales.


### PR DESCRIPTION
This PR introduces support for Irish (Gaeilge), the first official language of Ireland and an EU working language.

The translation file was initialized using the standard gettext tooling:

` msginit -i po/com.mitchellh.ghostty.pot -l $LANG -o "po/$LANG.po"`

The locale code `ga_IE` follows ISO standards for Gaeilge as spoken in Ireland.

I'm happy to volunteer as the ongoing maintainer of the Irish translation and will keep it up to date as Ghostty evolves.

Go raibh maith agat!
