### PR TITLE
core: PageList tracks minimum metadata for rendering a scrollbar

### DIFF
--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -149,13 +149,23 @@ viewport: Viewport,
 /// never be access directly; use `viewport`.
 viewport_pin: *Pin,
 
-/// The row offset from the bottom that the viewport pin is at. We
-/// store the offset from the bottom because its less likely the user
-/// is scrolled to the top in a custom pin so it makes our search faster.
+/// The row offset from the top that the viewport pin is at. We
+/// store the offset from the top because it doesn't change while more
+/// data is printed to the terminal.
+///
+/// This is null when it isn't calculated. It is calculated on demand
+/// when the viewportRowOffset function is called, because it is only
+/// required for certain operations such as rendering the scrollbar.
+///
+/// In order to make this more efficient, in many places where the value
+/// would be invalidated, we update it in-place instead. This is key to
+/// keeping our performance decent in normal cases since recalculating
+/// this from scratch, depending on the size of the scrollback and position
+/// of the pin, can be very expensive.
 ///
 /// This is only valid if viewport is `pin`. Every other offset is
 /// self-evident or quick to calculate.
-viewport_pin_row_offset: usize,
+viewport_pin_row_offset: ?usize,
 
 /// The current desired screen dimensions. I say "desired" because individual
 /// pages may still be a different size and not yet reflowed since we lazily
@@ -279,7 +289,7 @@ pub fn init(
         .tracked_pins = tracked_pins,
         .viewport = .{ .active = {} },
         .viewport_pin = viewport_pin,
-        .viewport_pin_row_offset = 0,
+        .viewport_pin_row_offset = null,
     };
     result.assertIntegrity();
     return result;
@@ -352,6 +362,7 @@ pub inline fn pauseIntegrityChecks(self: *PageList, pause: bool) void {
 
 const IntegrityError = error{
     TotalRowsMismatch,
+    ViewportPinOffsetMismatch,
 };
 
 /// Verify the integrity of the PageList. This is expensive and should
@@ -368,6 +379,36 @@ fn verifyIntegrity(self: *const PageList) IntegrityError!void {
             .{ self.total_rows, actual_total },
         );
         return IntegrityError.TotalRowsMismatch;
+    }
+
+    // Verify that our viewport pin row offset is correct.
+    if (self.viewport == .pin) pin: {
+        const cached_offset = self.viewport_pin_row_offset orelse break :pin;
+        const actual_offset: usize = offset: {
+            var offset: usize = 0;
+            var node = self.pages.last;
+            while (node) |n| : (node = n.prev) {
+                offset += n.data.size.rows;
+                if (n == self.viewport_pin.node) {
+                    offset -= self.viewport_pin.y;
+                    break :offset self.total_rows - offset;
+                }
+            }
+
+            log.warn(
+                "PageList integrity violation: viewport pin not in list",
+                .{},
+            );
+            return error.ViewportPinOffsetMismatch;
+        };
+
+        if (cached_offset != actual_offset) {
+            log.warn(
+                "PageList integrity violation: viewport pin offset mismatch cached={} actual={}",
+                .{ cached_offset, actual_offset },
+            );
+            return error.ViewportPinOffsetMismatch;
+        }
     }
 }
 
@@ -647,7 +688,7 @@ pub fn clone(
         .tracked_pins = tracked_pins,
         .viewport = .{ .active = {} },
         .viewport_pin = viewport_pin,
-        .viewport_pin_row_offset = 0,
+        .viewport_pin_row_offset = null,
     };
 
     // We always need to have enough rows for our viewport because this is
@@ -704,6 +745,12 @@ pub fn resize(self: *PageList, opts: Resize) !void {
         if (opts.cols) |v| assert(v > 0);
         if (opts.rows) |v| assert(v > 0);
     }
+
+    // Resizing (especially with reflow) can cause our row offset to
+    // become invalid. Rather than do something fancy like we do other
+    // places and try to update it in place, we just invalidate it because
+    // its too easy to get the logic wrong in here.
+    self.viewport_pin_row_offset = null;
 
     if (!opts.reflow) return try self.resizeWithoutReflow(opts);
 
