### PR TITLE
gtk(wayland): prevent gtk4-layer-shell crash on old versions

### DIFF
--- a/pkg/gtk4-layer-shell/src/main.zig
+++ b/pkg/gtk4-layer-shell/src/main.zig
@@ -1,3 +1,5 @@
+const std = @import("std");
+
 const c = @cImport({
     @cInclude("gtk4-layer-shell.h");
 });
@@ -29,6 +31,14 @@ pub fn isSupported() bool {
 
 pub fn getProtocolVersion() c_uint {
     return c.gtk_layer_get_protocol_version();
+}
+
+pub fn getLibraryVersion() std.SemanticVersion {
+    return .{
+        .major = c.gtk_layer_get_major_version(),
+        .minor = c.gtk_layer_get_minor_version(),
+        .patch = c.gtk_layer_get_micro_version(),
+    };
 }
 
 pub fn initForWindow(window: *gtk.Window) void {


### PR DESCRIPTION
Supersedes #7154

In gtk4-layer-shell versions < 1.0.4, the app could crash upon opening a quick terminal window on certain compositors that implement the `xdg_wm_dialog_v1` protocol. The exact reason is a bit complicated, but is nicely summarized in the upstream issue (wmww/gtk4-layer-shell#50).

The circumstances that could cause this crash to occur should gradually diminish as distros update to newer gtk4-layer-shell versions, but this is known to crash on Fedora 41 and Hyprland, which could be a sizable chunk of our userbase given that this would also occur on GNOME/Mutter and KDE/KWin. The diff should be minimal enough that this can be removed or reverted once this band-aid fix is no longer necessary.