### PR TITLE
fix: file creation when directory already exists

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3351,7 +3351,7 @@ pub fn loadOptionalFile(
 fn writeConfigTemplate(path: []const u8) !void {
     log.info("creating template config file: path={s}", .{path});
     if (std.fs.path.dirname(path)) |dir_path| {
-        try std.fs.makeDirAbsolute(dir_path);
+        try std.fs.cwd().makePath(dir_path);
     }
     const file = try std.fs.createFileAbsolute(path, .{});
     defer file.close();


### PR DESCRIPTION
Resolves #8890 

If you try to create the config file when the directory already exists, you (I) get an error that the _file_ path already exists. 
```
warning(config): error creating template config file err=error.PathAlreadyExists
```
Even though the file does not exist. By changing the API entry point, this error goes away.

I have no solid explanation for why this change works.


| State | Old Behavior | New Behavior |
|--------|--------|--------|
| A config file exists | N/A | N/A |
| No config file, no directory | create directory and config file | N/A |
| No config file, yes directory | fail to create on config file  | create config file |

This behavior is confirmed on my macOS 26 machine. It is the least intrusive change I could make, and in all other situations should be a no-op.