### PR TITLE
macOS: Hide quick terminal after resigning as main window(fixes #4946)

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -153,18 +153,14 @@ class QuickTerminalController: BaseTerminalController {
         hiddenDock?.hide()
     }
 
-    override func windowDidResignKey(_ notification: Notification) {
-        super.windowDidResignKey(notification)
+    override func windowDidResignMain(_ notification: Notification) {
+        super.windowDidResignMain(notification)
 
         // If we're not visible then we don't want to run any of the logic below
         // because things like resetting our previous app assume we're visible.
         // windowDidResignKey will also get called after animateOut so this
         // ensures we don't run logic twice.
         guard visible else { return }
-
-        // We don't animate out if there is a modal sheet being shown currently.
-        // This lets us show alerts without causing the window to disappear.
-        guard window?.attachedSheet == nil else { return }
 
         // If our app is still active, then it means that we're switching
         // to another window within our app, so we remove the previous app

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -980,6 +980,10 @@ class BaseTerminalController: NSWindowController,
         self.syncFocusToSurfaceTree()
     }
 
+    func windowDidBecomeMain(_ notification: Notification) {}
+
+    func windowDidResignMain(_ notification: Notification) {}
+
     func windowDidChangeOcclusionState(_ notification: Notification) {
         let visible = self.window?.occlusionState.contains(.visible) ?? false
         for view in surfaceTree {

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -1062,7 +1062,8 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         }
     }
 
-    func windowDidBecomeMain(_ notification: Notification) {
+    override func windowDidBecomeMain(_ notification: Notification) {
+        super.windowDidBecomeMain(notification)
         // Whenever we get focused, use that as our last window position for
         // restart. This differs from Terminal.app but matches iTerm2 behavior
         // and I think its sensible.


### PR DESCRIPTION
~~Using `windowDidResignMain` instead of `windowDidResignKey` can solve #4946.~~

~~Typically, quick terminal resigns as main window when resigning as key window/first responder, but when dragging files from finder will only cause quick terminal lose its key window, not its main window status -- if the destination is quick terminal not other application.~~

~~I'm also deleting `window?.attachedSheet` check, since when a modal or sheet alert is presented, quick terminal only resigns only as the first responder (key window), but not as the main window, so we don't need that anymore.~~

### Reference
- [The Path of Mouse and Tablet Events](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/EventOverview/EventArchitecture/EventArchitecture.html#//apple_ref/doc/uid/10000060i-CH3-SW21)
- [Responder Chain for Action Messages](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/EventOverview/EventArchitecture/EventArchitecture.html#//apple_ref/doc/uid/10000060i-CH3-SW2)