### PR TITLE
macos: set initial window in TerminalWindow awakeFromNib

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -863,14 +863,6 @@ class BaseTerminalController: NSWindowController,
         // Everything beyond here is setting up the window
         guard let window else { return }
 
-        // If there is a hardcoded title in the configuration, we set that
-        // immediately. Future `set_title` apprt actions will override this
-        // if necessary but this ensures our window loads with the proper
-        // title immediately rather than on another event loop tick (see #5934)
-        if let title = derivedConfig.title {
-            window.title = title
-        }
-
         // We always initialize our fullscreen style to native if we can because
         // initialization sets up some state (i.e. observers). If its set already
         // somehow we don't do this.
@@ -1072,20 +1064,17 @@ class BaseTerminalController: NSWindowController,
     }
 
     private struct DerivedConfig {
-        let title: String?
         let macosTitlebarProxyIcon: Ghostty.MacOSTitlebarProxyIcon
         let windowStepResize: Bool
         let focusFollowsMouse: Bool
 
         init() {
-            self.title = nil
             self.macosTitlebarProxyIcon = .visible
             self.windowStepResize = false
             self.focusFollowsMouse = false
         }
 
         init(_ config: Ghostty.Config) {
-            self.title = config.title
             self.macosTitlebarProxyIcon = config.macosTitlebarProxyIcon
             self.windowStepResize = config.windowStepResize
             self.focusFollowsMouse = config.focusFollowsMouse

--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -49,6 +49,14 @@ class TerminalWindow: NSWindow {
 
         // Setup our initial config
         derivedConfig = .init(config)
+        
+        // If there is a hardcoded title in the configuration, we set that
+        // immediately. Future `set_title` apprt actions will override this
+        // if necessary but this ensures our window loads with the proper
+        // title immediately rather than on another event loop tick (see #5934)
+        if let title = derivedConfig.title {
+            self.title = title
+        }
 
         // If window decorations are disabled, remove our title
         if (!config.windowDecorations) { styleMask.remove(.titled) }
@@ -432,17 +440,20 @@ class TerminalWindow: NSWindow {
     // MARK: Config
 
     struct DerivedConfig {
+        let title: String?
         let backgroundColor: NSColor
         let backgroundOpacity: Double
         let macosWindowButtons: Ghostty.MacOSWindowButtons
 
         init() {
+            self.title = nil
             self.backgroundColor = NSColor.windowBackgroundColor
             self.backgroundOpacity = 1
             self.macosWindowButtons = .visible
         }
 
         init(_ config: Ghostty.Config) {
+            self.title = config.title
             self.backgroundColor = NSColor(config.backgroundColor)
             self.backgroundOpacity = config.backgroundOpacity
             self.macosWindowButtons = config.macosWindowButtons


### PR DESCRIPTION
Maybe fixes #8736

I thought `windowDidLoad` was early on because its before the window is shown but apparently not. Let's try `awakeFromNib` which is called just after the window is loaded from the nib. It is hard to get any earlier than that.