### PR TITLE
fix: reverse order of clipboard mime types to work around an apparent Electron bug

### DIFF
--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -3377,9 +3377,9 @@ const Clipboard = struct {
                         // MIME, when the charset is missing, the default
                         // charset is ASCII.
                         const text_provider_atoms = [_][:0]const u8{
-                            "text/plain",
-                            "text/plain;charset=utf-8",
                             "UTF8_STRING",
+                            "text/plain;charset=utf-8",
+                            "text/plain",
                         };
                         // Following on the same logic as our outer union,
                         // looks like we only need this memory during union

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -3376,6 +3376,20 @@ const Clipboard = struct {
                         // MIME parameter for correctness; technically, for
                         // MIME, when the charset is missing, the default
                         // charset is ASCII.
+                        //
+                        // At least in some versions of GTK it appears as though
+                        // the providers union acts like a stack, with the first
+                        // thing we create ending up as the bottom entry. Because
+                        // (some?) Electron apps fail to paste if they encounter
+                        // an invalid mime type like UTF8_STRING before they
+                        // encounter a mime type they want (usually text/plain),
+                        // we create the UTF8_STRING atom first then push the rest
+                        // of the types on top of it.
+                        //
+                        // This still needs testing in other versions of GTK which
+                        // may have different behaviour. It's possible the only
+                        // solution here (other than fixing Electron) is to not
+                        // use the UTF8_STRING atom unless we're running on X11.
                         const text_provider_atoms = [_][:0]const u8{
                             "UTF8_STRING",
                             "text/plain;charset=utf-8",


### PR DESCRIPTION
Per the discussion in #9532, it seems as though GTK may be treating clipboard mime types as a stack, with the first type created ending up on the bottom and subsequent types ending up above.

In parallel, it seems as though Electron may have a bug where if it encounters an invalid mime type before it encounters one it's willing to accept it will simply fail to paste.

This causes problems when specifying atoms for X11 apps to deal with, e.g. `UTF8_STRING`, which are not valid mime types. This means that in cases like this:

```
wl-paste --list-types
text/html
UTF8_STRING
text/plain;charset=utf=8
text/plain
```

...Electron will reach the invalid mime type `UTF8_STRING` before reaching the acceptable mime type `text/plain` and will fail to paste (with no error that I can find).

Reversing the order in which we add these mime types was suggested by @mitchellh, and testing that finds that it does seem to work on my system, but it may be that later versions of GTK change this behavior as a build by @vancluever using GTK 4.18 appeared to be appending types (as would be intuitive) rather than the stack-like behavior I've been seeing.

This will need more testing to ensure that we're not just breaking newer GTK versions instead of older ones.