### PR TITLE
core/gtk: add apprt action to show native GUI warning when child exits

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -680,6 +680,12 @@ typedef struct {
   uintptr_t len;
 } ghostty_action_open_url_s;
 
+// apprt.surface.Message.ChildExited
+typedef struct {
+  uint32_t exit_code;
+  uint64_t timetime_ms;
+} ghostty_surface_message_childexited_s;
+
 // apprt.Action.Key
 typedef enum {
   GHOSTTY_ACTION_QUIT,
@@ -731,6 +737,7 @@ typedef enum {
   GHOSTTY_ACTION_REDO,
   GHOSTTY_ACTION_CHECK_FOR_UPDATES,
   GHOSTTY_ACTION_OPEN_URL,
+  GHOSTTY_ACTION_SHOW_CHILD_EXITED
 } ghostty_action_tag_e;
 
 typedef union {
@@ -759,6 +766,7 @@ typedef union {
   ghostty_action_reload_config_s reload_config;
   ghostty_action_config_change_s config_change;
   ghostty_action_open_url_s open_url;
+  ghostty_surface_message_childexited_s child_exited;
 } ghostty_action_u;
 
 typedef struct {

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -579,6 +579,8 @@ extension Ghostty {
             case GHOSTTY_ACTION_SIZE_LIMIT:
                 fallthrough
             case GHOSTTY_ACTION_QUIT_TIMER:
+                fallthrough
+            case GHOSTTY_SHOW_CHILD_EXITED:
                 Ghostty.logger.info("known but unimplemented action action=\(action.tag.rawValue)")
                 return false
             default:

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -580,7 +580,7 @@ extension Ghostty {
                 fallthrough
             case GHOSTTY_ACTION_QUIT_TIMER:
                 fallthrough
-            case GHOSTTY_SHOW_CHILD_EXITED:
+            case GHOSTTY_ACTION_SHOW_CHILD_EXITED:
                 Ghostty.logger.info("known but unimplemented action action=\(action.tag.rawValue)")
                 return false
             default:

--- a/po/bg_BG.UTF-8.po
+++ b/po/bg_BG.UTF-8.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-07-08 15:13-0500\n"
+"POT-Creation-Date: 2025-07-11 22:56-0500\n"
 "PO-Revision-Date: 2025-05-19 11:34+0300\n"
 "Last-Translator: Damyan Bogoev <damyan.bogoev@gmail.com>\n"
 "Language-Team: Bulgarian <dict@ludost.net>\n"
@@ -236,7 +236,7 @@ msgstr ""
 "Поставянето на този текст в терминала може да е опасно, тъй като изглежда, "
 "че може да бъдат изпълнени някои команди."
 
-#: src/apprt/gtk/CloseDialog.zig:47
+#: src/apprt/gtk/CloseDialog.zig:47 src/apprt/gtk/Surface.zig:2520
 msgid "Close"
 msgstr "Затвори"
 
@@ -275,6 +275,14 @@ msgstr "Текущият процес в това разделяне ще бъд
 #: src/apprt/gtk/Surface.zig:1257
 msgid "Copied to clipboard"
 msgstr "Копирано в клипборда"
+
+#: src/apprt/gtk/Surface.zig:2514
+msgid "Command succeeded"
+msgstr ""
+
+#: src/apprt/gtk/Surface.zig:2516
+msgid "Command failed"
+msgstr ""
 
 #: src/apprt/gtk/Window.zig:216
 msgid "Main Menu"

--- a/po/ca_ES.UTF-8.po
+++ b/po/ca_ES.UTF-8.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-07-08 15:13-0500\n"
+"POT-Creation-Date: 2025-07-11 22:56-0500\n"
 "PO-Revision-Date: 2025-03-20 08:07+0100\n"
 "Last-Translator: Francesc Arpi <francesc.arpi@gmail.com>\n"
 "Language-Team: \n"
@@ -236,7 +236,7 @@ msgstr ""
 "Enganxar aquest text al terminal pot ser perillós, ja que sembla que es "
 "podrien executar algunes ordres."
 
-#: src/apprt/gtk/CloseDialog.zig:47
+#: src/apprt/gtk/CloseDialog.zig:47 src/apprt/gtk/Surface.zig:2520
 msgid "Close"
 msgstr "Tanca"
 
@@ -275,6 +275,14 @@ msgstr "El procés actualment en execució en aquesta divisió es tancarà."
 #: src/apprt/gtk/Surface.zig:1257
 msgid "Copied to clipboard"
 msgstr "Copiat al porta-retalls"
+
+#: src/apprt/gtk/Surface.zig:2514
+msgid "Command succeeded"
+msgstr ""
+
+#: src/apprt/gtk/Surface.zig:2516
+msgid "Command failed"
+msgstr ""
 
 #: src/apprt/gtk/Window.zig:216
 msgid "Main Menu"

--- a/po/com.mitchellh.ghostty.pot
+++ b/po/com.mitchellh.ghostty.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-07-08 15:13-0500\n"
+"POT-Creation-Date: 2025-07-11 22:56-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -228,7 +228,7 @@ msgid ""
 "commands may be executed."
 msgstr ""
 
-#: src/apprt/gtk/CloseDialog.zig:47
+#: src/apprt/gtk/CloseDialog.zig:47 src/apprt/gtk/Surface.zig:2520
 msgid "Close"
 msgstr ""
 
@@ -266,6 +266,14 @@ msgstr ""
 
 #: src/apprt/gtk/Surface.zig:1257
 msgid "Copied to clipboard"
+msgstr ""
+
+#: src/apprt/gtk/Surface.zig:2514
+msgid "Command succeeded"
+msgstr ""
+
+#: src/apprt/gtk/Surface.zig:2516
+msgid "Command failed"
 msgstr ""
 
 #: src/apprt/gtk/Window.zig:216

--- a/po/de_DE.UTF-8.po
+++ b/po/de_DE.UTF-8.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-07-08 15:13-0500\n"
+"POT-Creation-Date: 2025-07-11 22:56-0500\n"
 "PO-Revision-Date: 2025-03-06 14:57+0100\n"
 "Last-Translator: Robin <r@rpfaeffle.com>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
@@ -235,7 +235,7 @@ msgstr ""
 "Diesen Text in das Terminal einzufügen könnte möglicherweise gefährlich "
 "sein. Es scheint, dass Anweisungen ausgeführt werden könnten."
 
-#: src/apprt/gtk/CloseDialog.zig:47
+#: src/apprt/gtk/CloseDialog.zig:47 src/apprt/gtk/Surface.zig:2520
 msgid "Close"
 msgstr "Schließen"
 
@@ -274,6 +274,14 @@ msgstr "Der aktuell laufende Prozess in diesem geteilten Fenster wird beendet."
 #: src/apprt/gtk/Surface.zig:1257
 msgid "Copied to clipboard"
 msgstr "In die Zwischenablage kopiert"
+
+#: src/apprt/gtk/Surface.zig:2514
+msgid "Command succeeded"
+msgstr ""
+
+#: src/apprt/gtk/Surface.zig:2516
+msgid "Command failed"
+msgstr ""
 
 #: src/apprt/gtk/Window.zig:216
 msgid "Main Menu"

--- a/po/es_AR.UTF-8.po
+++ b/po/es_AR.UTF-8.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-07-08 15:13-0500\n"
+"POT-Creation-Date: 2025-07-11 22:56-0500\n"
 "PO-Revision-Date: 2025-05-19 20:17-0300\n"
 "Last-Translator: Alan Moyano <alanmoyano203@gmail.com>\n"
 "Language-Team: Argentinian <es@tp.org.es>\n"
@@ -236,7 +236,7 @@ msgstr ""
 "Pegar este texto en la terminal puede ser peligroso ya que parece que "
 "algunos comandos podrían ejecutarse."
 
-#: src/apprt/gtk/CloseDialog.zig:47
+#: src/apprt/gtk/CloseDialog.zig:47 src/apprt/gtk/Surface.zig:2520
 msgid "Close"
 msgstr "Cerrar"
 
@@ -275,6 +275,14 @@ msgstr "El proceso actualmente en ejecución en esta división será terminado."
 #: src/apprt/gtk/Surface.zig:1257
 msgid "Copied to clipboard"
 msgstr "Copiado al portapapeles"
+
+#: src/apprt/gtk/Surface.zig:2514
+msgid "Command succeeded"
+msgstr ""
+
+#: src/apprt/gtk/Surface.zig:2516
+msgid "Command failed"
+msgstr ""
 
 #: src/apprt/gtk/Window.zig:216
 msgid "Main Menu"

--- a/po/es_BO.UTF-8.po
+++ b/po/es_BO.UTF-8.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-07-08 15:13-0500\n"
+"POT-Creation-Date: 2025-07-11 22:56-0500\n"
 "PO-Revision-Date: 2025-03-28 17:46+0200\n"
 "Last-Translator: Miguel Peredo <miguelp@quientienemail.com>\n"
 "Language-Team: Spanish <es@tp.org.es>\n"
@@ -236,7 +236,7 @@ msgstr ""
 "Pegar este texto en la terminal puede ser peligroso ya que parece que "
 "algunos comandos podrían ejecutarse."
 
-#: src/apprt/gtk/CloseDialog.zig:47
+#: src/apprt/gtk/CloseDialog.zig:47 src/apprt/gtk/Surface.zig:2520
 msgid "Close"
 msgstr "Cerrar"
 
@@ -275,6 +275,14 @@ msgstr "El proceso actualmente en ejecución en esta división será terminado."
 #: src/apprt/gtk/Surface.zig:1257
 msgid "Copied to clipboard"
 msgstr "Copiado al portapapeles"
+
+#: src/apprt/gtk/Surface.zig:2514
+msgid "Command succeeded"
+msgstr ""
+
+#: src/apprt/gtk/Surface.zig:2516
+msgid "Command failed"
+msgstr ""
 
 #: src/apprt/gtk/Window.zig:216
 msgid "Main Menu"

--- a/po/fr_FR.UTF-8.po
+++ b/po/fr_FR.UTF-8.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-07-08 15:13-0500\n"
+"POT-Creation-Date: 2025-07-11 22:56-0500\n"
 "PO-Revision-Date: 2025-03-22 09:31+0100\n"
 "Last-Translator: Kirwiisp <swiip__@hotmail.com>\n"
 "Language-Team: French <traduc@traduc.org>\n"
@@ -237,7 +237,7 @@ msgstr ""
 "Coller ce texte dans le terminal pourrait être dangereux, il semblerait que "
 "certaines commandes pourraient être exécutées."
 
-#: src/apprt/gtk/CloseDialog.zig:47
+#: src/apprt/gtk/CloseDialog.zig:47 src/apprt/gtk/Surface.zig:2520
 msgid "Close"
 msgstr "Fermer"
 
@@ -276,6 +276,14 @@ msgstr "Le processus en cours dans ce panneau va être arrêté."
 #: src/apprt/gtk/Surface.zig:1257
 msgid "Copied to clipboard"
 msgstr "Copié dans le presse-papiers"
+
+#: src/apprt/gtk/Surface.zig:2514
+msgid "Command succeeded"
+msgstr ""
+
+#: src/apprt/gtk/Surface.zig:2516
+msgid "Command failed"
+msgstr ""
 
 #: src/apprt/gtk/Window.zig:216
 msgid "Main Menu"

--- a/po/ga_IE.UTF-8.po
+++ b/po/ga_IE.UTF-8.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-07-08 15:13-0500\n"
+"POT-Creation-Date: 2025-07-11 22:56-0500\n"
 "PO-Revision-Date: 2025-06-29 21:15+0100\n"
 "Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@gmail.com>\n"
 "Language-Team: Irish <gaeilge-gnulinux@lists.sourceforge.net>\n"
@@ -237,7 +237,7 @@ msgstr ""
 "D’fhéadfadh sé a bheith contúirteach an téacs seo a ghreamú isteach sa "
 "teirminéal, toisc go d'fhéadfadh roinnt orduithe a fhorghníomhú."
 
-#: src/apprt/gtk/CloseDialog.zig:47
+#: src/apprt/gtk/CloseDialog.zig:47 src/apprt/gtk/Surface.zig:2520
 msgid "Close"
 msgstr "Dún"
 
@@ -277,6 +277,14 @@ msgstr ""
 #: src/apprt/gtk/Surface.zig:1257
 msgid "Copied to clipboard"
 msgstr "Cóipeáilte chuig an ghearrthaisce"
+
+#: src/apprt/gtk/Surface.zig:2514
+msgid "Command succeeded"
+msgstr ""
+
+#: src/apprt/gtk/Surface.zig:2516
+msgid "Command failed"
+msgstr ""
 
 #: src/apprt/gtk/Window.zig:216
 msgid "Main Menu"

--- a/po/he_IL.UTF-8.po
+++ b/po/he_IL.UTF-8.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-07-08 15:13-0500\n"
+"POT-Creation-Date: 2025-07-11 22:56-0500\n"
 "PO-Revision-Date: 2025-03-13 00:00+0000\n"
 "Last-Translator: Sl (Shahaf Levi), Sl's Repository Ltd <ghostty@slsrepo."
 "com>\n"
@@ -234,7 +234,7 @@ msgstr ""
 "הדבקת טקסט זה במסוף עלולה להיות מסוכנת, מכיוון שככל הנראה היא תוביל להרצה של "
 "פקודות מסוימות."
 
-#: src/apprt/gtk/CloseDialog.zig:47
+#: src/apprt/gtk/CloseDialog.zig:47 src/apprt/gtk/Surface.zig:2520
 msgid "Close"
 msgstr "סגירה"
 
@@ -273,6 +273,14 @@ msgstr "התהליך שרץ כרגע בפיצול זה יסתיים."
 #: src/apprt/gtk/Surface.zig:1257
 msgid "Copied to clipboard"
 msgstr "הועתק ללוח ההעתקה"
+
+#: src/apprt/gtk/Surface.zig:2514
+msgid "Command succeeded"
+msgstr ""
+
+#: src/apprt/gtk/Surface.zig:2516
+msgid "Command failed"
+msgstr ""
 
 #: src/apprt/gtk/Window.zig:216
 msgid "Main Menu"

--- a/po/id_ID.UTF-8.po
+++ b/po/id_ID.UTF-8.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-07-08 15:13-0500\n"
+"POT-Creation-Date: 2025-07-11 22:56-0500\n"
 "PO-Revision-Date: 2025-03-20 15:19+0700\n"
 "Last-Translator: Satrio Bayu Aji <halosatrio@gmail.com>\n"
 "Language-Team: Indonesian <translation-team-id@lists.sourceforge.net>\n"
@@ -235,7 +235,7 @@ msgstr ""
 "Menempelkan teks ini ke terminal mungkin berbahaya karena sepertinya "
 "beberapa perintah mungkin dijalankan."
 
-#: src/apprt/gtk/CloseDialog.zig:47
+#: src/apprt/gtk/CloseDialog.zig:47 src/apprt/gtk/Surface.zig:2520
 msgid "Close"
 msgstr "Tutup"
 
@@ -274,6 +274,14 @@ msgstr "Proses yang sedang berjalan dalam belahan ini akan diakhiri."
 #: src/apprt/gtk/Surface.zig:1257
 msgid "Copied to clipboard"
 msgstr "Disalin ke papan klip"
+
+#: src/apprt/gtk/Surface.zig:2514
+msgid "Command succeeded"
+msgstr ""
+
+#: src/apprt/gtk/Surface.zig:2516
+msgid "Command failed"
+msgstr ""
 
 #: src/apprt/gtk/Window.zig:216
 msgid "Main Menu"

--- a/po/ja_JP.UTF-8.po
+++ b/po/ja_JP.UTF-8.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-07-08 15:13-0500\n"
+"POT-Creation-Date: 2025-07-11 22:56-0500\n"
 "PO-Revision-Date: 2025-03-21 00:08+0900\n"
 "Last-Translator: Lon Sagisawa <lon@sagisawa.me>\n"
 "Language-Team: Japanese\n"
@@ -237,7 +237,7 @@ msgstr ""
 "このテキストには実行可能なコマンドが含まれており、ターミナルに貼り付けるのは"
 "危険な可能性があります。"
 
-#: src/apprt/gtk/CloseDialog.zig:47
+#: src/apprt/gtk/CloseDialog.zig:47 src/apprt/gtk/Surface.zig:2520
 msgid "Close"
 msgstr "閉じる"
 
@@ -276,6 +276,14 @@ msgstr "分割ウィンドウ内のすべてのプロセスが終了します。
 #: src/apprt/gtk/Surface.zig:1257
 msgid "Copied to clipboard"
 msgstr "クリップボードにコピーしました"
+
+#: src/apprt/gtk/Surface.zig:2514
+msgid "Command succeeded"
+msgstr ""
+
+#: src/apprt/gtk/Surface.zig:2516
+msgid "Command failed"
+msgstr ""
 
 #: src/apprt/gtk/Window.zig:216
 msgid "Main Menu"

--- a/po/ko_KR.UTF-8.po
+++ b/po/ko_KR.UTF-8.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-07-08 15:13-0500\n"
+"POT-Creation-Date: 2025-07-11 22:56-0500\n"
 "PO-Revision-Date: 2025-07-09 16:11-0400\n"
 "Last-Translator: Hojin You <dev.hojin@gmail.com>\n"
 "Language-Team: Korean <translation-team-ko@googlegroups.com>\n"
@@ -236,7 +236,7 @@ msgstr ""
 "이 텍스트를 터미널에 붙여넣는 것은 위험할 수 있습니다. 일부 명령이 실행될 수 "
 "있는 것으로 보입니다."
 
-#: src/apprt/gtk/CloseDialog.zig:47
+#: src/apprt/gtk/CloseDialog.zig:47 src/apprt/gtk/Surface.zig:2520
 msgid "Close"
 msgstr "닫기"
 
@@ -275,6 +275,14 @@ msgstr "이 분할에서 현재 실행 중인 프로세스가 종료됩니다."
 #: src/apprt/gtk/Surface.zig:1257
 msgid "Copied to clipboard"
 msgstr "클립보드에 복사됨"
+
+#: src/apprt/gtk/Surface.zig:2514
+msgid "Command succeeded"
+msgstr ""
+
+#: src/apprt/gtk/Surface.zig:2516
+msgid "Command failed"
+msgstr ""
 
 #: src/apprt/gtk/Window.zig:216
 msgid "Main Menu"

--- a/po/mk_MK.UTF-8.po
+++ b/po/mk_MK.UTF-8.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-07-08 15:13-0500\n"
+"POT-Creation-Date: 2025-07-11 22:56-0500\n"
 "PO-Revision-Date: 2025-03-23 14:17+0100\n"
 "Last-Translator: Andrej Daskalov <andrej.daskalov@gmail.com>\n"
 "Language-Team: Macedonian\n"
@@ -236,7 +236,7 @@ msgstr ""
 "Вметнувањето на овој текст во терминалот може да биде опасно, бидејќи "
 "изгледа како да ќе се извршат одредени команди."
 
-#: src/apprt/gtk/CloseDialog.zig:47
+#: src/apprt/gtk/CloseDialog.zig:47 src/apprt/gtk/Surface.zig:2520
 msgid "Close"
 msgstr "Затвори"
 
@@ -275,6 +275,14 @@ msgstr "Процесот кој моментално се извршува во 
 #: src/apprt/gtk/Surface.zig:1257
 msgid "Copied to clipboard"
 msgstr "Копирано во привремена меморија"
+
+#: src/apprt/gtk/Surface.zig:2514
+msgid "Command succeeded"
+msgstr ""
+
+#: src/apprt/gtk/Surface.zig:2516
+msgid "Command failed"
+msgstr ""
 
 #: src/apprt/gtk/Window.zig:216
 msgid "Main Menu"

--- a/po/nb_NO.UTF-8.po
+++ b/po/nb_NO.UTF-8.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-07-08 15:13-0500\n"
+"POT-Creation-Date: 2025-07-11 22:56-0500\n"
 "PO-Revision-Date: 2025-04-14 16:25+0200\n"
 "Last-Translator: cryptocode <cryptocode@zolo.io>\n"
 "Language-Team: Norwegian Bokmal <l10n-no@lister.huftis.org>\n"
@@ -239,7 +239,7 @@ msgstr ""
 "Det ser ut som at kommandoer vil bli kjørt hvis du limer inn dette, vurder "
 "om du mener det er trygt."
 
-#: src/apprt/gtk/CloseDialog.zig:47
+#: src/apprt/gtk/CloseDialog.zig:47 src/apprt/gtk/Surface.zig:2520
 msgid "Close"
 msgstr "Lukk"
 
@@ -278,6 +278,14 @@ msgstr "Den kjørende prosessen for denne splitten vil bli avsluttet."
 #: src/apprt/gtk/Surface.zig:1257
 msgid "Copied to clipboard"
 msgstr "Kopiert til utklippstavlen"
+
+#: src/apprt/gtk/Surface.zig:2514
+msgid "Command succeeded"
+msgstr ""
+
+#: src/apprt/gtk/Surface.zig:2516
+msgid "Command failed"
+msgstr ""
 
 #: src/apprt/gtk/Window.zig:216
 msgid "Main Menu"

--- a/po/nl_NL.UTF-8.po
+++ b/po/nl_NL.UTF-8.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-07-08 15:13-0500\n"
+"POT-Creation-Date: 2025-07-11 22:56-0500\n"
 "PO-Revision-Date: 2025-03-24 15:00+0100\n"
 "Last-Translator: Nico Geesink <geesinknico@gmail.com>\n"
 "Language-Team: Dutch <vertaling@vrijschrift.org>\n"
@@ -236,7 +236,7 @@ msgstr ""
 "Het plakken van deze tekst in de terminal is mogelijk gevaarlijk, omdat het "
 "lijkt op een commando dat uitgevoerd kan worden."
 
-#: src/apprt/gtk/CloseDialog.zig:47
+#: src/apprt/gtk/CloseDialog.zig:47 src/apprt/gtk/Surface.zig:2520
 msgid "Close"
 msgstr "Afsluiten"
 
@@ -276,6 +276,14 @@ msgstr ""
 #: src/apprt/gtk/Surface.zig:1257
 msgid "Copied to clipboard"
 msgstr "Gekopieerd naar klembord"
+
+#: src/apprt/gtk/Surface.zig:2514
+msgid "Command succeeded"
+msgstr ""
+
+#: src/apprt/gtk/Surface.zig:2516
+msgid "Command failed"
+msgstr ""
 
 #: src/apprt/gtk/Window.zig:216
 msgid "Main Menu"

--- a/po/pl_PL.UTF-8.po
+++ b/po/pl_PL.UTF-8.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-07-08 15:13-0500\n"
+"POT-Creation-Date: 2025-07-11 22:56-0500\n"
 "PO-Revision-Date: 2025-03-17 12:15+0100\n"
 "Last-Translator: Bartosz Sokorski <b.sokorski@gmail.com>\n"
 "Language-Team: Polish <translation-team-pl@lists.sourceforge.net>\n"
@@ -238,7 +238,7 @@ msgstr ""
 "Wklejenie tego tekstu do terminala może być niebezpieczne, ponieważ może "
 "spowodować wykonanie komend."
 
-#: src/apprt/gtk/CloseDialog.zig:47
+#: src/apprt/gtk/CloseDialog.zig:47 src/apprt/gtk/Surface.zig:2520
 msgid "Close"
 msgstr "Zamknij"
 
@@ -277,6 +277,14 @@ msgstr "Wszyskie trwające procesy w obecnym podziale zostaną zakończone."
 #: src/apprt/gtk/Surface.zig:1257
 msgid "Copied to clipboard"
 msgstr "Skopiowano do schowka"
+
+#: src/apprt/gtk/Surface.zig:2514
+msgid "Command succeeded"
+msgstr ""
+
+#: src/apprt/gtk/Surface.zig:2516
+msgid "Command failed"
+msgstr ""
 
 #: src/apprt/gtk/Window.zig:216
 msgid "Main Menu"

--- a/po/pt_BR.UTF-8.po
+++ b/po/pt_BR.UTF-8.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-07-08 15:13-0500\n"
+"POT-Creation-Date: 2025-07-11 22:56-0500\n"
 "PO-Revision-Date: 2025-06-20 10:19-0300\n"
 "Last-Translator: Mário Victor Ribeiro Silva <mariovictorrs@gmail.com>\n"
 "Language-Team: Brazilian Portuguese <ldpbr-translation@lists.sourceforge."
@@ -238,7 +238,7 @@ msgstr ""
 "Colar esse texto em um terminal pode ser perigoso, pois parece que alguns "
 "comandos podem ser executados."
 
-#: src/apprt/gtk/CloseDialog.zig:47
+#: src/apprt/gtk/CloseDialog.zig:47 src/apprt/gtk/Surface.zig:2520
 msgid "Close"
 msgstr "Fechar"
 
@@ -277,6 +277,14 @@ msgstr "O processo atual rodando nessa divisão será finalizado."
 #: src/apprt/gtk/Surface.zig:1257
 msgid "Copied to clipboard"
 msgstr "Copiado para a área de transferência"
+
+#: src/apprt/gtk/Surface.zig:2514
+msgid "Command succeeded"
+msgstr ""
+
+#: src/apprt/gtk/Surface.zig:2516
+msgid "Command failed"
+msgstr ""
 
 #: src/apprt/gtk/Window.zig:216
 msgid "Main Menu"

--- a/po/ru_RU.UTF-8.po
+++ b/po/ru_RU.UTF-8.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-07-08 15:13-0500\n"
+"POT-Creation-Date: 2025-07-11 22:56-0500\n"
 "PO-Revision-Date: 2025-03-24 00:01+0500\n"
 "Last-Translator: blackzeshi <sergey_zhuzhgov@mail.ru>\n"
 "Language-Team: Russian <gnu@d07.ru>\n"
@@ -237,7 +237,7 @@ msgstr ""
 "Вставка этого текста в терминал может быть опасной. Это выглядит как "
 "команды, которые могут быть исполнены."
 
-#: src/apprt/gtk/CloseDialog.zig:47
+#: src/apprt/gtk/CloseDialog.zig:47 src/apprt/gtk/Surface.zig:2520
 msgid "Close"
 msgstr "Закрыть"
 
@@ -276,6 +276,14 @@ msgstr "Процесс, работающий в этой сплит-област
 #: src/apprt/gtk/Surface.zig:1257
 msgid "Copied to clipboard"
 msgstr "Скопировано в буфер обмена"
+
+#: src/apprt/gtk/Surface.zig:2514
+msgid "Command succeeded"
+msgstr ""
+
+#: src/apprt/gtk/Surface.zig:2516
+msgid "Command failed"
+msgstr ""
 
 #: src/apprt/gtk/Window.zig:216
 msgid "Main Menu"

--- a/po/tr_TR.UTF-8.po
+++ b/po/tr_TR.UTF-8.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-07-08 15:13-0500\n"
+"POT-Creation-Date: 2025-07-11 22:56-0500\n"
 "PO-Revision-Date: 2025-03-24 22:01+0300\n"
 "Last-Translator: Emir SARI <emir_sari@icloud.com>\n"
 "Language-Team: Turkish\n"
@@ -237,7 +237,7 @@ msgstr ""
 "Bu metni uçbirime yapıştırmak tehlikeli olabilir; çünkü bir komut "
 "yürütülebilecekmiş gibi duruyor."
 
-#: src/apprt/gtk/CloseDialog.zig:47
+#: src/apprt/gtk/CloseDialog.zig:47 src/apprt/gtk/Surface.zig:2520
 msgid "Close"
 msgstr "Kapat"
 
@@ -276,6 +276,14 @@ msgstr "Bu bölmedeki şu anda çalışan süreç sonlandırılacaktır."
 #: src/apprt/gtk/Surface.zig:1257
 msgid "Copied to clipboard"
 msgstr "Panoya kopyalandı"
+
+#: src/apprt/gtk/Surface.zig:2514
+msgid "Command succeeded"
+msgstr ""
+
+#: src/apprt/gtk/Surface.zig:2516
+msgid "Command failed"
+msgstr ""
 
 #: src/apprt/gtk/Window.zig:216
 msgid "Main Menu"

--- a/po/uk_UA.UTF-8.po
+++ b/po/uk_UA.UTF-8.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-07-08 15:13-0500\n"
+"POT-Creation-Date: 2025-07-11 22:56-0500\n"
 "PO-Revision-Date: 2025-03-16 20:16+0200\n"
 "Last-Translator: Danylo Zalizchuk <danilmail0110@gmail.com>\n"
 "Language-Team: Ukrainian <trans-uk@lists.fedoraproject.org>\n"
@@ -238,7 +238,7 @@ msgstr ""
 "Вставка цього тексту в термінал може бути небезпечною, оскільки виглядає "
 "так, ніби деякі команди можуть бути виконані."
 
-#: src/apprt/gtk/CloseDialog.zig:47
+#: src/apprt/gtk/CloseDialog.zig:47 src/apprt/gtk/Surface.zig:2520
 msgid "Close"
 msgstr "Закрити"
 
@@ -278,6 +278,14 @@ msgstr ""
 #: src/apprt/gtk/Surface.zig:1257
 msgid "Copied to clipboard"
 msgstr "Скопійовано в буфер обміну"
+
+#: src/apprt/gtk/Surface.zig:2514
+msgid "Command succeeded"
+msgstr ""
+
+#: src/apprt/gtk/Surface.zig:2516
+msgid "Command failed"
+msgstr ""
 
 #: src/apprt/gtk/Window.zig:216
 msgid "Main Menu"

--- a/po/zh_CN.UTF-8.po
+++ b/po/zh_CN.UTF-8.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2025-07-08 15:13-0500\n"
+"POT-Creation-Date: 2025-07-11 22:56-0500\n"
 "PO-Revision-Date: 2025-02-27 09:16+0100\n"
 "Last-Translator: Leah <hi@pluie.me>\n"
 "Language-Team: Chinese (simplified) <i18n-zh@googlegroups.com>\n"
@@ -229,7 +229,7 @@ msgid ""
 "commands may be executed."
 msgstr "将以下内容粘贴至终端内将可能执行有害命令。"
 
-#: src/apprt/gtk/CloseDialog.zig:47
+#: src/apprt/gtk/CloseDialog.zig:47 src/apprt/gtk/Surface.zig:2520
 msgid "Close"
 msgstr "关闭"
 
@@ -268,6 +268,14 @@ msgstr "分屏内正在运行中的进程将被终止。"
 #: src/apprt/gtk/Surface.zig:1257
 msgid "Copied to clipboard"
 msgstr "已复制至剪贴板"
+
+#: src/apprt/gtk/Surface.zig:2514
+msgid "Command succeeded"
+msgstr ""
+
+#: src/apprt/gtk/Surface.zig:2516
+msgid "Command failed"
+msgstr ""
 
 #: src/apprt/gtk/Window.zig:216
 msgid "Main Menu"

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1018,6 +1018,14 @@ fn childExited(self: *Surface, info: apprt.surface.Message.ChildExited) void {
             return;
         };
 
+        _ = self.rt_app.performAction(
+            .{ .surface = self },
+            .show_child_exited,
+            info,
+        ) catch |err| {
+            log.err("error trying to show native child exited GUI err={}", .{err});
+        };
+
         return;
     }
 
@@ -1043,6 +1051,14 @@ fn childExited(self: *Surface, info: apprt.surface.Message.ChildExited) void {
         t.modes.set(.disable_keyboard, false);
         t.screen.kitty_keyboard.set(.set, .{});
     }
+
+    _ = self.rt_app.performAction(
+        .{ .surface = self },
+        .show_child_exited,
+        info,
+    ) catch |err| {
+        log.err("error trying to show native child exited GUI err={}", .{err});
+    };
 
     // Waiting after command we stop here. The terminal is updated, our
     // state is updated, and now its up to the user to decide what to do.

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -272,6 +272,9 @@ pub const Action = union(Key) {
     /// apprt.
     open_url: OpenUrl,
 
+    /// Show a native GUI notification that the child process has exited.
+    show_child_exited: apprt.surface.Message.ChildExited,
+
     /// Sync with: ghostty_action_tag_e
     pub const Key = enum(c_int) {
         quit,
@@ -323,6 +326,7 @@ pub const Action = union(Key) {
         redo,
         check_for_updates,
         open_url,
+        show_child_exited,
     };
 
     /// Sync with: ghostty_action_u

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -521,6 +521,7 @@ pub fn performAction(
         .ring_bell => try self.ringBell(target),
         .toggle_command_palette => try self.toggleCommandPalette(target),
         .open_url => self.openUrl(value),
+        .show_child_exited => try self.showChildExited(target, value),
 
         // Unimplemented
         .close_all_windows,
@@ -843,6 +844,13 @@ fn toggleCommandPalette(_: *App, target: apprt.Target) !void {
 
             window.toggleCommandPalette();
         },
+    }
+}
+
+fn showChildExited(_: *App, target: apprt.Target, value: apprt.surface.Message.ChildExited) !void {
+    switch (target) {
+        .app => {},
+        .surface => |surface| try surface.rt_surface.showChildExited(value),
     }
 }
 

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -521,7 +521,7 @@ pub fn performAction(
         .ring_bell => try self.ringBell(target),
         .toggle_command_palette => try self.toggleCommandPalette(target),
         .open_url => self.openUrl(value),
-        .show_child_exited => try self.showChildExited(target, value),
+        .show_child_exited => return try self.showChildExited(target, value),
 
         // Unimplemented
         .close_all_windows,
@@ -847,10 +847,10 @@ fn toggleCommandPalette(_: *App, target: apprt.Target) !void {
     }
 }
 
-fn showChildExited(_: *App, target: apprt.Target, value: apprt.surface.Message.ChildExited) !void {
+fn showChildExited(_: *App, target: apprt.Target, value: apprt.surface.Message.ChildExited) (error{})!bool {
     switch (target) {
-        .app => {},
-        .surface => |surface| try surface.rt_surface.showChildExited(value),
+        .app => return false,
+        .surface => |surface| return try surface.rt_surface.showChildExited(value),
     }
 }
 

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -847,7 +847,7 @@ fn toggleCommandPalette(_: *App, target: apprt.Target) !void {
     }
 }
 
-fn showChildExited(_: *App, target: apprt.Target, value: apprt.surface.Message.ChildExited) (error{})!bool {
+fn showChildExited(_: *App, target: apprt.Target, value: apprt.surface.Message.ChildExited) error{}!bool {
     switch (target) {
         .app => return false,
         .surface => |surface| return try surface.rt_surface.showChildExited(value),

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -2513,7 +2513,7 @@ pub fn showChildExited(self: *Surface, info: apprt.surface.Message.ChildExited) 
     warning_box.as(gtk.Widget).setValign(.end);
 
     const warning_text = if (info.exit_code == 0)
-        i18n._("⚠️ Process exited normally. Press any key to close the terminal.")
+        i18n._("✔️ Process exited normally. Press any key to close the terminal.")
     else
         i18n._("⚠️ Process exited abnormally. Press any key to close the terminal.");
 

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -2522,8 +2522,6 @@ pub fn showChildExited(self: *Surface, info: apprt.surface.Message.ChildExited) 
 
     const banner_widget = banner.as(gtk.Widget);
 
-    banner_widget.addCssClass("child_exited");
-
     if (info.exit_code == 0)
         banner_widget.addCssClass("child_exited_normally")
     else

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -2507,11 +2507,6 @@ fn gtkStreamEnded(media_file: *gtk.MediaFile, _: *gobject.ParamSpec, _: ?*anyopa
 pub fn showChildExited(self: *Surface, info: apprt.surface.Message.ChildExited) error{}!bool {
     if (!adw_version.supportsBanner()) return false;
 
-    const warning_box = gtk.Box.new(.vertical, 0);
-
-    warning_box.as(gtk.Widget).setHalign(.fill);
-    warning_box.as(gtk.Widget).setValign(.end);
-
     const warning_text = if (info.exit_code == 0)
         i18n._("Process exited normally. Press any key to close the terminal.")
     else
@@ -2521,15 +2516,15 @@ pub fn showChildExited(self: *Surface, info: apprt.surface.Message.ChildExited) 
     banner.setRevealed(1);
 
     const banner_widget = banner.as(gtk.Widget);
+    banner_widget.setHalign(.fill);
+    banner_widget.setValign(.end);
 
     if (info.exit_code == 0)
         banner_widget.addCssClass("child_exited_normally")
     else
         banner_widget.addCssClass("child_exited_abnormally");
 
-    warning_box.append(banner_widget);
-
-    self.overlay.addOverlay(warning_box.as(gtk.Widget));
+    self.overlay.addOverlay(banner_widget);
 
     return true;
 }

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -2504,8 +2504,8 @@ fn gtkStreamEnded(media_file: *gtk.MediaFile, _: *gobject.ParamSpec, _: ?*anyopa
     media_file.unref();
 }
 
-pub fn showChildExited(self: *Surface, info: apprt.surface.Message.ChildExited) (error{})!void {
-    if (!adw_version.supportsBanner()) return;
+pub fn showChildExited(self: *Surface, info: apprt.surface.Message.ChildExited) (error{})!bool {
+    if (!adw_version.supportsBanner()) return false;
 
     const warning_box = gtk.Box.new(.vertical, 0);
 
@@ -2528,4 +2528,6 @@ pub fn showChildExited(self: *Surface, info: apprt.surface.Message.ChildExited) 
     warning_box.append(banner_widget);
 
     self.overlay.addOverlay(warning_box.as(gtk.Widget));
+
+    return true;
 }

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -2504,7 +2504,7 @@ fn gtkStreamEnded(media_file: *gtk.MediaFile, _: *gobject.ParamSpec, _: ?*anyopa
     media_file.unref();
 }
 
-pub fn showChildExited(self: *Surface, info: apprt.surface.Message.ChildExited) (error{})!bool {
+pub fn showChildExited(self: *Surface, info: apprt.surface.Message.ChildExited) error{}!bool {
     if (!adw_version.supportsBanner()) return false;
 
     const warning_box = gtk.Box.new(.vertical, 0);

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -2513,9 +2513,9 @@ pub fn showChildExited(self: *Surface, info: apprt.surface.Message.ChildExited) 
     warning_box.as(gtk.Widget).setValign(.end);
 
     const warning_text = if (info.exit_code == 0)
-        i18n._("✔️ Process exited normally. Press any key to close the terminal.")
+        i18n._("Process exited normally. Press any key to close the terminal.")
     else
-        i18n._("⚠️ Process exited abnormally. Press any key to close the terminal.");
+        i18n._("Process exited abnormally. Press any key to close the terminal.");
 
     const banner = adw.Banner.new(warning_text);
     banner.setRevealed(1);

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -2503,3 +2503,20 @@ fn gtkStreamError(media_file: *gtk.MediaFile, _: *gobject.ParamSpec, _: ?*anyopa
 fn gtkStreamEnded(media_file: *gtk.MediaFile, _: *gobject.ParamSpec, _: ?*anyopaque) callconv(.c) void {
     media_file.unref();
 }
+
+pub fn showChildExited(self: *Surface, _: apprt.surface.Message.ChildExited) (error{})!void {
+    if (!adw_version.supportsBanner()) return;
+
+    const warning_box = gtk.Box.new(.vertical, 0);
+
+    warning_box.as(gtk.Widget).setHalign(.fill);
+    warning_box.as(gtk.Widget).setValign(.end);
+
+    const warning_text = i18n._("⚠️ Process exited. Press any key to close the terminal.");
+    const banner = adw.Banner.new(warning_text);
+    banner.setRevealed(1);
+
+    warning_box.append(banner.as(gtk.Widget));
+
+    self.overlay.addOverlay(warning_box.as(gtk.Widget));
+}

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -2504,7 +2504,7 @@ fn gtkStreamEnded(media_file: *gtk.MediaFile, _: *gobject.ParamSpec, _: ?*anyopa
     media_file.unref();
 }
 
-pub fn showChildExited(self: *Surface, _: apprt.surface.Message.ChildExited) (error{})!void {
+pub fn showChildExited(self: *Surface, info: apprt.surface.Message.ChildExited) (error{})!void {
     if (!adw_version.supportsBanner()) return;
 
     const warning_box = gtk.Box.new(.vertical, 0);
@@ -2516,7 +2516,16 @@ pub fn showChildExited(self: *Surface, _: apprt.surface.Message.ChildExited) (er
     const banner = adw.Banner.new(warning_text);
     banner.setRevealed(1);
 
-    warning_box.append(banner.as(gtk.Widget));
+    const banner_widget = banner.as(gtk.Widget);
+
+    banner_widget.addCssClass("child_exited");
+
+    if (info.exit_code == 0)
+        banner_widget.addCssClass("child_exited_normally")
+    else
+        banner_widget.addCssClass("child_exited_abnormally");
+
+    warning_box.append(banner_widget);
 
     self.overlay.addOverlay(warning_box.as(gtk.Widget));
 }

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -2504,6 +2504,9 @@ fn gtkStreamEnded(media_file: *gtk.MediaFile, _: *gobject.ParamSpec, _: ?*anyopa
     media_file.unref();
 }
 
+/// Show native GUI element with a notification that the child process has
+/// closed. Return `true` if we are able to show the GUI notification, and
+/// `false` if we are not.
 pub fn showChildExited(self: *Surface, info: apprt.surface.Message.ChildExited) error{}!bool {
     if (!adw_version.supportsBanner()) return false;
 

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -2512,7 +2512,11 @@ pub fn showChildExited(self: *Surface, info: apprt.surface.Message.ChildExited) 
     warning_box.as(gtk.Widget).setHalign(.fill);
     warning_box.as(gtk.Widget).setValign(.end);
 
-    const warning_text = i18n._("⚠️ Process exited. Press any key to close the terminal.");
+    const warning_text = if (info.exit_code == 0)
+        i18n._("⚠️ Process exited normally. Press any key to close the terminal.")
+    else
+        i18n._("⚠️ Process exited abnormally. Press any key to close the terminal.");
+
     const banner = adw.Banner.new(warning_text);
     banner.setRevealed(1);
 

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -2510,10 +2510,10 @@ fn gtkStreamEnded(media_file: *gtk.MediaFile, _: *gobject.ParamSpec, _: ?*anyopa
 pub fn showChildExited(self: *Surface, info: apprt.surface.Message.ChildExited) error{}!bool {
     if (!adw_version.supportsBanner()) return false;
 
-    const warning_text = if (info.exit_code == 0)
-        i18n._("Process exited normally.")
+    const warning_text, const css_class = if (info.exit_code == 0)
+        .{ i18n._("Command succeeded"), "child_exited_normally" }
     else
-        i18n._("Process exited abnormally.");
+        .{ i18n._("Command failed"), "child_exited_abnormally" };
 
     const banner = adw.Banner.new(warning_text);
     banner.setRevealed(1);
@@ -2530,11 +2530,7 @@ pub fn showChildExited(self: *Surface, info: apprt.surface.Message.ChildExited) 
     const banner_widget = banner.as(gtk.Widget);
     banner_widget.setHalign(.fill);
     banner_widget.setValign(.end);
-
-    if (info.exit_code == 0)
-        banner_widget.addCssClass("child_exited_normally")
-    else
-        banner_widget.addCssClass("child_exited_abnormally");
+    banner_widget.addCssClass(css_class);
 
     self.overlay.addOverlay(banner_widget);
 

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -2511,12 +2511,21 @@ pub fn showChildExited(self: *Surface, info: apprt.surface.Message.ChildExited) 
     if (!adw_version.supportsBanner()) return false;
 
     const warning_text = if (info.exit_code == 0)
-        i18n._("Process exited normally. Press any key to close the terminal.")
+        i18n._("Process exited normally.")
     else
-        i18n._("Process exited abnormally. Press any key to close the terminal.");
+        i18n._("Process exited abnormally.");
 
     const banner = adw.Banner.new(warning_text);
     banner.setRevealed(1);
+    banner.setButtonLabel(i18n._("Close"));
+
+    _ = adw.Banner.signals.button_clicked.connect(
+        banner,
+        *Surface,
+        showChildExitedButtonClosed,
+        self,
+        .{},
+    );
 
     const banner_widget = banner.as(gtk.Widget);
     banner_widget.setHalign(.fill);
@@ -2530,4 +2539,8 @@ pub fn showChildExited(self: *Surface, info: apprt.surface.Message.ChildExited) 
     self.overlay.addOverlay(banner_widget);
 
     return true;
+}
+
+fn showChildExitedButtonClosed(_: *adw.Banner, self: *Surface) callconv(.c) void {
+    self.close(false);
 }

--- a/src/apprt/gtk/style.css
+++ b/src/apprt/gtk/style.css
@@ -93,3 +93,15 @@ window.ssd.no-border-radius {
   margin-left: 4px;
   margin-right: 8px;
 }
+
+banner.child_exited_normally revealer widget {
+  background-color: rgba(38, 162, 105, 0.5);
+  /* after GTK 4.16 is a requirement, switch to the following:
+  /* background-color: color-mix(in srgb, var(--success-bg-color), transparent 50%); */
+}
+
+banner.child_exited_abnormally revealer widget {
+  background-color: rgba(192, 28, 40, 0.5);
+  /* after GTK 4.16 is a requirement, switch to the following:
+  /* background-color: color-mix(in srgb, var(--error-bg-color), transparent 50%); */
+}

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -98,7 +98,7 @@ pub const Message = union(enum) {
         // This enum is a placeholder for future title styles.
     };
 
-    pub const ChildExited = struct {
+    pub const ChildExited = extern struct {
         exit_code: u32,
         runtime_ms: u64,
     };


### PR DESCRIPTION
Addresses #7649 for the core and GTK. macOS support will need to be added later.

This adds an apprt action to show a native GUI warning of some kind when the child process of a terminal exits.

Also adds a basic GTK implementation of this. In GTK it overlays an Adwaita banner at the bottom of the window (similar to the banner that shows up in at the top of windows in debug builds).
![Screenshot From 2025-07-08 14-49-59](https://github.com/user-attachments/assets/5de4c065-6b35-4ef5-ba26-171c40c0c5ee)
![Screenshot From 2025-07-08 14-50-14](https://github.com/user-attachments/assets/d6259aa1-6eb2-4c7f-9a9b-13dbad706a3e)
