### PR TITLE
Add the command that finished to the command finished notifications

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -735,9 +735,22 @@ typedef struct {
 
 // apprt.action.CommandFinished.C
 typedef struct {
-  // -1 if no exit code was reported, otherwise 0-255
+  // The command line, as reported by OSC 133;C, or null if the command line
+  // is unknown.
+  const char *cmdline;
+  // The exit code, as reported by OSC 133;D. The exit code will be a number
+  // between 0 and 255 or -1 if no exit code was provided. 0 indicates that the
+  // command was successful. Any number from 1 to 255 indicates an application
+  // specific error code.
   int16_t exit_code;
-  // number of nanoseconds that command was running for
+  // How long the command took in nanoseconds, defined as the time between
+  // receiving an OSC 133;C and an OSC 133;D. This can vary from the "real"
+  // amount of time a command was running due to a number of factors like the
+  // latency of reading the OSC 133 commands, the time taken to decode the OSCs,
+  // and the latency propagating the information through Ghostty's subsystems.
+  // All of that is to say this is just an approximation and should not be used
+  // for any serious performance monitoring. Despite the duration being reported
+  // in nanoseconds it is nowhere near that accurate.
   uint64_t duration;
 } ghostty_action_command_finished_s;
 

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -747,17 +747,49 @@ pub const CloseTabMode = enum(c_int) {
 };
 
 pub const CommandFinished = struct {
+    /// The command line, as reported by OSC 133;C, or null if the command line
+    /// is unknown.
+    cmdline: ?[:0]const u8,
+    /// The exit code, as reported by OSC 133;D. The exit code will be a
+    /// number between 0 and 255  or null if no exit code was provided. 0
+    /// indicates that the command was successful. Any number from 1 to 255
+    /// indicates an application specific error code.
     exit_code: ?u8,
+    /// How long the command took, defined as the time between receiving an OSC
+    /// 133;C and an OSC 133;D. This can vary from the "real" amount of time
+    /// a command was running due to a number of factors like the latency of
+    /// reading the OSC 133 commands, the time taken to decode the OSCs, and the
+    /// latency propagating the information through Ghostty's subsystems. All of
+    /// that is to say this is just an approximation and should not be used for
+    /// any serious performance monitoring. Despite the duration being reported
+    /// in nanoseconds it is nowhere near that accurate.
     duration: configpkg.Config.Duration,
 
     /// sync with ghostty_action_command_finished_s in ghostty.h
     pub const C = extern struct {
+        /// The command line, as reported by OSC 133;C, or null if the command line
+        /// is unknown.
+        cmdline: ?[*:0]const u8,
+        /// The exit code, as reported by OSC 133;D. The exit code will be a
+        /// number between 0 and 255  or -1 if no exit code was provided. 0
+        /// indicates that the command was successful. Any number from 1 to 255
+        /// indicates an application specific error code.
         exit_code: i16,
+        /// How long the command took in nanoseconds, defined as the time
+        /// between receiving an OSC 133;C and an OSC 133;D. This can vary from
+        /// the "real" amount of time a command was running due to a number
+        /// of factors like the latency of reading the OSC 133 commands, the
+        /// time taken to decode the OSCs, and the latency propagating the
+        /// information through Ghostty's subsystems. All of that is to say
+        /// this is just an approximation and should not be used for any serious
+        /// performance monitoring. Despite the duration being reported in
+        /// nanoseconds it is nowhere near that accurate.
         duration: u64,
     };
 
     pub fn cval(self: CommandFinished) C {
         return .{
+            .cmdline = if (self.cmdline) |cmdline| cmdline.ptr else null,
             .exit_code = self.exit_code orelse -1,
             .duration = self.duration.duration,
         };

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -838,31 +838,52 @@ pub const Surface = extern struct {
             if (cfg.@"notify-on-command-finish" == .unfocused and self.getFocused()) return true;
         }
 
+        if (value.duration.lte(cfg.@"notify-on-command-finish-after")) return true;
+
         const action = cfg.@"notify-on-command-finish-action";
 
         if (action.bell) self.setBellRinging(true);
 
         if (action.notify) notify: {
-            const title_ = title: {
+            const title = std.mem.span(title: {
                 const exit_code = value.exit_code orelse break :title i18n._("Command Finished");
                 if (exit_code == 0) break :title i18n._("Command Succeeded");
                 break :title i18n._("Command Failed");
-            };
-            const title = std.mem.span(title_);
-            const body = body: {
-                const exit_code = value.exit_code orelse break :body std.fmt.allocPrintSentinel(
-                    alloc,
-                    "Command took {f}.",
-                    .{value.duration.round(std.time.ns_per_ms)},
-                    0,
-                ) catch break :notify;
-                break :body std.fmt.allocPrintSentinel(
-                    alloc,
-                    "Command took {f} and exited with code {d}.",
-                    .{ value.duration.round(std.time.ns_per_ms), exit_code },
-                    0,
-                ) catch break :notify;
-            };
+            });
+
+            var buf: std.Io.Writer.Allocating = .init(alloc);
+            defer buf.deinit();
+            const writer = &buf.writer;
+
+            writer.writeAll("Command ") catch break :notify;
+
+            if (value.cmdline) |cmdline| cmdline: {
+                // Don't bother with a zero length command line.
+                if (cmdline.len == 0) break :cmdline;
+                // The defacto standard for "hiding" a command line from being
+                // saved in history or other places is to prefix it with a
+                // space. Honor that here.
+                if (cmdline[0] == ' ') {
+                    writer.writeAll("̈́«hidden» ") catch break :notify;
+                    break :cmdline;
+                }
+                writer.writeAll("̈́“") catch break :notify;
+                writer.writeAll(cmdline) catch break :notify;
+                writer.writeAll("” ") catch break :notify;
+            }
+
+            writer.print(
+                "took {f}",
+                .{value.duration.round(std.time.ns_per_ms)},
+            ) catch break :notify;
+
+            if (value.exit_code) |exit_code| {
+                writer.print(" and exited with code {d}", .{exit_code}) catch break :notify;
+            }
+
+            writer.writeByte('.') catch break :notify;
+
+            const body = buf.toOwnedSliceSentinel(0) catch break :notify;
             defer alloc.free(body);
 
             self.sendDesktopNotification(title, body);

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -97,7 +97,10 @@ pub const Message = union(enum) {
     progress_report: terminal.osc.Command.ProgressReport,
 
     /// A command has started in the shell, start a timer.
-    start_command,
+    start_command: struct {
+        /// The commandline, as reported by OSC 133;C
+        cmdline: ?[:0]const u8,
+    },
 
     /// A command has finished in the shell, stop the timer and send out
     /// notifications as appropriate. The optional u8 is the exit code

--- a/src/os/inplace.zig
+++ b/src/os/inplace.zig
@@ -1,0 +1,267 @@
+const std = @import("std");
+
+/// Do an in-place decode of a string that has been encoded in the same way
+/// that `bash`'s `printf %q` encodes a string. This is safe because a string
+/// can only get shorter after decoding. This destructively modifies the buffer
+/// given to it. If an error is returned the buffer may be in an unusable state.
+pub fn printf_q_decode(buf: [:0]u8) error{DecodeError}![:0]const u8 {
+    const data: [:0]u8 = data: {
+        // Strip off `$''` quoting.
+        if (std.mem.startsWith(u8, buf, "$'")) {
+            if (buf.len < 3 or !std.mem.endsWith(u8, buf, "'")) return error.DecodeError;
+            buf[buf.len - 1] = 0;
+            break :data buf[2 .. buf.len - 1 :0];
+        }
+        // Strip off `''` quoting.
+        if (std.mem.startsWith(u8, buf, "'")) {
+            if (buf.len < 2 or !std.mem.endsWith(u8, buf, "'")) return error.DecodeError;
+            buf[buf.len - 1] = 0;
+            break :data buf[1 .. buf.len - 1 :0];
+        }
+        break :data buf;
+    };
+
+    var src: usize = 0;
+    var dst: usize = 0;
+
+    while (src < data.len) {
+        switch (data[src]) {
+            else => {
+                data[dst] = data[src];
+                src += 1;
+                dst += 1;
+            },
+            '\\' => {
+                if (src + 1 >= data.len) return error.DecodeError;
+                switch (data[src + 1]) {
+                    ' ',
+                    '\\',
+                    '"',
+                    '\'',
+                    '$',
+                    => |c| {
+                        data[dst] = c;
+                        src += 2;
+                        dst += 1;
+                    },
+                    'e' => {
+                        data[dst] = std.ascii.control_code.esc;
+                        src += 2;
+                        dst += 1;
+                    },
+                    'n' => {
+                        data[dst] = std.ascii.control_code.lf;
+                        src += 2;
+                        dst += 1;
+                    },
+                    'r' => {
+                        data[dst] = std.ascii.control_code.cr;
+                        src += 2;
+                        dst += 1;
+                    },
+                    't' => {
+                        data[dst] = std.ascii.control_code.ht;
+                        src += 2;
+                        dst += 1;
+                    },
+                    'v' => {
+                        data[dst] = std.ascii.control_code.vt;
+                        src += 2;
+                        dst += 1;
+                    },
+                    else => return error.DecodeError,
+                }
+            },
+        }
+    }
+
+    data[dst] = 0;
+    return data[0..dst :0];
+}
+
+test "printf_q 1" {
+    const s: [:0]const u8 = "bobr\\ kurwa";
+    var src: [s.len:0]u8 = undefined;
+    @memcpy(&src, s);
+    const dst = try printf_q_decode(&src);
+    try std.testing.expectEqualStrings("bobr kurwa", dst);
+}
+
+test "printf_q 2" {
+    const s: [:0]const u8 = "bobr\\nkurwa";
+    var src: [s.len:0]u8 = undefined;
+    @memcpy(&src, s);
+    const dst = try printf_q_decode(&src);
+    try std.testing.expectEqualStrings("bobr\nkurwa", dst);
+}
+
+test "printf_q 3" {
+    const s: [:0]const u8 = "bobr\\dkurwa";
+    var src: [s.len:0]u8 = undefined;
+    @memcpy(&src, s);
+    try std.testing.expectError(error.DecodeError, printf_q_decode(&src));
+}
+
+test "printf_q 4" {
+    const s: [:0]const u8 = "bobr kurwa\\";
+    var src: [s.len:0]u8 = undefined;
+    @memcpy(&src, s);
+    try std.testing.expectError(error.DecodeError, printf_q_decode(&src));
+}
+
+test "printf_q 5" {
+    const s: [:0]const u8 = "$'bobr kurwa'";
+    var src: [s.len:0]u8 = undefined;
+    @memcpy(&src, s);
+    const dst = try printf_q_decode(&src);
+    try std.testing.expectEqualStrings("bobr kurwa", dst);
+}
+
+test "printf_q 6" {
+    const s: [:0]const u8 = "'bobr kurwa'";
+    var src: [s.len:0]u8 = undefined;
+    @memcpy(&src, s);
+    const dst = try printf_q_decode(&src);
+    try std.testing.expectEqualStrings("bobr kurwa", dst);
+}
+
+test "printf_q 7" {
+    const s: [:0]const u8 = "$'bobr kurwa";
+    var src: [s.len:0]u8 = undefined;
+    @memcpy(&src, s);
+    try std.testing.expectError(error.DecodeError, printf_q_decode(&src));
+}
+
+test "printf_q 8" {
+    const s: [:0]const u8 = "$'";
+    var src: [s.len:0]u8 = undefined;
+    @memcpy(&src, s);
+    try std.testing.expectError(error.DecodeError, printf_q_decode(&src));
+}
+
+test "printf_q 9" {
+    const s: [:0]const u8 = "'bobr kurwa";
+    var src: [s.len:0]u8 = undefined;
+    @memcpy(&src, s);
+    try std.testing.expectError(error.DecodeError, printf_q_decode(&src));
+}
+
+test "printf_q 10" {
+    const s: [:0]const u8 = "'";
+    var src: [s.len:0]u8 = undefined;
+    @memcpy(&src, s);
+    try std.testing.expectError(error.DecodeError, printf_q_decode(&src));
+}
+
+/// Do an in-place decode of a string that has been URL percent encoded.
+/// This is safe because a string can only get shorter after decoding. This
+/// destructively modifies the buffer given to it. If an error is returned the
+/// buffer may be in an unusable state.
+pub fn percent_decode(buf: [:0]u8) error{DecodeError}![:0]const u8 {
+    var src: usize = 0;
+    var dst: usize = 0;
+    while (src < buf.len) {
+        switch (buf[src]) {
+            else => {
+                buf[dst] = buf[src];
+                src += 1;
+                dst += 1;
+            },
+            '%' => {
+                if (src + 2 >= buf.len) return error.DecodeError;
+                switch (buf[src + 1]) {
+                    '0'...'9', 'a'...'f', 'A'...'F' => {
+                        switch (buf[src + 2]) {
+                            '0'...'9', 'a'...'f', 'A'...'F' => {
+                                buf[dst] = std.math.shl(u8, hex(buf[src + 1]), 4) | hex(buf[src + 2]);
+                                src += 3;
+                                dst += 1;
+                            },
+                            else => return error.DecodeError,
+                        }
+                    },
+                    else => return error.DecodeError,
+                }
+            },
+        }
+    }
+    buf[dst] = 0;
+    return buf[0..dst :0];
+}
+
+inline fn hex(c: u8) u4 {
+    switch (c) {
+        '0'...'9' => return @truncate(c - '0'),
+        'a'...'f' => return @truncate(c - 'a' + 10),
+        'A'...'F' => return @truncate(c - 'A' + 10),
+        else => unreachable,
+    }
+}
+
+test "singles percent" {
+    for (0..255) |c| {
+        var buf_: [4]u8 = undefined;
+        const buf = try std.fmt.bufPrintZ(&buf_, "%{x:0>2}", .{c});
+        const decoded = try percent_decode(buf);
+        try std.testing.expectEqual(1, decoded.len);
+        try std.testing.expectEqual(c, decoded[0]);
+    }
+    for (0..255) |c| {
+        var buf_: [4]u8 = undefined;
+        const buf = try std.fmt.bufPrintZ(&buf_, "%{X:0>2}", .{c});
+        const decoded = try percent_decode(buf);
+        try std.testing.expectEqual(1, decoded.len);
+        try std.testing.expectEqual(c, decoded[0]);
+    }
+}
+
+test "percent 1" {
+    const s: [:0]const u8 = "bobr%20kurwa";
+    var src: [s.len:0]u8 = undefined;
+    @memcpy(&src, s);
+    const dst = try percent_decode(&src);
+    try std.testing.expectEqualStrings("bobr kurwa", dst);
+}
+
+test "percent 2" {
+    const s: [:0]const u8 = "bobr%2kurwa";
+    var src: [s.len:0]u8 = undefined;
+    @memcpy(&src, s);
+    try std.testing.expectError(error.DecodeError, percent_decode(&src));
+}
+
+test "percent 3" {
+    const s: [:0]const u8 = "bobr%kurwa";
+    var src: [s.len:0]u8 = undefined;
+    @memcpy(&src, s);
+    try std.testing.expectError(error.DecodeError, percent_decode(&src));
+}
+
+test "percent 4" {
+    const s: [:0]const u8 = "bobr%%kurwa";
+    var src: [s.len:0]u8 = undefined;
+    @memcpy(&src, s);
+    try std.testing.expectError(error.DecodeError, percent_decode(&src));
+}
+
+test "percent 5" {
+    const s: [:0]const u8 = "bobr%20kurwa%20";
+    var src: [s.len:0]u8 = undefined;
+    @memcpy(&src, s);
+    const dst = try percent_decode(&src);
+    try std.testing.expectEqualStrings("bobr kurwa ", dst);
+}
+
+test "percent 6" {
+    const s: [:0]const u8 = "bobr%20kurwa%2";
+    var src: [s.len:0]u8 = undefined;
+    @memcpy(&src, s);
+    try std.testing.expectError(error.DecodeError, percent_decode(&src));
+}
+
+test "percent 7" {
+    const s: [:0]const u8 = "bobr%20kurwa%";
+    var src: [s.len:0]u8 = undefined;
+    @memcpy(&src, s);
+    try std.testing.expectError(error.DecodeError, percent_decode(&src));
+}

--- a/src/terminal/osc.zig
+++ b/src/terminal/osc.zig
@@ -15,6 +15,7 @@ const LibEnum = @import("../lib/enum.zig").Enum;
 const RGB = @import("color.zig").RGB;
 const kitty_color = @import("kitty/color.zig");
 const osc_color = @import("osc/color.zig");
+const inplace = @import("../os/inplace.zig");
 pub const color = osc_color;
 
 const log = std.log.scoped(.osc);
@@ -89,12 +90,7 @@ pub const Command = union(Key) {
     end_of_input: struct {
         /// The command line that the user entered.
         /// See: https://sw.kovidgoyal.net/kitty/shell-integration/#notes-for-shell-developers
-        cmdline: ?union(enum) {
-            /// The command line has been encoded with bash's 'printf "%q"'.
-            printf_q_encoded: [:0]const u8,
-            /// The command line has been encoded with URL percent encoding.
-            percent_encoded: [:0]const u8,
-        } = null,
+        cmdline: ?[:0]const u8 = null,
     },
 
     /// End of current command.
@@ -1482,17 +1478,13 @@ pub const Parser = struct {
         } else if (mem.eql(u8, self.temp_state.key, "cmdline")) {
             // https://sw.kovidgoyal.net/kitty/shell-integration/#notes-for-shell-developers
             switch (self.command) {
-                .end_of_input => |*v| v.cmdline = .{
-                    .printf_q_encoded = value,
-                },
+                .end_of_input => |*v| v.cmdline = inplace.printf_q_decode(value) catch null,
                 else => {},
             }
         } else if (mem.eql(u8, self.temp_state.key, "cmdline_url")) {
             // https://sw.kovidgoyal.net/kitty/shell-integration/#notes-for-shell-developers
             switch (self.command) {
-                .end_of_input => |*v| v.cmdline = .{
-                    .percent_encoded = value,
-                },
+                .end_of_input => |*v| v.cmdline = inplace.percent_decode(value) catch null,
                 else => {},
             }
         } else if (mem.eql(u8, self.temp_state.key, "redraw")) {
@@ -3063,7 +3055,7 @@ test "OSC 133: end_of_input" {
     try testing.expect(cmd == .end_of_input);
 }
 
-test "OSC 133: end_of_input with cmdline" {
+test "OSC 133: end_of_input with cmdline 1" {
     const testing = std.testing;
 
     var p: Parser = .init();
@@ -3074,11 +3066,132 @@ test "OSC 133: end_of_input with cmdline" {
     const cmd = p.end(null).?.*;
     try testing.expect(cmd == .end_of_input);
     try testing.expect(cmd.end_of_input.cmdline != null);
-    try testing.expect(cmd.end_of_input.cmdline.? == .printf_q_encoded);
-    try testing.expectEqualStrings("echo bobr kurwa", cmd.end_of_input.cmdline.?.printf_q_encoded);
+    try testing.expectEqualStrings("echo bobr kurwa", cmd.end_of_input.cmdline.?);
 }
 
-test "OSC 133: end_of_input with cmdline_url" {
+test "OSC 133: end_of_input with cmdline 2" {
+    const testing = std.testing;
+
+    var p: Parser = .init();
+
+    const input = "133;C;cmdline=echo bobr\\ kurwa";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end(null).?.*;
+    try testing.expect(cmd == .end_of_input);
+    try testing.expect(cmd.end_of_input.cmdline != null);
+    try testing.expectEqualStrings("echo bobr kurwa", cmd.end_of_input.cmdline.?);
+}
+
+test "OSC 133: end_of_input with cmdline 3" {
+    const testing = std.testing;
+
+    var p: Parser = .init();
+
+    const input = "133;C;cmdline=echo bobr\\nkurwa";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end(null).?.*;
+    try testing.expect(cmd == .end_of_input);
+    try testing.expect(cmd.end_of_input.cmdline != null);
+    try testing.expectEqualStrings("echo bobr\nkurwa", cmd.end_of_input.cmdline.?);
+}
+
+test "OSC 133: end_of_input with cmdline 4" {
+    const testing = std.testing;
+
+    var p: Parser = .init();
+
+    const input = "133;C;cmdline=$'echo bobr kurwa'";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end(null).?.*;
+    try testing.expect(cmd == .end_of_input);
+    try testing.expect(cmd.end_of_input.cmdline != null);
+    try testing.expectEqualStrings("echo bobr kurwa", cmd.end_of_input.cmdline.?);
+}
+
+test "OSC 133: end_of_input with cmdline 5" {
+    const testing = std.testing;
+
+    var p: Parser = .init();
+
+    const input = "133;C;cmdline='echo bobr kurwa'";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end(null).?.*;
+    try testing.expect(cmd == .end_of_input);
+    try testing.expect(cmd.end_of_input.cmdline != null);
+    try testing.expectEqualStrings("echo bobr kurwa", cmd.end_of_input.cmdline.?);
+}
+
+test "OSC 133: end_of_input with cmdline 6" {
+    const testing = std.testing;
+
+    var p: Parser = .init();
+
+    const input = "133;C;cmdline='echo bobr kurwa";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end(null).?.*;
+    try testing.expect(cmd == .end_of_input);
+    try testing.expect(cmd.end_of_input.cmdline == null);
+}
+
+test "OSC 133: end_of_input with cmdline 7" {
+    const testing = std.testing;
+
+    var p: Parser = .init();
+
+    const input = "133;C;cmdline=$'echo bobr kurwa";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end(null).?.*;
+    try testing.expect(cmd == .end_of_input);
+    try testing.expect(cmd.end_of_input.cmdline == null);
+}
+
+test "OSC 133: end_of_input with cmdline 8" {
+    const testing = std.testing;
+
+    var p: Parser = .init();
+
+    const input = "133;C;cmdline=$'";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end(null).?.*;
+    try testing.expect(cmd == .end_of_input);
+    try testing.expect(cmd.end_of_input.cmdline == null);
+}
+
+test "OSC 133: end_of_input with cmdline 9" {
+    const testing = std.testing;
+
+    var p: Parser = .init();
+
+    const input = "133;C;cmdline=$'";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end(null).?.*;
+    try testing.expect(cmd == .end_of_input);
+    try testing.expect(cmd.end_of_input.cmdline == null);
+}
+
+test "OSC 133: end_of_input with cmdline 10" {
+    const testing = std.testing;
+
+    var p: Parser = .init();
+
+    const input = "133;C;cmdline=";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end(null).?.*;
+    try testing.expect(cmd == .end_of_input);
+    try testing.expect(cmd.end_of_input.cmdline != null);
+    try testing.expectEqualStrings("", cmd.end_of_input.cmdline.?);
+}
+
+test "OSC 133: end_of_input with cmdline_url 1" {
     const testing = std.testing;
 
     var p: Parser = .init();
@@ -3089,8 +3202,114 @@ test "OSC 133: end_of_input with cmdline_url" {
     const cmd = p.end(null).?.*;
     try testing.expect(cmd == .end_of_input);
     try testing.expect(cmd.end_of_input.cmdline != null);
-    try testing.expect(cmd.end_of_input.cmdline.? == .percent_encoded);
-    try testing.expectEqualStrings("echo bobr kurwa", cmd.end_of_input.cmdline.?.percent_encoded);
+    try testing.expectEqualStrings("echo bobr kurwa", cmd.end_of_input.cmdline.?);
+}
+
+test "OSC 133: end_of_input with cmdline_url 2" {
+    const testing = std.testing;
+
+    var p: Parser = .init();
+
+    const input = "133;C;cmdline_url=echo bobr%20kurwa";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end(null).?.*;
+    try testing.expect(cmd == .end_of_input);
+    try testing.expect(cmd.end_of_input.cmdline != null);
+    try testing.expectEqualStrings("echo bobr kurwa", cmd.end_of_input.cmdline.?);
+}
+
+test "OSC 133: end_of_input with cmdline_url 3" {
+    const testing = std.testing;
+
+    var p: Parser = .init();
+
+    const input = "133;C;cmdline_url=echo bobr%3bkurwa";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end(null).?.*;
+    try testing.expect(cmd == .end_of_input);
+    try testing.expect(cmd.end_of_input.cmdline != null);
+    try testing.expectEqualStrings("echo bobr;kurwa", cmd.end_of_input.cmdline.?);
+}
+
+test "OSC 133: end_of_input with cmdline_url 4" {
+    const testing = std.testing;
+
+    var p: Parser = .init();
+
+    const input = "133;C;cmdline_url=echo bobr%3kurwa";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end(null).?.*;
+    try testing.expect(cmd == .end_of_input);
+    try testing.expect(cmd.end_of_input.cmdline == null);
+}
+
+test "OSC 133: end_of_input with cmdline_url 5" {
+    const testing = std.testing;
+
+    var p: Parser = .init();
+
+    const input = "133;C;cmdline_url=echo bobr%kurwa";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end(null).?.*;
+    try testing.expect(cmd == .end_of_input);
+    try testing.expect(cmd.end_of_input.cmdline == null);
+}
+
+test "OSC 133: end_of_input with cmdline_url 6" {
+    const testing = std.testing;
+
+    var p: Parser = .init();
+
+    const input = "133;C;cmdline_url=echo bobr%kurwa";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end(null).?.*;
+    try testing.expect(cmd == .end_of_input);
+    try testing.expect(cmd.end_of_input.cmdline == null);
+}
+
+test "OSC 133: end_of_input with cmdline_url 7" {
+    const testing = std.testing;
+
+    var p: Parser = .init();
+
+    const input = "133;C;cmdline_url=echo bobr kurwa%20";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end(null).?.*;
+    try testing.expect(cmd == .end_of_input);
+    try testing.expect(cmd.end_of_input.cmdline != null);
+    try testing.expectEqualStrings("echo bobr kurwa ", cmd.end_of_input.cmdline.?);
+}
+
+test "OSC 133: end_of_input with cmdline_url 8" {
+    const testing = std.testing;
+
+    var p: Parser = .init();
+
+    const input = "133;C;cmdline_url=echo bobr kurwa%2";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end(null).?.*;
+    try testing.expect(cmd == .end_of_input);
+    try testing.expect(cmd.end_of_input.cmdline == null);
+}
+
+test "OSC 133: end_of_input with cmdline_url 9" {
+    const testing = std.testing;
+
+    var p: Parser = .init();
+
+    const input = "133;C;cmdline_url=echo bobr kurwa%2";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end(null).?.*;
+    try testing.expect(cmd == .end_of_input);
+    try testing.expect(cmd.end_of_input.cmdline == null);
 }
 
 test "OSC: OSC 777 show desktop notification with title" {

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -1539,9 +1539,9 @@ pub fn Stream(comptime Handler: type) type {
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },
 
-                .end_of_input => {
+                .end_of_input => |v| {
                     if (@hasDecl(T, "endOfInput")) {
-                        try self.handler.endOfInput();
+                        try self.handler.endOfInput(v.cmdline);
                         return;
                     } else log.warn("unimplemented OSC callback: {}", .{cmd});
                 },

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1052,9 +1052,15 @@ pub const StreamHandler = struct {
         self.terminal.markSemanticPrompt(.input);
     }
 
-    pub inline fn endOfInput(self: *StreamHandler) !void {
+    pub inline fn endOfInput(self: *StreamHandler, cmdline: ?[:0]const u8) !void {
         self.terminal.markSemanticPrompt(.command);
-        self.surfaceMessageWriter(.start_command);
+        self.surfaceMessageWriter(
+            .{
+                .start_command = .{
+                    .cmdline = cmdline,
+                },
+            },
+        );
     }
 
     pub inline fn endOfCommand(self: *StreamHandler, exit_code: ?u8) !void {


### PR DESCRIPTION
Some shells use OSC 133;C sequences to report the actual command that is about to be executed to the terminal. We take advantage of that to include the command in command finished notifications.

At this time I know of only one shell that does this, fish.