### PR TITLE
macOS: use unobtrusive driver when quick terminal is visible

### DIFF
--- a/macos/Sources/Features/Update/UpdateDriver.swift
+++ b/macos/Sources/Features/Update/UpdateDriver.swift
@@ -200,7 +200,7 @@ class UpdateDriver: NSObject, SPUUserDriver {
     /// True if there is a target that can render our unobtrusive update checker.
     var hasUnobtrusiveTarget: Bool {
         NSApp.windows.contains { window in
-            window is TerminalWindow &&
+            (window is TerminalWindow || window is QuickTerminalWindow) &&
             window.isVisible
         }
     }


### PR DESCRIPTION
Current:

<img width="1398" height="604" alt="image" src="https://github.com/user-attachments/assets/63f7e05e-03b9-413f-9622-285158dae1f6" />
