### PR TITLE
GTK: Readonly overlay

### DIFF
--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -732,6 +732,8 @@ pub const Application = extern struct {
             .search_total => Action.searchTotal(target, value),
             .search_selected => Action.searchSelected(target, value),
 
+            .readonly => return Action.toggleReadOnly(target),
+
             // Unimplemented
             .secure_input,
             .close_all_windows,
@@ -746,7 +748,6 @@ pub const Application = extern struct {
             .check_for_updates,
             .undo,
             .redo,
-            .readonly,
             => {
                 log.warn("unimplemented action={}", .{action});
                 return false;
@@ -2588,6 +2589,15 @@ const Action = struct {
             .app => return false,
             .surface => |surface| {
                 return surface.rt_surface.gobj().commandFinished(value);
+            },
+        }
+    }
+
+    pub fn toggleReadOnly(target: apprt.Target) bool {
+        switch (target) {
+            .app => return false,
+            .surface => |surface| {
+                return surface.rt_surface.gobj().toggleReadOnly();
             },
         }
     }

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -1009,9 +1009,8 @@ pub const Surface = extern struct {
         const priv = self.private();
         priv.read_only = !priv.read_only;
         self.as(gobject.Object).notifyByPspec(
-            properties.@"read-only".impl.param_spec
+            properties.@"read-only".impl.param_spec,
         );
-        log.info("read only state {}", .{priv.read_only});
         return true;
     }
 

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -547,6 +547,9 @@ pub const Surface = extern struct {
         url_left: *gtk.Label,
         url_right: *gtk.Label,
 
+        // The read only overlay
+        read_only: *gtk.MenuButton,
+
         /// The resize overlay
         resize_overlay: *ResizeOverlay,
 
@@ -978,6 +981,19 @@ pub const Surface = extern struct {
             defer alloc.free(body);
 
             self.sendDesktopNotification(title, body);
+        }
+
+        return true;
+    }
+
+    pub fn toggleReadOnly(self: *Self) bool {
+        const priv = self.private();
+
+        const readOnlyWidget = priv.read_only.as(gtk.Widget);
+        if (readOnlyWidget.getVisible() == 1) {
+            readOnlyWidget.setVisible(@intFromBool(false));
+        } else {
+            readOnlyWidget.setVisible(@intFromBool(true));
         }
 
         return true;
@@ -3256,6 +3272,7 @@ pub const Surface = extern struct {
             class.bindTemplateChildPrivate("gl_area", .{});
             class.bindTemplateChildPrivate("url_left", .{});
             class.bindTemplateChildPrivate("url_right", .{});
+            class.bindTemplateChildPrivate("read_only", .{});
             class.bindTemplateChildPrivate("child_exited_overlay", .{});
             class.bindTemplateChildPrivate("context_menu", .{});
             class.bindTemplateChildPrivate("error_page", .{});

--- a/src/apprt/gtk/ui/1.2/surface.blp
+++ b/src/apprt/gtk/ui/1.2/surface.blp
@@ -156,6 +156,28 @@ Overlay terminal_page {
   }
 
   [overlay]
+  MenuButton read_only {
+    styles [
+        "read-only"
+    ]
+
+    visible: false;
+    halign: end;
+    valign: start;
+    margin-end: 15;
+    margin-top: 15;
+    always-show-arrow: false;
+    direction: none;
+    label: "Read-only";
+
+    popover: Popover {
+        child: Label {
+            label: "This terminal is in read-only mode.\nYou can still view, select, and scroll through the content,\nbut no input events will be sent to the running application.";
+        };
+    };
+  }
+
+  [overlay]
   // Apply unfocused-split-fill and unfocused-split-opacity to current surface
   // this is only applied when a tab has more than one surface
   Revealer {

--- a/src/apprt/gtk/ui/1.2/surface.blp
+++ b/src/apprt/gtk/ui/1.2/surface.blp
@@ -148,33 +148,36 @@ Overlay terminal_page {
   }
 
   [overlay]
-  $GhosttySearchOverlay search_overlay {
-    stop-search => $search_stop();
-    search-changed => $search_changed();
-    next-match => $search_next_match();
-    previous-match => $search_previous_match();
-  }
+  Box {
+    orientation: vertical;
 
-  [overlay]
-  MenuButton read_only {
-    styles [
-        "read-only"
-    ]
+    $GhosttySearchOverlay search_overlay {
+      stop-search => $search_stop();
+      search-changed => $search_changed();
+      next-match => $search_next_match();
+      previous-match => $search_previous_match();
+    }
 
-    visible: false;
-    halign: end;
-    valign: start;
-    margin-end: 15;
-    margin-top: 15;
-    always-show-arrow: false;
-    direction: none;
-    label: "Read-only";
+    MenuButton read_only {
+      styles [
+        "read-only",
+      ]
 
-    popover: Popover {
+      visible: false;
+      halign: end;
+      valign: start;
+      margin-end: 15;
+      margin-top: 15;
+      always-show-arrow: false;
+      direction: none;
+      label: "Read-only";
+
+      popover: Popover {
         child: Label {
-            label: "This terminal is in read-only mode.\nYou can still view, select, and scroll through the content,\nbut no input events will be sent to the running application.";
+          label: _("This terminal is in read-only mode.\nYou can still view, select, and scroll through the content,\nbut no input events will be sent to the running application.");
         };
-    };
+      };
+    }
   }
 
   [overlay]

--- a/src/apprt/gtk/ui/1.2/surface.blp
+++ b/src/apprt/gtk/ui/1.2/surface.blp
@@ -168,7 +168,6 @@ Overlay terminal_page {
       valign: start;
       margin-end: 15;
       margin-top: 15;
-
       always-show-arrow: false;
       direction: none;
       label: _("Read-only");

--- a/src/apprt/gtk/ui/1.2/surface.blp
+++ b/src/apprt/gtk/ui/1.2/surface.blp
@@ -158,19 +158,20 @@ Overlay terminal_page {
       previous-match => $search_previous_match();
     }
 
-    MenuButton read_only {
+    MenuButton {
       styles [
         "read-only",
       ]
 
-      visible: false;
+      visible: bind template.read-only;
       halign: end;
       valign: start;
       margin-end: 15;
       margin-top: 15;
+
       always-show-arrow: false;
       direction: none;
-      label: "Read-only";
+      label: _("Read-only");
 
       popover: Popover {
         child: Label {


### PR DESCRIPTION
Closes: #9889

adds support for a readonly overlay on GTK.

I wouldn't say this PR is quite ready but I'm opening to get feedback if this is the right direction and possibly some tips.

1. ~The read only overlay overlaps with the search overlay right now I would assume this is due to the alignment rules?~ I figured out I can solve it with a box is that correct? Adding the box messes up the mouse reporting of the gl area looking into that
2. ~The label should wrap the text instead of the manual newlines~ This was easily solved with some wrap properties and max-width-chars
3. I disabled the arrow on the menu item should that be added back as context that you can click on the widget?

https://github.com/user-attachments/assets/84b268ba-da12-4403-b810-2774ae3c1339
