### PR TITLE
fix(docs): clarify `window-title-font-family` availability

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1765,7 +1765,7 @@ keybind: Keybinds = .{},
 /// Note: any font available on the system may be used, this font is not
 /// required to be a fixed-width font.
 ///
-/// Available since: 1.1.0 (on GTK)
+/// Available since: 1.0.0 on macOS, 1.1.0 on GTK
 @"window-title-font-family": ?[:0]const u8 = null,
 
 /// The text that will be displayed in the subtitle of the window. Valid values:


### PR DESCRIPTION
Address confusion discussed in #9650 