### PR TITLE
Terminal Background Image Support

### DIFF
--- a/pkg/opengl/Texture.zig
+++ b/pkg/opengl/Texture.zig
@@ -74,6 +74,9 @@ pub const InternalFormat = enum(c_int) {
     srgb = c.GL_SRGB8,
     srgba = c.GL_SRGB8_ALPHA8,
 
+    rgba_compressed = c.GL_COMPRESSED_RGBA_BPTC_UNORM,
+    srgba_compressed = c.GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM,
+
     // There are so many more that I haven't filled in.
     _,
 };
@@ -126,7 +129,6 @@ pub const Binding = struct {
         internal_format: InternalFormat,
         width: c.GLsizei,
         height: c.GLsizei,
-        border: c.GLint,
         format: Format,
         typ: DataType,
         data: ?*const anyopaque,
@@ -137,7 +139,7 @@ pub const Binding = struct {
             @intFromEnum(internal_format),
             width,
             height,
-            border,
+            0,
             @intFromEnum(format),
             @intFromEnum(typ),
             data,

--- a/pkg/wuffs/src/main.zig
+++ b/pkg/wuffs/src/main.zig
@@ -8,7 +8,7 @@ pub const Error = @import("error.zig").Error;
 pub const ImageData = struct {
     width: u32,
     height: u32,
-    data: []const u8,
+    data: []u8,
 };
 
 test {

--- a/pkg/wuffs/src/swizzle.zig
+++ b/pkg/wuffs/src/swizzle.zig
@@ -33,6 +33,24 @@ pub fn rgbToRgba(alloc: Allocator, src: []const u8) Error![]u8 {
     );
 }
 
+pub fn bgrToRgba(alloc: Allocator, src: []const u8) Error![]u8 {
+    return swizzle(
+        alloc,
+        src,
+        c.WUFFS_BASE__PIXEL_FORMAT__BGR,
+        c.WUFFS_BASE__PIXEL_FORMAT__RGBA_PREMUL,
+    );
+}
+
+pub fn bgraToRgba(alloc: Allocator, src: []const u8) Error![]u8 {
+    return swizzle(
+        alloc,
+        src,
+        c.WUFFS_BASE__PIXEL_FORMAT__BGRA_PREMUL,
+        c.WUFFS_BASE__PIXEL_FORMAT__RGBA_PREMUL,
+    );
+}
+
 fn swizzle(
     alloc: Allocator,
     src: []const u8,

--- a/src/config.zig
+++ b/src/config.zig
@@ -31,8 +31,11 @@ pub const RepeatableFontVariation = Config.RepeatableFontVariation;
 pub const RepeatableString = Config.RepeatableString;
 pub const RepeatableStringMap = @import("config/RepeatableStringMap.zig");
 pub const RepeatablePath = Config.RepeatablePath;
+pub const Path = Config.Path;
 pub const ShellIntegrationFeatures = Config.ShellIntegrationFeatures;
 pub const WindowPaddingColor = Config.WindowPaddingColor;
+pub const BackgroundImagePosition = Config.BackgroundImagePosition;
+pub const BackgroundImageFit = Config.BackgroundImageFit;
 
 // Alternate APIs
 pub const CAPI = @import("config/CAPI.zig");

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -468,8 +468,17 @@ foreground: Color = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF },
 
 /// Background image for the terminal.
 ///
-/// This should be a path to a PNG or JPEG file,
-/// other image formats are not yet supported.
+/// This should be a path to a PNG or JPEG file, other image formats are
+/// not yet supported.
+///
+/// The background image is currently per-terminal, not per-window. If
+/// you are a heavy split user, the background image will be repeated across
+/// splits. A future improvement to Ghostty will address this.
+///
+/// WARNING: Background images are currently duplicated in VRAM per-terminal.
+/// For sufficiently large images, this could lead to a large increase in
+/// memory usage (specifically VRAM usage). A future Ghostty improvement
+/// will resolve this by sharing image textures across terminals.
 @"background-image": ?Path = null,
 
 /// Background image opacity.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -466,6 +466,84 @@ background: Color = .{ .r = 0x28, .g = 0x2C, .b = 0x34 },
 /// Specified as either hex (`#RRGGBB` or `RRGGBB`) or a named X11 color.
 foreground: Color = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF },
 
+/// Background image for the terminal.
+///
+/// This should be a path to a PNG or JPEG file,
+/// other image formats are not yet supported.
+@"background-image": ?Path = null,
+
+/// Background image opacity.
+///
+/// This is relative to the value of `background-opacity`.
+///
+/// A value of `1.0` (the default) will result in the background image being
+/// placed on top of the general background color, and then the combined result
+/// will be adjusted to the opacity specified by `background-opacity`.
+///
+/// A value less than `1.0` will result in the background image being mixed
+/// with the general background color before the combined result is adjusted
+/// to the configured `background-opacity`.
+///
+/// A value greater than `1.0` will result in the background image having a
+/// higher opacity than the general background color. For instance, if the
+/// configured `background-opacity` is `0.5` and `background-image-opacity`
+/// is set to `1.5`, then the final opacity of the background image will be
+/// `0.5 * 1.5 = 0.75`.
+@"background-image-opacity": f32 = 1.0,
+
+/// Background image position.
+///
+/// Valid values are:
+///   * `top-left`
+///   * `top-center`
+///   * `top-right`
+///   * `center-left`
+///   * `center`
+///   * `center-right`
+///   * `bottom-left`
+///   * `bottom-center`
+///   * `bottom-right`
+///
+/// The default value is `center`.
+@"background-image-position": BackgroundImagePosition = .center,
+
+/// Background image fit.
+///
+/// Valid values are:
+///
+///  * `contain`
+///
+///     Preserving the aspect ratio, scale the background image to the largest
+///     size that can still be contained within the terminal, so that the whole
+///     image is visible.
+///
+///  * `cover`
+///
+///     Preserving the aspect ratio, scale the background image to the smallest
+///     size that can completely cover the terminal. This may result in one or
+///     more edges of the image being clipped by the edge of the terminal.
+///
+///  * `stretch`
+///
+///     Stretch the background image to the full size of the terminal, without
+///     preserving the aspect ratio.
+///
+///  * `none`
+///
+///     Don't scale the background image.
+///
+/// The default value is `contain`.
+@"background-image-fit": BackgroundImageFit = .contain,
+
+/// Whether to repeat the background image or not.
+///
+/// If this is set to true, the background image will be repeated if there
+/// would otherwise be blank space around it because it doesn't completely
+/// fill the terminal area.
+///
+/// The default value is `false`.
+@"background-image-repeat": bool = false,
+
 /// The foreground and background color for selection. If this is not set, then
 /// the selection color is just the inverted window background and foreground
 /// (note: not to be confused with the cell bg/fg).
@@ -3297,6 +3375,15 @@ fn expandPaths(self: *Config, base: []const u8) !void {
                     base,
                     &self._diagnostics,
                 );
+            },
+            ?RepeatablePath, ?Path => {
+                if (@field(self, field.name)) |*path| {
+                    try path.expand(
+                        arena_alloc,
+                        base,
+                        &self._diagnostics,
+                    );
+                }
             },
             else => {},
         }
