### PR TITLE
macOS: fix misplaced frame modifier

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalView.swift
+++ b/macos/Sources/Features/Terminal/TerminalView.swift
@@ -119,6 +119,7 @@ struct TerminalView<ViewModel: TerminalViewModel>: View {
                     UpdateOverlay()
                 }
             }
+            .frame(maxWidth: .greatestFiniteMagnitude, maxHeight: .greatestFiniteMagnitude)
         }
     }
 }
@@ -136,7 +137,6 @@ fileprivate struct UpdateOverlay: View {
                         .padding(.trailing, 9)
                 }
             }
-            .frame(maxWidth: .greatestFiniteMagnitude, maxHeight: .greatestFiniteMagnitude)
         }
     }
 }


### PR DESCRIPTION
As per #9504, this was supposed to be on `ZStack`, not on the overlay. See also #9503. I cherry-picked it in the wrong place before.