### PR TITLE
macOS: update new window behaviour on different screen

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -505,7 +505,7 @@ class AppDelegate: NSObject,
         case .new_tab:
             _ = TerminalController.newTab(
                 ghostty,
-                from: TerminalController.preferredParent?.window,
+                from: TerminalController.preferredNewTabParent?.window,
                 withBaseConfig: config
             )
         case .new_window: _ = TerminalController.newWindow(ghostty, withBaseConfig: config)
@@ -1137,7 +1137,7 @@ class AppDelegate: NSObject,
     @IBAction func newTab(_ sender: Any?) {
         _ = TerminalController.newTab(
             ghostty,
-            from: TerminalController.preferredParent?.window
+            from: TerminalController.preferredNewTabParent?.window
         )
     }
 

--- a/macos/Sources/Features/App Intents/NewTerminalIntent.swift
+++ b/macos/Sources/Features/App Intents/NewTerminalIntent.swift
@@ -125,13 +125,17 @@ struct NewTerminalIntent: AppIntent {
             }
 
         case .splitLeft, .splitRight, .splitUp, .splitDown:
-            guard let parent,
-                  let controller = parent.window?.windowController as? BaseTerminalController else {
+            // split parent is like tab parent
+            let splitParent = parent ??
+                TerminalController.preferredNewSplitParent?.focusedSurface ??
+                TerminalController.preferredNewSplitParent?.surfaceTree.root?.leftmostLeaf()
+            guard let splitParent,
+                  let controller = splitParent.window?.windowController as? BaseTerminalController else {
                 throw GhosttyIntentError.surfaceNotFound
             }
 
             if let view = controller.newSplit(
-                at: parent,
+                at: splitParent,
                 direction: location.splitDirection!,
                 baseConfig: config
             ) {

--- a/macos/Sources/Features/App Intents/NewTerminalIntent.swift
+++ b/macos/Sources/Features/App Intents/NewTerminalIntent.swift
@@ -94,8 +94,6 @@ struct NewTerminalIntent: AppIntent {
             }
 
             parent = view
-        } else if let preferred = TerminalController.preferredParent {
-            parent = preferred.focusedSurface ?? preferred.surfaceTree.root?.leftmostLeaf()
         } else {
             parent = nil
         }
@@ -107,18 +105,20 @@ struct NewTerminalIntent: AppIntent {
         }
         switch location {
         case .window:
+            let parentWindow = parent?.window ?? TerminalController.preferredNewWindowParent?.window
             let newController = TerminalController.newWindow(
                 ghostty,
                 withBaseConfig: config,
-                withParent: parent?.window)
+                withParent: parentWindow)
             if let view = newController.surfaceTree.root?.leftmostLeaf() {
                 return .result(value: TerminalEntity(view))
             }
 
         case .tab:
+            let parentWindow = parent?.window ?? TerminalController.preferredNewTabParent?.window
             let newController = TerminalController.newTab(
                 ghostty,
-                from: parent?.window,
+                from: parentWindow,
                 withBaseConfig: config)
             if let view = newController?.surfaceTree.root?.leftmostLeaf() {
                 return .result(value: TerminalEntity(view))

--- a/macos/Sources/Features/Services/ServiceProvider.swift
+++ b/macos/Sources/Features/Services/ServiceProvider.swift
@@ -52,12 +52,12 @@ class ServiceProvider: NSObject {
 
             switch (target) {
             case .window:
-                _ = TerminalController.newWindow(delegate.ghostty, withBaseConfig: config)
+                _ = TerminalController.newWindow(delegate.ghostty, withBaseConfig: config, withParent: TerminalController.preferredNewWindowParent?.window)
 
             case .tab:
                 _ = TerminalController.newTab(
                     delegate.ghostty,
-                    from: TerminalController.preferredParent?.window,
+                    from: TerminalController.preferredNewTabParent?.window,
                     withBaseConfig: config)
             }
         }

--- a/macos/Sources/Features/Services/ServiceProvider.swift
+++ b/macos/Sources/Features/Services/ServiceProvider.swift
@@ -52,7 +52,7 @@ class ServiceProvider: NSObject {
 
             switch (target) {
             case .window:
-                _ = TerminalController.newWindow(delegate.ghostty, withBaseConfig: config, withParent: TerminalController.preferredNewWindowParent?.window)
+                _ = TerminalController.newWindow(delegate.ghostty, withBaseConfig: config)
 
             case .tab:
                 _ = TerminalController.newTab(

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -729,7 +729,11 @@ class BaseTerminalController: NSWindowController,
     @objc private func ghosttySurfaceDragEndedNoTarget(_ notification: Notification) {
         guard let target = notification.object as? Ghostty.SurfaceView else { return }
         guard let targetNode = surfaceTree.root?.node(view: target) else { return }
-        
+        guard let position = notification.userInfo?[
+            Notification.Name.ghosttySurfaceDragEndedNoTargetPointKey
+        ] as? NSPoint else {
+            return
+        }
         // If our tree isn't split, then we never create a new window, because
         // it is already a single split.
         guard surfaceTree.isSplit else { return }
@@ -758,8 +762,9 @@ class BaseTerminalController: NSWindowController,
         _ = TerminalController.newWindow(
             ghostty,
             tree: newTree,
-            position: notification.userInfo?[Notification.Name.ghosttySurfaceDragEndedNoTargetPointKey] as? NSPoint,
-            confirmUndo: false)
+            position: position,
+            confirmUndo: false,
+        )
     }
 
     // MARK: Local Events

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -194,12 +194,43 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         }
     }
 
+    // The preferred parent terminal controller for new window.
+    static var preferredNewWindowParent: TerminalController? {
+        preferredParent(on: .main)
+    }
+
+    // The preferred parent terminal controller for new tab.
+    static var preferredNewTabParent: TerminalController? {
+        // We choose a proper window on the current screen first.
+        // If none is found, we use existing windows on another screen.
+        // This could be changed to match `preferredNewWindowParent`,
+        // but for now, we always use an existing window.
+        preferredParent(on: .main) ?? preferredParent(on: nil)
+    }
 
     // The preferred parent terminal controller.
     static var preferredParent: TerminalController? {
         all.first {
             $0.window?.isMainWindow ?? false
         } ?? lastMain ?? all.last
+    /// Preferred parent terminal controller on specified screen
+    private static func preferredParent(on screen: NSScreen?) -> TerminalController? {
+        guard let screen else {
+            return all.first {
+                $0.window?.isMainWindow ?? false
+            } ?? lastMain ?? all.last
+        }
+        return all.last {
+            // find last main window in the screen first
+            $0.window?.screen == screen && $0.window?.isMainWindow == true
+        } ?? all.last {
+            // if no main window was found(typically out of focus)
+            // then just find the last visible window in the screen
+            // AppKit will store closed window for a while,
+            // We want to keep the first visible window
+            // in the same spot
+            $0.window?.screen == screen && $0.window?.isVisible == true
+        }
     }
 
     // The last controller to be main. We use this when paired with "preferredParent"
@@ -218,7 +249,7 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
 
         // Get our parent. Our parent is the one explicitly given to us,
         // otherwise the focused terminal, otherwise an arbitrary one.
-        let parent: NSWindow? = explicitParent ?? preferredParent?.window
+        let parent: NSWindow? = explicitParent ?? preferredNewWindowParent?.window
 
         if let parent {
             if parent.styleMask.contains(.fullScreen) {

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -194,10 +194,6 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         }
     }
 
-    // Keep track of the last point that our window was launched at so that new
-    // windows "cascade" over each other and don't just launch directly on top
-    // of each other.
-    private static var lastCascadePoint = NSPoint(x: 0, y: 0)
 
     // The preferred parent terminal controller.
     static var preferredParent: TerminalController? {
@@ -249,22 +245,24 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
             }
         }
 
-        // We're dispatching this async because otherwise the lastCascadePoint doesn't
+        // All new_window actions force our app to be active, so that the new
+        // window is focused and visible.
+        // We want to activate first, then show the window.
+        // This covers the case where a new window is opened on a screen that has no
+        // existing terminal windows, so we can focus the new window on that screen
+        // rather than keeping focus on the last window on another screen.
+        NSApp.activate(ignoringOtherApps: true)
+        // We're dispatching this async because otherwise the `cascadeTopLeft` doesn't
         // take effect. Our best theory is there is some next-event-loop-tick logic
         // that Cocoa is doing that we need to be after.
         DispatchQueue.main.async {
-            // Only cascade if we aren't fullscreen.
+            // Only cascade to parent if we aren't fullscreen.
             if let window = c.window {
                 if (!window.styleMask.contains(.fullScreen)) {
-                    Self.lastCascadePoint = window.cascadeTopLeft(from: Self.lastCascadePoint)
+                    window.cascadeTopLeft(from: parent?.cascadeTopLeft(from: .zero) ?? .zero)
                 }
             }
-
-            c.showWindow(self)
-
-            // All new_window actions force our app to be active, so that the new
-            // window is focused and visible.
-            NSApp.activate(ignoringOtherApps: true)
+            c.showWindow(nil)
         }
 
         // Setup our undo
@@ -432,11 +430,11 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
             // Only cascade if we aren't fullscreen and are alone in the tab group.
             if !window.styleMask.contains(.fullScreen) &&
                 window.tabGroup?.windows.count ?? 1 == 1 {
-                Self.lastCascadePoint = window.cascadeTopLeft(from: Self.lastCascadePoint)
+                window.cascadeTopLeft(from: parent.cascadeTopLeft(from: .zero))
             }
 
-            controller.showWindow(self)
-            window.makeKeyAndOrderFront(self)
+            controller.showWindow(nil)
+            window.makeKeyAndOrderFront(nil)
 
             // We also activate our app so that it becomes front. This may be
             // necessary for the dock menu.
@@ -1118,35 +1116,6 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
     override func windowWillClose(_ notification: Notification) {
         super.windowWillClose(notification)
         self.relabelTabs()
-
-        // If we remove a window, we reset the cascade point to the key window so that
-        // the next window cascade's from that one.
-        if let focusedWindow = NSApplication.shared.keyWindow {
-            // If we are NOT the focused window, then we are a tabbed window. If we
-            // are closing a tabbed window, we want to set the cascade point to be
-            // the next cascade point from this window.
-            if focusedWindow != window {
-                // The cascadeTopLeft call below should NOT move the window. Starting with
-                // macOS 15, we found that specifically when used with the new window snapping
-                // features of macOS 15, this WOULD move the frame. So we keep track of the
-                // old frame and restore it if necessary. Issue:
-                // https://github.com/ghostty-org/ghostty/issues/2565
-                let oldFrame = focusedWindow.frame
-
-                Self.lastCascadePoint = focusedWindow.cascadeTopLeft(from: NSZeroPoint)
-
-                if focusedWindow.frame != oldFrame {
-                    focusedWindow.setFrame(oldFrame, display: true)
-                }
-
-                return
-            }
-
-            // If we are the focused window, then we set the last cascade point to
-            // our own frame so that it shows up in the same spot.
-            let frame = focusedWindow.frame
-            Self.lastCascadePoint = NSPoint(x: frame.minX, y: frame.maxY)
-        }
     }
 
     override func windowDidBecomeKey(_ notification: Notification) {

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -330,11 +330,11 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
     ///   - ghostty: The Ghostty app instance.
     ///   - tree: The split tree to use for the new window.
     ///   - position: Optional screen position (top-left corner) for the new window.
-    ///               If nil, the window will cascade from the last cascade point.
+    ///               If nil, the window will cascade from the original window where the tree is from.
     static func newWindow(
         _ ghostty: Ghostty.App,
         tree: SplitTree<Ghostty.SurfaceView>,
-        position: NSPoint? = nil,
+        position: NSPoint,
         confirmUndo: Bool = true,
     ) -> TerminalController {
         let c = TerminalController.init(ghostty, withSurfaceTree: tree)
@@ -351,12 +351,8 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
                 }
 
                 if !window.styleMask.contains(.fullScreen) {
-                    if let position {
-                        window.setFrameTopLeftPoint(position)
-                        window.constrainToScreen()
-                    } else {
-                        Self.lastCascadePoint = window.cascadeTopLeft(from: Self.lastCascadePoint)
-                    }
+                    window.setFrameTopLeftPoint(position)
+                    window.constrainToScreen()
                 }
             }
 
@@ -382,7 +378,7 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
                     withTarget: ghostty,
                     expiresAfter: target.undoExpiration
                 ) { ghostty in
-                    _ = TerminalController.newWindow(ghostty, tree: tree)
+                    _ = TerminalController.newWindow(ghostty, tree: tree, position: position)
                 }
             }
         }

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -208,11 +208,11 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         preferredParent(on: .main) ?? preferredParent(on: nil)
     }
 
