### PR TITLE
feat: added faint-opacity option

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3040,7 +3040,7 @@ else
 /// or greater than 1 will be clamped to the nearest valid value.
 ///
 /// Available since Ghostty 1.2.0.
-@"faint-opacity": f64 = 0.6,
+@"faint-opacity": f64 = 0.5,
 
 /// This will be used to set the `TERM` environment variable.
 /// HACK: We set this with an `xterm` prefix because vim uses that to enable key

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -4024,6 +4024,8 @@ pub fn finalize(self: *Config) !void {
     if (self.@"auto-update-channel" == null) {
         self.@"auto-update-channel" = build_config.release_channel;
     }
+
+    self.@"faint-opacity" = std.math.clamp(self.@"faint-opacity", 0.0, 1.0);
 }
 
 /// Callback for src/cli/args.zig to allow us to handle special cases

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3035,6 +3035,13 @@ else
 /// Available since Ghostty 1.2.0.
 @"bold-color": ?BoldColor = null,
 
+/// The opacity level (opposite of transparency) of the faint text. A value of
+/// 1 is fully opaque and a value of 0 is fully transparent. A value less than 0
+/// or greater than 1 will be clamped to the nearest valid value.
+///
+/// Available since Ghostty 1.2.0.
+@"faint-opacity": f64 = 0.6,
+
 /// This will be used to set the `TERM` environment variable.
 /// HACK: We set this with an `xterm` prefix because vim uses that to enable key
 /// protocols (specifically this will enable `modifyOtherKeys`), among other

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -585,7 +585,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     .background = config.background.toTerminalRGB(),
                     .foreground = config.foreground.toTerminalRGB(),
                     .bold_color = config.@"bold-color",
-                    .faint_opacity = @intFromFloat(@ceil(std.math.clamp(config.@"faint-opacity", 0.0, 1.0) * 255)),
+                    .faint_opacity = @intFromFloat(@ceil(config.@"faint-opacity" * 255)),
 
                     .min_contrast = @floatCast(config.@"minimum-contrast"),
                     .padding_color = config.@"window-padding-color",

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -522,6 +522,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             selection_background: ?configpkg.Config.TerminalColor,
             selection_foreground: ?configpkg.Config.TerminalColor,
             bold_color: ?configpkg.BoldColor,
+            faint_opacity: u8,
             min_contrast: f32,
             padding_color: configpkg.WindowPaddingColor,
             custom_shaders: configpkg.RepeatablePath,
@@ -584,6 +585,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     .background = config.background.toTerminalRGB(),
                     .foreground = config.foreground.toTerminalRGB(),
                     .bold_color = config.@"bold-color",
+                    .faint_opacity = @intFromFloat(@ceil(std.math.clamp(config.@"faint-opacity", 0.0, 1.0) * 255)),
 
                     .min_contrast = @floatCast(config.@"minimum-contrast"),
                     .padding_color = config.@"window-padding-color",
@@ -2612,7 +2614,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     };
 
                     // Foreground alpha for this cell.
-                    const alpha: u8 = if (style.flags.faint) 175 else 255;
+                    const alpha: u8 = if (style.flags.faint) self.config.faint_opacity else 255;
 
                     // Set the cell's background color.
                     {


### PR DESCRIPTION
This pull request adds the `--faint-opacity` option, as discussed in #7637.

The default value of the option is also changed from `0.68` to `0.5` for greater consistency with other popular terminal emulators.