### PR TITLE
fix(config): Make `macos-custom-icon` null-terminated

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2884,7 +2884,7 @@ keybind: Keybinds = .{},
 ///
 /// Note: This configuration is required when `macos-icon` is set to
 /// `custom`
-@"macos-custom-icon": ?[]const u8 = null,
+@"macos-custom-icon": ?[:0]const u8 = null,
 
 /// The material to use for the frame of the macOS app icon.
 ///


### PR DESCRIPTION
The config option `macos-custom-icon` wasn't working because, to pass successfully through the C API to Swift, the string must be null-terminated.

Fixes https://discord.com/channels/1005603569187160125/1423192859112116224