### PR TITLE
terminal: search will re-scroll to navigate to a single match

### DIFF
--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -3821,6 +3821,15 @@ pub const PageIterator = struct {
         pub fn fullPage(self: Chunk) bool {
             return self.start == 0 and self.end == self.node.data.size.rows;
         }
+
+        /// Returns true if this chunk overlaps with the given other chunk
+        /// in any way.
+        pub fn overlaps(self: Chunk, other: Chunk) bool {
+            if (self.node != other.node) return false;
+            if (self.end <= other.start) return false;
+            if (self.start >= other.end) return false;
+            return true;
+        }
     };
 };
 


### PR DESCRIPTION
Fixes #9958
Replaces #9989

This changes the search navigation logic to always scroll if there is a selected search result so long as the search result isn't already within the viewport.