### PR TITLE
zsh: move version check to ghostty-integration

### DIFF
--- a/src/shell-integration/README.md
+++ b/src/shell-integration/README.md
@@ -88,3 +88,5 @@ if [[ -n $GHOSTTY_RESOURCES_DIR ]]; then
   source "$GHOSTTY_RESOURCES_DIR"/shell-integration/zsh/ghostty-integration
 fi
 ```
+
+Shell integration requires Zsh 5.1+.

--- a/src/shell-integration/zsh/.zshenv
+++ b/src/shell-integration/zsh/.zshenv
@@ -43,11 +43,6 @@ fi
     [[ ! -r "$_ghostty_file" ]] || 'builtin' 'source' '--' "$_ghostty_file"
 } always {
     if [[ -o 'interactive' ]]; then
-        'builtin' 'autoload' '--' 'is-at-least' 2>/dev/null && 'is-at-least' "5.1" || {
-            'builtin' 'echo' "zsh ${ZSH_VERSION} is too old for ghostty shell integration" >&2
-            'builtin' 'unset' '_ghostty_file'
-            return
-        }
         # ${(%):-%x} is the path to the current file.
         # On top of it we add :A:h to get the directory.
         'builtin' 'typeset' _ghostty_file="${${(%):-%x}:A:h}"/ghostty-integration

--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -1,3 +1,5 @@
+# vim:ft=zsh
+#
 # Based on (started as) a copy of Kitty's zsh integration. Kitty is
 # distributed under GPLv3, so this file is also distributed under GPLv3.
 # The license header is reproduced below:
@@ -40,6 +42,13 @@ _entrypoint() {
 
     [[ -o interactive ]]              || builtin return 0  # non-interactive shell
     (( ! $+_ghostty_state ))          || builtin return 0  # already initialized
+
+    # We require zsh 5.1+ (released Sept 2015) for features like functions_source,
+    # introspection arrays, and array pattern substitution.
+    if ! { builtin autoload -- is-at-least 2>/dev/null && is-at-least 5.1; }; then
+        builtin echo "Zsh ${ZSH_VERSION} is too old for ghostty shell integration (5.1+ required)" >&2
+        builtin return 1
+    fi
 
     # 0: no OSC 133 [AC] marks have been written yet.
     # 1: the last written OSC 133 C has not been closed with D yet.


### PR DESCRIPTION
The ghostty-integration script can be manually sourced, and it uses the Zsh 5.1+ features, so that's a better place to guard against older Zsh versions.

This also keeps the .zshenv script focused on just bootstrapping our automatic shell integration.

I also changed the version check to a slightly more idiomatic pattern.