### PR TITLE
Add termio to terminal CODEOWNERS group

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -155,6 +155,7 @@
 /src/input/KeyEncoder.zig @ghostty-org/terminal
 /src/terminal/ @ghostty-org/terminal
 /src/terminfo/ @ghostty-org/terminal
+/src/termio/ @ghostty-org/terminal
 /src/unicode/ @ghostty-org/terminal
 /src/Surface.zig @ghostty-org/terminal
 /src/surface_mouse.zig @ghostty-org/terminal


### PR DESCRIPTION
The termio directory contains the implementation of many terminal features that those in the terminal reviewer group may want to be notified about.

---

An example of a terminal related PR that only changed files in the `termio` directory (and thus didn't assign @ghostty-org/terminal): https://github.com/ghostty-org/ghostty/pull/7725

I included the entire `termio` directory. If others in the @ghostty-org/terminal group think this is too broad we can narrow it down.