### PR TITLE
apprt: make gtk-ng the default apprt on Linux

### DIFF
--- a/src/apprt.zig
+++ b/src/apprt.zig
@@ -60,20 +60,22 @@ pub const Runtime = enum {
     /// This is only useful if you're only interested in the lib only (macOS).
     none,
 
-    /// GTK-backed. Rich windowed application. GTK is dynamically linked.
-    gtk,
-
-    /// GTK4. The "-ng" variant is a rewrite of the GTK backend using
-    /// GTK-native technologies such as full GObject classes, Blueprint
-    /// files, etc.
+    /// GTK4. Rich windowed application. This uses a full GObject-based
+    /// approach to building the application.
     @"gtk-ng",
 
+    /// GTK-backed. Rich windowed application. GTK is dynamically linked.
+    /// WARNING: Deprecated. This will be removed very soon. All bug fixes
+    /// and features should go into the gtk-ng backend.
+    gtk,
+
     pub fn default(target: std.Target) Runtime {
-        // The Linux default is GTK because it is full featured.
-        if (target.os.tag == .linux) return .gtk;
+        // The Linux default is GTK because it is a full featured application.
+        if (target.os.tag == .linux) return .@"gtk-ng";
 
         // Otherwise, we do NONE so we don't create an exe and we
-        // create libghostty.
+        // create libghostty. On macOS, Xcode is used to build the app
+        // that links to libghostty.
         return .none;
     }
 };

--- a/src/build/GhosttyDist.zig
+++ b/src/build/GhosttyDist.zig
@@ -25,6 +25,11 @@ pub fn init(b: *std.Build, cfg: *const Config) !GhosttyDist {
         try resources.append(alloc, gtk.resources_c);
         try resources.append(alloc, gtk.resources_h);
     }
+    {
+        const gtk = SharedDeps.gtkNgDistResources(b);
+        try resources.append(alloc, gtk.resources_c);
+        try resources.append(alloc, gtk.resources_h);
+    }
 
     // git archive to create the final tarball. "git archive" is the
     // easiest way I can find to create a tarball that ignores stuff


### PR DESCRIPTION
The journey to rewrite our legacy GTK backend to a full GObject-based backend is complete! The full background and motivation can be found in the original PR: #7961. ~75 PRs later, we've reached **full parity** with the legacy GTK backend.

Throughout the process, we've tested every feature under Valgrind, and this build is fully clean of memory leaks and undefined access. Its impossible to test the existing GTK backend because its full of false positives, but based on my experience working on `-ng`, I think its impossible we got it right. This isn't a dig at any of our GTK subsystem maintainers; I've simply found its very complicated to get all the memory management behaviors right with GTK. There are subtle, easy to miss, weakly documented things, such as [clearing weak refs on dispose](https://github.com/ghostty-org/ghostty/commit/7548dcfe634cd9447e0b7a0f5e2900fe7094a225).[^1] The point is, **gtk-ng is much higher quality than legacy.**

There is only regression we know of (#8208). I'm willing to swap the default despite this because the improvements not just in memory safety but also behavior: splits now support spatial navigation, better equalization behavior, etc. 

At this point, I think we should swap the default to see if we missed anything else. 

[^1]: This isn't a dig at Gnome developers either. Documenting these details is hard, too.