### PR TITLE
macos: add more Tahoe menu item icons from SF Symbols

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -471,6 +471,7 @@ class AppDelegate: NSObject,
         self.menuSplitUp?.setImageIfDesired(systemSymbolName: "rectangle.tophalf.inset.filled")
         self.menuSplitDown?.setImageIfDesired(systemSymbolName: "rectangle.bottomhalf.inset.filled")
         self.menuClose?.setImageIfDesired(systemSymbolName: "xmark")
+        self.menuPasteSelection?.setImageIfDesired(systemSymbolName: "doc.on.clipboard.fill")
         self.menuIncreaseFontSize?.setImageIfDesired(systemSymbolName: "textformat.size.larger")
         self.menuResetFontSize?.setImageIfDesired(systemSymbolName: "textformat.size")
         self.menuDecreaseFontSize?.setImageIfDesired(systemSymbolName: "textformat.size.smaller")


### PR DESCRIPTION
This is a follow up to https://github.com/ghostty-org/ghostty/pull/7594
<img width="487" height="318" alt="Screenshot 2025-07-24 at 23 10 20" src="https://github.com/user-attachments/assets/83491b18-ef64-4a8f-b63d-a0001352cc31" />
<img width="544" height="295" alt="Screenshot 2025-07-24 at 23 11 01" src="https://github.com/user-attachments/assets/10922879-ac1b-409d-8a3b-c298a1411813" />
