### PR TITLE
Allow for default or inherited CWD in new window, tab and split surfaces

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -899,7 +899,10 @@ ghostty_surface_t ghostty_surface_new(ghostty_app_t,
 void ghostty_surface_free(ghostty_surface_t);
 void* ghostty_surface_userdata(ghostty_surface_t);
 ghostty_app_t ghostty_surface_app(ghostty_surface_t);
-ghostty_surface_config_s ghostty_surface_inherited_config(ghostty_surface_t);
+ghostty_surface_config_s ghostty_surface_inherited_config(ghostty_surface_t); /* deprecated: use ghostty_surface_inherited_config_window, ghostty_surface_inherited_config_tab, or ghostty_surface_inherited_config_split */
+ghostty_surface_config_s ghostty_surface_inherited_config_window(ghostty_surface_t);
+ghostty_surface_config_s ghostty_surface_inherited_config_tab(ghostty_surface_t);
+ghostty_surface_config_s ghostty_surface_inherited_config_split(ghostty_surface_t);
 void ghostty_surface_update_config(ghostty_surface_t, ghostty_config_t);
 bool ghostty_surface_needs_confirm_quit(ghostty_surface_t);
 bool ghostty_surface_process_exited(ghostty_surface_t);

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -702,7 +702,7 @@ extension Ghostty {
                     name: Notification.ghosttyNewWindow,
                     object: surfaceView,
                     userInfo: [
-                        Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: ghostty_surface_inherited_config(surface)),
+                        Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: ghostty_surface_inherited_config_window(surface)),
                     ]
                 )
 
@@ -739,7 +739,7 @@ extension Ghostty {
                     name: Notification.ghosttyNewTab,
                     object: surfaceView,
                     userInfo: [
-                        Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: ghostty_surface_inherited_config(surface)),
+                        Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: ghostty_surface_inherited_config_tab(surface)),
                     ]
                 )
 
@@ -768,7 +768,7 @@ extension Ghostty {
                     object: surfaceView,
                     userInfo: [
                         "direction": direction,
-                        Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: ghostty_surface_inherited_config(surface)),
+                        Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: ghostty_surface_inherited_config_split(surface)),
                     ]
                 )
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -468,7 +468,8 @@ pub const Surface = struct {
         errdefer app.core_app.deleteSurface(self);
 
         // Shallow copy the config so that we can modify it.
-        var config = try apprt.surface.newConfig(app.core_app, &app.config);
+        // Embedded surfaces default to window context since they're typically new instances
+        var config = try apprt.surface.newConfig(app.core_app, &app.config, .window, null);
         defer config.deinit();
 
         // If we have a working directory from the options then we set it.
@@ -865,14 +866,38 @@ pub const Surface = struct {
         };
     }
 
