### PR TITLE
Invalid key sequence does not encode if a `catch_all` has `ignore`

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1521,6 +1521,11 @@ class: ?[:0]const u8 = null,
 ///     specifically output that key (e.g. `ctrl+a>ctrl+a=text:foo`) or
 ///     press an unbound key which will send both keys to the program.
 ///
+///   * If an unbound key is pressed during a sequence and a `catch_all`
+///     binding exists that would `ignore` the input, the entire sequence
+///     is dropped and nothing happens. Otherwise, the entire sequence is
+///     encoded and sent to the running program as if no keybind existed.
+///
 ///   * If a prefix in a sequence is previously bound, the sequence will
 ///     override the previous binding. For example, if `ctrl+a` is bound to
 ///     `new_window` and `ctrl+a>n` is bound to `new_tab`, pressing `ctrl+a`


### PR DESCRIPTION
This adds some new special case handling for key sequences when an unbound keyboard input is received. If the current keybinding set scope (i.e. active tables) has a `catch_all` binding that would `ignore` input, then the entire key sequence is dropped.

Normally, when an unbound key sequence is received, Ghostty encodes it and sends it to the running program. 

This special behavior is useful for things like Vim mode which have `g>g` to scroll to top, and a `catch_all=ignore` to drop all other input. If the user presses `g>h` (unbound), you don't want `gh` to show up in your  terminal input, because the `catch_all=ignore` indicates that the user wants that mode to drop all unbound input.