### PR TITLE
valgrind: GtkPopover suppressions

### DIFF
--- a/valgrind.supp
+++ b/valgrind.supp
@@ -13,6 +13,38 @@
 # You must gracefully exit Ghostty (do not SIGINT) by closing all windows
 # and quitting. Otherwise, we leave a number of GTK resources around.
 
+
+# Reproduction: 
+# 1. Launch Ghostty (no config)
+# 2. Right Click on the terminal
+# 3. Hover over "Split" to get a submenu
+# 4. Close menu by clicking away
+# 5. Exit
+#
+# The menu model and popover are fully defined in the blueprint so I don't
+# THINK we need to do any manual unrefing. But there's a lot of leaks here
+# so if someone wants to take a closer look I'd appreciate it.
+{
+   GTK PopOver Menu Model Leak
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:gtk_menu_section_box_insert_func
+   ...
+   fun:gtk_popover_menu_set_menu_model
+   ...
+}
+{
+   GTK/Blueprint Popover GSK Transform
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:gtk_popover_size_allocate
+   fun:gtk_widget_allocate
+   fun:gtk_popover_native_layout
+   ...
+}
+
 {
    GTK CSS Provider Leak
    Memcheck:Leak


### PR DESCRIPTION
We get a ton of leaks from GTK.PopOver when we run the steps given in the suppression file. I don't see how this could be us since we don't create or do anything with the popover manually; its simply defined in the Blueprint file.

The leaks specifically only happen when a Popover shows a sub-menu. Without that, everything is completely clean. So I actually suspect there's some leaks in GTK related to this behavior (not sure if they're on purpose not, a brief look at the code doesn't look like they're reused).

I tried alternate approaches where we create the Popover AND/OR the MenuModel in code without the Blueprint file and we get the same leaks. 

I'm kind of suspicious about this one but don't see how we can do anything about it, so I'm going to suppress for now. The suppression file has detailed repro steps that people can use to hopefully test this later.