### PR TITLE
gtk-ng: fix setting/unsetting of urgency

### DIFF
--- a/src/apprt/gtk-ng/ui/1.5/window.blp
+++ b/src/apprt/gtk-ng/ui/1.5/window.blp
@@ -10,6 +10,7 @@ template $GhosttyWindow: Adw.ApplicationWindow {
   realize => $realize();
   notify::config => $notify_config();
   notify::fullscreened => $notify_fullscreened();
+  notify::is-active => $notify_is_active();
   notify::maximized => $notify_maximized();
   notify::quick-terminal => $notify_quick_terminal();
   notify::scale-factor => $notify_scale_factor();


### PR DESCRIPTION
- Don't set urgency on windows that are the topmost window.
- Turn off urgency on windows that become the topmost window.

Fixes #8373