### PR TITLE
bash: stop using PS0 for the 'cursor' feature

### DIFF
--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -106,7 +106,6 @@ _ghostty_last_reported_cwd=""
 function __ghostty_precmd() {
     local ret="$?"
     if test "$_ghostty_executing" != "0"; then
-      _GHOSTTY_SAVE_PS0="$PS0"
       _GHOSTTY_SAVE_PS1="$PS1"
       _GHOSTTY_SAVE_PS2="$PS2"
 
@@ -123,8 +122,8 @@ function __ghostty_precmd() {
 
       # Cursor
       if [[ "$GHOSTTY_SHELL_FEATURES" == *"cursor"* ]]; then
-        PS1=$PS1'\[\e[5 q\]'
-        PS0=$PS0'\[\e[0 q\]'
+        PS1=$PS1'\[\e[5 q\]'      # blinking bar for input
+        builtin printf "\e[0 q"   # reset to default cursor
       fi
 
       # Title (working directory)
@@ -154,7 +153,6 @@ function __ghostty_precmd() {
 function __ghostty_preexec() {
     builtin local cmd="$1"
 
-    PS0="$_GHOSTTY_SAVE_PS0"
     PS1="$_GHOSTTY_SAVE_PS1"
     PS2="$_GHOSTTY_SAVE_PS2"
 


### PR DESCRIPTION
Our use of PS0 (which bash runs before command execution) was causing raw command sequences to be printed between multiple commands in a sequence.

    $ alias garbage='echo start
    > echo end'

    $ garbage
    start
    �\���dend

I wasn't able to definitely track down all of the reasons for why this only happens in the command sequence case, but I suspect it's related to the way that __ghostty_preexec runs from within the bash DEBUG trap (by way of bash-preexec).

This problem occurs when PS0 is set to _any_ string (even "") inside of __ghostty_preexec, which also rules out most/any Ghostty-specific code. PS1 and PS2 appear to be safe to (re)set in this context.

Fortunately, we can avoid using PS0 entirely by instead printing the cursor reset escape sequence directly from __ghostty_precmd because it also runs just before command execution.

Fixes #7802