### PR TITLE
osc: once again, fix up osd color operations

### DIFF
--- a/src/terminal/Parser.zig
+++ b/src/terminal/Parser.zig
@@ -915,14 +915,13 @@ test "osc: 112 incomplete sequence" {
         const cmd = a[0].?.osc_dispatch;
         try testing.expect(cmd == .color_operation);
         try testing.expectEqual(cmd.color_operation.terminator, .bel);
-        try testing.expect(cmd.color_operation.source == .reset_cursor);
         try testing.expect(cmd.color_operation.operations.count() == 1);
         var it = cmd.color_operation.operations.constIterator(0);
         {
             const op = it.next().?;
             try testing.expect(op.* == .reset);
             try testing.expectEqual(
-                osc.Command.ColorOperation.Kind.cursor,
+                osc.Command.ColorOperation.Kind{ .dynamic_color = .cursor },
                 op.reset,
             );
         }

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -1565,7 +1565,7 @@ pub fn Stream(comptime Handler: type) type {
 
                 .color_operation => |v| {
                     if (@hasDecl(T, "handleColorOperation")) {
-                        try self.handler.handleColorOperation(v.source, &v.operations, v.terminator);
+                        try self.handler.handleColorOperation(&v.operations, v.terminator);
                         return;
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1328,6 +1328,29 @@ pub const StreamHandler = struct {
                     }
                 },
 
+                .reset_all => |kind| {
+                    switch (kind) {
+                        .palette => {
+                            const mask = &self.terminal.color_palette.mask;
+                            var mask_iterator = mask.iterator(.{});
+                            while (mask_iterator.next()) |i| {
+                                self.terminal.flags.dirty.palette = true;
+                                self.terminal.color_palette.colors[i] = self.terminal.default_palette[i];
+                                self.surfaceMessageWriter(.{
+                                    .color_change = .{
+                                        .kind = .{ .palette = @intCast(i) },
+                                        .color = self.terminal.color_palette.colors[i],
+                                    },
+                                });
+                            }
+                            mask.* = .initEmpty();
+                        },
+                        .dynamic_color => {
+                            log.warn("resetting all dynamic colors is not supported", .{});
+                        },
+                    }
+                },
+
                 .report => |kind| report: {
                     if (self.osc_color_report_format == .none) break :report;
 


### PR DESCRIPTION
Fixes #7951

PR #7429 did a lot to improve handling of various OSC escape codes that get/set/reset colors. However, it didn't get it _quite_ right. This PR fixes OSC color handling to hopefully get things closer to perfect.