### PR TITLE
terminal: fix use-after-free in exec

### DIFF
--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1513,7 +1513,8 @@ fn execCommand(
     }
 
     return switch (command) {
-        .direct => |v| v,
+        // We need to clone the command since there's no guarantee the config remains valid.
+        .direct => |_| (try command.clone(alloc)).direct,
 
         .shell => |v| shell: {
             var args: std.ArrayList([:0]const u8) = try .initCapacity(alloc, 4);


### PR DESCRIPTION
This was only an issue on Linux, as MacOS' command is reallocated and rewritten. We hit this using embedded Ghostty w/o a login shell :p