### PR TITLE
macOS: fix undo new tab will cause a crash

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -377,9 +377,14 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
                 withTarget: controller,
                 expiresAfter: controller.undoExpiration
             ) { target in
-                // Close the tab when undoing
-                undoManager.disableUndoRegistration {
-                    target.closeTab(nil)
+                // Close the tab when undoing. We do this in a DispatchQueue because
+                // for some people on macOS Tahoe this caused a crash and the queue
+                // fixes it.
+                // https://github.com/ghostty-org/ghostty/pull/9512
+                DispatchQueue.main.async {
+                    undoManager.disableUndoRegistration {
+                        target.closeTab(nil)
+                    }
                 }
 
                 // Register redo action


### PR DESCRIPTION
### Reproduce Steps on Tip (1.2.3 seems fine)

1. Open a new window.
2. Open a new tab.
3. **Wait for 2-3 seconds.**
4. Undo.
5. 💥

**RC is unclear for me, but dispatching it seems to fix it.**