### PR TITLE
fix: explicitly allow preservation for TERMINFO in shell-integration

### DIFF
--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -103,7 +103,7 @@ if [[ "$GHOSTTY_SHELL_FEATURES" == *"sudo"* && -n "$TERMINFO" ]]; then
     if [[ "$sudo_has_sudoedit_flags" == "yes" ]]; then
       builtin command sudo "$@";
     else
-      builtin command sudo TERMINFO="$TERMINFO" "$@";
+      builtin command sudo --preserve-env=TERMINFO "$@";
     fi
   }
 fi

--- a/src/shell-integration/elvish/lib/ghostty-integration.elv
+++ b/src/shell-integration/elvish/lib/ghostty-integration.elv
@@ -97,7 +97,7 @@
       if (not (has-value $arg =)) { break }
     }
 
-    if (not $sudoedit) { set args = [ TERMINFO=$E:TERMINFO $@args ] }
+    if (not $sudoedit) { set args = [ --preserve-env=TERMINFO $@args ] }
     (external sudo) $@args
   }
 

--- a/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
+++ b/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
@@ -90,7 +90,7 @@ function __ghostty_setup --on-event fish_prompt -d "Setup ghostty integration"
             if test "$sudo_has_sudoedit_flags" = "yes"
                 command sudo $argv
             else
-                command sudo TERMINFO="$TERMINFO" $argv
+                command sudo --preserve-env=TERMINFO $argv
             end
         end
     end

--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -255,7 +255,7 @@ _ghostty_deferred_init() {
         if [[ "$sudo_has_sudoedit_flags" == "yes" ]]; then
           builtin command sudo "$@";
         else
-          builtin command sudo TERMINFO="$TERMINFO" "$@";
+          builtin command sudo --preserve-env=TERMINFO "$@";
         fi
       }
     fi


### PR DESCRIPTION
Due to security issues, `sudo` implementations may not preserve environment variables unless appended with `--preserve-env=list`.

Problem context: https://github.com/ghostty-org/ghostty/discussions/9861