### PR TITLE
gtk: add GSettings support for window state persistence

### DIFF
--- a/data/com.mitchellh.ghostty.gschema.xml
+++ b/data/com.mitchellh.ghostty.gschema.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <schema id="com.mitchellh.ghostty" path="/com/mitchellh/ghostty/">
+    <key name="window-size" type="(uu)">
+      <default>(0, 0)</default>
+      <summary>Last window size</summary>
+      <description>
+        The last window size in terminal columns and rows. This is used to
+        restore the window size when window-save-state is enabled. A value
+        of (0, 0) means no size has been saved yet.
+      </description>
+    </key>
+  </schema>
+</schemalist>

--- a/data/ghostty.gschema.xml.in
+++ b/data/ghostty.gschema.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
-  <schema id="@APPID@" path="/@APPID_PATH@/">
+  <schema id="@APPID@" path="@APPID_PATH@">
     <key name="window-size" type="(uu)">
       <default>(0, 0)</default>
       <summary>Last window size</summary>

--- a/data/ghostty.gschema.xml.in
+++ b/data/ghostty.gschema.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
-  <schema id="com.mitchellh.ghostty" path="/com/mitchellh/ghostty/">
+  <schema id="@APPID@" path="/@APPID_PATH@/">
     <key name="window-size" type="(uu)">
       <default>(0, 0)</default>
       <summary>Last window size</summary>

--- a/flatpak/com.mitchellh.ghostty-debug.yml
+++ b/flatpak/com.mitchellh.ghostty-debug.yml
@@ -46,6 +46,7 @@ modules:
         --prefix /app
         --search-prefix /app
         --system $PWD/vendor/p
+      - glib-compile-schemas /app/share/glib-2.0/schemas
     sources:
       - type: dir
         path: ..

--- a/flatpak/com.mitchellh.ghostty.yml
+++ b/flatpak/com.mitchellh.ghostty.yml
@@ -45,6 +45,7 @@ modules:
         --prefix /app
         --search-prefix /app
         --system $PWD/vendor/p
+      - glib-compile-schemas /app/share/glib-2.0/schemas
     sources:
       - type: dir
         path: ..

--- a/src/apprt/gtk/class/window.zig
+++ b/src/apprt/gtk/class/window.zig
@@ -19,7 +19,7 @@ const gtk_version = @import("../gtk_version.zig");
 const adw_version = @import("../adw_version.zig");
 const gresource = @import("../build/gresource.zig");
 const winprotopkg = @import("../winproto.zig");
-const gtkSettings = @import("../settings.zig");
+const gtk_settings = @import("../settings.zig");
 const Common = @import("../class.zig").Common;
 const Config = @import("config.zig").Config;
 const Application = @import("application.zig").Application;
