### PR TITLE
docs: add lacking version information

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2146,6 +2146,8 @@ keybind: Keybinds = .{},
 /// from the first by a comma (`,`). Percentage and pixel sizes can be mixed
 /// together: for instance, a size of `50%,500px` for a top-positioned quick
 /// terminal would be half a screen tall, and 500 pixels wide.
+///
+/// Available since: 1.2.0
 @"quick-terminal-size": QuickTerminalSize = .{},
 
 /// The layer of the quick terminal window. The higher the layer,


### PR DESCRIPTION
According to the release note (https://ghostty.org/docs/install/release-notes/1-2-0#quick-terminal-size), `quick-terminal-size` option is available since 1.2.0.
At first, I opened a PR in ghostty-org/website (https://github.com/ghostty-org/website/pull/370). Then the bot commented that the part was auto-generated content, so I created this PR.