### PR TITLE
gtk: Scrollbars

### DIFF
--- a/src/apprt/gtk/build/gresource.zig
+++ b/src/apprt/gtk/build/gresource.zig
@@ -46,6 +46,7 @@ pub const blueprints: []const Blueprint = &.{
     .{ .major = 1, .minor = 5, .name = "split-tree" },
     .{ .major = 1, .minor = 5, .name = "split-tree-split" },
     .{ .major = 1, .minor = 2, .name = "surface" },
+    .{ .major = 1, .minor = 5, .name = "surface-scrolled-window" },
     .{ .major = 1, .minor = 5, .name = "surface-title-dialog" },
     .{ .major = 1, .minor = 3, .name = "surface-child-exited" },
     .{ .major = 1, .minor = 5, .name = "tab" },

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -709,6 +709,8 @@ pub const Application = extern struct {
 
             .ring_bell => Action.ringBell(target),
 
+            .scrollbar => Action.scrollbar(target, value),
+
             .set_title => Action.setTitle(target, value),
 
             .show_child_exited => return Action.showChildExited(target, value),
@@ -728,7 +730,6 @@ pub const Application = extern struct {
             .command_finished => return Action.commandFinished(target, value),
 
             // Unimplemented
-            .scrollbar,
             .secure_input,
             .close_all_windows,
             .float_window,
@@ -2325,6 +2326,16 @@ const Action = struct {
         switch (target) {
             .app => {},
             .surface => |v| v.rt_surface.surface.setBellRinging(true),
+        }
+    }
+
+    pub fn scrollbar(
+        target: apprt.Target,
+        value: apprt.Action.Value(.scrollbar),
+    ) void {
+        switch (target) {
+            .app => {},
+            .surface => |v| v.rt_surface.surface.setScrollbar(value),
         }
     }
 

--- a/src/apprt/gtk/class/split_tree.zig
+++ b/src/apprt/gtk/class/split_tree.zig
@@ -22,6 +22,7 @@ const Config = @import("config.zig").Config;
 const Application = @import("application.zig").Application;
 const CloseConfirmationDialog = @import("close_confirmation_dialog.zig").CloseConfirmationDialog;
 const Surface = @import("surface.zig").Surface;
+const SurfaceScrolledWindow = @import("surface_scrolled_window.zig").SurfaceScrolledWindow;
 
 const log = std.log.scoped(.gtk_ghostty_split_tree);
 
@@ -874,7 +875,9 @@ pub const SplitTree = extern struct {
         current: Surface.Tree.Node.Handle,
     ) *gtk.Widget {
         return switch (tree.nodes[current.idx()]) {
-            .leaf => |v| v.as(gtk.Widget),
+            .leaf => |v| gobject.ext.newInstance(SurfaceScrolledWindow, .{
+                .surface = v,
+            }).as(gtk.Widget),
             .split => |s| SplitTreeSplit.new(
                 current,
                 &s,

--- a/src/apprt/gtk/class/surface_scrolled_window.zig
+++ b/src/apprt/gtk/class/surface_scrolled_window.zig
@@ -1,0 +1,209 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const adw = @import("adw");
+const gobject = @import("gobject");
+const gtk = @import("gtk");
+
+const gresource = @import("../build/gresource.zig");
+const Common = @import("../class.zig").Common;
+const Surface = @import("surface.zig").Surface;
+const Config = @import("config.zig").Config;
+
+const log = std.log.scoped(.gtk_ghostty_surface_scrolled_window);
+
+/// A wrapper widget that embeds a Surface inside a GtkScrolledWindow.
+/// This provides scrollbar functionality for the terminal surface.
+/// The surface property can be set during initialization or changed
+/// dynamically via the surface property.
+pub const SurfaceScrolledWindow = extern struct {
+    const Self = @This();
+    parent_instance: Parent,
+    pub const Parent = adw.Bin;
+    pub const getGObjectType = gobject.ext.defineClass(Self, .{
+        .name = "GhostttySurfaceScrolledWindow",
+        .instanceInit = &init,
+        .classInit = &Class.init,
+        .parent_class = &Class.parent,
+        .private = .{ .Type = Private, .offset = &Private.offset },
+    });
+
+    pub const properties = struct {
+        pub const config = struct {
+            pub const name = "config";
+            const impl = gobject.ext.defineProperty(
+                name,
+                Self,
+                ?*Config,
+                .{
+                    .accessor = C.privateObjFieldAccessor("config"),
+                },
+            );
+        };
+
+        pub const surface = struct {
+            pub const name = "surface";
+            const impl = gobject.ext.defineProperty(
+                name,
+                Self,
+                ?*Surface,
+                .{
+                    .accessor = .{
+                        .getter = getSurfaceValue,
+                        .setter = setSurfaceValue,
+                    },
+                },
+            );
+        };
+    };
+
+    const Private = struct {
+        config: ?*Config = null,
+        config_binding: ?*gobject.Binding = null,
+        surface: ?*Surface = null,
+        pub var offset: c_int = 0;
+    };
+
+    fn init(self: *Self, _: *Class) callconv(.c) void {
+        gtk.Widget.initTemplate(self.as(gtk.Widget));
+    }
+
+    fn dispose(self: *Self) callconv(.c) void {
+        const priv = self.private();
+
+        if (priv.config_binding) |binding| {
+            binding.as(gobject.Object).unref();
+            priv.config_binding = null;
+        }
+
+        if (priv.config) |v| {
+            v.unref();
+            priv.config = null;
+        }
+
+        gtk.Widget.disposeTemplate(
+            self.as(gtk.Widget),
+            getGObjectType(),
+        );
+
+        gobject.Object.virtual_methods.dispose.call(
+            Class.parent,
+            self.as(Parent),
+        );
+    }
+
+    fn finalize(self: *Self) callconv(.c) void {
+        gobject.Object.virtual_methods.finalize.call(
+            Class.parent,
+            self.as(Parent),
+        );
+    }
+
+    fn getSurfaceValue(self: *Self, value: *gobject.Value) void {
+        gobject.ext.Value.set(
+            value,
+            self.private().surface,
+        );
+    }
+
+    fn setSurfaceValue(self: *Self, value: *const gobject.Value) void {
+        self.setSurface(gobject.ext.Value.get(
+            value,
+            ?*Surface,
+        ));
+    }
+
+    pub fn getSurface(self: *Self) ?*Surface {
+        return self.private().surface;
+    }
+
+    pub fn setSurface(self: *Self, surface_: ?*Surface) void {
+        const priv = self.private();
+
+        if (surface_ == priv.surface) return;
+
+        self.as(gobject.Object).freezeNotify();
+        defer self.as(gobject.Object).thawNotify();
+        self.as(gobject.Object).notifyByPspec(properties.surface.impl.param_spec);
+
+        priv.surface = surface_;
+    }
+
+    fn closureScrollbarPolicy(
+        _: *Self,
+        config_: ?*Config,
+    ) callconv(.c) gtk.PolicyType {
+        const config = if (config_) |c| c.get() else return .automatic;
+        return switch (config.scrollbar) {
+            .never => .never,
+            .system => .automatic,
+        };
+    }
+
+    fn propSurface(
+        self: *Self,
+        _: *gobject.ParamSpec,
+        _: ?*anyopaque,
+    ) callconv(.c) void {
+        const priv = self.private();
+        const child: *gtk.Widget = self.as(Parent).getChild().?;
+        const scrolled_window = gobject.ext.cast(gtk.ScrolledWindow, child).?;
+        scrolled_window.setChild(if (priv.surface) |s| s.as(gtk.Widget) else null);
+
+        // Unbind old config binding if it exists
+        if (priv.config_binding) |binding| {
+            binding.as(gobject.Object).unref();
+            priv.config_binding = null;
+        }
+
+        // Bind config from surface to our config property
+        if (priv.surface) |surface| {
+            priv.config_binding = surface.as(gobject.Object).bindProperty(
+                properties.config.name,
+                self.as(gobject.Object),
+                properties.config.name,
+                .{ .sync_create = true },
+            );
+        }
+    }
+
+    const C = Common(Self, Private);
+    pub const as = C.as;
+    pub const ref = C.ref;
+    pub const unref = C.unref;
+    const private = C.private;
+
+    pub const Class = extern struct {
+        parent_class: Parent.Class,
+        var parent: *Parent.Class = undefined;
+        pub const Instance = Self;
+
+        fn init(class: *Class) callconv(.c) void {
+            gtk.Widget.Class.setTemplateFromResource(
+                class.as(gtk.Widget.Class),
+                comptime gresource.blueprint(.{
+                    .major = 1,
+                    .minor = 5,
+                    .name = "surface-scrolled-window",
+                }),
+            );
+
+            // Bindings
+            class.bindTemplateCallback("scrollbar_policy", &closureScrollbarPolicy);
+            class.bindTemplateCallback("notify_surface", &propSurface);
+
+            // Properties
+            gobject.ext.registerProperties(class, &.{
+                properties.config.impl,
+                properties.surface.impl,
+            });
+
+            // Virtual methods
+            gobject.Object.virtual_methods.dispose.implement(class, &dispose);
+            gobject.Object.virtual_methods.finalize.implement(class, &finalize);
+        }
+
+        pub const as = C.Class.as;
+        pub const bindTemplateChildPrivate = C.Class.bindTemplateChildPrivate;
+        pub const bindTemplateCallback = C.Class.bindTemplateCallback;
+    };
+};

--- a/src/apprt/gtk/ui/1.2/surface.blp
+++ b/src/apprt/gtk/ui/1.2/surface.blp
@@ -174,6 +174,7 @@ template $GhosttySurface: Adw.Bin {
   notify::mouse-hover-url => $notify_mouse_hover_url();
   notify::mouse-hidden => $notify_mouse_hidden();
   notify::mouse-shape => $notify_mouse_shape();
+  notify::vadjustment => $notify_vadjustment();
   // Some history: we used to use a Stack here and swap between the
   // terminal and error pages as needed. But a Stack doesn't play nice
   // with our SplitTree and Gtk.Paned usage[^1]. Replacing this with

--- a/src/apprt/gtk/ui/1.5/surface-scrolled-window.blp
+++ b/src/apprt/gtk/ui/1.5/surface-scrolled-window.blp
@@ -1,0 +1,11 @@
+using Gtk 4.0;
+using Adw 1;
+
+template $GhostttySurfaceScrolledWindow: Adw.Bin {
+  notify::surface => $notify_surface();
+
+  Gtk.ScrolledWindow {
+    hscrollbar-policy: never;
+    vscrollbar-policy: bind $scrollbar_policy(template.config) as <Gtk.PolicyType>;
+  }
+}


### PR DESCRIPTION
Fixes #111 

This builds on the prior work and adds scrollbars to the GTK application. After this PR, both the macOS and GTK applications support scrollbars and #111 can be closed.

## TODO

- [x] Verify that with text coming out if we manually scroll to the bottom we bind to the bottom
- [x] Valgrind checks