### PR TITLE
bash: preserve an existing ENV value

### DIFF
--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -26,6 +26,12 @@ if [ -n "$GHOSTTY_BASH_INJECT" ]; then
   builtin declare __ghostty_bash_flags="$GHOSTTY_BASH_INJECT"
   builtin unset ENV GHOSTTY_BASH_INJECT
 
+  # Restore an existing ENV that was replaced by the shell integration code.
+  if [[ -n "$GHOSTTY_BASH_ENV" ]]; then
+    builtin export ENV=$GHOSTTY_BASH_ENV
+    builtin unset GHOSTTY_BASH_ENV
+  fi
+
   # Restore bash's default 'posix' behavior. Also reset 'inherit_errexit',
   # which doesn't happen as part of the 'posix' reset.
   builtin set +o posix


### PR DESCRIPTION
Our bash shell integration code uses ENV (in POSIX mode) to bootstrap our shell integration script. This had the side effect of overwriting an existing ENV value.

This change preserves ENV by storing it temporarily in GHOSTTY_BASH_ENV.

Note that this doesn't enable --posix mode support for automatic shell integration. (--posix does work; we just skip shell integration when that flag is specified.) We can reconsider implementing full --posix support separately.

See #7895