### PR TITLE
gtk: why codegen when you can embed

### DIFF
--- a/src/build/GhosttyDist.zig
+++ b/src/build/GhosttyDist.zig
@@ -21,7 +21,7 @@ pub fn init(b: *std.Build, cfg: *const Config) !GhosttyDist {
     const alloc = b.allocator;
     var resources: std.ArrayListUnmanaged(Resource) = .empty;
     {
-        const gtk = SharedDeps.gtkNgDistResources(b);
+        const gtk = SharedDeps.gtkDistResources(b);
         try resources.append(alloc, gtk.resources_c);
         try resources.append(alloc, gtk.resources_h);
     }

--- a/src/build/GhosttyDist.zig
+++ b/src/build/GhosttyDist.zig
@@ -20,11 +20,7 @@ pub fn init(b: *std.Build, cfg: *const Config) !GhosttyDist {
     // Get the resources we're going to inject into the source tarball.
     const alloc = b.allocator;
     var resources: std.ArrayListUnmanaged(Resource) = .empty;
-    {
-        const gtk = SharedDeps.gtkDistResources(b);
-        try resources.append(alloc, gtk.resources_c);
-        try resources.append(alloc, gtk.resources_h);
-    }
+    try resources.append(alloc, SharedDeps.gtkDistResources(b));
 
     // git archive to create the final tarball. "git archive" is the
     // easiest way I can find to create a tarball that ignores stuff

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -551,7 +551,7 @@ pub fn add(
 
         switch (self.config.app_runtime) {
             .none => {},
-            .gtk => try self.addGtkNg(step),
+            .gtk => try self.addGtk(step),
         }
     }
 
@@ -563,7 +563,7 @@ pub fn add(
 }
 
 /// Setup the dependencies for the GTK apprt build.
-fn addGtkNg(
+fn addGtk(
     self: *const SharedDeps,
     step: *std.Build.Step.Compile,
 ) !void {
@@ -689,14 +689,14 @@ fn addGtkNg(
 
     {
         // Get our gresource c/h files and add them to our build.
-        const dist = gtkNgDistResources(b);
+        const dist = gtkDistResources(b);
         step.addCSourceFile(.{ .file = dist.resources_c.path(b), .flags = &.{} });
         step.addIncludePath(dist.resources_h.path(b).dirname());
     }
 }
 
 /// Creates the resources that can be prebuilt for our dist build.
-pub fn gtkNgDistResources(
+pub fn gtkDistResources(
     b: *std.Build,
 ) struct {
     resources_c: DistResource,


### PR DESCRIPTION
When you do `glib-compile-resources` with `--generate-header` or`--generate-source`, it generates really long and stinky C source files littered with lengthy escape codes, macros and compiler directives, just because C doesn't (yet!) have a standard way to just embed a file as a literal bunch of bytes.

However, we do have access to that in Zig. So why not just do the same thing but better?
