### PR TITLE
Fallback Font Size Adjustment

### DIFF
--- a/src/font/Glyph.zig
+++ b/src/font/Glyph.zig
@@ -17,9 +17,3 @@ offset_y: i32,
 /// be normalized to be between 0 and 1 prior to use in shaders.
 atlas_x: u32,
 atlas_y: u32,
-
-/// horizontal position to increase drawing position for strings
-advance_x: f32,
-
-/// Whether we drew this glyph ourselves with the sprite font.
-sprite: bool = false,

--- a/src/font/Metrics.zig
+++ b/src/font/Metrics.zig
@@ -107,6 +107,18 @@ pub const FaceMetrics = struct {
     /// a provided ex height metric or measured from the height of the
     /// lowercase x glyph.
     ex_height: ?f64 = null,
+
+    /// The width of the character "水" (CJK water ideograph, U+6C34),
+    /// if present. This is used for font size adjustment, to normalize
+    /// the width of CJK fonts mixed with latin fonts.
+    ///
+    /// NOTE: IC = Ideograph Character
+    ic_width: ?f64 = null,
+
+    /// Convenience function for getting the line height (ascent - descent).
+    pub inline fn lineHeight(self: FaceMetrics) f64 {
+        return self.ascent - self.descent;
+    }
 };
 
 /// Calculate our metrics based on values extracted from a font.

