### PR TITLE
Fix custom shader cursor uniforms not set for non-block cursors (#7893)

### DIFF
--- a/src/renderer/cell.zig
+++ b/src/renderer/cell.zig
@@ -361,14 +361,17 @@ test Contents {
     };
     c.setCursor(cursor_cell, .block);
     try testing.expectEqual(cursor_cell, c.fg_rows.lists[0].items[0]);
+    try testing.expectEqual(cursor_cell, c.getCursorGlyph().?);
 
     // And remove it.
     c.setCursor(null, null);
     try testing.expectEqual(0, c.fg_rows.lists[0].items.len);
+    try testing.expect(c.getCursorGlyph() == null);
 
     // Add a hollow cursor.
     c.setCursor(cursor_cell, .block_hollow);
     try testing.expectEqual(cursor_cell, c.fg_rows.lists[rows + 1].items[0]);
+    try testing.expectEqual(cursor_cell, c.getCursorGlyph().?);
 }
 
 test "Contents clear retains other content" {

--- a/src/renderer/cell.zig
+++ b/src/renderer/cell.zig
@@ -156,6 +156,17 @@ pub const Contents = struct {
         }
     }
 
+    /// Returns the current cursor glyph if present, checking both cursor lists.
+    pub fn getCursorGlyph(self: *Contents) ?shaderpkg.CellText {
+        if (self.fg_rows.lists[0].items.len > 0) {
+            return self.fg_rows.lists[0].items[0];
+        }
+        if (self.fg_rows.lists[self.size.rows + 1].items.len > 0) {
+            return self.fg_rows.lists[self.size.rows + 1].items[0];
+        }
+        return null;
+    }
+
     /// Access a background cell. Prefer this function over direct indexing
     /// of `bg_cells` in order to avoid integer size bugs causing overflows.
     pub inline fn bgCell(

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -2218,10 +2218,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             };
 
             // Update custom cursor uniforms, if we have a cursor.
-            if (self.cells.fg_rows.lists[0].items.len > 0) {
-                const cursor: shaderpkg.CellText =
-                    self.cells.fg_rows.lists[0].items[0];
-
+            if (self.cells.getCursorGlyph()) |cursor| {
                 const cursor_width: f32 = @floatFromInt(cursor.glyph_size[0]);
                 const cursor_height: f32 = @floatFromInt(cursor.glyph_size[1]);
 


### PR DESCRIPTION
Fixes #7893

Previously, custom shader cursor uniforms were only updated when the cursor glyph was in the front (block) cursor list. This caused non-block cursors (such as bar, underline, hollow block, and lock) to be missing from custom shader effects.

This commit adds a helper to the cell contents struct to retrieve the current cursor glyph from either the front or back cursor lists, and updates the renderer to use this helper when setting custom shader uniforms. As a result, custom shaders now receive correct cursor information for all supported cursor styles.