@@ -6567,6 +6654,28 @@ pub const AlphaBlending = enum {
             .linear, .@"linear-corrected" => true,
         };
     }
+};
+
+/// See background-image-position
+pub const BackgroundImagePosition = enum {
+    @"top-left",
+    @"top-center",
+    @"top-right",
+    @"center-left",
+    @"center-center",
+    @"center-right",
+    @"bottom-left",
+    @"bottom-center",
+    @"bottom-right",
+    center,
+};
+
+/// See background-image-fit
+pub const BackgroundImageFit = enum {
+    contain,
+    cover,
+    stretch,
+    none,
 };
 
 /// See freetype-load-flag

--- a/src/file_type.zig
+++ b/src/file_type.zig
@@ -1,0 +1,102 @@
+const std = @import("std");
+
+const type_details: []const struct {
+    typ: FileType,
+    sigs: []const []const ?u8,
+    exts: []const []const u8,
+} = &.{
+    .{
+        .typ = .jpeg,
+        .sigs = &.{
+            &.{ 0xFF, 0xD8, 0xFF, 0xDB },
+            &.{ 0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01 },
+            &.{ 0xFF, 0xD8, 0xFF, 0xEE },
+            &.{ 0xFF, 0xD8, 0xFF, 0xE1, null, null, 0x45, 0x78, 0x69, 0x66, 0x00, 0x00 },
+            &.{ 0xFF, 0xD8, 0xFF, 0xE0 },
+        },
+        .exts = &.{ ".jpg", ".jpeg", ".jfif" },
+    },
+    .{
+        .typ = .png,
+        .sigs = &.{&.{ 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A }},
+        .exts = &.{".png"},
+    },
+    .{
+        .typ = .gif,
+        .sigs = &.{
+            &.{ 'G', 'I', 'F', '8', '7', 'a' },
+            &.{ 'G', 'I', 'F', '8', '9', 'a' },
+        },
+        .exts = &.{".gif"},
+    },
+    .{
+        .typ = .bmp,
+        .sigs = &.{&.{ 'B', 'M' }},
+        .exts = &.{".bmp"},
+    },
+    .{
+        .typ = .qoi,
+        .sigs = &.{&.{ 'q', 'o', 'i', 'f' }},
+        .exts = &.{".qoi"},
+    },
+    .{
+        .typ = .webp,
+        .sigs = &.{
+            &.{ 0x52, 0x49, 0x46, 0x46, null, null, null, null, 0x57, 0x45, 0x42, 0x50 },
+        },
+        .exts = &.{".webp"},
+    },
+};
+
+/// This is a helper for detecting file types based on magic bytes.
+///
+/// Ref: https://en.wikipedia.org/wiki/List_of_file_signatures
+pub const FileType = enum {
+    /// JPEG image file.
+    jpeg,
+
+    /// PNG image file.
+    png,
+
+    /// GIF image file.
+    gif,
+
+    /// BMP image file.
+    bmp,
+
+    /// QOI image file.
+    qoi,
+
+    /// WebP image file.
+    webp,
+
+    /// Unknown file format.
+    unknown,
+
+    /// Detect file type based on the magic bytes
+    /// at the start of the provided file contents.
+    pub fn detect(contents: []const u8) FileType {
+        inline for (type_details) |typ| {
+            inline for (typ.sigs) |signature| {
+                if (contents.len >= signature.len) {
+                    for (contents[0..signature.len], signature) |f, sig| {
+                        if (sig) |s| if (f != s) break;
+                    } else {
+                        return typ.typ;
+                    }
+                }
+            }
+        }
+        return .unknown;
+    }
+
+    /// Guess file type from its extension.
+    pub fn guessFromExtension(extension: []const u8) FileType {
+        inline for (type_details) |typ| {
+            inline for (typ.exts) |ext| {
+                if (std.ascii.eqlIgnoreCase(extension, ext)) return typ.typ;
+            }
+        }
+        return .unknown;
+    }
+};

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -282,6 +282,7 @@ pub const uniformBufferOptions = bufferOptions;
 pub const fgBufferOptions = bufferOptions;
 pub const bgBufferOptions = bufferOptions;
 pub const imageBufferOptions = bufferOptions;
