### PR TITLE
macos: update permission request response should move state back to idle

### DIFF
--- a/macos/Sources/Features/Update/UpdateDriver.swift
+++ b/macos/Sources/Features/Update/UpdateDriver.swift
@@ -39,7 +39,10 @@ class UpdateDriver: NSObject, SPUUserDriver {
     
     func show(_ request: SPUUpdatePermissionRequest,
               reply: @escaping @Sendable (SUUpdatePermissionResponse) -> Void) {
-        viewModel.state = .permissionRequest(.init(request: request, reply: reply))
+        viewModel.state = .permissionRequest(.init(request: request, reply: { [weak viewModel] response in
+            viewModel?.state = .idle
+            reply(response)
+        }))
         if !hasUnobtrusiveTarget {
             standard.show(request, reply: reply)
         }


### PR DESCRIPTION
Previously, the permission request response would not move the state so it'd stay in the titlebar.