### PR TITLE
renderer: Include arrows block in constrained symbols

### DIFF
--- a/src/build/uucode_config.zig
+++ b/src/build/uucode_config.zig
@@ -41,6 +41,7 @@ fn computeIsSymbol(
     _ = tracking;
     const block = data.block;
     data.is_symbol = data.general_category == .other_private_use or
+        block == .arrows or
         block == .dingbats or
         block == .emoticons or
         block == .miscellaneous_symbols or

--- a/src/renderer/cell.zig
+++ b/src/renderer/cell.zig
@@ -238,6 +238,7 @@ pub fn isCovering(cp: u21) bool {
 /// Returns true of the codepoint is a "symbol-like" character, which
 /// for now we define as anything in a private use area, and anything
 /// in several unicode blocks:
+/// - Arrows
 /// - Dingbats
 /// - Emoticons
 /// - Miscellaneous Symbols


### PR DESCRIPTION
Fixes #8693 

**Before**
<img width="164" height="47" alt="Screenshot 2025-10-13 at 14 00 28" src="https://github.com/user-attachments/assets/df42df51-7706-4285-8c91-d79e227999ed" />

**After**
<img width="164" height="47" alt="Screenshot 2025-10-13 at 14 01 14" src="https://github.com/user-attachments/assets/c1ca314e-a2ad-47b2-9bcf-d4200db173f5" />

The effect is somewhat subtle with my combination of fonts. See #8693 for the more egregious examples that this fixes.