### PR TITLE
macos: if parent window is fullscreen, new window is fullscreen too

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -196,7 +196,12 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
 
         if let parent {
             if parent.styleMask.contains(.fullScreen) {
-                parent.toggleFullScreen(nil)
+                // If our previous window was fullscreen then we want our new window to
+                // be fullscreen. This behavior actually doesn't match the native tabbing
+                // behavior of macOS apps where new windows create tabs when in native
+                // fullscreen but this is how we've always done it. This matches iTerm2
+                // behavior.
+                c.toggleFullscreen(mode: .native)
             } else if ghostty.config.windowFullscreen {
                 switch (ghostty.config.windowFullscreenMode) {
                 case .native:


### PR DESCRIPTION
Fixes #8229

This was a regression. 

The discussion noted in #8229 requests we create a new window on the  non-fullscreen desktop but that isn't how Ghostty has behaved historically. I bisected back and tried 1.1.3 as well and we always created a new fullscreen window when the parent was fullscreen.

This behavior matches iTerm2. Its noteworthy that native tabbing and Apple apps such as Terminal.app and Safari do NOT do this. For both of these, new window creates a _tab_ when in fullscreen. I don't think that's particularly desirable, though.