### PR TITLE
ci: disable trigger-snap for PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -273,6 +273,7 @@ jobs:
             ghostty-source.tar.gz
 
   trigger-snap:
+    if: github.event_name != 'pull_request'
     runs-on: namespace-profile-ghostty-xsm
     needs: build-dist
     steps:


### PR DESCRIPTION
Fixes #8568

This will hide snap issues from PRs which is not ideal but we can address that in the future. We still run snap CI for main.

This more importantly ensures that CI can be green for maintainers to merge.