### PR TITLE
fix: alloc free off by one

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -353,6 +353,7 @@ typedef struct {
 typedef struct {
   const char* ptr;
   uintptr_t len;
+  uintptr_t cap;
 } ghostty_string_s;
 
 typedef struct {

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -353,7 +353,7 @@ typedef struct {
 typedef struct {
   const char* ptr;
   uintptr_t len;
-  uintptr_t cap;
+  bool sentinel;
 } ghostty_string_s;
 
 typedef struct {

--- a/src/config/CApi.zig
+++ b/src/config/CApi.zig
@@ -131,7 +131,7 @@ export fn ghostty_config_open_path() c.String {
     };
 
     // Capacity is len + 1 due to sentinel
-    return .fromSlice(path, path.len + 1);
+    return .fromSlice(path);
 }
 
 /// Sync with ghostty_diagnostic_s

--- a/src/config/CApi.zig
+++ b/src/config/CApi.zig
@@ -130,7 +130,6 @@ export fn ghostty_config_open_path() c.String {
         return .empty;
     };
 
-    // Capacity is len + 1 due to sentinel
     return .fromSlice(path);
 }
 

--- a/src/config/CApi.zig
+++ b/src/config/CApi.zig
@@ -130,7 +130,8 @@ export fn ghostty_config_open_path() c.String {
         return .empty;
     };
 
-    return .fromSlice(path);
+    // Capacity is len + 1 due to sentinel
+    return .fromSlice(path, path.len + 1);
 }
 
 /// Sync with ghostty_diagnostic_s

--- a/src/main_c.zig
+++ b/src/main_c.zig
@@ -63,16 +63,19 @@ const Info = extern struct {
 pub const String = extern struct {
     ptr: ?[*]const u8,
     len: usize,
+    cap: usize,
 
     pub const empty: String = .{
         .ptr = null,
         .len = 0,
+        .cap = 0,
     };
 
-    pub fn fromSlice(slice: []const u8) String {
+    pub fn fromSlice(slice: []const u8, cap: usize) String {
         return .{
             .ptr = slice.ptr,
             .len = slice.len,
+            .cap = cap,
         };
     }
 };
@@ -129,5 +132,5 @@ pub export fn ghostty_translate(msgid: [*:0]const u8) [*:0]const u8 {
 
 /// Free a string allocated by Ghostty.
 pub export fn ghostty_string_free(str: String) void {
-    state.alloc.free(str.ptr.?[0..str.len]);
+    state.alloc.free(str.ptr.?[0..str.cap]);
 }

--- a/src/main_c.zig
+++ b/src/main_c.zig
@@ -155,3 +155,43 @@ pub export fn ghostty_translate(msgid: [*:0]const u8) [*:0]const u8 {
 pub export fn ghostty_string_free(str: String) void {
     str.deinit();
 }
+
+test "ghostty_string_s empty string" {
+    const testing = std.testing;
+    const empty_string = String.empty;
+    defer empty_string.deinit();
+
+    try testing.expect(empty_string.len == 0);
+    try testing.expect(empty_string.sentinel == false);
+}
+
+test "ghostty_string_s c string" {
+    const testing = std.testing;
+    state.alloc = testing.allocator;
+
+    const slice: [:0]const u8 = "hello";
+    const allocated_slice = try testing.allocator.dupeZ(u8, slice);
+    const c_null_string = String.fromSlice(allocated_slice);
+    defer c_null_string.deinit();
+
+    try testing.expect(allocated_slice[5] == 0);
+    try testing.expect(@TypeOf(slice) == [:0]const u8);
+    try testing.expect(@TypeOf(allocated_slice) == [:0]u8);
+    try testing.expect(c_null_string.len == 5);
+    try testing.expect(c_null_string.sentinel == true);
+}
+
+test "ghostty_string_s zig string" {
+    const testing = std.testing;
+    state.alloc = testing.allocator;
+
+    const slice: []const u8 = "hello";
+    const allocated_slice = try testing.allocator.dupe(u8, slice);
+    const zig_string = String.fromSlice(allocated_slice);
+    defer zig_string.deinit();
+
+    try testing.expect(@TypeOf(slice) == []const u8);
+    try testing.expect(@TypeOf(allocated_slice) == []u8);
+    try testing.expect(zig_string.len == 5);
+    try testing.expect(zig_string.sentinel == false);
+}


### PR DESCRIPTION
Fix provided by @jcollie 

The swift `open_config` action was triggering an allocation error `error(gpa): Allocation size 41 bytes does not match free size 40.`. 

> A string that was created as a `[:0]const u8` was cast to `[]const u8` and then freed. The sentinel is the off-by-one. 

@jcollie 

For full context, see https://discord.com/channels/1005603569187160125/1420367156071239820

Co-authored-by: Jeffrey C. Ollie <jcollie@dmacc.edu>