### PR TITLE
apprt/gtk-ng: surface has correct initial size

### DIFF
--- a/src/apprt/gtk-ng/class/application.zig
+++ b/src/apprt/gtk-ng/class/application.zig
@@ -556,6 +556,13 @@ pub const Application = extern struct {
             .toggle_quick_terminal,
             .toggle_command_palette,
             .open_url,
+            => {
+                log.warn("unimplemented action={}", .{action});
+                return false;
+            },
+
+            // Unimplemented
+            .secure_input,
             .close_all_windows,
             .float_window,
             .toggle_visibility,
@@ -568,13 +575,6 @@ pub const Application = extern struct {
             .check_for_updates,
             .undo,
             .redo,
-            => {
-                log.warn("unimplemented action={}", .{action});
-                return false;
-            },
-
-            // Unimplemented
-            .secure_input,
             => {
                 log.warn("unimplemented action={}", .{action});
                 return false;


### PR DESCRIPTION
Ensure the surface has a correct initial size when created. This avoids a rapid resize event and also the pty reports the correct size for startup scripts.

This is a departure from macOS and legacy GTK. This has been an issue in Ghostty for awhile so this is the proper path forward.

This works by deferring Surface initialization until the first resize event. This MIGHT result in a frame or two not rendering but I haven't noticed anything visually and having the correct size is far more important.