### PR TITLE
fix: rename tab title popup focus

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -480,7 +480,10 @@ extension Ghostty {
             // Add buttons
             alert.addButton(withTitle: "OK")
             alert.addButton(withTitle: "Cancel")
-
+            
+            // Make the text field the first responder so it gets focus
+            alert.window.initialFirstResponder = textField
+            
             let response = alert.runModal()
 
             // Check if the user clicked "OK"


### PR DESCRIPTION
This fixes issue #7940 

<img width="394" height="354" alt="Screenshot 2025-07-14 at 17 20 03" src="https://github.com/user-attachments/assets/453c49ed-2b91-4520-a8fe-031159454453" />
