### PR TITLE
macOS: Always handle background rendering in `TerminalWindow`

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -562,19 +562,16 @@ class QuickTerminalController: BaseTerminalController {
         // Some APIs such as window blur have no effect unless the window is visible.
         guard window.isVisible else { return }
 
-        // If we have window transparency then set it transparent. Otherwise set it opaque.
-        if (self.derivedConfig.backgroundOpacity < 1) {
-            window.isOpaque = false
+        let alpha = self.derivedConfig.backgroundOpacity.clamped(to: 0.001...1)
+        window.backgroundColor = self.derivedConfig.backgroundColor.withAlphaComponent(alpha)
 
-            // This is weird, but we don't use ".clear" because this creates a look that
-            // matches Terminal.app much more closer. This lets users transition from
-            // Terminal.app more easily.
-            window.backgroundColor = .white.withAlphaComponent(0.001)
+        // If we have window transparency then set it transparent. Otherwise set it opaque.
+        if (alpha < 1) {
+            window.isOpaque = false
 
             ghostty_set_window_background_blur(ghostty.app, Unmanaged.passUnretained(window).toOpaque())
         } else {
             window.isOpaque = true
-            window.backgroundColor = .windowBackgroundColor
         }
     }
 
@@ -675,6 +672,7 @@ class QuickTerminalController: BaseTerminalController {
         let quickTerminalAutoHide: Bool
         let quickTerminalSpaceBehavior: QuickTerminalSpaceBehavior
         let quickTerminalSize: QuickTerminalSize
+        let backgroundColor: NSColor
         let backgroundOpacity: Double
 
         init() {
@@ -683,6 +681,7 @@ class QuickTerminalController: BaseTerminalController {
             self.quickTerminalAutoHide = true
             self.quickTerminalSpaceBehavior = .move
             self.quickTerminalSize = QuickTerminalSize()
+            self.backgroundColor = .windowBackgroundColor
             self.backgroundOpacity = 1.0
         }
 
@@ -692,6 +691,7 @@ class QuickTerminalController: BaseTerminalController {
             self.quickTerminalAutoHide = config.quickTerminalAutoHide
             self.quickTerminalSpaceBehavior = config.quickTerminalSpaceBehavior
             self.quickTerminalSize = config.quickTerminalSize
+            self.backgroundColor = NSColor(config.backgroundColor)
             self.backgroundOpacity = config.backgroundOpacity
         }
     }

--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -413,11 +413,7 @@ class TerminalWindow: NSWindow {
             surfaceConfig.backgroundOpacity < 1
         {
             isOpaque = false
-
-            // This is weird, but we don't use ".clear" because this creates a look that
-            // matches Terminal.app much more closer. This lets users transition from
-            // Terminal.app more easily.
-            backgroundColor = .white.withAlphaComponent(0.001)
+            self.backgroundColor = preferredBackgroundColor
 
             if let appDelegate = NSApp.delegate as? AppDelegate {
                 ghostty_set_window_background_blur(
@@ -426,9 +422,7 @@ class TerminalWindow: NSWindow {
             }
         } else {
             isOpaque = true
-
-            let backgroundColor = preferredBackgroundColor ?? NSColor(surfaceConfig.backgroundColor)
-            self.backgroundColor = backgroundColor.withAlphaComponent(1)
+            self.backgroundColor = preferredBackgroundColor.withAlphaComponent(1.0)
         }
     }
 
@@ -437,7 +431,7 @@ class TerminalWindow: NSWindow {
     ///
     /// This background color will include alpha transparency if set. If the caller doesn't want that,
     /// change the alpha channel again manually.
-    var preferredBackgroundColor: NSColor? {
+    var preferredBackgroundColor: NSColor {
         if let terminalController, !terminalController.surfaceTree.isEmpty {
             let surface: Ghostty.SurfaceView?
 

--- a/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsVenturaTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsVenturaTerminalWindow.swift
@@ -149,11 +149,7 @@ class TitlebarTabsVenturaTerminalWindow: TerminalWindow {
         isLightTheme = OSColor(surfaceConfig.backgroundColor).isLightColor
 
         // Update our titlebar color
-        if let preferredBackgroundColor {
-            titlebarColor = preferredBackgroundColor
-        } else {
-            titlebarColor = derivedConfig.backgroundColor.withAlphaComponent(derivedConfig.backgroundOpacity)
-        }
+        titlebarColor = self.backgroundColor
 
         if (isOpaque || themeChanged) {
             // If there is transparency, calling this will make the titlebar opaque

--- a/macos/Sources/Features/Terminal/Window Styles/TransparentTitlebarTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TransparentTitlebarTerminalWindow.swift
@@ -76,15 +76,16 @@ class TransparentTitlebarTerminalWindow: TerminalWindow {
 
     @available(macOS 26.0, *)
     private func syncAppearanceTahoe(_ surfaceConfig: Ghostty.SurfaceView.DerivedConfig) {
-        // When we have transparency, we need to set the titlebar background to match the
-        // window background but with opacity. The window background is set using the
-        // "preferred background color" property.
-        //
-        // Even if we aren't transparent, we still set this because this becomes the
-        // color of the titlebar in native fullscreen view.
+        // The titlebar should be clear to let the window background through.
+        // The exception is in fullscreen, where the titlebar is separate from the window
+        // and needs to be set to the same color.
         if let titlebarView = titlebarContainer?.firstDescendant(withClassName: "NSTitlebarView") {
             titlebarView.wantsLayer = true
-            titlebarView.layer?.backgroundColor = preferredBackgroundColor?.cgColor
+            if styleMask.contains(.fullScreen) {
+                titlebarView.layer?.backgroundColor = self.backgroundColor.cgColor
+            } else {
+                titlebarView.layer?.backgroundColor = .clear
+            }
         }
     
         // In all cases, we have to hide the background view since this has multiple subviews
@@ -98,7 +99,7 @@ class TransparentTitlebarTerminalWindow: TerminalWindow {
         
         // Setup the titlebar background color to match ours
         titlebarContainer.wantsLayer = true
-        titlebarContainer.layer?.backgroundColor = preferredBackgroundColor?.cgColor
+        titlebarContainer.layer?.backgroundColor = self.backgroundColor.cgColor
         
         // See the docs for the function that sets this to true on why
         effectViewIsHidden = false

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -639,6 +639,16 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             }
         };
 
+        /// Determines if the terminal background should be disabled based on
+        /// platform. On macOS, the UI handles the background rendering instead
+        /// of the terminal renderer.
+        fn shouldDisableBackground() bool {
+            return switch (builtin.os.tag) {
+                .macos => true,
+                else => false,
+            };
+        }
+
         pub fn init(alloc: Allocator, options: renderer.Options) !Self {
             // Initialize our graphics API wrapper, this will prepare the
             // surface provided by the apprt and set up any API-specific
@@ -714,7 +724,10 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                         options.config.background.r,
                         options.config.background.g,
                         options.config.background.b,
-                        @intFromFloat(@round(options.config.background_opacity * 255.0)),
+                        if (shouldDisableBackground())
+                            0
+                        else
+                            @intFromFloat(@round(options.config.background_opacity * 255.0)),
                     },
                     .bools = .{
                         .cursor_wide = false,
@@ -1301,7 +1314,10 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     critical.bg.r,
                     critical.bg.g,
                     critical.bg.b,
-                    @intFromFloat(@round(self.config.background_opacity * 255.0)),
+                    if (shouldDisableBackground())
+                        0
+                    else
+                        @intFromFloat(@round(self.config.background_opacity * 255.0)),
                 };
             }
         }


### PR DESCRIPTION
Taking a crack at fixing #9248. I figured the simplest and most robust solution would be if the macOS app always uses the `TerminalWindow` background on the Swift side to render the background, while all views including terminal surfaces have clear backgrounds. That way you avoid problems due to partially overlapping views with partial transparency, which is what #9248 is ultimately about. I think the implementation of #8801 would also be simpler once rebased on this.

I'd appreciate reviews of what I have here, so I won't mark this as draft. However, the PR is NOT ready to merge, as the Ventura titlebar tabs changes are not finished. I don't have an environment for testing those at the moment. If someone who does wants to take a crack at finishing this, please go ahead! Otherwise, I'll see what I can figure out within the next couple of days.

**To do**

- [ ] Make necessary changes to Ventura titlebar tabs