### PR TITLE
fix(font): No NF icon smoothing

### DIFF
--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -382,16 +382,6 @@ pub const Face = struct {
         var width = glyph_size.width;
         var height = glyph_size.height;
 
-        // If this is a bitmap glyph, it will always render as full pixels,
-        // not fractional pixels, so we need to quantize its position and
-        // size accordingly to align to full pixels so we get good results.
-        if (sbix) {
-            width = cell_width - @round(cell_width - width - x) - @round(x);
-            height = cell_height - @round(cell_height - height - y) - @round(y);
-            x = @round(x);
-            y = @round(y);
-        }
-
         // If the cell width was adjusted wider, we re-center all glyphs
         // in the new width, so that they aren't weirdly off to the left.
         if (metrics.original_cell_width) |original| recenter: {
@@ -405,6 +395,16 @@ pub const Face = struct {
 
             // We add half the difference to re-center.
             x += (cell_width - @as(f64, @floatFromInt(original))) / 2;
+        }
+
+        // If this is a bitmap glyph, it will always render as full pixels,
+        // not fractional pixels, so we need to quantize its position and
+        // size accordingly to align to full pixels so we get good results.
+        if (sbix) {
+            width = cell_width - @round(cell_width - width - x) - @round(x);
+            height = cell_height - @round(cell_height - height - y) - @round(y);
+            x = @round(x);
+            y = @round(y);
         }
 
         // Our whole-pixel bearings for the final glyph.

--- a/src/font/face/freetype.zig
+++ b/src/font/face/freetype.zig
@@ -443,8 +443,11 @@ pub const Face = struct {
                 .atlas_y = 0,
             };
 
-        // For synthetic bold, we embolden the glyph.
-        if (self.synthetic.bold) {
+        // Determine whether this is a constrained glyph (mostly icons and emoji).
+        const is_constrained = opts.constraint.doesAnything();
+
+        // For synthetic bold, we embolden the glyph, unless it's constrained.
+        if (!is_constrained and self.synthetic.bold) {
             // We need to scale the embolden amount based on the font size.
             // This is a heuristic I found worked well across a variety of
             // founts: 1 pixel per 64 units of height.
@@ -534,7 +537,7 @@ pub const Face = struct {
                 const scale_x = width / rect.width;
                 const scale_y = height / rect.height;
                 const skew: f64 =
-                    if (self.synthetic.italic)
+                    if (!is_constrained and self.synthetic.italic)
                         // We skew by 12 degrees to synthesize italics.
                         @tan(std.math.degreesToRadians(12))
                     else

--- a/src/font/face/freetype.zig
+++ b/src/font/face/freetype.zig
@@ -491,16 +491,6 @@ pub const Face = struct {
         var x = glyph_size.x;
         var y = glyph_size.y;
 
-        // If this is a bitmap glyph, it will always render as full pixels,
-        // not fractional pixels, so we need to quantize its position and
-        // size accordingly to align to full pixels so we get good results.
-        if (glyph.*.format == freetype.c.FT_GLYPH_FORMAT_BITMAP) {
-            width = cell_width - @round(cell_width - width - x) - @round(x);
-            height = cell_height - @round(cell_height - height - y) - @round(y);
-            x = @round(x);
-            y = @round(y);
-        }
-
         // If the cell width was adjusted wider, we re-center all glyphs
         // in the new width, so that they aren't weirdly off to the left.
         if (metrics.original_cell_width) |original| recenter: {
@@ -520,6 +510,16 @@ pub const Face = struct {
             //       a non-whole-pixel amount, it completely ruins the
             //       hinting.
             x += @round((cell_width - @as(f64, @floatFromInt(original))) / 2);
+        }
+
+        // If this is a bitmap glyph, it will always render as full pixels,
+        // not fractional pixels, so we need to quantize its position and
+        // size accordingly to align to full pixels so we get good results.
+        if (glyph.*.format == freetype.c.FT_GLYPH_FORMAT_BITMAP) {
+            width = cell_width - @round(cell_width - width - x) - @round(x);
+            height = cell_height - @round(cell_height - height - y) - @round(y);
+            x = @round(x);
+            y = @round(y);
         }
 
         // Now we can render the glyph.


### PR DESCRIPTION
This disables CoreText font smoothing for glyphs with nontrivial constraints, which, for the most part, means Nerd Font icons (also emojis, but they are bitmaps, so they were never smoothed anyway).

This is the right thing to do because icons aren't like other glyphs, and font smoothing may make their details less crisp (see, for example, the Nix snowflake and the TeX logo). Perhaps even more importantly, font smoothing interferes badly with icon scaling because it adds a 1-pixel border to the glyph bounding box, causing the scaling algorithm to perceive the icon as larger than it is and therefore scale it to be smaller than it should be. The magnitude of this effect depends on font size and monitor DPI, and is greater on lower-DPI monitors using smaller font sizes.

I also disabled synthetic bold and italic for icons (except italic in CoreText, as it applies per face, and I didn't see a way to opt out per glyph). This is a more hypothetical concern, but it's possible to set the primary font to a patched nerd font that lacks bold and/or italic, in which case you wouldn't want the synthesizing to apply to the icon glyphs.

Lastly, a fly-by bugfix: quantizing bitmap glyphs should be done after glyph centering, as the latter is generally fractional and would negate the quantizing.