### PR TITLE
macos: fix quick terminal fullscreen crash bug

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -223,7 +223,7 @@ class QuickTerminalController: BaseTerminalController {
               visible,
               !isHandlingResize else { return }
         guard let screen = window.screen ?? NSScreen.main else { return }
-        
+
         // Prevent recursive loops
         isHandlingResize = true
         defer { isHandlingResize = false }
@@ -481,6 +481,12 @@ class QuickTerminalController: BaseTerminalController {
     }
 
     private func animateWindowOut(window: NSWindow, to position: QuickTerminalPosition) {
+        // If we are in fullscreen, then we exit fullscreen. We do this immediately so
+        // we have th correct window.frame for the save state below.
+        if let fullscreenStyle, fullscreenStyle.isFullscreen {
+            fullscreenStyle.exit()
+        }
+
         // Save the current window frame before animating out. This preserves
         // the user's preferred window size and position for when the quick
         // terminal is reactivated with a new surface. Without this, SwiftUI
@@ -502,11 +508,6 @@ class QuickTerminalController: BaseTerminalController {
 
         // We always animate out to whatever screen the window is actually on.
         guard let screen = window.screen ?? NSScreen.main else { return }
-
-        // If we are in fullscreen, then we exit fullscreen.
-        if let fullscreenStyle, fullscreenStyle.isFullscreen {
-            fullscreenStyle.exit()
-        }
 
         // If we have a previously active application, restore focus to it. We
         // do this BEFORE the animation below because when the animation completes

--- a/macos/Sources/Helpers/Fullscreen.swift
+++ b/macos/Sources/Helpers/Fullscreen.swift
@@ -407,8 +407,14 @@ class NonNativeFullscreen: FullscreenBase, FullscreenStyle {
             self.styleMask = window.styleMask
             self.toolbar = window.toolbar
             self.toolbarStyle = window.toolbarStyle
-            self.titlebarAccessoryViewControllers = window.titlebarAccessoryViewControllers
             self.dock = window.screen?.hasDock ?? false
+            
+            self.titlebarAccessoryViewControllers = if (window.hasTitleBar) {
+                // Accessing titlebarAccessoryViewControllers without a titlebar triggers a crash.
+                window.titlebarAccessoryViewControllers
+            } else {
+                []
+            }
 
             if let cgWindowId = window.cgWindowId {
                 // We hide the menu only if this window is not on any fullscreen


### PR DESCRIPTION
Fullscreen on quick terminal was failing with a crash, when it tried
to save the state of a non-existent toolbar and its accessory view
controllers.

See #7980 
