### PR TITLE
apprt/gtk-ng: bell 

### DIFF
--- a/src/apprt/gtk-ng/class.zig
+++ b/src/apprt/gtk-ng/class.zig
@@ -53,6 +53,23 @@ pub fn Common(
             }
         }).private else {};
 
+        /// A helper that creates a property that reads and writes a
+        /// private field with only shallow copies. This is good for primitives
+        /// such as bools, numbers, etc.
+        pub fn privateShallowFieldAccessor(
+            comptime name: []const u8,
+        ) gobject.ext.Accessor(
+            Self,
+            @FieldType(Private.?, name),
+        ) {
+            return gobject.ext.privateFieldAccessor(
+                Self,
+                Private.?,
+                &Private.?.offset,
+                name,
+            );
+        }
+
         /// A helper that can be used to create a property that reads and
         /// writes a private boxed gobject field type.
         ///

--- a/src/apprt/gtk-ng/class/application.zig
+++ b/src/apprt/gtk-ng/class/application.zig
@@ -2043,7 +2043,7 @@ const Action = struct {
     pub fn ringBell(target: apprt.Target) void {
         switch (target) {
             .app => {},
-            .surface => |v| v.rt_surface.surface.ringBell(),
+            .surface => |v| v.rt_surface.surface.setBellRinging(true),
         }
     }
 

--- a/src/apprt/gtk-ng/class/split_tree.zig
+++ b/src/apprt/gtk-ng/class/split_tree.zig
@@ -418,6 +418,20 @@ pub const SplitTree = extern struct {
             if (entry.view.getFocused()) return entry.handle;
         }
 
+        // If none are currently focused, the most previously focused
+        // surface (if it exists) is our active surface. This lets things
+        // like apprt actions and bell ringing continue to work in the
+        // background.
+        if (self.private().last_focused.get()) |v| {
+            defer v.unref();
+
+            // We need to find the handle of the last focused surface.
+            it = tree.iterator();
+            while (it.next()) |entry| {
+                if (entry.view == v) return entry.handle;
+            }
+        }
+
         return null;
     }
 

--- a/src/apprt/gtk-ng/class/surface.zig
+++ b/src/apprt/gtk-ng/class/surface.zig
@@ -718,9 +718,6 @@ pub const Surface = extern struct {
         const key_event = gobject.ext.cast(gdk.KeyEvent, event) orelse return false;
         const priv = self.private();
 
-        // Bell stops ringing under any key event (press or release).
-        self.setBellRinging(false);
-
         // The block below is all related to input method handling. See the function
         // comment for some high level details and then the comments within
         // the block for more specifics.
@@ -905,6 +902,10 @@ pub const Surface = extern struct {
                     priv.im_context.as(gtk.IMContext).reset();
                     surface.preeditCallback(null) catch {};
                 }
+
+                // Bell stops ringing when any key is pressed that is used by
+                // the core in any way.
+                self.setBellRinging(false);
 
                 return true;
             },

--- a/src/apprt/gtk-ng/class/surface.zig
+++ b/src/apprt/gtk-ng/class/surface.zig
@@ -275,7 +275,8 @@ pub const Surface = extern struct {
         /// The surface view handles the audio bell feature but none of the
         /// others so it is up to the embedding widget to react to this.
         ///
-        /// Bell ringing will also emit the win.ring-bell action.
+        /// Bell ringing will also emit the tab.ring-bell and win.ring-bell
+        /// actions.
         pub const bell = struct {
             pub const name = "bell";
             pub const connect = impl.connect;
@@ -557,6 +558,7 @@ pub const Surface = extern struct {
         );
 
         // Activate a window action if it exists
+        _ = self.as(gtk.Widget).activateAction("tab.ring-bell", null);
         _ = self.as(gtk.Widget).activateAction("win.ring-bell", null);
     }
 

--- a/src/apprt/gtk-ng/class/surface.zig
+++ b/src/apprt/gtk-ng/class/surface.zig
@@ -274,6 +274,8 @@ pub const Surface = extern struct {
         ///
         /// The surface view handles the audio bell feature but none of the
         /// others so it is up to the embedding widget to react to this.
+        ///
+        /// Bell ringing will also emit the win.ring-bell action.
         pub const bell = struct {
             pub const name = "bell";
             pub const connect = impl.connect;
@@ -546,12 +548,16 @@ pub const Surface = extern struct {
         // Enable our bell ringing state
         self.setBellRinging(true);
 
+        // Emit our direct signal for anyone who cares
         signals.bell.impl.emit(
             self,
             null,
             .{},
             null,
         );
+
+        // Activate a window action if it exists
+        _ = self.as(gtk.Widget).activateAction("win.ring-bell", null);
     }
 
     pub fn toggleFullscreen(self: *Self) void {

--- a/src/apprt/gtk-ng/ui/1.2/surface.blp
+++ b/src/apprt/gtk-ng/ui/1.2/surface.blp
@@ -6,6 +6,7 @@ template $GhosttySurface: Adw.Bin {
     "surface",
   ]
 
+  notify::bell-ringing => $notify_bell_ringing();
   notify::config => $notify_config();
   notify::mouse-hover-url => $notify_mouse_hover_url();
   notify::mouse-hidden => $notify_mouse_hidden();

--- a/src/apprt/gtk-ng/ui/1.5/tab.blp
+++ b/src/apprt/gtk-ng/ui/1.5/tab.blp
@@ -8,7 +8,7 @@ template $GhosttyTab: Box {
   orientation: vertical;
   hexpand: true;
   vexpand: true;
-  title: bind $computed_title(split_tree.active-surface as <$GhosttySurface>.title, split_tree.is-zoomed) as <string>;
+  title: bind $computed_title(template.config, split_tree.active-surface as <$GhosttySurface>.title, split_tree.is-zoomed, split_tree.active-surface as <$GhosttySurface>.bell-ringing) as <string>;
   tooltip: bind split_tree.active-surface as <$GhosttySurface>.pwd;
 
   $GhosttySplitTree split_tree {


### PR DESCRIPTION
Supersedes #8129

This is a rewrite but I did take pieces of #8129. I dropped the new feature that was mixed into the PR because I'm trying not to introduce new features in `-ng` right now. Feel free to PR that separately @jcollie. I also dropped some of the action group validation stuff which admittedly would be nice, so also happy to add that.

A big change I made here is we don't need to expose `bell-features` from surface, because we can use the relevant config that we have access to. I passed the config as a closure parameter so it recomputes when config changes, too. 

I also fixed a bug I found where we'd lose computed titles on non-focused tabs because `active-surface` would start returning null (since none are focused there). We now fallback to the active surface being the _last focused_ surface if no focused surface exists, which matches the behavior we also have on macOS. 

