### PR TITLE
macOS: `command-palette-entry` shows up in command palette

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -454,6 +454,12 @@ typedef struct {
   size_t len;
 } ghostty_config_color_list_s;
 
+// config.RepeatableCommand
+typedef struct {
+  const ghostty_command_s* commands;
+  size_t len;
+} ghostty_config_command_list_s;
+
 // config.Palette
 typedef struct {
   ghostty_config_color_s colors[256];

--- a/macos/Ghostty.xcodeproj/project.pbxproj
+++ b/macos/Ghostty.xcodeproj/project.pbxproj
@@ -137,7 +137,6 @@
 				Features/Update/UpdateSimulator.swift,
 				Features/Update/UpdateViewModel.swift,
 				"Ghostty/FullscreenMode+Extension.swift",
-				Ghostty/Ghostty.Command.swift,
 				Ghostty/Ghostty.Error.swift,
 				Ghostty/Ghostty.Event.swift,
 				Ghostty/Ghostty.Input.swift,

--- a/macos/Sources/Features/Command Palette/TerminalCommandPalette.swift
+++ b/macos/Sources/Features/Command Palette/TerminalCommandPalette.swift
@@ -64,7 +64,7 @@ struct TerminalCommandPaletteView: View {
         // Sort the rest. We replace ":" with a character that sorts before space
         // so that "Foo:" sorts before "Foo Bar:". Use sortKey as a tie-breaker
         // for stable ordering when titles are equal.
-        options.append(contentsOf: (jumpOptions + terminalOptions).sorted { a, b in
+        options.append(contentsOf: (jumpOptions + terminalOptions + customEntries).sorted { a, b in
             let aNormalized = a.title.replacingOccurrences(of: ":", with: "\t")
             let bNormalized = b.title.replacingOccurrences(of: ":", with: "\t")
             let comparison = aNormalized.localizedCaseInsensitiveCompare(bNormalized)
@@ -132,6 +132,19 @@ struct TerminalCommandPaletteView: View {
             }
         } catch {
             return []
+        }
+    }
+
+    /// Custom commands from the command-palette-entry configuration.
+    private var customEntries: [CommandOption] {
+        guard let appDelegate = NSApp.delegate as? AppDelegate else { return [] }
+        return appDelegate.ghostty.config.commandPaletteEntries.map { c in
+            CommandOption(
+                title: c.title,
+                description: c.description
+            ) {
+                onAction(c.action)
+            }
         }
     }
 

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -622,6 +622,16 @@ extension Ghostty {
             let str = String(cString: ptr)
             return Scrollbar(rawValue: str) ?? defaultValue
         }
+
+        var commandPaletteEntries: [Ghostty.Command] {
+            guard let config = self.config else { return [] }
+            var v: ghostty_config_command_list_s = .init()
+            let key = "command-palette-entry"
+            guard ghostty_config_get(config, &v, key, UInt(key.lengthOfBytes(using: .utf8))) else { return [] }
+            guard v.len > 0 else { return [] }
+            let buffer = UnsafeBufferPointer(start: v.commands, count: v.len)
+            return buffer.map { Ghostty.Command(cValue: $0) }
+        }
     }
 }
 

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -43,13 +43,34 @@ pub const Command = struct {
         return true;
     }
 
-    /// Convert this command to a C struct.
+    /// Convert this command to a C struct at comptime.
     pub fn comptimeCval(self: Command) C {
         assert(@inComptime());
 
         return .{
             .action_key = @tagName(self.action),
             .action = std.fmt.comptimePrint("{f}", .{self.action}),
+            .title = self.title,
+            .description = self.description,
+        };
+    }
+
+    /// Convert this command to a C struct at runtime.
+    ///
+    /// This shares memory with the original command.
+    ///
+    /// The action string is allocated using the provided allocator. You can
+    /// free the slice directly if you need to but we recommend an arena
+    /// for this.
+    pub fn cval(self: Command, alloc: Allocator) Allocator.Error!C {
+        var buf: std.Io.Writer.Allocating = .init(alloc);
+        defer buf.deinit();
+        self.action.format(&buf.writer) catch return error.OutOfMemory;
+        const action = try buf.toOwnedSliceSentinel(0);
+
+        return .{
+            .action_key = @tagName(self.action),
+            .action = action.ptr,
             .title = self.title,
             .description = self.description,
         };


### PR DESCRIPTION
Fixes #7158

This has worked on GTK for awhile. This exposes custom command palette entries to the macOS app now. 