### PR TITLE
macOS: order out alert sheets to avoid Stage Manager focus loss

### DIFF
--- a/.github/workflows/build-macos-arm64.yml
+++ b/.github/workflows/build-macos-arm64.yml
@@ -64,15 +64,15 @@ jobs:
       - name: Build core with Zig (ReleaseFast)
         run: |
           set -euxo pipefail
-          zig build -Doptimize=ReleaseFast
+          zig build -Doptimize=ReleaseFast -Demit-macos-app=false
 
-      - name: Build macOS .app (arm64 only, ReleaseLocal)
+      - name: Build macOS .app (arm64, Release)
         working-directory: macos
         run: |
           set -euxo pipefail
           xcodebuild \
-            -configuration ReleaseLocal \
-            -scheme Ghostty \
+            -configuration Release \
+            -target Ghostty \
             -destination 'generic/platform=macOS,arch=arm64' \
             ONLY_ACTIVE_ARCH=YES \
             EXCLUDED_ARCHS='x86_64' \
@@ -81,7 +81,7 @@ jobs:
       - name: Package app
         run: |
           set -euxo pipefail
-          APPDIR=$(ls -d ~/Library/Developer/Xcode/DerivedData/Ghostty-*/Build/Products/ReleaseLocal/Ghostty.app | head -n1)
+          APPDIR=macos/build/Release/Ghostty.app
           ls -la "$APPDIR"
           mkdir -p dist
           ditto -c -k --sequesterRsrc --keepParent "$APPDIR" dist/Ghostty-mac-arm64.zip

--- a/.github/workflows/build-macos-arm64.yml
+++ b/.github/workflows/build-macos-arm64.yml
@@ -1,0 +1,103 @@
+name: build-macos-arm64
+
+on:
+  push:
+    branches: [ main, master ]
+    tags: [ 'v*', 'tip-*' ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-macos-arm64:
+    name: macOS arm64 build (.app + artifact)
+    runs-on: macos-15
+    env:
+      ZIG_VERSION: '0.14.1'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode 26 Beta
+        run: |
+          set -euxo pipefail
+          sudo xcode-select -s /Applications/Xcode_26_beta_5.app
+
+      - name: Confirm Xcode + SDK
+        run: |
+          set -euxo pipefail
+          xcodebuild -version
+          xcodebuild -showsdks
+          # Ensure Xcode 26 beta and macOS 26 SDK exist (Ghostty expects this on main)
+          xcodebuild -version | grep -E "Xcode 26" >/dev/null
+          xcodebuild -showsdks | grep -E "macOS 26.0" >/dev/null
+
+      - name: Install Metal Toolchain (for shaders)
+        run: |
+          set -euxo pipefail
+          xcodebuild -downloadComponent MetalToolchain || true
+
+      - name: Install Zig ${{ env.ZIG_VERSION }}
+        uses: korandoru/setup-zig@v1
+        with:
+          zig-version: ${{ env.ZIG_VERSION }}
+
+      - name: Verify Zig installation
+        run: zig version
+
+      - name: Cache Zig global package cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/zig
+          key: ${{ runner.os }}-zig-cache-${{ hashFiles('build.zig.zon') }}
+
+      - name: Cache project Zig build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .zig-cache
+            zig-cache
+          key: ${{ runner.os }}-zig-proj-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-zig-proj-
+
+      - name: Build core with Zig (ReleaseFast)
+        run: |
+          set -euxo pipefail
+          zig build -Doptimize=ReleaseFast
+
+      - name: Build macOS .app (arm64 only, ReleaseLocal)
+        working-directory: macos
+        run: |
+          set -euxo pipefail
+          xcodebuild \
+            -configuration ReleaseLocal \
+            -scheme Ghostty \
+            -destination 'generic/platform=macOS,arch=arm64' \
+            ONLY_ACTIVE_ARCH=YES \
+            EXCLUDED_ARCHS='x86_64' \
+            build
+
+      - name: Package app
+        run: |
+          set -euxo pipefail
+          APPDIR=$(ls -d ~/Library/Developer/Xcode/DerivedData/Ghostty-*/Build/Products/ReleaseLocal/Ghostty.app | head -n1)
+          ls -la "$APPDIR"
+          mkdir -p dist
+          ditto -c -k --sequesterRsrc --keepParent "$APPDIR" dist/Ghostty-mac-arm64.zip
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Ghostty-mac-arm64
+          path: dist/Ghostty-mac-arm64.zip
+          if-no-files-found: error
+
+      - name: Create GitHub Release (tags only)
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/Ghostty-mac-arm64.zip
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-macos-arm64.yml
+++ b/.github/workflows/build-macos-arm64.yml
@@ -101,3 +101,29 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Latest Release (main branch)
+        if: github.ref == 'refs/heads/main'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: latest
+          name: "Latest Build"
+          body: |
+            🚀 **Latest Ghostty Build**
+            
+            This is an automated build from the latest main branch.
+            Built from commit: ${{ github.sha }}
+            
+            **Installation via Homebrew:**
+            ```bash
+            brew tap fammasmaz/ghostty
+            brew install ghostty
+            ```
+            
+            **Manual Installation:**
+            Download `Ghostty-mac-arm64.zip`, extract, and move to Applications folder.
+          files: dist/Ghostty-mac-arm64.zip
+          prerelease: false
+          make_latest: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,70 @@
+name: Sync Fork with Upstream
+
+on:
+  schedule:
+    # Run weekly on Sundays at 6 AM UTC (adjust timezone as needed)
+    - cron: '0 6 * * 0'
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  sync:
+    name: Sync with upstream
+    runs-on: ubuntu-latest
+    if: github.event.repository.fork
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Add upstream remote
+        run: |
+          # Add upstream remote (adjust URL to match the original Ghostty repo)
+          git remote add upstream https://github.com/ghostty-org/ghostty.git
+          git fetch upstream
+
+      - name: Sync main branch
+        run: |
+          git checkout main
+          git merge upstream/main --no-edit
+          
+      - name: Push changes
+        run: git push origin main
+        
+      - name: Check for new commits
+        id: check-commits
+        run: |
+          # Check if there are new commits from upstream
+          BEHIND_COUNT=$(git rev-list --count HEAD..upstream/main)
+          echo "commits_behind=$BEHIND_COUNT" >> $GITHUB_OUTPUT
+          if [ "$BEHIND_COUNT" -gt 0 ]; then
+            echo "new_commits=true" >> $GITHUB_OUTPUT
+          else
+            echo "new_commits=false" >> $GITHUB_OUTPUT
+          fi
+
+  # Trigger build workflow if there are new commits
+  trigger-build:
+    name: Trigger build workflow
+    needs: sync
+    runs-on: ubuntu-latest
+    if: needs.sync.outputs.new_commits == 'true'
+    
+    steps:
+      - name: Trigger macOS build
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'build-macos-arm64.yml',
+              ref: 'main'
+            });

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ glad.zip
 /ghostty.qcow2
 
 vgcore.*
