### PR TITLE
config/os: add support for clickable tilde paths

### DIFF
--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const apprt = @import("../apprt.zig");
-const internal_os = @import("main.zig");
 
 const log = std.log.scoped(.@"os-open");
 
@@ -21,33 +20,21 @@ pub fn open(
     kind: apprt.action.OpenUrl.Kind,
     url: []const u8,
 ) !void {
-    // Trim trailing punctuation that may have been captured by the regex
-    var trimmed_url = url;
-    while (trimmed_url.len > 0 and (trimmed_url[trimmed_url.len - 1] == ':' or
-                                     trimmed_url[trimmed_url.len - 1] == ',' or
-                                     trimmed_url[trimmed_url.len - 1] == '.')) {
-        trimmed_url = trimmed_url[0..trimmed_url.len - 1];
-    }
-
-    // Expand tilde paths before opening
-    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const expanded_url = internal_os.expandHome(trimmed_url, &path_buf) catch trimmed_url;
-
     var exe: std.process.Child = switch (builtin.os.tag) {
         .linux, .freebsd => .init(
-            &.{ "xdg-open", expanded_url },
+            &.{ "xdg-open", url },
             alloc,
         ),
 
         .windows => .init(
-            &.{ "rundll32", "url.dll,FileProtocolHandler", expanded_url },
+            &.{ "rundll32", "url.dll,FileProtocolHandler", url },
             alloc,
         ),
 
         .macos => .init(
             switch (kind) {
-                .text => &.{ "open", "-t", expanded_url },
-                .unknown => &.{ "open", expanded_url },
+                .text => &.{ "open", "-t", url },
+                .unknown => &.{ "open", url },
             },
             alloc,
         ),


### PR DESCRIPTION
Enables clicking on tilde-based paths like ~/.config/file.txt. When clicked, the path is expanded to the user's home directory and opened.

Related to #1972

This addresses the maintainer feedback from PR #5813 by reusing the existing os.expandHome() function rather than duplicating tilde expansion logic. The implementation is cross-platform (Linux/macOS/FreeBSD) from the start.

Implementation:
- Modified URL regex to detect ~/path patterns (excludes bare ~ and ~user)
- Removed :,. from file path character class to avoid underlining punctuation
- Added negative lookbehind (?<!\.) to prevent trailing period matches
- Reuse os.expandHome() for tilde expansion in os/open.zig
- Added safety trimming for edge case punctuation handling
- Added test cases for positive and negative scenarios

The regex matches ~/path but not bare ~ or ~user/path (which would require different expansion logic). Trailing punctuation like colons and periods are excluded from matching to avoid visual clutter in common output like "Error at ~/.bashrc:42".