### PR TITLE
fix(mouse): avoid inflated wheel events in mouse reporting mode

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -888,6 +888,18 @@ palette: Palette = .{},
 /// to all scrolling devices. Specifying a prefix was introduced in Ghostty
 /// 1.2.1.
 ///
+/// Note: when a terminal application enables mouse reporting and the incoming
+/// scroll is discrete (not precision), the discrete multiplier also affects how
+/// many wheel events Ghostty reports to the application. In that mode, Ghostty
+/// treats `discrete` as an event count (rounded to the nearest integer, minimum
+/// 1) and ignores the raw
+/// OS tick magnitude (some systems report values >1 per detent), to avoid
+/// sending unexpectedly many events (e.g. 3×3 => 9).
+///
+/// See:
+/// - https://github.com/ghostty-org/ghostty/discussions/8875
+/// - https://github.com/ghostty-org/ghostty/pull/8907
+///
 /// The value will be clamped to [0.01, 10,000]. Both of these are extreme
 /// and you're likely to have a bad experience if you set either extreme.
 ///


### PR DESCRIPTION
When an app enables mouse reporting, Ghostty reports wheel scrolling as repeated mouse button events (4/5 vertical, 6/7 horizontal). Previously, discrete scroll input could be expanded using a delta that already incorporated both OS-provided tick magnitude (sometimes >1 per detent) and Ghostty’s discrete multiplier, leading to too many events (e.g. 3×3 => 9) and overly-fast scrolling in TUIs.

Change discrete mouse reporting to emit a stable number of wheel events per scroll callback per axis: round(mouse_scroll_multiplier.discrete) (min 1), using only the sign of xoff/yoff and ignoring raw tick magnitude. Precision scroll reporting is unchanged.

Refs:
- https://github.com/ghostty-org/ghostty/discussions/8875
- https://github.com/ghostty-org/ghostty/pull/8907

---

Credit to @ownia for starting this work in PR #8907.  I did some things a bit differently though
- removed the config and made this more correct without the need to configure anything 
- made the discrete multiplier actually the number of events still, just not doubly applied

AI Disclosure: I used Codex for writing this code (Seeded with a bunch of context of the previous commits, PRs, issues, discussions and review comments related to mouse wheel scrolling). I have checked all the code for reasonableness (though I am a zig n00b).

I tested this on macOS Sequoia 15.7.3 using `codex --enable tui2` (wip - lots still to do there - not ready for real testing), which uses DEC mode 1006 (mouse SGR). Tested with trackpad and logitech m720 mouse. I don't have a native linux machine to check this on. I was previously seeing big jumps of 9 lines when using the mouse scroll wheel instead of 3 like most other terminals. After I saw this was being handle more correctly for that case (as well as the more simple output of `printf '\e[?1000h\e[?1006h'; cat -v`)

Hoping that this is reasonably simple enough to test and merge without stalling like the previous PR.
Feel free to ping me either here or the discord - happy to make changes as necessary.
@rockorager I wonder if you have perspective on this?