### PR TITLE
macOS: remove scroll edge styling with hidden titlebar

### DIFF
--- a/macos/Sources/Ghostty/SurfaceScrollView.swift
+++ b/macos/Sources/Ghostty/SurfaceScrollView.swift
@@ -133,6 +133,20 @@ class SurfaceScrollView: NSView {
     
     override func layout() {
         super.layout()
+
+        // The SwiftUI ScrollView host likes to add its own styling overlays to
+        // the titlebar area, which are incompatible with the hidden titlebar
+        // style. They won't be present when the app is first opened, but will
+        // appear when creating splits or cycling fullscreen. There's no public
+        // way to disable them in AppKit, so we just have to play whack-a-mole.
+        // See https://developer.apple.com/forums/thread/798392.
+        if window is HiddenTitlebarTerminalWindow {
+            for view in scrollView.subviews {
+                if view.className.contains("NSScrollPocket") {
+                    view.removeFromSuperview()
+                }
+            }
+        }
         
         // Fill entire bounds with scroll view
         scrollView.frame = bounds


### PR DESCRIPTION
With `macos-titlebar-style = hidden`, creating splits or cycling fullscreen sometimes produces a transparent overlay in the titlebar area, clipping the top of the surfaces:

<img width="504" height="272" alt="Screenshot 2025-10-22 at 21 27 28" src="https://github.com/user-attachments/assets/e28c5226-2e47-4c1d-8c14-b286fdb261f3" />

This is actually SwiftUI styling for scroll views, and the fact that it pops up even though the titlebar is hidden is possibly a SwiftUI bug; at least it's causing frustration for others too, see https://developer.apple.com/forums/thread/798392 and https://stackoverflow.com/questions/79776037/strange-nsscrollpocket-height-on-my-nstableview-in-fullscreen-mode-on-macos-taho.

I tried setting `.scrollEdgeEffectHidden()` on various nodes in the SwiftUI hierarchy, but couldn't get it to work, so I ended up resorting to an old-fashioned game of imperative whack-a-mole. Now:

<img width="504" height="272" alt="Screenshot 2025-10-22 at 21 28 47" src="https://github.com/user-attachments/assets/e4499f16-5bd0-43cd-a7de-37fbc56eb1c4" />

AI disclosure (my first!): I consulted copilot trying to figure out of the whole SwiftUI/AppKit situation and whether there might be a declarative solution on the SwiftUI side. Just chatting in general terms without showing real-world code. No dice.