### PR TITLE
input: write_*_file actions take an optional format

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -700,6 +700,7 @@ typedef struct {
 typedef enum {
   GHOSTTY_ACTION_OPEN_URL_KIND_UNKNOWN,
   GHOSTTY_ACTION_OPEN_URL_KIND_TEXT,
+  GHOSTTY_ACTION_OPEN_URL_KIND_HTML,
 } ghostty_action_open_url_kind_e;
 
 // apprt.action.OpenUrl.C

--- a/macos/Sources/Ghostty/Ghostty.Action.swift
+++ b/macos/Sources/Ghostty/Ghostty.Action.swift
@@ -45,11 +45,14 @@ extension Ghostty.Action {
         enum Kind {
             case unknown
             case text
+            case html
             
             init(_ c: ghostty_action_open_url_kind_e) {
                 switch c {
                 case GHOSTTY_ACTION_OPEN_URL_KIND_TEXT:
                     self = .text
+                case GHOSTTY_ACTION_OPEN_URL_KIND_HTML:
+                    self = .html
                 default:
                     self = .unknown
                 }

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -676,6 +676,10 @@ extension Ghostty {
                     return true
                 }
                 
+            case .html:
+                // The extension will be HTML and we do the right thing automatically.
+                break
+                
             case .unknown:
                 break
             }

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -724,6 +724,9 @@ pub const OpenUrl = struct {
         /// should try to open the URL in a text editor or viewer or
         /// some equivalent, if possible.
         text,
+
+        /// The URL is known to contain HTML content.
+        html,
     };
 
     // Sync with: ghostty_action_open_url_s

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -239,6 +239,56 @@ fn actionCommands(action: Action.Key) []const Command {
                 .title = "Copy Screen to Temporary File and Open",
                 .description = "Copy the screen contents to a temporary file and open it.",
             },
+
+            .{
+                .action = .{ .write_screen_file = .{
+                    .action = .copy,
+                    .emit = .html,
+                } },
+                .title = "Copy Screen as HTML to Temporary File and Copy Path",
+                .description = "Copy the screen contents as HTML to a temporary file and copy the path to the clipboard.",
+            },
+            .{
+                .action = .{ .write_screen_file = .{
+                    .action = .paste,
+                    .emit = .html,
+                } },
+                .title = "Copy Screen as HTML to Temporary File and Paste Path",
+                .description = "Copy the screen contents as HTML to a temporary file and paste the path to the file.",
+            },
+            .{
+                .action = .{ .write_screen_file = .{
+                    .action = .open,
+                    .emit = .html,
+                } },
+                .title = "Copy Screen as HTML to Temporary File and Open",
+                .description = "Copy the screen contents as HTML to a temporary file and open it.",
+            },
+
+            .{
+                .action = .{ .write_screen_file = .{
+                    .action = .copy,
+                    .emit = .vt,
+                } },
+                .title = "Copy Screen as ANSI Sequences to Temporary File and Copy Path",
+                .description = "Copy the screen contents as ANSI escape sequences to a temporary file and copy the path to the clipboard.",
+            },
+            .{
+                .action = .{ .write_screen_file = .{
+                    .action = .paste,
+                    .emit = .vt,
+                } },
+                .title = "Copy Screen as ANSI Sequences to Temporary File and Paste Path",
+                .description = "Copy the screen contents as ANSI escape sequences to a temporary file and paste the path to the file.",
+            },
+            .{
+                .action = .{ .write_screen_file = .{
+                    .action = .open,
+                    .emit = .vt,
+                } },
+                .title = "Copy Screen as ANSI Sequences to Temporary File and Open",
+                .description = "Copy the screen contents as ANSI escape sequences to a temporary file and open it.",
+            },
         },
 
         .write_selection_file => comptime &.{
@@ -256,6 +306,56 @@ fn actionCommands(action: Action.Key) []const Command {
                 .action = .{ .write_selection_file = .open },
                 .title = "Copy Selection to Temporary File and Open",
                 .description = "Copy the selection contents to a temporary file and open it.",
+            },
+
+            .{
+                .action = .{ .write_selection_file = .{
+                    .action = .copy,
+                    .emit = .html,
+                } },
+                .title = "Copy Selection as HTML to Temporary File and Copy Path",
+                .description = "Copy the selection contents as HTML to a temporary file and copy the path to the clipboard.",
+            },
+            .{
+                .action = .{ .write_selection_file = .{
+                    .action = .paste,
+                    .emit = .html,
+                } },
+                .title = "Copy Selection as HTML to Temporary File and Paste Path",
+                .description = "Copy the selection contents as HTML to a temporary file and paste the path to the file.",
+            },
+            .{
+                .action = .{ .write_selection_file = .{
+                    .action = .open,
+                    .emit = .html,
+                } },
+                .title = "Copy Selection as HTML to Temporary File and Open",
+                .description = "Copy the selection contents as HTML to a temporary file and open it.",
+            },
+
+            .{
+                .action = .{ .write_selection_file = .{
+                    .action = .copy,
+                    .emit = .vt,
+                } },
+                .title = "Copy Selection as ANSI Sequences to Temporary File and Copy Path",
+                .description = "Copy the selection contents as ANSI escape sequences to a temporary file and copy the path to the clipboard.",
+            },
+            .{
+                .action = .{ .write_selection_file = .{
+                    .action = .paste,
+                    .emit = .vt,
+                } },
+                .title = "Copy Selection as ANSI Sequences to Temporary File and Paste Path",
+                .description = "Copy the selection contents as ANSI escape sequences to a temporary file and paste the path to the file.",
+            },
+            .{
+                .action = .{ .write_selection_file = .{
+                    .action = .open,
+                    .emit = .vt,
+                } },
+                .title = "Copy Selection as ANSI Sequences to Temporary File and Open",
+                .description = "Copy the selection contents as ANSI escape sequences to a temporary file and open it.",
             },
         },
 

--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -34,7 +34,7 @@ pub fn open(
         .macos => .init(
             switch (kind) {
                 .text => &.{ "open", "-t", url },
-                .unknown => &.{ "open", url },
+                .html, .unknown => &.{ "open", url },
             },
             alloc,
         ),


### PR DESCRIPTION
Fixes #9398

This is fully backwards compatible. Example: `write_screen_file:open,html`