### PR TITLE
macOS: remove `readyToInstall` state in update capsule

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -815,6 +815,14 @@ class AppDelegate: NSObject,
                 autoUpdate == .check || autoUpdate == .download
             updateController.updater.automaticallyDownloadsUpdates =
                 autoUpdate == .download
+            /**
+             To test `auto-update` easily, uncomment the line below and
+             delete `SUEnableAutomaticChecks` in Ghostty-Info.plist.
+
+             Note: When `auto-update = download`, you may need to
+             `Clean Build Folder` if a background install has already begun.
+             */
+            //updateController.updater.checkForUpdatesInBackground()
         }
 
         // Config could change keybindings, so update everything that depends on that

--- a/macos/Sources/Features/Update/UpdateController.swift
+++ b/macos/Sources/Features/Update/UpdateController.swift
@@ -10,7 +10,6 @@ import Combine
 class UpdateController {
     private(set) var updater: SPUUpdater
     private let userDriver: UpdateDriver
-    private let updaterDelegate = UpdaterDelegate()
     private var installCancellable: AnyCancellable?
     
     var viewModel: UpdateViewModel {
@@ -32,7 +31,7 @@ class UpdateController {
             hostBundle: hostBundle,
             applicationBundle: hostBundle,
             userDriver: userDriver,
-            delegate: updaterDelegate
+            delegate: userDriver
         )
     }
     

--- a/macos/Sources/Features/Update/UpdateDelegate.swift
+++ b/macos/Sources/Features/Update/UpdateDelegate.swift
@@ -1,7 +1,7 @@
 import Sparkle
 import Cocoa
 
-class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
+extension UpdateDriver: SPUUpdaterDelegate {
     func feedURLString(for updater: SPUUpdater) -> String? {
         guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else {
             return nil
@@ -14,6 +14,16 @@ class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
         case .tip: return "https://tip.files.ghostty.org/appcast.xml"
         case .stable: return "https://release.files.ghostty.org/appcast.xml"
         }
+    }
+
+    /// Called when an update is scheduled to install silently,
+    /// which occurs when `auto-update = download`.
+    ///
+    /// When `auto-update = check`, Sparkle will call the corresponding
+    /// delegate method on the responsible driver instead.
+    func updater(_ updater: SPUUpdater, willInstallUpdateOnQuit item: SUAppcastItem, immediateInstallationBlock immediateInstallHandler: @escaping () -> Void) -> Bool {
+        viewModel.state = .installing(.init(isAutoUpdate: true, retryTerminatingApplication: immediateInstallHandler))
+        return true
     }
 
     func updaterWillRelaunchApplication(_ updater: SPUUpdater) {

--- a/macos/Sources/Features/Update/UpdateDriver.swift
+++ b/macos/Sources/Features/Update/UpdateDriver.swift
@@ -164,10 +164,10 @@ class UpdateDriver: NSObject, SPUUserDriver {
     }
     
     func showReady(toInstallAndRelaunch reply: @escaping @Sendable (SPUUserUpdateChoice) -> Void) {
-        viewModel.state = .readyToInstall(.init(reply: reply))
-        
         if !hasUnobtrusiveTarget {
             standard.showReady(toInstallAndRelaunch: reply)
+        } else {
+            reply(.install)
         }
     }
     

--- a/macos/Sources/Features/Update/UpdatePopoverView.swift
+++ b/macos/Sources/Features/Update/UpdatePopoverView.swift
@@ -35,10 +35,10 @@ struct UpdatePopoverView: View {
             case .extracting(let extracting):
                 ExtractingView(extracting: extracting)
                 
-            case .readyToInstall(let ready):
-                ReadyToInstallView(ready: ready, dismiss: dismiss)
-                
             case .installing(let installing):
+                // This is only required when `installing.isAutoUpdate == true`,
+                // but we keep it anyway, just in case something unexpected
+                // happens during installing
                 InstallingView(installing: installing, dismiss: dismiss)
                 
             case .notFound(let notFound):
@@ -181,7 +181,7 @@ fileprivate struct UpdateAvailableView: View {
                     
                     Spacer()
                     
-                    Button("Install") {
+                    Button("Install and Relaunch") {
                         update.reply(.install)
                         dismiss()
                     }
@@ -268,44 +268,6 @@ fileprivate struct ExtractingView: View {
                 Text(String(format: "%.0f%%", min(1, max(0, extracting.progress)) * 100))
                     .font(.system(size: 11))
                     .foregroundColor(.secondary)
-            }
-        }
-        .padding(16)
-    }
-}
-
-fileprivate struct ReadyToInstallView: View {
-    let ready: UpdateState.ReadyToInstall
-    let dismiss: DismissAction
-    
-    var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Ready to Install")
-                    .font(.system(size: 13, weight: .semibold))
-                
-                Text("The update is ready to install.")
-                    .font(.system(size: 11))
-                    .foregroundColor(.secondary)
-            }
-            
-            HStack(spacing: 8) {
-                Button("Later") {
-                    ready.reply(.dismiss)
-                    dismiss()
-                }
-                .keyboardShortcut(.cancelAction)
-                .controlSize(.small)
-                
-                Spacer()
-                
-                Button("Install and Relaunch") {
-                    ready.reply(.install)
-                    dismiss()
-                }
-                .keyboardShortcut(.defaultAction)
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
             }
         }
         .padding(16)

--- a/macos/Sources/Features/Update/UpdateSimulator.swift
+++ b/macos/Sources/Features/Update/UpdateSimulator.swift
@@ -262,18 +262,7 @@ enum UpdateSimulator {
                 
                 if j == 5 {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                        viewModel.state = .readyToInstall(.init(
-                            reply: { choice in
-                                if choice == .install {
-                                    viewModel.state = .installing(.init(retryTerminatingApplication: {
-                                        print("Restart button clicked in simulator - resetting to idle")
-                                        viewModel.state = .idle
-                                    }))
-                                } else {
-                                    viewModel.state = .idle
-                                }
-                            }
-                        ))
+                        simulateInstalling(viewModel)
                     }
                 }
             }

--- a/macos/Tests/Update/UpdateStateTests.swift
+++ b/macos/Tests/Update/UpdateStateTests.swift
@@ -25,9 +25,11 @@ struct UpdateStateTests {
     }
     
     @Test func testInstallingEquality() {
-        let state1: UpdateState = .installing(.init(retryTerminatingApplication: {}))
-        let state2: UpdateState = .installing(.init(retryTerminatingApplication: {}))
+        let state1: UpdateState = .installing(.init(isAutoUpdate: false, retryTerminatingApplication: {}))
+        let state2: UpdateState = .installing(.init(isAutoUpdate: false, retryTerminatingApplication: {}))
         #expect(state1 == state2)
+        let state3: UpdateState = .installing(.init(isAutoUpdate: true, retryTerminatingApplication: {}))
+        #expect(state3 != state2)
     }
     
     @Test func testPermissionRequestEquality() {
@@ -35,12 +37,6 @@ struct UpdateStateTests {
         let request2 = SPUUpdatePermissionRequest(systemProfile: [])
         let state1: UpdateState = .permissionRequest(.init(request: request1, reply: { _ in }))
         let state2: UpdateState = .permissionRequest(.init(request: request2, reply: { _ in }))
-        #expect(state1 == state2)
-    }
-    
-    @Test func testReadyToInstallEquality() {
-        let state1: UpdateState = .readyToInstall(.init(reply: { _ in }))
-        let state2: UpdateState = .readyToInstall(.init(reply: { _ in }))
         #expect(state1 == state2)
     }
     

--- a/macos/Tests/Update/UpdateViewModelTests.swift
+++ b/macos/Tests/Update/UpdateViewModelTests.swift
@@ -50,15 +50,11 @@ struct UpdateViewModelTests {
         #expect(viewModel.text == "Preparing: 75%")
     }
     
-    @Test func testReadyToInstallText() {
-        let viewModel = UpdateViewModel()
-        viewModel.state = .readyToInstall(.init(reply: { _ in }))
-        #expect(viewModel.text == "Ready to Install Update")
-    }
-    
     @Test func testInstallingText() {
         let viewModel = UpdateViewModel()
-        viewModel.state = .installing(.init(retryTerminatingApplication: {}))
+        viewModel.state = .installing(.init(isAutoUpdate: false, retryTerminatingApplication: {}))
+        #expect(viewModel.text == "Installing…")
+        viewModel.state = .installing(.init(isAutoUpdate: true, retryTerminatingApplication: {}))
         #expect(viewModel.text == "Restart to Complete Update")
     }
     


### PR DESCRIPTION
There is a sparkle-related 'issue' with the previous implementation. When you download/install in the `updateAvailable` state, if you don't install it, then check the updates again. Sparkle loses its downloaded stage in the delegate (it's normal when I use the sparkle source code). This time, when you click install in the `updateAvailable` state, it just uses the previous downloaded package and starts to install, without calling `showReady(toInstallAndRelaunch:)`.

I think removing `readyToInstall` in our customised ui makes sense, since the current package is pretty small and only takes a few seconds to download for a normal network. And most of users intend to install this update.

Also, there is no way back once you reach "Install and Restart" stage in `SPUStandardUserDriver`, unless you force quit ofc.

~~This pr also contains some further cleanup for #9170, since `InstallingView` is no longer visible for users.~~

#### `auto-download`

When `auto-download = check`, Sparkle will call `UpdateDriver/showUpdateFound(with:state:reply:)`.

When `auto-download = download`, previously no update ui was presented to the user, neither Sparkle's nor Ghostty’s.
> I tried tick&untick auto download&install in Sparkle's alert, which doesn't seem to make any difference.

With this pr, `auto-download = check` will behave the same, **`auto-download = download` will now prompt the user with a capsule.**

https://github.com/user-attachments/assets/f994dd29-d348-4fea-8777-df3720d6e7af


> [!NOTE]
> I used AI to proofread my comments