### PR TITLE
gtk-ng: fix up background of resize and url overlays

### DIFF
--- a/src/apprt/gtk-ng/css/style.css
+++ b/src/apprt/gtk-ng/css/style.css
@@ -29,12 +29,12 @@ label.url-overlay.right {
 /*
  * GhosttySurface resize overlay
  */
-.size-overlay label {
+label.resize-overlay {
   padding: 4px 8px 4px 8px;
   border-radius: 6px 6px 6px 6px;
   outline-style: solid;
-  outline-width: 1px;
   outline-color: #555555;
+  outline-width: 1px;
 }
 
 /*

--- a/src/apprt/gtk-ng/ui/1.2/resize-overlay.blp
+++ b/src/apprt/gtk-ng/ui/1.2/resize-overlay.blp
@@ -11,6 +11,11 @@ template $GhosttyResizeOverlay: Adw.Bin {
   // See surface.blp for why we need to wrap this.
   Adw.Bin {
     Label label {
+      styles [
+        "background",
+        "resize-overlay",
+      ]
+
       focusable: false;
       focus-on-click: false;
       justify: center;

--- a/src/apprt/gtk-ng/ui/1.2/surface.blp
+++ b/src/apprt/gtk-ng/ui/1.2/surface.blp
@@ -47,15 +47,12 @@ template $GhosttySurface: Adw.Bin {
     }
 
     [overlay]
-    $GhosttyResizeOverlay resize_overlay {
-      styles [
-        "size-overlay",
-      ]
-    }
+    $GhosttyResizeOverlay resize_overlay {}
 
     [overlay]
     Label url_left {
       styles [
+        "background",
         "url-overlay",
       ]
 
@@ -73,6 +70,7 @@ template $GhosttySurface: Adw.Bin {
     [overlay]
     Label url_right {
       styles [
+        "background",
         "url-overlay",
       ]
 


### PR DESCRIPTION
PR #8088 had the unexpected side-effect of making the resize and url overlays transparent as well. This PR fixes that.