-    // The preferred parent terminal controller.
-    static var preferredParent: TerminalController? {
-        all.first {
-            $0.window?.isMainWindow ?? false
-        } ?? lastMain ?? all.last
+    // The preferred parent terminal controller for new split.
+    static var preferredNewSplitParent: TerminalController? {
+        preferredNewTabParent
+    }
+
     /// Preferred parent terminal controller on specified screen
     private static func preferredParent(on screen: NSScreen?) -> TerminalController? {
         guard let screen else {

--- a/macos/Sources/Helpers/LastWindowPosition.swift
+++ b/macos/Sources/Helpers/LastWindowPosition.swift
@@ -4,16 +4,24 @@ import Cocoa
 class LastWindowPosition {
     static let shared = LastWindowPosition()
 
-    private let positionKey = "NSWindowLastPosition"
+    private let deprecatedPositionKey = "NSWindowLastPosition"
+
+    private func positionKey(for window: NSWindow) -> String {
+        ["NSWindowLastPosition", window.screen?.displayUUID?.uuidString].compactMap(\.self).joined(separator: "-")
+    }
 
     func save(_ window: NSWindow) {
         let origin = window.frame.origin
         let point = [origin.x, origin.y]
-        UserDefaults.standard.set(point, forKey: positionKey)
+        UserDefaults.standard.set(point, forKey: positionKey(for: window))
+        UserDefaults.standard.removeObject(forKey: deprecatedPositionKey)
     }
 
     func restore(_ window: NSWindow) -> Bool {
-        guard let points = UserDefaults.standard.array(forKey: positionKey) as? [Double],
+        let deprecatedPosition = UserDefaults.standard.array(forKey: deprecatedPositionKey) as? [Double]
+        let newPosition = UserDefaults.standard.array(forKey: positionKey(for: window)) as? [Double]
+
+        guard let points = newPosition ?? deprecatedPosition,
               points.count == 2 else { return false }
 
         let lastPosition = CGPoint(x: points[0], y: points[1])


### PR DESCRIPTION
Fixes #9310, depends on #9509, **has some conflicts with #10129**

### New Window

- New Window in the dock menu will open a new window on the current focused screen.
- New Window by AppIntent/Shortcuts will open a new window on the current focused screen.
- New Window in the Ghostty's File menu, or by `cmd+n`, will open a new window on the current focused screen.

### New Tab/Split

New tab/split will choose a proper window on the current screen first. If none is found, we still use existing windows on another screen to create it.

> [!NOTE] 
> Using Finder services will still create a new terminal (window/tab) on the first screen Ghostty was focused on. If there are multiple screens that have Ghostty opened on, macOS will select a proper screen to create a new terminal. This for now cannot be changed by Ghostty itself. `Show in Finder` will behave the same.




https://github.com/user-attachments/assets/5fda2165-68ca-4951-ba3c-638f86f9c1aa



