### PR TITLE
feat(macos): implement GHOSTTY_ACTION_TOGGLE_WINDOW_DECORATIONS

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -160,6 +160,11 @@ class BaseTerminalController: NSWindowController,
             selector: #selector(ghosttyMaximizeDidToggle(_:)),
             name: .ghosttyMaximizeDidToggle,
             object: nil)
+        center.addObserver(
+            self,
+            selector: #selector(ghosttyToggleWindowDecorations(_:)),
+            name: .ghosttyToggleWindowDecorations,
+            object: nil)
 
         // Splits
         center.addObserver(
@@ -560,6 +565,12 @@ class BaseTerminalController: NSWindowController,
         guard let surfaceView = notification.object as? Ghostty.SurfaceView else { return }
         guard surfaceTree.contains(surfaceView) else { return }
         window.zoom(nil)
+    }
+
+    @objc private func ghosttyToggleWindowDecorations(_ notification: Notification) {
+        guard let surfaceView = notification.object as? Ghostty.SurfaceView else { return }
+        guard surfaceTree.contains(surfaceView) else { return }
+        toggleWindowDecorations()
     }
 
     @objc private func ghosttyDidCloseSurface(_ notification: Notification) {

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -869,6 +869,22 @@ class BaseTerminalController: NSWindowController,
         }
     }
 
+    // MARK: Window Decorations
+
+    /// Toggle window decorations for this window
+    func toggleWindowDecorations() {
+        guard let window = self.window as? TerminalWindow else { return }
+        
+        // Toggle the style mask to enable/disable decorations
+        if window.styleMask.contains(.titled) {
+            // Remove decorations (make window borderless)
+            window.styleMask.remove(.titled)
+        } else {
+            // Add decorations back
+            window.styleMask.insert(.titled)
+        }
+    }
+
     // MARK: Clipboard Confirmation
 
     @objc private func onConfirmClipboardRequest(notification: SwiftUI.Notification) {

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -627,7 +627,7 @@ extension Ghostty {
             case GHOSTTY_ACTION_TOGGLE_TAB_OVERVIEW:
                 fallthrough
             case GHOSTTY_ACTION_TOGGLE_WINDOW_DECORATIONS:
-                fallthrough
+                toggleWindowDecorations(app, target: target)
             case GHOSTTY_ACTION_PRESENT_TERMINAL:
                 fallthrough
             case GHOSTTY_ACTION_SIZE_LIMIT:
@@ -1415,6 +1415,26 @@ extension Ghostty {
         ) {
             guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
             appDelegate.toggleQuickTerminal(self)
+        }
+
+        private static func toggleWindowDecorations(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s
+        ) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                Ghostty.logger.warning("toggle window decorations does nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                guard let terminalController = surfaceView.window?.windowController as? BaseTerminalController else { return }
+                terminalController.toggleWindowDecorations()
+
+            default:
+                assertionFailure()
+            }
         }
 
         private static func setTitle(

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -1429,8 +1429,10 @@ extension Ghostty {
             case GHOSTTY_TARGET_SURFACE:
                 guard let surface = target.target.surface else { return }
                 guard let surfaceView = self.surfaceView(from: surface) else { return }
-                guard let terminalController = surfaceView.window?.windowController as? BaseTerminalController else { return }
-                terminalController.toggleWindowDecorations()
+                NotificationCenter.default.post(
+                    name: .ghosttyToggleWindowDecorations,
+                    object: surfaceView
+                )
 
             default:
                 assertionFailure()

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -299,17 +299,17 @@ extension Ghostty {
             }
         }
     }
-    
+
     struct ClipboardContent {
         let mime: String
         let data: String
-        
+
         static func from(content: ghostty_clipboard_content_s) -> ClipboardContent? {
             guard let mimePtr = content.mime,
                   let dataPtr = content.data else {
                 return nil
             }
-            
+
             return ClipboardContent(
                 mime: String(cString: mimePtr),
                 data: String(cString: dataPtr)
@@ -406,6 +406,9 @@ extension Notification.Name {
 
     /// Focus the search field
     static let ghosttySearchFocus = Notification.Name("com.mitchellh.ghostty.searchFocus")
+
+    /// Toggle window decorations
+    static let ghosttyToggleWindowDecorations = Notification.Name("com.mitchellh.ghostty.toggleWindowDecorations")
 }
 
 // NOTE: I am moving all of these to Notification.Name extensions over time. This


### PR DESCRIPTION
note: this will be useful to support going to full screen on macOS when `window-decorations = none`

see https://github.com/ghostty-org/ghostty/pull/8602