### PR TITLE
Nerd Font Icon Height Constraint

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -396,6 +396,18 @@ pub const compatibility = std.StaticStringMap(
 /// Thickness in pixels or percentage adjustment of box drawing characters.
 /// See the notes about adjustments in `adjust-cell-width`.
 @"adjust-box-thickness": ?MetricModifier = null,
+/// Height in pixels or percentage adjustment of maximum height for nerd font icons.
+///
+/// Increasing this value will allow nerd font icons to be larger, but won't
+/// necessarily force them to be. Decreasing this value will make nerd font
+/// icons smaller.
+///
+/// The default value for the icon height is 1.2 times the height of capital
+/// letters in your primary font, so something like -16.6% would make icons
+/// roughly the same height as capital letters.
+///
+/// See the notes about adjustments in `adjust-cell-width`.
+@"adjust-icon-height": ?MetricModifier = null,
 
 /// The method to use for calculating the cell width of a grapheme cluster.
 /// The default value is `unicode` which uses the Unicode standard to determine

--- a/src/font/Collection.zig
+++ b/src/font/Collection.zig
@@ -1072,6 +1072,7 @@ test "metrics" {
         .overline_thickness = 1,
         .box_thickness = 1,
         .cursor_height = 17,
+        .icon_height = 11,
     }, c.metrics);
 
     // Resize should change metrics
@@ -1088,6 +1089,7 @@ test "metrics" {
         .overline_thickness = 2,
         .box_thickness = 2,
         .cursor_height = 34,
+        .icon_height = 23,
     }, c.metrics);
 }
 

--- a/src/font/Metrics.zig
+++ b/src/font/Metrics.zig
@@ -35,10 +35,6 @@ cursor_thickness: u32 = 1,
 /// The height in pixels of the cursor sprite.
 cursor_height: u32,
 
