### PR TITLE
terminal: fix undefined memory access in OSC parser

### DIFF
--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -1608,6 +1608,12 @@ pub fn Stream(comptime Handler: type) type {
                 .sleep, .show_message_box, .change_conemu_tab_title, .wait_input => {
                     log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
+
+                .invalid => {
+                    // This is an invalid internal state, not an invalid OSC
+                    // string being parsed. We shouldn't see this.
+                    log.warn("invalid OSC, should never happen", .{});
+                },
             }
 
             // Fall through for when we don't have a handler.


### PR DESCRIPTION
Fixes #8007

Verified with `test-valgrind -Dtest-filter="OSC"` which had cond access errors before, and none after this. Basically a copy of #8008.