### PR TITLE
feat: list-themes cursor and selection colors

### DIFF
--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -895,6 +895,42 @@ const Preview = struct {
                     config.background.b,
                 },
             };
+            const cursor_fg: vaxis.Color = if (config.@"cursor-text") |cursor_text| .{
+                .rgb = [_]u8{
+                    cursor_text.color.r,
+                    cursor_text.color.g,
+                    cursor_text.color.b,
+                },
+            } else bg;
+            const cursor_bg: vaxis.Color = if (config.@"cursor-color") |cursor_bg| .{
+                .rgb = [_]u8{
+                    cursor_bg.color.r,
+                    cursor_bg.color.g,
+                    cursor_bg.color.b,
+                },
+            } else fg;
+            const selection_fg: vaxis.Color = if (config.@"selection-foreground") |selection_fg| .{
+                .rgb = [_]u8{
+                    selection_fg.color.r,
+                    selection_fg.color.g,
+                    selection_fg.color.b,
+                },
+            } else bg;
+            const selection_bg: vaxis.Color = if (config.@"selection-background") |selection_bg| .{
+                .rgb = [_]u8{
+                    selection_bg.color.r,
+                    selection_bg.color.g,
+                    selection_bg.color.b,
+                },
+            } else fg;
+            const cursor: vaxis.Style = .{
+                .fg = cursor_fg,
+                .bg = cursor_bg,
+            };
+            const standard_selection: vaxis.Style = .{
+                .fg = selection_fg,
+                .bg = selection_bg,
+            };
             const standard: vaxis.Style = .{
                 .fg = fg,
                 .bg = bg,
@@ -1433,11 +1469,8 @@ const Preview = struct {
                     &.{
                         .{ .text = "  14   │             ", .style = color238 },
                         .{ .text = "try ", .style = color5 },
-                        .{ .text = "stdout.print(", .style = standard },
-                        .{ .text = "\"{d}", .style = color10 },
-                        .{ .text = "\\n", .style = color12 },
-                        .{ .text = "\"", .style = color10 },
-                        .{ .text = ", .{i});", .style = standard },
+                        .{ .text = "stdout.print(\"{d}\\n\", .{i})", .style = standard_selection },
+                        .{ .text = ";", .style = cursor },
                     },
                     .{
                         .row_offset = 17,


### PR DESCRIPTION
Closes #8446

Adds the remaining theme colors: cursor-color, cursor-text, selection-background, and selection-foreground.

## Before
<img width="1840" height="1195" alt="image" src="https://github.com/user-attachments/assets/f39f0cf1-f1c4-468c-a706-a39e3efe2883" />

## After
<img width="1840" height="1195" alt="image" src="https://github.com/user-attachments/assets/a6995c35-070d-4971-9caf-ebae994deba5" />
