### PR TITLE
macos: restore tabs correctly into a single window

### DIFF
--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -35,9 +35,16 @@ class TerminalWindow: NSWindow {
     }
 
     override func awakeFromNib() {
-        guard let appDelegate = NSApp.delegate as? AppDelegate else { return }
-
+        // This is required so that window restoration properly creates our tabs
+        // again. I'm not sure why this is required. If you don't do this, then
+        // tabs restore as separate windows.
+        tabbingMode = .preferred
+        DispatchQueue.main.async {
+            self.tabbingMode = .automatic
+        }
+        
         // All new windows are based on the app config at the time of creation.
+        guard let appDelegate = NSApp.delegate as? AppDelegate else { return }
         let config = appDelegate.ghostty.config
 
         // Setup our initial config

--- a/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsVenturaTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsVenturaTerminalWindow.swift
@@ -30,14 +30,6 @@ class TitlebarTabsVenturaTerminalWindow: TerminalWindow {
     override func awakeFromNib() {
         super.awakeFromNib()
 
-        // Handle titlebar tabs config option. Something about what we do while setting up the
-        // titlebar tabs interferes with the window restore process unless window.tabbingMode
-        // is set to .preferred, so we set it, and switch back to automatic as soon as we can.
-        tabbingMode = .preferred
-        DispatchQueue.main.async {
-            self.tabbingMode = .automatic
-        }
-
         titlebarTabs = true
 
         // Set the background color of the window


### PR DESCRIPTION
Fixes #7941

I don't fully understand the fix here. Its code we've had for awhile it was just in the wrong place after I refactored our window management. The comment clearly states why its there but I don't know why it is required.