### PR TITLE
Allow for default or inherited CWD in new window, tab and split surfaces (redone for GTK-NG)

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1042,10 +1042,7 @@ ghostty_surface_t ghostty_surface_new(ghostty_app_t,
 void ghostty_surface_free(ghostty_surface_t);
 void* ghostty_surface_userdata(ghostty_surface_t);
 ghostty_app_t ghostty_surface_app(ghostty_surface_t);
-ghostty_surface_config_s ghostty_surface_inherited_config(ghostty_surface_t); /* deprecated: use context-specific functions */
-ghostty_surface_config_s ghostty_surface_inherited_config_window(ghostty_surface_t);
-ghostty_surface_config_s ghostty_surface_inherited_config_tab(ghostty_surface_t);
-ghostty_surface_config_s ghostty_surface_inherited_config_split(ghostty_surface_t);
+ghostty_surface_config_s ghostty_surface_inherited_config(ghostty_surface_t, ghostty_surface_context_e);
 void ghostty_surface_update_config(ghostty_surface_t, ghostty_config_t);
 bool ghostty_surface_needs_confirm_quit(ghostty_surface_t);
 bool ghostty_surface_process_exited(ghostty_surface_t);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -416,6 +416,12 @@ typedef union {
   ghostty_platform_ios_s ios;
 } ghostty_platform_u;
 
+typedef enum {
+  GHOSTTY_SURFACE_CONTEXT_WINDOW = 0,
+  GHOSTTY_SURFACE_CONTEXT_TAB = 1,
+  GHOSTTY_SURFACE_CONTEXT_SPLIT = 2,
+} ghostty_surface_context_e;
+
 typedef struct {
   ghostty_platform_e platform_tag;
   ghostty_platform_u platform;
@@ -428,7 +434,7 @@ typedef struct {
   size_t env_var_count;
   const char* initial_input;
   bool wait_after_command;
-  int context; // 0=window, 1=tab, 2=split
+  ghostty_surface_context_e context;
 } ghostty_surface_config_s;
 
 typedef struct {

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -428,6 +428,7 @@ typedef struct {
   size_t env_var_count;
   const char* initial_input;
   bool wait_after_command;
+  int context; // 0=window, 1=tab, 2=split
 } ghostty_surface_config_s;
 
 typedef struct {

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1036,7 +1036,10 @@ ghostty_surface_t ghostty_surface_new(ghostty_app_t,
 void ghostty_surface_free(ghostty_surface_t);
 void* ghostty_surface_userdata(ghostty_surface_t);
 ghostty_app_t ghostty_surface_app(ghostty_surface_t);
-ghostty_surface_config_s ghostty_surface_inherited_config(ghostty_surface_t);
+ghostty_surface_config_s ghostty_surface_inherited_config(ghostty_surface_t); /* deprecated: use context-specific functions */
+ghostty_surface_config_s ghostty_surface_inherited_config_window(ghostty_surface_t);
+ghostty_surface_config_s ghostty_surface_inherited_config_tab(ghostty_surface_t);
+ghostty_surface_config_s ghostty_surface_inherited_config_split(ghostty_surface_t);
 void ghostty_surface_update_config(ghostty_surface_t, ghostty_config_t);
 bool ghostty_surface_needs_confirm_quit(ghostty_surface_t);
 bool ghostty_surface_process_exited(ghostty_surface_t);

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -773,7 +773,7 @@ extension Ghostty {
                     name: Notification.ghosttyNewWindow,
                     object: surfaceView,
                     userInfo: [
-                        Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: ghostty_surface_inherited_config(surface)),
+                        Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: ghostty_surface_inherited_config_window(surface)),
                     ]
                 )
 
@@ -810,7 +810,7 @@ extension Ghostty {
                     name: Notification.ghosttyNewTab,
                     object: surfaceView,
                     userInfo: [
-                        Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: ghostty_surface_inherited_config(surface)),
+                        Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: ghostty_surface_inherited_config_tab(surface)),
                     ]
                 )
 
@@ -839,7 +839,7 @@ extension Ghostty {
                     object: surfaceView,
                     userInfo: [
                         "direction": direction,
-                        Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: ghostty_surface_inherited_config(surface)),
+                        Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: ghostty_surface_inherited_config_split(surface)),
                     ]
                 )
 

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -773,7 +773,7 @@ extension Ghostty {
                     name: Notification.ghosttyNewWindow,
                     object: surfaceView,
                     userInfo: [
-                        Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: ghostty_surface_inherited_config_window(surface)),
+                        Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: ghostty_surface_inherited_config(surface, GHOSTTY_SURFACE_CONTEXT_WINDOW)),
                     ]
                 )
 
