### PR TITLE
Switch macOS builds to Tahoe (Beta 7 currently)

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -47,7 +47,7 @@ jobs:
           sentry-cli dif upload --project ghostty --wait dsym.zip
 
   build-macos:
-    runs-on: namespace-profile-ghostty-macos-sequoia
+    runs-on: namespace-profile-ghostty-macos-sequoia-edge
     timeout-minutes: 90
     steps:
       - name: Checkout code
@@ -95,6 +95,7 @@ jobs:
         run: |
           cd macos
           sudo xcode-select -s /Applications/Xcode_26.0.app
+          xcodebuild -version
           xcodebuild -target Ghostty -configuration Release
 
       # We inject the "build number" as simply the number of commits since HEAD.
@@ -201,7 +202,7 @@ jobs:
           destination-dir: ./
 
   build-macos-debug:
-    runs-on: namespace-profile-ghostty-macos-sequoia
+    runs-on: namespace-profile-ghostty-macos-sequoia-edge
     timeout-minutes: 90
     steps:
       - name: Checkout code
@@ -249,6 +250,7 @@ jobs:
         run: |
           cd macos
           sudo xcode-select -s /Applications/Xcode_26.0.app
+          xcodebuild -version
           xcodebuild -target Ghostty -configuration Release
 
       # We inject the "build number" as simply the number of commits since HEAD.

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -47,7 +47,7 @@ jobs:
           sentry-cli dif upload --project ghostty --wait dsym.zip
 
   build-macos:
-    runs-on: namespace-profile-ghostty-macos-sequoia-edge
+    runs-on: namespace-profile-ghostty-macos-tahoe
     timeout-minutes: 90
     steps:
       - name: Checkout code
@@ -57,9 +57,9 @@ jobs:
           fetch-depth: 0
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31.5.2
+      - uses: DeterminateSystems/nix-installer-action@main
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
+          determinate: true
       - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
         with:
           name: ghostty
@@ -202,7 +202,7 @@ jobs:
           destination-dir: ./
 
   build-macos-debug:
-    runs-on: namespace-profile-ghostty-macos-sequoia-edge
+    runs-on: namespace-profile-ghostty-macos-tahoe
     timeout-minutes: 90
     steps:
       - name: Checkout code
@@ -212,9 +212,9 @@ jobs:
           fetch-depth: 0
 
       # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31.5.2
+      - uses: DeterminateSystems/nix-installer-action@main
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
+          determinate: true
       - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
         with:
           name: ghostty

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -120,7 +120,7 @@ jobs:
 
   build-macos:
     needs: [setup]
-    runs-on: namespace-profile-ghostty-macos-sequoia
+    runs-on: namespace-profile-ghostty-macos-sequoia-edge
     timeout-minutes: 90
     env:
       GHOSTTY_VERSION: ${{ needs.setup.outputs.version }}
@@ -140,6 +140,9 @@ jobs:
 
       - name: XCode Select
         run: sudo xcode-select -s /Applications/Xcode_16.4.app
+
+      - name: Xcode Version
+        run: xcodebuild -version
 
       - name: Setup Sparkle
         env:
@@ -291,7 +294,7 @@ jobs:
 
   appcast:
     needs: [setup, build-macos]
-    runs-on: namespace-profile-ghostty-macos-sequoia
+    runs-on: namespace-profile-ghostty-macos-sequoia-edge
     env:
       GHOSTTY_VERSION: ${{ needs.setup.outputs.version }}
       GHOSTTY_BUILD: ${{ needs.setup.outputs.build }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -120,7 +120,7 @@ jobs:
 
   build-macos:
     needs: [setup]
-    runs-on: namespace-profile-ghostty-macos-sequoia-edge
+    runs-on: namespace-profile-ghostty-macos-tahoe
     timeout-minutes: 90
     env:
       GHOSTTY_VERSION: ${{ needs.setup.outputs.version }}
@@ -130,9 +130,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31.5.2
+      - uses: DeterminateSystems/nix-installer-action@main
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
+          determinate: true
       - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
         with:
           name: ghostty
@@ -294,7 +294,7 @@ jobs:
 
   appcast:
     needs: [setup, build-macos]
-    runs-on: namespace-profile-ghostty-macos-sequoia-edge
+    runs-on: namespace-profile-ghostty-macos-tahoe
     env:
       GHOSTTY_VERSION: ${{ needs.setup.outputs.version }}
       GHOSTTY_BUILD: ${{ needs.setup.outputs.build }}

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -154,7 +154,7 @@ jobs:
         )
       }}
 
