### PR TITLE
documentation: fix MacOSDockDropBehavior valid values

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2710,7 +2710,7 @@ keybind: Keybinds = .{},
 ///
 ///   * `new-tab` - Create a new tab in the current window, or open
 ///     a new window if none exist.
-///   * `new-window` - Create a new window unconditionally.
+///   * `window` - Create a new window unconditionally.
 ///
 /// The default value is `new-tab`.
 ///


### PR DESCRIPTION
The documentation shows that the enum values should be "new-window" and "new-tab", 
However, "new-window" currently fails, but "window" is still accepted. 