### PR TITLE
macos: hide tab overview on `escape`

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -685,6 +685,18 @@ class AppDelegate: NSObject,
     }
 
     private func localEventKeyDown(_ event: NSEvent) -> NSEvent? {
+        // If the tab overview is visible and escape is pressed, close it.
+        // This can't POSSIBLY be right and is probably a FirstResponder problem
+        // that we should handle elsewhere in our program. But this works and it
+        // is guarded by the tab overview currently showing.
+        if event.keyCode == 0x35, // Escape key
+           let window = NSApp.keyWindow,
+           let tabGroup = window.tabGroup,
+           tabGroup.isOverviewVisible {
+            window.toggleTabOverview(nil)
+            return nil
+        }
+
         // If we have a main window then we don't process any of the keys
         // because we let it capture and propagate.
         guard NSApp.mainWindow == nil else { return event }


### PR DESCRIPTION
This hides the macOS tab overview when the `escape` key is pressed.

Our solution is a bit blunt here and I don't think its right. I think we have a first responder problem somewhere but I haven't been able to find it and find the proper place to implement `cancel` (or equivalent) to hide the overview. I tried implementing `cancel` in all the places I expect the responder chain to go through but none worked.

For now let's do this since it is pretty tightly scoped!