-    runs-on: namespace-profile-ghostty-macos-sequoia
+    runs-on: namespace-profile-ghostty-macos-sequoia-edge
     timeout-minutes: 90
     steps:
       - name: Checkout code
@@ -374,7 +374,7 @@ jobs:
         )
       }}
 
-    runs-on: namespace-profile-ghostty-macos-sequoia
+    runs-on: namespace-profile-ghostty-macos-sequoia-edge
     timeout-minutes: 90
     steps:
       - name: Checkout code
@@ -554,7 +554,7 @@ jobs:
         )
       }}
 
-    runs-on: namespace-profile-ghostty-macos-sequoia
+    runs-on: namespace-profile-ghostty-macos-sequoia-edge
     timeout-minutes: 90
     steps:
       - name: Checkout code

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -154,7 +154,7 @@ jobs:
         )
       }}
 
-    runs-on: namespace-profile-ghostty-macos-sequoia-edge
+    runs-on: namespace-profile-ghostty-macos-tahoe
     timeout-minutes: 90
     steps:
       - name: Checkout code
@@ -163,10 +163,10 @@ jobs:
           # Important so that build number generation works
           fetch-depth: 0
 
-      # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31.5.2
+      # TODO(tahoe): https://github.com/NixOS/nix/issues/13342
+      - uses: DeterminateSystems/nix-installer-action@main
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
+          determinate: true
       - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
         with:
           name: ghostty
@@ -374,7 +374,7 @@ jobs:
         )
       }}
 
-    runs-on: namespace-profile-ghostty-macos-sequoia-edge
+    runs-on: namespace-profile-ghostty-macos-tahoe
     timeout-minutes: 90
     steps:
       - name: Checkout code
@@ -383,10 +383,10 @@ jobs:
           # Important so that build number generation works
           fetch-depth: 0
 
-      # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31.5.2
+      # TODO(tahoe): https://github.com/NixOS/nix/issues/13342
+      - uses: DeterminateSystems/nix-installer-action@main
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
+          determinate: true
       - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
         with:
           name: ghostty
@@ -554,7 +554,7 @@ jobs:
         )
       }}
 
-    runs-on: namespace-profile-ghostty-macos-sequoia-edge
+    runs-on: namespace-profile-ghostty-macos-tahoe
     timeout-minutes: 90
     steps:
       - name: Checkout code
@@ -563,10 +563,10 @@ jobs:
           # Important so that build number generation works
           fetch-depth: 0
 
-      # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31.5.2
+      # TODO(tahoe): https://github.com/NixOS/nix/issues/13342
+      - uses: DeterminateSystems/nix-installer-action@main
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
+          determinate: true
       - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
         with:
           name: ghostty

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -273,7 +273,7 @@ jobs:
             ghostty-source.tar.gz
 
   build-macos:
-    runs-on: namespace-profile-ghostty-macos-sequoia
+    runs-on: namespace-profile-ghostty-macos-sequoia-edge
     needs: test
     steps:
       - name: Checkout code
@@ -334,6 +334,9 @@ jobs:
       - name: Xcode Select
         run: sudo xcode-select -s /Applications/Xcode_26.0.app
 
+      - name: Xcode Version
+        run: xcodebuild -version
+
       - name: get the Zig deps
         id: deps
         run: nix build -L .#deps && echo "deps=$(readlink ./result)" >> $GITHUB_OUTPUT
@@ -356,7 +359,7 @@ jobs:
           xcodebuild -target Ghostty-iOS "CODE_SIGNING_ALLOWED=NO"
 
   build-macos-matrix:
-    runs-on: namespace-profile-ghostty-macos-sequoia
+    runs-on: namespace-profile-ghostty-macos-sequoia-edge
     needs: test
     steps:
       - name: Checkout code
@@ -373,6 +376,9 @@ jobs:
 
       - name: Xcode Select
         run: sudo xcode-select -s /Applications/Xcode_26.0.app
+
+      - name: Xcode Version
+        run: xcodebuild -version
 
       - name: get the Zig deps
         id: deps
@@ -672,7 +678,7 @@ jobs:
           nix develop -c zig build -Dsentry=${{ matrix.sentry }}
 
   test-macos:
-    runs-on: namespace-profile-ghostty-macos-sequoia
+    runs-on: namespace-profile-ghostty-macos-sequoia-edge
     needs: test
     steps:
       - name: Checkout code
