### PR TITLE
build-system: Replace deprecated usages of addStaticLibrary with addLibrary

### DIFF
--- a/pkg/breakpad/build.zig
+++ b/pkg/breakpad/build.zig
@@ -4,10 +4,13 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "breakpad",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+        .linkage = .static,
     });
     lib.linkLibCpp();
     lib.addIncludePath(b.path("vendor"));

--- a/pkg/cimgui/build.zig
+++ b/pkg/cimgui/build.zig
@@ -12,10 +12,13 @@ pub fn build(b: *std.Build) !void {
     });
 
     const imgui = b.dependency("imgui", .{});
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "cimgui",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+        .linkage = .static,
     });
     lib.linkLibC();
     lib.linkLibCpp();

--- a/pkg/fontconfig/build.zig
+++ b/pkg/fontconfig/build.zig
@@ -64,10 +64,13 @@ fn buildLib(b: *std.Build, module: *std.Build.Module, options: anytype) !*std.Bu
     const libxml2_iconv_enabled = options.libxml2_iconv_enabled;
     const freetype_enabled = options.freetype_enabled;
 
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "fontconfig",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+        .linkage = .static,
     });
     lib.linkLibC();
     if (target.result.os.tag != .windows) {

--- a/pkg/freetype/build.zig
+++ b/pkg/freetype/build.zig
@@ -61,10 +61,13 @@ fn buildLib(b: *std.Build, module: *std.Build.Module, options: anytype) !*std.Bu
 
     const libpng_enabled = options.libpng_enabled;
 
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "freetype",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+        .linkage = .static,
     });
     lib.linkLibC();
     if (target.result.os.tag.isDarwin()) {

--- a/pkg/glslang/build.zig
+++ b/pkg/glslang/build.zig
@@ -40,10 +40,13 @@ fn buildGlslang(
     target: std.Build.ResolvedTarget,
     optimize: std.builtin.OptimizeMode,
 ) !*std.Build.Step.Compile {
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "glslang",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+        .linkage = .static,
     });
     lib.linkLibC();
     lib.linkLibCpp();

--- a/pkg/harfbuzz/build.zig
+++ b/pkg/harfbuzz/build.zig
@@ -92,10 +92,13 @@ fn buildLib(b: *std.Build, module: *std.Build.Module, options: anytype) !*std.Bu
         .@"enable-libpng" = true,
     });
 
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "harfbuzz",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+        .linkage = .static,
     });
     lib.linkLibC();
     lib.linkLibCpp();

--- a/pkg/highway/build.zig
+++ b/pkg/highway/build.zig
@@ -12,10 +12,13 @@ pub fn build(b: *std.Build) !void {
         .optimize = optimize,
     });
 
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "highway",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+        .linkage = .static,
     });
     lib.linkLibCpp();
     lib.addIncludePath(upstream.path(""));

--- a/pkg/libintl/build.zig
+++ b/pkg/libintl/build.zig
@@ -30,10 +30,13 @@ pub fn build(b: *std.Build) !void {
     });
 
     {
-        const lib = b.addStaticLibrary(.{
+        const lib = b.addLibrary(.{
             .name = "intl",
-            .target = target,
-            .optimize = optimize,
+            .root_module = b.createModule(.{
+                .target = target,
+                .optimize = optimize,
+            }),
+            .linkage = .static,
         });
         lib.linkLibC();
         lib.addIncludePath(b.path(""));

--- a/pkg/libpng/build.zig
+++ b/pkg/libpng/build.zig
@@ -4,10 +4,13 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "png",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+        .linkage = .static,
     });
     lib.linkLibC();
     if (target.result.os.tag == .linux) {

--- a/pkg/libxml2/build.zig
+++ b/pkg/libxml2/build.zig
@@ -6,10 +6,13 @@ pub fn build(b: *std.Build) !void {
 
     const upstream = b.dependency("libxml2", .{});
 
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "xml2",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+        .linkage = .static,
     });
     lib.linkLibC();
 

--- a/pkg/macos/build.zig
+++ b/pkg/macos/build.zig
@@ -12,10 +12,13 @@ pub fn build(b: *std.Build) !void {
         .optimize = optimize,
     });
 
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "macos",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+        .linkage = .static,
     });
 
     lib.addCSourceFile(.{

--- a/pkg/oniguruma/build.zig
+++ b/pkg/oniguruma/build.zig
@@ -57,10 +57,13 @@ fn buildLib(b: *std.Build, module: *std.Build.Module, options: anytype) !*std.Bu
     const target = options.target;
     const optimize = options.optimize;
 
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "oniguruma",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+        .linkage = .static,
     });
     const t = target.result;
     lib.linkLibC();

--- a/pkg/sentry/build.zig
+++ b/pkg/sentry/build.zig
@@ -12,10 +12,13 @@ pub fn build(b: *std.Build) !void {
         .optimize = optimize,
     });
 
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "sentry",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+        .linkage = .static,
     });
     lib.linkLibC();
     if (target.result.os.tag.isDarwin()) {

--- a/pkg/simdutf/build.zig
+++ b/pkg/simdutf/build.zig
@@ -4,10 +4,13 @@ pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
 
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "simdutf",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+        .linkage = .static,
     });
     lib.linkLibCpp();
     lib.addIncludePath(b.path("vendor"));

--- a/pkg/spirv-cross/build.zig
+++ b/pkg/spirv-cross/build.zig
@@ -35,10 +35,13 @@ fn buildSpirvCross(
     target: std.Build.ResolvedTarget,
     optimize: std.builtin.OptimizeMode,
 ) !*std.Build.Step.Compile {
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "spirv_cross",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+        .linkage = .static,
     });
     lib.linkLibC();
     lib.linkLibCpp();

--- a/pkg/utf8proc/build.zig
+++ b/pkg/utf8proc/build.zig
@@ -7,10 +7,13 @@ pub fn build(b: *std.Build) !void {
     const module = b.addModule("utf8proc", .{ .root_source_file = .{ .path = "main.zig" } });
 
     const upstream = b.dependency("utf8proc", .{});
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "utf8proc",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+        .linkage = .static,
     });
     lib.linkLibC();
 

--- a/pkg/utfcpp/build.zig
+++ b/pkg/utfcpp/build.zig
@@ -4,10 +4,13 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "utfcpp",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+        .linkage = .static,
     });
     lib.linkLibCpp();
 

--- a/pkg/zlib/build.zig
+++ b/pkg/zlib/build.zig
@@ -4,10 +4,13 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "z",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+        .linkage = .static,
     });
     lib.linkLibC();
     if (target.result.os.tag.isDarwin()) {

--- a/src/build/GhosttyLib.zig
+++ b/src/build/GhosttyLib.zig
@@ -18,7 +18,7 @@ pub fn initStatic(
     b: *std.Build,
     deps: *const SharedDeps,
 ) !GhosttyLib {
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "ghostty",
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/main_c.zig"),
@@ -28,6 +28,7 @@ pub fn initStatic(
             .omit_frame_pointer = deps.config.strip,
             .unwind_tables = if (deps.config.strip) .none else .sync,
         }),
+        .linkage = .static,
     });
     lib.linkLibC();
 


### PR DESCRIPTION
Hi there, this is just a low-hanging fruit and it also prepares the way for the future 0.15, which removes addStaticLibrary.
Please, let me know what to do on the `// TODO` comments.
