### PR TITLE
macos: use TextEditor instead of Text for clipboard confirmation

### DIFF
--- a/macos/Sources/Features/ClipboardConfirmation/ClipboardConfirmationView.swift
+++ b/macos/Sources/Features/ClipboardConfirmation/ClipboardConfirmationView.swift
@@ -45,19 +45,15 @@ struct ClipboardConfirmationView: View {
                     .font(.system(size: 42))
                     .padding()
                     .frame(alignment: .center)
-
+                
                 Text(request.text())
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding()
             }
-
-            ScrollView {
-                Text(contents)
-                    .textSelection(.enabled)
-                    .font(.system(.body, design: .monospaced))
-                    .padding(.all, 4)
-            }
-
+            
+            TextEditor(text: .constant(contents))
+                .font(.system(.body, design: .monospaced))
+            
             HStack {
                 Spacer()
                 Button(Action.text(.cancel, request)) { onCancel() }


### PR DESCRIPTION
Fixes #9322

SwiftUI `Text` has huge performance issues. On my maxed out MBP it hangs for any text more than 100KB (it took ~8s to display it!). `TextEditor` with a constant value works much better and handles scrolling for us, too!