### PR TITLE
macOS: Focus Terminal App Intent

### DIFF
--- a/macos/Ghostty.xcodeproj/project.pbxproj
+++ b/macos/Ghostty.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 				"Features/App Intents/CommandPaletteIntent.swift",
 				"Features/App Intents/Entities/CommandEntity.swift",
 				"Features/App Intents/Entities/TerminalEntity.swift",
+				"Features/App Intents/FocusTerminalIntent.swift",
 				"Features/App Intents/GetTerminalDetailsIntent.swift",
 				"Features/App Intents/GhosttyIntentError.swift",
 				"Features/App Intents/InputIntent.swift",

--- a/macos/Sources/Features/App Intents/FocusTerminalIntent.swift
+++ b/macos/Sources/Features/App Intents/FocusTerminalIntent.swift
@@ -1,0 +1,35 @@
+import AppKit
+import AppIntents
+import GhosttyKit
+
+struct FocusTerminalIntent: AppIntent {
+    static var title: LocalizedStringResource = "Focus Terminal"
+    static var description = IntentDescription("Move focus to an existing terminal.")
+
+    @Parameter(
+        title: "Terminal",
+        description: "The terminal to focus.",
+    )
+    var terminal: TerminalEntity
+
+    @available(macOS 26.0, *)
+    static var supportedModes: IntentModes = .background
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        guard await requestIntentPermission() else {
+            throw GhosttyIntentError.permissionDenied
+        }
+
+        guard let surfaceView = terminal.surfaceView else {
+            throw GhosttyIntentError.surfaceNotFound
+        }
+
+        guard let controller = surfaceView.window?.windowController as? BaseTerminalController else {
+            return .result()
+        }
+
+        controller.focusSurface(surfaceView)
+        return .result()
+    }
+}

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -255,7 +255,7 @@ class QuickTerminalController: BaseTerminalController {
         }
         // Check if target surface belongs to this quick terminal
         guard surfaceTree.contains(view) else { return }
-        // Set the target surface as focused before animation
+        // Set the target surface as focused
         DispatchQueue.main.async {
             Ghostty.moveFocus(to: view)
         }

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -257,7 +257,7 @@ class QuickTerminalController: BaseTerminalController {
         guard surfaceTree.contains(view) else { return }
         // Set the target surface as focused before animation
         DispatchQueue.main.async {
-            Ghostty.moveFocus(to: view, from: self.focusedSurface)
+            Ghostty.moveFocus(to: view)
         }
         // Animation completion handler will handle window/app activation
         animateIn()

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -253,10 +253,14 @@ class QuickTerminalController: BaseTerminalController {
             super.focusSurface(view)
             return
         }
-        animateIn()
-        DispatchQueue.main.asyncAfter(deadline: .now() + derivedConfig.quickTerminalAnimationDuration) {
-            super.focusSurface(view)
+        // Check if target surface belongs to this quick terminal
+        guard surfaceTree.contains(view) else { return }
+        // Set the target surface as focused before animation
+        DispatchQueue.main.async {
+            Ghostty.moveFocus(to: view, from: self.focusedSurface)
         }
+        // Animation completion handler will handle window/app activation
+        animateIn()
     }
 
     override func surfaceTreeDidChange(from: SplitTree<Ghostty.SurfaceView>, to: SplitTree<Ghostty.SurfaceView>) {

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -247,6 +247,18 @@ class QuickTerminalController: BaseTerminalController {
 
     // MARK: Base Controller Overrides
 
+    override func focusSurface(_ view: Ghostty.SurfaceView) {
+        if visible {
+            // If we're visible, we just focus the surface as normal.
+            super.focusSurface(view)
+            return
+        }
+        animateIn()
+        DispatchQueue.main.asyncAfter(deadline: .now() + derivedConfig.quickTerminalAnimationDuration) {
+            super.focusSurface(view)
+        }
+    }
+
     override func surfaceTreeDidChange(from: SplitTree<Ghostty.SurfaceView>, to: SplitTree<Ghostty.SurfaceView>) {
         super.surfaceTreeDidChange(from: from, to: to)
 

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -240,12 +240,7 @@ class BaseTerminalController: NSWindowController,
 
         // Move focus to the target surface and activate the window/app
         DispatchQueue.main.async {
-            // We suppress the spurious unfocus signal by passing nil for `from`
-            // when the surface is already the logically focused one.
-            Ghostty.moveFocus(
-                to: view,
-                from: (self.focusedSurface == view) ? nil : self.focusedSurface
-            )
+            Ghostty.moveFocus(to: view)
             view.window?.makeKeyAndOrderFront(nil)
             if !NSApp.isActive {
                 NSApp.activate(ignoringOtherApps: true)

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -239,7 +239,9 @@ class BaseTerminalController: NSWindowController,
         DispatchQueue.main.async {
             Ghostty.moveFocus(to: view, from: self.focusedSurface)
             view.window?.makeKeyAndOrderFront(nil)
-            NSApp.activate(ignoringOtherApps: true)
+            if !NSApp.isActive {
+                NSApp.activate(ignoringOtherApps: true)
+            }
         }
     }
 

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -233,6 +233,16 @@ class BaseTerminalController: NSWindowController,
         return newView
     }
 
+    func focusSurface(_ view: Ghostty.SurfaceView) {
+        guard surfaceTree.contains(view) else { return }
+
+        DispatchQueue.main.async {
+            Ghostty.moveFocus(to: view, from: self.focusedSurface)
+            view.window?.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+        }
+    }
+
     /// Called when the surfaceTree variable changed.
     ///
     /// Subclasses should call super first.

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -240,7 +240,12 @@ class BaseTerminalController: NSWindowController,
 
         // Move focus to the target surface and activate the window/app
         DispatchQueue.main.async {
-            Ghostty.moveFocus(to: view, from: self.focusedSurface)
+            // We suppress the spurious unfocus signal by passing nil for `from`
+            // when the surface is already the logically focused one.
+            Ghostty.moveFocus(
+                to: view,
+                from: (self.focusedSurface == view) ? nil : self.focusedSurface
+            )
             view.window?.makeKeyAndOrderFront(nil)
             if !NSApp.isActive {
                 NSApp.activate(ignoringOtherApps: true)

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -233,9 +233,12 @@ class BaseTerminalController: NSWindowController,
         return newView
     }
 
+    /// Move focus to a surface view.
     func focusSurface(_ view: Ghostty.SurfaceView) {
+        // Check if target surface is in our tree
         guard surfaceTree.contains(view) else { return }
 
+        // Move focus to the target surface and activate the window/app
         DispatchQueue.main.async {
             Ghostty.moveFocus(to: view, from: self.focusedSurface)
             view.window?.makeKeyAndOrderFront(nil)


### PR DESCRIPTION
Closes #8791 
Discussion: #8657 

### Summary
This adds the FocusTerminalIntent App Intent and related function (focusSurface), allows external tools (such as Shortcuts/Siri) to programmatically move focus to a specific terminal window or tab.

### Verification
This functionality has been tested across following scenarios, confirming correct focus behavior for:

- Split Window
- Tab Group
- Quick Terminal

### Note
It is not supported to move focus to a split that is hidden by a zoomed split. The same applies to the CloseTerminalIntent.

### AI Disclosure
This pull request was made with assistance from Claude Code.
I reviewed all AI-generated code and wrote the final output manually.