### PR TITLE
apprt/gtk-ng: hook up bell ringing

### DIFF
--- a/src/apprt/gtk-ng/class/application.zig
+++ b/src/apprt/gtk-ng/class/application.zig
@@ -485,6 +485,8 @@ pub const Application = extern struct {
 
             .render => Action.render(self, target),
 
+            .ring_bell => Action.ringBell(target),
+
             .set_title => Action.setTitle(target, value),
 
             .show_child_exited => return Action.showChildExited(target, value),
@@ -515,7 +517,6 @@ pub const Application = extern struct {
             .toggle_window_decorations,
             .prompt_title,
             .toggle_quick_terminal,
-            .ring_bell,
             .toggle_command_palette,
             .open_url,
             .close_all_windows,
@@ -1135,6 +1136,13 @@ const Action = struct {
         switch (target) {
             .app => {},
             .surface => |v| v.rt_surface.surface.redraw(),
+        }
+    }
+
+    pub fn ringBell(target: apprt.Target) void {
+        switch (target) {
+            .app => {},
+            .surface => |v| v.rt_surface.surface.ringBell(),
         }
     }
 

--- a/src/apprt/gtk-ng/class/surface.zig
+++ b/src/apprt/gtk-ng/class/surface.zig
@@ -213,6 +213,21 @@ pub const Surface = extern struct {
             );
         };
 
+        /// The bell is rung.
+        ///
+        /// The surface view handles the audio bell feature but none of the
+        /// others so it is up to the embedding widget to react to this.
+        pub const bell = struct {
+            pub const name = "bell";
+            pub const connect = impl.connect;
+            const impl = gobject.ext.defineSignal(
+                name,
+                Self,
+                &.{},
+                void,
+            );
+        };
+
         /// Emitted whenever the clipboard has been written.
         pub const @"clipboard-write" = struct {
             pub const name = "clipboard-write";
@@ -341,6 +356,18 @@ pub const Surface = extern struct {
     pub fn redraw(self: *Self) void {
         const priv = self.private();
         priv.gl_area.queueRender();
+    }
+
+    /// Ring the bell.
+    pub fn ringBell(self: *Self) void {
+        // TODO: Audio feature
+
+        signals.bell.impl.emit(
+            self,
+            null,
+            .{},
+            null,
+        );
     }
 
     /// Set the current progress report state.
@@ -1979,6 +2006,7 @@ pub const Surface = extern struct {
 
             // Signals
             signals.@"close-request".impl.register(.{});
+            signals.bell.impl.register(.{});
             signals.@"clipboard-read".impl.register(.{});
             signals.@"clipboard-write".impl.register(.{});
 


### PR DESCRIPTION
For now, this just emits a signal that an embedding widget will react to to do something like flashing the window. 

I think we should implement the audio bell in the actual surface view but I don't currently have audio drivers hooked up in my Linux VM and I'm away from my desktop PC. :)

cc @jcollie if you're interested, pretty tightly scoped.