### PR TITLE
pkg/oniguruma: fix memory leak for failed regex searches

### DIFF
--- a/pkg/oniguruma/regex.zig
+++ b/pkg/oniguruma/regex.zig
@@ -45,6 +45,12 @@ pub const Regex = struct {
         options: Option,
     ) !Region {
         var region: Region = .{};
+
+        // As part of the searchAdvanced API call below, onig may allocate
+        // memory even if we fail to match. We need to deinit if there are
+        // any errors to free that memory.
+        errdefer region.deinit();
+
         _ = try self.searchAdvanced(str, 0, str.len, &region, options);
         return region;
     }


### PR DESCRIPTION
Found by Valgrind:

```
==265734== 320 bytes in 8 blocks are definitely lost in loss record 13,786 of 15,141
==265734==    at 0x5A65810: malloc (in /nix/store/l431jn8ahj09g5c1arrl7q6wcxngg21q-valgrind-3.24.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==265734==    by 0x3D799EB: onig_region_resize (.cache/zig/p/N-V-__8AAHjwMQDBXnLq3Q2QhaivE0kE2aD138vtX2Bq1g7c/src/regexec.c:923)
==265734==    by 0x3D81BCA: onig_region_resize_clear (.cache/zig/p/N-V-__8AAHjwMQDBXnLq3Q2QhaivE0kE2aD138vtX2Bq1g7c/src/regexec.c:949)
==265734==    by 0x3DA814F: search_in_range (.cache/zig/p/N-V-__8AAHjwMQDBXnLq3Q2QhaivE0kE2aD138vtX2Bq1g7c/src/regexec.c:5454)
==265734==    by 0x3DA7F25: onig_search (.cache/zig/p/N-V-__8AAHjwMQDBXnLq3Q2QhaivE0kE2aD138vtX2Bq1g7c/src/regexec.c:5414)
==265734==    by 0x382E7E8: regex.Regex.searchAdvanced (regex.zig:61)
==265734==    by 0x382E974: regex.Regex.search (regex.zig:48)
==265734==    by 0x382EC08: terminal.StringMap.SearchIterator.next (StringMap.zig:40)
==265734==    by 0x39ADDCD: renderer.link.Set.matchSetFromLinks (link.zig:320)
==265734==    by 0x39AE5C7: renderer.link.Set.matchSet (link.zig:95)
==265734==    by 0x39BCCE1: renderer.generic.Renderer(renderer.OpenGL).rebuildCells (generic.zig:2307)
==265734==    by 0x39C3BDB: renderer.generic.Renderer(renderer.OpenGL).updateFrame (generic.zig:1228)
==265734==    by 0x3993E88: renderer.Thread.renderCallback (Thread.zig:607)
==265734==    by 0x3993CFF: renderer.Thread.wakeupCallback (Thread.zig:524)
==265734==    by 0x39C522E: callback (async.zig:679)
==265734==    by 0x39C522E: watcher.async.AsyncEventFd(api.Xev(.io_uring,backend.io_uring)).waitPoll__anon_592685__struct_596870.callback (async.zig:181)
==265734==    by 0x3970EAE: backend.io_uring.Completion.invoke (io_uring.zig:804)
==265734==    by 0x3973AD8: backend.io_uring.Loop.tick___anon_586861 (io_uring.zig:193)
==265734==    by 0x3973BCD: backend.io_uring.Loop.run (io_uring.zig:84)
==265734==    by 0x3978673: dynamic.Xev(&.{ .io_uring, .epoll }[0..2]).Loop.run (dynamic.zig:172)
==265734==    by 0x3978972: renderer.Thread.threadMain_ (Thread.zig:263)
==265734==    by 0x3954580: renderer.Thread.threadMain (Thread.zig:202)
==265734==    by 0x39279CA: Thread.callFn__anon_573552 (Thread.zig:488)
==265734==    by 0x38F4594: Thread.PosixThreadImpl.spawn__anon_570448.Instance.entryFn (Thread.zig:757)
==265734==    by 0x6E567EA: start_thread (pthread_create.c:448)
==265734==    by 0x6ED9FB3: clone (clone.S:100)
==265734==
```