### PR TITLE
ci: put a 10 minute timeout on the Debian build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -857,6 +857,7 @@ jobs:
   test-debian-13:
     name: Test build on Debian 13
     runs-on: namespace-profile-ghostty-sm
+    timeout-minutes: 10
     needs: [test, build-dist]
     steps:
       - name: Install and configure Namespace CLI


### PR DESCRIPTION
This usually takes around 2 minutes. I just saw a runaway one spending 30+ minutes.