### PR TITLE
config: make default copy_to_clipboard binds performable

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -5525,10 +5525,11 @@ pub const Keybinds = struct {
             else
                 .{ .ctrl = true, .shift = true };
 
-            try self.set.put(
+            try self.set.putFlags(
                 alloc,
                 .{ .key = .{ .unicode = 'c' }, .mods = mods },
                 .{ .copy_to_clipboard = {} },
+                .{ .performable = true },
             );
             try self.set.put(
                 alloc,


### PR DESCRIPTION
Make the default keybind for copy_to_clipboard performable. This allows
TUIs to receive events when keybinds aren't used, for example cmd+c on
macos for copy, or ctrl+shift+c elsewhere.

Disclosure: This commit was made with the assistance of AI (ampcode.com)
