### PR TITLE
apprt/gtk-ng: `goto_split` (including spatial navigation for the first time for our GTK backend)

### DIFF
--- a/src/apprt/gtk-ng/class/application.zig
+++ b/src/apprt/gtk-ng/class/application.zig
@@ -1675,7 +1675,10 @@ const Action = struct {
                 return tree.goto(switch (to) {
                     .previous => .previous_wrapped,
                     .next => .next_wrapped,
-                    else => @panic("TODO"),
+                    .up => .{ .spatial = .up },
+                    .down => .{ .spatial = .down },
+                    .left => .{ .spatial = .left },
+                    .right => .{ .spatial = .right },
                 });
             },
         }

--- a/src/apprt/gtk-ng/class/split_tree.zig
+++ b/src/apprt/gtk-ng/class/split_tree.zig
@@ -246,6 +246,7 @@ pub const SplitTree = extern struct {
             alloc,
             handle,
             direction,
+            0.5, // Always split equally for new splits
             &single_tree,
         );
         defer new_tree.deinit();

--- a/src/apprt/gtk-ng/class/split_tree.zig
+++ b/src/apprt/gtk-ng/class/split_tree.zig
@@ -258,6 +258,23 @@ pub const SplitTree = extern struct {
         self.setTree(&new_tree);
     }
 
+    /// Move focus from the currently focused surface to the given
+    /// direction. Returns true if focus switched to a new surface.
+    pub fn goto(self: *Self, to: Surface.Tree.Goto) bool {
+        const tree = self.getTree() orelse return false;
+        const active = self.getActiveSurfaceHandle() orelse return false;
+        const target = tree.goto(active, to) orelse return false;
+
+        // If we aren't changing targets then we did nothing.
+        if (active == target) return false;
+
+        // Get the surface at the target location and grab focus.
+        const surface = tree.nodes[target].leaf;
+        surface.grabFocus();
+
+        return true;
+    }
+
     fn disconnectSurfaceHandlers(self: *Self) void {
         const tree = self.getTree() orelse return;
         var it = tree.iterator();


### PR DESCRIPTION
This continues #8202 by fixing two of the known issues: `goto_split` key binds work and closing a split moves focus to the proper place.

A big improvement in this PR is that for the first time ever in our GTK backend, the up/down/left/right `goto_split` bindings **use spatial navigation.** "Spatial navigation" means that the direction to move focus is done based on the nearest split _visually_ from the current split, rather than via a tree traversal. We did this on macOS a couple months ago, with a lot more details there: #7523 

Similar to macOS, the spatial navigation is currently based on top-left corner. Now that our split tree is implemented in Zig though it should be a lot easier for us to work in the current cursor position as the reference point.

~~🚧 TODO: Going to add some unit tests for the spatial navigation before merge.~~