### PR TITLE
(macOS) Memory Leak Fixes

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -26,8 +26,8 @@
         },
         .zig_objc = .{
             // mitchellh/zig-objc
-            .url = "https://github.com/mitchellh/zig-objc/archive/3ab0d37c7d6b933d6ded1b3a35b6b60f05590a98.tar.gz",
-            .hash = "zig_objc-0.0.0-Ir_Sp3TyAADEVRTxXlScq3t_uKAM91MYNerZkHfbD0yt",
+            .url = "https://github.com/mitchellh/zig-objc/archive/c9e917a4e15a983b672ca779c7985d738a2d517c.tar.gz",
+            .hash = "zig_objc-0.0.0-Ir_SpwsPAQBJgi9YRm2ubJMfdoysSq5gKpsIj3izQ8Zk",
             .lazy = true,
         },
         .zig_js = .{

--- a/build.zig.zon.json
+++ b/build.zig.zon.json
@@ -144,10 +144,10 @@
     "url": "https://deps.files.ghostty.org/zig_js-12205a66d423259567764fa0fc60c82be35365c21aeb76c5a7dc99698401f4f6fefc.tar.gz",
     "hash": "sha256-fyNeCVbC9UAaKJY6JhAZlT0A479M/AKYMPIWEZbDWD0="
   },
