### PR TITLE
macOS: Fix more `macos-titlebar-style` related issues

### DIFF
--- a/macos/Sources/Features/App Intents/CloseTerminalIntent.swift
+++ b/macos/Sources/Features/App Intents/CloseTerminalIntent.swift
@@ -12,8 +12,10 @@ struct CloseTerminalIntent: AppIntent {
     )
     var terminal: TerminalEntity
 
+#if compiler(>=6.2)
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = .background
+#endif
 
     @MainActor
     func perform() async throws -> some IntentResult {

--- a/macos/Sources/Features/App Intents/CommandPaletteIntent.swift
+++ b/macos/Sources/Features/App Intents/CommandPaletteIntent.swift
@@ -19,8 +19,10 @@ struct CommandPaletteIntent: AppIntent {
     )
     var command: CommandEntity
 
+#if compiler(>=6.2)
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = .background
+#endif
 
     @MainActor
     func perform() async throws -> some IntentResult & ReturnsValue<Bool> {

--- a/macos/Sources/Features/App Intents/FocusTerminalIntent.swift
+++ b/macos/Sources/Features/App Intents/FocusTerminalIntent.swift
@@ -12,8 +12,10 @@ struct FocusTerminalIntent: AppIntent {
     )
     var terminal: TerminalEntity
 
+#if compiler(>=6.2)
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = .background
+#endif
 
     @MainActor
     func perform() async throws -> some IntentResult {

--- a/macos/Sources/Features/App Intents/GetTerminalDetailsIntent.swift
+++ b/macos/Sources/Features/App Intents/GetTerminalDetailsIntent.swift
@@ -17,8 +17,10 @@ struct GetTerminalDetailsIntent: AppIntent {
     )
     var terminal: TerminalEntity
 
+#if compiler(>=6.2)
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = .background
+#endif
 
     static var parameterSummary: some ParameterSummary {
         Summary("Get \(\.$detail) from \(\.$terminal)")

--- a/macos/Sources/Features/App Intents/InputIntent.swift
+++ b/macos/Sources/Features/App Intents/InputIntent.swift
@@ -24,8 +24,10 @@ struct InputTextIntent: AppIntent {
     )
     var terminal: TerminalEntity
 
+#if compiler(>=6.2)
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = [.background, .foreground]
+#endif
 
     @MainActor
     func perform() async throws -> some IntentResult {
@@ -74,8 +76,10 @@ struct KeyEventIntent: AppIntent {
     )
     var terminal: TerminalEntity
 
+#if compiler(>=6.2)
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = [.background, .foreground]
+#endif
 
     @MainActor
     func perform() async throws -> some IntentResult {
@@ -136,8 +140,10 @@ struct MouseButtonIntent: AppIntent {
     )
     var terminal: TerminalEntity
 
+#if compiler(>=6.2)
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = [.background, .foreground]
+#endif
 
     @MainActor
     func perform() async throws -> some IntentResult {
@@ -197,8 +203,10 @@ struct MousePosIntent: AppIntent {
     )
     var terminal: TerminalEntity
 
+#if compiler(>=6.2)
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = [.background, .foreground]
+#endif
 
     @MainActor
     func perform() async throws -> some IntentResult {
@@ -265,8 +273,10 @@ struct MouseScrollIntent: AppIntent {
     )
     var terminal: TerminalEntity
 
+#if compiler(>=6.2)
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = [.background, .foreground]
+#endif
 
     @MainActor
     func perform() async throws -> some IntentResult {

--- a/macos/Sources/Features/App Intents/KeybindIntent.swift
+++ b/macos/Sources/Features/App Intents/KeybindIntent.swift
@@ -16,8 +16,10 @@ struct KeybindIntent: AppIntent {
     )
     var action: String
 
+#if compiler(>=6.2)
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = [.background, .foreground]
+#endif
 
     @MainActor
     func perform() async throws -> some IntentResult & ReturnsValue<Bool> {

--- a/macos/Sources/Features/App Intents/NewTerminalIntent.swift
+++ b/macos/Sources/Features/App Intents/NewTerminalIntent.swift
@@ -45,8 +45,10 @@ struct NewTerminalIntent: AppIntent {
 
     // Performing in the background can avoid opening multiple windows at the same time
     // using `foreground` will cause `perform` and `AppDelegate.applicationDidBecomeActive(_:)`/`AppDelegate.applicationShouldHandleReopen(_:hasVisibleWindows:)` running at the 'same' time
+#if compiler(>=6.2)
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = .background
+#endif
 
     @available(macOS, obsoleted: 26.0, message: "Replaced by supportedModes")
     static var openAppWhenRun = false

--- a/macos/Sources/Features/App Intents/QuickTerminalIntent.swift
+++ b/macos/Sources/Features/App Intents/QuickTerminalIntent.swift
@@ -5,8 +5,10 @@ struct QuickTerminalIntent: AppIntent {
     static var title: LocalizedStringResource = "Open the Quick Terminal"
     static var description = IntentDescription("Open the Quick Terminal. If it is already open, then do nothing.")
 
+#if compiler(>=6.2)
     @available(macOS 26.0, *)
     static var supportedModes: IntentModes = .background
+#endif
 
     @MainActor
     func perform() async throws -> some IntentResult & ReturnsValue<[TerminalEntity]> {

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -23,11 +23,15 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         case "hidden": "TerminalHiddenTitlebar"
         case "transparent": "TerminalTransparentTitlebar"
         case "tabs":
+#if compiler(>=6.2)
             if #available(macOS 26.0, *) {
                 "TerminalTabsTitlebarTahoe"
             } else {
                 "TerminalTabsTitlebarVentura"
             }
+#else
+            "TerminalTabsTitlebarVentura"
+#endif
         default: defaultValue
         }
 

--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -330,6 +330,7 @@ class TerminalWindow: NSWindow {
             let font = titlebarFont ?? NSFont.titleBarFont(ofSize: NSFont.systemFontSize)
 
             titlebarTextField?.font = font
+            titlebarTextField?.usesSingleLineMode = true
             tab.attributedTitle = attributedTitle
         }
     }

--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -159,6 +159,12 @@ class TerminalWindow: NSWindow {
         } else {
             tabBarDidDisappear()
         }
+        viewModel.isMainWindow = true
+    }
+
+    override func resignMain() {
+        super.resignMain()
+        viewModel.isMainWindow = false
     }
 
     override func mergeAllWindows(_ sender: Any?) {
@@ -298,7 +304,7 @@ class TerminalWindow: NSWindow {
         button.isBordered = false
         button.allowsExpansionToolTips = true
         button.toolTip = "Reset Zoom"
-        button.contentTintColor = .controlAccentColor
+        button.contentTintColor = isMainWindow ? .controlAccentColor : .secondaryLabelColor
         button.state = .on
         button.image = NSImage(named:"ResetZoom")
         button.frame = NSRect(x: 0, y: 0, width: 20, height: 20)
@@ -505,7 +511,8 @@ extension TerminalWindow {
     class ViewModel: ObservableObject {
         @Published var isSurfaceZoomed: Bool = false
         @Published var hasToolbar: Bool = false
-        
+        @Published var isMainWindow: Bool = true
+
         /// Calculates the top padding based on toolbar visibility and macOS version
         fileprivate var accessoryTopPadding: CGFloat {
             if #available(macOS 26.0, *) {
@@ -525,7 +532,7 @@ extension TerminalWindow {
                 VStack {
                     Button(action: action) {
                         Image("ResetZoom")
-                            .foregroundColor(.accentColor)
+                            .foregroundColor(viewModel.isMainWindow ? .accentColor : .secondary)
                     }
                     .buttonStyle(.plain)
                     .help("Reset Split Zoom")

--- a/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsVenturaTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsVenturaTerminalWindow.swift
@@ -145,6 +145,7 @@ class TitlebarTabsVenturaTerminalWindow: TerminalWindow {
         super.syncAppearance(surfaceConfig)
 
         // Update our window light/darkness based on our updated background color
+        let themeChanged = isLightTheme != OSColor(surfaceConfig.backgroundColor).isLightColor
         isLightTheme = OSColor(surfaceConfig.backgroundColor).isLightColor
 
         // Update our titlebar color
@@ -154,7 +155,7 @@ class TitlebarTabsVenturaTerminalWindow: TerminalWindow {
             titlebarColor = derivedConfig.backgroundColor.withAlphaComponent(derivedConfig.backgroundOpacity)
         }
 
-        if (isOpaque) {
+        if (isOpaque || themeChanged) {
             // If there is transparency, calling this will make the titlebar opaque
             // so we only call this if we are opaque.
             updateTabBar()

--- a/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsVenturaTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsVenturaTerminalWindow.swift
@@ -193,8 +193,8 @@ class TitlebarTabsVenturaTerminalWindow: TerminalWindow {
         newTabButtonImageView.alphaValue = isKeyWindow ? 1 : 0.5
     }
 
-	/// Update: This method only add a vibrant overlay now,
-    /// since the image it self supports light/dark tint,
+    /// Update: This method only add a vibrant overlay now,
+    /// since the image itself supports light/dark tint,
     /// and system could restore it any time,
     /// altering it will only cause maintenance burden for us.
     ///
@@ -449,7 +449,7 @@ class TitlebarTabsVenturaTerminalWindow: TerminalWindow {
             /// replacing existing backdrop aggressively
             /// may cause incorrect hierarchy
             ///
-            /// because multiple windows are adding this 'at the same time'
+            /// because multiple windows are adding this around the 'same time'
             return
         }
         windowButtonsBackdrop?.removeFromSuperview()
@@ -471,10 +471,7 @@ class TitlebarTabsVenturaTerminalWindow: TerminalWindow {
     private func addWindowDragHandle(titlebarView: NSView, toolbarView: NSView) {
         // If we already made the view, just make sure it's unhidden and correctly placed as a subview.
         guard windowDragHandle?.superview != titlebarView.superview else {
-            /// replacing existing drag handle aggressively
-            /// may cause incorrect hierarchy
-            ///
-            /// because multiple windows are adding this 'at the same time'
+            // similar to `addWindowButtonsBackdrop`
             return
         }
         windowDragHandle?.removeFromSuperview()

--- a/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsVenturaTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsVenturaTerminalWindow.swift
@@ -445,6 +445,13 @@ class TitlebarTabsVenturaTerminalWindow: TerminalWindow {
     }
 
     private func addWindowButtonsBackdrop(titlebarView: NSView, toolbarView: NSView) {
+        guard windowButtonsBackdrop?.superview != titlebarView else {
+            /// replacing existing backdrop aggressively
+            /// may cause incorrect hierarchy
+            ///
+            /// because multiple windows are adding this 'at the same time'
+            return
+        }
         windowButtonsBackdrop?.removeFromSuperview()
         windowButtonsBackdrop = nil
 
@@ -463,16 +470,14 @@ class TitlebarTabsVenturaTerminalWindow: TerminalWindow {
 
     private func addWindowDragHandle(titlebarView: NSView, toolbarView: NSView) {
         // If we already made the view, just make sure it's unhidden and correctly placed as a subview.
-        if let view = windowDragHandle {
-            view.removeFromSuperview()
-            view.isHidden = false
-            titlebarView.superview?.addSubview(view)
-            view.leftAnchor.constraint(equalTo: toolbarView.leftAnchor).isActive = true
-            view.rightAnchor.constraint(equalTo: toolbarView.rightAnchor).isActive = true
-            view.topAnchor.constraint(equalTo: toolbarView.topAnchor).isActive = true
-            view.bottomAnchor.constraint(equalTo: toolbarView.topAnchor, constant: 12).isActive = true
+        guard windowDragHandle?.superview != titlebarView.superview else {
+            /// replacing existing drag handle aggressively
+            /// may cause incorrect hierarchy
+            ///
+            /// because multiple windows are adding this 'at the same time'
             return
         }
+        windowDragHandle?.removeFromSuperview()
 
         let view = WindowDragView()
         view.identifier = NSUserInterfaceItemIdentifier("_windowDragHandle")
@@ -533,7 +538,10 @@ fileprivate class WindowButtonsBackdropView: NSView {
     // This must be weak because the window has this view. Otherwise
     // a retain cycle occurs.
 	private weak var terminalWindow: TitlebarTabsVenturaTerminalWindow?
-	private let isLightTheme: Bool
+    private var isLightTheme: Bool {
+        // using up-to-date value from hosting window directly
+        terminalWindow?.isLightTheme ?? false
+    }
     private let overlayLayer = VibrantLayer()
 
     var isHighlighted: Bool = true {
@@ -562,7 +570,6 @@ fileprivate class WindowButtonsBackdropView: NSView {
 
     init(window: TitlebarTabsVenturaTerminalWindow) {
 		self.terminalWindow = window
-        self.isLightTheme = window.isLightTheme
 
         super.init(frame: .zero)
 


### PR DESCRIPTION
### This PR depends on #9162 

#1691 doesn't seem to be an issue anymore, but changing appearance while Ghosty is active will result in similar nastiness.


https://github.com/user-attachments/assets/fcd7761e-a521-4382-8d7a-9d93dc0806bc



### Changes

- [Sequoia/Ventura] Fix flickering new tab icon, and it also didn't respond to window's key status change correctly
- [Sequoia/Ventura] Fix after changing appearance, tab bar may disappear or have inconsistent background colour
- Fix initial tint of reset zoom button on Sequoia/Ventura with `macos-titlebar-style=tabs` and all `native/transparent` titlebars
- Fix title alignment with custom font with `native/transparent` titlebar

