### PR TITLE
fix webdata build, run it in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -527,7 +527,7 @@ jobs:
         run: nix develop -c zig build -Dapp-runtime=none test
 
       - name: Test GTK Build
-        run: nix develop -c zig build -Dapp-runtime=gtk -Demit-docs
+        run: nix develop -c zig build -Dapp-runtime=gtk -Demit-docs -Demit-webdata
 
       # This relies on the cache being populated by the commands above.
       - name: Test System Build

--- a/src/build/webgen/main_commands.zig
+++ b/src/build/webgen/main_commands.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const Action = @import("../../cli/action.zig").Action;
+const Action = @import("../../cli/ghostty.zig").Action;
 const help_strings = @import("help_strings");
 
 pub fn main() !void {


### PR DESCRIPTION
This fixes our build for `-Demit-webdata`. Turns out we weren't  running this in CI so this adds that there.