### PR TITLE
macOS: move search result counter inside text field

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -409,11 +409,27 @@ extension Ghostty {
                     TextField("Search", text: $searchState.needle)
                     .textFieldStyle(.plain)
                     .frame(width: 180)
-                    .padding(.horizontal, 8)
+                    .padding(.leading, 8)
+                    .padding(.trailing, 50)
                     .padding(.vertical, 6)
                     .background(Color.primary.opacity(0.1))
                     .cornerRadius(6)
                     .focused($isSearchFieldFocused)
+                    .overlay(alignment: .trailing) {
+                        if let selected = searchState.selected {
+                            Text("\(selected + 1)/\(searchState.total, default: "?")")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .monospacedDigit()
+                                .padding(.trailing, 8)
+                        } else if let total = searchState.total {
+                            Text("-/\(total)")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .monospacedDigit()
+                                .padding(.trailing, 8)
+                        }
+                    }
 #if canImport(AppKit)
                     .onExitCommand {
                         Ghostty.moveFocus(to: surfaceView)
@@ -427,19 +443,7 @@ extension Ghostty {
                         ghostty_surface_binding_action(surface, action, UInt(action.count))
                         return .handled
                     }
-                    
-                    if let selected = searchState.selected {
-                        Text("\(selected + 1)/\(searchState.total, default: "?")")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                            .monospacedDigit()
-                    } else if let total = searchState.total {
-                        Text("-/\(total)")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                            .monospacedDigit()
-                    }
-                    
+
                     Button(action: {
                         guard let surface = surfaceView.surface else { return }
                         let action = "navigate_search:next"


### PR DESCRIPTION
Move the search result counter inside the search text field using an overlay, preventing layout shift when results appear.

**Before:** The counter appeared as a separate element in the HStack, causing the text field to shift when results loaded.

**After:** The counter is overlaid inside the text field on the right side with reserved padding, eliminating layout shift.

---

**AI Disclosure: The was entirely authored with Claude Code, specifically with Claude Opus 4.5.**