### PR TITLE
font: Measure ascii height and use to upper bound ic_width

### DIFF
--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -775,7 +775,10 @@ pub const Face = struct {
         // Cell width is calculated by calculating the widest width of the
         // visible ASCII characters. Usually 'M' is widest but we just take
         // whatever is widest.
-        const cell_width: f64 = cell_width: {
+        //
+        // ASCII height is calculated as the height of the overall bounding
+        // box of the same characters.
+        const cell_width: f64, const ascii_height: f64 = measurements: {
             // Build a comptime array of all the ASCII chars
             const unichars = comptime unichars: {
                 const len = 127 - 32;
@@ -803,7 +806,10 @@ pub const Face = struct {
                 max = @max(advances[i].width, max);
             }
 
-            break :cell_width max;
+            // Get the overall bounding rect for the glyphs
+            const rect = ct_font.getBoundingRectsForGlyphs(.horizontal, &glyphs, null);
+
+            break :measurements .{ max, rect.size.height };
         };
 
         // Measure "水" (CJK water ideograph, U+6C34) for our ic width.
@@ -864,6 +870,7 @@ pub const Face = struct {
 
             .cap_height = cap_height,
             .ex_height = ex_height,
+            .ascii_height = ascii_height,
             .ic_width = ic_width,
         };
     }


### PR DESCRIPTION
Measure the ~actual height between the ascender and descender lines as the height of the~ overall bounding box of the font's ASCII characters[^1], and use this to upper bound the IC width estimate. This ensures that the scaling of fallback CJK fonts to a wide-aspect primary font doesn't result in oversized CJK glyphs.

Fixes #8709.

I'd appreciate feedback from Chinese speakers on the suitability of this metric across a variety of primary fonts.

Screenshots using an empty Ghostty config on macOS and the test file from #8651. The font loaded as fallback for CJK is PingFang SC.

**1.2.0**
<img width="592" height="301" alt="Screenshot 2025-09-17 at 09 51 43" src="https://github.com/user-attachments/assets/e553885d-009a-4205-88c9-24747b195211" />

**This PR**
<img width="592" height="301" alt="Screenshot 2025-09-17 at 09 51 25" src="https://github.com/user-attachments/assets/3a8e8d95-ec0a-4d23-a5f0-85b2f47253e3" />

[^1]: Note that this may be different from the difference between the nominal ascent - descent, as non-letter ASCII characters often exceed the ascender and descnder lines, and fonts often bake the line gap into the ascent/descent and set `line_gap` to zero, as per official recommendations like those from Google Fonts: https://simoncozens.github.io/gf-docs/metrics.html