### PR TITLE
nix: fix flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -116,8 +116,8 @@
       },
       "original": {
         "owner": "jcollie",
-        "ref": "56c159be489cc6c0e73c3930bd908ddc6fe89613",
         "repo": "zon2nix",
+        "rev": "56c159be489cc6c0e73c3930bd908ddc6fe89613",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -73,7 +73,9 @@
     },
     "zig": {
       "inputs": {
-        "flake-compat": [],
+        "flake-compat": [
+          "flake-compat"
+        ],
         "flake-utils": [
           "flake-utils"
         ],

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
     };
 
     zon2nix = {
-      url = "github:jcollie/zon2nix?ref=56c159be489cc6c0e73c3930bd908ddc6fe89613";
+      url = "github:jcollie/zon2nix?rev=56c159be489cc6c0e73c3930bd908ddc6fe89613";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-utils.follows = "flake-utils";

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-utils.follows = "flake-utils";
-        flake-compat.follows = "";
+        flake-compat.follows = "flake-compat";
       };
     };
 


### PR DESCRIPTION
Setting `zig/flake-compat` to follow `""` (the current flake, ghostty) is incorrect and introduces an unnecessary dependency cycle. This causes problems in my NixOS configuration, because I collect flake inputs recursively and add them to my system closure to work around https://github.com/NixOS/nix/issues/3995#issuecomment-1537108310.

The other change to `flake.lock` was done automatically by my version of Nix (Lix 2.91.3).