### PR TITLE
add default keybinding for ctrl+shift+plus

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -6006,6 +6006,18 @@ pub const Keybinds = struct {
             .{ .key = .{ .unicode = '+' }, .mods = inputpkg.ctrlOrSuper(.{}) },
             .{ .increase_font_size = 1 },
         );
+        // This key-binding make the intuitive keybinding work for layouts that
+        // achieves plus by using the shift key (like UK)
+        //try self.set.put(
+        //    alloc,
+        //    .{ .key = .{ .unicode = '+' }, .mods = inputpkg.ctrlOrSuper(.{ .shift = true }) },
+        //    .{ .increase_font_size = 1 },
+        //);
+        try self.set.put(
+            alloc,
+            .{ .key = .{ .physical = .equal }, .mods = inputpkg.ctrlOrSuper(.{ .shift = true }) },
+            .{ .increase_font_size = 1 },
+        );
 
         try self.set.put(
             alloc,


### PR DESCRIPTION
I tried to create a default keybinding in line with this discussion: https://github.com/ghostty-org/ghostty/discussions/7243