### PR TITLE
Feat: Dynamic configurable statusbar

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -460,6 +460,69 @@ typedef struct {
   size_t len;
 } ghostty_config_command_list_s;
 
+// config.StatusBarWidget
+typedef enum {
+  GHOSTTY_STATUS_BAR_WIDGET_TIME,
+  GHOSTTY_STATUS_BAR_WIDGET_CWD,
+  GHOSTTY_STATUS_BAR_WIDGET_PWD,
+  GHOSTTY_STATUS_BAR_WIDGET_SIZE,
+  GHOSTTY_STATUS_BAR_WIDGET_MODIFIERS,
+  GHOSTTY_STATUS_BAR_WIDGET_PENDING_KEY,
+  GHOSTTY_STATUS_BAR_WIDGET_CPU,
+  GHOSTTY_STATUS_BAR_WIDGET_MEMORY,
+  GHOSTTY_STATUS_BAR_WIDGET_CURSOR_POS,
+} ghostty_status_bar_widget_kind_e;
+
+typedef struct {
+  ghostty_status_bar_widget_kind_e kind;
+  const char* name;
+  const char* format;
+  const char* style;
+  const char* style_range;
+} ghostty_status_bar_widget_s;
+
+typedef struct {
+  const ghostty_status_bar_widget_s* widgets;
+  size_t len;
+} ghostty_config_status_bar_widget_list_s;
+
+// config.StatusBarStyle
+typedef struct {
+  const char* name;
+  ghostty_config_color_s fg;
+  bool has_fg;
+  bool bold;
+  bool has_bold;
+  float size;
+  bool has_size;
+} ghostty_status_bar_style_s;
+
+typedef struct {
+  const ghostty_status_bar_style_s* styles;
+  size_t len;
+} ghostty_config_status_bar_style_list_s;
+
+// config.StatusBarStyleRangeEntry
+typedef struct {
+  float min;
+  bool has_min;
+  float max;
+  bool has_max;
+  const char* style;
+} ghostty_status_bar_style_range_entry_s;
+
+// config.StatusBarStyleRange
+typedef struct {
+  const char* name;
+  const ghostty_status_bar_style_range_entry_s* entries;
+  size_t len;
+} ghostty_status_bar_style_range_s;
+
+typedef struct {
+  const ghostty_status_bar_style_range_s* ranges;
+  size_t len;
+} ghostty_config_status_bar_style_range_list_s;
+
 // config.Palette
 typedef struct {
   ghostty_config_color_s colors[256];
@@ -848,6 +911,7 @@ typedef enum {
   GHOSTTY_ACTION_SCROLLBAR,
   GHOSTTY_ACTION_RENDER,
   GHOSTTY_ACTION_INSPECTOR,
+  GHOSTTY_ACTION_TOGGLE_STATUS_BAR,
   GHOSTTY_ACTION_SHOW_GTK_INSPECTOR,
   GHOSTTY_ACTION_RENDER_INSPECTOR,
   GHOSTTY_ACTION_DESKTOP_NOTIFICATION,

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -516,6 +516,9 @@ extension Ghostty {
             case GHOSTTY_ACTION_INSPECTOR:
                 controlInspector(app, target: target, mode: action.action.inspector)
 
+            case GHOSTTY_ACTION_TOGGLE_STATUS_BAR:
+                toggleStatusBar(app, target: target)
+
             case GHOSTTY_ACTION_RENDER_INSPECTOR:
                 renderInspector(app, target: target)
 
@@ -1330,6 +1333,24 @@ extension Ghostty {
                     userInfo: ["mode": mode]
                 )
 
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        private static func toggleStatusBar(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                Ghostty.logger.warning("toggle status bar does nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                surfaceView.showStatusBar.toggle()
 
             default:
                 assertionFailure()

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -548,6 +548,45 @@ extension Ghostty {
             return v;
         }
 
+        var statusBarLayout: String {
+            guard let config = self.config else { return "" }
+            var v: UnsafePointer<Int8>? = nil
+            let key = "status-bar"
+            guard ghostty_config_get(config, &v, key, UInt(key.lengthOfBytes(using: .utf8))) else { return "" }
+            guard let ptr = v else { return "" }
+            return String(cString: ptr)
+        }
+
+        var statusBarWidgets: [StatusBarWidget] {
+            guard let config = self.config else { return [] }
+            var v: ghostty_config_status_bar_widget_list_s = .init()
+            let key = "status-bar-widget"
+            guard ghostty_config_get(config, &v, key, UInt(key.lengthOfBytes(using: .utf8))) else { return [] }
+            guard v.len > 0, let widgets = v.widgets else { return [] }
+            let buffer = UnsafeBufferPointer(start: widgets, count: v.len)
+            return buffer.compactMap { StatusBarWidget(cValue: $0) }
+        }
+
+        var statusBarStyles: [StatusBarStyle] {
+            guard let config = self.config else { return [] }
+            var v: ghostty_config_status_bar_style_list_s = .init()
+            let key = "status-bar-style"
+            guard ghostty_config_get(config, &v, key, UInt(key.lengthOfBytes(using: .utf8))) else { return [] }
+            guard v.len > 0, let styles = v.styles else { return [] }
+            let buffer = UnsafeBufferPointer(start: styles, count: v.len)
+            return buffer.compactMap { StatusBarStyle(cValue: $0) }
+        }
+
+        var statusBarStyleRanges: [StatusBarStyleRange] {
+            guard let config = self.config else { return [] }
+            var v: ghostty_config_status_bar_style_range_list_s = .init()
+            let key = "status-bar-style-range"
+            guard ghostty_config_get(config, &v, key, UInt(key.lengthOfBytes(using: .utf8))) else { return [] }
+            guard v.len > 0, let ranges = v.ranges else { return [] }
+            let buffer = UnsafeBufferPointer(start: ranges, count: v.len)
+            return buffer.compactMap { StatusBarStyleRange(cValue: $0) }
+        }
+
         var undoTimeout: Duration {
             guard let config = self.config else { return .seconds(5) }
             var v: UInt = 0
@@ -638,6 +677,154 @@ extension Ghostty {
 // MARK: Configuration Enums
 
 extension Ghostty.Config {
+    struct StatusBarWidget {
+        enum Kind: String {
+            case time
+            case cwd
+            case pwd
+            case size
+            case modifiers
+            case pending_key
+            case cpu
+            case memory
+            case cursor_pos
+
+            init?(_ c: ghostty_status_bar_widget_kind_e) {
+                switch c {
+                case GHOSTTY_STATUS_BAR_WIDGET_TIME: self = .time
+                case GHOSTTY_STATUS_BAR_WIDGET_CWD: self = .cwd
+                case GHOSTTY_STATUS_BAR_WIDGET_PWD: self = .pwd
+                case GHOSTTY_STATUS_BAR_WIDGET_SIZE: self = .size
+                case GHOSTTY_STATUS_BAR_WIDGET_MODIFIERS: self = .modifiers
+                case GHOSTTY_STATUS_BAR_WIDGET_PENDING_KEY: self = .pending_key
+                case GHOSTTY_STATUS_BAR_WIDGET_CPU: self = .cpu
+                case GHOSTTY_STATUS_BAR_WIDGET_MEMORY: self = .memory
+                case GHOSTTY_STATUS_BAR_WIDGET_CURSOR_POS: self = .cursor_pos
+                default: return nil
+                }
+            }
+
+            static func fromToken(_ token: String) -> Kind? {
+                switch token {
+                case "modifier_state", "mods": return .modifiers
+                case "terminal_size", "term_size": return .size
+                case "mem": return .memory
+                default: return Kind(rawValue: token)
+                }
+            }
+        }
+
+        let kind: Kind
+        let name: String?
+        let format: String?
+        let style: String?
+        let styleRange: String?
+
+        init(kind: Kind, name: String?, format: String?, style: String?, styleRange: String?) {
+            self.kind = kind
+            self.name = name
+            self.format = format
+            self.style = style
+            self.styleRange = styleRange
+        }
+
+        init?(cValue: ghostty_status_bar_widget_s) {
+            guard let kind = Kind(cValue.kind) else { return nil }
+            self.kind = kind
+            if let name = cValue.name {
+                self.name = String(cString: name)
+            } else {
+                self.name = nil
+            }
+            if let format = cValue.format {
+                self.format = String(cString: format)
+            } else {
+                self.format = nil
+            }
+            if let style = cValue.style {
+                self.style = String(cString: style)
+            } else {
+                self.style = nil
+            }
+            if let styleRange = cValue.style_range {
+                self.styleRange = String(cString: styleRange)
+            } else {
+                self.styleRange = nil
+            }
+        }
+    }
+
+    struct StatusBarStyle {
+        let name: String
+        let fg: Color?
+        let bold: Bool?
+        let size: Double?
+
+        init(name: String, fg: Color?, bold: Bool?, size: Double?) {
+            self.name = name
+            self.fg = fg
+            self.bold = bold
+            self.size = size
+        }
+
+        init?(cValue: ghostty_status_bar_style_s) {
+            guard let name = cValue.name else { return nil }
+            self.name = String(cString: name)
+            if cValue.has_fg {
+                self.fg = Color(
+                    red: Double(cValue.fg.r) / 255,
+                    green: Double(cValue.fg.g) / 255,
+                    blue: Double(cValue.fg.b) / 255
+                )
+            } else {
+                self.fg = nil
+            }
+            self.bold = cValue.has_bold ? cValue.bold : nil
+            self.size = cValue.has_size ? Double(cValue.size) : nil
+        }
+    }
+
+    struct StatusBarStyleRangeEntry {
+        let min: Double?
+        let max: Double?
+        let style: String
+
+        func matches(_ value: Double) -> Bool {
+            if let min, value < min { return false }
+            if let max, value > max { return false }
+            return min != nil || max != nil
+        }
+    }
+
+    struct StatusBarStyleRange {
+        let name: String
+        let entries: [StatusBarStyleRangeEntry]
+
+        init?(cValue: ghostty_status_bar_style_range_s) {
+            guard let name = cValue.name else { return nil }
+            self.name = String(cString: name)
+            guard cValue.len > 0, let entriesPtr = cValue.entries else {
+                self.entries = []
+                return
+            }
+            let buffer = UnsafeBufferPointer(start: entriesPtr, count: cValue.len)
+            self.entries = buffer.compactMap { entry in
+                guard let stylePtr = entry.style else { return nil }
+                let styleName = String(cString: stylePtr)
+                let min = entry.has_min ? Double(entry.min) : nil
+                let max = entry.has_max ? Double(entry.max) : nil
+                return StatusBarStyleRangeEntry(min: min, max: max, style: styleName)
+            }
+        }
+
+        func styleName(for value: Double) -> String? {
+            for entry in entries {
+                if entry.matches(value) { return entry.style }
+            }
+            return nil
+        }
+    }
+
     enum AutoUpdate : String {
         case off
         case check

--- a/macos/Sources/Ghostty/SurfaceView.swift
+++ b/macos/Sources/Ghostty/SurfaceView.swift
@@ -128,6 +128,14 @@ extension Ghostty {
                     keyTables: surfaceView.keyTables,
                     keySequence: surfaceView.keySequence
                 )
+
+                // Status bar overlay
+                if surfaceView.showStatusBar {
+                    StatusBarOverlay(surfaceView: surfaceView)
+                        .frame(maxWidth: .infinity)
+                        .allowsHitTesting(false)
+                        .transition(.opacity)
+                }
 #endif
 
                 // If we have a URL from hovering a link, we show that.
@@ -947,6 +955,44 @@ extension Ghostty {
                 let offset = Double(index) / 3.0
                 let wave = sin((phase + offset) * .pi * 2)
                 return 0.3 + 0.7 * ((wave + 1) / 2)
+            }
+        }
+    }
+
+    /// Status bar overlay showing configurable widgets.
+    struct StatusBarOverlay: View {
+        @ObservedObject var surfaceView: SurfaceView
+
+        var body: some View {
+            if surfaceView.statusBarLeft.characters.isEmpty && surfaceView.statusBarRight.characters.isEmpty {
+                EmptyView()
+            } else {
+                VStack {
+                    Spacer()
+                    HStack(spacing: 8) {
+                        Text(surfaceView.statusBarLeft)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Spacer(minLength: 8)
+                        Text(surfaceView.statusBarRight)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    .font(.system(.caption, design: .monospaced))
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(.background)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(Color.gray.opacity(0.5), lineWidth: 1)
+                    )
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 8)
+                }
+                .frame(maxWidth: .infinity)
             }
         }
     }

--- a/macos/Sources/Ghostty/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/SurfaceView_AppKit.swift
@@ -880,7 +880,7 @@ extension Ghostty {
                 return StatusBarValue(text: pwd, number: nil)
             case .size:
                 guard let size = surfaceSize else { return nil }
-                return StatusBarValue(text: "\(size.rows)x\(size.columns)", number: nil)
+                return StatusBarValue(text: "\(size.columns)x\(size.rows)", number: nil)
             case .modifiers:
                 guard let mods = formatModifiers() else { return nil }
                 return StatusBarValue(text: mods, number: nil)

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -5705,6 +5705,12 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             },
         ),
 
+        .toggle_status_bar => return try self.rt_app.performAction(
+            .{ .surface = self },
+            .toggle_status_bar,
+            {},
+        ),
+
         .close_surface => self.close(),
 
         .close_window => return try self.rt_app.performAction(

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -183,6 +183,9 @@ pub const Action = union(Key) {
     /// Control whether the inspector is shown or hidden.
     inspector: Inspector,
 
+    /// Toggle the status bar overlay.
+    toggle_status_bar,
+
     /// Show the GTK inspector.
     show_gtk_inspector,
 
@@ -359,6 +362,7 @@ pub const Action = union(Key) {
         scrollbar,
         render,
         inspector,
+        toggle_status_bar,
         show_gtk_inspector,
         render_inspector,
         desktop_notification,

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -671,6 +671,7 @@ pub const Application = extern struct {
 
             .key_sequence => return Action.keySequence(target, value),
             .key_table => return Action.keyTable(target, value),
+            .toggle_status_bar => return Action.toggleStatusBar(target),
 
             .mouse_over_link => Action.mouseOverLink(target, value),
             .mouse_shape => Action.mouseShape(target, value),
@@ -2649,6 +2650,15 @@ const Action = struct {
             .app => return false,
             .surface => |surface| {
                 return surface.rt_surface.gobj().controlInspector(value);
+            },
+        }
+    }
+
+    pub fn toggleStatusBar(target: apprt.Target) bool {
+        switch (target) {
+            .app => return false,
+            .surface => |surface| {
+                return surface.rt_surface.gobj().toggleStatusBar();
             },
         }
     }

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const assert = @import("../../../quirks.zig").inlineAssert;
 const Allocator = std.mem.Allocator;
 const adw = @import("adw");
@@ -7,8 +8,12 @@ const gio = @import("gio");
 const glib = @import("glib");
 const gobject = @import("gobject");
 const gtk = @import("gtk");
+const c_time = @cImport({
+    @cInclude("time.h");
+});
 
 const apprt = @import("../../../apprt.zig");
+const configpkg = @import("../../../config.zig");
 const build_config = @import("../../../build_config.zig");
 const datastruct = @import("../../../datastruct/main.zig");
 const font = @import("../../../font/main.zig");
@@ -35,6 +40,122 @@ const InspectorWindow = @import("inspector_window.zig").InspectorWindow;
 const i18n = @import("../../../os/i18n.zig");
 
 const log = std.log.scoped(.gtk_ghostty_surface);
+
+const CpuSample = struct {
+    idle: u64,
+    total: u64,
+};
+
+const default_time_fmt: [*:0]const u8 = "%H:%M";
+
+fn formatTime(fmt: [*:0]const u8, buf: []u8) ?[]const u8 {
+    var t: c_time.time_t = c_time.time(null);
+    if (t == -1) return null;
+    var tm: c_time.tm = undefined;
+    if (c_time.localtime_r(&t, &tm) == null) return null;
+
+    const written = c_time.strftime(@ptrCast(buf.ptr), buf.len, fmt, &tm);
+    if (written == 0 or written >= buf.len) return null;
+    buf[written] = 0;
+    return buf[0..written];
+}
+
+fn readCpuSampleLinux() ?CpuSample {
+    var file = std.fs.cwd().openFile("/proc/stat", .{}) catch return null;
+    defer file.close();
+
+    var buf: [512]u8 = undefined;
+    const n = file.readAll(&buf) catch return null;
+    if (n == 0) return null;
+    const data = buf[0..n];
+
+    const line = std.mem.splitScalar(u8, data, '\n').next() orelse return null;
+    if (!std.mem.startsWith(u8, line, "cpu ")) return null;
+
+    var it = std.mem.tokenizeAny(u8, line[4..], " \t");
+    var total: u64 = 0;
+    var idle: u64 = 0;
+    var idx: usize = 0;
+    while (it.next()) |tok| : (idx += 1) {
+        const val = std.fmt.parseUnsigned(u64, tok, 10) catch continue;
+        total += val;
+        if (idx == 3 or idx == 4) idle += val; // idle + iowait
+    }
+
+    if (total == 0) return null;
+    return .{ .idle = idle, .total = total };
+}
+
+fn cpuUsagePercent(prev: *?CpuSample) ?u8 {
+    if (builtin.target.os.tag != .linux) return null;
+    const sample = readCpuSampleLinux() orelse return null;
+    if (prev.*) |prev_sample| {
+        if (sample.total <= prev_sample.total or sample.idle < prev_sample.idle) {
+            prev.* = sample;
+            return null;
+        }
+        const total_delta = sample.total - prev_sample.total;
+        const idle_delta = sample.idle - prev_sample.idle;
+        if (total_delta == 0 or total_delta < idle_delta) {
+            prev.* = sample;
+            return null;
+        }
+        const usage = (total_delta - idle_delta) * 100 / total_delta;
+        prev.* = sample;
+        return @intCast(@min(usage, 100));
+    }
+
+    prev.* = sample;
+    return null;
+}
+
+fn memUsagePercentLinux() ?u8 {
+    var file = std.fs.cwd().openFile("/proc/meminfo", .{}) catch return null;
+    defer file.close();
+
+    var buf: [2048]u8 = undefined;
+    const n = file.readAll(&buf) catch return null;
+    if (n == 0) return null;
+    const data = buf[0..n];
+
+    var total_kb: u64 = 0;
+    var avail_kb: u64 = 0;
+    var free_kb: u64 = 0;
+
+    var it = std.mem.splitScalar(u8, data, '\n');
+    while (it.next()) |line| {
+        if (std.mem.startsWith(u8, line, "MemTotal:")) {
+            var tok = std.mem.tokenizeAny(u8, line["MemTotal:".len..], " \t");
+            if (tok.next()) |value| {
+                total_kb = std.fmt.parseUnsigned(u64, value, 10) catch total_kb;
+            }
+        } else if (std.mem.startsWith(u8, line, "MemAvailable:")) {
+            var tok = std.mem.tokenizeAny(u8, line["MemAvailable:".len..], " \t");
+            if (tok.next()) |value| {
+                avail_kb = std.fmt.parseUnsigned(u64, value, 10) catch avail_kb;
+            }
+        } else if (std.mem.startsWith(u8, line, "MemFree:")) {
+            var tok = std.mem.tokenizeAny(u8, line["MemFree:".len..], " \t");
+            if (tok.next()) |value| {
+                free_kb = std.fmt.parseUnsigned(u64, value, 10) catch free_kb;
+            }
+        }
+    }
+
+    if (total_kb == 0) return null;
+    const available = if (avail_kb != 0) avail_kb else free_kb;
+    if (available == 0) return null;
+    const used = total_kb -| available;
+    const percent = used * 100 / total_kb;
+    return @intCast(@min(percent, 100));
+}
+
+fn memUsagePercent() ?u8 {
+    return switch (builtin.target.os.tag) {
+        .linux => memUsagePercentLinux(),
+        else => null,
+    };
+}
 
 pub const Surface = extern struct {
     const Self = @This();
@@ -399,6 +520,24 @@ pub const Surface = extern struct {
                 },
             );
         };
+
+        pub const @"show-status-bar" = struct {
+            pub const name = "show-status-bar";
+            const impl = gobject.ext.defineProperty(
+                name,
+                Self,
+                bool,
+                .{
+                    .default = false,
+                    .accessor = gobject.ext.privateFieldAccessor(
+                        Self,
+                        Private,
+                        &Private.offset,
+                        "show_status_bar",
+                    ),
+                },
+            );
+        };
     };
 
     pub const signals = struct {
@@ -595,6 +734,18 @@ pub const Surface = extern struct {
         /// The key state overlay
         key_state_overlay: *KeyStateOverlay,
 
+        /// Status bar overlay widgets
+        status_bar_revealer: *gtk.Revealer,
+        status_bar_left: *gtk.Label,
+        status_bar_right: *gtk.Label,
+
+        /// Status bar timer and cached modifier state
+        status_bar_timer: ?c_uint = null,
+        status_bar_mods: input.Mods = .{},
+        status_bar_cpu_prev: ?CpuSample = null,
+        status_bar_cpu_percent: ?u8 = null,
+        status_bar_mem_percent: ?u8 = null,
+
         /// The apprt Surface.
         rt_surface: ApprtSurface = undefined,
 
@@ -649,6 +800,9 @@ pub const Surface = extern struct {
         // True if the current surface is a split, this is used to apply
         // unfocused-split-* options
         is_split: bool = false,
+
+        // True if the status bar should be shown
+        show_status_bar: bool = false,
 
         action_group: ?*gio.SimpleActionGroup = null,
 
@@ -818,6 +972,316 @@ pub const Surface = extern struct {
         return true;
     }
 
+    /// Toggle the status bar visibility.
+    pub fn toggleStatusBar(self: *Self) bool {
+        const priv = self.private();
+        priv.show_status_bar = !priv.show_status_bar;
+        self.as(gobject.Object).notifyByPspec(properties.@"show-status-bar".impl.param_spec);
+        if (priv.show_status_bar) {
+            priv.status_bar_cpu_prev = readCpuSampleLinux();
+            priv.status_bar_cpu_percent = if (priv.status_bar_cpu_prev != null) 0 else null;
+            priv.status_bar_mem_percent = memUsagePercent();
+            self.statusBarUpdate();
+            if (priv.status_bar_timer == null) {
+                priv.status_bar_timer = glib.timeoutAdd(
+                    1000,
+                    statusBarTimer,
+                    self,
+                );
+            }
+        } else if (priv.status_bar_timer) |timer| {
+            if (glib.Source.remove(timer) == 0) {
+                log.warn("unable to remove status bar timer", .{});
+            }
+            priv.status_bar_timer = null;
+        }
+        return true;
+    }
+
+    fn statusBarTimer(ud: ?*anyopaque) callconv(.c) c_int {
+        const self: *Self = @ptrCast(@alignCast(ud orelse return @intFromBool(glib.SOURCE_REMOVE)));
+        const priv = self.private();
+
+        if (!priv.show_status_bar) {
+            priv.status_bar_timer = null;
+            return @intFromBool(glib.SOURCE_REMOVE);
+        }
+
+        if (cpuUsagePercent(&priv.status_bar_cpu_prev)) |percent| {
+            priv.status_bar_cpu_percent = percent;
+        }
+        if (memUsagePercent()) |percent| {
+            priv.status_bar_mem_percent = percent;
+        }
+        self.statusBarUpdate();
+        return @intFromBool(glib.SOURCE_CONTINUE);
+    }
+
+    fn statusBarUpdate(self: *Self) void {
+        const priv = self.private();
+        if (!priv.show_status_bar) return;
+
+        const config_obj = priv.config orelse return;
+        const cfg = config_obj.get();
+
+        const layout = std.mem.trim(u8, cfg.@"status-bar", &std.ascii.whitespace);
+        if (layout.len == 0) {
+            statusBarSetLabel(Application.default().allocator(), priv.status_bar_left, "");
+            statusBarSetLabel(Application.default().allocator(), priv.status_bar_right, "");
+            return;
+        }
+
+        const split_idx = std.mem.indexOf(u8, layout, "<->");
+        const left = if (split_idx) |idx| layout[0..idx] else layout;
+        const right = if (split_idx) |idx| layout[idx + 3 ..] else "";
+
+        const alloc = Application.default().allocator();
+        var left_buf: std.Io.Writer.Allocating = .init(alloc);
+        defer left_buf.deinit();
+        _ = self.statusBarWriteSide(cfg, left, &left_buf.writer) catch {};
+
+        var right_buf: std.Io.Writer.Allocating = .init(alloc);
+        defer right_buf.deinit();
+        _ = self.statusBarWriteSide(cfg, right, &right_buf.writer) catch {};
+
+        statusBarSetLabel(alloc, priv.status_bar_left, left_buf.written());
+        statusBarSetLabel(alloc, priv.status_bar_right, right_buf.written());
+    }
+
+    fn statusBarWriteSide(
+        self: *Self,
+        cfg: *const configpkg.Config,
+        side: []const u8,
+        writer: *std.Io.Writer,
+    ) !bool {
+        var any = false;
+        var it = std.mem.tokenizeAny(u8, side, &std.ascii.whitespace);
+        while (it.next()) |token| {
+            const widget = statusBarWidgetForToken(cfg, token) orelse continue;
+            var buf: [256]u8 = undefined;
+            const value = self.statusBarWidgetValue(widget, &buf) orelse continue;
+            const style = statusBarStyleForWidget(cfg, widget, value.number);
+            if (any) try writer.writeAll("  ");
+            try statusBarWriteStyled(writer, value.text, style);
+            any = true;
+        }
+
+        return any;
+    }
+
+    fn statusBarWidgetForToken(
+        cfg: *const configpkg.Config,
+        token: []const u8,
+    ) ?configpkg.StatusBarWidget {
+        for (cfg.@"status-bar-widget".value.items) |widget| {
+            const name = if (widget.name) |v| std.mem.span(v) else @tagName(widget.kind);
+            if (std.mem.eql(u8, name, token)) return widget;
+        }
+
+        if (configpkg.StatusBarWidget.parseKind(token)) |kind| {
+            return .{ .kind = kind };
+        }
+
+        return null;
+    }
+
+    const StatusBarValue = struct {
+        text: []const u8,
+        number: ?f32,
+    };
+
+    fn statusBarWidgetValue(
+        self: *Self,
+        widget: configpkg.StatusBarWidget,
+        buf: []u8,
+    ) ?StatusBarValue {
+        const priv = self.private();
+
+        switch (widget.kind) {
+            .time => {
+                const fmt: [*:0]const u8 = if (widget.format) |f| @ptrCast(f.ptr) else default_time_fmt;
+                const text = formatTime(fmt, buf) orelse return null;
+                return .{ .text = text, .number = null };
+            },
+            .cwd, .pwd => {
+                if (priv.pwd) |pwd| return .{ .text = std.mem.span(pwd), .number = null };
+                return null;
+            },
+            .size => {
+                const surface = priv.core_surface orelse return null;
+                const grid = surface.size.grid();
+                const text = std.fmt.bufPrint(buf, "{d}x{d}", .{ grid.rows, grid.columns }) catch return null;
+                return .{ .text = text, .number = null };
+            },
+            .modifiers => {
+                const text = formatMods(priv.status_bar_mods, buf) orelse return null;
+                return .{ .text = text, .number = null };
+            },
+            .pending_key => {
+                if (priv.key_sequence.items.len == 0) return null;
+                var writer: std.Io.Writer = .fixed(buf);
+                for (priv.key_sequence.items, 0..) |key, i| {
+                    if (i > 0) writer.writeByte(' ') catch return null;
+                    writer.writeAll(std.mem.span(key)) catch return null;
+                }
+                return .{ .text = writer.buffered(), .number = null };
+            },
+            .cpu => {
+                if (priv.status_bar_cpu_percent) |percent| {
+                    const text = std.fmt.bufPrint(buf, "CPU {d}%", .{percent}) catch return null;
+                    return .{ .text = text, .number = @floatFromInt(percent) };
+                }
+                return null;
+            },
+            .memory => {
+                if (priv.status_bar_mem_percent) |percent| {
+                    const text = std.fmt.bufPrint(buf, "Mem {d}%", .{percent}) catch return null;
+                    return .{ .text = text, .number = @floatFromInt(percent) };
+                }
+                return null;
+            },
+            .cursor_pos => return null,
+        }
+    }
+
+    fn statusBarStyleForWidget(
+        cfg: *const configpkg.Config,
+        widget: configpkg.StatusBarWidget,
+        value: ?f32,
+    ) ?configpkg.StatusBarStyle {
+        if (value) |num| {
+            if (widget.style_range) |range_name| {
+                const range_slice = std.mem.sliceTo(range_name, 0);
+                if (statusBarStyleForRange(cfg, range_slice, num)) |style| return style;
+            }
+        }
+        if (widget.style) |style_name| {
+            const style_slice = std.mem.sliceTo(style_name, 0);
+            return statusBarStyleByName(cfg, style_slice);
+        }
+        return null;
+    }
+
+    fn statusBarStyleByName(
+        cfg: *const configpkg.Config,
+        name: []const u8,
+    ) ?configpkg.StatusBarStyle {
+        for (cfg.@"status-bar-style".value.items) |style| {
+            if (std.mem.eql(u8, style.name, name)) return style;
+        }
+        return null;
+    }
+
+    fn statusBarStyleForRange(
+        cfg: *const configpkg.Config,
+        range_name: []const u8,
+        value: f32,
+    ) ?configpkg.StatusBarStyle {
+        for (cfg.@"status-bar-style-range".value.items) |range| {
+            if (!std.mem.eql(u8, range.name, range_name)) continue;
+            if (range.styleForValue(value)) |style_name| {
+                return statusBarStyleByName(cfg, style_name);
+            }
+            return null;
+        }
+        return null;
+    }
+
+    fn statusBarWriteStyled(
+        writer: *std.Io.Writer,
+        text: []const u8,
+        style: ?configpkg.StatusBarStyle,
+    ) !void {
+        var escaped_buf: [512]u8 = undefined;
+        const escaped = escapeMarkup(text, &escaped_buf);
+
+        if (style == null) {
+            try writer.writeAll(escaped);
+            return;
+        }
+
+        const st = style.?;
+        var has_attr = false;
+        try writer.writeAll("<span");
+
+        if (st.fg) |fg| {
+            var color_buf: [128]u8 = undefined;
+            const color = fg.formatBuf(&color_buf) catch return error.OutOfMemory;
+            try writer.print(" foreground=\"{s}\"", .{color});
+            has_attr = true;
+        }
+        if (st.bold == true) {
+            try writer.writeAll(" weight=\"bold\"");
+            has_attr = true;
+        }
+        if (st.size) |size| {
+            const pango_size: u32 = @intFromFloat(size * 1024.0);
+            if (pango_size > 0) {
+                try writer.print(" size=\"{d}\"", .{pango_size});
+                has_attr = true;
+            }
+        }
+
+        if (!has_attr) {
+            // No attributes set, avoid emitting an empty span.
+            try writer.writeAll(">");
+            try writer.writeAll(escaped);
+            try writer.writeAll("</span>");
+            return;
+        }
+
+        try writer.writeAll(">");
+        try writer.writeAll(escaped);
+        try writer.writeAll("</span>");
+    }
+
+    fn escapeMarkup(text: []const u8, buf: []u8) []const u8 {
+        var writer: std.Io.Writer = .fixed(buf);
+        for (text) |ch| {
+            switch (ch) {
+                '&' => writer.writeAll("&amp;") catch break,
+                '<' => writer.writeAll("&lt;") catch break,
+                '>' => writer.writeAll("&gt;") catch break,
+                else => writer.writeByte(ch) catch break,
+            }
+        }
+        return writer.buffered();
+    }
+
+    fn formatMods(mods: input.Mods, buf: []u8) ?[]const u8 {
+        var writer: std.Io.Writer = .fixed(buf);
+        var any = false;
+
+        if (mods.alt) {
+            writer.writeAll("Alt") catch return null;
+            any = true;
+        }
+        if (mods.ctrl) {
+            if (any) writer.writeByte(' ') catch return null;
+            writer.writeAll("Ctrl") catch return null;
+            any = true;
+        }
+        if (mods.shift) {
+            if (any) writer.writeByte(' ') catch return null;
+            writer.writeAll("Shift") catch return null;
+            any = true;
+        }
+        if (mods.caps_lock) {
+            if (any) writer.writeByte(' ') catch return null;
+            writer.writeAll("Caps") catch return null;
+            any = true;
+        }
+
+        if (!any) return null;
+        return writer.buffered();
+    }
+
+    fn statusBarSetLabel(alloc: Allocator, label: *gtk.Label, text: []const u8) void {
+        const duped = alloc.dupeZ(u8, text) catch return;
+        defer alloc.free(duped);
+        label.setLabel(duped);
+    }
+
     /// Redraw our inspector, if there is one associated with this surface.
     pub fn redrawInspector(self: *Self) void {
         const priv = self.private();
@@ -859,6 +1323,8 @@ pub const Surface = extern struct {
                 priv.key_sequence.clearAndFree(alloc);
             },
         }
+
+        self.statusBarUpdate();
     }
 
     /// Handle a key table action from the apprt.
@@ -1276,6 +1742,11 @@ pub const Surface = extern struct {
             action,
             Application.default().winproto(),
         );
+
+        if (!mods.equal(priv.status_bar_mods)) {
+            priv.status_bar_mods = mods;
+            self.statusBarUpdate();
+        }
 
         // Get our consumed modifiers
         const consumed_mods: input.Mods = consumed: {
@@ -1830,6 +2301,13 @@ pub const Surface = extern struct {
             priv.progress_bar_timer = null;
         }
 
+        if (priv.status_bar_timer) |timer| {
+            if (glib.Source.remove(timer) == 0) {
+                log.warn("unable to remove status bar timer", .{});
+            }
+            priv.status_bar_timer = null;
+        }
+
         if (priv.idle_rechild) |v| {
             if (glib.Source.remove(v) == 0) {
                 log.warn("unable to remove idle source", .{});
@@ -1958,6 +2436,7 @@ pub const Surface = extern struct {
         priv.pwd = null;
         if (pwd) |v| priv.pwd = glib.ext.dupeZ(u8, v);
         self.as(gobject.Object).notifyByPspec(properties.pwd.impl.param_spec);
+        self.statusBarUpdate();
     }
 
     /// Returns the focus state of this surface.
@@ -2159,6 +2638,8 @@ pub const Surface = extern struct {
                 &valign,
             );
         }
+
+        self.statusBarUpdate();
     }
 
     fn propError(
@@ -3157,6 +3638,7 @@ pub const Surface = extern struct {
 
             // Setup our resize overlay if configured
             self.resizeOverlaySchedule();
+            self.statusBarUpdate();
 
             return;
         }
@@ -3394,6 +3876,9 @@ pub const Surface = extern struct {
             class.bindTemplateChildPrivate("resize_overlay", .{});
             class.bindTemplateChildPrivate("search_overlay", .{});
             class.bindTemplateChildPrivate("key_state_overlay", .{});
+            class.bindTemplateChildPrivate("status_bar_revealer", .{});
+            class.bindTemplateChildPrivate("status_bar_left", .{});
+            class.bindTemplateChildPrivate("status_bar_right", .{});
             class.bindTemplateChildPrivate("terminal_page", .{});
             class.bindTemplateChildPrivate("drop_target", .{});
             class.bindTemplateChildPrivate("im_context", .{});
@@ -3456,6 +3941,7 @@ pub const Surface = extern struct {
                 properties.@"title-override".impl,
                 properties.zoom.impl,
                 properties.@"is-split".impl,
+                properties.@"show-status-bar".impl,
 
                 // For Gtk.Scrollable
                 properties.hadjustment.impl,

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -1110,7 +1110,7 @@ pub const Surface = extern struct {
             .size => {
                 const surface = priv.core_surface orelse return null;
                 const grid = surface.size.grid();
-                const text = std.fmt.bufPrint(buf, "{d}x{d}", .{ grid.rows, grid.columns }) catch return null;
+                const text = std.fmt.bufPrint(buf, "{d}x{d}", .{ grid.columns, grid.rows }) catch return null;
                 return .{ .text = text, .number = null };
             },
             .modifiers => {

--- a/src/apprt/gtk/css/style.css
+++ b/src/apprt/gtk/css/style.css
@@ -35,6 +35,21 @@ label.url-overlay.right {
 }
 
 /*
+ * GhosttySurface status bar
+ */
+.status-bar {
+  padding: 6px 12px;
+  border-radius: 6px;
+  outline-style: solid;
+  outline-color: #555555;
+  outline-width: 1px;
+}
+
+label.status-bar-text {
+  font-family: monospace;
+}
+
+/*
  * GhosttySurface search overlay
  */
 .search-overlay {

--- a/src/apprt/gtk/ui/1.2/surface.blp
+++ b/src/apprt/gtk/ui/1.2/surface.blp
@@ -117,6 +117,47 @@ Overlay terminal_page {
   $GhosttyResizeOverlay resize_overlay {}
 
   [overlay]
+  Revealer status_bar_revealer {
+    reveal-child: bind template.show-status-bar;
+    transition-type: crossfade;
+    transition-duration: 150;
+    halign: fill;
+    valign: end;
+    margin-bottom: 8;
+    margin-start: 12;
+    margin-end: 12;
+    can-focus: false;
+    can-target: false;
+    focusable: false;
+
+    Box status_bar_box {
+      hexpand: true;
+      spacing: 8;
+      styles [
+        "background",
+        "status-bar",
+      ]
+
+      Label status_bar_left {
+        hexpand: true;
+        xalign: 0;
+        use-markup: true;
+        styles [
+          "status-bar-text",
+        ]
+      }
+
+      Label status_bar_right {
+        xalign: 1;
+        use-markup: true;
+        styles [
+          "status-bar-text",
+        ]
+      }
+    }
+  }
+
+  [overlay]
   Label url_left {
     styles [
       "background",

--- a/src/config/c_get.zig
+++ b/src/config/c_get.zig
@@ -27,6 +27,11 @@ pub fn get(config: *const Config, k: Key, ptr_raw: *anyopaque) bool {
 /// the type is not supported by the C API yet or the value is null.
 fn getValue(ptr_raw: *anyopaque, value: anytype) bool {
     switch (@TypeOf(value)) {
+        [:0]const u8 => {
+            const ptr: *[*:0]const u8 = @ptrCast(@alignCast(ptr_raw));
+            ptr.* = @ptrCast(value.ptr);
+        },
+
         ?[:0]const u8 => {
             const ptr: *?[*:0]const u8 = @ptrCast(@alignCast(ptr_raw));
             ptr.* = if (value) |slice| @ptrCast(slice.ptr) else null;

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -613,6 +613,11 @@ pub const Action = union(enum) {
     /// Valid arguments: `toggle`, `show`, `hide`.
     inspector: InspectorMode,
 
+    /// Toggle the status bar overlay.
+    ///
+    /// Shows a configurable status bar for the focused terminal surface.
+    toggle_status_bar,
+
     /// Show the GTK inspector.
     ///
     /// Has no effect on macOS.
@@ -1338,6 +1343,7 @@ pub const Action = union(enum) {
             .resize_split,
             .equalize_splits,
             .inspector,
+            .toggle_status_bar,
             => .surface,
         };
     }

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -645,6 +645,12 @@ fn actionCommands(action: Action.Key) []const Command {
             .description = "Toggle the background opacity of a window that started transparent.",
         }},
 
+        .toggle_status_bar => comptime &.{.{
+            .action = .toggle_status_bar,
+            .title = "Toggle Status Bar",
+            .description = "Toggle the status bar overlay.",
+        }},
+
         .check_for_updates => comptime &.{.{
             .action = .check_for_updates,
             .title = "Check for Updates",


### PR DESCRIPTION
## Overview & Motivation

**AI Usage Note:** This feature was built utilizing `opus-4.5` and `gpt-5.2-codex`

This feature was built addressing the issues discussed in #[2421](https://github.com/ghostty-org/ghostty/discussions/2421). This gives us the ability to define a configurable status bar (in a format suggested by mitchellh) that is displayed upon invoking a configurable key bind (default CMD/SUPER + .)

- Status bar widgets: time (strftime), cwd/pwd, size, modifiers, pending key, CPU, memory (cursor pos stubbed for now).
- Styling for widgets via status-bar-style and per‑widget style.
- Range‑based styling via status-bar-style-range + widget style-range (e.g. CPU/mem thresholds).

My personal interest in this feature stems from the way I use ghostty in fullscreen usually split in 2 or 4. It's very difficult to tell the splits apart sometimes, especially when running certain AI agents, and having a per surface display that can be toggled on or off is very helpful.

## Config

 - `status-bar-widget`: repeatable widget definitions.
    Syntax: `kind[:param=value,...]`
      - kind: `time`, `cwd`, `pwd`, `size`, `modifiers`, `pending_key`, `cpu`, `memory`, `cursor_pos` (stub)
      - params:
          - `name` (string): token used in status-bar
          - `format` (string): strftime format for time
          - `style` (string): name from status-bar-style
          - `style-range` / `style_range` (string): name from status-bar-style-range

  - `status-bar-style`: repeatable style definitions.
    Syntax: `name=<name>,fg=<color>,bold=<bool>,size=<pt>`
      - fg supports hex or X11 names
  - `status-bar-style-range`: repeatable numeric range mappings.
    Syntax: `name=<name>,range=<min>..<max>=<style>,...`
      - inclusive bounds, evaluated in order
      - open-ended allowed (..40, 80..)
      - exact match allowed (50=style)
  - status-bar: layout string.
    Use whitespace-separated widget tokens; `<->` splits left/right.

###  Minimal (CPU + mem + cwd):

```
  status-bar-widget = cpu
  status-bar-widget = memory
  status-bar-widget = cwd
  status-bar = cpu memory <-> cwd
```

###  Styled widgets:

```
  status-bar-style = name=muted,fg=#777
  status-bar-widget = time:format=%H:%M,style=muted
  status-bar = time <-> cwd
```

###  Range styling (CPU/mem thresholds):

```
  status-bar-style = name=ok,fg=#5cb85c
  status-bar-style = name=warn,fg=#f0ad4e
  status-bar-style = name=hot,fg=#d9534f

  status-bar-style-range = name=cpu,range=0..40=ok,range=40..80=warn,range=80..=hot
  status-bar-style-range = name=mem,range=0..60=ok,range=60..85=warn,range=85..=hot

  status-bar-widget = cpu:style-range=cpu
  status-bar-widget = memory:style-range=mem
  status-bar-widget = cwd
  status-bar = cpu memory <-> cwd
```

## Notes

  - style-range takes precedence over style when the widget has a numeric value (CPU/memory).
  - cursor_pos is defined but still unimplemented.


Quick screen recording:
https://github.com/user-attachments/assets/e64dddaf-2990-4368-9599-ccdc48693efb

