### PR TITLE
apprt/gtk: set the title on the window immediately if set

### DIFF
--- a/src/apprt/gtk/class/window.zig
+++ b/src/apprt/gtk/class/window.zig
@@ -306,6 +306,13 @@ pub const Window = extern struct {
             const config = config_obj.get();
             if (config.maximize) self.as(gtk.Window).maximize();
             if (config.fullscreen) self.as(gtk.Window).fullscreen();
+
+            // If we have an explicit title set, we set that immediately
+            // so that any applications inspecting the window states see
+            // an immediate title set when the window appears, rather than
+            // waiting possibly a few event loop ticks for it to sync from
+            // the surface.
+            if (config.title) |v| self.as(gtk.Window).setTitle(v);
         }
 
         // We always sync our appearance at the end because loading our


### PR DESCRIPTION
Fixes #5934

This was never confirmed to be a real issue on GTK, but it is theoretically possible and good hygiene in general. Typically, we'd get the title through a binding which comes from a bindinggroup which comes from the active surface in the active tab. All of this takes multiple event loop ticks to settle, if you will.

This commit changes it so that if an explicit, static title is set, we set that title on startup before the window is mapped. The syncing still happens later, but at least the window will have a title from the initialization.