### PR TITLE
config: for now, make goto_tab NOT performable on macOS

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -5455,7 +5455,14 @@ pub const Keybinds = struct {
                         .mods = mods,
                     },
                     .{ .goto_tab = (i - start) + 1 },
-                    .{ .performable = true },
+                    .{
+                        // On macOS we keep this not performable so that the
+                        // keyboard shortcuts in tabs work. In the future the
+                        // correct fix is to fix the reverse mapping lookup
+                        // to allow us to lookup performable keybinds
+                        // conditionally.
+                        .performable = !builtin.target.os.tag.isDarwin(),
+                    },
                 );
             }
             try self.set.putFlags(
@@ -5465,7 +5472,10 @@ pub const Keybinds = struct {
                     .mods = mods,
                 },
                 .{ .last_tab = {} },
-                .{ .performable = true },
+                .{
+                    // See comment above with the numeric goto_tab
+                    .performable = !builtin.target.os.tag.isDarwin(),
+                },
             );
         }
 


### PR DESCRIPTION
Fixes #7786
Fixes regression from #7683

This is a band-aid fix. The issue is that performable keybinds don't show up in the reverse mapping that GUI toolkits use to find their key equivalents. The full explanation of why is already in Binding.zig.

For macOS, we have a way to validate menu items before they're triggered so we ideally do want a way to get reverse mappings even with performable keybinds. But I think this wants to be optional and that's all a bigger change. For now, this is a simple fix that will work.