### PR TITLE
linux: interpret 'dark' window-theme as 'prefer_dark'

### DIFF
--- a/src/apprt/gtk-ng/class/application.zig
+++ b/src/apprt/gtk-ng/class/application.zig
@@ -1006,7 +1006,7 @@ pub const Application = extern struct {
                     .prefer_dark;
             },
             .system => .prefer_light,
-            .dark => .force_dark,
+            .dark => .prefer_dark,
             .light => .force_light,
         });
 

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -334,7 +334,7 @@ pub fn init(self: *App, core_app: *CoreApp, opts: Options) !void {
                     .prefer_dark;
             },
             .system => .prefer_light,
-            .dark => .force_dark,
+            .dark => .prefer_dark,
             .light => .force_light,
         },
     );

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1591,6 +1591,7 @@ keybind: Keybinds = .{},
 ///   * `system` - Use the system theme.
 ///   * `light` - Use the light theme regardless of system theme.
 ///   * `dark` - Use the dark theme regardless of system theme.
+///     On Linux, prefer the dark theme, but still respect the system theme.
 ///   * `ghostty` - Use the background and foreground colors specified in the
 ///     Ghostty configuration. This is only supported on Linux builds.
 ///


### PR DESCRIPTION
Linux allows applications to express four color schemes that related to dark mode: force-light, prefer-light, prefer-dark, force-dark. The system then has three schemes: prefer-light, default, prefer-dark. The schemes and their interaction is pretty well explored in the blog post at https://blogs.gnome.org/alicem/2021/10/04/dark-style-preference/.

This commit changes Ghostty's 'dark' window-theme to mean 'prefer-dark' instead of 'force-dark'. For most users, this should have no impact. GNOME (and likely other desktops) do not actually set the 'prefer-light' system scheme, so the result for both 'dark' and 'prefer-dark' is that Ghostty will use the configured dark theme. However, this change will allow a user to manually set 'prefer-light' as the system scheme to override the (now) 'prefer-dark' setting in Ghostty.

This does mean that there is now no window-theme which maps to 'force-dark' as the application scheme. Again, that should be fine for most users since common desktops never set 'prefer-light' anyway. But if force-dark is still desired, users can achieve that simply by setting a single dark theme, rather than separate light and dark themes.

Discussion: https://github.com/ghostty-org/ghostty/discussions/8134