### PR TITLE
Add action to set font size

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4484,6 +4484,14 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             try self.setFontSize(size);
         },
 
+        .set_font_size => |points| {
+            log.debug("set font size={d}", .{points});
+
+            var size = self.font_size;
+            size.points = std.math.clamp(points, 1.0, 255.0);
+            try self.setFontSize(size);
+        },
+
         .prompt_surface_title => return try self.rt_app.performAction(
             .{ .surface = self },
             .prompt_title,

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -6531,8 +6531,9 @@ pub const RepeatableCommand = struct {
         try list.parseCLI(alloc, "title:Foo,action:ignore");
         try list.parseCLI(alloc, "title:Bar,description:bobr,action:text:ale bydle");
         try list.parseCLI(alloc, "title:Quux,description:boo,action:increase_font_size:2.5");
+        try list.parseCLI(alloc, "title:Baz,description:Raspberry Pie,action:set_font_size:3.14");
 
-        try testing.expectEqual(@as(usize, 3), list.value.items.len);
+        try testing.expectEqual(@as(usize, 4), list.value.items.len);
 
         try testing.expectEqual(inputpkg.Binding.Action.ignore, list.value.items[0].action);
         try testing.expectEqualStrings("Foo", list.value.items[0].title);
@@ -6548,6 +6549,13 @@ pub const RepeatableCommand = struct {
         );
         try testing.expectEqualStrings("Quux", list.value.items[2].title);
         try testing.expectEqualStrings("boo", list.value.items[2].description);
+
+        try testing.expectEqual(
+            inputpkg.Binding.Action{ .set_font_size = 3.14 },
+            list.value.items[3].action,
+        );
+        try testing.expectEqualStrings("Baz", list.value.items[3].title);
+        try testing.expectEqualStrings("Raspberry Pie", list.value.items[3].description);
 
         try list.parseCLI(alloc, "");
         try testing.expectEqual(@as(usize, 0), list.value.items.len);

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -296,6 +296,12 @@ pub const Action = union(enum) {
     /// Reset the font size to the original configured size.
     reset_font_size,
 
+    /// Set the font size to the specified size in points (pt).
+    ///
+    /// For example, `set_font_size:14.5` will set the font size
+    /// to 14.5 points.
+    set_font_size: f32,
+
     /// Clear the screen and all scrollback.
     clear_screen,
 
@@ -1004,6 +1010,7 @@ pub const Action = union(enum) {
             .increase_font_size,
             .decrease_font_size,
             .reset_font_size,
+            .set_font_size,
             .prompt_surface_title,
             .clear_screen,
             .select_all,
@@ -3065,6 +3072,7 @@ test "set: getEvent codepoint case folding" {
         try testing.expect(action == null);
     }
 }
+
 test "Action: clone" {
     const testing = std.testing;
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
@@ -3081,5 +3089,44 @@ test "Action: clone" {
         var a: Action = .{ .text = "foo" };
         const b = try a.clone(alloc);
         try testing.expect(b == .text);
+    }
+}
+
+test "parse: increase_font_size" {
+    const testing = std.testing;
+
+    {
+        const binding = try parseSingle("a=increase_font_size:1.5");
+        try testing.expect(binding.action == .increase_font_size);
+        try testing.expectEqual(1.5, binding.action.increase_font_size);
+    }
+}
+
+test "parse: decrease_font_size" {
+    const testing = std.testing;
+
+    {
+        const binding = try parseSingle("a=decrease_font_size:2.5");
+        try testing.expect(binding.action == .decrease_font_size);
+        try testing.expectEqual(2.5, binding.action.decrease_font_size);
+    }
+}
+
+test "parse: reset_font_size" {
+    const testing = std.testing;
+
+    {
+        const binding = try parseSingle("a=reset_font_size");
+        try testing.expect(binding.action == .reset_font_size);
+    }
+}
+
+test "parse: set_font_size" {
+    const testing = std.testing;
+
+    {
+        const binding = try parseSingle("a=set_font_size:13.5");
+        try testing.expect(binding.action == .set_font_size);
+        try testing.expectEqual(13.5, binding.action.set_font_size);
     }
 }

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const Action = @import("Binding.zig").Action;
@@ -460,6 +461,7 @@ fn actionCommands(action: Action.Key) []const Command {
         .esc,
         .text,
         .cursor_key,
+        .set_font_size,
         .scroll_page_fractional,
         .scroll_page_lines,
         .adjust_selection,


### PR DESCRIPTION
Fixes #7795 

Adds the `set_font_size` keybind action.