@@ -689,6 +695,9 @@ jobs:
 
       - name: Xcode Select
         run: sudo xcode-select -s /Applications/Xcode_26.0.app
+
+      - name: Xcode Version
+        run: xcodebuild -version
 
       - name: get the Zig deps
         id: deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
       - build-nix
       - build-snap
       - build-macos
-      - build-macos-tahoe
       - build-macos-matrix
       - build-windows
       - flatpak-check-zig-cache
@@ -273,53 +272,6 @@ jobs:
             ghostty-source.tar.gz
 
   build-macos:
-    runs-on: namespace-profile-ghostty-macos-sequoia-edge
-    needs: test
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
-      # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31.5.2
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
-        with:
-          name: ghostty
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-
-      - name: Xcode Select
-        run: sudo xcode-select -s /Applications/Xcode_26.0.app
-
-      - name: Xcode Version
-        run: xcodebuild -version
-
-      # Workaround a bug where some Namespace images don't have the the metal
-      # toolchain installed. We should be able to remove this eventually.
-      - run: xcodebuild -downloadComponent MetalToolchain
-
-      - name: get the Zig deps
-        id: deps
-        run: nix build -L .#deps && echo "deps=$(readlink ./result)" >> $GITHUB_OUTPUT
-
-      # GhosttyKit is the framework that is built from Zig for our native
-      # Mac app to access.
-      - name: Build GhosttyKit
-        run: nix develop -c zig build --system ${{ steps.deps.outputs.deps }} -Demit-macos-app=false
-
-      # The native app is built with native Xcode tooling. This also does
-      # codesigning. IMPORTANT: this must NOT run in a Nix environment.
-      # Nix breaks xcodebuild so this has to be run outside.
-      - name: Build Ghostty.app
-        run: cd macos && xcodebuild -target Ghostty
-
-      # Build the iOS target without code signing just to verify it works.
-      - name: Build Ghostty iOS
-        run: |
-          cd macos
-          xcodebuild -target Ghostty-iOS "CODE_SIGNING_ALLOWED=NO"
-
-  build-macos-tahoe:
     runs-on: namespace-profile-ghostty-macos-tahoe
     needs: test
     steps:
@@ -363,16 +315,16 @@ jobs:
           xcodebuild -target Ghostty-iOS "CODE_SIGNING_ALLOWED=NO"
 
   build-macos-matrix:
-    runs-on: namespace-profile-ghostty-macos-sequoia-edge
+    runs-on: namespace-profile-ghostty-macos-tahoe
     needs: test
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31.5.2
+      # TODO(tahoe): https://github.com/NixOS/nix/issues/13342
+      - uses: DeterminateSystems/nix-installer-action@main
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
+          determinate: true
       - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
         with:
           name: ghostty
@@ -682,16 +634,16 @@ jobs:
           nix develop -c zig build -Dsentry=${{ matrix.sentry }}
 
   test-macos:
-    runs-on: namespace-profile-ghostty-macos-sequoia-edge
+    runs-on: namespace-profile-ghostty-macos-tahoe
     needs: test
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      # Install Nix and use that to run our tests so our environment matches exactly.
-      - uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31.5.2
+      # TODO(tahoe): https://github.com/NixOS/nix/issues/13342
+      - uses: DeterminateSystems/nix-installer-action@main
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
+          determinate: true
       - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
         with:
           name: ghostty

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -294,6 +294,10 @@ jobs:
       - name: Xcode Version
         run: xcodebuild -version
 
+      # Workaround a bug where some Namespace images don't have the the metal
+      # toolchain installed. We should be able to remove this eventually.
+      - run: xcodebuild -downloadComponent MetalToolchain
+
       - name: get the Zig deps
         id: deps
         run: nix build -L .#deps && echo "deps=$(readlink ./result)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This switches our macOS builds to build on Tahoe, rather than on Sequoia. 

The primary motivation is to get builds out using a new Xcode version (our builds at the time of writing this are _still produced_ with beta 1! ONE!). Every subsequent beta has had bugs that have prevented us from upgrading, amusingly enough. But the later betas _also_ have a bunch of fixes I want to get in. I hope this one works...

The reason we have to use Tahoe instead of Sequoia is because on Sequoia, builds in CI _crash xcodebuild_. This is definitely an Apple bug but I can't reproduce it locally to create a bug report, so I'm not sure what to do.