### PR TITLE
gtk-ng: deprecate detection of launch source

### DIFF
--- a/dist/linux/app.desktop.in
+++ b/dist/linux/app.desktop.in
@@ -4,7 +4,7 @@ Name=@NAME@
 Type=Application
 Comment=A terminal emulator
 TryExec=@GHOSTTY@
-Exec=@GHOSTTY@ --launched-from=desktop
+Exec=@GHOSTTY@ --gtk-single-instance=true
 Icon=com.mitchellh.ghostty
 Categories=System;TerminalEmulator;
 Keywords=terminal;tty;pty;
@@ -23,4 +23,4 @@ X-KDE-Shortcuts=Ctrl+Alt+T
 
 [Desktop Action new-window]
 Name=New Window
-Exec=@GHOSTTY@ --launched-from=desktop
+Exec=@GHOSTTY@ --gtk-single-instance=true

--- a/dist/linux/dbus.service.flatpak.in
+++ b/dist/linux/dbus.service.flatpak.in
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=@APPID@
-Exec=@GHOSTTY@ --launched-from=dbus
+Exec=@GHOSTTY@ --gtk-single-instance=true --initial-window=false

--- a/dist/linux/dbus.service.in
+++ b/dist/linux/dbus.service.in
@@ -1,4 +1,4 @@
 [D-BUS Service]
 Name=@APPID@
 SystemdService=app-@APPID@.service
-Exec=@GHOSTTY@ --launched-from=dbus
+Exec=@GHOSTTY@ --gtk-single-instance=true --initial-window=false

--- a/dist/linux/systemd.service.in
+++ b/dist/linux/systemd.service.in
@@ -8,7 +8,7 @@ Requires=dbus.socket
 Type=notify-reload
 ReloadSignal=SIGUSR2
 BusName=@APPID@
-ExecStart=@GHOSTTY@ --launched-from=systemd
+ExecStart=@GHOSTTY@ --gtk-single-instance=true --initial-window=false
 
 [Install]
 WantedBy=graphical-session.target

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -909,7 +909,7 @@ pub const Surface = struct {
             // our translation settings for Ghostty. If we aren't from
             // the desktop then we didn't set our LANGUAGE var so we
             // don't need to remove it.
-            switch (self.app.config.@"launched-from".?) {
+            switch (self.app.config.@"launched-from") {
                 .desktop => env.remove("LANGUAGE"),
                 .dbus, .systemd, .cli => {},
             }

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -909,10 +909,7 @@ pub const Surface = struct {
             // our translation settings for Ghostty. If we aren't from
             // the desktop then we didn't set our LANGUAGE var so we
             // don't need to remove it.
-            switch (self.app.config.@"launched-from") {
-                .desktop => env.remove("LANGUAGE"),
-                .dbus, .systemd, .cli => {},
-            }
+            if (internal_os.launchedFromDesktop()) env.remove("LANGUAGE");
         }
 
         return env;

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -223,10 +223,8 @@ pub const Application = extern struct {
         const single_instance = switch (config.@"gtk-single-instance") {
             .true => true,
             .false => false,
-            .desktop => switch (config.@"launched-from".?) {
-                .desktop, .systemd, .dbus => true,
-                .cli => false,
-            },
+            // This should have been resolved to true/false during config loading.
+            .detect => unreachable,
         };
 
         // Setup the flags for our application.
@@ -428,7 +426,7 @@ pub const Application = extern struct {
             // We need to scope any config access because once we run our
             // event loop, this can change out from underneath us.
             const config = priv.config.get();
-            if (config.@"initial-window") switch (config.@"launched-from".?) {
+            if (config.@"initial-window") switch (config.@"launched-from") {
                 .desktop, .cli => self.as(gio.Application).activate(),
                 .dbus, .systemd => {},
             };

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -416,9 +416,7 @@ pub const Application = extern struct {
         // This just calls the `activate` signal but its part of the normal startup
         // routine so we just call it, but only if the config allows it (this allows
         // for launching Ghostty in the "background" without immediately opening
-        // a window). An initial window will not be immediately created if we were
-        // launched by D-Bus activation or systemd.  D-Bus activation will send it's
-        // own `activate` or `new-window` signal later.
+        // a window).
         //
         // https://gitlab.gnome.org/GNOME/glib/-/blob/bd2ccc2f69ecfd78ca3f34ab59e42e2b462bad65/gio/gapplication.c#L2302
         const priv = self.private();
@@ -426,15 +424,11 @@ pub const Application = extern struct {
             // We need to scope any config access because once we run our
             // event loop, this can change out from underneath us.
             const config = priv.config.get();
-            if (config.@"initial-window") switch (config.@"launched-from") {
-                .desktop, .cli => self.as(gio.Application).activate(),
-                .dbus, .systemd => {},
-            };
+            if (config.@"initial-window") self.as(gio.Application).activate();
         }
 
         // If we are NOT the primary instance, then we never want to run.
-        // This means that another instance of the GTK app is running and
-        // our "activate" call above will open a window.
+        // This means that another instance of the GTK app is running.
         if (self.as(gio.Application).getIsRemote() != 0) {
             log.debug(
                 "application is remote, exiting run loop after activation",

--- a/src/cli/args.zig
+++ b/src/cli/args.zig
@@ -260,6 +260,7 @@ fn formatInvalidValue(
 }
 
 fn formatValues(comptime T: type, key: []const u8, writer: anytype) std.mem.Allocator.Error!void {
+    @setEvalBranchQuota(2000);
     const typeinfo = @typeInfo(T);
     inline for (typeinfo.@"struct".fields) |f| {
         if (std.mem.eql(u8, key, f.name)) {


### PR DESCRIPTION
Detecting the launch source frequently failed because various launchers fail to sanitize the environment variables that Ghostty used to detect the launch source. For example, if your desktop environment was launched by `systemd`, but your desktop environment did not sanitize the `INVOCATION_ID` or the `JOURNAL_STREAM` environment variables, Ghostty would assume that it had been launched by `systemd` and behave as such.

This led to complaints about Ghostty not creating new windows when users expected that it would.

To remedy this, Ghostty no longer does any detection of the launch source. If your launch source is something other than the CLI, it must be explicitly speciflied on the CLI. All of Ghostty's default desktop and service files do this. Users or packagers that create custom desktop or service files will need to take this into account.

On GTK, the `desktop` setting for `gtk-single-instance` is replaced with `detect`. `detect` behaves as `gtk-single-instance=true` if one of the following conditions is true:

1. If no CLI arguments have been set.
2. If `--launched-from` has been set to `desktop`, `dbus`, or `systemd`.

Otherwise `detect` behaves as `gtk-single-instance=false`.