### PR TITLE
renderer: don't allow the scrollbar state to block the renderer

### DIFF
--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1322,10 +1322,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // After the graphics API is complete (so we defer) we want to
             // update our scrollbar state.
             defer if (self.scrollbar_dirty) {
-                self.scrollbar_dirty = false;
-                _ = self.surface_mailbox.push(.{
+                // Fail instantly if the surface mailbox if full, we'll just
+                // get it on the next frame.
+                if (self.surface_mailbox.push(.{
                     .scrollbar = self.scrollbar,
-                }, .{ .forever = {} });
+                }, .instant) > 0) self.scrollbar_dirty = false;
             };
 
             // Let our graphics API do any bookkeeping, etc.


### PR DESCRIPTION
This fixes the source of a deadlock that some tip users have hit. If our  surface mailbox is full and there is a dirty scrollbar state, then drawFrame would block forever trying to queue to the surface mailbox.

We now fail instantly if the queue is full and keep the scrollbar state dirty. We can try again on the next frame, it's not a critical thing to get updated.