### PR TITLE
terminal: fix build with -Di18n=false

### DIFF
--- a/src/os/i18n.zig
+++ b/src/os/i18n.zig
@@ -136,7 +136,12 @@ pub fn canonicalizeLocale(
     buf: []u8,
     locale: []const u8,
 ) error{NoSpaceLeft}![:0]const u8 {
-    if (comptime !build_config.i18n) return locale;
+    if (comptime !build_config.i18n) {
+        if (buf.len < locale.len + 1) return error.NoSpaceLeft;
+        @memcpy(buf[0..locale.len], locale);
+        buf[locale.len] = 0;
+        return buf[0..locale.len :0];
+    }
 
     // Fix zh locales for macOS
     if (fixZhLocale(locale)) |fixed| {


### PR DESCRIPTION
canonicalizeLocale should return a null-terminated string, and didn't previously.

Compiler output:
```
src/os/i18n.zig:139:45: error: expected type 'error{NoSpaceLeft}![:0]const u8', found '[]const u8'
    if (comptime !build_config.i18n) return locale;
                                            ^~~~~~
src/os/i18n.zig:139:45: note: destination pointer requires '0' sentinel
src/os/i18n.zig:138:21: note: function return type declared here
) error{NoSpaceLeft}![:0]const u8 {
  ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
```