### PR TITLE
selection scrolling should only depend on y value

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4012,7 +4012,7 @@ pub fn cursorPosCallback(
 
     // Stop selection scrolling when inside the viewport within a 1px buffer
     // for fullscreen windows, but only when selection scrolling is active.
-    if (pos.x >= 1 and pos.y >= 1 and self.selection_scroll_active) {
+    if (pos.y >= 1 and self.selection_scroll_active) {
         self.io.queueMessage(
             .{ .selection_scroll = false },
             .locked,


### PR DESCRIPTION
Fixes #8683

The selection scrolling logic should only depend on the y value of the cursor position, not the x value. This presents unwanted scroll behaviors, such as reversing the scroll direction which was just a side effect of attempting to scroll tick to begin with.