### PR TITLE
macOS: Run scripts using stdin rather than executing directly

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -413,6 +413,7 @@ typedef struct {
   const char* command;
   ghostty_env_var_s* env_vars;
   size_t env_var_count;
+  const char* initial_input;
 } ghostty_surface_config_s;
 
 typedef struct {

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -384,10 +384,17 @@ class AppDelegate: NSObject,
             config.workingDirectory = filename
             _ = TerminalController.newTab(ghostty, withBaseConfig: config)
         } else {
-            // When opening a file, open a new window with that file as the command,
-            // and its parent directory as the working directory.
-            config.command = filename
+            // When opening a file, we want to execute the file. To do this, we
+            // don't override the command directly, because it won't load the
+            // profile/rc files for the shell, which is super important on macOS
+            // due to things like Homebrew. Instead, we set the command to
+            // `<filename>; exit` which is what Terminal and iTerm2 do.
+            config.initialInput = "\(filename); exit\n"
+
+            // Set the parent directory to our working directory so that relative
+            // paths in scripts work.
             config.workingDirectory = (filename as NSString).deletingLastPathComponent
+
             _ = TerminalController.newWindow(ghostty, withBaseConfig: config)
         }
 

--- a/macos/Sources/Features/App Intents/IntentPermission.swift
+++ b/macos/Sources/Features/App Intents/IntentPermission.swift
@@ -45,7 +45,7 @@ func requestIntentPermission() async -> Bool {
 
 
             PermissionRequest.show(
-                "org.mitchellh.ghostty.shortcutsPermission",
+                "com.mitchellh.ghostty.shortcutsPermission",
                 message: "Allow Shortcuts to interact with Ghostty?",
                 allowDuration: .forever,
                 rememberDuration: nil,

--- a/macos/Sources/Features/App Intents/NewTerminalIntent.swift
+++ b/macos/Sources/Features/App Intents/NewTerminalIntent.swift
@@ -19,7 +19,7 @@ struct NewTerminalIntent: AppIntent {
 
     @Parameter(
         title: "Command",
-        description: "Command to execute instead of the default shell."
+        description: "Command to execute within your configured shell.",
     )
     var command: String?
 
@@ -60,7 +60,12 @@ struct NewTerminalIntent: AppIntent {
         let ghostty = appDelegate.ghostty
 
         var config = Ghostty.SurfaceConfiguration()
-        config.command = command
+
+        // We don't run command as "command" and instead use "initialInput" so
+        // that we can get all the login scripts to setup things like PATH.
+        if let command {
+            config.initialInput = "\(command); exit\n"
+        }
 
         // If we were given a working directory then open that directory
         if let url = workingDirectory?.fileURL {

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -430,6 +430,9 @@ pub const Surface = struct {
         /// Extra environment variables to set for the surface.
         env_vars: ?[*]EnvVar = null,
         env_var_count: usize = 0,
+
+        /// Input to send to the command after it is started.
+        initial_input: ?[*:0]const u8 = null,
     };
 
     pub fn init(self: *Surface, app: *App, opts: Options) !void {
@@ -508,6 +511,19 @@ pub const Surface = struct {
                     try alloc.dupeZ(u8, value),
                 );
             }
+        }
+
+        // If we have an initial input then we set it.
+        if (opts.initial_input) |c_input| {
+            const alloc = config.arenaAlloc();
+            config.input.list.clearRetainingCapacity();
+            try config.input.list.append(
+                alloc,
+                .{ .raw = try alloc.dupeZ(u8, std.mem.sliceTo(
+                    c_input,
+                    0,
+                )) },
+            );
         }
 
         // Initialize our surface right away. We're given a view that is


### PR DESCRIPTION
Fixes #7647

See #7647 for context. This commit works by extending the `input` work introduced in #7652 to libghostty so that the macOS can take advantage of it. At that point, it's just the macOS utilizing `input` in order to set the command and `exit` up similar to Terminal and iTerm2.

This applies both to files opened directly by Ghostty as well as the App Intent to run a command in a new terminal.