+pub const bgImageBufferOptions = bufferOptions;
 
 /// Returns the options to use when constructing textures.
 pub inline fn textureOptions(self: Metal) Texture.Options {

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -388,6 +388,7 @@ pub const uniformBufferOptions = bufferOptions;
 pub const fgBufferOptions = bufferOptions;
 pub const bgBufferOptions = bufferOptions;
 pub const imageBufferOptions = bufferOptions;
+pub const bgImageBufferOptions = bufferOptions;
 
 /// Returns the options to use when constructing textures.
 pub inline fn textureOptions(self: OpenGL) Texture.Options {

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -395,7 +395,7 @@ pub inline fn textureOptions(self: OpenGL) Texture.Options {
     _ = self;
     return .{
         .format = .rgba,
-        .internal_format = .srgba,
+        .internal_format = .srgba_compressed,
         .target = .@"2D",
     };
 }

--- a/src/renderer/metal/Pipeline.zig
+++ b/src/renderer/metal/Pipeline.zig
@@ -160,6 +160,7 @@ fn autoAttribute(T: type, attrs: objc.Object) void {
         const offset = @offsetOf(T, field.name);
 
         const FT = switch (@typeInfo(field.type)) {
+            .@"struct" => |e| e.backing_integer.?,
             .@"enum" => |e| e.tag_type,
             else => field.type,
         };
@@ -169,13 +170,17 @@ fn autoAttribute(T: type, attrs: objc.Object) void {
             [4]u8 => mtl.MTLVertexFormat.uchar4,
             [2]u16 => mtl.MTLVertexFormat.ushort2,
             [2]i16 => mtl.MTLVertexFormat.short2,
+            f32 => mtl.MTLVertexFormat.float,
             [2]f32 => mtl.MTLVertexFormat.float2,
             [4]f32 => mtl.MTLVertexFormat.float4,
+            i32 => mtl.MTLVertexFormat.int,
             [2]i32 => mtl.MTLVertexFormat.int2,
+            [4]i32 => mtl.MTLVertexFormat.int2,
             u32 => mtl.MTLVertexFormat.uint,
             [2]u32 => mtl.MTLVertexFormat.uint2,
             [4]u32 => mtl.MTLVertexFormat.uint4,
             u8 => mtl.MTLVertexFormat.uchar,
+            i8 => mtl.MTLVertexFormat.char,
             else => comptime unreachable,
         };
 

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -36,6 +36,13 @@ const pipeline_descs: []const struct { [:0]const u8, PipelineDescription } =
             .step_fn = .per_instance,
             .blending_enabled = true,
         } },
+        .{ "bg_image", .{
+            .vertex_attributes = BgImage,
+            .vertex_fn = "bg_image_vertex",
+            .fragment_fn = "bg_image_fragment",
+            .step_fn = .per_instance,
+            .blending_enabled = true,
+        } },
     };
 
 /// All the comptime-known info about a pipeline, so that
