### PR TITLE
build: many more lazy dependencies, defer deps add unless needed

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -45,6 +45,7 @@
             // codeberg ifreund/zig-wayland
             .url = "https://codeberg.org/ifreund/zig-wayland/archive/f3c5d503e540ada8cbcb056420de240af0c094f7.tar.gz",
             .hash = "wayland-0.4.0-dev-lQa1kjfIAQCmhhQu3xF0KH-94-TzeMXOqfnP0-Dg6Wyy",
+            .lazy = true,
         },
         .zf = .{
             // natecraddock/zf
@@ -103,10 +104,12 @@
         .jetbrains_mono = .{
             .url = "https://deps.files.ghostty.org/JetBrainsMono-2.304.tar.gz",
             .hash = "N-V-__8AAIC5lwAVPJJzxnCAahSvZTIlG-HhtOvnM1uh-66x",
+            .lazy = true,
         },
         .nerd_fonts_symbols_only = .{
             .url = "https://deps.files.ghostty.org/NerdFontsSymbolsOnly-3.4.0.tar.gz",
             .hash = "N-V-__8AAMVLTABmYkLqhZPLXnMl-KyN38R8UVYqGrxqO26s",
+            .lazy = true,
         },
 
         // Other

--- a/pkg/cimgui/build.zig.zon
+++ b/pkg/cimgui/build.zig.zon
@@ -10,6 +10,7 @@
             // ocornut/imgui
             .url = "https://deps.files.ghostty.org/imgui-1220bc6b9daceaf7c8c60f3c3998058045ba0c5c5f48ae255ff97776d9cd8bfc6402.tar.gz",
             .hash = "N-V-__8AAH0GaQC8a52s6vfIxg88OZgFgEW6DFxfSK4lX_l3",
+            .lazy = true,
         },
 
         .apple_sdk = .{ .path = "../apple-sdk" },

--- a/pkg/glslang/build.zig.zon
+++ b/pkg/glslang/build.zig.zon
@@ -8,6 +8,7 @@
         .glslang = .{
             .url = "https://deps.files.ghostty.org/glslang-12201278a1a05c0ce0b6eb6026c65cd3e9247aa041b1c260324bf29cee559dd23ba1.tar.gz",
             .hash = "N-V-__8AABzkUgISeKGgXAzgtutgJsZc0-kkeqBBscJgMkvy",
+            .lazy = true,
         },
 
         .apple_sdk = .{ .path = "../apple-sdk" },

