### PR TITLE
deps/ci: Use Ghostty-specific themes release

### DIFF
--- a/.github/workflows/update-colorschemes.yml
+++ b/.github/workflows/update-colorschemes.yml
@@ -40,9 +40,11 @@ jobs:
       - name: Run zig fetch
         id: zig_fetch
         run: |
-          UPSTREAM_REV="$(curl "https://api.github.com/repos/mbadolato/iTerm2-Color-Schemes/commits/master" | jq -r '.sha')"
-          nix develop -c zig fetch --save="iterm2_themes" "https://github.com/mbadolato/iTerm2-Color-Schemes/archive/$UPSTREAM_REV.tar.gz"
-          echo "upstream_rev=$UPSTREAM_REV" >> "$GITHUB_OUTPUT"
+          # Get the latest release from iTerm2-Color-Schemes
+          RELEASE_INFO=$(gh api repos/mbadolato/iTerm2-Color-Schemes/releases/latest)
+          TAG_NAME=$(echo "$RELEASE_INFO" | jq -r '.tag_name')
+          nix develop -c zig fetch --save="iterm2_themes" "https://github.com/mbadolato/iTerm2-Color-Schemes/releases/download/${TAG_NAME}/ghostty-themes.tgz"
+          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
 
       - name: Update zig cache hash
         run: |
@@ -71,5 +73,5 @@ jobs:
             build.zig.zon.json
             flatpak/zig-packages.json
           body: |
-            Upstream revision: https://github.com/mbadolato/iTerm2-Color-Schemes/tree/${{ steps.zig_fetch.outputs.upstream_rev }}
+            Upstream release: https://github.com/mbadolato/iTerm2-Color-Schemes/releases/tag/${{ steps.zig_fetch.outputs.tag_name }}
           labels: dependencies

--- a/HACKING.md
+++ b/HACKING.md
@@ -150,7 +150,7 @@ hash in CI, and builds will fail if it drifts.
 To update it, you can run the following in the repository root:
 
 ```
-./nix/build-support/check-zig-cache-hash.sh --update
+./nix/build-support/check-zig-cache.sh --update
 ```
 
 This will write out the `nix/zigCacheHash.nix` file with the updated hash

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -112,8 +112,8 @@
         // Other
         .apple_sdk = .{ .path = "./pkg/apple-sdk" },
         .iterm2_themes = .{
-            .url = "https://github.com/mbadolato/iTerm2-Color-Schemes/archive/b314fc540434cc037c2811fc048d32854b5b78c3.tar.gz",
-            .hash = "N-V-__8AAGupuwFrRxb2dkqFqmEChLEa4J3e95GReqvomV1b",
+            .url = "https://github.com/mbadolato/iTerm2-Color-Schemes/releases/download/release-20250912-175234-6e04af3/ghostty-themes.tgz",
+            .hash = "N-V-__8AALEfAwCyd2u6A3yOkdQx0rzl5druY97Lyl0bbTsv",
             .lazy = true,
         },
     },

--- a/build.zig.zon.json
+++ b/build.zig.zon.json
@@ -49,10 +49,10 @@
     "url": "https://deps.files.ghostty.org/imgui-1220bc6b9daceaf7c8c60f3c3998058045ba0c5c5f48ae255ff97776d9cd8bfc6402.tar.gz",
     "hash": "sha256-oF/QHgTPEat4Hig4fGIdLkIPHmBEyOJ6JeYD6pnveGA="
   },
