### PR TITLE
bash: conditionally add cursor shape sequences

### DIFF
--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -122,8 +122,8 @@ function __ghostty_precmd() {
 
       # Cursor
       if [[ "$GHOSTTY_SHELL_FEATURES" == *"cursor"* ]]; then
-        PS1=$PS1'\[\e[5 q\]'      # blinking bar for input
-        builtin printf "\e[0 q"   # reset to default cursor
+        [[ "$PS1" != *'\[\e[5 q\]'* ]] && PS1=$PS1'\[\e[5 q\]' # input
+        [[ "$PS0" != *'\[\e[0 q\]'* ]] && PS0=$PS0'\[\e[0 q\]' # reset
       fi
 
       # Title (working directory)


### PR DESCRIPTION
In #7808, we stopped using PS0 to reset the cursor shape because restoring PS0 in __ghostty_preexec was causing issues (#7802).

The alternate approach of printing the cursor reset escape sequence directly from __ghostty_preexec caused a new issue: the input cursor would persist longer than intended, such as when a suspended vim process was restored to the foreground.

This change takes a different approach. We now conditionally add the cursor shape escape sequences to PS0 (and PS1, for consistency) when they don't already appear. The fixes the cursor shape reset problem.

The main downside to this approach is that PS0 will continue to contain this escape sequence; it won't be cleared/reset in __ghostty_preexec for the reasons described in #7808. This feels like an acceptable outcome because there's no harm in the modified PS0 existing for the life of the bash session (rather than it being modified and then restored for each command cycle), and it's consistent with how some other terminals' bash integration works (e.g. kitty).