### PR TITLE
Add scrollbar margin to surfaces

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -429,13 +429,25 @@ typedef struct {
 } ghostty_surface_config_s;
 
 typedef struct {
+  uint32_t width;
+  uint32_t height;
+} ghostty_surface_size_s;
+
+typedef struct {
+  uint32_t top;
+  uint32_t bottom;
+  uint32_t left;
+  uint32_t right;
+} ghostty_surface_edge_insets_s;
+
+typedef struct {
   uint16_t columns;
   uint16_t rows;
   uint32_t width_px;
   uint32_t height_px;
   uint32_t cell_width_px;
   uint32_t cell_height_px;
-} ghostty_surface_size_s;
+} ghostty_screen_size_s;
 
 // Config types
 
@@ -966,8 +978,11 @@ void ghostty_surface_draw(ghostty_surface_t);
 void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);
 void ghostty_surface_set_focus(ghostty_surface_t, bool);
 void ghostty_surface_set_occlusion(ghostty_surface_t, bool);
-void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t);
-ghostty_surface_size_s ghostty_surface_size(ghostty_surface_t);
+void ghostty_surface_set_size(ghostty_surface_t, ghostty_surface_size_s);
+void ghostty_surface_set_size_and_edge_insets(ghostty_surface_t,
+                                              ghostty_surface_size_s,
+                                              ghostty_surface_edge_insets_s);
+ghostty_screen_size_s ghostty_screen_size(ghostty_surface_t);
 void ghostty_surface_set_color_scheme(ghostty_surface_t,
                                       ghostty_color_scheme_e);
 ghostty_input_mods_e ghostty_surface_key_translation_mods(ghostty_surface_t,
@@ -1022,7 +1037,7 @@ ghostty_inspector_t ghostty_surface_inspector(ghostty_surface_t);
 void ghostty_inspector_free(ghostty_surface_t);
 void ghostty_inspector_set_focus(ghostty_inspector_t, bool);
 void ghostty_inspector_set_content_scale(ghostty_inspector_t, double, double);
-void ghostty_inspector_set_size(ghostty_inspector_t, uint32_t, uint32_t);
+void ghostty_inspector_set_size(ghostty_inspector_t, ghostty_surface_size_s);
 void ghostty_inspector_mouse_button(ghostty_inspector_t,
                                     ghostty_input_mouse_state_e,
                                     ghostty_input_mouse_button_e,

--- a/macos/Sources/Ghostty/InspectorView.swift
+++ b/macos/Sources/Ghostty/InspectorView.swift
@@ -172,7 +172,10 @@ extension Ghostty {
             ghostty_inspector_set_content_scale(inspector, xScale, yScale)
 
             // When our scale factor changes, so does our fb size so we send that too
-            ghostty_inspector_set_size(inspector, UInt32(fbFrame.size.width), UInt32(fbFrame.size.height))
+            ghostty_inspector_set_size(
+                inspector,
+                ghostty_surface_size_s(width: UInt32(fbFrame.size.width), height: UInt32(fbFrame.size.height)),
+            )
         }
 
         // MARK: NSView

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -92,10 +92,10 @@ extension Ghostty {
                     #endif
 
                     // If our geo size changed then we show the resize overlay as configured.
-                    if let surfaceSize = surfaceView.surfaceSize {
+                    if let screenSize = surfaceView.screenSize {
                         SurfaceResizeOverlay(
                             geoSize: geo.size,
-                            size: surfaceSize,
+                            size: screenSize,
                             overlay: ghostty.config.resizeOverlay,
                             position: ghostty.config.resizeOverlayPosition,
                             duration: ghostty.config.resizeOverlayDuration,
@@ -280,7 +280,7 @@ extension Ghostty {
     // size during a resize operation.
     struct SurfaceResizeOverlay: View {
         let geoSize: CGSize
-        let size: ghostty_surface_size_s
+        let size: ghostty_screen_size_s
         let overlay: Ghostty.Config.ResizeOverlay
         let position: Ghostty.Config.ResizeOverlayPosition
         let duration: UInt

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -68,9 +68,9 @@ extension Ghostty {
         // on supported platforms.
         @Published var focusInstant: ContinuousClock.Instant? = nil
 
-        // Returns sizing information for the surface. This is the raw C
+        // Returns sizing information for the screen. This is the raw C
         // structure because I'm lazy.
-        @Published var surfaceSize: ghostty_surface_size_s? = nil
+        @Published var screenSize: ghostty_screen_size_s? = nil
 
         // Whether the pointer should be visible or not
         @Published private(set) var pointerStyle: BackportPointerStyle = .default
@@ -429,15 +429,18 @@ extension Ghostty {
             guard let surface = self.surface else { return }
 
             // Update our core surface
-            ghostty_surface_set_size(surface, width, height)
+            ghostty_surface_set_size(
+                surface,
+                ghostty_surface_size_s(width: width, height: height),
+            )
 
             // Update our cached size metrics
-            let size = ghostty_surface_size(surface)
+            let size = ghostty_screen_size(surface)
             DispatchQueue.main.async {
                 // DispatchQueue required since this may be called by SwiftUI off
                 // the main thread and Published changes need to be on the main
                 // thread. This caused a crash on macOS <= 14.
-                self.surfaceSize = size
+                self.screenSize = size
             }
         }
 

--- a/macos/Sources/Ghostty/SurfaceView_UIKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_UIKit.swift
@@ -43,9 +43,9 @@ extension Ghostty {
 
         // Returns sizing information for the surface. This is the raw C
         // structure because I'm lazy.
-        var surfaceSize: ghostty_surface_size_s? {
+        var screenSize: ghostty_screen_size_s? {
             guard let surface = self.surface else { return nil }
-            return ghostty_surface_size(surface)
+            return ghostty_screen_size(surface)
         }
 
         private(set) var surface: ghostty_surface_t?
@@ -100,8 +100,7 @@ extension Ghostty {
             ghostty_surface_set_content_scale(surface, scale, scale)
             ghostty_surface_set_size(
                 surface,
-                UInt32(size.width * scale),
-                UInt32(size.height * scale)
+                ghostty_surface_size_s(width: UInt32(size.width * scale), height: UInt32(size.height * scale)),
             )
         }
 

--- a/src/apprt.zig
+++ b/src/apprt.zig
@@ -36,6 +36,7 @@ pub const CursorPos = structs.CursorPos;
 pub const IMEPos = structs.IMEPos;
 pub const Selection = structs.Selection;
 pub const SurfaceSize = structs.SurfaceSize;
+pub const SurfaceEdgeInsets = structs.SurfaceEdgeInsets;
 
 /// The implementation to use for the app runtime. This is comptime chosen
 /// so that every build has exactly one application runtime implementation.

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -52,6 +52,10 @@ pub fn getSize(self: *const Self) !apprt.SurfaceSize {
     return self.surface.getSize();
 }
 
+pub fn getEdgeInsets(self: *const Self) !apprt.SurfaceEdgeInsets {
+    return self.surface.getEdgeInsets();
+}
+
 pub fn getCursorPos(self: *const Self) !apprt.CursorPos {
     return self.surface.getCursorPos();
 }

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -1426,6 +1426,12 @@ pub const Surface = extern struct {
         return priv.size;
     }
 
+    pub fn getEdgeInsets(self: *Self) apprt.SurfaceEdgeInsets {
+        // The gtk apprt doesn't require edge insets.
+        _ = self;
+        return .{};
+    }
+
     pub fn getCursorPos(self: *Self) apprt.CursorPos {
         return self.private().cursor_pos;
     }
@@ -2991,7 +2997,7 @@ pub const Surface = extern struct {
                 log.warn("error in content scale callback err={}", .{err});
             };
 
-            surface.sizeCallback(priv.size) catch |err| {
+            surface.sizeCallback(priv.size, .{}) catch |err| {
                 log.warn("error in size callback err={}", .{err});
             };
 

--- a/src/apprt/structs.zig
+++ b/src/apprt/structs.zig
@@ -14,6 +14,14 @@ pub const SurfaceSize = struct {
     height: u32,
 };
 
+/// The apprt insets for the surface
+pub const SurfaceEdgeInsets = struct {
+    top: u32 = 0,
+    bottom: u32 = 0,
+    left: u32 = 0,
+    right: u32 = 0,
+};
+
 /// The position of the cursor in pixels.
 pub const CursorPos = struct {
     x: f32,


### PR DESCRIPTION
Alright, second attempt to fix #9248. This gives surfaces a right-hand margin that is distinct from padding, solely for keeping the terminal content out of the way of scrollbars. That way, the surface itself can fill the whole SurfaceScrollView and keep drawing the background behind the transparent scrollbar.

On the macOS app side, this means that `surfaceView` cannot be a child view of `documentView`, since the latter is automatically resized to avoid overlap with the scrollbar. Instead, `surfaceView` is now a direct subview of the `SurfaceScrollView`, stacked behind `scrollView`. This actually simplifies the scrollbar implementation quite a bit, since the origin of the `surfaceView` frame no longer has to change as we scroll, as it's relative to the fixed `SurfaceScrollView` rather than the moving `documentView`. That means we no longer have to listen and synchronize to bounds changes on the `contentView`. The only time we need to worry about the `surfaceView` frame is when there are layout changes.

This also provides #9255 for free. It would be _more_ work to condition the margin on whether the legacy scrollbar is visible or hidden.

Along the way, I fixed a bug where the layout recalculation wasn't taking into account the change of padding around the terminal grid when the surface is resized. This change must be reflected in the height of the `documentView` even if the number of rows haven't changed, otherwise the scrollbar will pop up out of nowhere when resizing an empty surface (see #9241).

Also committed some drive-by simplification of the padding math from #9241.

---

I hope this can be a step towards addressing the concern I voiced here: https://github.com/ghostty-org/ghostty/discussions/9254#discussioncomment-14716483. Basically, I think the terminal/surface should ignore the scrollbar margin for the alternate screen (or, more generally, when max scrollback is zero). With this PR, all that could be done in the core without the macOS app's involvement. But that's a future PR.