### PR TITLE
Don't pass arena allocator to internal_os.open

### DIFF
--- a/src/config/edit.zig
+++ b/src/config/edit.zig
@@ -20,10 +20,10 @@ pub fn open(alloc_gpa: Allocator) !void {
     // Use an arena to make memory management easier in here.
     var arena = ArenaAllocator.init(alloc_gpa);
     defer arena.deinit();
-    const alloc = arena.allocator();
+    const alloc_arena = arena.allocator();
 
     // Get the path we should open
-    const config_path = try configPath(alloc);
+    const config_path = try configPath(alloc_arena);
 
     // Create config directory recursively.
     if (std.fs.path.dirname(config_path)) |config_dir| {
@@ -41,7 +41,7 @@ pub fn open(alloc_gpa: Allocator) !void {
         }
     };
 
-    try internal_os.open(alloc, .text, config_path);
+    try internal_os.open(alloc_gpa, .text, config_path);
 }
 
 /// Returns the config path to use for open for the current OS.


### PR DESCRIPTION
This fixes #7702 by no longer passing the arena allocator to a task that outlives its caller.

As far as I can tell, a reference to `config_path` may live on in the `argv` field of the ChildProcess after the arena is cleared (unless `argv` itself becomes a dangling pointer because the literal it's referencing goes out of scope? Struggling to wrap my head around some of the finer points of Zig array/slice/literal semantics). However, I suppose it's safe to assume that `argv` is never referenced after `exe.spawn()` has returned, in which case there's no issue. If this were a problem, it would apply equally to all uses of `internal_os.open`, not just the open config code path.