### PR TITLE
Compare fields directly instead of PackedStyle

### DIFF
--- a/src/terminal/style.zig
+++ b/src/terminal/style.zig
@@ -85,9 +85,10 @@ pub const Style = struct {
 
     /// True if the style is equal to another style.
     pub fn eql(self: Style, other: Style) bool {
-        // We convert the styles to packed structs and compare as integers
-        // because this is much faster than comparing each field separately.
-        return PackedStyle.fromStyle(self) == PackedStyle.fromStyle(other);
+        return @as(u16, @bitCast(self.flags)) == @as(u16, @bitCast(other.flags)) and
+               std.meta.eql(self.fg_color, other.fg_color) and
+               std.meta.eql(self.bg_color, other.bg_color) and
+               std.meta.eql(self.underline_color, other.underline_color);
     }
 
     /// Returns the bg color for a cell with this style given the cell

--- a/src/terminal/style.zig
+++ b/src/terminal/style.zig
@@ -86,9 +86,9 @@ pub const Style = struct {
     /// True if the style is equal to another style.
     pub fn eql(self: Style, other: Style) bool {
         return @as(u16, @bitCast(self.flags)) == @as(u16, @bitCast(other.flags)) and
-               std.meta.eql(self.fg_color, other.fg_color) and
-               std.meta.eql(self.bg_color, other.bg_color) and
-               std.meta.eql(self.underline_color, other.underline_color);
+            std.meta.eql(self.fg_color, other.fg_color) and
+            std.meta.eql(self.bg_color, other.bg_color) and
+            std.meta.eql(self.underline_color, other.underline_color);
     }
 
     /// Returns the bg color for a cell with this style given the cell

--- a/src/terminal/style.zig
+++ b/src/terminal/style.zig
@@ -85,7 +85,7 @@ pub const Style = struct {
 
     /// True if the style is equal to another style.
     pub fn eql(self: Style, other: Style) bool {
-        return @as(u16, @bitCast(self.flags)) == @as(u16, @bitCast(other.flags)) and
+        return self.flags == other.flags and
             std.meta.eql(self.fg_color, other.fg_color) and
             std.meta.eql(self.bg_color, other.bg_color) and
             std.meta.eql(self.underline_color, other.underline_color);


### PR DESCRIPTION
This is a small, but I think worthwhile micro optimization in style.zig, I uncovered while investigating wider ranging optimizations in the rendering section.

For me it results in ~4-5% increase in fps for DOOM-fire-zig benchmark, which maximally stresses this code path.

Comparing the fields directly is actually faster than PackedStyle.

I wrote the code in style.zig, claude 4 wrote the benchmark, all PR responses will be generated by jcm-slow-1


Style.eql Benchmark Comparison
==============================

Test: Small (1K pairs, 50% equal)
--------------------------------------------------
New implementation:
  Iterations: 49937
  Duration: 500.01 ms
  Throughput: 99872402 comparisons/sec
Old implementation:
  Iterations: 8508
  Duration: 500.06 ms
  Throughput: 17014026 comparisons/sec
Performance improvement:
  Speedup: 5.87x
  Improvement: +487.0%

Test: Medium (10K pairs, 50% equal)
--------------------------------------------------
New implementation:
  Iterations: 4435
  Duration: 500.09 ms
  Throughput: 88684746 comparisons/sec
Old implementation:
  Iterations: 850
  Duration: 500.50 ms
  Throughput: 16983017 comparisons/sec
Performance improvement:
  Speedup: 5.22x
  Improvement: +422.2%

Test: Large (50K pairs, 50% equal)
--------------------------------------------------
New implementation:
  Iterations: 861
  Duration: 500.41 ms
  Throughput: 86030144 comparisons/sec
Old implementation:
  Iterations: 171
  Duration: 501.70 ms
  Throughput: 17041989 comparisons/sec
Performance improvement:
  Speedup: 5.05x
  Improvement: +404.8%

Test: Mostly equal (10K pairs, 90% equal)
--------------------------------------------------
New implementation:
  Iterations: 4608
  Duration: 500.03 ms
  Throughput: 92154471 comparisons/sec
Old implementation:
  Iterations: 854
  Duration: 500.45 ms
  Throughput: 17064744 comparisons/sec
Performance improvement:
  Speedup: 5.40x
  Improvement: +440.0%

Test: Mostly different (10K pairs, 10% equal)
--------------------------------------------------
New implementation:
  Iterations: 4065
  Duration: 500.03 ms
  Throughput: 81294960 comparisons/sec
Old implementation:
  Iterations: 848
  Duration: 500.21 ms
  Throughput: 16952948 comparisons/sec
Performance improvement:
  Speedup: 4.80x
  Improvement: +379.5%

Test: Same flags (10K pairs, 50% equal)
--------------------------------------------------
New implementation:
  Iterations: 2799
  Duration: 500.00 ms
  Throughput: 55979776 comparisons/sec
Old implementation:
  Iterations: 859
  Duration: 500.13 ms
  Throughput: 17175672 comparisons/sec
Performance improvement:
  Speedup: 3.26x
  Improvement: +225.9%