### PR TITLE
tmux: control mode core loop (no GUI connections yet)

### DIFF
--- a/src/terminal/tmux.zig
+++ b/src/terminal/tmux.zig
@@ -6,6 +6,7 @@ pub const output = @import("tmux/output.zig");
 pub const ControlParser = control.Parser;
 pub const ControlNotification = control.Notification;
 pub const Layout = layout.Layout;
+pub const Viewer = @import("tmux/viewer.zig").Viewer;
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/terminal/tmux/control.zig
+++ b/src/terminal/tmux/control.zig
@@ -531,7 +531,31 @@ pub const Notification = union(enum) {
         session_id: usize,
         name: []const u8,
     },
-};
+
+    pub fn format(self: Notification, writer: *std.Io.Writer) !void {
+        const T = Notification;
+        const info = @typeInfo(T).@"union";
+
+        try writer.writeAll(@typeName(T));
+        if (info.tag_type) |TagType| {
+            try writer.writeAll("{ .");
+            try writer.writeAll(@tagName(@as(TagType, self)));
+            try writer.writeAll(" = ");
+
+            inline for (info.fields) |u_field| {
+                if (self == @field(TagType, u_field.name)) {
+                    const value = @field(self, u_field.name);
+                    switch (u_field.type) {
+                        []const u8 => try writer.print("\"{s}\"", .{std.mem.trim(u8, value, " \t\r\n")}),
+                        else => try writer.print("{any}", .{value}),
+                    }
+                }
+            }
+
+            try writer.writeAll(" }");
+        }
+    }
+            };
 
 test "tmux begin/end empty" {
     const testing = std.testing;

--- a/src/terminal/tmux/control.zig
+++ b/src/terminal/tmux/control.zig
@@ -555,7 +555,7 @@ pub const Notification = union(enum) {
             try writer.writeAll(" }");
         }
     }
