### PR TITLE
apprt/gtk-ng: set cursor on Surface widget, not GL area

### DIFF
--- a/src/apprt/gtk-ng/class/surface.zig
+++ b/src/apprt/gtk-ng/class/surface.zig
@@ -1240,7 +1240,7 @@ pub const Surface = extern struct {
             renderer.OpenGL.MIN_VERSION_MAJOR,
             renderer.OpenGL.MIN_VERSION_MINOR,
         );
-        gl_area.as(gtk.Widget).setCursorFromName("text");
+        self.as(gtk.Widget).setCursorFromName("text");
 
         // Initialize our config
         self.propConfig(undefined, null);
@@ -1570,7 +1570,7 @@ pub const Surface = extern struct {
 
         // If we're hidden we set it to "none"
         if (priv.mouse_hidden) {
-            priv.gl_area.as(gtk.Widget).setCursorFromName("none");
+            self.as(gtk.Widget).setCursorFromName("none");
             return;
         }
 
@@ -1628,7 +1628,7 @@ pub const Surface = extern struct {
         };
 
         // Set our new cursor.
-        priv.gl_area.as(gtk.Widget).setCursorFromName(name.ptr);
+        self.as(gtk.Widget).setCursorFromName(name.ptr);
     }
 
     fn propBellRinging(


### PR DESCRIPTION
This fixes `mouse-hide-while-typing`. Don't know why this worked before (I tested it yesterday!) but stopped working today. But this now works, and conceptually makes some sense.