### PR TITLE
pin iTerm2 themes dependency

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -112,8 +112,8 @@
         // Other
         .apple_sdk = .{ .path = "./pkg/apple-sdk" },
         .iterm2_themes = .{
-            .url = "https://github.com/mbadolato/iTerm2-Color-Schemes/releases/download/release-20250915-154825-b4500fc/ghostty-themes.tgz",
-            .hash = "N-V-__8AANodAwCEvYCmi9reftwnr5UhMTCWm1aFAfhImHqB",
+            .url = "https://deps.files.ghostty.org/ghostty-themes-20250915-162204-b1fe546.tgz",
+            .hash = "N-V-__8AANodAwDnyHwhlOv5cVRn2rx_dTvija-wy5YtTw1B",
             .lazy = true,
         },
     },

--- a/build.zig.zon.json
+++ b/build.zig.zon.json
@@ -49,10 +49,10 @@
     "url": "https://deps.files.ghostty.org/imgui-1220bc6b9daceaf7c8c60f3c3998058045ba0c5c5f48ae255ff97776d9cd8bfc6402.tar.gz",
     "hash": "sha256-oF/QHgTPEat4Hig4fGIdLkIPHmBEyOJ6JeYD6pnveGA="
   },
-  "N-V-__8AANodAwCEvYCmi9reftwnr5UhMTCWm1aFAfhImHqB": {
+  "N-V-__8AANodAwDnyHwhlOv5cVRn2rx_dTvija-wy5YtTw1B": {
     "name": "iterm2_themes",
-    "url": "https://github.com/mbadolato/iTerm2-Color-Schemes/releases/download/release-20250915-154825-b4500fc/ghostty-themes.tgz",
-    "hash": "sha256-/6wSC8KIO1tJVxIXpIH1wiQKJazrx+b8RBt5tEYQPXU="
+    "url": "https://deps.files.ghostty.org/ghostty-themes-20250915-162204-b1fe546.tgz",
+    "hash": "sha256-6rKNFpaUvSbvNZ0/+u0h4I/RRaV5V7xIPQ9y7eNVbCA="
   },
   "N-V-__8AAIC5lwAVPJJzxnCAahSvZTIlG-HhtOvnM1uh-66x": {
     "name": "jetbrains_mono",

--- a/build.zig.zon.nix
+++ b/build.zig.zon.nix
@@ -163,11 +163,11 @@ in
       };
     }
     {
-      name = "N-V-__8AANodAwCEvYCmi9reftwnr5UhMTCWm1aFAfhImHqB";
+      name = "N-V-__8AANodAwDnyHwhlOv5cVRn2rx_dTvija-wy5YtTw1B";
       path = fetchZigArtifact {
         name = "iterm2_themes";
-        url = "https://github.com/mbadolato/iTerm2-Color-Schemes/releases/download/release-20250915-154825-b4500fc/ghostty-themes.tgz";
-        hash = "sha256-/6wSC8KIO1tJVxIXpIH1wiQKJazrx+b8RBt5tEYQPXU=";
+        url = "https://deps.files.ghostty.org/ghostty-themes-20250915-162204-b1fe546.tgz";
+        hash = "sha256-6rKNFpaUvSbvNZ0/+u0h4I/RRaV5V7xIPQ9y7eNVbCA=";
       };
     }
     {

--- a/build.zig.zon.txt
+++ b/build.zig.zon.txt
@@ -8,6 +8,7 @@ https://deps.files.ghostty.org/breakpad-b99f444ba5f6b98cac261cbb391d8766b34a5918
 https://deps.files.ghostty.org/fontconfig-2.14.2.tar.gz
 https://deps.files.ghostty.org/freetype-1220b81f6ecfb3fd222f76cf9106fecfa6554ab07ec7fdc4124b9bb063ae2adf969d.tar.gz
 https://deps.files.ghostty.org/gettext-0.24.tar.gz
+https://deps.files.ghostty.org/ghostty-themes-20250915-162204-b1fe546.tgz
 https://deps.files.ghostty.org/glslang-12201278a1a05c0ce0b6eb6026c65cd3e9247aa041b1c260324bf29cee559dd23ba1.tar.gz
 https://deps.files.ghostty.org/gtk4-layer-shell-1.1.0.tar.gz
 https://deps.files.ghostty.org/harfbuzz-11.0.0.tar.xz
@@ -28,7 +29,6 @@ https://deps.files.ghostty.org/zig_js-12205a66d423259567764fa0fc60c82be35365c21a
 https://deps.files.ghostty.org/ziglyph-b89d43d1e3fb01b6074bc1f7fc980324b04d26a5.tar.gz
 https://deps.files.ghostty.org/zlib-1220fed0c74e1019b3ee29edae2051788b080cd96e90d56836eea857b0b966742efb.tar.gz
 https://github.com/jcollie/ghostty-gobject/releases/download/0.15.1-2025-09-04-48-1/ghostty-gobject-0.15.1-2025-09-04-48-1.tar.zst
-https://github.com/mbadolato/iTerm2-Color-Schemes/releases/download/release-20250915-154825-b4500fc/ghostty-themes.tgz
 https://github.com/mitchellh/libxev/archive/7f803181b158a10fec8619f793e3b4df515566cb.tar.gz
 https://github.com/mitchellh/zig-objc/archive/c9e917a4e15a983b672ca779c7985d738a2d517c.tar.gz
 https://github.com/natecraddock/zf/archive/7aacbe6d155d64d15937ca95ca6c014905eb531f.tar.gz

--- a/flatpak/zig-packages.json
+++ b/flatpak/zig-packages.json
@@ -61,9 +61,9 @@
   },
   {
     "type": "archive",
-    "url": "https://github.com/mbadolato/iTerm2-Color-Schemes/releases/download/release-20250915-154825-b4500fc/ghostty-themes.tgz",
-    "dest": "vendor/p/N-V-__8AANodAwCEvYCmi9reftwnr5UhMTCWm1aFAfhImHqB",
-    "sha256": "ffac120bc2883b5b49571217a481f5c2240a25acebc7e6fc441b79b446103d75"
+    "url": "https://deps.files.ghostty.org/ghostty-themes-20250915-162204-b1fe546.tgz",
+    "dest": "vendor/p/N-V-__8AANodAwDnyHwhlOv5cVRn2rx_dTvija-wy5YtTw1B",
+    "sha256": "eab28d169694bd26ef359d3ffaed21e08fd145a57957bc483d0f72ede3556c20"
   },
   {
     "type": "archive",


### PR DESCRIPTION
There is an upstream bug where subsequent releases will nuke prior released packages, resulting in 404s. Not good!