### PR TITLE
gtk4-layer-shell: version from build.zig.zon, reenable ubsan

### DIFF
--- a/pkg/gtk4-layer-shell/build.zig
+++ b/pkg/gtk4-layer-shell/build.zig
@@ -120,16 +120,6 @@ fn buildLib(b: *std.Build, module: *std.Build.Module, options: anytype) !*std.Bu
             b.fmt("-DGTK_LAYER_SHELL_MAJOR={}", .{lib_version.major}),
             b.fmt("-DGTK_LAYER_SHELL_MINOR={}", .{lib_version.minor}),
             b.fmt("-DGTK_LAYER_SHELL_MICRO={}", .{lib_version.patch}),
-
-            // Zig 0.14 regression: this is required because building with
-            // ubsan results in unknown symbols. Bundling the ubsan/compiler
-            // RT doesn't help. I'm not sure what the root cause is but I
-            // suspect its related to this:
-            // https://github.com/ziglang/zig/issues/23052
-            //
-            // We can remove this in the future for Zig updates and see
-            // if our binaries run in debug on NixOS.
-            "-fno-sanitize=undefined",
         },
     });
 

--- a/pkg/gtk4-layer-shell/build.zig
+++ b/pkg/gtk4-layer-shell/build.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 
-// TODO: Import this from build.zig.zon when possible
-const version: std.SemanticVersion = .{ .major = 1, .minor = 1, .patch = 0 };
+const version = @import("build.zig.zon").version;
 
 const dynamic_link_opts: std.Build.Module.LinkSystemLibraryOptions = .{
     .preferred_link_mode = .dynamic,
@@ -32,6 +31,7 @@ pub fn build(b: *std.Build) !void {
 }
 
 fn buildLib(b: *std.Build, module: *std.Build.Module, options: anytype) !*std.Build.Step.Compile {
+    const lib_version = try std.SemanticVersion.parse(version);
     const target = options.target;
     const optimize = options.optimize;
 
@@ -117,9 +117,9 @@ fn buildLib(b: *std.Build, module: *std.Build.Module, options: anytype) !*std.Bu
         .root = upstream.path("src"),
         .files = srcs,
         .flags = &.{
-            b.fmt("-DGTK_LAYER_SHELL_MAJOR={}", .{version.major}),
-            b.fmt("-DGTK_LAYER_SHELL_MINOR={}", .{version.minor}),
-            b.fmt("-DGTK_LAYER_SHELL_MICRO={}", .{version.patch}),
+            b.fmt("-DGTK_LAYER_SHELL_MAJOR={}", .{lib_version.major}),
+            b.fmt("-DGTK_LAYER_SHELL_MINOR={}", .{lib_version.minor}),
+            b.fmt("-DGTK_LAYER_SHELL_MICRO={}", .{lib_version.patch}),
 
             // Zig 0.14 regression: this is required because building with
             // ubsan results in unknown symbols. Bundling the ubsan/compiler


### PR DESCRIPTION
added version read from build.zig.zon
didn't get any ubsan error locally with zig 0.15.1 (related to https://github.com/ghostty-org/ghostty/issues/5744#issuecomment-2719313984)