### PR TITLE
build: fix path access to work with relative build roots

### DIFF
--- a/src/build/GhosttyDist.zig
+++ b/src/build/GhosttyDist.zig
@@ -170,11 +170,11 @@ pub const Resource = struct {
 
     /// Returns true if the dist path exists at build time.
     pub fn exists(self: *const Resource, b: *std.Build) bool {
-        if (std.fs.accessAbsolute(b.pathFromRoot(self.dist), .{})) {
+        if (b.build_root.handle.access(self.dist, .{})) {
             // If we have a ".git" directory then we're a git checkout
             // and we never want to use the dist path. This shouldn't happen
             // so show a warning to the user.
-            if (std.fs.accessAbsolute(b.pathFromRoot(".git"), .{})) {
+            if (b.build_root.handle.access(".git", .{})) {
                 std.log.warn(
                     "dist resource '{s}' should not be in a git checkout",
                     .{self.dist},


### PR DESCRIPTION
## Problem

When ghostty is used as a dependency (e.g., in another Zig project), the build can panic on Linux with:

\`\`\`
GhosttyDist.zig:173:34: 0x1768046 in exists (build.zig)
    if (std.fs.accessAbsolute(b.pathFromRoot(self.dist), .{})) {
\`\`\`

This happens because \`b.pathFromRoot()\` can return a relative path (e.g., when the build root is \`.\`), but \`std.fs.accessAbsolute()\` asserts the path must be absolute.

## Solution

Replace \`std.fs.accessAbsolute(b.pathFromRoot(...))\` with \`b.build_root.handle.access(...)\`, which uses the build root's directory handle directly and works correctly with relative paths.

Context: https://ampcode.com/threads/T-7511e7e4-4b4a-4f11-9c3c-817aaa519b84