### PR TITLE
minor: service should not quit after last window is closed

### DIFF
--- a/dist/linux/dbus.service.flatpak.in
+++ b/dist/linux/dbus.service.flatpak.in
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=@APPID@
-Exec=@GHOSTTY@ --gtk-single-instance=true --initial-window=false
+Exec=@GHOSTTY@ --gtk-single-instance=true --quit-after-last-window-closed=false --initial-window=false

--- a/dist/linux/dbus.service.in
+++ b/dist/linux/dbus.service.in
@@ -1,4 +1,4 @@
 [D-BUS Service]
 Name=@APPID@
 SystemdService=app-@APPID@.service
-Exec=@GHOSTTY@ --gtk-single-instance=true --initial-window=false
+Exec=@GHOSTTY@ --gtk-single-instance=true --quit-after-last-window-closed=false --initial-window=false


### PR DESCRIPTION
Hello,

currently the ghostty service is pointless if you don't have `quit-after-last-window-closed = false` in your config. The problem: if you HAVE that AND run ghostty with `--class=my.class` ghostty will launch a new instance, which will be kept open as well after closing, so you'd need to run `--close-after-last-window-closed=true --class=my.class` which seems... wrong?

is there a reason the service should EVER be closed? Unless ofc you actually stop the systemd service.

if not this pr should be fine?

Regards