### PR TITLE
gtk-ng: use virtual methods to draw the inspector

### DIFF
--- a/src/apprt/gtk-ng/class.zig
+++ b/src/apprt/gtk-ng/class.zig
@@ -53,6 +53,18 @@ pub fn Common(
             }
         }).private else {};
 
+        /// Get the class structure for the object.
+        ///
+        /// This seems ugly and unsafe to me but this is what GObject is doing
+        /// under the hood.
+        ///
+        /// https://gitlab.gnome.org/GNOME/glib/-/blob/main/gobject/gtype.h?ref_type=heads#L555-571
+        /// https://gitlab.gnome.org/GNOME/glib/-/blob/main/gobject/gtype.h?ref_type=heads#L2673
+        pub fn getClass(self: *Self) ?*Self.Class {
+            const type_instance: *gobject.TypeInstance = @ptrCast(self);
+            return @ptrCast(type_instance.f_g_class orelse return null);
+        }
+
         /// A helper that creates a property that reads and writes a
         /// private field with only shallow copies. This is good for primitives
         /// such as bools, numbers, etc.

--- a/src/apprt/gtk-ng/class.zig
+++ b/src/apprt/gtk-ng/class.zig
@@ -61,41 +61,6 @@ pub fn Common(
         /// https://gitlab.gnome.org/GNOME/glib/-/blob/2c08654b62d52a31c4e4d13d7d85e12b989e72be/gobject/gtype.h#L555-571
         /// https://gitlab.gnome.org/GNOME/glib/-/blob/2c08654b62d52a31c4e4d13d7d85e12b989e72be/gobject/gtype.h#L2673
         ///
-        /// This works because when you create a new object in GObject, the pointer
-        /// that you get back wasn't allocated using your original type struct.
-        /// Instead you get the following block of data:
-        ///
-        ///
-        ///                 ┌─────────────────┐
-        ///                 │                 │
-        ///                 │                 │
-        ///                 │    Private      │
-        ///                 │                 │
-        ///                 │                 │
-        ///                 │                 │
-        ///                 │                 │
-        ///            ┌───►├─────────────────┤
-        /// *object────┘    │                 │
-        ///                 │  TypeInstance   │
-        ///                 │                 │   ┌───►┌────────────────┐
-        ///                 │                 │   │    │                │
-        ///                 │                 │   │    │    Class       │
-        ///                 │    *g_class ────┼───┘    │                │
-        ///                 │                 │        │                │
-        ///                 └─────────────────┘        │                │
-        ///                                            │                │
-        ///                                            │                │
-        ///                                            └────────────────┘
-        ///
-        /// First is a block of data that holds the instance's private data. That private
-        /// data is accessed by taking the instance pointer and subtracting the size of the
-        /// private data to get a pointer to the data.
-        ///
-        /// Next is an instance of a TypeInstance, whose purpose is to hold a pointer
-        /// to the class instance.
-        ///
-        /// https://gitlab.gnome.org/GNOME/glib/-/blob/2c08654b62d52a31c4e4d13d7d85e12b989e72be/gobject/gtype.c#L1792-1912
-        ///
         pub fn getClass(self: *Self) ?*Self.Class {
             const type_instance: *gobject.TypeInstance = @ptrCast(self);
             return @ptrCast(type_instance.f_g_class orelse return null);

--- a/src/apprt/gtk-ng/class.zig
+++ b/src/apprt/gtk-ng/class.zig
@@ -53,13 +53,49 @@ pub fn Common(
             }
         }).private else {};
 
-        /// Get the class structure for the object.
+        /// Get the class for the object.
         ///
-        /// This seems ugly and unsafe to me but this is what GObject is doing
-        /// under the hood.
+        /// This _seems_ ugly and unsafe but this is what GObject is doing
+        /// under the hood when it wants to access the class instance:
         ///
         /// https://gitlab.gnome.org/GNOME/glib/-/blob/2c08654b62d52a31c4e4d13d7d85e12b989e72be/gobject/gtype.h#L555-571
         /// https://gitlab.gnome.org/GNOME/glib/-/blob/2c08654b62d52a31c4e4d13d7d85e12b989e72be/gobject/gtype.h#L2673
