### PR TITLE
macOS: Use sentinel scrollbar state to disable scroller margin

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.Action.swift
+++ b/macos/Sources/Ghostty/Ghostty.Action.swift
@@ -108,6 +108,7 @@ extension Ghostty.Action {
         let total: UInt64
         let offset: UInt64
         let len: UInt64
+        var active: Bool { return total >= len }
         
         init(c: ghostty_action_scrollbar_s) {
             total = c.total

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -789,9 +789,13 @@ pub const Surface = extern struct {
         // scrolled window.
         const vadj = self.getVAdjustment() orelse return;
 
-        // Check if values match existing adjustment and skip update if so
+        // Check if values match existing adjustment and skip update if so.
+        // We may have scrollbar.total < scrollbar.len, indicating that the
+        // terminal is not in a scrollable state (e.g., alternate screen). Since
+        // the GTK apprt does not adjust the surface size/layout to accommodate
+        // the scrollbar, this is irrelevant for us, so we just lower bound it.
         const value: f64 = @floatFromInt(scrollbar.offset);
-        const upper: f64 = @floatFromInt(scrollbar.total);
+        const upper: f64 = @floatFromInt(@max(scrollbar.total, scrollbar.len));
         const page_size: f64 = @floatFromInt(scrollbar.len);
 
         if (std.math.approxEqAbs(f64, vadj.getValue(), value, 0.001) and


### PR DESCRIPTION
This adresses the issue of having a scrollbar margin (with the legacy scroller style on macOS) even when the terminal state is explicitly non-scrollable, such as in the alternate screen. I reported this in https://github.com/ghostty-org/ghostty/discussions/9254#discussioncomment-14716483 and more extensively in https://github.com/ghostty-org/ghostty/pull/9291#issuecomment-3427521889.

**Before**
<img width="336" height="176" alt="Screenshot 2025-10-21 at 12 25 58" src="https://github.com/user-attachments/assets/c9cb5312-7809-47b2-a7a7-ec3eebd7624d" />

**After**
<img width="336" height="176" alt="Screenshot 2025-10-21 at 12 20 30" src="https://github.com/user-attachments/assets/81fa81aa-f9f3-48f4-a642-738c5b0ce133" />