### PR TITLE
core: encode mouse buttons 8 & 9 (back/forward)

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3464,6 +3464,8 @@ fn mouseReport(
                 .five => 65,
                 .six => 66,
                 .seven => 67,
+                .eight => 128,
+                .nine => 129,
                 else => return, // unsupported
             };
         }


### PR DESCRIPTION
For some reason button 8 & 9 support is missing.