### PR TITLE
macos: "new tab" service should set preferred parent to ensure tab

### DIFF
--- a/macos/Sources/Features/Services/ServiceProvider.swift
+++ b/macos/Sources/Features/Services/ServiceProvider.swift
@@ -55,7 +55,10 @@ class ServiceProvider: NSObject {
                 _ = TerminalController.newWindow(delegate.ghostty, withBaseConfig: config)
 
             case .tab:
-                _ = TerminalController.newTab(delegate.ghostty, withBaseConfig: config)
+                _ = TerminalController.newTab(
+                    delegate.ghostty,
+                    from: TerminalController.preferredParent?.window,
+                    withBaseConfig: config)
             }
         }
 

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -184,8 +184,14 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
     static var preferredParent: TerminalController? {
         all.first {
             $0.window?.isMainWindow ?? false
-        } ?? all.last
+        } ?? lastMain ?? all.last
     }
+    
+    // The last controller to be main. We use this when paired with "preferredParent"
+    // to find the preferred window to attach new tabs, perform actions, etc. We
+    // always prefer the main window but if there isn't any (because we're triggered
+    // by something like an App Intent) then we prefer the most previous main.
+    static private(set) weak var lastMain: TerminalController? = nil
 
     /// The "new window" action.
     static func newWindow(
@@ -1036,6 +1042,9 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         if let window {
             LastWindowPosition.shared.save(window)
         }
+        
+        // Remember our last main
+        Self.lastMain = self
     }
 
     // Called when the window will be encoded. We handle the data encoding here in the


### PR DESCRIPTION
Fixes #8783

Our new tab flow will never have a previously focused window because its triggered by a service so we need to use the "preferred parent" logic we have to open this in the last focused window.