### PR TITLE
Fix `macos-titlebar-tabs` related issues

### DIFF
--- a/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
@@ -157,6 +157,9 @@ class TitlebarTabsTahoeTerminalWindow: TransparentTitlebarTerminalWindow, NSTool
         guard let accessoryView = clipView.subviews[safe: 0] else { return }
         guard let titlebarView else { return }
         guard let toolbarView = titlebarView.firstDescendant(withClassName: "NSToolbarView") else { return }
+        // make sure tabBar's height won't be stretched
+        guard let newTabButton = titlebarView.firstDescendant(withClassName: "NSTabBarNewTabButton") else { return }
+        tabBar.frame.size.height = newTabButton.frame.width
 
         // The container is the view that we'll constrain our tab bar within.
         let container = toolbarView

--- a/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
@@ -19,9 +19,19 @@ class TitlebarTabsTahoeTerminalWindow: TransparentTitlebarTerminalWindow, NSTool
 
     // MARK: NSWindow
 
+    override var titlebarFont: NSFont? {
+        didSet {
+            DispatchQueue.main.async {
+                self.viewModel.titleFont = self.titlebarFont
+            }
+        }
+    }
+
     override var title: String {
         didSet {
-            viewModel.title = title
+            DispatchQueue.main.async {
+                self.viewModel.title = self.title
+            }
         }
     }
 
@@ -46,6 +56,16 @@ class TitlebarTabsTahoeTerminalWindow: TransparentTitlebarTerminalWindow, NSTool
         // Check if we have a tab bar and set it up if we have to. See the comment
         // on this function to learn why we need to check this here.
         setupTabBar()
+    }
+
+    override func becomeKey() {
+        super.becomeKey()
+        viewModel.isKeyWindow = isKeyWindow
+    }
+
+    override func resignKey() {
+        super.resignKey()
+        viewModel.isKeyWindow = isKeyWindow
     }
 
     // This is called by macOS for native tabbing in order to add the tab bar. We hook into
@@ -227,8 +247,10 @@ class TitlebarTabsTahoeTerminalWindow: TransparentTitlebarTerminalWindow, NSTool
     // MARK: SwiftUI
 
     class ViewModel: ObservableObject {
+        @Published var titleFont: NSFont?
         @Published var title: String = "👻 Ghostty"
         @Published var hasTabBar: Bool = false
+        @Published var isKeyWindow: Bool = true
     }
 }
 
@@ -254,6 +276,8 @@ extension TitlebarTabsTahoeTerminalWindow {
             // as of 26.1 Beta (25B5057f) though
             // we could't guarantee that this behaviour won't change in the future
             Text(title)
+                .font(viewModel.titleFont.flatMap(Font.init(_:)))
+                .foregroundStyle(viewModel.isKeyWindow ? .primary : .secondary)
                 .lineLimit(1)
                 .truncationMode(.tail)
                 .frame(maxWidth: .greatestFiniteMagnitude, alignment: .center)

--- a/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
@@ -209,6 +209,8 @@ class TitlebarTabsTahoeTerminalWindow: TransparentTitlebarTerminalWindow, NSTool
         case .title:
             let item = NSToolbarItem(itemIdentifier: .title)
             item.view = NSHostingView(rootView: TitleItem(viewModel: viewModel))
+            // fix: https://github.com/ghostty-org/ghostty/discussions/9027
+            item.view?.setContentCompressionResistancePriority(.required, for: .horizontal)
             item.visibilityPriority = .user
             item.isEnabled = true
 
@@ -248,16 +250,14 @@ extension TitlebarTabsTahoeTerminalWindow {
         }
 
         var body: some View {
-            if !viewModel.hasTabBar {
-                Text(title)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            } else {
-                // 1x1.gif strikes again! For real: if we render a zero-sized
-                // view here then the toolbar just disappears our view. I don't
-                // know.
-                Color.clear.frame(width: 1, height: 1)
-            }
+            // even when there is tab bar, it's safe to maintain the same content
+            // as of 26.1 Beta (25B5057f) though
+            // we could't guarantee that this behaviour won't change in the future
+            Text(title)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .greatestFiniteMagnitude, alignment: .center)
+                // .background(.red) // easier to debug
         }
     }
 }

--- a/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
@@ -74,6 +74,10 @@ class TitlebarTabsTahoeTerminalWindow: TransparentTitlebarTerminalWindow, NSTool
             return
         }
 
+        // When an existing tab being dragged in to another tab group,
+        // system will also try to add tab bar to this window,
+        // so we want to reset observer, to put tab bar where we want again
+        tabBarObserver = nil
         // Some setup needs to happen BEFORE it is added, such as layout. If
         // we don't do this before the call below, we'll trigger an AppKit
         // assertion.

