### PR TITLE
notification draft

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -145,6 +145,11 @@ class BaseTerminalController: NSWindowController,
             selector: #selector(ghosttyMaximizeDidToggle(_:)),
             name: .ghosttyMaximizeDidToggle,
             object: nil)
+        center.addObserver(
+            self,
+            selector: #selector(ghosttyToggleWindowDecorations(_:)),
+            name: .ghosttyToggleWindowDecorations,
+            object: nil)
 
         // Splits
         center.addObserver(
@@ -499,6 +504,12 @@ class BaseTerminalController: NSWindowController,
         guard let surfaceView = notification.object as? Ghostty.SurfaceView else { return }
         guard surfaceTree.contains(surfaceView) else { return }
         window.zoom(nil)
+    }
+
+    @objc private func ghosttyToggleWindowDecorations(_ notification: Notification) {
+        guard let surfaceView = notification.object as? Ghostty.SurfaceView else { return }
+        guard surfaceTree.contains(surfaceView) else { return }
+        toggleWindowDecorations()
     }
 
     @objc private func ghosttyDidCloseSurface(_ notification: Notification) {

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -790,6 +790,22 @@ class BaseTerminalController: NSWindowController,
 
     func fullscreenDidChange() {}
 
+    // MARK: Window Decorations
+
+    /// Toggle window decorations for this window
+    func toggleWindowDecorations() {
+        guard let window = self.window as? TerminalWindow else { return }
+        
+        // Toggle the style mask to enable/disable decorations
+        if window.styleMask.contains(.titled) {
+            // Remove decorations (make window borderless)
+            window.styleMask.remove(.titled)
+        } else {
+            // Add decorations back
+            window.styleMask.insert(.titled)
+        }
+    }
+
     // MARK: Clipboard Confirmation
 
     @objc private func onConfirmClipboardRequest(notification: SwiftUI.Notification) {

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -799,10 +799,9 @@ class BaseTerminalController: NSWindowController,
             // Exiting fullscreen - restore decorations if needed
             fullscreenStyle.exit()
             if let shouldHaveDecorations = decorationsBeforeFullscreen {
-                if shouldHaveDecorations && !window.styleMask.contains(.titled) {
-                    window.styleMask.insert(.titled)
-                } else if !shouldHaveDecorations && window.styleMask.contains(.titled) {
-                    window.styleMask.remove(.titled)
+                let currentHasDecorations = window.styleMask.contains(.titled)
+                if shouldHaveDecorations != currentHasDecorations {
+                    toggleWindowDecorations()
                 }
                 decorationsBeforeFullscreen = nil
             }
@@ -812,7 +811,7 @@ class BaseTerminalController: NSWindowController,
             
             // If window decoration = none, enable decorations temporarily for fullscreen
             if !window.styleMask.contains(.titled) {
-                window.styleMask.insert(.titled)
+                toggleWindowDecorations()
             }
             
             fullscreenStyle.enter()

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -1261,8 +1261,10 @@ extension Ghostty {
             case GHOSTTY_TARGET_SURFACE:
                 guard let surface = target.target.surface else { return }
                 guard let surfaceView = self.surfaceView(from: surface) else { return }
-                guard let terminalController = surfaceView.window?.windowController as? BaseTerminalController else { return }
-                terminalController.toggleWindowDecorations()
+                NotificationCenter.default.post(
+                    name: .ghosttyToggleWindowDecorations,
+                    object: surfaceView
+                )
 
             default:
                 assertionFailure()

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -576,7 +576,7 @@ extension Ghostty {
             case GHOSTTY_ACTION_TOGGLE_TAB_OVERVIEW:
                 fallthrough
             case GHOSTTY_ACTION_TOGGLE_WINDOW_DECORATIONS:
-                fallthrough
+                toggleWindowDecorations(app, target: target)
             case GHOSTTY_ACTION_PRESENT_TERMINAL:
                 fallthrough
             case GHOSTTY_ACTION_SIZE_LIMIT:
@@ -1247,6 +1247,26 @@ extension Ghostty {
         ) {
             guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
             appDelegate.toggleQuickTerminal(self)
+        }
+
+        private static func toggleWindowDecorations(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s
+        ) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                Ghostty.logger.warning("toggle window decorations does nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                guard let terminalController = surfaceView.window?.windowController as? BaseTerminalController else { return }
+                terminalController.toggleWindowDecorations()
+
+            default:
+                assertionFailure()
+            }
         }
 
         private static func setTitle(

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -344,6 +344,9 @@ extension Notification.Name {
 
     /// Toggle maximize of current window
     static let ghosttyMaximizeDidToggle = Notification.Name("com.mitchellh.ghostty.maximizeDidToggle")
+
+    /// Toggle window decorations
+    static let ghosttyToggleWindowDecorations = Notification.Name("com.mitchellh.ghostty.toggleWindowDecorations")
 }
 
 // NOTE: I am moving all of these to Notification.Name extensions over time. This


### PR DESCRIPTION
Allow going to fullscreen by pressing <kbd>cmd</kbd>+<kbd>ctrl</kbd>+<kbd>f</kbd> on macos (the macOS default) even when `window-decorations = none`