### PR TITLE
ci: update tag release to Xcode 26, sparkle to 2.7.3

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -39,7 +39,7 @@ jobs:
 
           echo "Version is valid: ${{ github.event.inputs.version }}"
 
-      - name: Exract the Version
+      - name: Extract the Version
         id: extract_version
         run: |
           if [[ "${{ github.event_name }}" == "push" ]]; then
@@ -139,14 +139,14 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: XCode Select
-        run: sudo xcode-select -s /Applications/Xcode_16.4.app
+        run: sudo xcode-select -s /Applications/Xcode_26.0.app
 
       - name: Xcode Version
         run: xcodebuild -version
 
       - name: Setup Sparkle
         env:
-          SPARKLE_VERSION: 2.7.1
+          SPARKLE_VERSION: 2.7.3
         run: |
           mkdir -p .action/sparkle
           cd .action/sparkle
@@ -311,7 +311,7 @@ jobs:
 
       - name: Setup Sparkle
         env:
-          SPARKLE_VERSION: 2.7.1
+          SPARKLE_VERSION: 2.7.3
         run: |
           mkdir -p .action/sparkle
           cd .action/sparkle

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -243,7 +243,7 @@ jobs:
       # Setup Sparkle
       - name: Setup Sparkle
         env:
-          SPARKLE_VERSION: 2.7.1
+          SPARKLE_VERSION: 2.7.3
         run: |
           mkdir -p .action/sparkle
           cd .action/sparkle
@@ -481,7 +481,7 @@ jobs:
       # Setup Sparkle
       - name: Setup Sparkle
         env:
-          SPARKLE_VERSION: 2.7.1
+          SPARKLE_VERSION: 2.7.3
         run: |
           mkdir -p .action/sparkle
           cd .action/sparkle
@@ -666,7 +666,7 @@ jobs:
       # Setup Sparkle
       - name: Setup Sparkle
         env:
-          SPARKLE_VERSION: 2.7.1
+          SPARKLE_VERSION: 2.7.3
         run: |
           mkdir -p .action/sparkle
           cd .action/sparkle


### PR DESCRIPTION
Our built sparkle was always 2.7.3 recently, this just updates our CI jobs for the auxiliary binaries.