### PR TITLE
deps: update z2d to v0.7.2

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -20,8 +20,8 @@
         },
         .z2d = .{
             // vancluever/z2d
-            .url = "https://github.com/vancluever/z2d/archive/refs/tags/v0.7.1.tar.gz",
-            .hash = "z2d-0.7.1-j5P_HhFQDQC6T5srG235r_nQpCrNwI15Gu2zqVrtUxN5",
+            .url = "https://github.com/vancluever/z2d/archive/refs/tags/v0.7.2.tar.gz",
+            .hash = "z2d-0.7.2-j5P_Hm1oDQDQsWpGfSCMARhowBnuTHlQ_sBfij6TuG7l",
             .lazy = true,
         },
         .zig_objc = .{

--- a/build.zig.zon.json
+++ b/build.zig.zon.json
@@ -129,10 +129,10 @@
     "url": "https://deps.files.ghostty.org/wuffs-122037b39d577ec2db3fd7b2130e7b69ef6cc1807d68607a7c232c958315d381b5cd.tar.gz",
     "hash": "sha256-nkzSCr6W5sTG7enDBXEIhgEm574uLD41UVR2wlC+HBM="
   },
-  "z2d-0.7.1-j5P_HhFQDQC6T5srG235r_nQpCrNwI15Gu2zqVrtUxN5": {
+  "z2d-0.7.2-j5P_Hm1oDQDQsWpGfSCMARhowBnuTHlQ_sBfij6TuG7l": {
     "name": "z2d",
-    "url": "https://github.com/vancluever/z2d/archive/refs/tags/v0.7.1.tar.gz",
-    "hash": "sha256-6ZqgrO/bcjgnuQcfq89VYptUUodsErM8Fz6nwBZhTJs="
+    "url": "https://github.com/vancluever/z2d/archive/refs/tags/v0.7.2.tar.gz",
+    "hash": "sha256-tWrLlEOU4/0ZOlzgGOXB08fW7sqfyAFf3rlv0wl9b/c="
   },
   "zf-0.10.3-OIRy8aiIAACLrBllz0zjxaH0aOe5oNm3KtEMyCntST-9": {
     "name": "zf",

--- a/build.zig.zon.nix
+++ b/build.zig.zon.nix
@@ -290,11 +290,11 @@ in
       };
     }
     {
-      name = "z2d-0.7.1-j5P_HhFQDQC6T5srG235r_nQpCrNwI15Gu2zqVrtUxN5";
+      name = "z2d-0.7.2-j5P_Hm1oDQDQsWpGfSCMARhowBnuTHlQ_sBfij6TuG7l";
       path = fetchZigArtifact {
         name = "z2d";
-        url = "https://github.com/vancluever/z2d/archive/refs/tags/v0.7.1.tar.gz";
-        hash = "sha256-6ZqgrO/bcjgnuQcfq89VYptUUodsErM8Fz6nwBZhTJs=";
+        url = "https://github.com/vancluever/z2d/archive/refs/tags/v0.7.2.tar.gz";
+        hash = "sha256-tWrLlEOU4/0ZOlzgGOXB08fW7sqfyAFf3rlv0wl9b/c=";
       };
     }
     {

--- a/build.zig.zon.txt
+++ b/build.zig.zon.txt
@@ -32,4 +32,4 @@ https://github.com/mbadolato/iTerm2-Color-Schemes/archive/8b639f0c2605557bd23ba1
 https://github.com/mitchellh/libxev/archive/7f803181b158a10fec8619f793e3b4df515566cb.tar.gz
 https://github.com/mitchellh/zig-objc/archive/c9e917a4e15a983b672ca779c7985d738a2d517c.tar.gz
 https://github.com/natecraddock/zf/archive/7aacbe6d155d64d15937ca95ca6c014905eb531f.tar.gz
-https://github.com/vancluever/z2d/archive/refs/tags/v0.7.1.tar.gz
+https://github.com/vancluever/z2d/archive/refs/tags/v0.7.2.tar.gz

--- a/flatpak/zig-packages.json
+++ b/flatpak/zig-packages.json
@@ -157,9 +157,9 @@
   },
   {
     "type": "archive",
-    "url": "https://github.com/vancluever/z2d/archive/refs/tags/v0.7.1.tar.gz",
-    "dest": "vendor/p/z2d-0.7.1-j5P_HhFQDQC6T5srG235r_nQpCrNwI15Gu2zqVrtUxN5",
-    "sha256": "e99aa0acefdb723827b9071fabcf55629b5452876c12b33c173ea7c016614c9b"
+    "url": "https://github.com/vancluever/z2d/archive/refs/tags/v0.7.2.tar.gz",
+    "dest": "vendor/p/z2d-0.7.2-j5P_Hm1oDQDQsWpGfSCMARhowBnuTHlQ_sBfij6TuG7l",
+    "sha256": "b56acb944394e3fd193a5ce018e5c1d3c7d6eeca9fc8015fdeb96fd3097d6ff7"
   },
   {
     "type": "archive",


### PR DESCRIPTION
Release notes at:
  https://github.com/vancluever/z2d/blob/v0.7.2/CHANGELOG.md

This is mostly a bugfix release for text rendering, including a fix for an invalid free flagged as:
  https://github.com/vancluever/z2d/security/advisories/GHSA-v7f4-f3hm-282w

Note that the invalid free affects the new in-library text rendering only and as such is likely not in use in Ghostty.

I'm anticipating *maybe* one more release after this ahead of Ghostty 1.2.0, depending on if I find any more bugs, but close to around the release I am planning a freeze to ensure a clean versioned release continues to be set.