### PR TITLE
Add GHOSTTY_QUICK_TERMINAL for quick terminal detection

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -342,7 +342,10 @@ class QuickTerminalController: BaseTerminalController {
         // animate out.
         if surfaceTree.isEmpty,
            let ghostty_app = ghostty.app {
-            let view = Ghostty.SurfaceView(ghostty_app, baseConfig: nil)
+            var config = Ghostty.SurfaceConfiguration()
+            config.environmentVariables["GHOSTTY_QUICK_TERMINAL"] = "1"
+
+            let view = Ghostty.SurfaceView(ghostty_app, baseConfig: config)
             surfaceTree = SplitTree(view: view)
             focusedSurface = view
         }

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -1465,6 +1465,10 @@ pub const Surface = extern struct {
         // EnvMap is a bit annoying so I'm punting it.
         if (ext.getAncestor(Window, self.as(gtk.Widget))) |window| {
             try window.winproto().addSubprocessEnv(&env);
+
+            if (window.isQuickTerminal()) {
+                try env.put("GHOSTTY_QUICK_TERMINAL", "1");
+            }
         }
 
         return env;


### PR DESCRIPTION
## Summary

Adds a new environment variable `GHOSTTY_QUICK_TERMINAL=1` that is set when a terminal surface is launched as a quick terminal. This allows shell configurations to conditionally adjust behavior based on whether the terminal is a quick terminal.

Closes #3985

<img width="1430" height="228" alt="CleanShot 2025-11-23 at 12 39 27 png" src="https://github.com/user-attachments/assets/1085c19b-9d58-4603-a03d-662bfde47095" />

## Motivation

Quick terminals are designed as ephemeral, singleton windows for quick commands. Many users (especially tmux users) have shell configurations that automatically attach to or start tmux sessions on terminal launch. This automatic behavior conflicts with the quick terminal use case.

Example from the issue:
```zsh
# Users want to skip this in quick terminals
if [[ -z "$TMUX" ]]; then
  tmux attach || tmux new
fi

With this PR, users can now detect quick terminals and adjust their shell behavior:
if [[ -z "$TMUX" ]] && [[ -z "$GHOSTTY_QUICK_TERMINAL" ]]; then
  tmux attach || tmux new
fi
```

## Implementation

- macOS: Added GHOSTTY_QUICK_TERMINAL=1 to SurfaceConfiguration environment variables in QuickTerminalController.swift:345-351
- Linux/GTK: Added environment variable check in src/apprt/gtk/class/surface.zig:1469-1472 within defaultTermioEnv()

 The environment variable is automatically inherited by split surfaces.

## Note on Scripting API

I'm aware that @rhodes-b mentioned this functionality was planned for the scripting API (issue #3985). However, I believe this simpler environment variable approach provides immediate value for tmux users and shell configuration use cases, while the scripting API can later provide more comprehensive surface introspection capabilities.

## AI Assistance Disclosure

This PR was written with Claude Code assistance. The Linux/GTK implementation was fully AI-generated. I implemented the mac version myself after Claude Code helped me understand the codebase architecture and locate the appropriate files.