### PR TITLE
fix(renderer/generic): deinit render targets with framestate

### DIFF
--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -395,6 +395,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             }
 
             pub fn deinit(self: *FrameState) void {
+                self.target.deinit();
                 self.uniforms.deinit();
                 self.cells.deinit();
                 self.cells_bg.deinit();


### PR DESCRIPTION
This was a memory leak under Metal, leaked 1 swapchain worth of targets every time a surface was closed.

Under OpenGL I think it was all cleaned up when the GL context was destroyed.