### PR TITLE
apprt/gtk-ng: create/close split functionality

### DIFF
--- a/src/apprt/gtk-ng/build/gresource.zig
+++ b/src/apprt/gtk-ng/build/gresource.zig
@@ -41,6 +41,7 @@ pub const blueprints: []const Blueprint = &.{
     .{ .major = 1, .minor = 3, .name = "debug-warning" },
     .{ .major = 1, .minor = 2, .name = "resize-overlay" },
     .{ .major = 1, .minor = 5, .name = "split-tree" },
+    .{ .major = 1, .minor = 5, .name = "split-tree-split" },
     .{ .major = 1, .minor = 2, .name = "surface" },
     .{ .major = 1, .minor = 3, .name = "surface-child-exited" },
     .{ .major = 1, .minor = 5, .name = "tab" },

--- a/src/apprt/gtk-ng/class/application.zig
+++ b/src/apprt/gtk-ng/class/application.zig
@@ -1257,6 +1257,7 @@ pub const Application = extern struct {
             diag.close();
             diag.unref(); // strong ref from get()
         }
+        priv.config_errors_dialog.set(null);
         if (priv.signal_source) |v| {
             if (glib.Source.remove(v) == 0) {
                 log.warn("unable to remove signal source", .{});

--- a/src/apprt/gtk-ng/class/application.zig
+++ b/src/apprt/gtk-ng/class/application.zig
@@ -882,6 +882,10 @@ pub const Application = extern struct {
         self.syncActionAccelerator("win.reset", .{ .reset = {} });
         self.syncActionAccelerator("win.clear", .{ .clear_screen = {} });
         self.syncActionAccelerator("win.prompt-title", .{ .prompt_surface_title = {} });
+        self.syncActionAccelerator("split-tree.new-left", .{ .new_split = .left });
+        self.syncActionAccelerator("split-tree.new-right", .{ .new_split = .right });
+        self.syncActionAccelerator("split-tree.new-up", .{ .new_split = .up });
+        self.syncActionAccelerator("split-tree.new-down", .{ .new_split = .down });
     }
 
     fn syncActionAccelerator(

--- a/src/apprt/gtk-ng/class/application.zig
+++ b/src/apprt/gtk-ng/class/application.zig
@@ -562,6 +562,8 @@ pub const Application = extern struct {
 
             .move_tab => return Action.moveTab(target, value),
 
+            .new_split => return Action.newSplit(target, value),
+
             .new_tab => return Action.newTab(target),
 
             .new_window => try Action.newWindow(
@@ -611,7 +613,6 @@ pub const Application = extern struct {
             .prompt_title,
             .inspector,
             // TODO: splits
-            .new_split,
             .resize_split,
             .equalize_splits,
             .goto_split,
@@ -1743,6 +1744,28 @@ const Action = struct {
                     surface,
                     @intCast(value.amount),
                 );
+            },
+        }
+    }
+
+    pub fn newSplit(
+        target: apprt.Target,
+        direction: apprt.action.SplitDirection,
+    ) bool {
+        switch (target) {
+            .app => {
+                log.warn("new split to app is unexpected", .{});
+                return false;
+            },
+
+            .surface => |core| {
+                const surface = core.rt_surface.surface;
+                return surface.as(gtk.Widget).activateAction(switch (direction) {
+                    .right => "split-tree.new-right",
+                    .left => "split-tree.new-left",
+                    .down => "split-tree.new-down",
+                    .up => "split-tree.new-up",
+                }, null) != 0;
             },
         }
     }

--- a/src/apprt/gtk-ng/class/close_confirmation_dialog.zig
+++ b/src/apprt/gtk-ng/class/close_confirmation_dialog.zig
@@ -133,6 +133,7 @@ pub const CloseConfirmationDialog = extern struct {
     const C = Common(Self, Private);
     pub const as = C.as;
     pub const ref = C.ref;
+    pub const refSink = C.refSink;
     pub const unref = C.unref;
     const private = C.private;
 
@@ -179,12 +180,14 @@ pub const Target = enum(c_int) {
     app,
     tab,
     window,
+    surface,
 
     pub fn title(self: Target) [*:0]const u8 {
         return switch (self) {
             .app => i18n._("Quit Ghostty?"),
             .tab => i18n._("Close Tab?"),
             .window => i18n._("Close Window?"),
+            .surface => i18n._("Close Split?"),
         };
     }
 
@@ -193,6 +196,7 @@ pub const Target = enum(c_int) {
             .app => i18n._("All terminal sessions will be terminated."),
             .tab => i18n._("All terminal sessions in this tab will be terminated."),
             .window => i18n._("All terminal sessions in this window will be terminated."),
+            .surface => i18n._("The currently running process in this split will be terminated."),
         };
     }
 

--- a/src/apprt/gtk-ng/class/split_tree.zig
+++ b/src/apprt/gtk-ng/class/split_tree.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const build_config = @import("../../../build_config.zig");
 const assert = std.debug.assert;
+const Allocator = std.mem.Allocator;
 const adw = @import("adw");
 const gio = @import("gio");
 const glib = @import("glib");
@@ -36,6 +37,30 @@ pub const SplitTree = extern struct {
     });
 
     pub const properties = struct {
+        /// The active surface is the surface that should be receiving all
+        /// surface-targeted actions. This is usually the focused surface,
+        /// but may also not be focused if the user has selected a non-surface
+        /// widget.
+        pub const @"active-surface" = struct {
+            pub const name = "active-surface";
+            const impl = gobject.ext.defineProperty(
+                name,
+                Self,
+                ?*Surface,
+                .{
+                    .nick = "Active Surface",
+                    .blurb = "The currently active surface.",
+                    .accessor = gobject.ext.typedAccessor(
+                        Self,
+                        ?*Surface,
+                        .{
+                            .getter = getActiveSurface,
+                        },
+                    ),
+                },
+            );
+        };
+
         pub const @"has-surfaces" = struct {
             pub const name = "has-surfaces";
             const impl = gobject.ext.defineProperty(
@@ -98,10 +123,131 @@ pub const SplitTree = extern struct {
 
     fn init(self: *Self, _: *Class) callconv(.c) void {
         gtk.Widget.initTemplate(self.as(gtk.Widget));
+
+        // Initialize our actions
+        self.initActions();
+    }
+
+    fn initActions(self: *Self) void {
+        // The set of actions. Each action has (in order):
+        // [0] The action name
+        // [1] The callback function
+        // [2] The glib.VariantType of the parameter
+        //
+        // For action names:
+        // https://docs.gtk.org/gio/type_func.Action.name_is_valid.html
+        const actions = .{
+            // All of these will eventually take a target surface parameter.
+            // For now all our targets originate from the focused surface.
+            .{ "new-left", actionNew, null },
+            .{ "new-right", actionNew, null },
+            .{ "new-up", actionNew, null },
+            .{ "new-down", actionNew, null },
+        };
+
+        // We need to collect our actions into a group since we're just
+        // a plain widget that doesn't implement ActionGroup directly.
+        const group = gio.SimpleActionGroup.new();
+        errdefer group.unref();
+        const map = group.as(gio.ActionMap);
+        inline for (actions) |entry| {
+            const action = gio.SimpleAction.new(
+                entry[0],
+                entry[2],
+            );
+            defer action.unref();
+            _ = gio.SimpleAction.signals.activate.connect(
+                action,
+                *Self,
+                entry[1],
+                self,
+                .{},
+            );
+            map.addAction(action.as(gio.Action));
+        }
+
+        self.as(gtk.Widget).insertActionGroup(
+            "split-tree",
+            group.as(gio.ActionGroup),
+        );
+    }
+
+    /// Create a new split in the given direction from the currently
+    /// active surface.
+    ///
+    /// If the tree is empty this will create a new tree with a new surface
+    /// and ignore the direction.
+    ///
+    /// The parent will be used as the parent of the surface regardless of
+    /// if that parent is in this split tree or not. This allows inheriting
+    /// surface properties from anywhere.
+    pub fn newSplit(
+        self: *Self,
+        direction: Surface.Tree.Split.Direction,
+        parent_: ?*Surface,
+    ) Allocator.Error!void {
+        const alloc = Application.default().allocator();
+
+        // Create our new surface.
+        const surface: *Surface = .new();
+        defer surface.unref();
+        _ = surface.refSink();
+
+        // Inherit properly if we were asked to.
+        if (parent_) |p| {
+            if (p.core()) |core| {
+                surface.setParent(core);
+            }
+        }
+
+        // Create our tree
+        var single_tree = try Surface.Tree.init(alloc, surface);
+        defer single_tree.deinit();
+
+        // If we have no tree yet, then this becomes our tree and we're done.
+        const old_tree = self.getTree() orelse {
+            self.setTree(&single_tree);
+            return;
+        };
+
+        // The handle we create the split relative to. Today this is the active
+        // surface but this might be the handle of the given parent if we want.
+        const handle = self.getActiveSurfaceHandle() orelse 0;
+
+        // Create our split!
+        var new_tree = try old_tree.split(
+            alloc,
+            handle,
+            direction,
+            &single_tree,
+        );
+        defer new_tree.deinit();
+        self.setTree(&new_tree);
+
+        // Focus our new surface
+        surface.grabFocus();
     }
 
     //---------------------------------------------------------------
     // Properties
+
+    /// Get the currently active surface. See the "active-surface" property.
+    /// This does not ref the value.
+    pub fn getActiveSurface(self: *Self) ?*Surface {
+        const tree = self.getTree() orelse return null;
+        const handle = self.getActiveSurfaceHandle() orelse return null;
+        return tree.nodes[handle].leaf;
+    }
+
+    fn getActiveSurfaceHandle(self: *Self) ?Surface.Tree.Node.Handle {
+        const tree = self.getTree() orelse return null;
+        var it = tree.iterator();
+        while (it.next()) |entry| {
+            if (entry.view.getFocused()) return entry.handle;
+        }
+
+        return null;
+    }
 
     pub fn getHasSurfaces(self: *Self) bool {
         const tree: *const Surface.Tree = self.private().tree orelse &.empty;
@@ -184,6 +330,20 @@ pub const SplitTree = extern struct {
 
     //---------------------------------------------------------------
     // Signal handlers
+
+    pub fn actionNew(
+        _: *gio.SimpleAction,
+        parameter_: ?*glib.Variant,
+        self: *Self,
+    ) callconv(.c) void {
+        _ = parameter_;
+        self.newSplit(
+            .right,
+            self.getActiveSurface(),
+        ) catch |err| {
+            log.warn("new split failed error={}", .{err});
+        };
+    }
 
     fn propTree(
         self: *Self,

--- a/src/apprt/gtk-ng/class/split_tree.zig
+++ b/src/apprt/gtk-ng/class/split_tree.zig
@@ -379,7 +379,7 @@ pub const SplitTree = extern struct {
     ) *gtk.Widget {
         switch (tree.nodes[current]) {
             .leaf => |v| {
-                // We have to setup our signal handlers.
+                v.as(gtk.Widget).unparent();
                 return v.as(gtk.Widget);
             },
 

--- a/src/apprt/gtk-ng/class/split_tree.zig
+++ b/src/apprt/gtk-ng/class/split_tree.zig
@@ -49,8 +49,6 @@ pub const SplitTree = extern struct {
                 Self,
                 ?*Surface,
                 .{
-                    .nick = "Active Surface",
-                    .blurb = "The currently active surface.",
                     .accessor = gobject.ext.typedAccessor(
                         Self,
                         ?*Surface,
@@ -481,6 +479,7 @@ pub const SplitTree = extern struct {
             // Remove the surface from the tree.
             .surface => {
                 // TODO: close confirmation
+                // TODO: invalid free on final close
 
                 // Find the surface in the tree.
                 const tree = self.getTree() orelse return;
@@ -517,6 +516,9 @@ pub const SplitTree = extern struct {
         // the surface is destroyed.
         if (!surface.getFocused()) return;
         self.private().last_focused.set(surface);
+
+        // Our active surface probably changed
+        self.as(gobject.Object).notifyByPspec(properties.@"active-surface".impl.param_spec);
     }
 
     fn propTree(
@@ -565,6 +567,9 @@ pub const SplitTree = extern struct {
             defer v.unref();
             v.grabFocus();
         }
+
+        // Our active surface may have changed
+        self.as(gobject.Object).notifyByPspec(properties.@"active-surface".impl.param_spec);
 
         return 0;
     }
@@ -616,6 +621,7 @@ pub const SplitTree = extern struct {
 
             // Properties
             gobject.ext.registerProperties(class, &.{
+                properties.@"active-surface".impl,
                 properties.@"has-surfaces".impl,
                 properties.tree.impl,
             });

--- a/src/apprt/gtk-ng/class/split_tree.zig
+++ b/src/apprt/gtk-ng/class/split_tree.zig
@@ -243,9 +243,6 @@ pub const SplitTree = extern struct {
 
         // Replace our tree
         self.setTree(&new_tree);
-
-        // Focus our new surface
-        surface.grabFocus();
     }
 
     fn disconnectSurfaceHandlers(self: *Self) void {

--- a/src/apprt/gtk-ng/class/split_tree.zig
+++ b/src/apprt/gtk-ng/class/split_tree.zig
@@ -148,10 +148,10 @@ pub const SplitTree = extern struct {
         const actions = .{
             // All of these will eventually take a target surface parameter.
             // For now all our targets originate from the focused surface.
-            .{ "new-left", actionNew, null },
-            .{ "new-right", actionNew, null },
-            .{ "new-up", actionNew, null },
-            .{ "new-down", actionNew, null },
+            .{ "new-left", actionNewLeft, null },
+            .{ "new-right", actionNewRight, null },
+            .{ "new-up", actionNewUp, null },
+            .{ "new-down", actionNewDown, null },
         };
 
         // We need to collect our actions into a group since we're just
@@ -405,7 +405,21 @@ pub const SplitTree = extern struct {
     //---------------------------------------------------------------
     // Signal handlers
 
-    pub fn actionNew(
+    pub fn actionNewLeft(
+        _: *gio.SimpleAction,
+        parameter_: ?*glib.Variant,
+        self: *Self,
+    ) callconv(.c) void {
+        _ = parameter_;
+        self.newSplit(
+            .left,
+            self.getActiveSurface(),
+        ) catch |err| {
+            log.warn("new split failed error={}", .{err});
+        };
+    }
+
+    pub fn actionNewRight(
         _: *gio.SimpleAction,
         parameter_: ?*glib.Variant,
         self: *Self,
@@ -413,6 +427,34 @@ pub const SplitTree = extern struct {
         _ = parameter_;
         self.newSplit(
             .right,
+            self.getActiveSurface(),
+        ) catch |err| {
+            log.warn("new split failed error={}", .{err});
+        };
+    }
+
+    pub fn actionNewUp(
+        _: *gio.SimpleAction,
+        parameter_: ?*glib.Variant,
+        self: *Self,
+    ) callconv(.c) void {
+        _ = parameter_;
+        self.newSplit(
+            .up,
+            self.getActiveSurface(),
+        ) catch |err| {
+            log.warn("new split failed error={}", .{err});
+        };
+    }
+
+    pub fn actionNewDown(
+        _: *gio.SimpleAction,
+        parameter_: ?*glib.Variant,
+        self: *Self,
+    ) callconv(.c) void {
+        _ = parameter_;
+        self.newSplit(
+            .down,
             self.getActiveSurface(),
         ) catch |err| {
             log.warn("new split failed error={}", .{err});

--- a/src/apprt/gtk-ng/class/split_tree.zig
+++ b/src/apprt/gtk-ng/class/split_tree.zig
@@ -490,7 +490,6 @@ pub const SplitTree = extern struct {
             // Remove the surface from the tree.
             .surface => {
                 // TODO: close confirmation
-                // TODO: invalid free on final close
 
                 // Find the surface in the tree.
                 const tree = self.getTree() orelse return;

--- a/src/apprt/gtk-ng/class/split_tree.zig
+++ b/src/apprt/gtk-ng/class/split_tree.zig
@@ -222,6 +222,12 @@ pub const SplitTree = extern struct {
             &single_tree,
         );
         defer new_tree.deinit();
+        log.debug(
+            "new split at={} direction={} old_tree={} new_tree={}",
+            .{ handle, direction, old_tree, &new_tree },
+        );
+
+        // Replace our tree
         self.setTree(&new_tree);
 
         // Focus our new surface

--- a/src/apprt/gtk-ng/class/split_tree.zig
+++ b/src/apprt/gtk-ng/class/split_tree.zig
@@ -330,8 +330,17 @@ pub const SplitTree = extern struct {
 
     /// Set the tree data model that we're showing in this widget. This
     /// will clone the given tree.
-    pub fn setTree(self: *Self, tree: ?*const Surface.Tree) void {
+    pub fn setTree(self: *Self, tree_: ?*const Surface.Tree) void {
         const priv = self.private();
+
+        // We always normalize our tree parameter so that empty trees
+        // become null so that we don't have to deal with callers being
+        // confused about that.
+        const tree: ?*const Surface.Tree = tree: {
+            const tree = tree_ orelse break :tree null;
+            if (tree.isEmpty()) break :tree null;
+            break :tree tree;
+        };
 
         // Emit the signal so that handlers can witness both the before and
         // after values of the tree.
@@ -349,6 +358,8 @@ pub const SplitTree = extern struct {
         }
 
         if (tree) |new_tree| {
+            assert(priv.tree == null);
+            assert(!new_tree.isEmpty());
             priv.tree = ext.boxedCopy(Surface.Tree, new_tree);
             self.connectSurfaceHandlers();
         }

--- a/src/apprt/gtk-ng/class/tab.zig
+++ b/src/apprt/gtk-ng/class/tab.zig
@@ -242,14 +242,15 @@ pub const Tab = extern struct {
     //---------------------------------------------------------------
     // Signal handlers
 
-    fn splitTreeChanged(
+    fn propSplitTree(
         _: *SplitTree,
-        _: ?*const Surface.Tree,
-        new_tree: ?*const Surface.Tree,
+        _: *gobject.ParamSpec,
         self: *Self,
     ) callconv(.c) void {
+        self.as(gobject.Object).notifyByPspec(properties.@"surface-tree".impl.param_spec);
+
         // If our tree is empty we close the tab.
-        const tree: *const Surface.Tree = new_tree orelse &.empty;
+        const tree: *const Surface.Tree = self.getSurfaceTree() orelse &.empty;
         if (tree.isEmpty()) {
             signals.@"close-request".impl.emit(
                 self,
@@ -259,14 +260,6 @@ pub const Tab = extern struct {
             );
             return;
         }
-    }
-
-    fn propSplitTree(
-        _: *SplitTree,
-        _: *gobject.ParamSpec,
-        self: *Self,
-    ) callconv(.c) void {
-        self.as(gobject.Object).notifyByPspec(properties.@"surface-tree".impl.param_spec);
     }
 
     fn propActiveSurface(
@@ -318,7 +311,6 @@ pub const Tab = extern struct {
             class.bindTemplateChildPrivate("split_tree", .{});
 
             // Template Callbacks
-            class.bindTemplateCallback("tree_changed", &splitTreeChanged);
             class.bindTemplateCallback("notify_active_surface", &propActiveSurface);
             class.bindTemplateCallback("notify_tree", &propSplitTree);
 

--- a/src/apprt/gtk-ng/class/window.zig
+++ b/src/apprt/gtk-ng/class/window.zig
@@ -335,6 +335,10 @@ pub const Window = extern struct {
             .{ "close-tab", actionCloseTab, null },
             .{ "new-tab", actionNewTab, null },
             .{ "new-window", actionNewWindow, null },
+            .{ "split-right", actionSplitRight, null },
+            .{ "split-left", actionSplitLeft, null },
+            .{ "split-up", actionSplitUp, null },
+            .{ "split-down", actionSplitDown, null },
             .{ "copy", actionCopy, null },
             .{ "paste", actionPaste, null },
             .{ "reset", actionReset, null },
@@ -1648,6 +1652,38 @@ pub const Window = extern struct {
         self: *Window,
     ) callconv(.c) void {
         self.performBindingAction(.new_tab);
+    }
+
+    fn actionSplitRight(
+        _: *gio.SimpleAction,
+        _: ?*glib.Variant,
+        self: *Window,
+    ) callconv(.c) void {
+        self.performBindingAction(.{ .new_split = .right });
+    }
+
+    fn actionSplitLeft(
+        _: *gio.SimpleAction,
+        _: ?*glib.Variant,
+        self: *Window,
+    ) callconv(.c) void {
+        self.performBindingAction(.{ .new_split = .left });
+    }
+
+    fn actionSplitUp(
+        _: *gio.SimpleAction,
+        _: ?*glib.Variant,
+        self: *Window,
+    ) callconv(.c) void {
+        self.performBindingAction(.{ .new_split = .up });
+    }
+
+    fn actionSplitDown(
+        _: *gio.SimpleAction,
+        _: ?*glib.Variant,
+        self: *Window,
+    ) callconv(.c) void {
+        self.performBindingAction(.{ .new_split = .down });
     }
 
     fn actionCopy(

--- a/src/apprt/gtk-ng/css/style-dark.css
+++ b/src/apprt/gtk-ng/css/style-dark.css
@@ -1,3 +1,8 @@
 .transparent {
   background-color: transparent;
 }
+
+.window .split paned > separator {
+  background-color: rgba(36, 36, 36, 1);
+  background-clip: content-box;
+}

--- a/src/apprt/gtk-ng/css/style.css
+++ b/src/apprt/gtk-ng/css/style.css
@@ -114,3 +114,26 @@ label.resize-overlay {
   margin-left: 4px;
   margin-right: 8px;
 }
+
+/*
+ * Splits
+ */
+
+.window .split paned > separator {
+  background-color: rgba(250, 250, 250, 1);
+  background-clip: content-box;
+
+  /* This works around the oversized drag area for the right side of GtkPaned.
+   *
+   * Upstream Gtk issue:
+   * https://gitlab.gnome.org/GNOME/gtk/-/issues/4484#note_2362002
+   *
+   * Ghostty issue:
+   * https://github.com/ghostty-org/ghostty/issues/3020
+   *
+   * Without this, it's not possible to select the first character on the
+   * right-hand side of a split.
+   */
+  margin: 0;
+  padding: 0;
+}

--- a/src/apprt/gtk-ng/ui/1.2/surface.blp
+++ b/src/apprt/gtk-ng/ui/1.2/surface.blp
@@ -172,22 +172,22 @@ menu context_menu_model {
 
       item {
         label: _("Split Up");
-        action: "win.split-up";
+        action: "split-tree.new-up";
       }
 
       item {
         label: _("Split Down");
-        action: "win.split-down";
+        action: "split-tree.new-down";
       }
 
       item {
         label: _("Split Left");
-        action: "win.split-left";
+        action: "split-tree.new-left";
       }
 
       item {
         label: _("Split Right");
-        action: "win.split-right";
+        action: "split-tree.new-right";
       }
     }
 

--- a/src/apprt/gtk-ng/ui/1.5/split-tree-split.blp
+++ b/src/apprt/gtk-ng/ui/1.5/split-tree-split.blp
@@ -2,6 +2,10 @@ using Gtk 4.0;
 using Adw 1;
 
 template $GhosttySplitTreeSplit: Adw.Bin {
+  styles [
+    "split",
+  ]
+
   // The double-nesting is required due to a GTK bug where you can't
   // bind the first child of a builder layout. If you do, you get a double
   // dispose. Easiest way to see that is simply remove this and see the

--- a/src/apprt/gtk-ng/ui/1.5/split-tree-split.blp
+++ b/src/apprt/gtk-ng/ui/1.5/split-tree-split.blp
@@ -1,0 +1,16 @@
+using Gtk 4.0;
+using Adw 1;
+
+template $GhosttySplitTreeSplit: Adw.Bin {
+  // The double-nesting is required due to a GTK bug where you can't
+  // bind the first child of a builder layout. If you do, you get a double
+  // dispose. Easiest way to see that is simply remove this and see the
+  // GTK critical errors (and sometimes crashes).
+  Adw.Bin {
+    Paned paned {
+      notify::max-position => $notify_max_position();
+      notify::min-position => $notify_min_position();
+      notify::position => $notify_position();
+    }
+  }
+}

--- a/src/apprt/gtk-ng/ui/1.5/tab.blp
+++ b/src/apprt/gtk-ng/ui/1.5/tab.blp
@@ -5,12 +5,12 @@ template $GhosttyTab: Box {
     "tab",
   ]
 
-  notify::active-surface => $notify_active_surface();
   orientation: vertical;
   hexpand: true;
   vexpand: true;
 
   $GhosttySplitTree split_tree {
+    notify::active-surface => $notify_active_surface();
     notify::tree => $notify_tree();
     changed => $tree_changed();
   }

--- a/src/apprt/gtk-ng/ui/1.5/tab.blp
+++ b/src/apprt/gtk-ng/ui/1.5/tab.blp
@@ -12,6 +12,5 @@ template $GhosttyTab: Box {
   $GhosttySplitTree split_tree {
     notify::active-surface => $notify_active_surface();
     notify::tree => $notify_tree();
-    changed => $tree_changed();
   }
 }

--- a/src/datastruct/split_tree.zig
+++ b/src/datastruct/split_tree.zig
@@ -119,6 +119,9 @@ pub fn SplitTree(comptime V: type) type {
 
         /// Clone this tree, returning a new tree with the same nodes.
         pub fn clone(self: *const Self, gpa: Allocator) Allocator.Error!Self {
+            // If we're empty then return an empty tree.
+            if (self.isEmpty()) return .empty;
+
             // Create a new arena allocator for the clone.
             var arena = ArenaAllocator.init(gpa);
             errdefer arena.deinit();

--- a/src/datastruct/split_tree.zig
+++ b/src/datastruct/split_tree.zig
@@ -1151,3 +1151,21 @@ test "SplitTree: split twice, remove intermediary" {
         t.deinit();
     }
 }
+
+test "SplitTree: clone empty tree" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    var t: TestTree = .empty;
+    defer t.deinit();
+
+    var t2 = try t.clone(alloc);
+    defer t2.deinit();
+
+    {
+        const str = try std.fmt.allocPrint(alloc, "{}", .{t2});
+        defer alloc.free(str);
+        try testing.expectEqualStrings(str,
+            \\empty
+        );
+    }
+}

--- a/src/datastruct/split_tree.zig
+++ b/src/datastruct/split_tree.zig
@@ -174,6 +174,27 @@ pub fn SplitTree(comptime V: type) type {
             }
         };
 
+        /// Resize the given node in place. The node MUST be a split (asserted).
+        ///
+        /// In general, this is an immutable data structure so this is
+        /// heavily discouraged. However, this is provided for convenience
+        /// and performance reasons where its very important for GUIs to
+        /// update the ratio during a live resize than to redraw the entire
+        /// widget tree.
+        pub fn resizeInPlace(
+            self: *Self,
+            at: Node.Handle,
+            ratio: f16,
+        ) void {
+            // Let's talk about this constCast. Our member are const but
+            // we actually always own their memory. We don't want consumers
+            // who directly access the nodes to be able to modify them
+            // (without nasty stuff like this), but given this is internal
+            // usage its perfectly fine to modify the node in-place.
+            const s: *Split = @constCast(&self.nodes[at].split);
+            s.ratio = ratio;
+        }
+
         /// Insert another tree into this tree at the given node in the
         /// specified direction. The other tree will be inserted in the
         /// new direction. For example, if the direction is "right" then

--- a/src/datastruct/split_tree.zig
+++ b/src/datastruct/split_tree.zig
@@ -826,8 +826,10 @@ pub fn SplitTree(comptime V: type) type {
                         .copy = &struct {
                             fn copy(self: *Self) callconv(.c) *Self {
                                 const ptr = @import("glib").ext.create(Self);
-                                const alloc = self.arena.child_allocator;
-                                ptr.* = self.clone(alloc) catch @panic("oom");
+                                ptr.* = if (self.nodes.len == 0)
+                                    .empty
+                                else
+                                    self.clone(self.arena.child_allocator) catch @panic("oom");
                                 return ptr;
                             }
                         }.copy,

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -45,6 +45,38 @@
    ...
 }
 
+# Reproduction:
+#
+# 1. Launch Ghostty
+# 2. Split Right
+# 3. Hit "X" to close
+{
+   GTK CSS Node State
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:g_malloc
+   fun:g_memdup2
+   fun:gtk_css_node_declaration_set_state
+   fun:gtk_css_node_set_state
+   fun:gtk_widget_propagate_state
+   fun:gtk_widget_update_state_flags
+   fun:gtk_main_do_event
+   fun:surface_event
+   fun:_gdk_marshal_BOOLEAN__POINTERv
+   fun:gdk_surface_event_marshallerv
+   fun:_g_closure_invoke_va
+   fun:signal_emit_valist_unlocked
+   fun:g_signal_emit_valist
+   fun:g_signal_emit
+   fun:gdk_surface_handle_event
+   fun:gdk_wayland_event_source_dispatch
+   fun:g_main_context_dispatch_unlocked
+   fun:g_main_context_iterate_unlocked.isra.0
+   fun:g_main_context_iteration
+   ...
+}
+
 {
    GTK CSS Provider Leak
    Memcheck:Leak
@@ -516,9 +548,7 @@
    pango font map 
    Memcheck:Leak
    match-leak-kinds: possible
-   fun:calloc
-   fun:g_malloc0
-   fun:g_rc_box_alloc_full
+   ...
    fun:pango_fc_font_map_load_fontset
    ...
 }

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -70,10 +70,6 @@
    fun:g_signal_emit_valist
    fun:g_signal_emit
    fun:gdk_surface_handle_event
-   fun:gdk_wayland_event_source_dispatch
-   fun:g_main_context_dispatch_unlocked
-   fun:g_main_context_iterate_unlocked.isra.0
-   fun:g_main_context_iteration
    ...
 }
 


### PR DESCRIPTION
This adds on to our existing foundations from #8165 and adds the ability to create and close splits. We're still missing split navigation, resizing via keybindings, etc. And there are a number of known issues (listed below). But this is a strict improvement from where we're at and includes a number of important bug fixes to our split tree.

The only nasty thing in this PR is that I learned that GTK _did not like_ rebuilding our split widget tree on every data model change. I don't know enough about how all the re-parenting plus size allocation interactions work together. As a compromise, this PR adds a listener, waits for our surface tree to "settle" by having all surfaces have no parents, then schedules a single rebuild after that. This works well, but results in some noticeable flashing for a frame or so. I think we can improve this later, it works completely well enough.

Importantly, all of this is Valgrind clean. I long suspected our splits on legacy are NOT free of leaks, but never proved it, so this makes me happy.

## Demo


https://github.com/user-attachments/assets/e231d89f-581e-486b-ade0-1d7e6795262e



## Known Issues

I may fix this in this PR, I may follow up.

- #8208
- [x] Focus doesn't go to the right place after closing a split (#8210)
- [x] Divider with a transparent background is transparent
- [x] Close split doesn't show any close confirmation dialog
- Missing features:
  * [x] Equalize splits (#8211)
  * [ ] Resize splits keybind (manual mouse action works fine)
  * [x] Go to split keybind (#8210)