### PR TITLE
renderer: force a full rebuild on any font grid change

### DIFF
--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1068,6 +1068,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
             // Update relevant uniforms
             self.updateFontGridUniforms();
+
+            // Force a full rebuild, because cached rows may still reference
+            // an outdated atlas from the old grid and this can cause garbage
+            // to be rendered.
+            self.cells_viewport = null;
         }
 
         /// Update uniforms that are based on the font grid.


### PR DESCRIPTION
Fixes #2731 (again)

This regressed in 1.2 due to the renderer rework missing porting this. I believe this issue is still valid even with the rework since the font grid changes the atlas and if there are still cached cells that reference the old atlas coordinates it will produce garbage.