### PR TITLE
GTK: Fix split-divider-color

### DIFF
--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -809,6 +809,9 @@ pub const Application = extern struct {
 
         const writer = buf.writer(alloc);
 
+        try loadRuntimeCss414(config, &writer);
+        try loadRuntimeCss416(config, &writer);
+
         const unfocused_fill: CoreConfig.Color = config.@"unfocused-split-fill" orelse config.background;
 
         try writer.print(
@@ -846,9 +849,6 @@ pub const Application = extern struct {
                 \\
             , .{ .font_family = font_family });
         }
-
-        try loadRuntimeCss414(config, &writer);
-        try loadRuntimeCss416(config, &writer);
 
         // ensure that we have a sentinel
         try writer.writeByte(0);

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -809,6 +809,7 @@ pub const Application = extern struct {
 
         const writer = buf.writer(alloc);
 
+        // Load standard css first as it can override some of the user configured styling.
         try loadRuntimeCss414(config, &writer);
         try loadRuntimeCss416(config, &writer);
 


### PR DESCRIPTION
The `loadRuntimeCss416` overrode a color option for the split divider color
https://github.com/ghostty-org/ghostty/blob/main/src/apprt/gtk/class/application.zig#L959-L965

I moved the user config options until the other runtime css is loaded so they will always take priority