### PR TITLE
macOS: Add debug info to "About Ghostty"

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -347,6 +347,23 @@ typedef struct {
 } ghostty_info_s;
 
 typedef struct {
+  const char* version;
+  uintptr_t version_len;
+  const char* zig_version;
+  uintptr_t zig_version_len;
+  const char* build_mode;
+  uintptr_t build_mode_len;
+  const char* app_runtime;
+  uintptr_t app_runtime_len;
+  const char* font_backend;
+  uintptr_t font_backend_len;
+  const char* renderer;
+  uintptr_t renderer_len;
+  const char* release_channel;
+  uintptr_t release_channel_len;
+} ghostty_build_info_s;
+
+typedef struct {
   const char* message;
 } ghostty_diagnostic_s;
 
@@ -859,6 +876,7 @@ typedef enum {
 int ghostty_init(uintptr_t, char**);
 void ghostty_cli_try_action(void);
 ghostty_info_s ghostty_info(void);
+ghostty_build_info_s ghostty_build_info(void);
 const char* ghostty_translate(const char*);
 void ghostty_string_free(ghostty_string_s);
 

--- a/macos/Sources/App/macOS/ghostty-bridging-header.h
+++ b/macos/Sources/App/macOS/ghostty-bridging-header.h
@@ -1,3 +1,4 @@
 // C imports here are exposed to Swift.
 
 #import "VibrantLayer.h"
+#import "ghostty.h"

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -35,6 +35,16 @@ extension Ghostty {
         var mode: ghostty_build_mode_e
         var version: String
     }
+    
+    struct BuildInfo {
+        var version: String
+        var zigVersion: String
+        var buildMode: String
+        var appRuntime: String
+        var fontBackend: String
+        var renderer: String
+        var releaseChannel: String
+    }
 
     static var info: Info {
         let raw = ghostty_info()
@@ -45,6 +55,62 @@ extension Ghostty {
         ) ?? "unknown"
 
         return Info(mode: raw.build_mode, version: String(version))
+    }
+    
+    static var buildInfo: BuildInfo {
+        let raw = ghostty_build_info()
+        
+        let version = NSString(
+            bytes: raw.version,
+            length: Int(raw.version_len),
+            encoding: NSUTF8StringEncoding
+        ) ?? "unknown"
+        
+        let zigVersion = NSString(
+            bytes: raw.zig_version,
+            length: Int(raw.zig_version_len),
+            encoding: NSUTF8StringEncoding
+        ) ?? "unknown"
+        
+        let buildMode = NSString(
+            bytes: raw.build_mode,
+            length: Int(raw.build_mode_len),
+            encoding: NSUTF8StringEncoding
+        ) ?? "unknown"
+        
+        let appRuntime = NSString(
+            bytes: raw.app_runtime,
+            length: Int(raw.app_runtime_len),
+            encoding: NSUTF8StringEncoding
+        ) ?? "unknown"
+        
+        let fontBackend = NSString(
+            bytes: raw.font_backend,
+            length: Int(raw.font_backend_len),
+            encoding: NSUTF8StringEncoding
+        ) ?? "unknown"
+        
+        let renderer = NSString(
+            bytes: raw.renderer,
+            length: Int(raw.renderer_len),
+            encoding: NSUTF8StringEncoding
+        ) ?? "unknown"
+        
+        let releaseChannel = NSString(
+            bytes: raw.release_channel,
+            length: Int(raw.release_channel_len),
+            encoding: NSUTF8StringEncoding
+        ) ?? "unknown"
+        
+        return BuildInfo(
+            version: String(version),
+            zigVersion: String(zigVersion),
+            buildMode: String(buildMode),
+            appRuntime: String(appRuntime),
+            fontBackend: String(fontBackend),
+            renderer: String(renderer),
+            releaseChannel: String(releaseChannel)
+        )
     }
 }
 

--- a/src/main_c.zig
+++ b/src/main_c.zig
@@ -59,6 +59,27 @@ const Info = extern struct {
     };
 };
 
+/// ghostty_build_info_s
+const BuildInfo = extern struct {
+    // Basic version info
+    version: [*]const u8,
+    version_len: usize,
+    
+    // Build configuration 
+    zig_version: [*]const u8,
+    zig_version_len: usize,
+    build_mode: [*]const u8,
+    build_mode_len: usize,
+    app_runtime: [*]const u8,
+    app_runtime_len: usize,
+    font_backend: [*]const u8,
+    font_backend_len: usize,
+    renderer: [*]const u8,
+    renderer_len: usize,
+    release_channel: [*]const u8,
+    release_channel_len: usize,
+};
+
 /// ghostty_string_s
 pub const String = extern struct {
     ptr: ?[*]const u8,
@@ -114,6 +135,32 @@ pub export fn ghostty_info() Info {
         },
         .version = build_config.version_string.ptr,
         .version_len = build_config.version_string.len,
+    };
+}
+
+pub export fn ghostty_build_info() BuildInfo {
+    const zig_version = builtin.zig_version_string;
+    const build_mode = @tagName(builtin.mode);
+    const app_runtime = @tagName(build_config.app_runtime);
+    const font_backend = @tagName(build_config.font_backend);
+    const renderer = @tagName(build_config.renderer);
+    const release_channel = @tagName(build_config.release_channel);
+    
+    return .{
+        .version = build_config.version_string.ptr,
+        .version_len = build_config.version_string.len,
+        .zig_version = zig_version.ptr,
+        .zig_version_len = zig_version.len,
+        .build_mode = build_mode.ptr,
+        .build_mode_len = build_mode.len,
+        .app_runtime = app_runtime.ptr,
+        .app_runtime_len = app_runtime.len,
+        .font_backend = font_backend.ptr,
+        .font_backend_len = font_backend.len,
+        .renderer = renderer.ptr,
+        .renderer_len = renderer.len,
+        .release_channel = release_channel.ptr,
+        .release_channel_len = release_channel.len,
     };
 }
 


