### PR TITLE
terminal: HTML formatting

### DIFF
--- a/src/lib_vt.zig
+++ b/src/lib_vt.zig
@@ -25,6 +25,7 @@ pub const osc = terminal.osc;
 pub const point = terminal.point;
 pub const color = terminal.color;
 pub const device_status = terminal.device_status;
+pub const formatter = terminal.formatter;
 pub const kitty = terminal.kitty;
 pub const modes = terminal.modes;
 pub const page = terminal.page;


### PR DESCRIPTION
This adds HTML formatting capabilities to the formatter package. HTML is emitted as inline styles. For palette indexes, direct RGB is emitted if we have access to a palette; otherwise, we fall back to CSS variables.

This isn't exposed to end users yet, but will enable copy as html features. This is available in libghostty. 

Fixes #9395

**AI disclosure:** I used AI (Amp) to help me write tests, but the implementation was done manually. I reviewed everything. 