### PR TITLE
macOS: Session Search

### DIFF
--- a/macos/Ghostty.xcodeproj/project.pbxproj
+++ b/macos/Ghostty.xcodeproj/project.pbxproj
@@ -157,6 +157,7 @@
 				"Helpers/Extensions/KeyboardShortcut+Extension.swift",
 				"Helpers/Extensions/NSAppearance+Extension.swift",
 				"Helpers/Extensions/NSApplication+Extension.swift",
+				"Helpers/Extensions/NSColor+Extension.swift",
 				"Helpers/Extensions/NSImage+Extension.swift",
 				"Helpers/Extensions/NSMenu+Extension.swift",
 				"Helpers/Extensions/NSMenuItem+Extension.swift",

--- a/macos/Sources/Features/Command Palette/CommandPalette.swift
+++ b/macos/Sources/Features/Command Palette/CommandPalette.swift
@@ -6,6 +6,7 @@ struct CommandOption: Identifiable, Hashable {
     let description: String?
     let symbols: [String]?
     let leadingIcon: String?
+    let leadingColor: Color?
     let badge: String?
     let emphasis: Bool
     let action: () -> Void
@@ -15,6 +16,7 @@ struct CommandOption: Identifiable, Hashable {
         description: String? = nil,
         symbols: [String]? = nil,
         leadingIcon: String? = nil,
+        leadingColor: Color? = nil,
         badge: String? = nil,
         emphasis: Bool = false,
         action: @escaping () -> Void
@@ -23,6 +25,7 @@ struct CommandOption: Identifiable, Hashable {
         self.description = description
         self.symbols = symbols
         self.leadingIcon = leadingIcon
+        self.leadingColor = leadingColor
         self.badge = badge
         self.emphasis = emphasis
         self.action = action
@@ -283,6 +286,12 @@ fileprivate struct CommandRow: View {
     var body: some View {
         Button(action: action) {
             HStack(spacing: 8) {
+                if let color = option.leadingColor {
+                    Circle()
+                        .fill(color)
+                        .frame(width: 8, height: 8)
+                }
+                
                 if let icon = option.leadingIcon {
                     Image(systemName: icon)
                         .foregroundStyle(option.emphasis ? Color.accentColor : .secondary)

--- a/macos/Sources/Features/Command Palette/CommandPalette.swift
+++ b/macos/Sources/Features/Command Palette/CommandPalette.swift
@@ -1,15 +1,27 @@
 import SwiftUI
 
 struct CommandOption: Identifiable, Hashable {
+    /// Unique identifier for this option.
     let id = UUID()
+    /// The primary text displayed for this command.
     let title: String
+    /// Secondary text displayed below the title.
     let subtitle: String?
+    /// Tooltip text shown on hover.
     let description: String?
+    /// Keyboard shortcut symbols to display.
     let symbols: [String]?
+    /// SF Symbol name for the leading icon.
     let leadingIcon: String?
+    /// Color for the leading indicator circle.
     let leadingColor: Color?
+    /// Badge text displayed as a pill.
     let badge: String?
+    /// Whether to visually emphasize this option.
     let emphasis: Bool
+    /// Sort key for stable ordering when titles are equal.
+    let sortKey: AnySortKey?
+    /// The action to perform when this option is selected.
     let action: () -> Void
     
     init(
@@ -21,6 +33,7 @@ struct CommandOption: Identifiable, Hashable {
         leadingColor: Color? = nil,
         badge: String? = nil,
         emphasis: Bool = false,
+        sortKey: AnySortKey? = nil,
         action: @escaping () -> Void
     ) {
         self.title = title
@@ -31,6 +44,7 @@ struct CommandOption: Identifiable, Hashable {
         self.leadingColor = leadingColor
         self.badge = badge
         self.emphasis = emphasis
+        self.sortKey = sortKey
         self.action = action
     }
 

--- a/macos/Sources/Features/Command Palette/CommandPalette.swift
+++ b/macos/Sources/Features/Command Palette/CommandPalette.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct CommandOption: Identifiable, Hashable {
     let id = UUID()
     let title: String
+    let subtitle: String?
     let description: String?
     let symbols: [String]?
     let leadingIcon: String?
@@ -13,6 +14,7 @@ struct CommandOption: Identifiable, Hashable {
     
     init(
         title: String,
+        subtitle: String? = nil,
         description: String? = nil,
         symbols: [String]? = nil,
         leadingIcon: String? = nil,
@@ -22,6 +24,7 @@ struct CommandOption: Identifiable, Hashable {
         action: @escaping () -> Void
     ) {
         self.title = title
+        self.subtitle = subtitle
         self.description = description
         self.symbols = symbols
         self.leadingIcon = leadingIcon
@@ -55,7 +58,10 @@ struct CommandPaletteView: View {
         if query.isEmpty {
             return options
         } else {
-            return options.filter { $0.title.localizedCaseInsensitiveContains(query) }
+            return options.filter {
+                $0.title.localizedCaseInsensitiveContains(query) ||
+                ($0.subtitle?.localizedCaseInsensitiveContains(query) ?? false)
+            }
         }
     }
 
@@ -298,8 +304,16 @@ fileprivate struct CommandRow: View {
                         .font(.system(size: 14, weight: .medium))
                 }
                 
-                Text(option.title)
-                    .fontWeight(option.emphasis ? .medium : .regular)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(option.title)
+                        .fontWeight(option.emphasis ? .medium : .regular)
+                    
+                    if let subtitle = option.subtitle {
+                        Text(subtitle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
                 
                 Spacer()
                 

--- a/macos/Sources/Features/Command Palette/TerminalCommandPalette.swift
+++ b/macos/Sources/Features/Command Palette/TerminalCommandPalette.swift
@@ -63,9 +63,16 @@ struct TerminalCommandPaletteView: View {
     /// All commands available in the command palette, combining update and terminal options.
     private var commandOptions: [CommandOption] {
         var options: [CommandOption] = []
+        // Updates always appear first
         options.append(contentsOf: updateOptions)
-        options.append(contentsOf: jumpOptions)
-        options.append(contentsOf: terminalOptions)
+        
+        // Sort the rest. We replace ":" with a character that sorts before space
+        // so that "Foo:" sorts before "Foo Bar:".
+        options.append(contentsOf: (jumpOptions + terminalOptions).sorted { a, b in
+            let aNormalized = a.title.replacingOccurrences(of: ":", with: "\t")
+            let bNormalized = b.title.replacingOccurrences(of: ":", with: "\t")
+            return aNormalized.localizedCaseInsensitiveCompare(bNormalized) == .orderedAscending
+        })
         return options
     }
 

--- a/macos/Sources/Features/Command Palette/TerminalCommandPalette.swift
+++ b/macos/Sources/Features/Command Palette/TerminalCommandPalette.swift
@@ -62,7 +62,7 @@ struct TerminalCommandPaletteView: View {
                 return CommandOption(
                     title: c.title,
                     description: c.description,
-                    symbols: ghosttyConfig.keyboardShortcut(for: c.action)?.keyList
+                    symbols: ghosttyConfig.keyboardShortcut(for: c.action)?.keyList,
                 ) {
                     onAction(c.action)
                 }

--- a/macos/Sources/Features/Command Palette/TerminalCommandPalette.swift
+++ b/macos/Sources/Features/Command Palette/TerminalCommandPalette.swift
@@ -142,10 +142,16 @@ struct TerminalCommandPaletteView: View {
             return controller.surfaceTree.map { surface in
                 let title = surface.title.isEmpty ? window.title : surface.title
                 let displayTitle = title.isEmpty ? "Untitled" : title
+                let pwd = surface.pwd?.abbreviatedPath
+                let subtitle: String? = if let pwd, !displayTitle.contains(pwd) {
+                    pwd
+                } else {
+                    nil
+                }
 
                 return CommandOption(
                     title: "Focus: \(displayTitle)",
-                    description: surface.pwd?.abbreviatedPath,
+                    subtitle: subtitle,
                     leadingIcon: "rectangle.on.rectangle",
                     leadingColor: displayColor?.displayColor.map { Color($0) }
                 ) {

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -195,6 +195,11 @@ class BaseTerminalController: NSWindowController,
             selector: #selector(ghosttyDidResizeSplit(_:)),
             name: Ghostty.Notification.didResizeSplit,
             object: nil)
+        center.addObserver(
+            self,
+            selector: #selector(ghosttyDidPresentTerminal(_:)),
+            name: Ghostty.Notification.ghosttyPresentTerminal,
+            object: nil)
 
         // Listen for local events that we need to know of outside of
         // single surface handlers.
@@ -698,6 +703,15 @@ class BaseTerminalController: NSWindowController,
         } catch {
             Ghostty.logger.warning("failed to resize split: \(error)")
         }
+    }
+
+    @objc private func ghosttyDidPresentTerminal(_ notification: Notification) {
+        guard let target = notification.object as? Ghostty.SurfaceView else { return }
+        guard surfaceTree.contains(target) else { return }
+
+        // Bring the window to front and focus the surface without activating the app
+        window?.orderFrontRegardless()
+        Ghostty.moveFocus(to: target)
     }
 
     // MARK: Local Events

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -714,6 +714,7 @@ class BaseTerminalController: NSWindowController,
         
         // We use a small delay to ensure this runs after any UI cleanup
         // (e.g., command palette restoring focus to its original surface).
+        Ghostty.moveFocus(to: target)
         Ghostty.moveFocus(to: target, delay: 0.1)
 
         // Show a brief highlight to help the user locate the presented terminal.

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -715,6 +715,9 @@ class BaseTerminalController: NSWindowController,
         // We use a small delay to ensure this runs after any UI cleanup
         // (e.g., command palette restoring focus to its original surface).
         Ghostty.moveFocus(to: target, delay: 0.1)
+
+        // Show a brief highlight to help the user locate the presented terminal.
+        target.highlight()
     }
 
     // MARK: Local Events

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -709,9 +709,12 @@ class BaseTerminalController: NSWindowController,
         guard let target = notification.object as? Ghostty.SurfaceView else { return }
         guard surfaceTree.contains(target) else { return }
 
-        // Bring the window to front and focus the surface without activating the app
-        window?.orderFrontRegardless()
-        Ghostty.moveFocus(to: target)
+        // Bring the window to front and focus the surface.
+        window?.makeKeyAndOrderFront(nil)
+        
+        // We use a small delay to ensure this runs after any UI cleanup
+        // (e.g., command palette restoring focus to its original surface).
+        Ghostty.moveFocus(to: target, delay: 0.1)
     }
 
     // MARK: Local Events

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -627,11 +627,12 @@ extension Ghostty {
             case GHOSTTY_ACTION_SEARCH_SELECTED:
                 searchSelected(app, target: target, v: action.action.search_selected)
 
+            case GHOSTTY_ACTION_PRESENT_TERMINAL:
+                return presentTerminal(app, target: target)
+
             case GHOSTTY_ACTION_TOGGLE_TAB_OVERVIEW:
                 fallthrough
             case GHOSTTY_ACTION_TOGGLE_WINDOW_DECORATIONS:
-                fallthrough
-            case GHOSTTY_ACTION_PRESENT_TERMINAL:
                 fallthrough
             case GHOSTTY_ACTION_SIZE_LIMIT:
                 fallthrough
@@ -842,6 +843,30 @@ extension Ghostty {
 
             default:
                 assertionFailure()
+            }
+        }
+
+        private static func presentTerminal(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s
+        ) -> Bool {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                return false
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return false }
+                guard let surfaceView = self.surfaceView(from: surface) else { return false }
+
+                NotificationCenter.default.post(
+                    name: Notification.ghosttyPresentTerminal,
+                    object: surfaceView
+                )
+                return true
+
+            default:
+                assertionFailure()
+                return false
             }
         }
 

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -435,6 +435,9 @@ extension Ghostty.Notification {
     /// New window. Has base surface config requested in userinfo.
     static let ghosttyNewWindow = Notification.Name("com.mitchellh.ghostty.newWindow")
 
+    /// Present terminal. Bring the surface's window to focus without activating the app.
+    static let ghosttyPresentTerminal = Notification.Name("com.mitchellh.ghostty.presentTerminal")
+
     /// Toggle fullscreen of current window
     static let ghosttyToggleFullscreen = Notification.Name("com.mitchellh.ghostty.toggleFullscreen")
     static let FullscreenModeKey = ghosttyToggleFullscreen.rawValue

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -126,6 +126,9 @@ extension Ghostty {
         /// True when the surface is in readonly mode.
         @Published private(set) var readonly: Bool = false
 
+        /// True when the surface should show a highlight effect (e.g., when presented via goto_split).
+        @Published private(set) var highlighted: Bool = false
+
         // An initial size to request for a window. This will only affect
         // then the view is moved to a new window.
         var initialSize: NSSize? = nil
@@ -1520,6 +1523,14 @@ extension Ghostty {
             let action = "toggle_readonly"
             if (!ghostty_surface_binding_action(surface, action, UInt(action.lengthOfBytes(using: .utf8)))) {
                 AppDelegate.logger.warning("action failed action=\(action)")
+            }
+        }
+
+        /// Triggers a brief highlight animation on this surface.
+        func highlight() {
+            highlighted = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { [weak self] in
+                self?.highlighted = false
             }
         }
 

--- a/macos/Sources/Ghostty/SurfaceView_UIKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_UIKit.swift
@@ -46,6 +46,9 @@ extension Ghostty {
         
         /// True when the surface is in readonly mode.
         @Published private(set) var readonly: Bool = false
+        
+        /// True when the surface should show a highlight effect (e.g., when presented via goto_split).
+        @Published private(set) var highlighted: Bool = false
 
         // Returns sizing information for the surface. This is the raw C
         // structure because I'm lazy.

--- a/macos/Sources/Helpers/AnySortKey.swift
+++ b/macos/Sources/Helpers/AnySortKey.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Type-erased wrapper for any Comparable type to use as a sort key.
+struct AnySortKey: Comparable {
+    private let value: Any
+    private let comparator: (Any, Any) -> ComparisonResult
+    
+    init<T: Comparable>(_ value: T) {
+        self.value = value
+        self.comparator = { lhs, rhs in
+            guard let l = lhs as? T, let r = rhs as? T else { return .orderedSame }
+            if l < r { return .orderedAscending }
+            if l > r { return .orderedDescending }
+            return .orderedSame
+        }
+    }
+    
+    static func < (lhs: AnySortKey, rhs: AnySortKey) -> Bool {
+        lhs.comparator(lhs.value, rhs.value) == .orderedAscending
+    }
+    
+    static func == (lhs: AnySortKey, rhs: AnySortKey) -> Bool {
+        lhs.comparator(lhs.value, rhs.value) == .orderedSame
+    }
+}

--- a/macos/Sources/Helpers/Extensions/NSColor+Extension.swift
+++ b/macos/Sources/Helpers/Extensions/NSColor+Extension.swift
@@ -1,0 +1,39 @@
+import AppKit
+
+extension NSColor {
+    /// Using a color list let's us get localized names.
+    private static let appleColorList: NSColorList? = NSColorList(named: "Apple")
+
+    convenience init?(named name: String) {
+        guard let colorList = Self.appleColorList,
+              let color = colorList.color(withKey: name.capitalized) else {
+            return nil
+        }
+        guard let components = color.usingColorSpace(.sRGB) else {
+            return nil
+        }
+        self.init(
+            red: components.redComponent,
+            green: components.greenComponent,
+            blue: components.blueComponent,
+            alpha: components.alphaComponent
+        )
+    }
+
+    static var colorNames: [String] {
+        appleColorList?.allKeys.map { $0.lowercased() } ?? []
+    }
+
+    /// Calculates the perceptual distance to another color in RGB space.
+    func distance(to other: NSColor) -> Double {
+        guard let a = self.usingColorSpace(.sRGB),
+              let b = other.usingColorSpace(.sRGB) else { return .infinity }
+
+        let dr = a.redComponent - b.redComponent
+        let dg = a.greenComponent - b.greenComponent
+        let db = a.blueComponent - b.blueComponent
+
+        // Weighted Euclidean distance (human eye is more sensitive to green)
+        return sqrt(2 * dr * dr + 4 * dg * dg + 3 * db * db)
+    }
+}

--- a/macos/Sources/Helpers/Extensions/String+Extension.swift
+++ b/macos/Sources/Helpers/Extensions/String+Extension.swift
@@ -7,7 +7,7 @@ extension String {
         return self.prefix(maxLength) + trailing
     }
 
-    #if canImport(AppKit)
+#if canImport(AppKit)
     func temporaryFile(_ filename: String = "temp") -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent(filename)
@@ -16,7 +16,6 @@ extension String {
         try? string.write(to: url, atomically: true, encoding: .utf8)
         return url
     }
-    #endif
 
     /// Returns the path with the home directory abbreviated as ~.
     var abbreviatedPath: String {
@@ -26,4 +25,5 @@ extension String {
         }
         return self
     }
+#endif
 }

--- a/macos/Sources/Helpers/Extensions/String+Extension.swift
+++ b/macos/Sources/Helpers/Extensions/String+Extension.swift
@@ -17,4 +17,13 @@ extension String {
         return url
     }
     #endif
+
+    /// Returns the path with the home directory abbreviated as ~.
+    var abbreviatedPath: String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        if hasPrefix(home) {
+            return "~" + dropFirst(home.count)
+        }
+        return self
+    }
 }


### PR DESCRIPTION
Replaces #9785 

This adds session search to the command palette on macOS. Session search lets you jump to any running terminal based on title or working directory. The command palette shows you the title, working directory, and tab color (if any) to help you identify the terminal you care about.

This also enhances our command palette in general to support better sorting, more stable sorts when keys are identical, etc.

## Demo

https://github.com/user-attachments/assets/602a9424-e182-4651-bf08-378e9c5e1616




## Future

Since this inherits the command palette infrastructure, we don't have fuzzy search capabilities yet, but I still think this is useful already. We should add fuzzy searching in the future.

Thanks @phaistonian for the inspiration here but I did do a full rewrite.

**AI disclosure:** I used AI to assist with this in places, but I understand everything and touched up almost everything manually.