### PR TITLE
macos: disable NSAutoFillHeuristicController on macOS 26

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -147,6 +147,16 @@ class AppDelegate: NSObject,
             // Disable the automatic full screen menu item because we handle
             // it manually.
             "NSFullScreenMenuItemEverywhere": false,
+            
+            // On macOS 26 RC1, the autofill heuristic controller causes unusable levels
+            // of slowdowns and CPU usage in the terminal window under certain [unknown]
+            // conditions. We don't know exactly why/how. This disables the full heuristic
+            // controller.
+            //
+            // Practically, this means things like SMS autofill don't work, but that is
+            // a desirable behavior to NOT have happen for a terminal, so this is a win.
+            // Manual autofill via the `Edit => AutoFill` menu item still work as expected.
+            "NSAutoFillHeuristicControllerEnabled": false,
         ])
     }
 


### PR DESCRIPTION
Fixes #8616

macOS 26 (as of RC1) has some pathological performance bug where the terminal becomes unusably slow after some period of time. We aren't 100% sure what triggers the slowdown, but it is app-wide (new tabs or windows don't resolve it) and Instruments traces point directly to NSAutoFillHeuristicController. Specifically, to the `debounceTextUpdate` selector.

This is all not documented as far as I can find and also not open source, so I have no idea what's going on.

The best I can tell is that the NSAutoFillHeuristicController has something to do with enabling heuristic-based autofill such as SMS auth codes in text input fields. I don't know what is causing it to go haywire.

SMS autofill is not desirable in a terminal app, nor is any of the other automatic autofill in macOS I know of (contact info, passwords, etc.). So, we can just disable it.

This default isn't documented but I found it via a strings dump of the AppKit binary blob and comparing it to the disassembly to see how it is used. In my limited testing, this seems to work around the problem.