### PR TITLE
ci: update macOS builds to use Xcode 26.2

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -143,7 +143,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: XCode Select
-        run: sudo xcode-select -s /Applications/Xcode_26.0.app
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app
 
       - name: Xcode Version
         run: xcodebuild -version

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -232,7 +232,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: XCode Select
-        run: sudo xcode-select -s /Applications/Xcode_26.0.app
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app
 
       - name: Xcode Version
         run: xcodebuild -version
@@ -466,7 +466,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: XCode Select
-        run: sudo xcode-select -s /Applications/Xcode_26.0.app
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app
 
       - name: Xcode Version
         run: xcodebuild -version
@@ -650,7 +650,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: XCode Select
-        run: sudo xcode-select -s /Applications/Xcode_26.0.app
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app
 
       - name: Xcode Version
         run: xcodebuild -version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -456,7 +456,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Xcode Select
-        run: sudo xcode-select -s /Applications/Xcode_26.0.app
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app
 
       - name: Xcode Version
         run: xcodebuild -version
@@ -499,7 +499,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Xcode Select
-        run: sudo xcode-select -s /Applications/Xcode_26.0.app
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app
 
       - name: Xcode Version
         run: xcodebuild -version
@@ -764,7 +764,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Xcode Select
-        run: sudo xcode-select -s /Applications/Xcode_26.0.app
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app
 
       - name: Xcode Version
         run: xcodebuild -version


### PR DESCRIPTION
We were fixed on 26.0 previously.