### PR TITLE
macOS: update window appearance based on `preferredBackgroundColor`

### DIFF
--- a/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsVenturaTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsVenturaTerminalWindow.swift
@@ -143,6 +143,10 @@ class TitlebarTabsVenturaTerminalWindow: TerminalWindow {
 
     override func syncAppearance(_ surfaceConfig: Ghostty.SurfaceView.DerivedConfig) {
         super.syncAppearance(surfaceConfig)
+        // override appearance based on the terminal's background color
+        if let preferredBackgroundColor {
+            appearance = (preferredBackgroundColor.isLightColor ? NSAppearance(named: .aqua) : NSAppearance(named: .darkAqua))
+        }
 
         // Update our window light/darkness based on our updated background color
         let themeChanged = isLightTheme != OSColor(surfaceConfig.backgroundColor).isLightColor

--- a/macos/Sources/Features/Terminal/Window Styles/TransparentTitlebarTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TransparentTitlebarTerminalWindow.swift
@@ -59,6 +59,10 @@ class TransparentTitlebarTerminalWindow: TerminalWindow {
 
     override func syncAppearance(_ surfaceConfig: Ghostty.SurfaceView.DerivedConfig) {
         super.syncAppearance(surfaceConfig)
+        // override appearance based on the terminal's background color
+        if let preferredBackgroundColor {
+            appearance = (preferredBackgroundColor.isLightColor ? NSAppearance(named: .aqua) : NSAppearance(named: .darkAqua))
+        }
 
         // Save our config in case we need to reapply
         lastSurfaceConfig = surfaceConfig

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1765,7 +1765,7 @@ keybind: Keybinds = .{},
 ///   * `ghostty` - Use the background and foreground colors specified in the
 ///     Ghostty configuration. This is only supported on Linux builds.
 ///
-/// On macOS, if `macos-titlebar-style` is "tabs", the window theme will be
+/// On macOS, if `macos-titlebar-style` is `tabs` or `transparent`, the window theme will be
 /// automatically set based on the luminosity of the terminal background color.
 /// This only applies to terminal windows. This setting will still apply to
 /// non-terminal windows within Ghostty.


### PR DESCRIPTION
### Background

> Reported from https://discord.com/channels/1005603569187160125/1320882404717625374/1431258448439279709


Per current implementation, when `macos-titlebar-style` is `tabs` or `transparent`, the titlebar's background is hidden to enable a blur effect, but this could result in an incorrect appearance when the window's appearance is different from the one based on the terminal's background color. For instance, with the following configs: 

```
window-theme = "light"
// theme will be default to Ghostty, which is dark
```

or

```
window-theme = "system"
// theme will be default to Ghostty, which is dark
// and system theme is set to light
```

### Changes

Update window theme based on the terminal's background color when using `tabs` or `transparent`