### PR TITLE
Pass config to splits in NewTerminalConfig

### DIFF
--- a/macos/Sources/Features/App Intents/NewTerminalIntent.swift
+++ b/macos/Sources/Features/App Intents/NewTerminalIntent.swift
@@ -123,7 +123,8 @@ struct NewTerminalIntent: AppIntent {
 
             if let view = controller.newSplit(
                 at: parent,
-                direction: location.splitDirection!
+                direction: location.splitDirection!,
+                baseConfig: config
             ) {
                 return .result(value: TerminalEntity(view))
             }


### PR DESCRIPTION

Config contains the command, working directory, and environment
variables intended to be passed to the new split, but it looks like we
forgot to include it as an argument in this branch.

Discussion: https://github.com/ghostty-org/ghostty/discussions/8637
