### PR TITLE
input: use std.Io.Writer for key encoder, new API, expose via libghostty

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -29,7 +29,6 @@ pub const Keybinds = Config.Keybinds;
 pub const MouseShiftCapture = Config.MouseShiftCapture;
 pub const MouseScrollMultiplier = Config.MouseScrollMultiplier;
 pub const NonNativeFullscreen = Config.NonNativeFullscreen;
-pub const OptionAsAlt = Config.OptionAsAlt;
 pub const RepeatableCodepointMap = Config.RepeatableCodepointMap;
 pub const RepeatableFontVariation = Config.RepeatableFontVariation;
 pub const RepeatableString = Config.RepeatableString;

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2861,7 +2861,7 @@ keybind: Keybinds = .{},
 ///
 /// The values `left` or `right` enable this for the left or right *Option*
 /// key, respectively.
-@"macos-option-as-alt": ?OptionAsAlt = null,
+@"macos-option-as-alt": ?inputpkg.OptionAsAlt = null,
 
 /// Whether to enable the macOS window shadow. The default value is true.
 /// With some window managers and window transparency settings, you may
@@ -4819,14 +4819,6 @@ pub const NonNativeFullscreen = enum(c_int) {
     true,
     @"visible-menu",
     @"padded-notch",
-};
-
-/// Valid values for macos-option-as-alt.
-pub const OptionAsAlt = enum {
-    false,
-    true,
-    left,
-    right,
 };
 
 pub const WindowPaddingColor = enum {

--- a/src/input.zig
+++ b/src/input.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
+const config = @import("input/config.zig");
 const mouse = @import("input/mouse.zig");
 const key = @import("input/key.zig");
 const keyboard = @import("input/keyboard.zig");
@@ -8,6 +9,7 @@ const keyboard = @import("input/keyboard.zig");
 pub const command = @import("input/command.zig");
 pub const function_keys = @import("input/function_keys.zig");
 pub const keycodes = @import("input/keycodes.zig");
+pub const key_encode = @import("input/key_encode.zig");
 pub const kitty = @import("input/kitty.zig");
 pub const paste = @import("input/paste.zig");
 
@@ -18,13 +20,13 @@ pub const Command = command.Command;
 pub const Link = @import("input/Link.zig");
 pub const Key = key.Key;
 pub const KeyboardLayout = keyboard.Layout;
-pub const KeyEncoder = @import("input/KeyEncoder.zig");
 pub const KeyEvent = key.KeyEvent;
 pub const InspectorMode = Binding.Action.InspectorMode;
 pub const Mods = key.Mods;
 pub const MouseButton = mouse.Button;
 pub const MouseButtonState = mouse.ButtonState;
 pub const MousePressureStage = mouse.PressureStage;
+pub const OptionAsAlt = config.OptionAsAlt;
 pub const ScrollMods = mouse.ScrollMods;
 pub const SplitFocusDirection = Binding.Action.SplitFocusDirection;
 pub const SplitResizeDirection = Binding.Action.SplitResizeDirection;

--- a/src/input/config.zig
+++ b/src/input/config.zig
@@ -1,0 +1,8 @@
+/// Determines the macOS option key behavior. See the config
+/// `macos-option-as-alt` for a lot more details.
+pub const OptionAsAlt = enum(c_int) {
+    false,
+    true,
+    left,
+    right,
+};

--- a/src/input/function_keys.zig
+++ b/src/input/function_keys.zig
@@ -293,6 +293,11 @@ fn pcStyle(comptime fmt: []const u8) []Entry {
 
 test "keys" {
     const testing = std.testing;
+    switch (@import("terminal_options").artifact) {
+        .ghostty => {},
+        // Don't want to bring in termio into libghostty-vt
+        .lib => return error.SkipZigTest,
+    }
 
     // Force resolution for comptime evaluation.
     _ = keys;

--- a/src/input/key.zig
+++ b/src/input/key.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const cimgui = @import("cimgui");
-const config = @import("../config.zig");
+const OptionAsAlt = @import("config.zig").OptionAsAlt;
 
 /// A generic key input event. This is the information that is necessary
 /// regardless of apprt in order to generate the proper terminal
@@ -146,7 +146,7 @@ pub const Mods = packed struct(Mods.Backing) {
     /// Return the mods to use for key translation. This handles settings
     /// like macos-option-as-alt. The translation mods should be used for
     /// translation but never sent back in for the key callback.
-    pub fn translation(self: Mods, option_as_alt: config.OptionAsAlt) Mods {
+    pub fn translation(self: Mods, option_as_alt: OptionAsAlt) Mods {
         var result = self;
 
         // macos-option-as-alt for darwin

--- a/src/input/keyboard.zig
+++ b/src/input/keyboard.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const OptionAsAlt = @import("../config.zig").OptionAsAlt;
+const OptionAsAlt = @import("config.zig").OptionAsAlt;
 
 /// Keyboard layouts.
 ///

--- a/src/lib_vt.zig
+++ b/src/lib_vt.zig
@@ -72,10 +72,22 @@ pub const input = struct {
     // the input package because the full package brings in too many
     // other dependencies.
     const paste = @import("input/paste.zig");
+    const key = @import("input/key.zig");
+    const key_encode = @import("input/key_encode.zig");
+
+    // Paste-related APIs
     pub const PasteError = paste.Error;
     pub const PasteOptions = paste.Options;
     pub const isSafePaste = paste.isSafe;
     pub const encodePaste = paste.encode;
+
+    // Key encoding
+    pub const Key = key.Key;
+    pub const KeyAction = key.Action;
+    pub const KeyEvent = key.KeyEvent;
+    pub const KeyMods = key.Mods;
+    pub const KeyEncodeOptions = key_encode.Options;
+    pub const encodeKey = key_encode.encode;
 };
 
 comptime {

--- a/src/terminal/kitty/key.zig
+++ b/src/terminal/kitty/key.zig
@@ -8,7 +8,7 @@ const std = @import("std");
 pub const FlagStack = struct {
     const len = 8;
 
-    flags: [len]Flags = @splat(.{}),
+    flags: [len]Flags = @splat(.disabled),
     idx: u3 = 0,
 
     /// Return the current stack value
@@ -51,12 +51,12 @@ pub const FlagStack = struct {
         // could send a huge number of pop commands to waste cpu.
         if (n >= self.flags.len) {
             self.idx = 0;
-            self.flags = @splat(.{});
+            self.flags = @splat(.disabled);
             return;
         }
 
         for (0..n) |_| {
-            self.flags[self.idx] = .{};
+            self.flags[self.idx] = .disabled;
             self.idx -%= 1;
         }
     }
@@ -82,6 +82,15 @@ pub const Flags = packed struct(u5) {
     report_alternates: bool = false,
     report_all: bool = false,
     report_associated: bool = false,
+
+    /// Kitty keyboard protocol disabled (all flags off).
+    pub const disabled: Flags = .{
+        .disambiguate = false,
+        .report_events = false,
+        .report_alternates = false,
+        .report_all = false,
+        .report_associated = false,
+    };
 
     /// Sets all modes on.
     pub const @"true": Flags = .{


### PR DESCRIPTION
This modernizes `KeyEncoder` to a new `std.Io.Writer`-based API. Additionally, instead of a single struct, it is now an `encode` function that takes a series of more focused options. This is more idiomatic Zig while also making it easier to expose via libghostty-vt.

libghostty-vt Zig module also gains access to key encoding APIs. The C APIs will follow another time.

Converting the KeyEncoder tests was done using AI: https://ampcode.com/threads/T-9731bbdc-e0a9-41ad-9404-2b781a66ee39 Reviewed and understood.