### PR TITLE
macOS: remove @DeferredProperty usage from TerminalEntity

### DIFF
--- a/macos/Sources/Features/App Intents/Entities/TerminalEntity.swift
+++ b/macos/Sources/Features/App Intents/Entities/TerminalEntity.swift
@@ -14,26 +14,6 @@ struct TerminalEntity: AppEntity {
     @Property(title: "Kind")
     var kind: Kind
 
-    @MainActor
-    @DeferredProperty(title: "Full Contents")
-    @available(macOS 26.0, *)
-    var screenContents: String? {
-        get async {
-            guard let surfaceView else { return nil }
-            return surfaceView.cachedScreenContents.get()
-        }
-    }
-
-    @MainActor
-    @DeferredProperty(title: "Visible Contents")
-    @available(macOS 26.0, *)
-    var visibleContents: String? {
-        get async {
-            guard let surfaceView else { return nil }
-            return surfaceView.cachedVisibleContents.get()
-        }
-    }
-
     var screenshot: Image?
 
     static var typeDisplayRepresentation: TypeDisplayRepresentation {


### PR DESCRIPTION
This fixes an Apple Shortcuts crash for macOS 15 and earlier. Unfortunately it looks like we can't guard these with `@available`. I'm going to report an Apple Feedback about this but for now this gets shortcuts working on macOS 15 and earlier.