### PR TITLE
Fix LangSet.hasLang() to compare against FcLangEqual instead of FcTrue

### DIFF
--- a/pkg/fontconfig/lang_set.zig
+++ b/pkg/fontconfig/lang_set.zig
@@ -11,8 +11,12 @@ pub const LangSet = opaque {
         c.FcLangSetDestroy(self.cval());
     }
 
+    pub fn addLang(self: *LangSet, lang: [:0]const u8) bool {
+        return c.FcLangSetAdd(self.cval(), lang.ptr) == c.FcTrue;
+    }
+
     pub fn hasLang(self: *const LangSet, lang: [:0]const u8) bool {
-        return c.FcLangSetHasLang(self.cvalConst(), lang.ptr) == c.FcTrue;
+        return c.FcLangSetHasLang(self.cvalConst(), lang.ptr) == c.FcLangEqual;
     }
 
     pub inline fn cval(self: *LangSet) *c.struct__FcLangSet {
@@ -31,4 +35,27 @@ test "create" {
     defer fs.destroy();
 
     try testing.expect(!fs.hasLang("und-zsye"));
+}
+
+test "hasLang exact match" {
+    const testing = std.testing;
+
+    // Test exact match: langset with "en-US" should return true for "en-US"
+    var fs = LangSet.create();
+    defer fs.destroy();
+    try testing.expect(fs.addLang("en-US"));
+    try testing.expect(fs.hasLang("en-US"));
+
+    // Test exact match: langset with "und-zsye" should return true for "und-zsye"
+    var fs_emoji = LangSet.create();
+    defer fs_emoji.destroy();
+    try testing.expect(fs_emoji.addLang("und-zsye"));
+    try testing.expect(fs_emoji.hasLang("und-zsye"));
+
+    // Test mismatch: langset with "en-US" should return false for "fr"
+    try testing.expect(!fs.hasLang("fr"));
+
+    // Test partial match: langset with "en-US" should return false for "en-GB"
+    // (different territory, but we only want exact matches)
+    try testing.expect(!fs.hasLang("en-GB"));
 }


### PR DESCRIPTION
FcLangSetHasLang returns FcLangResult enum values:
- FcLangEqual (0): Exact match
- FcLangDifferentTerritory (1): Same language, different territory
- FcLangDifferentLang (2): Different language
See also https://www.freedesktop.org/software/fontconfig/fontconfig-devel/fclangsethaslang.html and https://codebrowser.dev/qt6/include/fontconfig/fontconfig.h.html#_FcLangResult

The previous comparison to FcTrue (1) caused:
- Exact matches (0) to incorrectly return false
- Partial matches (1) to incorrectly return true

This fix changes the comparison to FcLangEqual (0) so hasLang() correctly returns true only for exact language matches.