### PR TITLE
nix: don't use deprecated pkgs.system

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -107,10 +107,10 @@
       overlays = {
         default = self.overlays.releasefast;
         releasefast = final: prev: {
-          ghostty = self.packages.${prev.system}.ghostty-releasefast;
+          ghostty = self.packages.${prev.stdenv.hostPlatform.system}.ghostty-releasefast;
         };
         debug = final: prev: {
-          ghostty = self.packages.${prev.system}.ghostty-debug;
+          ghostty = self.packages.${prev.stdenv.hostPlatform.system}.ghostty-debug;
         };
       };
       create-vm = import ./nix/vm/create.nix;


### PR DESCRIPTION
'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'

https://github.com/NixOS/nixpkgs/pull/456527