### PR TITLE
macOS: refine Search UI

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -469,7 +469,7 @@ extension Ghostty {
                 }
                 .padding(8)
                 .background(.background)
-                .cornerRadius(8)
+                .clipShape(clipShape)
                 .shadow(radius: 4)
                 .onAppear {
                     isSearchFieldFocused = true
@@ -508,7 +508,15 @@ extension Ghostty {
                 )
             }
         }
-        
+
+        private var clipShape: some Shape {
+            if #available(iOS 26.0, macOS 26.0, *) {
+                return ConcentricRectangle(corners: .concentric(minimum: 8), isUniform: true)
+            } else {
+                return RoundedRectangle(cornerRadius: 8)
+            }
+        }
+
         enum Corner {
             case topLeft, topRight, bottomLeft, bottomRight
             

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -499,11 +499,13 @@ extension Ghostty {
                                 x: centerPos.x + value.translation.width,
                                 y: centerPos.y + value.translation.height
                             )
-                            corner = closestCorner(to: newCenter, in: geo.size)
-                            dragOffset = .zero
+                            let newCorner = closestCorner(to: newCenter, in: geo.size)
+                            withAnimation(.easeOut(duration: 0.2)) {
+                                corner = newCorner
+                                dragOffset = .zero
+                            }
                         }
                 )
-                .animation(.easeOut(duration: 0.2), value: corner)
             }
         }
         


### PR DESCRIPTION
- fix search dragging animation when corner is not changed
- use ConcentricRectangle on Tahoe

https://github.com/user-attachments/assets/64c294a7-70bd-484d-b153-4aa2d734b1a7

