### PR TITLE
Workaround for #8669

### DIFF
--- a/macos/Sources/Features/App Intents/NewTerminalIntent.swift
+++ b/macos/Sources/Features/App Intents/NewTerminalIntent.swift
@@ -98,6 +98,11 @@ struct NewTerminalIntent: AppIntent {
             parent = nil
         }
 
+        defer {
+            if !NSApp.isActive {
+                NSApp.activate(ignoringOtherApps: true)
+            }
+        }
         switch location {
         case .window:
             let newController = TerminalController.newWindow(

--- a/macos/Sources/Features/App Intents/NewTerminalIntent.swift
+++ b/macos/Sources/Features/App Intents/NewTerminalIntent.swift
@@ -43,11 +43,13 @@ struct NewTerminalIntent: AppIntent {
     )
     var parent: TerminalEntity?
 
+    // Performing in the background can avoid opening multiple windows at the same time
+    // using `foreground` will cause `perform` and `AppDelegate.applicationDidBecomeActive(_:)`/`AppDelegate.applicationShouldHandleReopen(_:hasVisibleWindows:)` running at the 'same' time
     @available(macOS 26.0, *)
-    static var supportedModes: IntentModes = .foreground(.immediate)
+    static var supportedModes: IntentModes = .background
 
     @available(macOS, obsoleted: 26.0, message: "Replaced by supportedModes")
-    static var openAppWhenRun = true
+    static var openAppWhenRun = false
 
     @MainActor
     func perform() async throws -> some IntentResult & ReturnsValue<TerminalEntity?> {


### PR DESCRIPTION
Changing `supportedModes` to `background` seems to have fixed #8669.

> Debugging AppIntents with Xcode is a pain. I had to delete all the local builds to make it take effect. The build product of `zig` might cause confusion if none of your changes reflect in the Shortcuts app. There were too many ghosts on my computer. 👻👻👻

- Tahoe

https://github.com/user-attachments/assets/88d0d567-edf5-4a7e-b0a3-720e50053746

- Sequoia 

https://github.com/user-attachments/assets/a77f1431-ca92-4450-bce9-5f37ef232d4f

