### PR TITLE
apprt/gtk-ng: configuration reloading, toasts

### DIFF
--- a/src/apprt/gtk-ng/class/clipboard_confirmation_dialog.zig
+++ b/src/apprt/gtk-ng/class/clipboard_confirmation_dialog.zig
@@ -59,12 +59,7 @@ pub const ClipboardConfirmationDialog = extern struct {
                 .{
                     .nick = "Request",
                     .blurb = "The clipboard request.",
-                    .accessor = gobject.ext.privateFieldAccessor(
-                        Self,
-                        Private,
-                        &Private.offset,
-                        "request",
-                    ),
+                    .accessor = C.privateBoxedFieldAccessor("request"),
                 },
             );
         };
@@ -78,12 +73,7 @@ pub const ClipboardConfirmationDialog = extern struct {
                 .{
                     .nick = "Clipboard Contents",
                     .blurb = "The clipboard contents being read/written.",
-                    .accessor = gobject.ext.privateFieldAccessor(
-                        Self,
-                        Private,
-                        &Private.offset,
-                        "clipboard_contents",
-                    ),
+                    .accessor = C.privateObjFieldAccessor("clipboard_contents"),
                 },
             );
         };

--- a/src/apprt/gtk-ng/class/surface.zig
+++ b/src/apprt/gtk-ng/class/surface.zig
@@ -275,7 +275,10 @@ pub const Surface = extern struct {
             const impl = gobject.ext.defineSignal(
                 name,
                 Self,
-                &.{},
+                &.{
+                    apprt.Clipboard,
+                    [*:0]const u8,
+                },
                 void,
             );
         };
@@ -2236,7 +2239,7 @@ const Clipboard = struct {
             Surface.signals.@"clipboard-write".impl.emit(
                 self,
                 null,
-                .{},
+                .{ clipboard_type, val.ptr },
                 null,
             );
 

--- a/src/apprt/gtk-ng/class/surface.zig
+++ b/src/apprt/gtk-ng/class/surface.zig
@@ -50,12 +50,7 @@ pub const Surface = extern struct {
                 .{
                     .nick = "Config",
                     .blurb = "The configuration that this surface is using.",
-                    .accessor = gobject.ext.privateFieldAccessor(
-                        Self,
-                        Private,
-                        &Private.offset,
-                        "config",
-                    ),
+                    .accessor = C.privateObjFieldAccessor("config"),
                 },
             );
         };
@@ -89,12 +84,7 @@ pub const Surface = extern struct {
                 .{
                     .nick = "Desired Font Size",
                     .blurb = "The desired font size, only affects initialization.",
-                    .accessor = gobject.ext.privateFieldAccessor(
-                        Self,
-                        Private,
-                        &Private.offset,
-                        "font_size_request",
-                    ),
+                    .accessor = C.privateBoxedFieldAccessor("font_size_request"),
                 },
             );
         };

--- a/src/apprt/gtk-ng/class/surface.zig
+++ b/src/apprt/gtk-ng/class/surface.zig
@@ -1193,6 +1193,14 @@ pub const Surface = extern struct {
         return self.private().pwd;
     }
 
+    /// Change the configuration for this surface.
+    pub fn setConfig(self: *Self, config: *Config) void {
+        const priv = self.private();
+        if (priv.config) |c| c.unref();
+        priv.config = config.ref();
+        self.as(gobject.Object).notifyByPspec(properties.config.impl.param_spec);
+    }
+
     fn propConfig(
         self: *Self,
         _: *gobject.ParamSpec,

--- a/src/apprt/gtk-ng/class/surface_child_exited.zig
+++ b/src/apprt/gtk-ng/class/surface_child_exited.zig
@@ -42,12 +42,7 @@ const SurfaceChildExitedBanner = extern struct {
                 .{
                     .nick = "Data",
                     .blurb = "The child exit data.",
-                    .accessor = gobject.ext.privateFieldAccessor(
-                        Self,
-                        Private,
-                        &Private.offset,
-                        "data",
-                    ),
+                    .accessor = C.privateBoxedFieldAccessor("data"),
                 },
             );
         };

--- a/src/apprt/gtk-ng/class/window.zig
+++ b/src/apprt/gtk-ng/class/window.zig
@@ -8,6 +8,7 @@ const gobject = @import("gobject");
 const gtk = @import("gtk");
 
 const i18n = @import("../../../os/main.zig").i18n;
+const apprt = @import("../../../apprt.zig");
 const input = @import("../../../input.zig");
 const CoreSurface = @import("../../../Surface.zig");
 const gtk_version = @import("../gtk_version.zig");
@@ -122,7 +123,8 @@ pub const Window = extern struct {
         config: ?*Config = null,
 
         // Template bindings
-        surface: *Surface = undefined,
+        surface: *Surface,
+        toast_overlay: *adw.ToastOverlay,
 
         pub var offset: c_int = 0;
     };
