### PR TITLE
gtk-ng: fix toggle_window_decoration

### DIFF
--- a/src/apprt/gtk-ng/class/application.zig
+++ b/src/apprt/gtk-ng/class/application.zig
@@ -2216,7 +2216,7 @@ const Action = struct {
                     Window,
                     surface.as(gtk.Widget),
                 ) orelse {
-                    log.warn("surface is not in a window, ignoring new_tab", .{});
+                    log.warn("surface is not in a window, ignoring toggle_window_decorations", .{});
                     return false;
                 };
 

--- a/src/apprt/gtk-ng/class/window.zig
+++ b/src/apprt/gtk-ng/class/window.zig
@@ -780,9 +780,18 @@ pub const Window = extern struct {
 
     /// Toggle the window decorations for this window.
     pub fn toggleWindowDecorations(self: *Self) void {
-        self.setWindowDecoration(switch (self.getWindowDecoration()) {
-            // Null will force using the central config
-            .none => null,
+        const priv = self.private();
+
+        if (priv.window_decoration) |_| {
+            // Unset any previously set window decoration settings
+            self.setWindowDecoration(null);
+            return;
+        }
+
+        const config = if (priv.config) |v| v.get() else return;
+        self.setWindowDecoration(switch (config.@"window-decoration") {
+            // Use auto when the decoration is initially none
+            .none => .auto,
 
             // Anything non-none to none
             .auto, .client, .server => .none,


### PR DESCRIPTION
When window-decoration=none, setting the window decoration to null would just mean it would default to none again, creating a cycle of torment none can break out of... that sounds a bit too dramatic doesn't it

Fixes #8274
