### PR TITLE
GTK: UI for key sequences and tables

### DIFF
--- a/src/apprt/gtk.zig
+++ b/src/apprt/gtk.zig
@@ -10,4 +10,5 @@ pub const WeakRef = @import("gtk/weak_ref.zig").WeakRef;
 test {
     @import("std").testing.refAllDecls(@This());
     _ = @import("gtk/ext.zig");
+    _ = @import("gtk/key.zig");
 }

--- a/src/apprt/gtk/build/gresource.zig
+++ b/src/apprt/gtk/build/gresource.zig
@@ -44,6 +44,7 @@ pub const blueprints: []const Blueprint = &.{
     .{ .major = 1, .minor = 5, .name = "inspector-window" },
     .{ .major = 1, .minor = 2, .name = "resize-overlay" },
     .{ .major = 1, .minor = 2, .name = "search-overlay" },
+    .{ .major = 1, .minor = 2, .name = "key-state-overlay" },
     .{ .major = 1, .minor = 5, .name = "split-tree" },
     .{ .major = 1, .minor = 5, .name = "split-tree-split" },
     .{ .major = 1, .minor = 2, .name = "surface" },

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -669,6 +669,9 @@ pub const Application = extern struct {
 
             .inspector => return Action.controlInspector(target, value),
 
+            .key_sequence => return Action.keySequence(target, value),
+            .key_table => return Action.keyTable(target, value),
+
             .mouse_over_link => Action.mouseOverLink(target, value),
             .mouse_shape => Action.mouseShape(target, value),
             .mouse_visibility => Action.mouseVisibility(target, value),
@@ -743,8 +746,6 @@ pub const Application = extern struct {
             .toggle_visibility,
             .toggle_background_opacity,
             .cell_size,
-            .key_sequence,
-            .key_table,
             .render_inspector,
             .renderer_health,
             .color_change,
@@ -2657,6 +2658,36 @@ const Action = struct {
             .app => return false,
             .surface => |surface| {
                 return surface.rt_surface.gobj().commandFinished(value);
+            },
+        }
+    }
+
+    pub fn keySequence(target: apprt.Target, value: apprt.Action.Value(.key_sequence)) bool {
+        switch (target) {
+            .app => {
+                log.warn("key_sequence action to app is unexpected", .{});
+                return false;
+            },
+            .surface => |core| {
+                core.rt_surface.gobj().keySequenceAction(value) catch |err| {
+                    log.warn("error handling key_sequence action: {}", .{err});
+                };
+                return true;
+            },
+        }
+    }
+
+    pub fn keyTable(target: apprt.Target, value: apprt.Action.Value(.key_table)) bool {
+        switch (target) {
+            .app => {
+                log.warn("key_table action to app is unexpected", .{});
+                return false;
+            },
+            .surface => |core| {
+                core.rt_surface.gobj().keyTableAction(value) catch |err| {
+                    log.warn("error handling key_table action: {}", .{err});
+                };
+                return true;
             },
         }
     }

--- a/src/apprt/gtk/class/key_state_overlay.zig
+++ b/src/apprt/gtk/class/key_state_overlay.zig
@@ -1,0 +1,290 @@
+const std = @import("std");
+const adw = @import("adw");
+const glib = @import("glib");
+const gobject = @import("gobject");
+const gdk = @import("gdk");
+const gtk = @import("gtk");
+
+const gresource = @import("../build/gresource.zig");
+const Common = @import("../class.zig").Common;
+
+const log = std.log.scoped(.gtk_ghostty_key_state_overlay);
+
+/// An overlay that displays the current key table stack and pending key sequence.
+/// This helps users understand what key bindings are active and what keys they've
+/// pressed in a multi-key sequence.
+pub const KeyStateOverlay = extern struct {
+    const Self = @This();
+    parent_instance: Parent,
+    pub const Parent = adw.Bin;
+    pub const getGObjectType = gobject.ext.defineClass(Self, .{
+        .name = "GhosttyKeyStateOverlay",
+        .instanceInit = &init,
+        .classInit = &Class.init,
+        .parent_class = &Class.parent,
+        .private = .{ .Type = Private, .offset = &Private.offset },
+    });
+
+    pub const properties = struct {
+        pub const active = struct {
+            pub const name = "active";
+            const impl = gobject.ext.defineProperty(
+                name,
+                Self,
+                bool,
+                .{
+                    .default = false,
+                    .accessor = C.privateShallowFieldAccessor("active"),
+                },
+            );
+        };
+
+        pub const @"tables-text" = struct {
+            pub const name = "tables-text";
+            const impl = gobject.ext.defineProperty(
+                name,
+                Self,
+                ?[:0]const u8,
+                .{
+                    .default = null,
+                    .accessor = C.privateStringFieldAccessor("tables_text"),
+                },
+            );
+        };
+
+        pub const @"has-tables" = struct {
+            pub const name = "has-tables";
+            const impl = gobject.ext.defineProperty(
+                name,
+                Self,
+                bool,
+                .{
+                    .default = false,
+                    .accessor = gobject.ext.typedAccessor(
+                        Self,
+                        bool,
+                        .{ .getter = getHasTables },
+                    ),
+                },
+            );
+        };
+
+        pub const @"sequence-text" = struct {
+            pub const name = "sequence-text";
+            const impl = gobject.ext.defineProperty(
+                name,
+                Self,
+                ?[:0]const u8,
+                .{
+                    .default = null,
+                    .accessor = C.privateStringFieldAccessor("sequence_text"),
+                },
+            );
+        };
+
+        pub const @"has-sequence" = struct {
+            pub const name = "has-sequence";
+            const impl = gobject.ext.defineProperty(
+                name,
+                Self,
+                bool,
+                .{
+                    .default = false,
+                    .accessor = gobject.ext.typedAccessor(
+                        Self,
+                        bool,
+                        .{ .getter = getHasSequence },
+                    ),
+                },
+            );
+        };
+
+        pub const pending = struct {
+            pub const name = "pending";
+            const impl = gobject.ext.defineProperty(
+                name,
+                Self,
+                bool,
+                .{
+                    .default = false,
+                    .accessor = C.privateShallowFieldAccessor("pending"),
+                },
+            );
+        };
+
+        pub const @"valign-target" = struct {
+            pub const name = "valign-target";
+            const impl = gobject.ext.defineProperty(
+                name,
+                Self,
+                gtk.Align,
+                .{
+                    .default = .end,
+                    .accessor = C.privateShallowFieldAccessor("valign_target"),
+                },
+            );
+        };
+    };
+
+    const Private = struct {
+        /// Whether the overlay is active/visible.
+        active: bool = false,
+
+        /// The formatted key table stack text (e.g., "default › vim").
+        tables_text: ?[:0]const u8 = null,
+
+        /// The formatted key sequence text (e.g., "Ctrl+A B").
+        sequence_text: ?[:0]const u8 = null,
+
+        /// Whether we're waiting for more keys in a sequence.
+        pending: bool = false,
+
+        /// Target vertical alignment for the overlay.
+        valign_target: gtk.Align = .end,
+
+        pub var offset: c_int = 0;
+    };
+
+    fn init(self: *Self, _: *Class) callconv(.c) void {
+        gtk.Widget.initTemplate(self.as(gtk.Widget));
+
+        // Set dummy data for UI iteration
+        const priv = self.private();
+        priv.active = true;
+        priv.tables_text = glib.ext.dupeZ(u8, "default › vim");
+        priv.sequence_text = glib.ext.dupeZ(u8, "Ctrl+A");
+        priv.pending = true;
+
+        // Notify property changes so bindings update
+        const obj = self.as(gobject.Object);
+        obj.notifyByPspec(properties.active.impl.param_spec);
+        obj.notifyByPspec(properties.@"tables-text".impl.param_spec);
+        obj.notifyByPspec(properties.@"has-tables".impl.param_spec);
+        obj.notifyByPspec(properties.@"sequence-text".impl.param_spec);
+        obj.notifyByPspec(properties.@"has-sequence".impl.param_spec);
+        obj.notifyByPspec(properties.pending.impl.param_spec);
+    }
+
+    fn getHasTables(self: *Self) bool {
+        return self.private().tables_text != null;
+    }
+
+    fn getHasSequence(self: *Self) bool {
+        return self.private().sequence_text != null;
+    }
+
+    fn closureShowChevron(
+        _: *Self,
+        has_tables: bool,
+        has_sequence: bool,
+    ) callconv(.c) c_int {
+        return if (has_tables and has_sequence) 1 else 0;
+    }
+
+    //---------------------------------------------------------------
+    // Template callbacks
+
+    fn onDragEnd(
+        _: *gtk.GestureDrag,
+        _: f64,
+        offset_y: f64,
+        self: *Self,
+    ) callconv(.c) void {
+        // Key state overlay only moves between top-center and bottom-center.
+        // Horizontal alignment is always center.
+        const priv = self.private();
+        const widget = self.as(gtk.Widget);
+        const parent = widget.getParent() orelse return;
+
+        const parent_height: f64 = @floatFromInt(parent.getAllocatedHeight());
+        const self_height: f64 = @floatFromInt(widget.getAllocatedHeight());
+
+        const self_y: f64 = if (priv.valign_target == .start) 0 else parent_height - self_height;
+        const new_y = self_y + offset_y + (self_height / 2);
+
+        const new_valign: gtk.Align = if (new_y > parent_height / 2) .end else .start;
+
+        if (new_valign != priv.valign_target) {
+            priv.valign_target = new_valign;
+            self.as(gobject.Object).notifyByPspec(properties.@"valign-target".impl.param_spec);
+            self.as(gtk.Widget).queueResize();
+        }
+    }
+
+    //---------------------------------------------------------------
+    // Virtual methods
+
+    fn dispose(self: *Self) callconv(.c) void {
+        gtk.Widget.disposeTemplate(
+            self.as(gtk.Widget),
+            getGObjectType(),
+        );
+
+        gobject.Object.virtual_methods.dispose.call(
+            Class.parent,
+            self.as(Parent),
+        );
+    }
+
+    fn finalize(self: *Self) callconv(.c) void {
+        const priv = self.private();
+
+        if (priv.tables_text) |v| {
+            glib.free(@ptrCast(@constCast(v)));
+        }
+        if (priv.sequence_text) |v| {
+            glib.free(@ptrCast(@constCast(v)));
+        }
+
+        gobject.Object.virtual_methods.finalize.call(
+            Class.parent,
+            self.as(Parent),
+        );
+    }
+
+    const C = Common(Self, Private);
+    pub const as = C.as;
+    pub const ref = C.ref;
+    pub const unref = C.unref;
+    const private = C.private;
+
+    pub const Class = extern struct {
+        parent_class: Parent.Class,
+        var parent: *Parent.Class = undefined;
+        pub const Instance = Self;
+
+        fn init(class: *Class) callconv(.c) void {
+            gtk.Widget.Class.setTemplateFromResource(
+                class.as(gtk.Widget.Class),
+                comptime gresource.blueprint(.{
+                    .major = 1,
+                    .minor = 2,
+                    .name = "key-state-overlay",
+                }),
+            );
+
+            // Template Callbacks
+            class.bindTemplateCallback("on_drag_end", &onDragEnd);
+            class.bindTemplateCallback("show_chevron", &closureShowChevron);
+
+            // Properties
+            gobject.ext.registerProperties(class, &.{
+                properties.active.impl,
+                properties.@"tables-text".impl,
+                properties.@"has-tables".impl,
+                properties.@"sequence-text".impl,
+                properties.@"has-sequence".impl,
+                properties.pending.impl,
+                properties.@"valign-target".impl,
+            });
+
+            // Virtual methods
+            gobject.Object.virtual_methods.dispose.implement(class, &dispose);
+            gobject.Object.virtual_methods.finalize.implement(class, &finalize);
+        }
+
+        pub const as = C.Class.as;
+        pub const bindTemplateChildPrivate = C.Class.bindTemplateChildPrivate;
+        pub const bindTemplateCallback = C.Class.bindTemplateCallback;
+    };
+};

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -832,6 +832,10 @@ pub const Surface = extern struct {
         const priv = self.private();
         const alloc = Application.default().allocator();
 
+        self.as(gobject.Object).freezeNotify();
+        defer self.as(gobject.Object).thawNotify();
+        self.as(gobject.Object).notifyByPspec(properties.@"key-sequence".impl.param_spec);
+
         switch (value) {
             .trigger => |trigger| {
                 // Convert the trigger to a human-readable label
@@ -864,6 +868,10 @@ pub const Surface = extern struct {
     ) Allocator.Error!void {
         const priv = self.private();
         const alloc = Application.default().allocator();
+
+        self.as(gobject.Object).freezeNotify();
+        defer self.as(gobject.Object).thawNotify();
+        self.as(gobject.Object).notifyByPspec(properties.@"key-table".impl.param_spec);
 
         switch (value) {
             .activate => |name| {

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -26,6 +26,7 @@ const Application = @import("application.zig").Application;
 const Config = @import("config.zig").Config;
 const ResizeOverlay = @import("resize_overlay.zig").ResizeOverlay;
 const SearchOverlay = @import("search_overlay.zig").SearchOverlay;
+const KeyStateOverlay = @import("key_state_overlay.zig").KeyStateOverlay;
 const ChildExited = @import("surface_child_exited.zig").SurfaceChildExited;
 const ClipboardConfirmationDialog = @import("clipboard_confirmation_dialog.zig").ClipboardConfirmationDialog;
 const TitleDialog = @import("surface_title_dialog.zig").SurfaceTitleDialog;
@@ -552,6 +553,9 @@ pub const Surface = extern struct {
 
         /// The search overlay
         search_overlay: *SearchOverlay,
+
+        /// The key state overlay
+        key_state_overlay: *KeyStateOverlay,
 
         /// The apprt Surface.
         rt_surface: ApprtSurface = undefined,
@@ -3308,6 +3312,7 @@ pub const Surface = extern struct {
         fn init(class: *Class) callconv(.c) void {
             gobject.ext.ensureType(ResizeOverlay);
             gobject.ext.ensureType(SearchOverlay);
+            gobject.ext.ensureType(KeyStateOverlay);
             gobject.ext.ensureType(ChildExited);
             gtk.Widget.Class.setTemplateFromResource(
                 class.as(gtk.Widget.Class),
@@ -3328,6 +3333,7 @@ pub const Surface = extern struct {
             class.bindTemplateChildPrivate("progress_bar_overlay", .{});
             class.bindTemplateChildPrivate("resize_overlay", .{});
             class.bindTemplateChildPrivate("search_overlay", .{});
+            class.bindTemplateChildPrivate("key_state_overlay", .{});
             class.bindTemplateChildPrivate("terminal_page", .{});
             class.bindTemplateChildPrivate("drop_target", .{});
             class.bindTemplateChildPrivate("im_context", .{});

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -361,6 +361,44 @@ pub const Surface = extern struct {
                 },
             );
         };
+
+        pub const @"key-sequence" = struct {
+            pub const name = "key-sequence";
+            const impl = gobject.ext.defineProperty(
+                name,
+                Self,
+                ?*ext.StringList,
+                .{
+                    .accessor = gobject.ext.typedAccessor(
+                        Self,
+                        ?*ext.StringList,
+                        .{
+                            .getter = getKeySequence,
+                            .getter_transfer = .full,
+                        },
+                    ),
+                },
+            );
+        };
+
+        pub const @"key-table" = struct {
+            pub const name = "key-table";
+            const impl = gobject.ext.defineProperty(
+                name,
+                Self,
+                ?*ext.StringList,
+                .{
+                    .accessor = gobject.ext.typedAccessor(
+                        Self,
+                        ?*ext.StringList,
+                        .{
+                            .getter = getKeyTable,
+                            .getter_transfer = .full,
+                        },
+                    ),
+                },
+            );
+        };
     };
 
     pub const signals = struct {
@@ -1949,6 +1987,20 @@ pub const Surface = extern struct {
         self.as(gobject.Object).notifyByPspec(properties.@"default-size".impl.param_spec);
     }
 
+    /// Get the key sequence list. Full transfer.
+    fn getKeySequence(self: *Self) ?*ext.StringList {
+        const priv = self.private();
+        const alloc = Application.default().allocator();
+        return ext.StringList.create(alloc, priv.key_sequence.items) catch null;
+    }
+
+    /// Get the key table list. Full transfer.
+    fn getKeyTable(self: *Self) ?*ext.StringList {
+        const priv = self.private();
+        const alloc = Application.default().allocator();
+        return ext.StringList.create(alloc, priv.key_tables.items) catch null;
+    }
+
     /// Return the min size, if set.
     pub fn getMinSize(self: *Self) ?*Size {
         const priv = self.private();
@@ -3385,6 +3437,8 @@ pub const Surface = extern struct {
                 properties.@"error".impl,
                 properties.@"font-size-request".impl,
                 properties.focused.impl,
+                properties.@"key-sequence".impl,
+                properties.@"key-table".impl,
                 properties.@"min-size".impl,
                 properties.@"mouse-shape".impl,
                 properties.@"mouse-hidden".impl,

--- a/src/apprt/gtk/css/style.css
+++ b/src/apprt/gtk/css/style.css
@@ -47,6 +47,18 @@ label.url-overlay.right {
 }
 
 /*
+ * GhosttySurface key state overlay
+ */
+.key-state-overlay {
+  padding: 6px 10px;
+  margin: 8px;
+  border-radius: 8px;
+  outline-style: solid;
+  outline-color: #555555;
+  outline-width: 1px;
+}
+
+/*
  * GhosttySurface resize overlay
  */
 label.resize-overlay {

--- a/src/apprt/gtk/ext.zig
+++ b/src/apprt/gtk/ext.zig
@@ -12,6 +12,8 @@ const gobject = @import("gobject");
 const gtk = @import("gtk");
 
 pub const actions = @import("ext/actions.zig");
+const slice = @import("ext/slice.zig");
+pub const StringList = slice.StringList;
 
 /// Wrapper around `gobject.boxedCopy` to copy a boxed type `T`.
 pub fn boxedCopy(comptime T: type, ptr: *const T) *T {
@@ -64,4 +66,5 @@ pub fn gValueHolds(value_: ?*const gobject.Value, g_type: gobject.Type) bool {
 
 test {
     _ = actions;
+    _ = slice;
 }

--- a/src/apprt/gtk/ext/slice.zig
+++ b/src/apprt/gtk/ext/slice.zig
@@ -36,6 +36,11 @@ pub const StringList = struct {
         alloc.destroy(self);
     }
 
+    /// Returns the general-purpose allocator used by this StringList.
+    pub fn allocator(self: *const StringList) Allocator {
+        return self.arena.child_allocator;
+    }
+
     pub const getGObjectType = gobject.ext.defineBoxed(
         StringList,
         .{

--- a/src/apprt/gtk/ext/slice.zig
+++ b/src/apprt/gtk/ext/slice.zig
@@ -1,0 +1,106 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const ArenaAllocator = std.heap.ArenaAllocator;
+const glib = @import("glib");
+const gobject = @import("gobject");
+
+/// A boxed type that holds a list of string slices.
+pub const StringList = struct {
+    arena: ArenaAllocator,
+    strings: []const [:0]const u8,
+
+    pub fn create(
+        alloc: Allocator,
+        strings: []const [:0]const u8,
+    ) Allocator.Error!*StringList {
+        var arena: ArenaAllocator = .init(alloc);
+        errdefer arena.deinit();
+        const arena_alloc = arena.allocator();
+        var stored = try arena_alloc.alloc([:0]const u8, strings.len);
+        for (strings, 0..) |s, i| stored[i] = try arena_alloc.dupeZ(u8, s);
+
+        const ptr = try alloc.create(StringList);
+        errdefer alloc.destroy(ptr);
+        ptr.* = .{ .arena = arena, .strings = stored };
+
+        return ptr;
+    }
+
+    pub fn deinit(self: *StringList) void {
+        self.arena.deinit();
+    }
+
+    pub fn destroy(self: *StringList) void {
+        const alloc = self.arena.child_allocator;
+        self.deinit();
+        alloc.destroy(self);
+    }
+
+    pub const getGObjectType = gobject.ext.defineBoxed(
+        StringList,
+        .{
+            .name = "GhosttyStringList",
+            .funcs = .{
+                .copy = &struct {
+                    fn copy(self: *StringList) callconv(.c) *StringList {
+                        return StringList.create(
+                            self.arena.child_allocator,
+                            self.strings,
+                        ) catch @panic("OOM");
+                    }
+                }.copy,
+                .free = &struct {
+                    fn free(self: *StringList) callconv(.c) void {
+                        self.destroy();
+                    }
+                }.free,
+            },
+        },
+    );
+};
+
+test "StringList create and destroy" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const input: []const [:0]const u8 = &.{ "hello", "world" };
+    const list = try StringList.create(alloc, input);
+    defer list.destroy();
+
+    try testing.expectEqual(@as(usize, 2), list.strings.len);
+    try testing.expectEqualStrings("hello", list.strings[0]);
+    try testing.expectEqualStrings("world", list.strings[1]);
+}
+
+test "StringList create empty list" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const input: []const [:0]const u8 = &.{};
+    const list = try StringList.create(alloc, input);
+    defer list.destroy();
+
+    try testing.expectEqual(@as(usize, 0), list.strings.len);
+}
+
+test "StringList boxedCopy and boxedFree" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const input: []const [:0]const u8 = &.{ "foo", "bar", "baz" };
+    const original = try StringList.create(alloc, input);
+    defer original.destroy();
+
+    const copied: *StringList = @ptrCast(@alignCast(gobject.boxedCopy(
+        StringList.getGObjectType(),
+        original,
+    )));
+    defer gobject.boxedFree(StringList.getGObjectType(), copied);
+
+    try testing.expectEqual(@as(usize, 3), copied.strings.len);
+    try testing.expectEqualStrings("foo", copied.strings[0]);
+    try testing.expectEqualStrings("bar", copied.strings[1]);
+    try testing.expectEqualStrings("baz", copied.strings[2]);
+
+    try testing.expect(original.strings.ptr != copied.strings.ptr);
+}

--- a/src/apprt/gtk/key.zig
+++ b/src/apprt/gtk/key.zig
@@ -233,6 +233,70 @@ pub fn keyvalFromKey(key: input.Key) ?c_uint {
     }
 }
 
+/// Converts a trigger to a human-readable label for display in UI.
+///
+/// Uses GTK accelerator-style formatting (e.g., "Ctrl+Shift+A").
+/// Returns false if the trigger cannot be formatted (e.g., catch_all).
+pub fn labelFromTrigger(
+    writer: *std.Io.Writer,
+    trigger: input.Binding.Trigger,
+) std.Io.Writer.Error!bool {
+    // Modifiers first, using human-readable format
+    if (trigger.mods.super) try writer.writeAll("Super+");
+    if (trigger.mods.ctrl) try writer.writeAll("Ctrl+");
+    if (trigger.mods.alt) try writer.writeAll("Alt+");
+    if (trigger.mods.shift) try writer.writeAll("Shift+");
+
+    // Write the key
+    return writeTriggerKeyLabel(writer, trigger);
+}
+
+/// Writes the key portion of a trigger in human-readable format.
+fn writeTriggerKeyLabel(
+    writer: *std.Io.Writer,
+    trigger: input.Binding.Trigger,
+) error{WriteFailed}!bool {
+    switch (trigger.key) {
+        .physical => |k| {
+            const keyval = keyvalFromKey(k) orelse return false;
+            const name = gdk.keyvalName(keyval) orelse return false;
+            // Capitalize the first letter for nicer display
+            const span = std.mem.span(name);
+            if (span.len > 0) {
+                if (span[0] >= 'a' and span[0] <= 'z') {
+                    try writer.writeByte(span[0] - 'a' + 'A');
+                    if (span.len > 1) try writer.writeAll(span[1..]);
+                } else {
+                    try writer.writeAll(span);
+                }
+            }
+        },
+
+        .unicode => |cp| {
+            // Try to get a nice name from GDK first
+            if (gdk.keyvalName(cp)) |name| {
+                const span = std.mem.span(name);
+                if (span.len > 0) {
+                    // Capitalize the first letter for nicer display
+                    if (span[0] >= 'a' and span[0] <= 'z') {
+                        try writer.writeByte(span[0] - 'a' + 'A');
+                        if (span.len > 1) try writer.writeAll(span[1..]);
+                    } else {
+                        try writer.writeAll(span);
+                    }
+                }
+            } else {
+                // Fall back to printing the character
+                try writer.print("{u}", .{cp});
+            }
+        },
+
+        .catch_all => return false,
+    }
+
+    return true;
+}
+
 test "accelFromTrigger" {
     const testing = std.testing;
     var buf: [256]u8 = undefined;
@@ -261,6 +325,64 @@ test "xdgShortcutFromTrigger" {
         .mods = .{ .ctrl = true, .alt = true, .super = true, .shift = true },
         .key = .{ .unicode = 92 },
     })).?);
+}
+
+test "labelFromTrigger" {
+    const testing = std.testing;
+
+    // Simple unicode key with modifier
+    {
+        var buf: std.Io.Writer.Allocating = .init(testing.allocator);
+        defer buf.deinit();
+        try testing.expect(try labelFromTrigger(&buf.writer, .{
+            .mods = .{ .super = true },
+            .key = .{ .unicode = 'q' },
+        }));
+        try testing.expectEqualStrings("Super+Q", buf.written());
+    }
+
+    // Multiple modifiers
+    {
+        var buf: std.Io.Writer.Allocating = .init(testing.allocator);
+        defer buf.deinit();
+        try testing.expect(try labelFromTrigger(&buf.writer, .{
+            .mods = .{ .ctrl = true, .alt = true, .super = true, .shift = true },
+            .key = .{ .unicode = 92 },
+        }));
+        try testing.expectEqualStrings("Super+Ctrl+Alt+Shift+Backslash", buf.written());
+    }
+
+    // Physical key
+    {
+        var buf: std.Io.Writer.Allocating = .init(testing.allocator);
+        defer buf.deinit();
+        try testing.expect(try labelFromTrigger(&buf.writer, .{
+            .mods = .{ .ctrl = true },
+            .key = .{ .physical = .key_a },
+        }));
+        try testing.expectEqualStrings("Ctrl+A", buf.written());
+    }
+
+    // No modifiers
+    {
+        var buf: std.Io.Writer.Allocating = .init(testing.allocator);
+        defer buf.deinit();
+        try testing.expect(try labelFromTrigger(&buf.writer, .{
+            .mods = .{},
+            .key = .{ .physical = .escape },
+        }));
+        try testing.expectEqualStrings("Escape", buf.written());
+    }
+
+    // catch_all returns false
+    {
+        var buf: std.Io.Writer.Allocating = .init(testing.allocator);
+        defer buf.deinit();
+        try testing.expect(!try labelFromTrigger(&buf.writer, .{
+            .mods = .{},
+            .key = .catch_all,
+        }));
+    }
 }
 
 /// A raw entry in the keymap. Our keymap contains mappings between

--- a/src/apprt/gtk/ui/1.2/key-state-overlay.blp
+++ b/src/apprt/gtk/ui/1.2/key-state-overlay.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 template $GhosttyKeyStateOverlay: Adw.Bin {
-  visible: bind template.active;
+  visible: bind $has_state(template.has-tables, template.has-sequence) as <bool>;
   valign-target: end;
   halign: center;
   valign: bind template.valign-target;
@@ -30,7 +30,7 @@ template $GhosttyKeyStateOverlay: Adw.Bin {
 
       Label tables_label {
         visible: bind template.has-tables;
-        label: bind template.tables-text;
+        label: bind $tables_text(template.tables) as <string>;
         xalign: 0.0;
       }
 
@@ -45,13 +45,13 @@ template $GhosttyKeyStateOverlay: Adw.Bin {
 
       Label sequence_label {
         visible: bind template.has-sequence;
-        label: bind template.sequence-text;
+        label: bind $sequence_text(template.sequence) as <string>;
         xalign: 0.0;
       }
 
       Spinner pending_spinner {
-        visible: bind template.pending;
-        spinning: bind template.pending;
+        visible: bind template.has-sequence;
+        spinning: bind template.has-sequence;
       }
     }
   }

--- a/src/apprt/gtk/ui/1.2/key-state-overlay.blp
+++ b/src/apprt/gtk/ui/1.2/key-state-overlay.blp
@@ -1,0 +1,58 @@
+using Gtk 4.0;
+using Adw 1;
+
+template $GhosttyKeyStateOverlay: Adw.Bin {
+  visible: bind template.active;
+  valign-target: end;
+  halign: center;
+  valign: bind template.valign-target;
+
+  GestureDrag {
+    button: 1;
+    propagation-phase: capture;
+    drag-end => $on_drag_end();
+  }
+
+  Adw.Bin {
+    Box container {
+      styles [
+        "background",
+        "key-state-overlay",
+      ]
+
+      orientation: horizontal;
+      spacing: 6;
+
+      Image {
+        icon-name: "input-keyboard-symbolic";
+        pixel-size: 16;
+      }
+
+      Label tables_label {
+        visible: bind template.has-tables;
+        label: bind template.tables-text;
+        xalign: 0.0;
+      }
+
+      Label chevron_label {
+        visible: bind $show_chevron(template.has-tables, template.has-sequence) as <bool>;
+        label: "›";
+
+        styles [
+          "dim-label",
+        ]
+      }
+
+      Label sequence_label {
+        visible: bind template.has-sequence;
+        label: bind template.sequence-text;
+        xalign: 0.0;
+      }
+
+      Spinner pending_spinner {
+        visible: bind template.pending;
+        spinning: bind template.pending;
+      }
+    }
+  }
+}

--- a/src/apprt/gtk/ui/1.2/surface.blp
+++ b/src/apprt/gtk/ui/1.2/surface.blp
@@ -156,7 +156,10 @@ Overlay terminal_page {
   }
 
   [overlay]
-  $GhosttyKeyStateOverlay key_state_overlay {}
+  $GhosttyKeyStateOverlay key_state_overlay {
+    tables: bind template.key-table;
+    sequence: bind template.key-sequence;
+  }
 
   [overlay]
   // Apply unfocused-split-fill and unfocused-split-opacity to current surface

--- a/src/apprt/gtk/ui/1.2/surface.blp
+++ b/src/apprt/gtk/ui/1.2/surface.blp
@@ -156,6 +156,9 @@ Overlay terminal_page {
   }
 
   [overlay]
+  $GhosttyKeyStateOverlay key_state_overlay {}
+
+  [overlay]
   // Apply unfocused-split-fill and unfocused-split-opacity to current surface
   // this is only applied when a tab has more than one surface
   Revealer {

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -72,7 +72,16 @@
    fun:gdk_surface_handle_event
    ...
 }
-
+{
+   GTK CSS Node Validation
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   fun:gtk_css_node_validate_internal
+   fun:gtk_css_node_validate
+   ...
+}
 {
    GTK CSS Provider Leak
    Memcheck:Leak
@@ -196,8 +205,44 @@
    fun:svga_context_flush
   ...
 }
-
 {
+   SVGA Stuff
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:calloc
+   fun:svga_create_surface_view
+   fun:svga_set_framebuffer_state
+   fun:st_update_framebuffer_state
+   fun:st_Clear
+   fun:gsk_gpu_render_pass_op_gl_command
+   ...
+}
+{
+   GTK Icon
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:*alloc
+   ...
+   fun:gtk_icon_theme_set_display
+   fun:gtk_icon_theme_get_for_display
+   ...
+}
+{
+   GDK Wayland Connection
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   fun:wl_closure_init
+   fun:wl_connection_demarshal
+   fun:wl_display_read_events
+   fun:gdk_wayland_poll_source_check
+   fun:g_main_context_check_unlocked
+   fun:g_main_context_iterate_unlocked.isra.0
+   fun:g_main_context_iteration
+   ...
+}
+{
+
    GSK Renderer GPU Stuff
    Memcheck:Leak
    match-leak-kinds: possible
@@ -295,6 +340,21 @@
    fun:g_main_context_dispatch_unlocked
    fun:g_main_context_iterate_unlocked.isra.0
    fun:g_main_context_iteration
+   ...
+}
+{
+   GSK More Forms
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:gsk_gl_device_use_program
+   fun:gsk_gl_frame_use_program
+   fun:gsk_gpu_shader_op_gl_command_n
+   fun:gsk_gpu_render_pass_op_gl_command
+   fun:gsk_gl_frame_submit
+   fun:gsk_gpu_renderer_render_texture
+   fun:gsk_renderer_render_texture
+   fun:render_contents
    ...
 }
 {


### PR DESCRIPTION
Fixes #2127 

This adds a UI similar to macOS to show the current state of key sequences and/or key tables.

https://github.com/user-attachments/assets/4399d2af-a88c-4b70-922b-7727dc4d2053

**AI disclosure:** AI was used for various things, but I did write most of the code myself, especially around the memory management of properties since agents can't get that quite right yet. 😄 