### PR TITLE
apprt/gtk-ng: surface context menu

### DIFF
--- a/src/apprt/gtk-ng/ui/1.2/surface.blp
+++ b/src/apprt/gtk-ng/ui/1.2/surface.blp
@@ -15,19 +15,32 @@ template $GhosttySurface: Adw.Bin {
     focusable: false;
     focus-on-click: false;
 
-    GLArea gl_area {
-      realize => $gl_realize();
-      unrealize => $gl_unrealize();
-      render => $gl_render();
-      resize => $gl_resize();
+    child: Box {
       hexpand: true;
       vexpand: true;
-      focusable: true;
-      focus-on-click: true;
-      has-stencil-buffer: false;
-      has-depth-buffer: false;
-      use-es: false;
-    }
+
+      GLArea gl_area {
+        realize => $gl_realize();
+        unrealize => $gl_unrealize();
+        render => $gl_render();
+        resize => $gl_resize();
+        hexpand: true;
+        vexpand: true;
+        focusable: true;
+        focus-on-click: true;
+        has-stencil-buffer: false;
+        has-depth-buffer: false;
+        use-es: false;
+      }
+
+      PopoverMenu context_menu {
+        closed => $context_menu_closed();
+        menu-model: context_menu_model;
+        flags: nested;
+        halign: start;
+        has-arrow: false;
+      }
+    };
 
     [overlay]
     ProgressBar progress_bar_overlay {
@@ -121,4 +134,105 @@ IMMulticontext im_context {
   preedit-changed => $im_preedit_changed();
   preedit-end => $im_preedit_end();
   commit => $im_commit();
+}
+
+menu context_menu_model {
+  section {
+    item {
+      label: _("Copy");
+      action: "win.copy";
+    }
+
+    item {
+      label: _("Paste");
+      action: "win.paste";
+    }
+  }
+
+  section {
+    item {
+      label: _("Clear");
+      action: "win.clear";
+    }
+
+    item {
+      label: _("Reset");
+      action: "win.reset";
+    }
+  }
+
+  section {
+    submenu {
+      label: _("Split");
+
+      item {
+        label: _("Change Title…");
+        action: "win.prompt-title";
+      }
+
+      item {
+        label: _("Split Up");
+        action: "win.split-up";
+      }
+
+      item {
+        label: _("Split Down");
+        action: "win.split-down";
+      }
+
+      item {
+        label: _("Split Left");
+        action: "win.split-left";
+      }
+
+      item {
+        label: _("Split Right");
+        action: "win.split-right";
+      }
+    }
+
+    submenu {
+      label: _("Tab");
+
+      item {
+        label: _("New Tab");
+        action: "win.new-tab";
+      }
+
+      item {
+        label: _("Close Tab");
+        action: "win.close-tab";
+      }
+    }
+
+    submenu {
+      label: _("Window");
+
+      item {
+        label: _("New Window");
+        action: "win.new-window";
+      }
+
+      item {
+        label: _("Close Window");
+        action: "win.close";
+      }
+    }
+  }
+
+  section {
+    submenu {
+      label: _("Config");
+
+      item {
+        label: _("Open Configuration");
+        action: "app.open-config";
+      }
+
+      item {
+        label: _("Reload Configuration");
+        action: "app.reload-config";
+      }
+    }
+  }
 }

--- a/src/apprt/gtk/menu.zig
+++ b/src/apprt/gtk/menu.zig
@@ -82,10 +82,6 @@ pub fn Menu(
             return self.menu_widget.as(gtk.Widget).getVisible() != 0;
         }
 
-        pub fn setVisible(self: *const Self, visible: bool) void {
-            self.menu_widget.as(gtk.Widget).setVisible(@intFromBool(visible));
-        }
-
         /// Refresh the menu. Right now that means enabling/disabling the "Copy"
         /// menu item based on whether there is an active selection or not, but
         /// that may change in the future.


### PR DESCRIPTION
Port with changes:

* Utilizes the Surface blueprint for defining the `PopoverMenu`
* We can't attach it directly to the Overlay using blueprints because an overlay can only have a single child property and you can't see other children via Blueprint. To overcome this, use a `Box`
* Utilizing a `menu` signal the window can listen to to refresh its action map instead of digging into ancestor hierarchy.



