### PR TITLE
deps: Allow dynamic-linking of spirv-cross

### DIFF
--- a/pkg/spirv-cross/build.zig
+++ b/pkg/spirv-cross/build.zig
@@ -4,16 +4,19 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const upstream = b.lazyDependency("spirv_cross", .{});
+    const module = b.addModule("spirv_cross", .{ .root_source_file = b.path("main.zig"), .target = target, .optimize = optimize });
 
-    const module = b.addModule("spirv_cross", .{ .root_source_file = b.path("main.zig") });
-    if (upstream) |v| module.addIncludePath(v.path(""));
+    // For dynamic linking, we prefer dynamic linking and to search by
+    // mode first. Mode first will search all paths for a dynamic library
+    // before falling back to static.
+    const dynamic_link_opts: std.Build.Module.LinkSystemLibraryOptions = .{
+        .preferred_link_mode = .dynamic,
+        .search_strategy = .mode_first,
+    };
 
-    const lib = try buildSpirvCross(b, upstream, target, optimize);
-    b.installArtifact(lib);
-
+    var test_exe: ?*std.Build.Step.Compile = null;
     if (target.query.isNative()) {
-        const test_exe = b.addTest(.{
+        test_exe = b.addTest(.{
             .name = "test",
             .root_module = b.createModule(.{
                 .root_source_file = b.path("main.zig"),
@@ -21,19 +24,28 @@ pub fn build(b: *std.Build) !void {
                 .optimize = optimize,
             }),
         });
-        test_exe.linkLibrary(lib);
-        const tests_run = b.addRunArtifact(test_exe);
+        const tests_run = b.addRunArtifact(test_exe.?);
         const test_step = b.step("test", "Run tests");
         test_step.dependOn(&tests_run.step);
 
         // Uncomment this if we're debugging tests
-        // b.installArtifact(test_exe);
+        // b.installArtifact(test_exe.?);
+    }
+    if (b.systemIntegrationOption("spirv-cross", .{})) {
+        module.linkSystemLibrary("spirv-cross-c-shared", dynamic_link_opts);
+        if (test_exe) |exe| {
+            exe.linkSystemLibrary2("spirv-cross-c-shared", dynamic_link_opts);
+        }
+    } else {
+        const lib = try buildSpirvCross(b, module, target, optimize);
+        b.installArtifact(lib);
+        if (test_exe) |exe| exe.linkLibrary(lib);
     }
 }
 
 fn buildSpirvCross(
     b: *std.Build,
-    upstream_: ?*std.Build.Dependency,
+    module: *std.Build.Module,
     target: std.Build.ResolvedTarget,
     optimize: std.builtin.OptimizeMode,
 ) !*std.Build.Step.Compile {
@@ -62,33 +74,36 @@ fn buildSpirvCross(
         "-fno-sanitize-trap=undefined",
     });
 
-    const upstream = upstream_ orelse return lib;
-    lib.addCSourceFiles(.{
-        .root = upstream.path(""),
-        .flags = flags.items,
-        .files = &.{
-            // Core
-            "spirv_cross.cpp",
-            "spirv_parser.cpp",
-            "spirv_cross_parsed_ir.cpp",
-            "spirv_cfg.cpp",
+    if (b.lazyDependency("spirv_cross", .{})) |upstream| {
+        lib.addIncludePath(upstream.path(""));
+        module.addIncludePath(upstream.path(""));
+        lib.addCSourceFiles(.{
+            .root = upstream.path(""),
+            .flags = flags.items,
+            .files = &.{
+                // Core
+                "spirv_cross.cpp",
+                "spirv_parser.cpp",
+                "spirv_cross_parsed_ir.cpp",
+                "spirv_cfg.cpp",
 
-            // C
-            "spirv_cross_c.cpp",
+                // C
+                "spirv_cross_c.cpp",
 
-            // GLSL
-            "spirv_glsl.cpp",
+                // GLSL
+                "spirv_glsl.cpp",
 
-            // MSL
-            "spirv_msl.cpp",
-        },
-    });
+                // MSL
+                "spirv_msl.cpp",
+            },
+        });
 
-    lib.installHeadersDirectory(
-        upstream.path(""),
-        "",
-        .{ .include_extensions = &.{".h"} },
-    );
+        lib.installHeadersDirectory(
+            upstream.path(""),
+            "",
+            .{ .include_extensions = &.{".h"} },
+        );
+    }
 
     return lib;
 }

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -260,7 +260,7 @@ pub fn add(
             spirv_cross_dep.module("spirv_cross"),
         );
         if (b.systemIntegrationOption("spirv-cross", .{})) {
-            step.linkSystemLibrary2("spirv-cross", dynamic_link_opts);
+            step.linkSystemLibrary2("spirv-cross-c-shared", dynamic_link_opts);
         } else {
             step.linkLibrary(spirv_cross_dep.artifact("spirv_cross"));
             try static_libs.append(


### PR DESCRIPTION
- Use the pkg-config name of 'spirv-cross-c-shared' exported by the upstream SPIRV-Cross build https://github.com/KhronosGroup/SPIRV-Cross/blob/main/pkg-config/spirv-cross-c-shared.pc.in