@@ -810,7 +810,7 @@ extension Ghostty {
                     name: Notification.ghosttyNewTab,
                     object: surfaceView,
                     userInfo: [
-                        Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: ghostty_surface_inherited_config_tab(surface)),
+                        Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: ghostty_surface_inherited_config(surface, GHOSTTY_SURFACE_CONTEXT_TAB)),
                     ]
                 )
 
@@ -839,7 +839,7 @@ extension Ghostty {
                     object: surfaceView,
                     userInfo: [
                         "direction": direction,
-                        Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: ghostty_surface_inherited_config_split(surface)),
+                        Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: ghostty_surface_inherited_config(surface, GHOSTTY_SURFACE_CONTEXT_SPLIT)),
                     ]
                 )
 

--- a/macos/Sources/Ghostty/Surface View/SurfaceView.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView.swift
@@ -625,6 +625,13 @@ extension Ghostty {
         #endif
     }
 
+    /// Context for surface creation, matching the Zig NewSurfaceContext enum
+    enum NewSurfaceContext: Int32 {
+        case window = 0
+        case tab = 1
+        case split = 2
+    }
+
     /// The configuration for a surface. For any configuration not set, defaults will be chosen from
     /// libghostty, usually from the Ghostty configuration.
     struct SurfaceConfiguration {
@@ -645,6 +652,9 @@ extension Ghostty {
         
         /// Wait after the command
         var waitAfterCommand: Bool = false
+
+        /// Context for surface creation
+        var context: NewSurfaceContext = .window
 
         init() {}
 
@@ -667,6 +677,7 @@ extension Ghostty {
                     }
                 }
             }
+            self.context = NewSurfaceContext(rawValue: config.context) ?? .window
         }
 
         /// Provides a C-compatible ghostty configuration within a closure. The configuration
