### PR TITLE
macOS: opt out of probable_cli

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -4535,6 +4535,11 @@ fn probableCliEnvironment() bool {
         // its not a real supported target and GTK via WSL2 assuming
         // single instance is probably fine.
         .windows => return false,
+        // On macOS there is no direct CLI launch, only `open -a`,
+        // which detaches the process and doesn't provide a working
+        // directory to inherit. This should not be treated as a CLI
+        // environment for the purposes of this function.
+        .macos => return false,
         else => {},
     }
 


### PR DESCRIPTION
Suggested fix for the quirk reported in https://github.com/ghostty-org/ghostty/pull/8511#issuecomment-3261123413, i.e., that the working directory of `open -a Ghostty.app` and `open -a Ghostty.app --args <something>` are different.

The `probable_cli` detection seems poorly suited for macOS because the only CLI-like way to launch there is with `open -a`, which invokes the launch system and starts a detached process with no working directory to inherit. It seems more akin to a desktop/systemd launch. So, until it's possible to directly invoke a `ghostty` executable on the command line in macOS, my suggestion is to have this function always return false there.