### PR TITLE
linux/systemd: add an app- prefix to the systemd unit

### DIFF
--- a/dist/linux/dbus.service.in
+++ b/dist/linux/dbus.service.in
@@ -1,4 +1,4 @@
 [D-BUS Service]
 Name=@APPID@
-SystemdService=@APPID@.service
+SystemdService=app-@APPID@.service
 Exec=@GHOSTTY@ --launched-from=dbus

--- a/src/build/GhosttyResources.zig
+++ b/src/build/GhosttyResources.zig
@@ -293,7 +293,7 @@ fn addLinuxAppResources(
         if (!cfg.flatpak) try ts.append(.{
             b.path("dist/linux/systemd.service.in"),
             b.fmt(
-                "{s}/systemd/user/{s}.service",
+                "{s}/systemd/user/app-{s}.service",
                 .{
                     if (b.graph.system_package_mode) "lib" else "share",
                     app_id,

--- a/src/build/GhosttyResources.zig
+++ b/src/build/GhosttyResources.zig
@@ -283,13 +283,23 @@ fn addLinuxAppResources(
             b.fmt("share/dbus-1/services/{s}.service", .{app_id}),
         });
 
-        // systemd user service. This is kind of nasty but systemd
-        // looks for user services in different paths depending on
-        // if we are installed as a system package or not (lib vs.
-        // share) so we have to handle that here. We might be able
-        // to get away with always installing to both because it
-        // only ever searches in one... but I don't want to do that hack
-        // until we have to.
+        // `systemd` user service. This is kind of nasty but `systemd` looks for
+        // user services in different paths depending on if we are installed
+        // as a system package or not (lib vs. share) so we have to handle that
+        // here. We might be able to get away with always installing to both
+        // because it only ever searches in one... but I don't want to do that
+        // hack until we have to.
+        //
+        // The XDG Freedesktop Portal has a major undocumented requirement
+        // for programs that are launched/controlled by `systemd` to interact
+        // with the Portal. The unit must be named `app-<appid>.service`. The
+        // Portal uses the `systemd` unit name figure out what the program's
+        // application ID is and it will only look at unit names that begin with
+        // `app-`. I can find no place that this is documented other than by
+        // inspecting the code or the issue and PR that introduced this feature.
+        // See the following code:
+        //
+        // https://github.com/flatpak/xdg-desktop-portal/blob/7d4d48cf079147c8887da17ec6c3954acd5a285c/src/xdp-utils.c#L152-L220
         if (!cfg.flatpak) try ts.append(.{
             b.path("dist/linux/systemd.service.in"),
             b.fmt(


### PR DESCRIPTION
The XDG Freedesktop Portal has a _major_ undocumented requirement for
programs that are launched/controlled by `systemd` to interact with the
Portal. The unit _must_ be named `app-<appid>.service`. The Portal uses
the systemd unit name figure out what the program's application ID is
and it will only look at unit names that begin with `app-`. I can find
no place that this is documented other than by inspecting the code or the
issue and PR that introduced this feature. See the following code:

https://github.com/flatpak/xdg-desktop-portal/blob/7d4d48cf079147c8887da17ec6c3954acd5a285c/src/xdp-utils.c#L152-L220

This may fix many people's issues with getting global shortcuts
to work.

Note that this is a breaking change if you have been using Ghostty
compiled from source since https://github.com/ghostty-org/ghostty/pull/7433 was merged. You will need to ensure
that any Ghosty systemd unit files _not_ prefixed with `app-` are
deleted.

Original discussion/PR in the XDG Desktop Portal repository:

https://github.com/flatpak/xdg-desktop-portal/issues/579
https://github.com/flatpak/xdg-desktop-portal/pull/719

Originally discussed on Discord:

https://discord.com/channels/1005603569187160125/1394845362186879026

Co-authored-by: ambareeshbalaji@gmail.com