-            };
+};
 
 test "tmux begin/end empty" {
     const testing = std.testing;

--- a/src/terminal/tmux/output.zig
+++ b/src/terminal/tmux/output.zig
@@ -95,16 +95,107 @@ pub fn FormatStruct(comptime vars: []const Variable) type {
 /// a subset of them here that are relevant to the use case of implementing
 /// control mode for terminal emulators.
 pub const Variable = enum {
+    /// 1 if pane is in alternate screen.
+    alternate_on,
+    /// Saved cursor X in alternate screen.
+    alternate_saved_x,
+    /// Saved cursor Y in alternate screen.
+    alternate_saved_y,
+    /// 1 if bracketed paste mode is enabled.
+    bracketed_paste,
+    /// 1 if the cursor is blinking.
+    cursor_blinking,
+    /// Cursor colour in pane. Possible formats:
+    /// - Named colors: `black`, `red`, `green`, `yellow`, `blue`, `magenta`,
+    ///   `cyan`, `white`, `default`, `terminal`, or bright variants.
+    /// - 256 colors: `colour<N>` where N is 0-255 (e.g., `colour100`).
+    /// - RGB hex: `#RRGGBB` (e.g., `#ff0000`).
+    /// - Empty string if unset.
+    cursor_colour,
+    /// Pane cursor flag.
+    cursor_flag,
+    /// Cursor shape in pane. Possible values: `block`, `underline`, `bar`,
+    /// or `default`.
+    cursor_shape,
+    /// Cursor X position in pane.
+    cursor_x,
+    /// Cursor Y position in pane.
+    cursor_y,
+    /// 1 if focus reporting is enabled.
+    focus_flag,
+    /// Pane insert flag.
+    insert_flag,
+    /// Pane keypad cursor flag.
+    keypad_cursor_flag,
+    /// Pane keypad flag.
+    keypad_flag,
+    /// Pane mouse all flag.
+    mouse_all_flag,
+    /// Pane mouse any flag.
+    mouse_any_flag,
+    /// Pane mouse button flag.
+    mouse_button_flag,
+    /// Pane mouse SGR flag.
+    mouse_sgr_flag,
+    /// Pane mouse standard flag.
+    mouse_standard_flag,
+    /// Pane mouse UTF-8 flag.
+    mouse_utf8_flag,
+    /// Pane origin flag.
+    origin_flag,
+    /// Unique pane ID prefixed with `%` (e.g., `%0`, `%42`).
+    pane_id,
+    /// Pane tab positions as a comma-separated list of 0-indexed column
+    /// numbers (e.g., `8,16,24,32`). Empty string if no tabs are set.
+    pane_tabs,
+    /// Bottom of scroll region in pane.
+    scroll_region_lower,
+    /// Top of scroll region in pane.
+    scroll_region_upper,
+    /// Unique session ID prefixed with `$` (e.g., `$0`, `$42`).
     session_id,
+    /// Unique window ID prefixed with `@` (e.g., `@0`, `@42`).
     window_id,
+    /// Width of window.
     window_width,
+    /// Height of window.
     window_height,
+    /// Window layout description, ignoring zoomed window panes. Format is
+    /// `<checksum>,<layout>` where checksum is a 4-digit hex CRC16 and layout
+    /// encodes pane dimensions as `WxH,X,Y[,ID]` with `{...}` for horizontal
+    /// splits and `[...]` for vertical splits.
     window_layout,
+    /// Pane wrap flag.
+    wrap_flag,
 
     /// Parse the given string value into the appropriate resulting
     /// type for this variable.
     pub fn parse(comptime self: Variable, value: []const u8) !Type(self) {
         return switch (self) {
+            .alternate_on,
+            .bracketed_paste,
+            .cursor_blinking,
+            .cursor_flag,
+            .focus_flag,
+            .insert_flag,
+            .keypad_cursor_flag,
+            .keypad_flag,
+            .mouse_all_flag,
+            .mouse_any_flag,
+            .mouse_button_flag,
+            .mouse_sgr_flag,
+            .mouse_standard_flag,
+            .mouse_utf8_flag,
+            .origin_flag,
+            .wrap_flag,
+            => std.mem.eql(u8, value, "1"),
+            .alternate_saved_x,
+            .alternate_saved_y,
+            .cursor_x,
+            .cursor_y,
+            .scroll_region_lower,
+            .scroll_region_upper,
+            => try std.fmt.parseInt(usize, value, 10),
             .session_id => if (value.len >= 2 and value[0] == '$')
                 try std.fmt.parseInt(usize, value[1..], 10)
             else
@@ -113,23 +204,104 @@ pub const Variable = enum {
                 try std.fmt.parseInt(usize, value[1..], 10)
             else
                 return error.FormatError,
+            .pane_id => if (value.len >= 2 and value[0] == '%')
+                try std.fmt.parseInt(usize, value[1..], 10)
+            else
+                return error.FormatError,
             .window_width => try std.fmt.parseInt(usize, value, 10),
             .window_height => try std.fmt.parseInt(usize, value, 10),
-            .window_layout => value,
+            .cursor_colour,
+            .cursor_shape,
+            .pane_tabs,
+            .window_layout,
+            => value,
         };
     }
 
     /// The type of the parsed value for this variable type.
     pub fn Type(comptime self: Variable) type {
         return switch (self) {
-            .session_id => usize,
-            .window_id => usize,
-            .window_width => usize,
-            .window_height => usize,
-            .window_layout => []const u8,
+            .alternate_on,
+            .bracketed_paste,
+            .cursor_blinking,
+            .cursor_flag,
+            .focus_flag,
+            .insert_flag,
+            .keypad_cursor_flag,
+            .keypad_flag,
+            .mouse_all_flag,
+            .mouse_any_flag,
+            .mouse_button_flag,
+            .mouse_sgr_flag,
+            .mouse_standard_flag,
+            .mouse_utf8_flag,
+            .origin_flag,
+            .wrap_flag,
+            => bool,
+            .alternate_saved_x,
+            .alternate_saved_y,
+            .cursor_x,
+            .cursor_y,
+            .scroll_region_lower,
+            .scroll_region_upper,
+            .session_id,
+            .window_id,
+            .pane_id,
+            .window_width,
+            .window_height,
+            => usize,
+            .cursor_colour,
+            .cursor_shape,
+            .pane_tabs,
+            .window_layout,
+            => []const u8,
         };
     }
 };
+
+test "parse alternate_on" {
+    try testing.expectEqual(true, try Variable.parse(.alternate_on, "1"));
+    try testing.expectEqual(false, try Variable.parse(.alternate_on, "0"));
+    try testing.expectEqual(false, try Variable.parse(.alternate_on, ""));
+    try testing.expectEqual(false, try Variable.parse(.alternate_on, "true"));
+    try testing.expectEqual(false, try Variable.parse(.alternate_on, "yes"));
+}
+
+test "parse alternate_saved_x" {
+    try testing.expectEqual(0, try Variable.parse(.alternate_saved_x, "0"));
+    try testing.expectEqual(42, try Variable.parse(.alternate_saved_x, "42"));
+    try testing.expectError(error.InvalidCharacter, Variable.parse(.alternate_saved_x, "abc"));
+}
+
+test "parse alternate_saved_y" {
+    try testing.expectEqual(0, try Variable.parse(.alternate_saved_y, "0"));
+    try testing.expectEqual(42, try Variable.parse(.alternate_saved_y, "42"));
+    try testing.expectError(error.InvalidCharacter, Variable.parse(.alternate_saved_y, "abc"));
+}
+
+test "parse cursor_x" {
+    try testing.expectEqual(0, try Variable.parse(.cursor_x, "0"));
+    try testing.expectEqual(79, try Variable.parse(.cursor_x, "79"));
+    try testing.expectError(error.InvalidCharacter, Variable.parse(.cursor_x, "abc"));
+}
+
+test "parse cursor_y" {
+    try testing.expectEqual(0, try Variable.parse(.cursor_y, "0"));
+    try testing.expectEqual(23, try Variable.parse(.cursor_y, "23"));
+    try testing.expectError(error.InvalidCharacter, Variable.parse(.cursor_y, "abc"));
+}
+
+test "parse scroll_region_upper" {
+    try testing.expectEqual(0, try Variable.parse(.scroll_region_upper, "0"));
+    try testing.expectEqual(5, try Variable.parse(.scroll_region_upper, "5"));
+    try testing.expectError(error.InvalidCharacter, Variable.parse(.scroll_region_upper, "abc"));
+}
+
+test "parse scroll_region_lower" {
+    try testing.expectEqual(0, try Variable.parse(.scroll_region_lower, "0"));
+    try testing.expectEqual(23, try Variable.parse(.scroll_region_lower, "23"));
+    try testing.expectError(error.InvalidCharacter, Variable.parse(.scroll_region_lower, "abc"));
+}
 
 test "parse session id" {
     try testing.expectEqual(42, try Variable.parse(.session_id, "$42"));
@@ -174,6 +346,140 @@ test "parse window layout" {
     try testing.expectEqualStrings("abc123", try Variable.parse(.window_layout, "abc123"));
     try testing.expectEqualStrings("", try Variable.parse(.window_layout, ""));
     try testing.expectEqualStrings("a]b,c{d}e(f)", try Variable.parse(.window_layout, "a]b,c{d}e(f)"));
+}
+
+test "parse cursor_flag" {
+    try testing.expectEqual(true, try Variable.parse(.cursor_flag, "1"));
+    try testing.expectEqual(false, try Variable.parse(.cursor_flag, "0"));
+    try testing.expectEqual(false, try Variable.parse(.cursor_flag, ""));
+    try testing.expectEqual(false, try Variable.parse(.cursor_flag, "true"));
+}
+
+test "parse insert_flag" {
+    try testing.expectEqual(true, try Variable.parse(.insert_flag, "1"));
+    try testing.expectEqual(false, try Variable.parse(.insert_flag, "0"));
+    try testing.expectEqual(false, try Variable.parse(.insert_flag, ""));
+    try testing.expectEqual(false, try Variable.parse(.insert_flag, "true"));
+}
+
+test "parse keypad_cursor_flag" {
+    try testing.expectEqual(true, try Variable.parse(.keypad_cursor_flag, "1"));
+    try testing.expectEqual(false, try Variable.parse(.keypad_cursor_flag, "0"));
+    try testing.expectEqual(false, try Variable.parse(.keypad_cursor_flag, ""));
+    try testing.expectEqual(false, try Variable.parse(.keypad_cursor_flag, "true"));
+}
+
+test "parse keypad_flag" {
+    try testing.expectEqual(true, try Variable.parse(.keypad_flag, "1"));
+    try testing.expectEqual(false, try Variable.parse(.keypad_flag, "0"));
+    try testing.expectEqual(false, try Variable.parse(.keypad_flag, ""));
+    try testing.expectEqual(false, try Variable.parse(.keypad_flag, "true"));
+}
+
+test "parse mouse_any_flag" {
+    try testing.expectEqual(true, try Variable.parse(.mouse_any_flag, "1"));
+    try testing.expectEqual(false, try Variable.parse(.mouse_any_flag, "0"));
+    try testing.expectEqual(false, try Variable.parse(.mouse_any_flag, ""));
+    try testing.expectEqual(false, try Variable.parse(.mouse_any_flag, "true"));
+}
+
+test "parse mouse_button_flag" {
+    try testing.expectEqual(true, try Variable.parse(.mouse_button_flag, "1"));
+    try testing.expectEqual(false, try Variable.parse(.mouse_button_flag, "0"));
+    try testing.expectEqual(false, try Variable.parse(.mouse_button_flag, ""));
+    try testing.expectEqual(false, try Variable.parse(.mouse_button_flag, "true"));
+}
+
+test "parse mouse_sgr_flag" {
+    try testing.expectEqual(true, try Variable.parse(.mouse_sgr_flag, "1"));
+    try testing.expectEqual(false, try Variable.parse(.mouse_sgr_flag, "0"));
+    try testing.expectEqual(false, try Variable.parse(.mouse_sgr_flag, ""));
+    try testing.expectEqual(false, try Variable.parse(.mouse_sgr_flag, "true"));
+}
+
+test "parse mouse_standard_flag" {
+    try testing.expectEqual(true, try Variable.parse(.mouse_standard_flag, "1"));
+    try testing.expectEqual(false, try Variable.parse(.mouse_standard_flag, "0"));
+    try testing.expectEqual(false, try Variable.parse(.mouse_standard_flag, ""));
+    try testing.expectEqual(false, try Variable.parse(.mouse_standard_flag, "true"));
+}
+
+test "parse mouse_utf8_flag" {
+    try testing.expectEqual(true, try Variable.parse(.mouse_utf8_flag, "1"));
+    try testing.expectEqual(false, try Variable.parse(.mouse_utf8_flag, "0"));
+    try testing.expectEqual(false, try Variable.parse(.mouse_utf8_flag, ""));
+    try testing.expectEqual(false, try Variable.parse(.mouse_utf8_flag, "true"));
+}
+
+test "parse wrap_flag" {
+    try testing.expectEqual(true, try Variable.parse(.wrap_flag, "1"));
+    try testing.expectEqual(false, try Variable.parse(.wrap_flag, "0"));
+    try testing.expectEqual(false, try Variable.parse(.wrap_flag, ""));
+    try testing.expectEqual(false, try Variable.parse(.wrap_flag, "true"));
+}
+
+test "parse bracketed_paste" {
+    try testing.expectEqual(true, try Variable.parse(.bracketed_paste, "1"));
+    try testing.expectEqual(false, try Variable.parse(.bracketed_paste, "0"));
+    try testing.expectEqual(false, try Variable.parse(.bracketed_paste, ""));
+    try testing.expectEqual(false, try Variable.parse(.bracketed_paste, "true"));
+}
+
+test "parse cursor_blinking" {
+    try testing.expectEqual(true, try Variable.parse(.cursor_blinking, "1"));
+    try testing.expectEqual(false, try Variable.parse(.cursor_blinking, "0"));
+    try testing.expectEqual(false, try Variable.parse(.cursor_blinking, ""));
+    try testing.expectEqual(false, try Variable.parse(.cursor_blinking, "true"));
+}
+
+test "parse focus_flag" {
+    try testing.expectEqual(true, try Variable.parse(.focus_flag, "1"));
+    try testing.expectEqual(false, try Variable.parse(.focus_flag, "0"));
+    try testing.expectEqual(false, try Variable.parse(.focus_flag, ""));
+    try testing.expectEqual(false, try Variable.parse(.focus_flag, "true"));
+}
+
+test "parse mouse_all_flag" {
+    try testing.expectEqual(true, try Variable.parse(.mouse_all_flag, "1"));
+    try testing.expectEqual(false, try Variable.parse(.mouse_all_flag, "0"));
+    try testing.expectEqual(false, try Variable.parse(.mouse_all_flag, ""));
+    try testing.expectEqual(false, try Variable.parse(.mouse_all_flag, "true"));
+}
+
+test "parse origin_flag" {
+    try testing.expectEqual(true, try Variable.parse(.origin_flag, "1"));
+    try testing.expectEqual(false, try Variable.parse(.origin_flag, "0"));
+    try testing.expectEqual(false, try Variable.parse(.origin_flag, ""));
+    try testing.expectEqual(false, try Variable.parse(.origin_flag, "true"));
+}
+
+test "parse pane_id" {
+    try testing.expectEqual(42, try Variable.parse(.pane_id, "%42"));
+    try testing.expectEqual(0, try Variable.parse(.pane_id, "%0"));
+    try testing.expectError(error.FormatError, Variable.parse(.pane_id, "0"));
+    try testing.expectError(error.FormatError, Variable.parse(.pane_id, "@0"));
+    try testing.expectError(error.FormatError, Variable.parse(.pane_id, "%"));
+    try testing.expectError(error.FormatError, Variable.parse(.pane_id, ""));
+    try testing.expectError(error.InvalidCharacter, Variable.parse(.pane_id, "%abc"));
+}
+
+test "parse cursor_colour" {
+    try testing.expectEqualStrings("red", try Variable.parse(.cursor_colour, "red"));
+    try testing.expectEqualStrings("#ff0000", try Variable.parse(.cursor_colour, "#ff0000"));
+    try testing.expectEqualStrings("", try Variable.parse(.cursor_colour, ""));
+}
+
+test "parse cursor_shape" {
+    try testing.expectEqualStrings("block", try Variable.parse(.cursor_shape, "block"));
+    try testing.expectEqualStrings("underline", try Variable.parse(.cursor_shape, "underline"));
+    try testing.expectEqualStrings("bar", try Variable.parse(.cursor_shape, "bar"));
+    try testing.expectEqualStrings("", try Variable.parse(.cursor_shape, ""));
+}
+
+test "parse pane_tabs" {
+    try testing.expectEqualStrings("0,8,16,24", try Variable.parse(.pane_tabs, "0,8,16,24"));
+    try testing.expectEqualStrings("", try Variable.parse(.pane_tabs, ""));
+    try testing.expectEqualStrings("0", try Variable.parse(.pane_tabs, "0"));
 }
 
 test "parseFormatStruct single field" {

--- a/src/terminal/tmux/output.zig
+++ b/src/terminal/tmux/output.zig
@@ -154,6 +154,8 @@ pub const Variable = enum {
     scroll_region_upper,
     /// Unique session ID prefixed with `$` (e.g., `$0`, `$42`).
     session_id,
+    /// Server version (e.g., `3.5a`).
+    version,
     /// Unique window ID prefixed with `@` (e.g., `@0`, `@42`).
     window_id,
     /// Width of window.
@@ -213,6 +215,7 @@ pub const Variable = enum {
             .cursor_colour,
             .cursor_shape,
             .pane_tabs,
+            .version,
             .window_layout,
             => value,
         };
@@ -253,6 +256,7 @@ pub const Variable = enum {
             .cursor_colour,
             .cursor_shape,
             .pane_tabs,
+            .version,
             .window_layout,
             => []const u8,
         };
@@ -480,6 +484,13 @@ test "parse pane_tabs" {
     try testing.expectEqualStrings("0,8,16,24", try Variable.parse(.pane_tabs, "0,8,16,24"));
     try testing.expectEqualStrings("", try Variable.parse(.pane_tabs, ""));
     try testing.expectEqualStrings("0", try Variable.parse(.pane_tabs, "0"));
+}
+
+test "parse version" {
+    try testing.expectEqualStrings("3.5a", try Variable.parse(.version, "3.5a"));
+    try testing.expectEqualStrings("3.5", try Variable.parse(.version, "3.5"));
+    try testing.expectEqualStrings("next-3.5", try Variable.parse(.version, "next-3.5"));
+    try testing.expectEqualStrings("", try Variable.parse(.version, ""));
 }
 
 test "parseFormatStruct single field" {

--- a/src/terminal/tmux/viewer.zig
+++ b/src/terminal/tmux/viewer.zig
@@ -1,0 +1,235 @@
+const std = @import("std");
+const testing = std.testing;
+const assert = @import("../../quirks.zig").inlineAssert;
+const control = @import("control.zig");
+const output = @import("output.zig");
+
+const log = std.log.scoped(.terminal_tmux_viewer);
+
+// NOTE: There is some fragility here that can possibly break if tmux
+// changes their implementation. In particular, the order of notifications
+// and assurances about what is sent when are based on reading the tmux
+// source code as of Dec, 2025. These aren't documented as fixed.
+//
+// I've tried not to depend on anything that seems like it'd change
+// in the future. For example, it seems reasonable that command output
+// always comes before session attachment. But, I am noting this here
+// in case something breaks in the future we can consider it. We should
+// be able to easily unit test all variations seen in the real world.
+
+/// A viewer is a tmux control mode client that attempts to create
+/// a remote view of a tmux session, including providing the ability to send
+/// new input to the session.
+///
+/// This is the primary use case for tmux control mode, but technically
+/// tmux control mode clients can do anything a normal tmux client can do,
+/// so the `control.zig` and other files in this folder are more general
+/// purpose.
+///
+/// This struct helps move through a state machine of connecting to a tmux
+/// session, negotiating capabilities, listing window state, etc.
+pub const Viewer = struct {
+    state: State = .startup_block,
+
+    /// The current session ID we're attached to. The default value
+    /// is meaningless, because this has to be sent down during
+    /// the startup process.
+    session_id: usize = 0,
+
+    pub const Action = union(enum) {
+        /// Tmux has closed the control mode connection, we should end
+        /// our viewer session in some way.
+        exit,
+
+        /// Send a command to tmux, e.g. `list-windows`. The caller
+        /// should not worry about parsing this or reading what command
+        /// it is; just send it to tmux as-is. This will include the
+        /// trailing newline so you can send it directly.
+        command: []const u8,
+    };
+
+    /// Initial state
+    pub const init: Viewer = .{};
+
+    /// Send in the next tmux notification we got from the control mode
+    /// protocol. The return value is any action that needs to be taken
+    /// in reaction to this notification (could be none).
+    pub fn next(self: *Viewer, n: control.Notification) ?Action {
+        return switch (self.state) {
+            .startup_block => self.nextStartupBlock(n),
+            .startup_session => self.nextStartupSession(n),
+            .defunct => defunct: {
+                log.info("received notification in defunct state, ignoring", .{});
+                break :defunct null;
+            },
+
+            // Once we're in the main states, there's a bunch of shared
+            // logic so we centralize it.
+            .list_windows => self.nextCommand(n),
+        };
+    }
+
+    fn nextStartupBlock(self: *Viewer, n: control.Notification) ?Action {
+        assert(self.state == .startup_block);
+
+        switch (n) {
+            // This is only sent by the DCS parser when we first get
+            // DCS 1000p, it should never reach us here.
+            .enter => unreachable,
+
+            // I don't think this is technically possible (reading the
+            // tmux source code), but if we see an exit we can semantically
+            // handle this without issue.
+            .exit => {
+                self.state = .defunct;
+                return .exit;
+            },
+
+            // Any begin and end (even error) is fine! Now we wait for
+            // session-changed to get the initial session ID. session-changed
+            // is guaranteed to come after the initial command output
+            // since if the initial command is `attach` tmux will run that,
+            // queue the notification, then do notificatins.
+            .block_end, .block_err => {
+                self.state = .startup_session;
+                return null;
+            },
+
+            // I don't like catch-all else branches but startup is such
+            // a special case of looking for very specific things that
+            // are unlikely to expand.
+            else => return null,
+        }
+    }
+
+    fn nextStartupSession(self: *Viewer, n: control.Notification) ?Action {
+        assert(self.state == .startup_session);
+
+        switch (n) {
+            .enter => unreachable,
+
+            .exit => {
+                self.state = .defunct;
+                return .exit;
+            },
+
+            .session_changed => |info| {
+                self.session_id = info.id;
+                self.state = .list_windows;
+                return .{ .command = std.fmt.comptimePrint(
+                    "list-windows -F '{s}'",
+                    .{comptime Format.list_windows.comptimeFormat()},
+                ) };
+            },
+
+            else => return null,
+        }
+    }
+
+    fn nextCommand(self: *Viewer, n: control.Notification) ?Action {
+        assert(self.state != .startup_block);
+        assert(self.state != .startup_session);
+        assert(self.state != .defunct);
+
+        switch (n) {
+            .enter => unreachable,
+
+            .exit => {
+                self.state = .defunct;
+                return .exit;
+            },
+
+            .block_end,
+            .block_err,
+            => |content| switch (self.state) {
+                .startup_block, .startup_session, .defunct => unreachable,
+                .list_windows => {
+                    // TODO: parse the content
+                    _ = content;
+                    return null;
+                },
+            },
+
+            // TODO: Use exhaustive matching here, determine if we need
+            // to handle the other cases.
+            else => return null,
+        }
+    }
+};
+
+const State = enum {
+    /// We start in this state just after receiving the initial
+    /// DCS 1000p opening sequence. We wait for an initial
+    /// begin/end block that is guaranteed to be sent by tmux for
+    /// the initial control mode command. (See tmux server-client.c
+    /// where control mode starts).
+    startup_block,
+
+    /// After receiving the initial block, we wait for a session-changed
+    /// notification to record the initial session ID.
+    startup_session,
+
+    /// Tmux has closed the control mode connection
+    defunct,
+
+    /// We're waiting on a list-windows response from tmux.
+    list_windows,
+};
+
+/// Format strings used for commands in our viewer.
+const Format = struct {
+    /// The variables included in this format, in order.
+    vars: []const output.Variable,
+
+    /// The delimiter to use between variables. This must be a character
+    /// guaranteed to not appear in any of the variable outputs.
+    delim: u8,
+
+    const list_windows: Format = .{
+        .delim = ' ',
+        .vars = &.{
+            .session_id,
+            .window_id,
+            .window_width,
+            .window_height,
+            .window_layout,
+        },
+    };
+
+    /// The format string, available at comptime.
+    pub fn comptimeFormat(comptime self: Format) []const u8 {
+        return output.comptimeFormat(self.vars, self.delim);
+    }
+
+    /// The struct that can contain the parsed output.
+    pub fn Struct(comptime self: Format) type {
+        return output.FormatStruct(self.vars);
+    }
+};
+
+test "immediate exit" {
+    var viewer: Viewer = .init;
+    try testing.expectEqual(.exit, viewer.next(.exit).?);
+    try testing.expect(viewer.next(.exit) == null);
+}
+
+test "initial flow" {
+    var viewer: Viewer = .init;
+
+    // First we receive the initial block end
+    try testing.expect(viewer.next(.{ .block_end = "" }) == null);
+
+    // Then we receive session-changed with the initial session
+    {
+        const action = viewer.next(.{ .session_changed = .{
+            .id = 42,
+            .name = "main",
+        } }).?;
+        try testing.expect(action == .command);
+        try testing.expect(std.mem.startsWith(u8, action.command, "list-windows"));
+        try testing.expectEqual(42, viewer.session_id);
+    }
+
+    try testing.expectEqual(.exit, viewer.next(.exit).?);
+    try testing.expect(viewer.next(.exit) == null);
+}

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -384,7 +384,7 @@ pub const StreamHandler = struct {
                 // If tmux control mode is disabled at the build level,
                 // then this whole block shouldn't be analyzed.
                 if (comptime !tmux_enabled) break :tmux;
-                log.info("tmux control mode event cmd={}", .{tmux});
+                log.info("tmux control mode event cmd={f}", .{tmux});
 
                 switch (tmux) {
                     .enter => {
@@ -415,7 +415,7 @@ pub const StreamHandler = struct {
                     // This can only really happen if we failed to
                     // initialize the viewer on enter.
                     log.info(
-                        "received tmux control mode command without viewer: {}",
+                        "received tmux control mode command without viewer: {f}",
                         .{tmux},
                     );
 
@@ -423,7 +423,7 @@ pub const StreamHandler = struct {
                 };
 
                 for (try viewer.next(.{ .tmux = tmux })) |action| {
-                    log.info("tmux viewer action={}", .{action});
+                    log.info("tmux viewer action={f}", .{action});
                     switch (action) {
                         .exit => {
                             // We ignore this because we will fully exit when

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -70,6 +70,9 @@ pub const StreamHandler = struct {
     /// such as XTGETTCAP.
     dcs: terminal.dcs.Handler = .{},
 
+    /// The tmux control mode viewer state.
+    tmux_viewer: if (tmux_enabled) ?*terminal.tmux.Viewer else void = if (tmux_enabled) null else {},
+
     /// This is set to true when a message was written to the termio
     /// mailbox. This can be used by callers to determine if they need
     /// to wake up the termio thread.
@@ -81,9 +84,18 @@ pub const StreamHandler = struct {
 
     pub const Stream = terminal.Stream(StreamHandler);
 
+    /// True if we have tmux control mode built in.
+    pub const tmux_enabled = terminal.options.tmux_control_mode;
+
     pub fn deinit(self: *StreamHandler) void {
         self.apc.deinit();
         self.dcs.deinit();
+        if (comptime tmux_enabled) tmux: {
+            const viewer = self.tmux_viewer orelse break :tmux;
+            viewer.deinit();
+            self.alloc.destroy(viewer);
+            self.tmux_viewer = null;
+        }
     }
 
     /// This queues a render operation with the renderer thread. The render
@@ -371,10 +383,69 @@ pub const StreamHandler = struct {
             .tmux => |tmux| tmux: {
                 // If tmux control mode is disabled at the build level,
                 // then this whole block shouldn't be analyzed.
-                if (comptime !terminal.options.tmux_control_mode) break :tmux;
+                if (comptime !tmux_enabled) break :tmux;
+                log.info("tmux control mode event cmd={}", .{tmux});
 
-                // TODO: process it
-                log.warn("tmux control mode event unimplemented cmd={}", .{tmux});
+                switch (tmux) {
+                    .enter => {
+                        // Setup our viewer state
+                        assert(self.tmux_viewer == null);
+                        const viewer = try self.alloc.create(terminal.tmux.Viewer);
+                        errdefer self.alloc.destroy(viewer);
+                        viewer.* = .init(self.alloc);
+                        self.tmux_viewer = viewer;
+                        break :tmux;
+                    },
+
+                    .exit => if (self.tmux_viewer) |viewer| {
+                        // Free our viewer state
+                        viewer.deinit();
+                        self.alloc.destroy(viewer);
+                        self.tmux_viewer = null;
+                        break :tmux;
+                    },
+
+                    else => {},
+                }
+
+                assert(tmux != .enter);
+                assert(tmux != .exit);
+
+                const viewer = self.tmux_viewer orelse {
+                    // This can only really happen if we failed to
+                    // initialize the viewer on enter.
+                    log.info(
+                        "received tmux control mode command without viewer: {}",
+                        .{tmux},
+                    );
+
+                    break :tmux;
+                };
+
+                for (try viewer.next(.{ .tmux = tmux })) |action| {
+                    log.info("tmux viewer action={}", .{action});
+                    switch (action) {
+                        .exit => {
+                            // We ignore this because we will fully exit when
+                            // our DCS connection ends. We may want to handle
+                            // this in the future to notify our GUI we're
+                            // disconnected though.
+                        },
+
+                        .command => |command| {
+                            assert(command.len > 0);
+                            assert(command[command.len - 1] == '\n');
+                            self.messageWriter(try termio.Message.writeReq(
+                                self.alloc,
+                                command,
+                            ));
+                        },
+
+                        .windows => {
+                            // TODO
+                        },
+                    }
+                }
             },
 
             .xtgettcap => |*gettcap| {

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -368,7 +368,11 @@ pub const StreamHandler = struct {
     fn dcsCommand(self: *StreamHandler, cmd: *terminal.dcs.Command) !void {
         // log.warn("DCS command: {}", .{cmd});
         switch (cmd.*) {
-            .tmux => |tmux| {
+            .tmux => |tmux| tmux: {
+                // If tmux control mode is disabled at the build level,
+                // then this whole block shouldn't be analyzed.
+                if (comptime !terminal.options.tmux_control_mode) break :tmux;
+
                 // TODO: process it
                 log.warn("tmux control mode event unimplemented cmd={}", .{tmux});
             },

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -422,7 +422,7 @@ pub const StreamHandler = struct {
                     break :tmux;
                 };
 
-                for (try viewer.next(.{ .tmux = tmux })) |action| {
+                for (viewer.next(.{ .tmux = tmux })) |action| {
                     log.info("tmux viewer action={f}", .{action});
                     switch (action) {
                         .exit => {

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -392,7 +392,8 @@ pub const StreamHandler = struct {
                         assert(self.tmux_viewer == null);
                         const viewer = try self.alloc.create(terminal.tmux.Viewer);
                         errdefer self.alloc.destroy(viewer);
-                        viewer.* = .init(self.alloc);
+                        viewer.* = try .init(self.alloc);
+                        errdefer viewer.deinit();
                         self.tmux_viewer = viewer;
                         break :tmux;
                     },


### PR DESCRIPTION
Related to #1935

This adds a new structure `terminal.tmux.Viewer` which continues building on all the prior tmux control mode work to add a full bidirectional reconciliation loop to discover and sync terminal states from tmux to Ghostty and vice versa. **This is the core, cross-platform business logic that will power the GUIs, later.**

Our prior work were protocol building blocks, and this PR is an actual functional piece of work. You can now start Ghostty, run `tmux -CC attach`, and we _will_ be creating full blown terminals internal that capture the content and mirror the state exactly (barring inevitable bugs in something this complex). But, we don't yet show them visually. :) And we don't yet send inputs to it (it's a viewer only, for now).

**This sucked.** The control mode protocol is difficult, to put it mildly, for a variety of reasons. Correctness of this is going to be hard. Therefore, I focused really hard on this design to make it **fully unit test friendly.** We're able to simulate full tmux sessions and runt through our state machine and assert various states. I think this will be critical to correctness as we eventually collect real world data.

> [!WARNING]
>
> This does actually have user-impacting changes! When you run `tmux -CC attach` we will now run our full control mode client. This could result in bugs or crashes or other problems. This only activates if you have a real tmux session, though, so it should be avoidable by most users. Since we don't actually take our state and send it to the GUI or anything, this should be pretty safe.

**AI disclosure:** I used AI for a lot of the protocol reverse engineering and documentation to figure out how it all works. I designed the architecture myself and implemented most of it manually. 