### PR TITLE
Position-independent font shaper caching

### DIFF
--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -2530,7 +2530,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
                         // Advance our index until we reach or pass
                         // our current x position in the shaper cells.
-                        while (shaper_cells.?[shaper_cells_i].x < x) {
+                        while (shaper_cells.?[shaper_cells_i].x < x - run.offset) {
                             shaper_cells_i += 1;
                         }
                     }
@@ -2769,13 +2769,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                         // If we encounter a shaper cell to the left of the current
                         // cell then we have some problems. This logic relies on x
                         // position monotonically increasing.
-                        assert(cells[shaper_cells_i].x >= x);
+                        assert(cells[shaper_cells_i].x >= x - run.offset);
 
                         // NOTE: An assumption is made here that a single cell will never
                         // be present in more than one shaper run. If that assumption is
                         // violated, this logic breaks.
 
-                        while (shaper_cells_i < cells.len and cells[shaper_cells_i].x == x) : ({
+                        while (shaper_cells_i < cells.len and cells[shaper_cells_i].x == x - run.offset) : ({
                             shaper_cells_i += 1;
                         }) {
                             self.addGlyph(


### PR DESCRIPTION
Use relative cluster positioning to allow identical texts runs in different row positions to share the same cache entry.

I am opening this PR clean w/o the cache size change. There could be some benefit to a larger 256->512 shaper cache, but this still performs amazingly well and I don't know the full memory impacts of moving the cache size up.

https://github.com/ghostty-org/ghostty/discussions/8547#discussioncomment-14329590

