### PR TITLE
apprt/gtk-ng: equalize splits

### DIFF
--- a/src/apprt/gtk-ng/class/application.zig
+++ b/src/apprt/gtk-ng/class/application.zig
@@ -553,6 +553,8 @@ pub const Application = extern struct {
 
             .desktop_notification => Action.desktopNotification(self, target, value),
 
+            .equalize_splits => return Action.equalizeSplits(target),
+
             .goto_split => return Action.gotoSplit(target, value),
 
             .goto_tab => return Action.gotoTab(target, value),
@@ -617,7 +619,6 @@ pub const Application = extern struct {
             .inspector,
             // TODO: splits
             .resize_split,
-            .equalize_splits,
             .toggle_split_zoom,
             => {
                 log.warn("unimplemented action={}", .{action});
@@ -1650,6 +1651,20 @@ const Action = struct {
         // same, this notification may replace a previous notification
         const gio_app = self.as(gio.Application);
         gio_app.sendNotification(n.body, notification);
+    }
+
+    pub fn equalizeSplits(target: apprt.Target) bool {
+        switch (target) {
+            .app => {
+                log.warn("equalize splits to app is unexpected", .{});
+                return false;
+            },
+
+            .surface => |core| {
+                const surface = core.rt_surface.surface;
+                return surface.as(gtk.Widget).activateAction("split-tree.equalize", null) != 0;
+            },
+        }
     }
 
     pub fn gotoSplit(

--- a/src/apprt/gtk-ng/class/split_tree.zig
+++ b/src/apprt/gtk-ng/class/split_tree.zig
@@ -163,6 +163,8 @@ pub const SplitTree = extern struct {
             .{ "new-right", actionNewRight, null },
             .{ "new-up", actionNewUp, null },
             .{ "new-down", actionNewDown, null },
+
+            .{ "equalize", actionEqualize, null },
         };
 
         // We need to collect our actions into a group since we're just
@@ -535,6 +537,22 @@ pub const SplitTree = extern struct {
         ) catch |err| {
             log.warn("new split failed error={}", .{err});
         };
+    }
+
+    pub fn actionEqualize(
+        _: *gio.SimpleAction,
+        parameter_: ?*glib.Variant,
+        self: *Self,
+    ) callconv(.c) void {
+        _ = parameter_;
+
+        const old_tree = self.getTree() orelse return;
+        var new_tree = old_tree.equalize(Application.default().allocator()) catch |err| {
+            log.warn("unable to equalize tree: {}", .{err});
+            return;
+        };
+        defer new_tree.deinit();
+        self.setTree(&new_tree);
     }
 
     fn surfaceCloseRequest(


### PR DESCRIPTION
Fixes known issues from #8202. Also brings in the better equalization logic on macOS from #7710.