### PR TITLE
build: make the xcframework step dsym aware, even though we don't use it

### DIFF
--- a/src/build/GhosttyXCFramework.zig
+++ b/src/build/GhosttyXCFramework.zig
@@ -64,20 +64,24 @@ pub fn init(
                 .{
                     .library = macos_universal.output,
                     .headers = b.path("include"),
+                    .dsym = macos_universal.dsym,
                 },
                 .{
                     .library = ios.output,
                     .headers = b.path("include"),
+                    .dsym = ios.dsym,
                 },
                 .{
                     .library = ios_sim.output,
                     .headers = b.path("include"),
+                    .dsym = ios_sim.dsym,
                 },
             },
 
             .native => &.{.{
                 .library = macos_native.output,
                 .headers = b.path("include"),
+                .dsym = macos_native.dsym,
             }},
         },
     });

--- a/src/build/XCFrameworkStep.zig
+++ b/src/build/XCFrameworkStep.zig
@@ -26,6 +26,9 @@ pub const Library = struct {
 
     /// Path to a directory with the headers.
     headers: LazyPath,
+
+    /// Path to a debug symbols file (.dSYM) if available.
+    dsym: ?LazyPath,
 };
 
 step: *Step,
@@ -52,6 +55,10 @@ pub fn create(b: *std.Build, opts: Options) *XCFrameworkStep {
             run.addFileArg(lib.library);
             run.addArg("-headers");
             run.addFileArg(lib.headers);
+            if (lib.dsym) |dsym| {
+                run.addArg("-debug-symbols");
+                run.addFileArg(dsym);
+            }
         }
         run.addArg("-output");
         run.addArg(opts.out_path);


### PR DESCRIPTION
This was in pursuit of trying to get line numbers in `zig build run` on macOS to work, but I wasn't able to figure that out and this wasn't the right path because static libs can't have dsyms. But, it may still be useful to make the xcframework step dsym aware for future use so I'm PRing this.

This also updates our libghostty build steps to use the new `root_module` form which is recommend for Zig 0.14 and we forgot to update long ago.