-    pub fn newSurfaceOptions(self: *const Surface) apprt.Surface.Options {
-        const font_size: f32 = font_size: {
-            if (!self.app.config.@"window-inherit-font-size") break :font_size 0;
-            break :font_size self.core_surface.font_size.points;
+    pub fn newSurfaceOptions(self: *const Surface, context: apprt.surface.NewSurfaceContext) apprt.Surface.Options {
+        // Use the centralized inheritance logic
+        var cfg = apprt.surface.newConfig(
+            self.app.core_app,
+            &self.app.config,
+            context,
+            &self.core_surface,
+        ) catch {
+            // If allocation fails, fall back to original config
+            return .{
+                .font_size = if (self.app.config.@"window-inherit-font-size")
+                    self.core_surface.font_size.points
+                else
+                    0,
+                .working_directory = null,
+            };
         };
+        defer cfg.deinit();
+
+        const font_size: f32 = if (self.app.config.@"window-inherit-font-size")
+            self.core_surface.font_size.points
+        else
+            0;
+
+        const working_directory: ?[*:0]const u8 = if (cfg.@"working-directory") |wd|
+            self.app.core_app.alloc.dupeZ(u8, wd) catch null
+        else
+            null;
 
         return .{
             .font_size = font_size,
+            .working_directory = working_directory,
         };
     }
 
@@ -1489,8 +1514,30 @@ pub const CAPI = struct {
     }
 
     /// Returns the config to use for surfaces that inherit from this one.
+    ///
+    /// DEPRECATED: This function is kept for backward compatibility only.
+    /// External code should migrate to ghostty_surface_inherited_config_window(),
+    /// ghostty_surface_inherited_config_tab(), or ghostty_surface_inherited_config_split()
+    /// for explicit context.
+    /// This function assumes window context (.window) for legacy behavior.
+    /// TODO: Remove in next major version.
     export fn ghostty_surface_inherited_config(surface: *Surface) Surface.Options {
-        return surface.newSurfaceOptions();
+        return surface.newSurfaceOptions(.window);
+    }
+
+    /// Returns the config to use for new windows that inherit from this surface.
+    export fn ghostty_surface_inherited_config_window(surface: *Surface) Surface.Options {
+        return surface.newSurfaceOptions(.window);
+    }
+
+    /// Returns the config to use for new tabs that inherit from this surface.
+    export fn ghostty_surface_inherited_config_tab(surface: *Surface) Surface.Options {
+        return surface.newSurfaceOptions(.tab);
+    }
+
+    /// Returns the config to use for new split panes that inherit from this surface.
+    export fn ghostty_surface_inherited_config_split(surface: *Surface) Surface.Options {
+        return surface.newSurfaceOptions(.split);
     }
 
     /// Update the configuration to the provided config for only this surface.

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -1506,8 +1506,8 @@ fn newWindow(self: *App, parent_: ?*CoreSurface) !void {
     // freed when the window is closed.
     var window = try Window.create(alloc, self);
 
-    // Add our initial tab
-    try window.newTab(parent_);
+    // Add our initial tab (for a new window, use window context)
+    try window.newTabWithContext(parent_, .window);
 
     // Show the new window
     window.present();

--- a/src/apprt/gtk/Tab.zig
+++ b/src/apprt/gtk/Tab.zig
@@ -13,6 +13,7 @@ const gtk = @import("gtk");
 const font = @import("../../font/main.zig");
 const input = @import("../../input.zig");
 const CoreSurface = @import("../../Surface.zig");
+const apprt = @import("../../apprt.zig");
 
 const Surface = @import("Surface.zig");
 const Window = @import("Window.zig");
@@ -42,15 +43,19 @@ elem: Surface.Container.Elem,
 focus_child: ?*Surface,
 
 pub fn create(alloc: Allocator, window: *Window, parent_: ?*CoreSurface) !*Tab {
+    return createWithContext(alloc, window, parent_, .tab);
+}
+
+pub fn createWithContext(alloc: Allocator, window: *Window, parent_: ?*CoreSurface, context: apprt.surface.NewSurfaceContext) !*Tab {
     var tab = try alloc.create(Tab);
     errdefer alloc.destroy(tab);
-    try tab.init(window, parent_);
+    try tab.init(window, parent_, context);
     return tab;
 }
 
 /// Initialize the tab, create a surface, and add it to the window. "self" needs
 /// to be a stable pointer, since it is used for GTK events.
-pub fn init(self: *Tab, window: *Window, parent_: ?*CoreSurface) !void {
+pub fn init(self: *Tab, window: *Window, parent_: ?*CoreSurface, context: apprt.surface.NewSurfaceContext) !void {
     self.* = .{
         .window = window,
         .label_text = undefined,
@@ -72,6 +77,7 @@ pub fn init(self: *Tab, window: *Window, parent_: ?*CoreSurface) !void {
     // Create the initial surface since all tabs start as a single non-split
     var surface = try Surface.create(window.app.core_app.alloc, window.app, .{
         .parent = parent_,
+        .context = context,
     });
     errdefer surface.unref();
     surface.container = .{ .tab_ = self };

--- a/src/apprt/gtk/Window.zig
+++ b/src/apprt/gtk/Window.zig
@@ -23,6 +23,7 @@ const font = @import("../../font/main.zig");
 const i18n = @import("../../os/main.zig").i18n;
 const input = @import("../../input.zig");
 const CoreSurface = @import("../../Surface.zig");
+const apprt = @import("../../apprt.zig");
 
 const App = @import("App.zig");
 const Builder = @import("Builder.zig");
@@ -640,8 +641,12 @@ pub fn setSubtitle(self: *Window, subtitle: [:0]const u8) void {
 
 /// Add a new tab to this window.
 pub fn newTab(self: *Window, parent: ?*CoreSurface) !void {
+    return self.newTabWithContext(parent, .tab);
+}
+
+pub fn newTabWithContext(self: *Window, parent: ?*CoreSurface, context: apprt.surface.NewSurfaceContext) !void {
     const alloc = self.app.core_app.alloc;
-    _ = try Tab.create(alloc, self, parent);
+    _ = try Tab.createWithContext(alloc, self, parent, context);
 
     // TODO: When this is triggered through a GTK action, the new surface
     // redraws correctly. When it's triggered through keyboard shortcuts, it

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -146,12 +146,21 @@ pub const Mailbox = struct {
     }
 };
 
+/// Context for new surface creation to determine inheritance behavior
+pub const NewSurfaceContext = enum {
+    tab,
+    window,
+    split,
+};
+
 /// Returns a new config for a surface for the given app that should be
 /// used for any new surfaces. The resulting config should be deinitialized
 /// after the surface is initialized.
 pub fn newConfig(
     app: *const App,
     config: *const Config,
+    context: NewSurfaceContext,
+    parent: ?*const Surface,
 ) Allocator.Error!Config {
     // Create a shallow clone
     var copy = config.shallowClone(app.alloc);
@@ -159,10 +168,18 @@ pub fn newConfig(
     // Our allocator is our config's arena
     const alloc = copy._arena.?.allocator();
 
-    // Get our previously focused surface for some inherited values.
-    const prev = app.focusedSurface();
-    if (prev) |p| {
-        if (config.@"window-inherit-working-directory") {
+    // Use the parent surface if provided, otherwise fall back to focused surface
+    const inherit_from = parent orelse app.focusedSurface();
+    
+    if (inherit_from) |p| {
+        // Determine if we should inherit working directory based on context
+        const should_inherit = switch (context) {
+            .tab => config.@"tab-inherit-working-directory",
+            .window => config.@"window-inherit-working-directory",
+            .split => config.@"split-inherit-working-directory",
+        };
+        
+        if (should_inherit) {
             if (try p.pwd(alloc)) |pwd| {
                 copy.@"working-directory" = pwd;
             }
@@ -170,4 +187,267 @@ pub fn newConfig(
     }
 
     return copy;
+}
+
+// Tests
+
+const testing = std.testing;
+
+test "newConfig: tab inherits working directory when enabled" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    // Create a test config with tab inheritance enabled
+    var base_config = try Config.default(testing.allocator);
+    defer base_config.deinit();
+    base_config.@"window-inherit-working-directory" = false;
+    base_config.@"tab-inherit-working-directory" = true;
+    base_config.@"working-directory" = "/default";
+
+    // Create a mock app with no focused surface
+    const MockApp = struct {
+        alloc: Allocator,
+        
+        pub fn focusedSurface(self: *const @This()) ?*const Surface {
+            _ = self;
+            return null;
+        }
+    };
+    
+    var mock_app = MockApp{ .alloc = alloc };
+
+    // Create a mock parent surface with a current working directory
+    const MockSurface = struct {
+        current_pwd: []const u8,
+        
+        pub fn pwd(self: *const @This(), allocator: Allocator) !?[]const u8 {
+            return try allocator.dupe(u8, self.current_pwd);
+        }
+    };
+    
+    var parent_surface = MockSurface{ .current_pwd = "/parent/directory" };
+
+    // Test tab creation - should inherit from parent
+    {
+        var config = try newConfig(&mock_app, &base_config, .tab, &parent_surface);
+        defer config.deinit();
+        
+        try testing.expect(config.@"working-directory" != null);
+        try testing.expectEqualStrings("/parent/directory", config.@"working-directory".?);
+    }
+
+    // Test window creation - should NOT inherit (window inheritance disabled)
+    {
+        var config = try newConfig(&mock_app, &base_config, .window, &parent_surface);
+        defer config.deinit();
+        
+        // Should use the default working directory since window inheritance is disabled
+        try testing.expectEqualStrings("/default", config.@"working-directory".?);
+    }
+}
+
+test "newConfig: window inherits working directory when enabled" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    // Create a test config with window inheritance enabled, tab inheritance disabled
+    var base_config = try Config.default(testing.allocator);
+    defer base_config.deinit();
+    base_config.@"window-inherit-working-directory" = true;
+    base_config.@"tab-inherit-working-directory" = false;
+    base_config.@"working-directory" = "/default";
+
+    // Create a mock app with no focused surface
+    const MockApp = struct {
+        alloc: Allocator,
+        
+        pub fn focusedSurface(self: *const @This()) ?*const Surface {
+            _ = self;
+            return null;
+        }
+    };
+    
+    var mock_app = MockApp{ .alloc = alloc };
+
+    // Create a mock parent surface with a current working directory
+    const MockSurface = struct {
+        current_pwd: []const u8,
+        
+        pub fn pwd(self: *const @This(), allocator: Allocator) !?[]const u8 {
+            return try allocator.dupe(u8, self.current_pwd);
+        }
+    };
+    
+    var parent_surface = MockSurface{ .current_pwd = "/parent/directory" };
+
+    // Test window creation - should inherit from parent
+    {
+        var config = try newConfig(&mock_app, &base_config, .window, &parent_surface);
+        defer config.deinit();
+        
+        try testing.expect(config.@"working-directory" != null);
+        try testing.expectEqualStrings("/parent/directory", config.@"working-directory".?);
+    }
+
+    // Test tab creation - should NOT inherit (tab inheritance disabled)
+    {
+        var config = try newConfig(&mock_app, &base_config, .tab, &parent_surface);
+        defer config.deinit();
+        
+        // Should use the default working directory since tab inheritance is disabled
+        try testing.expectEqualStrings("/default", config.@"working-directory".?);
+    }
+}
+
+test "newConfig: no inheritance when both disabled" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    // Create a test config with both inheritance settings disabled
+    var base_config = try Config.default(testing.allocator);
+    defer base_config.deinit();
+    base_config.@"window-inherit-working-directory" = false;
+    base_config.@"tab-inherit-working-directory" = false;
+    base_config.@"working-directory" = "/default";
+
+    // Create a mock app with no focused surface
+    const MockApp = struct {
+        alloc: Allocator,
+        
+        pub fn focusedSurface(self: *const @This()) ?*const Surface {
+            _ = self;
+            return null;
+        }
+    };
+    
+    var mock_app = MockApp{ .alloc = alloc };
+
+    // Create a mock parent surface with a current working directory
+    const MockSurface = struct {
+        current_pwd: []const u8,
+        
+        pub fn pwd(self: *const @This(), allocator: Allocator) !?[]const u8 {
+            return try allocator.dupe(u8, self.current_pwd);
+        }
+    };
+    
+    var parent_surface = MockSurface{ .current_pwd = "/parent/directory" };
+
+    // Test both tab and window creation - neither should inherit
+    {
+        var tab_config = try newConfig(&mock_app, &base_config, .tab, &parent_surface);
+        defer tab_config.deinit();
+        
+        var window_config = try newConfig(&mock_app, &base_config, .window, &parent_surface);
+        defer window_config.deinit();
+        
+        // Both should use the default working directory
+        try testing.expectEqualStrings("/default", tab_config.@"working-directory".?);
+        try testing.expectEqualStrings("/default", window_config.@"working-directory".?);
+    }
+}
+
+test "newConfig: no parent surface uses default directory" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    // Create a test config with inheritance enabled
+    var base_config = try Config.default(testing.allocator);
+    defer base_config.deinit();
+    base_config.@"window-inherit-working-directory" = true;
+    base_config.@"tab-inherit-working-directory" = true;
+    base_config.@"working-directory" = "/default";
+
+    // Create a mock app with no focused surface
+    const MockApp = struct {
+        alloc: Allocator,
+        
+        pub fn focusedSurface(self: *const @This()) ?*const Surface {
+            _ = self;
+            return null;
+        }
+    };
+    
+    var mock_app = MockApp{ .alloc = alloc };
+
+    // Test with no parent surface provided
+    {
+        var tab_config = try newConfig(&mock_app, &base_config, .tab, null);
+        defer tab_config.deinit();
+        
+        var window_config = try newConfig(&mock_app, &base_config, .window, null);
+        defer window_config.deinit();
+        
+        // Both should use the default working directory since there's no parent to inherit from
+        try testing.expectEqualStrings("/default", tab_config.@"working-directory".?);
+        try testing.expectEqualStrings("/default", window_config.@"working-directory".?);
+    }
+}
+
+test "newConfig: split inherits working directory when enabled" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    // Create a test config with split inheritance enabled
+    var base_config = try Config.default(testing.allocator);
+    defer base_config.deinit();
+    base_config.@"window-inherit-working-directory" = false;
+    base_config.@"tab-inherit-working-directory" = false;
+    base_config.@"split-inherit-working-directory" = true;
+    base_config.@"working-directory" = "/default";
+
+    // Create a mock app with no focused surface
+    const MockApp = struct {
+        alloc: Allocator,
+        
+        pub fn focusedSurface(self: *const @This()) ?*const Surface {
+            _ = self;
+            return null;
+        }
+    };
+    
+    var mock_app = MockApp{ .alloc = alloc };
+
+    // Create a mock parent surface with a current working directory
+    const MockSurface = struct {
+        current_pwd: []const u8,
+        
+        pub fn pwd(self: *const @This(), allocator: Allocator) !?[]const u8 {
+            return try allocator.dupe(u8, self.current_pwd);
+        }
+    };
+    
+    var parent_surface = MockSurface{ .current_pwd = "/parent/directory" };
+
+    // Test split creation - should inherit from parent
+    {
+        var config = try newConfig(&mock_app, &base_config, .split, &parent_surface);
+        defer config.deinit();
+        
+        try testing.expect(config.@"working-directory" != null);
+        try testing.expectEqualStrings("/parent/directory", config.@"working-directory".?);
+    }
+
+    // Test window creation - should NOT inherit (window inheritance disabled)
+    {
+        var config = try newConfig(&mock_app, &base_config, .window, &parent_surface);
+        defer config.deinit();
+        
+        // Should use the default working directory since window inheritance is disabled
+        try testing.expectEqualStrings("/default", config.@"working-directory".?);
+    }
+
+    // Test tab creation - should NOT inherit (tab inheritance disabled)
+    {
+        var config = try newConfig(&mock_app, &base_config, .tab, &parent_surface);
+        defer config.deinit();
+        
+        // Should use the default working directory since tab inheritance is disabled
+        try testing.expectEqualStrings("/default", config.@"working-directory".?);
+    }
 }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1171,11 +1171,12 @@ class: ?[:0]const u8 = null,
 
 /// The directory to change to after starting the command.
 ///
-/// This setting is secondary to the `window-inherit-working-directory`
-/// setting. If a previous Ghostty terminal exists in the same process,
-/// `window-inherit-working-directory` will take precedence. Otherwise, this
-/// setting will be used. Typically, this setting is used only for the first
-/// window.
+/// This setting is secondary to the inheritance settings. For new windows,
+/// `window-inherit-working-directory` takes precedence. For new tabs,
+/// `tab-inherit-working-directory` takes precedence over both this setting
+/// and the window inheritance setting. For new split panes,
+/// `split-inherit-working-directory` takes precedence. If inheritance is
+/// disabled for the specific context (tab, window, or split), this setting will be used.
 ///
 /// The default is `inherit` except in special scenarios listed next. On macOS,
 /// if Ghostty can detect it is launched from launchd (double-clicked) or
@@ -1508,6 +1509,17 @@ keybind: Keybinds = .{},
 /// previously focused window. If no window was previously focused, the default
 /// working directory will be used (the `working-directory` option).
 @"window-inherit-working-directory": bool = true,
+
+/// If true, new tabs will inherit the working directory of the previously
+/// focused window. This setting takes precedence over `window-inherit-working-directory`
+/// for new tabs only. If false, new tabs will use the `working-directory` setting.
+/// This allows different behavior for new tabs vs new windows.
+@"tab-inherit-working-directory": bool = true,
+
+/// If true, new split panes will inherit the working directory of the previously
+/// focused window. If false, new split panes will use the `working-directory` setting.
+/// This allows different behavior for new split panes vs new tabs and windows.
+@"split-inherit-working-directory": bool = true,
 
 /// If true, new windows and tabs will inherit the font size of the previously
 /// focused window. If no window was previously focused, the default font size
@@ -8484,4 +8496,26 @@ test "compatibility: removed bold-is-bright" {
             cfg.@"bold-color",
         );
     }
+}
+
+test "tab-inherit-working-directory field" {
+    const testing = std.testing;
+    
+    var config = Config{};
+    config.@"tab-inherit-working-directory" = false;
+    try testing.expect(config.@"tab-inherit-working-directory" == false);
+    
+    config.@"tab-inherit-working-directory" = true;
+    try testing.expect(config.@"tab-inherit-working-directory" == true);
+}
+
+test "split-inherit-working-directory field" {
+    const testing = std.testing;
+    
+    var config = Config{};
+    config.@"split-inherit-working-directory" = false;
+    try testing.expect(config.@"split-inherit-working-directory" == false);
+    
+    config.@"split-inherit-working-directory" = true;
+    try testing.expect(config.@"split-inherit-working-directory" == true);
 }


### PR DESCRIPTION
Closes [1392](https://github.com/ghostty-org/ghostty/issues/1392)

Add two new config settings:
- `tab-inherit-working-directory`
- `split-inherit-working-directory`

Both boolean.

They mimic the existing `window-inherit-working-directory`, and it's interaction with `working-directory`.

- Add tab-inherit-working-directory and split-inherit-working-directory config options
- Add NewSurfaceContext enum to differentiate tab, window, and split creation
- Update newConfig function to handle inheritance based on context
- Add C API functions: `ghostty_surface_inherited_config_window`, `ghostty_surface_inherited_config_tab`, `ghostty_surface_inherited_config_split`
- Update Swift code to use context-specific inheritance functions
- Add comprehensive behavioral tests for inheritance logic
- Consolidate inheritance logic to single source of truth
- Clean up dead code from previous implementation
- Update documentation for new precedence rules

This allows users to configure working directory inheritance independently for new tabs, windows, and split panes, providing maximum flexibility for different workflow patterns.

Amp-Thread-ID: https://ampcode.com/threads/T-ca9d78cb-c1c2-450a-9730-b3975423d800