### PR TITLE
fix(docs): `window-decoration` is now `none` instead of `false`

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1329,7 +1329,7 @@ maximize: bool = false,
 /// new windows, not just the first one.
 ///
 /// On macOS, this setting does not work if window-decoration is set to
-/// "false", because native fullscreen on macOS requires window decorations
+/// "none", because native fullscreen on macOS requires window decorations
 /// to be set.
 fullscreen: bool = false,
 
@@ -2825,7 +2825,7 @@ keybind: Keybinds = .{},
 /// also known as the traffic lights, that allow you to close, miniaturize, and
 /// zoom the window.
 ///
-/// This setting has no effect when `window-decoration = false` or
+/// This setting has no effect when `window-decoration = none` or
 /// `macos-titlebar-style = hidden`, as the window buttons are always hidden in
 /// these modes.
 ///
@@ -2866,7 +2866,7 @@ keybind: Keybinds = .{},
 /// macOS 14 does not have this issue and any other macOS version has not
 /// been tested.
 ///
-/// The "hidden" style hides the titlebar. Unlike `window-decoration = false`,
+/// The "hidden" style hides the titlebar. Unlike `window-decoration = none`,
 /// however, it does not remove the frame from the window or cause it to have
 /// squared corners. Changing to or from this option at run-time may affect
 /// existing windows in buggy ways.
@@ -3205,7 +3205,7 @@ else
 /// manager's simple titlebar. The behavior of this option will vary with your
 /// window manager.
 ///
-/// This option does nothing when `window-decoration` is false or when running
+/// This option does nothing when `window-decoration` is none or when running
 /// under macOS.
 @"gtk-titlebar": bool = true,
 


### PR DESCRIPTION
Heya,
super random but i saw this in the documentation and felt like it should be fixed 😅 