### PR TITLE
fix fish shell syntax for ssh-env shell integration

### DIFF
--- a/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
+++ b/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
@@ -165,7 +165,7 @@ function __ghostty_setup --on-event fish_prompt -d "Setup ghostty integration"
             end
 
             # Execute SSH with TERM environment variable
-            env TERM="$ssh_term" command ssh $ssh_opts $argv
+            TERM="$ssh_term" command ssh $ssh_opts $argv
         end
     end
 


### PR DESCRIPTION
As discussed here https://github.com/ghostty-org/ghostty/discussions/8021

This fixes invalid fish shell syntax.

As an example, run ghostty like so: `XDG_CONFIG_HOME=/tmp ghostty --shell-integration-features=ssh-env --command="/usr/bin/env fish"`. Setting `XDG_CONFIG_HOME` to `/tmp` is just to start from the default configs for ghostty and fish.

Before:

```
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish
robbiev@neo ~/s/ghostty (fish-shell-ssh)> ssh git@github.com
env: ‘command’: No such file or directory
robbiev@neo ~/s/ghostty (fish-shell-ssh) [127]>
```

After:

```
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish
robbiev@neo ~/s/ghostty (fish-shell-ssh)> ssh git@github.com
PTY allocation request failed on channel 0
Hi robbiev! You've successfully authenticated, but GitHub does not provide shell access.
Connection to github.com closed.
robbiev@neo ~/s/ghostty (fish-shell-ssh) [1]>
```

(This fails correctly)

I've also tried with a correctly accessible ssh server but of course you can't repro that easily if you don't have some place to ssh to.

```
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish
robbiev@neo ~/s/ghostty (fish-shell-ssh)> ssh trinity

[robbiev@trinity:~]$ echo $TERM
xterm-ghostty
```

My understanding of the fix follows.

The script is using `command` to make sure it calls the actual ssh binary and not some intermediate shell function with the same name (`man command` explains).

`env` can be useful for fish compat < 3.1, where [the KEY=value syntax was introduced](https://fishshell.com/docs/current/faq.html#how-do-i-set-or-clear-an-environment-variable). However because `command` is a builtin it doesn't work in this case.

So a simple solution is this, requiring fish >= 3.1

```
TERM="$ssh_term" command ssh $ssh_opts $argv
```

An [alternative](https://serverfault.com/questions/164305/how-can-i-set-environment-variable-for-just-one-command-in-fish-shell) for maximum fish compat could be the following:

```
begin
  set -lx TERM "$ssh_term"
  command ssh $ssh_opts $argv
end
```

According to `man set`, `-l` means local to the block and `-x` means export.

I'm in favour of keeping `command` as it makes the integration more predicable.

The reason I went with the current fix:
- It's easier to understand without knowing fish shell.
- [kat found that fish 3.1 should be widely available](https://github.com/ghostty-org/ghostty/discussions/8021#discussioncomment-13877129).