### PR TITLE
core: hold lock during keyCallback when mouseRefreshLinks is called

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2592,6 +2592,8 @@ pub fn keyCallback(
         {
             // Refresh our link state
             const pos = self.rt_surface.getCursorPos() catch break :mouse_mods;
+            self.renderer_state.mutex.lock();
+            defer self.renderer_state.mutex.unlock();
             self.mouseRefreshLinks(
                 pos,
                 self.posToViewport(pos.x, pos.y),


### PR DESCRIPTION
From #9812

I'm not sure if this is the root cause of the crash in #9812 but the LLM-discovered issue that we are not holding a lock here appears to be a real issue. I manually traced the code paths and thought about this and looked where we call `mouseRefreshLinks` in other places and this appears to be a real bug.