### PR TITLE
keybind: add copy_title_to_clipboard action

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4445,6 +4445,7 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
 
         .copy_title_to_clipboard => {
             const title = self.rt_surface.getTitle() orelse return false;
+            if (title.len == 0) return false;
 
             self.rt_surface.setClipboardString(title, .standard, false) catch |err| {
                 log.err("error copying title to clipboard err={}", .{err});

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4443,6 +4443,17 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             return false;
         },
 
+        .copy_title => {
+            const title = self.rt_surface.getTitle() orelse return false;
+
+            self.rt_surface.setClipboardString(title, .standard, false) catch |err| {
+                log.err("error copying title to clipboard err={}", .{err});
+                return true;
+            };
+
+            return true;
+        },
+
         .paste_from_clipboard => try self.startClipboardRequest(
             .standard,
             .{ .paste = {} },

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4443,7 +4443,7 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             return false;
         },
 
-        .copy_title => {
+        .copy_title_to_clipboard => {
             const title = self.rt_surface.getTitle() orelse return false;
 
             self.rt_surface.setClipboardString(title, .standard, false) catch |err| {

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -283,7 +283,7 @@ pub const Action = union(enum) {
 
     /// Copy the terminal title to the clipboard. If the terminal title is not
     /// set this has no effect.
-    copy_title,
+    copy_title_to_clipboard,
 
     /// Increase the font size by the specified amount in points (pt).
     ///
@@ -1009,7 +1009,7 @@ pub const Action = union(enum) {
             .reset,
             .copy_to_clipboard,
             .copy_url_to_clipboard,
-            .copy_title,
+            .copy_title_to_clipboard,
             .paste_from_clipboard,
             .paste_from_selection,
             .increase_font_size,

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -282,7 +282,7 @@ pub const Action = union(enum) {
     copy_url_to_clipboard,
 
     /// Copy the terminal title to the clipboard. If the terminal title is not
-    /// set this has no effect.
+    /// set or is empty this has no effect.
     copy_title_to_clipboard,
 
     /// Increase the font size by the specified amount in points (pt).

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -281,6 +281,10 @@ pub const Action = union(enum) {
     /// If there is a URL under the cursor, copy it to the default clipboard.
     copy_url_to_clipboard,
 
+    /// Copy the terminal title to the clipboard. If the terminal title is not
+    /// set this has no effect.
+    copy_title,
+
     /// Increase the font size by the specified amount in points (pt).
     ///
     /// For example, `increase_font_size:1.5` will increase the font size
@@ -1005,6 +1009,7 @@ pub const Action = union(enum) {
             .reset,
             .copy_to_clipboard,
             .copy_url_to_clipboard,
+            .copy_title,
             .paste_from_clipboard,
             .paste_from_selection,
             .increase_font_size,

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -132,6 +132,12 @@ fn actionCommands(action: Action.Key) []const Command {
             .description = "Copy the URL under the cursor to the clipboard.",
         }},
 
+        .copy_title => comptime &.{.{
+            .action = .copy_title,
+            .title = "Copy Terminal Title to Clipboard",
+            .description = "Copy the terminal title to the clipboard. If the terminal title is not set this has no effect.",
+        }},
+
         .paste_from_clipboard => comptime &.{.{
             .action = .paste_from_clipboard,
             .title = "Paste from Clipboard",

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -132,8 +132,8 @@ fn actionCommands(action: Action.Key) []const Command {
             .description = "Copy the URL under the cursor to the clipboard.",
         }},
 
-        .copy_title => comptime &.{.{
-            .action = .copy_title,
+        .copy_title_to_clipboard => comptime &.{.{
+            .action = .copy_title_to_clipboard,
             .title = "Copy Terminal Title to Clipboard",
             .description = "Copy the terminal title to the clipboard. If the terminal title is not set this has no effect.",
         }},


### PR DESCRIPTION
Fixes #7829

This will copy the terminal title to the clipboard. If the terminal title is not set or the title is empty the action has no effect.