### PR TITLE
lib-vt: Add SemanticVersion to provide SONAME versions

### DIFF
--- a/src/build/GhosttyLibVt.zig
+++ b/src/build/GhosttyLibVt.zig
@@ -27,6 +27,7 @@ pub fn initShared(
     const lib = b.addSharedLibrary(.{
         .name = "ghostty-vt",
         .root_module = zig.vt_c,
+        .version = std.SemanticVersion{ .major = 0, .minor = 1, .patch = 0 },
     });
     lib.installHeader(
         b.path("include/ghostty/vt.h"),


### PR DESCRIPTION
- Provide SONAME versioned shared libraries with major version numbers to separate ABI breaks

Adding a SemanticVersion to the shared library's module generates symlings for `libghostty-vt.so.<major version>` and `libghostty-vt.so.<major>.<minor>`

```
> zig build
> ls zig-out/lib/
libghostty-vt.so@  libghostty-vt.so.0@  libghostty-vt.so.0.1.0*
> readelf -d zig-out/lib/libghostty-vt.so

Dynamic section at offset 0x452858 contains 25 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
 0x000000000000000e (SONAME)             Library soname: [libghostty-vt.so.0]
...
 ```

Major versions are important for allowing multiple versions of a library to co-exist and let the SONAME section in an ELF binary request a specific major version of a shared library.[^1]

I believe the rules for updating SONAME versions match the SemVer spec for ABI changes.

> 1.    MAJOR version when you make incompatible API changes
> 2.    MINOR version when you add functionality in a backward compatible manner
> 3.    PATCH version when you make backward compatible bug fixes
[^2]

[^1]: https://www.man7.org/conf/lca2006/shared_libraries/slide5d.html 
[^2]: https://semver.org/#summary