### PR TITLE
macOS: Update core surface size when config changes

### DIFF
--- a/macos/Sources/Ghostty/SurfaceScrollView.swift
+++ b/macos/Sources/Ghostty/SurfaceScrollView.swift
@@ -129,7 +129,7 @@ class SurfaceScrollView: NSView {
         surfaceView.$derivedConfig
             .sink { [weak self] _ in
                 DispatchQueue.main.async { [weak self] in
-                    self?.synchronizeAppearance()
+                    self?.handleConfigChange()
                 }
             }
             .store(in: &cancellables)
@@ -230,6 +230,12 @@ class SurfaceScrollView: NSView {
 
     /// Handles scrollbar style changes
     private func handleScrollerStyleChange() {
+        synchronizeCoreSurface()
+    }
+
+    /// Handles config changes
+    private func handleConfigChange() {
+        synchronizeAppearance()
         synchronizeCoreSurface()
     }
     


### PR DESCRIPTION
More or less the same as #9523, but for config reloads. Matters if `scrollbar = never` has been added or removed since the last config reload.