### PR TITLE
Expand `~` in `macos-custom-icon`

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -314,17 +314,14 @@ extension Ghostty {
 
         var macosCustomIcon: String {
             #if os(macOS)
-            let homeDirURL = FileManager.default.homeDirectoryForCurrentUser
-            let ghosttyConfigIconPath = homeDirURL.appendingPathComponent(
-                ".config/ghostty/Ghostty.icns",
-                conformingTo: .fileURL).path()
-            let defaultValue = ghosttyConfigIconPath
+            let defaultValue = NSString("~/.config/ghostty/Ghostty.icns").expandingTildeInPath
             guard let config = self.config else { return defaultValue }
             var v: UnsafePointer<Int8>? = nil
             let key = "macos-custom-icon"
             guard ghostty_config_get(config, &v, key, UInt(key.count)) else { return defaultValue }
             guard let ptr = v else { return defaultValue }
-            return String(cString: ptr)
+            guard let path = NSString(utf8String: ptr) else { return defaultValue }
+            return path.expandingTildeInPath
             #else
             return ""
             #endif

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2957,9 +2957,6 @@ keybind: Keybinds = .{},
 /// Supported formats include PNG, JPEG, and ICNS.
 ///
 /// Defaults to `~/.config/ghostty/Ghostty.icns`
-///
-/// Note: This configuration is required when `macos-icon` is set to
-/// `custom`
 @"macos-custom-icon": ?[:0]const u8 = null,
 
 /// The material to use for the frame of the macOS app icon.


### PR DESCRIPTION
Since #8999, `macos-custom-icon` works when its a fully expanded absolute path like `/Users/username/dir/icon.icns`, but not when it's abbreviated as `~/dir/icon.icns`. Users were understandably surprised and confused by this. This PR adds tilde expansion using `NSString`s built-in property for this.

Also removed a line from the config docs that seemed erroneous. Given that the option has a functional default, it seems incorrect to say that it's required.