### PR TITLE
Micro-optimize GlyphKey Context

### DIFF
--- a/src/font/SharedGrid.zig
+++ b/src/font/SharedGrid.zig
@@ -332,11 +332,12 @@ const GlyphKey = struct {
 
     const Context = struct {
         pub fn hash(_: Context, key: GlyphKey) u64 {
-            return @bitCast(Packed.from(key));
+            const packed_key = Packed.from(key);
+            return std.hash.CityHash64.hash(std.mem.asBytes(&packed_key));
         }
 
         pub fn eql(_: Context, a: GlyphKey, b: GlyphKey) bool {
-            return Packed.from(a) == Packed.from(b);
+            return a.glyph == b.glyph and Packed.from(a) == Packed.from(b);
         }
     };
 

--- a/src/font/SharedGrid.zig
+++ b/src/font/SharedGrid.zig
@@ -332,11 +332,15 @@ const GlyphKey = struct {
 
     const Context = struct {
         pub fn hash(_: Context, key: GlyphKey) u64 {
+            // Packed is a u64 but std.hash.int improves uniformity and
+            // avoids collisions in our hashmap.
             const packed_key = Packed.from(key);
-            return std.hash.CityHash64.hash(std.mem.asBytes(&packed_key));
+            return std.hash.int(@as(u64, @bitCast(packed_key)));
         }
 
         pub fn eql(_: Context, a: GlyphKey, b: GlyphKey) bool {
+            // Packed checks glyphs but in most cases the glyphs are NOT
+            // equal so the first check leads to increased throughput.
             return a.glyph == b.glyph and Packed.from(a) == Packed.from(b);
         }
     };


### PR DESCRIPTION
Use fast hash function on key for better distribution.

Direct compare glyph in eql to avoid Packed.from() if not neccessary.

16% -> 6.4% reduction during profiling runs.