### PR TITLE
shell-integration: simplify "ssh target" checks

### DIFF
--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -120,9 +120,9 @@ if [[ "$GHOSTTY_SHELL_FEATURES" == *ssh-* ]]; then
         [[ -n "$ssh_user" && -n "$ssh_hostname" ]] && break
       done < <(builtin command ssh -G "$@" 2>/dev/null)
 
-      builtin local ssh_target="${ssh_user}@${ssh_hostname}"
-
       if [[ -n "$ssh_hostname" ]]; then
+        builtin local ssh_target="${ssh_user}@${ssh_hostname}"
+
         # Check if terminfo is already cached
         if ghostty +ssh-cache --host="$ssh_target" >/dev/null 2>&1; then
           ssh_term="xterm-ghostty"
@@ -147,9 +147,7 @@ if [[ "$GHOSTTY_SHELL_FEATURES" == *ssh-* ]]; then
               ssh_opts+=(-o "ControlPath=$ssh_cpath")
 
               # Cache successful installation
-              if [[ -n "$ssh_target" ]] && builtin command -v ghostty >/dev/null 2>&1; then
-                ghostty +ssh-cache --add="$ssh_target" >/dev/null 2>&1 || true
-              fi
+              ghostty +ssh-cache --add="$ssh_target" >/dev/null 2>&1 || true
             else
               builtin echo "Warning: Failed to install terminfo." >&2
             fi

--- a/src/shell-integration/elvish/lib/ghostty-integration.elv
+++ b/src/shell-integration/elvish/lib/ghostty-integration.elv
@@ -137,9 +137,9 @@
                   }
               }
 
-              var ssh-target = $ssh-user"@"$ssh-hostname
-
               if (not-eq $ssh-hostname "") {
+                  var ssh-target = $ssh-user"@"$ssh-hostname
+
                   # Check if terminfo is already cached
                   if (and (has-external ghostty) (bool ?(external ghostty +ssh-cache --host=$ssh-target >/dev/null 2>&1))) {
                       set ssh-term = "xterm-ghostty"
@@ -167,7 +167,7 @@
                               set ssh-opts = (conj $ssh-opts -o ControlPath=$ssh-cpath)
 
                               # Cache successful installation
-                              if (and (not-eq $ssh-target "") (has-external ghostty)) {
+                              if (has-external ghostty) {
                                   external ghostty +ssh-cache --add=$ssh-target >/dev/null 2>&1
                               }
                           } else {

--- a/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
+++ b/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
@@ -149,7 +149,7 @@ function __ghostty_setup --on-event fish_prompt -d "Setup ghostty integration"
                                 set -a ssh_opts -o "ControlPath=$ssh_cpath"
 
                                 # Cache successful installation
-                                if test -n "$ssh_target"; and command -q ghostty
+                                if command -q ghostty
                                     ghostty +ssh-cache --add="$ssh_target" >/dev/null 2>&1; or true
                                 end
                             else

--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -272,9 +272,9 @@ _ghostty_deferred_init() {
             [[ -n "$ssh_user" && -n "$ssh_hostname" ]] && break
           done < <(command ssh -G "$@" 2>/dev/null)
 
-          local ssh_target="${ssh_user}@${ssh_hostname}"
-
           if [[ -n "$ssh_hostname" ]]; then
+            local ssh_target="${ssh_user}@${ssh_hostname}"
+
             # Check if terminfo is already cached
             if (( $+commands[ghostty] )) && ghostty +ssh-cache --host="$ssh_target" >/dev/null 2>&1; then
               ssh_term="xterm-ghostty"
@@ -299,9 +299,7 @@ _ghostty_deferred_init() {
                   ssh_opts+=(-o "ControlPath=$ssh_cpath")
 
                   # Cache successful installation
-                  if [[ -n "$ssh_target" ]] && (( $+commands[ghostty] )); then
-                    ghostty +ssh-cache --add="$ssh_target" >/dev/null 2>&1 || true
-                  fi
+                  ghostty +ssh-cache --add="$ssh_target" >/dev/null 2>&1 || true
                 else
                   print "Warning: Failed to install terminfo." >&2
                 fi


### PR DESCRIPTION
This value is always set to a non-empty string, and we only need this value after we've determined that 'ssh_hostname' is non-empty.

In bash and zsh, we also don't need to check for the 'ghostty' command before we attempt to add the target to the cache. That command will safely fail silently if it's not available.