+homebrew-ghostty/

--- a/HOMEBREW-SETUP.md
+++ b/HOMEBREW-SETUP.md
@@ -1,0 +1,138 @@
+# 🍺 Homebrew Setup for Ghostty
+
+Much simpler than scripts! With Homebrew, users can install and update Ghostty with standard brew commands.
+
+## 🚀 Quick Setup (One-Time)
+
+### 1. **Create the Homebrew Tap Repository**
+
+```bash
+# Navigate to homebrew-ghostty directory
+cd homebrew-ghostty
+
+# Initialize git repository  
+git init
+git add .
+git commit -m "Initial Homebrew tap for Ghostty"
+
+# Create repository on GitHub (replace with your username)
+gh repo create fammasmaz/homebrew-ghostty --public --source=. --remote=origin --push
+```
+
+### 2. **Commit the Updated Build Workflow**
+
+```bash
+# Go back to main Ghostty repository
+cd ..
+
+# Commit the workflow changes
+git add .github/workflows/build-macos-arm64.yml
+git commit -m "Add latest release creation for Homebrew tap"
+git push
+```
+
+### 3. **Test the Setup**
+
+```bash
+# Trigger a build to create the first "latest" release
+gh workflow run build-macos-arm64.yml
+
+# Wait for build to complete, then test the tap
+brew tap fammasmaz/ghostty
+brew install ghostty
+```
+
+## 🎯 **User Experience (Super Simple)**
+
+### **Installation:**
+```bash
+brew tap fammasmaz/ghostty
+brew install ghostty
+```
+
+### **Updates:**
+```bash
+# Update just Ghostty
+brew upgrade ghostty
+
+# Update everything (including Ghostty)
+brew upgrade
+```
+
+### **Automatic Updates:**
+```bash
+# Add to crontab for daily auto-updates
+echo "0 9 * * * /opt/homebrew/bin/brew upgrade" | crontab -
+```
+
+## 📋 **How It Works**
+
+1. **Weekly Sync**: Your fork syncs with upstream weekly (via `.github/workflows/sync-upstream.yml`)
+2. **Auto-Build**: When changes are detected, build workflow runs automatically
+3. **Release Creation**: Build creates/updates a "latest" GitHub release
+4. **Homebrew Detection**: `brew upgrade` detects new releases automatically
+5. **Seamless Update**: Users get the latest version with `brew upgrade`
+
+## ✨ **Benefits of Homebrew Approach**
+
+✅ **Familiar**: Users already know `brew install` and `brew upgrade`  
+✅ **Automatic**: Works with existing `brew upgrade` workflows  
+✅ **Clean**: Proper uninstall with `brew uninstall --zap ghostty`  
+✅ **Fast**: Homebrew handles caching and optimization  
+✅ **Standard**: Follows macOS app distribution best practices  
+✅ **Simple**: No custom scripts or authentication needed  
+
+## 🔧 **Customization**
+
+### **Update Cask Formula**
+Edit `homebrew-ghostty/Casks/ghostty.rb`:
+- Change GitHub repository URL
+- Modify app metadata
+- Adjust system requirements
+
+### **Update Release Names**
+Edit the workflow in `.github/workflows/build-macos-arm64.yml`:
+- Change `tag_name` from "latest" 
+- Customize release body content
+- Modify artifact names
+
+## 🐛 **Troubleshooting**
+
+### **Release Issues:**
+```bash
+# Check if releases are being created
+gh release list --repo fammasmaz/ghostty
+
+# Manual release creation
+gh release create latest dist/Ghostty-mac-arm64.zip --title "Latest Build" --repo fammasmaz/ghostty
+```
+
+### **Tap Issues:**
+```bash
+# Refresh tap information
+brew untap fammasmaz/ghostty
+brew tap fammasmaz/ghostty
+
+# Force reinstall
+brew reinstall ghostty
+```
+
+### **Build Issues:**
+```bash
+# Check workflow status
+gh run list --repo fammasmaz/ghostty --workflow build-macos-arm64.yml
+
+# Trigger manual build
+gh workflow run build-macos-arm64.yml --repo fammasmaz/ghostty
+```
+
+## 🎉 **Final Result**
+
+Your users can now:
+
+1. **Install once**: `brew tap fammasmaz/ghostty && brew install ghostty`
+2. **Update easily**: `brew upgrade` (works with their existing update routine)
+3. **Stay current**: Automatic weekly sync ensures latest upstream changes
+4. **Clean uninstall**: `brew uninstall --zap ghostty` removes everything
+
+**Much simpler than custom scripts!** 🚀

