### PR TITLE
input: command palette actions must use formatter, not tag

### DIFF
--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -50,7 +50,7 @@ pub const Command = struct {
 
         return .{
             .action_key = @tagName(self.action),
-            .action = std.fmt.comptimePrint("{t}", .{self.action}),
+            .action = std.fmt.comptimePrint("{f}", .{self.action}),
             .title = self.title,
             .description = self.description,
         };


### PR DESCRIPTION
Regression from our Zig 0.15 migration.