### PR TITLE
macos: add ignore list for autohide behavior for quick term

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -933,6 +933,9 @@ ghostty_input_trigger_s ghostty_config_trigger(ghostty_config_t,
 uint32_t ghostty_config_diagnostics_count(ghostty_config_t);
 ghostty_diagnostic_s ghostty_config_get_diagnostic(ghostty_config_t, uint32_t);
 ghostty_string_s ghostty_config_open_path(void);
+bool ghostty_config_quick_terminal_autohide_ignore_contains(ghostty_config_t,
+                                                            const char*,
+                                                            uintptr_t);
 
 ghostty_app_t ghostty_app_new(const ghostty_runtime_config_s*,
                               ghostty_config_t);

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -492,6 +492,15 @@ extension Ghostty {
             return v
         }
 
+        func quickTerminalAutohideIgnoreContains(_ bundleId: String) -> Bool {
+            guard let config = self.config else { return false }
+            return ghostty_config_quick_terminal_autohide_ignore_contains(
+                config,
+                bundleId,
+                UInt(bundleId.utf8.count)
+            )
+        }
+
         var quickTerminalSpaceBehavior: QuickTerminalSpaceBehavior {
             guard let config = self.config else { return .move }
             var v: UnsafePointer<Int8>? = nil

--- a/src/config/CApi.zig
+++ b/src/config/CApi.zig
@@ -133,6 +133,21 @@ export fn ghostty_config_open_path() c.String {
     return .fromSlice(path);
 }
 
+/// Check if a bundle ID is in the quick-terminal-autohide-ignore list.
+/// Returns true if the bundle ID should be ignored (i.e., quick terminal
+/// should NOT auto-hide when this app becomes active).
+export fn ghostty_config_quick_terminal_autohide_ignore_contains(
+    self: *Config,
+    bundle_id: [*]const u8,
+    len: usize,
+) bool {
+    const id = bundle_id[0..len];
+    for (self.@"quick-terminal-autohide-ignore".list.items) |item| {
+        if (std.mem.eql(u8, item, id)) return true;
+    }
+    return false;
+}
+
 /// Sync with ghostty_diagnostic_s
 const Diagnostic = extern struct {
     message: [*:0]const u8 = "",

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2358,6 +2358,23 @@ keybind: Keybinds = .{},
     else => false,
 },
 
+/// List of application bundle identifiers that should not trigger the quick
+/// terminal to auto-hide when they become active. This is useful for launcher
+/// apps (like Alfred, Raycast) or other utilities that are often used alongside
+/// the terminal.
+///
+/// This configuration can be repeated multiple times to specify multiple apps.
+///
+/// Example:
+///
+///     quick-terminal-autohide-ignore = com.runningwithcrayons.Alfred
+///     quick-terminal-autohide-ignore = com.raycast.macos
+///
+/// Only implemented on macOS.
+///
+/// Available since: 1.3.0
+@"quick-terminal-autohide-ignore": RepeatableString = .{},
+
 /// This configuration option determines the behavior of the quick terminal
 /// when switching between macOS spaces. macOS spaces are virtual desktops
 /// that can be manually created or are automatically created when an


### PR DESCRIPTION
Add configuration option to specify apps that should not trigger quick terminal autohide
when they become active. This is useful for launcher apps like Alfred or Raycast that
are often used alongside the terminal. The feature includes a new config field and
Swift/Zig implementations to check the ignore list.

Disclosure: I used an AI assistant to develop this pull request but tested it manually. I may have missed some features, and I apologize if anything is broken. Please let me know if you find any issues, and I'll fix them if possible.