### PR TITLE
ci: do not run release tip workflow if corresponding commit released

### DIFF
--- a/.github/scripts/ghostty-tip
+++ b/.github/scripts/ghostty-tip
@@ -1,0 +1,19 @@
+#!/usr/bin/env nu
+
+# Check if a given commit SHA has a corresponding tip release.
+#
+# This does not validate that the commit SHA is valid for the
+# Ghostty repository, only that a tip release exists for it.
+def main [
+  commit: string, # The full length commit SHA 
+] {
+  let url = $"https://tip.files.ghostty.org/($commit)/ghostty-macos-universal.zip"
+
+  try {
+    http head $url
+    exit 0
+  } catch {
+    print -e $"The SHA ($commit) does not have a corresponding tip release."
+    exit 1
+  }
+}

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -15,9 +15,57 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  setup:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.repository_owner == 'ghostty-org' &&
+        github.ref_name == 'main'
+      )
+    runs-on: namespace-profile-ghostty-sm
+    outputs:
+      should_skip: ${{ steps.check.outputs.should_skip }}
+      build: ${{ steps.extract_build_info.outputs.build }}
+      commit: ${{ steps.extract_build_info.outputs.commit }}
+      commit_long: ${{ steps.extract_build_info.outputs.commit_long }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          # Important so that build number generation works
+          fetch-depth: 0
+      - uses: cachix/install-nix-action@56a7bb7b56d9a92d4fd1bc05758de7eea4a370a8 # v31.6.0
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
+        with:
+          name: ghostty
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - name: Extract build info
+        id: extract_build_info
+        run: |
+          GHOSTTY_BUILD=$(git rev-list --count HEAD)
+          GHOSTTY_COMMIT=$(git rev-parse --short HEAD)
+          GHOSTTY_COMMIT_LONG=$(git rev-parse HEAD)
+          echo "build=$GHOSTTY_BUILD" >> $GITHUB_OUTPUT
+          echo "commit=$GHOSTTY_COMMIT" >> $GITHUB_OUTPUT
+          echo "commit_long=$GHOSTTY_COMMIT_LONG" >> $GITHUB_OUTPUT
+      - name: Check if tip already exists
+        id: check
+        run: |
+          GHOSTTY_COMMIT_LONG=$(git rev-parse HEAD)
+          if nix develop -c nu .github/scripts/ghostty-tip $GHOSTTY_COMMIT_LONG; then
+            echo "Tip release already exists for commit $GHOSTTY_COMMIT_LONG"
+            echo "should_skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "No tip release found for commit $GHOSTTY_COMMIT_LONG"
+            echo "should_skip=false" >> $GITHUB_OUTPUT
+          fi
+
   tag:
     runs-on: namespace-profile-ghostty-sm
-    needs: [build-macos]
+    needs: [setup, build-macos]
+    if: needs.setup.outputs.should_skip != 'true'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Tip Tag
@@ -29,7 +77,10 @@ jobs:
 
   sentry-dsym-debug-slow:
     runs-on: namespace-profile-ghostty-sm
-    needs: [build-macos-debug-slow]
+    needs: [setup, build-macos-debug-slow]
+    if: needs.setup.outputs.should_skip != 'true'
+    env:
+      GHOSTTY_COMMIT_LONG: ${{ needs.setup.outputs.commit_long }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -39,7 +90,6 @@ jobs:
 
       - name: Download dSYM
         run: |
-          GHOSTTY_COMMIT_LONG=$(git rev-parse HEAD)
           curl -L https://tip.files.ghostty.dev/${GHOSTTY_COMMIT_LONG}/ghostty-macos-universal-debug-slow-dsym.zip > dsym.zip
 
       - name: Upload dSYM to Sentry
@@ -50,7 +100,10 @@ jobs:
 
   sentry-dsym-debug-fast:
     runs-on: namespace-profile-ghostty-sm
-    needs: [build-macos-debug-fast]
+    needs: [setup, build-macos-debug-fast]
+    if: needs.setup.outputs.should_skip != 'true'
+    env:
+      GHOSTTY_COMMIT_LONG: ${{ needs.setup.outputs.commit_long }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -60,7 +113,6 @@ jobs:
 
       - name: Download dSYM
         run: |
-          GHOSTTY_COMMIT_LONG=$(git rev-parse HEAD)
           curl -L https://tip.files.ghostty.dev/${GHOSTTY_COMMIT_LONG}/ghostty-macos-universal-debug-fast-dsym.zip > dsym.zip
 
       - name: Upload dSYM to Sentry
@@ -71,7 +123,10 @@ jobs:
 
   sentry-dsym:
     runs-on: namespace-profile-ghostty-sm
-    needs: [build-macos]
+    needs: [setup, build-macos]
+    if: needs.setup.outputs.should_skip != 'true'
+    env:
+      GHOSTTY_COMMIT_LONG: ${{ needs.setup.outputs.commit_long }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -81,7 +136,6 @@ jobs:
 
       - name: Download dSYM
         run: |
-          GHOSTTY_COMMIT_LONG=$(git rev-parse HEAD)
           curl -L https://tip.files.ghostty.dev/${GHOSTTY_COMMIT_LONG}/ghostty-macos-universal-dsym.zip > dsym.zip
 
       - name: Upload dSYM to Sentry
@@ -91,15 +145,17 @@ jobs:
           sentry-cli dif upload --project ghostty --wait dsym.zip
 
   source-tarball:
+    needs: [setup]
     if: |
-      ${{
+      needs.setup.outputs.should_skip != 'true' &&
+      (
         github.event_name == 'workflow_dispatch' ||
         (
           github.event.workflow_run.conclusion == 'success' &&
           github.repository_owner == 'ghostty-org' &&
           github.ref_name == 'main'
         )
-      }}
+      )
     runs-on: namespace-profile-ghostty-md
     env:
       ZIG_LOCAL_CACHE_DIR: /zig/local-cache
@@ -144,18 +200,24 @@ jobs:
           token: ${{ secrets.GH_RELEASE_TOKEN }}
 
   build-macos:
+    needs: [setup]
     if: |
-      ${{
+      needs.setup.outputs.should_skip != 'true' &&
+      (
         github.event_name == 'workflow_dispatch' ||
         (
           github.event.workflow_run.conclusion == 'success' &&
           github.repository_owner == 'ghostty-org' &&
           github.ref_name == 'main'
         )
-      }}
+      )
 
     runs-on: namespace-profile-ghostty-macos-tahoe
     timeout-minutes: 90
+    env:
+      GHOSTTY_BUILD: ${{ needs.setup.outputs.build }}
+      GHOSTTY_COMMIT: ${{ needs.setup.outputs.commit }}
+      GHOSTTY_COMMIT_LONG: ${{ needs.setup.outputs.commit_long }}
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -188,13 +250,6 @@ jobs:
           curl -L https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-for-Swift-Package-Manager.zip > sparkle.zip
           unzip sparkle.zip
           echo "$(pwd)/bin" >> $GITHUB_PATH
-
-      # Load Build Number
-      - name: Build Number
-        run: |
-          echo "GHOSTTY_BUILD=$(git rev-list --count head)" >> $GITHUB_ENV
-          echo "GHOSTTY_COMMIT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-          echo "GHOSTTY_COMMIT_LONG=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
       # GhosttyKit is the framework that is built from Zig for our native
       # Mac app to access. Build this in release mode.
@@ -364,18 +419,24 @@ jobs:
           destination-dir: ./
 
   build-macos-debug-slow:
+    needs: [setup]
     if: |
-      ${{
+      needs.setup.outputs.should_skip != 'true' &&
+      (
         github.event_name == 'workflow_dispatch' ||
         (
           github.event.workflow_run.conclusion == 'success' &&
           github.repository_owner == 'ghostty-org' &&
           github.ref_name == 'main'
         )
-      }}
+      )
 
     runs-on: namespace-profile-ghostty-macos-tahoe
     timeout-minutes: 90
+    env:
+      GHOSTTY_BUILD: ${{ needs.setup.outputs.build }}
+      GHOSTTY_COMMIT: ${{ needs.setup.outputs.commit }}
+      GHOSTTY_COMMIT_LONG: ${{ needs.setup.outputs.commit_long }}
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -408,13 +469,6 @@ jobs:
           curl -L https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-for-Swift-Package-Manager.zip > sparkle.zip
           unzip sparkle.zip
           echo "$(pwd)/bin" >> $GITHUB_PATH
-
-      # Load Build Number
-      - name: Build Number
-        run: |
-          echo "GHOSTTY_BUILD=$(git rev-list --count head)" >> $GITHUB_ENV
-          echo "GHOSTTY_COMMIT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-          echo "GHOSTTY_COMMIT_LONG=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
       # GhosttyKit is the framework that is built from Zig for our native
       # Mac app to access. Build this in release mode.
@@ -544,18 +598,24 @@ jobs:
           destination-dir: ./
 
   build-macos-debug-fast:
+    needs: [setup]
     if: |
-      ${{
+      needs.setup.outputs.should_skip != 'true' &&
+      (
         github.event_name == 'workflow_dispatch' ||
         (
           github.event.workflow_run.conclusion == 'success' &&
           github.repository_owner == 'ghostty-org' &&
           github.ref_name == 'main'
         )
-      }}
+      )
 
     runs-on: namespace-profile-ghostty-macos-tahoe
     timeout-minutes: 90
+    env:
+      GHOSTTY_BUILD: ${{ needs.setup.outputs.build }}
+      GHOSTTY_COMMIT: ${{ needs.setup.outputs.commit }}
+      GHOSTTY_COMMIT_LONG: ${{ needs.setup.outputs.commit_long }}
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -588,13 +648,6 @@ jobs:
           curl -L https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-for-Swift-Package-Manager.zip > sparkle.zip
           unzip sparkle.zip
           echo "$(pwd)/bin" >> $GITHUB_PATH
-
-      # Load Build Number
-      - name: Build Number
-        run: |
-          echo "GHOSTTY_BUILD=$(git rev-list --count head)" >> $GITHUB_ENV
-          echo "GHOSTTY_COMMIT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-          echo "GHOSTTY_COMMIT_LONG=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
       # GhosttyKit is the framework that is built from Zig for our native
       # Mac app to access. Build this in release mode.


### PR DESCRIPTION
Fixes #8549

This also brings the release tip workflow more in line with the release tag workflow by using a setup job to create outputs that are reused by the other jobs.

This PR was almost fully written by AI (Amp) because being a YAML engineer fucking sucks. I understand GHA and the changes look good to me, but it's hard to tell until the job is run, AI or not. Full prompt/context here:

https://ampcode.com/threads/T-e2d431ad-8be8-46d2-aaa3-9fae71f9ff31