### PR TITLE
apprt/gtk-ng: mouse shape,visibility

### DIFF
--- a/src/apprt/gtk-ng/Surface.zig
+++ b/src/apprt/gtk-ng/Surface.zig
@@ -14,6 +14,12 @@ pub fn deinit(self: *Self) void {
     _ = self;
 }
 
+/// Returns the GObject surface for this apprt surface. This is a function
+/// so we can add some extra logic if we ever have to here.
+pub fn gobj(self: *Self) *Surface {
+    return self.surface;
+}
+
 pub fn core(self: *Self) *CoreSurface {
     // This asserts the non-optional because libghostty should only
     // be calling this for initialized surfaces.

--- a/src/apprt/gtk-ng/class/application.zig
+++ b/src/apprt/gtk-ng/class/application.zig
@@ -15,6 +15,7 @@ const cgroup = @import("../cgroup.zig");
 const CoreApp = @import("../../../App.zig");
 const configpkg = @import("../../../config.zig");
 const internal_os = @import("../../../os/main.zig");
+const terminal = @import("../../../terminal/main.zig");
 const xev = @import("../../../global.zig").xev;
 const CoreConfig = configpkg.Config;
 const CoreSurface = @import("../../../Surface.zig");
@@ -404,6 +405,8 @@ pub const Application = extern struct {
                 value.config,
             ),
 
+            .mouse_shape => Action.mouseShape(target, value),
+
             .new_window => try Action.newWindow(
                 self,
                 switch (target) {
@@ -440,7 +443,6 @@ pub const Application = extern struct {
             .initial_size,
             .size_limit,
             .mouse_visibility,
-            .mouse_shape,
             .mouse_over_link,
             .toggle_tab_overview,
             .toggle_split_zoom,
@@ -882,6 +884,24 @@ const Action = struct {
 
                 // Show our errors if we have any
                 self.showConfigErrorsDialog();
+            },
+        }
+    }
+
+    pub fn mouseShape(
+        target: apprt.Target,
+        shape: terminal.MouseShape,
+    ) void {
+        switch (target) {
+            .app => log.warn("mouse shape to app is unexpected", .{}),
+            .surface => |surface| {
+                var value = gobject.ext.Value.newFrom(shape);
+                defer value.unset();
+                gobject.Object.setProperty(
+                    surface.rt_surface.gobj().as(gobject.Object),
+                    "mouse-shape",
+                    &value,
+                );
             },
         }
     }

--- a/src/apprt/gtk-ng/class/application.zig
+++ b/src/apprt/gtk-ng/class/application.zig
@@ -406,6 +406,7 @@ pub const Application = extern struct {
             ),
 
             .mouse_shape => Action.mouseShape(target, value),
+            .mouse_visibility => Action.mouseVisibility(target, value),
 
             .new_window => try Action.newWindow(
                 self,
@@ -442,7 +443,6 @@ pub const Application = extern struct {
             .present_terminal,
             .initial_size,
             .size_limit,
-            .mouse_visibility,
             .mouse_over_link,
             .toggle_tab_overview,
             .toggle_split_zoom,
@@ -900,6 +900,27 @@ const Action = struct {
                 gobject.Object.setProperty(
                     surface.rt_surface.gobj().as(gobject.Object),
                     "mouse-shape",
+                    &value,
+                );
+            },
+        }
+    }
+
+    pub fn mouseVisibility(
+        target: apprt.Target,
+        visibility: apprt.action.MouseVisibility,
+    ) void {
+        switch (target) {
+            .app => log.warn("mouse visibility to app is unexpected", .{}),
+            .surface => |surface| {
+                var value = gobject.ext.Value.newFrom(switch (visibility) {
+                    .visible => false,
+                    .hidden => true,
+                });
+                defer value.unset();
+                gobject.Object.setProperty(
+                    surface.rt_surface.gobj().as(gobject.Object),
+                    "mouse-hidden",
                     &value,
                 );
             },

--- a/src/apprt/gtk-ng/class/surface.zig
+++ b/src/apprt/gtk-ng/class/surface.zig
@@ -83,7 +83,7 @@ pub const Surface = extern struct {
                 .{
                     .nick = "Mouse Shape",
                     .blurb = "The current mouse shape to show for the surface.",
-                    .default = .default,
+                    .default = .text,
                     .accessor = gobject.ext.privateFieldAccessor(
                         Self,
                         Private,
@@ -563,6 +563,8 @@ pub const Surface = extern struct {
         priv.rt_surface = .{ .surface = self };
         priv.precision_scroll = false;
         priv.cursor_pos = .{ .x = 0, .y = 0 };
+        priv.mouse_shape = .text;
+        priv.mouse_hidden = false;
         priv.size = .{
             // Funky numbers on purpose so they stand out if for some reason
             // our size doesn't get properly set.

--- a/src/terminal/mouse_shape.zig
+++ b/src/terminal/mouse_shape.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const build_config = @import("../build_config.zig");
 
 /// The possible cursor shapes. Not all app runtimes support these shapes.
 /// The shapes are always based on the W3C supported cursor styles so we
@@ -45,6 +46,16 @@ pub const MouseShape = enum(c_int) {
     pub fn fromString(v: []const u8) ?MouseShape {
         return string_map.get(v);
     }
+
+    /// Make this a valid gobject if we're in a GTK environment.
+    pub const getGObjectType = switch (build_config.app_runtime) {
+        .gtk, .@"gtk-ng" => @import("gobject").ext.defineEnum(
+            MouseShape,
+            .{ .name = "GhosttyMouseShape" },
+        ),
+
+        .none => void,
+    };
 };
 
 const string_map = std.StaticStringMap(MouseShape).initComptime(.{


### PR DESCRIPTION
Relatively simple port. A few cool things:

1. We use properties on `GhosttySurface` to set this now and standard property listeners 
2. We make `terminal.MouseShape` a GObject enum if we have gobject available.
3. The property based approach means we don't have to manage `*gdk.Cursor` memory anywhere anymore.

And, we're still Valgrind clean.
