### PR TITLE
Upgrade hustcer/milestone-action to v2.9

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -15,7 +15,7 @@ jobs:
     name: Milestone Update
     steps:
       - name: Set Milestone for PR
-        uses: hustcer/milestone-action@09bdc6fda0f43a4df28cda5815cc47df74cfdba7 # v2.8
+        uses: hustcer/milestone-action@b57a7e52e9913b6b0cdefb10add762af0398659d # v2.9
         if: github.event.pull_request.merged == true
         with:
           action: bind-pr # `bind-pr` is the default action
@@ -24,7 +24,7 @@ jobs:
 
       # Bind milestone to closed issue that has a merged PR fix
       - name: Set Milestone for Issue
-        uses: hustcer/milestone-action@09bdc6fda0f43a4df28cda5815cc47df74cfdba7 # v2.8
+        uses: hustcer/milestone-action@b57a7e52e9913b6b0cdefb10add762af0398659d # v2.9
         if: github.event.issue.state == 'closed'
         with:
           action: bind-issue


### PR DESCRIPTION
Upgrade [hustcer/milestone-action](https://github.com/hustcer/milestone-action) to v2.9, [Release Detail](https://github.com/hustcer/milestone-action/releases/tag/v2.9)

Fix the deprecated warning here: https://github.com/ghostty-org/ghostty/actions/runs/16531137360/job/46756561930#step:3:37