### PR TITLE
osc: conemu cleanup

### DIFF
--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -1598,17 +1598,17 @@ pub fn Stream(comptime Handler: type) type {
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
 
-                .progress_report => |v| {
+                .conemu_progress_report => |v| {
                     if (@hasDecl(T, "handleProgressReport")) {
                         try self.handler.handleProgressReport(v);
                         return;
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
 
-                .sleep,
-                .show_message_box,
-                .change_conemu_tab_title,
-                .wait_input,
+                .conemu_sleep,
+                .conemu_show_message_box,
+                .conemu_change_tab_title,
+                .conemu_wait_input,
                 .conemu_guimacro,
                 => {
                     log.warn("unimplemented OSC callback: {}", .{cmd});


### PR DESCRIPTION
- Add more comments, and make existing ones more consistent.
- Rename commands so they consitently have a `conemu_` prefix.
- Ensure that OSC 9 desktop notifications can be sent in the maximum number of circumstances. There are still many notifications that can't be sent because of our support for the ConEmu OSCs but that's the tradeoff we have chosen. We recommend that you switch to OSC 777 to ensure desktop notifications can be sent in all circumstances.
- Make sure that the tests that exercise the ConEmu OSCs have a consistent naming structure. That will make them easier to find through searching as well as make it easier to filter only the ConEmu OSC tests.
- Add more tests to make sure that desktop notifications are sent properly.