### PR TITLE
font-size reloads at runtime if the font wasn't manually set

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -66,6 +66,12 @@ font_grid_key: font.SharedGridSet.Key,
 font_size: font.face.DesiredSize,
 font_metrics: font.Metrics,
 
+/// This keeps track of if the font size was ever modified. If it wasn't,
+/// then config reloading will change the font. If it was manually adjusted,
+/// we don't change it on config reload since we assume the user wants
+/// a specific size.
+font_size_adjusted: bool,
+
 /// The renderer for this surface.
 renderer: Renderer,
 
@@ -514,6 +520,7 @@ pub fn init(
         .rt_surface = rt_surface,
         .font_grid_key = font_grid_key,
         .font_size = font_size,
+        .font_size_adjusted = false,
         .font_metrics = font_grid.metrics,
         .renderer = renderer_impl,
         .renderer_thread = render_thread,
@@ -1446,7 +1453,21 @@ pub fn updateConfig(
     // but this is easier and pretty rare so it's not a performance concern.
     //
     // (Calling setFontSize builds and sends a new font grid to the renderer.)
-    try self.setFontSize(self.font_size);
+    try self.setFontSize(font_size: {
+        // If we have manually adjusted the font size, keep it that way.
+        if (self.font_size_adjusted) {
+            log.info("font size manually adjusted, preserving previous size on config reload", .{});
+            break :font_size self.font_size;
+        }
+
+        // If we haven't, then we update to the configured font size.
+        // This allows config changes to update the font size. We used to
+        // never do this but it was a common source of confusion and people
+        // assumed that Ghostty was broken! This logic makes more sense.
+        var size = self.font_size;
+        size.points = std.math.clamp(config.@"font-size", 1.0, 255.0);
+        break :font_size size;
+    });
 
     // We need to store our configs in a heap-allocated pointer so that
     // our messages aren't huge.
@@ -4637,10 +4658,13 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
 
             log.debug("increase font size={}", .{clamped_delta});
 
-            var size = self.font_size;
             // Max point size is somewhat arbitrary.
+            var size = self.font_size;
             size.points = @min(size.points + clamped_delta, 255);
             try self.setFontSize(size);
+
+            // Mark that we manually adjusted the font size
+            self.font_size_adjusted = true;
         },
 
         .decrease_font_size => |delta| {
@@ -4652,6 +4676,9 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             var size = self.font_size;
             size.points = @max(1, size.points - clamped_delta);
             try self.setFontSize(size);
+
+            // Mark that we manually adjusted the font size
+            self.font_size_adjusted = true;
         },
 
         .reset_font_size => {
@@ -4660,6 +4687,9 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             var size = self.font_size;
             size.points = self.config.original_font_size;
             try self.setFontSize(size);
+
+            // Reset font size also resets the manual adjustment state
+            self.font_size_adjusted = false;
         },
 
         .set_font_size => |points| {
@@ -4668,6 +4698,9 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             var size = self.font_size;
             size.points = std.math.clamp(points, 1.0, 255.0);
             try self.setFontSize(size);
+
+            // Mark that we manually adjusted the font size
+            self.font_size_adjusted = true;
         },
 
         .prompt_surface_title => return try self.rt_app.performAction(

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -127,9 +127,6 @@ pub const compatibility = std.StaticStringMap(
 /// this within config files if you want to clear previously set values in
 /// configuration files or on the CLI if you want to clear values set on the
 /// CLI.
-///
-/// Changing this configuration at runtime will only affect new terminals, i.e.
-/// new windows, tabs, etc.
 @"font-family": RepeatableString = .{},
 @"font-family-bold": RepeatableString = .{},
 @"font-family-italic": RepeatableString = .{},
@@ -214,11 +211,12 @@ pub const compatibility = std.StaticStringMap(
 ///
 /// For example, 13.5pt @ 2px/pt = 27px
 ///
-/// Changing this configuration at runtime will only affect new terminals,
-/// i.e. new windows, tabs, etc. Note that you may still not see the change
-/// depending on your `window-inherit-font-size` setting. If that setting is
-/// true, only the first window will be affected by this change since all
-/// subsequent windows will inherit the font size of the previous window.
+/// Changing this configuration at runtime will only affect existing
+/// terminals that have NOT manually adjusted their font size in some way
+/// (e.g. increased or decreased the font size). Terminals that have manually
+/// adjusted their font size will retain their manually adjusted size.
+/// Otherwise, the font size of existing terminals will be updated on
+/// reload.
 ///
 /// On Linux with GTK, font size is scaled according to both display-wide and
 /// text-specific scaling factors, which are often managed by your desktop


### PR DESCRIPTION
This was a very common pitfall for users. The new logic will reload the font-size at runtime, but only if the font wasn't manually set by the user using actions such as `increase_font_size`, `decrease_font_size`, or `set_font_size`. The `reset_font_size` action will reset our state to assume the font-size wasn't manually set.

This was requested by the Omarchy project since their themes also can adjust font size. It makes sense to me.

I also updated a comment about `font-family` not reloading at runtime; this wasn't true even prior to this commit.