### PR TITLE
pkg/{highway,simdutf}: disable ubsan

### DIFF
--- a/pkg/highway/build.zig
+++ b/pkg/highway/build.zig
@@ -67,6 +67,10 @@ pub fn build(b: *std.Build) !void {
         "-fno-cxx-exceptions",
         "-fno-slp-vectorize",
         "-fno-vectorize",
+
+        // Fixes linker issues for release builds missing ubsanitizer symbols
+        "-fno-sanitize=undefined",
+        "-fno-sanitize-trap=undefined",
     });
     if (target.result.os.tag != .windows) {
         try flags.appendSlice(b.allocator, &.{

--- a/pkg/simdutf/build.zig
+++ b/pkg/simdutf/build.zig
@@ -24,7 +24,13 @@ pub fn build(b: *std.Build) !void {
     defer flags.deinit(b.allocator);
     // Zig 0.13 bug: https://github.com/ziglang/zig/issues/20414
     // (See root Ghostty build.zig on why we do this)
-    try flags.appendSlice(b.allocator, &.{"-DSIMDUTF_IMPLEMENTATION_ICELAKE=0"});
+    try flags.appendSlice(b.allocator, &.{
+        "-DSIMDUTF_IMPLEMENTATION_ICELAKE=0",
+
+        // Fixes linker issues for release builds missing ubsanitizer symbols
+        "-fno-sanitize=undefined",
+        "-fno-sanitize-trap=undefined",
+    });
 
     lib.addCSourceFiles(.{
         .flags = flags.items,


### PR DESCRIPTION
This causes linker issues for some libghostty users. I don't know why we never saw these issues with Ghostty release builds, but generally speaking I think its fine to do this for 3rd party code unless we've witnessed an issue. And these deps have been stable for a long, long time.