### PR DESCRIPTION
I should start this PR with an honest clarification:

_I am not familiar with macOS, C or Zig development_.

What is being proposed is proposed with the assistance of Claude agentic development.  I should clearly state that like many I am cynical of these sorts of PRs, but I decided to post it here for three reasons:

1. This is a tight change, which does not propose largescale refactoring or introduction of major new features, it builds upon existing code.

2. I have had a quick look through the `git diff` and to my non-macOS dev eyes, it looks clean, reasonable and easy to follow.

3. I have run `zig build` on a macOS Sequoia 15.5.  `ghostty` compiles without error (*IMPORTANT*: See note [below](#important-note)) and I can open the binary and confirmed the new functionality works.

I understand this is a controversial PR so if you want to delete it, no hard feelings.  I just ask that you do it silently without bashing me about the use of Claude etc.

<img width="412" height="596" alt="Ghostty1" src="https://github.com/user-attachments/assets/f0fdce28-692d-4683-aa88-6bda431a8382" />


<img width="412" height="691" alt="Ghostty2" src="https://github.com/user-attachments/assets/f3c7d863-c0f7-4d75-a33a-a063b6e86d2d" />


# Important note

Finally, regarding the **IMPORTANT** note:

As i said, `zig build` works with this PR on Sequoia 15.5, it worked because (in order to fix build errors) Claude also proposed to remove:

```diff
-    @available(macOS 26.0, *)
-    static var supportedModes: IntentModes = [.background, .foreground]
```

From the following files:

1. [macos/Sources/Features/App Intents/CloseTerminalIntent.swift](https://github.com/ghostty-org/ghostty/blob/70ec59d5663eb4d62df0431c1f71d7c64a6a3630/macos/Sources/Features/App%20Intents/CloseTerminalIntent.swift#L15-L16)
2. [macos/Sources/Features/App Intents/CommandPaletteIntent.swift](https://github.com/ghostty-org/ghostty/blob/70ec59d5663eb4d62df0431c1f71d7c64a6a3630/macos/Sources/Features/App%20Intents/CommandPaletteIntent.swift#L22-L23)
3. [macos/Sources/Features/App Intents/GetTerminalDetailsIntent.swift](https://github.com/ghostty-org/ghostty/blob/70ec59d5663eb4d62df0431c1f71d7c64a6a3630/macos/Sources/Features/App%20Intents/GetTerminalDetailsIntent.swift#L20-L21)
5. [macos/Sources/Features/App Intents/InputIntent.swift](https://github.com/ghostty-org/ghostty/blob/70ec59d5663eb4d62df0431c1f71d7c64a6a3630/macos/Sources/Features/App%20Intents/InputIntent.swift#L27-L28)
6. [macos/Sources/Features/App Intents/KeybindIntent.swift](https://github.com/ghostty-org/ghostty/blob/70ec59d5663eb4d62df0431c1f71d7c64a6a3630/macos/Sources/Features/App%20Intents/KeybindIntent.swift#L19-L20)
7. [macos/Sources/Features/App Intents/NewTerminalIntent.swift](https://github.com/ghostty-org/ghostty/blob/70ec59d5663eb4d62df0431c1f71d7c64a6a3630/macos/Sources/Features/App%20Intents/NewTerminalIntent.swift#L46-L47)
8. [macos/Sources/Features/App Intents/QuickTerminalIntent.swift](https://github.com/ghostty-org/ghostty/blob/70ec59d5663eb4d62df0431c1f71d7c64a6a3630/macos/Sources/Features/App%20Intents/QuickTerminalIntent.swift#L8-L9)

For, example:

```diff
diff --git a/macos/Sources/Features/App Intents/QuickTerminalIntent.swift b/macos/Sources/Features/App Intents/QuickTerminalIntent.swift
index 2e6c9850c..1936d3e0c 100644
--- a/macos/Sources/Features/App Intents/QuickTerminalIntent.swift
+++ b/macos/Sources/Features/App Intents/QuickTerminalIntent.swift
@@ -5,8 +5,6 @@ struct QuickTerminalIntent: AppIntent {
     static var title: LocalizedStringResource = "Open the Quick Terminal"
     static var description = IntentDescription("Open the Quick Terminal. If it is already open, then do nothing.")

-    @available(macOS 26.0, *)
-    static var supportedModes: IntentModes = .background

     @MainActor
     func perform() async throws -> some IntentResult & ReturnsValue<[TerminalEntity]> {
```

I decided ***NOT*** to include these changes in this PR.  Because I thought that you may well be looking to build against the upcoming macOS Tahoe. 

So if you try to build this PR on a 15.5 machine it will fail due to the above, as IntentModes API is only available in the Tahoe SDK, not in Seqoia SDK which is what my machine has.
