### PR TITLE
benchmarks: align read_buf to cache line

### DIFF
--- a/src/benchmark/CodepointWidth.zig
+++ b/src/benchmark/CodepointWidth.zig
@@ -107,7 +107,7 @@ fn stepWcwidth(ptr: *anyopaque) Benchmark.Error!void {
     const self: *CodepointWidth = @ptrCast(@alignCast(ptr));
 
     const f = self.data_f orelse return;
-    var read_buf: [4096]u8 = undefined;
+    var read_buf: [4096]u8 align(std.atomic.cache_line) = undefined;
     var f_reader = f.reader(&read_buf);
     var r = &f_reader.interface;
 
@@ -134,7 +134,7 @@ fn stepTable(ptr: *anyopaque) Benchmark.Error!void {
     const self: *CodepointWidth = @ptrCast(@alignCast(ptr));
 
     const f = self.data_f orelse return;
-    var read_buf: [4096]u8 = undefined;
+    var read_buf: [4096]u8 align(std.atomic.cache_line) = undefined;
     var f_reader = f.reader(&read_buf);
     var r = &f_reader.interface;
 
@@ -166,7 +166,7 @@ fn stepSimd(ptr: *anyopaque) Benchmark.Error!void {
     const self: *CodepointWidth = @ptrCast(@alignCast(ptr));
 
     const f = self.data_f orelse return;
-    var read_buf: [4096]u8 = undefined;
+    var read_buf: [4096]u8 align(std.atomic.cache_line) = undefined;
     var f_reader = f.reader(&read_buf);
     var r = &f_reader.interface;
 

--- a/src/benchmark/GraphemeBreak.zig
+++ b/src/benchmark/GraphemeBreak.zig
@@ -90,7 +90,7 @@ fn stepNoop(ptr: *anyopaque) Benchmark.Error!void {
     const self: *GraphemeBreak = @ptrCast(@alignCast(ptr));
 
     const f = self.data_f orelse return;
-    var read_buf: [4096]u8 = undefined;
+    var read_buf: [4096]u8 align(std.atomic.cache_line) = undefined;
     var f_reader = f.reader(&read_buf);
     var r = &f_reader.interface;
 
@@ -113,7 +113,7 @@ fn stepTable(ptr: *anyopaque) Benchmark.Error!void {
     const self: *GraphemeBreak = @ptrCast(@alignCast(ptr));
 
     const f = self.data_f orelse return;
-    var read_buf: [4096]u8 = undefined;
+    var read_buf: [4096]u8 align(std.atomic.cache_line) = undefined;
     var f_reader = f.reader(&read_buf);
     var r = &f_reader.interface;
 

--- a/src/benchmark/IsSymbol.zig
+++ b/src/benchmark/IsSymbol.zig
@@ -90,7 +90,7 @@ fn stepUucode(ptr: *anyopaque) Benchmark.Error!void {
     const self: *IsSymbol = @ptrCast(@alignCast(ptr));
 
     const f = self.data_f orelse return;
-    var read_buf: [4096]u8 = undefined;
+    var read_buf: [4096]u8 align(std.atomic.cache_line) = undefined;
     var f_reader = f.reader(&read_buf);
     var r = &f_reader.interface;
 
@@ -117,7 +117,7 @@ fn stepTable(ptr: *anyopaque) Benchmark.Error!void {
     const self: *IsSymbol = @ptrCast(@alignCast(ptr));
 
     const f = self.data_f orelse return;
-    var read_buf: [4096]u8 = undefined;
+    var read_buf: [4096]u8 align(std.atomic.cache_line) = undefined;
     var f_reader = f.reader(&read_buf);
     var r = &f_reader.interface;
 

--- a/src/benchmark/ScreenClone.zig
+++ b/src/benchmark/ScreenClone.zig
@@ -109,7 +109,7 @@ fn setup(ptr: *anyopaque) Benchmark.Error!void {
     var stream = self.terminal.vtStream();
     defer stream.deinit();
 
-    var read_buf: [4096]u8 = undefined;
+    var read_buf: [4096]u8 align(std.atomic.cache_line) = undefined;
     var f_reader = data_f.reader(&read_buf);
     const r = &f_reader.interface;
 

--- a/src/benchmark/TerminalParser.zig
+++ b/src/benchmark/TerminalParser.zig
@@ -75,7 +75,7 @@ fn step(ptr: *anyopaque) Benchmark.Error!void {
     // the benchmark results and... I know writing this that we
     // aren't currently IO bound.
     const f = self.data_f orelse return;
-    var read_buf: [4096]u8 = undefined;
+    var read_buf: [4096]u8 align(std.atomic.cache_line) = undefined;
     var f_reader = f.reader(&read_buf);
     var r = &f_reader.interface;
 

--- a/src/benchmark/TerminalStream.zig
+++ b/src/benchmark/TerminalStream.zig
@@ -114,7 +114,7 @@ fn step(ptr: *anyopaque) Benchmark.Error!void {
     // aren't currently IO bound.
     const f = self.data_f orelse return;
 
-    var read_buf: [4096]u8 = undefined;
+    var read_buf: [4096]u8 align(std.atomic.cache_line) = undefined;
     var f_reader = f.reader(&read_buf);
     const r = &f_reader.interface;
 


### PR DESCRIPTION
This aligns the `read_buf`s in `src/benchmark` to the cache line, so that we don't leave that alignment up to chance in case it can very slightly affect the benchmarks.

I ran the before and after on a few of the benchmarks and I don't think it changes much (data is 200 MiB from `ghostty-gen`):

### codepoint-width

<img width="1738" height="470" alt="CleanShot 2025-11-25 at 09 10 14@2x" src="https://github.com/user-attachments/assets/f4ea3014-db21-4a4a-8d67-49161829a4b4" />

### grapheme-break

<img width="1726" height="470" alt="CleanShot 2025-11-25 at 09 10 51@2x" src="https://github.com/user-attachments/assets/d99d220b-3221-4adc-b7f5-58c7b86765bb" />

### is-symbol

<img width="1654" height="466" alt="CleanShot 2025-11-25 at 09 11 09@2x" src="https://github.com/user-attachments/assets/d55e6c12-a650-49cc-aee9-b887eccd42dd" />

AI: no AI, just a simple replace.
