### PR TITLE
apprt/gtk-ng: hook up title, pwd surface properties

### DIFF
--- a/src/apprt/gtk-ng/Surface.zig
+++ b/src/apprt/gtk-ng/Surface.zig
@@ -36,8 +36,7 @@ pub fn close(self: *Self, process_active: bool) void {
 }
 
 pub fn getTitle(self: *Self) ?[:0]const u8 {
-    _ = self;
-    return null;
+    return self.surface.getTitle();
 }
 
 pub fn getContentScale(self: *const Self) !apprt.ContentScale {

--- a/src/apprt/gtk-ng/class.zig
+++ b/src/apprt/gtk-ng/class.zig
@@ -49,7 +49,11 @@ pub fn Common(
         /// A helper that can be used to create a property that reads and
         /// writes a private `?[:0]const u8` field type.
         ///
-        /// This helper helps properly manage the memory to avoid memory leaks.
+        /// Reading the property will result in a copy of the string
+        /// and callers are responsible for freeing it.
+        ///
+        /// Writing the property will free the previous value and copy
+        /// the new value into the private field.
         ///
         /// The object class (Self) must still free the private field
         /// in finalize!

--- a/src/apprt/gtk-ng/class/application.zig
+++ b/src/apprt/gtk-ng/class/application.zig
@@ -422,6 +422,8 @@ pub const Application = extern struct {
 
             .render => Action.render(self, target),
 
+            .set_title => Action.setTitle(target, value),
+
             // Unimplemented
             .quit,
             .close_window,
@@ -440,7 +442,6 @@ pub const Application = extern struct {
             .inspector,
             .show_gtk_inspector,
             .desktop_notification,
-            .set_title,
             .present_terminal,
             .initial_size,
             .size_limit,
@@ -975,6 +976,24 @@ const Action = struct {
         switch (target) {
             .app => {},
             .surface => |v| v.rt_surface.surface.redraw(),
+        }
+    }
+
+    pub fn setTitle(
+        target: apprt.Target,
+        value: apprt.action.SetTitle,
+    ) void {
+        switch (target) {
+            .app => log.warn("set_title to app is unexpected", .{}),
+            .surface => |surface| {
+                var v = gobject.ext.Value.newFrom(value.title);
+                defer v.unset();
+                gobject.Object.setProperty(
+                    surface.rt_surface.gobj().as(gobject.Object),
+                    "title",
+                    &v,
+                );
+            },
         }
     }
 };

--- a/src/apprt/gtk-ng/class/application.zig
+++ b/src/apprt/gtk-ng/class/application.zig
@@ -416,6 +416,8 @@ pub const Application = extern struct {
                 },
             ),
 
+            .pwd => Action.pwd(target, value),
+
             .quit_timer => try Action.quitTimer(self, value),
 
             .render => Action.render(self, target),
@@ -439,7 +441,6 @@ pub const Application = extern struct {
             .show_gtk_inspector,
             .desktop_notification,
             .set_title,
-            .pwd,
             .present_terminal,
             .initial_size,
             .size_limit,
@@ -935,6 +936,24 @@ const Action = struct {
 
         const win = Window.new(self);
         gtk.Window.present(win.as(gtk.Window));
+    }
+
+    pub fn pwd(
+        target: apprt.Target,
+        value: apprt.action.Pwd,
+    ) void {
+        switch (target) {
+            .app => log.warn("pwd to app is unexpected", .{}),
+            .surface => |surface| {
+                var v = gobject.ext.Value.newFrom(value.pwd);
+                defer v.unset();
+                gobject.Object.setProperty(
+                    surface.rt_surface.gobj().as(gobject.Object),
+                    "pwd",
+                    &v,
+                );
+            },
+        }
     }
 
     pub fn quitTimer(

--- a/src/apprt/gtk-ng/class/application.zig
+++ b/src/apprt/gtk-ng/class/application.zig
@@ -424,7 +424,7 @@ pub const Application = extern struct {
 
             .set_title => Action.setTitle(target, value),
 
-            // Unimplemented
+            // Unimplemented but todo on gtk-ng branch
             .quit,
             .close_window,
             .toggle_maximize,
@@ -451,7 +451,6 @@ pub const Application = extern struct {
             .toggle_window_decorations,
             .prompt_title,
             .toggle_quick_terminal,
-            .secure_input,
             .ring_bell,
             .toggle_command_palette,
             .open_url,
@@ -469,6 +468,13 @@ pub const Application = extern struct {
             .undo,
             .redo,
             .progress_report,
+            => {
+                log.warn("unimplemented action={}", .{action});
+                return false;
+            },
+
+            // Unimplemented
+            .secure_input,
             => {
                 log.warn("unimplemented action={}", .{action});
                 return false;

--- a/src/apprt/gtk-ng/class/surface.zig
+++ b/src/apprt/gtk-ng/class/surface.zig
@@ -881,6 +881,11 @@ pub const Surface = extern struct {
     //---------------------------------------------------------------
     // Properties
 
+    /// Returns the title property without a copy.
+    pub fn getTitle(self: *Self) ?[:0]const u8 {
+        return self.private().title;
+    }
+
     fn propMouseHidden(
         self: *Self,
         _: *gobject.ParamSpec,

--- a/src/apprt/gtk-ng/class/surface.zig
+++ b/src/apprt/gtk-ng/class/surface.zig
@@ -863,9 +863,14 @@ pub const Surface = extern struct {
             priv.core_surface = null;
         }
 
-        var @"null": gobject.Value = undefined;
-        if (priv.pwd != null) properties.pwd.set(self, &@"null");
-        if (priv.title != null) properties.pwd.set(self, &@"null");
+        if (priv.pwd) |v| {
+            glib.free(@constCast(@ptrCast(v)));
+            priv.pwd = null;
+        }
+        if (priv.title) |v| {
+            glib.free(@constCast(@ptrCast(v)));
+            priv.title = null;
+        }
 
         gobject.Object.virtual_methods.finalize.call(
             Class.parent,

--- a/src/apprt/gtk-ng/class/surface.zig
+++ b/src/apprt/gtk-ng/class/surface.zig
@@ -96,6 +96,8 @@ pub const Surface = extern struct {
 
         pub const pwd = struct {
             pub const name = "pwd";
+            pub const get = impl.get;
+            pub const set = impl.set;
             const impl = gobject.ext.defineProperty(
                 name,
                 Self,
@@ -104,22 +106,15 @@ pub const Surface = extern struct {
                     .nick = "Working Directory",
                     .blurb = "The current working directory as reported by core.",
                     .default = null,
-                    .accessor = gobject.ext.typedAccessor(
-                        Self,
-                        ?[:0]const u8,
-                        .{
-                            .getter = getPwd,
-                            .getter_transfer = .none,
-                            .setter = setPwd,
-                            .setter_transfer = .full,
-                        },
-                    ),
+                    .accessor = C.privateStringFieldAccessor("pwd"),
                 },
             );
         };
 
         pub const title = struct {
             pub const name = "title";
+            pub const get = impl.get;
+            pub const set = impl.set;
             const impl = gobject.ext.defineProperty(
                 name,
                 Self,
@@ -128,16 +123,7 @@ pub const Surface = extern struct {
                     .nick = "Title",
                     .blurb = "The title of the surface.",
                     .default = null,
-                    .accessor = gobject.ext.typedAccessor(
-                        Self,
-                        ?[:0]const u8,
-                        .{
-                            .getter = getTitle,
-                            .getter_transfer = .none,
-                            .setter = setTitle,
-                            .setter_transfer = .full,
-                        },
-                    ),
+                    .accessor = C.privateStringFieldAccessor("title"),
                 },
             );
         };
@@ -876,8 +862,10 @@ pub const Surface = extern struct {
 
             priv.core_surface = null;
         }
-        if (priv.pwd != null) self.setPwd(null);
-        if (priv.title != null) self.setTitle(null);
+
+        var @"null": gobject.Value = undefined;
+        if (priv.pwd != null) properties.pwd.set(self, &@"null");
+        if (priv.title != null) properties.pwd.set(self, &@"null");
 
         gobject.Object.virtual_methods.finalize.call(
             Class.parent,
@@ -887,41 +875,6 @@ pub const Surface = extern struct {
 
     //---------------------------------------------------------------
     // Properties
-
-    fn getPwd(
-        self: *Self,
-    ) ?[:0]const u8 {
-        return self.private().pwd;
-    }
-
-    fn setPwd(
-        self: *Self,
-        value: ?[:0]const u8,
-    ) void {
-        const priv = self.private();
-
-        // Free the previous value
-        if (priv.pwd) |v| glib.free(@constCast(@ptrCast(v.ptr)));
-
-        // Set the new value, which is already copied since we
-        // set our setter_transfer value to full.
-        priv.pwd = value;
-    }
-
-    fn getTitle(
-        self: *Self,
-    ) ?[:0]const u8 {
-        return self.private().title;
-    }
-
-    fn setTitle(
-        self: *Self,
-        value: ?[:0]const u8,
-    ) void {
-        const priv = self.private();
-        if (priv.title) |v| glib.free(@constCast(@ptrCast(v.ptr)));
-        priv.title = value;
-    }
 
     fn propMouseHidden(
         self: *Self,


### PR DESCRIPTION
Continuing to plumb along the APIs necessary basic surface functionality before moving onto windowing functionality. This adds title/pwd as properties to Surface, adds abstractions necessary to manage that memory correctly, and also adds a tiny change to renderers to make everything slightly more usable under Valgrind.