### PR TITLE
macos: bell-features=title works again

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -688,6 +688,8 @@ class BaseTerminalController: NSWindowController,
            surfaceTree.contains(titleSurface) {
             // If we have a surface, we want to listen for title changes.
             titleSurface.$title
+                .combineLatest(titleSurface.$bell)
+                .map { [weak self] in self?.computeTitle(title: $0, bell: $1) ?? "" }
                 .sink { [weak self] in self?.titleDidChange(to: $0) }
                 .store(in: &focusedSurfaceCancellables)
         } else {
@@ -695,8 +697,17 @@ class BaseTerminalController: NSWindowController,
             titleDidChange(to: "👻")
         }
     }
+    
+    private func computeTitle(title: String, bell: Bool) -> String {
+        var result = title
+        if (bell && ghostty.config.bellFeatures.contains(.title)) {
+            result = "🔔 \(result)"
+        }
 
-    func titleDidChange(to: String) {
+        return result
+    }
+
+    private func titleDidChange(to: String) {
         guard let window else { return }
         
         // Set the main window title

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -625,6 +625,7 @@ extension Ghostty.Config {
         static let audio = BellFeatures(rawValue: 1 << 1)
         static let attention = BellFeatures(rawValue: 1 << 2)
         static let title = BellFeatures(rawValue: 1 << 3)
+        static let border = BellFeatures(rawValue: 1 << 4)
     }
     
     enum MacDockDropBehavior: String {

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -57,15 +57,6 @@ extension Ghostty {
 
         @EnvironmentObject private var ghostty: Ghostty.App
 
-        var title: String {
-            var result = surfaceView.title
-            if (surfaceView.bell && ghostty.config.bellFeatures.contains(.title)) {
-                result = "🔔 \(result)"
-            }
-
-            return result
-        }
-
         var body: some View {
             let center = NotificationCenter.default
 


### PR DESCRIPTION
This was a regression we didn't fix before 1.2.