### PR TITLE
Fix for when pressing enter twice didn't refocus the found word

### DIFF
--- a/src/terminal/search/Thread.zig
+++ b/src/terminal/search/Thread.zig
@@ -257,17 +257,19 @@ fn select(self: *Thread, sel: ScreenSearch.Select) !void {
     self.opts.mutex.lock();
     defer self.opts.mutex.unlock();
 
+    _ = try screen_search.select(sel);
+
     // The selection will trigger a selection change notification
     // if it did change.
-    if (try screen_search.select(sel)) scroll: {
-        if (screen_search.selected) |m| {
-            // Selection changed, let's scroll the viewport to see it
-            // since we have the lock anyways.
-            const screen = self.opts.terminal.screens.get(
-                s.last_screen.key,
-            ) orelse break :scroll;
-            screen.scroll(.{ .pin = m.highlight.start.* });
-        }
+    if (screen_search.selected) |m| {
+        // Selection changed, let's scroll the viewport to see it
+        // since we have the lock anyways.
+        const screen = self.opts.terminal.screens.get(
+            s.last_screen.key,
+        ) orelse return;
+        screen.scroll(.{ .pin = m.highlight.start.* });
+        s.viewport.reset();
+        s.stale_viewport_matches = true;
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/ghostty-org/ghostty/issues/9958

Fix for the bug where the found word wasn't re-focused after pressing Enter when it was found, I'm happy to explore other ways to fix this bug if there's something I'm not seeing or misunderstanding.

https://github.com/user-attachments/assets/a059ec37-70f7-4b6f-bef0-e7d010a1ab3f

**AI Disclosure**
I typed all of this code by hand but I used Claude Opus 4.5 to get an idea of how the bug could be fixed and read carefully its solution and tested it and verified that it works.