### PR TITLE
macOS: fix funky resolution in quick terminal

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalView.swift
+++ b/macos/Sources/Features/Terminal/TerminalView.swift
@@ -136,6 +136,7 @@ fileprivate struct UpdateOverlay: View {
                         .padding(.trailing, 9)
                 }
             }
+            .frame(maxWidth: .greatestFiniteMagnitude, maxHeight: .greatestFiniteMagnitude)
         }
     }
 }


### PR DESCRIPTION
Discord report: https://discord.com/channels/1005603569187160125/1430634248741589192

### Reproduce on 1.2.3

```
font-size   = 24
```

1. Setting a larger font size to make this issue easier to spot. 
2. Close all Ghostty windows.
3. Open Quick Terminal (no matter how you open it).
4. Exit with `ctrl+d`.

**Repeat 3-4 quickly within 10 times, and you will see the font in Quick Terminal become smaller.**

> Or you can reproduce on main, with line 117 to line 120 commented out in [TerminalView](https://github.com/ghostty-org/ghostty/blob/923bde72d81d039b19fd1dce27b48265ba023bad/macos/Sources/Features/Terminal/TerminalView.swift#L117)
> 
### Interesting RC

After some bisecting, I got this: [81e3ff90a35ed75839cea83d909790bf7d807c63](https://github.com/ghostty-org/ghostty/commit/81e3ff90a35ed75839cea83d909790bf7d807c63#diff-a268c57b94a4b10230d75b1e25aa7e66449684a022f9b70363ad37184a655625R113) is the first proper commit.

Apparently, the newly added `UpdateOverlay()` fixed the issue. With some testing, I think SwiftUI View updates in the terminal are affecting cell size.

```
screen size size=renderer.size.Size{ .screen = renderer.size.ScreenSize{ .width = 3024, .height = 736 }, .cell = renderer.size.CellSize{ .width = 29, .height = 64 }, .padding = renderer.size.Padding{ .top = 4, .bottom = 4, .right = 4, .left = 4 } }
# this is why the font became smaller
screen size size=renderer.size.Size{ .screen = renderer.size.ScreenSize{ .width = 3024, .height = 0 }, .cell = renderer.size.CellSize{ .width = 15, .height = 32 }, .padding = renderer.size.Padding{ .top = 2, .bottom = 2, .right = 4, .left = 4 } }
```

So the fix is pretty straightforward, just fill the whole ZStack in the window. 

These issues won't occur in a normal terminal window. Maybe it’s because their size is determined early or it’s another difference between NSPanel and NSWindow.