### PR TITLE
apprt/gtk-ng: move overlays and event controllers into Blueprint

### DIFF
--- a/src/apprt/gtk-ng/ui/1.2/surface.blp
+++ b/src/apprt/gtk-ng/ui/1.2/surface.blp
@@ -16,35 +16,52 @@ template $GhosttySurface: Adw.Bin {
         focusable: true;
         focus-on-click: true;
       }
+
+      [overlay]
+      $GhosttyResizeOverlay resize_overlay {
+        styles [
+          "size-overlay",
+        ]
+      }
+
+      [overlay]
+      Label url_left {
+        styles [
+          "url-overlay",
+        ]
+
+        visible: false;
+        halign: start;
+        valign: end;
+        label: bind template.mouse-hover-url;
+
+        EventControllerMotion url_ec_motion {}
+      }
+
+      [overlay]
+      Label url_right {
+        styles [
+          "url-overlay",
+        ]
+
+        visible: false;
+        halign: end;
+        valign: end;
+        label: bind template.mouse-hover-url;
+      }
     }
   }
-}
 
-// The label that shows the currently hovered URL.
-Label url_left {
-  styles [
-    "url-overlay",
-  ]
+  // Event controllers for interactivity
+  EventControllerFocus ec_focus {}
 
-  visible: false;
-  halign: start;
-  valign: end;
-  label: bind template.mouse-hover-url;
-}
+  EventControllerKey ec_key {}
 
-Label url_right {
-  styles [
-    "url-overlay",
-  ]
+  EventControllerMotion ec_motion {}
 
-  visible: false;
-  halign: end;
-  valign: end;
-  label: bind template.mouse-hover-url;
-}
+  EventControllerScroll ec_scroll {}
 
-$GhosttyResizeOverlay resize_overlay {
-  styles [
-    "size-overlay",
-  ]
+  GestureClick gesture_click {
+    button: 0;
+  }
 }

--- a/src/apprt/gtk-ng/ui/1.5/window.blp
+++ b/src/apprt/gtk-ng/ui/1.5/window.blp
@@ -2,5 +2,8 @@ using Gtk 4.0;
 using Adw 1;
 
 template $GhosttyWindow: Adw.ApplicationWindow {
+  default-width: 800;
+  default-height: 600;
+
   content: $GhosttySurface surface {};
 }


### PR DESCRIPTION
I became far less stupid and figured out how to figure this out by reading the source code and since then I've been enlightened and can clean up our Blueprints quite a bit. Yay!

I learned that you can add overlays to a `gtk.Overlay` with the `[overlay]` child type. And if you embed event controllers directly, `gtk.Widget` adds them (https://gitlab.gnome.org/GNOME/gtk/-/blob/main/gtk/gtkwidget.c#L8805-8808).

cc @tristan957 yay!