### PR TITLE
deps: update z2d to v0.8.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -20,8 +20,8 @@
         },
         .z2d = .{
             // vancluever/z2d
-            .url = "https://github.com/vancluever/z2d/archive/refs/tags/v0.7.2.tar.gz",
-            .hash = "z2d-0.7.2-j5P_Hm1oDQDQsWpGfSCMARhowBnuTHlQ_sBfij6TuG7l",
+            .url = "https://github.com/vancluever/z2d/archive/refs/tags/v0.8.0.tar.gz",
+            .hash = "z2d-0.8.0-j5P_HgW8DQBvCefcGWPZA1WC5Nco08WhKjG3XCW3thMr",
             .lazy = true,
         },
         .zig_objc = .{

--- a/build.zig.zon.json
+++ b/build.zig.zon.json
@@ -129,10 +129,10 @@
     "url": "https://deps.files.ghostty.org/wuffs-122037b39d577ec2db3fd7b2130e7b69ef6cc1807d68607a7c232c958315d381b5cd.tar.gz",
     "hash": "sha256-nkzSCr6W5sTG7enDBXEIhgEm574uLD41UVR2wlC+HBM="
   },
-  "z2d-0.7.2-j5P_Hm1oDQDQsWpGfSCMARhowBnuTHlQ_sBfij6TuG7l": {
+  "z2d-0.8.0-j5P_HgW8DQBvCefcGWPZA1WC5Nco08WhKjG3XCW3thMr": {
     "name": "z2d",
-    "url": "https://github.com/vancluever/z2d/archive/refs/tags/v0.7.2.tar.gz",
-    "hash": "sha256-tWrLlEOU4/0ZOlzgGOXB08fW7sqfyAFf3rlv0wl9b/c="
+    "url": "https://github.com/vancluever/z2d/archive/refs/tags/v0.8.0.tar.gz",
+    "hash": "sha256-0yR5Yc5MxOJBV1cv4LOWBwWkZYcGU53qFZd40TlZPcg="
   },
   "zf-0.10.3-OIRy8aiIAACLrBllz0zjxaH0aOe5oNm3KtEMyCntST-9": {
     "name": "zf",

--- a/build.zig.zon.nix
+++ b/build.zig.zon.nix
@@ -291,11 +291,11 @@ in
       };
     }
     {
-      name = "z2d-0.7.2-j5P_Hm1oDQDQsWpGfSCMARhowBnuTHlQ_sBfij6TuG7l";
+      name = "z2d-0.8.0-j5P_HgW8DQBvCefcGWPZA1WC5Nco08WhKjG3XCW3thMr";
       path = fetchZigArtifact {
         name = "z2d";
-        url = "https://github.com/vancluever/z2d/archive/refs/tags/v0.7.2.tar.gz";
-        hash = "sha256-tWrLlEOU4/0ZOlzgGOXB08fW7sqfyAFf3rlv0wl9b/c=";
+        url = "https://github.com/vancluever/z2d/archive/refs/tags/v0.8.0.tar.gz";
+        hash = "sha256-0yR5Yc5MxOJBV1cv4LOWBwWkZYcGU53qFZd40TlZPcg=";
       };
     }
     {

--- a/build.zig.zon.txt
+++ b/build.zig.zon.txt
@@ -32,4 +32,4 @@ https://github.com/mbadolato/iTerm2-Color-Schemes/archive/b314fc540434cc037c2811
 https://github.com/mitchellh/libxev/archive/7f803181b158a10fec8619f793e3b4df515566cb.tar.gz
 https://github.com/mitchellh/zig-objc/archive/c9e917a4e15a983b672ca779c7985d738a2d517c.tar.gz
 https://github.com/natecraddock/zf/archive/7aacbe6d155d64d15937ca95ca6c014905eb531f.tar.gz
-https://github.com/vancluever/z2d/archive/refs/tags/v0.7.2.tar.gz
+https://github.com/vancluever/z2d/archive/refs/tags/v0.8.0.tar.gz

--- a/flatpak/zig-packages.json
+++ b/flatpak/zig-packages.json
@@ -157,9 +157,9 @@
   },
   {
     "type": "archive",
-    "url": "https://github.com/vancluever/z2d/archive/refs/tags/v0.7.2.tar.gz",
-    "dest": "vendor/p/z2d-0.7.2-j5P_Hm1oDQDQsWpGfSCMARhowBnuTHlQ_sBfij6TuG7l",
-    "sha256": "b56acb944394e3fd193a5ce018e5c1d3c7d6eeca9fc8015fdeb96fd3097d6ff7"
+    "url": "https://github.com/vancluever/z2d/archive/refs/tags/v0.8.0.tar.gz",
+    "dest": "vendor/p/z2d-0.8.0-j5P_HgW8DQBvCefcGWPZA1WC5Nco08WhKjG3XCW3thMr",
+    "sha256": "d3247961ce4cc4e24157572fe0b3960705a4658706539dea159778d139593dc8"
   },
   {
     "type": "archive",


### PR DESCRIPTION
Release notes at:
  https://github.com/vancluever/z2d/blob/v0.8.0/CHANGELOG.md

This is a small update and likely contains nothing related to Ghostty, but I wanted to make sure it got in before the 1.2.0 release since it contains the removal of non-functional code that wasn't compiling, just for correctness' sake.

Also if for some reason ARGB/XRGB is needed for some utility purpose, it's there now. :slightly_smiling_face: 