### PR TITLE
search: navigable search results (previous/next)

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4918,6 +4918,19 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
                 .{ .change_needle = text },
                 .forever,
             );
+            s.state.wakeup.notify() catch {};
+        },
+
+        .navigate_search => |nav| {
+            const s: *Search = if (self.search) |*s| s else return false;
+            _ = s.state.mailbox.push(
+                .{ .select = switch (nav) {
+                    .next => .next,
+                    .previous => .prev,
+                } },
+                .forever,
+            );
+            s.state.wakeup.notify() catch {};
         },
 
         .copy_to_clipboard => |format| {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1376,6 +1376,7 @@ fn searchCallback_(
         },
 
         // Unhandled, so far.
+        .selected_match,
         .total_matches,
         .complete,
         => {},

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -988,9 +988,24 @@ palette: Palette = .{},
 ///   - "cell-foreground" to match the cell foreground color
 ///   - "cell-background" to match the cell background color
 ///
-/// The default value is
+/// The default value is black text on a golden yellow background.
 @"search-foreground": TerminalColor = .{ .color = .{ .r = 0, .g = 0, .b = 0 } },
 @"search-background": TerminalColor = .{ .color = .{ .r = 0xFF, .g = 0xE0, .b = 0x82 } },
+
+/// The foreground and background color for the currently selected search match.
+/// This is the focused match that will be jumped to when using next/previous
+/// search navigation.
+///
+/// Valid values:
+///
+///   - Hex (`#RRGGBB` or `RRGGBB`)
+///   - Named X11 color
+///   - "cell-foreground" to match the cell foreground color
+///   - "cell-background" to match the cell background color
+///
+/// The default value is black text on a bright orange background.
+@"search-selected-foreground": TerminalColor = .{ .color = .{ .r = 0, .g = 0, .b = 0 } },
+@"search-selected-background": TerminalColor = .{ .color = .{ .r = 0xFE, .g = 0xA6, .b = 0x2B } },
 
 /// The command to run, usually a shell. If this is not an absolute path, it'll
 /// be looked up in the `PATH`. If this is not set, a default will be looked up

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1003,9 +1003,9 @@ palette: Palette = .{},
 ///   - "cell-foreground" to match the cell foreground color
 ///   - "cell-background" to match the cell background color
 ///
-/// The default value is black text on a bright orange background.
+/// The default value is black text on a soft peach background.
 @"search-selected-foreground": TerminalColor = .{ .color = .{ .r = 0, .g = 0, .b = 0 } },
-@"search-selected-background": TerminalColor = .{ .color = .{ .r = 0xFE, .g = 0xA6, .b = 0x2B } },
+@"search-selected-background": TerminalColor = .{ .color = .{ .r = 0xF2, .g = 0xA5, .b = 0x7E } },
 
 /// The command to run, usually a shell. If this is not an absolute path, it'll
 /// be looked up in the `PATH`. If this is not set, a default will be looked up

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -336,6 +336,10 @@ pub const Action = union(enum) {
     /// the search is canceled. If a previous search is active, it is replaced.
     search: []const u8,
 
+    /// Navigate the search results. If there is no active search, this
+    /// is not performed.
+    navigate_search: NavigateSearch,
+
     /// Clear the screen and all scrollback.
     clear_screen,
 
@@ -826,6 +830,11 @@ pub const Action = union(enum) {
         }
     };
 
+    pub const NavigateSearch = enum {
+        previous,
+        next,
+    };
+
     pub const AdjustSelection = enum {
         left,
         right,
@@ -1157,6 +1166,7 @@ pub const Action = union(enum) {
             .text,
             .cursor_key,
             .search,
+            .navigate_search,
             .reset,
             .copy_to_clipboard,
             .copy_url_to_clipboard,

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -163,6 +163,16 @@ fn actionCommands(action: Action.Key) []const Command {
             .description = "Paste the contents of the selection clipboard.",
         }},
 
+        .navigate_search => comptime &.{ .{
+            .action = .{ .navigate_search = .next },
+            .title = "Next Search Result",
+            .description = "Navigate to the next search result, if any.",
+        }, .{
+            .action = .{ .navigate_search = .previous },
+            .title = "Previous Search Result",
+            .description = "Navigate to the previous search result, if any.",
+        } },
+
         .increase_font_size => comptime &.{.{
             .action = .{ .increase_font_size = 1 },
             .title = "Increase Font Size",

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -459,6 +459,14 @@ fn drainMailbox(self: *Thread) !void {
                 self.renderer.search_matches_dirty = true;
             },
 
+            .search_selected_match => |v| {
+                // Note we don't free the new value because we expect our
+                // allocators to match.
+                if (self.renderer.search_selected_match) |*m| m.arena.deinit();
+                self.renderer.search_selected_match = v;
+                self.renderer.search_matches_dirty = true;
+            },
+
             .inspector => |v| self.flags.has_inspector = v,
 
             .macos_display_id => |v| {

--- a/src/renderer/message.zig
+++ b/src/renderer/message.zig
@@ -58,6 +58,10 @@ pub const Message = union(enum) {
     /// viewport. The renderer must handle this gracefully.
     search_viewport_matches: SearchMatches,
 
+    /// The selected match from the search thread. May be null to indicate
+    /// no match currently.
+    search_selected_match: ?SearchMatch,
+
     /// Activate or deactivate the inspector.
     inspector: bool,
 
@@ -67,6 +71,11 @@ pub const Message = union(enum) {
     pub const SearchMatches = struct {
         arena: ArenaAllocator,
         matches: []const terminal.highlight.Flattened,
+    };
+
+    pub const SearchMatch = struct {
+        arena: ArenaAllocator,
+        match: terminal.highlight.Flattened,
     };
 
     /// Initialize a change_config message.

--- a/src/terminal/highlight.zig
+++ b/src/terminal/highlight.zig
@@ -43,6 +43,10 @@ pub const Untracked = struct {
             self.end,
         );
     }
+
+    pub fn eql(self: Untracked, other: Untracked) bool {
+        return self.start.eql(other.start) and self.end.eql(other.end);
+    }
 };
 
 /// A tracked highlight is a highlight that stores its highlighted

--- a/src/terminal/highlight.zig
+++ b/src/terminal/highlight.zig
@@ -32,6 +32,17 @@ const Screen = @import("Screen.zig");
 pub const Untracked = struct {
     start: Pin,
     end: Pin,
+
+    pub fn track(
+        self: *const Untracked,
+        screen: *Screen,
+    ) Allocator.Error!Tracked {
+        return try .init(
+            screen,
+            self.start,
+            self.end,
+        );
+    }
 };
 
 /// A tracked highlight is a highlight that stores its highlighted

--- a/src/terminal/highlight.zig
+++ b/src/terminal/highlight.zig
@@ -155,8 +155,19 @@ pub const Flattened = struct {
         };
     }
 
+    pub fn startPin(self: Flattened) Pin {
+        const slice = self.chunks.slice();
+        return .{
+            .node = slice.items(.node)[0],
+            .x = self.top_x,
+            .y = slice.items(.start)[0],
+        };
+    }
+
     /// Convert to an Untracked highlight.
     pub fn untracked(self: Flattened) Untracked {
+        // Note: we don't use startPin/endPin here because it is slightly
+        // faster to reuse the slices.
         const slice = self.chunks.slice();
         const nodes = slice.items(.node);
         const starts = slice.items(.start);

--- a/src/terminal/render.zig
+++ b/src/terminal/render.zig
@@ -193,9 +193,17 @@ pub const RenderState = struct {
         /// The x range of the selection within this row.
         selection: ?[2]size.CellCountInt,
 
-        /// The x ranges of highlights within this row. Highlights are
-        /// applied after the update by calling `updateHighlights`.
-        highlights: std.ArrayList([2]size.CellCountInt),
+        /// The highlights within this row.
+        highlights: std.ArrayList(Highlight),
+    };
+
+    pub const Highlight = struct {
+        /// A special tag that can be used by the caller to differentiate
+        /// different highlight types. The value is opaque to the RenderState.
+        tag: u8,
+
+        /// The x ranges of highlights within this row.
+        range: [2]size.CellCountInt,
     };
 
     pub const Cell = struct {
@@ -646,6 +654,7 @@ pub const RenderState = struct {
     pub fn updateHighlightsFlattened(
         self: *RenderState,
         alloc: Allocator,
+        tag: u8,
         hls: []const highlight.Flattened,
     ) Allocator.Error!void {
         // Fast path, we have no highlights!
@@ -691,8 +700,11 @@ pub const RenderState = struct {
                     try row_highlights.append(
                         arena_alloc,
                         .{
-                            if (i == 0) hl.top_x else 0,
-                            if (i == nodes.len - 1) hl.bot_x else self.cols - 1,
+                            .tag = tag,
+                            .range = .{
+                                if (i == 0) hl.top_x else 0,
+                                if (i == nodes.len - 1) hl.bot_x else self.cols - 1,
+                            },
                         },
                     );
 

--- a/src/terminal/search/Thread.zig
+++ b/src/terminal/search/Thread.zig
@@ -257,7 +257,16 @@ fn select(self: *Thread, sel: ScreenSearch.Select) !void {
 
     // The selection will trigger a selection change notification
     // if it did change.
-    try screen_search.select(sel);
+    if (try screen_search.select(sel)) scroll: {
+        if (screen_search.selected) |m| {
+            // Selection changed, let's scroll the viewport to see it
+            // since we have the lock anyways.
+            const screen = self.opts.terminal.screens.get(
+                s.last_screen.key,
+            ) orelse break :scroll;
+            screen.scroll(.{ .pin = m.highlight.start.* });
+        }
+    }
 }
 
 /// Change the search term to the given value.

--- a/src/terminal/search/screen.zig
+++ b/src/terminal/search/screen.zig
@@ -57,7 +57,7 @@ pub const ScreenSearch = struct {
     history_results: std.ArrayList(FlattenedHighlight),
     active_results: std.ArrayList(FlattenedHighlight),
 
-    const SelectedMatch = struct {
+    pub const SelectedMatch = struct {
         /// Index from the end of the match list (0 = most recent match)
         idx: usize,
 


### PR DESCRIPTION
Continuing #189

This adds the `navigate_search:previous` and `next` key bindings which allow search matches to be navigated. The currently selected search match is highlighted using a new `search-selected-foreground/background` configuration with a reasonable default.

As search results are navigated, the viewport moves to keep them visible.

## Demo


https://github.com/user-attachments/assets/facc9f3e-e327-4c65-b5f7-0279480ac357

