### PR TITLE
Feat/agent sparkle indicator

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1008,6 +1008,7 @@ ghostty_surface_config_s ghostty_surface_inherited_config(ghostty_surface_t);
 void ghostty_surface_update_config(ghostty_surface_t, ghostty_config_t);
 bool ghostty_surface_needs_confirm_quit(ghostty_surface_t);
 bool ghostty_surface_process_exited(ghostty_surface_t);
+bool ghostty_surface_agent_running(ghostty_surface_t);
 void ghostty_surface_refresh(ghostty_surface_t);
 void ghostty_surface_draw(ghostty_surface_t);
 void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -157,6 +157,14 @@ extension Ghostty {
             return String(cString: ptr)
         }
 
+        var titleAgentIndicator: Bool {
+            guard let config = self.config else { return false }
+            var v = false
+            let key = "title-agent-indicator"
+            _ = ghostty_config_get(config, &v, key, UInt(key.lengthOfBytes(using: .utf8)))
+            return v
+        }
+
         var windowSaveState: String {
             guard let config = self.config else { return "" }
             var v: UnsafePointer<Int8>? = nil

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -389,8 +389,8 @@ extension Ghostty {
 
             // Poll the foreground process name periodically so we can update UI
             // indicators (tab title prefix) even if the terminal title itself
-            // doesn't change.
-            startAgentRunningTimer()
+            // doesn't change. This is only enabled when configured.
+            updateAgentRunningTimer()
 
             // Setup our tracking area so we get mouse moved events
             updateTrackingAreas()
@@ -444,6 +444,22 @@ extension Ghostty {
 
             // Prime the state immediately.
             refreshAgentRunning()
+        }
+
+        private func stopAgentRunningTimer() {
+            agentRunningTimer?.invalidate()
+            agentRunningTimer = nil
+
+            if agentRunning { agentRunning = false }
+        }
+
+        private func updateAgentRunningTimer() {
+            let enabled = (NSApplication.shared.delegate as? AppDelegate)?.ghostty.config.titleAgentIndicator ?? false
+            if enabled {
+                startAgentRunningTimer()
+            } else {
+                stopAgentRunningTimer()
+            }
         }
 
         private func refreshAgentRunning() {
@@ -737,6 +753,7 @@ extension Ghostty {
             // Update our derived config
             DispatchQueue.main.async { [weak self] in
                 self?.derivedConfig = DerivedConfig(config)
+                self?.updateAgentRunningTimer()
             }
         }
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -942,13 +942,7 @@ pub fn agentCliRunning(self: *Surface) bool {
         },
     };
 
-    var name_buf: [256]u8 = undefined;
-    const name = foreground_process.foregroundProcessNameFromPtyMaster(
-        pty_master_fd,
-        name_buf[0..],
-    ) orelse return false;
-
-    return foreground_process.isAgentCliProcessName(name);
+    return foreground_process.isAgentCliFromPtyMaster(pty_master_fd);
 }
 
 /// Called from the app thread to handle mailbox messages to our specific

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1542,6 +1542,12 @@ pub const CAPI = struct {
         return surface.core_surface.child_exited;
     }
 
+    /// Returns true if a supported "agent CLI" is currently the foreground
+    /// process for this surface (best-effort).
+    export fn ghostty_surface_agent_running(surface: *Surface) bool {
+        return surface.core_surface.agentCliRunning();
+    }
+
     /// Returns true if the surface has a selection.
     export fn ghostty_surface_has_selection(surface: *Surface) bool {
         return surface.core_surface.hasSelection();

--- a/src/apprt/gtk/class/tab.zig
+++ b/src/apprt/gtk/class/tab.zig
@@ -375,10 +375,12 @@ pub const Tab = extern struct {
         override_: ?[*:0]const u8,
         zoomed_: c_int,
         bell_ringing_: c_int,
+        agent_running_: c_int,
         _: *gobject.ParamSpec,
     ) callconv(.c) ?[*:0]const u8 {
         const zoomed = zoomed_ != 0;
         const bell_ringing = bell_ringing_ != 0;
+        const agent_running = agent_running_ != 0;
 
         // Our plain title is the overridden title if it exists, otherwise
         // the terminal title if it exists, otherwise a default string.
@@ -408,6 +410,11 @@ pub const Tab = extern struct {
         // Use an allocator to build up our string as we write it.
         var buf: std.Io.Writer.Allocating = .init(Application.default().allocator());
         defer buf.deinit();
+
+        // If an agent CLI is running, prefix with a sparkle emoji.
+        if (agent_running and config.@"title-agent-indicator") {
+            buf.writer.writeAll("✨ ") catch {};
+        }
 
         // If our bell is ringing, then we prefix the bell icon to the title.
         if (bell_ringing and config.@"bell-features".title) {

--- a/src/apprt/gtk/ui/1.5/tab.blp
+++ b/src/apprt/gtk/ui/1.5/tab.blp
@@ -8,7 +8,7 @@ template $GhosttyTab: Box {
   orientation: vertical;
   hexpand: true;
   vexpand: true;
-  title: bind $computed_title(template.config, split_tree.active-surface as <$GhosttySurface>.title, split_tree.active-surface as <$GhosttySurface>.title-override, split_tree.is-zoomed, split_tree.active-surface as <$GhosttySurface>.bell-ringing) as <string>;
+  title: bind $computed_title(template.config, split_tree.active-surface as <$GhosttySurface>.title, split_tree.active-surface as <$GhosttySurface>.title-override, split_tree.is-zoomed, split_tree.active-surface as <$GhosttySurface>.bell-ringing, split_tree.active-surface as <$GhosttySurface>.agent-running) as <string>;
   tooltip: bind split_tree.active-surface as <$GhosttySurface>.pwd;
 
   $GhosttySplitTree split_tree {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2772,6 +2772,15 @@ keybind: Keybinds = .{},
 /// Available since: 1.2.0
 @"bell-features": BellFeatures = .{},
 
+/// When enabled, Ghostty will try to detect if the foreground process running
+/// in a surface is a supported "agent CLI" (currently: `gemini`, `codex`,
+/// `claude`). If so, Ghostty will prepend a sparkle emoji (✨) to the tab title.
+///
+/// This is best-effort and OS-dependent.
+///
+/// Available since: 1.2.0
+@"title-agent-indicator": bool = false,
+
 /// If `audio` is an enabled bell feature, this is a path to an audio file. If
 /// the path is not absolute, it is considered relative to the directory of the
 /// configuration file that it is referenced from, or from the current working

--- a/src/os/foreground_process.zig
+++ b/src/os/foreground_process.zig
@@ -48,14 +48,18 @@ pub fn processName(pid: std.c.pid_t, buf: []u8) ?[]const u8 {
 pub fn isAgentCliProcessName(name: []const u8) bool {
     // Keep this intentionally small and explicit; we'll expand to per-agent
     // icons later.
-    const known = [_][]const u8{
+    const known_prefixes = [_][]const u8{
+        // Common binary names (and variants) for the CLIs we care about.
+        //
+        // Note: these are prefix matches (case-insensitive) because many
+        // package managers install with suffixes like `-cli` or `-code`.
         "gemini",
         "codex",
         "claude",
     };
 
-    for (known) |k| {
-        if (std.ascii.eqlIgnoreCase(name, k)) return true;
+    for (known_prefixes) |k| {
+        if (std.ascii.startsWithIgnoreCase(name, k)) return true;
     }
 
     return false;

--- a/src/os/foreground_process.zig
+++ b/src/os/foreground_process.zig
@@ -1,0 +1,82 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+const posix = std.posix;
+
+const c = if (builtin.os.tag == .windows) struct {} else @cImport({
+    @cInclude("sys/ioctl.h");
+});
+
+// macOS: process name lookup helper (libproc).
+extern fn proc_name(pid: c_int, buffer: [*]u8, buffersize: u32) callconv(.c) c_int;
+
+/// Returns the basename of the process that is currently in the foreground
+/// process group for the PTY associated with `pty_master_fd`.
+///
+/// This is best-effort: if we can't query it on the current platform (or due to
+/// permissions), this returns `null` rather than erroring.
+pub fn foregroundProcessNameFromPtyMaster(
+    pty_master_fd: posix.fd_t,
+    buf: []u8,
+) ?[]const u8 {
+    if (comptime builtin.os.tag == .windows) return null;
+    if (comptime builtin.os.tag == .ios) return null;
+    if (buf.len == 0) return null;
+
+    var pgid: std.c.pid_t = 0;
+    if (c.ioctl(pty_master_fd, c.TIOCGPGRP, @intFromPtr(&pgid)) < 0) return null;
+    if (pgid <= 0) return null;
+
+    return processName(pgid, buf);
+}
+
+/// Returns the basename of the process with the given pid, if it can be
+/// determined.
+///
+/// The returned slice is always a subslice of `buf`.
+pub fn processName(pid: std.c.pid_t, buf: []u8) ?[]const u8 {
+    if (buf.len == 0) return null;
+    if (pid <= 0) return null;
+
+    return switch (comptime builtin.os.tag) {
+        .linux => linuxProcessName(pid, buf),
+        .macos => macosProcessName(pid, buf),
+        else => null,
+    };
+}
+
+pub fn isAgentCliProcessName(name: []const u8) bool {
+    // Keep this intentionally small and explicit; we'll expand to per-agent
+    // icons later.
+    const known = [_][]const u8{
+        "gemini",
+        "codex",
+        "claude",
+    };
+
+    for (known) |k| {
+        if (std.ascii.eqlIgnoreCase(name, k)) return true;
+    }
+
+    return false;
+}
+
+fn linuxProcessName(pid: std.c.pid_t, buf: []u8) ?[]const u8 {
+    var path_buf: [64]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, "/proc/{d}/comm", .{pid}) catch return null;
+
+    const file = std.fs.openFileAbsolute(path, .{}) catch return null;
+    defer file.close();
+
+    const n = file.readAll(buf) catch return null;
+    if (n == 0) return null;
+
+    return std.mem.trimRight(u8, buf[0..n], "\r\n");
+}
+
+fn macosProcessName(pid: std.c.pid_t, buf: []u8) ?[]const u8 {
+    const rc = proc_name(@intCast(pid), buf.ptr, @intCast(buf.len));
+    if (rc <= 0) return null;
+
+    return std.mem.sliceTo(buf[0..@intCast(rc)], 0);
+}

--- a/src/os/foreground_process.zig
+++ b/src/os/foreground_process.zig
@@ -5,10 +5,17 @@ const posix = std.posix;
 
 const c = if (builtin.os.tag == .windows) struct {} else @cImport({
     @cInclude("sys/ioctl.h");
+    @cInclude("sys/sysctl.h");
+    @cInclude("errno.h");
 });
 
 // macOS: process name lookup helper (libproc).
 extern fn proc_name(pid: c_int, buffer: [*]u8, buffersize: u32) callconv(.c) c_int;
+
+pub fn isAgentCliFromPtyMaster(pty_master_fd: posix.fd_t) bool {
+    const pgid = foregroundProcessGroupIdFromPtyMaster(pty_master_fd) orelse return false;
+    return isAgentCliPid(pgid);
+}
 
 /// Returns the basename of the process that is currently in the foreground
 /// process group for the PTY associated with `pty_master_fd`.
@@ -23,11 +30,18 @@ pub fn foregroundProcessNameFromPtyMaster(
     if (comptime builtin.os.tag == .ios) return null;
     if (buf.len == 0) return null;
 
+    const pgid = foregroundProcessGroupIdFromPtyMaster(pty_master_fd) orelse return null;
+    return processName(pgid, buf);
+}
+
+pub fn foregroundProcessGroupIdFromPtyMaster(pty_master_fd: posix.fd_t) ?std.c.pid_t {
+    if (comptime builtin.os.tag == .windows) return null;
+    if (comptime builtin.os.tag == .ios) return null;
+
     var pgid: std.c.pid_t = 0;
     if (c.ioctl(pty_master_fd, c.TIOCGPGRP, @intFromPtr(&pgid)) < 0) return null;
     if (pgid <= 0) return null;
-
-    return processName(pgid, buf);
+    return pgid;
 }
 
 /// Returns the basename of the process with the given pid, if it can be
@@ -54,8 +68,11 @@ pub fn isAgentCliProcessName(name: []const u8) bool {
         // Note: these are prefix matches (case-insensitive) because many
         // package managers install with suffixes like `-cli` or `-code`.
         "gemini",
+        "gemini-cli",
         "codex",
+        "openai-codex",
         "claude",
+        "claude-code",
     };
 
     for (known_prefixes) |k| {
@@ -63,6 +80,87 @@ pub fn isAgentCliProcessName(name: []const u8) bool {
     }
 
     return false;
+}
+
+fn isAgentCliPid(pid: std.c.pid_t) bool {
+    var name_buf: [256]u8 = undefined;
+    if (processName(pid, name_buf[0..])) |name| {
+        if (isAgentCliProcessName(name)) return true;
+    }
+
+    var cmdline_buf: [16 * 1024]u8 = undefined;
+    const cmdline = processCommandLine(pid, cmdline_buf[0..]) orelse return false;
+    return isAgentCliCmdline(cmdline);
+}
+
+fn isAgentCliCmdline(cmdline: []const u8) bool {
+    return switch (comptime builtin.os.tag) {
+        .linux => isAgentCliNullSeparatedArgs(cmdline, null),
+        .macos => isAgentCliMacosProcargs(cmdline),
+        else => false,
+    };
+}
+
+fn isAgentCliNullSeparatedArgs(data: []const u8, max_args: ?usize) bool {
+    var count: usize = 0;
+    var i: usize = 0;
+    while (i < data.len) {
+        // Skip NUL separators.
+        while (i < data.len and data[i] == 0) i += 1;
+        if (i >= data.len) break;
+
+        const start = i;
+        while (i < data.len and data[i] != 0) i += 1;
+        const arg = data[start..i];
+        if (arg.len != 0 and isAgentCliArg(arg)) return true;
+
+        count += 1;
+        if (max_args) |m| if (count >= m) break;
+    }
+
+    return false;
+}
+
+fn isAgentCliMacosProcargs(data: []const u8) bool {
+    if (data.len < @sizeOf(c_int)) return false;
+
+    // Format: int argc; exec_path\0 ... argv[0]\0 argv[1]\0 ... env...
+    const argc: usize = @intCast(std.mem.readInt(
+        c_int,
+        data[0..@sizeOf(c_int)],
+        builtin.cpu.arch.endian(),
+    ));
+    var i: usize = @sizeOf(c_int);
+
+    // exec path
+    const exec_start = i;
+    while (i < data.len and data[i] != 0) i += 1;
+    if (i > exec_start) {
+        const exec_path = data[exec_start..i];
+        if (isAgentCliArg(exec_path)) return true;
+    }
+
+    // Skip NUL padding to argv region
+    while (i < data.len and data[i] == 0) i += 1;
+
+    // Parse argv strings (bounded by argc)
+    return isAgentCliNullSeparatedArgs(data[i..], argc);
+}
+
+fn isAgentCliArg(arg: []const u8) bool {
+    const base = std.fs.path.basename(arg);
+    return isAgentCliProcessName(base);
+}
+
+fn processCommandLine(pid: std.c.pid_t, buf: []u8) ?[]const u8 {
+    if (buf.len == 0) return null;
+    if (pid <= 0) return null;
+
+    return switch (comptime builtin.os.tag) {
+        .linux => linuxCmdline(pid, buf),
+        .macos => macosProcargs(pid, buf),
+        else => null,
+    };
 }
 
 fn linuxProcessName(pid: std.c.pid_t, buf: []u8) ?[]const u8 {
@@ -83,4 +181,29 @@ fn macosProcessName(pid: std.c.pid_t, buf: []u8) ?[]const u8 {
     if (rc <= 0) return null;
 
     return std.mem.sliceTo(buf[0..@intCast(rc)], 0);
+}
+
+fn linuxCmdline(pid: std.c.pid_t, buf: []u8) ?[]const u8 {
+    var path_buf: [64]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, "/proc/{d}/cmdline", .{pid}) catch return null;
+
+    const file = std.fs.openFileAbsolute(path, .{}) catch return null;
+    defer file.close();
+
+    const n = file.readAll(buf) catch return null;
+    if (n == 0) return null;
+    return buf[0..n];
+}
+
+fn macosProcargs(pid: std.c.pid_t, buf: []u8) ?[]const u8 {
+    var mib = [_]c_int{
+        c.CTL_KERN,
+        c.KERN_PROCARGS2,
+        @intCast(pid),
+    };
+
+    var size: usize = buf.len;
+    if (c.sysctl(&mib, mib.len, buf.ptr, &size, null, 0) != 0) return null;
+    if (size == 0) return null;
+    return buf[0..size];
 }


### PR DESCRIPTION
Adds an optional “agent CLI” sparkle indicator for tab/window titles. When enabled, Ghostty will best-effort detect if the PTY foreground process is a supported agent CLI and prepend ✨ to the  computed title.

https://github.com/user-attachments/assets/e2d18898-6428-4c10-93c7-a6d0cf3024d0


 ### User-Facing Change

- New config: title-agent-indicator (default false)
- When true, tab/window titles get a ✨ prefix while an agent CLI is detected in the foreground.

 ### Detection Details

 - Best-effort + OS-dependent:
      - macOS: uses TIOCGPGRP + KERN_PROCARGS2 (argv/exec path) in addition to short process name.
      - Linux: uses TIOCGPGRP + /proc/<pid>/cmdline in addition to /proc/<pid>/comm.
 - Matches common agent names/variants (e.g. codex, openai-codex, gemini, gemini-cli, claude,  claude-code).

### Platform Notes

 - macOS: only polls for agent state when title-agent-indicator is enabled and updates on config reload.
 - GTK: title binding includes the agent-running property so the tab title updates appropriately.


### Usage

`title-agent-indicator = true`

—-

@mitchellh  This is more of working POC; An endgame would be to have provider-based icons (e.g. one for Google, one for Claude etc) and make it a default - perhaps. Cause, hey, we live in the AI era and all :)