### PR TITLE
macOS: fix Dictation icon starting above the text, not below

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -1728,10 +1728,13 @@ extension Ghostty.SurfaceView: NSTextInputClient {
 
         // Ghostty coordinates are in top-left (0, 0) so we have to convert to
         // bottom-left since that is what UIKit expects
+        // when there's is no characters selected,
+        // width should be 0 so that dictation indicator
+        // can start in the right place
         let viewRect = NSMakeRect(
             x,
             frame.size.height - y,
-            max(width, cellSize.width),
+            width,
             max(height, cellSize.height))
 
         // Convert the point to the window coordinates


### PR DESCRIPTION
Partially fixes #8493.

After dictating some texts, the icon still appears above, but it will return to its right position after resizing or `\n` (saying newline, not hitting enter).

This behaviour is better than before, where the icon always appeared above.

> Quicklook doesn't seem to call this on Tahoe, but it still works well anyway.

### Reference:

https://github.com/emacs-mirror/emacs/blob/9e905357bb5da9c0d54ec9d8a708ff0ac0411a09/src/nsterm.m#L7426


https://github.com/user-attachments/assets/6bf818c3-a0bb-412f-ae06-673f67cdeae4

