### PR TITLE
GTK: Search UI

### DIFF
--- a/src/apprt/gtk/build/gresource.zig
+++ b/src/apprt/gtk/build/gresource.zig
@@ -43,6 +43,7 @@ pub const blueprints: []const Blueprint = &.{
     .{ .major = 1, .minor = 5, .name = "inspector-widget" },
     .{ .major = 1, .minor = 5, .name = "inspector-window" },
     .{ .major = 1, .minor = 2, .name = "resize-overlay" },
+    .{ .major = 1, .minor = 2, .name = "search-overlay" },
     .{ .major = 1, .minor = 5, .name = "split-tree" },
     .{ .major = 1, .minor = 5, .name = "split-tree-split" },
     .{ .major = 1, .minor = 2, .name = "surface" },

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -727,6 +727,9 @@ pub const Application = extern struct {
             .show_on_screen_keyboard => return Action.showOnScreenKeyboard(target),
             .command_finished => return Action.commandFinished(target, value),
 
+            .start_search => Action.startSearch(target),
+            .end_search => Action.endSearch(target),
+
             // Unimplemented
             .secure_input,
             .close_all_windows,
@@ -741,8 +744,6 @@ pub const Application = extern struct {
             .check_for_updates,
             .undo,
             .redo,
-            .start_search,
-            .end_search,
             .search_total,
             .search_selected,
             => {
@@ -2338,6 +2339,20 @@ const Action = struct {
         switch (target) {
             .app => {},
             .surface => |v| v.rt_surface.surface.setScrollbar(value),
+        }
+    }
+
+    pub fn startSearch(target: apprt.Target) void {
+        switch (target) {
+            .app => {},
+            .surface => |v| v.rt_surface.surface.setSearchActive(true),
+        }
+    }
+
+    pub fn endSearch(target: apprt.Target) void {
+        switch (target) {
+            .app => {},
+            .surface => |v| v.rt_surface.surface.setSearchActive(false),
         }
     }
 

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -729,6 +729,8 @@ pub const Application = extern struct {
 
             .start_search => Action.startSearch(target),
             .end_search => Action.endSearch(target),
+            .search_total => Action.searchTotal(target, value),
+            .search_selected => Action.searchSelected(target, value),
 
             // Unimplemented
             .secure_input,
@@ -744,8 +746,6 @@ pub const Application = extern struct {
             .check_for_updates,
             .undo,
             .redo,
-            .search_total,
-            .search_selected,
             => {
                 log.warn("unimplemented action={}", .{action});
                 return false;
@@ -2353,6 +2353,20 @@ const Action = struct {
         switch (target) {
             .app => {},
             .surface => |v| v.rt_surface.surface.setSearchActive(false),
+        }
+    }
+
+    pub fn searchTotal(target: apprt.Target, value: apprt.action.SearchTotal) void {
+        switch (target) {
+            .app => {},
+            .surface => |v| v.rt_surface.surface.setSearchTotal(value.total),
+        }
+    }
+
+    pub fn searchSelected(target: apprt.Target, value: apprt.action.SearchSelected) void {
+        switch (target) {
+            .app => {},
+            .surface => |v| v.rt_surface.surface.setSearchSelected(value.selected),
         }
     }
 

--- a/src/apprt/gtk/class/search_overlay.zig
+++ b/src/apprt/gtk/class/search_overlay.zig
@@ -48,6 +48,20 @@ pub const SearchOverlay = extern struct {
         };
     };
 
+    pub const signals = struct {
+        /// Emitted when the search is stopped (e.g., Escape pressed).
+        pub const @"stop-search" = struct {
+            pub const name = "stop-search";
+            pub const connect = impl.connect;
+            const impl = gobject.ext.defineSignal(
+                name,
+                Self,
+                &.{},
+                void,
+            );
+        };
+    };
+
     const Private = struct {
         /// The search entry widget.
         search_entry: *gtk.SearchEntry,
@@ -67,6 +81,13 @@ pub const SearchOverlay = extern struct {
         const priv = self.private();
         _ = priv.search_entry.as(gtk.Widget).grabFocus();
         priv.search_entry.as(gtk.Editable).selectRegion(0, -1);
+    }
+
+    //---------------------------------------------------------------
+    // Template callbacks
+
+    fn stopSearch(_: *gtk.SearchEntry, self: *Self) callconv(.c) void {
+        signals.@"stop-search".impl.emit(self, null, .{}, null);
     }
 
     //---------------------------------------------------------------
@@ -121,10 +142,16 @@ pub const SearchOverlay = extern struct {
             // Bindings
             class.bindTemplateChildPrivate("search_entry", .{});
 
+            // Template Callbacks
+            class.bindTemplateCallback("stop_search", &stopSearch);
+
             // Properties
             gobject.ext.registerProperties(class, &.{
                 properties.active.impl,
             });
+
+            // Signals
+            signals.@"stop-search".impl.register(.{});
 
             // Virtual methods
             gobject.Object.virtual_methods.dispose.implement(class, &dispose);
@@ -133,5 +160,6 @@ pub const SearchOverlay = extern struct {
 
         pub const as = C.Class.as;
         pub const bindTemplateChildPrivate = C.Class.bindTemplateChildPrivate;
+        pub const bindTemplateCallback = C.Class.bindTemplateCallback;
     };
 };

--- a/src/apprt/gtk/class/search_overlay.zig
+++ b/src/apprt/gtk/class/search_overlay.zig
@@ -187,6 +187,10 @@ pub const SearchOverlay = extern struct {
         signals.@"stop-search".impl.emit(self, null, .{}, null);
     }
 
+    fn stopSearchButton(_: *gtk.Button, self: *Self) callconv(.c) void {
+        signals.@"stop-search".impl.emit(self, null, .{}, null);
+    }
+
     fn searchChanged(entry: *gtk.SearchEntry, self: *Self) callconv(.c) void {
         const text = entry.as(gtk.Editable).getText();
         signals.@"search-changed".impl.emit(self, null, .{text}, null);
@@ -262,6 +266,7 @@ pub const SearchOverlay = extern struct {
 
             // Template Callbacks
             class.bindTemplateCallback("stop_search", &stopSearch);
+            class.bindTemplateCallback("stop_search_button", &stopSearchButton);
             class.bindTemplateCallback("search_changed", &searchChanged);
             class.bindTemplateCallback("match_label_closure", &closureMatchLabel);
             class.bindTemplateCallback("next_match", &nextMatch);

--- a/src/apprt/gtk/class/search_overlay.zig
+++ b/src/apprt/gtk/class/search_overlay.zig
@@ -185,6 +185,9 @@ pub const SearchOverlay = extern struct {
     pub fn grabFocus(self: *Self) void {
         const priv = self.private();
         _ = priv.search_entry.as(gtk.Widget).grabFocus();
+
+        // Select all text in the search entry field. -1 is distance from
+        // the end, causing the entire text to be selected.
         priv.search_entry.as(gtk.Editable).selectRegion(0, -1);
     }
 

--- a/src/apprt/gtk/class/search_overlay.zig
+++ b/src/apprt/gtk/class/search_overlay.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const adw = @import("adw");
 const glib = @import("glib");
 const gobject = @import("gobject");
+const gdk = @import("gdk");
 const gtk = @import("gtk");
 
 const gresource = @import("../build/gresource.zig");
@@ -204,6 +205,26 @@ pub const SearchOverlay = extern struct {
         signals.@"previous-match".impl.emit(self, null, .{}, null);
     }
 
+    fn searchEntryKeyPressed(
+        _: *gtk.EventControllerKey,
+        keyval: c_uint,
+        _: c_uint,
+        gtk_mods: gdk.ModifierType,
+        self: *Self,
+    ) callconv(.c) c_int {
+        if (keyval == gdk.KEY_Return or keyval == gdk.KEY_KP_Enter) {
+            if (gtk_mods.shift_mask) {
+                signals.@"previous-match".impl.emit(self, null, .{}, null);
+            } else {
+                signals.@"next-match".impl.emit(self, null, .{}, null);
+            }
+
+            return 1;
+        }
+
+        return 0;
+    }
+
     //---------------------------------------------------------------
     // Virtual methods
 
@@ -262,6 +283,7 @@ pub const SearchOverlay = extern struct {
             class.bindTemplateCallback("match_label_closure", &closureMatchLabel);
             class.bindTemplateCallback("next_match", &nextMatch);
             class.bindTemplateCallback("previous_match", &previousMatch);
+            class.bindTemplateCallback("search_entry_key_pressed", &searchEntryKeyPressed);
 
             // Properties
             gobject.ext.registerProperties(class, &.{

--- a/src/apprt/gtk/class/search_overlay.zig
+++ b/src/apprt/gtk/class/search_overlay.zig
@@ -60,6 +60,18 @@ pub const SearchOverlay = extern struct {
                 void,
             );
         };
+
+        /// Emitted when the search text changes (debounced).
+        pub const @"search-changed" = struct {
+            pub const name = "search-changed";
+            pub const connect = impl.connect;
+            const impl = gobject.ext.defineSignal(
+                name,
+                Self,
+                &.{?[*:0]const u8},
+                void,
+            );
+        };
     };
 
     const Private = struct {
@@ -88,6 +100,11 @@ pub const SearchOverlay = extern struct {
 
     fn stopSearch(_: *gtk.SearchEntry, self: *Self) callconv(.c) void {
         signals.@"stop-search".impl.emit(self, null, .{}, null);
+    }
+
+    fn searchChanged(entry: *gtk.SearchEntry, self: *Self) callconv(.c) void {
+        const text = entry.as(gtk.Editable).getText();
+        signals.@"search-changed".impl.emit(self, null, .{text}, null);
     }
 
     //---------------------------------------------------------------
@@ -144,6 +161,7 @@ pub const SearchOverlay = extern struct {
 
             // Template Callbacks
             class.bindTemplateCallback("stop_search", &stopSearch);
+            class.bindTemplateCallback("search_changed", &searchChanged);
 
             // Properties
             gobject.ext.registerProperties(class, &.{
@@ -152,6 +170,7 @@ pub const SearchOverlay = extern struct {
 
             // Signals
             signals.@"stop-search".impl.register(.{});
+            signals.@"search-changed".impl.register(.{});
 
             // Virtual methods
             gobject.Object.virtual_methods.dispose.implement(class, &dispose);

--- a/src/apprt/gtk/class/search_overlay.zig
+++ b/src/apprt/gtk/class/search_overlay.zig
@@ -184,32 +184,23 @@ pub const SearchOverlay = extern struct {
     //---------------------------------------------------------------
     // Template callbacks
 
-    fn stopSearch(_: *gtk.SearchEntry, self: *Self) callconv(.c) void {
-        signals.@"stop-search".impl.emit(self, null, .{}, null);
-    }
-
-    fn stopSearchButton(_: *gtk.Button, self: *Self) callconv(.c) void {
-        signals.@"stop-search".impl.emit(self, null, .{}, null);
-    }
-
     fn searchChanged(entry: *gtk.SearchEntry, self: *Self) callconv(.c) void {
         const text = entry.as(gtk.Editable).getText();
         signals.@"search-changed".impl.emit(self, null, .{text}, null);
     }
 
-    fn nextMatch(_: *gtk.Button, self: *Self) callconv(.c) void {
+    // NOTE: The callbacks below use anyopaque for the first parameter
+    // because they're shared with multiple widgets in the template.
+
+    fn stopSearch(_: *anyopaque, self: *Self) callconv(.c) void {
+        signals.@"stop-search".impl.emit(self, null, .{}, null);
+    }
+
+    fn nextMatch(_: *anyopaque, self: *Self) callconv(.c) void {
         signals.@"next-match".impl.emit(self, null, .{}, null);
     }
 
-    fn previousMatch(_: *gtk.Button, self: *Self) callconv(.c) void {
-        signals.@"previous-match".impl.emit(self, null, .{}, null);
-    }
-
-    fn nextMatchEntry(_: *gtk.SearchEntry, self: *Self) callconv(.c) void {
-        signals.@"next-match".impl.emit(self, null, .{}, null);
-    }
-
-    fn previousMatchEntry(_: *gtk.SearchEntry, self: *Self) callconv(.c) void {
+    fn previousMatch(_: *anyopaque, self: *Self) callconv(.c) void {
         signals.@"previous-match".impl.emit(self, null, .{}, null);
     }
 
@@ -267,13 +258,10 @@ pub const SearchOverlay = extern struct {
 
             // Template Callbacks
             class.bindTemplateCallback("stop_search", &stopSearch);
-            class.bindTemplateCallback("stop_search_button", &stopSearchButton);
             class.bindTemplateCallback("search_changed", &searchChanged);
             class.bindTemplateCallback("match_label_closure", &closureMatchLabel);
             class.bindTemplateCallback("next_match", &nextMatch);
             class.bindTemplateCallback("previous_match", &previousMatch);
-            class.bindTemplateCallback("next_match_entry", &nextMatchEntry);
-            class.bindTemplateCallback("previous_match_entry", &previousMatchEntry);
 
             // Properties
             gobject.ext.registerProperties(class, &.{

--- a/src/apprt/gtk/class/search_overlay.zig
+++ b/src/apprt/gtk/class/search_overlay.zig
@@ -1,0 +1,141 @@
+const std = @import("std");
+const adw = @import("adw");
+const glib = @import("glib");
+const gobject = @import("gobject");
+const gtk = @import("gtk");
+
+const gresource = @import("../build/gresource.zig");
+const Common = @import("../class.zig").Common;
+
+const log = std.log.scoped(.gtk_ghostty_search_overlay);
+
+/// The overlay that shows the current size while a surface is resizing.
+/// This can be used generically to show pretty much anything with a
+/// disappearing overlay, but we have no other use at this point so it
+/// is named specifically for what it does.
+///
+/// General usage:
+///
+///   1. Add it to an overlay
+///   2. Set the label with `setLabel`
+///   3. Schedule to show it with `schedule`
+///
+/// Set any properties to change the behavior.
+pub const SearchOverlay = extern struct {
+    const Self = @This();
+    parent_instance: Parent,
+    pub const Parent = adw.Bin;
+    pub const getGObjectType = gobject.ext.defineClass(Self, .{
+        .name = "GhosttySearchOverlay",
+        .instanceInit = &init,
+        .classInit = &Class.init,
+        .parent_class = &Class.parent,
+        .private = .{ .Type = Private, .offset = &Private.offset },
+    });
+
+    pub const properties = struct {
+        pub const duration = struct {
+            pub const name = "duration";
+            const impl = gobject.ext.defineProperty(
+                name,
+                Self,
+                c_uint,
+                .{
+                    .default = 750,
+                    .minimum = 250,
+                    .maximum = std.math.maxInt(c_uint),
+                    .accessor = gobject.ext.privateFieldAccessor(
+                        Self,
+                        Private,
+                        &Private.offset,
+                        "duration",
+                    ),
+                },
+            );
+        };
+    };
+
+    const Private = struct {
+        /// The time that the overlay appears.
+        duration: c_uint,
+
+        pub var offset: c_int = 0;
+    };
+
+    fn init(self: *Self, _: *Class) callconv(.c) void {
+        gtk.Widget.initTemplate(self.as(gtk.Widget));
+
+        const priv = self.private();
+        _ = priv;
+    }
+
+    //---------------------------------------------------------------
+    // Virtual methods
+
+    fn dispose(self: *Self) callconv(.c) void {
+        const priv = self.private();
+        _ = priv;
+
+        gtk.Widget.disposeTemplate(
+            self.as(gtk.Widget),
+            getGObjectType(),
+        );
+
+        gobject.Object.virtual_methods.dispose.call(
+            Class.parent,
+            self.as(Parent),
+        );
+    }
+
+    fn finalize(self: *Self) callconv(.c) void {
+        const priv = self.private();
+        _ = priv;
+
+        gobject.Object.virtual_methods.finalize.call(
+            Class.parent,
+            self.as(Parent),
+        );
+    }
+
+    const C = Common(Self, Private);
+    pub const as = C.as;
+    pub const ref = C.ref;
+    pub const unref = C.unref;
+    const private = C.private;
+
+    pub const Class = extern struct {
+        parent_class: Parent.Class,
+        var parent: *Parent.Class = undefined;
+        pub const Instance = Self;
+
+        fn init(class: *Class) callconv(.c) void {
+            gtk.Widget.Class.setTemplateFromResource(
+                class.as(gtk.Widget.Class),
+                comptime gresource.blueprint(.{
+                    .major = 1,
+                    .minor = 2,
+                    .name = "search-overlay",
+                }),
+            );
+
+            // Bindings
+            // class.bindTemplateChildPrivate("label", .{});
+
+            // Properties
+            // gobject.ext.registerProperties(class, &.{
+            //     properties.duration.impl,
+            //     properties.label.impl,
+            //     properties.@"first-delay".impl,
+            //     properties.@"overlay-halign".impl,
+            //     properties.@"overlay-valign".impl,
+            // });
+
+            // Virtual methods
+            gobject.Object.virtual_methods.dispose.implement(class, &dispose);
+            gobject.Object.virtual_methods.finalize.implement(class, &finalize);
+        }
+
+        pub const as = C.Class.as;
+        pub const bindTemplateChildPrivate = C.Class.bindTemplateChildPrivate;
+    };
+};

--- a/src/apprt/gtk/class/search_overlay.zig
+++ b/src/apprt/gtk/class/search_overlay.zig
@@ -102,6 +102,30 @@ pub const SearchOverlay = extern struct {
                 void,
             );
         };
+
+        /// Emitted when navigating to the next match.
+        pub const @"next-match" = struct {
+            pub const name = "next-match";
+            pub const connect = impl.connect;
+            const impl = gobject.ext.defineSignal(
+                name,
+                Self,
+                &.{},
+                void,
+            );
+        };
+
+        /// Emitted when navigating to the previous match.
+        pub const @"previous-match" = struct {
+            pub const name = "previous-match";
+            pub const connect = impl.connect;
+            const impl = gobject.ext.defineSignal(
+                name,
+                Self,
+                &.{},
+                void,
+            );
+        };
     };
 
     const Private = struct {
@@ -168,6 +192,22 @@ pub const SearchOverlay = extern struct {
         signals.@"search-changed".impl.emit(self, null, .{text}, null);
     }
 
+    fn nextMatch(_: *gtk.Button, self: *Self) callconv(.c) void {
+        signals.@"next-match".impl.emit(self, null, .{}, null);
+    }
+
+    fn previousMatch(_: *gtk.Button, self: *Self) callconv(.c) void {
+        signals.@"previous-match".impl.emit(self, null, .{}, null);
+    }
+
+    fn nextMatchEntry(_: *gtk.SearchEntry, self: *Self) callconv(.c) void {
+        signals.@"next-match".impl.emit(self, null, .{}, null);
+    }
+
+    fn previousMatchEntry(_: *gtk.SearchEntry, self: *Self) callconv(.c) void {
+        signals.@"previous-match".impl.emit(self, null, .{}, null);
+    }
+
     //---------------------------------------------------------------
     // Virtual methods
 
@@ -224,6 +264,10 @@ pub const SearchOverlay = extern struct {
             class.bindTemplateCallback("stop_search", &stopSearch);
             class.bindTemplateCallback("search_changed", &searchChanged);
             class.bindTemplateCallback("match_label_closure", &closureMatchLabel);
+            class.bindTemplateCallback("next_match", &nextMatch);
+            class.bindTemplateCallback("previous_match", &previousMatch);
+            class.bindTemplateCallback("next_match_entry", &nextMatchEntry);
+            class.bindTemplateCallback("previous_match_entry", &previousMatchEntry);
 
             // Properties
             gobject.ext.registerProperties(class, &.{
@@ -235,6 +279,8 @@ pub const SearchOverlay = extern struct {
             // Signals
             signals.@"stop-search".impl.register(.{});
             signals.@"search-changed".impl.register(.{});
+            signals.@"next-match".impl.register(.{});
+            signals.@"previous-match".impl.register(.{});
 
             // Virtual methods
             gobject.Object.virtual_methods.dispose.implement(class, &dispose);

--- a/src/apprt/gtk/class/search_overlay.zig
+++ b/src/apprt/gtk/class/search_overlay.zig
@@ -172,9 +172,10 @@ pub const SearchOverlay = extern struct {
     }
 
     fn closureMatchLabel(_: *Self, selected: i64, total: i64) callconv(.c) ?[*:0]const u8 {
+        if (total <= 0) return glib.ext.dupeZ(u8, "0/0");
         var buf: [32]u8 = undefined;
         const label = std.fmt.bufPrintZ(&buf, "{}/{}", .{
-            if (selected >= 0) selected else 0,
+            if (selected >= 0) selected + 1 else 0,
             if (total >= 0) total else 0,
         }) catch return null;
         return glib.ext.dupeZ(u8, label);

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -3197,10 +3197,10 @@ pub const Surface = extern struct {
     }
 
     fn searchStop(_: *SearchOverlay, self: *Self) callconv(.c) void {
-        // Note: at the time of writing this, this behavior doesn't match
-        // macOS. But I think it makes more sense on Linux/GTK to do this.
-        // We may follow suit on macOS in the future.
-        self.setSearchActive(false);
+        const surface = self.core() orelse return;
+        _ = surface.performBindingAction(.end_search) catch |err| {
+            log.warn("unable to perform end_search action err={}", .{err});
+        };
         _ = self.private().gl_area.as(gtk.Widget).grabFocus();
     }
 

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -550,6 +550,9 @@ pub const Surface = extern struct {
         /// The resize overlay
         resize_overlay: *ResizeOverlay,
 
+        /// The search overlay
+        search_overlay: *SearchOverlay,
+
         /// The apprt Surface.
         rt_surface: ApprtSurface = undefined,
 
@@ -1952,6 +1955,20 @@ pub const Surface = extern struct {
         self.as(gobject.Object).notifyByPspec(properties.@"error".impl.param_spec);
     }
 
+    pub fn setSearchActive(self: *Self, active: bool) void {
+        const priv = self.private();
+        var value = gobject.ext.Value.newFrom(active);
+        defer value.unset();
+        gobject.Object.setProperty(
+            priv.search_overlay.as(gobject.Object),
+            SearchOverlay.properties.active.name,
+            &value,
+        );
+        if (active) {
+            priv.search_overlay.grabFocus();
+        }
+    }
+
     fn propConfig(
         self: *Self,
         _: *gobject.ParamSpec,
@@ -3205,6 +3222,7 @@ pub const Surface = extern struct {
             class.bindTemplateChildPrivate("error_page", .{});
             class.bindTemplateChildPrivate("progress_bar_overlay", .{});
             class.bindTemplateChildPrivate("resize_overlay", .{});
+            class.bindTemplateChildPrivate("search_overlay", .{});
             class.bindTemplateChildPrivate("terminal_page", .{});
             class.bindTemplateChildPrivate("drop_target", .{});
             class.bindTemplateChildPrivate("im_context", .{});

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -3188,6 +3188,14 @@ pub const Surface = extern struct {
         self.setTitleOverride(if (title.len == 0) null else title);
     }
 
+    fn searchStop(_: *SearchOverlay, self: *Self) callconv(.c) void {
+        // Note: at the time of writing this, this behavior doesn't match
+        // macOS. But I think it makes more sense on Linux/GTK to do this.
+        // We may follow suit on macOS in the future.
+        self.setSearchActive(false);
+        _ = self.private().gl_area.as(gtk.Widget).grabFocus();
+    }
+
     const C = Common(Self, Private);
     pub const as = C.as;
     pub const ref = C.ref;
@@ -3260,6 +3268,7 @@ pub const Surface = extern struct {
             class.bindTemplateCallback("notify_vadjustment", &propVAdjustment);
             class.bindTemplateCallback("should_border_be_shown", &closureShouldBorderBeShown);
             class.bindTemplateCallback("should_unfocused_split_be_shown", &closureShouldUnfocusedSplitBeShown);
+            class.bindTemplateCallback("search_stop", &searchStop);
 
             // Properties
             gobject.ext.registerProperties(class, &.{

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -1969,6 +1969,14 @@ pub const Surface = extern struct {
         }
     }
 
+    pub fn setSearchTotal(self: *Self, total: ?usize) void {
+        self.private().search_overlay.setSearchTotal(total);
+    }
+
+    pub fn setSearchSelected(self: *Self, selected: ?usize) void {
+        self.private().search_overlay.setSearchSelected(selected);
+    }
+
     fn propConfig(
         self: *Self,
         _: *gobject.ParamSpec,

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -25,6 +25,7 @@ const Common = @import("../class.zig").Common;
 const Application = @import("application.zig").Application;
 const Config = @import("config.zig").Config;
 const ResizeOverlay = @import("resize_overlay.zig").ResizeOverlay;
+const SearchOverlay = @import("search_overlay.zig").SearchOverlay;
 const ChildExited = @import("surface_child_exited.zig").SurfaceChildExited;
 const ClipboardConfirmationDialog = @import("clipboard_confirmation_dialog.zig").ClipboardConfirmationDialog;
 const TitleDialog = @import("surface_title_dialog.zig").SurfaceTitleDialog;
@@ -3184,6 +3185,7 @@ pub const Surface = extern struct {
 
         fn init(class: *Class) callconv(.c) void {
             gobject.ext.ensureType(ResizeOverlay);
+            gobject.ext.ensureType(SearchOverlay);
             gobject.ext.ensureType(ChildExited);
             gtk.Widget.Class.setTemplateFromResource(
                 class.as(gtk.Widget.Class),

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -3196,6 +3196,13 @@ pub const Surface = extern struct {
         _ = self.private().gl_area.as(gtk.Widget).grabFocus();
     }
 
+    fn searchChanged(_: *SearchOverlay, needle: ?[*:0]const u8, self: *Self) callconv(.c) void {
+        const surface = self.core() orelse return;
+        _ = surface.performBindingAction(.{ .search = std.mem.sliceTo(needle orelse "", 0) }) catch |err| {
+            log.warn("unable to perform search action err={}", .{err});
+        };
+    }
+
     const C = Common(Self, Private);
     pub const as = C.as;
     pub const ref = C.ref;
@@ -3269,6 +3276,7 @@ pub const Surface = extern struct {
             class.bindTemplateCallback("should_border_be_shown", &closureShouldBorderBeShown);
             class.bindTemplateCallback("should_unfocused_split_be_shown", &closureShouldUnfocusedSplitBeShown);
             class.bindTemplateCallback("search_stop", &searchStop);
+            class.bindTemplateCallback("search_changed", &searchChanged);
 
             // Properties
             gobject.ext.registerProperties(class, &.{

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -3211,6 +3211,20 @@ pub const Surface = extern struct {
         };
     }
 
+    fn searchNextMatch(_: *SearchOverlay, self: *Self) callconv(.c) void {
+        const surface = self.core() orelse return;
+        _ = surface.performBindingAction(.{ .navigate_search = .next }) catch |err| {
+            log.warn("unable to perform navigate_search action err={}", .{err});
+        };
+    }
+
+    fn searchPreviousMatch(_: *SearchOverlay, self: *Self) callconv(.c) void {
+        const surface = self.core() orelse return;
+        _ = surface.performBindingAction(.{ .navigate_search = .previous }) catch |err| {
+            log.warn("unable to perform navigate_search action err={}", .{err});
+        };
+    }
+
     const C = Common(Self, Private);
     pub const as = C.as;
     pub const ref = C.ref;
@@ -3285,6 +3299,8 @@ pub const Surface = extern struct {
             class.bindTemplateCallback("should_unfocused_split_be_shown", &closureShouldUnfocusedSplitBeShown);
             class.bindTemplateCallback("search_stop", &searchStop);
             class.bindTemplateCallback("search_changed", &searchChanged);
+            class.bindTemplateCallback("search_next_match", &searchNextMatch);
+            class.bindTemplateCallback("search_previous_match", &searchPreviousMatch);
 
             // Properties
             gobject.ext.registerProperties(class, &.{

--- a/src/apprt/gtk/css/style.css
+++ b/src/apprt/gtk/css/style.css
@@ -35,6 +35,18 @@ label.url-overlay.right {
 }
 
 /*
+ * GhosttySurface search overlay
+ */
+.search-overlay {
+  padding: 6px 8px;
+  margin: 8px;
+  border-radius: 8px;
+  outline-style: solid;
+  outline-color: #555555;
+  outline-width: 1px;
+}
+
+/*
  * GhosttySurface resize overlay
  */
 label.resize-overlay {

--- a/src/apprt/gtk/ui/1.2/search-overlay.blp
+++ b/src/apprt/gtk/ui/1.2/search-overlay.blp
@@ -4,8 +4,16 @@ using Adw 1;
 
 template $GhosttySearchOverlay: Adw.Bin {
   visible: bind template.active;
-  halign: end;
-  valign: start;
+  halign-target: end;
+  valign-target: start;
+  halign: bind template.halign-target;
+  valign: bind template.valign-target;
+
+  GestureDrag {
+    button: 1;
+    propagation-phase: capture;
+    drag-end => $on_drag_end();
+  }
 
   Adw.Bin {
     Box container {

--- a/src/apprt/gtk/ui/1.2/search-overlay.blp
+++ b/src/apprt/gtk/ui/1.2/search-overlay.blp
@@ -69,6 +69,7 @@ template $GhosttySearchOverlay: Adw.Bin {
       Button close_button {
         icon-name: "window-close-symbolic";
         tooltip-text: _("Close");
+        clicked => $stop_search_button();
 
         cursor: Gdk.Cursor {
           name: "pointer";

--- a/src/apprt/gtk/ui/1.2/search-overlay.blp
+++ b/src/apprt/gtk/ui/1.2/search-overlay.blp
@@ -21,6 +21,7 @@ template $GhosttySearchOverlay: Adw.Bin {
         placeholder-text: _("Find…");
         width-chars: 20;
         hexpand: true;
+        stop-search => $stop_search();
       }
 
       Label match_label {

--- a/src/apprt/gtk/ui/1.2/search-overlay.blp
+++ b/src/apprt/gtk/ui/1.2/search-overlay.blp
@@ -46,7 +46,7 @@ template $GhosttySearchOverlay: Adw.Bin {
           "dim-label",
         ]
 
-        label: bind $match_label_closure(template.search-selected, template.search-total) as <string>;
+        label: bind $match_label_closure(template.has-search-selected, template.search-selected, template.has-search-total, template.search-total) as <string>;
         width-chars: 6;
         xalign: 1.0;
       }

--- a/src/apprt/gtk/ui/1.2/search-overlay.blp
+++ b/src/apprt/gtk/ui/1.2/search-overlay.blp
@@ -3,6 +3,7 @@ using Gdk 4.0;
 using Adw 1;
 
 template $GhosttySearchOverlay: Adw.Bin {
+  visible: bind template.active;
   halign: end;
   valign: start;
 

--- a/src/apprt/gtk/ui/1.2/search-overlay.blp
+++ b/src/apprt/gtk/ui/1.2/search-overlay.blp
@@ -1,0 +1,72 @@
+using Gtk 4.0;
+using Gdk 4.0;
+using Adw 1;
+
+template $GhosttySearchOverlay: Adw.Bin {
+  halign: end;
+  valign: start;
+
+  Adw.Bin {
+    Box container {
+      styles [
+        "background",
+        "search-overlay",
+      ]
+
+      orientation: horizontal;
+      spacing: 6;
+
+      SearchEntry search_entry {
+        placeholder-text: _("Find…");
+        width-chars: 20;
+        hexpand: true;
+      }
+
+      Label match_label {
+        styles [
+          "dim-label",
+        ]
+
+        label: "0/0";
+        width-chars: 6;
+        xalign: 1.0;
+      }
+
+      Box button_box {
+        orientation: horizontal;
+        spacing: 1;
+
+        styles [
+          "linked",
+        ]
+
+        Button prev_button {
+          icon-name: "go-up-symbolic";
+          tooltip-text: _("Previous Match");
+
+          cursor: Gdk.Cursor {
+            name: "pointer";
+          };
+        }
+
+        Button next_button {
+          icon-name: "go-down-symbolic";
+          tooltip-text: _("Next Match");
+
+          cursor: Gdk.Cursor {
+            name: "pointer";
+          };
+        }
+      }
+
+      Button close_button {
+        icon-name: "window-close-symbolic";
+        tooltip-text: _("Close");
+
+        cursor: Gdk.Cursor {
+          name: "pointer";
+        };
+      }
+    }
+  }
+}

--- a/src/apprt/gtk/ui/1.2/search-overlay.blp
+++ b/src/apprt/gtk/ui/1.2/search-overlay.blp
@@ -22,6 +22,7 @@ template $GhosttySearchOverlay: Adw.Bin {
         width-chars: 20;
         hexpand: true;
         stop-search => $stop_search();
+        search-changed => $search_changed();
       }
 
       Label match_label {

--- a/src/apprt/gtk/ui/1.2/search-overlay.blp
+++ b/src/apprt/gtk/ui/1.2/search-overlay.blp
@@ -23,8 +23,8 @@ template $GhosttySearchOverlay: Adw.Bin {
         hexpand: true;
         stop-search => $stop_search();
         search-changed => $search_changed();
-        next-match => $next_match_entry();
-        previous-match => $previous_match_entry();
+        next-match => $next_match();
+        previous-match => $previous_match();
       }
 
       Label {
@@ -69,7 +69,7 @@ template $GhosttySearchOverlay: Adw.Bin {
       Button close_button {
         icon-name: "window-close-symbolic";
         tooltip-text: _("Close");
-        clicked => $stop_search_button();
+        clicked => $stop_search();
 
         cursor: Gdk.Cursor {
           name: "pointer";

--- a/src/apprt/gtk/ui/1.2/search-overlay.blp
+++ b/src/apprt/gtk/ui/1.2/search-overlay.blp
@@ -25,12 +25,12 @@ template $GhosttySearchOverlay: Adw.Bin {
         search-changed => $search_changed();
       }
 
-      Label match_label {
+      Label {
         styles [
           "dim-label",
         ]
 
-        label: "0/0";
+        label: bind $match_label_closure(template.search-selected, template.search-total) as <string>;
         width-chars: 6;
         xalign: 1.0;
       }

--- a/src/apprt/gtk/ui/1.2/search-overlay.blp
+++ b/src/apprt/gtk/ui/1.2/search-overlay.blp
@@ -25,6 +25,12 @@ template $GhosttySearchOverlay: Adw.Bin {
         search-changed => $search_changed();
         next-match => $next_match();
         previous-match => $previous_match();
+
+        EventControllerKey {
+          // We need this so we capture before the SearchEntry.
+          propagation-phase: capture;
+          key-pressed => $search_entry_key_pressed();
+        }
       }
 
       Label {

--- a/src/apprt/gtk/ui/1.2/search-overlay.blp
+++ b/src/apprt/gtk/ui/1.2/search-overlay.blp
@@ -23,6 +23,8 @@ template $GhosttySearchOverlay: Adw.Bin {
         hexpand: true;
         stop-search => $stop_search();
         search-changed => $search_changed();
+        next-match => $next_match_entry();
+        previous-match => $previous_match_entry();
       }
 
       Label {
@@ -46,6 +48,7 @@ template $GhosttySearchOverlay: Adw.Bin {
         Button prev_button {
           icon-name: "go-up-symbolic";
           tooltip-text: _("Previous Match");
+          clicked => $next_match();
 
           cursor: Gdk.Cursor {
             name: "pointer";
@@ -55,6 +58,7 @@ template $GhosttySearchOverlay: Adw.Bin {
         Button next_button {
           icon-name: "go-down-symbolic";
           tooltip-text: _("Next Match");
+          clicked => $previous_match();
 
           cursor: Gdk.Cursor {
             name: "pointer";

--- a/src/apprt/gtk/ui/1.2/surface.blp
+++ b/src/apprt/gtk/ui/1.2/surface.blp
@@ -151,6 +151,7 @@ Overlay terminal_page {
   $GhosttySearchOverlay search_overlay {
     halign: end;
     valign: start;
+    stop-search => $search_stop();
   }
 
   [overlay]

--- a/src/apprt/gtk/ui/1.2/surface.blp
+++ b/src/apprt/gtk/ui/1.2/surface.blp
@@ -153,6 +153,8 @@ Overlay terminal_page {
     valign: start;
     stop-search => $search_stop();
     search-changed => $search_changed();
+    next-match => $search_next_match();
+    previous-match => $search_previous_match();
   }
 
   [overlay]

--- a/src/apprt/gtk/ui/1.2/surface.blp
+++ b/src/apprt/gtk/ui/1.2/surface.blp
@@ -152,6 +152,7 @@ Overlay terminal_page {
     halign: end;
     valign: start;
     stop-search => $search_stop();
+    search-changed => $search_changed();
   }
 
   [overlay]

--- a/src/apprt/gtk/ui/1.2/surface.blp
+++ b/src/apprt/gtk/ui/1.2/surface.blp
@@ -148,11 +148,23 @@ Overlay terminal_page {
   }
 
   [overlay]
+  $GhosttySearchOverlay search_overlay {
+    halign: end;
+    valign: start;
+  }
+
+  [overlay]
   // Apply unfocused-split-fill and unfocused-split-opacity to current surface
   // this is only applied when a tab has more than one surface
   Revealer {
     reveal-child: bind $should_unfocused_split_be_shown(template.focused, template.is-split) as <bool>;
     transition-duration: 0;
+    // This is all necessary so that the Revealer itself doesn't override
+    // any input events from the other overlays. Namely, if you don't have
+    // these then the search overlay won't get mouse events.
+    can-focus: false;
+    can-target: false;
+    focusable: false;
 
     DrawingArea {
       styles [

--- a/src/apprt/gtk/ui/1.2/surface.blp
+++ b/src/apprt/gtk/ui/1.2/surface.blp
@@ -149,8 +149,6 @@ Overlay terminal_page {
 
   [overlay]
   $GhosttySearchOverlay search_overlay {
-    halign: end;
-    valign: start;
     stop-search => $search_stop();
     search-changed => $search_changed();
     next-match => $search_next_match();

--- a/src/apprt/gtk/ui/1.2/surface.blp
+++ b/src/apprt/gtk/ui/1.2/surface.blp
@@ -41,6 +41,34 @@ Overlay terminal_page {
       halign: start;
       has-arrow: false;
     }
+
+    EventControllerFocus {
+      enter => $focus_enter();
+      leave => $focus_leave();
+    }
+
+    EventControllerKey {
+      key-pressed => $key_pressed();
+      key-released => $key_released();
+    }
+
+    EventControllerScroll {
+      scroll => $scroll();
+      scroll-begin => $scroll_begin();
+      scroll-end => $scroll_end();
+      flags: both_axes;
+    }
+
+    EventControllerMotion {
+      motion => $mouse_motion();
+      leave => $mouse_leave();
+    }
+
+    GestureClick {
+      pressed => $mouse_down();
+      released => $mouse_up();
+      button: 0;
+    }
   };
 
   [overlay]
@@ -64,6 +92,10 @@ Overlay terminal_page {
     reveal-child: bind $should_border_be_shown(template.config, template.bell-ringing) as <bool>;
     transition-type: crossfade;
     transition-duration: 500;
+    // Revealers take up the full size, we need this to not capture events.
+    can-focus: false;
+    can-target: false;
+    focusable: false;
 
     Box bell_overlay {
       styles [
@@ -127,35 +159,6 @@ Overlay terminal_page {
         "unfocused-split",
       ]
     }
-  }
-
-  // Event controllers for interactivity
-  EventControllerFocus {
-    enter => $focus_enter();
-    leave => $focus_leave();
-  }
-
-  EventControllerKey {
-    key-pressed => $key_pressed();
-    key-released => $key_released();
-  }
-
-  EventControllerMotion {
-    motion => $mouse_motion();
-    leave => $mouse_leave();
-  }
-
-  EventControllerScroll {
-    scroll => $scroll();
-    scroll-begin => $scroll_begin();
-    scroll-end => $scroll_end();
-    flags: both_axes;
-  }
-
-  GestureClick {
-    pressed => $mouse_down();
-    released => $mouse_up();
-    button: 0;
   }
 
   DropTarget drop_target {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -6098,6 +6098,20 @@ pub const Keybinds = struct {
                 .{ .jump_to_prompt = 1 },
             );
 
+            // Search
+            try self.set.putFlags(
+                alloc,
+                .{ .key = .{ .unicode = 'f' }, .mods = .{ .ctrl = true, .shift = true } },
+                .start_search,
+                .{ .performable = true },
+            );
+            try self.set.putFlags(
+                alloc,
+                .{ .key = .{ .physical = .escape } },
+                .end_search,
+                .{ .performable = true },
+            );
+
             // Inspector, matching Chromium
             try self.set.put(
                 alloc,


### PR DESCRIPTION
Fixes #189 

This adds the UI for search to GTK. There is still polish to be done in follow-ups but this makes search work well with GTK to start! 

**AI disclosure:** Believe it or not, almost this entire PR was AI-written. Amp did an excellent job looking at our existing codebase, comparing it to the macOS codebase, writing blueprint files, etc. I reviewed everything written, modified some basics, and verified it manually and under Valgrind.

## Demo

<img width="1654" height="1234" alt="CleanShot 2025-11-29 at 20 52 11@2x" src="https://github.com/user-attachments/assets/0eb38367-398f-4165-9838-7a35465857bc" />

## Future Improvements

- When dragging the overlay, we should change the cursor and show drop targets
- There's probably some small stylistic tweaks we can make to this
- I'm not sure the CSS is right for both light and dark modes so we may need to tweak that