--- a/pkg/highway/build.zig
+++ b/pkg/highway/build.zig
@@ -4,7 +4,7 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const upstream = b.dependency("highway", .{});
+    const upstream_ = b.lazyDependency("highway", .{});
 
     const module = b.addModule("highway", .{
         .root_source_file = b.path("main.zig"),
@@ -21,8 +21,10 @@ pub fn build(b: *std.Build) !void {
         .linkage = .static,
     });
     lib.linkLibCpp();
-    lib.addIncludePath(upstream.path(""));
-    module.addIncludePath(upstream.path(""));
+    if (upstream_) |upstream| {
+        lib.addIncludePath(upstream.path(""));
+        module.addIncludePath(upstream.path(""));
+    }
 
     if (target.result.os.tag.isDarwin()) {
         const apple_sdk = @import("apple_sdk");
@@ -74,24 +76,26 @@ pub fn build(b: *std.Build) !void {
     }
 
     lib.addCSourceFiles(.{ .flags = flags.items, .files = &.{"bridge.cpp"} });
-    lib.addCSourceFiles(.{
-        .root = upstream.path(""),
-        .flags = flags.items,
-        .files = &.{
-            "hwy/abort.cc",
-            "hwy/aligned_allocator.cc",
-            "hwy/nanobenchmark.cc",
-            "hwy/per_target.cc",
-            "hwy/print.cc",
-            "hwy/targets.cc",
-            "hwy/timer.cc",
-        },
-    });
-    lib.installHeadersDirectory(
-        upstream.path("hwy"),
-        "hwy",
-        .{ .include_extensions = &.{".h"} },
-    );
+    if (upstream_) |upstream| {
+        lib.addCSourceFiles(.{
+            .root = upstream.path(""),
+            .flags = flags.items,
+            .files = &.{
+                "hwy/abort.cc",
+                "hwy/aligned_allocator.cc",
+                "hwy/nanobenchmark.cc",
+                "hwy/per_target.cc",
+                "hwy/print.cc",
+                "hwy/targets.cc",
+                "hwy/timer.cc",
+            },
+        });
+        lib.installHeadersDirectory(
+            upstream.path("hwy"),
+            "hwy",
+            .{ .include_extensions = &.{".h"} },
+        );
+    }
 
     b.installArtifact(lib);
 

--- a/pkg/highway/build.zig.zon
+++ b/pkg/highway/build.zig.zon
@@ -8,6 +8,7 @@
         .highway = .{
             .url = "https://deps.files.ghostty.org/highway-66486a10623fa0d72fe91260f96c892e41aceb06.tar.gz",
             .hash = "N-V-__8AAGmZhABbsPJLfbqrh6JTHsXhY6qCaLAQyx25e0XE",
+            .lazy = true,
         },
 
         .apple_sdk = .{ .path = "../apple-sdk" },

--- a/pkg/libxml2/build.zig.zon
+++ b/pkg/libxml2/build.zig.zon
@@ -7,6 +7,7 @@
         .libxml2 = .{
             .url = "https://deps.files.ghostty.org/libxml2-2.11.5.tar.gz",
             .hash = "N-V-__8AAG3RoQEyRC2Vw7Qoro5SYBf62IHn3HjqtNVY6aWK",
+            .lazy = true,
         },
     },
 }

