### PR TITLE
cli: make +ssh-cache contains() a read-only op

### DIFF
--- a/src/cli/ssh-cache/DiskCache.zig
+++ b/src/cli/ssh-cache/DiskCache.zig
@@ -181,13 +181,12 @@ pub fn contains(
     // Open our file
     const file = std.fs.openFileAbsolute(
         self.path,
-        .{ .mode = .read_write },
+        .{},
     ) catch |err| switch (err) {
         error.FileNotFound => return false,
         else => return err,
     };
     defer file.close();
-    try fixupPermissions(file);
 
     // Read existing entries
     var entries = try readEntries(alloc, file);


### PR DESCRIPTION
contains() checks the cache for an existing entry. It's a read-only operation, so we can drop the write bit and fixupPermissions() call. This is also consistent with the list() operation.

fixupPermissions() is unnecessary in this code path. It provided minimal additional security because all of our creation and update operations enforce 0o600 (owner-only) permissions, so anyone tampering with this file has already gotten around that. The contents of this (ssh host cache) file are also not sensitive enough to warrant any additional hardening on reads.