### PR TITLE
Constrain dingbats + add some more symbol-like blocks to isSymbol

### DIFF
--- a/src/font/nerd_font_attributes.zig
+++ b/src/font/nerd_font_attributes.zig
@@ -7,7 +7,7 @@
 const Constraint = @import("face.zig").RenderOptions.Constraint;
 
 /// Get the a constraints for the provided codepoint.
-pub fn getConstraint(cp: u21) Constraint {
+pub fn getConstraint(cp: u21) ?Constraint {
     return switch (cp) {
         0x2500...0x259f,
         => .{
@@ -1060,6 +1060,6 @@ pub fn getConstraint(cp: u21) Constraint {
             .align_vertical = .center,
             .group_width = 1.3001222493887530,
         },
-        else => .none,
+        else => null,
     };
 }

--- a/src/font/nerd_font_codegen.py
+++ b/src/font/nerd_font_codegen.py
@@ -351,8 +351,8 @@ if __name__ == "__main__":
 const Constraint = @import("face.zig").RenderOptions.Constraint;
 
 /// Get the a constraints for the provided codepoint.
-pub fn getConstraint(cp: u21) Constraint {
+pub fn getConstraint(cp: u21) ?Constraint {
     return switch (cp) {
 """)
         f.write(generate_zig_switch_arms(patch_set, nerd_font))
-        f.write("\n        else => .none,\n    };\n}\n")
+        f.write("\n        else => null,\n    };\n}\n")

--- a/src/renderer/cell.zig
+++ b/src/renderer/cell.zig
@@ -237,13 +237,27 @@ pub fn isCovering(cp: u21) bool {
 
 /// Returns true of the codepoint is a "symbol-like" character, which
 /// for now we define as anything in a private use area and anything
-/// in the "dingbats" unicode block.
+/// in several unicode blocks:
+/// - Dingbats
+/// - Emoticons
+/// - Miscellaneous Symbols
+/// - Enclosed Alphanumerics
+/// - Enclosed Alphanumeric Supplement
+/// - Miscellaneous Symbols and Pictographs
+/// - Transport and Map Symbols
 ///
 /// In the future it may be prudent to expand this to encompass more
 /// symbol-like characters, and/or exclude some PUA sections.
 pub fn isSymbol(cp: u21) bool {
+    // TODO: This should probably become a codegen'd LUT
     return ziglyph.general_category.isPrivateUse(cp) or
-        ziglyph.blocks.isDingbats(cp);
+        ziglyph.blocks.isDingbats(cp) or
+        ziglyph.blocks.isEmoticons(cp) or
+        ziglyph.blocks.isMiscellaneousSymbols(cp) or
+        ziglyph.blocks.isEnclosedAlphanumerics(cp) or
+        ziglyph.blocks.isEnclosedAlphanumericSupplement(cp) or
+        ziglyph.blocks.isMiscellaneousSymbolsAndPictographs(cp) or
+        ziglyph.blocks.isTransportAndMapSymbols(cp);
 }
 
 /// Returns the appropriate `constraint_width` for

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -3066,7 +3066,14 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     .thicken = self.config.font_thicken,
                     .thicken_strength = self.config.font_thicken_strength,
                     .cell_width = cell.gridWidth(),
-                    .constraint = getConstraint(cp),
+                    // If there's no Nerd Font constraint for this codepoint
+                    // then, if it's a symbol, we constrain it to fit inside
+                    // its cell(s), we don't modify the alignment at all.
+                    .constraint = getConstraint(cp) orelse
+                        if (cellpkg.isSymbol(cp)) .{
+                            .size_horizontal = .fit,
+                            .size_vertical = .fit,
+                        } else .none,
                     .constraint_width = constraintWidth(cell_pin),
                 },
             );


### PR DESCRIPTION
This is a very minimal change to fix a regression from when the constraints were reworked (moved off the GPU and on to the CPU), where we weren't constraining dingbats anymore. This fixes that and also adds several other Unicode blocks to also treat as symbols.

In the future (post-1.2) I'll make a more comprehensive set of custom constraints that differ depending on a hand-rolled list of character attributes.

|Before|After|
|-|-|
|<img width="1708" height="2096" alt="image" src="https://github.com/user-attachments/assets/8ce593ac-f032-4c75-80e1-030dd301115d" />|<img width="1708" height="2096" alt="image" src="https://github.com/user-attachments/assets/06dc2307-342d-4ea2-959d-7416eee6ddc2" />|

You'll notice that with spaces in between (so each glyph can be up to 2 cells wide), there's very little change with a font with wider cells, there would be more of a change for people with narrower fonts. The real star of the show is when they're all shoved together and need to be constrained to 1 cell; it's utter chaos without constraints, but with constraints it's nice and orderly (some glyphs get too small to read well, but there's nothing we can really do about that, users should really have a font like Iosevka Fixed installed on their system if they want a good source for terminal-compatible symbol glyphs)