### PR TITLE
fix default increase_font_size binding config from physical to unicode

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -5620,7 +5620,7 @@ pub const Keybinds = struct {
         // set the expected keybind for the menu.
         try self.set.put(
             alloc,
-            .{ .key = .{ .physical = .equal }, .mods = inputpkg.ctrlOrSuper(.{}) },
+            .{ .key = .{ .unicode = '=' }, .mods = inputpkg.ctrlOrSuper(.{}) },
             .{ .increase_font_size = 1 },
         );
         try self.set.put(


### PR DESCRIPTION
During d015efc87d59f873e2ae7a5df8fa432cd5db2bdc some of the bindings were converted from physical keys to unicode. The binding for font size increase via `=` was missed. Therefore there was an inconsistency between font size increase and font size decrease. Decreasing with `-` would be relative to the keyboard layout, whereas increase required the physical `=` key.

Dedicated discussion: https://github.com/ghostty-org/ghostty/discussions/8743
Original thread on: https://github.com/ghostty-org/ghostty/discussions/8729#discussioncomment-14439306

I've ran `zig build run` to sanity check the behaviour and all seems well.
Let me know if there's anything else I need to do.

---

A work-around in the mean time is:
```
keybind = ctrl+equal=unbind
keybind = ctrl+==increase_font_size:1
```