### PR TITLE
build: explicitly suffix generated Zig source files

### DIFF
--- a/src/build/HelpStrings.zig
+++ b/src/build/HelpStrings.zig
@@ -31,9 +31,14 @@ pub fn init(b: *std.Build, cfg: *const Config) !HelpStrings {
     exe.root_module.addOptions("build_options", options);
 
     const help_run = b.addRunArtifact(exe);
+
+    // Generated Zig files have to end with .zig
+    const wf = b.addWriteFiles();
+    const output = wf.addCopyFile(help_run.captureStdOut(), "helpgen.zig");
+
     return .{
         .exe = exe,
-        .output = help_run.captureStdOut(),
+        .output = output,
     };
 }
 

--- a/src/build/UnicodeTables.zig
+++ b/src/build/UnicodeTables.zig
@@ -48,11 +48,16 @@ pub fn init(b: *std.Build) !UnicodeTables {
     const props_run = b.addRunArtifact(props_exe);
     const symbols_run = b.addRunArtifact(symbols_exe);
 
+    // Generated Zig files have to end with .zig
+    const wf = b.addWriteFiles();
+    const props_output = wf.addCopyFile(props_run.captureStdOut(), "props.zig");
+    const symbols_output = wf.addCopyFile(symbols_run.captureStdOut(), "symbols.zig");
+
     return .{
         .props_exe = props_exe,
         .symbols_exe = symbols_exe,
-        .props_output = props_run.captureStdOut(),
-        .symbols_output = symbols_run.captureStdOut(),
+        .props_output = props_output,
+        .symbols_output = symbols_output,
     };
 }
 


### PR DESCRIPTION
Previously we're just feeding the compiler source files generated via capturing stdout, which all by default have the filename `stdout`. Under some particular yet uncertain circumstances in Zig 0.14 (only factor we've found so far is a large amount of cores/compilation shards) the compiler will actually crash on an unreachable code path that assumes all source files either end in .zig or .zon, causing crashes for packagers for distros like Nixpkgs and Gentoo.

Given this has been explicitly made illegal in Zig 0.15 (see ziglang/zig#24957) I don't really see why we shouldn't fix this for 1.2 too. We have to do this at some point no matter what anyways.