### PR TITLE
build: disable fuzzy matching for msgmerge

### DIFF
--- a/src/build/GhosttyI18n.zig
+++ b/src/build/GhosttyI18n.zig
@@ -156,7 +156,7 @@ fn createUpdateStep(b: *std.Build) !*std.Build.Step {
     );
 
     inline for (internal_os.i18n.locales) |locale| {
-        const msgmerge = b.addSystemCommand(&.{ "msgmerge", "-q" });
+        const msgmerge = b.addSystemCommand(&.{ "msgmerge", "--quiet", "--no-fuzzy-matching" });
         msgmerge.addFileArg(b.path("po/" ++ locale ++ ".po"));
         msgmerge.addFileArg(xgettext.captureStdOut());
         usf.addCopyFileToSource(msgmerge.captureStdOut(), "po/" ++ locale ++ ".po");


### PR DESCRIPTION
CI is currently configured to fail if there are any fuzzy matches in translation files. This change prevents `msgmerge` from creating any fuzzy matches when translations are updated.