### PR TITLE
terminal: change OSC parser to explicit init to set undefined

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,6 @@ jobs:
       - build-macos-matrix
       - build-windows
       - flatpak-check-zig-cache
-      - flatpak
       - test
       - test-gtk
       - test-gtk-ng
@@ -1013,28 +1012,29 @@ jobs:
       - name: Check Flatpak Zig Dependencies
         run: nix develop -c ./flatpak/build-support/check-zig-cache.sh
 
-  flatpak:
-    if: github.repository == 'ghostty-org/ghostty'
-    name: "Flatpak"
-    container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-47
-      options: --privileged
-    strategy:
-      fail-fast: false
-      matrix:
-        variant:
-          - arch: x86_64
-            runner: namespace-profile-ghostty-md
-          - arch: aarch64
-            runner: namespace-profile-ghostty-md-arm64
-    runs-on: ${{ matrix.variant.runner }}
-    needs: [flatpak-check-zig-cache, test]
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: flatpak/flatpak-github-actions/flatpak-builder@10a3c29f0162516f0f68006be14c92f34bd4fa6c # v6.5
-        with:
-          bundle: com.mitchellh.ghostty
-          manifest-path: flatpak/com.mitchellh.ghostty.yml
-          cache-key: flatpak-builder-${{ github.sha }}
-          arch: ${{ matrix.variant.arch }}
-          verbose: true
+  # Disabled until we update to Zig 0.15 or if we can pin this to Zig 0.14
+  # flatpak:
+  #   if: github.repository == 'ghostty-org/ghostty'
+  #   name: "Flatpak"
+  #   container:
+  #     image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-47
+  #     options: --privileged
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       variant:
+  #         - arch: x86_64
+  #           runner: namespace-profile-ghostty-md
+  #         - arch: aarch64
+  #           runner: namespace-profile-ghostty-md-arm64
+  #   runs-on: ${{ matrix.variant.runner }}
+  #   needs: [flatpak-check-zig-cache, test]
+  #   steps:
+  #     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+  #     - uses: flatpak/flatpak-github-actions/flatpak-builder@10a3c29f0162516f0f68006be14c92f34bd4fa6c # v6.5
+  #       with:
+  #         bundle: com.mitchellh.ghostty
+  #         manifest-path: flatpak/com.mitchellh.ghostty.yml
+  #         cache-key: flatpak-builder-${{ github.sha }}
+  #         arch: ${{ matrix.variant.arch }}
+  #         verbose: true

--- a/src/benchmark/TerminalParser.zig
+++ b/src/benchmark/TerminalParser.zig
@@ -77,7 +77,7 @@ fn step(ptr: *anyopaque) Benchmark.Error!void {
     const f = self.data_f orelse return;
     var r = std.io.bufferedReader(f.reader());
 
-    var p: terminalpkg.Parser = .{};
+    var p: terminalpkg.Parser = .init();
 
     var buf: [4096]u8 = undefined;
     while (true) {

--- a/src/benchmark/TerminalStream.zig
+++ b/src/benchmark/TerminalStream.zig
@@ -62,7 +62,7 @@ pub fn create(
             .cols = opts.@"terminal-cols",
         }),
         .handler = .{ .t = &ptr.terminal },
-        .stream = .{ .handler = &ptr.handler },
+        .stream = .init(&ptr.handler),
     };
 
     return ptr;

--- a/src/inspector/Inspector.zig
+++ b/src/inspector/Inspector.zig
@@ -172,13 +172,10 @@ pub fn init(surface: *Surface) !Inspector {
         .surface = surface,
         .key_events = key_buf,
         .vt_events = vt_events,
-        .vt_stream = .{
-            .handler = vt_handler,
-            .parser = .{
-                .osc_parser = .{
-                    .alloc = surface.alloc,
-                },
-            },
+        .vt_stream = stream: {
+            var s: inspector.termio.Stream = .init(vt_handler);
+            s.parser.osc_parser.alloc = surface.alloc;
+            break :stream s;
         },
     };
 }

--- a/src/synthetic/Osc.zig
+++ b/src/synthetic/Osc.zig
@@ -196,7 +196,7 @@ test "OSC generator valid" {
     };
     for (0..50) |_| {
         const seq = try gen.next(&buf);
-        var parser: terminal.osc.Parser = .{};
+        var parser: terminal.osc.Parser = .init();
         for (seq[2 .. seq.len - 1]) |c| parser.next(c);
         try testing.expect(parser.end(null) != null);
     }
@@ -214,7 +214,7 @@ test "OSC generator invalid" {
     };
     for (0..50) |_| {
         const seq = try gen.next(&buf);
-        var parser: terminal.osc.Parser = .{};
+        var parser: terminal.osc.Parser = .init();
         for (seq[2 .. seq.len - 1]) |c| parser.next(c);
         try testing.expect(parser.end(null) == null);
     }

