### PR TITLE
Allow list-theme action with --plain to sort with --color argument

### DIFF
--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -180,7 +180,13 @@ pub fn run(gpa_alloc: std.mem.Allocator) !u8 {
         return 0;
     }
 
+    var theme_config = try Config.default(gpa_alloc);
+    defer theme_config.deinit();
     for (themes.items) |theme| {
+        try theme_config.loadFile(theme_config._arena.?.allocator(), theme.path);
+        if (!shouldIncludeTheme(opts.color, theme_config)) {
+            continue;
+        }
         if (opts.path)
             try stdout.print("{s} ({t}) {s}\n", .{ theme.theme, theme.location, theme.path })
         else


### PR DESCRIPTION
not an accepted issue https://github.com/ghostty-org/ghostty/discussions/9745 but it seemed simple enough to add, pretty much copies how the previewer sorts based on color

This allows --color argument to work when using --plain to sort the list returned