### PR TITLE
feat: support macos fullscreen with window-decorations=none

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -576,7 +576,7 @@ extension Ghostty {
             case GHOSTTY_ACTION_TOGGLE_TAB_OVERVIEW:
                 fallthrough
             case GHOSTTY_ACTION_TOGGLE_WINDOW_DECORATIONS:
-                fallthrough
+                toggleWindowDecorations(app, target: target)
             case GHOSTTY_ACTION_PRESENT_TERMINAL:
                 fallthrough
             case GHOSTTY_ACTION_SIZE_LIMIT:
@@ -1201,6 +1201,26 @@ extension Ghostty {
                 if let appDelegate = NSApplication.shared.delegate as? AppDelegate {
                     appDelegate.syncFloatOnTopMenu(window)
                 }
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        private static func toggleWindowDecorations(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s
+        ) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                Ghostty.logger.warning("toggle window decorations does nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                guard let terminalController = surfaceView.window?.windowController as? BaseTerminalController else { return }
+                terminalController.toggleWindowDecorations()
 
             default:
                 assertionFailure()


### PR DESCRIPTION
**before**
on macos with `window-decoration = none` clicking `cmd + shift - f` (macos shortcut to go fullscreen) did nothing


https://github.com/user-attachments/assets/5d4c750c-322d-47ed-834c-2f1152e7573b



**after**
now it correctly goes to full screen, and back to normal (without window-decorations) when pressed from fullscreen



https://github.com/user-attachments/assets/4f8c2364-d5ef-4cff-9e8c-4d9633f6d801

