### PR TITLE
fix(renderer): load linearized fg color for cursor cell

### DIFF
--- a/src/renderer/shaders/shaders.metal
+++ b/src/renderer/shaders/shaders.metal
@@ -668,7 +668,7 @@ vertex CellTextVertexOut cell_text_vertex(
     out.color = load_color(
       uniforms.cursor_color,
       uniforms.use_display_p3,
-      false
+      true
     );
   }
 


### PR DESCRIPTION
It's clear from the surrounding code that the RGB values returned from `cell_text_vertex` are expected to be linearized. This was not the case for the cursor cell, resulting in the cursor text being too bright when using `cursor-text = cell-background`.

Fixes #8353/#9138.

xref #8960, which would also fixe this issue, but I don't know where that's heading