### PR TITLE
Add link-previews option

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -37,6 +37,7 @@ pub const ShellIntegrationFeatures = Config.ShellIntegrationFeatures;
 pub const WindowPaddingColor = Config.WindowPaddingColor;
 pub const BackgroundImagePosition = Config.BackgroundImagePosition;
 pub const BackgroundImageFit = Config.BackgroundImageFit;
+pub const LinkPreviews = Config.LinkPreviews;
 
 // Alternate APIs
 pub const CAPI = @import("config/CAPI.zig");

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1046,6 +1046,14 @@ link: RepeatableLink = .{},
 /// `link`). If you want to customize URL matching, use `link` and disable this.
 @"link-url": bool = true,
 
+/// Show link previews for a matched URL.
+///
+/// When true, link previews are shown for all matched URLs. When false, link
+/// previews are never shown. When set to "osc8", link previews are only shown
+/// for hyperlinks created with the OSC 8 sequence (in this case, the link text
+/// can differ from the link destination).
+@"link-previews": LinkPreviews = .true,
+
 /// Whether to start the window in a maximized state. This setting applies
 /// to new windows and does not apply to tabs, splits, etc. However, this setting
 /// will apply to all new windows, not just the first one.
@@ -4324,6 +4332,12 @@ pub const WindowPaddingColor = enum {
 pub const WindowSubtitle = enum {
     false,
     @"working-directory",
+};
+
+pub const LinkPreviews = enum {
+    false,
+    true,
+    osc8,
 };
 
 /// Color represents a color using RGB.


### PR DESCRIPTION
Implement the `link-previews` option from https://github.com/ghostty-org/ghostty/discussions/7727.

The feature request isn't accepted yet, but I had a bit of free time to write this up and it was pretty quick, so I figure there's no harm in proposing an implementation.

Demo of `link-previews = osc8`:


https://github.com/user-attachments/assets/17a72ab2-c727-4a85-9edd-9b6e7da05d98

