### PR TITLE
flush output for our builddata executable

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3998,6 +3998,8 @@ pub fn cursorPosCallback(
     crash.sentry.thread_state = self.crashThreadState();
     defer crash.sentry.thread_state = null;
 
+    // log.debug("cursor pos x={} y={} mods={?}", .{ pos.x, pos.y, mods });
+
     // If the position is negative, it is outside our viewport and
     // we need to clear any hover states.
     if (pos.x < 0 or pos.y < 0) {

--- a/src/main_build_data.zig
+++ b/src/main_build_data.zig
@@ -47,4 +47,5 @@ pub fn main() !void {
         .@"vim-compiler" => try writer.writeAll(@import("extra/vim.zig").compiler),
         .terminfo => try @import("terminfo/ghostty.zig").ghostty.encode(writer),
     }
+    try stdout_writer.end();
 }


### PR DESCRIPTION
Fixes #9018

We were truncated our terminfo causing tmux to not respect some features.