### PR TITLE
fix(iOS): fix iOS app startup failure

### DIFF
--- a/macos/Sources/App/iOS/iOSApp.swift
+++ b/macos/Sources/App/iOS/iOSApp.swift
@@ -1,8 +1,16 @@
 import SwiftUI
+import GhosttyKit
 
 @main
 struct Ghostty_iOSApp: App {
-    @StateObject private var ghostty_app = Ghostty.App()
+    @StateObject private var ghostty_app: Ghostty.App
+
+    init() {
+        if ghostty_init(UInt(CommandLine.argc), CommandLine.unsafeArgv) != GHOSTTY_SUCCESS {
+            preconditionFailure("Initialize ghostty backend failed")
+        }
+        _ghostty_app = StateObject(wrappedValue: Ghostty.App())
+    }
 
     var body: some Scene {
         WindowGroup {


### PR DESCRIPTION
Fixes #7643

This commit address the issue with 3 minor fixes:
1. Initialize ghostty lib before app start, or global allocator will be null.
2. `addSublayer` should be called on CALayer object, which is the property 'layer' of UIView
3. According to apple's [document](https://developer.apple.com/documentation/metal/mtlstoragemode/managed?language=objc), managed storage mode is not supported by iOS. So always use shared mode.

FYI, another [fix](https://github.com/mitchellh/libxev/pull/204) in libxev is also required to make iOS app work.