--- a/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
@@ -56,18 +56,13 @@ class TitlebarTabsTahoeTerminalWindow: TransparentTitlebarTerminalWindow, NSTool
         // Check if we have a tab bar and set it up if we have to. See the comment
         // on this function to learn why we need to check this here.
         setupTabBar()
+        viewModel.isMainWindow = true
     }
 
-    override func becomeKey() {
-        super.becomeKey()
-        viewModel.isKeyWindow = isKeyWindow
+    override func resignMain() {
+        super.resignMain()
+        viewModel.isMainWindow = false
     }
-
-    override func resignKey() {
-        super.resignKey()
-        viewModel.isKeyWindow = isKeyWindow
-    }
-
     // This is called by macOS for native tabbing in order to add the tab bar. We hook into
     // this, detect the tab bar being added, and override its behavior.
     override func addTitlebarAccessoryViewController(_ childViewController: NSTitlebarAccessoryViewController) {
@@ -258,7 +253,7 @@ class TitlebarTabsTahoeTerminalWindow: TransparentTitlebarTerminalWindow, NSTool
         @Published var titleFont: NSFont?
         @Published var title: String = "👻 Ghostty"
         @Published var hasTabBar: Bool = false
-        @Published var isKeyWindow: Bool = true
+        @Published var isMainWindow: Bool = true
     }
 }
 
@@ -285,7 +280,7 @@ extension TitlebarTabsTahoeTerminalWindow {
             // we could't guarantee that this behaviour won't change in the future
             Text(title)
                 .font(viewModel.titleFont.flatMap(Font.init(_:)))
-                .foregroundStyle(viewModel.isKeyWindow ? .primary : .secondary)
+                .foregroundStyle(viewModel.isMainWindow ? .primary : .secondary)
                 .lineLimit(1)
                 .truncationMode(.tail)
                 .frame(maxWidth: .greatestFiniteMagnitude, alignment: .center)

--- a/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
@@ -68,6 +68,8 @@ class TitlebarTabsTahoeTerminalWindow: TransparentTitlebarTerminalWindow, NSTool
     override func addTitlebarAccessoryViewController(_ childViewController: NSTitlebarAccessoryViewController) {
         // If this is the tab bar then we need to set it up for the titlebar
         guard isTabBar(childViewController) else {
+            // After dragging a tab into a new window, `hasTabBar` needs to be update to properly review window title
+            self.viewModel.hasTabBar = false
             super.addTitlebarAccessoryViewController(childViewController)
             return
         }


### PR DESCRIPTION
### This pr fixes multiple issues related to `macos-titlebar-tabs`

- [Window title clipping **on Tahoe**](https://github.com/ghostty-org/ghostty/discussions/9027#discussion-8981483)
- Clipped tab bar **on Tahoe** when creating new ones in fullscreen
  > Sequoia doesn't seem to have this issue (at least I didn't reproduce myself)
- [Title missing **on Tahoe** after dragging a tab into a separate window](https://github.com/ghostty-org/ghostty/discussions/9027#discussioncomment-14617088)
- [Clipped tab bar **on Tahoe** after dragging from one tab group to another](https://github.com/ghostty-org/ghostty/discussions/9027#discussioncomment-14626078)
- [Stretched tab bar after switching system appearance](https://github.com/ghostty-org/ghostty/discussions/9027#discussioncomment-14626918)


### Related issues
I checked all of the open sub-issues in #2349 , most of them should be fixed in latest main branch (I didn't reproduce)

- [#1692](https://github.com/ghostty-org/ghostty/issues/1692) @peteschaffner
- [#1945](https://github.com/ghostty-org/ghostty/issues/1945) this one I reproduce only on Tahoe, and fixed in this pr, @injust
- [#1813](https://github.com/ghostty-org/ghostty/issues/1813) @jacakira
- [#1787](https://github.com/ghostty-org/ghostty/issues/1787) @roguesherlock
- [#1691](https://github.com/ghostty-org/ghostty/issues/1691) ~**haven't found a solution yet**(building zig on VM is a pain**)~
  > Tried commenting out `isOpaque` check in `TitlebarTabsVenturaTerminalWindow`, which would fix the issue, but I see the note there about transparency issue. 
  >
  > After commenting it out, it worked fine for me with blur and opacity config, so **I might need some more background on this**. Didn't include this change yet.
  > 
  > [See screenshot here](https://github.com/user-attachments/assets/eb17642d-b0de-46b2-b42a-19fb38a2c7f0)



### Minor improvements

- Match window title style with `window-title-font-family` and focus state
  
<img width="843" height="198" alt="image" src="https://github.com/user-attachments/assets/0138c4fa-1a4b-4bab-a415-b32695899ccf" />