--- a/src/terminal/Parser.zig
+++ b/src/terminal/Parser.zig
@@ -223,10 +223,12 @@ param_acc: u16 = 0,
 param_acc_idx: u8 = 0,
 
 /// Parser for OSC sequences
-osc_parser: osc.Parser = .{},
+osc_parser: osc.Parser,
 
 pub fn init() Parser {
-    return .{};
+    return .{
+        .osc_parser = .init(),
+    };
 }
 
 pub fn deinit(self: *Parser) void {

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -47,8 +47,16 @@ pub fn Stream(comptime Handler: type) type {
         };
 
         handler: Handler,
-        parser: Parser = .{},
-        utf8decoder: UTF8Decoder = .{},
+        parser: Parser,
+        utf8decoder: UTF8Decoder,
+
+        pub fn init(h: Handler) Self {
+            return .{
+                .handler = h,
+                .parser = .init(),
+                .utf8decoder = .{},
+            };
+        }
 
         pub fn deinit(self: *Self) void {
             self.parser.deinit();
@@ -1842,7 +1850,7 @@ test "stream: print" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
     try s.next('x');
     try testing.expectEqual(@as(u21, 'x'), s.handler.c.?);
 }
@@ -1856,7 +1864,7 @@ test "simd: print invalid utf-8" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
     try s.nextSlice(&.{0xFF});
     try testing.expectEqual(@as(u21, 0xFFFD), s.handler.c.?);
 }
@@ -1870,7 +1878,7 @@ test "simd: complete incomplete utf-8" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
     try s.nextSlice(&.{0xE0}); // 3 byte
     try testing.expect(s.handler.c == null);
     try s.nextSlice(&.{0xA0}); // still incomplete
@@ -1888,7 +1896,7 @@ test "stream: cursor right (CUF)" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
     try s.nextSlice("\x1B[C");
     try testing.expectEqual(@as(u16, 1), s.handler.amount);
 
@@ -1913,7 +1921,7 @@ test "stream: dec set mode (SM) and reset mode (RM)" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
     try s.nextSlice("\x1B[?6h");
     try testing.expectEqual(@as(modes.Mode, .origin), s.handler.mode);
 
@@ -1935,7 +1943,7 @@ test "stream: ansi set mode (SM) and reset mode (RM)" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
     try s.nextSlice("\x1B[4h");
     try testing.expectEqual(@as(modes.Mode, .insert), s.handler.mode.?);
 
@@ -1957,7 +1965,7 @@ test "stream: ansi set mode (SM) and reset mode (RM) with unknown value" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
     try s.nextSlice("\x1B[6h");
     try testing.expect(s.handler.mode == null);
 
@@ -1977,7 +1985,7 @@ test "stream: restore mode" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
     for ("\x1B[?42r") |c| try s.next(c);
     try testing.expect(!s.handler.called);
 }
@@ -1992,7 +2000,7 @@ test "stream: pop kitty keyboard with no params defaults to 1" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
     for ("\x1B[<u") |c| try s.next(c);
     try testing.expectEqual(@as(u16, 1), s.handler.n);
 }
@@ -2007,7 +2015,7 @@ test "stream: DECSCA" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
     {
         for ("\x1B[\"q") |c| try s.next(c);
         try testing.expectEqual(ansi.ProtectedMode.off, s.handler.v.?);
@@ -2042,7 +2050,7 @@ test "stream: DECED, DECSED" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
     {
         for ("\x1B[?J") |c| try s.next(c);
         try testing.expectEqual(csi.EraseDisplay.below, s.handler.mode.?);
@@ -2118,7 +2126,7 @@ test "stream: DECEL, DECSEL" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
     {
         for ("\x1B[?K") |c| try s.next(c);
         try testing.expectEqual(csi.EraseLine.right, s.handler.mode.?);
@@ -2177,7 +2185,7 @@ test "stream: DECSCUSR" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
     try s.nextSlice("\x1B[ q");
     try testing.expect(s.handler.style.? == .default);
 
@@ -2198,7 +2206,7 @@ test "stream: DECSCUSR without space" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
     try s.nextSlice("\x1B[q");
     try testing.expect(s.handler.style == null);
 
@@ -2215,7 +2223,7 @@ test "stream: XTSHIFTESCAPE" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
     try s.nextSlice("\x1B[>2s");
     try testing.expect(s.handler.escape == null);
 
@@ -2245,13 +2253,13 @@ test "stream: change window title with invalid utf-8" {
     };
 
     {
-        var s: Stream(H) = .{ .handler = .{} };
+        var s: Stream(H) = .init(.{});
         try s.nextSlice("\x1b]2;abc\x1b\\");
         try testing.expect(s.handler.seen);
     }
 
     {
-        var s: Stream(H) = .{ .handler = .{} };
+        var s: Stream(H) = .init(.{});
         try s.nextSlice("\x1b]2;abc\xc0\x1b\\");
         try testing.expect(!s.handler.seen);
     }
@@ -2268,7 +2276,7 @@ test "stream: insert characters" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
     for ("\x1B[42@") |c| try s.next(c);
     try testing.expect(s.handler.called);
 
@@ -2294,7 +2302,7 @@ test "stream: SCOSC" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
     for ("\x1B[s") |c| try s.next(c);
     try testing.expect(s.handler.called);
 }
@@ -2309,7 +2317,7 @@ test "stream: SCORC" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
     for ("\x1B[u") |c| try s.next(c);
     try testing.expect(s.handler.called);
 }
@@ -2323,7 +2331,7 @@ test "stream: too many csi params" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
     try s.nextSlice("\x1B[1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1C");
 }
 
