### PR TITLE
build: more Zig 0.15.2 updates

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -10,10 +10,6 @@ comptime {
 }
 
 pub fn build(b: *std.Build) !void {
-    // Works around a Zig but still present in 0.15.1. Remove when fixed.
-    // https://github.com/ghostty-org/ghostty/issues/8924
-    try limitCoresForZigBug();
-
     // This defines all the available build options (e.g. `-D`). If you
     // want to know what options are available, you can run `--help` or
     // you can read `src/build/Config.zig`.
@@ -311,14 +307,4 @@ pub fn build(b: *std.Build) !void {
     } else {
         try translations_step.addError("cannot update translations when i18n is disabled", .{});
     }
-}
-
-// WARNING: Remove this when https://github.com/ghostty-org/ghostty/issues/8924 is resolved!
-// Limit ourselves to 32 cpus on Linux because of an upstream Zig bug.
-fn limitCoresForZigBug() !void {
-    if (comptime builtin.os.tag != .linux) return;
-    const pid = std.os.linux.getpid();
-    var set: std.bit_set.ArrayBitSet(usize, std.os.linux.CPU_SETSIZE * 8) = .initEmpty();
-    for (0..32) |cpu| set.set(cpu);
-    try std.os.linux.sched_setaffinity(pid, &set.masks);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,7 +3,7 @@
     .version = "1.2.1",
     .paths = .{""},
     .fingerprint = 0x64407a2a0b4147e5,
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.15.2",
     .dependencies = .{
         // Zig libs
 

--- a/flake.lock
+++ b/flake.lock
@@ -37,10 +37,10 @@
     "nixpkgs": {
       "locked": {
         "lastModified": 315532800,
-        "narHash": "sha256-YwoXN6fthkakCFD7nXPcUK+rkNr6ZTNTuF8zdGaxZo0=",
-        "rev": "dc704e6102e76aad573f63b74c742cd96f8f1e6c",
+        "narHash": "sha256-sV6pJNzFkiPc6j9Bi9JuHBnWdVhtKB/mHgVmMPvDFlk=",
+        "rev": "82c2e0d6dde50b17ae366d2aa36f224dc19af469",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.11pre870318.dc704e6102e7/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.11pre877938.82c2e0d6dde5/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",

--- a/flatpak/dependencies.yml
+++ b/flatpak/dependencies.yml
@@ -13,12 +13,12 @@ modules:
       - chmod a+x /app/zig/zig
     sources:
       - type: archive
-        sha256: c61c5da6edeea14ca51ecd5e4520c6f4189ef5250383db33d01848293bfafe05
-        url: https://ziglang.org/download/0.15.1/zig-x86_64-linux-0.15.1.tar.xz
+        sha256: 02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239
+        url: https://ziglang.org/download/0.15.2/zig-x86_64-linux-0.15.2.tar.xz
         only-arches: [x86_64]
       - type: archive
-        sha256: bb4a8d2ad735e7fba764c497ddf4243cb129fece4148da3222a7046d3f1f19fe
-        url: https://ziglang.org/download/0.15.1/zig-aarch64-linux-0.15.1.tar.xz
+        sha256: 958ed7d1e00d0ea76590d27666efbf7a932281b3d7ba0c6b01b0ff26498f667f
+        url: https://ziglang.org/download/0.15.2/zig-aarch64-linux-0.15.2.tar.xz
         only-arches: [aarch64]
 
   - name: bzip2-redirect

--- a/src/build/zig.zig
+++ b/src/build/zig.zig
@@ -7,10 +7,11 @@ pub fn requireZig(comptime required_zig: []const u8) void {
     const current_vsn = builtin.zig_version;
     const required_vsn = std.SemanticVersion.parse(required_zig) catch unreachable;
     if (current_vsn.major != required_vsn.major or
-        current_vsn.minor != required_vsn.minor)
+        current_vsn.minor != required_vsn.minor or
+        current_vsn.patch < required_vsn.patch)
     {
         @compileError(std.fmt.comptimePrint(
-            "Your Zig version v{} does not meet the required build version of v{}",
+            "Your Zig version v{f} does not meet the required build version of v{f}",
             .{ current_vsn, required_vsn },
         ));
     }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -4109,7 +4109,7 @@ pub fn finalize(self: *Config) !void {
     // Clamp our contrast
     self.@"minimum-contrast" = @min(21, @max(1, self.@"minimum-contrast"));
 
-    // Minimmum window size
+    // Minimum window size
     if (self.@"window-width" > 0) self.@"window-width" = @max(10, self.@"window-width");
     if (self.@"window-height" > 0) self.@"window-height" = @max(4, self.@"window-height");
 

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -1976,7 +1976,7 @@ pub const AdjustCapacity = struct {
 
 pub const AdjustCapacityError = Allocator.Error || Page.CloneFromError;
 
-/// Adjust the capcaity of the given page in the list. This should
+/// Adjust the capacity of the given page in the list. This should
 /// be used in cases where OutOfMemory is returned by some operation
 /// i.e to increase style counts, grapheme counts, etc.
 ///

--- a/typos.toml
+++ b/typos.toml
@@ -55,6 +55,10 @@ typ = "typ"
 kend = "kend"
 # GTK
 GIR = "GIR"
+# terminfo
+rin = "rin"
+# sprites
+ower = "ower"
 
 [type.po]
 extend-glob = ["*.po"]


### PR DESCRIPTION
- update nixpkgs now that Zig 0.15.2 is available in nixpkgs
- drop hack that worked around compile failures on systems with more than 32 cores
- enforce patch version of Zig