### PR TITLE
os: handle nil languageCode/countryCode in setLangFromCocoa

### DIFF
--- a/src/os/locale.zig
+++ b/src/os/locale.zig
@@ -83,6 +83,13 @@ fn setLangFromCocoa() void {
     const lang = locale.getProperty(objc.Object, "languageCode");
     const country = locale.getProperty(objc.Object, "countryCode");
 
+    // If either property is nil, we can't construct a valid locale string.
+    // Return early and let the normal locale resolution continue.
+    if (lang.value == null or country.value == null) {
+        log.debug("languageCode or countryCode is nil", .{});
+        return;
+    }
+
     // Get our UTF8 string values
     const c_lang = lang.getProperty([*:0]const u8, "UTF8String");
     const c_country = country.getProperty([*:0]const u8, "UTF8String");

--- a/src/os/locale.zig
+++ b/src/os/locale.zig
@@ -83,10 +83,8 @@ fn setLangFromCocoa() void {
     const lang = locale.getProperty(objc.Object, "languageCode");
     const country = locale.getProperty(objc.Object, "countryCode");
 
-    // If either property is nil, we can't construct a valid locale string.
-    // Return early and let the normal locale resolution continue.
     if (lang.value == null or country.value == null) {
-        log.debug("languageCode or countryCode is nil", .{});
+        log.warn("languageCode or countryCode not found. Locale may be incorrect.", .{});
         return;
     }
 


### PR DESCRIPTION
Fixes a crash when NSLocale returns nil for languageCode or countryCode properties. This can happen when the app launches without locale environment variables set.

The crash occurs at `src/os/locale.zig:87-88` when trying to call `getProperty()` on a nil object. The fix adds a null check and falls back to `en_US.UTF-8` instead of dereferencing null.

## Testing
Tested by running with locale variables unset:
```bash
unset LC_ALL && ./zig-out/Ghostty.app/Contents/MacOS/ghostty
```

Before: segmentation fault  
After: launches successfully with fallback locale