### PR TITLE
macOS: fix title misalignment in tabs

### DIFF
--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -205,7 +205,14 @@ class TerminalWindow: NSWindow {
 
     /// Returns true if there is a tab bar visible on this window.
     var hasTabBar: Bool {
+        // TODO: use titlebarView to find it instead
         contentView?.firstViewFromRoot(withClassName: "NSTabBar") != nil
+    }
+
+    var hasMoreThanOneTabs: Bool {
+        /// accessing ``tabGroup?.windows`` here
+        /// will cause other edge cases, be careful
+        (tabbedWindows?.count ?? 0) > 1
     }
 
     func isTabBar(_ childViewController: NSTitlebarAccessoryViewController) -> Bool {
@@ -321,6 +328,12 @@ class TerminalWindow: NSWindow {
             // Whenever we change the window title we must also update our
             // tab title if we're using custom fonts.
             tab.attributedTitle = attributedTitle
+            /// We also needs to update this here, just in case
+            /// the value is not what we want
+            ///
+            /// Check ``titlebarFont`` down below
+            /// to see why we need to check `hasMoreThanOneTabs` here
+            titlebarTextField?.usesSingleLineMode = !hasMoreThanOneTabs
         }
     }
 
@@ -330,7 +343,12 @@ class TerminalWindow: NSWindow {
             let font = titlebarFont ?? NSFont.titleBarFont(ofSize: NSFont.systemFontSize)
 
             titlebarTextField?.font = font
-            titlebarTextField?.usesSingleLineMode = true
+            /// We check `hasMoreThanOneTabs` here because the system
+            /// may copy this setting to the tab’s text field at some point(e.g. entering/exiting fullscreen),
+            /// which can cause the title to be vertically misaligned (shifted downward).
+            ///
+            /// This behaviour is the opposite of what happens in the title bar’s text field, which is quite odd...
+            titlebarTextField?.usesSingleLineMode = !hasMoreThanOneTabs
             tab.attributedTitle = attributedTitle
         }
     }


### PR DESCRIPTION
While I was testing #9166, noticed another edge case🤯. 

This appears both in Tahoe and Sequoia👇🏻

https://github.com/user-attachments/assets/9cecea35-1241-4f31-9c15-0f2a7a6f342a

