### PR TITLE
gtk: some bell features need to happen on receipt of every BEL

### DIFF
--- a/src/apprt/gtk/ui/1.2/surface.blp
+++ b/src/apprt/gtk/ui/1.2/surface.blp
@@ -169,7 +169,6 @@ template $GhosttySurface: Adw.Bin {
     "surface",
   ]
 
-  notify::bell-ringing => $notify_bell_ringing();
   notify::config => $notify_config();
   notify::error => $notify_error();
   notify::mouse-hover-url => $notify_mouse_hover_url();


### PR DESCRIPTION
Some bell features should be triggered on the receipt of every BEL character, namely `audio` and `system`. However, Ghostty was setting a boolean to `true` upon the receipt of the first BEL. Subsequent BEL characters would be ignored until that boolean was reset to `false`, usually by keyboard/mouse activity.

This PR fixes the problem by ensuring that the `audio` and `system` features are triggered every time a BEL is received. Other features continue to be triggered only when the `bell-ringing` boolean state changes.

Fixes #8957