### PR TITLE
build: fix pkgs on freebsd

### DIFF
--- a/pkg/highway/build.zig
+++ b/pkg/highway/build.zig
@@ -72,6 +72,11 @@ pub fn build(b: *std.Build) !void {
         "-fno-sanitize=undefined",
         "-fno-sanitize-trap=undefined",
     });
+
+    if (target.result.os.tag == .freebsd) {
+        try flags.append(b.allocator, "-fPIC");
+    }
+
     if (target.result.os.tag != .windows) {
         try flags.appendSlice(b.allocator, &.{
             "-fmath-errno",

--- a/pkg/simdutf/build.zig
+++ b/pkg/simdutf/build.zig
@@ -32,6 +32,10 @@ pub fn build(b: *std.Build) !void {
         "-fno-sanitize-trap=undefined",
     });
 
+    if (target.result.os.tag == .freebsd) {
+        try flags.append(b.allocator, "-fPIC");
+    }
+
     lib.addCSourceFiles(.{
         .flags = flags.items,
         .files = &.{


### PR DESCRIPTION
Enables position-independent code for `simdutf`/`libhighway` on FBSD.