@@ -1858,21 +1905,81 @@ pub const Scroll = union(enum) {
 /// previously allocated pages.
 pub fn scroll(self: *PageList, behavior: Scroll) void {
     switch (behavior) {
-        .active => self.viewport = .{ .active = {} },
-        .top => self.viewport = .{ .top = {} },
+        .active => self.viewport = .active,
+        .top => self.viewport = .top,
         .pin => |p| {
             if (self.pinIsActive(p)) {
-                self.viewport = .{ .active = {} };
+                self.viewport = .active;
+                return;
+            } else if (self.pinIsTop(p)) {
+                self.viewport = .top;
                 return;
             }
 
             self.viewport_pin.* = p;
-            self.viewport = .{ .pin = {} };
+            self.viewport = .pin;
+            self.viewport_pin_row_offset = null; // invalidate cache
         },
         .delta_prompt => |n| self.scrollPrompt(n),
-        .delta_row => |n| {
-            if (n == 0) return;
+        .delta_row => |n| delta_row: {
+            switch (self.viewport) {
+                // If we're at the top and we're scrolling backwards,
+                // we don't have to do anything, because there's nowhere to go.
+                .top => if (n <= 0) break :delta_row,
 
+                // If we're at active and we're scrolling forwards, we don't
+                // have to do anything because it'll result in staying in
+                // the active.
+                .active => if (n >= 0) break :delta_row,
+
+                // If we're already a pin type, then we can fast-path our
+                // delta by simply moving the pin. This has the added benefit
+                // that we can update our row offset cache efficiently, too.
+                .pin => switch (std.math.order(n, 0)) {
+                    .eq => break :delta_row,
+
+                    .lt => switch (self.viewport_pin.upOverflow(@intCast(-n))) {
+                        .offset => |new_pin| {
+                            self.viewport_pin.* = new_pin;
+                            if (self.viewport_pin_row_offset) |*v| {
+                                v.* -= @as(usize, @intCast(-n));
+                            }
+                            break :delta_row;
+                        },
+
+                        // If we overflow up we're at the top.
+                        .overflow => {
+                            self.viewport = .top;
+                            break :delta_row;
+                        },
+                    },
+
+                    .gt => switch (self.viewport_pin.downOverflow(@intCast(n))) {
+                        // If we offset its a valid pin but we still have to
+                        // check if we're in the active area.
+                        .offset => |new_pin| {
+                            if (self.pinIsActive(new_pin)) {
+                                self.viewport = .active;
+                            } else {
+                                self.viewport_pin.* = new_pin;
+                                if (self.viewport_pin_row_offset) |*v| {
+                                    v.* += @intCast(n);
+                                }
+                            }
+                            break :delta_row;
+                        },
+
+                        // If we overflow down we're at active.
+                        .overflow => {
+                            self.viewport = .active;
+                            break :delta_row;
+                        },
+                    },
+                },
+            }
+
+            // Slow path: we have to calculate the new pin by moving
+            // from our viewport.
             const top = self.getTopLeft(.viewport);
             const p: Pin = if (n < 0) switch (top.upOverflow(@intCast(-n))) {
                 .offset => |v| v,
@@ -1890,13 +1997,22 @@ pub fn scroll(self: *PageList, behavior: Scroll) void {
             // active area, you usually expect that the viewport will now
             // follow the active area.
             if (self.pinIsActive(p)) {
-                self.viewport = .{ .active = {} };
+                self.viewport = .active;
+                return;
+            }
+
+            // If we're at the top, then just set the top. This is a lot
+            // more efficient everywhere. We must check this after the
+            // active check above because we prefer active if they overlap.
+            if (self.pinIsTop(p)) {
+                self.viewport = .top;
                 return;
             }
 
             // Pin is not active so we need to track it.
             self.viewport_pin.* = p;
-            self.viewport = .{ .pin = {} };
+            self.viewport = .pin;
+            self.viewport_pin_row_offset = null; // invalidate cache
         },
     }
 }
@@ -1932,10 +2048,11 @@ fn scrollPrompt(self: *PageList, delta: isize) void {
     // into the active area. Otherwise, we scroll up to the pin.
     if (prompt_pin) |p| {
         if (self.pinIsActive(p)) {
-            self.viewport = .{ .active = {} };
+            self.viewport = .active;
         } else {
             self.viewport_pin.* = p;
-            self.viewport = .{ .pin = {} };
+            self.viewport = .pin;
+            self.viewport_pin_row_offset = null; // invalidate cache
         }
     }
 }
@@ -1970,6 +2087,124 @@ pub fn scrollClear(self: *PageList) !void {
 
     // Scroll
     for (0..non_empty) |_| _ = try self.grow();
+}
+
+/// This represents the state necessary to render a scrollbar for this
+/// PageList. It has the total size, the offset, and the size of the viewport.
+pub const Scrollbar = struct {
+    /// Total size of the scrollable area.
+    total: usize,
+
+    /// The offset into the total area that the viewport is at. This is
+    /// guaranteed to be less than or equal to total. This includes the
+    /// visible row.
+    offset: usize,
+
+    /// The length of the visible area. This is including the offset row.
+    len: usize,
+
+    /// Comparison for scrollbars.
+    pub fn eql(self: Scrollbar, other: Scrollbar) bool {
+        return self.total == other.total and
+            self.offset == other.offset and
+            self.len == other.len;
+    }
+};
+
+/// Return the scrollbar state for this PageList.
+///
+/// This may be expensive to calculate depending on where the viewport
+/// is (arbitrary pins are expensive). The caller should take care to only
+/// call this as needed and not too frequently.
+pub fn scrollbar(self: *PageList) Scrollbar {
+    return .{
+        .total = self.total_rows,
+        .offset = self.viewportRowOffset(),
+        .len = self.rows, // Length is always rows
+    };
+}
+
+/// Returns the offset of the current viewport from the top of the
+/// screen.
+///
+/// This is potentially expensive to calculate because if the viewport
+/// is a pin and the pin is near the beginning of the scrollback, we
+/// will traverse a lot of linked list nodes.
+///
+/// The result is cached so repeated calls are cheap.
+fn viewportRowOffset(self: *PageList) usize {
+    return switch (self.viewport) {
+        .top => 0,
+        .active => self.total_rows - self.rows,
+        .pin => pin: {
+            // We assert integrity on this code path because it verifies
+            // that the cached value is correct.
+            defer self.assertIntegrity();
+
+            // Return cached value if available
+            if (self.viewport_pin_row_offset) |cached| break :pin cached;
+
+            // Traverse from the end and count rows until we reach the
+            // viewport pin. We count backwards because most of the time
+            // a user is scrolling near the active area.
+            const top_offset: usize = offset: {
+                var offset: usize = 0;
+                var node = self.pages.last;
+                while (node) |n| : (node = n.prev) {
+                    offset += n.data.size.rows;
+                    if (n == self.viewport_pin.node) {
+                        assert(n.data.size.rows > self.viewport_pin.y);
+                        offset -= self.viewport_pin.y;
+                        break :offset self.total_rows - offset;
+                    }
+                }
+
+                // Invalid pins are not possible.
+                unreachable;
+            };
+
+            // The offset is from the bottom and our cached value and this
+            // function returns from the top, so we need to invert it.
+            self.viewport_pin_row_offset = top_offset;
+            break :pin top_offset;
+        },
+    };
+}
+
+/// This fixes up the viewport data when rows are removed from the
+/// PageList. This will update a viewport to `active` if row removal
+/// puts the viewport into the active area, to `top` if the viewport
+/// is now at row 0, and updates any row offset caches as necessary.
+///
+/// This is unit tested transitively through other tests such as
+/// eraseRows.
+fn fixupViewport(
+    self: *PageList,
+    removed: usize,
+) void {
+    switch (self.viewport) {
+        .active => {},
+
+        // For pin, we check if our pin is now in the active area and if so
+        // we move our viewport back to the active area.
+        .pin => if (self.pinIsActive(self.viewport_pin.*)) {
+            self.viewport = .active;
+        } else if (self.viewport_pin_row_offset) |*v| {
+            // If we have a cached row offset, we need to update it
+            // to account for the erased rows.
+            if (v.* < removed) {
+                self.viewport = .top;
+            } else {
+                v.* -= removed;
+            }
+        },
+
+        // For top, we move back to active if our erasing moved our
+        // top page into the active area.
+        .top => if (self.pinIsActive(.{ .node = self.pages.first.? })) {
+            self.viewport = .active;
+        },
+    }
 }
 
 /// Returns the actual max size. This may be greater than the explicit
@@ -2047,6 +2282,22 @@ pub fn grow(self: *PageList) !?*List.Node {
         // add one for our new row.
         self.total_rows -= first.data.size.rows;
         self.total_rows += 1;
+
+        // If we have a pin viewport cache then we need to update it.
+        if (self.viewport == .pin) viewport: {
+            if (self.viewport_pin_row_offset) |*v| {
+                // If our offset is less than the number of rows in the
+                // pruned page, then we are now at the top.
+                if (v.* < first.data.size.rows) {
+                    self.viewport = .top;
+                    break :viewport;
+                }
+
+                // Otherwise, our viewport pin is below what we pruned
+                // so we just decrement our offset.
+                v.* -= first.data.size.rows;
+            }
+        }
 
         // Initialize our new page and reinsert it as the last
         first.data = .initBuf(.init(buf), layout);
@@ -2302,6 +2553,9 @@ pub fn eraseRow(
         }
     }
 
+    // If we have a pinned viewport, we need to adjust for active area.
+    self.fixupViewport(1);
+
     {
         // Set all the rows as dirty in this page
         var dirty = node.data.dirtyBitSet();
@@ -2396,6 +2650,21 @@ pub fn eraseRowBounded(
         var dirty = node.data.dirtyBitSet();
         dirty.setRangeValue(.{ .start = pn.y, .end = pn.y + limit }, true);
 
+        // If our viewport is a pin and our pin is within the erased
+        // region we need to maybe shift our cache up. We do this here instead
+        // of in the pin loop below because its unlikely to be true and we
+        // don't want to run the conditional N times.
+        if (self.viewport == .pin) viewport: {
+            if (self.viewport_pin_row_offset) |*v| {
+                const p = self.viewport_pin;
+                if (p.node != node or
+                    p.y < pn.y or
+                    p.y > pn.y + limit or
+                    p.y == 0) break :viewport;
+                v.* -= 1;
+            }
+        }
+
         // Update pins in the shifted region.
         const pin_keys = self.tracked_pins.keys();
         for (pin_keys) |p| {
@@ -2429,6 +2698,18 @@ pub fn eraseRowBounded(
 
     // Update tracked pins.
     {
+        // See the other places we do something similar in this function
+        // for a detailed explanation.
+        if (self.viewport == .pin) viewport: {
+            if (self.viewport_pin_row_offset) |*v| {
+                const p = self.viewport_pin;
+                if (p.node != node or
+                    p.y < pn.y or
+                    p.y == 0) break :viewport;
+                v.* -= 1;
+            }
+        }
+
         const pin_keys = self.tracked_pins.keys();
         for (pin_keys) |p| {
             if (p.node == node and p.y >= pn.y) {
@@ -2467,6 +2748,17 @@ pub fn eraseRowBounded(
             var dirty = node.data.dirtyBitSet();
             dirty.setRangeValue(.{ .start = 0, .end = shifted_limit }, true);
 
+            // See the other places we do something similar in this function
+            // for a detailed explanation.
+            if (self.viewport == .pin) viewport: {
+                if (self.viewport_pin_row_offset) |*v| {
+                    const p = self.viewport_pin;
+                    if (p.node != node or
+                        p.y > shifted_limit) break :viewport;
+                    v.* -= 1;
+                }
+            }
+
             // Update pins in the shifted region.
             const pin_keys = self.tracked_pins.keys();
             for (pin_keys) |p| {
@@ -2490,6 +2782,16 @@ pub fn eraseRowBounded(
 
         // Account for the rows shifted in this node.
         shifted += node.data.size.rows;
+
+        // See the other places we do something similar in this function
+        // for a detailed explanation.
+        if (self.viewport == .pin) viewport: {
+            if (self.viewport_pin_row_offset) |*v| {
+                const p = self.viewport_pin;
+                if (p.node != node) break :viewport;
+                v.* -= 1;
+            }
+        }
 
         // Update tracked pins.
         const pin_keys = self.tracked_pins.keys();
@@ -2616,21 +2918,7 @@ pub fn eraseRows(
     }
 
     // If we have a pinned viewport, we need to adjust for active area.
-    switch (self.viewport) {
-        .active => {},
-
-        // For pin, we check if our pin is now in the active area and if so
-        // we move our viewport back to the active area.
-        .pin => if (self.pinIsActive(self.viewport_pin.*)) {
-            self.viewport = .{ .active = {} };
-        },
-
-        // For top, we move back to active if our erasing moved our
-        // top page into the active area.
-        .top => if (self.pinIsActive(.{ .node = self.pages.first.? })) {
-            self.viewport = .{ .active = {} };
-        },
-    }
+    self.fixupViewport(erased);
 }
 
 /// Erase a single page, freeing all its resources. The page can be
@@ -2746,6 +3034,11 @@ fn pinIsActive(self: *const PageList, p: Pin) bool {
     }
 
     return false;
+}
+
+/// Returns true if the pin is at the top of the scrollback area.
+fn pinIsTop(self: *const PageList, p: Pin) bool {
+    return p.y == 0 and p.node == self.pages.first.?;
 }
 
 /// Convert a pin to a point in the given context. If the pin can't fit
@@ -4042,6 +4335,13 @@ test "PageList" {
         .y = 0,
         .x = 0,
     }, s.getTopLeft(.active));
+
+    // Scrollbar should be where we expect it
+    try testing.expectEqual(Scrollbar{
+        .total = s.rows,
+        .offset = 0,
+        .len = s.rows,
+    }, s.scrollbar());
 }
 
 test "PageList init rows across two pages" {
@@ -4068,6 +4368,13 @@ test "PageList init rows across two pages" {
 
     // Initial total rows should be our row count
     try testing.expectEqual(s.rows, s.total_rows);
+
+    // Scrollbar should be where we expect it
+    try testing.expectEqual(Scrollbar{
+        .total = s.rows,
+        .offset = 0,
+        .len = s.rows,
+    }, s.scrollbar());
 }
 
 test "PageList pointFromPin active no history" {
@@ -4255,6 +4562,13 @@ test "PageList active after grow" {
             .y = 10,
         } }, pt);
     }
+
+    // Scrollbar should be in the active area
+    try testing.expectEqual(Scrollbar{
+        .total = s.totalRows(),
+        .offset = 10,
+        .len = s.rows,
+    }, s.scrollbar());
 }
 
 test "PageList grow allows exceeding max size for active area" {
@@ -4334,6 +4648,13 @@ test "PageList grow prune required with a single page" {
     const new = try s.grow();
     try testing.expect(new != null);
     try testing.expect(new != s.pages.first);
+
+    // Scrollbar should be in the active area
+    try testing.expectEqual(Scrollbar{
+        .total = s.totalRows(),
+        .offset = s.total_rows - s.rows,
+        .len = s.rows,
+    }, s.scrollbar());
 }
 
 test "PageList scroll top" {
@@ -4362,6 +4683,12 @@ test "PageList scroll top" {
         } }, pt);
     }
 
+    try testing.expectEqual(Scrollbar{
+        .total = s.totalRows(),
+        .offset = 0,
+        .len = s.rows,
+    }, s.scrollbar());
+
     try s.growRows(10);
     {
         const pt = s.getCell(.{ .viewport = .{} }).?.screenPoint();
@@ -4371,6 +4698,12 @@ test "PageList scroll top" {
         } }, pt);
     }
 
+    try testing.expectEqual(Scrollbar{
+        .total = s.totalRows(),
+        .offset = 0,
+        .len = s.rows,
+    }, s.scrollbar());
+
     s.scroll(.{ .active = {} });
     {
         const pt = s.getCell(.{ .viewport = .{} }).?.screenPoint();
@@ -4379,6 +4712,12 @@ test "PageList scroll top" {
             .y = 20,
         } }, pt);
     }
+
+    try testing.expectEqual(Scrollbar{
+        .total = s.totalRows(),
+        .offset = s.total_rows - s.rows,
+        .len = s.rows,
+    }, s.scrollbar());
 }
 
 test "PageList scroll delta row back" {
@@ -4399,6 +4738,12 @@ test "PageList scroll delta row back" {
 
     s.scroll(.{ .delta_row = -1 });
 
+    try testing.expectEqual(Scrollbar{
+        .total = s.totalRows(),
+        .offset = s.total_rows - s.rows - 1,
+        .len = s.rows,
+    }, s.scrollbar());
+
     {
         const pt = s.getCell(.{ .viewport = .{} }).?.screenPoint();
         try testing.expectEqual(point.Point{ .screen = .{
@@ -4415,6 +4760,20 @@ test "PageList scroll delta row back" {
             .y = 9,
         } }, pt);
     }
+
+    try testing.expectEqual(Scrollbar{
+        .total = s.totalRows(),
+        .offset = s.total_rows - s.rows - 11,
+        .len = s.rows,
+    }, s.scrollbar());
+
+    s.scroll(.{ .delta_row = -1 });
+
+    try testing.expectEqual(Scrollbar{
+        .total = s.totalRows(),
+        .offset = s.total_rows - s.rows - 12,
+        .len = s.rows,
+    }, s.scrollbar());
 }
 
 test "PageList scroll delta row back overflow" {
@@ -4443,6 +4802,12 @@ test "PageList scroll delta row back overflow" {
         } }, pt);
     }
 
+    try testing.expectEqual(Scrollbar{
+        .total = s.totalRows(),
+        .offset = 0,
+        .len = s.rows,
+    }, s.scrollbar());
+
     try s.growRows(10);
     {
         const pt = s.getCell(.{ .viewport = .{} }).?.screenPoint();
@@ -4451,6 +4816,12 @@ test "PageList scroll delta row back overflow" {
             .y = 0,
         } }, pt);
     }
