### PR TITLE
Add default bindings for the "copy" and "paste" keyboard keys.

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -5564,6 +5564,17 @@ pub const Keybinds = struct {
         );
 
         {
+            try self.set.put(
+                alloc,
+                .{ .key = .{ .physical = .copy } },
+                .{ .copy_to_clipboard = {} },
+            );
+            try self.set.put(
+                alloc,
+                .{ .key = .{ .physical = .paste } },
+                .{ .paste_from_clipboard = {} },
+            );
+
             // On non-MacOS desktop envs (Windows, KDE, Gnome, Xfce), ctrl+insert is an
             // alt keybinding for Copy and shift+ins is an alt keybinding for Paste
             //


### PR DESCRIPTION
These keys are present in some old unix keyboards, but more importantly, their keycodes can be mapped to physical keys in modern programmable keyboards.
Using them in Linux is a way to be able to have the same keys for copy/pasting in GUI apps and in terminal apps instead of switching between ctrl-c/ctrl-v and ctrl-shift-c/ctrl-shift-v.