### PR TITLE
osc: parse additional OSC 133 options

### DIFF
--- a/src/inspector/termio.zig
+++ b/src/inspector/termio.zig
@@ -264,6 +264,11 @@ pub const VTEvent = struct {
                     if (std.mem.eql(u8, field.name, tag_name)) {
                         const s = if (field.type == void)
                             try alloc.dupeZ(u8, tag_name)
+                        else if (field.type == [:0]const u8 or field.type == []const u8)
+                            try std.fmt.allocPrintSentinel(alloc, "{s}={s}", .{
+                                tag_name,
+                                @field(value, field.name),
+                            }, 0)
                         else
                             try std.fmt.allocPrintSentinel(alloc, "{s}={}", .{
                                 tag_name,


### PR DESCRIPTION
OSC 133;A can have:

- special_key
- click_events

OSC 133;C can have:

- cmdline
- cmdline_url

Notably, they are in use by `fish`. Not sure what other shells currently use these options.

Note that the options are only parsed. Nothing further is done with them at this point.