### PR TITLE
fix make clean: change dir name from zig-cache to .zig-cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ vendor/glad/include/glad/glad.h: vendor/glad/include/glad/gl.h
 
 clean:
 	rm -rf \
-		zig-out zig-cache \
+		zig-out .zig-cache \
 		macos/build \
 		macos/GhosttyKit.xcframework
 .PHONY: clean


### PR DESCRIPTION
`make clean` was not removing the `.zig-cache` directory. Instead it was removing the `zig-cache` directory.