### PR TITLE
font: Add comprehensive constraint tests

### DIFF
--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -363,7 +363,11 @@ pub const Face = struct {
         // We center all glyphs within the pixel-rounded and adjusted
         // cell width if it's larger than the face width, so that they
         // aren't weirdly off to the left.
-        if (metrics.face_width < cell_width) {
+        //
+        // We don't do this if the glyph has a stretch constraint,
+        // since in that case the position was already calculated with the
+        // new cell width in mind.
+        if ((constraint.size != .stretch) and (metrics.face_width < cell_width)) {
             // We add half the difference to re-center.
             x += (cell_width - metrics.face_width) / 2;
         }
@@ -376,18 +380,6 @@ pub const Face = struct {
             height = cell_height - @round(cell_height - height - y) - @round(y);
             x = @round(x);
             y = @round(y);
-        }
-
-        // We center all glyphs within the pixel-rounded and adjusted
-        // cell width if it's larger than the face width, so that they
-        // aren't weirdly off to the left.
-        //
-        // We don't do this if the glyph has a stretch constraint,
-        // since in that case the position was already calculated with the
-        // new cell width in mind.
-        if ((constraint.size != .stretch) and (metrics.face_width < cell_width)) {
-            // We add half the difference to re-center.
-            x += (cell_width - metrics.face_width) / 2;
         }
 
         // We make an assumption that font smoothing ("thicken")

--- a/src/font/face/freetype.zig
+++ b/src/font/face/freetype.zig
@@ -1177,43 +1177,6 @@ test "color emoji" {
         const glyph_id = ft_font.glyphIndex('🥸').?;
         try testing.expect(ft_font.isColorGlyph(glyph_id));
     }
-
-    // resize
-    // TODO: Comprehensive tests for constraints,
-    //       this is just an adapted legacy test.
-    {
-        const glyph = try ft_font.renderGlyph(
-            alloc,
-            &atlas,
-            ft_font.glyphIndex('🥸').?,
-            .{
-                .grid_metrics = .{
-                    .cell_width = 13,
-                    .cell_height = 24,
-                    .cell_baseline = 0,
-                    .underline_position = 0,
-                    .underline_thickness = 0,
-                    .strikethrough_position = 0,
-                    .strikethrough_thickness = 0,
-                    .overline_position = 0,
-                    .overline_thickness = 0,
-                    .box_thickness = 0,
-                    .cursor_height = 0,
-                    .icon_height = 0,
-                    .face_width = 13,
-                    .face_height = 24,
-                    .face_y = 0,
-                },
-                .constraint_width = 2,
-                .constraint = .{
-                    .size = .fit,
-                    .align_horizontal = .center,
-                    .align_vertical = .center,
-                },
-            },
-        );
-        try testing.expectEqual(@as(u32, 24), glyph.height);
-    }
 }
 
 test "mono to bgra" {


### PR DESCRIPTION
As promised in #8990.

I opted for hardcoded metrics and bounding boxes rather than actually loading fonts and glyphs, both to avoid backend dependence and limit the focus to the constraint calculations themselves, and because I wanted to test a case that isn't exhibited by any of the fonts available in the repo.

This also fixes an error from #8990, probably due to a botched cherry-pick or rebase.