### PR TITLE
i18n: add Croatian hr_HR translation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -185,6 +185,7 @@
 /po/he_IL.UTF-8.po @ghostty-org/he_IL
 /po/it_IT.UTF-8.po @ghostty-org/it_IT
 /po/zh_TW.UTF-8.po @ghostty-org/zh_TW
+/po/hr_HR.UTF-8.po @ghostty-org/hr_HR
 
 # Packaging - Snap
 /snap/ @ghostty-org/snap

--- a/po/hr_HR.UTF-8.po
+++ b/po/hr_HR.UTF-8.po
@@ -210,12 +210,12 @@ msgstr "Dopusti"
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:81
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:77
 msgid "Remember choice for this split"
-msgstr "Zapamti izbor za ovaj podjeljak"
+msgstr "Zapamti izbor za ovu podjelu"
 
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:82
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:78
 msgid "Reload configuration to show this prompt again"
-msgstr "Ponovno učitaj postavke za ponovni prikaz prompta"
+msgstr "Ponovno učitaj postavke za prikaz ovog upita"
 
 #: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:7
 #: src/apprt/gtk/ui/1.2/ccw-osc-52-write.blp:7

--- a/po/hr_HR.UTF-8.po
+++ b/po/hr_HR.UTF-8.po
@@ -48,8 +48,8 @@ msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
 msgstr ""
-"Pronađene su jedna ili više grešaka u postavkama. Pregledaj greške navedene niže,"
-"te ponovno učitaj vaše postavke ili zanemari ove greške."
+"Pronađene su jedna ili više grešaka u postavkama. Pregledaj niže navedene greške,"
+"te ponovno učitaj postavke ili zanemari ove greške."
 
 #: src/apprt/gtk/ui/1.5/config-errors-dialog.blp:9
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:9
@@ -110,7 +110,7 @@ msgstr "Očisti"
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:23
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:78
 msgid "Reset"
-msgstr "Osvježi"
+msgstr "Resetiraj"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:30
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:42

--- a/po/hr_HR.UTF-8.po
+++ b/po/hr_HR.UTF-8.po
@@ -306,7 +306,7 @@ msgstr "Nova podjela"
 msgid ""
 "⚠️ You're running a debug build of Ghostty! Performance will be degraded."
 msgstr ""
-"⚠️ Pokrenuta je debug verzija Ghosttyja! Performanse će biti smanjene"
+"⚠️ Pokrenuta je debug verzija Ghosttyja! Performanse će biti smanjene."
 
 #: src/apprt/gtk/Window.zig:775
 msgid "Reloaded the configuration"

--- a/po/hr_HR.UTF-8.po
+++ b/po/hr_HR.UTF-8.po
@@ -306,11 +306,11 @@ msgstr "Nova podjela"
 msgid ""
 "⚠️ You're running a debug build of Ghostty! Performance will be degraded."
 msgstr ""
-"⚠️ Pokrenuli ste debug verziju Ghosttyja! Performanse će biti smanjene"
+"⚠️ Pokrenuta je debug verzija Ghosttyja! Performanse će biti smanjene"
 
 #: src/apprt/gtk/Window.zig:775
 msgid "Reloaded the configuration"
-msgstr "Ponovno učitana konfiguracija"
+msgstr "Ponovno učitane postavke"
 
 #: src/apprt/gtk/Window.zig:1019
 msgid "Ghostty Developers"

--- a/po/hr_HR.UTF-8.po
+++ b/po/hr_HR.UTF-8.po
@@ -25,7 +25,7 @@ msgstr "Promijeni naslov terminala"
 
 #: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:6
 msgid "Leave blank to restore the default title."
-msgstr "Ostavi prazno za zadržavanje zadanog naslova."
+msgstr "Ostavi prazno za povratak zadanog naslova."
 
 #: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:9
 #: src/apprt/gtk/ui/1.5/ccw-paste.blp:10 src/apprt/gtk/ui/1.2/ccw-paste.blp:10
@@ -48,7 +48,7 @@ msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
 msgstr ""
-"Pronađene su jedna ili više grešaka u postavkama. Pregledaj niže navedene greške,"
+"Pronađene su jedna ili više grešaka u postavkama. Pregledaj niže navedene greške"
 "te ponovno učitaj postavke ili zanemari ove greške."
 
 #: src/apprt/gtk/ui/1.5/config-errors-dialog.blp:9
