### PR TITLE
macOS: move focus if command palette is not showing

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -903,6 +903,7 @@ extension Ghostty {
             // Handle focus-follows-mouse
             if let window,
                let controller = window.windowController as? BaseTerminalController,
+               !controller.commandPaletteIsShowing,
                (window.isKeyWindow &&
                     !self.focused &&
                     controller.focusFollowsMouse)


### PR DESCRIPTION
Fixes #9533