### PR TITLE
macOS: restore visiblity state when hiding quick terminal

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -110,7 +110,7 @@ class AppDelegate: NSObject,
     }
 
     /// Tracks the windows that we hid for toggleVisibility.
-    private var hiddenState: ToggleVisibilityState? = nil
+    private(set) var hiddenState: ToggleVisibilityState? = nil
 
     /// The observer for the app appearance.
     private var appearanceObserver: NSKeyValueObservation? = nil
@@ -278,6 +278,11 @@ class AppDelegate: NSObject,
                 NSApp.arrangeInFront(nil)
             }
         }
+    }
+
+    func applicationDidHide(_ notification: Notification) {
+        // Keep track of our hidden state to restore properly
+        self.hiddenState = .init()
     }
 
     func applicationDidBecomeActive(_ notification: Notification) {
@@ -1084,8 +1089,6 @@ class AppDelegate: NSObject,
             guard let keyWindow = NSApp.keyWindow,
                   !keyWindow.styleMask.contains(.fullScreen) else { return }
 
-            // Keep track of our hidden state to restore properly
-            self.hiddenState = .init()
             NSApp.hide(nil)
             return
         }
@@ -1134,11 +1137,11 @@ class AppDelegate: NSObject,
         }
     }
 
-    private struct ToggleVisibilityState {
+    struct ToggleVisibilityState {
         let hiddenWindows: [Weak<NSWindow>]
         let keyWindow: Weak<NSWindow>?
 
-        init() {
+        fileprivate init() {
             // We need to know the key window so that we can bring focus back to the
             // right window if it was hidden.
             self.keyWindow = if let keyWindow = NSApp.keyWindow {

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -513,6 +513,10 @@ class QuickTerminalController: BaseTerminalController {
         if !window.isOnActiveSpace {
             self.previousApp = nil
             window.orderOut(self)
+            // If our application is hidden previously, we hide it again
+            if (NSApp.delegate as? AppDelegate)?.hiddenState != nil {
+                NSApp.hide(nil)
+            }
             return
         }
 
@@ -549,6 +553,10 @@ class QuickTerminalController: BaseTerminalController {
             // This causes the window to be removed from the screen list and macOS
             // handles what should be focused next.
             window.orderOut(self)
+            // If our application is hidden previously, we hide it again
+            if (NSApp.delegate as? AppDelegate)?.hiddenState != nil {
+                NSApp.hide(nil)
+            }
         })
     }
 


### PR DESCRIPTION
Fixes #8414 and a case where `toggle_visibility` is not working after hiding using `cmd+h`

https://github.com/user-attachments/assets/be28c2d9-b416-467f-9fe9-7b7c97278330
