### PR TITLE
macOS: order out alert sheets to avoid Stage Manager focus loss

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -290,8 +290,12 @@ class BaseTerminalController: NSWindowController,
         alert.addButton(withTitle: "Cancel")
         alert.alertStyle = .warning
         alert.beginSheetModal(for: window) { response in
+            let alertWindow = alert.window
             self.alert = nil
             if response == .alertFirstButtonReturn {
+                // This is important so that we avoid losing focus when Stage
+                // Manager is used (#8336)
+                alertWindow.orderOut(nil)
                 completion()
             }
         }

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -747,6 +747,9 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         alert.alertStyle = .warning
         alert.beginSheetModal(for: alertWindow, completionHandler: { response in
             if (response == .alertFirstButtonReturn) {
+                // This is important so that we avoid losing focus when Stage
+                // Manager is used (#8336)
+                alert.window.orderOut(nil)
                 closeAllWindowsImmediately()
             }
         })


### PR DESCRIPTION
On macOS, when using stage manager, ghostty loses focus when a running process is terminated.

This aims to fix #8336  which has reappeared since the previously fixed #5108.

Opened a new pr following the closure of the previous #8343 