### PR TITLE
macOS: grab text field focus of command palette after tick

### DIFF
--- a/macos/Sources/Features/Command Palette/CommandPalette.swift
+++ b/macos/Sources/Features/Command Palette/CommandPalette.swift
@@ -165,7 +165,12 @@ fileprivate struct CommandPaletteQuery: View {
                 .textFieldStyle(.plain)
                 .focused($isTextFieldFocused)
                 .onAppear {
-                    isTextFieldFocused = true
+                    // We want to grab focus on appearance. We have to do this after a tick
+                    // on macOS Tahoe otherwise this doesn't work. See:
+                    // https://github.com/ghostty-org/ghostty/issues/8497
+                    DispatchQueue.main.async {
+                        isTextFieldFocused = true
+                    }
                 }
                 .onChange(of: isTextFieldFocused) { focused in
                     if !focused {


### PR DESCRIPTION
Fixes #8497

This works on every other supported version of macOS but doesn't work on macOS tahoe. Putting it on the next event loop tick works at least on Sequoia and Tahoe so let's just do that.