### PR TITLE
Surface: use rect selection state when setting selection on release

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3341,7 +3341,7 @@ pub fn mouseButtonCallback(
                 try self.setSelection(terminal.Selection.init(
                     prev.start(),
                     prev.end(),
-                    false,
+                    prev.rectangle,
                 ));
             }
         }


### PR DESCRIPTION
Looks like 52354b8 missed noting the outgoing screen selection state's rectangle flag when setting the selection on mouse release, this was causing the selection that was actually set to be
standard/wrap-selected. This corrects that by just shipping said flag when calling `setSelection`.