### PR TITLE
macOS: use default app for `*.ghostty` files first

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -637,8 +637,9 @@ extension Ghostty {
             
             switch action.kind {
             case .text:
-                // Open with the default text editor
-                if let textEditor = NSWorkspace.shared.defaultTextEditor {
+                // Open with the default editor for `*.ghostty` file or just system text editor
+                let editor = NSWorkspace.shared.defaultApplicationURL(forExtension: url.pathExtension) ?? NSWorkspace.shared.defaultTextEditor
+                if let textEditor = editor {
                     NSWorkspace.shared.open([url], withApplicationAt: textEditor, configuration: NSWorkspace.OpenConfiguration())
                     return true
                 }


### PR DESCRIPTION
A small improvement for #8885, tested `config` and `config.ghostty`

<img width="526" height="267" alt="image" src="https://github.com/user-attachments/assets/d09305ab-4a87-4393-b09c-804e618968f3" />
