### PR TITLE
Add linux kernel information to +version

### DIFF
--- a/src/cli/version.zig
+++ b/src/cli/version.zig
@@ -15,8 +15,6 @@ pub const Options = struct {};
 /// The `version` command is used to display information about Ghostty. Recognized as
 /// either `+version` or `--version`.
 pub fn run(alloc: Allocator) !u8 {
-    _ = alloc;
-
     const stdout = std.io.getStdOut().writer();
     const tty = std.io.getStdOut().isTty();
 
@@ -34,32 +32,37 @@ pub fn run(alloc: Allocator) !u8 {
     try stdout.print("  - channel: {s}\n", .{@tagName(build_config.release_channel)});
 
     try stdout.print("Build Config\n", .{});
-    try stdout.print("  - Zig version: {s}\n", .{builtin.zig_version_string});
-    try stdout.print("  - build mode : {}\n", .{builtin.mode});
-    try stdout.print("  - app runtime: {}\n", .{build_config.app_runtime});
-    try stdout.print("  - font engine: {}\n", .{build_config.font_backend});
-    try stdout.print("  - renderer   : {}\n", .{renderer.Renderer});
-    try stdout.print("  - libxev     : {s}\n", .{@tagName(xev.backend)});
+    try stdout.print("  - Zig version   : {s}\n", .{builtin.zig_version_string});
+    try stdout.print("  - build mode    : {}\n", .{builtin.mode});
+    try stdout.print("  - app runtime   : {}\n", .{build_config.app_runtime});
+    try stdout.print("  - font engine   : {}\n", .{build_config.font_backend});
+    try stdout.print("  - renderer      : {}\n", .{renderer.Renderer});
+    try stdout.print("  - libxev        : {s}\n", .{@tagName(xev.backend)});
     if (comptime build_config.app_runtime == .gtk) {
-        try stdout.print("  - desktop env: {s}\n", .{@tagName(internal_os.desktopEnvironment())});
-        try stdout.print("  - GTK version:\n", .{});
-        try stdout.print("    build      : {}\n", .{gtk_version.comptime_version});
-        try stdout.print("    runtime    : {}\n", .{gtk_version.getRuntimeVersion()});
-        try stdout.print("  - libadwaita : enabled\n", .{});
-        try stdout.print("    build      : {}\n", .{adw_version.comptime_version});
-        try stdout.print("    runtime    : {}\n", .{adw_version.getRuntimeVersion()});
+        if (comptime builtin.os.tag == .linux) {
+            const kernel_info = internal_os.getKernelInfo(alloc);
+            defer if (kernel_info) |k| alloc.free(k);
+            try stdout.print("  - kernel version: {s}\n", .{kernel_info orelse "Kernel information unavailable"});
+        }
+        try stdout.print("  - desktop env   : {s}\n", .{@tagName(internal_os.desktopEnvironment())});
+        try stdout.print("  - GTK version   :\n", .{});
+        try stdout.print("    build         : {}\n", .{gtk_version.comptime_version});
+        try stdout.print("    runtime       : {}\n", .{gtk_version.getRuntimeVersion()});
+        try stdout.print("  - libadwaita    : enabled\n", .{});
+        try stdout.print("    build         : {}\n", .{adw_version.comptime_version});
+        try stdout.print("    runtime       : {}\n", .{adw_version.getRuntimeVersion()});
         if (comptime build_options.x11) {
-            try stdout.print("  - libX11     : enabled\n", .{});
+            try stdout.print("  - libX11        : enabled\n", .{});
         } else {
-            try stdout.print("  - libX11     : disabled\n", .{});
+            try stdout.print("  - libX11        : disabled\n", .{});
         }
 
         // We say `libwayland` since it is possible to build Ghostty without
         // Wayland integration but with Wayland-enabled GTK
         if (comptime build_options.wayland) {
-            try stdout.print("  - libwayland : enabled\n", .{});
+            try stdout.print("  - libwayland    : enabled\n", .{});
         } else {
-            try stdout.print("  - libwayland : disabled\n", .{});
+            try stdout.print("  - libwayland    : disabled\n", .{});
         }
     }
     return 0;

--- a/src/os/kernel_info.zig
+++ b/src/os/kernel_info.zig
@@ -1,0 +1,27 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub fn getKernelInfo(alloc: std.mem.Allocator) ?[]const u8 {
+    if (comptime builtin.os.tag != .linux) return null;
+    const path = "/proc/sys/kernel/osrelease";
+    var file = std.fs.openFileAbsolute(path, .{}) catch return null;
+    defer file.close();
+
+    // 128 bytes should be enough to hold the kernel information
+    const kernel_info = file.readToEndAlloc(alloc, 128) catch return null;
+    defer alloc.free(kernel_info);
+    return alloc.dupe(u8, std.mem.trim(u8, kernel_info, &std.ascii.whitespace)) catch return null;
+}
+
+test "read /proc/sys/kernel/osrelease" {
+    if (comptime builtin.os.tag != .linux) return null;
+    const allocator = std.testing.allocator;
+
+    const kernel_info = try getKernelInfo(allocator);
+    defer allocator.free(kernel_info);
+
+    // Since we can't hardcode the info in tests, just check
+    // if something was read from the file
+    try std.testing.expect(kernel_info.len > 0);
+    try std.testing.expect(!std.mem.eql(u8, kernel_info, ""));
+}

--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -14,6 +14,7 @@ const openpkg = @import("open.zig");
 const pipepkg = @import("pipe.zig");
 const resourcesdir = @import("resourcesdir.zig");
 const systemd = @import("systemd.zig");
+const kernelInfo = @import("kernel_info.zig");
 
 // Namespaces
 pub const args = @import("args.zig");
@@ -58,6 +59,7 @@ pub const pipe = pipepkg.pipe;
 pub const resourcesDir = resourcesdir.resourcesDir;
 pub const ResourcesDir = resourcesdir.ResourcesDir;
 pub const ShellEscapeWriter = shell.ShellEscapeWriter;
+pub const getKernelInfo = kernelInfo.getKernelInfo;
 
 test {
     _ = i18n;


### PR DESCRIPTION
Adds basic kernel information to `ghostty +version`. 
`ghostty +version` on my machine now prints:
```
Ghostty 1.1.4-kernel-version-info+cdbc78bce

Version
  - version: 1.1.4-kernel-version-info+cdbc78bce
  - channel: tip
Build Config
  - Zig version   : 0.14.1
  - build mode    : builtin.OptimizeMode.Debug
  - app runtime   : apprt.Runtime.gtk
  - font engine   : font.main.Backend.fontconfig_freetype
  - renderer      : renderer.generic.Renderer(renderer.OpenGL)
  - libxev        : io_uring
  - kernel version: 6.15.4-200.fc42.x86_64
  - desktop env   : other
  - GTK version   :
    build         : 4.18.5
    runtime       : 4.18.5
  - libadwaita    : enabled
    build         : 1.7.4
    runtime       : 1.7.4
  - libX11        : enabled
  - libwayland    : enabled

```


PS This is my first time writing prod code in Zig, so any suggestions and guidelines are welcome