### PR TITLE
Revert "linux: add dbus and systemd activation services (#7433)"

### DIFF
--- a/dist/linux/app.desktop
+++ b/dist/linux/app.desktop
@@ -1,10 +1,8 @@
 [Desktop Entry]
-Version=1.0
 Name=Ghostty
 Type=Application
 Comment=A terminal emulator
-TryExec=ghostty
-Exec=ghostty --launched-from=desktop
+Exec=ghostty
 Icon=com.mitchellh.ghostty
 Categories=System;TerminalEmulator;
 Keywords=terminal;tty;pty;
@@ -18,8 +16,7 @@ X-TerminalArgTitle=--title=
 X-TerminalArgAppId=--class=
 X-TerminalArgDir=--working-directory=
 X-TerminalArgHold=--wait-after-command
-DBusActivatable=true
 
 [Desktop Action new-window]
 Name=New Window
-Exec=ghostty --launched-from=desktop
+Exec=ghostty

--- a/dist/linux/dbus.service
+++ b/dist/linux/dbus.service
@@ -1,4 +1,0 @@
-[D-BUS Service]
-Name=com.mitchellh.ghostty
-SystemdService=com.mitchellh.ghostty.service
-Exec=ghostty --launched-from=dbus

--- a/dist/linux/systemd.service
+++ b/dist/linux/systemd.service
@@ -1,7 +1,0 @@
-[Unit]
-Description=Ghostty
-
-[Service]
-Type=dbus
-BusName=com.mitchellh.ghostty
-ExecStart=ghostty --launched-from=systemd

--- a/flatpak/com.mitchellh.ghostty-debug.yml
+++ b/flatpak/com.mitchellh.ghostty-debug.yml
@@ -52,13 +52,6 @@ modules:
         --prefix /app
         --search-prefix /app
         --system $PWD/vendor/p
-
-      # Rename to match service and drop systemd references
-      - sed -e 's/^Name=.*/\0-debug/'
-        -e '/^SystemdService=/d'
-        /app/share/dbus-1/services/com.mitchellh.ghostty.service
-        > /app/share/dbus-1/services/com.mitchellh.ghostty-debug.service
-      - rm /app/share/dbus-1/services/com.mitchellh.ghostty.service
     sources:
       - type: dir
         path: ..

--- a/flatpak/com.mitchellh.ghostty.yml
+++ b/flatpak/com.mitchellh.ghostty.yml
@@ -47,10 +47,6 @@ modules:
         --prefix /app
         --search-prefix /app
         --system $PWD/vendor/p
-
-      # Remove references to the user service. Flatpak does not export those.
-      - sed -i '/^SystemdService=/d'
-        /app/share/dbus-1/services/com.mitchellh.ghostty.service
     sources:
       - type: dir
         path: ..

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -117,11 +117,6 @@ in
 
       mkdir -p "$out/nix-support"
 
-      sed -i -e "s@^Exec=.*ghostty@Exec=$out/bin/ghostty@" $out/share/applications/com.mitchellh.ghostty.desktop
-      sed -i -e "s@^TryExec=.*ghostty@TryExec=$out/bin/ghostty@" $out/share/applications/com.mitchellh.ghostty.desktop
-      sed -i -e "s@^Exec=.*ghostty@Exec=$out/bin/ghostty@" $out/share/dbus-1/services/com.mitchellh.ghostty.service
-      sed -i -e "s@^ExecStart=.*ghostty@ExecStart=$out/bin/ghostty@" $out/lib/systemd/user/com.mitchellh.ghostty.service
-
       mkdir -p "$terminfo/share"
       mv "$terminfo_src" "$terminfo/share/terminfo"
       ln -sf "$terminfo/share/terminfo" "$terminfo_src"

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -2325,15 +2325,6 @@ pub fn defaultTermioEnv(self: *Surface) !std.process.EnvMap {
     env.remove("GDK_DISABLE");
     env.remove("GSK_RENDERER");
 
-    // Remove some environment variables that are set when Ghostty is launched
-    // from a `.desktop` file, by D-Bus activation, or systemd.
-    env.remove("GIO_LAUNCHED_DESKTOP_FILE");
-    env.remove("GIO_LAUNCHED_DESKTOP_FILE_PID");
-    env.remove("DBUS_STARTER_ADDRESS");
-    env.remove("DBUS_STARTER_BUS_TYPE");
-    env.remove("INVOCATION_ID");
-    env.remove("JOURNAL_STREAM");
-
     // Unset environment varies set by snaps if we're running in a snap.
     // This allows Ghostty to further launch additional snaps.
     if (env.get("SNAP")) |_| {

--- a/src/build/GhosttyResources.zig
+++ b/src/build/GhosttyResources.zig
@@ -228,16 +228,6 @@ pub fn init(b: *std.Build, cfg: *const Config) !GhosttyResources {
             b.path("dist/linux/app.desktop"),
             "share/applications/com.mitchellh.ghostty.desktop",
         ).step);
-        // DBus service for DBus activation
-        try steps.append(&b.addInstallFile(
-            b.path("dist/linux/dbus.service"),
-            "share/dbus-1/services/com.mitchellh.ghostty.service",
-        ).step);
-        // systemd user service
-        try steps.append(&b.addInstallFile(
-            b.path("dist/linux/systemd.service"),
-            "lib/systemd/user/com.mitchellh.ghostty.service",
-        ).step);
 
         // AppStream metainfo so that application has rich metadata within app stores
         try steps.append(&b.addInstallFile(

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -942,16 +942,11 @@ title: ?[:0]const u8 = null,
 /// The setting that will change the application class value.
 ///
 /// This controls the class field of the `WM_CLASS` X11 property (when running
-/// under X11), the Wayland application ID (when running under Wayland), and the
-/// bus name that Ghostty uses to connect to DBus.
+/// under X11), and the Wayland application ID (when running under Wayland).
 ///
 /// Note that changing this value between invocations will create new, separate
 /// instances, of Ghostty when running with `gtk-single-instance=true`. See that
 /// option for more details.
-///
-/// Changing this value may break launching Ghostty from `.desktop` files, via
-/// DBus activation, or systemd user services as the system is expecting Ghostty
-/// to connect to DBus using the default `class` when it is launched.
 ///
 /// The class name must follow the requirements defined [in the GTK
 /// documentation](https://docs.gtk.org/gio/type_func.Application.id_is_valid.html).


### PR DESCRIPTION
Reverts two commits:

977cd530c7bb9551de93900170bdaec4601b1b5b
820b7e432b57cd08c49d2e76cce4cb78016f0418

These break build from source on Linux for two reasons:

1.) The systemd user service needs to be installed in the `share` prefix, not the `lib` prefix. This lets it get picked up in `~/.local` but is also correct for just standard FHS paths.

2.) The `ghostty` path in the systemd user service needs to be absolute. We should interpolate in the build install prefix to form an absolute path.