### PR TITLE
i18n: Update Korean Translations

### DIFF
--- a/po/ko_KR.UTF-8.po
+++ b/po/ko_KR.UTF-8.po
@@ -213,7 +213,7 @@ msgstr "이 분할에 대한 선택 기억하기"
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:82
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:78
 msgid "Reload configuration to show this prompt again"
-msgstr "이 프롬프트를 다시 표시하려면 구성을 다시 로드하십시오."
+msgstr "이 창을 다시 보려면 설정을  다시 불러오세요"
 
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:7
 #: src/apprt/gtk/ui/1.2/ccw-osc-52-write.blp:7

--- a/po/ko_KR.UTF-8.po
+++ b/po/ko_KR.UTF-8.po
@@ -213,7 +213,7 @@ msgstr "이 분할에 대한 선택 기억하기"
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:82
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:78
 msgid "Reload configuration to show this prompt again"
-msgstr "이 창을 다시 보려면 설정을  다시 불러오세요"
+msgstr "이 창을 다시 보려면 설정을 다시 불러오세요"
 
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:7
 #: src/apprt/gtk/ui/1.2/ccw-osc-52-write.blp:7

--- a/po/ko_KR.UTF-8.po
+++ b/po/ko_KR.UTF-8.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
 "POT-Creation-Date: 2025-07-08 15:13-0500\n"
-"PO-Revision-Date: 2025-03-31 03:08+0200\n"
-"Last-Translator: Ruben Engelbrecht <hey@rme.gg>\n"
+"PO-Revision-Date: 2025-07-09 16:11-0400\n"
+"Last-Translator: Hojin You <dev.hojin@gmail.com>\n"
 "Language-Team: Korean <translation-team-ko@googlegroups.com>\n"
 "Language: ko\n"
 "MIME-Version: 1.0\n"
@@ -87,7 +87,7 @@ msgstr "오른쪽으로 창 나누기"
 
 #: src/apprt/gtk/ui/1.5/command-palette.blp:16
 msgid "Execute a command…"
-msgstr ""
+msgstr "명령을 실행하세요…"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:6
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:6
@@ -160,7 +160,7 @@ msgstr "설정 열기"
 
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:85
 msgid "Command Palette"
-msgstr ""
+msgstr "명령 팔레트"
 
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:90
 msgid "Terminal Inspector"
@@ -208,12 +208,12 @@ msgstr "허용"
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:81
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:77
 msgid "Remember choice for this split"
-msgstr ""
+msgstr "이 분할에 대한 선택 기억하기"
 
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:82
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:78
 msgid "Reload configuration to show this prompt again"
-msgstr ""
+msgstr "이 프롬프트를 다시 표시하려면 구성을 다시 로드하십시오."
 
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:7
 #: src/apprt/gtk/ui/1.2/ccw-osc-52-write.blp:7
@@ -285,9 +285,8 @@ msgid "View Open Tabs"
 msgstr "열린 탭 보기"
 
 #: src/apprt/gtk/Window.zig:266
-#, fuzzy
 msgid "New Split"
-msgstr "나누기"
+msgstr "새 분할"
 
 #: src/apprt/gtk/Window.zig:329
 msgid ""


### PR DESCRIPTION
This pull request updates the Korean translations.

Fix fuzzy translation "나누기" for creating new split as per #7875 

Add missing translations for 4 new strings