-/// Original cell width in pixels. This is used to keep
-/// glyphs centered if the cell width is adjusted wider.
-original_cell_width: ?u32 = null,
-
 /// Minimum acceptable values for some fields to prevent modifiers
 /// from being able to, for example, cause 0-thickness underlines.
 const Minimums = struct {
@@ -213,11 +209,6 @@ pub fn apply(self: *Metrics, mods: ModifierSet) void {
                 const original = @field(self, @tagName(tag));
                 const new = @max(entry.value_ptr.apply(original), 1);
                 if (new == original) continue;
-
-                // Preserve the original cell width if not set.
-                if (self.original_cell_width == null) {
-                    self.original_cell_width = self.cell_width;
-                }
 
                 // Set the new value
                 @field(self, @tagName(tag)) = new;

--- a/src/font/SharedGridSet.zig
+++ b/src/font/SharedGridSet.zig
@@ -449,6 +449,7 @@ pub const DerivedConfig = struct {
     @"adjust-cursor-thickness": ?Metrics.Modifier,
     @"adjust-cursor-height": ?Metrics.Modifier,
     @"adjust-box-thickness": ?Metrics.Modifier,
+    @"adjust-icon-height": ?Metrics.Modifier,
     @"freetype-load-flags": font.face.FreetypeLoadFlags,
 
     /// Initialize a DerivedConfig. The config should be either a
@@ -488,6 +489,7 @@ pub const DerivedConfig = struct {
             .@"adjust-cursor-thickness" = config.@"adjust-cursor-thickness",
             .@"adjust-cursor-height" = config.@"adjust-cursor-height",
             .@"adjust-box-thickness" = config.@"adjust-box-thickness",
+            .@"adjust-icon-height" = config.@"adjust-icon-height",
             .@"freetype-load-flags" = if (font.face.FreetypeLoadFlags != void) config.@"freetype-load-flags" else {},
 
             // This must be last so the arena contains all our allocations
@@ -634,6 +636,7 @@ pub const Key = struct {
             if (config.@"adjust-cursor-thickness") |m| try set.put(alloc, .cursor_thickness, m);
             if (config.@"adjust-cursor-height") |m| try set.put(alloc, .cursor_height, m);
             if (config.@"adjust-box-thickness") |m| try set.put(alloc, .box_thickness, m);
+            if (config.@"adjust-icon-height") |m| try set.put(alloc, .icon_height, m);
             break :set set;
         };
 

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -341,7 +341,7 @@ pub const Face = struct {
 
         const metrics = opts.grid_metrics;
         const cell_width: f64 = @floatFromInt(metrics.cell_width);
-        const cell_height: f64 = @floatFromInt(metrics.cell_height);
+        // const cell_height: f64 = @floatFromInt(metrics.cell_height);
 
         const glyph_size = opts.constraint.constrain(
             .{
@@ -350,8 +350,7 @@ pub const Face = struct {
                 .x = rect.origin.x,
                 .y = rect.origin.y + @as(f64, @floatFromInt(metrics.cell_baseline)),
             },
-            cell_width,
-            cell_height,
+            metrics,
             opts.constraint_width,
         );
 

--- a/src/font/face/freetype.zig
+++ b/src/font/face/freetype.zig
@@ -395,7 +395,7 @@ pub const Face = struct {
         const metrics = opts.grid_metrics;
 
         const cell_width: f64 = @floatFromInt(metrics.cell_width);
-        const cell_height: f64 = @floatFromInt(metrics.cell_height);
+        // const cell_height: f64 = @floatFromInt(metrics.cell_height);
 
         const glyph_x: f64 = f26dot6ToF64(glyph.*.metrics.horiBearingX);
         const glyph_y: f64 = f26dot6ToF64(glyph.*.metrics.horiBearingY) - glyph_height;
@@ -407,8 +407,7 @@ pub const Face = struct {
                 .x = glyph_x,
                 .y = glyph_y + @as(f64, @floatFromInt(metrics.cell_baseline)),
             },
-            cell_width,
-            cell_height,
+            metrics,
             opts.constraint_width,
         );
 
@@ -1058,6 +1057,7 @@ test "color emoji" {
                 .overline_thickness = 0,
                 .box_thickness = 0,
                 .cursor_height = 0,
+                .icon_height = 0,
             }, .constraint_width = 2, .constraint = .{
                 .size_horizontal = .cover,
                 .size_vertical = .cover,

--- a/src/font/nerd_font_attributes.zig
+++ b/src/font/nerd_font_attributes.zig
@@ -25,6 +25,7 @@ pub fn getConstraint(cp: u21) Constraint {
         => .{
             .size_horizontal = .cover,
             .size_vertical = .fit,
+            .height = .icon,
             .max_constraint_width = 1,
             .align_horizontal = .center,
             .align_vertical = .center,
@@ -285,7 +286,7 @@ pub fn getConstraint(cp: u21) Constraint {
         0xe0d0...0xe0d1,
         => .{
             .size_horizontal = .cover,
-            .size_vertical = .cover,
+            .size_vertical = .fit,
             .align_horizontal = .start,
             .align_vertical = .center,
         },
@@ -294,7 +295,7 @@ pub fn getConstraint(cp: u21) Constraint {
         0xe0d5,
         => .{
             .size_horizontal = .cover,
-            .size_vertical = .cover,
+            .size_vertical = .fit,
             .align_horizontal = .center,
             .align_vertical = .center,
         },
@@ -362,6 +363,7 @@ pub fn getConstraint(cp: u21) Constraint {
         => .{
             .size_horizontal = .fit,
             .size_vertical = .fit,
+            .height = .icon,
             .align_horizontal = .center,
             .align_vertical = .center,
         },

--- a/src/font/nerd_font_codegen.py
+++ b/src/font/nerd_font_codegen.py
@@ -180,15 +180,18 @@ def emit_zig_entry_multikey(codepoints: list[int], attr: PatchSetAttributeEntry)
     if "xy" in stretch:
         s += "            .size_horizontal = .stretch,\n"
         s += "            .size_vertical = .stretch,\n"
-    elif "!" in stretch:
+    elif "!" in stretch or "^" in stretch:
         s += "            .size_horizontal = .cover,\n"
         s += "            .size_vertical = .fit,\n"
-    elif "^" in stretch:
-        s += "            .size_horizontal = .cover,\n"
-        s += "            .size_vertical = .cover,\n"
     else:
         s += "            .size_horizontal = .fit,\n"
         s += "            .size_vertical = .fit,\n"
+
+    # `^` indicates that scaling should fill
+    # the whole cell, not just the icon height.
+    if "^" not in stretch:
+        s += "            .height = .icon,\n"
+
 
     # There are two cases where we want to limit the constraint width to 1:
     # - If there's a `1` in the stretch mode string.


### PR DESCRIPTION
Nerd font icons were ***WAY*** too big depending on your font setup, this is because we were always using the full cell height when the nerd font patcher instead uses an "icon height" for most things. The patcher calculates the icon height as two thirds of the font's cap height and one third of the line height, but I've chosen to instead use 1.2 times the cap height for more consistent results across fonts-- if the user wants their icons bigger, they can use the `adjust-icon-height` metric modifier (and they can also use it to make them smaller if they want that for some reason).

I also adjusted the attributes to user horizontal cover + vertical fit for `^` stretch modes (proportional scaling but scale up), which makes it so that it never exceeds the cell size, since first it covers horizontally and then scales down to fit vertically if necessary; previously, if there were a particularly wide glyph that was scaled with cover/cover it would exceed the available width and overflow in to neighboring cells which wasn't good.