### PR TITLE
apprt/gtk: set the correct window title from the start

### DIFF
--- a/src/apprt/gtk/class/tab.zig
+++ b/src/apprt/gtk/class/tab.zig
@@ -389,8 +389,14 @@ pub const Tab = extern struct {
         // the terminal title if it exists, otherwise a default string.
         const plain = plain: {
             const default = "Ghostty";
+            const config_title: ?[*:0]const u8 = title: {
+                const config = config_ orelse break :title null;
+                break :title config.get().title orelse null;
+            };
+
             const plain = override_ orelse
                 terminal_ orelse
+                config_title orelse
                 break :plain default;
             break :plain std.mem.span(plain);
         };


### PR DESCRIPTION
Previous PR: #8535 (merged but problem persists)
Issues: #5934

The Ghostty window will always start with the title "Ghostty" at startup, and then immediately change to the correct window title. This is a problem when using compositors like Hyprland and Niri if you want to create rules for floating windows and similar, as the window title isn't detected at startup.

This fixes the bad behaviour both for title configured in the config file, and for processes started with the --title argument.

In this fix I've updated the `tags.zig` `closureComputedTitle()` function to get the title from the passed in config, and use that as a fallback before the default `Ghostty` fallback.

Previous behaviour as logged by `niri msg event-stream`:

> Window opened or changed: Window { id: 19, title: Some("Ghostty"), app_id: Some("com.mitchellh.ghostty-debug"), pid: Some(802495), workspace_id: Some(1), is_focused: true, is_floating: false, is_urgent: false, layout: WindowLayout { pos_in_scrolling_layout: Some((3, 1)), tile_size: (2266.0, 1365.0), window_size: (2266, 1365), tile_pos_in_workspace_view: None, window_offset_in_tile: (0.0, 0.0) } }
Window layouts changed: [(6, WindowLayout { pos_in_scrolling_layout: Some((4, 1)), tile_size: (2266.0, 1365.0), window_size: (2266, 1365), tile_pos_in_workspace_view: None, window_offset_in_tile: (0.0, 0.0) })]
Window opened or changed: Window { id: 19, title: Some("pr-test-title-fix"), app_id: Some("com.mitchellh.ghostty-debug"), pid: Some(802495), workspace_id: Some(1), is_focused: true, is_floating: false, is_urgent: false, layout: WindowLayout { pos_in_scrolling_layout: Some((3, 1)), tile_size: (2266.0, 1365.0), window_size: (2266, 1365), tile_pos_in_workspace_view: None, window_offset_in_tile: (0.0, 0.0) } }

New behaviour:

> Window opened or changed: Window { id: 20, title: Some("pr-test-title-fix"), app_id: Some("com.mitchellh.ghostty-debug"), pid: Some(804534), workspace_id: Some(1), is_focused: true, is_floating: false, is_urgent: false, layout: WindowLayout { pos_in_scrolling_layout: Some((3, 1)), tile_size: (2266.0, 1365.0), window_size: (2266, 1365), tile_pos_in_workspace_view: None, window_offset_in_tile: (0.0, 0.0) } }
Window layouts changed: [(6, WindowLayout { pos_in_scrolling_layout: Some((4, 1)), tile_size: (2266.0, 1365.0), window_size: (2266, 1365), tile_pos_in_workspace_view: None, window_offset_in_tile: (0.0, 0.0) })]

This fixes the problem as shown in the output. I have only tested this on Linux (Arch with Niri).