### PR TITLE
Update Inspector to the new Stream/VTHandler APIs

### DIFF
--- a/src/inspector/Inspector.zig
+++ b/src/inspector/Inspector.zig
@@ -172,11 +172,7 @@ pub fn init(surface: *Surface) !Inspector {
         .surface = surface,
         .key_events = key_buf,
         .vt_events = vt_events,
-        .vt_stream = stream: {
-            var s: inspector.termio.Stream = .init(vt_handler);
-            s.parser.osc_parser.alloc = surface.alloc;
-            break :stream s;
-        },
+        .vt_stream = .initAlloc(surface.alloc, vt_handler),
     };
 }
 
@@ -194,7 +190,6 @@ pub fn deinit(self: *Inspector) void {
         while (it.next()) |v| v.deinit(self.surface.alloc);
         self.vt_events.deinit(self.surface.alloc);
 
-        self.vt_stream.handler.deinit();
         self.vt_stream.deinit();
     }
 }


### PR DESCRIPTION
Fixes a double-free bug when closing the inspector.

Not sure if there's a good way to add a test to check that allocation and deallocation are sound here? To instantiate an Inspector you need a Surface, which in turn requires an entire App/apprt. Doesn't look like the repo has any tests with that kind of scope at the moment?