### PR TITLE
flatpak: update GNOME runtime to 49

### DIFF
--- a/flatpak/com.mitchellh.ghostty-debug.yml
+++ b/flatpak/com.mitchellh.ghostty-debug.yml
@@ -1,6 +1,6 @@
 app-id: com.mitchellh.ghostty-debug
 runtime: org.gnome.Platform
-runtime-version: "48"
+runtime-version: "49"
 sdk: org.gnome.Sdk
 default-branch: tip
 command: ghostty

--- a/flatpak/com.mitchellh.ghostty.yml
+++ b/flatpak/com.mitchellh.ghostty.yml
@@ -1,6 +1,6 @@
 app-id: com.mitchellh.ghostty
 runtime: org.gnome.Platform
-runtime-version: "48"
+runtime-version: "49"
 sdk: org.gnome.Sdk
 default-branch: tip
 command: ghostty

--- a/flatpak/dependencies.yml
+++ b/flatpak/dependencies.yml
@@ -30,19 +30,6 @@ modules:
         contents: INPUT(libbz2.so)
         dest-filename: libbzip2.so
 
-  - name: blueprint-compiler
-    buildsystem: meson
-    cleanup:
-      - "*"
-    sources:
-      - type: git
-        url: https://gitlab.gnome.org/jwestman/blueprint-compiler.git
-        tag: v0.16.0
-        commit: 04ef0944db56ab01307a29aaa7303df6067cb3c0
-        x-checker-data:
-          type: git
-          tag-pattern: ^v([\d.]+)$
-
   - name: gtk4-layer-shell
     buildsystem: meson
     sources:


### PR DESCRIPTION
Notable dependencies changes:

- blueprint-compiler is dropped as it has been bundled in the SDK
- GTK 4.18.6 -> 4.20.1
- libadwaita 1.7.7 -> 1.8.0