### PR TITLE
ci: update sequoia builders to xcode 26 beta 3, output version in CI

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -47,7 +47,7 @@ jobs:
           sentry-cli dif upload --project ghostty --wait dsym.zip
 
   build-macos:
-    runs-on: namespace-profile-ghostty-macos-sequoia
+    runs-on: namespace-profile-ghostty-macos-sequoia-edge
     timeout-minutes: 90
     steps:
       - name: Checkout code
@@ -201,7 +201,7 @@ jobs:
           destination-dir: ./
 
   build-macos-debug:
-    runs-on: namespace-profile-ghostty-macos-sequoia
+    runs-on: namespace-profile-ghostty-macos-sequoia-edge
     timeout-minutes: 90
     steps:
       - name: Checkout code

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -154,7 +154,7 @@ jobs:
         )
       }}
 
-    runs-on: namespace-profile-ghostty-macos-sequoia
+    runs-on: namespace-profile-ghostty-macos-sequoia-edge
     timeout-minutes: 90
     steps:
       - name: Checkout code
@@ -174,6 +174,9 @@ jobs:
 
       - name: XCode Select
         run: sudo xcode-select -s /Applications/Xcode_26.0.app
+
+      - name: Xcode Version
+        run: xcodebuild -version
 
       # Setup Sparkle
       - name: Setup Sparkle
@@ -371,7 +374,7 @@ jobs:
         )
       }}
 
-    runs-on: namespace-profile-ghostty-macos-sequoia
+    runs-on: namespace-profile-ghostty-macos-sequoia-edge
     timeout-minutes: 90
     steps:
       - name: Checkout code
@@ -391,6 +394,9 @@ jobs:
 
       - name: XCode Select
         run: sudo xcode-select -s /Applications/Xcode_26.0.app
+
+      - name: Xcode Version
+        run: xcodebuild -version
 
       # Setup Sparkle
       - name: Setup Sparkle
@@ -548,7 +554,7 @@ jobs:
         )
       }}
 
-    runs-on: namespace-profile-ghostty-macos-sequoia
+    runs-on: namespace-profile-ghostty-macos-sequoia-edge
     timeout-minutes: 90
     steps:
       - name: Checkout code
@@ -568,6 +574,9 @@ jobs:
 
       - name: XCode Select
         run: sudo xcode-select -s /Applications/Xcode_26.0.app
+
+      - name: Xcode Version
+        run: xcodebuild -version
 
       # Setup Sparkle
       - name: Setup Sparkle

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -270,7 +270,7 @@ jobs:
             ghostty-source.tar.gz
 
   build-macos:
-    runs-on: namespace-profile-ghostty-macos-sequoia
+    runs-on: namespace-profile-ghostty-macos-sequoia-edge
     needs: test
     steps:
       - name: Checkout code
@@ -287,6 +287,9 @@ jobs:
 
       - name: Xcode Select
         run: sudo xcode-select -s /Applications/Xcode_26.0.app
+
+      - name: Xcode Version
+        run: xcodebuild -version
 
       - name: get the Zig deps
         id: deps
@@ -350,7 +353,7 @@ jobs:
           xcodebuild -target Ghostty-iOS "CODE_SIGNING_ALLOWED=NO"
 
   build-macos-matrix:
-    runs-on: namespace-profile-ghostty-macos-sequoia
+    runs-on: namespace-profile-ghostty-macos-sequoia-edge
     needs: test
     steps:
       - name: Checkout code
@@ -614,7 +617,7 @@ jobs:
           nix develop -c zig build -Dsentry=${{ matrix.sentry }}
 
   test-macos:
-    runs-on: namespace-profile-ghostty-macos-sequoia
+    runs-on: namespace-profile-ghostty-macos-sequoia-edge
     needs: test
     steps:
       - name: Checkout code


### PR DESCRIPTION
The `-edge` variant of these builders will always use the latest macOS images that may not be stable. We'll remove this once Xcode 26 is released.