### PR TITLE
terminal: fix csi parsing

### DIFF
--- a/src/terminal/Parser.zig
+++ b/src/terminal/Parser.zig
@@ -206,7 +206,7 @@ const MAX_INTERMEDIATE = 4;
 /// number. I implore TUI authors to not use more than this number of CSI
 /// params, but I suspect we'll introduce a slow path with heap allocation
 /// one day.
-const MAX_PARAMS = 24;
+pub const MAX_PARAMS = 24;
 
 /// Current state of the state machine
 state: State,

--- a/src/terminal/Parser.zig
+++ b/src/terminal/Parser.zig
@@ -949,6 +949,31 @@ test "csi: too many params" {
     }
 }
 
+test "csi: 17 parameters" {
+    // Test with exactly 17 parameters (the Kakoune case)
+    var p = init();
+    _ = p.next(0x1B);
+    _ = p.next('[');
+    // Build 17 parameters separated by semicolons
+    for (0..16) |_| {
+        _ = p.next('1');
+        _ = p.next(';');
+    }
+    _ = p.next('2'); // 17th parameter
+
+    {
+        const a = p.next('H');
+        try testing.expect(p.state == .ground);
+        try testing.expect(a[0] == null);
+        try testing.expect(a[1].? == .csi_dispatch);
+        try testing.expect(a[2] == null);
+
+        const csi = a[1].?.csi_dispatch;
+        try testing.expectEqual(@as(usize, 17), csi.params.len);
+        try testing.expectEqual(@as(u16, 2), csi.params[16]);
+    }
+}
+
 test "dcs: XTGETTCAP" {
     var p = init();
     _ = p.next(0x1B);

--- a/src/terminal/sgr.zig
+++ b/src/terminal/sgr.zig
@@ -134,7 +134,7 @@ pub const Parser = struct {
                 self.idx += 1;
                 return .{ .unknown = .{
                     .full = self.params,
-                    .partial = slice[0 .. self.idx - start + 1],
+                    .partial = slice[0..@min(self.idx - start + 1, slice.len)],
                 } };
             },
         };

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -249,7 +249,7 @@ pub fn Stream(comptime Handler: type) type {
                     // the parser state to ground.
                     0x18, 0x1A => self.parser.state = .ground,
                     // A parameter digit:
-                    '0'...'9' => if (self.parser.params_idx < 16) {
+                    '0'...'9' => if (self.parser.params_idx < Parser.MAX_PARAMS) {
                         self.parser.param_acc *|= 10;
                         self.parser.param_acc +|= c - '0';
                         // The parser's CSI param action uses param_acc_idx
@@ -259,7 +259,7 @@ pub fn Stream(comptime Handler: type) type {
                         self.parser.param_acc_idx |= 1;
                     },
                     // A parameter separator:
-                    ':', ';' => if (self.parser.params_idx < 16) {
+                    ':', ';' => if (self.parser.params_idx < Parser.MAX_PARAMS) {
                         self.parser.params[self.parser.params_idx] = self.parser.param_acc;
                         if (c == ':') self.parser.params_sep.set(self.parser.params_idx);
                         self.parser.params_idx += 1;

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -2601,3 +2601,22 @@ test "stream CSI ? W reset tab stops" {
     try s.nextSlice("\x1b[?1;2;3W");
     try testing.expect(s.handler.reset);
 }
+
+test "stream: SGR with 17+ parameters for underline color" {
+    const H = struct {
+        attrs: ?sgr.Attribute = null,
+        called: bool = false,
+
+        pub fn setAttribute(self: *@This(), attr: sgr.Attribute) !void {
+            self.attrs = attr;
+            self.called = true;
+        }
+    };
+
+    var s: Stream(H) = .init(.{});
+
+    // Kakoune-style SGR with underline color as 17th parameter
+    // This tests the fix where param 17 was being dropped
+    try s.nextSlice("\x1b[4:3;38;2;51;51;51;48;2;170;170;170;58;2;255;97;136;0m");
+    try testing.expect(s.handler.called);
+}


### PR DESCRIPTION
Make `MAX_PARAMS` public and increase CSI parameter limit from 16 to 24. Fix potential out-of-bounds read in SGR partial sequence extraction.

Related discussion: https://github.com/ghostty-org/ghostty/discussions/5198

DISCLAIMER: the tests were written with Claude Code's help.