### PR TITLE
terminal: selectionString now uses ScreenFormatter

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2006,7 +2006,9 @@ keybind: Keybinds = .{},
 @"clipboard-write": ClipboardAccess = .allow,
 
 /// Trims trailing whitespace on data that is copied to the clipboard. This does
-/// not affect data sent to the clipboard via `clipboard-write`.
+/// not affect data sent to the clipboard via `clipboard-write`. This only
+/// applies to trailing whitespace on lines that have other characters.
+/// Completely blank lines always have their whitespace trimmed.
 @"clipboard-trim-trailing-spaces": bool = true,
 
 /// Require confirmation before pasting text that appears unsafe. This helps


### PR DESCRIPTION
This replaces the logic of Screen.selectionString with calls to ScreenFormatter. 

This means that all our various selection-based features like copying to clipboards now uses the new formatter. The formatter code is now user-facing.

This forced us to pass all selectionString tests which  revealed some edge cases that were not handled correctly before in the  formatter! The formatter now handles:

- Plain text now emits `\n` instead of `\r\n`. VT emits `\r\n`
 - Rectangular selections
 - Various wide character edge cases
 - Selection is now inclusive on the end, not exclusive