### PR TITLE
introduce split-preserve-zoom config to maintain zoomed splits during navigation

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -621,9 +621,14 @@ class BaseTerminalController: NSWindowController,
             return
         }
 
-        // Remove the zoomed state for this surface tree.
         if surfaceTree.zoomed != nil {
-            surfaceTree = .init(root: surfaceTree.root, zoomed: nil)
+            if derivedConfig.splitPreserveZoom.contains(.navigation) {
+                surfaceTree = SplitTree(
+                    root: surfaceTree.root,
+                    zoomed: surfaceTree.root?.node(view: nextSurface))
+            } else {
+                surfaceTree = SplitTree(root: surfaceTree.root, zoomed: nil)
+            }
         }
 
         // Move focus to the next surface
@@ -1188,17 +1193,20 @@ class BaseTerminalController: NSWindowController,
         let macosTitlebarProxyIcon: Ghostty.MacOSTitlebarProxyIcon
         let windowStepResize: Bool
         let focusFollowsMouse: Bool
+        let splitPreserveZoom: Ghostty.Config.SplitPreserveZoom
 
         init() {
             self.macosTitlebarProxyIcon = .visible
             self.windowStepResize = false
             self.focusFollowsMouse = false
+            self.splitPreserveZoom = .init()
         }
 
         init(_ config: Ghostty.Config) {
             self.macosTitlebarProxyIcon = config.macosTitlebarProxyIcon
             self.windowStepResize = config.windowStepResize
             self.focusFollowsMouse = config.focusFollowsMouse
+            self.splitPreserveZoom = config.splitPreserveZoom
         }
     }
 }

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -124,6 +124,14 @@ extension Ghostty {
             return .init(rawValue: v)
         }
 
+        var splitPreserveZoom: SplitPreserveZoom {
+            guard let config = self.config else { return .init() }
+            var v: CUnsignedInt = 0
+            let key = "split-preserve-zoom"
+            guard ghostty_config_get(config, &v, key, UInt(key.count)) else { return .init() }
+            return .init(rawValue: v)
+        }
+
         var initialWindow: Bool {
             guard let config = self.config else { return true }
             var v = true;
@@ -690,6 +698,12 @@ extension Ghostty.Config {
         static let border = BellFeatures(rawValue: 1 << 4)
     }
 
+    struct SplitPreserveZoom: OptionSet {
+        let rawValue: CUnsignedInt
+
+        static let navigation = SplitPreserveZoom(rawValue: 1 << 0)
+    }
+    
     enum MacDockDropBehavior: String {
         case new_tab = "new-tab"
         case new_window = "new-window"

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -985,6 +985,14 @@ palette: Palette = .{},
 /// Available since: 1.1.0
 @"split-divider-color": ?Color = null,
 
+/// Control when Ghostty preserves the zoomed state of a split. This is a packed
+/// struct so more options can be added in the future. The `navigation` option
+/// keeps the current split zoomed when split navigation (`goto_split`) changes
+/// the focused split.
+///
+/// Example: `split-preserve-zoom = navigation`
+@"split-preserve-zoom": SplitPreserveZoom = .{},
+
 /// The foreground and background color for search matches. This only applies
 /// to non-focused search matches, also known as candidate matches.
 ///
@@ -7421,6 +7429,10 @@ pub const ShellIntegrationFeatures = packed struct {
     @"ssh-env": bool = false,
     @"ssh-terminfo": bool = false,
     path: bool = true,
+};
+
+pub const SplitPreserveZoom = packed struct {
+    navigation: bool = false,
 };
 
 pub const RepeatableCommand = struct {

--- a/src/config/c_get.zig
+++ b/src/config/c_get.zig
@@ -222,3 +222,19 @@ test "c_get: background-blur" {
         try testing.expectEqual(-2, cval);
     }
 }
+
+test "c_get: split-preserve-zoom" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var c = try Config.default(alloc);
+    defer c.deinit();
+
+    var bits: c_uint = undefined;
+    try testing.expect(get(&c, .@"split-preserve-zoom", @ptrCast(&bits)));
+    try testing.expectEqual(@as(c_uint, 0), bits);
+
+    c.@"split-preserve-zoom".navigation = true;
+    try testing.expect(get(&c, .@"split-preserve-zoom", @ptrCast(&bits)));
+    try testing.expectEqual(@as(c_uint, 1), bits);
+}


### PR DESCRIPTION
Closes #8458.

- Adds the split-preserve-zoom config option with a navigation flag.
- GTK and macOS runtimes now respect the flag so zoomed splits stay zoomed when using split navigation. I've tested this on macOS (video below), but have not tested on GTK.

This PR was written primarily with Codex CLI, using the [gh-issue](https://github.com/ghostty-org/ghostty/blob/main/.agents/commands/gh-issue) command.

Here is a short video of the debug build:

https://github.com/user-attachments/assets/3abea255-98e1-4a4f-9196-7c1b2663b9d2


