### PR TITLE
Fix macOS log command for Ghostty

### DIFF
--- a/src/build/mdgen/ghostty_5_header.md
+++ b/src/build/mdgen/ghostty_5_header.md
@@ -101,7 +101,7 @@ On Linux if Ghostty is launched by the default `systemd` user service, you can u
 `journald` to see Ghostty's logs: `journalctl --user --unit app-com.mitchellh.ghostty.service`.
 
 On macOS logging to the macOS unified log is available and enabled by default.
---Use the system `log` CLI to view Ghostty's logs: `sudo log stream level debug
+--Use the system `log` CLI to view Ghostty's logs: `sudo log stream --level debug
 --predicate 'subsystem=="com.mitchellh.ghostty"'`.
 
 Ghostty's logging can be configured in two ways. The first is by what


### PR DESCRIPTION
Corrected the command for viewing Ghostty logs on macOS.