### PR TITLE
macOS: Fix New Tab behaviours

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -1007,13 +1007,15 @@ class AppDelegate: NSObject,
         //UpdateSimulator.happyPath.simulate(with: updateViewModel)
     }
 
-
     @IBAction func newWindow(_ sender: Any?) {
         _ = TerminalController.newWindow(ghostty)
     }
 
     @IBAction func newTab(_ sender: Any?) {
-        _ = TerminalController.newTab(ghostty)
+        _ = TerminalController.newTab(
+            ghostty,
+            from: TerminalController.preferredParent?.window
+        )
     }
 
     @IBAction func closeAllWindows(_ sender: Any?) {

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -465,7 +465,12 @@ class AppDelegate: NSObject,
         }
         
         switch ghostty.config.macosDockDropBehavior {
-        case .new_tab: _ = TerminalController.newTab(ghostty, withBaseConfig: config)
+        case .new_tab:
+            _ = TerminalController.newTab(
+                ghostty,
+                from: TerminalController.preferredParent?.window,
+                withBaseConfig: config
+            )
         case .new_window: _ = TerminalController.newWindow(ghostty, withBaseConfig: config)
         }
         


### PR DESCRIPTION
- Fix `macos-dock-drop-behavior = new-tab` not working, which also affects `open /path/to/directory -a Ghostty.app`
- Fix 'New Tab' in dock icon not working **when Ghostty's not active**

### Issue preview with `1.2.2(12187)`

https://github.com/user-attachments/assets/18068cc2-c25d-4360-97ab-cec22d5d3ff4

