### PR TITLE
fix: fish shell integration should not update the universal `fish_user_paths` variable

### DIFF
--- a/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
+++ b/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
@@ -67,7 +67,7 @@ function __ghostty_setup --on-event fish_prompt -d "Setup ghostty integration"
 
     # Add Ghostty binary to PATH if the path feature is enabled
     if contains path $features; and test -n "$GHOSTTY_BIN_DIR"
-        fish_add_path --append "$GHOSTTY_BIN_DIR"
+        fish_add_path --global --path --append "$GHOSTTY_BIN_DIR"
     end
 
     # When using sudo shell integration feature, ensure $TERMINFO is set


### PR DESCRIPTION
`fish_add_path` by default updates the `fish_user_paths` universal variable which makes the modification persist across shell sessions.

The integration also tries to update the `fish_user_paths` when the desired path already appears in the `PATH` environment variable but not in `fish_user_paths`. Because `fish_user_paths` will always be inserted before the inherited `PATH` env. This makes the added path unintentionally has a higher priority.

This patch fixes  the above issues by adding `--global` and `--path` options to `fish_user_paths` which limits the modification scope and ensures that the path won't be added if it already exists in `PATH`.

Ref: https://fishshell.com/docs/current/cmds/fish_add_path.html