-  "zig_objc-0.0.0-Ir_Sp3TyAADEVRTxXlScq3t_uKAM91MYNerZkHfbD0yt": {
+  "zig_objc-0.0.0-Ir_SpwsPAQBJgi9YRm2ubJMfdoysSq5gKpsIj3izQ8Zk": {
     "name": "zig_objc",
-    "url": "https://github.com/mitchellh/zig-objc/archive/3ab0d37c7d6b933d6ded1b3a35b6b60f05590a98.tar.gz",
-    "hash": "sha256-zn1tR6xhSmDla4UJ3t+Gni4Ni3R8deSK3tEe7DGzNXw="
+    "url": "https://github.com/mitchellh/zig-objc/archive/c9e917a4e15a983b672ca779c7985d738a2d517c.tar.gz",
+    "hash": "sha256-o3vl7qfkSi0bKXa6JWuF92qMEGP8Af/shcip5nRo5Nw="
   },
   "wayland-0.4.0-dev-lQa1kjfIAQCmhhQu3xF0KH-94-TzeMXOqfnP0-Dg6Wyy": {
     "name": "zig_wayland",

--- a/build.zig.zon.nix
+++ b/build.zig.zon.nix
@@ -314,11 +314,11 @@ in
       };
     }
     {
-      name = "zig_objc-0.0.0-Ir_Sp3TyAADEVRTxXlScq3t_uKAM91MYNerZkHfbD0yt";
+      name = "zig_objc-0.0.0-Ir_SpwsPAQBJgi9YRm2ubJMfdoysSq5gKpsIj3izQ8Zk";
       path = fetchZigArtifact {
         name = "zig_objc";
-        url = "https://github.com/mitchellh/zig-objc/archive/3ab0d37c7d6b933d6ded1b3a35b6b60f05590a98.tar.gz";
-        hash = "sha256-zn1tR6xhSmDla4UJ3t+Gni4Ni3R8deSK3tEe7DGzNXw=";
+        url = "https://github.com/mitchellh/zig-objc/archive/c9e917a4e15a983b672ca779c7985d738a2d517c.tar.gz";
+        hash = "sha256-o3vl7qfkSi0bKXa6JWuF92qMEGP8Af/shcip5nRo5Nw=";
       };
     }
     {

--- a/build.zig.zon.txt
+++ b/build.zig.zon.txt
@@ -29,6 +29,6 @@ https://github.com/glfw/glfw/archive/e7ea71be039836da3a98cea55ae5569cb5eb885c.ta
 https://github.com/jcollie/ghostty-gobject/releases/download/0.14.0-2025-03-18-21-1/ghostty-gobject-0.14.0-2025-03-18-21-1.tar.zst
 https://github.com/mbadolato/iTerm2-Color-Schemes/archive/6fa671fdc1daf1fcfa025cb960ffa3e7373a2ed8.tar.gz
 https://github.com/mitchellh/libxev/archive/75a10d0fb374e8eb84948dcfc68d865e755e59c2.tar.gz
-https://github.com/mitchellh/zig-objc/archive/3ab0d37c7d6b933d6ded1b3a35b6b60f05590a98.tar.gz
+https://github.com/mitchellh/zig-objc/archive/c9e917a4e15a983b672ca779c7985d738a2d517c.tar.gz
 https://github.com/natecraddock/zf/archive/7aacbe6d155d64d15937ca95ca6c014905eb531f.tar.gz
 https://github.com/vancluever/z2d/archive/8bbd035f4101f02b1d27947def0d7da3215df7fe.tar.gz

--- a/flatpak/zig-packages.json
+++ b/flatpak/zig-packages.json
@@ -175,9 +175,9 @@
   },
   {
     "type": "archive",
-    "url": "https://github.com/mitchellh/zig-objc/archive/3ab0d37c7d6b933d6ded1b3a35b6b60f05590a98.tar.gz",
-    "dest": "vendor/p/zig_objc-0.0.0-Ir_Sp3TyAADEVRTxXlScq3t_uKAM91MYNerZkHfbD0yt",
-    "sha256": "ce7d6d47ac614a60e56b8509dedf869e2e0d8b747c75e48aded11eec31b3357c"
+    "url": "https://github.com/mitchellh/zig-objc/archive/c9e917a4e15a983b672ca779c7985d738a2d517c.tar.gz",
+    "dest": "vendor/p/zig_objc-0.0.0-Ir_SpwsPAQBJgi9YRm2ubJMfdoysSq5gKpsIj3izQ8Zk",
+    "sha256": "a37be5eea7e44a2d1b2976ba256b85f76a8c1063fc01ffec85c8a9e67468e4dc"
   },
   {
     "type": "archive",

--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -831,6 +831,9 @@ pub const CoreText = struct {
         i: usize,
 
         pub fn deinit(self: *DiscoverIterator) void {
+            for (self.list) |desc| {
+                desc.release();
+            }
             self.alloc.free(self.list);
             self.* = undefined;
         }

--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -109,7 +109,8 @@ pub const Shaper = struct {
     /// settings the font features of a CoreText font.
     fn makeFeaturesDict(feats: []const Feature) !*macos.foundation.Dictionary {
         const list = try macos.foundation.MutableArray.create();
-        errdefer list.release();
+        // The list will be retained by the dict once we add it to it.
+        defer list.release();
 
         for (feats) |feat| {
             const value_num: c_int = @intCast(feat.value);

--- a/src/renderer/metal/Target.zig
+++ b/src/renderer/metal/Target.zig
@@ -68,7 +68,7 @@ pub fn init(opts: Options) !Self {
         const id_init = id_alloc.msgSend(objc.Object, objc.sel("init"), .{});
         break :init id_init;
     };
-    errdefer desc.msgSend(void, objc.sel("release"), .{});
+    defer desc.release();
 
     // Set our properties
     desc.setProperty("width", @as(c_ulong, @intCast(opts.width)));

--- a/src/renderer/metal/Texture.zig
+++ b/src/renderer/metal/Texture.zig
@@ -50,7 +50,7 @@ pub fn init(
         const id_init = id_alloc.msgSend(objc.Object, objc.sel("init"), .{});
         break :init id_init;
     };
-    errdefer desc.msgSend(void, objc.sel("release"), .{});
+    defer desc.release();
 
     // Set our properties
     desc.setProperty("pixelFormat", @intFromEnum(opts.pixel_format));


### PR DESCRIPTION
This PR contains fixes for 4 different memory leaks that affected Ghostty on macOS.

1. (whenever a font is loaded) CoreText font features dict list wasn't properly released. Fixed by releasing.
2. (whenever a font is searched for) CoreText discovery iterator descriptors weren't properly released. Fixed by releasing.
3. (during resize) Metal texture descriptors were not properly released. Fixed by releasing.
4. (every frame) Objective-C runtime blocks for buffer completion handler and IOSurfaceLayer set surface were not properly deallocated due to issues with the internal implementation in `zig-objc`. Fixed in `zig-objc`, dependency hash updated with fix.

A handful of small apparent leaks remain but their cause is not clear and they're all static (not increasing over time, seemingly).

### Xcode memory graph "leaks" comparison
|Before (main)|After (this PR)|
|-|-|
|<img width="445" alt="image" src="https://github.com/user-attachments/assets/d1c89918-8ab2-4201-bf1e-9b3a519a85a8" />|<img width="445" alt="image" src="https://github.com/user-attachments/assets/88c60807-756e-48d8-9918-2a52d6556035"/>|

<sup>Images taken after launching Ghostty, creating 4 tabs, and rapidly switching between them to force render many frames.</sup>

---

Hopefully this fixes the occasional OOM issues some users have reported.