--- a/src/font/Metrics.zig
+++ b/src/font/Metrics.zig
@@ -115,9 +115,10 @@ pub const FaceMetrics = struct {
     /// NOTE: IC = Ideograph Character
     ic_width: ?f64 = null,
 
-    /// Convenience function for getting the line height (ascent - descent).
+    /// Convenience function for getting the line height
+    /// (ascent - descent + line_gap).
     pub inline fn lineHeight(self: FaceMetrics) f64 {
-        return self.ascent - self.descent;
+        return self.ascent - self.descent + self.line_gap;
     }
 };
 

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -31,6 +31,9 @@ pub const Face = struct {
     /// tables).
     color: ?ColorState = null,
 
+    /// The current size this font is set to.
+    size: font.face.DesiredSize,
+
     /// True if our build is using Harfbuzz. If we're not, we can avoid
     /// some Harfbuzz-specific code paths.
     const harfbuzz_shaper = font.options.backend.hasHarfbuzz();
@@ -106,6 +109,7 @@ pub const Face = struct {
             .font = ct_font,
             .hb_font = hb_font,
             .color = color,
+            .size = opts.size,
         };
         result.quirks_disable_default_font_features = quirks.disableDefaultFontFeatures(&result);
 

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -333,7 +333,6 @@ pub const Face = struct {
                 .offset_y = 0,
                 .atlas_x = 0,
                 .atlas_y = 0,
-                .advance_x = 0,
             };
 
         const metrics = opts.grid_metrics;
@@ -498,10 +497,6 @@ pub const Face = struct {
             break :offset_x result;
         };
 
-        // Get our advance
-        var advances: [glyphs.len]macos.graphics.Size = undefined;
-        _ = self.font.getAdvancesForGlyphs(.horizontal, &glyphs, &advances);
-
         return .{
             .width = px_width,
             .height = px_height,
@@ -509,7 +504,6 @@ pub const Face = struct {
             .offset_y = offset_y,
             .atlas_x = region.x,
             .atlas_y = region.y,
-            .advance_x = @floatCast(advances[0].width),
         };
     }
 

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -481,20 +481,42 @@ pub const Face = struct {
         // This should be the distance from the left of
         // the cell to the left of the glyph's bounding box.
         const offset_x: i32 = offset_x: {
-            var result: i32 = @intFromFloat(@round(x));
-
-            // If our cell was resized then we adjust our glyph's
-            // position relative to the new center. This keeps glyphs
-            // centered in the cell whether it was made wider or narrower.
-            if (metrics.original_cell_width) |original_width| {
-                const before: i32 = @intCast(original_width);
-                const after: i32 = @intCast(metrics.cell_width);
-                // Increase the offset by half of the difference
-                // between the widths to keep things centered.
-                result += @divTrunc(after - before, 2);
+            // If the glyph's advance is narrower than the cell width then we
+            // center the advance of the glyph within the cell width. At first
+            // I implemented this to proportionally scale the center position
+            // of the glyph but that messes up glyphs that are meant to align
+            // vertically with others, so this is a compromise.
+            //
+            // This makes it so that when the `adjust-cell-width` config is
+            // used, or when a fallback font with a different advance width
+            // is used, we don't get weirdly aligned glyphs.
+            //
+            // We don't do this if the constraint has a horizontal alignment,
+            // since in that case the position was already calculated with the
+            // new cell width in mind.
+            if (opts.constraint.align_horizontal == .none) {
+                var advances: [glyphs.len]macos.graphics.Size = undefined;
+                _ = self.font.getAdvancesForGlyphs(.horizontal, &glyphs, &advances);
+                const advance = advances[0].width;
+                const new_advance =
+                    cell_width * @as(f64, @floatFromInt(opts.cell_width orelse 1));
+                // If the original advance is greater than the cell width then
+                // it's possible that this is a ligature or other glyph that is
+                // intended to overflow the cell to one side or the other, and
+                // adjusting the bearings could mess that up, so we just leave
+                // it alone if that's the case.
+                //
+                // We also don't want to do anything if the advance is zero or
+                // less, since this is used for stuff like combining characters.
+                if (advance > new_advance or advance <= 0.0) {
+                    break :offset_x @intFromFloat(@round(x));
+                }
+                break :offset_x @intFromFloat(
+                    @round(x + (new_advance - advance) / 2),
+                );
+            } else {
+                break :offset_x @intFromFloat(@round(x));
             }
-
-            break :offset_x result;
         };
 
         return .{

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -757,6 +757,20 @@ pub const Face = struct {
             break :cell_width max;
         };
 
+        // Measure "水" (CJK water ideograph, U+6C34) for our ic width.
+        const ic_width: ?f64 = ic_width: {
+            const glyph = self.glyphIndex('水') orelse break :ic_width null;
+
+            var advances: [1]macos.graphics.Size = undefined;
+            _ = ct_font.getAdvancesForGlyphs(
+                .horizontal,
+                &.{@intCast(glyph)},
+                &advances,
+            );
+
+            break :ic_width advances[0].width;
+        };
+
         return .{
             .cell_width = cell_width,
             .ascent = ascent,
@@ -768,6 +782,7 @@ pub const Face = struct {
             .strikethrough_thickness = strikethrough_thickness,
             .cap_height = cap_height,
             .ex_height = ex_height,
+            .ic_width = ic_width,
         };
     }
 

--- a/src/font/face/freetype.zig
+++ b/src/font/face/freetype.zig
@@ -373,7 +373,6 @@ pub const Face = struct {
                 .offset_y = 0,
                 .atlas_x = 0,
                 .atlas_y = 0,
-                .advance_x = 0,
             };
 
         // For synthetic bold, we embolden the glyph.
@@ -662,7 +661,6 @@ pub const Face = struct {
             .offset_y = offset_y,
             .atlas_x = region.x,
             .atlas_y = region.y,
-            .advance_x = f26dot6ToFloat(glyph.*.advance.x),
         };
     }
 

--- a/src/font/face/freetype.zig
+++ b/src/font/face/freetype.zig
@@ -851,7 +851,7 @@ pub const Face = struct {
             while (c < 127) : (c += 1) {
                 if (face.getCharIndex(c)) |glyph_index| {
                     if (face.loadGlyph(glyph_index, .{
-                        .render = true,
+                        .render = false,
                         .no_svg = true,
                     })) {
                         max = @max(
@@ -889,7 +889,7 @@ pub const Face = struct {
                     defer self.ft_mutex.unlock();
                     if (face.getCharIndex('H')) |glyph_index| {
                         if (face.loadGlyph(glyph_index, .{
-                            .render = true,
+                            .render = false,
                             .no_svg = true,
                         })) {
                             break :cap f26dot6ToF64(face.handle.*.glyph.*.metrics.height);
@@ -902,7 +902,7 @@ pub const Face = struct {
                     defer self.ft_mutex.unlock();
                     if (face.getCharIndex('x')) |glyph_index| {
                         if (face.loadGlyph(glyph_index, .{
-                            .render = true,
+                            .render = false,
                             .no_svg = true,
                         })) {
                             break :ex f26dot6ToF64(face.handle.*.glyph.*.metrics.height);
@@ -911,6 +911,21 @@ pub const Face = struct {
                     break :ex null;
                 },
             };
+        };
+
+        // Measure "水" (CJK water ideograph, U+6C34) for our ic width.
+        const ic_width: ?f64 = ic_width: {
+            self.ft_mutex.lock();
+            defer self.ft_mutex.unlock();
+
+            const glyph = face.getCharIndex('水') orelse break :ic_width null;
+
+            face.loadGlyph(glyph, .{
+                .render = false,
+                .no_svg = true,
+            }) catch break :ic_width null;
+
+            break :ic_width f26dot6ToF64(face.handle.*.glyph.*.advance.x);
         };
 
         return .{
@@ -928,6 +943,7 @@ pub const Face = struct {
 
             .cap_height = cap_height,
             .ex_height = ex_height,
+            .ic_width = ic_width,
         };
     }
 

--- a/src/font/face/freetype.zig
+++ b/src/font/face/freetype.zig
@@ -59,6 +59,9 @@ pub const Face = struct {
         bold: bool = false,
     } = .{},
 
+    /// The current size this font is set to.
+    size: font.face.DesiredSize,
+
     /// Initialize a new font face with the given source in-memory.
     pub fn initFile(
         lib: Library,
@@ -107,6 +110,7 @@ pub const Face = struct {
             .hb_font = hb_font,
             .ft_mutex = ft_mutex,
             .load_flags = opts.freetype_load_flags,
+            .size = opts.size,
         };
         result.quirks_disable_default_font_features = quirks.disableDefaultFontFeatures(&result);
 
@@ -203,6 +207,7 @@ pub const Face = struct {
     /// for clearing any glyph caches, font atlas data, etc.
     pub fn setSize(self: *Face, opts: font.face.Options) !void {
         try setSize_(self.face, opts.size);
+        self.size = opts.size;
     }
 
     fn setSize_(face: freetype.Face, size: font.face.DesiredSize) !void {

--- a/src/font/face/web_canvas.zig
+++ b/src/font/face/web_canvas.zig
@@ -235,7 +235,6 @@ pub const Face = struct {
             .offset_y = 0,
             .atlas_x = region.x,
             .atlas_y = region.y,
-            .advance_x = 0,
         };
     }
 

--- a/src/font/sprite/Face.zig
+++ b/src/font/sprite/Face.zig
@@ -195,7 +195,6 @@ pub fn renderGlyph(
         .offset_y = 0,
         .atlas_x = 0,
         .atlas_y = 0,
-        .advance_x = 0,
     };
 
     const metrics = self.metrics;
@@ -227,8 +226,6 @@ pub fn renderGlyph(
         .offset_y = @as(i32, @intCast(region.height +| canvas.clip_bottom)) - @as(i32, @intCast(padding_y)),
         .atlas_x = region.x,
         .atlas_y = region.y,
-        .advance_x = @floatFromInt(width),
-        .sprite = true,
     };
 }
 


### PR DESCRIPTION
This PR changes `font.Collection` to automagically adjust the sizes of added fonts so that their metrics (specifically their ex height, or their ideograph character width if they have one) match the primary font. This is like [`font-size-adjust`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size-adjust) from CSS.

This is a big win for users who use mixed writing systems and rely heavily on fallback fonts. For example, in #7774 it's pointed out that CJK characters are not very well harmonized with existing Latin glyphs, well:
|Before (`main`)|After (this PR)|
|-|-|
|<img width="326" alt="image" src="https://github.com/user-attachments/assets/c11d372d-ec69-426d-b008-1f56a7430f23" />|<img width="326" alt="image" src="https://github.com/user-attachments/assets/efcb56ea-0572-481a-b632-a0b5cd170fa9" />|

This also improves our handling of the horizontal alignment of fallback glyphs. It's not an ideal solution; it only works for glyphs narrower than the cell width because it messes with ligatures if we include glyphs wider than the cell width; and most things would look better if the center were proportionally remapped based on the ratio from the glyph advance to the cell width, but that messes with glyphs designed to align vertically so it can't be done, instead the original advance width is centered in the cell width.

> [!NOTE]
> I can add a couple tests for the size adjust behavior (one for ex height, one for ic width) if you'd like.

### Future work
When working on this I was very bothered by the fact that our fallback fonts are not selected deterministically. That is, if a fallback with glyphs A and B is selected as the fallback for B because no other font has it, then it will automatically be used as the fallback for A as well even if other fonts would otherwise rank higher. This is a big problem if you have something like UniFont installed, since the moment that's loaded no other font will be loaded afterwards and you get very suboptimal selections for your glyphs.

So I'll have a think on how to go about making our fallbacks deterministic without killing performance (it's not a trivial problem unfortunately) and that will probably be my next area of work.