### PR TITLE
linux: add install target to systemd user service

### DIFF
--- a/dist/linux/systemd.service.in
+++ b/dist/linux/systemd.service.in
@@ -1,7 +1,11 @@
 [Unit]
 Description=@NAME@
+After=graphical-session.target
 
 [Service]
 Type=dbus
 BusName=@APPID@
 ExecStart=@GHOSTTY@ --launched-from=systemd
+
+[Install]
+WantedBy=graphical-session.target


### PR DESCRIPTION
This will allow users to enable Ghostty startup on login. Users will need to explicitly enable startup on login via this command:

```sh
systemctl enable --user com.mitchellh.ghostty.service
```