### PR TITLE
Bash shell-integration mark ssh wrapper as a function

### DIFF
--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -103,7 +103,7 @@ fi
 
 # SSH Integration
 if [[ "$GHOSTTY_SHELL_FEATURES" == *ssh-* ]]; then
-  ssh() {
+  function ssh() {
     builtin local ssh_term ssh_opts
     ssh_term="xterm-256color"
     ssh_opts=()


### PR DESCRIPTION
mark ssh-wrapper as a function, this follows the other shell-integration wrappers like `sudo`

in bash you aren't required to mark a function with the keyword except in the case the function name is a defined alias

so if a user made an alias for ssh like
```bash
alias ssh="TERM=xterm-256color ssh`
```

then they see an error with the bash shell-integration on startup
```
bash: /mnt/hard-disk/workspace/ghostty/zig-out/share/ghostty/shell-integration/bash/ghostty.bash: line 106: syntax error near unexpected token `('
bash: /mnt/hard-disk/workspace/ghostty/zig-out/share/ghostty/shell-integration/bash/ghostty.bash: line 106: `  ssh() {'
```

someone did run into this
https://github.com/ghostty-org/ghostty/discussions/8641

