### PR TITLE
feat: add liquid glass background effect support

### DIFF
--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -627,6 +627,7 @@ class TerminalWindow: NSWindow {
         let backgroundOpacity: Double
         let macosWindowButtons: Ghostty.MacOSWindowButtons
         let macosBackgroundStyle: Ghostty.MacBackgroundStyle
+        let macosTitlebarStyle: String
         let windowCornerRadius: CGFloat
 
         init() {
@@ -635,6 +636,7 @@ class TerminalWindow: NSWindow {
             self.backgroundOpacity = 1
             self.macosWindowButtons = .visible
             self.macosBackgroundStyle = .defaultStyle
+            self.macosTitlebarStyle = "transparent"
             self.windowCornerRadius = 16
         }
 
@@ -644,6 +646,7 @@ class TerminalWindow: NSWindow {
             self.backgroundOpacity = config.backgroundOpacity
             self.macosWindowButtons = config.macosWindowButtons
             self.macosBackgroundStyle = config.macosBackgroundStyle
+            self.macosTitlebarStyle = config.macosTitlebarStyle
 
             // Set corner radius based on macos-titlebar-style
             // Native, transparent, and hidden styles use 16pt radius

--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -480,7 +480,7 @@ class TerminalWindow: NSWindow {
             backgroundColor = .white.withAlphaComponent(0.001)
 
             // Add liquid glass behind terminal content
-            if #available(macOS 26.0, *), derivedConfig.macosBackgroundStyle != .defaultStyle {
+            if #available(macOS 26.0, *), derivedConfig.backgroundBlur.isGlassStyle {
                 setupGlassLayer()
             } else if let appDelegate = NSApp.delegate as? AppDelegate {
                 ghostty_set_window_background_blur(
@@ -590,14 +590,13 @@ class TerminalWindow: NSWindow {
         let effectView = NSGlassEffectView()
 
         // Map Ghostty config to NSGlassEffectView style
-        let backgroundStyle = derivedConfig.macosBackgroundStyle
-        switch backgroundStyle {
-        case .regularGlass:
+        switch derivedConfig.backgroundBlur {
+        case .macosGlassRegular:
             effectView.style = NSGlassEffectView.Style.regular
-        case .clearGlass:
+        case .macosGlassClear:
             effectView.style = NSGlassEffectView.Style.clear
         default:
-            // Should not reach here since we check for "default" before calling setupGlassLayer()
+            // Should not reach here since we check for glass style before calling setupGlassLayer()
             return
         }
 
@@ -623,10 +622,10 @@ class TerminalWindow: NSWindow {
 
     struct DerivedConfig {
         let title: String?
+        let backgroundBlur: Ghostty.Config.BackgroundBlur
         let backgroundColor: NSColor
         let backgroundOpacity: Double
         let macosWindowButtons: Ghostty.MacOSWindowButtons
-        let macosBackgroundStyle: Ghostty.MacBackgroundStyle
         let macosTitlebarStyle: String
         let windowCornerRadius: CGFloat
 
@@ -635,7 +634,7 @@ class TerminalWindow: NSWindow {
             self.backgroundColor = NSColor.windowBackgroundColor
             self.backgroundOpacity = 1
             self.macosWindowButtons = .visible
-            self.macosBackgroundStyle = .defaultStyle
+            self.backgroundBlur = .disabled
             self.macosTitlebarStyle = "transparent"
             self.windowCornerRadius = 16
         }
@@ -645,7 +644,7 @@ class TerminalWindow: NSWindow {
             self.backgroundColor = NSColor(config.backgroundColor)
             self.backgroundOpacity = config.backgroundOpacity
             self.macosWindowButtons = config.macosWindowButtons
-            self.macosBackgroundStyle = config.macosBackgroundStyle
+            self.backgroundBlur = config.backgroundBlur
             self.macosTitlebarStyle = config.macosTitlebarStyle
 
             // Set corner radius based on macos-titlebar-style

--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -480,7 +480,7 @@ class TerminalWindow: NSWindow {
             backgroundColor = .white.withAlphaComponent(0.001)
 
             // Add liquid glass behind terminal content
-            if #available(macOS 26.0, *), derivedConfig.macosBackgroundStyle != .blur {
+            if #available(macOS 26.0, *), derivedConfig.macosBackgroundStyle != .defaultStyle {
                 setupGlassLayer()
             } else if let appDelegate = NSApp.delegate as? AppDelegate {
                 ghostty_set_window_background_blur(
@@ -633,7 +633,7 @@ class TerminalWindow: NSWindow {
             self.backgroundColor = NSColor.windowBackgroundColor
             self.backgroundOpacity = 1
             self.macosWindowButtons = .visible
-            self.macosBackgroundStyle = .blur
+            self.macosBackgroundStyle = .defaultStyle
             self.windowCornerRadius = 16
         }
 

--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -573,6 +573,7 @@ class TerminalWindow: NSWindow {
         }
     }
 
+#if compiler(>=6.2)
     // MARK: Glass
 
     @available(macOS 26.0, *)
@@ -616,8 +617,8 @@ class TerminalWindow: NSWindow {
         glassEffectView?.removeFromSuperview()
         glassEffectView = nil
     }
-
->>>>>>> Conflict 4 of 4 ends
+#endif // compiler(>=6.2)
+    
     // MARK: Config
 
     struct DerivedConfig {

--- a/macos/Sources/Features/Terminal/Window Styles/TransparentTitlebarTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TransparentTitlebarTerminalWindow.swift
@@ -91,8 +91,7 @@ class TransparentTitlebarTerminalWindow: TerminalWindow {
 
             // For glass background styles, use a transparent titlebar to let the glass effect show through
             // Only apply this for transparent and tabs titlebar styles
-            let isGlassStyle = derivedConfig.macosBackgroundStyle == .regularGlass ||
-                               derivedConfig.macosBackgroundStyle == .clearGlass
+            let isGlassStyle = derivedConfig.backgroundBlur.isGlassStyle
             let isTransparentTitlebar = derivedConfig.macosTitlebarStyle == "transparent" ||
                                        derivedConfig.macosTitlebarStyle == "tabs"
 

--- a/macos/Sources/Features/Terminal/Window Styles/TransparentTitlebarTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TransparentTitlebarTerminalWindow.swift
@@ -88,7 +88,17 @@ class TransparentTitlebarTerminalWindow: TerminalWindow {
         // color of the titlebar in native fullscreen view.
         if let titlebarView = titlebarContainer?.firstDescendant(withClassName: "NSTitlebarView") {
             titlebarView.wantsLayer = true
-            titlebarView.layer?.backgroundColor = preferredBackgroundColor?.cgColor
+
+            // For glass background styles, use a transparent titlebar to let the glass effect show through
+            // Only apply this for transparent and tabs titlebar styles
+            let isGlassStyle = derivedConfig.macosBackgroundStyle == .regularGlass ||
+                               derivedConfig.macosBackgroundStyle == .clearGlass
+            let isTransparentTitlebar = derivedConfig.macosTitlebarStyle == "transparent" ||
+                                       derivedConfig.macosTitlebarStyle == "tabs"
+
+            titlebarView.layer?.backgroundColor = (isGlassStyle && isTransparentTitlebar)
+                ? NSColor.clear.cgColor
+                : preferredBackgroundColor?.cgColor
         }
     
         // In all cases, we have to hide the background view since this has multiple subviews

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -261,16 +261,16 @@ extension Ghostty {
             return MacOSWindowButtons(rawValue: str) ?? defaultValue
         }
 
-        var backgroundGlassStyle: String {
-            let defaultValue = "off"
+        var macosBackgroundStyle: MacBackgroundStyle {
+            let defaultValue = MacBackgroundStyle.blur
             guard let config = self.config else { return defaultValue }
             var v: UnsafePointer<Int8>? = nil
-            let key = "background-glass-style"
+            let key = "macos-background-style"
             guard ghostty_config_get(config, &v, key, UInt(key.count)) else { return defaultValue }
             guard let ptr = v else { return defaultValue }
-            return String(cString: ptr)
+            let str = String(cString: ptr)
+            return MacBackgroundStyle(rawValue: str) ?? defaultValue
         }
-
 
         var macosTitlebarStyle: String {
             let defaultValue = "transparent"

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -261,17 +261,6 @@ extension Ghostty {
             return MacOSWindowButtons(rawValue: str) ?? defaultValue
         }
 
-        var macosBackgroundStyle: MacBackgroundStyle {
-            let defaultValue = MacBackgroundStyle.defaultStyle
-            guard let config = self.config else { return defaultValue }
-            var v: UnsafePointer<Int8>? = nil
-            let key = "macos-background-style"
-            guard ghostty_config_get(config, &v, key, UInt(key.count)) else { return defaultValue }
-            guard let ptr = v else { return defaultValue }
-            let str = String(cString: ptr)
-            return MacBackgroundStyle(rawValue: str) ?? defaultValue
-        }
-
         var macosTitlebarStyle: String {
             let defaultValue = "transparent"
             guard let config = self.config else { return defaultValue }
@@ -665,6 +654,16 @@ extension Ghostty.Config {
                 return false
             default:
                 return true
+            }
+        }
+
+        /// Returns true if this is a macOS glass style (regular or clear).
+        var isGlassStyle: Bool {
+            switch self {
+            case .macosGlassRegular, .macosGlassClear:
+                return true
+            default:
+                return false
             }
         }
 

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -261,6 +261,17 @@ extension Ghostty {
             return MacOSWindowButtons(rawValue: str) ?? defaultValue
         }
 
+        var backgroundGlassStyle: String {
+            let defaultValue = "off"
+            guard let config = self.config else { return defaultValue }
+            var v: UnsafePointer<Int8>? = nil
+            let key = "background-glass-style"
+            guard ghostty_config_get(config, &v, key, UInt(key.count)) else { return defaultValue }
+            guard let ptr = v else { return defaultValue }
+            return String(cString: ptr)
+        }
+
+
         var macosTitlebarStyle: String {
             let defaultValue = "transparent"
             guard let config = self.config else { return defaultValue }
@@ -635,7 +646,7 @@ extension Ghostty.Config {
         static let title = BellFeatures(rawValue: 1 << 3)
         static let border = BellFeatures(rawValue: 1 << 4)
     }
-    
+
     enum MacDockDropBehavior: String {
         case new_tab = "new-tab"
         case new_window = "new-window"

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -262,7 +262,7 @@ extension Ghostty {
         }
 
         var macosBackgroundStyle: MacBackgroundStyle {
-            let defaultValue = MacBackgroundStyle.blur
+            let defaultValue = MacBackgroundStyle.defaultStyle
             guard let config = self.config else { return defaultValue }
             var v: UnsafePointer<Int8>? = nil
             let key = "macos-background-style"

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -56,7 +56,7 @@ extension Ghostty {
         case app
         case zig_run
     }
-    
+
     /// Returns the mechanism that launched the app. This is based on an env var so
     /// its up to the env var being set in the correct circumstance.
     static var launchSource: LaunchSource {
@@ -65,7 +65,7 @@ extension Ghostty {
             // source. If its unset we assume we're in a CLI environment.
             return .cli
         }
-        
+
         // If the env var is set but its unknown then we default back to the app.
         return LaunchSource(rawValue: envValue) ?? .app
     }
@@ -76,17 +76,17 @@ extension Ghostty {
 extension Ghostty {
     class AllocatedString {
         private let cString: ghostty_string_s
-        
+
         init(_ c: ghostty_string_s) {
             self.cString = c
         }
-        
+
         var string: String {
             guard let ptr = cString.ptr else { return "" }
             let data = Data(bytes: ptr, count: Int(cString.len))
             return String(data: data, encoding: .utf8) ?? ""
         }
-        
+
         deinit {
             ghostty_string_free(cString)
         }
@@ -350,6 +350,13 @@ extension Ghostty {
     enum MacOSTitlebarProxyIcon: String {
         case visible
         case hidden
+    }
+
+    /// Enum for the macos-background-style config option
+    enum MacBackgroundStyle: String {
+        case blur
+        case regularGlass = "regular-glass"
+        case clearGlass = "clear-glass"
     }
 
     /// Enum for auto-update-channel config option

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -352,13 +352,6 @@ extension Ghostty {
         case hidden
     }
 
-    /// Enum for the macos-background-style config option
-    enum MacBackgroundStyle: String {
-        case defaultStyle = "default"
-        case regularGlass = "regular-glass"
-        case clearGlass = "clear-glass"
-    }
-
     /// Enum for auto-update-channel config option
     enum AutoUpdateChannel: String {
         case tip

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -354,7 +354,7 @@ extension Ghostty {
 
     /// Enum for the macos-background-style config option
     enum MacBackgroundStyle: String {
-        case blur
+        case defaultStyle = "default"
         case regularGlass = "regular-glass"
         case clearGlass = "clear-glass"
     }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -927,6 +927,12 @@ palette: Palette = .{},
 ///     reasonable for a good looking blur. Higher blur intensities may
 ///     cause strange rendering and performance issues.
 ///
+/// On macOS 26.0 and later, there are additional special values that
+/// can be set to use the native macOS glass effects:
+///
+///   * `macos-glass-regular` - Standard glass effect with some opacity
+///   * `macos-glass-clear` - Highly transparent glass effect
+///
 /// Supported on macOS and on some Linux desktop environments, including:
 ///
 ///   * KDE Plasma (Wayland and X11)
@@ -3105,22 +3111,6 @@ keybind: Keybinds = .{},
 ///
 /// Available since: 1.2.0
 @"macos-shortcuts": MacShortcuts = .ask,
-
-/// The background style for macOS windows when `background-opacity` is less
-/// than 1. This controls the visual effect applied behind the terminal
-/// background.
-///
-/// Valid values are:
-///
-///   * `default` - Uses the standard background behavior. The `background-blur`
-///     configuration will control whether blur is applied (available on
-///     all macOS versions)
-///   * `regular-glass` - Standard glass effect with some opacity (macOS
-///      26.0+ only)
-///   * `clear-glass` - Highly transparent glass effect (macOS 26.0+ only)
-///
-/// Available since: 1.3.0
-@"macos-background-style": MacBackgroundStyle = .default,
 
 /// Put every surface (tab, split, window) into a dedicated Linux cgroup.
 ///
@@ -7704,13 +7694,6 @@ pub const MacShortcuts = enum {
     allow,
     deny,
     ask,
-};
-
-/// See macos-background-style
-pub const MacBackgroundStyle = enum {
-    default,
-    @"regular-glass",
-    @"clear-glass",
 };
 
 /// See gtk-single-instance

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -950,24 +950,6 @@ palette: Palette = .{},
 /// doing so.
 @"background-blur": BackgroundBlur = .false,
 
-/// The style of the glass effect when `background-opacity` is less than 1
-/// and the terminal is using a modern glass effect (macOS 26.0+ only).
-///
-/// Valid values are:
-///
-///   * `off` - No glass effect
-///   * `regular` - Standard glass effect with some opacity
-///   * `clear` - Highly transparent glass effect
-///
-/// This setting only takes effect on macOS 26.0+ when transparency is enabled
-/// (`background-opacity` < 1). On older macOS versions or when transparency
-/// is disabled, this setting has no effect.
-///
-/// The default value is `off`.
-///
-/// Available since: 1.2.2
-@"background-glass-style": BackgroundGlassStyle = .off,
-
 /// The opacity level (opposite of transparency) of an unfocused split.
 /// Unfocused splits by default are slightly faded out to make it easier to see
 /// which split is focused. To disable this feature, set this value to 1.
@@ -3123,6 +3105,28 @@ keybind: Keybinds = .{},
 ///
 /// Available since: 1.2.0
 @"macos-shortcuts": MacShortcuts = .ask,
+
+/// The background style for macOS windows when `background-opacity` is less than 1.
+/// This controls the visual effect applied behind the terminal background.
+///
+/// Valid values are:
+///
+///   * `blur` - Uses the standard background behavior. The `background-blur`
+///     configuration will control whether blur is applied (available on all macOS versions)
+///   * `regular-glass` - Standard glass effect with some opacity (macOS 26.0+ only)
+///   * `clear-glass` - Highly transparent glass effect (macOS 26.0+ only)
+///
+/// The `blur` option does not force any blur effect - it simply respects the
+/// `background-blur` configuration. The glass options override `background-blur`
+/// and apply their own visual effects.
+///
+/// On macOS versions prior to 26.0, only `blur` has an effect. The glass
+/// options will fall back to `blur` behavior on older versions.
+///
+/// The default value is `blur`.
+///
+/// Available since: 1.2.2
+@"macos-background-style": MacBackgroundStyle = .blur,
 
 /// Put every surface (tab, split, window) into a dedicated Linux cgroup.
 ///
@@ -7708,6 +7712,13 @@ pub const MacShortcuts = enum {
     ask,
 };
 
+/// See macos-background-style
+pub const MacBackgroundStyle = enum {
+    blur,
+    @"regular-glass",
+    @"clear-glass",
+};
+
 /// See gtk-single-instance
 pub const GtkSingleInstance = enum {
     false,
@@ -8399,13 +8410,6 @@ pub const BackgroundBlur = union(enum) {
         try testing.expectError(error.InvalidValue, v.parseCLI("aaaa"));
         try testing.expectError(error.InvalidValue, v.parseCLI("420"));
     }
-};
-
-/// See background-glass-style
-pub const BackgroundGlassStyle = enum {
-    off,
-    regular,
-    clear,
 };
 
 /// See window-decoration

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -950,6 +950,24 @@ palette: Palette = .{},
 /// doing so.
 @"background-blur": BackgroundBlur = .false,
 
+/// The style of the glass effect when `background-opacity` is less than 1
+/// and the terminal is using a modern glass effect (macOS 26.0+ only).
+///
+/// Valid values are:
+///
+///   * `off` - No glass effect
+///   * `regular` - Standard glass effect with some opacity
+///   * `clear` - Highly transparent glass effect
+///
+/// This setting only takes effect on macOS 26.0+ when transparency is enabled
+/// (`background-opacity` < 1). On older macOS versions or when transparency
+/// is disabled, this setting has no effect.
+///
+/// The default value is `off`.
+///
+/// Available since: 1.2.2
+@"background-glass-style": BackgroundGlassStyle = .off,
+
 /// The opacity level (opposite of transparency) of an unfocused split.
 /// Unfocused splits by default are slightly faded out to make it easier to see
 /// which split is focused. To disable this feature, set this value to 1.
@@ -8381,6 +8399,13 @@ pub const BackgroundBlur = union(enum) {
         try testing.expectError(error.InvalidValue, v.parseCLI("aaaa"));
         try testing.expectError(error.InvalidValue, v.parseCLI("420"));
     }
+};
+
+/// See background-glass-style
+pub const BackgroundGlassStyle = enum {
+    off,
+    regular,
+    clear,
 };
 
 /// See window-decoration

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -933,6 +933,9 @@ palette: Palette = .{},
 ///   * `macos-glass-regular` - Standard glass effect with some opacity
 ///   * `macos-glass-clear` - Highly transparent glass effect
 ///
+/// If the macOS values are set, then this implies `background-blur = true`
+/// on non-macOS platforms.
+///
 /// Supported on macOS and on some Linux desktop environments, including:
 ///
 ///   * KDE Plasma (Wayland and X11)
@@ -8368,6 +8371,11 @@ pub const BackgroundBlur = union(enum) {
             .false => false,
             .true => true,
             .radius => |v| v > 0,
+
+            // We treat these as true because they both imply some blur!
+            // This has the effect of making the standard blur happen on
+            // Linux.
+            .@"macos-glass-regular", .@"macos-glass-clear" => true,
         };
     }
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3111,22 +3111,13 @@ keybind: Keybinds = .{},
 ///
 /// Valid values are:
 ///
-///   * `blur` - Uses the standard background behavior. The `background-blur`
+///   * `default` - Uses the standard background behavior. The `background-blur`
 ///     configuration will control whether blur is applied (available on all macOS versions)
 ///   * `regular-glass` - Standard glass effect with some opacity (macOS 26.0+ only)
 ///   * `clear-glass` - Highly transparent glass effect (macOS 26.0+ only)
 ///
-/// The `blur` option does not force any blur effect - it simply respects the
-/// `background-blur` configuration. The glass options override `background-blur`
-/// and apply their own visual effects.
-///
-/// On macOS versions prior to 26.0, only `blur` has an effect. The glass
-/// options will fall back to `blur` behavior on older versions.
-///
-/// The default value is `blur`.
-///
 /// Available since: 1.2.2
-@"macos-background-style": MacBackgroundStyle = .blur,
+@"macos-background-style": MacBackgroundStyle = .default,
 
 /// Put every surface (tab, split, window) into a dedicated Linux cgroup.
 ///
@@ -7714,7 +7705,7 @@ pub const MacShortcuts = enum {
 
 /// See macos-background-style
 pub const MacBackgroundStyle = enum {
-    blur,
+    default,
     @"regular-glass",
     @"clear-glass",
 };

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3106,17 +3106,20 @@ keybind: Keybinds = .{},
 /// Available since: 1.2.0
 @"macos-shortcuts": MacShortcuts = .ask,
 
-/// The background style for macOS windows when `background-opacity` is less than 1.
-/// This controls the visual effect applied behind the terminal background.
+/// The background style for macOS windows when `background-opacity` is less
+/// than 1. This controls the visual effect applied behind the terminal
+/// background.
 ///
 /// Valid values are:
 ///
 ///   * `default` - Uses the standard background behavior. The `background-blur`
-///     configuration will control whether blur is applied (available on all macOS versions)
-///   * `regular-glass` - Standard glass effect with some opacity (macOS 26.0+ only)
+///     configuration will control whether blur is applied (available on
+///     all macOS versions)
+///   * `regular-glass` - Standard glass effect with some opacity (macOS
+///      26.0+ only)
 ///   * `clear-glass` - Highly transparent glass effect (macOS 26.0+ only)
 ///
-/// Available since: 1.2.2
+/// Available since: 1.3.0
 @"macos-background-style": MacBackgroundStyle = .default,
 
 /// Put every surface (tab, split, window) into a dedicated Linux cgroup.

--- a/src/config/c_get.zig
+++ b/src/config/c_get.zig
@@ -193,20 +193,32 @@ test "c_get: background-blur" {
 
     {
         c.@"background-blur" = .false;
-        var cval: u8 = undefined;
+        var cval: i16 = undefined;
         try testing.expect(get(&c, .@"background-blur", @ptrCast(&cval)));
         try testing.expectEqual(0, cval);
     }
     {
         c.@"background-blur" = .true;
-        var cval: u8 = undefined;
+        var cval: i16 = undefined;
         try testing.expect(get(&c, .@"background-blur", @ptrCast(&cval)));
         try testing.expectEqual(20, cval);
     }
     {
         c.@"background-blur" = .{ .radius = 42 };
-        var cval: u8 = undefined;
+        var cval: i16 = undefined;
         try testing.expect(get(&c, .@"background-blur", @ptrCast(&cval)));
         try testing.expectEqual(42, cval);
+    }
+    {
+        c.@"background-blur" = .@"macos-glass-regular";
+        var cval: i16 = undefined;
+        try testing.expect(get(&c, .@"background-blur", @ptrCast(&cval)));
+        try testing.expectEqual(-1, cval);
+    }
+    {
+        c.@"background-blur" = .@"macos-glass-clear";
+        var cval: i16 = undefined;
+        try testing.expect(get(&c, .@"background-blur", @ptrCast(&cval)));
+        try testing.expectEqual(-2, cval);
     }
 }

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -561,6 +561,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             vsync: bool,
             colorspace: configpkg.Config.WindowColorspace,
             blending: configpkg.Config.AlphaBlending,
+            macos_background_style: configpkg.Config.MacBackgroundStyle,
 
             pub fn init(
                 alloc_gpa: Allocator,
@@ -633,6 +634,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     .vsync = config.@"window-vsync",
                     .colorspace = config.@"window-colorspace",
                     .blending = config.@"alpha-blending",
+                    .macos_background_style = config.@"macos-background-style",
                     .arena = arena,
                 };
             }
@@ -643,6 +645,16 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 self.arena.deinit();
             }
         };
+
+        /// Determines if the terminal background should be disabled based on platform and config.
+        /// On macOS, when background effects are enabled (background style != default), the effect
+        /// layer handles the background rendering instead of the terminal renderer.
+        fn shouldDisableBackground(config: DerivedConfig) bool {
+            return switch (builtin.os.tag) {
+                .macos => config.macos_background_style != .default,
+                else => false,
+            };
+        }
 
         pub fn init(alloc: Allocator, options: renderer.Options) !Self {
             // Initialize our graphics API wrapper, this will prepare the
@@ -716,7 +728,10 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                         options.config.background.r,
                         options.config.background.g,
                         options.config.background.b,
-                        @intFromFloat(@round(options.config.background_opacity * 255.0)),
+                        if (shouldDisableBackground(options.config))
+                            0
+                        else
+                            @intFromFloat(@round(options.config.background_opacity * 255.0)),
                     },
                     .bools = .{
                         .cursor_wide = false,
@@ -1293,7 +1308,10 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     self.terminal_state.colors.background.r,
                     self.terminal_state.colors.background.g,
                     self.terminal_state.colors.background.b,
-                    @intFromFloat(@round(self.config.background_opacity * 255.0)),
+                    if (shouldDisableBackground(self.config))
+                        0
+                    else
+                        @intFromFloat(@round(self.config.background_opacity * 255.0)),
                 };
             }
         }

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -728,10 +728,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                         options.config.background.r,
                         options.config.background.g,
                         options.config.background.b,
-                        if (shouldDisableBackground(options.config))
-                            0
-                        else
-                            @intFromFloat(@round(options.config.background_opacity * 255.0)),
+                        @intFromFloat(@round(options.config.background_opacity * 255.0)),
                     },
                     .bools = .{
                         .cursor_wide = false,


### PR DESCRIPTION
## Description

This PR implements the basic functionality for "Liquid Glass" style background support (#8155). I used OpenCode (Claude 4) in some capacity to write this as I'm not super familiar with AppKit / SwiftUI. A good chunk of this I still needed to write by hand since Claude doesn't understand the Glass APIs, but I'm not 100% if the implementation here makes the best decisions since the practices in Ghostty config and separation of the AppKit code and SwiftUI seemed inconsistent to me.

Some of the combinations of options obviously create entirely unreadable terminals, but I've found that regular glass and transparent with opacity to be fairly readable. We *don't* enable this feature by default since it would of course break existing users setups.

## Open Questions

- [x] How to determine the correct cornerRadius? For now this is eyeballed, I can't see any macOS public API or clearly documented constants.
- [x] Should boolean options be exposed for reasonable defaults?
- [x] Should the option need to be namespaced to macos-\*?

## Screenshots

0% Opacity, Regular
<img width="917" height="683" alt="image" src="https://github.com/user-attachments/assets/ccb96ba7-5df2-4284-8526-e07bbb62e3e5" />
50% Opacity, Transparent
<img width="880" height="680" alt="image" src="https://github.com/user-attachments/assets/5bdf12f9-3209-4aa9-8a4f-9a6eb4f95894" />
0% Opacity, Transparent
<img width="860" height="681" alt="image" src="https://github.com/user-attachments/assets/1b33d400-4d8b-479a-94d7-47b844743e52" />

