### PR TITLE
macOS: shed responsible process using private API

### DIFF
--- a/src/Command.zig
+++ b/src/Command.zig
@@ -409,7 +409,10 @@ pub fn getData(self: Command, comptime DT: type) ?*DT {
 
 // Copied from Zig. This is a publicly exported function but there is no
 // way to get it from the std package.
-fn createNullDelimitedEnvMap(arena: mem.Allocator, env_map: *const EnvMap) ![:null]?[*:0]u8 {
+fn createNullDelimitedEnvMap(
+    arena: mem.Allocator,
+    env_map: *const EnvMap,
+) ![:null]?[*:0]u8 {
     const envp_count = env_map.count();
     const envp_buf = try arena.allocSentinel(?[*:0]u8, envp_count, null);
 

--- a/src/cli/ghostty.zig
+++ b/src/cli/ghostty.zig
@@ -19,6 +19,7 @@ const crash_report = @import("crash_report.zig");
 const show_face = @import("show_face.zig");
 const boo = @import("boo.zig");
 const new_window = @import("new_window.zig");
+const macos_disclaim = @import("macos_disclaim.zig");
 
 /// Special commands that can be invoked via CLI flags. These are all
 /// invoked by using `+<action>` as a CLI flag. The only exception is
@@ -69,6 +70,9 @@ pub const Action = enum {
     // Use IPC to tell the running Ghostty to open a new window.
     @"new-window",
 
+    // Internal helper for posix_spawn that performs pre-exec setup
+    @"_macos-disclaim",
+
     pub fn detectSpecialCase(arg: []const u8) ?SpecialCase(Action) {
         // If we see a "-e" and we haven't seen a command yet, then
         // we are done looking for commands. This special case enables
@@ -102,6 +106,9 @@ pub const Action = enum {
             // to find this action in the help strings and output that.
             help_error => err: {
                 inline for (@typeInfo(Action).@"enum".fields) |field| {
+                    // Skip internal commands (prefixed with underscore)
+                    if (field.name[0] == '_') continue;
+
                     // Future note: for now we just output the help text directly
                     // to stdout. In the future we can style this much prettier
                     // for all commands by just changing this one place.
@@ -147,6 +154,7 @@ pub const Action = enum {
             .@"show-face" => try show_face.run(alloc),
             .boo => try boo.run(alloc),
             .@"new-window" => try new_window.run(alloc),
+            .@"_macos-disclaim" => try macos_disclaim.run(alloc),
         };
     }
 
@@ -186,6 +194,7 @@ pub const Action = enum {
                 .@"show-face" => show_face.Options,
                 .boo => boo.Options,
                 .@"new-window" => new_window.Options,
+                .@"_macos-disclaim" => macos_disclaim.Options,
             };
         }
     }

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -63,6 +63,8 @@ pub fn run(alloc: Allocator) !u8 {
     );
 
     inline for (@typeInfo(Action).@"enum".fields) |field| {
+        // Skip internal commands (prefixed with underscore)
+        if (field.name[0] == '_') continue;
         try stdout.print("  +{s}\n", .{field.name});
     }
 

--- a/src/cli/macos_disclaim.zig
+++ b/src/cli/macos_disclaim.zig
@@ -1,0 +1,76 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const posix = std.posix;
+const Allocator = std.mem.Allocator;
+const posix_spawn = @import("../os/posix_spawn.zig");
+
+const log = std.log.scoped(.macos_disclaim);
+
+pub const Options = struct {
+    pub fn deinit(self: Options) void {
+        _ = self;
+    }
+};
+
+/// The `_macos-disclaim` command is an internal-only Ghostty command that
+/// is only available on macOS. It uses private posix_spawn APIs to
+/// make the child process the "responssible process" in macOS so it is
+/// in charge of its own TCC (permissions like Downloads folder access or
+/// camera) and resource accounting rather than Ghostty.
+pub fn run(alloc: Allocator) !u8 {
+    // This helper is only for Apple systems. POSIX in general has posix_spawn
+    // but we only use it on Apple platforms because it lets us shed our
+    // responsible process bit.
+    if (comptime builtin.os.tag != .macos) {
+        log.warn("macos-disclaim is only supported on macOS", .{});
+        return 1;
+    }
+
+    // Get the command to exec from the remaining args
+    // Skip arg 0 (our program name) and arg 1 (the action "+_macos-disclaim")
+    var arg_iter = try std.process.argsWithAllocator(alloc);
+    defer arg_iter.deinit();
+    _ = arg_iter.skip();
+    _ = arg_iter.skip();
+
+    // Collect remaining args for exec
+    var args: std.ArrayList(?[*:0]const u8) = .empty;
+    defer args.deinit(alloc);
+    while (arg_iter.next()) |arg| try args.append(alloc, arg);
+    if (args.items.len == 0) {
+        log.err("no command specified to exec", .{});
+        return 1;
+    }
+    try args.append(alloc, null);
+
+    var attrs = try posix_spawn.spawn_attr.create();
+    defer posix_spawn.spawn_attr.destroy(&attrs);
+    {
+        try posix_spawn.spawn_attr.setflags(&attrs, .{
+            // Act like exec(): replace this process.
+            .setexec = true,
+        });
+
+        // This is the magical private API that makes it so that this
+        // child process doesn't get looped into the TCC and resource
+        // accounting of Ghostty.
+        try posix_spawn.spawn_attr.disclaim(&attrs, true);
+    }
+
+    _ = posix_spawn.spawnp(
+        std.mem.span(args.items[0].?),
+        null,
+        &attrs,
+        args.items[0 .. args.items.len - 1 :null].ptr,
+        std.c.environ,
+    ) catch |err| {
+        log.err("failed to posix_spawn command '{s}': {}", .{
+            std.mem.span(args.items[0].?),
+            err,
+        });
+        return 1;
+    };
+
+    // We set the exec flag so we can't reach this point.
+    unreachable;
+}

--- a/src/helpgen.zig
+++ b/src/helpgen.zig
@@ -82,6 +82,9 @@ fn genActions(alloc: std.mem.Allocator, writer: *std.Io.Writer) !void {
     );
 
     inline for (@typeInfo(Action).@"enum".fields) |field| {
+        // Skip internal commands (prefixed with underscore)
+        if (field.name[0] == '_') continue;
+
         const action_file = comptime action_file: {
             const action = @field(Action, field.name);
             break :action_file action.file();

--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -25,6 +25,7 @@ pub const hostname = @import("hostname.zig");
 pub const i18n = @import("i18n.zig");
 pub const path = @import("path.zig");
 pub const passwd = @import("passwd.zig");
+pub const posix_spawn = @import("posix_spawn.zig");
 pub const xdg = @import("xdg.zig");
 pub const windows = @import("windows.zig");
 pub const macos = @import("macos.zig");
@@ -72,5 +73,9 @@ test {
 
     if (comptime builtin.os.tag == .linux) {
         _ = kernel_info;
+    }
+
+    if (comptime builtin.os.tag.isDarwin()) {
+        _ = posix_spawn;
     }
 }

--- a/src/os/posix_spawn.zig
+++ b/src/os/posix_spawn.zig
@@ -1,0 +1,257 @@
+//! This file contains a wrapper around the `posix_spawn` API and
+//! exposes it in a higher-level idiomatic Zig way.
+
+const std = @import("std");
+const c = std.c;
+const Allocator = std.mem.Allocator;
+const UnexpectedError = std.posix.UnexpectedError;
+const unexpectedErrno = std.posix.unexpectedErrno;
+const errno = std.posix.errno;
+const fd_t = std.posix.fd_t;
+const pid_t = std.posix.pid_t;
+
+extern "c" fn posix_spawnattr_setsigdefault(
+    attr: *c.posix_spawnattr_t,
+    sigdefault: *const std.posix.sigset_t,
+) c_int;
+extern "c" fn responsibility_spawnattrs_setdisclaim(
+    attrs: *const c.posix_spawnattr_t,
+    disclaim: bool,
+) c_int;
+
+pub fn spawnp(
+    path: [:0]const u8,
+    actions: ?*file_actions.T,
+    attr: ?*spawn_attr.T,
+    argv: [*:null]const ?[*:0]const u8,
+    env: [*:null]const ?[*:0]const u8,
+) UnexpectedError!pid_t {
+    var pid: pid_t = undefined;
+    return switch (errno(c.posix_spawnp(
+        &pid,
+        path,
+        actions,
+        attr,
+        argv,
+        env,
+    ))) {
+        .SUCCESS => pid,
+        else => |err| return unexpectedErrno(err),
+    };
+}
+
+/// Wrapper around the posix_spawn_file_actions_t type. This will be
+/// sparsely documented since it should mostly just match the man pages.
+///
+/// NOTE: This purposely does not implement many functions. We only
+/// implement what we need for our use case. It is trivial to add more.
+pub const file_actions = struct {
+    pub const T = c.posix_spawn_file_actions_t;
+
+    pub fn create() (Allocator.Error || UnexpectedError)!T {
+        var actions: T = undefined;
+        return switch (errno(c.posix_spawn_file_actions_init(&actions))) {
+            .SUCCESS => actions,
+            .NOMEM => return error.OutOfMemory,
+            else => |err| return unexpectedErrno(err),
+        };
+    }
+
+    pub fn destroy(actions: *T) void {
+        _ = c.posix_spawn_file_actions_destroy(actions);
+    }
+
+    pub fn close(
+        actions: *T,
+        fildes: fd_t,
+    ) (error{BadFileDescriptor} || UnexpectedError)!void {
+        return switch (errno(c.posix_spawn_file_actions_addclose(
+            actions,
+            fildes,
+        ))) {
+            .SUCCESS => {},
+            .BADF => return error.BadFileDescriptor,
+            else => |err| return unexpectedErrno(err),
+        };
+    }
+
+    pub fn dup2(
+        actions: *T,
+        fildes: fd_t,
+        newfildes: fd_t,
+    ) (error{BadFileDescriptor} || UnexpectedError)!void {
+        return switch (errno(c.posix_spawn_file_actions_adddup2(
+            actions,
+            fildes,
+            newfildes,
+        ))) {
+            .SUCCESS => {},
+            .BADF => return error.BadFileDescriptor,
+            else => |err| return unexpectedErrno(err),
+        };
+    }
+
+    pub fn chdir(
+        actions: *T,
+        path: [*:0]const u8,
+    ) UnexpectedError!void {
+        return switch (errno(c.posix_spawn_file_actions_addchdir_np(
+            actions,
+            path,
+        ))) {
+            .SUCCESS => {},
+            else => |err| return unexpectedErrno(err),
+        };
+    }
+};
+
+/// Wrapper around the posix_spawnattr_t type. This will be
+/// sparsely documented since it should mostly just match the man pages.
+///
+/// NOTE: This purposely does not implement many functions. We only
+/// implement what we need for our use case. It is trivial to add more.
+pub const spawn_attr = struct {
+    pub const T = c.posix_spawnattr_t;
+
+    pub fn create() (Allocator.Error || UnexpectedError)!T {
+        var attr: T = undefined;
+        return switch (errno(c.posix_spawnattr_init(&attr))) {
+            .SUCCESS => attr,
+            .NOMEM => return error.OutOfMemory,
+            else => |err| return unexpectedErrno(err),
+        };
+    }
+
+    pub fn destroy(attr: *T) void {
+        _ = c.posix_spawnattr_destroy(attr);
+    }
+
+    pub fn setflags(attr: *T, flags: Flags) UnexpectedError!void {
+        return switch (errno(c.posix_spawnattr_setflags(
+            attr,
+            flags.int(),
+        ))) {
+            .SUCCESS => {},
+            else => |err| return unexpectedErrno(err),
+        };
+    }
+
+    pub fn setsigdefault(attr: *T, sigdefault: *const std.posix.sigset_t) UnexpectedError!void {
+        return switch (errno(posix_spawnattr_setsigdefault(
+            attr,
+            sigdefault,
+        ))) {
+            .SUCCESS => {},
+            else => |err| return unexpectedErrno(err),
+        };
+    }
+
+    /// This is undocumented, private API, so I'll link to some resources
+    /// here: https://www.qt.io/blog/the-curious-case-of-the-responsible-process
+    pub fn disclaim(attr: *T, v: bool) UnexpectedError!void {
+        return switch (errno(responsibility_spawnattrs_setdisclaim(
+            attr,
+            v,
+        ))) {
+            .SUCCESS => {},
+            else => |err| return unexpectedErrno(err),
+        };
+    }
+};
+
+pub const Flags = packed struct(c_short) {
+    resetids: bool = false,
+    setpgroup: bool = false,
+    setsigdef: bool = false,
+    setsigmask: bool = false,
+    _pad1: u2 = 0,
+    setexec: bool = false,
+    start_suspended: bool = false,
+    disable_aslr: bool = false,
+    _pad2: u1 = 0,
+    setsid: bool = false,
+    reslide: bool = false,
+    _pad3: u2 = 0,
+    cloexec_default: bool = false,
+    _pad4: u1 = 0,
+
+    /// Integer value of this struct.
+    pub fn int(self: Flags) c_short {
+        return @bitCast(self);
+    }
+};
+
+test file_actions {
+    var actions = try file_actions.create();
+    defer file_actions.destroy(&actions);
+}
+
+test "dup2" {
+    var actions = try file_actions.create();
+    defer file_actions.destroy(&actions);
+    try file_actions.dup2(&actions, 0, 1);
+}
+
+test "close" {
+    var actions = try file_actions.create();
+    defer file_actions.destroy(&actions);
+    try file_actions.close(&actions, 0);
+}
+
+test "chdir" {
+    var actions = try file_actions.create();
+    defer file_actions.destroy(&actions);
+    try file_actions.chdir(&actions, "/tmp");
+}
+
+test spawn_attr {
+    var attr = try spawn_attr.create();
+    defer spawn_attr.destroy(&attr);
+}
+
+test "spawn_attr.setflags" {
+    var attr = try spawn_attr.create();
+    defer spawn_attr.destroy(&attr);
+    try spawn_attr.setflags(&attr, .{ .setsid = true });
+}
+
+test "spawn_attr.setsigdefault" {
+    var attr = try spawn_attr.create();
+    defer spawn_attr.destroy(&attr);
+    var sigset = std.mem.zeroes(std.posix.sigset_t);
+    try spawn_attr.setsigdefault(&attr, &sigset);
+}
+
+test "spawn_attr.disclaim" {
+    var attr = try spawn_attr.create();
+    defer spawn_attr.destroy(&attr);
+    try spawn_attr.disclaim(&attr, true);
+}
+
+test "flags match std.c values" {
+    const testing = std.testing;
+    try testing.expectEqual(std.c.POSIX_SPAWN.RESETIDS, Flags.int(.{ .resetids = true }));
+    try testing.expectEqual(std.c.POSIX_SPAWN.SETPGROUP, Flags.int(.{ .setpgroup = true }));
+    try testing.expectEqual(std.c.POSIX_SPAWN.SETSIGDEF, Flags.int(.{ .setsigdef = true }));
+    try testing.expectEqual(std.c.POSIX_SPAWN.SETSIGMASK, Flags.int(.{ .setsigmask = true }));
+    try testing.expectEqual(std.c.POSIX_SPAWN.SETEXEC, Flags.int(.{ .setexec = true }));
+    try testing.expectEqual(std.c.POSIX_SPAWN.START_SUSPENDED, Flags.int(.{ .start_suspended = true }));
+    try testing.expectEqual(std.c.POSIX_SPAWN.DISABLE_ASLR, Flags.int(.{ .disable_aslr = true }));
+    try testing.expectEqual(std.c.POSIX_SPAWN.SETSID, Flags.int(.{ .setsid = true }));
+    try testing.expectEqual(std.c.POSIX_SPAWN.RESLIDE, Flags.int(.{ .reslide = true }));
+    try testing.expectEqual(std.c.POSIX_SPAWN.CLOEXEC_DEFAULT, Flags.int(.{ .cloexec_default = true }));
+}
+
+test spawnp {
+    const testing = std.testing;
+    const pid = try spawnp(
+        "true",
+        null,
+        null,
+        &.{"true"},
+        &.{},
+    );
+    try testing.expect(pid > 0);
+    const result = std.posix.waitpid(pid, 0);
+    try std.testing.expectEqual(@as(u32, 0), result.status);
+}

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -83,7 +83,7 @@ const NullPty = struct {
 /// Linux PTY creation and management. This is just a thin layer on top
 /// of Linux syscalls. The caller is responsible for detail-oriented handling
 /// of the returned file handles.
-const PosixPty = struct {
+pub const PosixPty = struct {
     pub const Error = OpenError || GetModeError || GetSizeError || SetSizeError || ChildPreExecError;
 
     pub const Fd = posix.fd_t;
@@ -248,6 +248,20 @@ const PosixPty = struct {
         // Can close master/slave pair now
         posix.close(self.slave);
         posix.close(self.master);
+    }
+
+    /// This is the pre-exec that needs to happen for posix_spawn on macOS
+    /// because the API doesn't support all the actions/attrs we need to
+    /// create a proper terminal environment.
+    pub fn posixSpawnPreExec(self: PosixPty) !void {
+        // Set controlling terminal
+        switch (posix.errno(c.ioctl(self.slave, TIOCSCTTY, @as(c_ulong, 0)))) {
+            .SUCCESS => {},
+            else => |err| {
+                log.err("error setting controlling terminal errno={}", .{err});
+                return error.SetControllingTerminalFailed;
+            },
+        }
     }
 };
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -102,24 +102,17 @@ pub fn threadEnter(
     errdefer self.subprocess.stop();
 
     // Watcher to detect subprocess exit
-    var process: ?xev.Process = process: {
+    var process: ?xev.Process = if (self.subprocess.process) |v| switch (v) {
+        .fork_exec => |cmd| try xev.Process.init(
+            cmd.pid orelse return error.ProcessNoPid,
+        ),
+
         // If we're executing via Flatpak then we can't do
         // traditional process watching (its implemented
         // as a special case in os/flatpak.zig) since the
         // command is on the host.
-        if (comptime build_config.flatpak) {
-            if (self.subprocess.flatpak_command != null) {
-                break :process null;
-            }
-        }
-
-        // Get the pid from the subprocess
-        const command = self.subprocess.command orelse
-            return error.ProcessNotStarted;
-        const pid = command.pid orelse
-            return error.ProcessNoPid;
-        break :process try xev.Process.init(pid);
-    };
+        .flatpak => null,
+    } else return error.ProcessNotStarted;
     errdefer if (process) |*p| p.deinit();
 
     // Track our process start time for abnormal exits
@@ -167,17 +160,19 @@ pub fn threadEnter(
         termio.Termio.ThreadData,
         td,
         processExit,
-    ) else if (comptime build_config.flatpak) {
-        // If we're in flatpak and we have a flatpak command
-        // then we can run the special flatpak logic for watching.
-        if (self.subprocess.flatpak_command) |*c| {
-            c.waitXev(
+    ) else if (comptime build_config.flatpak) flatpak: {
+        switch (self.subprocess.process orelse break :flatpak) {
+            // If we're in flatpak and we have a flatpak command
+            // then we can run the special flatpak logic for watching.
+            .flatpak => |*c| c.waitXev(
                 td.loop,
                 &td.backend.exec.flatpak_wait_c,
                 termio.Termio.ThreadData,
                 td,
                 flatpakExit,
-            );
+            ),
+
+            .fork_exec => {},
         }
     }
 
@@ -587,9 +582,17 @@ const Subprocess = struct {
     grid_size: renderer.GridSize,
     screen_size: renderer.ScreenSize,
     pty: ?Pty = null,
-    command: ?Command = null,
-    flatpak_command: ?FlatpakHostCommand = null,
+    process: ?Process = null,
     linux_cgroup: Command.LinuxCgroup = Command.linux_cgroup_default,
+
+    /// Union that represents the running process type.
+    const Process = union(enum) {
+        /// Standard POSIX fork/exec
+        fork_exec: Command,
+
+        /// Flatpak DBus command
+        flatpak: FlatpakHostCommand,
+    };
 
     const ArgsFormatter = struct {
         args: []const [:0]const u8,
@@ -883,7 +886,7 @@ const Subprocess = struct {
         read: Pty.Fd,
         write: Pty.Fd,
     } {
-        assert(self.pty == null and self.command == null);
+        assert(self.pty == null and self.process == null);
 
         // This function is funny because on POSIX systems it can
         // fail in the forked process. This is flipped to true if
@@ -959,15 +962,15 @@ const Subprocess = struct {
             }
 
             // Flatpak command must have a stable pointer.
-            self.flatpak_command = .{
+            self.process = .{ .flatpak = .{
                 .argv = self.args,
                 .cwd = cwd,
                 .env = if (self.env) |*env| env else null,
                 .stdin = pty.slave,
                 .stdout = pty.slave,
                 .stderr = pty.slave,
-            };
-            var cmd = &self.flatpak_command.?;
+            } };
+            var cmd = &self.process.?.flatpak;
             const pid = try cmd.spawn(alloc);
             errdefer killCommandFlatpak(cmd);
 
@@ -1046,7 +1049,7 @@ const Subprocess = struct {
             self.env = null;
         }
 
-        self.command = cmd;
+        self.process = .{ .fork_exec = cmd };
         return switch (builtin.os.tag) {
             .windows => .{
                 .read = pty.out_pipe,
@@ -1071,7 +1074,7 @@ const Subprocess = struct {
     /// Called to notify that we exited externally so we can unset our
     /// running state.
     pub fn externalExit(self: *Subprocess) void {
-        self.command = null;
+        self.process = null;
     }
 
     /// Stop the subprocess. This is safe to call anytime. This will wait
@@ -1079,25 +1082,23 @@ const Subprocess = struct {
     /// for it to terminate, so it will not block.
     /// This does not close the pty.
     pub fn stop(self: *Subprocess) void {
-        // Kill our command
-        if (self.command) |*cmd| {
-            // Note: this will also wait for the command to exit, so
-            // DO NOT call cmd.wait
-            killCommand(cmd) catch |err|
-                log.err("error sending SIGHUP to command, may hang: {}", .{err});
-            self.command = null;
-        }
+        switch (self.process orelse return) {
+            .fork_exec => |*cmd| {
+                // Note: this will also wait for the command to exit, so
+                // DO NOT call cmd.wait
+                killCommand(cmd) catch |err|
+                    log.err("error sending SIGHUP to command, may hang: {}", .{err});
+            },
 
-        // Kill our Flatpak command
-        if (comptime build_config.flatpak) {
-            if (self.flatpak_command) |*cmd| {
+            .flatpak => |*cmd| if (comptime build_config.flatpak) {
                 killCommandFlatpak(cmd) catch |err|
                     log.err("error sending SIGHUP to command, may hang: {}", .{err});
                 _ = cmd.wait() catch |err|
                     log.err("error waiting for command to exit: {}", .{err});
-                self.flatpak_command = null;
-            }
+            },
         }
+
+        self.process = null;
     }
 
     /// Resize the pty subprocess. This is safe to call anytime.


### PR DESCRIPTION
Fixes #9263 

This changes macOS process launching to use the private API `responsibility_spawnattrs_setdisclaim` to make the spawned process the "responsible process." This ensures that child processes spawned from Ghostty are responsible for their own TCC (Transparency, Consent, and Control) permissions and resource accounting rather than being attributed to Ghostty itself.

Concretely, this means things like Downloads folder access, Camera access, etc. all are attributed to the child process (usually the shell) rather than Ghostty. This has been a common source of confusion/concern for Ghostty, since it is understandably alarming when Ghostty asks for camera access (we have no code that uses the camera) and it was actually a child process!

This also has security implications, related to GHSA-q9fg-cpmh-c78x. More details below.

## Implementation

The `responsibility_spawnattrs_setdisclaim` private API only works with `posix_spawn`. We can't use `posix_spawn` on its own because it is missing one critical function for a terminal: the ability to set the `TIOCSCTTY` ioctl on the pty fd. 

To workaround this, we use the standard `fork/exec` mechanism we always have to launch a trampoline command `ghostty +_macos-disclaim`. This then uses `posix_spawn` with two Apple-specific, private APIs:

- `POSIX_SPAWN_SETEXEC` flag to have `posix_spawn` behave like `exec` (replace the process)
- `responsibility_spawnattrs_setdisclaim` API to disclaim responsible process attribution

> [!NOTE]
>
> This PR also includes a change so that `_`-prefixed CLI actions are hidden from help. They're considered internal-only.

## Performance

This adds extra overhead on macOS to the process start codepath which likely slows down terminal start. I haven't noticed anything, but it is an extra process and an extra syscall. 

## Security 

GHSA-q9fg-cpmh-c78x fully revolved around launched programs inheriting Ghostty's TCC permissions. I suspect that with this change, we can now provide an option to avoid asking for permission entirely and may also be able to do other heuristics to simply trust launching the program completely without permission. This PR doesn't go this far, since I want to think about this further. cc @nmggithub