### PR TITLE
renderer/metal: provide MTLTextureUsage render target for custom shaders

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -273,6 +273,15 @@ pub inline fn textureOptions(self: Metal) Texture.Options {
             .cpu_cache_mode = .write_combined,
             .storage_mode = self.default_storage_mode,
         },
+        .usage = .{
+            // textureOptions is currently only used for custom shaders,
+            // which require both the shader read (for when multiple shaders
+            // are chained) and render target (for the final output) usage.
+            // Disabling either of these will lead to metal validation
+            // errors in Xcode.
+            .shader_read = true,
+            .render_target = true,
+        },
     };
 }
 
@@ -311,6 +320,10 @@ pub inline fn imageTextureOptions(
             .cpu_cache_mode = .write_combined,
             .storage_mode = self.default_storage_mode,
         },
+        .usage = .{
+            // We only need to read from this texture from a shader.
+            .shader_read = true,
+        },
     };
 }
 
@@ -333,6 +346,10 @@ pub fn initAtlasTexture(
                 // Indicate that the CPU writes to this resource but never reads it.
                 .cpu_cache_mode = .write_combined,
                 .storage_mode = self.default_storage_mode,
+            },
+            .usage = .{
+                // We only need to read from this texture from a shader.
+                .shader_read = true,
             },
         },
         atlas.size,

--- a/src/renderer/metal/Texture.zig
+++ b/src/renderer/metal/Texture.zig
@@ -18,6 +18,7 @@ pub const Options = struct {
     device: objc.Object,
     pixel_format: mtl.MTLPixelFormat,
     resource_options: mtl.MTLResourceOptions,
+    usage: mtl.MTLTextureUsage,
 };
 
 /// The underlying MTLTexture Object.
@@ -57,6 +58,7 @@ pub fn init(
     desc.setProperty("width", @as(c_ulong, width));
     desc.setProperty("height", @as(c_ulong, height));
     desc.setProperty("resourceOptions", opts.resource_options);
+    desc.setProperty("usage", opts.usage);
 
     // Initialize
     const id = opts.device.msgSend(


### PR DESCRIPTION
This fixes a Metal validation error in Xcode when using custom shaders.  I suspect this is one part of custom shaders not working properly on Intel macs (probably anything with a discrete GPU).

This happens to work on Apple Silicon but this is undefined behavior and we're just getting lucky.

There is one more issue I'm chasing down that I think is also still blocking custom shaders working on Intel macs.