### PR TITLE
macos: show copy menu item if selection start is outside viewport

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -1327,7 +1327,7 @@ extension Ghostty {
             var item: NSMenuItem
 
             // If we have a selection, add copy
-            if self.selectedRange().length > 0 {
+            if let text = self.accessibilitySelectedText(), text.count > 0 {
                 menu.addItem(withTitle: "Copy", action: #selector(copy(_:)), keyEquivalent: "")
             }
             menu.addItem(withTitle: "Paste", action: #selector(paste(_:)), keyEquivalent: "")


### PR DESCRIPTION
Fixes #8187

This properly handles the scenario with our `read_text` C API when the selection start is outside the viewport. Previously we'd report null (no text) which would cascade into things like the right click menu not showing a copy option.