### PR TITLE
Inline All The Things

### DIFF
--- a/src/datastruct/intrusive_linked_list.zig
+++ b/src/datastruct/intrusive_linked_list.zig
@@ -23,7 +23,7 @@ pub fn DoublyLinkedList(comptime T: type) type {
         /// Arguments:
         ///     node: Pointer to a node in the list.
         ///     new_node: Pointer to the new node to insert.
-        pub fn insertAfter(list: *Self, node: *Node, new_node: *Node) void {
+        pub inline fn insertAfter(list: *Self, node: *Node, new_node: *Node) void {
             new_node.prev = node;
             if (node.next) |next_node| {
                 // Intermediate node.
@@ -42,7 +42,7 @@ pub fn DoublyLinkedList(comptime T: type) type {
         /// Arguments:
         ///     node: Pointer to a node in the list.
         ///     new_node: Pointer to the new node to insert.
-        pub fn insertBefore(list: *Self, node: *Node, new_node: *Node) void {
+        pub inline fn insertBefore(list: *Self, node: *Node, new_node: *Node) void {
             new_node.next = node;
             if (node.prev) |prev_node| {
                 // Intermediate node.
@@ -60,7 +60,7 @@ pub fn DoublyLinkedList(comptime T: type) type {
         ///
         /// Arguments:
         ///     new_node: Pointer to the new node to insert.
-        pub fn append(list: *Self, new_node: *Node) void {
+        pub inline fn append(list: *Self, new_node: *Node) void {
             if (list.last) |last| {
                 // Insert after last.
                 list.insertAfter(last, new_node);
@@ -74,7 +74,7 @@ pub fn DoublyLinkedList(comptime T: type) type {
         ///
         /// Arguments:
         ///     new_node: Pointer to the new node to insert.
-        pub fn prepend(list: *Self, new_node: *Node) void {
+        pub inline fn prepend(list: *Self, new_node: *Node) void {
             if (list.first) |first| {
                 // Insert before first.
                 list.insertBefore(first, new_node);
@@ -91,7 +91,7 @@ pub fn DoublyLinkedList(comptime T: type) type {
         ///
         /// Arguments:
         ///     node: Pointer to the node to be removed.
-        pub fn remove(list: *Self, node: *Node) void {
+        pub inline fn remove(list: *Self, node: *Node) void {
             if (node.prev) |prev_node| {
                 // Intermediate node.
                 prev_node.next = node.next;
@@ -113,7 +113,7 @@ pub fn DoublyLinkedList(comptime T: type) type {
         ///
         /// Returns:
         ///     A pointer to the last node in the list.
-        pub fn pop(list: *Self) ?*Node {
+        pub inline fn pop(list: *Self) ?*Node {
             const last = list.last orelse return null;
             list.remove(last);
             return last;
@@ -123,7 +123,7 @@ pub fn DoublyLinkedList(comptime T: type) type {
         ///
         /// Returns:
         ///     A pointer to the first node in the list.
-        pub fn popFirst(list: *Self) ?*Node {
+        pub inline fn popFirst(list: *Self) ?*Node {
             const first = list.first orelse return null;
             list.remove(first);
             return first;

--- a/src/terminal/Parser.zig
+++ b/src/terminal/Parser.zig
@@ -254,7 +254,7 @@ pub fn deinit(self: *Parser) void {
 /// Next consumes the next character c and returns the actions to execute.
 /// Up to 3 actions may need to be executed -- in order -- representing
 /// the state exit, transition, and entry actions.
-pub fn next(self: *Parser, c: u8) [3]?Action {
+pub inline fn next(self: *Parser, c: u8) [3]?Action {
     const effect = table[c][@intFromEnum(self.state)];
 
     // log.info("next: {x}", .{c});
@@ -314,7 +314,7 @@ pub fn next(self: *Parser, c: u8) [3]?Action {
     };
 }
 
-pub fn collect(self: *Parser, c: u8) void {
+pub inline fn collect(self: *Parser, c: u8) void {
     if (self.intermediates_idx >= MAX_INTERMEDIATE) {
         log.warn("invalid intermediates count", .{});
         return;
@@ -324,7 +324,7 @@ pub fn collect(self: *Parser, c: u8) void {
     self.intermediates_idx += 1;
 }
 
-fn doAction(self: *Parser, action: TransitionAction, c: u8) ?Action {
+inline fn doAction(self: *Parser, action: TransitionAction, c: u8) ?Action {
     return switch (action) {
         .none, .ignore => null,
         .print => Action{ .print = c },
@@ -410,7 +410,7 @@ fn doAction(self: *Parser, action: TransitionAction, c: u8) ?Action {
     };
 }
 
-pub fn clear(self: *Parser) void {
+pub inline fn clear(self: *Parser) void {
     self.intermediates_idx = 0;
     self.params_idx = 0;
     self.params_sep = .initEmpty();

--- a/src/terminal/Parser.zig
+++ b/src/terminal/Parser.zig
@@ -254,7 +254,7 @@ pub fn deinit(self: *Parser) void {
 /// Next consumes the next character c and returns the actions to execute.
 /// Up to 3 actions may need to be executed -- in order -- representing
 /// the state exit, transition, and entry actions.
-pub inline fn next(self: *Parser, c: u8) [3]?Action {
+pub fn next(self: *Parser, c: u8) [3]?Action {
     const effect = table[c][@intFromEnum(self.state)];
 
     // log.info("next: {x}", .{c});

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -533,13 +533,13 @@ pub fn adjustCapacity(
     return new_node;
 }
 
-pub fn cursorCellRight(self: *Screen, n: size.CellCountInt) *pagepkg.Cell {
+pub inline fn cursorCellRight(self: *Screen, n: size.CellCountInt) *pagepkg.Cell {
     assert(self.cursor.x + n < self.pages.cols);
     const cell: [*]pagepkg.Cell = @ptrCast(self.cursor.page_cell);
     return @ptrCast(cell + n);
 }
 
-pub fn cursorCellLeft(self: *Screen, n: size.CellCountInt) *pagepkg.Cell {
+pub inline fn cursorCellLeft(self: *Screen, n: size.CellCountInt) *pagepkg.Cell {
     assert(self.cursor.x >= n);
     const cell: [*]pagepkg.Cell = @ptrCast(self.cursor.page_cell);
     return @ptrCast(cell - n);
@@ -959,7 +959,7 @@ fn cursorScrollAboveRotate(self: *Screen) !void {
 
 /// Move the cursor down if we're not at the bottom of the screen. Otherwise
 /// scroll. Currently only used for testing.
-fn cursorDownOrScroll(self: *Screen) !void {
+inline fn cursorDownOrScroll(self: *Screen) !void {
     if (self.cursor.y + 1 < self.pages.rows) {
         self.cursorDown(1);
     } else {
@@ -1034,7 +1034,7 @@ pub fn cursorCopy(self: *Screen, other: Cursor, opts: struct {
 /// page than the old AND we have a style or hyperlink set. In that case,
 /// we must release our old one and insert the new one, since styles are
 /// stored per-page.
-fn cursorChangePin(self: *Screen, new: Pin) void {
+inline fn cursorChangePin(self: *Screen, new: Pin) void {
     // Moving the cursor affects text run splitting (ligatures) so
     // we must mark the old and new page dirty. We do this as long
     // as the pins are not equal
@@ -1108,7 +1108,7 @@ fn cursorChangePin(self: *Screen, new: Pin) void {
 
 /// Mark the cursor position as dirty.
 /// TODO: test
-pub fn cursorMarkDirty(self: *Screen) void {
+pub inline fn cursorMarkDirty(self: *Screen) void {
     self.cursor.page_pin.markDirty();
 }
 
@@ -1160,7 +1160,7 @@ pub const Scroll = union(enum) {
 };
 
 /// Scroll the viewport of the terminal grid.
-pub fn scroll(self: *Screen, behavior: Scroll) void {
+pub inline fn scroll(self: *Screen, behavior: Scroll) void {
     defer self.assertIntegrity();
 
     if (comptime build_options.kitty_graphics) {
@@ -1181,7 +1181,7 @@ pub fn scroll(self: *Screen, behavior: Scroll) void {
 
 /// See PageList.scrollClear. In addition to that, we reset the cursor
 /// to be on top.
-pub fn scrollClear(self: *Screen) !void {
+pub inline fn scrollClear(self: *Screen) !void {
     defer self.assertIntegrity();
 
     try self.pages.scrollClear();
@@ -1196,14 +1196,14 @@ pub fn scrollClear(self: *Screen) !void {
 }
 
 /// Returns true if the viewport is scrolled to the bottom of the screen.
-pub fn viewportIsBottom(self: Screen) bool {
+pub inline fn viewportIsBottom(self: Screen) bool {
     return self.pages.viewport == .active;
 }
 
 /// Erase the region specified by tl and br, inclusive. This will physically
 /// erase the rows meaning the memory will be reclaimed (if the underlying
 /// page is empty) and other rows will be shifted up.
-pub fn eraseRows(
+pub inline fn eraseRows(
     self: *Screen,
     tl: point.Point,
     bl: ?point.Point,
@@ -1539,7 +1539,7 @@ pub fn splitCellBoundary(
 
 /// Returns the blank cell to use when doing terminal operations that
 /// require preserving the bg color.
-pub fn blankCell(self: *const Screen) Cell {
+pub inline fn blankCell(self: *const Screen) Cell {
     if (self.cursor.style_id == style.default_id) return .{};
     return self.cursor.style.bgCell() orelse .{};
 }
@@ -1557,7 +1557,7 @@ pub fn blankCell(self: *const Screen) Cell {
 /// probably means the system is in trouble anyways. I'd like to improve this
 /// in the future but it is not a priority particularly because this scenario
 /// (resize) is difficult.
-pub fn resize(
+pub inline fn resize(
     self: *Screen,
     cols: size.CellCountInt,
     rows: size.CellCountInt,
@@ -1568,7 +1568,7 @@ pub fn resize(
 /// Resize the screen without any reflow. In this mode, columns/rows will
 /// be truncated as they are shrunk. If they are grown, the new space is filled
 /// with zeros.
-pub fn resizeWithoutReflow(
+pub inline fn resizeWithoutReflow(
     self: *Screen,
     cols: size.CellCountInt,
     rows: size.CellCountInt,

--- a/src/terminal/point.zig
+++ b/src/terminal/point.zig
@@ -56,7 +56,7 @@ pub const Point = union(Tag) {
     screen: Coordinate,
     history: Coordinate,
 
-    pub fn coord(self: Point) Coordinate {
+    pub inline fn coord(self: Point) Coordinate {
         return switch (self) {
             .active,
             .viewport,

--- a/src/terminal/size.zig
+++ b/src/terminal/size.zig
@@ -31,7 +31,7 @@ pub fn Offset(comptime T: type) type {
         };
 
         /// Returns a pointer to the start of the data, properly typed.
-        pub fn ptr(self: Self, base: anytype) [*]T {
+        pub inline fn ptr(self: Self, base: anytype) [*]T {
             // The offset must be properly aligned for the type since
             // our return type is naturally aligned. We COULD modify this
             // to return arbitrary alignment, but its not something we need.

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -64,7 +64,7 @@ pub fn Stream(comptime Handler: type) type {
         }
 
         /// Process a string of characters.
-        pub fn nextSlice(self: *Self, input: []const u8) !void {
+        pub inline fn nextSlice(self: *Self, input: []const u8) !void {
             // Disable SIMD optimizations if build requests it or if our
             // manual debug mode is on.
             if (comptime debug or !build_options.simd) {
@@ -87,7 +87,7 @@ pub fn Stream(comptime Handler: type) type {
             }
         }
 
-        fn nextSliceCapped(self: *Self, input: []const u8, cp_buf: []u32) !void {
+        inline fn nextSliceCapped(self: *Self, input: []const u8, cp_buf: []u32) !void {
             assert(input.len <= cp_buf.len);
 
             var offset: usize = 0;
@@ -144,7 +144,7 @@ pub fn Stream(comptime Handler: type) type {
         ///
         /// Expects input to start with 0x1B, use consumeUntilGround first
         /// if the stream may be in the middle of an escape sequence.
-        fn consumeAllEscapes(self: *Self, input: []const u8) !usize {
+        inline fn consumeAllEscapes(self: *Self, input: []const u8) !usize {
             var offset: usize = 0;
             while (input[offset] == 0x1B) {
                 self.parser.state = .escape;
@@ -158,7 +158,7 @@ pub fn Stream(comptime Handler: type) type {
 
         /// Parses escape sequences until the parser reaches the ground state.
         /// Returns the number of bytes consumed from the provided input.
-        fn consumeUntilGround(self: *Self, input: []const u8) !usize {
+        inline fn consumeUntilGround(self: *Self, input: []const u8) !usize {
             var offset: usize = 0;
             while (self.parser.state != .ground) {
                 if (offset >= input.len) return input.len;
@@ -171,7 +171,7 @@ pub fn Stream(comptime Handler: type) type {
         /// Like nextSlice but takes one byte and is necessarily a scalar
         /// operation that can't use SIMD. Prefer nextSlice if you can and
         /// try to get multiple bytes at once.
-        pub fn next(self: *Self, c: u8) !void {
+        pub inline fn next(self: *Self, c: u8) !void {
             // The scalar path can be responsible for decoding UTF-8.
             if (self.parser.state == .ground) {
                 try self.nextUtf8(c);
@@ -185,7 +185,7 @@ pub fn Stream(comptime Handler: type) type {
         ///
         /// This assumes we're in the UTF-8 decoding state. If we may not
         /// be in the UTF-8 decoding state call nextSlice or next.
-        fn nextUtf8(self: *Self, c: u8) !void {
+        inline fn nextUtf8(self: *Self, c: u8) !void {
             assert(self.parser.state == .ground);
 
             const res = self.utf8decoder.next(c);
@@ -326,13 +326,13 @@ pub fn Stream(comptime Handler: type) type {
             }
         }
 
-        pub fn print(self: *Self, c: u21) !void {
+        pub inline fn print(self: *Self, c: u21) !void {
             if (@hasDecl(T, "print")) {
                 try self.handler.print(c);
             }
         }
 
-        pub fn execute(self: *Self, c: u8) !void {
+        pub inline fn execute(self: *Self, c: u8) !void {
             const c0: ansi.C0 = @enumFromInt(c);
             if (comptime debug) log.info("execute: {}", .{c0});
             switch (c0) {
@@ -383,7 +383,7 @@ pub fn Stream(comptime Handler: type) type {
             }
         }
 
-        fn csiDispatch(self: *Self, input: Parser.Action.CSI) !void {
+        inline fn csiDispatch(self: *Self, input: Parser.Action.CSI) !void {
             switch (input.final) {
                 // CUU - Cursor Up
                 'A', 'k' => switch (input.intermediates.len) {
@@ -1490,7 +1490,7 @@ pub fn Stream(comptime Handler: type) type {
             }
         }
 
-        fn oscDispatch(self: *Self, cmd: osc.Command) !void {
+        inline fn oscDispatch(self: *Self, cmd: osc.Command) !void {
             switch (cmd) {
                 .change_window_title => |title| {
                     if (@hasDecl(T, "changeWindowTitle")) {
@@ -1635,7 +1635,7 @@ pub fn Stream(comptime Handler: type) type {
             }
         }
 
-        fn configureCharset(
+        inline fn configureCharset(
             self: *Self,
             intermediates: []const u8,
             set: charsets.Charset,
@@ -1669,7 +1669,7 @@ pub fn Stream(comptime Handler: type) type {
             });
         }
 
-        fn escDispatch(
+        inline fn escDispatch(
             self: *Self,
             action: Parser.Action.ESC,
         ) !void {

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -278,7 +278,14 @@ pub fn Stream(comptime Handler: type) type {
                 return;
             }
 
-            const actions = self.parser.next(c);
+            // We explicitly inline this call here for performance reasons.
+            //
+            // We do this rather than mark Parser.next as inline because doing
+            // that causes weird behavior in some tests- I'm not sure if they
+            // miscompile or it's just very counter-intuitive comptime stuff,
+            // but regardless, this is the easy solution.
+            const actions = @call(.always_inline, Parser.next, .{ &self.parser, c });
+
             for (actions) |action_opt| {
                 const action = action_opt orelse continue;
                 if (comptime debug) log.info("action: {}", .{action});

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -186,19 +186,19 @@ pub const StreamHandler = struct {
         _ = self.renderer_mailbox.push(msg, .{ .forever = {} });
     }
 
-    pub fn dcsHook(self: *StreamHandler, dcs: terminal.DCS) !void {
+    pub inline fn dcsHook(self: *StreamHandler, dcs: terminal.DCS) !void {
         var cmd = self.dcs.hook(self.alloc, dcs) orelse return;
         defer cmd.deinit();
         try self.dcsCommand(&cmd);
     }
 
-    pub fn dcsPut(self: *StreamHandler, byte: u8) !void {
+    pub inline fn dcsPut(self: *StreamHandler, byte: u8) !void {
         var cmd = self.dcs.put(byte) orelse return;
         defer cmd.deinit();
         try self.dcsCommand(&cmd);
     }
 
-    pub fn dcsUnhook(self: *StreamHandler) !void {
+    pub inline fn dcsUnhook(self: *StreamHandler) !void {
         var cmd = self.dcs.unhook() orelse return;
         defer cmd.deinit();
         try self.dcsCommand(&cmd);
@@ -293,11 +293,11 @@ pub const StreamHandler = struct {
         }
     }
 
-    pub fn apcStart(self: *StreamHandler) !void {
+    pub inline fn apcStart(self: *StreamHandler) !void {
         self.apc.start();
     }
 
-    pub fn apcPut(self: *StreamHandler, byte: u8) !void {
+    pub inline fn apcPut(self: *StreamHandler, byte: u8) !void {
         self.apc.feed(self.alloc, byte);
     }
 
@@ -322,23 +322,23 @@ pub const StreamHandler = struct {
         }
     }
 
-    pub fn print(self: *StreamHandler, ch: u21) !void {
+    pub inline fn print(self: *StreamHandler, ch: u21) !void {
         try self.terminal.print(ch);
     }
 
-    pub fn printRepeat(self: *StreamHandler, count: usize) !void {
+    pub inline fn printRepeat(self: *StreamHandler, count: usize) !void {
         try self.terminal.printRepeat(count);
     }
 
-    pub fn bell(self: *StreamHandler) !void {
+    pub inline fn bell(self: *StreamHandler) !void {
         self.surfaceMessageWriter(.ring_bell);
     }
 
-    pub fn backspace(self: *StreamHandler) !void {
+    pub inline fn backspace(self: *StreamHandler) !void {
         self.terminal.backspace();
     }
 
-    pub fn horizontalTab(self: *StreamHandler, count: u16) !void {
+    pub inline fn horizontalTab(self: *StreamHandler, count: u16) !void {
         for (0..count) |_| {
             const x = self.terminal.screen.cursor.x;
             try self.terminal.horizontalTab();
@@ -346,7 +346,7 @@ pub const StreamHandler = struct {
         }
     }
 
-    pub fn horizontalTabBack(self: *StreamHandler, count: u16) !void {
+    pub inline fn horizontalTabBack(self: *StreamHandler, count: u16) !void {
         for (0..count) |_| {
             const x = self.terminal.screen.cursor.x;
             try self.terminal.horizontalTabBack();
@@ -354,61 +354,61 @@ pub const StreamHandler = struct {
         }
     }
 
-    pub fn linefeed(self: *StreamHandler) !void {
+    pub inline fn linefeed(self: *StreamHandler) !void {
         // Small optimization: call index instead of linefeed because they're
         // identical and this avoids one layer of function call overhead.
         try self.terminal.index();
     }
 
-    pub fn carriageReturn(self: *StreamHandler) !void {
+    pub inline fn carriageReturn(self: *StreamHandler) !void {
         self.terminal.carriageReturn();
     }
 
-    pub fn setCursorLeft(self: *StreamHandler, amount: u16) !void {
+    pub inline fn setCursorLeft(self: *StreamHandler, amount: u16) !void {
         self.terminal.cursorLeft(amount);
     }
 
-    pub fn setCursorRight(self: *StreamHandler, amount: u16) !void {
+    pub inline fn setCursorRight(self: *StreamHandler, amount: u16) !void {
         self.terminal.cursorRight(amount);
     }
 
-    pub fn setCursorDown(self: *StreamHandler, amount: u16, carriage: bool) !void {
+    pub inline fn setCursorDown(self: *StreamHandler, amount: u16, carriage: bool) !void {
         self.terminal.cursorDown(amount);
         if (carriage) self.terminal.carriageReturn();
     }
 
-    pub fn setCursorUp(self: *StreamHandler, amount: u16, carriage: bool) !void {
+    pub inline fn setCursorUp(self: *StreamHandler, amount: u16, carriage: bool) !void {
         self.terminal.cursorUp(amount);
         if (carriage) self.terminal.carriageReturn();
     }
 
-    pub fn setCursorCol(self: *StreamHandler, col: u16) !void {
+    pub inline fn setCursorCol(self: *StreamHandler, col: u16) !void {
         self.terminal.setCursorPos(self.terminal.screen.cursor.y + 1, col);
     }
 
-    pub fn setCursorColRelative(self: *StreamHandler, offset: u16) !void {
+    pub inline fn setCursorColRelative(self: *StreamHandler, offset: u16) !void {
         self.terminal.setCursorPos(
             self.terminal.screen.cursor.y + 1,
             self.terminal.screen.cursor.x + 1 +| offset,
         );
     }
 
-    pub fn setCursorRow(self: *StreamHandler, row: u16) !void {
+    pub inline fn setCursorRow(self: *StreamHandler, row: u16) !void {
         self.terminal.setCursorPos(row, self.terminal.screen.cursor.x + 1);
     }
 
-    pub fn setCursorRowRelative(self: *StreamHandler, offset: u16) !void {
+    pub inline fn setCursorRowRelative(self: *StreamHandler, offset: u16) !void {
         self.terminal.setCursorPos(
             self.terminal.screen.cursor.y + 1 +| offset,
             self.terminal.screen.cursor.x + 1,
         );
     }
 
-    pub fn setCursorPos(self: *StreamHandler, row: u16, col: u16) !void {
+    pub inline fn setCursorPos(self: *StreamHandler, row: u16, col: u16) !void {
         self.terminal.setCursorPos(row, col);
     }
 
-    pub fn eraseDisplay(self: *StreamHandler, mode: terminal.EraseDisplay, protected: bool) !void {
+    pub inline fn eraseDisplay(self: *StreamHandler, mode: terminal.EraseDisplay, protected: bool) !void {
         if (mode == .complete) {
             // Whenever we erase the full display, scroll to bottom.
             try self.terminal.scrollViewport(.{ .bottom = {} });
@@ -418,48 +418,48 @@ pub const StreamHandler = struct {
         self.terminal.eraseDisplay(mode, protected);
     }
 
-    pub fn eraseLine(self: *StreamHandler, mode: terminal.EraseLine, protected: bool) !void {
+    pub inline fn eraseLine(self: *StreamHandler, mode: terminal.EraseLine, protected: bool) !void {
         self.terminal.eraseLine(mode, protected);
     }
 
-    pub fn deleteChars(self: *StreamHandler, count: usize) !void {
+    pub inline fn deleteChars(self: *StreamHandler, count: usize) !void {
         self.terminal.deleteChars(count);
     }
 
-    pub fn eraseChars(self: *StreamHandler, count: usize) !void {
+    pub inline fn eraseChars(self: *StreamHandler, count: usize) !void {
         self.terminal.eraseChars(count);
     }
 
-    pub fn insertLines(self: *StreamHandler, count: usize) !void {
+    pub inline fn insertLines(self: *StreamHandler, count: usize) !void {
         self.terminal.insertLines(count);
     }
 
-    pub fn insertBlanks(self: *StreamHandler, count: usize) !void {
+    pub inline fn insertBlanks(self: *StreamHandler, count: usize) !void {
         self.terminal.insertBlanks(count);
     }
 
-    pub fn deleteLines(self: *StreamHandler, count: usize) !void {
+    pub inline fn deleteLines(self: *StreamHandler, count: usize) !void {
         self.terminal.deleteLines(count);
     }
 
-    pub fn reverseIndex(self: *StreamHandler) !void {
+    pub inline fn reverseIndex(self: *StreamHandler) !void {
         self.terminal.reverseIndex();
     }
 
-    pub fn index(self: *StreamHandler) !void {
+    pub inline fn index(self: *StreamHandler) !void {
         try self.terminal.index();
     }
 
-    pub fn nextLine(self: *StreamHandler) !void {
+    pub inline fn nextLine(self: *StreamHandler) !void {
         try self.terminal.index();
         self.terminal.carriageReturn();
     }
 
-    pub fn setTopAndBottomMargin(self: *StreamHandler, top: u16, bot: u16) !void {
+    pub inline fn setTopAndBottomMargin(self: *StreamHandler, top: u16, bot: u16) !void {
         self.terminal.setTopAndBottomMargin(top, bot);
     }
 
-    pub fn setLeftAndRightMarginAmbiguous(self: *StreamHandler) !void {
+    pub inline fn setLeftAndRightMarginAmbiguous(self: *StreamHandler) !void {
         if (self.terminal.modes.get(.enable_left_and_right_margin)) {
             try self.setLeftAndRightMargin(0, 0);
         } else {
@@ -467,7 +467,7 @@ pub const StreamHandler = struct {
         }
     }
 
-    pub fn setLeftAndRightMargin(self: *StreamHandler, left: u16, right: u16) !void {
+    pub inline fn setLeftAndRightMargin(self: *StreamHandler, left: u16, right: u16) !void {
         self.terminal.setLeftAndRightMargin(left, right);
     }
 
@@ -504,12 +504,12 @@ pub const StreamHandler = struct {
         self.messageWriter(msg);
     }
 
-    pub fn saveMode(self: *StreamHandler, mode: terminal.Mode) !void {
+    pub inline fn saveMode(self: *StreamHandler, mode: terminal.Mode) !void {
         // log.debug("save mode={}", .{mode});
         self.terminal.modes.save(mode);
     }
 
-    pub fn restoreMode(self: *StreamHandler, mode: terminal.Mode) !void {
+    pub inline fn restoreMode(self: *StreamHandler, mode: terminal.Mode) !void {
         // For restore mode we have to restore but if we set it, we
         // always have to call setMode because setting some modes have
         // side effects and we want to make sure we process those.
@@ -696,11 +696,11 @@ pub const StreamHandler = struct {
         }
     }
 
-    pub fn setMouseShiftCapture(self: *StreamHandler, v: bool) !void {
+    pub inline fn setMouseShiftCapture(self: *StreamHandler, v: bool) !void {
         self.terminal.flags.mouse_shift_capture = if (v) .true else .false;
     }
 
-    pub fn setAttribute(self: *StreamHandler, attr: terminal.Attribute) !void {
+    pub inline fn setAttribute(self: *StreamHandler, attr: terminal.Attribute) !void {
         switch (attr) {
             .unknown => |unk| log.warn("unimplemented or unknown SGR attribute: {any}", .{unk}),
 
@@ -709,11 +709,11 @@ pub const StreamHandler = struct {
         }
     }
 
-    pub fn startHyperlink(self: *StreamHandler, uri: []const u8, id: ?[]const u8) !void {
+    pub inline fn startHyperlink(self: *StreamHandler, uri: []const u8, id: ?[]const u8) !void {
         try self.terminal.screen.startHyperlink(uri, id);
     }
 
-    pub fn endHyperlink(self: *StreamHandler) !void {
+    pub inline fn endHyperlink(self: *StreamHandler) !void {
         self.terminal.screen.endHyperlink();
     }
 
@@ -832,31 +832,31 @@ pub const StreamHandler = struct {
         }
     }
 
-    pub fn setProtectedMode(self: *StreamHandler, mode: terminal.ProtectedMode) !void {
+    pub inline fn setProtectedMode(self: *StreamHandler, mode: terminal.ProtectedMode) !void {
         self.terminal.setProtectedMode(mode);
     }
 
-    pub fn decaln(self: *StreamHandler) !void {
+    pub inline fn decaln(self: *StreamHandler) !void {
         try self.terminal.decaln();
     }
 
-    pub fn tabClear(self: *StreamHandler, cmd: terminal.TabClear) !void {
+    pub inline fn tabClear(self: *StreamHandler, cmd: terminal.TabClear) !void {
         self.terminal.tabClear(cmd);
     }
 
-    pub fn tabSet(self: *StreamHandler) !void {
+    pub inline fn tabSet(self: *StreamHandler) !void {
         self.terminal.tabSet();
     }
 
-    pub fn tabReset(self: *StreamHandler) !void {
+    pub inline fn tabReset(self: *StreamHandler) !void {
         self.terminal.tabReset();
     }
 
-    pub fn saveCursor(self: *StreamHandler) !void {
+    pub inline fn saveCursor(self: *StreamHandler) !void {
         self.terminal.saveCursor();
     }
 
-    pub fn restoreCursor(self: *StreamHandler) !void {
+    pub inline fn restoreCursor(self: *StreamHandler) !void {
         try self.terminal.restoreCursor();
     }
 
@@ -865,11 +865,11 @@ pub const StreamHandler = struct {
         self.messageWriter(try termio.Message.writeReq(self.alloc, self.enquiry_response));
     }
 
-    pub fn scrollDown(self: *StreamHandler, count: usize) !void {
+    pub inline fn scrollDown(self: *StreamHandler, count: usize) !void {
         self.terminal.scrollDown(count);
     }
 
-    pub fn scrollUp(self: *StreamHandler, count: usize) !void {
+    pub inline fn scrollUp(self: *StreamHandler, count: usize) !void {
         self.terminal.scrollUp(count);
     }
 
@@ -995,7 +995,7 @@ pub const StreamHandler = struct {
         self.surfaceMessageWriter(.{ .set_title = buf });
     }
 
-    pub fn setMouseShape(
+    pub inline fn setMouseShape(
         self: *StreamHandler,
         shape: terminal.MouseShape,
     ) !void {
@@ -1037,22 +1037,22 @@ pub const StreamHandler = struct {
         });
     }
 
-    pub fn promptStart(self: *StreamHandler, aid: ?[]const u8, redraw: bool) !void {
+    pub inline fn promptStart(self: *StreamHandler, aid: ?[]const u8, redraw: bool) !void {
         _ = aid;
         self.terminal.markSemanticPrompt(.prompt);
         self.terminal.flags.shell_redraws_prompt = redraw;
     }
 
-    pub fn promptContinuation(self: *StreamHandler, aid: ?[]const u8) !void {
+    pub inline fn promptContinuation(self: *StreamHandler, aid: ?[]const u8) !void {
         _ = aid;
         self.terminal.markSemanticPrompt(.prompt_continuation);
     }
 
-    pub fn promptEnd(self: *StreamHandler) !void {
+    pub inline fn promptEnd(self: *StreamHandler) !void {
         self.terminal.markSemanticPrompt(.input);
     }
 
-    pub fn endOfInput(self: *StreamHandler) !void {
+    pub inline fn endOfInput(self: *StreamHandler) !void {
         self.terminal.markSemanticPrompt(.command);
     }
 


### PR DESCRIPTION
I used the new CPU counter mode in Instruments.app to track down functions that had instruction delivery bottlenecks (indicating i-cache misses) and picked a bunch of trivial functions to mark as inline (plus a couple that are only used once or twice and which benefit from inlining).

The size of `macos-arm64/libghostty-fat.a` built with `zig build -Doptimize=ReleaseFast -Dxcframework-target=native` goes from `145,538,856` bytes on `main` to `145,595,952` on this branch, a negligible increase.

These changes resulted in some pretty sizable improvements in vtebench results on my machine (Apple M3 Max):
<img width="983" height="696" alt="image" src="https://github.com/user-attachments/assets/cac595ca-7616-48ed-983c-208c2ca2023f" />

With this, the only vtebench test we're slower than Alacritty in (on my machine, at 130x51 window size) is `dense_cells` (which, IMO, is so artificial that optimizing for it might actually negatively impact real world performance).

I also did a pretty simple improvement to how we copy the screen in the renderer, gave it its own page pool for less memory churn. Further optimization in that area should be explored since in some scenarios it seems like as much as 35% of the time on the `io-reader` thread is spent waiting for the lock.

> [!NOTE]
> Before this is merged, someone really ought to test this on an x86 processor to see how the performance compares there, since this *is* tuning for my processor specifically, and I know that M chips have pretty big i-cache compared to some x86 processors which could impact the performance characteristics of these changes.