### PR TITLE
Only use macOS 26.0 workarounds on macOS 26.0

### DIFF
--- a/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
@@ -322,7 +322,8 @@ extension TitlebarTabsTahoeTerminalWindow {
             } else {
                 // 1x1.gif strikes again! For real: if we render a zero-sized
                 // view here then the toolbar just disappears our view. I don't
-                // know. This appears fixed in 26.1 Beta but keep it safe for 26.0.
+                // know. On macOS 26.1+ the view no longer disappears, but the
+                // toolbar still logs an ambiguous content size warning.
                 Color.clear.frame(width: 1, height: 1)
             }
         }


### PR DESCRIPTION
Following up on my comment here about ripping out the NSScrollPocket frame change observer in SurfaceScrollView once it's no longer needed: https://github.com/ghostty-org/ghostty/pull/9446#issuecomment-3505314976

I tested the full macOS {26.0, 26.1, 26.2} times Xcode {26.0, 26.1, 26.2} matrix, and the fix was actually on the macOS side, i.e., the workaround is always needed on macOS 26.0 and never on macOS 26.1+, regardless of Xcode version. So if we want to avoid this kludge when it's not needed, we have to use `#available` predicates rather than removing the code outright.

I'll let maintainers judge whether the juice is worth the squeeze.

I also looked into the other 26.0-only workaround, pertaining to the window title in the tabs titlebar, but I found that even though the behavior with an empty view is OK on 26.1+, a warning about ambiguous content size is still logged, so I figured this should be left as-is. I updated the comment accordingly.