### PR TITLE
core: add 'command finished' notifications

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -733,6 +733,14 @@ typedef struct {
   int8_t progress;
 } ghostty_action_progress_report_s;
 
+// apprt.action.CommandFinished.C
+typedef struct {
+  // -1 if no exit code was reported, otherwise 0-255
+  int16_t exit_code;
+  // number of nanoseconds that command was running for
+  uint64_t duration;
+} ghostty_action_command_finished_s;
+
 // apprt.Action.Key
 typedef enum {
   GHOSTTY_ACTION_QUIT,
@@ -788,6 +796,7 @@ typedef enum {
   GHOSTTY_ACTION_SHOW_CHILD_EXITED,
   GHOSTTY_ACTION_PROGRESS_REPORT,
   GHOSTTY_ACTION_SHOW_ON_SCREEN_KEYBOARD,
+  GHOSTTY_ACTION_COMMAND_FINISHED,
 } ghostty_action_tag_e;
 
 typedef union {
@@ -819,6 +828,7 @@ typedef union {
   ghostty_action_close_tab_mode_e close_tab_mode;
   ghostty_surface_message_childexited_s child_exited;
   ghostty_action_progress_report_s progress_report;
+  ghostty_action_command_finished_s command_finished;
 } ghostty_action_u;
 
 typedef struct {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -33,6 +33,7 @@ const font = @import("font/main.zig");
 const Command = @import("Command.zig");
 const terminal = @import("terminal/main.zig");
 const configpkg = @import("config.zig");
+const Duration = configpkg.Config.Duration;
 const input = @import("input.zig");
 const App = @import("App.zig");
 const internal_os = @import("os/main.zig");
@@ -146,6 +147,13 @@ focused: bool = true,
 
 /// Used to determine whether to continuously scroll.
 selection_scroll_active: bool = false,
+
+/// Used to send notifications that long running commands have finished.
+/// Requires that shell integration be active. Should represent a nanosecond
+/// precision timestamp. It does not necessarily need to correspond to the
+/// actual time, but we must be able to compare two subsequent timestamps to get
+/// the wall clock time that has elapsed between timestamps.
+command_timer: ?i128 = null,
 
 /// The effect of an input event. This can be used by callers to take
 /// the appropriate action after an input event. For example, key
@@ -280,6 +288,9 @@ const DerivedConfig = struct {
     links: []Link,
     link_previews: configpkg.LinkPreviews,
     scroll_to_bottom: configpkg.Config.ScrollToBottom,
+    notify_on_command_finish: configpkg.Config.NotifyOnCommandFinish,
+    notify_on_command_finish_action: configpkg.Config.NotifyOnCommandFinishAction,
+    notify_on_command_finish_after: Duration,
 
     const Link = struct {
         regex: oni.Regex,
@@ -350,6 +361,9 @@ const DerivedConfig = struct {
             .links = links,
             .link_previews = config.@"link-previews",
             .scroll_to_bottom = config.@"scroll-to-bottom",
+            .notify_on_command_finish = config.@"notify-on-command-finish",
+            .notify_on_command_finish_action = config.@"notify-on-command-finish-action",
+            .notify_on_command_finish_after = config.@"notify-on-command-finish-after",
 
             // Assignments happen sequentially so we have to do this last
             // so that the memory is captured from allocs above.
@@ -983,6 +997,36 @@ pub fn handleMessage(self: *Surface, msg: Message) !void {
         .selection_scroll_tick => |active| {
             self.selection_scroll_active = active;
             try self.selectionScrollTick();
+        },
+
+        .start_command_timer => {
+            self.command_timer = std.time.nanoTimestamp();
+        },
+
+        .stop_command_timer => |v| timer: {
+            const end = std.time.nanoTimestamp();
+            const start = self.command_timer orelse break :timer;
+            self.command_timer = null;
+
+            const difference = end - start;
+
+            // skip obviously silly results
+            if (difference < 0) break :timer;
+            if (difference > std.math.maxInt(u64)) break :timer;
+
+            const duration: Duration = .{ .duration = @intCast(difference) };
+            log.debug("command took {}", .{duration});
+
+            _ = self.rt_app.performAction(
+                .{ .surface = self },
+                .command_finished,
+                .{
+                    .exit_code = v,
+                    .duration = duration,
+                },
+            ) catch |err| {
+                log.warn("apprt failed to notify command finish={}", .{err});
+            };
         },
     }
 }

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -295,6 +295,9 @@ pub const Action = union(Key) {
     /// Show the on-screen keyboard.
     show_on_screen_keyboard,
 
+    /// A command has finished,
+    command_finished: CommandFinished,
+
     /// Sync with: ghostty_action_tag_e
     pub const Key = enum(c_int) {
         quit,
@@ -350,6 +353,7 @@ pub const Action = union(Key) {
         show_child_exited,
         progress_report,
         show_on_screen_keyboard,
+        command_finished,
     };
 
     /// Sync with: ghostty_action_u
@@ -740,4 +744,22 @@ pub const CloseTabMode = enum(c_int) {
     this,
     /// Close all other tabs.
     other,
+};
+
+pub const CommandFinished = struct {
+    exit_code: ?u8,
+    duration: configpkg.Config.Duration,
+
+    /// sync with ghostty_action_command_finished_s in ghostty.h
+    pub const C = extern struct {
+        exit_code: i16,
+        duration: u64,
+    };
+
+    pub fn cval(self: CommandFinished) C {
+        return .{
+            .exit_code = self.exit_code orelse -1,
+            .duration = self.duration.duration,
+        };
+    }
 };

--- a/src/apprt/gtk/class/split_tree.zig
+++ b/src/apprt/gtk/class/split_tree.zig
@@ -198,7 +198,7 @@ pub const SplitTree = extern struct {
             .init("zoom", actionZoom, null),
         };
 
-        ext.actions.addAsGroup(Self, self, "split-tree", &actions);
+        _ = ext.actions.addAsGroup(Self, self, "split-tree", &actions);
     }
 
     /// Create a new split in the given direction from the currently

--- a/src/apprt/gtk/class/tab.zig
+++ b/src/apprt/gtk/class/tab.zig
@@ -206,7 +206,7 @@ pub const Tab = extern struct {
             .init("ring-bell", actionRingBell, null),
         };
 
-        ext.actions.addAsGroup(Self, self, "tab", &actions);
+        _ = ext.actions.addAsGroup(Self, self, "tab", &actions);
     }
 
     //---------------------------------------------------------------

--- a/src/apprt/gtk/ui/1.2/surface.blp
+++ b/src/apprt/gtk/ui/1.2/surface.blp
@@ -203,6 +203,11 @@ menu context_menu_model {
       label: _("Paste");
       action: "win.paste";
     }
+
+    item {
+      label: _("Notify on Next Command Finish");
+      action: "surface.notify-on-next-command-finish";
+    }
   }
 
   section {

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -96,6 +96,14 @@ pub const Message = union(enum) {
     /// Report the progress of an action using a GUI element
     progress_report: terminal.osc.Command.ProgressReport,
 
+    /// A command has started in the shell, start a timer.
+    start_command_timer,
+
+    /// A command has finished in the shell, stop the timer and send out
+    /// notifications as appropriate. The optional u8 is the exit code
+    /// of the command.
+    stop_command_timer: ?u8,
+
     pub const ReportTitleStyle = enum {
         csi_21_t,
 

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -97,12 +97,12 @@ pub const Message = union(enum) {
     progress_report: terminal.osc.Command.ProgressReport,
 
     /// A command has started in the shell, start a timer.
-    start_command_timer,
+    start_command,
 
     /// A command has finished in the shell, stop the timer and send out
     /// notifications as appropriate. The optional u8 is the exit code
     /// of the command.
-    stop_command_timer: ?u8,
+    stop_command: ?u8,
 
     pub const ReportTitleStyle = enum {
         csi_21_t,

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1004,6 +1004,82 @@ command: ?Command = null,
 ///     manually.
 @"initial-command": ?Command = null,
 
+/// Controls when command finished notifications are sent. There are
+/// three options:
+///
+/// * `never` - Never send notifications (the default).
+/// * `unfocused` - Only send notifications if the surface that the command is
+///   running in is not focused.
+/// * `always` - Always send notifications.
+///
+/// Command finished notifications requires that either shell integration is
+/// enabled, or that your shell sends OSC 133 escape sequences to mark the start
+/// and end of commands.
+///
+/// On GTK, there is a context menu item that will enable command finished
+/// notifications for a single command, overriding the `never` and `unfocused`
+/// options.
+///
+/// GTK only.
+///
+/// Available since 1.3.0.
+@"notify-on-command-finish": NotifyOnCommandFinish = .never,
+
+/// If command finished notifications are enabled, this controls how the user is
+/// notified.
+///
+/// Available options:
+///
+/// * `bell` - enabled by default
+/// * `notify` - disabled by default
+///
+/// Options can be combined by listing them as a comma separated list. Options
+/// can be negated by prefixing them with `no-`. For example `no-bell,notify`.
+///
+/// GTK only.
+///
+/// Available since 1.3.0.
+@"notify-on-command-finish-action": NotifyOnCommandFinishAction = .{
+    .bell = true,
+    .notify = false,
+},
+
+/// If command finished notifications are enabled, this controls how long a
+/// command must have been running before a notification will be sent. The
+/// default is five seconds.
+///
+/// The duration is specified as a series of numbers followed by time units.
+/// Whitespace is allowed between numbers and units. Each number and unit will
+/// be added together to form the total duration.
+///
+/// The allowed time units are as follows:
+///
+///   * `y` - 365 SI days, or 8760 hours, or 31536000 seconds. No adjustments
+///     are made for leap years or leap seconds.
+///   * `d` - one SI day, or 86400 seconds.
+///   * `h` - one hour, or 3600 seconds.
+///   * `m` - one minute, or 60 seconds.
+///   * `s` - one second.
+///   * `ms` - one millisecond, or 0.001 second.
+///   * `us` or `µs` - one microsecond, or 0.000001 second.
+///   * `ns` - one nanosecond, or 0.000000001 second.
+///
+/// Examples:
+///   * `1h30m`
+///   * `45s`
+///
+/// Units can be repeated and will be added together. This means that
+/// `1h1h` is equivalent to `2h`. This is confusing and should be avoided.
+/// A future update may disallow this.
+///
+/// The maximum value is `584y 49w 23h 34m 33s 709ms 551µs 615ns`. Any
+/// value larger than this will be clamped to the maximum value.
+///
+/// GTK only.
+///
+/// Available since 1.3.0
+@"notify-on-command-finish-after": Duration = .{ .duration = 5 * std.time.ns_per_s },
+
 /// Extra environment variables to pass to commands launched in a terminal
 /// surface. The format is `env=KEY=VALUE`.
 ///
@@ -8165,6 +8241,10 @@ pub const Duration = struct {
         return .{ .duration = self.duration / to * to };
     }
 
+    pub fn lte(self: Duration, other: Duration) bool {
+        return self.duration <= other.duration;
+    }
+
     pub fn parseCLI(input: ?[]const u8) !Duration {
         var remaining = input orelse return error.ValueRequired;
 
@@ -8376,6 +8456,19 @@ pub const ScrollToBottom = packed struct {
     output: bool = false,
 
     pub const default: ScrollToBottom = .{};
+};
+
+/// See notify-on-command-finish
+pub const NotifyOnCommandFinish = enum {
+    never,
+    unfocused,
+    always,
+};
+
+/// See notify-on-command-finish-action
+pub const NotifyOnCommandFinishAction = packed struct {
+    bell: bool = true,
+    notify: bool = false,
 };
 
 test "parse duration" {

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1054,6 +1054,11 @@ pub const StreamHandler = struct {
 
     pub inline fn endOfInput(self: *StreamHandler) !void {
         self.terminal.markSemanticPrompt(.command);
+        self.surfaceMessageWriter(.start_command_timer);
+    }
+
+    pub inline fn endOfCommand(self: *StreamHandler, exit_code: ?u8) !void {
+        self.surfaceMessageWriter(.{ .stop_command_timer = exit_code });
     }
 
     pub fn reportPwd(self: *StreamHandler, url: []const u8) !void {

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1054,11 +1054,11 @@ pub const StreamHandler = struct {
 
     pub inline fn endOfInput(self: *StreamHandler) !void {
         self.terminal.markSemanticPrompt(.command);
-        self.surfaceMessageWriter(.start_command_timer);
+        self.surfaceMessageWriter(.start_command);
     }
 
     pub inline fn endOfCommand(self: *StreamHandler, exit_code: ?u8) !void {
-        self.surfaceMessageWriter(.{ .stop_command_timer = exit_code });
+        self.surfaceMessageWriter(.{ .stop_command = exit_code });
     }
 
     pub fn reportPwd(self: *StreamHandler, url: []const u8) !void {


### PR DESCRIPTION
Fixes #8991

Uses OSC 133 esc sequences to keep track of how long commands take to execute. If the user chooses, commands that take longer than a user specified limit will trigger a notification. The user can choose between a bell notification or a desktop notification.