### PR TITLE
apprt/gtk-ng: show error widget if GLArea fails to initialize

### DIFF
--- a/src/apprt/gtk-ng/ui/1.2/surface.blp
+++ b/src/apprt/gtk-ng/ui/1.2/surface.blp
@@ -8,146 +8,172 @@ template $GhosttySurface: Adw.Bin {
 
   notify::bell-ringing => $notify_bell_ringing();
   notify::config => $notify_config();
+  notify::error => $notify_error();
   notify::mouse-hover-url => $notify_mouse_hover_url();
   notify::mouse-hidden => $notify_mouse_hidden();
   notify::mouse-shape => $notify_mouse_shape();
 
-  Overlay {
-    focusable: false;
-    focus-on-click: false;
+  Stack {
+    StackPage {
+      name: "terminal";
 
-    child: Box {
-      hexpand: true;
-      vexpand: true;
+      child: Overlay {
+        focusable: false;
+        focus-on-click: false;
 
-      GLArea gl_area {
-        realize => $gl_realize();
-        unrealize => $gl_unrealize();
-        render => $gl_render();
-        resize => $gl_resize();
-        hexpand: true;
-        vexpand: true;
-        focusable: true;
-        focus-on-click: true;
-        has-stencil-buffer: false;
-        has-depth-buffer: false;
-        allowed-apis: gl;
-      }
+        child: Box {
+          hexpand: true;
+          vexpand: true;
 
-      PopoverMenu context_menu {
-        closed => $context_menu_closed();
-        menu-model: context_menu_model;
-        flags: nested;
-        halign: start;
-        has-arrow: false;
-      }
-    };
+          GLArea gl_area {
+            realize => $gl_realize();
+            unrealize => $gl_unrealize();
+            render => $gl_render();
+            resize => $gl_resize();
+            hexpand: true;
+            vexpand: true;
+            focusable: true;
+            focus-on-click: true;
+            has-stencil-buffer: false;
+            has-depth-buffer: false;
+            allowed-apis: gl;
+          }
 
-    [overlay]
-    ProgressBar progress_bar_overlay {
-      styles [
-        "osd",
-      ]
+          PopoverMenu context_menu {
+            closed => $context_menu_closed();
+            menu-model: context_menu_model;
+            flags: nested;
+            halign: start;
+            has-arrow: false;
+          }
+        };
 
-      visible: false;
-      halign: fill;
-      valign: start;
+        [overlay]
+        ProgressBar progress_bar_overlay {
+          styles [
+            "osd",
+          ]
+
+          visible: false;
+          halign: fill;
+          valign: start;
+        }
+
+        [overlay]
+        // The "border" bell feature is implemented here as an overlay rather than
+        // just adding a border to the GLArea or other widget for two reasons.
+        // First, adding a border to an existing widget causes a resize of the
+        // widget which undesirable side effects. Second, we can make it reactive
+        // here in the blueprint with relatively little code.
+        Revealer {
+          reveal-child: bind $should_border_be_shown(template.config, template.bell-ringing) as <bool>;
+          transition-type: crossfade;
+          transition-duration: 500;
+
+          Box bell_overlay {
+            styles [
+              "bell-overlay",
+            ]
+
+            halign: fill;
+            valign: fill;
+          }
+        }
+
+        [overlay]
+        $GhosttySurfaceChildExited child_exited_overlay {
+          visible: bind template.child-exited;
+          close-request => $child_exited_close();
+        }
+
+        [overlay]
+        $GhosttyResizeOverlay resize_overlay {}
+
+        [overlay]
+        Label url_left {
+          styles [
+            "background",
+            "url-overlay",
+          ]
+
+          visible: false;
+          halign: start;
+          valign: end;
+          label: bind template.mouse-hover-url;
+
+          EventControllerMotion url_ec_motion {
+            enter => $url_mouse_enter();
+            leave => $url_mouse_leave();
+          }
+        }
+
+        [overlay]
+        Label url_right {
+          styles [
+            "background",
+            "url-overlay",
+          ]
+
+          visible: false;
+          halign: end;
+          valign: end;
+          label: bind template.mouse-hover-url;
+        }
+
+        // Event controllers for interactivity
+        EventControllerFocus {
+          enter => $focus_enter();
+          leave => $focus_leave();
+        }
+
+        EventControllerKey {
+          key-pressed => $key_pressed();
+          key-released => $key_released();
+        }
+
+        EventControllerMotion {
+          motion => $mouse_motion();
+          leave => $mouse_leave();
+        }
+
+        EventControllerScroll {
+          scroll => $scroll();
+          scroll-begin => $scroll_begin();
+          scroll-end => $scroll_end();
+          flags: both_axes;
+        }
+
+        GestureClick {
+          pressed => $mouse_down();
+          released => $mouse_up();
+          button: 0;
+        }
+
+        DropTarget drop_target {
+          drop => $drop();
+          actions: copy;
+        }
+      };
     }
 
-    [overlay]
-    // The "border" bell feature is implemented here as an overlay rather than
-    // just adding a border to the GLArea or other widget for two reasons.
-    // First, adding a border to an existing widget causes a resize of the
-    // widget which undesirable side effects. Second, we can make it reactive
-    // here in the blueprint with relatively little code.
-    Revealer {
-      reveal-child: bind $should_border_be_shown(template.config, template.bell-ringing) as <bool>;
-      transition-type: crossfade;
-      transition-duration: 500;
+    StackPage {
+      name: "error";
 
-      Box bell_overlay {
-        styles [
-          "bell-overlay",
-        ]
+      child: Adw.StatusPage {
+        icon-name: "computer-fail-symbolic";
+        title: _("Oh, no.");
+        description: _("Unable to acquire an OpenGL context for rendering.");
 
-        halign: fill;
-        valign: fill;
-      }
+        child: LinkButton {
+          label: "https://ghostty.org/docs/help/gtk-opengl-context";
+          uri: "https://ghostty.org/docs/help/gtk-opengl-context";
+        };
+      };
     }
 
-    [overlay]
-    $GhosttySurfaceChildExited child_exited_overlay {
-      visible: bind template.child-exited;
-      close-request => $child_exited_close();
-    }
-
-    [overlay]
-    $GhosttyResizeOverlay resize_overlay {}
-
-    [overlay]
-    Label url_left {
-      styles [
-        "background",
-        "url-overlay",
-      ]
-
-      visible: false;
-      halign: start;
-      valign: end;
-      label: bind template.mouse-hover-url;
-
-      EventControllerMotion url_ec_motion {
-        enter => $url_mouse_enter();
-        leave => $url_mouse_leave();
-      }
-    }
-
-    [overlay]
-    Label url_right {
-      styles [
-        "background",
-        "url-overlay",
-      ]
-
-      visible: false;
-      halign: end;
-      valign: end;
-      label: bind template.mouse-hover-url;
-    }
-  }
-
-  // Event controllers for interactivity
-  EventControllerFocus {
-    enter => $focus_enter();
-    leave => $focus_leave();
-  }
-
-  EventControllerKey {
-    key-pressed => $key_pressed();
-    key-released => $key_released();
-  }
-
-  EventControllerMotion {
-    motion => $mouse_motion();
-    leave => $mouse_leave();
-  }
-
-  EventControllerScroll {
-    scroll => $scroll();
-    scroll-begin => $scroll_begin();
-    scroll-end => $scroll_end();
-    flags: both_axes;
-  }
-
-  GestureClick {
-    pressed => $mouse_down();
-    released => $mouse_up();
-    button: 0;
-  }
-
-  DropTarget drop_target {
-    drop => $drop();
-    actions: copy;
+    // The order matters here: we can only set this after the stack
+    // pages above have been created.
+    visible-child-name: bind $stack_child_name(template.error) as <string>;
   }
 }
 


### PR DESCRIPTION
If GTK can't acquire an OpenGL context, this shows a message. Previously, we would only log a warning which was difficult to find. The GUI previously was the default GTK view which showed "Failed to acquire EGL display" which was equally confusing.

This is a draft. There are TODOs (listed below).

## TODO

- [x] Disable context menu in error state
- [x] Use property to bind to unhealthy state instead of directly setting stack child
- [x] Create a web page and put that in the error description
- [x] Set non-transparent background in error state
- [x] Bug where closing the window isn't exiting Ghostty