### PR TITLE
shell-integration: use $GHOSTTY_BIN_DIR/ghostty

### DIFF
--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -124,7 +124,7 @@ if [[ "$GHOSTTY_SHELL_FEATURES" == *ssh-* ]]; then
         builtin local ssh_target="${ssh_user}@${ssh_hostname}"
 
         # Check if terminfo is already cached
-        if ghostty +ssh-cache --host="$ssh_target" >/dev/null 2>&1; then
+        if "$GHOSTTY_BIN_DIR/ghostty" +ssh-cache --host="$ssh_target" >/dev/null 2>&1; then
           ssh_term="xterm-ghostty"
         elif builtin command -v infocmp >/dev/null 2>&1; then
           builtin local ssh_terminfo ssh_cpath_dir ssh_cpath
@@ -147,7 +147,7 @@ if [[ "$GHOSTTY_SHELL_FEATURES" == *ssh-* ]]; then
               ssh_opts+=(-o "ControlPath=$ssh_cpath")
 
               # Cache successful installation
-              ghostty +ssh-cache --add="$ssh_target" >/dev/null 2>&1 || true
+              "$GHOSTTY_BIN_DIR/ghostty" +ssh-cache --add="$ssh_target" >/dev/null 2>&1 || true
             else
               builtin echo "Warning: Failed to install terminfo." >&2
             fi

--- a/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
+++ b/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
@@ -120,11 +120,11 @@ function __ghostty_setup --on-event fish_prompt -d "Setup ghostty integration"
                     end
                 end
 
-                set -l ssh_target "$ssh_user@$ssh_hostname"
-
                 if test -n "$ssh_hostname"
+                    set -l ssh_target "$ssh_user@$ssh_hostname"
+
                     # Check if terminfo is already cached
-                    if command -q ghostty; and ghostty +ssh-cache --host="$ssh_target" >/dev/null 2>&1
+                    if test -x "$GHOSTTY_BIN_DIR/ghostty"; and "$GHOSTTY_BIN_DIR/ghostty" +ssh-cache --host="$ssh_target" >/dev/null 2>&1
                         set ssh_term "xterm-ghostty"
                     else if command -q infocmp
                         set -l ssh_terminfo
@@ -149,8 +149,8 @@ function __ghostty_setup --on-event fish_prompt -d "Setup ghostty integration"
                                 set -a ssh_opts -o "ControlPath=$ssh_cpath"
 
                                 # Cache successful installation
-                                if command -q ghostty
-                                    ghostty +ssh-cache --add="$ssh_target" >/dev/null 2>&1; or true
+                                if test -x "$GHOSTTY_BIN_DIR/ghostty"
+                                    "$GHOSTTY_BIN_DIR/ghostty" +ssh-cache --add="$ssh_target" >/dev/null 2>&1; or true
                                 end
                             else
                                 echo "Warning: Failed to install terminfo." >&2

--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -276,7 +276,7 @@ _ghostty_deferred_init() {
             local ssh_target="${ssh_user}@${ssh_hostname}"
 
             # Check if terminfo is already cached
-            if (( $+commands[ghostty] )) && ghostty +ssh-cache --host="$ssh_target" >/dev/null 2>&1; then
+            if "$GHOSTTY_BIN_DIR/ghostty" +ssh-cache --host="$ssh_target" >/dev/null 2>&1; then
               ssh_term="xterm-ghostty"
             elif (( $+commands[infocmp] )); then
               local ssh_terminfo ssh_cpath_dir ssh_cpath
@@ -299,7 +299,7 @@ _ghostty_deferred_init() {
                   ssh_opts+=(-o "ControlPath=$ssh_cpath")
 
                   # Cache successful installation
-                  ghostty +ssh-cache --add="$ssh_target" >/dev/null 2>&1 || true
+                  "$GHOSTTY_BIN_DIR/ghostty" +ssh-cache --add="$ssh_target" >/dev/null 2>&1 || true
                 else
                   print "Warning: Failed to install terminfo." >&2
                 fi


### PR DESCRIPTION
Locate our ghostty binary using $GHOSTTY_BIN_DIR rather than searching the PATH.