### PR TITLE
macOS: make text editor in clipboard confirmation non focusable

### DIFF
--- a/macos/Sources/Features/ClipboardConfirmation/ClipboardConfirmationView.swift
+++ b/macos/Sources/Features/ClipboardConfirmation/ClipboardConfirmationView.swift
@@ -52,6 +52,7 @@ struct ClipboardConfirmationView: View {
             }
             
             TextEditor(text: .constant(contents))
+                .focusable(false)
                 .font(.system(.body, design: .monospaced))
             
             HStack {


### PR DESCRIPTION
With its being `focusable`(default), the first responder became the text editor instead of the paste button.

This fixes the issue where one can't confirm with the keyboard.

This doesn't affect its selection.