### PR TITLE
apprt/gtk-ng: must quit scenarios should quit immediately

### DIFF
--- a/src/apprt/gtk-ng/class/application.zig
+++ b/src/apprt/gtk-ng/class/application.zig
@@ -476,7 +476,14 @@ pub const Application = extern struct {
                 break :q false;
             };
 
-            if (must_quit) self.quit();
+            if (must_quit) {
+                // All must quit scenarios do not need confirmation.
+                // Furthermore, must quit scenarios may result in a situation
+                // where its unsafe to even access the app/surface memory
+                // since its in the process of being freed. We must simply
+                // begin our exit immediately.
+                self.quitNow();
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #8495

We were incorrectly calling graceful quit under must quit scenarios. This would do things like confirm quit by inspecting for running processes. However, must quit scenarios (namely when all windows are destroyed) should quit immediately without any checks because the dispose process takes more event loop ticks to fully finish.