### PR TITLE
macos: Don't encode option as alt in kitty mode

### DIFF
--- a/src/input/key_encode.zig
+++ b/src/input/key_encode.zig
@@ -116,7 +116,20 @@ fn kitty(
         }
     }
 
-    const all_mods = event.mods;
+    const all_mods = mods: {
+        var mods_binding = event.mods;
+        if (comptime builtin.target.os.tag.isDarwin()) alt: {
+            switch (opts.macos_option_as_alt) {
+                .false => {},
+                .true => break :alt,
+                .left => if (event.mods.sides.alt == .left) break :alt,
+                .right => if (event.mods.sides.alt == .right) break :alt,
+            }
+            mods_binding.alt = false;
+        }
+        break :mods mods_binding;
+    };
+
     const effective_mods = event.effectiveMods();
     const binding_mods = effective_mods.binding();
 


### PR DESCRIPTION
This is the same fix as #9406 applied to kitty keyboard.

Note: I cannot personally test this as I do not have a mac, but there has been some user testing in the flow community. See the discussion at https://github.com/neurocyte/flow/discussions/413