### PR TITLE
Changed behaviour of bold-color

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2825,8 +2825,8 @@ else
 /// This can be set to a specific color, using the same format as
 /// `background` or `foreground` (e.g. `#RRGGBB` but other formats
 /// are also supported; see the aforementioned documentation). If a
-/// specific color is set, this color will always be used for all
-/// bold text regardless of the terminal's color scheme.
+/// specific color is set, this color will always be used for the default
+/// bold text color. It will set the rest of the bold colors to `bright`.
 ///
 /// This can also be set to `bright`, which uses the bright color palette
 /// for bold text. For example, if the text is red, then the bold will

--- a/src/terminal/style.zig
+++ b/src/terminal/style.zig
@@ -154,15 +154,12 @@ pub const Style = struct {
 
             .palette => |idx| palette: {
                 if (self.flags.bold) {
-                    if (opts.bold) |bold| switch (bold) {
-                        .color => |v| break :palette v.toTerminalRGB(),
-                        .bright => {
-                            const bright_offset = @intFromEnum(color.Name.bright_black);
-                            if (idx < bright_offset) {
-                                break :palette opts.palette[idx + bright_offset];
-                            }
-                        },
-                    };
+                    if (opts.bold) |_| {
+                        const bright_offset = @intFromEnum(color.Name.bright_black);
+                        if (idx < bright_offset) {
+                            break :palette opts.palette[idx + bright_offset];
+                        }
+                    }
                 }
 
                 break :palette opts.palette[idx];


### PR DESCRIPTION
Continuation of discussion in https://github.com/ghostty-org/ghostty/discussions/3134

This changes the behaviour of the new bold-color option to only affect the default foreground text when set to a static colour. By using a static colour, the remaining colours are rendered as bright.