### PR TITLE
build: framegen can use self-hosted

### DIFF
--- a/src/build/GhosttyFrameData.zig
+++ b/src/build/GhosttyFrameData.zig
@@ -43,7 +43,6 @@ pub fn distResources(b: *std.Build) struct {
         .root_module = b.createModule(.{
             .target = b.graph.host,
         }),
-        .use_llvm = true,
     });
     exe.addCSourceFile(.{
         .file = b.path("src/build/framegen/main.c"),


### PR DESCRIPTION
This was a red herring when I was doing the 0.15 port. It works with self-hosted just fine.