### PR TITLE
feat: enable scaling mouse-scroll-multiplier for both precision and discrete scrolling

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -260,7 +260,7 @@ const DerivedConfig = struct {
     font: font.SharedGridSet.DerivedConfig,
     mouse_interval: u64,
     mouse_hide_while_typing: bool,
-    mouse_scroll_multiplier: f64,
+    mouse_scroll_multiplier: configpkg.MouseScrollMultiplier,
     mouse_shift_capture: configpkg.MouseShiftCapture,
     macos_non_native_fullscreen: configpkg.NonNativeFullscreen,
     macos_option_as_alt: ?configpkg.OptionAsAlt,
@@ -2829,7 +2829,7 @@ pub fn scrollCallback(
         // scroll events to pixels by multiplying the wheel tick value and the cell size. This means
         // that a wheel tick of 1 results in single scroll event.
         const yoff_adjusted: f64 = if (scroll_mods.precision)
-            yoff
+            yoff * self.config.mouse_scroll_multiplier.precision
         else yoff_adjusted: {
             // Round out the yoff to an absolute minimum of 1. macos tries to
             // simulate precision scrolling with non precision events by
@@ -2843,7 +2843,7 @@ pub fn scrollCallback(
             else
                 @min(yoff, -1);
 
-            break :yoff_adjusted yoff_max * cell_size * self.config.mouse_scroll_multiplier;
+            break :yoff_adjusted yoff_max * cell_size * self.config.mouse_scroll_multiplier.discrete;
         };
 
         // Add our previously saved pending amount to the offset to get the

--- a/src/config.zig
+++ b/src/config.zig
@@ -27,6 +27,7 @@ pub const FontStyle = Config.FontStyle;
 pub const FreetypeLoadFlags = Config.FreetypeLoadFlags;
 pub const Keybinds = Config.Keybinds;
 pub const MouseShiftCapture = Config.MouseShiftCapture;
+pub const MouseScrollMultiplier = Config.MouseScrollMultiplier;
 pub const NonNativeFullscreen = Config.NonNativeFullscreen;
 pub const OptionAsAlt = Config.OptionAsAlt;
 pub const RepeatableCodepointMap = Config.RepeatableCodepointMap;

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -7424,6 +7424,53 @@ pub const MouseScrollMultiplier = struct {
         const formatted = try std.fmt.bufPrint(&buf, "precision:{d},discrete:{d}", .{ self.precision, self.discrete });
         try formatter.formatEntry([]const u8, formatted);
     }
+
+    test "parse MouseScrollMultiplier" {
+        const testing = std.testing;
+
+        var args: Self = .{ .precision = 0.1, .discrete = 3 };
+        try args.parseCLI("3");
+        try testing.expect(args.precision == 3 and args.discrete == 3);
+        args = .{ .precision = 0.1, .discrete = 3 };
+        try args.parseCLI("precision:1");
+        try testing.expect(args.precision == 1 and args.discrete == 3);
+        args = .{ .precision = 0.1, .discrete = 3 };
+        try args.parseCLI("discrete:5");
+        try testing.expect(args.precision == 0.1 and args.discrete == 5);
+        args = .{ .precision = 0.1, .discrete = 3 };
+        try args.parseCLI("precision:3,discrete:7");
+        try testing.expect(args.precision == 3 and args.discrete == 7);
+        args = .{ .precision = 0.1, .discrete = 3 };
+        try args.parseCLI("discrete:8,precision:6");
+        try testing.expect(args.precision == 6 and args.discrete == 8);
+
+        args = .{ .precision = 0.1, .discrete = 3 };
+        try testing.expectError(error.InvalidValue, args.parseCLI("foo:1"));
+        args = .{ .precision = 0.1, .discrete = 3 };
+        try testing.expectError(error.InvalidValue, args.parseCLI("precision:bar"));
+        args = .{ .precision = 0.1, .discrete = 3 };
+        try testing.expectError(error.InvalidValue, args.parseCLI("precision:1,precision:3"));
+        args = .{ .precision = 0.1, .discrete = 3 };
+        try testing.expectError(error.ValueRequired, args.parseCLI(""));
+        args = .{ .precision = 0.1, .discrete = 3 };
+        try testing.expectError(error.InvalidValue, args.parseCLI("precision:1,discrete:3,foo:5"));
+        args = .{ .precision = 0.1, .discrete = 3 };
+        try testing.expectError(error.InvalidValue, args.parseCLI("precision:1,,discrete:3"));
+        args = .{ .precision = 0.1, .discrete = 3 };
+        try testing.expectError(error.InvalidValue, args.parseCLI("precision:1,discrete:3,"));
+        args = .{ .precision = 0.1, .discrete = 3 };
+        try testing.expectError(error.InvalidValue, args.parseCLI(",precision:1,discrete:3"));
+    }
+
+    test "format entry MouseScrollMultiplier" {
+        const testing = std.testing;
+        var buf = std.ArrayList(u8).init(testing.allocator);
+        defer buf.deinit();
+
+        var args: Self = .{ .precision = 1.5, .discrete = 2.5 };
+        try args.formatEntry(formatterpkg.entryFormatter("mouse-scroll-multiplier", buf.writer()));
+        try testing.expectEqualSlices(u8, "mouse-scroll-multiplier = precision:1.5,discrete:2.5\n", buf.items);
+    }
 };
 
 /// How to treat requests to write to or read from the clipboard


### PR DESCRIPTION
Resolves Issue: #8670 

Now precision and discrete scrolling can be scaled independently.  Supports following configuration,

```code
# Apply everywhere
mouse-scroll-multiplier = 3

# Apply separately
mouse-scroll-multiplier = precision:0.1,discrete:3 (default)

# Also it's order agnostic
mouse-scroll-multiplier = discrete:3,precision:2

# Apply one, default other
mouse-scroll-multiplier = precision:2
```

The default precision value is set 0.1, as it felt natural to me at least on my track-pad. I've also set the min clamp value precision to 0.1 as 0.01 felt kind of useless to me but I'm unsure.