### PR TITLE
GTK fix quick terminal autohide

### DIFF
--- a/src/apprt/gtk/class/window.zig
+++ b/src/apprt/gtk/class/window.zig
@@ -1015,6 +1015,15 @@ pub const Window = extern struct {
         _: *gobject.ParamSpec,
         self: *Self,
     ) callconv(.c) void {
+        // Hide quick-terminal if set to autohide
+        if (self.isQuickTerminal()) {
+            if (self.getConfig()) |cfg| {
+                if (cfg.get().@"quick-terminal-autohide" and self.as(gtk.Window).isActive() == 0) {
+                    self.toggleVisibility();
+                }
+            }
+        }
+
         // Don't change urgency if we're not the active window.
         if (self.as(gtk.Window).isActive() == 0) return;
 


### PR DESCRIPTION
This is pretty much a direct port of the previous GTK app. still inside of the `isActive` handler for a window

https://github.com/ghostty-org/ghostty/blob/7e429d73d6af65a397c6264b18ab60609ae8eefe/src/apprt/gtk/Window.zig#L822-L837

Fixes: https://github.com/ghostty-org/ghostty/discussions/9137
