### PR TITLE
build: improve caching of macOS builds

### DIFF
--- a/src/build/XCFrameworkStep.zig
+++ b/src/build/XCFrameworkStep.zig
@@ -12,9 +12,6 @@ pub const Options = struct {
     /// The name of the xcframework to create.
     name: []const u8,
 
-    /// The path to write the framework
-    out_path: []const u8,
-
     /// The libraries to bundle
     libraries: []const Library,
 };
@@ -30,40 +27,33 @@ pub const Library = struct {
 
 step: *Step,
 
+output: LazyPath,
+
 pub fn create(b: *std.Build, opts: Options) *XCFrameworkStep {
     const self = b.allocator.create(XCFrameworkStep) catch @panic("OOM");
 
-    // We have to delete the old xcframework first since we're writing
-    // to a static path.
-    const run_delete = run: {
-        const run = RunStep.create(b, b.fmt("xcframework delete {s}", .{opts.name}));
-        run.has_side_effects = true;
-        run.addArgs(&.{ "rm", "-rf", opts.out_path });
-        break :run run;
-    };
-
     // Then we run xcodebuild to create the framework.
-    const run_create = run: {
+    const run_create, const run_output = run: {
         const run = RunStep.create(b, b.fmt("xcframework {s}", .{opts.name}));
-        run.has_side_effects = true;
         run.addArgs(&.{ "xcodebuild", "-create-xcframework" });
         for (opts.libraries) |lib| {
             run.addArg("-library");
             run.addFileArg(lib.library);
             run.addArg("-headers");
-            run.addFileArg(lib.headers);
+            run.addDirectoryArg(lib.headers);
         }
         run.addArg("-output");
-        run.addArg(opts.out_path);
+        const output = run.addOutputDirectoryArg(b.fmt(
+            "{s}.xcframework",
+            .{opts.name},
+        ));
         run.expectExitCode(0);
-        _ = run.captureStdOut();
-        _ = run.captureStdErr();
-        break :run run;
+        break :run .{ run, output };
     };
-    run_create.step.dependOn(&run_delete.step);
 
     self.* = .{
         .step = &run_create.step,
+        .output = run_output,
     };
 
     return self;


### PR DESCRIPTION
This improves caching of builds to speed up `zig build` and `zig build run` on macOS by avoiding unnecessary rebuilds of the Ghostty xcframework.

I had bigger ambitions to avoid the `xcodebuild` as well but I kept running into issues where the Zig build system wasn't getting the hit/miss right. This is surely my problem with setting the proper inputs, but I couldn't figure it out so just want to get this in to start.