### PR TITLE
linux/kde: add KDE shortcut to desktop file

### DIFF
--- a/dist/linux/app.desktop.in
+++ b/dist/linux/app.desktop.in
@@ -19,6 +19,7 @@ X-TerminalArgAppId=--class=
 X-TerminalArgDir=--working-directory=
 X-TerminalArgHold=--wait-after-command
 DBusActivatable=true
+X-KDE-Shortcuts=Ctrl+Alt+T
 
 [Desktop Action new-window]
 Name=New Window


### PR DESCRIPTION
Fixes #7673

This adds `Ctrl+Alt+T` as a KDE shortcut to the desktop file. If Konsole is installed (or any other prorgam that has the same shortcut) the user will need to go into the KDE system settings and manually reassign the `Ctrl+Alt+T` shortcut to Ghostty.

If Ghostty is the only terminal installed that claims that shortcut KDE _should_ automatically enable the shortcut (but YMMV).

Non-KDE systems will ignore this setting and if the user desires a global shortcut to open a Ghostty window it will need to be accomplished in other ways.