### PR TITLE
termio: don't send extra OSC terminator for color reports

### DIFF
--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1429,7 +1429,6 @@ pub const StreamHandler = struct {
         if (response.items.len > 0) {
             // If any of the operations were reports, finalize the report
             // string and send it to the terminal.
-            try writer.writeAll(terminator.string());
             const msg = try termio.Message.writeReq(self.alloc, response.items);
             self.messageWriter(msg);
         }


### PR DESCRIPTION
Fixes #8613

I reiterate my comment in my own PR that this needs to be extracted so we can unit test this. :)