### PR TITLE
devshell: add deps that allow GTK to load SVG resources

### DIFF
--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -69,6 +69,10 @@
   zon2nix,
   system,
   pkgs,
+  # needed by GTK for loading SVG icons while running from within the
+  # developer shell
+  glycin-loaders,
+  librsvg,
 }: let
   # See package.nix. Keep in sync.
   ld_library_path = import ./build-support/ld-library-path.nix {
@@ -174,6 +178,11 @@ in
         gst_all_1.gstreamer
         gst_all_1.gst-plugins-base
         gst_all_1.gst-plugins-good
+
+        # needed by GTK for loading SVG icons while running from within the
+        # developer shell
+        glycin-loaders
+        librsvg
       ];
 
     # This should be set onto the rpath of the ghostty binary if you want


### PR DESCRIPTION
GTK dynamically loads librsvg when it needs to convert a SVG-only icon (or any other SVG-only resource) for display. This PR adds the libraries that GTK needs so that running programs from within the developer shell can display those SVG resources.