### PR TITLE
build: build ReleaseFast and baseline CPU by default for system packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -300,7 +300,11 @@ jobs:
       # GhosttyKit is the framework that is built from Zig for our native
       # Mac app to access.
       - name: Build GhosttyKit
-        run: nix develop -c zig build --system ${{ steps.deps.outputs.deps }} -Demit-macos-app=false
+        run: |
+          nix develop -c zig build \
+            --system ${{ steps.deps.outputs.deps }} \
+            -Doptimize=Debug \
+            -Demit-macos-app=false
 
       # The native app is built with native Xcode tooling. This also does
       # codesigning. IMPORTANT: this must NOT run in a Nix environment.
@@ -350,11 +354,11 @@ jobs:
 
       - name: Build All
         run: |
-          nix develop -c zig build --system ${{ steps.deps.outputs.deps }} -Demit-macos-app=false -Drenderer=metal -Dfont-backend=freetype
-          nix develop -c zig build --system ${{ steps.deps.outputs.deps }} -Demit-macos-app=false -Drenderer=metal -Dfont-backend=coretext
-          nix develop -c zig build --system ${{ steps.deps.outputs.deps }} -Demit-macos-app=false -Drenderer=metal -Dfont-backend=coretext_freetype
-          nix develop -c zig build --system ${{ steps.deps.outputs.deps }} -Demit-macos-app=false -Drenderer=metal -Dfont-backend=coretext_harfbuzz
-          nix develop -c zig build --system ${{ steps.deps.outputs.deps }} -Demit-macos-app=false -Drenderer=metal -Dfont-backend=coretext_noshape
+          nix develop -c zig build --system ${{ steps.deps.outputs.deps }} -Demit-macos-app=false -Doptimize=Debug -Drenderer=metal -Dfont-backend=freetype
+          nix develop -c zig build --system ${{ steps.deps.outputs.deps }} -Demit-macos-app=false -Doptimize=Debug -Drenderer=metal -Dfont-backend=coretext
+          nix develop -c zig build --system ${{ steps.deps.outputs.deps }} -Demit-macos-app=false -Doptimize=Debug -Drenderer=metal -Dfont-backend=coretext_freetype
+          nix develop -c zig build --system ${{ steps.deps.outputs.deps }} -Demit-macos-app=false -Doptimize=Debug -Drenderer=metal -Dfont-backend=coretext_harfbuzz
+          nix develop -c zig build --system ${{ steps.deps.outputs.deps }} -Demit-macos-app=false -Doptimize=Debug -Drenderer=metal -Dfont-backend=coretext_noshape
 
   build-snap:
     strategy:
@@ -500,7 +504,10 @@ jobs:
 
       # This relies on the cache being populated by the commands above.
       - name: Test System Build
-        run: nix develop -c zig build --system ${ZIG_GLOBAL_CACHE_DIR}/p
+        run: |
+          nix develop -c zig build \
+            --system ${ZIG_GLOBAL_CACHE_DIR}/p \
+            -Doptimize=Debug
 
   test-gtk:
     strategy:

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -81,9 +81,7 @@ ZIG_GLOBAL_CACHE_DIR=/tmp/offline-cache ./nix/build-support/fetch-zig-cache.sh
 DESTDIR=/tmp/ghostty \
 zig build \
   --prefix /usr \
-  --system /tmp/offline-cache/p \
-  -Doptimize=ReleaseFast \
-  -Dcpu=baseline
+  --system /tmp/offline-cache/p
 ```
 
 The build options are covered in the next section, but this will build
@@ -96,8 +94,8 @@ to wherever the package manager expects it).
 ### Build Options
 
 Ghostty uses the Zig build system. You can see all available build options by
-running `zig build --help`. The following are options that are particularly
-relevant to package maintainers:
+running `zig build --help`. The following are options are very important
+and should always be used:
 
 - `--prefix`: The installation prefix. Combine with the `DESTDIR` environment
   variable to install to a temporary directory for packaging.
@@ -106,17 +104,20 @@ relevant to package maintainers:
   any package fetching from the internet. This flag also triggers all
   dependencies to be dynamically linked by default. This flag also makes
   the binary a PIE (Position Independent Executable) by default (override
-  with `-Dpie`).
+  with `-Dpie`). This flag also enables a default baseline CPU and enables
+  all optimizations.
+
+Additional options packagers may find useful:
 
 - `-Doptimize=ReleaseFast`: Build with optimizations enabled and safety checks
   disabled. This is the recommended build mode for distribution. I'd prefer
   a safe build but terminal emulators are performance-sensitive and the
-  safe build is currently too slow. I plan to improve this in the future.
-  Other build modes are available: `Debug`, `ReleaseSafe`, and `ReleaseSmall`.
+  safe build is currently too slow. This is the default when `--system`
+  is specified.
 
 - `-Dcpu=baseline`: Build for the "baseline" CPU of the target architecture.
   This avoids building for newer CPU features that may not be available on
-  all target machines.
+  all target machines. This is the default when `--system` is specified.
 
 - `-Dtarget=$arch-$os-$abi`: Build for a specific target triple. This is
   often necessary for system packages to specify a specific minimum Linux


### PR DESCRIPTION
This makes `--system` imply `-Doptimize=ReleaseFast` and `-Dcpu=baseline`. These can still be overridden by the user by setting the same flags explicitly.

The `--system` flag is used to build system packages and its a safe assumption that in those cases, Ghostty is being built for general use amongst many users, so the default should be optimized for performance and compatibility.

This was always documented in our PACKAGING.md, but is now automatic. The PACKAGING.md file has been updated to reflect this.