### PR TITLE
flatpak: manually install Zig 0.14.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
       - test-debian-13
       - valgrind
       - zig-fmt
+      - flatpak
     steps:
       - id: status
         name: Determine status

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1013,32 +1013,31 @@ jobs:
       - name: Check Flatpak Zig Dependencies
         run: nix develop -c ./flatpak/build-support/check-zig-cache.sh
 
-  # Disabled until we update to Zig 0.15 or if we can pin this to Zig 0.14
-  # flatpak:
-  #   if: github.repository == 'ghostty-org/ghostty'
-  #   name: "Flatpak"
-  #   container:
-  #     image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-47
-  #     options: --privileged
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       variant:
-  #         - arch: x86_64
-  #           runner: namespace-profile-ghostty-md
-  #         - arch: aarch64
-  #           runner: namespace-profile-ghostty-md-arm64
-  #   runs-on: ${{ matrix.variant.runner }}
-  #   needs: [flatpak-check-zig-cache, test]
-  #   steps:
-  #     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-  #     - uses: flatpak/flatpak-github-actions/flatpak-builder@10a3c29f0162516f0f68006be14c92f34bd4fa6c # v6.5
-  #       with:
-  #         bundle: com.mitchellh.ghostty
-  #         manifest-path: flatpak/com.mitchellh.ghostty.yml
-  #         cache-key: flatpak-builder-${{ github.sha }}
-  #         arch: ${{ matrix.variant.arch }}
-  #         verbose: true
+  flatpak:
+    if: github.repository == 'ghostty-org/ghostty'
+    name: "Flatpak"
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-47
+      options: --privileged
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+          - arch: x86_64
+            runner: namespace-profile-ghostty-md
+          - arch: aarch64
+            runner: namespace-profile-ghostty-md-arm64
+    runs-on: ${{ matrix.variant.runner }}
+    needs: [flatpak-check-zig-cache, test]
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: flatpak/flatpak-github-actions/flatpak-builder@10a3c29f0162516f0f68006be14c92f34bd4fa6c # v6.5
+        with:
+          bundle: com.mitchellh.ghostty
+          manifest-path: flatpak/com.mitchellh.ghostty.yml
+          cache-key: flatpak-builder-${{ github.sha }}
+          arch: ${{ matrix.variant.arch }}
+          verbose: true
 
   valgrind:
     if: github.repository == 'ghostty-org/ghostty'

--- a/flatpak/com.mitchellh.ghostty-debug.yml
+++ b/flatpak/com.mitchellh.ghostty-debug.yml
@@ -2,8 +2,6 @@ app-id: com.mitchellh.ghostty-debug
 runtime: org.gnome.Platform
 runtime-version: "48"
 sdk: org.gnome.Sdk
-sdk-extensions:
-  - org.freedesktop.Sdk.Extension.ziglang
 default-branch: tip
 command: ghostty
 rename-icon: com.mitchellh.ghostty
@@ -37,7 +35,7 @@ modules:
   - name: ghostty
     buildsystem: simple
     build-options:
-      append-path: /usr/lib/sdk/ziglang
+      append-path: /app/zig
     build-commands:
       - zig build
         -Doptimize=Debug

--- a/flatpak/com.mitchellh.ghostty.yml
+++ b/flatpak/com.mitchellh.ghostty.yml
@@ -2,8 +2,6 @@ app-id: com.mitchellh.ghostty
 runtime: org.gnome.Platform
 runtime-version: "48"
 sdk: org.gnome.Sdk
-sdk-extensions:
-  - org.freedesktop.Sdk.Extension.ziglang
 default-branch: tip
 command: ghostty
 finish-args:
@@ -36,7 +34,7 @@ modules:
   - name: ghostty
     buildsystem: simple
     build-options:
-      append-path: /usr/lib/sdk/ziglang
+      append-path: /app/zig
     build-commands:
       - zig build
         -Doptimize=ReleaseFast

--- a/flatpak/dependencies.yml
+++ b/flatpak/dependencies.yml
@@ -3,6 +3,24 @@ buildsystem: simple
 build-commands:
   - true
 modules:
+  - name: zig
+    buildsystem: simple
+    cleanup:
+      - "*"
+    build-commands:
+      - mkdir -p /app/zig
+      - cp -r ./* /app/zig
+      - chmod a+x /app/zig/zig
+    sources:
+      - type: archive
+        sha256: 24aeeec8af16c381934a6cd7d95c807a8cb2cf7df9fa40d359aa884195c4716c
+        url: https://ziglang.org/download/0.14.1/zig-x86_64-linux-0.14.1.tar.xz
+        only-arches: [x86_64]
+      - type: archive
+        sha256: f7a654acc967864f7a050ddacfaa778c7504a0eca8d2b678839c21eea47c992b
+        url: https://ziglang.org/download/0.14.1/zig-aarch64-linux-0.14.1.tar.xz
+        only-arches: [aarch64]
+
   - name: bzip2-redirect
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
The SDK published on Flathub updated to Zig 0.15.1 which broke the Flathub build in CI. So let's install it ourselves so that we can control the version.