### PR TITLE
macos: don't overwrite the .fullScreen styleMask option in reapplyHiddenStyle

### DIFF
--- a/macos/Sources/Features/Terminal/Window Styles/HiddenTitlebarTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/HiddenTitlebarTerminalWindow.swift
@@ -19,20 +19,27 @@ class HiddenTitlebarTerminalWindow: TerminalWindow {
         NotificationCenter.default.removeObserver(self)
     }
 
+    private let hiddenStyleMask: NSWindow.StyleMask = [
+        // We need `titled` in the mask to get the normal window frame
+        .titled,
+
+        // Full size content view so we can extend
+        // content in to the hidden titlebar's area
+        .fullSizeContentView,
+
+        .resizable,
+        .closable,
+        .miniaturizable,
+    ]
+
     /// Apply the hidden titlebar style.
     private func reapplyHiddenStyle() {
-        styleMask = [
-            // We need `titled` in the mask to get the normal window frame
-            .titled,
-
-            // Full size content view so we can extend
-            // content in to the hidden titlebar's area
-            .fullSizeContentView,
-
-            .resizable,
-            .closable,
-            .miniaturizable,
-        ]
+        // Apply our style mask while preserving the .fullScreen option
+        if styleMask.contains(.fullScreen) {
+            styleMask = hiddenStyleMask.union([.fullScreen])
+        } else {
+            styleMask = hiddenStyleMask
+        }
 
         // Hide the title
         titleVisibility = .hidden

--- a/macos/Sources/Features/Terminal/Window Styles/HiddenTitlebarTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/HiddenTitlebarTerminalWindow.swift
@@ -19,7 +19,7 @@ class HiddenTitlebarTerminalWindow: TerminalWindow {
         NotificationCenter.default.removeObserver(self)
     }
 
-    private let hiddenStyleMask: NSWindow.StyleMask = [
+    private static let hiddenStyleMask: NSWindow.StyleMask = [
         // We need `titled` in the mask to get the normal window frame
         .titled,
 
@@ -36,9 +36,9 @@ class HiddenTitlebarTerminalWindow: TerminalWindow {
     private func reapplyHiddenStyle() {
         // Apply our style mask while preserving the .fullScreen option
         if styleMask.contains(.fullScreen) {
-            styleMask = hiddenStyleMask.union([.fullScreen])
+            styleMask = Self.hiddenStyleMask.union([.fullScreen])
         } else {
-            styleMask = hiddenStyleMask
+            styleMask = Self.hiddenStyleMask
         }
 
         // Hide the title


### PR DESCRIPTION
Fixes #7625 (which apparently didn't catch anyone's attention, but I'd be very surprised if no one were able to reproduce it if they tried; also, re discord chat)