### PR TITLE
macOS: match scroller’s appearance with surface’s background

### DIFF
--- a/macos/Sources/Ghostty/SurfaceScrollView.swift
+++ b/macos/Sources/Ghostty/SurfaceScrollView.swift
@@ -172,13 +172,16 @@ class SurfaceScrollView: NSView {
     }
     
     // MARK: Scrolling
-    
+
     private func synchronizeAppearance() {
         let scrollbarConfig = surfaceView.derivedConfig.scrollbar
         scrollView.hasVerticalScroller = scrollbarConfig != .never
         scrollView.verticalScroller?.controlSize = .small
+        let hasLightBackground = OSColor(surfaceView.derivedConfig.backgroundColor).isLightColor
+        // Make sure the scroller’s appearance matches the surface's background color.
+        scrollView.appearance = NSAppearance(named: hasLightBackground ? .aqua : .darkAqua)
     }
-    
+
     /// Positions the surface view to fill the currently visible rectangle.
     ///
     /// This is called whenever the scroll position changes. The surface view (which does the


### PR DESCRIPTION
Currently, the scroller's appearance is the same as the window's.

So, with the light system appearance and the following config:

```
window-theme = system
macos-titlebar-style = native
```

It's hard to see where the scroller is. This pr changes the scroller’s(ScrollView) appearance to match the surface's background colour, so it's always easier to find.

> Changing `verticalScroller?.appearance` doesn't seem to work

<img width="601" height="630" alt="image" src="https://github.com/user-attachments/assets/9dc18439-9dcb-479a-802a-de439b7dc9d8" />
