### PR TITLE
Introduce action for copying into clipboard

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4845,6 +4845,11 @@ fn writeScreenFile(
     const path = try tmp_dir.dir.realpath(filename, &path_buf);
 
     switch (write_action) {
+        .copy => {
+            const pathZ = try self.alloc.dupeZ(u8, path);
+            defer self.alloc.free(pathZ);
+            try self.rt_surface.setClipboardString(pathZ, .standard, false);
+        },
         .open => try internal_os.open(self.alloc, .text, path),
         .paste => self.io.queueMessage(try termio.Message.writeReq(
             self.alloc,

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -5034,6 +5034,12 @@ pub const Keybinds = struct {
 
         try self.set.put(
             alloc,
+            .{ .key = .{ .unicode = 'j' }, .mods = .{ .shift = true, .ctrl = true, .super = true } },
+            .{ .write_screen_file = .copy },
+        );
+
+        try self.set.put(
+            alloc,
             .{ .key = .{ .unicode = 'j' }, .mods = inputpkg.ctrlOrSuper(.{ .shift = true }) },
             .{ .write_screen_file = .paste },
         );

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -379,6 +379,10 @@ pub const Action = union(enum) {
     ///
     /// Valid actions are:
     ///
+    ///   - `copy`
+    ///
+    ///     Copy the file path into the clipboard.
+    ///
     ///   - `paste`
     ///
     ///     Paste the file path into the terminal.
@@ -813,6 +817,7 @@ pub const Action = union(enum) {
     };
 
     pub const WriteScreenAction = enum {
+        copy,
         paste,
         open,
     };

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -205,6 +205,11 @@ fn actionCommands(action: Action.Key) []const Command {
 
         .write_screen_file => comptime &.{
             .{
+                .action = .{ .write_screen_file = .copy },
+                .title = "Copy Screen to Temporary File and Copy Path",
+                .description = "Copy the screen contents to a temporary file and copy the path to the clipboard.",
+            },
+            .{
                 .action = .{ .write_screen_file = .paste },
                 .title = "Copy Screen to Temporary File and Paste Path",
                 .description = "Copy the screen contents to a temporary file and paste the path to the file.",
@@ -217,6 +222,11 @@ fn actionCommands(action: Action.Key) []const Command {
         },
 
         .write_selection_file => comptime &.{
+            .{
+                .action = .{ .write_selection_file = .copy },
+                .title = "Copy Selection to Temporary File and Copy Path",
+                .description = "Copy the selection contents to a temporary file and copy the path to the clipboard.",
+            },
             .{
                 .action = .{ .write_selection_file = .paste },
                 .title = "Copy Selection to Temporary File and Paste Path",


### PR DESCRIPTION
This introduces an action for copying the path of a written screen/selection file into the clipboard.

Pasting the path into the terminal doesn't work well if you have a program still running and opening the file outside the terminal (on macOS in TextEdit by default) isn't always a great experience.

Allowing to copy the file path into the clipboard seems like a minor and hopefully uncontroversial addition. 😅