### PR TITLE
macOS: fix toggle_visibility behaviour with tabbed windows

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -1184,10 +1184,19 @@ class AppDelegate: NSObject,
             // want to bring back these windows if we remove the toggle.
             //
             // We also ignore fullscreen windows because they don't hide anyways.
-            self.hiddenWindows = NSApp.windows.filter {
+            var visibleWindows = [Weak<NSWindow>]()
+            NSApp.windows.filter {
                 $0.isVisible &&
                 !$0.styleMask.contains(.fullScreen)
-            }.map { Weak($0) }
+            }.forEach { window in
+                // We only keep track of selectedWindow if it's in a tabGroup,
+                // so we can keep its selection state when restoring
+                let windowToHide = window.tabGroup?.selectedWindow ?? window
+                if !visibleWindows.contains(where: { $0.value === windowToHide }) {
+                    visibleWindows.append(Weak(windowToHide))
+                }
+            }
+            self.hiddenWindows = visibleWindows
         }
 
         func restore() {


### PR DESCRIPTION
This fixes regression of #5690, which kind of comes from #9576. 

05b42919d5ce53b51be25cc4f900ee3f00988259 (before #9576) has weird behaviours too: restored windows are not properly focused. With this pr, we only order `selectedWindow` front so we won't mess up with its selection and focused state and the order of the tab group.

https://github.com/user-attachments/assets/8c3b120e-4077-4cb5-8ed3-9b46522e2f8e

