### PR TITLE
Key tables apprt action plus macOS UI

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -691,6 +691,27 @@ typedef struct {
   ghostty_input_trigger_s trigger;
 } ghostty_action_key_sequence_s;
 
+// apprt.action.KeyTable.Tag
+typedef enum {
+  GHOSTTY_KEY_TABLE_ACTIVATE,
+  GHOSTTY_KEY_TABLE_DEACTIVATE,
+  GHOSTTY_KEY_TABLE_DEACTIVATE_ALL,
+} ghostty_action_key_table_tag_e;
+
+// apprt.action.KeyTable.CValue
+typedef union {
+  struct {
+    const char *name;
+    size_t len;
+  } activate;
+} ghostty_action_key_table_u;
+
+// apprt.action.KeyTable.C
+typedef struct {
+  ghostty_action_key_table_tag_e tag;
+  ghostty_action_key_table_u value;
+} ghostty_action_key_table_s;
+
 // apprt.action.ColorKind
 typedef enum {
   GHOSTTY_ACTION_COLOR_KIND_FOREGROUND = -1,
@@ -836,6 +857,7 @@ typedef enum {
   GHOSTTY_ACTION_FLOAT_WINDOW,
   GHOSTTY_ACTION_SECURE_INPUT,
   GHOSTTY_ACTION_KEY_SEQUENCE,
+  GHOSTTY_ACTION_KEY_TABLE,
   GHOSTTY_ACTION_COLOR_CHANGE,
   GHOSTTY_ACTION_RELOAD_CONFIG,
   GHOSTTY_ACTION_CONFIG_CHANGE,
@@ -881,6 +903,7 @@ typedef union {
   ghostty_action_float_window_e float_window;
   ghostty_action_secure_input_e secure_input;
   ghostty_action_key_sequence_s key_sequence;
+  ghostty_action_key_table_s key_table;
   ghostty_action_color_change_s color_change;
   ghostty_action_reload_config_s reload_config;
   ghostty_action_config_change_s config_change;

--- a/macos/Sources/Ghostty/Ghostty.Action.swift
+++ b/macos/Sources/Ghostty/Ghostty.Action.swift
@@ -150,12 +150,8 @@ extension Ghostty.Action {
         init?(c: ghostty_action_key_table_s) {
             switch c.tag {
             case GHOSTTY_KEY_TABLE_ACTIVATE:
-                let name = String(
-                    bytesNoCopy: UnsafeMutableRawPointer(mutating: c.value.activate.name),
-                    length: c.value.activate.len,
-                    encoding: .utf8,
-                    freeWhenDone: false
-                ) ?? ""
+                let data = Data(bytes: c.value.activate.name, count: c.value.activate.len)
+                let name = String(data: data, encoding: .utf8) ?? ""
                 self = .activate(name: name)
             case GHOSTTY_KEY_TABLE_DEACTIVATE:
                 self = .deactivate

--- a/macos/Sources/Ghostty/Ghostty.Action.swift
+++ b/macos/Sources/Ghostty/Ghostty.Action.swift
@@ -141,6 +141,31 @@ extension Ghostty.Action {
             }
         }
     }
+
+    enum KeyTable {
+        case activate(name: String)
+        case deactivate
+        case deactivateAll
+
+        init?(c: ghostty_action_key_table_s) {
+            switch c.tag {
+            case GHOSTTY_KEY_TABLE_ACTIVATE:
+                let name = String(
+                    bytesNoCopy: UnsafeMutableRawPointer(mutating: c.value.activate.name),
+                    length: c.value.activate.len,
+                    encoding: .utf8,
+                    freeWhenDone: false
+                ) ?? ""
+                self = .activate(name: name)
+            case GHOSTTY_KEY_TABLE_DEACTIVATE:
+                self = .deactivate
+            case GHOSTTY_KEY_TABLE_DEACTIVATE_ALL:
+                self = .deactivateAll
+            default:
+                return nil
+            }
+        }
+    }
 }
 
 // Putting the initializer in an extension preserves the automatic one.

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -578,7 +578,10 @@ extension Ghostty {
 
             case GHOSTTY_ACTION_KEY_SEQUENCE:
                 keySequence(app, target: target, v: action.action.key_sequence)
-                
+
+            case GHOSTTY_ACTION_KEY_TABLE:
+                keyTable(app, target: target, v: action.action.key_table)
+
             case GHOSTTY_ACTION_PROGRESS_REPORT:
                 progressReport(app, target: target, v: action.action.progress_report)
 
@@ -1771,7 +1774,32 @@ extension Ghostty {
                 assertionFailure()
             }
         }
-        
+
+        private static func keyTable(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s,
+            v: ghostty_action_key_table_s) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                Ghostty.logger.warning("key table does nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                guard let action = Ghostty.Action.KeyTable(c: v) else { return }
+
+                NotificationCenter.default.post(
+                    name: Notification.didChangeKeyTable,
+                    object: surfaceView,
+                    userInfo: [Notification.KeyTableKey: action]
+                )
+
+            default:
+                assertionFailure()
+            }
+        }
+
         private static func progressReport(
             _ app: ghostty_app_t,
             target: ghostty_target_s,

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -475,6 +475,10 @@ extension Ghostty.Notification {
     static let didContinueKeySequence = Notification.Name("com.mitchellh.ghostty.didContinueKeySequence")
     static let didEndKeySequence = Notification.Name("com.mitchellh.ghostty.didEndKeySequence")
     static let KeySequenceKey = didContinueKeySequence.rawValue + ".key"
+
+    /// Notifications related to key tables
+    static let didChangeKeyTable = Notification.Name("com.mitchellh.ghostty.didChangeKeyTable")
+    static let KeyTableKey = didChangeKeyTable.rawValue + ".action"
 }
 
 // Make the input enum hashable.

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -123,30 +123,12 @@ extension Ghostty {
                     }
                 }
                 
-                // If we are in the middle of a key sequence, then we show a visual element. We only
-                // support this on macOS currently although in theory we can support mobile with keyboards!
-                if !surfaceView.keySequence.isEmpty {
-                    let padding: CGFloat = 5
-                    VStack {
-                        Spacer()
-
-                        HStack {
-                            Text(verbatim: "Pending Key Sequence:")
-                            ForEach(0..<surfaceView.keySequence.count, id: \.description) { index in
-                                let key = surfaceView.keySequence[index]
-                                Text(verbatim: key.description)
-                                    .font(.system(.body, design: .monospaced))
-                                    .padding(3)
-                                    .background(
-                                        RoundedRectangle(cornerRadius: 5)
-                                            .fill(Color(NSColor.selectedTextBackgroundColor))
-                                    )
-                            }
-                        }
-                        .padding(.init(top: padding, leading: padding, bottom: padding, trailing: padding))
-                        .frame(maxWidth: .infinity)
-                        .background(.background)
-                    }
+                // Show key state indicator for active key tables and/or pending key sequences
+                if !surfaceView.keyTables.isEmpty || !surfaceView.keySequence.isEmpty {
+                    KeyStateIndicator(
+                        keyTables: surfaceView.keyTables,
+                        keySequence: surfaceView.keySequence
+                    )
                 }
 #endif
 
@@ -751,6 +733,233 @@ extension Ghostty {
             }
         }
     }
+
+#if canImport(AppKit)
+    /// Floating indicator that shows active key tables and pending key sequences.
+    /// Displayed as a compact draggable pill that can be positioned at the top or bottom.
+    struct KeyStateIndicator: View {
+        let keyTables: [String]
+        let keySequence: [KeyboardShortcut]
+        
+        @State private var isShowingPopover = false
+        @State private var position: Position = .bottom
+        @State private var dragOffset: CGSize = .zero
+        @State private var isDragging = false
+        @State private var capsuleSize: CGSize = .zero
+        
+        private let padding: CGFloat = 8
+        
+        enum Position {
+            case top, bottom
+            
+            var alignment: Alignment {
+                switch self {
+                case .top: return .top
+                case .bottom: return .bottom
+                }
+            }
+            
+            var popoverEdge: Edge {
+                switch self {
+                case .top: return .top
+                case .bottom: return .bottom
+                }
+            }
+        }
+        
+        var body: some View {
+            GeometryReader { geo in
+                indicatorContent
+                    .background(
+                        GeometryReader { capsuleGeo in
+                            Color.clear.preference(
+                                key: CapsuleSizeKey.self,
+                                value: capsuleGeo.size
+                            )
+                        }
+                    )
+                    .offset(dragOffset)
+                    .padding(padding)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: position.alignment)
+                    .onPreferenceChange(CapsuleSizeKey.self) { size in
+                        capsuleSize = size
+                    }
+                    .highPriorityGesture(
+                        DragGesture(coordinateSpace: .local)
+                            .onChanged { value in
+                                isDragging = true
+                                dragOffset = CGSize(width: 0, height: value.translation.height)
+                            }
+                            .onEnded { value in
+                                isDragging = false
+                                let dragThreshold: CGFloat = 50
+                                
+                                withAnimation(.easeOut(duration: 0.2)) {
+                                    if position == .bottom && value.translation.height < -dragThreshold {
+                                        position = .top
+                                    } else if position == .top && value.translation.height > dragThreshold {
+                                        position = .bottom
+                                    }
+                                    dragOffset = .zero
+                                }
+                            }
+                    )
+            }
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+            .animation(.spring(response: 0.3, dampingFraction: 0.8), value: keyTables)
+            .animation(.spring(response: 0.3, dampingFraction: 0.8), value: keySequence.count)
+        }
+        
+        private struct CapsuleSizeKey: PreferenceKey {
+            static var defaultValue: CGSize = .zero
+            static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
+                value = nextValue()
+            }
+        }
+        
+        private var indicatorContent: some View {
+            HStack(alignment: .center, spacing: 8) {
+                // Key table indicator
+                if !keyTables.isEmpty {
+                    HStack(alignment: .firstTextBaseline, spacing: 5) {
+                        Image(systemName: "keyboard.badge.ellipsis")
+                            .font(.system(size: 13))
+                            .foregroundStyle(.secondary)
+                        
+                        // Show table stack with arrows between them
+                        ForEach(Array(keyTables.enumerated()), id: \.offset) { index, table in
+                            if index > 0 {
+                                Image(systemName: "chevron.right")
+                                    .font(.system(size: 10, weight: .semibold))
+                                    .foregroundStyle(.tertiary)
+                            }
+                            Text(verbatim: table)
+                                .font(.system(size: 13, weight: .medium, design: .rounded))
+                        }
+                    }
+                }
+                
+                // Separator when both are active
+                if !keyTables.isEmpty && !keySequence.isEmpty {
+                    Divider()
+                        .frame(height: 14)
+                }
+                
+                // Key sequence indicator
+                if !keySequence.isEmpty {
+                    HStack(alignment: .center, spacing: 4) {
+                        ForEach(Array(keySequence.enumerated()), id: \.offset) { index, key in
+                            KeyCap(key.description)
+                        }
+                        
+                        // Animated ellipsis to indicate waiting for next key
+                        PendingIndicator()
+                    }
+                }
+            }
+            .frame(height: 18)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background {
+                Capsule()
+                    .fill(.regularMaterial)
+                    .overlay {
+                        Capsule()
+                            .strokeBorder(Color.primary.opacity(0.15), lineWidth: 1)
+                    }
+                    .shadow(color: .black.opacity(0.2), radius: 8, y: 2)
+            }
+            .contentShape(Capsule())
+            .backport.pointerStyle(.link)
+            .popover(isPresented: $isShowingPopover, arrowEdge: position.popoverEdge) {
+                VStack(alignment: .leading, spacing: 8) {
+                    if !keyTables.isEmpty {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Label("Key Table", systemImage: "keyboard.badge.ellipsis")
+                                .font(.headline)
+                            Text("A key table is a named set of keybindings, activated by some other key. Keys are interpreted using this table until it is deactivated.")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    
+                    if !keyTables.isEmpty && !keySequence.isEmpty {
+                        Divider()
+                    }
+                    
+                    if !keySequence.isEmpty {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Label("Key Sequence", systemImage: "character.cursor.ibeam")
+                                .font(.headline)
+                            Text("A key sequence is a series of key presses that trigger an action. A pending key sequence is currently active.")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .padding()
+                .frame(maxWidth: 400)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+            .onTapGesture {
+                isShowingPopover.toggle()
+            }
+        }
+        
+        /// A small keycap-style view for displaying keyboard shortcuts
+        struct KeyCap: View {
+            let text: String
+            
+            init(_ text: String) {
+                self.text = text
+            }
+            
+            var body: some View {
+                Text(verbatim: text)
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 2)
+                    .background(
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(Color(NSColor.controlBackgroundColor))
+                            .shadow(color: .black.opacity(0.12), radius: 0.5, y: 0.5)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4)
+                            .strokeBorder(Color.primary.opacity(0.15), lineWidth: 0.5)
+                    )
+            }
+        }
+        
+        /// Animated dots to indicate waiting for the next key
+        struct PendingIndicator: View {
+            @State private var animationPhase: Int = 0
+            
+            var body: some View {
+                HStack(spacing: 2) {
+                    ForEach(0..<3, id: \.self) { index in
+                        Circle()
+                            .fill(Color.secondary)
+                            .frame(width: 4, height: 4)
+                            .opacity(dotOpacity(for: index))
+                    }
+                }
+                .onAppear {
+                    withAnimation(.easeInOut(duration: 0.4).repeatForever(autoreverses: false)) {
+                        animationPhase = 3
+                    }
+                }
+            }
+            
+            private func dotOpacity(for index: Int) -> Double {
+                let phase = Double(animationPhase)
+                let offset = Double(index) / 3.0
+                let wave = sin((phase + offset) * .pi * 2)
+                return 0.3 + 0.7 * ((wave + 1) / 2)
+            }
+        }
+    }
+#endif
 
     /// Visual overlay that shows a border around the edges when the bell rings with border feature enabled.
     struct BellBorderOverlay: View {

--- a/macos/Sources/Ghostty/SurfaceView_UIKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_UIKit.swift
@@ -43,7 +43,10 @@ extension Ghostty {
         
         // The current search state. When non-nil, the search overlay should be shown.
         @Published var searchState: SearchState? = nil
-        
+
+        // The currently active key tables. Empty if no tables are active.
+        @Published var keyTables: [String] = []
+
         /// True when the surface is in readonly mode.
         @Published private(set) var readonly: Bool = false
         

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -250,6 +250,9 @@ pub const Action = union(Key) {
     /// key mode because other input may be ignored.
     key_sequence: KeySequence,
 
+    /// A key table has been activated or deactivated.
+    key_table: KeyTable,
+
     /// A terminal color was changed programmatically through things
     /// such as OSC 10/11.
     color_change: ColorChange,
@@ -371,6 +374,7 @@ pub const Action = union(Key) {
         float_window,
         secure_input,
         key_sequence,
+        key_table,
         color_change,
         reload_config,
         config_change,
@@ -707,6 +711,50 @@ pub const KeySequence = union(enum) {
         return switch (self) {
             .trigger => |t| .{ .active = true, .trigger = t.cval() },
             .end => .{ .active = false, .trigger = .{} },
+        };
+    }
+};
+
+pub const KeyTable = union(enum) {
+    activate: []const u8,
+    deactivate,
+    deactivate_all,
+
+    // Sync with: ghostty_action_key_table_tag_e
+    pub const Tag = enum(c_int) {
+        activate,
+        deactivate,
+        deactivate_all,
+    };
+
+    // Sync with: ghostty_action_key_table_u
+    pub const CValue = extern union {
+        activate: extern struct {
+            name: [*]const u8,
+            len: usize,
+        },
+    };
+
+    // Sync with: ghostty_action_key_table_s
+    pub const C = extern struct {
+        tag: Tag,
+        value: CValue,
+    };
+
+    pub fn cval(self: KeyTable) C {
+        return switch (self) {
+            .activate => |name| .{
+                .tag = .activate,
+                .value = .{ .activate = .{ .name = name.ptr, .len = name.len } },
+            },
+            .deactivate => .{
+                .tag = .deactivate,
+                .value = undefined,
+            },
+            .deactivate_all => .{
+                .tag = .deactivate_all,
+                .value = undefined,
+            },
         };
     }
 };

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -744,6 +744,7 @@ pub const Application = extern struct {
             .toggle_background_opacity,
             .cell_size,
             .key_sequence,
+            .key_table,
             .render_inspector,
             .renderer_health,
             .color_change,


### PR DESCRIPTION
Fixes #9963 (we'll open new issues to track GTK and other stuff)

This adds the apprt actions necessary for key tables to be shown visually, and adapts the macOS UI to show them.

## Demo

```
keybind = example/
keybind = example/ctrl+a=text:hello
keybind = example/ctrl+b>x=text:wow
keybind = example/ctrl+c=activate_key_table:another
keybind = example/escape=deactivate_key_table
keybind = ctrl+a=activate_key_table:example

keybind = another/
keybind = another/catch_all=deactivate_key_table
```

https://github.com/user-attachments/assets/75e94ec9-b52e-439d-b0ca-229ce533c656

**AI disclosure:** The SwiftUI view was written by AI, everything else was manual. 