### PR TITLE
macOS: Adjust documentView padding on layout changes

### DIFF
--- a/macos/Sources/Ghostty/SurfaceScrollView.swift
+++ b/macos/Sources/Ghostty/SurfaceScrollView.swift
@@ -174,10 +174,19 @@ class SurfaceScrollView: NSView {
             }
         }
         
-        // Keep document width synchronized with content width
+        // Keep document width synchronized with content width, and
+        // recalculate the height of the document view to account for the
+        // change in padding around the cell grid due to the resize.
+        var documentHeight = documentView.frame.height
+        let cellHeight = surfaceView.cellSize.height
+        if cellHeight > 0 {
+            let oldPadding = fmod(documentHeight, cellHeight)
+            let newPadding = fmod(contentSize.height, cellHeight)
+            documentHeight += newPadding - oldPadding
+        }
         documentView.setFrameSize(CGSize(
             width: contentSize.width,
-            height: documentView.frame.height
+            height: documentHeight
         ))
         
         // Inform the actual pty of our size change. This doesn't change the actual view
@@ -261,8 +270,7 @@ class SurfaceScrollView: NSView {
         // The full document height must include the vertical padding around the cell
         // grid, otherwise the content view ends up misaligned with the surface.
         let documentGridHeight = CGFloat(scrollbar.total) * cellHeight
-        let gridHeight = CGFloat(scrollbar.len) * cellHeight
-        let padding = scrollView.contentSize.height - gridHeight
+        let padding = fmod(scrollView.contentSize.height, cellHeight)
         let documentHeight = documentGridHeight + padding
 
         // Our width should be the content width to account for visible scrollers.


### PR DESCRIPTION
Fixes a bug described in #9291, where resizing an empty window causes the scrollbar to appear even though the window remains larger than the total content, because the relayouting fails to account for the change in padding around the cell grid.

To reproduce the issue:
1. Enable legacy scrollbars (System Settings -> Appearance -> Show scroll bars -> Always)
2. Open Ghostty
3. Vertically resize the window to make it smaller. The scrollbar will pop up, and as you drag the window edge, it will cycle between a maximum offset and zero depending on how far the resize is from an integer multiple of the cell height.

With this PR you'll still see the scrollbar flicker while resizing, but when you stop it will always disappear. Haven't figured out how to get rid of the flickering yet. I tried to condition various updates on the window not being in a live resize, but so far no luck.