### PR TITLE
nix: replace deprecated system with stdenv.hostPlatform.system

### DIFF
--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -70,7 +70,6 @@
   wayland-scanner,
   wayland-protocols,
   zon2nix,
-  system,
   pkgs,
   # needed by GTK for loading SVG icons while running from within the
   # developer shell
@@ -100,7 +99,7 @@ in
         scdoc
         zig
         zip
-        zon2nix.packages.${system}.zon2nix
+        zon2nix.packages.${stdenv.hostPlatform.system}.zon2nix
 
         # For web and wasm stuff
         nodejs


### PR DESCRIPTION
Reported by Mr. Hashimoto in discord. 

These changes removedthe following warning:
`evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'`