@@ -192,6 +199,9 @@ pub const Uniforms = extern struct {
     /// This is calculated based on the size of the screen.
     projection_matrix: math.Mat align(16),
 
+    /// Size of the screen (render target) in pixels.
+    screen_size: [2]f32 align(8),
+
     /// Size of a single cell in pixels, unscaled.
     cell_size: [2]f32 align(8),
 
@@ -286,6 +296,38 @@ pub const Image = extern struct {
     cell_offset: [2]f32,
     source_rect: [4]f32,
     dest_size: [2]f32,
+};
+
+/// Single parameter for the bg image shader.
+pub const BgImage = extern struct {
+    opacity: f32 align(4),
+    info: Info align(1),
+
+    pub const Info = packed struct(u8) {
+        position: Position,
+        fit: Fit,
+        repeat: bool,
+        _padding: u1 = 0,
+
+        pub const Position = enum(u4) {
+            tl = 0,
+            tc = 1,
+            tr = 2,
+            ml = 3,
+            mc = 4,
+            mr = 5,
+            bl = 6,
+            bc = 7,
+            br = 8,
+        };
+
+        pub const Fit = enum(u2) {
+            contain = 0,
+            cover = 1,
+            stretch = 2,
+            none = 3,
+        };
+    };
 };
 
 /// Initialize the MTLLibrary. A MTLLibrary is a collection of shaders.

--- a/src/renderer/opengl/Pipeline.zig
+++ b/src/renderer/opengl/Pipeline.zig
@@ -98,6 +98,7 @@ fn autoAttribute(
         const offset = @offsetOf(T, field.name);
 
         const FT = switch (@typeInfo(field.type)) {
+            .@"struct" => |s| s.backing_integer.?,
             .@"enum" => |e| e.tag_type,
             else => field.type,
         };

--- a/src/renderer/opengl/Texture.zig
+++ b/src/renderer/opengl/Texture.zig
@@ -57,7 +57,6 @@ pub fn init(
             opts.internal_format,
             @intCast(width),
             @intCast(height),
-            0,
             opts.format,
             .UnsignedByte,
             if (data) |d| @ptrCast(d.ptr) else null,

--- a/src/renderer/opengl/shaders.zig
+++ b/src/renderer/opengl/shaders.zig
@@ -33,6 +33,13 @@ const pipeline_descs: []const struct { [:0]const u8, PipelineDescription } =
             .step_fn = .per_instance,
             .blending_enabled = true,
         } },
+        .{ "bg_image", .{
+            .vertex_attributes = BgImage,
+            .vertex_fn = loadShaderCode("../shaders/glsl/bg_image.v.glsl"),
+            .fragment_fn = loadShaderCode("../shaders/glsl/bg_image.f.glsl"),
+            .step_fn = .per_instance,
+            .blending_enabled = true,
+        } },
     };
 
 /// All the comptime-known info about a pipeline, so that
