### PR TITLE
terminal: fix test w/ freed config

### DIFF
--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1698,7 +1698,7 @@ test "execCommand: direct command, config freed" {
     defer arena.deinit();
     const alloc = arena.allocator();
 
-    var command_arena = ArenaAllocator.init(alloc);
+    var command_arena = ArenaAllocator.init(testing.allocator);
     const command_alloc = command_arena.allocator();
     const command = try (configpkg.Command{
         .direct = &.{


### PR DESCRIPTION
this test previously didn't fail when accessing freed members of config because deiniting `command_arena` was a no-op; `command_arena` was derived from `arena`, which allocated memory after `command_arena` was created/used