### PR TITLE
apprt/gtk-ng: clean up close handling of all types

### DIFF
--- a/src/apprt/gtk-ng/Surface.zig
+++ b/src/apprt/gtk-ng/Surface.zig
@@ -32,7 +32,8 @@ pub fn rtApp(self: *Self) *ApprtApp {
 }
 
 pub fn close(self: *Self, process_active: bool) void {
-    self.surface.close(.{ .surface = process_active });
+    _ = process_active;
+    self.surface.close();
 }
 
 pub fn cgroup(self: *Self) ?[]const u8 {

--- a/src/apprt/gtk-ng/class/application.zig
+++ b/src/apprt/gtk-ng/class/application.zig
@@ -542,8 +542,8 @@ pub const Application = extern struct {
         value: apprt.Action.Value(action),
     ) !bool {
         switch (action) {
-            .close_tab => Action.close(target, .tab),
-            .close_window => Action.close(target, .window),
+            .close_tab => return Action.closeTab(target),
+            .close_window => return Action.closeWindow(target),
 
             .config_change => try Action.configChange(
                 self,
@@ -1582,13 +1582,23 @@ pub const Application = extern struct {
 
 /// All apprt action handlers
 const Action = struct {
-    pub fn close(
-        target: apprt.Target,
-        scope: Surface.CloseScope,
-    ) void {
+    pub fn closeTab(target: apprt.Target) bool {
         switch (target) {
-            .app => {},
-            .surface => |v| v.rt_surface.surface.close(scope),
+            .app => return false,
+            .surface => |core| {
+                const surface = core.rt_surface.surface;
+                return surface.as(gtk.Widget).activateAction("tab.close", null) != 0;
+            },
+        }
+    }
+
+    pub fn closeWindow(target: apprt.Target) bool {
+        switch (target) {
+            .app => return false,
+            .surface => |core| {
+                const surface = core.rt_surface.surface;
+                return surface.as(gtk.Widget).activateAction("win.close", null) != 0;
+            },
         }
     }
 

--- a/src/apprt/gtk-ng/class/surface.zig
+++ b/src/apprt/gtk-ng/class/surface.zig
@@ -275,7 +275,7 @@ pub const Surface = extern struct {
             const impl = gobject.ext.defineSignal(
                 name,
                 Self,
-                &.{*const CloseScope},
+                &.{},
                 void,
             );
         };
@@ -1047,11 +1047,11 @@ pub const Surface = extern struct {
     //---------------------------------------------------------------
     // Libghostty Callbacks
 
-    pub fn close(self: *Self, scope: CloseScope) void {
+    pub fn close(self: *Self) void {
         signals.@"close-request".impl.emit(
             self,
             null,
-            .{&scope},
+            .{},
             null,
         );
     }
@@ -1749,7 +1749,7 @@ pub const Surface = extern struct {
         self: *Self,
     ) callconv(.c) void {
         // This closes the surface with no confirmation.
-        self.close(.{ .surface = false });
+        self.close();
     }
 
     fn contextMenuClosed(
@@ -2707,25 +2707,6 @@ pub const Surface = extern struct {
         pub const as = C.Class.as;
         pub const bindTemplateChildPrivate = C.Class.bindTemplateChildPrivate;
         pub const bindTemplateCallback = C.Class.bindTemplateCallback;
-    };
-
-    /// The scope of a close request.
-    pub const CloseScope = union(enum) {
-        /// Close the surface. The boolean determines if there is a
-        /// process active.
-        surface: bool,
-
-        /// Close the tab. We can't know if there are processes active
-        /// for the entire tab scope so listeners must query the app.
-        tab,
-
-        /// Close the window.
-        window,
-
-        pub const getGObjectType = gobject.ext.defineBoxed(
-            CloseScope,
-            .{ .name = "GhosttySurfaceCloseScope" },
-        );
     };
 
     /// Simple dimensions struct for the surface used by various properties.

--- a/src/apprt/gtk-ng/class/window.zig
+++ b/src/apprt/gtk-ng/class/window.zig
@@ -683,13 +683,6 @@ pub const Window = extern struct {
         var it = tree.iterator();
         while (it.next()) |entry| {
             const surface = entry.view;
-            _ = Surface.signals.@"close-request".connect(
-                surface,
-                *Self,
-                surfaceCloseRequest,
-                self,
-                .{},
-            );
             _ = Surface.signals.@"present-request".connect(
                 surface,
                 *Self,
@@ -1456,25 +1449,6 @@ pub const Window = extern struct {
             self.addToast(i18n._("Copied to clipboard"))
         else
             self.addToast(i18n._("Cleared clipboard"));
-    }
-
-    fn surfaceCloseRequest(
-        _: *Surface,
-        scope: *const Surface.CloseScope,
-        self: *Self,
-    ) callconv(.c) void {
-        switch (scope.*) {
-            // Handled directly by the tab. If the surface is the last
-            // surface then the tab will emit its own signal to request
-            // closing itself.
-            .surface => return,
-
-            // Also handled directly by the tab.
-            .tab => return,
-
-            // The only one we care about!
-            .window => self.as(gtk.Window).close(),
-        }
     }
 
     fn surfaceMenu(


### PR DESCRIPTION
This cleans up our close handling of all types (surfaces, tabs, windows). Surfaces no longer emit their scope; their scope is always just the surface itself. For tab and window scope we use widget actions.

This makes `close_tab` work properly (previously broken).