### PR TITLE
Default config template be explicit that you do not copy the default values

### DIFF
--- a/src/config/config-template
+++ b/src/config/config-template
@@ -6,14 +6,14 @@
 #   {[path]s}
 #
 # The template does not set any default options, since Ghostty ships
-# with sensible defaults for all options. Users should only need to set
-# options that they want to change from the default.
+# with sensible defaults for all options.
+# Note that you should not paste the output of `ghostty +show-config
+# --default` into your config: some default options actually conflict with each other
+# when explicitly set in a configuration file. Instead, only set the
+# options you actually need.
 #
 # Run `ghostty +show-config --default --docs` to view a list of
 # all available config options and their default values.
-#
-# Do not copy the output of the defaults into your config, like stated above
-# users only need to set options to change the defaults.
 #
 # Additionally, each config option is also explained in detail
 # on Ghostty's website, at https://ghostty.org/docs/config.

--- a/src/config/config-template
+++ b/src/config/config-template
@@ -12,6 +12,9 @@
 # Run `ghostty +show-config --default --docs` to view a list of
 # all available config options and their default values.
 #
+# Do not copy the output of the defaults into your config, like stated above
+# users only need to set options to change the defaults.
+#
 # Additionally, each config option is also explained in detail
 # on Ghostty's website, at https://ghostty.org/docs/config.
 #


### PR DESCRIPTION
This has been brought up against at least 2 times since the 1.2 release.

Ideally this should also have a big warning on the website somewhere.



