### PR TITLE
build: fix compilation failures when using older SDKs with macOS 26 APIs

### DIFF
--- a/macos/Sources/App/macOS/ghostty-bridging-header.h
+++ b/macos/Sources/App/macOS/ghostty-bridging-header.h
@@ -1,3 +1,12 @@
 // C imports here are exposed to Swift.
 
 #import "VibrantLayer.h"
+
+// SDK version check for macOS 26 features
+#import <AvailabilityMacros.h>
+
+// Check if SDK version is macOS 26 or higher
+// macOS 26.0 would be 260000 in the version macro
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 260000
+    #define SUPPORTS_MACOS_26_FEATURES 1
+#endif

--- a/macos/Sources/Features/App Intents/CloseTerminalIntent.swift
+++ b/macos/Sources/Features/App Intents/CloseTerminalIntent.swift
@@ -12,8 +12,10 @@ struct CloseTerminalIntent: AppIntent {
     )
     var terminal: TerminalEntity
 
+    #if SUPPORTS_MACOS_26_FEATURES
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = .background
+    #endif
 
     @MainActor
     func perform() async throws -> some IntentResult {

--- a/macos/Sources/Features/App Intents/CommandPaletteIntent.swift
+++ b/macos/Sources/Features/App Intents/CommandPaletteIntent.swift
@@ -19,8 +19,10 @@ struct CommandPaletteIntent: AppIntent {
     )
     var command: CommandEntity
 
+    #if SUPPORTS_MACOS_26_FEATURES
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = .background
+    #endif
 
     @MainActor
     func perform() async throws -> some IntentResult & ReturnsValue<Bool> {

--- a/macos/Sources/Features/App Intents/GetTerminalDetailsIntent.swift
+++ b/macos/Sources/Features/App Intents/GetTerminalDetailsIntent.swift
@@ -17,8 +17,10 @@ struct GetTerminalDetailsIntent: AppIntent {
     )
     var terminal: TerminalEntity
 
+    #if SUPPORTS_MACOS_26_FEATURES
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = .background
+    #endif
 
     static var parameterSummary: some ParameterSummary {
         Summary("Get \(\.$detail) from \(\.$terminal)")

--- a/macos/Sources/Features/App Intents/InputIntent.swift
+++ b/macos/Sources/Features/App Intents/InputIntent.swift
@@ -24,8 +24,10 @@ struct InputTextIntent: AppIntent {
     )
     var terminal: TerminalEntity
 
+    #if SUPPORTS_MACOS_26_FEATURES
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = [.background, .foreground]
+    #endif
 
     @MainActor
     func perform() async throws -> some IntentResult {
@@ -74,8 +76,10 @@ struct KeyEventIntent: AppIntent {
     )
     var terminal: TerminalEntity
 
+    #if SUPPORTS_MACOS_26_FEATURES
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = [.background, .foreground]
+    #endif
 
     @MainActor
     func perform() async throws -> some IntentResult {
@@ -136,8 +140,10 @@ struct MouseButtonIntent: AppIntent {
     )
     var terminal: TerminalEntity
 
+    #if SUPPORTS_MACOS_26_FEATURES
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = [.background, .foreground]
+    #endif
 
     @MainActor
     func perform() async throws -> some IntentResult {
@@ -197,8 +203,10 @@ struct MousePosIntent: AppIntent {
     )
     var terminal: TerminalEntity
 
+    #if SUPPORTS_MACOS_26_FEATURES
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = [.background, .foreground]
+    #endif
 
     @MainActor
     func perform() async throws -> some IntentResult {
@@ -265,8 +273,10 @@ struct MouseScrollIntent: AppIntent {
     )
     var terminal: TerminalEntity
 
+    #if SUPPORTS_MACOS_26_FEATURES
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = [.background, .foreground]
+    #endif
 
     @MainActor
     func perform() async throws -> some IntentResult {

--- a/macos/Sources/Features/App Intents/KeybindIntent.swift
+++ b/macos/Sources/Features/App Intents/KeybindIntent.swift
@@ -16,8 +16,10 @@ struct KeybindIntent: AppIntent {
     )
     var action: String
 
+    #if SUPPORTS_MACOS_26_FEATURES
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = [.background, .foreground]
+    #endif
 
     @MainActor
     func perform() async throws -> some IntentResult & ReturnsValue<Bool> {

--- a/macos/Sources/Features/App Intents/NewTerminalIntent.swift
+++ b/macos/Sources/Features/App Intents/NewTerminalIntent.swift
@@ -43,8 +43,10 @@ struct NewTerminalIntent: AppIntent {
     )
     var parent: TerminalEntity?
 
+    #if SUPPORTS_MACOS_26_FEATURES
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = .foreground(.immediate)
+    #endif
 
     @available(macOS, obsoleted: 26.0, message: "Replaced by supportedModes")
     static var openAppWhenRun = true

--- a/macos/Sources/Features/App Intents/QuickTerminalIntent.swift
+++ b/macos/Sources/Features/App Intents/QuickTerminalIntent.swift
@@ -5,8 +5,10 @@ struct QuickTerminalIntent: AppIntent {
     static var title: LocalizedStringResource = "Open the Quick Terminal"
     static var description = IntentDescription("Open the Quick Terminal. If it is already open, then do nothing.")
 
+    #if SUPPORTS_MACOS_26_FEATURES
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = .background
+    #endif
 
     @MainActor
     func perform() async throws -> some IntentResult & ReturnsValue<[TerminalEntity]> {

--- a/macos/Sources/Features/Terminal/Window Styles/TransparentTitlebarTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TransparentTitlebarTerminalWindow.swift
@@ -67,13 +67,14 @@ class TransparentTitlebarTerminalWindow: TerminalWindow {
         // references changed (e.g. tabGroup is new).
         setupKVO()
 
-        if #available(macOS 26.0, *) {
-            syncAppearanceTahoe(surfaceConfig)
-        } else {
-            syncAppearanceVentura(surfaceConfig)
-        }
+        #if SUPPORTS_MACOS_26_FEATURES
+        syncAppearanceTahoe(surfaceConfig)
+        #else
+        syncAppearanceVentura(surfaceConfig)
+        #endif
     }
 
+    #if SUPPORTS_MACOS_26_FEATURES
     @available(macOS 26.0, *)
     private func syncAppearanceTahoe(_ surfaceConfig: Ghostty.SurfaceView.DerivedConfig) {
         // When we have transparency, we need to set the titlebar background to match the
@@ -94,6 +95,7 @@ class TransparentTitlebarTerminalWindow: TerminalWindow {
         // that force a background color.
         titlebarBackgroundView?.isHidden = true
     }
+    #endif
 
     @available(macOS 13.0, *)
     private func syncAppearanceVentura(_ surfaceConfig: Ghostty.SurfaceView.DerivedConfig) {


### PR DESCRIPTION
## Background

When using an SDK older than macOS Tahoe 26 (e.g., the macOS 15 SDK), the compiler cannot find types that are only defined in the macOS Tahoe 26 SDK. This results in a fatal compile-time error, not just a runtime availability warning:

```
/path/to/file.swift:XX:XX: error: Cannot find type 'IntentModes' in scope
```

This prevents the project from being built on any system that doesn't have the very latest macOS SDK installed.

## Solution

Implement compile-time SDK version checking using the Objective-C bridging header. This separates new APIs from the core codebase, allowing them to be compiled only when the required SDK is present.

1.  **Add SDK version macro** in `ghostty-bridging-header.h`:
    *   Define a new flag, `SUPPORTS_MACOS_26_FEATURES`, only when the build environment's `__MAC_OS_X_VERSION_MAX_ALLOWED` corresponds to the macOS 26.0 SDK or newer.

2.  **Wrap macOS 26 APIs** with `#if SUPPORTS_MACOS_26_FEATURES`:
    *   All App Intents' `supportedModes` properties, which use the `IntentModes` type.
    *   The `syncAppearanceTahoe` method call in `TransparentTitlebarTerminalWindow`, which is part of the new feature set.

## Why some runtime checks remain unchanged

Three instances of `#available(macOS 26.0, *)` were intentionally left unchanged:

1.  *TerminalController.swift* - ["TerminalTabsTitlebarTahoe" string selection](https://github.com/liby/ghostty/blob/main/macos/Sources/Features/Terminal/TerminalController.swift#L26-L30)
2.  *TerminalWindow.swift* - [`topPadding` calculation](https://github.com/liby/ghostty/blob/main/macos/Sources/Features/Terminal/Window%20Styles/TerminalWindow.swift#L453-L457)

These don't reference macOS 26-specific APIs, only string literals and numeric values. The runtime checks here are appropriate since they determine behavior differences between OS versions at runtime, not compile-time API availability.