### PR TITLE
macOS: release builds from source using `zig build` uses ReleaseLocal

### DIFF
--- a/src/build/GhosttyXcodebuild.zig
+++ b/src/build/GhosttyXcodebuild.zig
@@ -31,7 +31,7 @@ pub fn init(
         .ReleaseSafe,
         .ReleaseSmall,
         .ReleaseFast,
-        => "Release",
+        => "ReleaseLocal",
     };
 
     const xc_arch: ?[]const u8 = switch (deps.xcframework.target) {


### PR DESCRIPTION
This fixes codesign issues that are common. The official release process does not use this, but it is useful for local builds.