### PR TITLE
Add configurable corner radius for macOS quick terminal window

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -143,6 +143,10 @@ class QuickTerminalController: BaseTerminalController {
             delegate: self
         )
 
+        if let qtWindow = window as? QuickTerminalWindow {
+            qtWindow.setupRoundedCorners(cornerRadius: derivedConfig.quickTerminalCornerRadius)
+        }
+
         // Clear out our frame at this point, the fixup from above is complete.
         if let qtWindow = window as? QuickTerminalWindow {
             qtWindow.initialFrame = nil
@@ -722,6 +726,7 @@ class QuickTerminalController: BaseTerminalController {
         let quickTerminalAutoHide: Bool
         let quickTerminalSpaceBehavior: QuickTerminalSpaceBehavior
         let quickTerminalSize: QuickTerminalSize
+        let quickTerminalCornerRadius: Double
         let backgroundOpacity: Double
         let backgroundBlur: Ghostty.Config.BackgroundBlur
 
@@ -731,6 +736,7 @@ class QuickTerminalController: BaseTerminalController {
             self.quickTerminalAutoHide = true
             self.quickTerminalSpaceBehavior = .move
             self.quickTerminalSize = QuickTerminalSize()
+            self.quickTerminalCornerRadius = 16.0
             self.backgroundOpacity = 1.0
             self.backgroundBlur = .disabled
         }
@@ -741,6 +747,7 @@ class QuickTerminalController: BaseTerminalController {
             self.quickTerminalAutoHide = config.quickTerminalAutoHide
             self.quickTerminalSpaceBehavior = config.quickTerminalSpaceBehavior
             self.quickTerminalSize = config.quickTerminalSize
+            self.quickTerminalCornerRadius = config.quickTerminalCornerRadius
             self.backgroundOpacity = config.backgroundOpacity
             self.backgroundBlur = config.backgroundBlur
         }

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -143,8 +143,13 @@ class QuickTerminalController: BaseTerminalController {
             delegate: self
         )
 
-        if let qtWindow = window as? QuickTerminalWindow {
-            qtWindow.setupRoundedCorners(cornerRadius: derivedConfig.quickTerminalCornerRadius)
+
+        if
+            let qtWindow = window as? QuickTerminalWindow,
+            let radius = derivedConfig.quickTerminalCornerRadius,
+            radius > 0
+        {
+            qtWindow.setupRoundedCorners(cornerRadius: CGFloat(radius))
         }
 
         // Clear out our frame at this point, the fixup from above is complete.
@@ -726,7 +731,7 @@ class QuickTerminalController: BaseTerminalController {
         let quickTerminalAutoHide: Bool
         let quickTerminalSpaceBehavior: QuickTerminalSpaceBehavior
         let quickTerminalSize: QuickTerminalSize
-        let quickTerminalCornerRadius: Double
+        let quickTerminalCornerRadius: Double?
         let backgroundOpacity: Double
         let backgroundBlur: Ghostty.Config.BackgroundBlur
 
@@ -736,7 +741,7 @@ class QuickTerminalController: BaseTerminalController {
             self.quickTerminalAutoHide = true
             self.quickTerminalSpaceBehavior = .move
             self.quickTerminalSize = QuickTerminalSize()
-            self.quickTerminalCornerRadius = 16.0
+            self.quickTerminalCornerRadius = nil
             self.backgroundOpacity = 1.0
             self.backgroundBlur = .disabled
         }

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -150,6 +150,8 @@ class QuickTerminalController: BaseTerminalController {
             radius > 0
         {
             qtWindow.setupRoundedCorners(cornerRadius: CGFloat(radius))
+        } else if let qtWindow = window as? QuickTerminalWindow {
+            qtWindow.setupRoundedCorners(cornerRadius: 0)
         }
 
         // Clear out our frame at this point, the fixup from above is complete.

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -143,19 +143,14 @@ class QuickTerminalController: BaseTerminalController {
             delegate: self
         )
 
-
-        if
-            let qtWindow = window as? QuickTerminalWindow,
-            let radius = derivedConfig.quickTerminalCornerRadius,
-            radius > 0
-        {
-            qtWindow.setupRoundedCorners(cornerRadius: CGFloat(radius))
-        } else if let qtWindow = window as? QuickTerminalWindow {
-            qtWindow.setupRoundedCorners(cornerRadius: 0)
-        }
-
         // Clear out our frame at this point, the fixup from above is complete.
         if let qtWindow = window as? QuickTerminalWindow {
+            if let radius = derivedConfig.quickTerminalCornerRadius, radius > 0 {
+                qtWindow.setupRoundedCorners(cornerRadius: CGFloat(radius))
+            } else {
+                qtWindow.setupRoundedCorners(cornerRadius: 0)
+            }
+            
             qtWindow.initialFrame = nil
         }
 

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalWindow.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalWindow.swift
@@ -44,4 +44,13 @@ class QuickTerminalWindow: NSPanel {
         // https://github.com/ghostty-org/ghostty/pull/8026
         super.setFrame(initialFrame ?? frameRect, display: flag)
     }
+    
+    // Apply rounded corners to match macOS window design
+    func setupRoundedCorners(cornerRadius: CGFloat = 16) {
+        guard let contentView = self.contentView else { return }
+        
+        contentView.wantsLayer = true
+        contentView.layer?.cornerRadius = cornerRadius
+        contentView.layer?.masksToBounds = true
+    }
 }

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -560,11 +560,13 @@ extension Ghostty {
             return QuickTerminalSize(from: v)
         }
 
-        var quickTerminalCornerRadius: Double {
-            guard let config = self.config else { return 16.0 }
-            var v: Double = 16.0
+        var quickTerminalCornerRadius: Double? {
+            guard let config = self.config else { return nil }
+            var v: Double = 0.0
             let key = "quick-terminal-corner-radius"
-            _ = ghostty_config_get(config, &v, key, UInt(key.lengthOfBytes(using: .utf8)))
+            guard ghostty_config_get(config, &v, key, UInt(key.lengthOfBytes(using: .utf8))) else {
+                return nil
+            }
             return v
         }
         #endif

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -559,6 +559,14 @@ extension Ghostty {
             guard ghostty_config_get(config, &v, key, UInt(key.lengthOfBytes(using: .utf8))) else { return QuickTerminalSize() }
             return QuickTerminalSize(from: v)
         }
+
+        var quickTerminalCornerRadius: Double {
+            guard let config = self.config else { return 16.0 }
+            var v: Double = 16.0
+            let key = "quick-terminal-corner-radius"
+            _ = ghostty_config_get(config, &v, key, UInt(key.lengthOfBytes(using: .utf8)))
+            return v
+        }
         #endif
 
         var resizeOverlay: ResizeOverlay {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2727,6 +2727,13 @@ keybind: Keybinds = .{},
 /// Available since: 1.1.0
 @"quick-terminal-space-behavior": QuickTerminalSpaceBehavior = .move,
 
+/// Corner radius (in points) for the quick terminal window on macOS.
+/// This controls how rounded the corners of the quick terminal window are.
+/// The default value of 16 matches the standard macOS window corner radius.
+///
+/// Only implemented on macOS.
+@"quick-terminal-corner-radius": f64 = 16.0,
+
 /// Determines under which circumstances that the quick terminal should receive
 /// keyboard input. See the corresponding [Wayland documentation](https://wayland.app/protocols/wlr-layer-shell-unstable-v1#zwlr_layer_surface_v1:enum:keyboard_interactivity)
 /// for a more detailed explanation of the behavior of each option.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2731,7 +2731,7 @@ keybind: Keybinds = .{},
 /// This controls how rounded the corners of the quick terminal window are.
 ///
 /// If this value is unset (the default), the quick terminal window uses
-/// sharp corners.
+/// macOS defaults for the window decorations (which are usually sharp corners).
 ///
 /// If this value is set to a positive number, that radius is used for rounding
 /// the quick terminal window corners.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2729,10 +2729,15 @@ keybind: Keybinds = .{},
 
 /// Corner radius (in points) for the quick terminal window on macOS.
 /// This controls how rounded the corners of the quick terminal window are.
-/// The default value of 16 matches the standard macOS window corner radius.
+///
+/// If this value is unset (the default), the quick terminal window uses
+/// sharp corners.
+///
+/// If this value is set to a positive number, that radius is used for rounding
+/// the quick terminal window corners.
 ///
 /// Only implemented on macOS.
-@"quick-terminal-corner-radius": f64 = 16.0,
+@"quick-terminal-corner-radius": ?f64 = null,
 
 /// Determines under which circumstances that the quick terminal should receive
 /// keyboard input. See the corresponding [Wayland documentation](https://wayland.app/protocols/wlr-layer-shell-unstable-v1#zwlr_layer_surface_v1:enum:keyboard_interactivity)


### PR DESCRIPTION
## Summary

Adds a configurable corner radius option for the macOS quick terminal window, allowing users to customize the rounded corners to match their preferences or other macOS windows.

## Changes

- Added `quick-terminal-corner-radius` configuration option (default: ~~16.0 points~~ unset a.k.a 0)
- Updated `QuickTerminalWindow` to accept and apply configurable corner radius
- Updated `QuickTerminalController` to pass config value from `DerivedConfig`
- Added Swift property `quickTerminalCornerRadius` to `Ghostty.Config`

## Testing

- [x] Tested on macOS with default value (~~`16.0`~~ unset)
- [x] Tested with custom values in config file
- [x] Verified corners render correctly in production build
- [x] Verified default matches standard macOS window corner radius

`quick-terminal-corner-radius = 32`

<img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/87e782ce-035c-43bb-88f2-d9c66689fc5b" />

`quick-terminal-corner-radius = 16` ~~(default)~~

<img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/e67ac8fb-8b71-4dab-9ddd-c69ab8999e3a" />

## Configuration

Users can now set the corner radius in their config file `quick-terminal-corner-radius = 20` 

The default value of ~~`16.0`~~ unset a.k.a 0 points matches the standard macOS window corner radius

## Related

This addresses the visual inconsistency where the quick terminal window had sharp corners while other macOS windows have rounded corners. https://github.com/ghostty-org/ghostty/discussions/8666