### PR TITLE
Fix (#9921) link opening by resolving existing relative paths

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2048,6 +2048,12 @@ fn resolvePathForOpening(
         };
 
         const resolved = try std.fs.path.resolve(self.alloc, &.{ terminal_pwd, path });
+
+        std.fs.accessAbsolute(resolved, .{}) catch {
+            self.alloc.free(resolved);
+            return null;
+        };
+
         return resolved;
     }
 


### PR DESCRIPTION
This PR fixes an issue in the change I merged yesterday (#9921), which was reported by @quonb. Apology

I verified the fix by testing a wide range of URL schemes:
```
echo "https://example.com"
echo "http://example.com"
echo "mailto:test@example.com"
echo "ftp://example.com/file.txt"
echo "file:/Users/you/file.txt"
echo "ssh:user@example.com"
echo "git://github.com/user/repo.git"
echo "ssh://example.com/path"
echo "tel:+12123456789"
echo "ipns://example.com/path"
echo "gemini://example.com/"
echo "gopher://example.com/1menu"
echo "news:comp.lang.zig"
  ```