### PR TITLE
apprt/gtk-ng: window headerbar, maximize, fullscreen

### DIFF
--- a/src/apprt/gtk-ng/Surface.zig
+++ b/src/apprt/gtk-ng/Surface.zig
@@ -32,7 +32,7 @@ pub fn rtApp(self: *Self) *ApprtApp {
 }
 
 pub fn close(self: *Self, process_active: bool) void {
-    self.surface.close(process_active);
+    self.surface.close(.{ .surface = process_active });
 }
 
 pub fn cgroup(self: *Self) ?[]const u8 {

--- a/src/apprt/gtk-ng/class/application.zig
+++ b/src/apprt/gtk-ng/class/application.zig
@@ -509,9 +509,10 @@ pub const Application = extern struct {
 
             .show_gtk_inspector => Action.showGtkInspector(),
 
+            .toggle_maximize => Action.toggleMaximize(target),
+            .toggle_fullscreen => Action.toggleFullscreen(target),
+
             // Unimplemented but todo on gtk-ng branch
-            .toggle_maximize,
-            .toggle_fullscreen,
             .new_tab,
             .goto_tab,
             .move_tab,
@@ -1236,6 +1237,20 @@ const Action = struct {
 
     pub fn showGtkInspector() void {
         gtk.Window.setInteractiveDebugging(@intFromBool(true));
+    }
+
+    pub fn toggleFullscreen(target: apprt.Target) void {
+        switch (target) {
+            .app => {},
+            .surface => |v| v.rt_surface.surface.toggleFullscreen(),
+        }
+    }
+
+    pub fn toggleMaximize(target: apprt.Target) void {
+        switch (target) {
+            .app => {},
+            .surface => |v| v.rt_surface.surface.toggleMaximize(),
+        }
     }
 };
 

--- a/src/apprt/gtk-ng/class/surface.zig
+++ b/src/apprt/gtk-ng/class/surface.zig
@@ -2172,7 +2172,7 @@ pub const Surface = extern struct {
         surface: bool,
 
         /// Close the tab. We can't know if there are processes active
-        /// for the entire tab scope so listners must query the app.
+        /// for the entire tab scope so listeners must query the app.
         tab,
 
         /// Close the window.

--- a/src/apprt/gtk-ng/class/window.zig
+++ b/src/apprt/gtk-ng/class/window.zig
@@ -72,8 +72,14 @@ pub const Window = extern struct {
     fn init(self: *Self, _: *Class) callconv(.C) void {
         gtk.Widget.initTemplate(self.as(gtk.Widget));
 
-        if (comptime build_config.is_debug)
+        // Add our dev CSS class if we're in debug mode.
+        if (comptime build_config.is_debug) {
             self.as(gtk.Widget).addCssClass("devel");
+        }
+
+        // Set our window icon. We can't set this in the blueprint file
+        // because its dependent on the build config.
+        self.as(gtk.Window).setIconName(build_config.bundle_id);
     }
 
     //---------------------------------------------------------------

--- a/src/apprt/gtk-ng/class/window.zig
+++ b/src/apprt/gtk-ng/class/window.zig
@@ -142,6 +142,34 @@ pub const Window = extern struct {
         self.as(gtk.Window).close();
     }
 
+    fn surfaceToggleFullscreen(
+        surface: *Surface,
+        self: *Self,
+    ) callconv(.c) void {
+        _ = surface;
+        if (self.as(gtk.Window).isMaximized() != 0) {
+            self.as(gtk.Window).unmaximize();
+        } else {
+            self.as(gtk.Window).maximize();
+        }
+
+        // We react to the changes in the propFullscreen callback
+    }
+
+    fn surfaceToggleMaximize(
+        surface: *Surface,
+        self: *Self,
+    ) callconv(.c) void {
+        _ = surface;
+        if (self.as(gtk.Window).isMaximized() != 0) {
+            self.as(gtk.Window).unmaximize();
+        } else {
+            self.as(gtk.Window).maximize();
+        }
+
+        // We react to the changes in the propMaximized callback
+    }
+
     fn actionAbout(
         _: *gio.SimpleAction,
         _: ?*glib.Variant,
@@ -219,6 +247,8 @@ pub const Window = extern struct {
 
             // Template Callbacks
             class.bindTemplateCallback("surface_close_request", &surfaceCloseRequest);
+            class.bindTemplateCallback("surface_toggle_fullscreen", &surfaceToggleFullscreen);
+            class.bindTemplateCallback("surface_toggle_maximize", &surfaceToggleMaximize);
 
             // Virtual methods
             gobject.Object.virtual_methods.dispose.implement(class, &dispose);

--- a/src/apprt/gtk-ng/class/window.zig
+++ b/src/apprt/gtk-ng/class/window.zig
@@ -132,11 +132,11 @@ pub const Window = extern struct {
 
     fn surfaceCloseRequest(
         surface: *Surface,
-        process_active: bool,
+        scope: *const Surface.CloseScope,
         self: *Self,
     ) callconv(.c) void {
         // Todo
-        _ = process_active;
+        _ = scope;
 
         assert(surface == self.private().surface);
         self.as(gtk.Window).close();

--- a/src/apprt/gtk-ng/ui/1.5/window.blp
+++ b/src/apprt/gtk-ng/ui/1.5/window.blp
@@ -29,6 +29,7 @@ template $GhosttyWindow: Adw.ApplicationWindow {
           icon-name: "open-menu-symbolic";
           menu-model: main_menu;
           tooltip-text: _("Main Menu");
+          can-focus: false;
         }
       }
     }

--- a/src/apprt/gtk-ng/ui/1.5/window.blp
+++ b/src/apprt/gtk-ng/ui/1.5/window.blp
@@ -9,7 +9,6 @@ template $GhosttyWindow: Adw.ApplicationWindow {
   notify::config => $notify_config();
   notify::fullscreened => $notify_fullscreened();
   notify::maximized => $notify_maximized();
-
   default-width: 800;
   default-height: 600;
   // GTK4 grabs F10 input by default to focus the menubar icon. We want

--- a/src/apprt/gtk-ng/ui/1.5/window.blp
+++ b/src/apprt/gtk-ng/ui/1.5/window.blp
@@ -40,6 +40,8 @@ template $GhosttyWindow: Adw.ApplicationWindow {
 
     $GhosttySurface surface {
       close-request => $surface_close_request();
+      toggle-fullscreen => $surface_toggle_fullscreen();
+      toggle-maximize => $surface_toggle_maximize();
     }
   };
 }

--- a/src/apprt/gtk-ng/ui/1.5/window.blp
+++ b/src/apprt/gtk-ng/ui/1.5/window.blp
@@ -8,10 +8,30 @@ template $GhosttyWindow: Adw.ApplicationWindow {
 
   default-width: 800;
   default-height: 600;
+  // GTK4 grabs F10 input by default to focus the menubar icon. We want
+  // to disable this so that terminal programs can capture F10 (such as htop)
+  handle-menubar-accel: false;
+  // A default, this will get overwritten by the terminal application
+  // pretty quickly, usually.
+  title: "Ghostty";
 
-  content: Gtk.Box {
+  content: Box {
     orientation: vertical;
-    spacing: 0;
+
+    Adw.HeaderBar {
+      title-widget: Adw.WindowTitle {
+        title: bind surface.title;
+      };
+
+      [end]
+      Gtk.Box {
+        Gtk.MenuButton {
+          icon-name: "open-menu-symbolic";
+          menu-model: main_menu;
+          tooltip-text: _("Main Menu");
+        }
+      }
+    }
 
     $GhosttyDebugWarning {
       visible: bind template.debug;
@@ -21,4 +41,141 @@ template $GhosttyWindow: Adw.ApplicationWindow {
       close-request => $surface_close_request();
     }
   };
+}
+
+menu split_menu {
+  item {
+    label: _("Split Up");
+    action: "win.split-up";
+  }
+
+  item {
+    label: _("Split Down");
+    action: "win.split-down";
+  }
+
+  item {
+    label: _("Split Left");
+    action: "win.split-left";
+  }
+
+  item {
+    label: _("Split Right");
+    action: "win.split-right";
+  }
+}
+
+menu main_menu {
+  section {
+    item {
+      label: _("Copy");
+      action: "win.copy";
+    }
+
+    item {
+      label: _("Paste");
+      action: "win.paste";
+    }
+  }
+
+  section {
+    item {
+      label: _("New Window");
+      action: "win.new-window";
+    }
+
+    item {
+      label: _("Close Window");
+      action: "win.close";
+    }
+  }
+
+  section {
+    item {
+      label: _("New Tab");
+      action: "win.new-tab";
+    }
+
+    item {
+      label: _("Close Tab");
+      action: "win.close-tab";
+    }
+  }
+
+  section {
+    submenu {
+      label: _("Split");
+
+      item {
+        label: _("Change Title…");
+        action: "win.prompt-title";
+      }
+
+      item {
+        label: _("Split Up");
+        action: "win.split-up";
+      }
+
+      item {
+        label: _("Split Down");
+        action: "win.split-down";
+      }
+
+      item {
+        label: _("Split Left");
+        action: "win.split-left";
+      }
+
+      item {
+        label: _("Split Right");
+        action: "win.split-right";
+      }
+    }
+  }
+
+  section {
+    item {
+      label: _("Clear");
+      action: "win.clear";
+    }
+
+    item {
+      label: _("Reset");
+      action: "win.reset";
+    }
+  }
+
+  section {
+    item {
+      label: _("Command Palette");
+      action: "win.toggle-command-palette";
+    }
+
+    item {
+      label: _("Terminal Inspector");
+      action: "win.toggle-inspector";
+    }
+
+    item {
+      label: _("Open Configuration");
+      action: "app.open-config";
+    }
+
+    item {
+      label: _("Reload Configuration");
+      action: "app.reload-config";
+    }
+  }
+
+  section {
+    item {
+      label: _("About Ghostty");
+      action: "win.about";
+    }
+
+    item {
+      label: _("Quit");
+      action: "app.quit";
+    }
+  }
 }

--- a/src/apprt/gtk-ng/ui/1.5/window.blp
+++ b/src/apprt/gtk-ng/ui/1.5/window.blp
@@ -6,6 +6,7 @@ template $GhosttyWindow: Adw.ApplicationWindow {
     "window",
   ]
 
+  notify::config => $notify_config();
   notify::fullscreened => $notify_fullscreened();
   notify::maximized => $notify_maximized();
 

--- a/src/apprt/gtk-ng/ui/1.5/window.blp
+++ b/src/apprt/gtk-ng/ui/1.5/window.blp
@@ -6,6 +6,9 @@ template $GhosttyWindow: Adw.ApplicationWindow {
     "window",
   ]
 
+  notify::fullscreened => $notify_fullscreened();
+  notify::maximized => $notify_maximized();
+
   default-width: 800;
   default-height: 600;
   // GTK4 grabs F10 input by default to focus the menubar icon. We want
@@ -19,6 +22,8 @@ template $GhosttyWindow: Adw.ApplicationWindow {
     orientation: vertical;
 
     Adw.HeaderBar {
+      visible: bind template.headerbar-visible;
+
       title-widget: Adw.WindowTitle {
         title: bind surface.title;
       };

--- a/src/apprt/gtk-ng/ui/1.5/window.blp
+++ b/src/apprt/gtk-ng/ui/1.5/window.blp
@@ -14,9 +14,7 @@ template $GhosttyWindow: Adw.ApplicationWindow {
   // GTK4 grabs F10 input by default to focus the menubar icon. We want
   // to disable this so that terminal programs can capture F10 (such as htop)
   handle-menubar-accel: false;
-  // A default, this will get overwritten by the terminal application
-  // pretty quickly, usually.
-  title: "Ghostty";
+  title: bind (template.active-surface as <$GhosttySurface>).title;
 
   content: Box {
     orientation: vertical;
@@ -25,12 +23,13 @@ template $GhosttyWindow: Adw.ApplicationWindow {
       visible: bind template.headerbar-visible;
 
       title-widget: Adw.WindowTitle {
-        title: bind surface.title;
+        title: bind (template.active-surface as <$GhosttySurface>).title;
       };
 
       [end]
       Gtk.Box {
         Gtk.MenuButton {
+          notify::active => $notify_menu_active();
           icon-name: "open-menu-symbolic";
           menu-model: main_menu;
           tooltip-text: _("Main Menu");

--- a/src/apprt/gtk-ng/ui/1.5/window.blp
+++ b/src/apprt/gtk-ng/ui/1.5/window.blp
@@ -6,6 +6,7 @@ template $GhosttyWindow: Adw.ApplicationWindow {
     "window",
   ]
 
+  close-request => $close_request();
   notify::config => $notify_config();
   notify::fullscreened => $notify_fullscreened();
   notify::maximized => $notify_maximized();

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -25,14 +25,8 @@
    fun:load_from_stream
    fun:gdk_pixbuf_new_from_stream_at_scale
    fun:gtk_make_symbolic_pixbuf_from_data
-   fun:gdk_texture_new_from_filename_symbolic
-   fun:icon_ensure_texture__locked.isra.0
-   fun:load_icon_thread
-   fun:g_task_thread_pool_thread
-   fun:g_thread_pool_thread_proxy
-   fun:g_thread_proxy
-   fun:start_thread
-   fun:thread_start
+   fun:gdk_texture_new_*
+   ...
 }
 
 {
@@ -44,15 +38,7 @@
    fun:gdk_pixbuf_loader_close
    fun:load_from_stream
    fun:gdk_pixbuf_new_from_stream_at_scale
-   fun:gtk_make_symbolic_pixbuf_from_data
-   fun:gdk_texture_new_from_filename_symbolic
-   fun:icon_ensure_texture__locked.isra.0
-   fun:load_icon_thread
-   fun:g_task_thread_pool_thread
-   fun:g_thread_pool_thread_proxy
-   fun:g_thread_proxy
-   fun:start_thread
-   fun:thread_start
+   ...
 }
 
 {
@@ -178,13 +164,43 @@
    fun:signal_emit_valist_unlocked
    fun:g_signal_emit_valist
    fun:g_signal_emit
-   fun:gdk_frame_clock_paint_idle
+   fun:gdk_frame_clock_*
    ...
    fun:g_timeout_dispatch
    fun:g_main_context_dispatch_unlocked
    fun:g_main_context_iterate_unlocked.isra.0
    fun:g_main_context_iteration
   ...
+}
+{
+   GSK GPU Rendering Another Form
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:gsk_gpu_render_pass_op_gl_command
+   fun:gsk_gl_frame_submit
+   fun:gsk_gpu_renderer_render
+   fun:gsk_renderer_render
+   fun:gtk_widget_render
+   fun:surface_render
+   fun:_gdk_marshal_BOOLEAN__BOXEDv
+   fun:_g_closure_invoke_va
+   fun:signal_emit_valist_unlocked
+   fun:g_signal_emit_valist
+   fun:g_signal_emit
+   fun:gdk_surface_paint_on_clock
+   fun:g_closure_invoke
+   fun:signal_emit_unlocked_R.isra.0
+   fun:signal_emit_valist_unlocked
+   fun:g_signal_emit_valist
+   fun:g_signal_emit
+   fun:gdk_frame_clock_*
+   ...
+   fun:g_timeout_dispatch
+   fun:g_main_context_dispatch_unlocked
+   fun:g_main_context_iterate_unlocked.isra.0
+   fun:g_main_context_iteration
+   ...
 }
 {
    GTK Shader Selector
@@ -220,6 +236,31 @@
    ...
 }
 
+{
+   Another tooltip
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:gtk_string_accessible_value_new
+   fun:gtk_accessible_update_property
+   fun:gtk_label_set_text_internal
+   fun:gtk_label_set_markup_internal
+   fun:gtk_label_recalculate
+   fun:gtk_label_set_markup
+   fun:gtk_tooltip_window_set_label_markup
+   fun:gtk_widget_real_query_tooltip
+   fun:_gtk_marshal_BOOLEAN__INT_INT_BOOLEAN_OBJECTv
+   fun:g_type_class_meta_marshalv
+   fun:_g_closure_invoke_va
+   fun:signal_emit_valist_unlocked
+   fun:g_signal_emit_valist
+   fun:g_signal_emit
+   fun:gtk_widget_query_tooltip
+   fun:gtk_tooltip_run_requery
+   fun:gtk_tooltip_handle_event_internal
+   fun:_gtk_tooltip_handle_event
+  ...
+}
 {
    Not sure about this one, I can't figure it out.
    Memcheck:Leak
@@ -282,6 +323,32 @@
 }
 
 {
+   GTK FontConfig
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:FcFontSet*
+   fun:FcFontSet*
+   fun:sort_in_thread.isra.0
+   fun:fc_thread_func
+   fun:g_thread_proxy
+   fun:start_thread
+   fun:thread_start
+}
+
+{
+   GTK FontConfig
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:strdup
+   fun:FcValueSave
+   fun:FcConfigEvaluate
+   fun:FcConfigValues
+   ...
+}
+
+{
    GTK init 
    Memcheck:Leak
    match-leak-kinds: possible
@@ -339,6 +406,17 @@
    fun:RegisterStubCallbacks
    fun:__glDispatchRegisterStubCallbacks
    fun:__libGLInit
+   ...
+}
+
+{
+   pango and fontconfig
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:*alloc
+   ...
+   fun:FcChar*
+   fun:pango_fc_coverage_real_get
    ...
 }
 

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -14,6 +14,48 @@
 # and quitting. Otherwise, we leave a number of GTK resources around.
 
 {
+   GDK SVG Loading Leaks
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   fun:rsvg_*
+   ...
+   fun:gdk_pixbuf_loader_close
+   fun:load_from_stream
+   fun:gdk_pixbuf_new_from_stream_at_scale
+   fun:gtk_make_symbolic_pixbuf_from_data
+   fun:gdk_texture_new_from_filename_symbolic
+   fun:icon_ensure_texture__locked.isra.0
+   fun:load_icon_thread
+   fun:g_task_thread_pool_thread
+   fun:g_thread_pool_thread_proxy
+   fun:g_thread_proxy
+   fun:start_thread
+   fun:thread_start
+}
+
+{
+   GDK SVG Loading Touches Undefined Memory
+   Memcheck:Cond
+   ...
+   fun:rsvg_handle_get_pixbuf_and_error
+   ...
+   fun:gdk_pixbuf_loader_close
+   fun:load_from_stream
+   fun:gdk_pixbuf_new_from_stream_at_scale
+   fun:gtk_make_symbolic_pixbuf_from_data
+   fun:gdk_texture_new_from_filename_symbolic
+   fun:icon_ensure_texture__locked.isra.0
+   fun:load_icon_thread
+   fun:g_task_thread_pool_thread
+   fun:g_thread_pool_thread_proxy
+   fun:g_thread_proxy
+   fun:start_thread
+   fun:thread_start
+}
+
+{
    GDK Drag and Drop Leaks Data
    Memcheck:Leak
    match-leak-kinds: definite


### PR DESCRIPTION
This ports over a basic headerbar, maximize, and fullscreen. The headerbar only has the main menu button for now since we have no tabbing or splits. The main menu has the full main menu that mainline GTK has but most of it is disabled since we don't implement the actions yet. 

I didn't use anything from your branch @tristan957 so I didn't add coauthor but I want to note that @tristan957 worked on this as well and I suspect there's overlap.