### PR TITLE
vim: use :setf to set the filetype

### DIFF
--- a/src/extra/vim.zig
+++ b/src/extra/vim.zig
@@ -10,7 +10,7 @@ pub const ftdetect =
     \\"
     \\" THIS FILE IS AUTO-GENERATED
     \\
-    \\au BufRead,BufNewFile */ghostty/config,*/ghostty/themes/* set ft=ghostty
+    \\au BufRead,BufNewFile */ghostty/config,*/ghostty/themes/* setf ghostty
     \\
 ;
 pub const ftplugin =


### PR DESCRIPTION
This is nicer because it only sets the filetype if it hasn't already been set. :setf[iletype] has been available since vim version 6.

See: https://vimhelp.org/options.txt.html#%3Asetf