### PR TITLE
shaders: add iPreviousTimeCursorChange uniform

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2603,6 +2603,9 @@ keybind: Keybinds = .{},
 ///    the same time as the `iTime` uniform, allowing you to compute the
 ///    time since the change by subtracting this from `iTime`.
 ///
+///  * `float iPreviousTimeCursorChange` - Timestamp of the previous terminal
+///    cursor change.
+///
 /// If the shader fails to compile, the shader will be ignored. Any errors
 /// related to shader compilation will not show up as configuration errors
 /// and only show up in the log, since shader compilation happens after

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -739,6 +739,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     .current_cursor_color = @splat(0),
                     .previous_cursor_color = @splat(0),
                     .cursor_change_time = 0,
+                    .previous_cursor_change_time = 0,
                 },
                 .bg_image_buffer = undefined,
 
@@ -2353,6 +2354,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     uniforms.previous_cursor_color = uniforms.current_cursor_color;
                     uniforms.current_cursor = new_cursor;
                     uniforms.current_cursor_color = cursor_color;
+                    uniforms.previous_cursor_change_time = uniforms.cursor_change_time;
                     uniforms.cursor_change_time = uniforms.time;
                 }
             }

--- a/src/renderer/shaders/shadertoy_prefix.glsl
+++ b/src/renderer/shaders/shadertoy_prefix.glsl
@@ -16,6 +16,7 @@ layout(binding = 1, std140) uniform Globals {
     uniform vec4  iCurrentCursorColor;
     uniform vec4  iPreviousCursorColor;
     uniform float iTimeCursorChange;
+    uniform float iPreviousTimeCursorChange;
 };
 
 layout(binding = 0) uniform sampler2D iChannel0;

--- a/src/renderer/shadertoy.zig
+++ b/src/renderer/shadertoy.zig
@@ -26,6 +26,7 @@ pub const Uniforms = extern struct {
     current_cursor_color: [4]f32 align(16),
     previous_cursor_color: [4]f32 align(16),
     cursor_change_time: f32 align(4),
+    previous_cursor_change_time: f32 align(4),
 };
 
 /// The target to load shaders for.


### PR DESCRIPTION
Add a new shader uniform that tracks the timestamp of the previous cursor change. This complements the existing iTimeCursorChange uniform and allows shader authors to calculate the time between cursor changes.

The uniform is automatically updated whenever the cursor position or color changes, storing the previous value of iTimeCursorChange before it gets updated to the current time.

This is useful for creating animations that depend on the duration between cursor movements or for implementing effects that need to track cursor change history.

Amp-Thread-ID: https://ampcode.com/threads/T-78e0a91a-5303-40b4-ae6c-1bb5f1efabdf
Co-authored-by: Amp <amp@ampcode.com>
