### PR TITLE
build: add run-valgrind and test-valgrind steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,37 +142,18 @@ Zig cannot detect by itself.
 
 ### On Linux
 
-On Linux the recommended tool to check for memory leaks is Valgrind. We supply
-a file containing suppressions for false positives and known leaks in 3rd party
-libraries. The recommended way to run Valgrind is:
+On Linux the recommended tool to check for memory leaks is Valgrind. The
+recommended way to run Valgrind is via `zig build`:
 
-```
-zig build -Dcpu=baseline -Doptimize=Debug
-valgrind \
-  --leak-check=full \
-  --num-callers=50 \
-  --suppressions=valgrind.supp \
-  ./zig-out/bin/ghostty
+```sh
+zig build run-valgrind
 ```
 
-> [!NOTE]
->
-> `-Dcpu=baseline` may not be needed depending on your CPU, but Valgrind cannot
-> deal with some instructions on certain newer CPUs so using `-Dcpu=baseline`
-> doesn't hurt.
+This builds a Ghostty executable with Valgrind support and runs Valgrind
+with the proper flags to ensure we're suppressing known false positives.
 
-Any leaks found by Valgrind should be investigated.
-
-If you use Nix, you can use the following commands to run Valgrind so that you
-don't need to look up the Valgrind invocation every time:
-
-```
-nix develop
-nix run .#valgrind -- --config-default-files=true
-```
-
-You can add any Ghostty CLI arguments after the `--` and they will be passed to
-the invocation of Ghostty.
+You can combine the same build args with `run-valgrind` that you can with
+`run`, such as specifying additional configurations after a trailing `--`.
 
 ## Input Stack Testing
 

--- a/flake.nix
+++ b/flake.nix
@@ -94,19 +94,6 @@
             x11-gnome = runVM ./nix/vm/x11-gnome.nix;
             x11-plasma6 = runVM ./nix/vm/x11-plasma6.nix;
             x11-xfce = runVM ./nix/vm/x11-xfce.nix;
-            valgrind = let
-              script = pkgs.writeShellScript "valgrind" ''
-                zig build -Dcpu=baseline -Doptimize=Debug
-                valgrind \
-                  --leak-check=full \
-                  --num-callers=50 \
-                  --suppressions=valgrind.supp \
-                  ./zig-out/bin/ghostty "$@"
-              '';
-            in {
-              type = "app";
-              program = "${script}";
-            };
           };
         }
         # Our supported systems are the same supported systems as the Zig binaries.


### PR DESCRIPTION
This adds two explicit `zig build` steps: `run-valgrind` and `test-valgrind` to run the Ghostty exe or tests under Valgrind, respectively.

This simplifies the manual Valgrind calls in a few ways:

1. It automatically sets the CPU to baseline, which is a frequent and requirement for Valgrind on newer CPUs, and generally safe.

2. It sets up the rather complicated set of flags to call Valgrind with, importantly setting up our suppressions.

3. It enables pairing it with the typical and comfortable workflow of specifying extra args (with `--`) or flags like `-Dtest-filter` for tests.