### PR TITLE
ci: add 30 minute timeout to valgrind

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1010,6 +1010,7 @@ jobs:
   valgrind:
     if: github.repository == 'ghostty-org/ghostty'
     runs-on: namespace-profile-ghostty-lg
+    timeout-minutes: 30
     needs: test
     env:
       ZIG_LOCAL_CACHE_DIR: /zig/local-cache


### PR DESCRIPTION
It usually takes less than a few minutes right now. Something is wrong if it takes more than that.