### PR TITLE
core: add a UUID to every core surface

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -510,6 +510,16 @@ fn hasSurface(self: *const App, surface: *const Surface) bool {
     return false;
 }
 
+/// Search for a surface by a 64 bit unique ID.
+pub fn findSurfaceByID(self: *const App, id: u64) ?*Surface {
+    for (self.surfaces.items) |v| {
+        const surface: *Surface = v.core();
+        if (surface.id == id) return surface;
+    }
+
+    return null;
+}
+
 fn hasRtSurface(self: *const App, surface: *apprt.Surface) bool {
     for (self.surfaces.items) |v| {
         if (v == surface) return true;

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -52,6 +52,11 @@ const Renderer = rendererpkg.Renderer;
 const min_window_width_cells: u32 = 10;
 const min_window_height_cells: u32 = 4;
 
+/// Unique ID used to identify this surface for IPC purposes. It is
+/// exposed to the commands running in surfaces as the environment variable
+/// GHOSTTY_SURFACE.
+id: u64,
+
 /// Allocator
 alloc: Allocator,
 
@@ -532,6 +537,7 @@ pub fn init(
     errdefer io_thread.deinit();
 
     self.* = .{
+        .id = std.crypto.random.int(u64),
         .alloc = alloc,
         .app = app,
         .rt_app = rt_app,
@@ -577,6 +583,12 @@ pub fn init(
                 std.process.EnvMap.init(alloc);
         };
         errdefer env.deinit();
+
+        var buf: [18]u8 = undefined;
+        try env.put(
+            "GHOSTTY_SURFACE",
+            std.fmt.bufPrint(&buf, "0x{x:0>16}", .{self.id}) catch unreachable,
+        );
 
         // Initialize our IO backend
         var io_exec = try termio.Exec.init(alloc, .{


### PR DESCRIPTION
- Adds a 128bit UUID to every core surface.
- Expose that UUID as an environment variable.
- Add a function to the core app to search for surfaces by UUID.
