### PR TITLE
Set title as argv[0] for commands specified with `-e`

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -679,14 +679,16 @@ pub fn init(
         switch (initial_command) {
             // If a user specifies a command with `-e` it is appropriate to set the title
             // as argv[0]
-            .direct => {
-                _ = try rt_app.performAction(
-                    .{ .surface = self },
-                    .set_title,
-                    .{ .title = initial_command.direct[0] },
-                );
+            .direct => |cmd| {
+                if (cmd.len != 0) {
+                    _ = try rt_app.performAction(
+                        .{ .surface = self },
+                        .set_title,
+                        .{ .title = cmd[0] },
+                    );
+                }
             },
-            // we won't set the title in the case the shell expands the command
+            // We won't set the title in the case the shell expands the command
             // as that should typically be used to launch a shell which should
             // set its own titles
             .shell => {},

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -675,6 +675,22 @@ pub fn init(
             .set_title,
             .{ .title = title },
         );
+    } else if (config.@"initial-command") |initial_command| {
+        switch (initial_command) {
+            // If a user specifies a command with `-e` it is appropriate to set the title
+            // as argv[0]
+            .direct => {
+                _ = try rt_app.performAction(
+                    .{ .surface = self },
+                    .set_title,
+                    .{ .title = initial_command.direct[0] },
+                );
+            },
+            // we won't set the title in the case the shell expands the command
+            // as that should typically be used to launch a shell which should
+            // set its own titles
+            .shell => {},
+        }
     }
 
     // We are no longer the first surface


### PR DESCRIPTION
If a user passes a command with `-e` we set the title of the window as `argv[0]` after `-e`

for example `ghostty -e nvim ~/directory` becomes `nvim`

Mitchell seemed fine with this approach and it sounded easy enough to do so I went ahead and raised a PR without an issue being made before hand
https://github.com/ghostty-org/ghostty/discussions/7870#discussioncomment-13745947

note this does not stop tuis like `yazi` to set the title with escape sequences it just simply sets the title for those that don't so it doesn't end up as a ghost emoji or nothing (if you don't have a font with that emoji on your system)

~~Note i didn't add a check if `direct[0]` exists as the cli parser should (and does) reject the command if you don't pass anything after `-e`
I can add that check for better defensive practice if you want~~