### PR TITLE
font: faster glyph hashing

### DIFF
--- a/src/terminal/style.zig
+++ b/src/terminal/style.zig
@@ -8,9 +8,6 @@ const Offset = size.Offset;
 const OffsetBuf = size.OffsetBuf;
 const RefCountedSet = @import("ref_counted_set.zig").RefCountedSet;
 
-const XxHash3 = std.hash.XxHash3;
-const autoHash = std.hash.autoHash;
-
 /// The unique identifier for a style. This is at most the number of cells
 /// that can fit into a terminal page.
 pub const Id = size.CellCountInt;
@@ -313,12 +310,15 @@ pub const Style = struct {
 
     pub fn hash(self: *const Style) u64 {
         const packed_style = PackedStyle.fromStyle(self.*);
-        return XxHash3.hash(0, std.mem.asBytes(&packed_style));
+        return std.hash.XxHash3.hash(0, std.mem.asBytes(&packed_style));
     }
 
     comptime {
         assert(@sizeOf(PackedStyle) == 16);
         assert(std.meta.hasUniqueRepresentation(PackedStyle));
+        for (@typeInfo(PackedStyle.Data).@"union".fields) |field| {
+            assert(@bitSizeOf(field.type) == @bitSizeOf(PackedStyle.Data));
+        }
     }
 };
 


### PR DESCRIPTION
There are two main improvements being made here. First, we move away from using autohash and instead use a one-shot strategy similar to the Style hashing. Since the GlyphKey includes the Metrics struct, which contains quite a few fields, autohash was performing expensive and unnecessary repeated updates.

The second improvement is actually just, not hashing Metrics. By ignoring the Metrics field, we can fit the rest of the GlyphKey into a 64-bit packed struct and just return that as the hash! It ends up being unique for each GlyphKey in renderGlyph, and is nearly a zero-cost operation.

This ends up boosting the performance (on my machine at least), from around 560fps to 590fps on the DOOM-fire benchmark.