### PR TITLE
gtk: fix xkb mapping not working in Linux

### DIFF
--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -1137,13 +1137,14 @@ pub const Surface = extern struct {
                 if (entry.native == keycode) break :w3c entry.key;
             } else .unidentified;
 
-            // If the key should be remappable, then consult the pre-remapped
-            // XKB keyval/keysym to get the (possibly) remapped key.
+            // Consult the pre-remapped XKB keyval/keysym to get the (possibly)
+            // remapped key. If the W3C key or the remapped key
+            // is eligible for remapping, we use it.
             //
             // See the docs for `shouldBeRemappable` for why we even have to
             // do this in the first place.
-            if (w3c_key.shouldBeRemappable()) {
-                if (gtk_key.keyFromKeyval(keyval)) |remapped|
+            if (gtk_key.keyFromKeyval(keyval)) |remapped| {
+                if (w3c_key.shouldBeRemappable() or remapped.shouldBeRemappable())
                     break :keycode remapped;
             }
 


### PR DESCRIPTION
Fix: https://github.com/ghostty-org/ghostty/discussions/8809#discussioncomment-14466017

If the physical key is non-remappable but is set to act as a remappable key in `xkb layout`, in the actual behavior, the key is dismissed by Ghostty (which is not the behavior in other apps).

With this modification, the key will be remapped if it is a remappable physical key or if the key it is remapped to is remappable.

This way, we respect the most possible the rules given by xkb, but we keep the non-remappable keys safe (cf previous bugs).