### PR TITLE
apprt/gtk-ng: template callbacks can't return bool, must be c_int

### DIFF
--- a/src/apprt/gtk-ng/class.zig
+++ b/src/apprt/gtk-ng/class.zig
@@ -222,6 +222,11 @@ pub fn Common(
                     if (func_ti != .@"fn") {
                         @compileError("bound function must be a function pointer");
                     }
+                    if (func_ti.@"fn".return_type == bool) {
+                        // glib booleans are ints and returning a Zig bool type
+                        // I think uses a byte and causes ABI issues.
+                        @compileError("bound function must return c_int instead of bool");
+                    }
                 }
 
                 gtk.Widget.Class.bindTemplateCallbackFull(

--- a/src/apprt/gtk-ng/class/window.zig
+++ b/src/apprt/gtk-ng/class/window.zig
@@ -1054,11 +1054,11 @@ pub const Window = extern struct {
     fn closureTitlebarStyleIsTab(
         _: *Self,
         value: TitlebarStyle,
-    ) callconv(.c) bool {
-        return switch (value) {
+    ) callconv(.c) c_int {
+        return @intFromBool(switch (value) {
             .native => false,
             .tabs => true,
-        };
+        });
     }
 
     //---------------------------------------------------------------


### PR DESCRIPTION
This fixes the tab bar showing the window controls sometimes.