+
+    try testing.expectEqual(Scrollbar{
+        .total = s.totalRows(),
+        .offset = 0,
+        .len = s.rows,
+    }, s.scrollbar());
 }
 
 test "PageList scroll delta row forward" {
@@ -4472,6 +4843,12 @@ test "PageList scroll delta row forward" {
     s.scroll(.{ .top = {} });
     s.scroll(.{ .delta_row = 2 });
 
+    try testing.expectEqual(Scrollbar{
+        .total = s.totalRows(),
+        .offset = 2,
+        .len = s.rows,
+    }, s.scrollbar());
+
     {
         const pt = s.getCell(.{ .viewport = .{} }).?.screenPoint();
         try testing.expectEqual(point.Point{ .screen = .{
@@ -4488,6 +4865,12 @@ test "PageList scroll delta row forward" {
             .y = 2,
         } }, pt);
     }
+
+    try testing.expectEqual(Scrollbar{
+        .total = s.totalRows(),
+        .offset = 2,
+        .len = s.rows,
+    }, s.scrollbar());
 }
 
 test "PageList scroll delta row forward into active" {
@@ -4506,6 +4889,12 @@ test "PageList scroll delta row forward into active" {
             .y = 0,
         } }, pt);
     }
+
+    try testing.expectEqual(Scrollbar{
+        .total = s.totalRows(),
+        .offset = s.total_rows - s.rows,
+        .len = s.rows,
+    }, s.scrollbar());
 }
 
 test "PageList scroll delta row back without space preserves active" {
@@ -4525,6 +4914,117 @@ test "PageList scroll delta row back without space preserves active" {
     }
 
     try testing.expect(s.viewport == .active);
+
+    try testing.expectEqual(Scrollbar{
+        .total = s.totalRows(),
+        .offset = s.total_rows - s.rows,
+        .len = s.rows,
+    }, s.scrollbar());
+}
+
+test "PageList scroll to pin" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, 80, 24, null);
+    defer s.deinit();
+    try s.growRows(10);
+
+    s.scroll(.{ .pin = s.pin(.{ .screen = .{
+        .y = 4,
+        .x = 2,
+    } }).? });
+
+    try testing.expectEqual(Scrollbar{
+        .total = s.totalRows(),
+        .offset = 4,
+        .len = s.rows,
+    }, s.scrollbar());
+
+    {
+        const pt = s.getCell(.{ .viewport = .{} }).?.screenPoint();
+        try testing.expectEqual(point.Point{ .screen = .{
+            .x = 0,
+            .y = 4,
+        } }, pt);
+    }
+
+    s.scroll(.{ .pin = s.pin(.{ .screen = .{
+        .y = 5,
+        .x = 2,
+    } }).? });
+
+    try testing.expectEqual(Scrollbar{
+        .total = s.totalRows(),
+        .offset = 5,
+        .len = s.rows,
+    }, s.scrollbar());
+
+    {
+        const pt = s.getCell(.{ .viewport = .{} }).?.screenPoint();
+        try testing.expectEqual(point.Point{ .screen = .{
+            .x = 0,
+            .y = 5,
+        } }, pt);
+    }
+}
+
+test "PageList scroll to pin in active" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, 80, 24, null);
+    defer s.deinit();
+    try s.growRows(10);
+
+    s.scroll(.{ .pin = s.pin(.{ .screen = .{
+        .y = 30,
+        .x = 2,
+    } }).? });
+
+    try testing.expectEqual(Scrollbar{
+        .total = s.totalRows(),
+        .offset = s.total_rows - s.rows,
+        .len = s.rows,
+    }, s.scrollbar());
+
+    {
+        const pt = s.getCell(.{ .viewport = .{} }).?.screenPoint();
+        try testing.expectEqual(point.Point{ .screen = .{
+            .x = 0,
+            .y = 10,
+        } }, pt);
+    }
+}
+
+test "PageList scroll to pin at top" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, 80, 24, null);
+    defer s.deinit();
+    try s.growRows(10);
+
+    s.scroll(.{ .pin = s.pin(.{ .screen = .{
+        .y = 0,
+        .x = 2,
+    } }).? });
+
+    try testing.expect(s.viewport == .top);
+
+    try testing.expectEqual(Scrollbar{
+        .total = s.totalRows(),
+        .offset = 0,
+        .len = s.rows,
+    }, s.scrollbar());
+
+    {
+        const pt = s.getCell(.{ .viewport = .{} }).?.screenPoint();
+        try testing.expectEqual(point.Point{ .screen = .{
+            .x = 0,
+            .y = 0,
+        } }, pt);
+    }
 }
 
 test "PageList scroll clear" {
@@ -4560,7 +5060,7 @@ test "PageList scroll clear" {
     }
 }
 