@@ -2335,7 +2343,7 @@ test "stream: csi param too long" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
     try s.nextSlice("\x1B[1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111C");
 }
 
@@ -2348,7 +2356,7 @@ test "stream: send report with CSI t" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
 
     try s.nextSlice("\x1b[14t");
     try testing.expectEqual(csi.SizeReportStyle.csi_14_t, s.handler.style);
@@ -2372,7 +2380,7 @@ test "stream: invalid CSI t" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
 
     try s.nextSlice("\x1b[19t");
     try testing.expectEqual(null, s.handler.style);
@@ -2387,7 +2395,7 @@ test "stream: CSI t push title" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
 
     try s.nextSlice("\x1b[22;0t");
     try testing.expectEqual(csi.TitlePushPop{
@@ -2405,7 +2413,7 @@ test "stream: CSI t push title with explicit window" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
 
     try s.nextSlice("\x1b[22;2t");
     try testing.expectEqual(csi.TitlePushPop{
@@ -2423,7 +2431,7 @@ test "stream: CSI t push title with explicit icon" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
 
     try s.nextSlice("\x1b[22;1t");
     try testing.expectEqual(null, s.handler.op);
@@ -2438,7 +2446,7 @@ test "stream: CSI t push title with index" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
 
     try s.nextSlice("\x1b[22;0;5t");
     try testing.expectEqual(csi.TitlePushPop{
@@ -2456,7 +2464,7 @@ test "stream: CSI t pop title" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
 
     try s.nextSlice("\x1b[23;0t");
     try testing.expectEqual(csi.TitlePushPop{
@@ -2474,7 +2482,7 @@ test "stream: CSI t pop title with explicit window" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
 
     try s.nextSlice("\x1b[23;2t");
     try testing.expectEqual(csi.TitlePushPop{
@@ -2492,7 +2500,7 @@ test "stream: CSI t pop title with explicit icon" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
 
     try s.nextSlice("\x1b[23;1t");
     try testing.expectEqual(null, s.handler.op);
@@ -2507,7 +2515,7 @@ test "stream: CSI t pop title with index" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
 
     try s.nextSlice("\x1b[23;0;5t");
     try testing.expectEqual(csi.TitlePushPop{
@@ -2525,7 +2533,7 @@ test "stream CSI W clear tab stops" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
 
     try s.nextSlice("\x1b[2W");
     try testing.expectEqual(csi.TabClear.current, s.handler.op.?);
@@ -2543,7 +2551,7 @@ test "stream CSI W tab set" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
 
     try s.nextSlice("\x1b[W");
     try testing.expect(s.handler.called);
@@ -2570,7 +2578,7 @@ test "stream CSI ? W reset tab stops" {
         }
     };
 
-    var s: Stream(H) = .{ .handler = .{} };
+    var s: Stream(H) = .init(.{});
 
     try s.nextSlice("\x1b[?2W");
     try testing.expect(!s.handler.reset);

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -313,15 +313,12 @@ pub fn init(self: *Termio, alloc: Allocator, opts: termio.Options) !void {
         .size = opts.size,
         .backend = backend,
         .mailbox = opts.mailbox,
-        .terminal_stream = .{
-            .handler = handler,
-            .parser = .{
-                .osc_parser = .{
-                    // Populate the OSC parser allocator (optional) because
-                    // we want to support large OSC payloads such as OSC 52.
-                    .alloc = alloc,
-                },
-            },
+        .terminal_stream = stream: {
+            var s: terminalpkg.Stream(StreamHandler) = .init(handler);
+            // Populate the OSC parser allocator (optional) because
+            // we want to support large OSC payloads such as OSC 52.
+            s.parser.osc_parser.alloc = alloc;
+            break :stream s;
         },
         .thread_enter_state = thread_enter_state,
     };


### PR DESCRIPTION
This works around: https://github.com/ziglang/zig/issues/19148 This lets our `test-valgrind` command catch some issues. We'll have to follow this pattern in more places but I want to do it incrementally so things keep passing.

I **do not** want to blindly follow this pattern everywhere. I want to start by focusing in only on the structs that set `undefined` as default fields that we're also about to test in isolation with Valgrind. It's just too much noise otherwise and not a general style I'm sure of; it's worth it for Valgrind though.

I'm making this PR separate from any fixes because the diff is so noisy I don't want to lose the fixes in the noise. **This PR is therefore functionally a no-op.**