### PR TITLE
apprt/gtk-ng: "cancel" should be default close response for dialog

### DIFF
--- a/src/apprt/gtk-ng/class/application.zig
+++ b/src/apprt/gtk-ng/class/application.zig
@@ -499,7 +499,15 @@ pub const Application = extern struct {
         const parent: ?*gtk.Widget = parent: {
             const list = gtk.Window.listToplevels();
             defer list.free();
-            const focused = list.findCustom(null, findActiveWindow);
+            const focused = @as(?*glib.List, list.findCustom(
+                null,
+                findActiveWindow,
+            )) orelse {
+                // If we have an active surface then we should have
+                // a window available but in the rare case we don't we
+                // should exit so we don't crash.
+                break :parent null;
+            };
             break :parent @ptrCast(@alignCast(focused.f_data));
         };
 

--- a/src/apprt/gtk-ng/class/close_confirmation_dialog.zig
+++ b/src/apprt/gtk-ng/class/close_confirmation_dialog.zig
@@ -10,7 +10,7 @@ const Common = @import("../class.zig").Common;
 const Config = @import("config.zig").Config;
 const Dialog = @import("dialog.zig").Dialog;
 
-const log = std.log.scoped(.gtk_ghostty_config_errors_dialog);
+const log = std.log.scoped(.gtk_ghostty_close_confirmation_dialog);
 
 pub const CloseConfirmationDialog = extern struct {
     const Self = @This();

--- a/src/apprt/gtk-ng/class/tab.zig
+++ b/src/apprt/gtk-ng/class/tab.zig
@@ -18,7 +18,6 @@ const gresource = @import("../build/gresource.zig");
 const Common = @import("../class.zig").Common;
 const Config = @import("config.zig").Config;
 const Application = @import("application.zig").Application;
-const CloseConfirmationDialog = @import("close_confirmation_dialog.zig").CloseConfirmationDialog;
 const SplitTree = @import("split_tree.zig").SplitTree;
 const Surface = @import("surface.zig").Surface;
 

--- a/src/apprt/gtk-ng/ui/1.2/close-confirmation-dialog.blp
+++ b/src/apprt/gtk-ng/ui/1.2/close-confirmation-dialog.blp
@@ -7,4 +7,6 @@ template $GhosttyCloseConfirmationDialog: $GhosttyDialog {
     cancel: _("Cancel"),
     close: _("Close") destructive,
   ]
+
+  close-response: "cancel";
 }


### PR DESCRIPTION
Fixes #8424

This is the response that will be sent when "escape" is pressed.

This also fixes a null ptr deref that was possible when this fix wasn't in.