### PR TITLE
ci: cancel prior test runs for the same git ref

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,5 +1,10 @@
 on: [push, pull_request]
 name: Nix
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name != 'main' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   required:
     name: "Required Checks: Nix"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,11 @@ on:
 
 name: Test
 
+# We only want the latest commit to test for any non-main ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name != 'main' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   required:
     name: "Required Checks: Test"


### PR DESCRIPTION
This should save on CI quite a bit. This will cancel our GHA runs when you push to the same ref, except for `main`, where I want to make sure every commit is tested.