### PR TITLE
apprt/gtk-ng: winproto behaviors (quick terminal, csd/ssd, blur, etc.)

### DIFF
--- a/src/apprt/gtk-ng/class/application.zig
+++ b/src/apprt/gtk-ng/class/application.zig
@@ -1727,20 +1727,20 @@ const Action = struct {
         // Find a quick terminal window.
         const list = gtk.Window.listToplevels();
         defer list.free();
-        const elem_: ?*glib.List = list.findCustom(null, struct {
-            fn callback(data: ?*const anyopaque, _: ?*const anyopaque) callconv(.c) c_int {
-                const ptr = data orelse return 1;
-                const gtk_window: *gtk.Window = @ptrCast(@alignCast(@constCast(ptr)));
-                const window = gobject.ext.cast(
+        if (ext.listFind(gtk.Window, list, struct {
+            fn find(gtk_win: *gtk.Window) bool {
+                const win = gobject.ext.cast(
                     Window,
-                    gtk_window,
-                ) orelse return 1;
-                if (window.isQuickTerminal()) return 0;
-                return 1;
+                    gtk_win,
+                ) orelse return false;
+                return win.isQuickTerminal();
             }
-        }.callback);
-        const elem = elem_ orelse return null;
-        return @ptrCast(@alignCast(elem.f_data));
+        }.find)) |w| return gobject.ext.cast(
+            Window,
+            w,
+        ).?;
+
+        return null;
     }
 
     pub fn toggleMaximize(target: apprt.Target) void {

--- a/src/apprt/gtk-ng/class/application.zig
+++ b/src/apprt/gtk-ng/class/application.zig
@@ -549,6 +549,7 @@ pub const Application = extern struct {
 
             .toggle_maximize => Action.toggleMaximize(target),
             .toggle_fullscreen => Action.toggleFullscreen(target),
+            .toggle_quick_terminal => return Action.toggleQuickTerminal(self),
             .toggle_tab_overview => return Action.toggleTabOverview(target),
 
             // Unimplemented but todo on gtk-ng branch
@@ -562,7 +563,6 @@ pub const Application = extern struct {
             .goto_split,
             .toggle_split_zoom,
             // TODO: winproto
-            .toggle_quick_terminal,
             .toggle_window_decorations,
             => {
                 log.warn("unimplemented action={}", .{action});
@@ -1477,7 +1477,14 @@ const Action = struct {
         parent: ?*CoreSurface,
     ) !void {
         const win = Window.new(self);
+        initAndShowWindow(self, win, parent);
+    }
 
+    fn initAndShowWindow(
+        self: *Application,
+        win: *Window,
+        parent: ?*CoreSurface,
+    ) void {
         // Setup a binding so that whenever our config changes so does the
         // window. There's never a time when the window config should be out
         // of sync with the application config.
@@ -1692,6 +1699,48 @@ const Action = struct {
             .app => {},
             .surface => |v| v.rt_surface.surface.toggleFullscreen(),
         }
+    }
+
+    pub fn toggleQuickTerminal(self: *Application) bool {
+        // If we already have a quick terminal window, we just toggle the
+        // visibility of it.
+        if (getQuickTerminalWindow()) |win| {
+            win.toggleVisibility();
+            return true;
+        }
+
+        // If we don't support quick terminals then we do nothing.
+        const priv = self.private();
+        if (!priv.winproto.supportsQuickTerminal()) return false;
+
+        // Create our new window as a quick terminal
+        const win = gobject.ext.newInstance(Window, .{
+            .application = self,
+            .@"quick-terminal" = true,
+        });
+        assert(win.isQuickTerminal());
+        initAndShowWindow(self, win, null);
+        return true;
+    }
+
+    fn getQuickTerminalWindow() ?*Window {
+        // Find a quick terminal window.
+        const list = gtk.Window.listToplevels();
+        defer list.free();
+        const elem_: ?*glib.List = list.findCustom(null, struct {
+            fn callback(data: ?*const anyopaque, _: ?*const anyopaque) callconv(.c) c_int {
+                const ptr = data orelse return 1;
+                const gtk_window: *gtk.Window = @ptrCast(@alignCast(@constCast(ptr)));
+                const window = gobject.ext.cast(
+                    Window,
+                    gtk_window,
+                ) orelse return 1;
+                if (window.isQuickTerminal()) return 0;
+                return 1;
+            }
+        }.callback);
+        const elem = elem_ orelse return null;
+        return @ptrCast(@alignCast(elem.f_data));
     }
 
     pub fn toggleMaximize(target: apprt.Target) void {

--- a/src/apprt/gtk-ng/class/window.zig
+++ b/src/apprt/gtk-ng/class/window.zig
@@ -363,6 +363,11 @@ pub const Window = extern struct {
         }
     }
 
+    /// Winproto backend for this window.
+    pub fn winproto(self: *Self) *winprotopkg.Window {
+        return &self.private().winproto;
+    }
+
     /// Create a new tab with the given parent. The tab will be inserted
     /// at the position dictated by the `window-new-tab-position` config.
     /// The new tab will be selected.

--- a/src/apprt/gtk-ng/css/style.css
+++ b/src/apprt/gtk-ng/css/style.css
@@ -4,6 +4,14 @@
  * https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.3/styles-and-appearance.html#custom-styles
  */
 
+window.ssd.no-border-radius {
+  /* Without clearing the border radius, at least on Mutter with
+   * gtk-titlebar=true and gtk-adwaita=false, there is some window artifacting
+   * that this will mitigate.
+   */
+  border-radius: 0 0;
+}
+
 /* 
  * GhosttySurface URL overlay
  */

--- a/src/apprt/gtk-ng/ui/1.5/window.blp
+++ b/src/apprt/gtk-ng/ui/1.5/window.blp
@@ -8,10 +8,11 @@ template $GhosttyWindow: Adw.ApplicationWindow {
 
   close-request => $close_request();
   realize => $realize();
+  notify::background-opaque => $notify_background_opaque();
   notify::config => $notify_config();
   notify::fullscreened => $notify_fullscreened();
   notify::maximized => $notify_maximized();
-  notify::background-opaque => $notify_background_opaque();
+  notify::scale-factor => $notify_scale_factor();
   default-width: 800;
   default-height: 600;
   // GTK4 grabs F10 input by default to focus the menubar icon. We want
@@ -21,8 +22,13 @@ template $GhosttyWindow: Adw.ApplicationWindow {
   content: Adw.TabOverview tab_overview {
     create-tab => $overview_create_tab();
     notify::open => $overview_notify_open();
-    enable-new-tab: true;
     view: tab_view;
+    enable-new-tab: true;
+    // Disable the title buttons (close, maximize, minimize, ...)
+    // *inside* the tab overview if CSDs are disabled.
+    // We do spare the search button, though.
+    show-start-title-buttons: bind template.decorated;
+    show-end-title-buttons: bind template.decorated;
 
     Adw.ToolbarView toolbar {
       top-bar-style: bind template.toolbar-style;

--- a/src/apprt/gtk-ng/ui/1.5/window.blp
+++ b/src/apprt/gtk-ng/ui/1.5/window.blp
@@ -12,6 +12,7 @@ template $GhosttyWindow: Adw.ApplicationWindow {
   notify::config => $notify_config();
   notify::fullscreened => $notify_fullscreened();
   notify::maximized => $notify_maximized();
+  notify::quick-terminal => $notify_quick_terminal();
   notify::scale-factor => $notify_scale_factor();
   default-width: 800;
   default-height: 600;

--- a/src/apprt/gtk-ng/ui/1.5/window.blp
+++ b/src/apprt/gtk-ng/ui/1.5/window.blp
@@ -7,6 +7,7 @@ template $GhosttyWindow: Adw.ApplicationWindow {
   ]
 
   close-request => $close_request();
+  realize => $realize();
   notify::config => $notify_config();
   notify::fullscreened => $notify_fullscreened();
   notify::maximized => $notify_maximized();

--- a/src/apprt/gtk-ng/winproto.zig
+++ b/src/apprt/gtk-ng/winproto.zig
@@ -7,9 +7,7 @@ const gdk = @import("gdk");
 const Config = @import("../../config.zig").Config;
 const input = @import("../../input.zig");
 const key = @import("key.zig");
-
-// TODO: As we get to these APIs the compiler should tell us
-const ApprtWindow = void;
+const ApprtWindow = @import("class/window.zig").Window;
 
 pub const noop = @import("winproto/noop.zig");
 pub const x11 = @import("winproto/x11.zig");

--- a/src/apprt/gtk-ng/winproto/noop.zig
+++ b/src/apprt/gtk-ng/winproto/noop.zig
@@ -5,7 +5,7 @@ const gdk = @import("gdk");
 
 const Config = @import("../../../config.zig").Config;
 const input = @import("../../../input.zig");
-const ApprtWindow = void; // TODO: fix
+const ApprtWindow = @import("../class/window.zig").Window;
 
 const log = std.log.scoped(.winproto_noop);
 

--- a/src/apprt/gtk-ng/winproto/wayland.zig
+++ b/src/apprt/gtk-ng/winproto/wayland.zig
@@ -364,7 +364,11 @@ pub const Window = struct {
     /// Update the blur state of the window.
     fn syncBlur(self: *Window) !void {
         const manager = self.app_context.kde_blur_manager orelse return;
-        const blur = self.apprt_window.config.background_blur;
+        const config = if (self.apprt_window.getConfig()) |v|
+            v.get()
+        else
+            return;
+        const blur = config.@"background-blur";
 
         if (self.blur_token) |tok| {
             // Only release token when transitioning from blurred -> not blurred
@@ -392,7 +396,12 @@ pub const Window = struct {
     }
 
     fn getDecorationMode(self: Window) org.KdeKwinServerDecorationManager.Mode {
-        return switch (self.apprt_window.config.window_decoration) {
+        const config = if (self.apprt_window.getConfig()) |v|
+            v.get()
+        else
+            return .Client;
+
+        return switch (config.@"window-decoration") {
             .auto => self.app_context.default_deco_mode orelse .Client,
             .client => .Client,
             .server => .Server,
@@ -401,12 +410,15 @@ pub const Window = struct {
     }
 
     fn syncQuickTerminal(self: *Window) !void {
-        const window = self.apprt_window.window.as(gtk.Window);
-        const config = &self.apprt_window.config;
+        const window = self.apprt_window.as(gtk.Window);
+        const config = if (self.apprt_window.getConfig()) |v|
+            v.get()
+        else
+            return;
 
         layer_shell.setKeyboardMode(
             window,
-            switch (config.quick_terminal_keyboard_interactivity) {
+            switch (config.@"quick-terminal-keyboard-interactivity") {
                 .none => .none,
                 .@"on-demand" => on_demand: {
                     if (layer_shell.getProtocolVersion() < 4) {
@@ -419,7 +431,7 @@ pub const Window = struct {
             },
         );
 
-        const anchored_edge: ?layer_shell.ShellEdge = switch (config.quick_terminal_position) {
+        const anchored_edge: ?layer_shell.ShellEdge = switch (config.@"quick-terminal-position") {
             .left => .left,
             .right => .right,
             .top => .top,

--- a/src/apprt/gtk-ng/winproto/wayland.zig
+++ b/src/apprt/gtk-ng/winproto/wayland.zig
@@ -12,7 +12,7 @@ const wayland = @import("wayland");
 
 const Config = @import("../../../config.zig").Config;
 const input = @import("../../../input.zig");
-const ApprtWindow = void; // TODO: fix
+const ApprtWindow = @import("../class/window.zig").Window;
 
 const wl = wayland.client.wl;
 const org = wayland.client.org;
@@ -257,7 +257,7 @@ pub const Window = struct {
     ) !Window {
         _ = alloc;
 
-        const gtk_native = apprt_window.window.as(gtk.Native);
+        const gtk_native = apprt_window.as(gtk.Native);
         const gdk_surface = gtk_native.getSurface() orelse return error.NotWaylandSurface;
 
         // This should never fail, because if we're being called at this point
@@ -470,14 +470,14 @@ pub const Window = struct {
         monitor: *gdk.Monitor,
         apprt_window: *ApprtWindow,
     ) callconv(.c) void {
-        const window = apprt_window.window.as(gtk.Window);
-        const config = &apprt_window.config;
+        const window = apprt_window.as(gtk.Window);
+        const config = if (apprt_window.getConfig()) |v| v.get() else return;
 
         var monitor_size: gdk.Rectangle = undefined;
         monitor.getGeometry(&monitor_size);
 
-        const dims = config.quick_terminal_size.calculate(
-            config.quick_terminal_position,
+        const dims = config.@"quick-terminal-size".calculate(
+            config.@"quick-terminal-position",
             .{
                 .width = @intCast(monitor_size.f_width),
                 .height = @intCast(monitor_size.f_height),

--- a/src/apprt/gtk-ng/winproto/wayland.zig
+++ b/src/apprt/gtk-ng/winproto/wayland.zig
@@ -127,7 +127,7 @@ pub const App = struct {
     }
 
     pub fn initQuickTerminal(_: *App, apprt_window: *ApprtWindow) !void {
-        const window = apprt_window.window.as(gtk.Window);
+        const window = apprt_window.as(gtk.Window);
 
         layer_shell.initForWindow(window);
         layer_shell.setLayer(window, .top);

--- a/src/apprt/gtk-ng/winproto/x11.zig
+++ b/src/apprt/gtk-ng/winproto/x11.zig
@@ -20,7 +20,7 @@ pub const c = @cImport({
 
 const input = @import("../../../input.zig");
 const Config = @import("../../../config.zig").Config;
-const ApprtWindow = void; // TODO: fix
+const ApprtWindow = @import("../class/window.zig").Window;
 
 const log = std.log.scoped(.gtk_x11);
 
@@ -170,8 +170,7 @@ pub const App = struct {
 
 pub const Window = struct {
     app: *App,
-    config: *const ApprtWindow.DerivedConfig,
-    gtk_window: *adw.ApplicationWindow,
+    apprt_window: *ApprtWindow,
     x11_surface: *gdk_x11.X11Surface,
 
     blur_region: Region = .{},
@@ -183,9 +182,8 @@ pub const Window = struct {
     ) !Window {
         _ = alloc;
 
-        const surface = apprt_window.window.as(
-            gtk.Native,
-        ).getSurface() orelse return error.NotX11Surface;
+        const surface = apprt_window.as(gtk.Native).getSurface() orelse
+            return error.NotX11Surface;
 
         const x11_surface = gobject.ext.cast(
             gdk_x11.X11Surface,
@@ -194,8 +192,7 @@ pub const Window = struct {
 
         return .{
             .app = app,
-            .config = &apprt_window.config,
-            .gtk_window = apprt_window.window,
+            .apprt_window = apprt_window,
             .x11_surface = x11_surface,
         };
     }
@@ -221,10 +218,10 @@ pub const Window = struct {
             var x: f64 = 0;
             var y: f64 = 0;
 
-            self.gtk_window.as(gtk.Native).getSurfaceTransform(&x, &y);
+            self.apprt_window.as(gtk.Native).getSurfaceTransform(&x, &y);
 
             // Transform surface coordinates to device coordinates.
-            const scale: f64 = @floatFromInt(self.gtk_window.as(gtk.Widget).getScaleFactor());
+            const scale: f64 = @floatFromInt(self.apprt_window.as(gtk.Widget).getScaleFactor());
             x *= scale;
             y *= scale;
 
@@ -257,10 +254,10 @@ pub const Window = struct {
         // and I think it's not really noticeable enough to justify the effort.
         // (Wayland also has this visual artifact anyway...)
 
-        const gtk_widget = self.gtk_window.as(gtk.Widget);
+        const gtk_widget = self.apprt_window.as(gtk.Widget);
 
         // Transform surface coordinates to device coordinates.
-        const scale = self.gtk_window.as(gtk.Widget).getScaleFactor();
+        const scale = self.apprt_window.as(gtk.Widget).getScaleFactor();
         self.blur_region.width = gtk_widget.getWidth() * scale;
         self.blur_region.height = gtk_widget.getHeight() * scale;
 


### PR DESCRIPTION
This ports over the winproto behaviors to gtk-ng. The core winproto logic is unchanged except for trivial typing changes. The interaction with winproto is a bit different in ng due to the class separation of logic between surfaces and windows, but functionally the same.

Ran against Valgrind and all looks good.