### PR TITLE
build: isolate XCFramework.Target so runtime code doesn't depend on it

### DIFF
--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -9,7 +9,7 @@ const ApprtRuntime = @import("../apprt/runtime.zig").Runtime;
 const FontBackend = @import("../font/backend.zig").Backend;
 const RendererBackend = @import("../renderer/backend.zig").Backend;
 const TerminalBuildOptions = @import("../terminal/build_options.zig").Options;
-const XCFramework = @import("GhosttyXCFramework.zig");
+const XCFrameworkTarget = @import("xcframework.zig").Target;
 const WasmTarget = @import("../os/wasm/target.zig").Target;
 const expandPath = @import("../os/path.zig").expand;
 
@@ -26,7 +26,7 @@ const app_version: std.SemanticVersion = .{ .major = 1, .minor = 2, .patch = 1 }
 /// Standard build configuration options.
 optimize: std.builtin.OptimizeMode,
 target: std.Build.ResolvedTarget,
-xcframework_target: XCFramework.Target = .universal,
+xcframework_target: XCFrameworkTarget = .universal,
 wasm_target: WasmTarget,
 
 /// Comptime interfaces
@@ -121,7 +121,7 @@ pub fn init(b: *std.Build) !Config {
     //---------------------------------------------------------------
     // Target-specific properties
     config.xcframework_target = b.option(
-        XCFramework.Target,
+        XCFrameworkTarget,
         "xcframework-target",
         "The target for the xcframework.",
     ) orelse .universal;

--- a/src/build/GhosttyXCFramework.zig
+++ b/src/build/GhosttyXCFramework.zig
@@ -5,11 +5,10 @@ const Config = @import("Config.zig");
 const SharedDeps = @import("SharedDeps.zig");
 const GhosttyLib = @import("GhosttyLib.zig");
 const XCFrameworkStep = @import("XCFrameworkStep.zig");
+const Target = @import("xcframework.zig").Target;
 
 xcframework: *XCFrameworkStep,
 target: Target,
-
-pub const Target = enum { native, universal };
 
 pub fn init(
     b: *std.Build,

--- a/src/build/xcframework.zig
+++ b/src/build/xcframework.zig
@@ -1,0 +1,3 @@
+/// Target for xcframework builds. This is a separate file so that
+/// our runtime code doesn't need to import build code.
+pub const Target = enum { native, universal };


### PR DESCRIPTION
This fixes the lazyImport importing outside of the build root. The build root for the build binary is always the root `build.zig` (which we want), but our `src/build_config.zig` transitively imported SharedDeps which led to issues with Zig 0.15.

This back ports to main early (outside our Zig 0.15 PR) because its compatible and will simplify that one.