### PR TITLE
quirks: remove type signature for inlineAssert

### DIFF
--- a/src/quirks.zig
+++ b/src/quirks.zig
@@ -42,7 +42,7 @@ pub fn disableDefaultFontFeatures(face: *const font.Face) bool {
 /// is negligible, but we have some asserts inside tight loops and hotpaths
 /// that cause significant overhead (as much as 15-20%) when they don't get
 /// optimized out.
-pub const inlineAssert: fn (bool) void = switch (builtin.mode) {
+pub const inlineAssert = switch (builtin.mode) {
     // In debug builds we just use std.debug.assert because this
     // fixes up stack traces. `inline` causes broken stack traces. This
     // is probably a Zig compiler bug but until it is fixed we have to


### PR DESCRIPTION
Functions with different calling conventions are not compatible with each other

Fixes all release builds + CI