### PR TITLE
macos: move activation to after new window/tab is created

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -957,18 +957,10 @@ class AppDelegate: NSObject,
 
     @IBAction func newWindow(_ sender: Any?) {
         _ = TerminalController.newWindow(ghostty)
-
-        // We also activate our app so that it becomes front. This may be
-        // necessary for the dock menu.
-        NSApp.activate(ignoringOtherApps: true)
     }
 
     @IBAction func newTab(_ sender: Any?) {
         _ = TerminalController.newTab(ghostty)
-
-        // We also activate our app so that it becomes front. This may be
-        // necessary for the dock menu.
-        NSApp.activate(ignoringOtherApps: true)
     }
 
     @IBAction func closeAllWindows(_ sender: Any?) {

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -214,10 +214,6 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
             }
         }
 
-        // All new_window actions force our app to be active, so that the new
-        // window is focused and visible.
-        NSApp.activate(ignoringOtherApps: true)
-
         // We're dispatching this async because otherwise the lastCascadePoint doesn't
         // take effect. Our best theory is there is some next-event-loop-tick logic
         // that Cocoa is doing that we need to be after.
@@ -230,6 +226,10 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
             }
 
             c.showWindow(self)
+
+            // All new_window actions force our app to be active, so that the new
+            // window is focused and visible.
+            NSApp.activate(ignoringOtherApps: true)
         }
 
         // Setup our undo
@@ -336,6 +336,10 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
 
             controller.showWindow(self)
             window.makeKeyAndOrderFront(self)
+
+            // We also activate our app so that it becomes front. This may be
+            // necessary for the dock menu.
+            NSApp.activate(ignoringOtherApps: true)
         }
 
         // It takes an event loop cycle until the macOS tabGroup state becomes


### PR DESCRIPTION
This is a follow-up to #8064, moving the activation into the async block such that it happens after the window is created. As discussed in #8064, this is necessary to bring only the newly created window to the front, rather than both the previous main window and the new window.

Also made the same change for the new tab action, which also needs to activate in case it was triggered from the dock menu or a global keybind.

Finally, I removed the activations within AppDelegate that are redundant now that TerminalController itself takes care of activating.