### PR TITLE
flatpak: remove references to systemd unit

### DIFF
--- a/flatpak/com.mitchellh.ghostty-debug.yml
+++ b/flatpak/com.mitchellh.ghostty-debug.yml
@@ -52,6 +52,13 @@ modules:
         --prefix /app
         --search-prefix /app
         --system $PWD/vendor/p
+
+      # Rename to match service and drop systemd references
+      - sed -e 's/^Name=.*/\0-debug/'
+        -e '/^SystemdService=/d'
+        /app/share/dbus-1/services/com.mitchellh.ghostty.service
+        > /app/share/dbus-1/services/com.mitchellh.ghostty-debug.service
+      - rm /app/share/dbus-1/services/com.mitchellh.ghostty.service
     sources:
       - type: dir
         path: ..

--- a/flatpak/com.mitchellh.ghostty.yml
+++ b/flatpak/com.mitchellh.ghostty.yml
@@ -47,6 +47,10 @@ modules:
         --prefix /app
         --search-prefix /app
         --system $PWD/vendor/p
+
+      # Remove references to the user service. Flatpak does not export those.
+      - sed -i '/^SystemdService=/d'
+        /app/share/dbus-1/services/com.mitchellh.ghostty.service
     sources:
       - type: dir
         path: ..


### PR DESCRIPTION
Flatpak currently does not export systemd user units. As such, remove references to it from D-Bus services to prevent D-Bus daemon from trying to start a non-existent service.

Additionally, make sure that the D-Bus service name is correct for debug builds.

Follow up to #7433 