### PR TITLE
scroll: add mouse-scroll-single-event config

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -842,6 +842,11 @@ palette: Palette = .{},
 /// Available since: 1.2.0
 @"mouse-scroll-multiplier": f64 = 3.0,
 
+/// If true, when mouse reporting is enabled (eg: SGR 1006), emit a single
+/// wheel event per scroll gesture regardless of computed y.delta. This
+/// prevents the multiplier from inflating the number of reported events.
+@"mouse-scroll-single-event": bool = false,
+
 /// The opacity level (opposite of transparency) of the background. A value of
 /// 1 is fully opaque and a value of 0 is fully transparent. A value less than 0
 /// or greater than 1 will be clamped to the nearest valid value.


### PR DESCRIPTION
Introduce a new config: mouse-scroll-single-event. If it is true, when mouse reporting is enabled, emit a single mouse wheel event per scroll gesture regardless of computed y.delta. This aligns other mainstream linux terminals and prevents the multiplier from inflating the number of reported events.

Fixes: https://github.com/ghostty-org/ghostty/discussions/8875

|               | Ghostty                   | Alacritty        | Kitty            | Ghostty (mouse-scroll-single-event = true) |
|---------------|---------------------------|------------------|------------------|--------------------------------------------|
| tmux scroll   | 15 lines per tick (3 * 5) | 5 lines per tick | 5 lines per tick | 5 lines per tick                           |
| vim scroll    | 9 lines per tick (3 * 3)  | 3 lines per tick | 3 lines per tick | 3 lines per tick                           |
| normal scroll | 3 lines per tick          | 1 lines per tick | 5 lines per tick | 3 lines per tick                           |

tmux conf has:
```
set -g mouse on
```
vimrc has:
```
set mouse=a
set ttymouse=sgr
```