### PR TITLE
macos: set the app icon in syncAppearance to delay the icon update

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -860,7 +860,12 @@ class AppDelegate: NSObject,
         } else {
             GlobalEventTap.shared.disable()
         }
+    }
 
+    /// Sync the appearance of our app with the theme specified in the config.
+    private func syncAppearance(config: Ghostty.Config) {
+        NSApplication.shared.appearance = .init(ghosttyConfig: config)
+        
         switch (config.macosIcon) {
         case .official:
             self.appIcon = nil
@@ -907,11 +912,6 @@ class AppDelegate: NSObject,
             ).makeImage() else { break }
             self.appIcon = icon
         }
-    }
-
-    /// Sync the appearance of our app with the theme specified in the config.
-    private func syncAppearance(config: Ghostty.Config) {
-        NSApplication.shared.appearance = .init(ghosttyConfig: config)
     }
 
     //MARK: - Restorable State


### PR DESCRIPTION
Fixes #8734

This forces the app icon to be set on another event loop tick from the main startup. 

In the future, we should load and set the icon completely in another thread. It appears that all the logic we have is totally thread-safe.