### PR TITLE
i18n: prefer using ellipsis over three dots

### DIFF
--- a/po/nb_NO.UTF-8.po
+++ b/po/nb_NO.UTF-8.po
@@ -90,7 +90,7 @@ msgstr "Del til høyre"
 
 #: src/apprt/gtk/ui/1.5/command-palette.blp:16
 msgid "Execute a command…"
-msgstr "Kjør en kommando..."
+msgstr "Kjør en kommando…"
 
 #: src/apprt/gtk/ui/1.0/menu-surface-context_menu.blp:6
 #: src/apprt/gtk/ui/1.0/menu-window-titlebar_menu.blp:6


### PR DESCRIPTION
After skimming through the norwegian bokmål translation (https://github.com/ghostty-org/ghostty/blob/main/po/nb_NO.UTF-8.po) I noticed a inconsistent use of three dots/ellipses. On [line 93](https://github.com/ghostty-org/ghostty/blob/main/po/nb_NO.UTF-8.po#L93), three dots (`...`) are present where the actual ellipsis sign (`…`) should be used instead. As mentioned in [this discord comment](https://discord.com/channels/1005603569187160125/1349894806180204625/1434515563496996988).

This is not a big "problem" by itself, but looking at the english translation and the rest of norwegian ones, you'll see that they all use the ellipsis sign. (e.g. `Execute a command…`, `Endre tittel…`)

This is just a simple one-liner replacing the three periods with an ellipsis sign.

cc @uzaaft 