### PR TITLE
custom shaders: add colorscheme information to shader uniforms

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2883,6 +2883,24 @@ keybind: Keybinds = .{},
 ///    (e.g., modifier key presses, link hover events in unfocused split panes).
 ///    Check `iFocus > 0` to determine if the surface is currently focused.
 ///
+///  * `vec3 iPalette[256]` - The 256-color terminal palette.
+///
+///    RGB values for all 256 colors in the terminal palette, normalized
+///    to [0.0, 1.0]. Index 0-15 are the ANSI colors, 16-231 are the 6x6x6
+///    color cube, and 232-255 are the grayscale colors.
+///
+///  * `vec3 iBackgroundColor` - Terminal background color (RGB).
+///
+///  * `vec3 iForegroundColor` - Terminal foreground color (RGB).
+///
+///  * `vec3 iCursorColor` - Terminal cursor color (RGB).
+///
+///  * `vec3 iCursorText` - Terminal cursor text color (RGB).
+///
+///  * `vec3 iSelectionBackgroundColor` - Selection background color (RGB).
+///
+///  * `vec3 iSelectionForegroundColor` - Selection foreground color (RGB).
+///
 /// If the shader fails to compile, the shader will be ignored. Any errors
 /// related to shader compilation will not show up as configuration errors
 /// and only show up in the log, since shader compilation happens after

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -2315,14 +2315,12 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 0,
             };
 
-            // Renderer state required for getting the colors
-            const state: *renderer.State = &self.surface_mailbox.surface.renderer_state;
-
             // (Updates on OSC sequence changes and configuration changes)
             if (self.palette_dirty) {
+                const colors: *const terminal.RenderState.Colors = &self.terminal_state.colors;
 
                 // 256-color palette
-                for (state.terminal.colors.palette.current, 0..) |color, i| {
+                for (colors.palette, 0..) |color, i| {
                     self.custom_shader_uniforms.palette[i] = .{
                         @as(f32, @floatFromInt(color.r)) / 255.0,
                         @as(f32, @floatFromInt(color.g)) / 255.0,
@@ -2332,27 +2330,23 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 }
 
                 // Background color
-                if (state.terminal.colors.background.get()) |bg| {
-                    self.custom_shader_uniforms.background_color = .{
-                        @as(f32, @floatFromInt(bg.r)) / 255.0,
-                        @as(f32, @floatFromInt(bg.g)) / 255.0,
-                        @as(f32, @floatFromInt(bg.b)) / 255.0,
-                        1.0,
-                    };
-                }
+                self.custom_shader_uniforms.background_color = .{
+                    @as(f32, @floatFromInt(colors.background.r)) / 255.0,
+                    @as(f32, @floatFromInt(colors.background.g)) / 255.0,
+                    @as(f32, @floatFromInt(colors.background.b)) / 255.0,
+                    1.0,
+                };
 
                 // Foreground color
-                if (state.terminal.colors.foreground.get()) |fg| {
-                    self.custom_shader_uniforms.foreground_color = .{
-                        @as(f32, @floatFromInt(fg.r)) / 255.0,
-                        @as(f32, @floatFromInt(fg.g)) / 255.0,
-                        @as(f32, @floatFromInt(fg.b)) / 255.0,
-                        1.0,
-                    };
-                }
+                self.custom_shader_uniforms.foreground_color = .{
+                    @as(f32, @floatFromInt(colors.foreground.r)) / 255.0,
+                    @as(f32, @floatFromInt(colors.foreground.g)) / 255.0,
+                    @as(f32, @floatFromInt(colors.foreground.b)) / 255.0,
+                    1.0,
+                };
 
                 // Cursor color
-                if (state.terminal.colors.cursor.get()) |cursor_color| {
+                if (colors.cursor) |cursor_color| {
                     self.custom_shader_uniforms.cursor_color = .{
                         @as(f32, @floatFromInt(cursor_color.r)) / 255.0,
                         @as(f32, @floatFromInt(cursor_color.g)) / 255.0,
@@ -2376,11 +2370,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 }
 
                 // Selection background color
-                if (self.config.selection_background) |seletion_bg| {
+                if (self.config.selection_background) |selection_bg| {
                     self.custom_shader_uniforms.selection_background_color = .{
-                        @as(f32, @floatFromInt(seletion_bg.color.r)) / 255.0,
-                        @as(f32, @floatFromInt(seletion_bg.color.g)) / 255.0,
-                        @as(f32, @floatFromInt(seletion_bg.color.b)) / 255.0,
+                        @as(f32, @floatFromInt(selection_bg.color.r)) / 255.0,
+                        @as(f32, @floatFromInt(selection_bg.color.g)) / 255.0,
+                        @as(f32, @floatFromInt(selection_bg.color.b)) / 255.0,
                         1.0,
                     };
                 }

--- a/src/renderer/shaders/shadertoy_prefix.glsl
+++ b/src/renderer/shaders/shadertoy_prefix.glsl
@@ -18,6 +18,13 @@ layout(binding = 1, std140) uniform Globals {
     uniform float iTimeCursorChange;
     uniform float iTimeFocus;
     uniform int iFocus;
+    uniform vec3  iPalette[256];
+    uniform vec3  iBackgroundColor;
+    uniform vec3  iForegroundColor;
+    uniform vec3  iCursorColor;
+    uniform vec3  iCursorText;
+    uniform vec3  iSelectionForegroundColor;
+    uniform vec3  iSelectionBackgroundColor;
 };
 
 layout(binding = 0) uniform sampler2D iChannel0;

--- a/src/renderer/shadertoy.zig
+++ b/src/renderer/shadertoy.zig
@@ -27,6 +27,13 @@ pub const Uniforms = extern struct {
     cursor_change_time: f32 align(4),
     time_focus: f32 align(4),
     focus: i32 align(4),
+    palette: [256][4]f32 align(16),
+    background_color: [4]f32 align(16),
+    foreground_color: [4]f32 align(16),
+    cursor_color: [4]f32 align(16),
+    cursor_text: [4]f32 align(16),
+    selection_background_color: [4]f32 align(16),
+    selection_foreground_color: [4]f32 align(16),
 };
 
 /// The target to load shaders for.


### PR DESCRIPTION
#9417
Adds palette and color scheme uniforms to custom shaders, allowing custom shaders to access terminal color information:

  - iPalette[256]: Full 256-color terminal palette (RGB)
  - iBackgroundColor, iForegroundColor: Terminal colors (RGB)
  - iCursorColor, iCursorText: Cursor colors (RGB)
  - iSelectionBackgroundColor, iSelectionForegroundColor: Selection colors (RGB)

Colors are normalized to [0.0, 1.0] range and update when the palette changes via OSC sequences or configuration changes. The palette_dirty flag tracks when colors need to be refreshed, initialized to true to ensure correct colors on new surfaces.