### PR TITLE
gtk-ng: deprecate gtk-single-instance=desktop

### DIFF
--- a/src/apprt/gtk-ng/class/application.zig
+++ b/src/apprt/gtk-ng/class/application.zig
@@ -223,10 +223,6 @@ pub const Application = extern struct {
         const single_instance = switch (config.@"gtk-single-instance") {
             .true => true,
             .false => false,
-            .desktop => switch (config.@"launched-from".?) {
-                .desktop, .systemd, .dbus => true,
-                .cli => false,
-            },
         };
 
         // Setup the flags for our application.

--- a/src/apprt/gtk/App.zig
+++ b/src/apprt/gtk/App.zig
@@ -280,10 +280,6 @@ pub fn init(self: *App, core_app: *CoreApp, opts: Options) !void {
     const single_instance = switch (config.@"gtk-single-instance") {
         .true => true,
         .false => false,
-        .desktop => switch (config.@"launched-from".?) {
-            .desktop, .systemd, .dbus => true,
-            .cli => false,
-        },
     };
 
     // Setup the flags for our application.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2925,14 +2925,14 @@ else
 ///
 /// If `false`, each new ghostty process will launch a separate application.
 ///
-/// The default value is `desktop` which will default to `true` if Ghostty
-/// detects that it was launched from the `.desktop` file such as an app
-/// launcher (like Gnome Shell)  or by D-Bus activation. If Ghostty is launched
-/// from the command line, it will default to `false`.
+/// The pre-1.2 option `desktop` has been deprecated. If encountered it will be
+/// treated as `true`.
+///
+/// The default value is `true`.
 ///
 /// Note that debug builds of Ghostty have a separate single-instance ID
 /// so you can test single instance without conflicting with release builds.
-@"gtk-single-instance": GtkSingleInstance = .desktop,
+@"gtk-single-instance": GtkSingleInstance = .default,
 
 /// When enabled, the full GTK titlebar is displayed instead of your window
 /// manager's simple titlebar. The behavior of this option will vary with your
@@ -7040,9 +7040,22 @@ pub const MacShortcuts = enum {
 
 /// See gtk-single-instance
 pub const GtkSingleInstance = enum {
-    desktop,
     false,
     true,
+
+    pub const default: GtkSingleInstance = .true;
+
+    pub fn parseCLI(input_: ?[]const u8) error{ ValueRequired, InvalidValue }!GtkSingleInstance {
+        const input = std.mem.trim(
+            u8,
+            input_ orelse return error.ValueRequired,
+            cli.args.whitespace,
+        );
+
+        if (std.mem.eql(u8, input, "desktop")) return .true;
+
+        return std.meta.stringToEnum(GtkSingleInstance, input) orelse error.InvalidValue;
+    }
 };
 
 /// See gtk-tabs-location


### PR DESCRIPTION
This fixes the problem of running a bare `ghostty` at the CLI (or from any of the numerous launchers used by tiling window managers) creating a new instance of Ghostty rather than sending a signal to an existing Ghostty instance to open up a new window.

This happened because when `gtk-single-instance=desktop` and you ran `ghostty` from the CLI, it was treated as `gtk-single-instance=false` which would create a new Ghostty instance.

The `desktop` option was introduced before we had the `launched-from` option. Now that `launched-from` is available, the `desktop` option is no longer necessary (and sometimes harmful).

`ghostty +new-window` will still be slightly faster at getting a new window since it does less initialization before it sends the signal to the existing process but this will eliminate _a lot_ of confusion from users.