### PR TITLE
OSC parser microbenchmarking

### DIFF
--- a/src/benchmark/OscParser.zig
+++ b/src/benchmark/OscParser.zig
@@ -1,0 +1,118 @@
+//! This benchmark tests the throughput of the OSC parser.
+const OscParser = @This();
+
+const std = @import("std");
+const builtin = @import("builtin");
+const assert = std.debug.assert;
+const Allocator = std.mem.Allocator;
+const Benchmark = @import("Benchmark.zig");
+const options = @import("options.zig");
+const Parser = @import("../terminal/osc.zig").Parser;
+const log = std.log.scoped(.@"osc-parser-bench");
+
+opts: Options,
+
+/// The file, opened in the setup function.
+data_f: ?std.fs.File = null,
+
+parser: Parser,
+
+pub const Options = struct {
+    /// The data to read as a filepath. If this is "-" then
+    /// we will read stdin. If this is unset, then we will
+    /// do nothing (benchmark is a noop). It'd be more unixy to
+    /// use stdin by default but I find that a hanging CLI command
+    /// with no interaction is a bit annoying.
+    data: ?[]const u8 = null,
+};
+
+/// Create a new terminal stream handler for the given arguments.
+pub fn create(
+    alloc: Allocator,
+    opts: Options,
+) !*OscParser {
+    const ptr = try alloc.create(OscParser);
+    errdefer alloc.destroy(ptr);
+    ptr.* = .{
+        .opts = opts,
+        .data_f = null,
+        .parser = .init(alloc),
+    };
+    return ptr;
+}
+
+pub fn destroy(self: *OscParser, alloc: Allocator) void {
+    self.parser.deinit();
+    alloc.destroy(self);
+}
+
+pub fn benchmark(self: *OscParser) Benchmark {
+    return .init(self, .{
+        .stepFn = step,
+        .setupFn = setup,
+        .teardownFn = teardown,
+    });
+}
+
+fn setup(ptr: *anyopaque) Benchmark.Error!void {
+    const self: *OscParser = @ptrCast(@alignCast(ptr));
+
+    // Open our data file to prepare for reading. We can do more
+    // validation here eventually.
+    assert(self.data_f == null);
+    self.data_f = options.dataFile(self.opts.data) catch |err| {
+        log.warn("error opening data file err={}", .{err});
+        return error.BenchmarkFailed;
+    };
+    self.parser.reset();
+}
+
+fn teardown(ptr: *anyopaque) void {
+    const self: *OscParser = @ptrCast(@alignCast(ptr));
+    if (self.data_f) |f| {
+        f.close();
+        self.data_f = null;
+    }
+}
+
+fn step(ptr: *anyopaque) Benchmark.Error!void {
+    const self: *OscParser = @ptrCast(@alignCast(ptr));
+
+    const f = self.data_f orelse return;
+    var read_buf: [4096]u8 align(std.atomic.cache_line) = undefined;
+    var r = f.reader(&read_buf);
+
+    var osc_buf: [4096]u8 align(std.atomic.cache_line) = undefined;
+    while (true) {
+        r.interface.fill(@bitSizeOf(usize) / 8) catch |err| switch (err) {
+            error.EndOfStream => return,
+            error.ReadFailed => return error.BenchmarkFailed,
+        };
+        const len = r.interface.takeInt(usize, .little) catch |err| switch (err) {
+            error.EndOfStream => return,
+            error.ReadFailed => return error.BenchmarkFailed,
+        };
+
+        if (len > osc_buf.len) return error.BenchmarkFailed;
+
+        r.interface.readSliceAll(osc_buf[0..len]) catch |err| switch (err) {
+            error.EndOfStream => return,
+            error.ReadFailed => return error.BenchmarkFailed,
+        };
+
+        for (osc_buf[0..len]) |c| self.parser.next(c);
+        _ = self.parser.end(std.ascii.control_code.bel);
+        self.parser.reset();
+    }
+}
+
+test OscParser {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const impl: *OscParser = try .create(alloc, .{});
+    defer impl.destroy(alloc);
+
+    const bench = impl.benchmark();
+    _ = try bench.run(.once);
+}