--- a/pkg/spirv-cross/build.zig.zon
+++ b/pkg/spirv-cross/build.zig.zon
@@ -8,6 +8,7 @@
         .spirv_cross = .{
             .url = "https://deps.files.ghostty.org/spirv_cross-1220fb3b5586e8be67bc3feb34cbe749cf42a60d628d2953632c2f8141302748c8da.tar.gz",
             .hash = "N-V-__8AANb6pwD7O1WG6L5nvD_rNMvnSc9Cpg1ijSlTYywv",
+            .lazy = true,
         },
 
         .apple_sdk = .{ .path = "../apple-sdk" },

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -502,38 +502,40 @@ pub fn add(
     // Fonts
     {
         // JetBrains Mono
-        const jb_mono = b.dependency("jetbrains_mono", .{});
-        step.root_module.addAnonymousImport(
-            "jetbrains_mono_regular",
-            .{ .root_source_file = jb_mono.path("fonts/ttf/JetBrainsMono-Regular.ttf") },
-        );
-        step.root_module.addAnonymousImport(
-            "jetbrains_mono_bold",
-            .{ .root_source_file = jb_mono.path("fonts/ttf/JetBrainsMono-Bold.ttf") },
-        );
-        step.root_module.addAnonymousImport(
-            "jetbrains_mono_italic",
-            .{ .root_source_file = jb_mono.path("fonts/ttf/JetBrainsMono-Italic.ttf") },
-        );
-        step.root_module.addAnonymousImport(
-            "jetbrains_mono_bold_italic",
-            .{ .root_source_file = jb_mono.path("fonts/ttf/JetBrainsMono-BoldItalic.ttf") },
-        );
-        step.root_module.addAnonymousImport(
-            "jetbrains_mono_variable",
-            .{ .root_source_file = jb_mono.path("fonts/variable/JetBrainsMono[wght].ttf") },
-        );
-        step.root_module.addAnonymousImport(
-            "jetbrains_mono_variable_italic",
-            .{ .root_source_file = jb_mono.path("fonts/variable/JetBrainsMono-Italic[wght].ttf") },
-        );
+        if (b.lazyDependency("jetbrains_mono", .{})) |jb_mono| {
+            step.root_module.addAnonymousImport(
+                "jetbrains_mono_regular",
+                .{ .root_source_file = jb_mono.path("fonts/ttf/JetBrainsMono-Regular.ttf") },
+            );
+            step.root_module.addAnonymousImport(
+                "jetbrains_mono_bold",
+                .{ .root_source_file = jb_mono.path("fonts/ttf/JetBrainsMono-Bold.ttf") },
+            );
+            step.root_module.addAnonymousImport(
+                "jetbrains_mono_italic",
+                .{ .root_source_file = jb_mono.path("fonts/ttf/JetBrainsMono-Italic.ttf") },
+            );
+            step.root_module.addAnonymousImport(
+                "jetbrains_mono_bold_italic",
+                .{ .root_source_file = jb_mono.path("fonts/ttf/JetBrainsMono-BoldItalic.ttf") },
+            );
+            step.root_module.addAnonymousImport(
+                "jetbrains_mono_variable",
+                .{ .root_source_file = jb_mono.path("fonts/variable/JetBrainsMono[wght].ttf") },
+            );
+            step.root_module.addAnonymousImport(
+                "jetbrains_mono_variable_italic",
+                .{ .root_source_file = jb_mono.path("fonts/variable/JetBrainsMono-Italic[wght].ttf") },
+            );
+        }
 
         // Symbols-only nerd font
-        const nf_symbols = b.dependency("nerd_fonts_symbols_only", .{});
-        step.root_module.addAnonymousImport(
-            "nerd_fonts_symbols_only",
-            .{ .root_source_file = nf_symbols.path("SymbolsNerdFont-Regular.ttf") },
-        );
+        if (b.lazyDependency("nerd_fonts_symbols_only", .{})) |nf_symbols| {
+            step.root_module.addAnonymousImport(
+                "nerd_fonts_symbols_only",
+                .{ .root_source_file = nf_symbols.path("SymbolsNerdFont-Regular.ttf") },
+            );
+        }
     }
 
     // If we're building an exe then we have additional dependencies.
@@ -615,17 +617,20 @@ fn addGtkNg(
             "plasma_wayland_protocols",
             .{},
         );
+        const zig_wayland_import_ = b.lazyImport(
+            @import("../../build.zig"),
+            "zig_wayland",
+        );
+        const zig_wayland_dep_ = b.lazyDependency("zig_wayland", .{});
 
         // Unwrap or return, there are no more dependencies below.
         const wayland_dep = wayland_dep_ orelse break :wayland;
         const wayland_protocols_dep = wayland_protocols_dep_ orelse break :wayland;
         const plasma_wayland_protocols_dep = plasma_wayland_protocols_dep_ orelse break :wayland;
+        const zig_wayland_import = zig_wayland_import_ orelse break :wayland;
+        const zig_wayland_dep = zig_wayland_dep_ orelse break :wayland;
 
-        // Note that zig_wayland cannot be lazy because lazy dependencies
-        // can't be imported since they don't exist and imports are
-        // resolved at compile time of the build.
-        const zig_wayland_dep = b.dependency("zig_wayland", .{});
-        const Scanner = @import("zig_wayland").Scanner;
+        const Scanner = zig_wayland_import.Scanner;
         const scanner = Scanner.create(zig_wayland_dep.builder, .{
             .wayland_xml = wayland_dep.path("protocol/wayland.xml"),
             .wayland_protocols = wayland_protocols_dep.path(""),


### PR DESCRIPTION
This makes more dependencies lazy. This has a practical effect of reducing the number of dependencies that need to be downloaded when running certain zig build steps.

This is all limited because we're blocked on an upstream Zig issue: https://github.com/ziglang/zig/issues/21525 This prevents us from fully avoiding downloading many dependencies, but at least they're relatively small.

One major improvement here is the usage of `lazyImport` for `zig-wayland` that prevents downloading `zig_wayland` unconditionally on all platforms. On macOS, we don't download this at all anymore.

Another, weirder change is that all our transitive dependencies are now marked lazy (e.g. glslang's upstream source) even if the glslang build always requires it. This was necessary because without this, even if we simply referenced glslang in the root build.zig, it would force the source package to download unconditionally. This no longer happens.

cc @pluiedev Minor improvements here, doesn't change the long term plan, but improves things in the interim. 