### PR TITLE
Misc search fixes

### DIFF
--- a/src/terminal/highlight.zig
+++ b/src/terminal/highlight.zig
@@ -114,7 +114,7 @@ pub const Flattened = struct {
     /// The page chunks that make up this highlight. This handles the
     /// y bounds since chunks[0].start is the first highlighted row
     /// and chunks[len - 1].end is the last highlighted row (exclsive).
-    chunks: std.MultiArrayList(PageChunk),
+    chunks: std.MultiArrayList(Chunk),
 
     /// The x bounds of the highlight. `bot_x` may be less than `top_x`
     /// for typical left-to-right highlights: can start the selection right
@@ -122,8 +122,16 @@ pub const Flattened = struct {
     top_x: size.CellCountInt,
     bot_x: size.CellCountInt,
 
-    /// Exposed for easier type references.
-    pub const Chunk = PageChunk;
+    /// A flattened chunk is almost identical to a PageList.Chunk but
+    /// we also flatten the serial number. This lets the flattened
+    /// highlight more robust for comparisons and validity checks with
+    /// the PageList.
+    pub const Chunk = struct {
+        node: *PageList.List.Node,
+        serial: u64,
+        start: size.CellCountInt,
+        end: size.CellCountInt,
+    };
 
     pub const empty: Flattened = .{
         .chunks = .empty,
@@ -139,7 +147,12 @@ pub const Flattened = struct {
         var result: std.MultiArrayList(PageChunk) = .empty;
         errdefer result.deinit(alloc);
         var it = start.pageIterator(.right_down, end);
-        while (it.next()) |chunk| try result.append(alloc, chunk);
+        while (it.next()) |chunk| try result.append(alloc, .{
+            .node = chunk.node,
+            .serial = chunk.node.serial,
+            .start = chunk.start,
+            .end = chunk.end,
+        });
         return .{
             .chunks = result,
             .top_x = start.x,

--- a/src/terminal/search/sliding_window.zig
+++ b/src/terminal/search/sliding_window.zig
@@ -87,6 +87,7 @@ pub const SlidingWindow = struct {
     const MetaBuf = CircBuf(Meta, undefined);
     const Meta = struct {
         node: *PageList.List.Node,
+        serial: u64,
         cell_map: std.ArrayList(point.Coordinate),
 
         pub fn deinit(self: *Meta, alloc: Allocator) void {
@@ -345,6 +346,7 @@ pub const SlidingWindow = struct {
                     result.bot_x = end_map.x;
                     self.chunk_buf.appendAssumeCapacity(.{
                         .node = meta.node,
+                        .serial = meta.serial,
                         .start = @intCast(start_map.y),
                         .end = @intCast(end_map.y + 1),
                     });
@@ -363,6 +365,7 @@ pub const SlidingWindow = struct {
                     result.top_x = map.x;
                     self.chunk_buf.appendAssumeCapacity(.{
                         .node = meta.node,
+                        .serial = meta.serial,
                         .start = @intCast(map.y),
                         .end = meta.node.data.size.rows,
                     });
@@ -397,6 +400,7 @@ pub const SlidingWindow = struct {
                     // to our results because we want the full flattened list.
                     self.chunk_buf.appendAssumeCapacity(.{
                         .node = meta.node,
+                        .serial = meta.serial,
                         .start = 0,
                         .end = meta.node.data.size.rows,
                     });
@@ -410,6 +414,7 @@ pub const SlidingWindow = struct {
                 result.bot_x = map.x;
                 self.chunk_buf.appendAssumeCapacity(.{
                     .node = meta.node,
+                    .serial = meta.serial,
                     .start = 0,
                     .end = @intCast(map.y + 1),
                 });
@@ -513,6 +518,7 @@ pub const SlidingWindow = struct {
         // Initialize our metadata for the node.
         var meta: Meta = .{
             .node = node,
+            .serial = node.serial,
             .cell_map = .empty,
         };
         errdefer meta.deinit(self.alloc);


### PR DESCRIPTION
- ScreenSearch has to restart on resize. We don't have any good way to handle reflow since our search results are unpinned. We can look into this later but this fixes correctness.
- PageList now tracks serial number by node that monotonically increases on any alloc or reuse. Our screen search uses this to prune invalid history results.