### PR TITLE
cli: make the entire +ssh-cache cache path

### DIFF
--- a/src/cli/ssh-cache/DiskCache.zig
+++ b/src/cli/ssh-cache/DiskCache.zig
@@ -70,7 +70,7 @@ pub fn add(
 
     // Create cache directory if needed
     if (std.fs.path.dirname(self.path)) |dir| {
-        std.fs.makeDirAbsolute(dir) catch |err| switch (err) {
+        std.fs.cwd().makePath(dir) catch |err| switch (err) {
             error.PathAlreadyExists => {},
             else => return err,
         };


### PR DESCRIPTION
std.fs.makeDirAbsolute() only creates the last directory. We instead need Dir.makePath() to make the entire path, including intermediate directories.

This fixes the problem where a missing $XDG_STATE_HOME directory (e.g. ~/.local/state/) would prevent our ssh cache file from being created.

Fixes #9393