### PR TITLE
fix(macos): close search ui on escape key press

### DIFF
--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -432,6 +432,7 @@ extension Ghostty {
                     }
 #if canImport(AppKit)
                     .onExitCommand {
+                        onClose()
                         Ghostty.moveFocus(to: surfaceView)
                     }
 #endif


### PR DESCRIPTION
On macOS, pressing the `ESC` key while the Search UI is active currently only returns focus to the terminal but keeps the Search UI open. This behavior is inconsistent with other platforms (GTK/Linux) and standard UI patterns.

This PR adds a call to `onClose()` in the `onExitCommand` modifier for the macOS `SurfaceSearchOverlay`. This ensures that the search state is cleared (triggering `end_search` action) and the UI is dismissed when `ESC` is pressed, aligning the behavior with the Linux implementation.