### PR TITLE
macOS: fix #8282

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -149,10 +149,7 @@ extension Ghostty {
             }
 
             ghostty_app_update_config(app, newConfig.config!)
-
-            // We can only set our config after updating it so that we don't free
-            // memory that may still be in use
-            self.config = newConfig
+            /// applied config will be updated in ``Self.configChange(_:target:v:)``
         }
 
         func reloadConfig(surface: ghostty_surface_t, soft: Bool = false) {


### PR DESCRIPTION
After `ghostty_app_update_config`, `ghostty_action_config_change_s` was fired with the correct config. This happens synchronously, which will update `App.config` in `App.configChange(_:target:v:)`.

Previously, after updating, `App.config` was set with the stale one, which caused #8282.