### PR TITLE
fix: draw cursor on top of text for most cursor styles

### DIFF
--- a/src/renderer/cell.zig
+++ b/src/renderer/cell.zig
@@ -145,15 +145,14 @@ pub const Contents = struct {
         self.fg_rows.lists[0].clearRetainingCapacity();
         self.fg_rows.lists[self.size.rows + 1].clearRetainingCapacity();
 
-        if (v) |cell| {
-            if (cursor_style) |style| {
-                switch (style) {
-                    // Block cursors should be drawn first
-                    .block => self.fg_rows.lists[0].appendAssumeCapacity(cell),
-                    // Other cursor styles should be drawn last
-                    .block_hollow, .bar, .underline, .lock => self.fg_rows.lists[self.size.rows + 1].appendAssumeCapacity(cell),
-                }
-            }
+        const cell = v orelse return;
+        const style = cursor_style orelse return;
+
+        switch (style) {
+            // Block cursors should be drawn first
+            .block => self.fg_rows.lists[0].appendAssumeCapacity(cell),
+            // Other cursor styles should be drawn last
+            .block_hollow, .bar, .underline, .lock => self.fg_rows.lists[self.size.rows + 1].appendAssumeCapacity(cell),
         }
     }
 

--- a/src/renderer/cell.zig
+++ b/src/renderer/cell.zig
@@ -103,11 +103,12 @@ pub const Contents = struct {
         // form a single grapheme, and multi-substitutions in fonts, the number
         // of glyphs in a row is theoretically unlimited.
         //
-        // We have size.rows + 1 lists because index 0 is used for a special
-        // list containing the cursor cell which needs to be first in the buffer.
+        // We have size.rows + 2 lists because indexes 0 and size.rows - 1 are
+        // used for special lists containing the cursor cell which need to
+        // be first and last in the buffer, respectively.
         var fg_rows = try ArrayListCollection(shaderpkg.CellText).init(
             alloc,
-            size.rows + 1,
+            size.rows + 2,
             size.columns * 3,
         );
         errdefer fg_rows.deinit(alloc);
@@ -118,12 +119,17 @@ pub const Contents = struct {
         self.bg_cells = bg_cells;
         self.fg_rows = fg_rows;
 
-        // We don't need 3*cols worth of cells for the cursor list, so we can
-        // replace it with a smaller list. This is technically a tiny bit of
+        // We don't need 3*cols worth of cells for the cursor lists, so we can
+        // replace them with smaller lists. This is technically a tiny bit of
         // extra work but resize is not a hot function so it's worth it to not
         // waste the memory.
         self.fg_rows.lists[0].deinit(alloc);
         self.fg_rows.lists[0] = try std.ArrayListUnmanaged(
+            shaderpkg.CellText,
+        ).initCapacity(alloc, 1);
+
+        self.fg_rows.lists[size.rows + 1].deinit(alloc);
+        self.fg_rows.lists[size.rows + 1] = try std.ArrayListUnmanaged(
             shaderpkg.CellText,
         ).initCapacity(alloc, 1);
     }
@@ -137,6 +143,7 @@ pub const Contents = struct {
     /// Set the cursor value. If the value is null then the cursor is hidden.
     pub fn setCursor(self: *Contents, v: ?shaderpkg.CellText) void {
         self.fg_rows.lists[0].clearRetainingCapacity();
+        self.fg_rows.lists[self.size.rows + 1].clearRetainingCapacity();
 
         if (v) |cell| {
             self.fg_rows.lists[0].appendAssumeCapacity(cell);

--- a/src/renderer/cell.zig
+++ b/src/renderer/cell.zig
@@ -393,6 +393,10 @@ test Contents {
     // And remove it.
     c.setCursor(null, null);
     try testing.expectEqual(0, c.fg_rows.lists[0].items.len);
+
+    // Add a hollow cursor.
+    c.setCursor(cursor_cell, .block_hollow);
+    try testing.expectEqual(cursor_cell, c.fg_rows.lists[rows + 1].items[0]);
 }
 
 test "Contents clear retains other content" {

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -2791,7 +2791,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // Setup our cursor rendering information.
             cursor: {
                 // By default, we don't handle cursor inversion on the shader.
-                self.cells.setCursor(null);
+                self.cells.setCursor(null, null);
                 self.uniforms.cursor_pos = .{
                     std.math.maxInt(u16),
                     std.math.maxInt(u16),
@@ -3162,7 +3162,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     @intCast(render.glyph.offset_x),
                     @intCast(render.glyph.offset_y),
                 },
-            });
+            }, cursor_style);
         }
 
         fn addPreeditCell(


### PR DESCRIPTION
This addresses #7739.

## Changes
* Added second cursor list to the renderer as suggested
* Modified `Contents.setCursor` to accept a cursor style argument in order to conditionally render the cursor
  * Not sure if this the optimal workaround so suggestions would be appreciated

## Screenshots
Block:
![Screenshot 2025-07-04 at 7 10 19 PM](https://github.com/user-attachments/assets/39caf936-863b-42f3-9ca9-a32a2da237b8)

Hollow block:
![Screenshot 2025-07-04 at 7 10 06 PM](https://github.com/user-attachments/assets/5063e1a0-06c7-46d1-9118-5855bff7cc5c)

