### PR TITLE
gtk: make Enter confirm "Change Terminal Title"

### DIFF
--- a/src/apprt/gtk/ui/1.5/surface-title-dialog.blp
+++ b/src/apprt/gtk/ui/1.5/surface-title-dialog.blp
@@ -6,11 +6,14 @@ template $GhosttySurfaceTitleDialog: Adw.AlertDialog {
   body: _("Leave blank to restore the default title.");
 
   responses [
-    cancel: _("Cancel") suggested,
-    ok: _("OK") destructive,
+    cancel: _("Cancel"),
+    ok: _("OK") suggested,
   ]
 
+  default-response: "ok";
   focus-widget: entry;
 
-  extra-child: Entry entry {};
+  extra-child: Entry entry {
+    activates-default: true;
+  };
 }


### PR DESCRIPTION
Fixes https://github.com/ghostty-org/ghostty/discussions/8697 by making `OK` the suggested default and activating it by default.

Previously `OK` was `destructive` which imo is not a good approach for just setting a terminal title.