### PR TITLE
build: skip git version detection when used as dependency

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const builtin = @import("builtin");
 const buildpkg = @import("src/build/main.zig");
+
 const appVersion = @import("build.zig.zon").version;
 const minimumZigVersion = @import("build.zig.zon").minimum_zig_version;
 
@@ -317,3 +318,8 @@ pub fn build(b: *std.Build) !void {
         try translations_step.addError("cannot update translations when i18n is disabled", .{});
     }
 }
+
+/// Marker used by Config.zig to detect if ghostty is the build root.
+/// This avoids running logic such as Git tag checking when Ghostty
+/// is used as a dependency.
+pub const _ghostty_build_root = true;


### PR DESCRIPTION
When ghostty is used as a Zig dependency, detect this by comparing the build root with ghostty's source directory. Skip git detection entirely and use the version from build.zig.zon.

This fixes build failures when downstream projects have git tags that don't match ghostty's version format. Previously, ghostty would read the downstream project's git tags and panic at Config.zig:246 with:

\`\`\`
tagged releases must be in vX.Y.Z format matching build.zig
\`\`\`

**Reproduction:**
1. Create a project that uses ghostty as a Zig dependency
2. Tag the project with a version like \`v0.2.0\`
3. Run \`zig build\` → panic

**Fix:**
Use \`@src().file\` to get ghostty's source directory and compare it with \`b.build_root\`. When they differ, ghostty is a dependency and we skip git detection.

Thread: https://ampcode.com/threads/T-197e6c33-b8f8-4b23-8fc8-7f6b6edd9f35