### PR TITLE
Spinlock

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -39,6 +39,7 @@ const App = @import("App.zig");
 const internal_os = @import("os/main.zig");
 const inspectorpkg = @import("inspector/main.zig");
 const SurfaceMouse = @import("surface_mouse.zig");
+const SpinnableLock = @import("datastruct/spinnable_lock.zig").SpinnableLock;
 
 const log = std.log.scoped(.surface);
 
@@ -512,7 +513,7 @@ pub fn init(
     errdefer renderer_impl.deinit();
 
     // The mutex used to protect our renderer state.
-    const mutex = try alloc.create(std.Thread.Mutex);
+    const mutex = try alloc.create(SpinnableLock(.spin_then_block));
     mutex.* = .{};
     errdefer alloc.destroy(mutex);
 

--- a/src/datastruct/spinnable_lock.zig
+++ b/src/datastruct/spinnable_lock.zig
@@ -1,0 +1,128 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+// TODO: Explore thread safety; we have a 32 bit lock value,
+//       so we might as well use it to store the thread ID
+//       there (ensuring that 0 isn't a valid thread ID),
+//       and then at least in debug mode add some asserts
+//       about ownership with that.
+
+/// How many times we loop when trying to obtain the lock
+/// by spinning before we give up and use the futex instead.
+///
+/// This number is arbitrary and I just based it on some other
+/// spin-then-block lock implementations I've seen in the wild.
+///
+/// NOTE(Qwerasd):
+/// This number seems to work well for Ghostty, at least on
+/// my machine, and my assumption is that on proportionally
+/// slower machines the individual checks will take longer,
+/// so it won't create a drastic difference where the lock
+/// doesn't work as intended on certain machines.
+const spin_tries = 10_000;
+
+pub const LockingMethod = enum {
+    /// Spin on the lock for a bit before giving up and
+    /// using the futex instead. We give up because we
+    /// don't want to waste too much CPU time if we're
+    /// wrong about the lock being released soon.
+    ///
+    /// Use this if you're reasonably certain that the
+    /// lock won't be held by anyone else for very long.
+    ///
+    /// (Very long being more than a few thousand cycles.)
+    spin_then_block,
+
+    /// Use the futex to lock, you should use this when
+    /// you're not sure whether whoever is holding the
+    /// lock might hold it for a considerable period of
+    /// time.
+    futex,
+};
+
+/// A futex-based lock which provides a method to spin
+/// the lock for some time before deferring to a futex.
+///
+/// This is useful for when you are reasonably certain
+/// that no other thread will hold the lock for very
+/// long (more than a few thousand cycles), since if
+/// that's the case then the futex will be quite slow
+/// since the thread has to go to sleep and wakes back
+/// up in order to obtain the lock, which can take an
+/// order of magnitude longer than the lock was really
+/// held for in reality.
+pub fn SpinnableLock(comptime default_locking_method: LockingMethod) type {
+    return extern struct {
+        const Self = @This();
+
+        value: u32 = 0,
+
+        /// Use the default locking method to obtain the lock.
+        ///
+        /// In order to use a different method, use `lockWith`.
+        pub inline fn lock(self: *Self) void {
+            self.lockWith(default_locking_method);
+        }
+
+        /// Obtain the lock using the specified method.
+        pub inline fn lockWith(
+            self: *Self,
+            comptime method: LockingMethod,
+        ) void {
+            switch (method) {
+                .spin_then_block => self.lockSpinThenBlock(),
+                .futex => self.lockFutex(),
+            }
+        }
+
+        /// Try to obtain the lock.
+        ///
+        /// Returns true if successful, false otherwise.
+        pub inline fn tryLock(self: *Self) bool {
+            const ptr: *u32 = @ptrCast(self);
+            return @atomicLoad(u32, ptr, .monotonic) == 0 and
+                @cmpxchgWeak(u32, ptr, 0, 1, .acquire, .monotonic) == null;
+        }
+
+        /// Release the lock.
+        pub inline fn unlock(self: *Self) void {
+            // We need to use `release` ordering here to
+            // ensure that the critical section does not
+            // get reordered before this write.
+            @atomicStore(u32, &self.value, 0, .release);
+            @call(
+                .always_inline,
+                std.Thread.Futex.wake,
+                .{ @as(*const std.atomic.Value(u32), @ptrCast(self)), 1 },
+            );
+        }
+
+        inline fn lockSpinThenBlock(self: *Self) void {
+            var tries: usize = spin_tries;
+            while (tries > 0) : (tries -= 1) {
+                if (self.tryLock()) {
+                    // Optimize for the uncontended case.
+                    @branchHint(.likely);
+                    return;
+                }
+                std.atomic.spinLoopHint();
+            } else {
+                // Optimize for the success of the spin lock, if this
+                // is regularly failing over to the futex then someone
+                // is using it wrong, since you should only spin lock
+                // if you're relatively certain you'll get it within
+                // the spin section.
+                @branchHint(.cold);
+                self.lockFutex();
+            }
+        }
+
+        inline fn lockFutex(self: *Self) void {
+            const ptr: *u32 = @ptrCast(self);
+            while (true) {
+                std.Thread.Futex.wait(@ptrCast(ptr), 1);
+                if (self.tryLock()) return;
+            }
+        }
+    };
+}

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -593,7 +593,7 @@ fn renderCallback(
         t.state,
         t.flags.cursor_blink_visible,
     ) catch |err|
-        log.warn("error rendering err={}", .{err});
+        log.warn("error updating frame err={}", .{err});
 
     // Draw
     t.drawFrame(false);

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -32,6 +32,8 @@ const getConstraint = @import("../font/nerd_font_attributes.zig").getConstraint;
 
 const FileType = @import("../file_type.zig").FileType;
 
+const SpinnableLock = @import("../datastruct/spinnable_lock.zig").SpinnableLock;
+
 const macos = switch (builtin.os.tag) {
     .macos => @import("macos"),
     else => void,
@@ -99,7 +101,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
         /// This mutex must be held whenever any state used in `drawFrame` is
         /// being modified, and also when it's being accessed in `drawFrame`.
-        draw_mutex: std.Thread.Mutex = .{},
+        draw_mutex: SpinnableLock(.spin_then_block) = .{},
 
         /// The configuration we need derived from the main config.
         config: DerivedConfig,

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -659,8 +659,8 @@ pub fn focusGained(self: *Termio, td: *ThreadData, focused: bool) !void {
 /// call with pty data but it is also called by the read thread when using
 /// an exec subprocess.
 pub fn processOutput(self: *Termio, buf: []const u8) void {
-    // We are modifying terminal state from here on out and we need
-    // the lock to grab our read data.
+    // We are modifying terminal state from here on
+    // out and we need the lock to grab our read data.
     self.renderer_state.mutex.lock();
     defer self.renderer_state.mutex.unlock();
     self.processOutputLocked(buf);

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -669,6 +669,12 @@ pub fn processOutput(self: *Termio, buf: []const u8) void {
 /// Process output from readdata but the lock is already held.
 fn processOutputLocked(self: *Termio, buf: []const u8) void {
     // Schedule a render. We can call this first because we have the lock.
+    //
+    // An assumption is made here that the time it takes to wake up the
+    // renderer thread will be roughly equivalent to the time it takes
+    // to process a chunk of output. At that point, the renderer thread
+    // will acquire the lock by spinning, so if we end up holding it
+    // for much longer than that it would actually be pretty wasteful.
     self.terminal_stream.handler.queueRender() catch unreachable;
 
     // Whenever a character is typed, we ensure the cursor is in the


### PR DESCRIPTION
This PR adds a custom lock that can be acquired by spinning briefly (10K tries) before deferring to a futex. This avoids the much larger overhead that comes from a thread having to sleep and wake to wait for a futex, when the critical area protected by the lock is much shorter than that.

I've replaced both `renderer_state.mutex` and `GenericRenderer(...).draw_mutex` with this. The `renderer_state` mutex directly impacts IO throughput since it's locked by the io-reader thread every time it processes output, and it's often contended for short periods by the renderer thread. The `draw_mutex` I don't have solid numbers on, but it should theoretically improve renderer latency by some amount.

The change of `renderer_state.mutex` gives a pretty decent improvement to our IO throughput:

### `vtebench`
<img width="1225" height="872" alt="image" src="https://github.com/user-attachments/assets/1b90c173-21a4-4ad7-8762-15e9fffc23c7" />

### `DOOM-fire-zig`
`DOOM-fire-zig` went from stabilizing at around 860FPS to 900FPS for me with this change, a nice ~4.5% increase.

---
**However**, while this overhead reduction shows up brilliantly in synthetic benchmarks of IO throughput, there's a more important consequence. I noticed while testing this change against `main` that it's suspiciously less *flickery* in a lot of things (DOOM-fire-zig, various of the vtebench tests), at which point I realized that we've actually had a pretty nasty race issue under our nose this entire time that this change circumvents.

The issue is as follows:
- The renderer thread is waiting for the renderer state lock, which is held by the io-reader thread.
- The io-reader thread finishes processing a chunk of output and releases the lock, which triggers the renderer thread to start waking up.
- In the mean time, the io-reader thread reads another chunk of output and begins processing it, acquiring the lock (which it can do since it's an unfair lock, and doesn't prioritize the renderer thread even though it started trying to lock it first).
- By the time the renderer thread is awake, the lock is held again, and it goes back to sleep to wait for it once more.

This was my speculation at least, and I thought maybe it would happen once every few output reads, but upon profiling I found relatively frequent sections like this:
<img width="1628" height="430" alt="image" src="https://github.com/user-attachments/assets/4dd039e1-b29b-49fe-a7da-8ce996eb949e" />
which not only confirmed my suspicion, but showed that it can happen in an arbitrarily long chain so long as the io-reader is receiving input in the right size/spacing of individual writes -- yikes!
<img width="1348" height="474" alt="image" src="https://github.com/user-attachments/assets/e8a6e7fc-0fea-44a2-9c40-e506cb239b96" />

So while I'm super happy about the IO throughput improvements this change yields, I'm *way* happier about eliminating this lockout problem, since it (qualitatively, I don't have hard numbers to prove this) seems to have seriously improved the *smoothness* of output when there are a lot of back-to-back writes from the program running in the terminal. It's my speculation that Ghostty's relative "flickeriness" with some TUIs/CLIs compared to other fast terminals was due to this problem, so I'm thrilled to have mitigated it.

# Boring work to do before merging
Before this is merged, I really wanna be sure that this lock doesn't somehow cause a horrible performance regression on a different OS or architecture. I don't *think* it should, but with concurrent code you never know. So these are the platforms that need to be benchmarked:
- [X] aarch64 macOS
- [ ] aarch64 Linux
- [ ] x86 macOS (intel mac)
- [ ] x86 Linux

I'll see about benchmarking aarch64 Linux in a vm on my mac in a while if no one else gets around to it before me- and if no one else can manage x86 macOS for me, I can pull my old intel mac out of storage to do it, though it's not the most convenient.