### PR TITLE
gtk: don't allow focusing on tab overview or menu buttons

### DIFF
--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -214,6 +214,7 @@ pub fn init(self: *Window, app: *App) !void {
     {
         const btn = gtk.MenuButton.new();
         btn.as(gtk.Widget).setTooltipText(i18n._("Main Menu"));
+        btn.as(gtk.Widget).setCanFocus(0);
         btn.setIconName("open-menu-symbolic");
         btn.setPopover(self.titlebar_menu.asWidget());
         _ = gobject.Object.signals.notify.connect(
@@ -253,6 +254,7 @@ pub fn init(self: *Window, app: *App) !void {
             },
         };
 
+        btn.setCanFocus(0);
         btn.setFocusOnClick(0);
         self.headerbar.packEnd(btn);
     }


### PR DESCRIPTION
This prevents GTK from focusing on those buttons, which would prevent focus from returning to the terminal after those buttons had been used.