### PR TITLE
renderer/opengl: fix issue with cell bg alignment on some systems

### DIFF
--- a/src/renderer/shaders/glsl/cell_bg.f.glsl
+++ b/src/renderer/shaders/glsl/cell_bg.f.glsl
@@ -1,7 +1,7 @@
 #include "common.glsl"
 
 // Position the origin to the upper left
-layout(origin_upper_left, pixel_center_integer) in vec4 gl_FragCoord;
+layout(origin_upper_left) in vec4 gl_FragCoord;
 
 // Must declare this output for some versions of OpenGL.
 layout(location = 0) out vec4 out_FragColor;


### PR DESCRIPTION
Discussed in #7714, fix confirmed by user as working.

Okay, so, what the hell? This implies that on this user's system, something that *should* be an integer multiple of the cell width, when divided by the cell width, is giving some epsilon less than the proper result. I can only guess that this is driver or hardware weirdness, possibly the fragcoord is being converted from a low precision float in NDC to the fragment-space coordinate so we're not actually getting an integer multiple, and the epsilon less is actually before the division?

Regardless, switching it back to use halves for pixel coordinates fixes this and shouldn't break the math at all, since `floor((n * k + 0.5)/k)` should always yield `n` just like without the `+ 0.5`.