### PR TITLE
Search Thread

### DIFF
--- a/src/datastruct/blocking_queue.zig
+++ b/src/datastruct/blocking_queue.zig
@@ -73,7 +73,7 @@ pub fn BlockingQueue(
         not_full_waiters: usize = 0,
 
         /// Allocate the blocking queue on the heap.
-        pub fn create(alloc: Allocator) !*Self {
+        pub fn create(alloc: Allocator) Allocator.Error!*Self {
             const ptr = try alloc.create(Self);
             errdefer alloc.destroy(ptr);
 

--- a/src/terminal/search.zig
+++ b/src/terminal/search.zig
@@ -3,6 +3,7 @@
 pub const Active = @import("search/active.zig").ActiveSearch;
 pub const PageList = @import("search/pagelist.zig").PageListSearch;
 pub const Screen = @import("search/screen.zig").ScreenSearch;
+pub const Viewport = @import("search/viewport.zig").ViewportSearch;
 pub const Thread = @import("search/Thread.zig");
 
 test {

--- a/src/terminal/search/Thread.zig
+++ b/src/terminal/search/Thread.zig
@@ -28,6 +28,13 @@ const ViewportSearch = @import("viewport.zig").ViewportSearch;
 
 const log = std.log.scoped(.search_thread);
 
+// TODO: Some stuff that could be improved:
+// - pause the refresh timer when the terminal isn't focused
+// - we probably want to know our progress through the search
+//   for viewport matches so we can show n/total UI.
+// - notifications should be coalesced to avoid spamming a massive
+//   amount of events if the terminal is changing rapidly.
+
 /// The interval at which we refresh the terminal state to check if
 /// there are any changes that require us to re-search. This should be
 /// balanced to be fast enough to be responsive but not so fast that

--- a/src/terminal/search/Thread.zig
+++ b/src/terminal/search/Thread.zig
@@ -9,8 +9,13 @@
 pub const Thread = @This();
 
 const std = @import("std");
+const builtin = @import("builtin");
+const testing = std.testing;
 const Allocator = std.mem.Allocator;
+const xev = @import("../../global.zig").xev;
+const internal_os = @import("../../os/main.zig");
 const BlockingQueue = @import("../../datastruct/main.zig").BlockingQueue;
+const Terminal = @import("../Terminal.zig");
 
 const log = std.log.scoped(.search_thread);
 
@@ -21,23 +26,57 @@ alloc: std.mem.Allocator,
 /// this is a blocking queue so if it is full you will get errors (or block).
 mailbox: *Mailbox,
 
+/// The event loop for the search thread.
+loop: xev.Loop,
+
+/// This can be used to wake up the renderer and force a render safely from
+/// any thread.
+wakeup: xev.Async,
+wakeup_c: xev.Completion = .{},
+
+/// This can be used to stop the thread on the next loop iteration.
+stop: xev.Async,
+stop_c: xev.Completion = .{},
+
+/// The options used to initialize this thread.
+opts: Options,
+
 /// Initialize the thread. This does not START the thread. This only sets
 /// up all the internal state necessary prior to starting the thread. It
 /// is up to the caller to start the thread with the threadMain entrypoint.
-pub fn init(alloc: Allocator) Thread {
+pub fn init(alloc: Allocator, opts: Options) !Thread {
     // The mailbox for messaging this thread
     var mailbox = try Mailbox.create(alloc);
     errdefer mailbox.destroy(alloc);
 
+    // Create our event loop.
+    var loop = try xev.Loop.init(.{});
+    errdefer loop.deinit();
+
+    // This async handle is used to "wake up" the renderer and force a render.
+    var wakeup_h = try xev.Async.init();
+    errdefer wakeup_h.deinit();
+
+    // This async handle is used to stop the loop and force the thread to end.
+    var stop_h = try xev.Async.init();
+    errdefer stop_h.deinit();
+
     return .{
         .alloc = alloc,
         .mailbox = mailbox,
+        .loop = loop,
+        .wakeup = wakeup_h,
+        .stop = stop_h,
+        .opts = opts,
     };
 }
 
 /// Clean up the thread. This is only safe to call once the thread
 /// completes executing; the caller must join prior to this.
 pub fn deinit(self: *Thread) void {
+    self.wakeup.deinit();
+    self.stop.deinit();
+    self.loop.deinit();
     // Nothing can possibly access the mailbox anymore, destroy it.
     self.mailbox.destroy(self.alloc);
 }
@@ -53,11 +92,110 @@ pub fn threadMain(self: *Thread) void {
 
 fn threadMain_(self: *Thread) !void {
     defer log.debug("search thread exited", .{});
-    _ = self;
+
+    // Right now, on Darwin, `std.Thread.setName` can only name the current
+    // thread, and we have no way to get the current thread from within it,
+    // so instead we use this code to name the thread instead.
+    if (comptime builtin.os.tag.isDarwin()) {
+        internal_os.macos.pthread_setname_np(&"search".*);
+
+        // We can run with lower priority than other threads.
+        const class: internal_os.macos.QosClass = .utility;
+        if (internal_os.macos.setQosClass(class)) {
+            log.debug("thread QoS class set class={}", .{class});
+        } else |err| {
+            log.warn("error setting QoS class err={}", .{err});
+        }
+    }
+
+    // Start the async handlers
+    self.wakeup.wait(&self.loop, &self.wakeup_c, Thread, self, wakeupCallback);
+    self.stop.wait(&self.loop, &self.stop_c, Thread, self, stopCallback);
+
+    // Send an initial wakeup so we drain our mailbox immediately.
+    try self.wakeup.notify();
+
+    // Run
+    log.debug("starting search thread", .{});
+    defer log.debug("starting search thread shutdown", .{});
+    _ = try self.loop.run(.until_done);
 }
+
+/// Drain the mailbox.
+fn drainMailbox(self: *Thread) !void {
+    while (self.mailbox.pop()) |message| {
+        log.debug("mailbox message={}", .{message});
+    }
+}
+
+fn wakeupCallback(
+    self_: ?*Thread,
+    _: *xev.Loop,
+    _: *xev.Completion,
+    r: xev.Async.WaitError!void,
+) xev.CallbackAction {
+    _ = r catch |err| {
+        log.warn("error in wakeup err={}", .{err});
+        return .rearm;
+    };
+
+    const self = self_.?;
+
+    // When we wake up, we drain the mailbox. Mailbox producers should
+    // wake up our thread after publishing.
+    self.drainMailbox() catch |err|
+        log.warn("error draining mailbox err={}", .{err});
+
+    return .rearm;
+}
+
+fn stopCallback(
+    self_: ?*Thread,
+    _: *xev.Loop,
+    _: *xev.Completion,
+    r: xev.Async.WaitError!void,
+) xev.CallbackAction {
+    _ = r catch unreachable;
+    self_.?.loop.stop();
+    return .disarm;
+}
+
+pub const Options = struct {
+    /// Mutex that must be held while reading/writing the terminal.
+    mutex: *std.Thread.Mutex,
+
+    /// The terminal data to search.
+    terminal: *Terminal,
+};
 
 /// The type used for sending messages to the thread.
 pub const Mailbox = BlockingQueue(Message, 64);
 
 /// The messages that can be sent to the thread.
-pub const Message = union(enum) {};
+pub const Message = union(enum) {
+    /// Change the search term. If no prior search term is given this
+    /// will start a search. If an existing search term is given this will
+    /// stop the prior search and start a new one.
+    change_needle: []const u8,
+};
+
+test {
+    const alloc = testing.allocator;
+    var mutex: std.Thread.Mutex = .{};
+    var t: Terminal = try .init(alloc, .{ .cols = 10, .rows = 2 });
+    defer t.deinit(alloc);
+
+    var thread: Thread = try .init(alloc, .{
+        .mutex = &mutex,
+        .terminal = &t,
+    });
+    defer thread.deinit();
+
+    var os_thread = try std.Thread.spawn(
+        .{},
+        threadMain,
+        .{&thread},
+    );
+    try thread.stop.notify();
+    os_thread.join();
+}

--- a/src/terminal/search/screen.zig
+++ b/src/terminal/search/screen.zig
@@ -78,6 +78,20 @@ pub const ScreenSearch = struct {
 
         /// Search is complete given the current terminal state.
         complete,
+
+        pub fn isComplete(self: State) bool {
+            return switch (self) {
+                .complete => true,
+                else => false,
+            };
+        }
+
+        pub fn needsFeed(self: State) bool {
+            return switch (self) {
+                .history_feed => true,
+                else => false,
+            };
+        }
     };
 
     // Initialize a screen search for the given screen and needle.
@@ -114,10 +128,10 @@ pub const ScreenSearch = struct {
         return self.active.window.alloc;
     }
 
-    pub const TickError = Allocator.Error || error{
-        FeedRequired,
-        SearchComplete,
-    };
+    /// Returns the total number of matches found so far.
+    pub fn matchesLen(self: *const ScreenSearch) usize {
+        return self.active_results.items.len + self.history_results.items.len;
+    }
 
     /// Returns all matches as an owned slice (caller must free).
     /// The matches are ordered from most recent to oldest (e.g. bottom
@@ -166,6 +180,11 @@ pub const ScreenSearch = struct {
             };
         }
     }
+
+    pub const TickError = Allocator.Error || error{
+        FeedRequired,
+        SearchComplete,
+    };
 
     /// Make incremental progress on the search without accessing any
     /// screen state (so no lock is required).

--- a/src/terminal/search/viewport.zig
+++ b/src/terminal/search/viewport.zig
@@ -1,0 +1,293 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const testing = std.testing;
+const Allocator = std.mem.Allocator;
+const point = @import("../point.zig");
+const size = @import("../size.zig");
+const PageList = @import("../PageList.zig");
+const Selection = @import("../Selection.zig");
+const SlidingWindow = @import("sliding_window.zig").SlidingWindow;
+const Terminal = @import("../Terminal.zig");
+
+/// Searches for a substring within the viewport of a PageList.
+///
+/// This contains logic to efficiently detect when the viewport changes
+/// and only re-search when necessary.
+///
+/// The specialization for "viewport" is because the viewport is the
+/// only part of the search where the user can actively see the results,
+/// usually. In that case, it is more efficient to re-search only the
+/// viewport rather than store all the results for the entire screen.
+///
+/// Note that this searches all the pages that viewport covers, so
+/// this can include extra matches outside the viewport if the data
+/// lives in the same page.
+pub const ViewportSearch = struct {
+    window: SlidingWindow,
+    fingerprint: ?Fingerprint,
+
+    pub fn init(
+        alloc: Allocator,
+        needle: []const u8,
+    ) Allocator.Error!ViewportSearch {
+        // We just do a forward search since the viewport is usually
+        // pretty small so search results are instant anyways. This avoids
+        // a small amount of work to reverse things.
+        var window: SlidingWindow = try .init(alloc, .forward, needle);
+        errdefer window.deinit();
+        return .{ .window = window, .fingerprint = null };
+    }
+
+    pub fn deinit(self: *ViewportSearch) void {
+        if (self.fingerprint) |*fp| fp.deinit(self.window.alloc);
+        self.window.deinit();
+    }
+
+    /// Update the sliding window to reflect the current viewport. This
+    /// will do nothing if the viewport hasn't changed since the last
+    /// search.
+    ///
+    /// The PageList must be safe to read throughout the lifetime of this
+    /// function.
+    ///
+    /// Returns true if the viewport changed and a re-search is needed.
+    /// Returns false if the viewport is unchanged.
+    pub fn update(
+        self: *ViewportSearch,
+        list: *PageList,
+    ) Allocator.Error!bool {
+        // See if our viewport changed
+        var fingerprint: Fingerprint = try .init(self.window.alloc, list);
+        if (self.fingerprint) |*old| {
+            if (old.eql(fingerprint)) match: {
+                // If our fingerprint contains the active area, then we always
+                // re-search since the active area is mutable.
+                const active_tl = list.getTopLeft(.active);
+                const active_br = list.getBottomRight(.active).?;
+
+                // If our viewport contains the start or end of the active area,
+                // we are in the active area. We purposely do this first
+                // because our viewport is always larger than the active area.
+                for (old.nodes) |node| {
+                    if (node == active_tl.node) break :match;
+                    if (node == active_br.node) break :match;
+                }
+
+                // No change
+                fingerprint.deinit(self.window.alloc);
+                return false;
+            }
+
+            old.deinit(self.window.alloc);
+            self.fingerprint = null;
+        }
+        assert(self.fingerprint == null);
+        self.fingerprint = fingerprint;
+        errdefer {
+            fingerprint.deinit(self.window.alloc);
+            self.fingerprint = null;
+        }
+
+        // Clear our previous sliding window
+        self.window.clearAndRetainCapacity();
+
+        // Add enough overlap to cover needle.len - 1 bytes (if it
+        // exists) so we can cover the overlap. We only do this for the
+        // soft-wrapped prior pages.
+        var node_ = fingerprint.nodes[0].prev;
+        var added: usize = 0;
+        while (node_) |node| : (node_ = node.prev) {
+            // If the last row of this node isn't wrapped we can't overlap.
+            const row = node.data.getRow(node.data.size.rows - 1);
+            if (!row.wrap) break;
+
+            // We could be more accurate here and count bytes since the
+            // last wrap but its complicated and unlikely multiple pages
+            // wrap so this should be fine.
+            added += try self.window.append(node);
+            if (added >= self.window.needle.len - 1) break;
+        }
+
+        // We can use our fingerprint nodes to initialize our sliding
+        // window, since we already traversed the viewport once.
+        for (fingerprint.nodes) |node| {
+            _ = try self.window.append(node);
+        }
+
+        // Add any trailing overlap as well.
+        trailing: {
+            const end: *PageList.List.Node = fingerprint.nodes[fingerprint.nodes.len - 1];
+            if (!end.data.getRow(end.data.size.rows - 1).wrap) break :trailing;
+
+            node_ = end.next;
+            added = 0;
+            while (node_) |node| : (node_ = node.next) {
+                added += try self.window.append(node);
+                if (added >= self.window.needle.len - 1) break;
+
+                // If this row doesn't wrap, then we can quit
+                const row = node.data.getRow(node.data.size.rows - 1);
+                if (!row.wrap) break;
+            }
+        }
+
+        return true;
+    }
+
+    /// Find the next match for the needle in the active area. This returns
+    /// null when there are no more matches.
+    pub fn next(self: *ViewportSearch) ?Selection {
+        return self.window.next();
+    }
+
+    /// Viewport fingerprint so we can detect when the viewport moves.
+    const Fingerprint = struct {
+        /// The nodes that make up the viewport. We need to flatten this
+        /// to a single list because we can't safely traverse the cached values
+        /// because the page nodes may be invalid. All that is safe is comparing
+        /// the actual pointer values.
+        nodes: []const *PageList.List.Node,
+
+        pub fn init(alloc: Allocator, pages: *PageList) Allocator.Error!Fingerprint {
+            var list: std.ArrayList(*PageList.List.Node) = .empty;
+            defer list.deinit(alloc);
+
+            // Get our viewport area. Bottom right of a viewport can never
+            // fail.
+            const tl = pages.getTopLeft(.viewport);
+            const br = pages.getBottomRight(.viewport).?;
+
+            var it = tl.pageIterator(.right_down, br);
+            while (it.next()) |chunk| try list.append(alloc, chunk.node);
+            return .{ .nodes = try list.toOwnedSlice(alloc) };
+        }
+
+        pub fn deinit(self: *Fingerprint, alloc: Allocator) void {
+            alloc.free(self.nodes);
+        }
+
+        pub fn eql(self: Fingerprint, other: Fingerprint) bool {
+            if (self.nodes.len != other.nodes.len) return false;
+            for (self.nodes, other.nodes) |a, b| {
+                if (a != b) return false;
+            }
+            return true;
+        }
+    };
+};
+
+test "simple search" {
+    const alloc = testing.allocator;
+    var t: Terminal = try .init(alloc, .{ .cols = 10, .rows = 10 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    try s.nextSlice("Fizz\r\nBuzz\r\nFizz\r\nBang");
+
+    var search: ViewportSearch = try .init(alloc, "Fizz");
+    defer search.deinit();
+    try testing.expect(try search.update(&t.screens.active.pages));
+
+    // Viewport contains active so update should always re-search.
+    try testing.expect(try search.update(&t.screens.active.pages));
+
+    {
+        const sel = search.next().?;
+        try testing.expectEqual(point.Point{ .active = .{
+            .x = 0,
+            .y = 0,
+        } }, t.screens.active.pages.pointFromPin(.active, sel.start()).?);
+        try testing.expectEqual(point.Point{ .active = .{
+            .x = 3,
+            .y = 0,
+        } }, t.screens.active.pages.pointFromPin(.active, sel.end()).?);
+    }
+    {
+        const sel = search.next().?;
+        try testing.expectEqual(point.Point{ .active = .{
+            .x = 0,
+            .y = 2,
+        } }, t.screens.active.pages.pointFromPin(.active, sel.start()).?);
+        try testing.expectEqual(point.Point{ .active = .{
+            .x = 3,
+            .y = 2,
+        } }, t.screens.active.pages.pointFromPin(.active, sel.end()).?);
+    }
+    try testing.expect(search.next() == null);
+}
+
+test "clear screen and search" {
+    const alloc = testing.allocator;
+    var t: Terminal = try .init(alloc, .{ .cols = 10, .rows = 10 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    try s.nextSlice("Fizz\r\nBuzz\r\nFizz\r\nBang");
+
+    var search: ViewportSearch = try .init(alloc, "Fizz");
+    defer search.deinit();
+    try testing.expect(try search.update(&t.screens.active.pages));
+
+    try s.nextSlice("\x1b[2J"); // Clear screen
+    try s.nextSlice("\x1b[H"); // Move cursor home
+    try s.nextSlice("Buzz\r\nFizz\r\nBuzz");
+    try testing.expect(try search.update(&t.screens.active.pages));
+
+    {
+        const sel = search.next().?;
+        try testing.expectEqual(point.Point{ .active = .{
+            .x = 0,
+            .y = 1,
+        } }, t.screens.active.pages.pointFromPin(.active, sel.start()).?);
+        try testing.expectEqual(point.Point{ .active = .{
+            .x = 3,
+            .y = 1,
+        } }, t.screens.active.pages.pointFromPin(.active, sel.end()).?);
+    }
+    try testing.expect(search.next() == null);
+}
+
+test "history search, no active area" {
+    const alloc = testing.allocator;
+    var t: Terminal = try .init(alloc, .{ .cols = 10, .rows = 2 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+
+    // Fill up first page
+    const first_page_rows = t.screens.active.pages.pages.first.?.data.capacity.rows;
+    try s.nextSlice("Fizz\r\n");
+    for (1..first_page_rows - 1) |_| try s.nextSlice("\r\n");
+    try testing.expect(t.screens.active.pages.pages.first == t.screens.active.pages.pages.last);
+
+    // Create second page
+    try s.nextSlice("\r\n");
+    try testing.expect(t.screens.active.pages.pages.first != t.screens.active.pages.pages.last);
+    try s.nextSlice("Buzz\r\nFizz");
+
+    try t.scrollViewport(.top);
+
+    var search: ViewportSearch = try .init(alloc, "Fizz");
+    defer search.deinit();
+    try testing.expect(try search.update(&t.screens.active.pages));
+
+    {
+        const sel = search.next().?;
+        try testing.expectEqual(point.Point{ .screen = .{
+            .x = 0,
+            .y = 0,
+        } }, t.screens.active.pages.pointFromPin(.screen, sel.start()).?);
+        try testing.expectEqual(point.Point{ .screen = .{
+            .x = 3,
+            .y = 0,
+        } }, t.screens.active.pages.pointFromPin(.screen, sel.end()).?);
+    }
+    try testing.expect(search.next() == null);
+
+    // Viewport doesn't contain active
+    try testing.expect(!try search.update(&t.screens.active.pages));
+    try testing.expect(search.next() == null);
+}


### PR DESCRIPTION
Progress towards #189 

## Search Thread

This completes an initial implementation of the search thread. This is a separate thread that manages a terminal search operation, triggering event callbacks for various scenarios. The performance goal of the search thread is to minimize time spent within the critical area of the terminal lock while making forward progress on search outside of that.

The search thread sends two messages back to the caller right now:

  - Total matches: sent continuously as new matches are found, just a number
  - Viewport matches: a list of `Selection` structures spanning the current viewport of matches within the visible viewport. Sent whenever the viewport changes (location or content).

I think that's enough to build a rudimentary search UI.

For this initial implementation, the search also relies on a "refresh timer" which trigger every 24ms (40 FPS) to grab the lock and look for any reconciliation that needs to happen: viewport moved, active screen changed, active area changed, etc. This is a total guess and is arbitrary currently. The value should be tuned to balance responsiveness and IO throughput (lock-holding). I actually suspect this may be too frequent right now.

A TODO is noted for the future to pause the refresh timer when the terminal being search isn't focused. We'll have to do that before shipping search because the way its built right now we will definitely consume unnecessary CPU while unfocused. But only while search is active.

## `ViewportSearch`

I also determined the need for what is called the `ViewportSearch` layer. This is similar to `ActiveSearch` in that it throws away and re-searches an area, but is tuned towards efficiently detecting viewport changes. I found its more efficient to continuously research the visible viewport than to hunt for those matches within the cached ScreenSearch results, which can be very large.

## Future

Next up we need to hook up the search thread to some keybindings to start and stop the search so we can then trigger those from our apprts (GUIs). 

I highly suspect this is going to expose some major performance issues (overly active message sending being the likely culprit) that we can fix up in the search thread thereafter. Up until this point we can only run this stuff in isolation in unit tests which is good for testing correctness but difficult for testing resource usage.

There are some written TODOs in the Thread.zig file in this PR. I may address some of them before merging, since I think a couple are pretty obvious performance gotchas.