@@ -272,7 +272,7 @@ msgstr "Sve sesije terminala u ovoj kartici će biti prekinute."
 
 #: src/apprt/gtk/CloseDialog.zig:99
 msgid "The currently running process in this split will be terminated."
-msgstr "Pokrenuti procesi u ovom podjeljku će biti prekinuti."
+msgstr "Pokrenuti procesi u ovom odjeljku će biti prekinuti."
 
 #: src/apprt/gtk/Surface.zig:1266
 msgid "Copied to clipboard"

--- a/po/hr_HR.UTF-8.po
+++ b/po/hr_HR.UTF-8.po
@@ -1,0 +1,321 @@
+# Croatian translations for com.mitchellh.ghostty package
+# Hrvatski prijevod za paket com.mitchellh.ghostty.
+# Copyright (C) 2025 "Mitchell Hashimoto, Ghostty contributors"
+# This file is distributed under the same license as the com.mitchellh.ghostty package.
+# Filip <filipm7@protonmail.com>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: com.mitchellh.ghostty\n"
+"Report-Msgid-Bugs-To: m@mitchellh.com\n"
+"POT-Creation-Date: 2025-07-22 17:18+0000\n"
+"PO-Revision-Date: 2025-09-16 17:47+0200\n"
+"Last-Translator: Filip7 <filipm7@protonmail.com>\n"
+"Language-Team: Croatian <lokalizacija@linux.hr>\n"
+"Language: hr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:5
+msgid "Change Terminal Title"
+msgstr "Promijeni naslov terminala"
+
+#: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:6
+msgid "Leave blank to restore the default title."
+msgstr "Ostavi prazno za zadržavanje zadanog naslova."
+
+#: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:9
+#: src/apprt/gtk/ui/1.5/ccw-paste.blp:10 src/apprt/gtk/ui/1.2/ccw-paste.blp:10
+#: src/apprt/gtk/CloseDialog.zig:44
+msgid "Cancel"
+msgstr "Otkaži"
+
+#: src/apprt/gtk/ui/1.5/prompt-title-dialog.blp:10
+msgid "OK"
+msgstr "OK"
+
+#: src/apprt/gtk/ui/1.5/config-errors-dialog.blp:5
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:5
+msgid "Configuration Errors"
+msgstr "Greške u postavkama"
+
+#: src/apprt/gtk/ui/1.5/config-errors-dialog.blp:6
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:6
+msgid ""
+"One or more configuration errors were found. Please review the errors below, "
+"and either reload your configuration or ignore these errors."
+msgstr ""
+"Pronađene su jedna ili više grešaka u postavkama. Pregledaj greške navedene niže,"
+"te ponovno učitaj vaše postavke ili zanemari ove greške."
+
+#: src/apprt/gtk/ui/1.5/config-errors-dialog.blp:9
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:9
+msgid "Ignore"
+msgstr "Zanemari"
+
+#: src/apprt/gtk/ui/1.5/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:97
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:100
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+msgid "Reload Configuration"
+msgstr "Ponovno učitaj postavke"
+
+#: src/apprt/gtk/ui/1.0/menu-headerbar-split_menu.blp:6
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:38
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:50
+msgid "Split Up"
+msgstr "Podijeli gore"
+
+#: src/apprt/gtk/ui/1.0/menu-headerbar-split_menu.blp:11
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:43
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:55
+msgid "Split Down"
+msgstr "Podijeli dolje"
+
+#: src/apprt/gtk/ui/1.0/menu-headerbar-split_menu.blp:16
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:48
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:60
+msgid "Split Left"
+msgstr "Podijeli lijevo"
+
+#: src/apprt/gtk/ui/1.0/menu-headerbar-split_menu.blp:21
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:53
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:65
+msgid "Split Right"
+msgstr "Podijeli desno"
+
+#: src/apprt/gtk/ui/1.5/command-palette.blp:16
+msgid "Execute a command…"
+msgstr "Izvrši naredbu…"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:6
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:6
+msgid "Copy"
+msgstr "Kopiraj"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:11
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:11
+#: src/apprt/gtk/ui/1.5/ccw-paste.blp:11 src/apprt/gtk/ui/1.2/ccw-paste.blp:11
+msgid "Paste"
+msgstr "Zalijepi"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:18
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:73
+msgid "Clear"
+msgstr "Očisti"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:23
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:78
+msgid "Reset"
+msgstr "Osvježi"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:30
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:42
+msgid "Split"
+msgstr "Podijeli"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:33
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:45
+msgid "Change Title…"
+msgstr "Promijeni naslov…"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:59
+msgid "Tab"
+msgstr "Kartica"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:62
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:30
+#: src/apprt/gtk/Window.zig:265
+msgid "New Tab"
+msgstr "Nova kartica"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:67
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:35
+msgid "Close Tab"
+msgstr "Zatvori karticu"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:73
+msgid "Window"
+msgstr "Prozor"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:76
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:18
+msgid "New Window"
+msgstr "Novi prozor"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:81
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:23
+msgid "Close Window"
+msgstr "Zatvori prozor"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:89
+msgid "Config"
+msgstr "Postavke"
+
+#: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:92
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:95
+msgid "Open Configuration"
+msgstr "Otvori postavke"
+
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:85
+msgid "Command Palette"
+msgstr "Paleta naredbi"
+
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:90
+msgid "Terminal Inspector"
+msgstr "Inspektor terminala"
+
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:107
+#: src/apprt/gtk/Window.zig:1038
+msgid "About Ghostty"
+msgstr "O Ghosttyju"
+
+#: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:112
+msgid "Quit"
+msgstr "Izađi"
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:6
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:6
+#: src/apprt/gtk/ui/1.2/ccw-osc-52-read.blp:6
+#: src/apprt/gtk/ui/1.2/ccw-osc-52-write.blp:6
+msgid "Authorize Clipboard Access"
+msgstr "Dopusti pristup međuspremniku"
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:7
+#: src/apprt/gtk/ui/1.2/ccw-osc-52-read.blp:7
+msgid ""
+"An application is attempting to read from the clipboard. The current "
+"clipboard contents are shown below."
+msgstr ""
+"Program pokušava pročitati vrijednost međuspremnika. Trenutna"
+"vrijednost međuspremnika je prikazana niže."
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:10
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:10
+#: src/apprt/gtk/ui/1.2/ccw-osc-52-read.blp:10
+#: src/apprt/gtk/ui/1.2/ccw-osc-52-write.blp:10
+msgid "Deny"
+msgstr "Odbij"
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:11
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:11
+#: src/apprt/gtk/ui/1.2/ccw-osc-52-read.blp:11
+#: src/apprt/gtk/ui/1.2/ccw-osc-52-write.blp:11
+msgid "Allow"
+msgstr "Dopusti"
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:81
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:77
+msgid "Remember choice for this split"
+msgstr "Zapamti izbor za ovaj podjeljak"
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-read.blp:82
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:78
+msgid "Reload configuration to show this prompt again"
+msgstr "Ponovno učitaj postavke za ponovni prikaz prompta"
+
+#: src/apprt/gtk/ui/1.5/ccw-osc-52-write.blp:7
+#: src/apprt/gtk/ui/1.2/ccw-osc-52-write.blp:7
+msgid ""
+"An application is attempting to write to the clipboard. The current "
+"clipboard contents are shown below."
+msgstr ""
+"Aplikacija pokušava pisati u međuspremnik. Trenutačna vrijednost "
+"međuspremnika prikazana je niže."
+
+#: src/apprt/gtk/ui/1.5/ccw-paste.blp:6 src/apprt/gtk/ui/1.2/ccw-paste.blp:6
+msgid "Warning: Potentially Unsafe Paste"
+msgstr "Upozorenje: Potencijalno opasno lijepljenje"
+
+#: src/apprt/gtk/ui/1.5/ccw-paste.blp:7 src/apprt/gtk/ui/1.2/ccw-paste.blp:7
+msgid ""
+"Pasting this text into the terminal may be dangerous as it looks like some "
+"commands may be executed."
+msgstr ""
+"Lijepljenje ovog teksta u terminal može biti opasno jer se čini da "
+"neke naredbe mogu biti izvršene."
+
+#: src/apprt/gtk/CloseDialog.zig:47 src/apprt/gtk/Surface.zig:2531
+msgid "Close"
+msgstr "Zatvori"
+
+#: src/apprt/gtk/CloseDialog.zig:87
+msgid "Quit Ghostty?"
+msgstr "Zatvori Ghostty?"
+
+#: src/apprt/gtk/CloseDialog.zig:88
+msgid "Close Window?"
+msgstr "Zatvori prozor?"
+
+#: src/apprt/gtk/CloseDialog.zig:89
+msgid "Close Tab?"
+msgstr "Zatvori karticu?"
+
+#: src/apprt/gtk/CloseDialog.zig:90
+msgid "Close Split?"
+msgstr "Zatvori podjelu?"
+
+#: src/apprt/gtk/CloseDialog.zig:96
+msgid "All terminal sessions will be terminated."
+msgstr "Sve sesije terminala će biti prekinute."
+
+#: src/apprt/gtk/CloseDialog.zig:97
+msgid "All terminal sessions in this window will be terminated."
+msgstr "Sve sesije terminala u ovom prozoru će biti prekinute."
+
+#: src/apprt/gtk/CloseDialog.zig:98
+msgid "All terminal sessions in this tab will be terminated."
+msgstr "Sve sesije terminala u ovoj kartici će biti prekinute."
+
+#: src/apprt/gtk/CloseDialog.zig:99
+msgid "The currently running process in this split will be terminated."
+msgstr "Pokrenuti procesi u ovom podjeljku će biti prekinuti."
+
+#: src/apprt/gtk/Surface.zig:1266
+msgid "Copied to clipboard"
+msgstr "Kopirano u međuspremnik"
+
+#: src/apprt/gtk/Surface.zig:1268
+msgid "Cleared clipboard"
+msgstr "Očišćen međuspremnik"
+
+#: src/apprt/gtk/Surface.zig:2525
+msgid "Command succeeded"
+msgstr "Naredba je uspjela"
+
+#: src/apprt/gtk/Surface.zig:2527
+msgid "Command failed"
+msgstr "Naredba nije uspjela"
+
+#: src/apprt/gtk/Window.zig:216
+msgid "Main Menu"
+msgstr "Glavni izbornik"
+
+#: src/apprt/gtk/Window.zig:239
+msgid "View Open Tabs"
+msgstr "Pregledaj otvorene kartice"
+
+#: src/apprt/gtk/Window.zig:266
+msgid "New Split"
+msgstr "Nova podjela"
+
+#: src/apprt/gtk/Window.zig:329
+msgid ""
+"⚠️ You're running a debug build of Ghostty! Performance will be degraded."
+msgstr ""
+"⚠️ Pokrenuli ste debug verziju Ghosttyja! Performanse će biti smanjene"
+
+#: src/apprt/gtk/Window.zig:775
+msgid "Reloaded the configuration"
+msgstr "Ponovno učitana konfiguracija"
+
+#: src/apprt/gtk/Window.zig:1019
+msgid "Ghostty Developers"
+msgstr "Razvijatelji Ghosttyja"
+
+#: src/apprt/gtk/inspector.zig:144
+msgid "Ghostty: Terminal Inspector"
+msgstr "Ghostty: inspektor terminala"

--- a/src/os/i18n_locales.zig
+++ b/src/os/i18n_locales.zig
@@ -51,4 +51,5 @@ pub const locales = [_][:0]const u8{
     "hu_HU.UTF-8",
     "he_IL.UTF-8",
     "zh_TW.UTF-8",
+    "hr_HR.UTF-8",
 };


### PR DESCRIPTION
Used ispravi.me for grammar checks and referenced pravopis.hr for certain grammar rules.

Most notably checked for how to write "Ghostty" in certain situations where we change the word ending in Croatian. Check section "c) strana imena:", example Vigny
http://pravopis.hr/pravilo/pisanje-oblika-i-posvojnih-pridjeva-od-opcih-rijeci-i-imena/48/
^ not sure why they still use http...

Tried double checking with Mistral Le chat, but it's not really good with Croatian and really did not want to fight battles with LLMs, so this here is my best effort.

The tone in the translations is informal Croatian.

