### PR TITLE
lib-vt: OSC data extraction boilerplate

### DIFF
--- a/example/c-vt/src/main.c
+++ b/example/c-vt/src/main.c
@@ -1,5 +1,6 @@
 #include <stddef.h>
 #include <stdio.h>
+#include <string.h>
 #include <ghostty/vt.h>
 
 int main() {
@@ -8,10 +9,13 @@ int main() {
     return 1;
   }
   
-  // Setup change window title command to change the title to "a"
+  // Setup change window title command to change the title to "hello"
   ghostty_osc_next(parser, '0');
   ghostty_osc_next(parser, ';');
-  ghostty_osc_next(parser, 'a');
+  const char *title = "hello";
+  for (size_t i = 0; i < strlen(title); i++) {
+    ghostty_osc_next(parser, title[i]);
+  }
   
   // End parsing and get command
   GhosttyOscCommand command = ghostty_osc_end(parser, 0);
@@ -19,6 +23,13 @@ int main() {
   // Get and print command type
   GhosttyOscCommandType type = ghostty_osc_command_type(command);
   printf("Command type: %d\n", type);
+  
+  // Extract and print the title
+  if (ghostty_osc_command_data(command, GHOSTTY_OSC_DATA_CHANGE_WINDOW_TITLE_STR, &title)) {
+    printf("Extracted title: %s\n", title);
+  } else {
+    printf("Failed to extract title\n");
+  }
   
   ghostty_osc_free(parser);
   return 0;

--- a/src/inspector/termio.zig
+++ b/src/inspector/termio.zig
@@ -197,7 +197,9 @@ pub const VTEvent = struct {
     ) !void {
         switch (@TypeOf(v)) {
             void => {},
-            []const u8 => try md.put("data", try alloc.dupeZ(u8, v)),
+            []const u8,
+            [:0]const u8,
+            => try md.put("data", try alloc.dupeZ(u8, v)),
             else => |T| switch (@typeInfo(T)) {
                 .@"struct" => |info| inline for (info.fields) |field| {
                     try encodeMetadataSingle(
@@ -284,7 +286,9 @@ pub const VTEvent = struct {
                     try std.fmt.allocPrintZ(alloc, "{}", .{value}),
                 ),
 
-                []const u8 => try md.put(key, try alloc.dupeZ(u8, value)),
+                []const u8,
+                [:0]const u8,
+                => try md.put(key, try alloc.dupeZ(u8, value)),
 
                 else => |T| {
                     @compileLog(T);

--- a/src/lib_vt.zig
+++ b/src/lib_vt.zig
@@ -77,6 +77,7 @@ comptime {
         @export(&c.osc_reset, .{ .name = "ghostty_osc_reset" });
         @export(&c.osc_end, .{ .name = "ghostty_osc_end" });
         @export(&c.osc_command_type, .{ .name = "ghostty_osc_command_type" });
+        @export(&c.osc_command_data, .{ .name = "ghostty_osc_command_data" });
     }
 }
 

--- a/src/terminal/c/main.zig
+++ b/src/terminal/c/main.zig
@@ -7,6 +7,7 @@ pub const osc_reset = osc.reset;
 pub const osc_next = osc.next;
 pub const osc_end = osc.end;
 pub const osc_command_type = osc.commandType;
+pub const osc_command_data = osc.commandData;
 
 test {
     _ = osc;

--- a/src/terminal/c/osc.zig
+++ b/src/terminal/c/osc.zig
@@ -49,6 +49,51 @@ pub fn commandType(command_: Command) callconv(.c) osc.Command.Key {
     return command.*;
 }
 
+/// C: GhosttyOscCommandData
+pub const CommandData = enum(c_int) {
+    invalid = 0,
+    change_window_title_str = 1,
+
+    /// Output type expected for querying the data of the given kind.
+    pub fn OutType(comptime self: CommandData) type {
+        return switch (self) {
+            .invalid => void,
+            .change_window_title_str => [*:0]const u8,
+        };
+    }
+};
+
+pub fn commandData(
+    command_: Command,
+    data: CommandData,
+    out: ?*anyopaque,
+) callconv(.c) bool {
+    return switch (data) {
+        inline else => |comptime_data| commandDataTyped(
+            command_,
+            comptime_data,
+            @ptrCast(@alignCast(out)),
+        ),
+    };
+}
+
+fn commandDataTyped(
+    command_: Command,
+    comptime data: CommandData,
+    out: *data.OutType(),
+) bool {
+    const command = command_.?;
+    switch (data) {
+        .invalid => return false,
+        .change_window_title_str => switch (command.*) {
+            .change_window_title => |v| out.* = v.ptr,
+            else => return false,
+        },
+    }
+
+    return true;
+}
+
 test "alloc" {
     const testing = std.testing;
     var p: Parser = undefined;
@@ -64,7 +109,7 @@ test "command type null" {
     try testing.expectEqual(.invalid, commandType(null));
 }
 
-test "command type" {
+test "change window title" {
     const testing = std.testing;
     var p: Parser = undefined;
     try testing.expectEqual(Result.success, new(
@@ -73,9 +118,15 @@ test "command type" {
     ));
     defer free(p);
 
+    // Parse it
     next(p, '0');
     next(p, ';');
     next(p, 'a');
     const cmd = end(p, 0);
     try testing.expectEqual(.change_window_title, commandType(cmd));
+
+    // Extract the title
+    var title: [*:0]const u8 = undefined;
+    try testing.expect(commandData(cmd, .change_window_title_str, @ptrCast(&title)));
+    try testing.expectEqualStrings("a", std.mem.span(title));
 }


### PR DESCRIPTION
This adds functions to extra data out of OSC commands, but it is mostly boilerplate since I only added one valid data extraction. 😄 The example was updated to show this.

This also changes OSC strings to be null-terminated to ease lib-vt integration. This shouldn't have any practical effect on terminal performance, but it does lower the maximum length of OSC strings by 1 since we always reserve space for the null terminator.