### PR TITLE
CoreText: Apply subpixel horizontal alignment also when cell width is less than advance

### DIFF
--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -367,9 +367,16 @@ pub const Face = struct {
         // We don't do this if the glyph has a stretch constraint,
         // since in that case the position was already calculated with the
         // new cell width in mind.
-        if ((constraint.size != .stretch) and (metrics.face_width < cell_width)) {
+        if (constraint.size != .stretch) {
             // We add half the difference to re-center.
-            x += (cell_width - metrics.face_width) / 2;
+            const dx = (cell_width - metrics.face_width) / 2;
+            x += dx;
+            if (dx < 0) {
+                // For negative diff (cell narrower than advance), we remove the
+                // integer part and only keep the fractional adjustment needed
+                // for consistent subpixel positioning.
+                x -= @trunc(dx);
+            }
         }
 
         // If this is a bitmap glyph, it will always render as full pixels,


### PR DESCRIPTION
Follow-up to #9432 to ensure that subpixel horizontal alignment is consistent whether `cell_width = @round(face_width)` rounds up or down.