### PR TITLE
Add Urdu translation to Ghostty

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -182,6 +182,7 @@
 /po/ga_IE.UTF-8.po @ghostty-org/ga_IE
 /po/ko_KR.UTF-8.po @ghostty-org/ko_KR
 /po/he_IL.UTF-8.po @ghostty-org/he_IL
+/po/ur_PK.UTF-8.po @ghostty-org/ur_PK
 
 # Packaging - Snap
 /snap/ @ghostty-org/snap

--- a/po/ur_PK.UTF-8.po
+++ b/po/ur_PK.UTF-8.po
@@ -1,0 +1,297 @@
+# Urdu translations for com.mitchellh.ghostty package.
+# Copyright (C) 2025 "Mitchell Hashimoto, Ghostty contributors"
+# This file is distributed under the same license as the com.mitchellh.ghostty package.
+# Abdul Hannan Ahmed <kyoyagami666kof@gmail.com>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: com.mitchellh.ghostty\n"
+"Report-Msgid-Bugs-To: mmitchellh.com\n"
+"POT-Creation-Date: 2025-06-28 17:01+0200\n"
+"PO-Revision-Date: 2025-07-07 12:01+0500\n"
+"Last-Translator: Abdul Hannan Ahmed <kyoyagami666kof@gmail.com>\n"
+"Language-Team: Urdu <jessbody@gmail.com>\n"
+"Language: ur\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:5
+msgid "Change Terminal Title"
+msgstr "ٹرمینل کا عنوان تبدیل کریں"
+
+#: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:6
+msgid "Leave blank to restore the default title."
+msgstr "اصل عنوان بحال کرنے کے لیے خالی چھوڑ دی"
+
+#: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:9
+#: src/apprt/gtk/ui/1.5/ccw-paste.blp:10 src/apprt/gtk/ui/1.2/ccw-paste.blp:10
+#: src/apprt/gtk/CloseDialog.zig:44
+msgid "Cancel"
+msgstr "منسوخ کریں"
+
+#: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:10
+msgid "OK"
+msgstr "ٹھیک ہے"
+
+#: src/apprt/gtk/ui/1.5/config-errors-dialog.blp:5
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:5
+msgid "Configuration Errors"
+msgstr "تشکیلاتی غلطیاں"
+
+#: src/apprt/gtk/ui/1.5/config-errors-dialog.blp:6
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:6
+msgid ""
+"One or more configuration errors were found. Please review the errors below, "
+"and either reload your configuration or ignore these errors."
+msgstr "ایک یا زیادہ تشکیلاتی غلطیاں پائی گئیں۔ براہ کرم درج ذیل غلطیوں کا جائزہ لیں، اور یا تو تشکیلات کو دوبارہ لوڈ کریں یا انہیں نظر انداز کریں۔"
+
+#: src/apprt/gtk/ui/1.5/config-errors-dialog.blp:9
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:9
+msgid "Ignore"
+msgstr "نظر انداز کریں"
+
+#: src/apprt/gtk/ui/1.5/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:97
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:100
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+msgid "Reload Configuration"
+msgstr "تشکیلات دوبارہ لوڈ کریں"
+
+#: src/apprt/gtk/ui/1.0/menu-headerbar-split_menu.blp:6
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:38
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:50
+msgid "Split Up"
+msgstr "اوپر تقسیم کریں"
+
+#: src/apprt/gtk/ui/1.0/menu-headerbar-split_menu.blp:11
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:43
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:55
+msgid "Split Down"
+msgstr "نیچے تقسیم کریں"
+
+#: src/apprt/gtk/ui/1.0/menu-headerbar-split_menu.blp:16
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:48
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:60
+msgid "Split Left"
+msgstr "بائیں تقسیم کریں"
+
+#: src/apprt/gtk/ui/1.0/menu-headerbar-split_menu.blp:21
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:53
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:65
+msgid "Split Right"
+msgstr "دائیں تقسیم کریں"
+
+#: src/apprt/gtk/ui/1.5/command-palette.blp:16
+msgid "Execute a command…"
+msgstr "ایک کمانڈ چلائیں…"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:6
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:6
+msgid "Copy"
+msgstr "نقل کریں"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:11
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:11
+#: src/apprt/gtk/ui/1.5/ccw-paste.blp:11 src/apprt/gtk/ui/1.2/ccw-paste.blp:11
+msgid "Paste"
+msgstr "چسپاں کریں"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:18
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:73
+msgid "Clear"
+msgstr "صاف کریں"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:23
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:78
+msgid "Reset"
+msgstr "دوبارہ ترتیب دیں"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:30
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:42
+msgid "Split"
+msgstr "تقسیم کریں"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:33
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:45
+msgid "Change Title…"
+msgstr "عنوان تبدیل کریں…"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:59
+msgid "Tab"
+msgstr "ٹیب"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:62
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:30
+#: src/apprt/gtk/Window.zig:263
+msgid "New Tab"
+msgstr "نیا ٹیب"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:67
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:35
+msgid "Close Tab"
+msgstr "ٹیب بند کریں"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:73
+msgid "Window"
+msgstr "ونڈو"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:76
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:18
+msgid "New Window"
+msgstr "نئی ونڈو"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:81
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:23
+msgid "Close Window"
+msgstr "ونڈو بند کریں"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:89
+msgid "Config"
+msgstr "تشکیلات"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:92
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:95
+msgid "Open Configuration"
+msgstr "تشکیلات کھولیں"
+
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:85
+msgid "Command Palette"
+msgstr "کمانڈ پیلیٹ"
+
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:90
+msgid "Terminal Inspector"
+msgstr "ٹرمینل انسپکٹر"
+
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:107
+#: src/apprt/gtk/Window.zig:1036
+msgid "About Ghostty"
+msgstr "Ghostty کے بارے میں"
+
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:112
+msgid "Quit"
+msgstr "بند کریں"
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:6
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:6
+#: src/apprt/gtk/ui/1.2/ccw-osc-52-read.blp:6
+#: src/apprt/gtk/ui/1.2/ccw-osc-52-write.blp:6
+msgid "Authorize Clipboard Access"
+msgstr "کلپ بورڈ تک رسائی کی اجازت دیں"
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:7
+#: src/apprt/gtk/ui/1.2/ccw-osc-52-read.blp:7
+msgid ""
+"An application is attempting to read from the clipboard. The current "
+"clipboard contents are shown below."
+msgstr "ایک ایپلیکیشن کلپ بورڈ سے پڑھنے کی کوشش کر رہی ہے۔ موجودہ کلپ بورڈ کا مواد نیچے دکھایا گیا ہے۔"
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:10
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:10
+#: src/apprt/gtk/ui/1.2/ccw-osc-52-read.blp:10
+#: src/apprt/gtk/ui/1.2/ccw-osc-52-write.blp:10
+msgid "Deny"
+msgstr "منع کریں"
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:11
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:11
+#: src/apprt/gtk/ui/1.2/ccw-osc-52-read.blp:11
+#: src/apprt/gtk/ui/1.2/ccw-osc-52-write.blp:11
+msgid "Allow"
+msgstr "اجازت دیں"
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:81
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:77
+msgid "Remember choice for this split"
+msgstr "اس تقسیم کے لیے انتخاب یاد رکھیں"
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:82
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:78
+msgid "Reload configuration to show this prompt again"
+msgstr "یہ پیغام دوبارہ دکھانے کے لیے تشکیلات دوبارہ لوڈ کریں"
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:7
+#: src/apprt/gtk/ui/1.2/ccw-osc-52-write.blp:7
+msgid ""
+"An application is attempting to write to the clipboard. The current "
+"clipboard contents are shown below."
+msgstr "ایک ایپلیکیشن کلپ بورڈ پر لکھنے کی کوشش کر رہی ہے۔ موجودہ کلپ بورڈ کا مواد نیچے دکھایا گیا ہے۔"
+
+#: src/apprt/gtk/ui/1.5/ccw-paste.blp:6 src/apprt/gtk/ui/1.2/ccw-paste.blp:6
+msgid "Warning: Potentially Unsafe Paste"
+msgstr "انتباہ: ممکنہ طور پر غیر محفوظ چسپاں"
+
+#: src/apprt/gtk/ui/1.5/ccw-paste.blp:7 src/apprt/gtk/ui/1.2/ccw-paste.blp:7
+msgid ""
+"Pasting this text into the terminal may be dangerous as it looks like some "
+"commands may be executed."
+msgstr "یہ متن ٹرمینل میں چسپاں کرنا خطرناک ہو سکتا ہے کیونکہ اس میں کچھ کمانڈز چلائی جا سکتی ہیں۔"
+
+#: src/apprt/gtk/Window.zig:216
+msgid "Main Menu"
+msgstr "مین مینو"
+
+#: src/apprt/gtk/Window.zig:238
+msgid "View Open Tabs"
+msgstr "کھلے ٹیبز دیکھیں"
+
+#: src/apprt/gtk/Window.zig:264
+msgid "New Split"
+msgstr "نئی تقسیم"
+
+#: src/apprt/gtk/Window.zig:327
+msgid ""
+"⚠️ You're running a debug build of Ghostty! Performance will be degraded."
+msgstr "⚠️ آپ Ghostty کا ڈیبگ ورژن چلا رہے ہیں! کارکردگی متاثر ہو سکتی ہے۔"
+
+#: src/apprt/gtk/Window.zig:773
+msgid "Reloaded the configuration"
+msgstr "تشکیلات دوبارہ لوڈ کر دی گئی ہیں"
+
+#: src/apprt/gtk/Window.zig:1017
+msgid "Ghostty Developers"
+msgstr "Ghostty کے ڈویلپرز"
+
+#: src/apprt/gtk/inspector.zig:144
+msgid "Ghostty: Terminal Inspector"
+msgstr "Ghostty: ٹرمینل انسپکٹر"
+
+#: src/apprt/gtk/CloseDialog.zig:47
+msgid "Close"
+msgstr "بند کریں"
+
+#: src/apprt/gtk/CloseDialog.zig:87
+msgid "Quit Ghostty?"
+msgstr "Ghostty بند کریں؟"
+
+#: src/apprt/gtk/CloseDialog.zig:88
+msgid "Close Window?"
+msgstr "ونڈو بند کریں؟"
+
+#: src/apprt/gtk/CloseDialog.zig:89
+msgid "Close Tab?"
+msgstr "ٹیب بند کریں؟"
+
+#: src/apprt/gtk/CloseDialog.zig:90
+msgid "Close Split?"
+msgstr "تقسیم بند کریں؟"
+
+#: src/apprt/gtk/CloseDialog.zig:96
+msgid "All terminal sessions will be terminated."
+msgstr "تمام ٹرمینل سیشنز ختم کر دیے جائیں گے۔"
+
+#: src/apprt/gtk/CloseDialog.zig:97
+msgid "All terminal sessions in this window will be terminated."
+msgstr "اس ونڈو میں موجود تمام ٹرمینل سیشنز ختم کر دیے جائیں گے۔"
+
+#: src/apprt/gtk/CloseDialog.zig:98
+msgid "All terminal sessions in this tab will be terminated."
+msgstr "اس ٹیب میں موجود تمام ٹرمینل سیشنز ختم کر دیے جائیں گے۔"
+
+#: src/apprt/gtk/CloseDialog.zig:99
+msgid "The currently running process in this split will be terminated."
+msgstr "اس تقسیم میں چلنے والا موجودہ عمل ختم کر دیا جائے گا۔"
+
+#: src/apprt/gtk/Surface.zig:1257
+msgid "Copied to clipboard"
+msgstr "کلپ بورڈ پر نقل کر دیا گیا"

--- a/src/os/i18n.zig
+++ b/src/os/i18n.zig
@@ -50,6 +50,7 @@ pub const locales = [_][:0]const u8{
     "bg_BG.UTF-8",
     "ga_IE.UTF-8",
     "he_IL.UTF-8",
+    "ur_PK.UTF-8",
 };
 
 /// Set for faster membership lookup of locales.


### PR DESCRIPTION
Hi there. As you can see, the the `po/` directory, there's a `ur_PK.UTF-8.po` file containing the Urdu translation for Ghostty that is tested and works on my end.

I think there should be an Urdu translation for Ghostty, so I've got the `po` file, hopefully Urdu will officially be supported in the later versions for Ghostty.