-  "N-V-__8AAGupuwFrRxb2dkqFqmEChLEa4J3e95GReqvomV1b": {
+  "N-V-__8AALEfAwCyd2u6A3yOkdQx0rzl5druY97Lyl0bbTsv": {
     "name": "iterm2_themes",
-    "url": "https://github.com/mbadolato/iTerm2-Color-Schemes/archive/b314fc540434cc037c2811fc048d32854b5b78c3.tar.gz",
-    "hash": "sha256-3vPlDDjv6BCLyro1YytzPtF0FfBH20skYuA9laDWhac="
+    "url": "https://github.com/mbadolato/iTerm2-Color-Schemes/releases/download/release-20250912-175234-6e04af3/ghostty-themes.tgz",
+    "hash": "sha256-ZGDpBXk3zGbHa4UNldAphybKcWz6eSaewZaJVAdPIh0="
   },
   "N-V-__8AAIC5lwAVPJJzxnCAahSvZTIlG-HhtOvnM1uh-66x": {
     "name": "jetbrains_mono",

--- a/build.zig.zon.nix
+++ b/build.zig.zon.nix
@@ -163,11 +163,11 @@ in
       };
     }
     {
-      name = "N-V-__8AAGupuwFrRxb2dkqFqmEChLEa4J3e95GReqvomV1b";
+      name = "N-V-__8AALEfAwCyd2u6A3yOkdQx0rzl5druY97Lyl0bbTsv";
       path = fetchZigArtifact {
         name = "iterm2_themes";
-        url = "https://github.com/mbadolato/iTerm2-Color-Schemes/archive/b314fc540434cc037c2811fc048d32854b5b78c3.tar.gz";
-        hash = "sha256-3vPlDDjv6BCLyro1YytzPtF0FfBH20skYuA9laDWhac=";
+        url = "https://github.com/mbadolato/iTerm2-Color-Schemes/releases/download/release-20250912-175234-6e04af3/ghostty-themes.tgz";
+        hash = "sha256-ZGDpBXk3zGbHa4UNldAphybKcWz6eSaewZaJVAdPIh0=";
       };
     }
     {

--- a/build.zig.zon.txt
+++ b/build.zig.zon.txt
@@ -28,7 +28,7 @@ https://deps.files.ghostty.org/zig_js-12205a66d423259567764fa0fc60c82be35365c21a
 https://deps.files.ghostty.org/ziglyph-b89d43d1e3fb01b6074bc1f7fc980324b04d26a5.tar.gz
 https://deps.files.ghostty.org/zlib-1220fed0c74e1019b3ee29edae2051788b080cd96e90d56836eea857b0b966742efb.tar.gz
 https://github.com/jcollie/ghostty-gobject/releases/download/0.15.1-2025-09-04-48-1/ghostty-gobject-0.15.1-2025-09-04-48-1.tar.zst
-https://github.com/mbadolato/iTerm2-Color-Schemes/archive/b314fc540434cc037c2811fc048d32854b5b78c3.tar.gz
+https://github.com/mbadolato/iTerm2-Color-Schemes/releases/download/release-20250912-175234-6e04af3/ghostty-themes.tgz
 https://github.com/mitchellh/libxev/archive/7f803181b158a10fec8619f793e3b4df515566cb.tar.gz
 https://github.com/mitchellh/zig-objc/archive/c9e917a4e15a983b672ca779c7985d738a2d517c.tar.gz
 https://github.com/natecraddock/zf/archive/7aacbe6d155d64d15937ca95ca6c014905eb531f.tar.gz

--- a/flatpak/zig-packages.json
+++ b/flatpak/zig-packages.json
@@ -61,9 +61,9 @@
   },
   {
     "type": "archive",
-    "url": "https://github.com/mbadolato/iTerm2-Color-Schemes/archive/b314fc540434cc037c2811fc048d32854b5b78c3.tar.gz",
-    "dest": "vendor/p/N-V-__8AAGupuwFrRxb2dkqFqmEChLEa4J3e95GReqvomV1b",
-    "sha256": "def3e50c38efe8108bcaba35632b733ed17415f047db4b2462e03d95a0d685a7"
+    "url": "https://github.com/mbadolato/iTerm2-Color-Schemes/releases/download/release-20250912-175234-6e04af3/ghostty-themes.tgz",
+    "dest": "vendor/p/N-V-__8AALEfAwCyd2u6A3yOkdQx0rzl5druY97Lyl0bbTsv",
+    "sha256": "6460e9057937cc66c76b850d95d0298726ca716cfa79269ec1968954074f221d"
   },
   {
     "type": "archive",

--- a/nix/build-support/check-zig-cache.sh
+++ b/nix/build-support/check-zig-cache.sh
@@ -34,7 +34,7 @@ help() {
   echo "To fix, please (manually) re-run the script from the repository root,"
   echo "commit, and submit a PR with the update:"
   echo ""
-  echo "    ./nix/build-support/check-zig-cache-hash.sh --update"
+  echo "    ./nix/build-support/check-zig-cache.sh --update"
   echo "    git add build.zig.zon.nix build.zig.zon.txt build.zig.zon.json flatpak/zig-packages.json"
   echo "    git commit -m \"nix: update build.zig.zon.nix build.zig.zon.txt build.zig.zon.json flatpak/zig-packages.json\""
   echo ""

--- a/src/build/GhosttyResources.zig
+++ b/src/build/GhosttyResources.zig
@@ -120,7 +120,7 @@ pub fn init(b: *std.Build, cfg: *const Config) !GhosttyResources {
     // Themes
     if (b.lazyDependency("iterm2_themes", .{})) |upstream| {
         const install_step = b.addInstallDirectory(.{
-            .source_dir = upstream.path("ghostty"),
+            .source_dir = upstream.path(""),
             .install_dir = .{ .custom = "share" },
             .install_subdir = b.pathJoin(&.{ "ghostty", "themes" }),
             .exclude_extensions = &.{".md"},


### PR DESCRIPTION
Closes #8608 
iterm2_themes now provides terminal-specific releases, this reduces the size of the dependency from 55MB->53kB.
- Update the `.github/workflows/update-colorschemes.yml` to track the latest release and fetch the ghostty-specific theme archive.