### PR TITLE
gtk/opengl: print an error when OpenGL version is too old

### DIFF
--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -1658,13 +1658,7 @@ pub const Surface = extern struct {
         };
         priv.drop_target.setGtypes(&drop_target_types, drop_target_types.len);
 
-        // Initialize our GLArea. We only set the values we can't set
-        // in our blueprint file.
-        const gl_area = priv.gl_area;
-        gl_area.setRequiredVersion(
-            renderer.OpenGL.MIN_VERSION_MAJOR,
-            renderer.OpenGL.MIN_VERSION_MINOR,
-        );
+        // Setup properties we can't set from our Blueprint file.
         self.as(gtk.Widget).setCursorFromName("text");
 
         // Initialize our config

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -137,15 +137,7 @@ fn prepareContext(getProcAddress: anytype) !void {
     errdefer gl.glad.unload();
     log.info("loaded OpenGL {}.{}", .{ major, minor });
 
-    // Enable debug output for the context.
-    try gl.enable(gl.c.GL_DEBUG_OUTPUT);
-
-    // Register our debug message callback with the OpenGL context.
-    gl.glad.context.DebugMessageCallback.?(glDebugMessageCallback, null);
-
-    // Enable SRGB framebuffer for linear blending support.
-    try gl.enable(gl.c.GL_FRAMEBUFFER_SRGB);
-
+    // Need to check version before trying to enable it
     if (major < MIN_VERSION_MAJOR or
         (major == MIN_VERSION_MAJOR and minor < MIN_VERSION_MINOR))
     {
@@ -155,6 +147,15 @@ fn prepareContext(getProcAddress: anytype) !void {
         );
         return error.OpenGLOutdated;
     }
+
+    // Enable debug output for the context.
+    try gl.enable(gl.c.GL_DEBUG_OUTPUT);
+
+    // Register our debug message callback with the OpenGL context.
+    gl.glad.context.DebugMessageCallback.?(glDebugMessageCallback, null);
+
+    // Enable SRGB framebuffer for linear blending support.
+    try gl.enable(gl.c.GL_FRAMEBUFFER_SRGB);
 }
 
 /// This is called early right after surface creation.


### PR DESCRIPTION
#1123 added a warning when the OpenGL version is too old, but it is never used because GTK enforces the version set with gl_area.setRequiredVersion() before prepareContext() is called: we end up with a generic "failed to make GL context" error:
```
warning(gtk_ghostty_surface): failed to make GL context current: Unable to create a GL context warning(gtk_ghostty_surface): this error is almost always due to a library, driver, or GTK issue warning(gtk_ghostty_surface): this is a common cause of this issue: https://ghostty.org/docs/help/gtk-opengl-context
```

This patch removes the requirement at the GTK level and lets the ghostty renderer check, now failing as follow:
```
info(opengl): loaded OpenGL 4.2
error(opengl): OpenGL version is too old. Ghostty requires OpenGL 4.3 warning(gtk_ghostty_surface): failed to initialize surface err=error.OpenGLOutdated warning(gtk_ghostty_surface): surface failed to initialize err=error.SurfaceError
```

(Note that this does not render a ghostty window, unlike the previous error which rendered the "Unable to acquire an OpenGL context for rendering." view, so while the error itself is easier to understand it might be harder to view)

-----------------------

I looked for why I couldn't get a context at all mostly to see what OpenGL 4.3 functions were required to see if there'd be easy fallbacks, but it also took me a good 15 minutes this morning to understand that there was nothing wrong with my gtk/mesa versions and it's just my hardware being old, so I think it'd good to take in itself even if the displaying itself is a bit meh.

Happy to try to display it in the error page if you think it's important and I can figure out how (haven't looked much yet)