### PR TITLE
macOS: update Float on Top menu icon to `square.filled.on.square`

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -493,7 +493,7 @@ class AppDelegate: NSObject,
         self.menuMoveSplitDividerDown?.setImageIfDesired(systemSymbolName: "arrow.down.to.line")
         self.menuMoveSplitDividerLeft?.setImageIfDesired(systemSymbolName: "arrow.left.to.line")
         self.menuMoveSplitDividerRight?.setImageIfDesired(systemSymbolName: "arrow.right.to.line")
-        self.menuFloatOnTop?.setImageIfDesired(systemSymbolName: "square.3.layers.3d.top.filled")
+        self.menuFloatOnTop?.setImageIfDesired(systemSymbolName: "square.filled.on.square")
     }
 
     /// Sync all of our menu item keyboard shortcuts with the Ghostty configuration.


### PR DESCRIPTION
Address a minor UI confusion introduced by #7594.

Ghostty's "Float on Top" action icon uses `square.3.layers.3d.top.filled`, which is the same as macOS's "Bring All to Front" action. This may cause confusion.

Before:
<img width="333" height="156" alt="image" src="https://github.com/user-attachments/assets/5148909c-f090-4b2f-8206-c45cb30cf30e" />

After:
<img width="336" height="148" alt="image" src="https://github.com/user-attachments/assets/3c3a820f-ece3-4778-af47-767758c23266" />
