### PR TITLE
macOS: prevent focus loss in hidden titlebar + non-native fullscreen

### DIFF
--- a/macos/Sources/Features/Terminal/Window Styles/HiddenTitlebarTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/HiddenTitlebarTerminalWindow.swift
@@ -31,9 +31,16 @@ class HiddenTitlebarTerminalWindow: TerminalWindow {
         .closable,
         .miniaturizable,
     ]
-
+    
     /// Apply the hidden titlebar style.
     private func reapplyHiddenStyle() {
+        // If our window is fullscreen then we don't reapply the hidden style because
+        // it can result in messing up non-native fullscreen. See:
+        // https://github.com/ghostty-org/ghostty/issues/8415
+        if terminalController?.fullscreenStyle?.isFullscreen ?? false {
+            return
+        }
+        
         // Apply our style mask while preserving the .fullScreen option
         if styleMask.contains(.fullScreen) {
             styleMask = Self.hiddenStyleMask.union([.fullScreen])


### PR DESCRIPTION
Fixes #8415

When using hidden titlebar with non-native fullscreen, the window would lose focus after entering the first command. This occurred because:

1. Shell commands update the window title
2. Title changes trigger reapplyHiddenStyle() 
3. reapplyHiddenStyle() re-adds .titled to the style mask
4. Style mask changes during fullscreen confuse AppKit, causing focus loss

Fixed by adding a guard to skip titlebar restyling while fullscreen is active, using terminalController.fullscreenStyle.isFullscreen for proper detection of both native and non-native fullscreen modes.

AI disclaimer: https://ampcode.com/threads/T-c4ef59cc-1232-4fa5-8f09-c65724ee84d3 But I hand-modified the end.