### PR TITLE
fix(font): Treat Powerline glyphs as normal characters for constraint width purposes

### DIFF
--- a/src/renderer/cell.zig
+++ b/src/renderer/cell.zig
@@ -352,7 +352,7 @@ fn isLegacyComputing(char: u21) bool {
 // Returns true if the codepoint is a part of the Powerline range.
 fn isPowerline(char: u21) bool {
     return switch (char) {
-        0xE0B0...0xE0C8, 0xE0CA, 0xE0CC...0xE0D2, 0xE0D4 => true,
+        0xE0B0...0xE0D7 => true,
         else => false,
     };
 }

--- a/src/renderer/cell.zig
+++ b/src/renderer/cell.zig
@@ -306,9 +306,10 @@ pub fn constraintWidth(cell_pin: terminal.Pin) u2 {
 }
 
 /// Whether min contrast should be disabled for a given glyph.
+/// True for glyphs used for terminal graphics, such as box
+/// drawing characters, block elements, and Powerline glyphs.
 pub fn noMinContrast(cp: u21) bool {
-    // TODO: We should disable for all box drawing type characters.
-    return isPowerline(cp);
+    return isBoxDrawing(cp) or isBlockElement(cp) or isLegacyComputing(cp) or isPowerline(cp);
 }
 
 // Some general spaces, others intentionally kept
@@ -318,6 +319,32 @@ fn isSpace(char: u21) bool {
         0x0020, // SPACE
         0x2002, // EN SPACE
         => true,
+        else => false,
+    };
+}
+
+// Returns true if the codepoint is a box drawing character.
+fn isBoxDrawing(char: u21) bool {
+    return switch (char) {
+        0x2500...0x257F => true,
+        else => false,
+    };
+}
+
+// Returns true if the codepoint is a block element.
+fn isBlockElement(char: u21) bool {
+    return switch (char) {
+        0x2580...0x259F => true,
+        else => false,
+    };
+}
+
+// Returns true if the codepoint is in a Symbols for Legacy
+// Computing block, including supplements.
+fn isLegacyComputing(char: u21) bool {
+    return switch (char) {
+        0x1FB00...0x1FBFF => true,
+        0x1CC00...0x1CEBF => true, // Supplement introduced in Unicode 16.0
         else => false,
     };
 }


### PR DESCRIPTION
Powerline glyphs were treated as whitespace, giving the preceding cell a constraint width of 2 and cutting off icons in people's prompts and statuslines. It is however correct to not treat Powerline glyphs like other Nerd Font symbols; they should simply be treated as normal characters, just like their relatives in the block elements unicode block.

This resolves https://discord.com/channels/1005603569187160125/1417236683266592798 (never promoted to an issue, but real and easy to reproduce).

**Tip**
<img width="215" height="63" alt="Screenshot 2025-09-21 at 16 57 58" src="https://github.com/user-attachments/assets/81e770c5-d688-4d8e-839c-1f4288703c06" />

**This PR**
<img width="215" height="63" alt="Screenshot 2025-09-21 at 16 58 42" src="https://github.com/user-attachments/assets/5d2dd770-0314-46f6-99b5-237a0933998e" />

The constraint width logic was untested but contains some quite subtle interactions, so I wrote a suite of tests covering the cases I'm aware of.

While working on this code I also resolved a TODO comment to add all the box drawing/block element type characters to the set of codepoints excluded from the minimum contrast settings.