### PR TITLE
macOS: Add macos-dock-drop-folder-behavior (new tab or window) configuration option

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -405,14 +405,6 @@ class AppDelegate: NSObject,
             // When opening a directory, check the configuration to decide
             // whether to open in a new tab or new window.
             config.workingDirectory = filename
-            
-            let behavior = ghostty.config.macosDockDropFolderBehavior
-            if behavior == .window {
-                _ = TerminalController.newWindow(ghostty, withBaseConfig: config)
-            } else {
-                // Default to tab behavior
-                _ = TerminalController.newTab(ghostty, withBaseConfig: config)
-            }
         } else {
             // When opening a file, we want to execute the file. To do this, we
             // don't override the command directly, because it won't load the
@@ -424,8 +416,11 @@ class AppDelegate: NSObject,
             // Set the parent directory to our working directory so that relative
             // paths in scripts work.
             config.workingDirectory = (filename as NSString).deletingLastPathComponent
-
-            _ = TerminalController.newWindow(ghostty, withBaseConfig: config)
+        }
+        
+        switch ghostty.config.macosDockDropBehavior {
+        case .new_tab: _ = TerminalController.newTab(ghostty, withBaseConfig: config)
+        case .new_window: _ = TerminalController.newWindow(ghostty, withBaseConfig: config)
         }
 
         return true

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -402,11 +402,17 @@ class AppDelegate: NSObject,
         var config = Ghostty.SurfaceConfiguration()
 
         if (isDirectory.boolValue) {
-            // When opening a directory, create a new tab in the main
-            // window with that as the working directory.
-            // If no windows exist, a new one will be created.
+            // When opening a directory, check the configuration to decide
+            // whether to open in a new tab or new window.
             config.workingDirectory = filename
-            _ = TerminalController.newTab(ghostty, withBaseConfig: config)
+            
+            let behavior = ghostty.config.macosDockDropFolderBehavior
+            if behavior == .window {
+                _ = TerminalController.newWindow(ghostty, withBaseConfig: config)
+            } else {
+                // Default to tab behavior
+                _ = TerminalController.newTab(ghostty, withBaseConfig: config)
+            }
         } else {
             // When opening a file, we want to execute the file. To do this, we
             // don't override the command directly, because it won't load the

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -282,15 +282,15 @@ extension Ghostty {
             return MacOSTitlebarProxyIcon(rawValue: str) ?? defaultValue
         }
 
-        var macosDockDropFolderBehavior: MacOSDockDropFolderBehavior {
-            let defaultValue = MacOSDockDropFolderBehavior.tab
+        var macosDockDropBehavior: MacDockDropBehavior {
+            let defaultValue = MacDockDropBehavior.new_tab
             guard let config = self.config else { return defaultValue }
             var v: UnsafePointer<Int8>? = nil
-            let key = "macos-dock-drop-folder-behavior"
+            let key = "macos-dock-drop-behavior"
             guard ghostty_config_get(config, &v, key, UInt(key.count)) else { return defaultValue }
             guard let ptr = v else { return defaultValue }
             let str = String(cString: ptr)
-            return MacOSDockDropFolderBehavior(rawValue: str) ?? defaultValue
+            return MacDockDropBehavior(rawValue: str) ?? defaultValue
         }
 
         var macosWindowShadow: Bool {
@@ -617,6 +617,11 @@ extension Ghostty.Config {
         static let audio = BellFeatures(rawValue: 1 << 1)
         static let attention = BellFeatures(rawValue: 1 << 2)
         static let title = BellFeatures(rawValue: 1 << 3)
+    }
+    
+    enum MacDockDropBehavior: String {
+        case new_tab = "new-tab"
+        case new_window = "new-window"
     }
 
     enum MacHidden : String {

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -282,6 +282,17 @@ extension Ghostty {
             return MacOSTitlebarProxyIcon(rawValue: str) ?? defaultValue
         }
 
+        var macosDockDropFolderBehavior: MacOSDockDropFolderBehavior {
+            let defaultValue = MacOSDockDropFolderBehavior.tab
+            guard let config = self.config else { return defaultValue }
+            var v: UnsafePointer<Int8>? = nil
+            let key = "macos-dock-drop-folder-behavior"
+            guard ghostty_config_get(config, &v, key, UInt(key.count)) else { return defaultValue }
+            guard let ptr = v else { return defaultValue }
+            let str = String(cString: ptr)
+            return MacOSDockDropFolderBehavior(rawValue: str) ?? defaultValue
+        }
+
         var macosWindowShadow: Bool {
             guard let config = self.config else { return false }
             var v = false;

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -304,12 +304,6 @@ extension Ghostty {
         case hidden
     }
 
-    /// Enum for the macos-dock-drop-folder-behavior config option
-    enum MacOSDockDropFolderBehavior: String {
-        case tab
-        case window
-    }
-
     /// Enum for auto-update-channel config option
     enum AutoUpdateChannel: String {
         case tip

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -304,6 +304,12 @@ extension Ghostty {
         case hidden
     }
 
+    /// Enum for the macos-dock-drop-folder-behavior config option
+    enum MacOSDockDropFolderBehavior: String {
+        case tab
+        case window
+    }
+
     /// Enum for auto-update-channel config option
     enum AutoUpdateChannel: String {
         case tip

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2631,19 +2631,20 @@ keybind: Keybinds = .{},
 /// editor, etc.
 @"macos-titlebar-proxy-icon": MacTitlebarProxyIcon = .visible,
 
-/// Controls the behavior when dropping a folder onto the Ghostty dock icon
-/// on macOS.
+/// Controls the windowing behavior when dropping a file or folder
+/// onto the Ghostty icon in the macOS dock.
 ///
 /// Valid values are:
 ///
-///   * `tab` - Open the folder in a new tab in the main window (default).
-///   * `window` - Open the folder in a new window.
+///   * `new-tab` - Create a new tab in the current window, or open
+///     a new window if none exist.
+///   * `new-window` - Create a new window unconditionally.
 ///
-/// The default value is `tab`.
+/// The default value is `new-tab`.
 ///
 /// This setting is only supported on macOS and has no effect on other
 /// platforms.
-@"macos-dock-drop-folder-behavior": MacOSDockDropFolderBehavior = .tab,
+@"macos-dock-drop-behavior": MacOSDockDropBehavior = .@"new-tab",
 
 /// macOS doesn't have a distinct "alt" key and instead has the "option"
 /// key which behaves slightly differently. On macOS by default, the
@@ -7096,9 +7097,9 @@ pub const WindowNewTabPosition = enum {
     end,
 };
 
-/// See macos-dock-drop-folder-behavior
-pub const MacOSDockDropFolderBehavior = enum {
-    tab,
+/// See macos-dock-drop-behavior
+pub const MacOSDockDropBehavior = enum {
+    @"new-tab",
     window,
 };
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2631,6 +2631,20 @@ keybind: Keybinds = .{},
 /// editor, etc.
 @"macos-titlebar-proxy-icon": MacTitlebarProxyIcon = .visible,
 
+/// Controls the behavior when dropping a folder onto the Ghostty dock icon
+/// on macOS.
+///
+/// Valid values are:
+///
+///   * `tab` - Open the folder in a new tab in the main window (default).
+///   * `window` - Open the folder in a new window.
+///
+/// The default value is `tab`.
+///
+/// This setting is only supported on macOS and has no effect on other
+/// platforms.
+@"macos-dock-drop-folder-behavior": MacOSDockDropFolderBehavior = .tab,
+
 /// macOS doesn't have a distinct "alt" key and instead has the "option"
 /// key which behaves slightly differently. On macOS by default, the
 /// option key plus a character will sometimes produce a Unicode character.
@@ -7080,6 +7094,12 @@ pub const WindowSaveState = enum {
 pub const WindowNewTabPosition = enum {
     current,
     end,
+};
+
+/// See macos-dock-drop-folder-behavior
+pub const MacOSDockDropFolderBehavior = enum {
+    tab,
+    window,
 };
 
 /// See window-show-tab-bar

--- a/src/config/formatter.zig
+++ b/src/config/formatter.zig
@@ -147,6 +147,8 @@ pub const FileFormatter = struct {
         opts: std.fmt.FormatOptions,
         writer: anytype,
     ) !void {
+        @setEvalBranchQuota(10_000);
+
         _ = layout;
         _ = opts;
 


### PR DESCRIPTION
This PR adds a new configuration option `macos-dock-drop-folder-behavior` that controls whether folders dropped onto the Ghostty dock icon open in a new tab (default) or a new window.

## Changes

### Configuration Option Added
- **Option name**: `macos-dock-drop-folder-behavior`
- **Valid values**: 
  - `tab` (default) - Opens folders in a new tab in the main window
  - `window` - Opens folders in a new window
- **Platform**: macOS only

### Files Modified

1. **`src/config/Config.zig`**
   - Added `MacOSDockDropFolderBehavior` enum with `tab` and `window` values
   - Added configuration field with default value of `.tab`
   - Added documentation explaining the option

2. **`macos/Sources/Ghostty/Package.swift`**
   - Added `MacOSDockDropFolderBehavior` enum to match the Zig enum

3. **`macos/Sources/Ghostty/Ghostty.Config.swift`**
   - Added `macosDockDropFolderBehavior` computed property to access the configuration value from Swift

4. **`macos/Sources/App/macOS/AppDelegate.swift`**
   - Modified `application(_:openFile:)` method to check the configuration
   - When a folder is dropped on the dock icon, it now respects the user's preference

## Usage

Add to your Ghostty configuration file:
```
macos-dock-drop-folder-behavior = window
```

## Motivation

This feature is useful for users (like me!) who prefer window-based workflows over tab-based workflows when opening folders via drag and drop on macOS.