### PR TITLE
apprt/gtk-ng: `resize_split` action

### DIFF
--- a/src/datastruct/split_tree.zig
+++ b/src/datastruct/split_tree.zig
@@ -723,6 +723,8 @@ pub fn SplitTree(comptime V: type) type {
             ratio: f16,
         ) Allocator.Error!Self {
             assert(ratio >= 0 and ratio <= 1);
+            assert(!std.math.isNan(ratio));
+            assert(!std.math.isInf(ratio));
 
             // Fast path empty trees.
             if (self.isEmpty()) return .empty;


### PR DESCRIPTION
Ports the resize split action (tied to the `resize_split` binding action).

This also includes fixes for splits that are exactly `0` or `1` ratio width (full width either direction). This would previously cause crashes.