### PR TITLE
apprt/gtk-ng: action accelerators, clean up explicit error sets

### DIFF
--- a/src/apprt/gtk-ng/key.zig
+++ b/src/apprt/gtk-ng/key.zig
@@ -9,7 +9,10 @@ const input = @import("../../input.zig");
 const winproto = @import("winproto.zig");
 
 /// Returns a GTK accelerator string from a trigger.
-pub fn accelFromTrigger(buf: []u8, trigger: input.Binding.Trigger) !?[:0]const u8 {
+pub fn accelFromTrigger(
+    buf: []u8,
+    trigger: input.Binding.Trigger,
+) error{NoSpaceLeft}!?[:0]const u8 {
     var buf_stream = std.io.fixedBufferStream(buf);
     const writer = buf_stream.writer();
 
@@ -30,7 +33,10 @@ pub fn accelFromTrigger(buf: []u8, trigger: input.Binding.Trigger) !?[:0]const u
 
 /// Returns a XDG-compliant shortcuts string from a trigger.
 /// Spec: https://specifications.freedesktop.org/shortcuts-spec/latest/
-pub fn xdgShortcutFromTrigger(buf: []u8, trigger: input.Binding.Trigger) !?[:0]const u8 {
+pub fn xdgShortcutFromTrigger(
+    buf: []u8,
+    trigger: input.Binding.Trigger,
+) error{NoSpaceLeft}!?[:0]const u8 {
     var buf_stream = std.io.fixedBufferStream(buf);
     const writer = buf_stream.writer();
 

--- a/src/apprt/gtk-ng/ui/1.5/window.blp
+++ b/src/apprt/gtk-ng/ui/1.5/window.blp
@@ -8,7 +8,6 @@ template $GhosttyWindow: Adw.ApplicationWindow {
 
   close-request => $close_request();
   realize => $realize();
-  notify::background-opaque => $notify_background_opaque();
   notify::config => $notify_config();
   notify::fullscreened => $notify_fullscreened();
   notify::maximized => $notify_maximized();


### PR DESCRIPTION
Not a lot here, ported the action accelerators which was small.

Besides that, cleaned up a bunch of explicit error sets which allowed us to remove some forwarded errors because they're so unlikely, and could unify others.