### PR TITLE
feat: introduce `toggle_macos_option_as_alt` binding action with a keybind.

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -274,6 +274,7 @@ const DerivedConfig = struct {
     mouse_shift_capture: configpkg.MouseShiftCapture,
     macos_non_native_fullscreen: configpkg.NonNativeFullscreen,
     macos_option_as_alt: ?input.OptionAsAlt,
+    macos_option_as_alt_original: ?input.OptionAsAlt,
     selection_clear_on_copy: bool,
     selection_clear_on_typing: bool,
     vt_kam_allowed: bool,
@@ -349,6 +350,7 @@ const DerivedConfig = struct {
             .mouse_shift_capture = config.@"mouse-shift-capture",
             .macos_non_native_fullscreen = config.@"macos-non-native-fullscreen",
             .macos_option_as_alt = config.@"macos-option-as-alt",
+            .macos_option_as_alt_original = config.@"macos-option-as-alt",
             .selection_clear_on_copy = config.@"selection-clear-on-copy",
             .selection_clear_on_typing = config.@"selection-clear-on-typing",
             .vt_kam_allowed = config.@"vt-kam-allowed",
@@ -5169,6 +5171,22 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             .toggle_command_palette,
             {},
         ),
+
+        .toggle_macos_option_as_alt => {
+            const current = self.config.macos_option_as_alt orelse .false;
+
+            switch (current) {
+                .false => {
+                    // Toggle ON the behavior by restoring from the saved state.
+                    self.config.macos_option_as_alt = self.config.macos_option_as_alt_original orelse .true;
+                },
+                .true, .left, .right => {
+                    // Toggle OFF and save the current value in the surface state.
+                    self.config.macos_option_as_alt_original = current;
+                    self.config.macos_option_as_alt = .false;
+                },
+            }
+        },
 
         .show_on_screen_keyboard => return try self.rt_app.performAction(
             .{ .surface = self },

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -6425,6 +6425,12 @@ pub const Keybinds = struct {
                 .{ .key = .{ .physical = .arrow_right }, .mods = .{ .alt = true } },
                 .{ .esc = "f" },
             );
+            // Toggle option-as-alt similar to Terminal.app.
+            try self.set.put(
+                alloc,
+                .{ .key = .{ .unicode = 'o' }, .mods = .{ .super = true, .alt = true } },
+                .toggle_macos_option_as_alt,
+            );
         }
     }
 

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -658,6 +658,15 @@ pub const Action = union(enum) {
     /// version can be found by running `ghostty +version`.
     toggle_command_palette,
 
+    /// Toggle the macos-option-as-alt behavior.
+    ///
+    /// When toggled off, sets the macos-option-as-alt to false.
+    /// When toggled on, restores to the original configured value (true, left,
+    /// or right). It defauls to true if none was set.
+    ///
+    /// Only available on macOS.
+    toggle_macos_option_as_alt,
+
     /// Toggle the quick terminal.
     ///
     /// The quick terminal, also known as the "Quake-style" or drop-down
@@ -1188,6 +1197,7 @@ pub const Action = union(enum) {
             .toggle_secure_input,
             .toggle_mouse_reporting,
             .toggle_command_palette,
+            .toggle_macos_option_as_alt,
             .show_on_screen_keyboard,
             .reset_window_size,
             .crash,

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -567,6 +567,12 @@ fn actionCommands(action: Action.Key) []const Command {
             .description = "Toggle whether mouse events are reported to terminal applications.",
         }},
 
+        .toggle_macos_option_as_alt => comptime &.{.{
+            .action = .toggle_macos_option_as_alt,
+            .title = "Toggle Option as Alt on macOS",
+            .description = "Toggle whether the macOS Option keys act as Alt",
+        }},
+
         .check_for_updates => comptime &.{.{
             .action = .check_for_updates,
             .title = "Check for Updates",


### PR DESCRIPTION
- Defines a surface level binding action for toggling the usage of Opt key on macOS as Alt.
- Use `cmd` + `opt` + `o` as the default keyboard binding (similar to Terminal.app).

This is my first PR with Zig so please let me know if there is room to adopt idiomatic patterns.

Refers #2520 

AI Assistance Disclosure: Claude Code assisted me in understanding the codebase. But I wrote the code myself manually without any AI Agents.