### PR TITLE
gtk-ng: prevent split button from becoming focused

### DIFF
--- a/src/apprt/gtk-ng/ui/1.5/window.blp
+++ b/src/apprt/gtk-ng/ui/1.5/window.blp
@@ -50,6 +50,8 @@ template $GhosttyWindow: Adw.ApplicationWindow {
           tooltip-text: _("New Tab");
           dropdown-tooltip: _("New Split");
           menu-model: split_menu;
+          can-focus: false;
+          focus-on-click: false;
         }
 
         [end]


### PR DESCRIPTION
Without this, if you create a new tab by clicking on the split button it will be the focus for any new input. So for example if you create a new tab and then immediately press the space bar a bunch of new tabs will be created. Other keypresses will just "disappear". Only by clicking in the new tab to focus it will keyboard input go to "the right place".