### PR TITLE
renderer: create explicit sampler state for custom shaders

### DIFF
--- a/pkg/opengl/Sampler.zig
+++ b/pkg/opengl/Sampler.zig
@@ -1,0 +1,43 @@
+const Sampler = @This();
+
+const std = @import("std");
+const c = @import("c.zig").c;
+const errors = @import("errors.zig");
+const glad = @import("glad.zig");
+const Texture = @import("Texture.zig");
+
+id: c.GLuint,
+
+/// Create a single sampler.
+pub fn create() errors.Error!Sampler {
+    var id: c.GLuint = undefined;
+    glad.context.GenSamplers.?(1, &id);
+    try errors.getError();
+    return .{ .id = id };
+}
+
+/// glBindSampler
+pub fn bind(v: Sampler, index: c_uint) !void {
+    glad.context.BindSampler.?(index, v.id);
+    try errors.getError();
+}
+
+pub fn parameter(
+    self: Sampler,
+    name: Texture.Parameter,
+    value: anytype,
+) errors.Error!void {
+    switch (@TypeOf(value)) {
+        c.GLint => glad.context.SamplerParameteri.?(
+            self.id,
+            @intFromEnum(name),
+            value,
+        ),
+        else => unreachable,
+    }
+    try errors.getError();
+}
+
+pub fn destroy(v: Sampler) void {
+    glad.context.DeleteSamplers.?(1, &v.id);
+}

--- a/pkg/opengl/main.zig
+++ b/pkg/opengl/main.zig
@@ -18,6 +18,7 @@ pub const Buffer = @import("Buffer.zig");
 pub const Framebuffer = @import("Framebuffer.zig");
 pub const Renderbuffer = @import("Renderbuffer.zig");
 pub const Program = @import("Program.zig");
+pub const Sampler = @import("Sampler.zig");
 pub const Shader = @import("Shader.zig");
 pub const Texture = @import("Texture.zig");
 pub const VertexArray = @import("VertexArray.zig");

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -25,6 +25,7 @@ pub const RenderPass = @import("metal/RenderPass.zig");
 pub const Pipeline = @import("metal/Pipeline.zig");
 const bufferpkg = @import("metal/buffer.zig");
 pub const Buffer = bufferpkg.Buffer;
+pub const Sampler = @import("metal/Sampler.zig");
 pub const Texture = @import("metal/Texture.zig");
 pub const shaders = @import("metal/shaders.zig");
 
@@ -282,6 +283,18 @@ pub inline fn textureOptions(self: Metal) Texture.Options {
             .shader_read = true,
             .render_target = true,
         },
+    };
+}
+
+pub inline fn samplerOptions(self: Metal) Sampler.Options {
+    return .{
+        .device = self.device,
+
+        // These parameters match Shadertoy behaviors.
+        .min_filter = .linear,
+        .mag_filter = .linear,
+        .s_address_mode = .clamp_to_edge,
+        .t_address_mode = .clamp_to_edge,
     };
 }
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -20,6 +20,7 @@ pub const RenderPass = @import("opengl/RenderPass.zig");
 pub const Pipeline = @import("opengl/Pipeline.zig");
 const bufferpkg = @import("opengl/buffer.zig");
 pub const Buffer = bufferpkg.Buffer;
+pub const Sampler = @import("opengl/Sampler.zig");
 pub const Texture = @import("opengl/Texture.zig");
 pub const shaders = @import("opengl/shaders.zig");
 
