### PR TITLE
zsh: minor shell integration improvements

### DIFF
--- a/src/shell-integration/zsh/.zshenv
+++ b/src/shell-integration/zsh/.zshenv
@@ -45,6 +45,7 @@ fi
         'builtin' 'autoload' '--' 'is-at-least'
         'is-at-least' "5.1" || {
             builtin echo "ZSH ${ZSH_VERSION} is too old for ghostty shell integration" > /dev/stderr
+            'builtin' 'unset' '_ghostty_file'
             return
         }
         # ${(%):-%x} is the path to the current file.

--- a/src/shell-integration/zsh/.zshenv
+++ b/src/shell-integration/zsh/.zshenv
@@ -29,14 +29,15 @@ fi
 
 # Use try-always to have the right error code.
 {
-    # Zsh treats empty $ZDOTDIR as if it was "/". We do the same.
+    # Zsh treats unset ZDOTDIR as if it was HOME. We do the same.
     #
-    # Source the user's zshenv before sourcing ghostty.zsh because the former
-    # might set fpath and other things without which ghostty.zsh won't work.
+    # Source the user's .zshenv before sourcing ghostty-integration because the
+    # former might set fpath and other things without which ghostty-integration
+    # won't work.
     #
     # Use typeset in case we are in a function with warn_create_global in
     # effect. Unlikely but better safe than sorry.
-    'builtin' 'typeset' _ghostty_file=${ZDOTDIR-~}"/.zshenv"
+    'builtin' 'typeset' _ghostty_file=${ZDOTDIR-$HOME}"/.zshenv"
     # Zsh ignores unreadable rc files. We do the same.
     # Zsh ignores rc files that are directories, and so does source.
     [[ ! -r "$_ghostty_file" ]] || 'builtin' 'source' '--' "$_ghostty_file"

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -670,3 +670,27 @@ fn setupZsh(
     );
     try env.put("ZDOTDIR", integ_dir);
 }
+
+test "zsh" {
+    const testing = std.testing;
+
+    var env = EnvMap.init(testing.allocator);
+    defer env.deinit();
+
+    try setupZsh(".", &env);
+    try testing.expectEqualStrings("./shell-integration/zsh", env.get("ZDOTDIR").?);
+    try testing.expect(env.get("GHOSTTY_ZSH_ZDOTDIR") == null);
+}
+
+test "zsh: ZDOTDIR" {
+    const testing = std.testing;
+
+    var env = EnvMap.init(testing.allocator);
+    defer env.deinit();
+
+    try env.put("ZDOTDIR", "$HOME/.config/zsh");
+
+    try setupZsh(".", &env);
+    try testing.expectEqualStrings("./shell-integration/zsh", env.get("ZDOTDIR").?);
+    try testing.expectEqualStrings("$HOME/.config/zsh", env.get("GHOSTTY_ZSH_ZDOTDIR").?);
+}


### PR DESCRIPTION
- test `setupZsh`
- clean up `_ghostty_file` in the early exit path
- improve some `.zshenv` comments