### PR TITLE
macOS: attach close confirmation alert to the first window that actually needs it

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -287,7 +287,6 @@ class BaseTerminalController: NSWindowController,
     func confirmClose(
         messageText: String,
         informativeText: String,
-        attachedWindow: NSWindow? = nil,
         completion: @escaping () -> Void
     ) {
         // If we already have an alert, we need to wait for that one.
@@ -295,7 +294,7 @@ class BaseTerminalController: NSWindowController,
 
         // If there is no window to attach the modal then we assume success
         // since we'll never be able to show the modal.
-        guard let window = attachedWindow ?? self.window else {
+        guard let window else {
             completion()
             return
         }

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -287,6 +287,7 @@ class BaseTerminalController: NSWindowController,
     func confirmClose(
         messageText: String,
         informativeText: String,
+        attachedWindow: NSWindow? = nil,
         completion: @escaping () -> Void
     ) {
         // If we already have an alert, we need to wait for that one.
@@ -294,7 +295,7 @@ class BaseTerminalController: NSWindowController,
 
         // If there is no window to attach the modal then we assume success
         // since we'll never be able to show the modal.
-        guard let window else {
+        guard let window = attachedWindow ?? self.window else {
             completion()
             return
         }


### PR DESCRIPTION
Currently, close confirmation is always attached to the first tab in the window group.

**This pr will attach the alert to the window that actually needs that confirmation, so upon close, the window with the running process will be focused.**

https://github.com/user-attachments/assets/8fddd4ce-a3f9-4e18-a645-80c85b5ba995

