### PR TITLE
feat: add option to disable the "Reloaded the configuration" notification

### DIFF
--- a/src/apprt/gtk-ng/class/window.zig
+++ b/src/apprt/gtk-ng/class/window.zig
@@ -306,7 +306,16 @@ pub const Window = extern struct {
         _: *gobject.ParamSpec,
         self: *Self,
     ) callconv(.c) void {
-        self.addToast(i18n._("Reloaded the configuration"));
+        // We only toast if configured to
+        const priv = self.private();
+        const config_obj = priv.config orelse {
+            self.syncAppearance();
+            return;
+        };
+        const config = config_obj.get();
+        if (config.@"app-notifications".@"config-reload") {
+            self.addToast(i18n._("Reloaded the configuration"));
+        }
         self.syncAppearance();
     }
 

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -772,7 +772,9 @@ pub fn focusCurrentTab(self: *Window) void {
 }
 
 pub fn onConfigReloaded(self: *Window) void {
-    self.sendToast(i18n._("Reloaded the configuration"));
+    if (self.app.config.@"app-notifications".@"config-reload") {
+        self.sendToast(i18n._("Reloaded the configuration"));
+    }
 }
 
 pub fn sendToast(self: *Window, title: [*:0]const u8) void {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2467,6 +2467,8 @@ keybind: Keybinds = .{},
 ///
 ///   - `clipboard-copy` (default: true) - Show a notification when text is copied
 ///     to the clipboard.
+///   - `config-reload` (default: true) - Show a notification when
+///     the configuration is reloaded.
 ///
 /// To specify a notification to enable, specify the name of the notification.
 /// To specify a notification to disable, prefix the name with `no-`. For
@@ -6950,6 +6952,7 @@ pub const GtkToolbarStyle = enum {
 /// See app-notifications
 pub const AppNotifications = packed struct {
     @"clipboard-copy": bool = true,
+    @"config-reload": bool = true,
 };
 
 /// See bell-features


### PR DESCRIPTION
These changes were discussed in #8048.

The option defaults to `true` for backwards compatibility.

**NOTE:** I was feeling a bit lazy and didn't want to setup Nix (always a pain on Windows), so I decided to take this chance to try the Copilot agent for the first time, using just the GitHub web UI. I hope that's okay given the small scope of these changes!