### PR TITLE
gtk: Register toggle-maximize and toggle-fullscreen as SimpleActions

### DIFF
--- a/src/apprt/gtk/class/window.zig
+++ b/src/apprt/gtk/class/window.zig
@@ -349,6 +349,7 @@ pub const Window = extern struct {
             .init("toggle-command-palette", actionToggleCommandPalette, null),
             .init("toggle-inspector", actionToggleInspector, null),
             .init("toggle-maximize", actionToggleMaximize, null),
+            .init("toggle-fullscreen", actionToggleFullscreen, null),
         };
 
         ext.actions.add(Self, self, &actions);
@@ -1836,6 +1837,14 @@ pub const Window = extern struct {
         self: *Window,
     ) callconv(.c) void {
         self.performBindingAction(.toggle_maximize);
+    }
+
+    fn actionToggleFullscreen(
+        _: *gio.SimpleAction,
+        _: ?*glib.Variant,
+        self: *Window,
+    ) callconv(.c) void {
+        self.performBindingAction(.toggle_fullscreen);
     }
 
     fn actionRingBell(

--- a/src/apprt/gtk/class/window.zig
+++ b/src/apprt/gtk/class/window.zig
@@ -348,6 +348,7 @@ pub const Window = extern struct {
             // TODO: accept the surface that toggled the command palette
             .init("toggle-command-palette", actionToggleCommandPalette, null),
             .init("toggle-inspector", actionToggleInspector, null),
+            .init("toggle-maximize", actionToggleMaximize, null),
         };
 
         ext.actions.add(Self, self, &actions);
@@ -1618,6 +1619,7 @@ pub const Window = extern struct {
         self: *Self,
     ) callconv(.c) void {
         _ = surface;
+
         if (self.as(gtk.Window).isMaximized() != 0) {
             self.as(gtk.Window).unmaximize();
         } else {
@@ -1826,6 +1828,14 @@ pub const Window = extern struct {
         self: *Window,
     ) callconv(.c) void {
         self.performBindingAction(.clear_screen);
+    }
+
+    fn actionToggleMaximize(
+        _: *gio.SimpleAction,
+        _: ?*glib.Variant,
+        self: *Window,
+    ) callconv(.c) void {
+        self.performBindingAction(.toggle_maximize);
     }
 
     fn actionRingBell(


### PR DESCRIPTION
  This PR adds GTK SimpleAction registration for `toggle_maximize` and `toggle_fullscreen`, enabling
  these actions to be triggered via D-Bus and other programmatic interfaces.

  ## Background

  These actions already work perfectly fine through keybinds (thanks to the apprt callback system in
  `application.zig`), but they weren't registered as GTK actions, which meant external tools and D-Bus
  couldn't trigger them.

  ## What Changed

  Added GTK SimpleAction registration for both actions in `window.zig`:
  - Added `"toggle-maximize"` and `"toggle-fullscreen"` to the window actions array
  - Implemented handler functions that route to the existing `performBindingAction()` infrastructure

  This follows the same pattern as other window actions like `split-*`, `copy`, `paste`, etc.

  ## What This Enables

  ### D-Bus Activation

  Before this PR (v1.2.3):
  ```bash
  $ gdbus call --session --dest com.mitchellh.ghostty \
      --object-path /com/mitchellh/ghostty/window/1 \
      --method org.gtk.Actions.Activate "toggle-fullscreen" "[]" '@a{sv} {}'
  Error: Unknown action 'toggle-fullscreen'

  After:
  $ gdbus call --session --dest com.mitchellh.ghostty \
      --object-path /com/mitchellh/ghostty/window/1 \
      --method org.gtk.Actions.Activate "toggle-fullscreen" "[]" '@a{sv} {}'
  ()  # Success - window toggles fullscreen

  GTK Action Discovery

  The actions now show up when you query the GTK action registry - useful for automation tools, desktop
   environment integrations, accessibility tools, and any other external software.

  Note on Keybinds

  Keybinds like keybind = alt+enter=toggle_maximize already work in v1.2.3 through the apprt callback
  system. This PR doesn't change keybind functionality - it only adds the ability to trigger these
  actions programmatically through D-Bus and GTK's action system.

  Testing

  Tested on GNOME/Wayland with GTK 4.14.5 - keybinds still work, D-Bus activation now works, and
  actions are present in GTK registry.

**AI Assistance**: This fix was developed with assistance from Claude Code (Anthropic), including root cause investigation, code analysis, patch creation, automated testing, and comprehensive feature testing that discovered the second bug.