### PR TITLE
apprt/gtk: set multiple content types for clipboard ops

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1962,7 +1962,7 @@ fn copySelectionToClipboards(
 ) !void {
     // Create an arena to simplify memory management here.
     var arena = ArenaAllocator.init(self.alloc);
-    errdefer arena.deinit();
+    defer arena.deinit();
     const alloc = arena.allocator();
 
     // The options we'll use for all formatting. We'll just override the


### PR DESCRIPTION
This supports the new `setClipboard` parameter that may provide data in multiple formats, allowing us to copy rich text to/from the clipboard as well as other types in the future.

This all fixes a memory leak on all clipboard ops that snuck through.