### PR TITLE
renderer: Allow the renderer to draw transparent cells

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -814,6 +814,22 @@ palette: Palette = .{},
 /// On macOS, changing this configuration requires restarting Ghostty completely.
 @"background-opacity": f64 = 1.0,
 
+/// Applies background opacity to cells with an explicit background color
+/// set.
+///
+/// Normally, `background-opacity` is only applied to the window background.
+/// If a cell has an explicit background color set, such as red, then that
+/// background color will be fully opaque. An effect of this is that some
+/// terminal applications that repaint the background color of the terminal
+/// such as a Neovim and Tmux may not respect the `background-opacity`
+/// (by design).
+///
+/// Setting this to `true` will apply the `background-opacity` to all cells
+/// regardless of whether they have an explicit background color set or not.
+///
+/// Available since: 1.2.0
+@"background-opacity-cells": bool = false,
+
 /// Whether to blur the background when `background-opacity` is less than 1.
 ///
 /// Valid values are:

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -516,6 +516,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             cursor_text: ?configpkg.Config.TerminalColor,
             background: terminal.color.RGB,
             background_opacity: f64,
+            background_opacity_cells: bool,
             foreground: terminal.color.RGB,
             selection_background: ?configpkg.Config.TerminalColor,
             selection_foreground: ?configpkg.Config.TerminalColor,
@@ -568,6 +569,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
                 return .{
                     .background_opacity = @max(0, @min(1, config.@"background-opacity")),
+                    .background_opacity_cells = config.@"background-opacity-cells",
                     .font_thicken = config.@"font-thicken",
                     .font_thicken_strength = config.@"font-thicken-strength",
                     .font_features = font_features.list,
@@ -2627,6 +2629,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
                             // Cells that are reversed should be fully opaque.
                             if (style.flags.inverse) break :bg_alpha default;
+
+                            // If the user requested to have opacity on all cells, apply it.
+                            if (self.config.background_opacity_cells and bg_style != null) {
+                                var opacity: f64 = @floatFromInt(default);
+                                opacity *= self.config.background_opacity;
+                                break :bg_alpha @intFromFloat(opacity);
+                            }
 
                             // Cells that have an explicit bg color should be fully opaque.
                             if (bg_style != null) break :bg_alpha default;


### PR DESCRIPTION
Fixes #5917

Allows the terminal to draw transparent cells even if they don't have the same background color, on user demand, with the `background-opacity-cells` feature

<img width="2560" height="1440" alt="transparent" src="https://github.com/user-attachments/assets/8c076671-3603-41a1-957d-46ddaeffa1ff" />
