### PR TITLE
libvt C Api expose paste encoding

### DIFF
--- a/example/c-vt-paste/src/main.c
+++ b/example/c-vt-paste/src/main.c
@@ -1,8 +1,10 @@
+#include <ghostty/vt.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
-#include <ghostty/vt.h>
 
 int main() {
+
   // Test safe paste data
   const char *safe_data = "hello world";
   if (ghostty_paste_is_safe(safe_data, strlen(safe_data))) {
@@ -26,6 +28,63 @@ int main() {
   if (ghostty_paste_is_safe(empty_data, 0)) {
     printf("Empty data is safe\n");
   }
+
+  // Create options for paste encoding
+  GhosttyPasteOptions options;
+  if (ghostty_paste_options_new(NULL, &options) != GHOSTTY_SUCCESS) {
+    printf("Failed to create paste options\n");
+    return 1;
+  }
+
+  // Enable bracketed paste mode
+  ghostty_paste_options_set_bracketed(options, true);
+
+  char *simple_paste = "pasted content";
+  char *encoded;
+  if (ghostty_paste_encode(NULL, simple_paste, strlen(simple_paste), options,
+                           &encoded) != GHOSTTY_SUCCESS) {
+    printf("Failed to encode paste data\n");
+    return 1;
+  }
+
+  printf("Encoded paste data: ");
+  for (size_t i = 0; i < strlen(encoded); i++) {
+    if (encoded[i] == 0x1b) {
+      printf("\\x1b");
+    } else {
+      printf("%c", encoded[i]);
+    }
+  }
+  printf("\n");
+
+  // Disable bracketed paste mode, so that \n will be replaced by \r
+  ghostty_paste_options_set_bracketed(options, false);
+
+  char *multiline_paste = "line1\nline2\n";
+  char *encoded_multi;
+
+  if (ghostty_paste_encode(NULL, multiline_paste, strlen(multiline_paste),
+                           options, &encoded_multi) != GHOSTTY_SUCCESS) {
+    printf("Failed to encode multiline paste data\n");
+    return 1;
+  }
+
+  printf("Encoded multiline paste data without bracketed: ");
+  for (size_t i = 0; i < strlen(encoded_multi); i++) {
+    if (encoded_multi[i] == 0x1b) {
+      printf("\\x1b");
+    } else if (encoded_multi[i] == '\r') {
+      printf("\\r");
+    } else {
+      printf("%c", encoded_multi[i]);
+    }
+  }
+  printf("\n");
+
+  // free resources
+  ghostty_paste_encode_free(NULL, encoded, strlen(encoded));
+  ghostty_paste_encode_free(NULL, encoded_multi, strlen(encoded_multi));
+  ghostty_paste_options_free(NULL, options);
 
   return 0;
 }

--- a/example/c-vt-paste/src/main.c
+++ b/example/c-vt-paste/src/main.c
@@ -29,20 +29,25 @@ int main() {
     printf("Empty data is safe\n");
   }
 
-  // Create options for paste encoding
-  GhosttyPasteOptions options;
-  if (ghostty_paste_options_new(NULL, &options) != GHOSTTY_SUCCESS) {
-    printf("Failed to create paste options\n");
+  // Create a paste encoder
+  GhosttyPasteEncoder encoder;
+  if (ghostty_paste_encoder_new(NULL, &encoder) != GHOSTTY_SUCCESS) {
+    printf("Failed to create paste encoder\n");
     return 1;
   }
 
   // Enable bracketed paste mode
-  ghostty_paste_options_set_bracketed(options, true);
+  ghostty_paste_encoder_set_bracketed(encoder, true);
 
-  char *simple_paste = "pasted content";
-  char *encoded;
-  if (ghostty_paste_encode(NULL, simple_paste, strlen(simple_paste), options,
-                           &encoded) != GHOSTTY_SUCCESS) {
+  // we could use this to find out the required size, or just use a large enough
+  // buffer
+  size_t required;
+  char simple_paste[] = "pasted content";
+  char encoded[128];
+
+  if (ghostty_paste_encoder_encode(simple_paste, strlen(simple_paste), encoder,
+                                   encoded, sizeof(encoded),
+                                   &required) != GHOSTTY_SUCCESS) {
     printf("Failed to encode paste data\n");
     return 1;
   }
@@ -58,13 +63,14 @@ int main() {
   printf("\n");
 
   // Disable bracketed paste mode, so that \n will be replaced by \r
-  ghostty_paste_options_set_bracketed(options, false);
+  ghostty_paste_encoder_set_bracketed(encoder, false);
 
-  char *multiline_paste = "line1\nline2\n";
-  char *encoded_multi;
+  char multiline_paste[] = "line1\nline2\n";
+  char encoded_multi[128];
 
-  if (ghostty_paste_encode(NULL, multiline_paste, strlen(multiline_paste),
-                           options, &encoded_multi) != GHOSTTY_SUCCESS) {
+  if (ghostty_paste_encoder_encode(
+          multiline_paste, strlen(multiline_paste), encoder, encoded_multi,
+          sizeof(encoded_multi), &required) != GHOSTTY_SUCCESS) {
     printf("Failed to encode multiline paste data\n");
     return 1;
   }
@@ -82,9 +88,9 @@ int main() {
   printf("\n");
 
   // free resources
-  ghostty_paste_encode_free(NULL, encoded, strlen(encoded));
-  ghostty_paste_encode_free(NULL, encoded_multi, strlen(encoded_multi));
-  ghostty_paste_options_free(NULL, options);
+  //  ghostty_paste_encode_free(NULL, encoded, strlen(encoded));
+  // ghostty_paste_encode_free(NULL, encoded_multi, strlen(encoded_multi));
+  ghostty_paste_encoder_free(encoder);
 
   return 0;
 }

--- a/example/c-vt-paste/src/main.c
+++ b/example/c-vt-paste/src/main.c
@@ -45,7 +45,7 @@ int main() {
   char simple_paste[] = "pasted content";
   char encoded[128];
 
-  if (ghostty_paste_encoder_encode(simple_paste, strlen(simple_paste), encoder,
+  if (ghostty_paste_encoder_encode(encoder, simple_paste, strlen(simple_paste),
                                    encoded, sizeof(encoded),
                                    &required) != GHOSTTY_SUCCESS) {
     printf("Failed to encode paste data\n");
@@ -69,7 +69,7 @@ int main() {
   char encoded_multi[128];
 
   if (ghostty_paste_encoder_encode(
-          multiline_paste, strlen(multiline_paste), encoder, encoded_multi,
+          encoder, multiline_paste, strlen(multiline_paste), encoded_multi,
           sizeof(encoded_multi), &required) != GHOSTTY_SUCCESS) {
     printf("Failed to encode multiline paste data\n");
     return 1;

--- a/include/ghostty/vt/paste.h
+++ b/include/ghostty/vt/paste.h
@@ -9,14 +9,19 @@
 
 /** @defgroup paste Paste Utilities
  *
- * Utilities for validating paste data safety.
+ * Utilities for validating paste data safety and encoding data to be pasted.
  *
  * ## Basic Usage
  *
- * Use ghostty_paste_is_safe() to check if paste data contains potentially
+ *1. Use ghostty_paste_is_safe() to check if paste data contains potentially
  * dangerous sequences before sending it to the terminal.
+ * 2. Create a GhosttyPasteEncoder instance using ghostty_paste_encoder_new().
+ * 3. Configure the encoder using ghostty_paste_encoder_set_bracketed() to set
+ *   bracketed paste mode if desired.
+ * 4. Use ghostty_paste_encoder_encode() to encode the paste data into a buffer
+ * 5. Free the encoder using ghostty_paste_encoder_free() when done.
  *
- * ## Example
+ * ## Paste Safety Check Example
  *
  * @code{.c}
  * #include <stdio.h>
@@ -39,13 +44,13 @@
  * }
  * @endcode
  *
- * Use ghostty_paste_encode() to encode
+ * Use ghostty_paste_encoder_encode() with a GhosttyPasteEncoder to encode
  * the paste data to be sent to the terminal.
  * There are two modes:
  * bracketed paste mode, which wraps the data in \x1b[200~ ... \x1b[201~,
  * and non-bracketed mode, which replaces newlines with carriage returns.
  *
- * ## Example
+ * ## Encoding Paste Data Example
  *
  * @code{.c}
  * #include <ghostty/vt.h>
@@ -54,38 +59,42 @@
  * #include <string.h>
  *
  * int main() {
- *  // Create options for paste encoding
- *  GhosttyPasteOptions options;
- *  if (ghostty_paste_options_new(NULL, &options) != GHOSTTY_SUCCESS) {
- *    printf("Failed to create paste options\n");
- *    return 1;
- *  }
+ * // Create a paste encoder
+ * GhosttyPasteEncoder encoder;
+ * if (ghostty_paste_encoder_new(NULL, &encoder) != GHOSTTY_SUCCESS) {
+ *   printf("Failed to create paste encoder\n");
+ *   return 1;
+ * }
+*
+ * // Enable bracketed paste mode
+ * ghostty_paste_encoder_set_bracketed(encoder, true);
  *
- *  // Enable bracketed paste mode
- *  ghostty_paste_options_set_bracketed(options, true);
+ * // we could use this to find out the required size, or just use a large
+ * // enough buffer
+ * size_t required;
+ * char simple_paste[] = "pasted content";
+ * char encoded[128];
  *
- *  char* simple_paste = "pasted content";
- *  char* encoded;
- *  if (ghostty_paste_encode(NULL, simple_paste, strlen(simple_paste), options,
- *                           &encoded) != GHOSTTY_SUCCESS) {
- *    printf("Failed to encode paste data\n");
- *    return 1;
- *  }
+ * if (ghostty_paste_encoder_encode(simple_paste, strlen(simple_paste), encoder,
+ *                                  encoded, sizeof(encoded),
+ *                                  &required) != GHOSTTY_SUCCESS) {
+ *   printf("Failed to encode paste data\n");
+ *   return 1;
+ * }
  *
- *  printf("Encoded paste data: ");
- *  for (size_t i = 0; i < strlen(encoded); i++) {
- *    if (encoded[i] == 0x1b) {
- *      printf("\\x1b");
- *    } else {
- *      printf("%c", encoded[i]);
- *    }
- *  }
- *  printf("\n");
+ * printf("Encoded paste data: ");
+ * for (size_t i = 0; i < strlen(encoded); i++) {
+ *   if (encoded[i] == 0x1b) {
+ *     printf("\\x1b");
+ *   } else {
+ *     printf("%c", encoded[i]);
+ *   }
+ * }
+
  *
  *  // free resources
- *  ghostty_paste_encode_free(NULL, encoded, strlen(encoded));
- *  ghostty_paste_options_free(NULL, options);
- *}
+ *  ghostty_paste_encoder_free(encoder);
+ * }
  * @endcode
  *
  *
@@ -103,14 +112,14 @@ extern "C" {
 #endif
 
 /**
- * Opaque handle to a Paste Options instance.
+ * Opaque handle to a Paste Encoder instance.
  *
- * This handle represents Options that can
+ * This handle represents a Paste Encoder that can
  * be used to encode data to be pasted into the terminal.
  *
  * @ingroup paste
  */
-typedef struct GhosttyPasteOptions* GhosttyPasteOptions;
+typedef struct GhosttyPasteEncoder* GhosttyPasteEncoder;
 
 /**
  * Check if paste data is safe to paste into the terminal.
@@ -130,21 +139,21 @@ typedef struct GhosttyPasteOptions* GhosttyPasteOptions;
 bool ghostty_paste_is_safe(const char* data, size_t len);
 
 /**
- * Create a new Paste Options instance.
+ * Create a new Paste Encoder instance.
  *
- * Creates a new Paste Options instance using the provided
- * allocator. The options must be freed using ghostty_paste_options_free() when
+ * Creates a new Paste Encoder instance using the provided
+ * allocator. The encoder must be freed using ghostty_paste_encoder_free() when
  * no longer needed.
  *
  * @param allocator Pointer to the allocator to use for memory management, or
  * NULL to use the default allocator
- * @param options Pointer to store the created paste options handle
+ * @param options Pointer to store the created paste encoder handle
  * @return GHOSTTY_SUCCESS on success, or an error code on failure
  *
  * @ingroup paste
  */
-GhosttyResult ghostty_paste_options_new(const GhosttyAllocator* allocator,
-                                        GhosttyPasteOptions* options);
+GhosttyResult ghostty_paste_encoder_new(const GhosttyAllocator* allocator,
+                                        GhosttyPasteEncoder* encoder);
 
 /**
  * Free an Paste Options instance.
@@ -154,70 +163,58 @@ GhosttyResult ghostty_paste_options_new(const GhosttyAllocator* allocator,
  * @param allocator The allocator used to create the options, or NULL if the
  * default allocator was used
  *
- * @param options The parser handle to free (may be NULL)
+ * @param options The paste encoder handle to free (may be NULL)
  *
  * @ingroup paste
  */
-void ghostty_paste_options_free(const GhosttyAllocator* allocator,
-                                GhosttyPasteOptions options);
+void ghostty_paste_encoder_free(GhosttyPasteEncoder encoder);
 
 /**
- * Enable or disable bracketed paste mode in the given options.
+ * Enable or disable bracketed paste mode.
  *
  * When enabled, pasted data will be wrapped in the appropriate
- * escape sequences to enter and exit bracketed paste mode.
+ * escape sequences.
  *
  * Default is disabled.
  *
- * @param options The paste options handle, must not be NULL
+ * @param options The paste encoder handle, must not be NULL
  * @param enabled true to enable bracketed paste mode, false to disable
  *
  * @ingroup paste
  */
-void ghostty_paste_options_set_bracketed(GhosttyPasteOptions options,
+void ghostty_paste_encoder_set_bracketed(GhosttyPasteEncoder encoder,
                                          bool enabled);
 
-/**
- * Encode data for pasting into the terminal.
+/** Encode data for pasting into the terminal.
  *
- * Encodes the given data according to the specified options, producing
- * a new buffer containing the encoded paste sequence. The caller is
- * responsible for freeing the returned buffer using ghostty_paste_encode_free()
- * when no longer needed.
+ * Encodes the given data according to the specified options, writing
+ * the encoded paste sequence into the provided output buffer.
  *
+ * If the output buffer is too small, the function returns
+ * GHOSTTY_OUT_OF_MEMORY and sets `out_written` to the required
+ * size. The caller can then allocate a larger buffer and call again.
  *
- * WARNING: The input data is not checked for safety. See the
- * `ghostty_paste_is_safe` function to check if the data is safe to paste.
+ * > WARNING: The input data is not checked for safety. See the
+ * ghostty_paste_is_safe() function to check if the data is safe to paste.
  *
- * @param allocator Pointer to the allocator to use for memory management, or
- * NULL to use the default allocator
- * @param data The paste data to encode (may be NULL)
+ * @param data The paste data to encode (must not be NULL)
  * @param len The length of the data in bytes
- * @param options The paste options handle, (may be NULL)
- * @param out Pointer to store the allocated encoded data buffer
+ * @param encoder The paste encoder handle, (must not be NULL)
+ * @param out The output buffer to write the encoded data into (must not be
+ * NULL)
+ * @param out_len The length of the output buffer in bytes
+ * @param out_written Pointer to store the number of bytes required or written
+ * (may be NULL)
  * @return GHOSTTY_SUCCESS on success, or an error code on failure
  *
  * @ingroup paste
  */
-GhosttyResult ghostty_paste_encode(GhosttyAllocator* allocator,
-                                   char* data,
-                                   size_t len,
-                                   GhosttyPasteOptions options,
-                                   char** out);
-
-/**
- * Free encoded paste data returned by ghostty_paste_encode().
- *
- * @param allocator The allocator used to create the encoded data, or NULL if
- * the default allocator was used
- * @param encoded The encoded data to free (may be NULL)
- * @param len The length of the encoded data in bytes
- *
- * @ingroup paste
- */
-void ghostty_paste_encode_free(GhosttyAllocator* allocator,
-                               char* encoded,
-                               size_t len);
+GhosttyResult ghostty_paste_encoder_encode(char* data,
+                                           size_t len,
+                                           GhosttyPasteEncoder encoder,
+                                           char* out,
+                                           size_t out_len,
+                                           size_t* out_written);
 
 #ifdef __cplusplus
 }

--- a/include/ghostty/vt/paste.h
+++ b/include/ghostty/vt/paste.h
@@ -22,22 +22,72 @@
  * #include <stdio.h>
  * #include <string.h>
  * #include <ghostty/vt.h>
- * 
+ *
  * int main() {
  *   const char* safe_data = "hello world";
  *   const char* unsafe_data = "rm -rf /\n";
- * 
+ *
  *   if (ghostty_paste_is_safe(safe_data, strlen(safe_data))) {
  *     printf("Safe to paste\n");
  *   }
- * 
+ *
  *   if (!ghostty_paste_is_safe(unsafe_data, strlen(unsafe_data))) {
  *     printf("Unsafe! Contains newline\n");
  *   }
- * 
+ *
  *   return 0;
  * }
  * @endcode
+ *
+ * Use ghostty_paste_encode() to encode
+ * the paste data to be sent to the terminal.
+ * There are two modes:
+ * bracketed paste mode, which wraps the data in \x1b[200~ ... \x1b[201~,
+ * and non-bracketed mode, which replaces newlines with carriage returns.
+ *
+ * ## Example
+ *
+ * @code{.c}
+ * #include <ghostty/vt.h>
+ * #include <stdbool.h>
+ * #include <stdio.h>
+ * #include <string.h>
+ *
+ * int main() {
+ *  // Create options for paste encoding
+ *  GhosttyPasteOptions options;
+ *  if (ghostty_paste_options_new(NULL, &options) != GHOSTTY_SUCCESS) {
+ *    printf("Failed to create paste options\n");
+ *    return 1;
+ *  }
+ *
+ *  // Enable bracketed paste mode
+ *  ghostty_paste_options_set_bracketed(options, true);
+ *
+ *  char* simple_paste = "pasted content";
+ *  char* encoded;
+ *  if (ghostty_paste_encode(NULL, simple_paste, strlen(simple_paste), options,
+ *                           &encoded) != GHOSTTY_SUCCESS) {
+ *    printf("Failed to encode paste data\n");
+ *    return 1;
+ *  }
+ *
+ *  printf("Encoded paste data: ");
+ *  for (size_t i = 0; i < strlen(encoded); i++) {
+ *    if (encoded[i] == 0x1b) {
+ *      printf("\\x1b");
+ *    } else {
+ *      printf("%c", encoded[i]);
+ *    }
+ *  }
+ *  printf("\n");
+ *
+ *  // free resources
+ *  ghostty_paste_encode_free(NULL, encoded, strlen(encoded));
+ *  ghostty_paste_options_free(NULL, options);
+ *}
+ * @endcode
+ *
  *
  * @{
  */
@@ -45,9 +95,22 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+#include <ghostty/vt/allocator.h>
+#include <ghostty/vt/result.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * Opaque handle to a Paste Options instance.
+ *
+ * This handle represents Options that can
+ * be used to encode data to be pasted into the terminal.
+ *
+ * @ingroup paste
+ */
+typedef struct GhosttyPasteOptions* GhosttyPasteOptions;
 
 /**
  * Check if paste data is safe to paste into the terminal.
@@ -65,6 +128,96 @@ extern "C" {
  * @return true if the data is safe to paste, false otherwise
  */
 bool ghostty_paste_is_safe(const char* data, size_t len);
+
+/**
+ * Create a new Paste Options instance.
+ *
+ * Creates a new Paste Options instance using the provided
+ * allocator. The options must be freed using ghostty_paste_options_free() when
+ * no longer needed.
+ *
+ * @param allocator Pointer to the allocator to use for memory management, or
+ * NULL to use the default allocator
+ * @param options Pointer to store the created paste options handle
+ * @return GHOSTTY_SUCCESS on success, or an error code on failure
+ *
+ * @ingroup paste
+ */
+GhosttyResult ghostty_paste_options_new(const GhosttyAllocator* allocator,
+                                        GhosttyPasteOptions* options);
+
+/**
+ * Free an Paste Options instance.
+ *
+ * After this call, the options handle becomes invalid and must not be used.
+ *
+ * @param allocator The allocator used to create the options, or NULL if the
+ * default allocator was used
+ *
+ * @param options The parser handle to free (may be NULL)
+ *
+ * @ingroup paste
+ */
+void ghostty_paste_options_free(const GhosttyAllocator* allocator,
+                                GhosttyPasteOptions options);
+
+/**
+ * Enable or disable bracketed paste mode in the given options.
+ *
+ * When enabled, pasted data will be wrapped in the appropriate
+ * escape sequences to enter and exit bracketed paste mode.
+ *
+ * Default is disabled.
+ *
+ * @param options The paste options handle, must not be NULL
+ * @param enabled true to enable bracketed paste mode, false to disable
+ *
+ * @ingroup paste
+ */
+void ghostty_paste_options_set_bracketed(GhosttyPasteOptions options,
+                                         bool enabled);
+
+/**
+ * Encode data for pasting into the terminal.
+ *
+ * Encodes the given data according to the specified options, producing
+ * a new buffer containing the encoded paste sequence. The caller is
+ * responsible for freeing the returned buffer using ghostty_paste_encode_free()
+ * when no longer needed.
+ *
+ *
+ * WARNING: The input data is not checked for safety. See the
+ * `ghostty_paste_is_safe` function to check if the data is safe to paste.
+ *
+ * @param allocator Pointer to the allocator to use for memory management, or
+ * NULL to use the default allocator
+ * @param data The paste data to encode (may be NULL)
+ * @param len The length of the data in bytes
+ * @param options The paste options handle, (may be NULL)
+ * @param out Pointer to store the allocated encoded data buffer
+ * @return GHOSTTY_SUCCESS on success, or an error code on failure
+ *
+ * @ingroup paste
+ */
+GhosttyResult ghostty_paste_encode(GhosttyAllocator* allocator,
+                                   char* data,
+                                   size_t len,
+                                   GhosttyPasteOptions options,
+                                   char** out);
+
+/**
+ * Free encoded paste data returned by ghostty_paste_encode().
+ *
+ * @param allocator The allocator used to create the encoded data, or NULL if
+ * the default allocator was used
+ * @param encoded The encoded data to free (may be NULL)
+ * @param len The length of the encoded data in bytes
+ *
+ * @ingroup paste
+ */
+void ghostty_paste_encode_free(GhosttyAllocator* allocator,
+                               char* encoded,
+                               size_t len);
 
 #ifdef __cplusplus
 }

--- a/include/ghostty/vt/paste.h
+++ b/include/ghostty/vt/paste.h
@@ -75,7 +75,7 @@
  * char simple_paste[] = "pasted content";
  * char encoded[128];
  *
- * if (ghostty_paste_encoder_encode(simple_paste, strlen(simple_paste), encoder,
+ * if (ghostty_paste_encoder_encode(encoder, simple_paste, strlen(simple_paste),
  *                                  encoded, sizeof(encoded),
  *                                  &required) != GHOSTTY_SUCCESS) {
  *   printf("Failed to encode paste data\n");
@@ -197,9 +197,9 @@ void ghostty_paste_encoder_set_bracketed(GhosttyPasteEncoder encoder,
  * > WARNING: The input data is not checked for safety. See the
  * ghostty_paste_is_safe() function to check if the data is safe to paste.
  *
+ * @param encoder The paste encoder handle, (must not be NULL)
  * @param data The paste data to encode (must not be NULL)
  * @param len The length of the data in bytes
- * @param encoder The paste encoder handle, (must not be NULL)
  * @param out The output buffer to write the encoded data into (must not be
  * NULL)
  * @param out_len The length of the output buffer in bytes
@@ -209,9 +209,9 @@ void ghostty_paste_encoder_set_bracketed(GhosttyPasteEncoder encoder,
  *
  * @ingroup paste
  */
-GhosttyResult ghostty_paste_encoder_encode(char* data,
+GhosttyResult ghostty_paste_encoder_encode(GhosttyPasteEncoder encoder,
+                                           char* data,
                                            size_t len,
-                                           GhosttyPasteEncoder encoder,
                                            char* out,
                                            size_t out_len,
                                            size_t* out_written);

--- a/src/lib_vt.zig
+++ b/src/lib_vt.zig
@@ -126,6 +126,11 @@ comptime {
         @export(&c.key_encoder_setopt, .{ .name = "ghostty_key_encoder_setopt" });
         @export(&c.key_encoder_encode, .{ .name = "ghostty_key_encoder_encode" });
         @export(&c.paste_is_safe, .{ .name = "ghostty_paste_is_safe" });
+        @export(&c.paste_options_new, .{ .name = "ghostty_paste_options_new" });
+        @export(&c.paste_options_free, .{ .name = "ghostty_paste_options_free" });
+        @export(&c.paste_options_set_bracketed, .{ .name = "ghostty_paste_options_set_bracketed" });
+        @export(&c.paste_encode, .{ .name = "ghostty_paste_encode" });
+        @export(&c.paste_encode_free, .{ .name = "ghostty_paste_encode_free" });
 
         // On Wasm we need to export our allocator convenience functions.
         if (builtin.target.cpu.arch.isWasm()) {

--- a/src/lib_vt.zig
+++ b/src/lib_vt.zig
@@ -126,11 +126,10 @@ comptime {
         @export(&c.key_encoder_setopt, .{ .name = "ghostty_key_encoder_setopt" });
         @export(&c.key_encoder_encode, .{ .name = "ghostty_key_encoder_encode" });
         @export(&c.paste_is_safe, .{ .name = "ghostty_paste_is_safe" });
-        @export(&c.paste_options_new, .{ .name = "ghostty_paste_options_new" });
-        @export(&c.paste_options_free, .{ .name = "ghostty_paste_options_free" });
-        @export(&c.paste_options_set_bracketed, .{ .name = "ghostty_paste_options_set_bracketed" });
-        @export(&c.paste_encode, .{ .name = "ghostty_paste_encode" });
-        @export(&c.paste_encode_free, .{ .name = "ghostty_paste_encode_free" });
+        @export(&c.paste_encoder_new, .{ .name = "ghostty_paste_encoder_new" });
+        @export(&c.paste_encoder_free, .{ .name = "ghostty_paste_encoder_free" });
+        @export(&c.paste_encoder_set_bracketed, .{ .name = "ghostty_paste_encoder_set_bracketed" });
+        @export(&c.paste_encode, .{ .name = "ghostty_paste_encoder_encode" });
 
         // On Wasm we need to export our allocator convenience functions.
         if (builtin.target.cpu.arch.isWasm()) {

--- a/src/terminal/c/main.zig
+++ b/src/terminal/c/main.zig
@@ -35,11 +35,10 @@ pub const key_encoder_setopt = key_encode.setopt;
 pub const key_encoder_encode = key_encode.encode;
 
 pub const paste_is_safe = paste.is_safe;
-pub const paste_options_new = paste.options_new;
-pub const paste_options_free = paste.options_free;
-pub const paste_options_set_bracketed = paste.options_set_bracketed;
+pub const paste_encoder_new = paste.new;
+pub const paste_encoder_free = paste.free;
+pub const paste_encoder_set_bracketed = paste.encoder_set_bracketed;
 pub const paste_encode = paste.encode;
-pub const paste_encode_free = paste.encode_free;
 
 test {
     _ = osc;

--- a/src/terminal/c/main.zig
+++ b/src/terminal/c/main.zig
@@ -35,6 +35,11 @@ pub const key_encoder_setopt = key_encode.setopt;
 pub const key_encoder_encode = key_encode.encode;
 
 pub const paste_is_safe = paste.is_safe;
+pub const paste_options_new = paste.options_new;
+pub const paste_options_free = paste.options_free;
+pub const paste_options_set_bracketed = paste.options_set_bracketed;
+pub const paste_encode = paste.encode;
+pub const paste_encode_free = paste.encode_free;
 
 test {
     _ = osc;

--- a/src/terminal/c/paste.zig
+++ b/src/terminal/c/paste.zig
@@ -1,9 +1,144 @@
 const std = @import("std");
 const paste = @import("../../input/paste.zig");
+const lib_alloc = @import("../../lib/allocator.zig");
+const CAllocator = lib_alloc.Allocator;
+const Result = @import("result.zig").Result;
+
+/// C: GhosttyPasteOptions
+pub const Options = ?*paste.Options;
+
+pub fn options_new(
+    alloc_: ?*const CAllocator,
+    result: *Options,
+) callconv(.c) Result {
+    const alloc = lib_alloc.default(alloc_);
+    const ptr = alloc.create(paste.Options) catch
+        return .out_of_memory;
+    result.* = ptr;
+    return .success;
+}
+
+pub fn options_free(alloc_: ?*const CAllocator, options_: Options) callconv(.c) void {
+    const alloc = lib_alloc.default(alloc_);
+    const options = options_ orelse return;
+    alloc.destroy(options);
+}
+
+pub fn options_set_bracketed(options_: Options, enabled: bool) callconv(.c) void {
+    const options = options_ orelse return;
+    options.bracketed = enabled;
+}
+
+pub fn encode(
+    alloc_: ?*const CAllocator,
+    data_: ?[*]u8,
+    len: usize,
+    options_: Options,
+    out: ?*[*]u8,
+) callconv(.c) Result {
+    const alloc = lib_alloc.default(alloc_);
+    // make data mutable
+    const data: []u8 = if (data_) |d|
+        alloc.dupe(u8, d[0..len]) catch {
+            return .out_of_memory;
+        }
+    else
+        &.{};
+
+    const options = if (options_) |o| o else &paste.Options{ .bracketed = false };
+    const encoded: [3][]const u8 = paste.encode(data, options.*);
+
+    const buf = alloc.alloc(u8, encoded[0].len + encoded[1].len + encoded[2].len) catch
+        return .out_of_memory;
+    var offset: usize = 0;
+    for (encoded[0..]) |part| {
+        @memmove(buf[offset..][0..part.len], part);
+        offset += part.len;
+    }
+    if (out) |o| {
+        o.* = buf.ptr;
+    }
+    alloc.free(data);
+    return .success;
+}
+
+pub fn encode_free(alloc_: ?*const CAllocator, data: ?[*]u8, len: usize) callconv(.c) void {
+    const alloc = lib_alloc.default(alloc_);
+    if (data) |d| {
+        alloc.free(d[0..len]);
+    }
+}
 
 pub fn is_safe(data: ?[*]const u8, len: usize) callconv(.c) bool {
     const slice: []const u8 = if (data) |v| v[0..len] else &.{};
     return paste.isSafe(slice);
+}
+
+test "alloc options" {
+    const testing = std.testing;
+    var opts: Options = null;
+    try testing.expectEqual(Result.success, options_new(&lib_alloc.test_allocator, &opts));
+    try testing.expect(opts != null);
+    options_free(&lib_alloc.test_allocator, opts);
+}
+
+test "set bracketed" {
+    const testing = std.testing;
+    var opts: Options = null;
+    try testing.expectEqual(Result.success, options_new(&lib_alloc.test_allocator, &opts));
+    try testing.expect(opts != null);
+    options_set_bracketed(opts, true);
+    try testing.expect(opts.?.bracketed);
+    options_free(&lib_alloc.test_allocator, opts);
+}
+
+test "encode simple" {
+    const testing = std.testing;
+    var out: ?[*]u8 = null;
+    const data = "hello world";
+
+    var opts: Options = null;
+    try testing.expectEqual(Result.success, options_new(&lib_alloc.test_allocator, &opts));
+    try testing.expect(opts != null);
+
+    try testing.expectEqual(
+        Result.success,
+        encode(
+            &lib_alloc.test_allocator,
+            data.ptr,
+            data.len,
+            opts,
+            &out,
+        ),
+    );
+    try testing.expect(out != null);
+    try testing.expectEqualStrings("hello world", out.?[0..data.len]);
+    encode_free(&lib_alloc.test_allocator, out, data.len);
+}
+
+test "encode bracketed" {
+    const testing = std.testing;
+    var opts: Options = null;
+    try testing.expectEqual(Result.success, options_new(&lib_alloc.test_allocator, &opts));
+    try testing.expect(opts != null);
+    options_set_bracketed(opts, true);
+
+    var out: ?[*]u8 = null;
+    const data = "hello world";
+    try testing.expectEqual(
+        Result.success,
+        encode(
+            &lib_alloc.test_allocator,
+            data.ptr,
+            data.len,
+            opts,
+            &out,
+        ),
+    );
+    try testing.expect(out != null);
+    try testing.expectEqualStrings("\x1b[200~hello world\x1b[201~", out.?[0 .. data.len + 12]);
+    encode_free(&lib_alloc.test_allocator, out, data.len + 12);
+    options_free(&lib_alloc.test_allocator, opts);
 }
 
 test "is_safe with safe data" {


### PR DESCRIPTION
As the title says, I exported the paste encoding function using the same pattern as with the key encoder. The GhosttyPasteEncoder is just a wrapper around the paste.Options and the allocator to keep track of. 
Here is an example how it can be used: 
```c
 #include <ghostty/vt.h>
#include <stdbool.h>
#include <stdio.h>
#include <string.h>

int main() {
// Create a paste encoder
GhosttyPasteEncoder encoder;
if (ghostty_paste_encoder_new(NULL, &encoder) != GHOSTTY_SUCCESS) {
  printf("Failed to create paste encoder\n");
  return 1;
}

// Enable bracketed paste mode
ghostty_paste_encoder_set_bracketed(encoder, true);

// we could use this to find out the required size, or just use a large
// enough buffer
size_t required;
char simple_paste[] = "pasted content";
char encoded[128];

if (ghostty_paste_encoder_encode(simple_paste, strlen(simple_paste), encoder,
                                 encoded, sizeof(encoded),
                                 &required) != GHOSTTY_SUCCESS) {
  printf("Failed to encode paste data\n");
  return 1;
}

printf("Encoded paste data: ");
for (size_t i = 0; i < strlen(encoded); i++) {
  if (encoded[i] == 0x1b) {
    printf("\\x1b");
  } else {
    printf("%c", encoded[i]);
  }
}

 // free resources
 ghostty_paste_encoder_free(encoder);
} 
```
(Mitchellh said in the discord that he would be interested in some help and wants small PRs so I didnt open an issue just for this).