### PR TITLE
macOS: fix tab context menu opens on macOS 26 with titlebar tabs

### DIFF
--- a/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
@@ -9,7 +9,7 @@ class TitlebarTabsTahoeTerminalWindow: TransparentTitlebarTerminalWindow, NSTool
     /// The view model for SwiftUI views
     private var viewModel = ViewModel()
 
-    /// Tb bar view for event routing
+    /// Tab bar view for event routing
     private weak var tabBarView: NSView?
     
     /// Titlebar tabs can't support the update accessory because of the way we layout


### PR DESCRIPTION
Description:
Context menu works on tabs with titlebar-style=tabs on MacOS Tahoe 26

Closes #9817 

Demo:

https://github.com/user-attachments/assets/60eaae6e-a3ff-41eb-8c86-ba700490d6e2



Note:
- Tried first a passthrough-views approach, but AppKit’s internal toolbar subviews continued intercepting right-clicks.
- Runtime subclassing proposed by Claude also worked but was rejected as too fragile.
- Final solution routes secondary-click events at the window level using sendEvent(_:), forwarding them to the tab bar only when the click is visually within its bounds.

AI Disclosure:
AI (Claude Code and Codex) assisted with early explorations, but final implementation was developed manually after evaluating and discarding the unsafe subclassing approach proposed by Claude.