### PR TITLE
Fix fish shell cursor integration in fish vi mode

### DIFF
--- a/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
+++ b/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
@@ -54,10 +54,14 @@ function __ghostty_setup --on-event fish_prompt -d "Setup ghostty integration"
     if contains cursor $features
         # Change the cursor to a beam on prompt.
         function __ghostty_set_cursor_beam --on-event fish_prompt -d "Set cursor shape"
-            echo -en "\e[5 q"
+            if not functions -q fish_vi_cursor_handle
+                echo -en "\e[5 q"
+            end
         end
         function __ghostty_reset_cursor --on-event fish_preexec -d "Reset cursor shape"
-            echo -en "\e[0 q"
+            if not functions -q fish_vi_cursor_handle
+                echo -en "\e[0 q"
+            end
         end
     end
 


### PR DESCRIPTION
Previously, the fish shell integration interfered with fish's builtin vi mode cursor switching configurations such as `$fish_cursor_default` and `$fish_cursor_insert`.

```console
$ ghostty --config-default-files=false -e fish --no-config --init-command 'source "$GHOSTTY_RESOURCES_DIR"/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish; fish_vi_key_bindings'
```

The above command starts fish in vi mode with Ghostty shell integrations. Manually loading the integration is necessary due to `--no-config` blocking auto injection.

 1. At the prompt, fish is in insert mode, and the cursor is a blinking beam. However, press escape and then "i" to exit then re-enter insert mode, and the cursor will be a solid beam due to the `$fish_cursor_unknown` setting. Without the shell integration, insert mode always uses a solid beam cursor.

 2. A similar problem shows if we start fish with `fish_vi_key_bindings default`. The cursor ends up as a blinking beam in normal mode only due to the shell integration interfering. This glitch can also be reset away by entering then exiting insert mode.

 3. Also, `$fish_cursor_external` has no effect when used with shell integration. After `fish_vi_key_bindings`, set it to `line`, run cat(1), and shell integration will give you a blinking block, not the asked for line/beam.

I verified that this patch makes the shell integration stop interfering in three scenarios above, and it still changes the cursor when not using fish's vi mode.

Note that `$fish_cursor_*` variables can be set when fish isn't in vi mode, so they're not great signals for the shell integration hooks.