+        ///
+        /// This works because when you create a new object in GObject, the pointer
+        /// that you get back wasn't allocated using your original type struct.
+        /// Instead you get the following block of data:
+        ///
+        ///
+        ///                 ┌─────────────────┐
+        ///                 │                 │
+        ///                 │                 │
+        ///                 │    Private      │
+        ///                 │                 │
+        ///                 │                 │
+        ///                 │                 │
+        ///                 │                 │
+        ///            ┌───►├─────────────────┤
+        /// *object────┘    │                 │
+        ///                 │  TypeInstance   │
+        ///                 │                 │   ┌───►┌────────────────┐
+        ///                 │                 │   │    │                │
+        ///                 │                 │   │    │    Class       │
+        ///                 │    *g_class ────┼───┘    │                │
+        ///                 │                 │        │                │
+        ///                 └─────────────────┘        │                │
+        ///                                            │                │
+        ///                                            │                │
+        ///                                            └────────────────┘
+        ///
+        /// First is a block of data that holds the instance's private data. That private
+        /// data is accessed by taking the instance pointer and subtracting the size of the
+        /// private data to get a pointer to the data.
+        ///
+        /// Next is an instance of a TypeInstance, whose purpose is to hold a pointer
+        /// to the class instance.
+        ///
+        /// https://gitlab.gnome.org/GNOME/glib/-/blob/2c08654b62d52a31c4e4d13d7d85e12b989e72be/gobject/gtype.c#L1792-1912
+        ///
         pub fn getClass(self: *Self) ?*Self.Class {
             const type_instance: *gobject.TypeInstance = @ptrCast(self);
             return @ptrCast(type_instance.f_g_class orelse return null);

--- a/src/apprt/gtk-ng/class.zig
+++ b/src/apprt/gtk-ng/class.zig
@@ -55,8 +55,29 @@ pub fn Common(
 
         /// Get the class for the object.
         ///
-        /// This _seems_ ugly and unsafe but this is what GObject is doing
-        /// under the hood when it wants to access the class instance:
+        /// This _seems_ ugly and unsafe but this is how GObject
+        /// works under the hood. From the [GObject Type System
+        /// Concepts](https://docs.gtk.org/gobject/concepts.html) documentation:
+        ///
+        ///     Every object must define two structures: its class structure
+        ///     and its instance structure. All class structures must contain
+        ///     as first member a GTypeClass structure. All instance structures
+        ///     must contain as first member a GTypeInstance structure.
+        ///     …
+        ///     These constraints allow the type system to make sure that
+        ///     every object instance (identified by a pointer to the object’s
+        ///     instance structure) contains in its first bytes a pointer to the
+        ///     object’s class structure.
+        ///     …
+        ///     The C standard mandates that the first field of a C structure is
+        ///     stored starting in the first byte of the buffer used to hold the
+        ///     structure’s fields in memory. This means that the first field of
+        ///     an instance of an object B is A’s first field which in turn is
+        ///     GTypeInstance‘s first field which in turn is g_class, a pointer
+        ///     to B’s class structure.
+        ///
+        /// This means that to access the class structure for an object you cast it
+        /// to `*gobject.TypeInstance` and then access the `f_g_class` field.
         ///
         /// https://gitlab.gnome.org/GNOME/glib/-/blob/2c08654b62d52a31c4e4d13d7d85e12b989e72be/gobject/gtype.h#L555-571
         /// https://gitlab.gnome.org/GNOME/glib/-/blob/2c08654b62d52a31c4e4d13d7d85e12b989e72be/gobject/gtype.h#L2673

--- a/src/apprt/gtk-ng/class.zig
+++ b/src/apprt/gtk-ng/class.zig
@@ -58,8 +58,8 @@ pub fn Common(
         /// This seems ugly and unsafe to me but this is what GObject is doing
         /// under the hood.
         ///
-        /// https://gitlab.gnome.org/GNOME/glib/-/blob/main/gobject/gtype.h?ref_type=heads#L555-571
-        /// https://gitlab.gnome.org/GNOME/glib/-/blob/main/gobject/gtype.h?ref_type=heads#L2673
+        /// https://gitlab.gnome.org/GNOME/glib/-/blob/2c08654b62d52a31c4e4d13d7d85e12b989e72be/gobject/gtype.h#L555-571
+        /// https://gitlab.gnome.org/GNOME/glib/-/blob/2c08654b62d52a31c4e4d13d7d85e12b989e72be/gobject/gtype.h#L2673
         pub fn getClass(self: *Self) ?*Self.Class {
             const type_instance: *gobject.TypeInstance = @ptrCast(self);
             return @ptrCast(type_instance.f_g_class orelse return null);

--- a/src/apprt/gtk-ng/class/imgui_widget.zig
+++ b/src/apprt/gtk-ng/class/imgui_widget.zig
@@ -35,37 +35,7 @@ pub const ImguiWidget = extern struct {
 
     pub const properties = struct {};
 
-    pub const signals = struct {
-        /// Emitted when the child widget should render. During the callback,
-        /// the Imgui context is valid.
-        pub const render = struct {
-            pub const name = "render";
-            pub const connect = impl.connect;
-            const impl = gobject.ext.defineSignal(
-                name,
-                Self,
-                &.{},
-                void,
-            );
-        };
-
-        /// Emitted when first realized to allow the embedded ImGui application
-        /// to initialize itself. When this is called, the ImGui context
-        /// is properly set.
-        ///
-        /// This might be called multiple times, but each time it is
-        /// called a new Imgui context will be created.
-        pub const setup = struct {
-            pub const name = "setup";
-            pub const connect = impl.connect;
-            const impl = gobject.ext.defineSignal(
-                name,
-                Self,
-                &.{},
-                void,
-            );
-        };
-    };
+    pub const signals = struct {};
 
     pub const virtual_methods = struct {
         /// This virtual method will be called to allow the Dear ImGui
@@ -484,8 +454,8 @@ pub const ImguiWidget = extern struct {
         parent_class: Parent.Class,
 
         /// Function pointers for virtual methods.
-        setup: ?*const fn (*Self) callconv(.c) void = null,
-        render: ?*const fn (*Self) callconv(.c) void = null,
+        setup: ?*const fn (*Self) callconv(.c) void,
+        render: ?*const fn (*Self) callconv(.c) void,
 
         var parent: *Parent.Class = undefined;
         pub const Instance = Self;
@@ -524,8 +494,6 @@ pub const ImguiWidget = extern struct {
             class.bindTemplateCallback("im_commit", &imCommit);
 
             // Signals
-            signals.render.impl.register(.{});
-            signals.setup.impl.register(.{});
 
             // Virtual methods
             gobject.Object.virtual_methods.dispose.implement(class, &dispose);

--- a/src/apprt/gtk-ng/class/imgui_widget.zig
+++ b/src/apprt/gtk-ng/class/imgui_widget.zig
@@ -41,28 +41,12 @@ pub const ImguiWidget = extern struct {
         /// This virtual method will be called to allow the Dear ImGui
         /// application to do one-time setup of the context. The correct context
         /// will be current when the virtual method is called.
-        pub const setup = struct {
-            pub fn call(class: anytype, object: *@typeInfo(@TypeOf(class)).pointer.child.Instance) void {
-                return gobject.ext.as(Self.Class, class).setup.?(gobject.ext.as(Self, object));
-            }
-
-            pub fn implement(class: anytype, implementation: *const fn (p_object: *@typeInfo(@TypeOf(class)).pointer.child.Instance) callconv(.c) void) void {
-                gobject.ext.as(Self.Class, class).setup = @ptrCast(implementation);
-            }
-        };
+        pub const setup = C.defineVirtualMethod("setup");
 
         /// This virtual method will be called at each frame to allow the Dear
         /// ImGui application to draw the application. The correct context will
         /// be current when the virtual method is called.
-        pub const render = struct {
-            pub fn call(class: anytype, object: *@typeInfo(@TypeOf(class)).pointer.child.Instance) void {
-                return gobject.ext.as(Self.Class, class).render.?(gobject.ext.as(Self, object));
-            }
-
-            pub fn implement(class: anytype, implementation: *const fn (p_object: *@typeInfo(@TypeOf(class)).pointer.child.Instance) callconv(.c) void) void {
-                gobject.ext.as(Self.Class, class).render = @ptrCast(implementation);
-            }
-        };
+        pub const render = C.defineVirtualMethod("render");
     };
 
     const Private = struct {
@@ -119,7 +103,7 @@ pub const ImguiWidget = extern struct {
     /// when the virtual method is called.
     pub fn setup(self: *Self) callconv(.c) void {
         const class = self.getClass() orelse return;
-        virtual_methods.setup.call(class, self);
+        virtual_methods.setup.call(class, self, .{});
     }
 
     /// This virtual method will be called at each frame to allow the Dear ImGui
@@ -127,7 +111,7 @@ pub const ImguiWidget = extern struct {
     /// when the virtual method is called.
     pub fn render(self: *Self) callconv(.c) void {
         const class = self.getClass() orelse return;
-        virtual_methods.render.call(class, self);
+        virtual_methods.render.call(class, self, .{});
     }
 
     //---------------------------------------------------------------

--- a/src/apprt/gtk-ng/class/imgui_widget.zig
+++ b/src/apprt/gtk-ng/class/imgui_widget.zig
@@ -67,6 +67,34 @@ pub const ImguiWidget = extern struct {
         };
     };
 
+    pub const virtual_methods = struct {
+        /// This virtual method will be called to allow the Dear ImGui
+        /// application to do one-time setup of the context. The correct context
+        /// will be current when the virtual method is called.
+        pub const setup = struct {
+            pub fn call(class: anytype, object: *@typeInfo(@TypeOf(class)).pointer.child.Instance) void {
+                return gobject.ext.as(Self.Class, class).setup.?(gobject.ext.as(Self, object));
+            }
+
+            pub fn implement(class: anytype, implementation: *const fn (p_object: *@typeInfo(@TypeOf(class)).pointer.child.Instance) callconv(.c) void) void {
+                gobject.ext.as(Self.Class, class).setup = @ptrCast(implementation);
+            }
+        };
+
+        /// This virtual method will be called at each frame to allow the Dear
+        /// ImGui application to draw the application. The correct context will
+        /// be current when the virtual method is called.
+        pub const render = struct {
+            pub fn call(class: anytype, object: *@typeInfo(@TypeOf(class)).pointer.child.Instance) void {
+                return gobject.ext.as(Self.Class, class).render.?(gobject.ext.as(Self, object));
+            }
+
+            pub fn implement(class: anytype, implementation: *const fn (p_object: *@typeInfo(@TypeOf(class)).pointer.child.Instance) callconv(.c) void) void {
+                gobject.ext.as(Self.Class, class).render = @ptrCast(implementation);
+            }
+        };
+    };
+
     const Private = struct {
         /// GL area where we display the Dear ImGui application.
         gl_area: *gtk.GLArea,
@@ -111,6 +139,25 @@ pub const ImguiWidget = extern struct {
     pub fn queueRender(self: *ImguiWidget) void {
         const priv = self.private();
         priv.gl_area.queueRender();
+    }
+
+    //---------------------------------------------------------------
+    // Public wrappers for virtual methods
+
+    /// This virtual method will be called to allow the Dear ImGui application
+    /// to do one-time setup of the context. The correct context will be current
+    /// when the virtual method is called.
+    pub fn setup(self: *Self) callconv(.c) void {
+        const class = self.getClass() orelse return;
+        virtual_methods.setup.call(class, self);
+    }
+
+    /// This virtual method will be called at each frame to allow the Dear ImGui
+    /// application to draw the application. The correct context will be current
+    /// when the virtual method is called.
+    pub fn render(self: *Self) callconv(.c) void {
+        const class = self.getClass() orelse return;
+        virtual_methods.render.call(class, self);
     }
 
     //---------------------------------------------------------------
@@ -232,13 +279,8 @@ pub const ImguiWidget = extern struct {
         // initialize the ImgUI OpenGL backend for our context.
         _ = cimgui.ImGui_ImplOpenGL3_Init(null);
 
-        // Setup our app
-        signals.setup.impl.emit(
-            self,
-            null,
-            .{},
-            null,
-        );
+        // Call the virtual method to setup the UI.
+        self.setup();
     }
 
     /// Handle a request to unrealize the GLArea
@@ -279,13 +321,8 @@ pub const ImguiWidget = extern struct {
             self.newFrame();
             cimgui.c.igNewFrame();
 
-            // Use the callback to draw the UI.
-            signals.render.impl.emit(
-                self,
-                null,
-                .{},
-                null,
-            );
+            // Call the virtual method to draw the UI.
+            self.render();
 
             // Render
             cimgui.c.igRender();
@@ -422,15 +459,34 @@ pub const ImguiWidget = extern struct {
         cimgui.c.ImGuiIO_AddInputCharactersUTF8(io, bytes);
     }
 
+    //---------------------------------------------------------------
+    // Default virtual method handlers
+
+    /// Default setup function. Does nothing but log a warning.
+    fn defaultSetup(_: *Self) callconv(.c) void {
+        log.warn("default Dear ImGui setup called, this is a bug.", .{});
+    }
+
+    /// Default render function. Does nothing but log a warning.
+    fn defaultRender(_: *Self) callconv(.c) void {
+        log.warn("default Dear ImGui render called, this is a bug.", .{});
+    }
+
     const C = Common(Self, Private);
     pub const as = C.as;
     pub const ref = C.ref;
     pub const refSink = C.refSink;
     pub const unref = C.unref;
+    pub const getClass = C.getClass;
     const private = C.private;
 
     pub const Class = extern struct {
         parent_class: Parent.Class,
+
+        /// Function pointers for virtual methods.
+        setup: ?*const fn (*Self) callconv(.c) void = null,
+        render: ?*const fn (*Self) callconv(.c) void = null,
+
         var parent: *Parent.Class = undefined;
         pub const Instance = Self;
 
@@ -443,6 +499,10 @@ pub const ImguiWidget = extern struct {
                     .name = "imgui-widget",
                 }),
             );
+
+            // Initialize our virtual methods with default functions.
+            class.setup = defaultSetup;
+            class.render = defaultRender;
 
             // Bindings
             class.bindTemplateChildPrivate("gl_area", .{});

--- a/src/apprt/gtk-ng/ui/1.5/inspector-widget.blp
+++ b/src/apprt/gtk-ng/ui/1.5/inspector-widget.blp
@@ -1,18 +1,10 @@
 using Gtk 4.0;
-using Adw 1;
 
-template $GhosttyInspectorWidget: Adw.Bin {
+template $GhosttyInspectorWidget: $GhosttyImguiWidget {
   styles [
     "inspector",
   ]
 
   hexpand: true;
   vexpand: true;
-
-  Adw.Bin {
-    $GhosttyImguiWidget imgui_widget {
-      render => $imgui_render();
-      setup => $imgui_setup();
-    }
-  }
 }


### PR DESCRIPTION
Insead of signals between the ImGui widget and the Inspector widget, make the Inspector widget a subclass of the ImGui widget and use virtual methods to handle setup and rendering of the Inspector.