@@ -699,6 +710,9 @@ extension Ghostty {
             
             // Set wait after command
             config.wait_after_command = waitAfterCommand
+
+            // Set context
+            config.context = context.rawValue
 
             // Use withCString to ensure strings remain valid for the duration of the closure
             return try workingDirectory.withCString { cWorkingDir in

--- a/macos/Sources/Ghostty/Surface View/SurfaceView.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView.swift
@@ -625,21 +625,6 @@ extension Ghostty {
         #endif
     }
 
-    /// Context for surface creation, matching ghostty_surface_context_e
-    enum NewSurfaceContext: ghostty_surface_context_e.RawValue {
-        case window = 0  // GHOSTTY_SURFACE_CONTEXT_WINDOW
-        case tab = 1     // GHOSTTY_SURFACE_CONTEXT_TAB
-        case split = 2   // GHOSTTY_SURFACE_CONTEXT_SPLIT
-        
-        init(_ cValue: ghostty_surface_context_e) {
-            self.init(rawValue: cValue.rawValue)!
-        }
-        
-        var cValue: ghostty_surface_context_e {
-            ghostty_surface_context_e(rawValue: self.rawValue)
-        }
-    }
-
     /// The configuration for a surface. For any configuration not set, defaults will be chosen from
     /// libghostty, usually from the Ghostty configuration.
     struct SurfaceConfiguration {
@@ -662,7 +647,7 @@ extension Ghostty {
         var waitAfterCommand: Bool = false
 
         /// Context for surface creation
-        var context: NewSurfaceContext = .window
+        var context: ghostty_surface_context_e = GHOSTTY_SURFACE_CONTEXT_WINDOW
 
         init() {}
 
@@ -685,7 +670,7 @@ extension Ghostty {
                     }
                 }
             }
-            self.context = NewSurfaceContext(config.context)
+            self.context = config.context
         }
 
         /// Provides a C-compatible ghostty configuration within a closure. The configuration
@@ -720,7 +705,7 @@ extension Ghostty {
             config.wait_after_command = waitAfterCommand
 
             // Set context
-            config.context = context.cValue
+            config.context = context
 
             // Use withCString to ensure strings remain valid for the duration of the closure
             return try workingDirectory.withCString { cWorkingDir in

--- a/macos/Sources/Ghostty/Surface View/SurfaceView.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView.swift
@@ -625,11 +625,19 @@ extension Ghostty {
         #endif
     }
 
-    /// Context for surface creation, matching the Zig NewSurfaceContext enum
-    enum NewSurfaceContext: Int32 {
-        case window = 0
-        case tab = 1
-        case split = 2
+    /// Context for surface creation, matching ghostty_surface_context_e
+    enum NewSurfaceContext: ghostty_surface_context_e.RawValue {
+        case window = 0  // GHOSTTY_SURFACE_CONTEXT_WINDOW
+        case tab = 1     // GHOSTTY_SURFACE_CONTEXT_TAB
+        case split = 2   // GHOSTTY_SURFACE_CONTEXT_SPLIT
+        
+        init(_ cValue: ghostty_surface_context_e) {
+            self.init(rawValue: cValue.rawValue)!
+        }
+        
+        var cValue: ghostty_surface_context_e {
+            ghostty_surface_context_e(rawValue: self.rawValue)
+        }
     }
 
     /// The configuration for a surface. For any configuration not set, defaults will be chosen from
@@ -677,7 +685,7 @@ extension Ghostty {
                     }
                 }
             }
-            self.context = NewSurfaceContext(rawValue: config.context) ?? .window
+            self.context = NewSurfaceContext(config.context)
         }
 
         /// Provides a C-compatible ghostty configuration within a closure. The configuration
@@ -712,7 +720,7 @@ extension Ghostty {
             config.wait_after_command = waitAfterCommand
 
             // Set context
-            config.context = context.rawValue
+            config.context = context.cValue
 
             // Use withCString to ensure strings remain valid for the duration of the closure
             return try workingDirectory.withCString { cWorkingDir in

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -458,13 +458,7 @@ pub const Surface = struct {
         wait_after_command: bool = false,
 
         /// Context for the new surface
-        context: Context = .c_window,
-
-        pub const Context = enum(c_int) {
-            c_window = 0,
-            c_tab = 1,
-            c_split = 2,
-        };
+        context: apprt.surface.NewSurfaceContext = .window,
     };
 
     pub fn init(self: *Surface, app: *App, opts: Options) !void {
@@ -486,13 +480,7 @@ pub const Surface = struct {
         errdefer app.core_app.deleteSurface(self);
 
         // Shallow copy the config so that we can modify it.
-        const surface_context: apprt.surface.NewSurfaceContext = switch (opts.context) {
-            .c_window => .window,
-            .c_tab => .tab,
-            .c_split => .split,
-        };
-
-        var config = try apprt.surface.newConfig(app.core_app, &app.config, surface_context);
+        var config = try apprt.surface.newConfig(app.core_app, &app.config, opts.context);
         defer config.deinit();
 
         // If we have a working directory from the options then we set it.
@@ -925,11 +913,7 @@ pub const Surface = struct {
         return .{
             .font_size = font_size,
             .working_directory = working_directory,
-            .context = switch (context) {
-                .window => .c_window,
-                .tab => .c_tab,
-                .split => .c_split,
-            },
+            .context = context,
         };
     }
 
@@ -1553,14 +1537,9 @@ pub const CAPI = struct {
     /// Returns the config to use for surfaces that inherit from this one.
     export fn ghostty_surface_inherited_config(
         surface: *Surface,
-        source: Surface.Options.Context,
+        source: apprt.surface.NewSurfaceContext,
     ) Surface.Options {
-        const context: apprt.surface.NewSurfaceContext = switch (source) {
-            .c_window => .window,
-            .c_tab => .tab,
-            .c_split => .split,
-        };
-        return surface.newSurfaceOptions(context);
+        return surface.newSurfaceOptions(source);
     }
 
     /// Update the configuration to the provided config for only this surface.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1551,8 +1551,24 @@ pub const CAPI = struct {
     }
 
     /// Returns the config to use for surfaces that inherit from this one.
+    /// Deprecated: Use ghostty_surface_inherited_config_window/tab/split instead.
     export fn ghostty_surface_inherited_config(surface: *Surface) Surface.Options {
-        return surface.newSurfaceOptions();
+        return surface.newSurfaceOptions(.window);
+    }
+
+    /// Returns the config to use for new windows that inherit from this surface.
+    export fn ghostty_surface_inherited_config_window(surface: *Surface) Surface.Options {
+        return surface.newSurfaceOptions(.window);
+    }
+
+    /// Returns the config to use for new tabs that inherit from this surface.
+    export fn ghostty_surface_inherited_config_tab(surface: *Surface) Surface.Options {
+        return surface.newSurfaceOptions(.tab);
+    }
+
+    /// Returns the config to use for new splits that inherit from this surface.
+    export fn ghostty_surface_inherited_config_split(surface: *Surface) Surface.Options {
+        return surface.newSurfaceOptions(.split);
     }
 
     /// Update the configuration to the provided config for only this surface.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1551,24 +1551,16 @@ pub const CAPI = struct {
     }
 
     /// Returns the config to use for surfaces that inherit from this one.
-    /// Deprecated: Use ghostty_surface_inherited_config_window/tab/split instead.
-    export fn ghostty_surface_inherited_config(surface: *Surface) Surface.Options {
-        return surface.newSurfaceOptions(.window);
-    }
-
-    /// Returns the config to use for new windows that inherit from this surface.
-    export fn ghostty_surface_inherited_config_window(surface: *Surface) Surface.Options {
-        return surface.newSurfaceOptions(.window);
-    }
-
-    /// Returns the config to use for new tabs that inherit from this surface.
-    export fn ghostty_surface_inherited_config_tab(surface: *Surface) Surface.Options {
-        return surface.newSurfaceOptions(.tab);
-    }
-
-    /// Returns the config to use for new splits that inherit from this surface.
-    export fn ghostty_surface_inherited_config_split(surface: *Surface) Surface.Options {
-        return surface.newSurfaceOptions(.split);
+    export fn ghostty_surface_inherited_config(
+        surface: *Surface,
+        source: Surface.Options.Context,
+    ) Surface.Options {
+        const context: apprt.surface.NewSurfaceContext = switch (source) {
+            .c_window => .window,
+            .c_tab => .tab,
+            .c_split => .split,
+        };
+        return surface.newSurfaceOptions(context);
     }
 
     /// Update the configuration to the provided config for only this surface.

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -2238,8 +2238,8 @@ const Action = struct {
             .{},
         );
 
-        // Create a new tab
-        win.newTab(parent);
+        // Create a new tab with window context (first tab in new window)
+        win.newTabForWindow(parent);
 
         // Show the window
         gtk.Window.present(win.as(gtk.Window));

--- a/src/apprt/gtk/class/split_tree.zig
+++ b/src/apprt/gtk/class/split_tree.zig
@@ -219,7 +219,7 @@ pub const SplitTree = extern struct {
         // Inherit properly if we were asked to.
         if (parent_) |p| {
             if (p.core()) |core| {
-                surface.setParent(core);
+                surface.setParent(core, .split);
             }
         }
 

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -699,6 +699,7 @@ pub const Surface = extern struct {
     pub fn setParent(
         self: *Self,
         parent: *CoreSurface,
+        context: apprt.surface.NewSurfaceContext,
     ) void {
         const priv = self.private();
 
@@ -708,6 +709,9 @@ pub const Surface = extern struct {
             log.warn("setParent called after surface is already realized", .{});
             return;
         }
+
+        // Store the context so initSurface can use it
+        priv.context = context;
 
         // Setup our font size
         const font_size_ptr = glib.ext.create(font.face.DesiredSize);

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -3208,7 +3208,11 @@ pub const Surface = extern struct {
         errdefer app.core().deleteSurface(self.rt());
 
         // Initialize our surface configuration.
-        var config = try apprt.surface.newConfig(app.core(), priv.config.?.get(), priv.context);
+        var config = try apprt.surface.newConfig(
+            app.core(),
+            priv.config.?.get(),
+            priv.context,
+        );
         defer config.deinit();
 
         // Properties that can impact surface init

--- a/src/apprt/gtk/class/tab.zig
+++ b/src/apprt/gtk/class/tab.zig
@@ -161,8 +161,12 @@ pub const Tab = extern struct {
     /// ever created for a tab. If a surface was already created this does
     /// nothing.
     pub fn setParent(self: *Self, parent: *CoreSurface) void {
+        self.setParentWithContext(parent, .tab);
+    }
+
+    pub fn setParentWithContext(self: *Self, parent: *CoreSurface, context: apprt.surface.NewSurfaceContext) void {
         if (self.getActiveSurface()) |surface| {
-            surface.setParent(parent);
+            surface.setParent(parent, context);
         }
     }
 

--- a/src/apprt/gtk/class/window.zig
+++ b/src/apprt/gtk/class/window.zig
@@ -361,10 +361,14 @@ pub const Window = extern struct {
     /// at the position dictated by the `window-new-tab-position` config.
     /// The new tab will be selected.
     pub fn newTab(self: *Self, parent_: ?*CoreSurface) void {
-        _ = self.newTabPage(parent_);
+        _ = self.newTabPage(parent_, .tab);
     }
 
-    fn newTabPage(self: *Self, parent_: ?*CoreSurface) *adw.TabPage {
+    pub fn newTabForWindow(self: *Self, parent_: ?*CoreSurface) void {
+        _ = self.newTabPage(parent_, .window);
+    }
+
+    fn newTabPage(self: *Self, parent_: ?*CoreSurface, context: apprt.surface.NewSurfaceContext) *adw.TabPage {
         const priv = self.private();
         const tab_view = priv.tab_view;
 
@@ -372,7 +376,9 @@ pub const Window = extern struct {
         const tab = gobject.ext.newInstance(Tab, .{
             .config = priv.config,
         });
-        if (parent_) |p| tab.setParent(p);
+        if (parent_) |p| {
+            tab.setParentWithContext(p, context);
+        }
 
         // Get the position that we should insert the new tab at.
         const config = if (priv.config) |v| v.get() else {
@@ -1231,7 +1237,7 @@ pub const Window = extern struct {
         _: *adw.TabOverview,
         self: *Self,
     ) callconv(.c) *adw.TabPage {
-        return self.newTabPage(if (self.getActiveSurface()) |v| v.core() else null);
+        return self.newTabPage(if (self.getActiveSurface()) |v| v.core() else null, .tab);
     }
 
     fn tabOverviewOpen(

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -159,12 +159,28 @@ pub const Mailbox = struct {
     }
 };
 
+/// Context for new surface creation to determine inheritance behavior
+pub const NewSurfaceContext = enum {
+    window,
+    tab,
+    split,
+};
+
+pub fn shouldInheritWorkingDirectory(context: NewSurfaceContext, config: *const Config) bool {
+    return switch (context) {
+        .window => config.@"window-inherit-working-directory",
+        .tab => config.@"tab-inherit-working-directory",
+        .split => config.@"split-inherit-working-directory",
+    };
+}
+
 /// Returns a new config for a surface for the given app that should be
 /// used for any new surfaces. The resulting config should be deinitialized
 /// after the surface is initialized.
 pub fn newConfig(
     app: *const App,
     config: *const Config,
+    context: NewSurfaceContext,
 ) Allocator.Error!Config {
     // Create a shallow clone
     var copy = config.shallowClone(app.alloc);
@@ -175,7 +191,7 @@ pub fn newConfig(
     // Get our previously focused surface for some inherited values.
     const prev = app.focusedSurface();
     if (prev) |p| {
-        if (config.@"window-inherit-working-directory") {
+        if (shouldInheritWorkingDirectory(context, config)) {
             if (try p.pwd(alloc)) |pwd| {
                 copy.@"working-directory" = pwd;
             }

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -160,10 +160,10 @@ pub const Mailbox = struct {
 };
 
 /// Context for new surface creation to determine inheritance behavior
-pub const NewSurfaceContext = enum {
-    window,
-    tab,
-    split,
+pub const NewSurfaceContext = enum(c_int) {
+    window = 0,
+    tab = 1,
+    split = 2,
 };
 
 pub fn shouldInheritWorkingDirectory(context: NewSurfaceContext, config: *const Config) bool {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1845,10 +1845,20 @@ keybind: Keybinds = .{},
 /// This setting is only supported currently on macOS.
 @"window-vsync": bool = true,
 
-/// If true, new windows and tabs will inherit the working directory of the
+/// If true, new windows will inherit the working directory of the
 /// previously focused window. If no window was previously focused, the default
 /// working directory will be used (the `working-directory` option).
 @"window-inherit-working-directory": bool = true,
+
+/// If true, new tabs will inherit the working directory of the
+/// previously focused window. If no window was previously focused, the default
+/// working directory will be used (the `working-directory` option).
+@"tab-inherit-working-directory": bool = true,
+
+/// If true, new split panes will inherit the working directory of the
+/// previously focused window. If no window was previously focused, the default
+/// working directory will be used (the `working-directory` option).
+@"split-inherit-working-directory": bool = true,
 
 /// If true, new windows and tabs will inherit the font size of the previously
 /// focused window. If no window was previously focused, the default font size

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1851,12 +1851,12 @@ keybind: Keybinds = .{},
 @"window-inherit-working-directory": bool = true,
 
 /// If true, new tabs will inherit the working directory of the
-/// previously focused window. If no window was previously focused, the default
+/// previously focused tab. If no tab was previously focused, the default
 /// working directory will be used (the `working-directory` option).
 @"tab-inherit-working-directory": bool = true,
 
 /// If true, new split panes will inherit the working directory of the
-/// previously focused window. If no window was previously focused, the default
+/// previously focused split. If no split was previously focused, the default
 /// working directory will be used (the `working-directory` option).
 @"split-inherit-working-directory": bool = true,
 


### PR DESCRIPTION
Closes [1392](https://github.com/ghostty-org/ghostty/issues/1392)

Add two boolean config settings:
- `tab-inherit-working-directory`
- `split-inherit-working-directory`

They mimic the existing `window-inherit-working-directory`, and it's interaction with `working-directory`.

This allows users to configure working directory inheritance independently for new tabs, windows, and split panes, 
providing maximum flexibility for different workflow patterns.

**Sample config entries**
```
window-inherit-working-directory = false
tab-inherit-working-directory = true
split-inherit-working-directory = true
```

**Authored with [Amp](https://ampcode.com)**
Relevant threads:
- [Original GTK thread](https://ampcode.com/threads/T-ca9d78cb-c1c2-450a-9730-b3975423d800) that contributed to [the old GTK PR](https://github.com/ghostty-org/ghostty/pull/8121)
- [GTK-NG thread](https://ampcode.com/threads/T-674a5c6b-523f-491f-9d18-21e41474c66b) that contributed to this PR

**Behavior in macOS**
https://share.cleanshot.com/7LsSGM53

**Behavior in linux (Ubuntu)**
https://share.cleanshot.com/qJf3Hp6w