### PR TITLE
renderer/opengl: minimum contrast for black sets proper color

### DIFF
--- a/src/renderer/shaders/glsl/common.glsl
+++ b/src/renderer/shaders/glsl/common.glsl
@@ -102,7 +102,7 @@ vec4 contrasted_color(float min_ratio, vec4 fg, vec4 bg) {
         if (white_ratio > black_ratio) {
             return vec4(1.0);
         } else {
-            return vec4(0.0);
+            return vec4(0.0, 0.0, 0.0, 1.0);
         }
     }
 


### PR DESCRIPTION
Fixes #8745

When rendering black for minimum contrast we were setting opacity to 0 making it invisible.