@@ -357,6 +358,17 @@ pub inline fn textureOptions(self: OpenGL) Texture.Options {
         .format = .rgba,
         .internal_format = .srgba,
         .target = .@"2D",
+        .min_filter = .linear,
+        .mag_filter = .linear,
+        .wrap_s = .clamp_to_edge,
+        .wrap_t = .clamp_to_edge,
+    };
+}
+
+/// Returns the options to use when constructing samplers.
+pub inline fn samplerOptions(self: OpenGL) Sampler.Options {
+    _ = self;
+    return .{
         .min_filter = .linear,
         .mag_filter = .linear,
         .wrap_s = .clamp_to_edge,

--- a/src/renderer/metal/RenderPass.zig
+++ b/src/renderer/metal/RenderPass.zig
@@ -9,6 +9,7 @@ const objc = @import("objc");
 
 const mtl = @import("api.zig");
 const Pipeline = @import("Pipeline.zig");
+const Sampler = @import("Sampler.zig");
 const Texture = @import("Texture.zig");
 const Target = @import("Target.zig");
 const Metal = @import("../Metal.zig");
@@ -41,6 +42,9 @@ pub const Step = struct {
     /// MTLBuffer
     buffers: []const ?objc.Object = &.{},
     textures: []const ?Texture = &.{},
+    /// Set of samplers to use for this step. The index maps to an index
+    /// of a fragment texture, set via setFragmentSamplerState(_:index:).
+    samplers: []const ?Sampler = &.{},
     draw: Draw,
 
     /// Describes the draw call for this step.
@@ -197,6 +201,15 @@ pub fn step(self: *const Self, s: Step) void {
             void,
             objc.sel("setFragmentTexture:atIndex:"),
             .{ tex.texture.value, @as(c_ulong, i) },
+        );
+    };
+
+    // Set samplers.
+    for (s.samplers, 0..) |samp, i| if (samp) |sampler| {
+        self.encoder.msgSend(
+            void,
+            objc.sel("setFragmentSamplerState:atIndex:"),
+            .{ sampler.sampler.value, @as(c_ulong, i) },
         );
     };
 

--- a/src/renderer/metal/Sampler.zig
+++ b/src/renderer/metal/Sampler.zig
@@ -1,0 +1,66 @@
+//! Wrapper for handling samplers.
+const Self = @This();
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const assert = std.debug.assert;
+const builtin = @import("builtin");
+const objc = @import("objc");
+
+const mtl = @import("api.zig");
+const Metal = @import("../Metal.zig");
+
+const log = std.log.scoped(.metal);
+
+/// Options for initializing a sampler.
+pub const Options = struct {
+    /// MTLDevice
+    device: objc.Object,
+    min_filter: mtl.MTLSamplerMinMagFilter,
+    mag_filter: mtl.MTLSamplerMinMagFilter,
+    s_address_mode: mtl.MTLSamplerAddressMode,
+    t_address_mode: mtl.MTLSamplerAddressMode,
+};
+
+/// The underlying MTLSamplerState Object.
+sampler: objc.Object,
+
+pub const Error = error{
+    /// A Metal API call failed.
+    MetalFailed,
+};
+
+/// Initialize a sampler
+pub fn init(
+    opts: Options,
+) Error!Self {
+    // Create our descriptor
+    const desc = init: {
+        const Class = objc.getClass("MTLSamplerDescriptor").?;
+        const id_alloc = Class.msgSend(objc.Object, objc.sel("alloc"), .{});
+        const id_init = id_alloc.msgSend(objc.Object, objc.sel("init"), .{});
+        break :init id_init;
+    };
+    defer desc.release();
+
+    // Properties
+    desc.setProperty("minFilter", opts.min_filter);
+    desc.setProperty("magFilter", opts.mag_filter);
+    desc.setProperty("sAddressMode", opts.s_address_mode);
+    desc.setProperty("tAddressMode", opts.t_address_mode);
+
+    // Create the sampler state
+    const id = opts.device.msgSend(
+        ?*anyopaque,
+        objc.sel("newSamplerStateWithDescriptor:"),
+        .{desc},
+    ) orelse return error.MetalFailed;
+
+    return .{
+        .sampler = objc.Object.fromId(id),
+    };
+}
+
+pub fn deinit(self: Self) void {
+    self.sampler.release();
+}

--- a/src/renderer/opengl/RenderPass.zig
+++ b/src/renderer/opengl/RenderPass.zig
@@ -8,6 +8,7 @@ const builtin = @import("builtin");
 const gl = @import("opengl");
 
 const OpenGL = @import("../OpenGL.zig");
+const Sampler = @import("Sampler.zig");
 const Target = @import("Target.zig");
 const Texture = @import("Texture.zig");
 const Pipeline = @import("Pipeline.zig");
@@ -35,6 +36,7 @@ pub const Step = struct {
     uniforms: ?gl.Buffer = null,
     buffers: []const ?gl.Buffer = &.{},
     textures: []const ?Texture = &.{},
+    samplers: []const ?Sampler = &.{},
     draw: Draw,
 
     /// Describes the draw call for this step.
@@ -101,6 +103,11 @@ pub fn step(self: *Self, s: Step) void {
     for (s.textures, 0..) |t, i| if (t) |tex| {
         gl.Texture.active(@intCast(i)) catch return;
         _ = tex.texture.bind(tex.target) catch return;
+    };
+
+    // Bind relevant samplers.
+    for (s.samplers, 0..) |s_, i| if (s_) |sampler| {
+        _ = sampler.sampler.bind(@intCast(i)) catch return;
     };
 
     // Bind 0th buffer as the vertex buffer,

--- a/src/renderer/opengl/Sampler.zig
+++ b/src/renderer/opengl/Sampler.zig
@@ -1,0 +1,47 @@
+//! Wrapper for handling samplers.
+const Self = @This();
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const assert = std.debug.assert;
+const builtin = @import("builtin");
+const gl = @import("opengl");
+
+const OpenGL = @import("../OpenGL.zig");
+
+const log = std.log.scoped(.opengl);
+
+/// Options for initializing a sampler.
+pub const Options = struct {
+    min_filter: gl.Texture.MinFilter,
+    mag_filter: gl.Texture.MagFilter,
+    wrap_s: gl.Texture.Wrap,
+    wrap_t: gl.Texture.Wrap,
+};
+
+sampler: gl.Sampler,
+
+pub const Error = error{
+    /// An OpenGL API call failed.
+    OpenGLFailed,
+};
+
+/// Initialize a sampler
+pub fn init(
+    opts: Options,
+) Error!Self {
+    const sampler = gl.Sampler.create() catch return error.OpenGLFailed;
+    errdefer sampler.destroy();
+    sampler.parameter(.WrapS, @intFromEnum(opts.wrap_s)) catch return error.OpenGLFailed;
+    sampler.parameter(.WrapT, @intFromEnum(opts.wrap_t)) catch return error.OpenGLFailed;
+    sampler.parameter(.MinFilter, @intFromEnum(opts.min_filter)) catch return error.OpenGLFailed;
+    sampler.parameter(.MagFilter, @intFromEnum(opts.mag_filter)) catch return error.OpenGLFailed;
+
+    return .{
+        .sampler = sampler,
+    };
+}
+
+pub fn deinit(self: Self) void {
+    self.sampler.destroy();
+}


### PR DESCRIPTION
The GLSL to MSL conversion process uses a passed-in sampler state for the `iChannel0` parameter and we weren't providing it. This magically worked on Apple Silicon for unknown reasons but failed on Intel GPUs.

In normal, hand-written MSL, we'd explicitly create the sampler state as a normal variable (we do this in `shaders.metal` already!), but the Shadertoy conversion stuff doesn't do this, probably because the exact sampler parameters can't be safely known.

This fixes a Metal validation error when using custom shaders:

```
-[MTLDebugRenderCommandEncoder validateCommonDrawErrors:]:5970: failed 
assertion `Draw Errors Validation Fragment Function(main0): missing Sampler 
binding at index 0 for iChannel0Smplr[0].
```

This wasn't a simple error message, the assertion would cause Xcode 26 to halt the program at that point.