### PR TITLE
Add an example for `palette` configuration

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -699,7 +699,8 @@ foreground: Color = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF },
 /// Color palette for the 256 color form that many terminal applications use.
 /// The syntax of this configuration is `N=COLOR` where `N` is 0 to 255 (for
 /// the 256 colors in the terminal color table) and `COLOR` is a typical RGB
-/// color code such as `#AABBCC` or `AABBCC`, or a named X11 color.
+/// color code such as `#AABBCC` or `AABBCC`, or a named X11 color. For example,
+/// `palette = 5=#BB78D9` will set the 'purple' color.
 ///
 /// The palette index can be in decimal, binary, octal, or hexadecimal.
 /// Decimal is assumed unless a prefix is used: `0b` for binary, `0o` for octal,


### PR DESCRIPTION
I found this syntax a bit confusing when I first read it, so I thought it would be helpful for the next person to add a short example.