### PR TITLE
build: limit cpu affinity to 32 cpus on Linux

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -8,6 +8,10 @@ comptime {
 }
 
 pub fn build(b: *std.Build) !void {
+    // Works around a Zig but still present in 0.15.1. Remove when fixed.
+    // https://github.com/ghostty-org/ghostty/issues/8924
+    try limitCoresForZigBug();
+
     // This defines all the available build options (e.g. `-D`). If you
     // want to know what options are available, you can run `--help` or
     // you can read `src/build/Config.zig`.
@@ -297,4 +301,14 @@ pub fn build(b: *std.Build) !void {
     } else {
         try translations_step.addError("cannot update translations when i18n is disabled", .{});
     }
+}
+
+// WARNING: Remove this when https://github.com/ghostty-org/ghostty/issues/8924 is resolved!
+// Limit ourselves to 32 cpus on Linux because of an upstream Zig bug.
+fn limitCoresForZigBug() !void {
+    if (comptime builtin.os.tag != .linux) return;
+    const pid = std.os.linux.getpid();
+    var set: std.bit_set.ArrayBitSet(usize, std.os.linux.CPU_SETSIZE * 8) = .initEmpty();
+    for (0..32) |cpu| set.set(cpu);
+    try std.os.linux.sched_setaffinity(pid, &set.masks);
 }


### PR DESCRIPTION
Related to #8924

Zig currenly has a bug where it crashes when compiling Ghostty on systems with more than 32 cpus (See the linked issue for the gory details). As a temporary hack, use `sched_setaffinity` on Linux systems to limit the compile to the first 32 cores. Note that this affects the build only. The resulting Ghostty executable is not limited in any way.

This is a more general fix than wrapping the Zig compiler with `taskset`. First of all, it requires no action from the user or packagers. Second, it will be easier for us to remove once the upstream Zig bug is fixed.