### PR TITLE
docs: Update build requirements for macOS

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -50,24 +50,22 @@ macOS users don't require any additional dependencies.
 ## Xcode Version and SDKs
 
 Building the Ghostty macOS app requires that Xcode, the macOS SDK,
-and the iOS SDK are all installed.
+the iOS SDK, and Metal Toolchain are all installed.
 
 A common issue is that the incorrect version of Xcode is either
 installed or selected. Use the `xcode-select` command to
 ensure that the correct version of Xcode is selected:
 
 ```shell-session
-sudo xcode-select --switch /Applications/Xcode-beta.app
+sudo xcode-select --switch /Applications/Xcode.app
 ```
 
 > [!IMPORTANT]
 >
-> Main branch development of Ghostty is preparing for the next major
-> macOS release, Tahoe (macOS 26). Therefore, the main branch requires
-> **Xcode 26 and the macOS 26 SDK**.
+> Main branch development of Ghostty requires **Xcode 26 and the macOS 26 SDK**.
 >
 > You do not need to be running on macOS 26 to build Ghostty, you can
-> still use Xcode 26 beta on macOS 15 stable.
+> still use Xcode 26 on macOS 15 stable.
 
 ## AI and Agents
 


### PR DESCRIPTION
Adds the Metal Toolchain as a required Xcode component for building Ghostty. Also updates the notes about Xcode 26 now that it and Tahoe are out of Beta.