### PR TITLE
macos: `window-width/height` is accurate even with other widgets

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalView.swift
+++ b/macos/Sources/Features/Terminal/TerminalView.swift
@@ -45,7 +45,7 @@ struct TerminalView<ViewModel: TerminalViewModel>: View {
 
     // An optional delegate to receive information about terminal changes.
     weak var delegate: (any TerminalViewDelegate)? = nil
-
+    
     // The most recently focused surface, equal to focusedSurface when
     // it is non-nil.
     @State private var lastFocusedSurface: Weak<Ghostty.SurfaceView> = .init()
@@ -100,6 +100,8 @@ struct TerminalView<ViewModel: TerminalViewModel>: View {
                             guard let size = newValue else { return }
                             self.delegate?.cellSizeDidChange(to: size)
                         }
+                        .frame(idealWidth: lastFocusedSurface.value?.initialSize?.width,
+                               idealHeight: lastFocusedSurface.value?.initialSize?.height)
                 }
                 // Ignore safe area to extend up in to the titlebar region if we have the "hidden" titlebar style
                 .ignoresSafeArea(.container, edges: ghostty.config.macosTitlebarStyle == "hidden" ? .top : [])

--- a/macos/Sources/Helpers/Extensions/NSWindow+Extension.swift
+++ b/macos/Sources/Helpers/Extensions/NSWindow+Extension.swift
@@ -15,4 +15,20 @@ extension NSWindow {
         guard let firstWindow = tabGroup?.windows.first else { return true }
         return firstWindow === self
     }
+
+    /// Adjusts the window origin if necessary to ensure the window remains visible on screen.
+    func constrainToScreen() {
+        guard let screen = screen ?? NSScreen.main else { return }
+        let visibleFrame = screen.visibleFrame
+        var windowFrame = frame
+
+        windowFrame.origin.x = max(visibleFrame.minX,
+            min(windowFrame.origin.x, visibleFrame.maxX - windowFrame.width))
+        windowFrame.origin.y = max(visibleFrame.minY,
+            min(windowFrame.origin.y, visibleFrame.maxY - windowFrame.height))
+
+        if windowFrame.origin != frame.origin {
+            setFrameOrigin(windowFrame.origin)
+        }
+    }
 }


### PR DESCRIPTION
Fixes #2660

Rather than calculate our window frame size based on various chrome calculations, we now utilize SwiftUI layouts and view intrinsic content sizes with `setContentSize` to setup our content size ignoring all our other widgets.

I'm sure there's some edge cases I'm missing here but this should be a whole lot more reliable on the whole.