### PR TITLE
gtk-ng/wayland: allow more quick terminal configs

### DIFF
--- a/src/apprt/gtk-ng/winproto/wayland.zig
+++ b/src/apprt/gtk-ng/winproto/wayland.zig
@@ -114,11 +114,13 @@ pub const App = struct {
             return false;
         }
 
-        if (self.context.xdg_wm_dialog_present and layer_shell.getLibraryVersion().order(.{
-            .major = 1,
-            .minor = 0,
-            .patch = 4,
-        }) == .lt) {
+        if (self.context.xdg_wm_dialog_present and
+            layer_shell.getLibraryVersion().order(.{
+                .major = 1,
+                .minor = 0,
+                .patch = 4,
+            }) == .lt)
+        {
             log.warn("the version of gtk4-layer-shell installed on your system is too old (must be 1.0.4 or newer); disabling quick terminal", .{});
             return false;
         }
@@ -128,10 +130,7 @@ pub const App = struct {
 
     pub fn initQuickTerminal(_: *App, apprt_window: *ApprtWindow) !void {
         const window = apprt_window.as(gtk.Window);
-
         layer_shell.initForWindow(window);
-        layer_shell.setLayer(window, .top);
-        layer_shell.setNamespace(window, "ghostty-quick-terminal");
     }
 
     fn getInterfaceType(comptime field: std.builtin.Type.StructField) ?type {
@@ -410,6 +409,14 @@ pub const Window = struct {
             v.get()
         else
             return;
+
+        layer_shell.setLayer(window, switch (config.@"gtk-quick-terminal-layer") {
+            .overlay => .overlay,
+            .top => .top,
+            .bottom => .bottom,
+            .background => .background,
+        });
+        layer_shell.setNamespace(window, config.@"gtk-quick-terminal-namespace");
 
         layer_shell.setKeyboardMode(
             window,

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2132,6 +2132,44 @@ keybind: Keybinds = .{},
 /// terminal would be half a screen tall, and 500 pixels wide.
 @"quick-terminal-size": QuickTerminalSize = .{},
 
+/// The layer of the quick terminal window. The higher the layer,
+/// the more windows the quick terminal may conceal.
+///
+/// Valid values are:
+///
+///  * `overlay`
+///
+///    The quick terminal appears in front of all windows.
+///
+///  * `top` (default)
+///
+///    The quick terminal appears in front of normal windows but behind
+///    fullscreen overlays like lock screens.
+///
+///  * `bottom`
+///
+///    The quick terminal appears behind normal windows but in front of
+///    wallpapers and other windows in the background layer.
+///
+///  * `background`
+///
+///    The quick terminal appears behind all windows.
+///
+/// GTK Wayland only.
+///
+/// Available since: 1.2.0
+@"gtk-quick-terminal-layer": QuickTerminalLayer = .top,
+/// The namespace for the quick terminal window.
+///
+/// This is an identifier that is used by the Wayland compositor and/or
+/// scripts to determine the type of layer surfaces and to possibly apply
+/// unique effects.
+///
+/// GTK Wayland only.
+///
+/// Available since: 1.2.0
+@"gtk-quick-terminal-namespace": [:0]const u8 = "ghostty-quick-terminal",
+
 /// The screen where the quick terminal should show up.
 ///
 /// Valid values are:
@@ -7163,6 +7201,14 @@ pub const QuickTerminalPosition = enum {
     left,
     right,
     center,
+};
+
+/// See quick-terminal-layer
+pub const QuickTerminalLayer = enum {
+    overlay,
+    top,
+    bottom,
+    background,
 };
 
 /// See quick-terminal-size


### PR DESCRIPTION
We should at least be on par with what Kitty's panels could do in terms of customization