### PR TITLE
deps: update z2d to v0.10.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -21,8 +21,8 @@
         },
         .z2d = .{
             // vancluever/z2d
-            .url = "https://deps.files.ghostty.org/z2d-0.9.0-j5P_Hu-WFgA_JEfRpiFss6gdvcvS47cgOc0Via2eKD_T.tar.gz",
-            .hash = "z2d-0.9.0-j5P_Hu-WFgA_JEfRpiFss6gdvcvS47cgOc0Via2eKD_T",
+            .url = "https://github.com/vancluever/z2d/archive/refs/tags/v0.10.0.tar.gz",
+            .hash = "z2d-0.10.0-j5P_Hu-6FgBsZNgwphIqh17jDnj8_yPtD8yzjO6PpHRQ",
             .lazy = true,
         },
         .zig_objc = .{

--- a/build.zig.zon.json
+++ b/build.zig.zon.json
@@ -139,10 +139,10 @@
     "url": "https://deps.files.ghostty.org/wuffs-122037b39d577ec2db3fd7b2130e7b69ef6cc1807d68607a7c232c958315d381b5cd.tar.gz",
     "hash": "sha256-nkzSCr6W5sTG7enDBXEIhgEm574uLD41UVR2wlC+HBM="
   },
-  "z2d-0.9.0-j5P_Hu-WFgA_JEfRpiFss6gdvcvS47cgOc0Via2eKD_T": {
+  "z2d-0.10.0-j5P_Hu-6FgBsZNgwphIqh17jDnj8_yPtD8yzjO6PpHRQ": {
     "name": "z2d",
-    "url": "https://deps.files.ghostty.org/z2d-0.9.0-j5P_Hu-WFgA_JEfRpiFss6gdvcvS47cgOc0Via2eKD_T.tar.gz",
-    "hash": "sha256-+QqCRoXwrFA1/l+oWvYVyAVebGQitAFQNhi9U3EVrxA="
+    "url": "https://github.com/vancluever/z2d/archive/refs/tags/v0.10.0.tar.gz",
+    "hash": "sha256-afIdou/V7gk3/lXE0J5Ir8T7L5GgHvFnyMJ1rgRnl/c="
   },
   "zf-0.10.3-OIRy8RuJAACKA3Lohoumrt85nRbHwbpMcUaLES8vxDnh": {
     "name": "zf",

--- a/build.zig.zon.nix
+++ b/build.zig.zon.nix
@@ -307,11 +307,11 @@ in
       };
     }
     {
-      name = "z2d-0.9.0-j5P_Hu-WFgA_JEfRpiFss6gdvcvS47cgOc0Via2eKD_T";
+      name = "z2d-0.10.0-j5P_Hu-6FgBsZNgwphIqh17jDnj8_yPtD8yzjO6PpHRQ";
       path = fetchZigArtifact {
         name = "z2d";
-        url = "https://deps.files.ghostty.org/z2d-0.9.0-j5P_Hu-WFgA_JEfRpiFss6gdvcvS47cgOc0Via2eKD_T.tar.gz";
-        hash = "sha256-+QqCRoXwrFA1/l+oWvYVyAVebGQitAFQNhi9U3EVrxA=";
+        url = "https://github.com/vancluever/z2d/archive/refs/tags/v0.10.0.tar.gz";
+        hash = "sha256-afIdou/V7gk3/lXE0J5Ir8T7L5GgHvFnyMJ1rgRnl/c=";
       };
     }
     {

--- a/build.zig.zon.txt
+++ b/build.zig.zon.txt
@@ -26,10 +26,10 @@ https://deps.files.ghostty.org/vaxis-7dbb9fd3122e4ffad262dd7c151d80d863b68558.ta
 https://deps.files.ghostty.org/wayland-9cb3d7aa9dc995ffafdbdef7ab86a949d0fb0e7d.tar.gz
 https://deps.files.ghostty.org/wayland-protocols-258d8f88f2c8c25a830c6316f87d23ce1a0f12d9.tar.gz
 https://deps.files.ghostty.org/wuffs-122037b39d577ec2db3fd7b2130e7b69ef6cc1807d68607a7c232c958315d381b5cd.tar.gz
-https://deps.files.ghostty.org/z2d-0.9.0-j5P_Hu-WFgA_JEfRpiFss6gdvcvS47cgOc0Via2eKD_T.tar.gz
 https://deps.files.ghostty.org/zf-3c52637b7e937c5ae61fd679717da3e276765b23.tar.gz
 https://deps.files.ghostty.org/zig_js-04db83c617da1956ac5adc1cb9ba1e434c1cb6fd.tar.gz
 https://deps.files.ghostty.org/zig_objc-f356ed02833f0f1b8e84d50bed9e807bf7cdc0ae.tar.gz
 https://deps.files.ghostty.org/zig_wayland-1b5c038ec10da20ed3a15b0b2a6db1c21383e8ea.tar.gz
 https://deps.files.ghostty.org/zlib-1220fed0c74e1019b3ee29edae2051788b080cd96e90d56836eea857b0b966742efb.tar.gz
 https://github.com/ivanstepanovftw/zigimg/archive/d7b7ab0ba0899643831ef042bd73289510b39906.tar.gz
+https://github.com/vancluever/z2d/archive/refs/tags/v0.10.0.tar.gz

--- a/flatpak/zig-packages.json
+++ b/flatpak/zig-packages.json
@@ -169,9 +169,9 @@
   },
   {
     "type": "archive",
-    "url": "https://deps.files.ghostty.org/z2d-0.9.0-j5P_Hu-WFgA_JEfRpiFss6gdvcvS47cgOc0Via2eKD_T.tar.gz",
-    "dest": "vendor/p/z2d-0.9.0-j5P_Hu-WFgA_JEfRpiFss6gdvcvS47cgOc0Via2eKD_T",
-    "sha256": "f90a824685f0ac5035fe5fa85af615c8055e6c6422b401503618bd537115af10"
+    "url": "https://github.com/vancluever/z2d/archive/refs/tags/v0.10.0.tar.gz",
+    "dest": "vendor/p/z2d-0.10.0-j5P_Hu-6FgBsZNgwphIqh17jDnj8_yPtD8yzjO6PpHRQ",
+    "sha256": "69f21da2efd5ee0937fe55c4d09e48afc4fb2f91a01ef167c8c275ae046797f7"
   },
   {
     "type": "archive",

--- a/src/font/sprite/canvas.zig
+++ b/src/font/sprite/canvas.zig
@@ -360,7 +360,7 @@ pub const Canvas = struct {
     pub fn strokePath(
         self: *Canvas,
         path: z2d.Path,
-        opts: z2d.painter.StrokeOpts,
+        opts: z2d.painter.StrokeOptions,
         color: Color,
     ) z2d.painter.StrokeError!void {
         try z2d.painter.stroke(
@@ -380,7 +380,7 @@ pub const Canvas = struct {
     pub fn innerStrokePath(
         self: *Canvas,
         path: z2d.Path,
-        opts: z2d.painter.StrokeOpts,
+        opts: z2d.painter.StrokeOptions,
         color: Color,
     ) (z2d.painter.StrokeError || z2d.painter.FillError)!void {
         // On one surface we fill the shape, this will be a mask we
@@ -459,7 +459,7 @@ pub const Canvas = struct {
     pub fn fillPath(
         self: *Canvas,
         path: z2d.Path,
-        opts: z2d.painter.FillOpts,
+        opts: z2d.painter.FillOptions,
         color: Color,
     ) z2d.painter.FillError!void {
         try z2d.painter.fill(


### PR DESCRIPTION
Release notes at:
 https://github.com/vancluever/z2d/blob/v0.10.0/CHANGELOG.md

Mainly a maintenance update with regards to Ghostty use, with a couple of minor changes required to some type references to match new API semantics.

However, the new release does bring hairline stroking, if that's of any interest :slightly_smiling_face: 