### PR TITLE
add the catch_all binding key

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -317,12 +317,14 @@ typedef struct {
 typedef enum {
   GHOSTTY_TRIGGER_PHYSICAL,
   GHOSTTY_TRIGGER_UNICODE,
+  GHOSTTY_TRIGGER_CATCH_ALL,
 } ghostty_input_trigger_tag_e;
 
 typedef union {
   ghostty_input_key_e translated;
   ghostty_input_key_e physical;
   uint32_t unicode;
+  // catch_all has no payload
 } ghostty_input_trigger_key_u;
 
 typedef struct {

--- a/macos/Sources/Ghostty/Ghostty.Input.swift
+++ b/macos/Sources/Ghostty/Ghostty.Input.swift
@@ -32,6 +32,10 @@ extension Ghostty {
             guard let scalar = UnicodeScalar(trigger.key.unicode) else { return nil }
             key = KeyEquivalent(Character(scalar))
 
+        case GHOSTTY_TRIGGER_CATCH_ALL:
+            // catch_all matches any key, so it can't be represented as a KeyboardShortcut
+            return nil
+
         default:
             return nil
         }

--- a/src/apprt/gtk/key.zig
+++ b/src/apprt/gtk/key.zig
@@ -74,6 +74,8 @@ fn writeTriggerKey(
                 try writer.print("{u}", .{cp});
             }
         },
+
+        .catch_all => return false,
     }
 
     return true;

--- a/src/cli/list_keybinds.zig
+++ b/src/cli/list_keybinds.zig
@@ -166,16 +166,19 @@ const ChordBinding = struct {
         var r_trigger = rhs.triggers.first;
 
         while (l_trigger != null and r_trigger != null) {
+            // We want catch_all to sort last.
             const lhs_key: c_int = blk: {
                 switch (TriggerNode.get(l_trigger.?).data.key) {
                     .physical => |key| break :blk @intFromEnum(key),
                     .unicode => |key| break :blk @intCast(key),
+                    .catch_all => break :blk std.math.maxInt(c_int),
                 }
             };
             const rhs_key: c_int = blk: {
                 switch (TriggerNode.get(r_trigger.?).data.key) {
                     .physical => |key| break :blk @intFromEnum(key),
                     .unicode => |key| break :blk @intCast(key),
+                    .catch_all => break :blk std.math.maxInt(c_int),
                 }
             };
 
@@ -268,6 +271,7 @@ fn prettyPrint(alloc: Allocator, keybinds: Config.Keybinds) !u8 {
             const key = switch (trigger.data.key) {
                 .physical => |k| try std.fmt.allocPrint(alloc, "{t}", .{k}),
                 .unicode => |c| try std.fmt.allocPrint(alloc, "{u}", .{c}),
+                .catch_all => "catch_all",
             };
             result = win.printSegment(.{ .text = key }, .{ .col_offset = result.col });
 
@@ -314,6 +318,7 @@ fn iterateBindings(
             switch (t.key) {
                 .physical => |k| try buf.writer.print("{t}", .{k}),
                 .unicode => |c| try buf.writer.print("{u}", .{c}),
+                .catch_all => try buf.writer.print("catch_all", .{}),
             }
 
             break :blk win.gwidth(buf.written());

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1477,6 +1477,13 @@ class: ?[:0]const u8 = null,
 /// so if you specify both `a` and `KeyA`, the physical key will always be used
 /// regardless of what order they are configured.
 ///
+/// The special key `catch_all` can be used to match any key that is not
+/// otherwise bound. This can be combined with modifiers, for example
+/// `ctrl+catch_all` will match any key pressed with `ctrl` that is not
+/// otherwise bound. When looking up a binding, Ghostty first tries to match
+/// `catch_all` with modifiers. If no match is found and the event has
+/// modifiers, it falls back to `catch_all` without modifiers.
+///
 /// Valid modifiers are `shift`, `ctrl` (alias: `control`), `alt` (alias: `opt`,
 /// `option`), and `super` (alias: `cmd`, `command`). You may use the modifier
 /// or the alias. When debugging keybinds, the non-aliased modifier will always


### PR DESCRIPTION
Part of #9963

This adds a new special key `catch_all` that can be used in keybinding definitions to match any key that is not explicitly bound. For example: `keybind = catch_all=new_window` (chaos!). 

`catch_all` can be used in combination with modifiers, so if you want to catch any non-bound key with Ctrl held down, you can do: `keybind = ctrl+catch_all=new_window`.

`catch_all` can also be used with trigger sequences, so you can do: `keybind = ctrl+a>catch_all=new_window` to catch any key pressed after `ctrl+a` that is not explicitly bound and make a new window!

And if you want to remove the catch all binding, it is like any other: `keybind = catch_all=unbind`.