### PR TITLE
apprt/gtk-ng: implement `Surface.close`

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -132,18 +132,6 @@ pub fn destroy(self: *App) void {
 /// events. This should be called by the application runtime on every loop
 /// tick.
 pub fn tick(self: *App, rt_app: *apprt.App) !void {
-    // If any surfaces are closing, destroy them
-    var i: usize = 0;
-    while (i < self.surfaces.items.len) {
-        const surface = self.surfaces.items[i];
-        if (surface.shouldClose()) {
-            surface.close(false);
-            continue;
-        }
-
-        i += 1;
-    }
-
     // Drain our mailbox
     try self.drainMailbox(rt_app);
 }

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -705,15 +705,6 @@ pub const Surface = struct {
         );
     }
 
-    pub fn setShouldClose(self: *Surface) void {
-        _ = self;
-    }
-
-    pub fn shouldClose(self: *const Surface) bool {
-        _ = self;
-        return false;
-    }
-
     pub fn getCursorPos(self: *const Surface) !apprt.CursorPos {
         return self.cursor_pos;
     }

--- a/src/apprt/gtk-ng/Surface.zig
+++ b/src/apprt/gtk-ng/Surface.zig
@@ -30,11 +30,6 @@ pub fn close(self: *Self, process_active: bool) void {
     _ = process_active;
 }
 
-pub fn shouldClose(self: *Self) bool {
-    _ = self;
-    return false;
-}
-
 pub fn getTitle(self: *Self) ?[:0]const u8 {
     _ = self;
     return null;

--- a/src/apprt/gtk-ng/Surface.zig
+++ b/src/apprt/gtk-ng/Surface.zig
@@ -26,8 +26,7 @@ pub fn rtApp(self: *Self) *ApprtApp {
 }
 
 pub fn close(self: *Self, process_active: bool) void {
-    _ = self;
-    _ = process_active;
+    self.surface.close(process_active);
 }
 
 pub fn getTitle(self: *Self) ?[:0]const u8 {

--- a/src/apprt/gtk-ng/ui/1.5/window.blp
+++ b/src/apprt/gtk-ng/ui/1.5/window.blp
@@ -2,5 +2,5 @@ using Gtk 4.0;
 using Adw 1;
 
 template $GhosttyWindow: Adw.ApplicationWindow {
-  content: $GhosttySurface {};
+  content: $GhosttySurface surface {};
 }

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -877,15 +877,6 @@ pub fn controlInspector(
     };
 }
 
-pub fn setShouldClose(self: *Surface) void {
-    _ = self;
-}
-
-pub fn shouldClose(self: *const Surface) bool {
-    _ = self;
-    return false;
-}
-
 pub fn getContentScale(self: *const Surface) !apprt.ContentScale {
     const gtk_scale: f32 = scale: {
         const widget = self.gl_area.as(gtk.Widget);


### PR DESCRIPTION
A small, simple change. This implements the `Surface.close` apprt required function. After this PR, a process exiting within the terminal will close the window properly (unless `wait-after-command` is set of course!).

This doesn't yet show close confirmation. I'm working on some dialog refactors on the side to see if we can simplify our Adw 1.2 vs. 1.5 dialogs and didn't want to include it here.

Close now works by the `GhosttySurface` class emitting the `close-request` signal (similar to a `gtk.Window`) and the parent container is responsible for closing it. This will let us reuse the surface within different contexts: tabs, splits, etc.

This also remove the unused `shouldClose`, `setShouldClose` apprt APIs which are a holdover from the glfw days!