### PR TITLE
macos: Sparkle notFound acknowledgement should only be called on dismiss

### DIFF
--- a/macos/Sources/Features/Update/UpdateDriver.swift
+++ b/macos/Sources/Features/Update/UpdateDriver.swift
@@ -73,12 +73,10 @@ class UpdateDriver: NSObject, SPUUserDriver {
     
     func showUpdateNotFoundWithError(_ error: any Error,
                                      acknowledgement: @escaping () -> Void) {
-        viewModel.state = .notFound
+        viewModel.state = .notFound(.init(acknowledgement: acknowledgement))
         
         if !hasUnobtrusiveTarget {
             standard.showUpdateNotFoundWithError(error, acknowledgement: acknowledgement)
-        } else {
-            acknowledgement()
         }
     }
     

--- a/macos/Sources/Features/Update/UpdatePill.swift
+++ b/macos/Sources/Features/Update/UpdatePill.swift
@@ -23,11 +23,12 @@ struct UpdatePill: View {
                 .transition(.opacity.combined(with: .scale(scale: 0.95)))
                 .onChange(of: model.state) { newState in
                     resetTask?.cancel()
-                    if case .notFound = newState {
+                    if case .notFound(let notFound) = newState {
                         resetTask = Task { [weak model] in
                             try? await Task.sleep(for: .seconds(5))
                             guard !Task.isCancelled, case .notFound? = model?.state else { return }
                             model?.state = .idle
+                            notFound.acknowledgement()
                         }
                     } else {
                         resetTask = nil
@@ -40,8 +41,9 @@ struct UpdatePill: View {
     @ViewBuilder
     private var pillButton: some View {
         Button(action: {
-            if case .notFound = model.state {
+            if case .notFound(let notFound) = model.state {
                 model.state = .idle
+                notFound.acknowledgement()
             } else {
                 showPopover.toggle()
             }

--- a/macos/Sources/Features/Update/UpdatePopoverView.swift
+++ b/macos/Sources/Features/Update/UpdatePopoverView.swift
@@ -41,8 +41,8 @@ struct UpdatePopoverView: View {
             case .installing:
                 InstallingView()
                 
-            case .notFound:
-                NotFoundView(dismiss: dismiss)
+            case .notFound(let notFound):
+                NotFoundView(notFound: notFound, dismiss: dismiss)
                 
             case .error(let error):
                 UpdateErrorView(error: error, dismiss: dismiss)
@@ -331,6 +331,7 @@ fileprivate struct InstallingView: View {
 }
 
 fileprivate struct NotFoundView: View {
+    let notFound: UpdateState.NotFound
     let dismiss: DismissAction
     
     var body: some View {
@@ -348,6 +349,7 @@ fileprivate struct NotFoundView: View {
             HStack {
                 Spacer()
                 Button("OK") {
+                    notFound.acknowledgement()
                     dismiss()
                 }
                 .keyboardShortcut(.defaultAction)

--- a/macos/Sources/Features/Update/UpdateSimulator.swift
+++ b/macos/Sources/Features/Update/UpdateSimulator.swift
@@ -72,7 +72,9 @@ enum UpdateSimulator {
         }))
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-            viewModel.state = .notFound
+            viewModel.state = .notFound(.init(acknowledgement: {
+                // Acknowledgement called when dismissed
+            }))
             
             DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
                 viewModel.state = .idle

--- a/macos/Sources/Features/Update/UpdateViewModel.swift
+++ b/macos/Sources/Features/Update/UpdateViewModel.swift
@@ -135,7 +135,7 @@ enum UpdateState: Equatable {
     case permissionRequest(PermissionRequest)
     case checking(Checking)
     case updateAvailable(UpdateAvailable)
-    case notFound
+    case notFound(NotFound)
     case error(Error)
     case downloading(Downloading)
     case extracting(Extracting)
@@ -157,6 +157,8 @@ enum UpdateState: Equatable {
             downloading.cancel()
         case .readyToInstall(let ready):
             ready.reply(.dismiss)
+        case .notFound(let notFound):
+            notFound.acknowledgement()
         case .error(let err):
             err.dismiss()
         default:
@@ -189,6 +191,10 @@ enum UpdateState: Equatable {
         default:
             return false
         }
+    }
+    
+    struct NotFound {
+        let acknowledgement: () -> Void
     }
     
     struct PermissionRequest {


### PR DESCRIPTION
This was causing the "no update found" message to never really appear in the real world.