### PR TITLE
font: fix nerd font patcher ypadding twice what it should be

### DIFF
--- a/src/font/nerd_font_attributes.zig
+++ b/src/font/nerd_font_attributes.zig
@@ -40,8 +40,8 @@ pub fn getConstraint(cp: u21) Constraint {
             .max_constraint_width = 1,
             .align_horizontal = .center,
             .align_vertical = .center,
-            .pad_top = 0.3,
-            .pad_bottom = 0.3,
+            .pad_top = 0.15,
+            .pad_bottom = 0.15,
         },
         0xe0b0,
         => .{

--- a/src/font/nerd_font_codegen.py
+++ b/src/font/nerd_font_codegen.py
@@ -213,8 +213,8 @@ def emit_zig_entry_multikey(codepoints: list[int], attr: PatchSetAttributeEntry)
         s += f"            .pad_top = {v_pad},\n"
         s += f"            .pad_bottom = {v_pad},\n"
     elif y_padding:
-        s += f"            .pad_top = {y_padding},\n"
-        s += f"            .pad_bottom = {y_padding},\n"
+        s += f"            .pad_top = {y_padding / 2},\n"
+        s += f"            .pad_bottom = {y_padding / 2},\n"
 
     if xy_ratio > 0:
         s += f"            .max_xy_ratio = {xy_ratio},\n"


### PR DESCRIPTION
The nerd font patcher uses `ypadding` as a single subtraction from the cell height, which means that half of it should go to the top padding and the other half to the bottom, but we were setting it for both the top and bottom! This was making the heavy brackets way too small lol (0.4 of the cell height instead of 0.7)

#7834 introduced the *opposite* problem to what it fixed haha. This fixes it for real!