### PR TITLE
build-system: Replace deprecated usages of root_source_file on addTests

### DIFF
--- a/pkg/cimgui/build.zig
+++ b/pkg/cimgui/build.zig
@@ -108,9 +108,11 @@ pub fn build(b: *std.Build) !void {
 
     const test_exe = b.addTest(.{
         .name = "test",
-        .root_source_file = b.path("main.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     test_exe.linkLibrary(lib);
     const tests_run = b.addRunArtifact(test_exe);

--- a/pkg/fontconfig/build.zig
+++ b/pkg/fontconfig/build.zig
@@ -29,9 +29,11 @@ pub fn build(b: *std.Build) !void {
 
     const test_exe = b.addTest(.{
         .name = "test",
-        .root_source_file = b.path("main.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     const tests_run = b.addRunArtifact(test_exe);
     const test_step = b.step("test", "Run tests");

--- a/pkg/freetype/build.zig
+++ b/pkg/freetype/build.zig
@@ -23,9 +23,11 @@ pub fn build(b: *std.Build) !void {
     if (target.query.isNative()) {
         test_exe = b.addTest(.{
             .name = "test",
-            .root_source_file = b.path("main.zig"),
-            .target = target,
-            .optimize = optimize,
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("main.zig"),
+                .target = target,
+                .optimize = optimize,
+            }),
         });
         const tests_run = b.addRunArtifact(test_exe.?);
         const test_step = b.step("test", "Run tests");

--- a/pkg/glslang/build.zig
+++ b/pkg/glslang/build.zig
@@ -20,9 +20,11 @@ pub fn build(b: *std.Build) !void {
     if (target.query.isNative()) {
         const test_exe = b.addTest(.{
             .name = "test",
-            .root_source_file = b.path("main.zig"),
-            .target = target,
-            .optimize = optimize,
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("main.zig"),
+                .target = target,
+                .optimize = optimize,
+            }),
         });
         test_exe.linkLibrary(lib);
         const tests_run = b.addRunArtifact(test_exe);

--- a/pkg/harfbuzz/build.zig
+++ b/pkg/harfbuzz/build.zig
@@ -43,9 +43,11 @@ pub fn build(b: *std.Build) !void {
 
     const test_exe = b.addTest(.{
         .name = "test",
-        .root_source_file = b.path("main.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
 
     {

--- a/pkg/highway/build.zig
+++ b/pkg/highway/build.zig
@@ -95,9 +95,11 @@ pub fn build(b: *std.Build) !void {
     {
         const test_exe = b.addTest(.{
             .name = "test",
-            .root_source_file = b.path("main.zig"),
-            .target = target,
-            .optimize = optimize,
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("main.zig"),
+                .target = target,
+                .optimize = optimize,
+            }),
         });
         test_exe.linkLibrary(lib);
 

--- a/pkg/macos/build.zig
+++ b/pkg/macos/build.zig
@@ -51,9 +51,11 @@ pub fn build(b: *std.Build) !void {
     {
         const test_exe = b.addTest(.{
             .name = "test",
-            .root_source_file = b.path("main.zig"),
-            .target = target,
-            .optimize = optimize,
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("main.zig"),
+                .target = target,
+                .optimize = optimize,
+            }),
         });
         if (target.result.os.tag.isDarwin()) {
             try apple_sdk.addPaths(b, test_exe);

--- a/pkg/oniguruma/build.zig
+++ b/pkg/oniguruma/build.zig
@@ -23,9 +23,11 @@ pub fn build(b: *std.Build) !void {
     if (target.query.isNative()) {
         test_exe = b.addTest(.{
             .name = "test",
-            .root_source_file = b.path("main.zig"),
-            .target = target,
-            .optimize = optimize,
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("main.zig"),
+                .target = target,
+                .optimize = optimize,
+            }),
         });
         const tests_run = b.addRunArtifact(test_exe.?);
         const test_step = b.step("test", "Run tests");

--- a/pkg/spirv-cross/build.zig
+++ b/pkg/spirv-cross/build.zig
@@ -15,9 +15,11 @@ pub fn build(b: *std.Build) !void {
     if (target.query.isNative()) {
         const test_exe = b.addTest(.{
             .name = "test",
-            .root_source_file = b.path("main.zig"),
-            .target = target,
-            .optimize = optimize,
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("main.zig"),
+                .target = target,
+                .optimize = optimize,
+            }),
         });
         test_exe.linkLibrary(lib);
         const tests_run = b.addRunArtifact(test_exe);

--- a/pkg/wuffs/build.zig
+++ b/pkg/wuffs/build.zig
@@ -12,9 +12,12 @@ pub fn build(b: *std.Build) !void {
     });
 
     const unit_tests = b.addTest(.{
-        .root_source_file = b.path("src/main.zig"),
-        .target = target,
-        .optimize = optimize,
+        .name = "test",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     unit_tests.linkLibC();
 


### PR DESCRIPTION
Yet another low-hanging fruit
