### PR TITLE
gtk-ng: a couple of minor fixes

### DIFF
--- a/src/apprt/gtk-ng/class/surface.zig
+++ b/src/apprt/gtk-ng/class/surface.zig
@@ -1495,7 +1495,7 @@ pub const Surface = extern struct {
         };
 
         // Set our new cursor.
-        priv.gl_area.as(gtk.Widget).setCursorFromName(name.ptr);
+        self.as(gtk.Widget).setCursorFromName(name.ptr);
     }
 
     //---------------------------------------------------------------

--- a/src/apprt/gtk-ng/ui/1.2/surface.blp
+++ b/src/apprt/gtk-ng/ui/1.2/surface.blp
@@ -30,7 +30,7 @@ template $GhosttySurface: Adw.Bin {
         focus-on-click: true;
         has-stencil-buffer: false;
         has-depth-buffer: false;
-        use-es: false;
+        allowed-apis: gl;
       }
 
       PopoverMenu context_menu {


### PR DESCRIPTION
A couple of minor fixes that I found while exploring tonight:

- OSC 22 wasn't working on gtk-ng. Fixed by setting the cursor shape directly on the surface.
- Removed use of deprecated property on GLArea