### PR TITLE
macOS: Support building with Xcode 16

### DIFF
--- a/macos/Sources/Features/App Intents/CloseTerminalIntent.swift
+++ b/macos/Sources/Features/App Intents/CloseTerminalIntent.swift
@@ -12,8 +12,10 @@ struct CloseTerminalIntent: AppIntent {
     )
     var terminal: TerminalEntity
 
+#if compiler(>=6.2)
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = .background
+#endif
 
     @MainActor
     func perform() async throws -> some IntentResult {

--- a/macos/Sources/Features/App Intents/CommandPaletteIntent.swift
+++ b/macos/Sources/Features/App Intents/CommandPaletteIntent.swift
@@ -19,8 +19,10 @@ struct CommandPaletteIntent: AppIntent {
     )
     var command: CommandEntity
 
+#if compiler(>=6.2)
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = .background
+#endif
 
     @MainActor
     func perform() async throws -> some IntentResult & ReturnsValue<Bool> {

--- a/macos/Sources/Features/App Intents/FocusTerminalIntent.swift
+++ b/macos/Sources/Features/App Intents/FocusTerminalIntent.swift
@@ -12,8 +12,10 @@ struct FocusTerminalIntent: AppIntent {
     )
     var terminal: TerminalEntity
 
+#if compiler(>=6.2)
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = .background
+#endif
 
     @MainActor
     func perform() async throws -> some IntentResult {

--- a/macos/Sources/Features/App Intents/GetTerminalDetailsIntent.swift
+++ b/macos/Sources/Features/App Intents/GetTerminalDetailsIntent.swift
@@ -17,8 +17,10 @@ struct GetTerminalDetailsIntent: AppIntent {
     )
     var terminal: TerminalEntity
 
+#if compiler(>=6.2)
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = .background
+#endif
 
     static var parameterSummary: some ParameterSummary {
         Summary("Get \(\.$detail) from \(\.$terminal)")

--- a/macos/Sources/Features/App Intents/InputIntent.swift
+++ b/macos/Sources/Features/App Intents/InputIntent.swift
@@ -24,8 +24,10 @@ struct InputTextIntent: AppIntent {
     )
     var terminal: TerminalEntity
 
+#if compiler(>=6.2)
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = [.background, .foreground]
+#endif
 
     @MainActor
     func perform() async throws -> some IntentResult {
@@ -74,8 +76,10 @@ struct KeyEventIntent: AppIntent {
     )
     var terminal: TerminalEntity
 
+#if compiler(>=6.2)
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = [.background, .foreground]
+#endif
 
     @MainActor
     func perform() async throws -> some IntentResult {
@@ -136,8 +140,10 @@ struct MouseButtonIntent: AppIntent {
     )
     var terminal: TerminalEntity
 
+#if compiler(>=6.2)
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = [.background, .foreground]
+#endif
 
     @MainActor
     func perform() async throws -> some IntentResult {
@@ -197,8 +203,10 @@ struct MousePosIntent: AppIntent {
     )
     var terminal: TerminalEntity
 
+#if compiler(>=6.2)
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = [.background, .foreground]
+#endif
 
     @MainActor
     func perform() async throws -> some IntentResult {
@@ -265,8 +273,10 @@ struct MouseScrollIntent: AppIntent {
     )
     var terminal: TerminalEntity
 
+#if compiler(>=6.2)
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = [.background, .foreground]
+#endif
 
     @MainActor
     func perform() async throws -> some IntentResult {

--- a/macos/Sources/Features/App Intents/KeybindIntent.swift
+++ b/macos/Sources/Features/App Intents/KeybindIntent.swift
@@ -16,8 +16,10 @@ struct KeybindIntent: AppIntent {
     )
     var action: String
 
+#if compiler(>=6.2)
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = [.background, .foreground]
+#endif
 
     @MainActor
     func perform() async throws -> some IntentResult & ReturnsValue<Bool> {

--- a/macos/Sources/Features/App Intents/NewTerminalIntent.swift
+++ b/macos/Sources/Features/App Intents/NewTerminalIntent.swift
@@ -45,8 +45,10 @@ struct NewTerminalIntent: AppIntent {
 
     // Performing in the background can avoid opening multiple windows at the same time
     // using `foreground` will cause `perform` and `AppDelegate.applicationDidBecomeActive(_:)`/`AppDelegate.applicationShouldHandleReopen(_:hasVisibleWindows:)` running at the 'same' time
+#if compiler(>=6.2)
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = .background
+#endif
 
     @available(macOS, obsoleted: 26.0, message: "Replaced by supportedModes")
     static var openAppWhenRun = false

--- a/macos/Sources/Features/App Intents/QuickTerminalIntent.swift
+++ b/macos/Sources/Features/App Intents/QuickTerminalIntent.swift
@@ -5,8 +5,10 @@ struct QuickTerminalIntent: AppIntent {
     static var title: LocalizedStringResource = "Open the Quick Terminal"
     static var description = IntentDescription("Open the Quick Terminal. If it is already open, then do nothing.")
 
+#if compiler(>=6.2)
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = .background
+#endif
 
     @MainActor
     func perform() async throws -> some IntentResult & ReturnsValue<[TerminalEntity]> {

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -23,11 +23,15 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         case "hidden": "TerminalHiddenTitlebar"
         case "transparent": "TerminalTransparentTitlebar"
         case "tabs":
+#if compiler(>=6.2)
             if #available(macOS 26.0, *) {
                 "TerminalTabsTitlebarTahoe"
             } else {
                 "TerminalTabsTitlebarVentura"
             }
+#else
+            "TerminalTabsTitlebarVentura"
+#endif
         default: defaultValue
         }
 


### PR DESCRIPTION
With this you can test most of the old tab bar behaviour without using a virtual machine