### PR TITLE
macOS: AppleScript

### DIFF
--- a/macos/Ghostty-Info.plist
+++ b/macos/Ghostty-Info.plist
@@ -100,5 +100,9 @@
 	<false/>
 	<key>SUPublicEDKey</key>
 	<string>wsNcGf5hirwtdXMVnYoxRIX/SqZQLMOsYlD3q3imeok=</string>
+	<key>NSAppleScriptEnabled</key>
+	<true/>
+	<key>OSAScriptingDefinition</key>
+	<string>Ghostty.sdef</string>
 </dict>
 </plist>

--- a/macos/Sources/App/macOS/AppleScript.swift
+++ b/macos/Sources/App/macOS/AppleScript.swift
@@ -1,12 +1,19 @@
 import Foundation
 import Cocoa
 
+
 @objc(GhosttyScriptNewWindowCommand)
 class ScriptNewWindowCommand: NSScriptCommand {
     override func performDefaultImplementation() -> Any? {
         print("ScriptNewWindowCommand called")
         if let appDelegate = NSApplication.shared.delegate as? AppDelegate {
-            _ = TerminalController.newWindow(appDelegate.ghostty)
+            var config: Ghostty.SurfaceConfiguration? = nil
+            if let command = evaluatedArguments?["command"] as? String {
+                config = Ghostty.SurfaceConfiguration()
+                config?.command = command
+                config?.waitAfterCommand = false
+            }
+            _ = TerminalController.newWindow(appDelegate.ghostty, withBaseConfig: config)
         }
         return nil
     }
@@ -17,10 +24,16 @@ class ScriptNewTabCommand: NSScriptCommand {
     override func performDefaultImplementation() -> Any? {
         print("ScriptNewTabCommand called")
         if let appDelegate = NSApplication.shared.delegate as? AppDelegate {
+            var config: Ghostty.SurfaceConfiguration? = nil
+            if let command = evaluatedArguments?["command"] as? String {
+                config = Ghostty.SurfaceConfiguration()
+                config?.command = command
+                config?.waitAfterCommand = false
+            }
             _ = TerminalController.newTab(
                 appDelegate.ghostty,
                 from: TerminalController.preferredParent?.window,
-                withBaseConfig: nil
+                withBaseConfig: config
             )
         }
         return nil

--- a/macos/Sources/App/macOS/AppleScript.swift
+++ b/macos/Sources/App/macOS/AppleScript.swift
@@ -10,8 +10,16 @@ class ScriptNewWindowCommand: NSScriptCommand {
             var config: Ghostty.SurfaceConfiguration? = nil
             if let command = evaluatedArguments?["command"] as? String {
                 config = Ghostty.SurfaceConfiguration()
-                config?.command = command
-                config?.waitAfterCommand = false
+                let wait = evaluatedArguments?["wait"] as? Bool ?? false
+                if wait {
+                    // Use command-based approach (forces waiting)
+                    config?.command = command
+                    config?.waitAfterCommand = true
+                } else {
+                    // Use initialInput approach (no waiting)
+                    config?.initialInput = "\(command); exit\n"
+                    config?.waitAfterCommand = false
+                }
             }
             _ = TerminalController.newWindow(appDelegate.ghostty, withBaseConfig: config)
         }
@@ -27,8 +35,16 @@ class ScriptNewTabCommand: NSScriptCommand {
             var config: Ghostty.SurfaceConfiguration? = nil
             if let command = evaluatedArguments?["command"] as? String {
                 config = Ghostty.SurfaceConfiguration()
-                config?.command = command
-                config?.waitAfterCommand = false
+                let wait = evaluatedArguments?["wait"] as? Bool ?? false
+                if wait {
+                    // Use command-based approach (forces waiting)
+                    config?.command = command
+                    config?.waitAfterCommand = true
+                } else {
+                    // Use initialInput approach (no waiting)
+                    config?.initialInput = "\(command); exit\n"
+                    config?.waitAfterCommand = false
+                }
             }
             _ = TerminalController.newTab(
                 appDelegate.ghostty,

--- a/macos/Sources/App/macOS/AppleScript.swift
+++ b/macos/Sources/App/macOS/AppleScript.swift
@@ -11,15 +11,8 @@ class ScriptNewWindowCommand: NSScriptCommand {
             if let command = evaluatedArguments?["command"] as? String {
                 config = Ghostty.SurfaceConfiguration()
                 let wait = evaluatedArguments?["wait"] as? Bool ?? false
-                if wait {
-                    // Use command-based approach (forces waiting)
-                    config?.command = command
-                    config?.waitAfterCommand = true
-                } else {
-                    // Use initialInput approach (no waiting)
-                    config?.initialInput = "\(command); exit\n"
-                    config?.waitAfterCommand = false
-                }
+                config?.initialInput = "\(command); exit\n"
+                config?.waitAfterCommand = wait
             }
             _ = TerminalController.newWindow(appDelegate.ghostty, withBaseConfig: config)
         }
@@ -36,15 +29,8 @@ class ScriptNewTabCommand: NSScriptCommand {
             if let command = evaluatedArguments?["command"] as? String {
                 config = Ghostty.SurfaceConfiguration()
                 let wait = evaluatedArguments?["wait"] as? Bool ?? false
-                if wait {
-                    // Use command-based approach (forces waiting)
-                    config?.command = command
-                    config?.waitAfterCommand = true
-                } else {
-                    // Use initialInput approach (no waiting)
-                    config?.initialInput = "\(command); exit\n"
-                    config?.waitAfterCommand = false
-                }
+                config?.initialInput = "\(command); exit\n"
+                config?.waitAfterCommand = wait
             }
             _ = TerminalController.newTab(
                 appDelegate.ghostty,

--- a/macos/Sources/App/macOS/AppleScript.swift
+++ b/macos/Sources/App/macOS/AppleScript.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Cocoa
+
+@objc(GhosttyScriptNewWindowCommand)
+class ScriptNewWindowCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+        print("ScriptNewWindowCommand called")
+        if let appDelegate = NSApplication.shared.delegate as? AppDelegate {
+            _ = TerminalController.newWindow(appDelegate.ghostty)
+        }
+        return nil
+    }
+}
+
+@objc(GhosttyScriptNewTabCommand)
+class ScriptNewTabCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+        print("ScriptNewTabCommand called")
+        if let appDelegate = NSApplication.shared.delegate as? AppDelegate {
+            _ = TerminalController.newTab(
+                appDelegate.ghostty,
+                from: TerminalController.preferredParent?.window,
+                withBaseConfig: nil
+            )
+        }
+        return nil
+    }
+}

--- a/macos/Sources/App/macOS/Ghostty.sdef
+++ b/macos/Sources/App/macOS/Ghostty.sdef
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE dictionary SYSTEM "file://localhost/System/Library/DTDs/sdef.dtd">
+<dictionary title="Ghostty Terminology">
+  <suite name="Ghostty Suite" code="Ghst" description="Commands and objects for Ghostty">
+    <class name="application" code="capp" description="The Ghostty application">
+      <cocoa class="NSApplication"/>
+      <property name="name" code="pnam" type="text" access="r" description="The name of the application"/>
+    </class>
+
+    <class name="window" code="cwin" description="A Ghostty window">
+      <cocoa class="GhosttyWindow"/>
+      <property name="id" code="ID  " type="integer" access="r" description="Unique ID of the window"/>
+      <property name="name" code="pnam" type="text" access="r" description="Name of the window"/>
+    </class>
+
+    <command name="new window" code="GhstNwin" description="Create a new window">
+      <cocoa class="Ghostty.ScriptNewWindowCommand"/>
+      <parameter name="with properties" code="prdt" type="record" optional="yes" description="Properties for the new window"/>
+    </command>
+    <command name="new tab" code="GhstNtab" description="Create a new tab">
+      <cocoa class="Ghostty.ScriptNewTabCommand"/>
+      <parameter name="with properties" code="prdt" type="record" optional="yes" description="Properties for the new tab"/>
+    </command>
+  </suite>
+</dictionary>

--- a/macos/Sources/App/macOS/Ghostty.sdef
+++ b/macos/Sources/App/macOS/Ghostty.sdef
@@ -3,6 +3,12 @@
 <dictionary title="Ghostty Terminology">
   <suite name="Standard Suite" code="????"
     description="Common classes and commands for all applications.">
+    <enumeration name="save options" code="savo">
+      <enumerator name="yes" code="yes " description="Save the file." />
+      <enumerator name="no" code="no  " description="Do not save the file." />
+      <enumerator name="ask" code="ask "
+        description="Ask the user whether or not to save the file." />
+    </enumeration>
     <command name="quit" code="aevtquit" description="Quit the application.">
       <cocoa class="NSQuitCommand" />
       <parameter name="saving" code="savo" type="save options" optional="yes"
@@ -114,13 +120,15 @@
   <suite name="Ghostty Suite" code="Ghst" description="Commands and objects for Ghostty">
     <command name="create window" code="GhstNwin" description="Create a new window">
       <cocoa class="Ghostty.ScriptNewWindowCommand" />
-      <parameter name="with properties" code="prdt" type="record" optional="yes"
-        description="Properties for the new window" />
+      <parameter name="command" code="cmd " type="text" optional="yes"
+        description="The shell command to execute in the new window" />
     </command>
     <command name="create tab" code="GhstNtab" description="Create a new tab">
       <cocoa class="Ghostty.ScriptNewTabCommand" />
-      <parameter name="with properties" code="prdt" type="record" optional="yes"
-        description="Properties for the new tab" />
+      <parameter name="command" code="cmd " type="text" optional="yes"
+        description="The shell command to execute in the new tab" />
     </command>
+    <class name="tab" code="Gtab" description="A Ghostty tab">
+    </class>
   </suite>
 </dictionary>

--- a/macos/Sources/App/macOS/Ghostty.sdef
+++ b/macos/Sources/App/macOS/Ghostty.sdef
@@ -122,11 +122,15 @@
       <cocoa class="Ghostty.ScriptNewWindowCommand" />
       <parameter name="command" code="cmd " type="text" optional="yes"
         description="The shell command to execute in the new window" />
+      <parameter name="wait" code="wait" type="boolean" optional="yes"
+        description="Wait after the command exits" />
     </command>
     <command name="create tab" code="GhstNtab" description="Create a new tab">
       <cocoa class="Ghostty.ScriptNewTabCommand" />
       <parameter name="command" code="cmd " type="text" optional="yes"
         description="The shell command to execute in the new tab" />
+      <parameter name="wait" code="wait" type="boolean" optional="yes"
+        description="Wait after the command exits" />
     </command>
     <class name="tab" code="Gtab" description="A Ghostty tab">
     </class>

--- a/macos/Sources/App/macOS/Ghostty.sdef
+++ b/macos/Sources/App/macOS/Ghostty.sdef
@@ -1,25 +1,126 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE dictionary SYSTEM "file://localhost/System/Library/DTDs/sdef.dtd">
 <dictionary title="Ghostty Terminology">
-  <suite name="Ghostty Suite" code="Ghst" description="Commands and objects for Ghostty">
-    <class name="application" code="capp" description="The Ghostty application">
-      <cocoa class="NSApplication"/>
-      <property name="name" code="pnam" type="text" access="r" description="The name of the application"/>
-    </class>
-
-    <class name="window" code="cwin" description="A Ghostty window">
-      <cocoa class="GhosttyWindow"/>
-      <property name="id" code="ID  " type="integer" access="r" description="Unique ID of the window"/>
-      <property name="name" code="pnam" type="text" access="r" description="Name of the window"/>
-    </class>
-
-    <command name="new window" code="GhstNwin" description="Create a new window">
-      <cocoa class="Ghostty.ScriptNewWindowCommand"/>
-      <parameter name="with properties" code="prdt" type="record" optional="yes" description="Properties for the new window"/>
+  <suite name="Standard Suite" code="????"
+    description="Common classes and commands for all applications.">
+    <command name="quit" code="aevtquit" description="Quit the application.">
+      <cocoa class="NSQuitCommand" />
+      <parameter name="saving" code="savo" type="save options" optional="yes"
+        description="Should changes be saved before quitting?">
+        <cocoa key="SaveOptions" />
+      </parameter>
     </command>
-    <command name="new tab" code="GhstNtab" description="Create a new tab">
-      <cocoa class="Ghostty.ScriptNewTabCommand"/>
-      <parameter name="with properties" code="prdt" type="record" optional="yes" description="Properties for the new tab"/>
+
+    <command name="count" code="corecnte"
+      description="Return the number of elements of a particular class within an object.">
+      <cocoa class="NSCountCommand" />
+      <access-group identifier="*" />
+      <direct-parameter type="specifier" requires-access="r"
+        description="The objects to be counted." />
+      <parameter name="each" code="kocl" type="type" optional="yes"
+        description="The class of objects to be counted." hidden="yes">
+        <cocoa key="ObjectClass" />
+      </parameter>
+      <result type="integer" description="The count." />
+    </command>
+
+    <command name="delete" code="coredelo" description="Delete an object.">
+      <cocoa class="NSDeleteCommand" />
+      <access-group identifier="*" />
+      <direct-parameter type="specifier" description="The object(s) to delete." />
+    </command>
+
+    <command name="duplicate" code="coreclon" description="Copy an object.">
+      <cocoa class="NSCloneCommand" />
+      <access-group identifier="*" />
+      <direct-parameter type="specifier" requires-access="r" description="The object(s) to copy." />
+      <parameter name="to" code="insh" type="location specifier"
+        description="The location for the new copy or copies." optional="yes">
+        <cocoa key="ToLocation" />
+      </parameter>
+      <parameter name="with properties" code="prdt" type="record"
+        description="Properties to set in the new copy or copies right away." optional="yes">
+        <cocoa key="WithProperties" />
+      </parameter>
+    </command>
+
+    <command name="exists" code="coredoex" description="Verify that an object exists.">
+      <cocoa class="NSExistsCommand" />
+      <access-group identifier="*" />
+      <direct-parameter type="any" requires-access="r" description="The object(s) to check." />
+      <result type="boolean" description="Did the object(s) exist?" />
+    </command>
+
+    <command name="make" code="corecrel" description="Create a new object.">
+      <cocoa class="NSCreateCommand" />
+      <access-group identifier="*" />
+      <parameter name="new" code="kocl" type="type" description="The class of the new object.">
+        <cocoa key="ObjectClass" />
+      </parameter>
+      <parameter name="at" code="insh" type="location specifier" optional="yes"
+        description="The location at which to insert the object.">
+        <cocoa key="Location" />
+      </parameter>
+      <parameter name="with data" code="data" type="any" optional="yes"
+        description="The initial contents of the object.">
+        <cocoa key="ObjectData" />
+      </parameter>
+      <parameter name="with properties" code="prdt" type="record" optional="yes"
+        description="The initial values for properties of the object.">
+        <cocoa key="KeyDictionary" />
+      </parameter>
+      <result type="specifier" description="The new object." />
+    </command>
+
+    <command name="move" code="coremove" description="Move an object to a new location.">
+      <cocoa class="NSMoveCommand" />
+      <access-group identifier="*" />
+      <direct-parameter type="specifier" requires-access="r" description="The object(s) to move." />
+      <parameter name="to" code="insh" type="location specifier"
+        description="The new location for the object(s).">
+        <cocoa key="ToLocation" />
+      </parameter>
+    </command>
+
+    <class name="application" code="capp"
+      description="The application's top-level scripting object.">
+      <cocoa class="NSApplication" />
+      <property name="name" code="pnam" type="text" access="r"
+        description="The name of the application." />
+      <property name="frontmost" code="pisf" type="boolean" access="r"
+        description="Is this the active application?">
+        <cocoa key="isActive" />
+      </property>
+      <property name="version" code="vers" type="text" access="r"
+        description="The version number of the application." />
+      <element type="window" access="r">
+        <cocoa key="orderedWindows" />
+      </element>
+      <property name="current window" code="Crwn" type="window"
+        description="The frontmost window">
+        <cocoa key="currentScriptingWindow" />
+      </property>
+    </class>
+    <class name="window" code="cwin" description="A Ghostty window">
+      <cocoa class="GhosttyWindow" />
+      <property name="id" code="ID  " type="integer" access="r"
+        description="Unique ID of the window" />
+      <property name="name" code="pnam" type="text" access="r" description="Name of the window" />
+      <element type="tab" access="r">
+        <cocoa key="tabs" />
+      </element>
+    </class>
+  </suite>
+  <suite name="Ghostty Suite" code="Ghst" description="Commands and objects for Ghostty">
+    <command name="create window" code="GhstNwin" description="Create a new window">
+      <cocoa class="Ghostty.ScriptNewWindowCommand" />
+      <parameter name="with properties" code="prdt" type="record" optional="yes"
+        description="Properties for the new window" />
+    </command>
+    <command name="create tab" code="GhstNtab" description="Create a new tab">
+      <cocoa class="Ghostty.ScriptNewTabCommand" />
+      <parameter name="with properties" code="prdt" type="record" optional="yes"
+        description="Properties for the new tab" />
     </command>
   </suite>
 </dictionary>


### PR DESCRIPTION
WIP.

WORKING:
tell application "Ghostty" to create window
tell application "Ghostty" to create tab

tell application "Ghostty" to create window command "btop"
tell application "Ghostty" to create tab command "btop"

tell application "Ghostty" to create window command "btop" with wait
tell application "Ghostty" to create tab command "btop" with wait


use initialInput not command for no wait to override:

https://github.com/ghostty-org/ghostty/blob/dffa4f4fc73798a3128efae4ee7b0ff099c97afe/src/apprt/embedded.zig#L511-L517

overrides config.waitForCommand when command is set.

NOT-WORKING:
Added some applicable standard definitions stubs from 
/System/Library/ScriptingDefinitions/CocoaStandard.sdef


