### PR TITLE
gtk: fix duplicate signal handlers

### DIFF
--- a/src/apprt/gtk/class/window.zig
+++ b/src/apprt/gtk/class/window.zig
@@ -693,6 +693,10 @@ pub const Window = extern struct {
         self: *Self,
         tree: *const Surface.Tree,
     ) void {
+        // Ensure that all old signal handlers have been removed before adding
+        // them. Otherwise we get duplicate surface handlers.
+        self.disconnectSurfaceHandlers(tree);
+
         const priv = self.private();
         var it = tree.iterator();
         while (it.next()) |entry| {


### PR DESCRIPTION
Signal handlers are connected to surface objects in two spots - when a tab is added to a page and when the split tree changes. This resulted in duplicate signal handlers being added for each surface. This was most noticeable when copying the selection to the clipboard - you would see two "Copied to clipboard" toasts. Ensure that there is only one signal handler by removing any old ones before adding the new ones.