-test "PageList: jump zero" {
+test "PageList: jump zero prompts" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
@@ -4580,9 +5080,15 @@ test "PageList: jump zero" {
 
     s.scroll(.{ .delta_prompt = 0 });
     try testing.expect(s.viewport == .active);
+
+    try testing.expectEqual(Scrollbar{
+        .total = s.totalRows(),
+        .offset = s.total_rows - s.rows,
+        .len = s.rows,
+    }, s.scrollbar());
 }
 
-test "Screen: jump to prompt" {
+test "Screen: jump back one prompt" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
@@ -4608,6 +5114,12 @@ test "Screen: jump to prompt" {
             .x = 0,
             .y = 1,
         } }, s.pointFromPin(.screen, s.pin(.{ .viewport = .{} }).?).?);
+
+        try testing.expectEqual(Scrollbar{
+            .total = s.totalRows(),
+            .offset = 1,
+            .len = s.rows,
+        }, s.scrollbar());
     }
     {
         s.scroll(.{ .delta_prompt = -1 });
@@ -4616,16 +5128,32 @@ test "Screen: jump to prompt" {
             .x = 0,
             .y = 1,
         } }, s.pointFromPin(.screen, s.pin(.{ .viewport = .{} }).?).?);
+
+        try testing.expectEqual(Scrollbar{
+            .total = s.totalRows(),
+            .offset = 1,
+            .len = s.rows,
+        }, s.scrollbar());
     }
 
     // Jump forward
     {
         s.scroll(.{ .delta_prompt = 1 });
         try testing.expect(s.viewport == .active);
+        try testing.expectEqual(Scrollbar{
+            .total = s.totalRows(),
+            .offset = s.total_rows - s.rows,
+            .len = s.rows,
+        }, s.scrollbar());
     }
     {
         s.scroll(.{ .delta_prompt = 1 });
         try testing.expect(s.viewport == .active);
+        try testing.expectEqual(Scrollbar{
+            .total = s.totalRows(),
+            .offset = s.total_rows - s.rows,
+            .len = s.rows,
+        }, s.scrollbar());
     }
 }
 
