### PR TITLE
renderer: manual selection should take priority over search matches

### DIFF
--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -2602,11 +2602,25 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                         search,
                         search_selected,
                     } = selected: {
+                        // Order below matters for precedence.
+
+                        // Selection should take the highest precedence.
+                        const x_compare = if (wide == .spacer_tail)
+                            x -| 1
+                        else
+                            x;
+                        if (selection) |sel| {
+                            if (x_compare >= sel[0] and
+                                x_compare <= sel[1]) break :selected .selection;
+                        }
+
                         // If we're highlighted, then we're selected. In the
                         // future we want to use a different style for this
                         // but this to get started.
                         for (highlights.items) |hl| {
-                            if (x >= hl.range[0] and x <= hl.range[1]) {
+                            if (x_compare >= hl.range[0] and
+                                x_compare <= hl.range[1])
+                            {
                                 const tag: HighlightTag = @enumFromInt(hl.tag);
                                 break :selected switch (tag) {
                                     .search_match => .search,
@@ -2614,15 +2628,6 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                                 };
                             }
                         }
-
-                        const sel = selection orelse break :selected .false;
-                        const x_compare = if (wide == .spacer_tail)
-                            x -| 1
-                        else
-                            x;
-
-                        if (x_compare >= sel[0] and
-                            x_compare <= sel[1]) break :selected .selection;
 
                         break :selected .false;
                     };


### PR DESCRIPTION
Previously it was impossible to select a search match. Well, it was selecting but it wasn't showing that it was selected.