### PR TITLE
Fully remove the redrawSurface API

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -293,14 +293,6 @@ fn redrawSurface(
 ) !void {
     if (!self.hasRtSurface(surface)) return;
 
-    // TODO: Remove this in a separate PR. We should transition to
-    // the `render` apprt action completely. This is only to make
-    // our initial gtk-ng work touch less things.
-    if (@hasDecl(apprt.App, "redrawSurface")) {
-        rt_app.redrawSurface(surface);
-        return;
-    }
-
     _ = try rt_app.performAction(
         .{ .surface = surface.core() },
         .render,

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -249,12 +249,6 @@ pub const App = struct {
         self.core_app.alloc.destroy(surface);
     }
 
-    pub fn redrawSurface(self: *App, surface: *Surface) void {
-        _ = self;
-        _ = surface;
-        // No-op, we use a threaded interface so we're constantly drawing.
-    }
-
     pub fn redrawInspector(self: *App, surface: *Surface) void {
         _ = self;
         surface.queueInspectorRender();


### PR DESCRIPTION
This is a tiny addon from the recent gtk-ng work. We've moved redraw requests into the apprt action system (the `render` action). I waited until I had my macOS machine to verify that this fix could work. We can now remove this completely.

We can probably remove the redraw inspector API too at some point but I'm not there yet with the GTK backend so I'll just wait on it.