@@ -4709,6 +5237,15 @@ test "PageList grow prune scrollback" {
     defer s.untrackPin(p);
     try testing.expect(p.node == s.pages.first.?);
 
+    // Scroll back to create a pinned viewport (not active)
+    const pin_y = page1.capacity.rows / 2;
+    s.scroll(.{ .pin = s.pin(.{ .screen = .{ .y = pin_y } }).? });
+    try testing.expect(s.viewport == .pin);
+
+    // Get the scrollbar state to populate the cache
+    const scrollbar_before = s.scrollbar();
+    try testing.expectEqual(pin_y, scrollbar_before.offset);
+
     // Next should create a new page, but it should reuse our first
     // page since we're at max size.
     const new = (try s.grow()).?;
@@ -4723,6 +5260,330 @@ test "PageList grow prune scrollback" {
     try testing.expect(p.node == s.pages.first.?);
     try testing.expect(p.x == 0);
     try testing.expect(p.y == 0);
+
+    // Verify the viewport offset cache was invalidated. After pruning,
+    // the offset should have changed because we removed rows from
+    // the beginning.
+    {
+        const scrollbar_after = s.scrollbar();
+        const rows_pruned = page1.capacity.rows;
+        const expected_offset = if (pin_y >= rows_pruned)
+            pin_y - rows_pruned
+        else
+            0;
+        try testing.expectEqual(expected_offset, scrollbar_after.offset);
+    }
+}
+
+test "PageList grow prune scrollback with viewport pin not in pruned page" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // Zero here forces minimum max size to effectively two pages.
+    var s = try init(alloc, 80, 24, 0);
+    defer s.deinit();
+
+    // Grow to capacity of first page
+    const page1_node = s.pages.last.?;
+    const page1 = page1_node.data;
+    for (0..page1.capacity.rows - page1.size.rows) |_| {
+        try testing.expect(try s.grow() == null);
+    }
+
+    // Grow and allocate second page, then fill it up
+    const page2_node = (try s.grow()).?;
+    const page2 = page2_node.data;
+    for (0..page2.capacity.rows - page2.size.rows) |_| {
+        try testing.expect(try s.grow() == null);
+    }
+
+    // Get our page size
+    const old_page_size = s.page_size;
+
+    // Scroll back to create a pinned viewport in page2 (NOT page1)
+    // This is the key difference from the previous test - the viewport
+    // pin is NOT in the page that will be pruned.
+    const pin_y = page1.capacity.rows + 5;
+    s.scroll(.{ .pin = s.pin(.{ .screen = .{ .y = pin_y } }).? });
+    try testing.expect(s.viewport == .pin);
+    try testing.expect(s.viewport_pin.node == page2_node);
+
+    // Get the scrollbar state to populate the cache
+    const scrollbar_before = s.scrollbar();
+    try testing.expectEqual(pin_y, scrollbar_before.offset);
+
+    // Next grow will trigger pruning of the first page.
+    // The viewport_pin.node is page2, not page1, so it won't be moved
+    // by the pin update loop, but the cached offset still needs to be
+    // invalidated because rows were removed from the beginning.
+    const new = (try s.grow()).?;
+    try testing.expect(s.pages.last.? == new);
+    try testing.expectEqual(s.page_size, old_page_size);
+
+    // Our first should now be page2 (page1 was pruned)
+    try testing.expectEqual(page2_node, s.pages.first.?);
+
+    // The viewport pin should still be on page2, unchanged
+    try testing.expect(s.viewport_pin.node == page2_node);
+
+    // Verify the viewport offset cache was invalidated/updated.
+    // After pruning, the offset should have decreased by the number
+    // of rows that were pruned.
+    const scrollbar_after = s.scrollbar();
+    const rows_pruned = page1.capacity.rows;
+    const expected_offset = pin_y - rows_pruned;
+    try testing.expectEqual(expected_offset, scrollbar_after.offset);
+}
+
+test "PageList eraseRows invalidates viewport offset cache" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, 80, 24, null);
+    defer s.deinit();
+
+    // Grow so we take up several pages worth of history
+    const page = &s.pages.last.?.data;
+    {
+        var cur_page = s.pages.last.?;
+        for (0..page.capacity.rows * 3) |_| {
+            if (try s.grow()) |new_page| cur_page = new_page;
+        }
+    }
+
+    // Scroll back to create a pinned viewport somewhere in the middle
+    // of the scrollback
+    const pin_y = page.capacity.rows;
+    s.scroll(.{ .pin = s.pin(.{ .screen = .{ .y = pin_y } }).? });
+    try testing.expect(s.viewport == .pin);
+    try testing.expectEqual(Scrollbar{
+        .total = s.total_rows,
+        .offset = pin_y,
+        .len = s.rows,
+    }, s.scrollbar());
+
+    // Erase some history rows BEFORE the viewport pin.
+    // This removes rows from before our pin, which changes its absolute
+    // offset from the top, but the cache is not invalidated.
+    const rows_to_erase = page.capacity.rows / 2;
+    s.eraseRows(
+        .{ .history = .{} },
+        .{ .history = .{ .y = rows_to_erase - 1 } },
+    );
+
+    try testing.expectEqual(Scrollbar{
+        .total = s.total_rows,
+        .offset = pin_y - rows_to_erase,
+        .len = s.rows,
+    }, s.scrollbar());
+}
+
+test "PageList eraseRow invalidates viewport offset cache" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, 80, 24, null);
+    defer s.deinit();
+
+    // Grow so we take up several pages worth of history
+    const page = &s.pages.last.?.data;
+    {
+        var cur_page = s.pages.last.?;
+        for (0..page.capacity.rows * 3) |_| {
+            if (try s.grow()) |new_page| cur_page = new_page;
+        }
+    }
+
+    // Scroll back to create a pinned viewport somewhere in the middle
+    // of the scrollback
+    const pin_y = page.capacity.rows;
+    s.scroll(.{ .pin = s.pin(.{ .screen = .{ .y = pin_y } }).? });
+    try testing.expect(s.viewport == .pin);
+    try testing.expectEqual(Scrollbar{
+        .total = s.total_rows,
+        .offset = pin_y,
+        .len = s.rows,
+    }, s.scrollbar());
+
+    // Erase a single row from the history BEFORE the viewport pin.
+    // This removes one row from before our pin, which changes its absolute
+    // offset from the top by 1, but the cache is not invalidated.
+    try s.eraseRow(.{ .history = .{ .y = 0 } });
+
+    try testing.expectEqual(Scrollbar{
+        .total = s.total_rows,
+        .offset = pin_y - 1,
+        .len = s.rows,
+    }, s.scrollbar());
+}
+
+test "PageList eraseRowBounded invalidates viewport offset cache" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, 80, 24, null);
+    defer s.deinit();
+
+    // Grow so we take up several pages worth of history
+    const page = &s.pages.last.?.data;
+    {
+        var cur_page = s.pages.last.?;
+        for (0..page.capacity.rows * 3) |_| {
+            if (try s.grow()) |new_page| cur_page = new_page;
+        }
+    }
+
+    // Scroll back to create a pinned viewport somewhere in the middle
+    // of the scrollback
+    const pin_y: u16 = 4;
+    s.scroll(.{ .pin = s.pin(.{ .screen = .{ .y = pin_y } }).? });
+    try testing.expect(s.viewport == .pin);
+    try testing.expectEqual(Scrollbar{
+        .total = s.total_rows,
+        .offset = pin_y,
+        .len = s.rows,
+    }, s.scrollbar());
+
+    // Erase a row from the history BEFORE the viewport pin with a bounded
+    // shift. This removes one row from before our pin, which changes its
+    // absolute offset from the top by 1, but the cache is not invalidated.
+    try s.eraseRowBounded(.{ .history = .{ .y = 0 } }, 10);
+
+    // Verify the scrollbar reflects the change (offset decreased by 1)
+    try testing.expectEqual(Scrollbar{
+        .total = s.total_rows,
+        .offset = pin_y - 1,
+        .len = s.rows,
+    }, s.scrollbar());
+}
+
+test "PageList eraseRowBounded multi-page invalidates viewport offset cache" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, 80, 24, null);
+    defer s.deinit();
+
+    // Grow so we take up several pages worth of history
+    const page = &s.pages.last.?.data;
+    {
+        var cur_page = s.pages.last.?;
+        for (0..page.capacity.rows * 3) |_| {
+            if (try s.grow()) |new_page| cur_page = new_page;
+        }
+    }
+
+    // Scroll back to create a pinned viewport somewhere in the middle
+    // of the scrollback, after the first page
+    const pin_y = page.capacity.rows + 1;
+    s.scroll(.{ .pin = s.pin(.{ .screen = .{ .y = pin_y } }).? });
+    try testing.expect(s.viewport == .pin);
+    try testing.expectEqual(Scrollbar{
+        .total = s.total_rows,
+        .offset = pin_y,
+        .len = s.rows,
+    }, s.scrollbar());
+
+    // Erase a row from the beginning of history with a limit that spans
+    // across multiple pages. This ensures we hit the code path where
+    // eraseRowBounded finds the limit boundary in a subsequent page.
+    const limit = page.capacity.rows + 10;
+    try s.eraseRowBounded(.{ .history = .{ .y = 0 } }, limit);
+
+    // Verify the scrollbar reflects the change (offset decreased by 1)
+    try testing.expectEqual(Scrollbar{
+        .total = s.total_rows,
+        .offset = pin_y - 1,
+        .len = s.rows,
+    }, s.scrollbar());
+}
+
+test "PageList eraseRowBounded full page shift invalidates viewport offset cache" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, 80, 24, null);
+    defer s.deinit();
+
+    // Grow so we take up several pages worth of history
+    const page = &s.pages.last.?.data;
+    {
+        var cur_page = s.pages.last.?;
+        for (0..page.capacity.rows * 4) |_| {
+            if (try s.grow()) |new_page| cur_page = new_page;
+        }
+    }
+
+    // Scroll back to create a pinned viewport somewhere well beyond
+    // the first two pages
+    const pin_y = 5;
+    s.scroll(.{ .pin = s.pin(.{ .screen = .{ .y = pin_y } }).? });
+    try testing.expect(s.viewport == .pin);
+    try testing.expectEqual(Scrollbar{
+        .total = s.total_rows,
+        .offset = pin_y,
+        .len = s.rows,
+    }, s.scrollbar());
+
+    // Erase a row from the beginning of history with a limit that is
+    // larger than multiple full pages. This ensures we hit the code path
+    // where eraseRowBounded continues looping through entire pages,
+    // rotating all rows in each page until it reaches the limit or
+    // runs out of pages.
+    const limit = page.capacity.rows * 2 + 10;
+    try s.eraseRowBounded(.{ .history = .{ .y = 0 } }, limit);
+
+    // Verify the scrollbar reflects the change (offset decreased by 1)
+    try testing.expectEqual(Scrollbar{
+        .total = s.total_rows,
+        .offset = pin_y - 1,
+        .len = s.rows,
+    }, s.scrollbar());
+}
+
+test "PageList eraseRowBounded exhausts pages invalidates viewport offset cache" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, 80, 24, null);
+    defer s.deinit();
+
+    // Grow so we take up several pages worth of history
+    const page = &s.pages.last.?.data;
+    {
+        var cur_page = s.pages.last.?;
+        for (0..page.capacity.rows * 3) |_| {
+            if (try s.grow()) |new_page| cur_page = new_page;
+        }
+    }
+
+    // Our total rows should include history
+    const total_rows_before = s.totalRows();
+    try testing.expect(total_rows_before > s.rows);
+
+    // Scroll back to create a pinned viewport somewhere in the history,
+    // well after the erase will complete
+    const pin_y = page.capacity.rows * 2 + 10;
+    s.scroll(.{ .pin = s.pin(.{ .screen = .{ .y = pin_y } }).? });
+    try testing.expect(s.viewport == .pin);
+    try testing.expectEqual(Scrollbar{
+        .total = s.total_rows,
+        .offset = pin_y,
+        .len = s.rows,
+    }, s.scrollbar());
+
+    // Erase a row from the beginning of history with a limit that is
+    // LARGER than all remaining pages combined. This ensures we exhaust
+    // all pages in the while loop and reach the cleanup code after the loop.
+    const limit = total_rows_before * 2;
+    try s.eraseRowBounded(.{ .history = .{ .y = 0 } }, limit);
+
+    // Verify the scrollbar reflects the change (offset decreased by 1)
+    try testing.expectEqual(Scrollbar{
+        .total = s.total_rows,
+        .offset = pin_y - 1,
+        .len = s.rows,
+    }, s.scrollbar());
 }
 
 test "PageList adjustCapacity to increase styles" {
@@ -5298,8 +6159,7 @@ test "PageList erase resets viewport to active if moves within active" {
 
     // Move our viewport to the top
     s.scroll(.{ .delta_row = -@as(isize, @intCast(s.totalRows())) });
-    try testing.expect(s.viewport == .pin);
-    try testing.expect(s.viewport_pin.node == s.pages.first.?);
+    try testing.expect(s.viewport == .top);
 
     // Erase the entire history, we should be back to just our active set.
     s.eraseRows(.{ .history = .{} }, null);
@@ -5328,13 +6188,11 @@ test "PageList erase resets viewport if inside erased page but not active" {
 
     // Move our viewport to the top
     s.scroll(.{ .delta_row = -@as(isize, @intCast(s.totalRows())) });
-    try testing.expect(s.viewport == .pin);
-    try testing.expect(s.viewport_pin.node == s.pages.first.?);
+    try testing.expect(s.viewport == .top);
 
     // Erase the entire history, we should be back to just our active set.
     s.eraseRows(.{ .history = .{} }, .{ .history = .{ .y = 2 } });
-    try testing.expect(s.viewport == .pin);
-    try testing.expect(s.viewport_pin.node == s.pages.first.?);
+    try testing.expect(s.viewport == .top);
 }
 
 test "PageList erase resets viewport to active if top is inside active" {
@@ -6238,14 +7096,16 @@ test "PageList resize (no reflow) more rows contains viewport" {
     // Set viewport above active by scrolling up one.
     s.scroll(.{ .delta_row = -1 });
     // The viewport should be a pin now.
-    try testing.expectEqual(Viewport.pin, s.viewport);
+    try testing.expectEqual(Viewport.top, s.viewport);
 
     // Resize
     try s.resize(.{ .rows = 7, .reflow = false });
     try testing.expectEqual(@as(usize, 7), s.rows);
     try testing.expectEqual(@as(usize, 7), s.totalRows());
-    // The viewport should now be active, not a pin.
-    try testing.expectEqual(Viewport.active, s.viewport);
+
+    // Question: maybe the viewport should actually be in the active
+    // here and not pinned to the top.
+    try testing.expectEqual(Viewport.top, s.viewport);
 }
 
 test "PageList resize (no reflow) less cols" {
@@ -6797,6 +7657,55 @@ test "PageList resize reflow more cols wrapped rows" {
         try testing.expectEqual(@as(u21, 'A'), cells[0].content.codepoint);
         try testing.expectEqual(@as(u21, 'A'), cells[2].content.codepoint);
     }
+}
+
+test "PageList resize reflow invalidates viewport offset cache" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, 2, 4, null);
+    defer s.deinit();
+    try s.growRows(20);
+
+    const page = &s.pages.last.?.data;
+    for (0..s.rows) |y| {
+        if (y % 2 == 0) {
+            const rac = page.getRowAndCell(0, y);
+            rac.row.wrap = true;
+        } else {
+            const rac = page.getRowAndCell(0, y);
+            rac.row.wrap_continuation = true;
+        }
+
+        for (0..s.cols) |x| {
+            const rac = page.getRowAndCell(x, y);
+            rac.cell.* = .{
+                .content_tag = .codepoint,
+                .content = .{ .codepoint = 'A' },
+            };
+        }
+    }
+
+    // Scroll to a pinned viewport in history
+    const pin_y = 10;
+    s.scroll(.{ .pin = s.pin(.{ .screen = .{ .y = pin_y } }).? });
+    try testing.expect(s.viewport == .pin);
+    try testing.expectEqual(Scrollbar{
+        .total = s.total_rows,
+        .offset = pin_y,
+        .len = s.rows,
+    }, s.scrollbar());
+
+    // Resize with reflow - unwrapping rows changes total_rows
+    try s.resize(.{ .cols = 4, .reflow = true });
+    try testing.expectEqual(@as(usize, 4), s.cols);
+
+    // Verify scrollbar cache was invalidated during reflow
+    try testing.expectEqual(Scrollbar{
+        .total = s.total_rows,
+        .offset = 8,
+        .len = s.rows,
+    }, s.scrollbar());
 }
 
 test "PageList resize reflow more cols creates multiple pages" {

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -2103,6 +2103,13 @@ pub const Scrollbar = struct {
     /// The length of the visible area. This is including the offset row.
     len: usize,
 
+    /// A zero-sized scrollable region.
+    pub const zero: Scrollbar = .{
+        .total = 0,
+        .offset = 0,
+        .len = 0,
+    };
+
     /// Comparison for scrollbars.
     pub fn eql(self: Scrollbar, other: Scrollbar) bool {
         return self.total == other.total and

--- a/src/terminal/main.zig
+++ b/src/terminal/main.zig
@@ -37,6 +37,7 @@ pub const Pin = PageList.Pin;
 pub const Point = point.Point;
 pub const Screen = @import("Screen.zig");
 pub const ScreenType = Terminal.ScreenType;
+pub const Scrollbar = PageList.Scrollbar;
 pub const Selection = @import("Selection.zig");
 pub const SizeReportStyle = csi.SizeReportStyle;
 pub const StringMap = @import("StringMap.zig");


### PR DESCRIPTION
Related to #111

This adds the necessary logic and data for the `PageList` data structure to keep track of **total length** of the screen, **offset** into the viewport, and **length** of the viewport. These three values are necessary to _render_ a scrollbar. This PR updates the renderer to grab this information but stops short of actually drawing a scrollbar (which we'll do with native UI), in the interest of having a PR that doesn't contain too many changes.

**This doesn't yet draw a scrollbar, these are just the internal changes necessary to support it.**

## Background

The `PageList` structure is very core to how we represent terminal state. It maintains a doubly linked list of "pages" (not literally virtual memory pages, but close). Each page stores cell information, styles, hyperlinks, etc fully self-contained in a contiguous sets of VM pages using offset addresses rather than full pointers. **Pages are not guaranteed to be equal sizes.** (This is where scrollbars get difficult)

Because it is a linked list structure of non-equal sized nodes, it isn't amenable to typical scrollbar behavior. A scrollbar needs to know: full size, offset, and length in order to draw the scrollbar properly. Getting these values naively is `O(N)` within the data structure that is on the hottest IO performance path in all of Ghostty. 

## Implementation

### PageList

We now maintain two cached values for **total length** and **viewport offset**. 

The total length is relatively straightforward, we just have to be careful to update it in every operation that could add or remove rows. I've done this and ensured that every place we update it is covered with unit test coverage.

The viewport offset is nasty, but I came up with what I believe is a good solution. The viewport when arbitrarily scrolled is defined as a direct pointer to the linked list node plus a row offset into that node. The only way to calculate offset from the top is `O(N)`. 

But we have a couple shortcuts:

1. If the viewport is at the bottom (most common) or top, calculating the offset is `O(1)`: bottom is `total_rows - active_rows`, both readily available. And top is `0` by definition.

2. Operations on the PageList typically add or remove rows. We don't do arbitrary linked list surgery. If we instrument those areas with delta updates to our cache, we can avoid the `O(N)` cost for most operations, including scrolling a scrollbar. The only expensive operation is a full, arbitrary jump (new node pointer). 

Point 1 was quick to implement, so I focused all the complexity on point 2. Whenever we have an operation that adds or removes rows (for example pruning the scroll back, adding more, erase rows within the active area, etc.) then I do the math to calculate the delta change required for the offset if we've already calculated it, and apply that directly. 

### Renderer

The other issue was how to notify the apprts of scrollbar state. Sending messages on any terminal change within the IO thread is a non-option because (1) sending messages is slow (2) the terminal changes a lot and (3) any slowness in the IO thread slows down overall terminal throughput.

The solution was to **trigger scrollbar notifications with the renderer vsync**. We read the scrollbar information when we render a frame, compare it to renderer previous state, and if the scrollbar changed, send a message to the apprt _after the frame is GPU-renderer_. 

The renderer spends _most_ of its time sleeping compared to the IO thread, and has more opportunities for optimizing its awake time. Additionally, there's no reason to update the scrollbar information if the renderer hasn't rendered the new frames because the user can't even see the stuff the scrollbar wants to scroll to. We're talking about millisecond scale stuff here at worst but it adds up.

## Performance

No noticeable performance impact for the additional metrics:

<img width="1012" height="738" alt="image" src="https://github.com/user-attachments/assets/4ed0a3e8-6d76-40c1-b249-e34041c2f6fd" />

## AI Usage

I used Amp to help audit the codebase and write tests. I wrote all the main implementation code manually. I came up with the main design myself. Relevant threads:

- https://ampcode.com/threads/T-95fff686-75bb-4553-a2fb-e41fe4cd4b77#message-0-block-0
- https://ampcode.com/threads/T-48e9a288-b280-4eec-83b7-ca73d029b4ef#message-91-block-0

## Future

This is just the internal changes necessary to _draw_ a scrollbar. There will be other changes we'll need to add to handle grabbing and actually jumping the scrollbar. I have a good idea of how to implement those performantly as well. 