### PR TITLE
gtk: fix clicking on desktop notifications

### DIFF
--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -1468,6 +1468,12 @@ pub const Surface = extern struct {
 
     pub fn sendDesktopNotification(self: *Self, title: [:0]const u8, body: [:0]const u8) void {
         const app = Application.default();
+        const priv: *Private = self.private();
+
+        const core_surface = priv.core_surface orelse {
+            log.warn("can't send notification because there is no core surface", .{});
+            return;
+        };
 
         const t = switch (title.len) {
             0 => "Ghostty",
@@ -1482,7 +1488,7 @@ pub const Surface = extern struct {
         defer icon.unref();
         notification.setIcon(icon.as(gio.Icon));
 
-        const pointer = glib.Variant.newUint64(@intFromPtr(self));
+        const pointer = glib.Variant.newUint64(@intFromPtr(core_surface));
         notification.setDefaultActionAndTargetValue(
             "app.present-surface",
             pointer,

--- a/src/apprt/gtk/class/window.zig
+++ b/src/apprt/gtk/class/window.zig
@@ -1585,6 +1585,9 @@ pub const Window = extern struct {
 
         // Grab focus
         surface.grabFocus();
+
+        // Bring the window to the front.
+        self.as(gtk.Window).present();
     }
 
     fn surfaceToggleFullscreen(


### PR DESCRIPTION
Clicking on desktop notifications sent by Ghostty _should_ cause the window that sent the notification to come to the top. However, because the notification that was sent targeted the wrong surface (apprt surface vs core surface) and the window did not call `present()` on itself the window would never be brought to the surface, the correct tab would not be selected, etc.

Fixes #9145