@@ -237,7 +237,7 @@ pub const Window = extern struct {
         winproto: winprotopkg.Window,
 
         /// GSettings for window state persistence
-        gsettings: gtkSettings.Settings,
+        gsettings: gtk_settings.Settings,
 
         /// Kind of hacky to have this but this lets us know if we've
         /// initialized any single surface yet. We need this because we
@@ -289,7 +289,7 @@ pub const Window = extern struct {
         priv.winproto = .none;
 
         // Initialize GSettings for window state persistence
-        priv.gsettings = gtkSettings.Settings.init();
+        priv.gsettings = gtk_settings.Settings.init();
 
         // Add our dev CSS class if we're in debug mode.
         if (comptime build_config.is_debug) {

--- a/src/apprt/gtk/class/window.zig
+++ b/src/apprt/gtk/class/window.zig
@@ -289,7 +289,10 @@ pub const Window = extern struct {
         priv.winproto = .none;
 
         // Initialize GSettings for window state persistence
-        priv.gsettings = gtk_settings.Settings.init();
+        // Get the actual app ID from the application (includes -debug suffix for debug builds)
+        const app = Application.default();
+        const app_id = app.as(gio.Application).getApplicationId() orelse build_config.bundle_id;
+        priv.gsettings = gtk_settings.Settings.init(app_id);
 
         // Add our dev CSS class if we're in debug mode.
         if (comptime build_config.is_debug) {

--- a/src/apprt/gtk/class/window.zig
+++ b/src/apprt/gtk/class/window.zig
@@ -1678,13 +1678,13 @@ pub const Window = extern struct {
 
             // Try to get saved size
             const saved_size = priv.gsettings.getWindowSize() orelse break :restore;
-            
+
             // Skip if no valid size was saved yet (0, 0 means unset)
             if (saved_size.columns == 0 or saved_size.rows == 0) break :restore;
 
             // Get the core surface to calculate pixel dimensions
             const core_surface = surface.core() orelse break :restore;
-            
+
             // Calculate pixel dimensions from grid size
             // pixel_size = (columns/rows * cell_width/height) + padding
             const cell_size = core_surface.size.cell;

--- a/src/apprt/gtk/settings.zig
+++ b/src/apprt/gtk/settings.zig
@@ -65,7 +65,7 @@ pub const Settings = struct {
             return null;
         }
 
-        return WindowSize{
+        return .{
             .columns = @intCast(columns),
             .rows = @intCast(rows),
         };

--- a/src/apprt/gtk/settings.zig
+++ b/src/apprt/gtk/settings.zig
@@ -1,0 +1,92 @@
+//! GSettings wrapper for window state persistence on Linux
+const std = @import("std");
+const gio = @import("gio");
+const glib = @import("glib");
+
+const log = std.log.scoped(.gtk_settings);
+
+/// Window size in terminal grid dimensions (columns, rows)
+pub const WindowSize = struct {
+    columns: u32,
+    rows: u32,
+};
+
+/// GSettings wrapper for Ghostty window state
+pub const Settings = struct {
+    settings: ?*gio.Settings,
+
+    const schema_id = "com.mitchellh.ghostty";
+
+    /// Initialize GSettings. Returns null if schema is not installed.
+    pub fn init() Settings {
+        // Check if schema exists before trying to use it
+        const source = gio.SettingsSchemaSource.getDefault() orelse {
+            log.warn("no GSettings schema source available", .{});
+            return .{ .settings = null };
+        };
+
+        const schema = gio.SettingsSchemaSource.lookup(
+            source,
+            schema_id,
+            @intFromBool(false),
+        ) orelse {
+            log.info("GSettings schema '{s}' not installed, window state will not persist", .{schema_id});
+            return .{ .settings = null };
+        };
+        defer schema.unref();
+
+        const settings = gio.Settings.new(schema_id);
+        return .{ .settings = settings };
+    }
+
+    pub fn deinit(self: *Settings) void {
+        if (self.settings) |s| {
+            s.unref();
+            self.settings = null;
+        }
+    }
+
+    /// Get the last saved window size
+    pub fn getWindowSize(self: *const Settings) ?WindowSize {
+        const settings = self.settings orelse return null;
+
+        var columns: c_uint = 0;
+        var rows: c_uint = 0;
+
+        gio.Settings.get(
+            settings,
+            "window-size",
+            "(uu)",
+            &columns,
+            &rows,
+        );
+
+        // Sanity check the values
+        if (columns == 0 or rows == 0 or columns > 999 or rows > 999) {
+            return null;
+        }
+
+        return WindowSize{
+            .columns = @intCast(columns),
+            .rows = @intCast(rows),
+        };
+    }
+
+    /// Save the current window size
+    pub fn setWindowSize(self: *const Settings, size: WindowSize) void {
+        const settings = self.settings orelse return;
+
+        const columns: c_uint = @intCast(size.columns);
+        const rows: c_uint = @intCast(size.rows);
+
+        _ = gio.Settings.set(
+            settings,
+            "window-size",
+            "(uu)",
+            columns,
+            rows,
+        );
+
+        log.debug("saved window size: {}x{}", .{ size.columns, size.rows });
+    }
+};

--- a/src/apprt/gtk/settings.zig
+++ b/src/apprt/gtk/settings.zig
@@ -29,7 +29,7 @@ pub const Settings = struct {
             app_id,
             @intFromBool(false),
         ) orelse {
-            log.info("GSettings schema '{s}' not installed, window state will not persist", .{app_id});
+            log.warn("GSettings schema '{s}' not installed, window state will not persist", .{app_id});
             return .{ .settings = null };
         };
         defer schema.unref();

--- a/src/apprt/gtk/settings.zig
+++ b/src/apprt/gtk/settings.zig
@@ -17,7 +17,7 @@ pub const Settings = struct {
     settings: ?*gio.Settings,
 
     /// Initialize GSettings. Returns null if schema is not installed.
-    pub fn init() Settings {
+    pub fn init(app_id: [*:0]const u8) Settings {
         // Check if schema exists before trying to use it
         const source = gio.SettingsSchemaSource.getDefault() orelse {
             log.warn("no GSettings schema source available", .{});
@@ -26,15 +26,15 @@ pub const Settings = struct {
 
         const schema = gio.SettingsSchemaSource.lookup(
             source,
-            build_config.bundle_id,
+            app_id,
             @intFromBool(false),
         ) orelse {
-            log.info("GSettings schema '{s}' not installed, window state will not persist", .{build_config.bundle_id});
+            log.info("GSettings schema '{s}' not installed, window state will not persist", .{app_id});
             return .{ .settings = null };
         };
         defer schema.unref();
 
-        const settings = gio.Settings.new(build_config.bundle_id);
+        const settings = gio.Settings.new(app_id);
         return .{ .settings = settings };
     }
 

--- a/src/apprt/gtk/settings.zig
+++ b/src/apprt/gtk/settings.zig
@@ -1,5 +1,6 @@
 //! GSettings wrapper for window state persistence on Linux
 const std = @import("std");
+const build_config = @import("../../build_config.zig");
 const gio = @import("gio");
 const glib = @import("glib");
 
@@ -15,8 +16,6 @@ pub const WindowSize = struct {
 pub const Settings = struct {
     settings: ?*gio.Settings,
 
-    const schema_id = "com.mitchellh.ghostty";
-
     /// Initialize GSettings. Returns null if schema is not installed.
     pub fn init() Settings {
         // Check if schema exists before trying to use it
@@ -27,15 +26,15 @@ pub const Settings = struct {
 
         const schema = gio.SettingsSchemaSource.lookup(
             source,
-            schema_id,
+            build_config.bundle_id,
             @intFromBool(false),
         ) orelse {
-            log.info("GSettings schema '{s}' not installed, window state will not persist", .{schema_id});
+            log.info("GSettings schema '{s}' not installed, window state will not persist", .{build_config.bundle_id});
             return .{ .settings = null };
         };
         defer schema.unref();
 
-        const settings = gio.Settings.new(schema_id);
+        const settings = gio.Settings.new(build_config.bundle_id);
         return .{ .settings = settings };
     }
 

--- a/src/build/GhosttyResources.zig
+++ b/src/build/GhosttyResources.zig
@@ -350,12 +350,13 @@ fn addLinuxAppResources(
         break :templates try ts.toOwnedSlice(b.allocator);
     };
 
-    // Convert app_id to path format (com.mitchellh.ghostty -> /com/mitchellh/ghostty)
+    // Convert app_id to path format (com.mitchellh.ghostty -> /com/mitchellh/ghostty/)
     const app_id_path = appid_path: {
-        const path = try b.allocator.alloc(u8, app_id.len);
-        for (app_id, 0..) |c, i| {
-            path[i] = if (c == '.') '/' else c;
-        }
+        const path = try b.allocator.alloc(u8, app_id.len + 2);
+        path[0] = '/';
+        @memcpy(path[1 .. app_id.len + 1], app_id);
+        std.mem.replaceScalar(u8, path[1 .. app_id.len + 1], '.', '/');
+        path[path.len - 1] = '/';
         break :appid_path path;
     };
 

--- a/src/build/GhosttyResources.zig
+++ b/src/build/GhosttyResources.zig
@@ -367,6 +367,15 @@ fn addLinuxAppResources(
         try steps.append(b.allocator, &copy.step);
     }
 
+    // GSettings schema for window state persistence
+    {
+        const schema_install = b.addInstallFile(
+            b.path("data/com.mitchellh.ghostty.gschema.xml"),
+            "share/glib-2.0/schemas/com.mitchellh.ghostty.gschema.xml",
+        );
+        try steps.append(b.allocator, &schema_install.step);
+    }
+
     // Right click menu action for Plasma desktop
     try steps.append(b.allocator, &b.addInstallFile(
         b.path("dist/linux/ghostty_dolphin.desktop"),

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1870,7 +1870,10 @@ keybind: Keybinds = .{},
 ///
 /// The default value is `default`.
 ///
-/// This is currently only supported on macOS. This has no effect on Linux.
+/// On macOS, this controls native window state restoration. On Linux with GTK,
+/// this saves/restores the window size (in terminal grid dimensions) using
+/// GSettings. Full session restoration (tabs, splits, working directories) is
+/// currently only supported on macOS.
 @"window-save-state": WindowSaveState = .default,
 
 /// Resize the window in discrete increments of the focused surface's cell size.


### PR DESCRIPTION
Implement GSettings to save and restore the window size in terminal grid dimensions on Linux. Include the necessary schema and update the application to handle window state management.

My solution is similar to how ptyxis does it in gnome.