@@ -227,6 +229,18 @@ pub const Window = extern struct {
         };
     }
 
+    /// Queue a simple text-based toast. All text-based toasts share the
+    /// same timeout for consistency.
+    ///
+    // This is not `pub` because we should be using signals emitted by
+    // other widgets to trigger our toasts. Other objects should not
+    // trigger toasts directly.
+    fn addToast(self: *Window, title: [*:0]const u8) void {
+        const toast = adw.Toast.new(title);
+        toast.setTimeout(3);
+        self.private().toast_overlay.addToast(toast);
+    }
+
     //---------------------------------------------------------------
     // Properties
 
@@ -264,6 +278,7 @@ pub const Window = extern struct {
         _: *gobject.ParamSpec,
         self: *Self,
     ) callconv(.c) void {
+        self.addToast(i18n._("Reloaded the configuration"));
         self.syncAppearance();
     }
 
@@ -375,6 +390,29 @@ pub const Window = extern struct {
         self: *Self,
     ) callconv(.c) void {
         self.as(gtk.Window).destroy();
+    }
+
+    fn surfaceClipboardWrite(
+        _: *Surface,
+        clipboard_type: apprt.Clipboard,
+        text: [*:0]const u8,
+        self: *Self,
+    ) callconv(.c) void {
+        // We only toast for the standard clipboard.
+        if (clipboard_type != .standard) return;
+
+        // We only toast if configured to
+        const priv = self.private();
+        const config_obj = priv.config orelse return;
+        const config = config_obj.get();
+        if (!config.@"app-notifications".@"clipboard-copy") {
+            return;
+        }
+
+        if (text[0] != 0)
+            self.addToast(i18n._("Copied to clipboard"))
+        else
+            self.addToast(i18n._("Cleared clipboard"));
     }
 
     fn surfaceCloseRequest(
@@ -542,9 +580,11 @@ pub const Window = extern struct {
 
             // Bindings
             class.bindTemplateChildPrivate("surface", .{});
+            class.bindTemplateChildPrivate("toast_overlay", .{});
 
             // Template Callbacks
             class.bindTemplateCallback("close_request", &windowCloseRequest);
+            class.bindTemplateCallback("surface_clipboard_write", &surfaceClipboardWrite);
             class.bindTemplateCallback("surface_close_request", &surfaceCloseRequest);
             class.bindTemplateCallback("surface_toggle_fullscreen", &surfaceToggleFullscreen);
             class.bindTemplateCallback("surface_toggle_maximize", &surfaceToggleMaximize);

--- a/src/apprt/gtk-ng/class/window.zig
+++ b/src/apprt/gtk-ng/class/window.zig
@@ -69,12 +69,7 @@ pub const Window = extern struct {
                 .{
                     .nick = "Config",
                     .blurb = "The configuration that this surface is using.",
-                    .accessor = gobject.ext.privateFieldAccessor(
-                        Self,
-                        Private,
-                        &Private.offset,
-                        "config",
-                    ),
+                    .accessor = C.privateObjFieldAccessor("config"),
                 },
             );
         };

--- a/src/apprt/gtk-ng/ui/1.5/window.blp
+++ b/src/apprt/gtk-ng/ui/1.5/window.blp
@@ -43,10 +43,13 @@ template $GhosttyWindow: Adw.ApplicationWindow {
       visible: bind template.debug;
     }
 
-    $GhosttySurface surface {
-      close-request => $surface_close_request();
-      toggle-fullscreen => $surface_toggle_fullscreen();
-      toggle-maximize => $surface_toggle_maximize();
+    Adw.ToastOverlay toast_overlay {
+      $GhosttySurface surface {
+        close-request => $surface_close_request();
+        clipboard-write => $surface_clipboard_write();
+        toggle-fullscreen => $surface_toggle_fullscreen();
+        toggle-maximize => $surface_toggle_maximize();
+      }
     }
   };
 }

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -353,8 +353,7 @@
    match-leak-kinds: possible
    fun:*alloc
    fun:FcFontSet*
-   fun:FcFontSet*
-   fun:sort_in_thread.isra.0
+   ...
    fun:fc_thread_func
    fun:g_thread_proxy
    fun:start_thread


### PR DESCRIPTION
This brings in configuration reloading and toasts to gtk-ng. 

Config reloading is fairly different in ng than legacy because we rely on our GObject `Config` class and ref counting more heavily. We rely on various property bindings and notify signals to propagate configuration changes out to all subscribers. Previously we manually had to chain this together. 

Toasts are straightforward, with the main difference being that the window owns its own toasts (surfaces can't trigger them) and triggers them via signal emission. 