@@ -158,6 +165,9 @@ pub const Uniforms = extern struct {
     /// This is calculated based on the size of the screen.
     projection_matrix: math.Mat align(16),
 
+    /// Size of the screen (render target) in pixels.
+    screen_size: [2]f32 align(8),
+
     /// Size of a single cell in pixels, unscaled.
     cell_size: [2]f32 align(8),
 
@@ -254,6 +264,38 @@ pub const Image = extern struct {
     cell_offset: [2]f32 align(8),
     source_rect: [4]f32 align(16),
     dest_size: [2]f32 align(8),
+};
+
+/// Single parameter for the bg image shader.
+pub const BgImage = extern struct {
+    opacity: f32 align(4),
+    info: Info align(1),
+
+    pub const Info = packed struct(u8) {
+        position: Position,
+        fit: Fit,
+        repeat: bool,
+        _padding: u1 = 0,
+
+        pub const Position = enum(u4) {
+            tl = 0,
+            tc = 1,
+            tr = 2,
+            ml = 3,
+            mc = 4,
+            mr = 5,
+            bl = 6,
+            bc = 7,
+            br = 8,
+        };
+
+        pub const Fit = enum(u2) {
+            contain = 0,
+            cover = 1,
+            stretch = 2,
+            none = 3,
+        };
+    };
 };
 
 /// Initialize our custom shader pipelines. The shaders argument is a

--- a/src/renderer/shaders/glsl/bg_image.f.glsl
+++ b/src/renderer/shaders/glsl/bg_image.f.glsl
@@ -1,0 +1,62 @@
+#include "common.glsl"
+
+// Position the FragCoord origin to the upper left
+// so as to align with our texture's directionality.
+layout(origin_upper_left) in vec4 gl_FragCoord;
+
+layout(binding = 0) uniform sampler2DRect image;
+
+flat in vec4 bg_color;
+flat in vec2 offset;
+flat in vec2 scale;
+flat in float opacity;
+flat in uint repeat;
+
+layout(location = 0) out vec4 out_FragColor;
+
+void main() {
+    bool use_linear_blending = (bools & USE_LINEAR_BLENDING) != 0;
+
+    // Our texture coordinate is based on the screen position, offset by the
+    // dest rect origin, and scaled by the ratio between the dest rect size
+    // and the original texture size, which effectively scales the original
+    // size of the texture to the dest rect size.
+    vec2 tex_coord = (gl_FragCoord.xy - offset) * scale;
+
+    vec2 tex_size = textureSize(image);
+
+    // If we need to repeat the texture, wrap the coordinates.
+    if (repeat != 0) {
+        tex_coord = mod(mod(tex_coord, tex_size) + tex_size, tex_size);
+    }
+
+    vec4 rgba;
+    // If we're out of bounds, we have no color,
+    // otherwise we sample the texture for it.
+    if (any(lessThan(tex_coord, vec2(0.0))) ||
+            any(greaterThan(tex_coord, tex_size)))
+    {
+        rgba = vec4(0.0);
+    } else {
+        rgba = texture(image, tex_coord);
+
+        if (!use_linear_blending) {
+            rgba = unlinearize(rgba);
+        }
+
+        rgba.rgb *= rgba.a;
+    }
+
+    // Multiply it by the configured opacity, but cap it at
+    // the value that will make it fully opaque relative to
+    // the background color alpha, so it isn't overexposed.
+    rgba *= min(opacity, 1.0 / bg_color.a);
+
+    // Blend it on to a fully opaque version of the background color.
+    rgba += max(vec4(0.0), vec4(bg_color.rgb, 1.0) * vec4(1.0 - rgba.a));
+
+    // Multiply everything by the background color alpha.
+    rgba *= bg_color.a;
+
+    out_FragColor = rgba;
+}

--- a/src/renderer/shaders/glsl/bg_image.v.glsl
+++ b/src/renderer/shaders/glsl/bg_image.v.glsl
@@ -1,0 +1,145 @@
+#include "common.glsl"
+
+layout(binding = 0) uniform sampler2DRect image;
+
+layout(location = 0) in float in_opacity;
+layout(location = 1) in uint info;
+
+// 4 bits of info.
+const uint BG_IMAGE_POSITION = 15u;
+const uint BG_IMAGE_TL = 0u;
+const uint BG_IMAGE_TC = 1u;
+const uint BG_IMAGE_TR = 2u;
+const uint BG_IMAGE_ML = 3u;
+const uint BG_IMAGE_MC = 4u;
+const uint BG_IMAGE_MR = 5u;
+const uint BG_IMAGE_BL = 6u;
+const uint BG_IMAGE_BC = 7u;
+const uint BG_IMAGE_BR = 8u;
+
+// 2 bits of info shifted 4.
+const uint BG_IMAGE_FIT = 3u << 4;
+const uint BG_IMAGE_CONTAIN = 0u << 4;
+const uint BG_IMAGE_COVER = 1u << 4;
+const uint BG_IMAGE_STRETCH = 2u << 4;
+const uint BG_IMAGE_NO_FIT = 3u << 4;
+
+// 1 bit of info shifted 6.
+const uint BG_IMAGE_REPEAT = 1u << 6;
+
+flat out vec4 bg_color;
+flat out vec2 offset;
+flat out vec2 scale;
+flat out float opacity;
+// We use a uint to pass the repeat value because
+// bools aren't allowed for vertex outputs in OpenGL.
+flat out uint repeat;
+
+void main() {
+    bool use_linear_blending = (bools & USE_LINEAR_BLENDING) != 0;
+
+    vec4 position;
+    position.x = (gl_VertexID == 2) ? 3.0 : -1.0;
+    position.y = (gl_VertexID == 0) ? -3.0 : 1.0;
+    position.z = 1.0;
+    position.w = 1.0;
+
+    // Single triangle is clipped to viewport.
+    //
+    // X <- vid == 0: (-1, -3)
+    // |\
+    // | \
+    // |  \
+    // |###\
+    // |#+# \ `+` is (0, 0). `#`s are viewport area.
+    // |###  \
+    // X------X <- vid == 2: (3, 1)
+    // ^
+    // vid == 1: (-1, 1)
+
+    gl_Position = position;
+
+    opacity = in_opacity;
+
+    repeat = info & BG_IMAGE_REPEAT;
+
+    vec2 screen_size = screen_size;
+    vec2 tex_size = textureSize(image);
+
+    vec2 dest_size = tex_size;
+    switch (info & BG_IMAGE_FIT) {
+        // For `contain` we scale by a factor that makes the image
+        // width match the screen width or makes the image height
+        // match the screen height, whichever is smaller.
+        case BG_IMAGE_CONTAIN: {
+            float scale = min(screen_size.x / tex_size.x, screen_size.y / tex_size.y);
+            dest_size = tex_size * scale;
+        } break;
+
+        // For `cover` we scale by a factor that makes the image
+        // width match the screen width or makes the image height
+        // match the screen height, whichever is larger.
+        case BG_IMAGE_COVER: {
+            float scale = max(screen_size.x / tex_size.x, screen_size.y / tex_size.y);
+            dest_size = tex_size * scale;
+        } break;
+
+        // For `stretch` we stretch the image to the size of
+        // the screen without worrying about aspect ratio.
+        case BG_IMAGE_STRETCH: {
+            dest_size = screen_size;
+        } break;
+
+        // For `none` we just use the original texture size.
+        case BG_IMAGE_NO_FIT: {
+            dest_size = tex_size;
+        } break;
+    }
+
+    vec2 start = vec2(0.0);
+    vec2 mid = (screen_size - dest_size) / vec2(2.0);
+    vec2 end = screen_size - dest_size;
+
+    vec2 dest_offset = mid;
+    switch (info & BG_IMAGE_POSITION) {
+        case BG_IMAGE_TL: {
+            dest_offset = vec2(start.x, start.y);
+        } break;
+        case BG_IMAGE_TC: {
+            dest_offset = vec2(mid.x, start.y);
+        } break;
+        case BG_IMAGE_TR: {
+            dest_offset = vec2(end.x, start.y);
+        } break;
+        case BG_IMAGE_ML: {
+            dest_offset = vec2(start.x, mid.y);
+        } break;
+        case BG_IMAGE_MC: {
+            dest_offset = vec2(mid.x, mid.y);
+        } break;
+        case BG_IMAGE_MR: {
+            dest_offset = vec2(end.x, mid.y);
+        } break;
+        case BG_IMAGE_BL: {
+            dest_offset = vec2(start.x, end.y);
+        } break;
+        case BG_IMAGE_BC: {
+            dest_offset = vec2(mid.x, end.y);
+        } break;
+        case BG_IMAGE_BR: {
+            dest_offset = vec2(end.x, end.y);
+        } break;
+    }
+
+    offset = dest_offset;
+    scale = tex_size / dest_size;
+
+    // We load a fully opaque version of the bg color and combine it with
+    // the alpha separately, because we need these as separate values in
+    // the framgment shader.
+    uvec4 u_bg_color = unpack4u8(bg_color_packed_4u8);
+    bg_color = vec4(load_color(
+                uvec4(u_bg_color.rgb, 255),
+                use_linear_blending
+            ).rgb, float(u_bg_color.a) / 255.0);
+}

--- a/src/renderer/shaders/glsl/common.glsl
+++ b/src/renderer/shaders/glsl/common.glsl
@@ -13,6 +13,7 @@
 //----------------------------------------------------------------------------//
 layout(binding = 1, std140) uniform Globals {
     uniform mat4 projection_matrix;
+    uniform vec2 screen_size;
     uniform vec2 cell_size;
     uniform uint grid_size_packed_2u16;
     uniform vec4 grid_padding;


### PR DESCRIPTION
Adds support for background images via the `background-image` config.

Resolves #3645, supersedes PRs #4226 and #5233.

See docs of added config keys for usage details.

> [!NOTE]
> Unlike what is implied by the original issue, because this is implemented in the renderer it is inherently per-surface not per-window, meaning a window with a split will have two copies of the background image.

### Future work
- We should probably introduce code in the apprts that tells surfaces their position and size relative to the window, which would allow us to add a `background-image-area` config with options for `surface` and `window` to control that behavior (and probably default it to `window`). That apprt code would also allow for window-relative custom shader locations, which is also a fairly common user request, so I think it's worth it.
- Currently if you use a high res background image this is fairly inefficient, since each surface independently loads a copy of the background image. On systems with limited VRAM this could be an issue for users who use a lot of surfaces, so it may be worth making a shared image cache to avoid this problem.
- ~~It's probably worth using compressed texture formats for images, I'll look in to doing that.~~ (c43702c)