--- a/src/benchmark/cli.zig
+++ b/src/benchmark/cli.zig
@@ -12,6 +12,7 @@ pub const Action = enum {
     @"terminal-parser",
     @"terminal-stream",
     @"is-symbol",
+    @"osc-parser",
 
     /// Returns the struct associated with the action. The struct
     /// should have a few decls:
@@ -29,6 +30,7 @@ pub const Action = enum {
             .@"grapheme-break" => @import("GraphemeBreak.zig"),
             .@"terminal-parser" => @import("TerminalParser.zig"),
             .@"is-symbol" => @import("IsSymbol.zig"),
+            .@"osc-parser" => @import("OscParser.zig"),
         };
     }
 };

--- a/src/os/string_encoding.zig
+++ b/src/os/string_encoding.zig
@@ -265,3 +265,16 @@ test "percent 7" {
     @memcpy(&src, s);
     try std.testing.expectError(error.DecodeError, urlPercentDecode(&src));
 }
+
+/// Is the given character valid in URI percent encoding?
+fn isValidChar(c: u8) bool {
+    return switch (c) {
+        ' ', ';', '=' => false,
+        else => return std.ascii.isPrint(c),
+    };
+}
+
+/// Write data to the writer after URI percent encoding.
+pub fn urlPercentEncode(writer: *std.Io.Writer, data: []const u8) std.Io.Writer.Error!void {
+    try std.Uri.Component.percentEncode(writer, data, isValidChar);
+}

--- a/src/synthetic/cli/Ascii.zig
+++ b/src/synthetic/cli/Ascii.zig
@@ -36,10 +36,12 @@ pub fn run(_: *Ascii, writer: *std.Io.Writer, rand: std.Random) !void {
     var gen: Bytes = .{
         .rand = rand,
         .alphabet = ascii,
+        .min_len = 1024,
+        .max_len = 1024,
     };
 
     while (true) {
-        gen.next(writer, 1024) catch |err| {
+        _ = gen.write(writer) catch |err| {
             const Error = error{ WriteFailed, BrokenPipe } || @TypeOf(err);
             switch (@as(Error, err)) {
                 error.BrokenPipe => return, // stdout closed


### PR DESCRIPTION
Add options to the Ghostty benchmark tool to test the OSC parser in isolation.

```
ghostty on  benchmark-osc [?] via  v0.15.2 via   impure (ghostty-env) took 5s
at 22:32:50 → ./zig-out/bin/ghostty-gen +osc --style=parser --p-valid=0.9 | head -c100000000 > osc.txt

ghostty on  benchmark-osc [?] via  v0.15.2 via   impure (ghostty-env)
at 22:32:52 → poop './zig-out/bin/ghostty-bench +osc-parser --data=osc.txt'
Benchmark 1 (12 runs): ./zig-out/bin/ghostty-bench +osc-parser --data=osc.txt
  measurement          mean ± σ            min … max           outliers
  wall_time           421ms ± 4.15ms     415ms …  430ms          0 ( 0%)
  peak_rss           5.89MB ± 74.1KB    5.73MB … 6.03MB          4 (33%)
  cpu_cycles         1.54G  ± 5.82M     1.54G  … 1.56G           2 (17%)
  instructions       4.12G  ± 15.6      4.12G  … 4.12G           1 ( 8%)
  cache_references   13.6M  ±  219K     13.3M  … 14.0M           0 ( 0%)
  cache_misses       72.7K  ± 16.5K     59.2K  …  121K           1 ( 8%)
  branch_misses      3.29M  ± 42.1K     3.23M  … 3.36M           0 ( 0%)
```