--- a/UPDATE-GUIDE.md
+++ b/UPDATE-GUIDE.md
@@ -1,0 +1,45 @@
+# 🚀 Ghostty Auto-Update Guide
+
+Simple, automated updates using Homebrew.
+
+## ⚡ Quick Start
+
+### Install:
+```bash
+brew tap fammasmaz/ghostty
+brew install ghostty
+```
+
+### Update:
+```bash
+brew upgrade ghostty
+```
+
+That's it! 🎉
+
+## 🔄 How It Works
+
+1. **Weekly Sync**: Fork automatically syncs with upstream Ghostty
+2. **Auto-Build**: New builds trigger when changes detected
+3. **Homebrew Ready**: Releases are created for Homebrew consumption
+4. **Easy Updates**: Standard `brew upgrade` keeps you current
+
+## 📋 Files Overview
+
+- **`.github/workflows/sync-upstream.yml`** - Daily upstream sync
+- **`.github/workflows/build-macos-arm64.yml`** - Build & release workflow  
+- **`homebrew-ghostty/`** - Homebrew tap files
+- **`HOMEBREW-SETUP.md`** - Detailed setup instructions
+
+## 🛠️ First-Time Setup
+
+See `HOMEBREW-SETUP.md` for complete setup instructions.
+
+## ✨ Benefits
+
+✅ **Familiar** - Standard Homebrew commands  
+✅ **Automatic** - Works with `brew upgrade`  
+✅ **Clean** - Proper macOS app management  
+✅ **Simple** - No complex scripts or authentication  
+
+Stay up-to-date with the latest Ghostty effortlessly! 🚀

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -290,8 +290,10 @@ class BaseTerminalController: NSWindowController,
         alert.addButton(withTitle: "Cancel")
         alert.alertStyle = .warning
         alert.beginSheetModal(for: window) { response in
+            let alertWindow = alert.window
             self.alert = nil
             if response == .alertFirstButtonReturn {
+                alertWindow.orderOut(nil)
                 completion()
             }
         }

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -747,6 +747,7 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         alert.alertStyle = .warning
         alert.beginSheetModal(for: alertWindow, completionHandler: { response in
             if (response == .alertFirstButtonReturn) {
+                alert.window.orderOut(nil)
                 closeAllWindowsImmediately()
             }
         })


### PR DESCRIPTION
On macOS, when using stage manager, ghostty loses focus when a running process is terminated.

This aims to fix #8336 which has reappeared since the previously fixed #5108.