### PR TITLE
apprt/gtk-ng: add proper setters for surface properties

### DIFF
--- a/src/apprt/gtk-ng/class/application.zig
+++ b/src/apprt/gtk-ng/class/application.zig
@@ -1693,16 +1693,9 @@ const Action = struct {
     ) void {
         switch (target) {
             .app => log.warn("mouse over link to app is unexpected", .{}),
-            .surface => |surface| {
-                var v = gobject.ext.Value.new([:0]const u8);
-                if (value.url.len > 0) gobject.ext.Value.set(&v, value.url);
-                defer v.unset();
-                gobject.Object.setProperty(
-                    surface.rt_surface.gobj().as(gobject.Object),
-                    "mouse-hover-url",
-                    &v,
-                );
-            },
+            .surface => |surface| surface.rt_surface.gobj().setMouseHoverUrl(
+                if (value.url.len > 0) value.url else null,
+            ),
         }
     }
 
@@ -1712,15 +1705,7 @@ const Action = struct {
     ) void {
         switch (target) {
             .app => log.warn("mouse shape to app is unexpected", .{}),
-            .surface => |surface| {
-                var value = gobject.ext.Value.newFrom(shape);
-                defer value.unset();
-                gobject.Object.setProperty(
-                    surface.rt_surface.gobj().as(gobject.Object),
-                    "mouse-shape",
-                    &value,
-                );
-            },
+            .surface => |surface| surface.rt_surface.gobj().setMouseShape(shape),
         }
     }
 
@@ -1730,18 +1715,10 @@ const Action = struct {
     ) void {
         switch (target) {
             .app => log.warn("mouse visibility to app is unexpected", .{}),
-            .surface => |surface| {
-                var value = gobject.ext.Value.newFrom(switch (visibility) {
-                    .visible => false,
-                    .hidden => true,
-                });
-                defer value.unset();
-                gobject.Object.setProperty(
-                    surface.rt_surface.gobj().as(gobject.Object),
-                    "mouse-hidden",
-                    &value,
-                );
-            },
+            .surface => |surface| surface.rt_surface.gobj().setMouseHidden(switch (visibility) {
+                .visible => false,
+                .hidden => true,
+            }),
         }
     }
 
@@ -1862,15 +1839,7 @@ const Action = struct {
     ) void {
         switch (target) {
             .app => log.warn("pwd to app is unexpected", .{}),
-            .surface => |surface| {
-                var v = gobject.ext.Value.newFrom(value.pwd);
-                defer v.unset();
-                gobject.Object.setProperty(
-                    surface.rt_surface.gobj().as(gobject.Object),
-                    "pwd",
-                    &v,
-                );
-            },
+            .surface => |surface| surface.rt_surface.gobj().setPwd(value.pwd),
         }
     }
 
@@ -1970,15 +1939,7 @@ const Action = struct {
     ) void {
         switch (target) {
             .app => log.warn("set_title to app is unexpected", .{}),
-            .surface => |surface| {
-                var v = gobject.ext.Value.newFrom(value.title);
-                defer v.unset();
-                gobject.Object.setProperty(
-                    surface.rt_surface.gobj().as(gobject.Object),
-                    "title",
-                    &v,
-                );
-            },
+            .surface => |surface| surface.rt_surface.gobj().setTitle(value.title),
         }
     }
 

--- a/src/apprt/gtk-ng/class/surface.zig
+++ b/src/apprt/gtk-ng/class/surface.zig
@@ -139,11 +139,13 @@ pub const Surface = extern struct {
                 bool,
                 .{
                     .default = false,
-                    .accessor = gobject.ext.privateFieldAccessor(
+                    .accessor = gobject.ext.typedAccessor(
                         Self,
-                        Private,
-                        &Private.offset,
-                        "mouse_hidden",
+                        bool,
+                        .{
+                            .getter = getMouseHidden,
+                            .setter = setMouseHidden,
+                        },
                     ),
                 },
             );
@@ -157,11 +159,13 @@ pub const Surface = extern struct {
                 terminal.MouseShape,
                 .{
                     .default = .text,
-                    .accessor = gobject.ext.privateFieldAccessor(
+                    .accessor = gobject.ext.typedAccessor(
                         Self,
-                        Private,
-                        &Private.offset,
-                        "mouse_shape",
+                        terminal.MouseShape,
+                        .{
+                            .getter = getMouseShape,
+                            .setter = setMouseShape,
+                        },
                     ),
                 },
             );
@@ -1289,9 +1293,27 @@ pub const Surface = extern struct {
         return self.private().title;
     }
 
+    /// Set the title for this surface, copies the value.
+    pub fn setTitle(self: *Self, title: ?[:0]const u8) void {
+        const priv = self.private();
+        if (priv.title) |v| glib.free(@constCast(@ptrCast(v)));
+        priv.title = null;
+        if (title) |v| priv.title = glib.ext.dupeZ(u8, v);
+        self.as(gobject.Object).notifyByPspec(properties.title.impl.param_spec);
+    }
+
     /// Returns the pwd property without a copy.
     pub fn getPwd(self: *Self) ?[:0]const u8 {
         return self.private().pwd;
+    }
+
+    /// Set the pwd for this surface, copies the value.
+    pub fn setPwd(self: *Self, pwd: ?[:0]const u8) void {
+        const priv = self.private();
+        if (priv.pwd) |v| glib.free(@constCast(@ptrCast(v)));
+        priv.pwd = null;
+        if (pwd) |v| priv.pwd = glib.ext.dupeZ(u8, v);
+        self.as(gobject.Object).notifyByPspec(properties.pwd.impl.param_spec);
     }
 
     /// Returns the focus state of this surface.
@@ -1349,6 +1371,34 @@ pub const Surface = extern struct {
             &size,
         );
         self.as(gobject.Object).notifyByPspec(properties.@"min-size".impl.param_spec);
+    }
+
+    pub fn getMouseShape(self: *Self) terminal.MouseShape {
+        return self.private().mouse_shape;
+    }
+
+    pub fn setMouseShape(self: *Self, shape: terminal.MouseShape) void {
+        const priv = self.private();
+        priv.mouse_shape = shape;
+        self.as(gobject.Object).notifyByPspec(properties.@"mouse-shape".impl.param_spec);
+    }
+
+    pub fn getMouseHidden(self: *Self) bool {
+        return self.private().mouse_hidden;
+    }
+
+    pub fn setMouseHidden(self: *Self, hidden: bool) void {
+        const priv = self.private();
+        priv.mouse_hidden = hidden;
+        self.as(gobject.Object).notifyByPspec(properties.@"mouse-hidden".impl.param_spec);
+    }
+
+    pub fn setMouseHoverUrl(self: *Self, url: ?[:0]const u8) void {
+        const priv = self.private();
+        if (priv.mouse_hover_url) |v| glib.free(@constCast(@ptrCast(v)));
+        priv.mouse_hover_url = null;
+        if (url) |v| priv.mouse_hover_url = glib.ext.dupeZ(u8, v);
+        self.as(gobject.Object).notifyByPspec(properties.@"mouse-hover-url".impl.param_spec);
     }
 
     fn propConfig(
@@ -1480,7 +1530,7 @@ pub const Surface = extern struct {
         };
 
         // Set our new cursor.
-        self.as(gtk.Widget).setCursorFromName(name.ptr);
+        priv.gl_area.as(gtk.Widget).setCursorFromName(name.ptr);
     }
 
     //---------------------------------------------------------------


### PR DESCRIPTION
This also fixes a bug where we were setting custom cursors on the wrong gtk widget, this showed up most terribly with `mouse-hide-while-typing` where the mouse would never reappear.