### PR TITLE
gtk: pass through keypress when clipboard has no text

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -652,7 +652,7 @@ pub const Surface = struct {
         self: *Surface,
         clipboard_type: apprt.Clipboard,
         state: apprt.ClipboardRequest,
-    ) !void {
+    ) !bool {
         // We need to allocate to get a pointer to store our clipboard request
         // so that it is stable until the read_clipboard callback and call
         // complete_clipboard_request. This sucks but clipboard requests aren't
@@ -667,6 +667,10 @@ pub const Surface = struct {
             @intCast(@intFromEnum(clipboard_type)),
             state_ptr,
         );
+
+        // Embedded apprt can't synchronously check clipboard content types,
+        // so we always return true to indicate the request was started.
+        return true;
     }
 
     fn completeClipboardRequest(

--- a/src/apprt/gtk/Surface.zig
+++ b/src/apprt/gtk/Surface.zig
@@ -73,8 +73,8 @@ pub fn clipboardRequest(
     self: *Self,
     clipboard_type: apprt.Clipboard,
     state: apprt.ClipboardRequest,
-) !void {
-    try self.surface.clipboardRequest(
+) !bool {
+    return try self.surface.clipboardRequest(
         clipboard_type,
         state,
     );

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -3642,11 +3642,9 @@ const Clipboard = struct {
         // pass through when the clipboard contains non-text content (e.g., images).
         if (state == .paste) {
             const formats = clipboard.getFormats();
-            if (formats.containMimeType("text/plain") == 0 and
-                formats.containMimeType("UTF8_STRING") == 0 and
-                formats.containMimeType("TEXT") == 0 and
-                formats.containMimeType("STRING") == 0)
-            {
+            // G_TYPE_STRING = G_TYPE_MAKE_FUNDAMENTAL(16) = (16 << 2) = 64
+            const G_TYPE_STRING: usize = 64;
+            if (formats.containGtype(G_TYPE_STRING) == 0) {
                 log.debug("clipboard has no text format, not starting paste request", .{});
                 return false;
             }

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -3642,9 +3642,7 @@ const Clipboard = struct {
         // pass through when the clipboard contains non-text content (e.g., images).
         if (state == .paste) {
             const formats = clipboard.getFormats();
-            // G_TYPE_STRING = G_TYPE_MAKE_FUNDAMENTAL(16) = (16 << 2) = 64
-            const G_TYPE_STRING: usize = 64;
-            if (formats.containGtype(G_TYPE_STRING) == 0) {
+            if (formats.containGtype(gobject.ext.types.string) == 0) {
                 log.debug("clipboard has no text format, not starting paste request", .{});
                 return false;
             }


### PR DESCRIPTION
## Summary

When `paste_from_clipboard` is triggered but the clipboard contains no text (e.g., an image), the action now returns `false` to indicate it couldn't be performed. This enables the `performable:` keybind prefix to work correctly for paste actions.

## Problem

On GTK/Linux, when a user has `keybind = ctrl+v=paste_from_clipboard` and the clipboard contains an image (not text), pressing Ctrl+V does nothing. Applications like `opencode` that handle their own clipboard reading via `wl-paste` never receive the keypress.

## Solution

Make `clipboardRequest` return `bool` to indicate whether the action could be performed. For paste requests on GTK, synchronously check if the clipboard contains text formats before starting the async read. When no text format is available, return `false`.

Users can now use:
```
keybind = performable:ctrl+v=paste_from_clipboard
```

When the clipboard has no text, the keybind is not consumed and Ctrl+V passes through to the terminal application.

## Changes

- `Surface.startClipboardRequest` now returns `bool`
- `paste_from_clipboard` / `paste_from_selection` actions return the result
- GTK apprt checks clipboard formats synchronously before async read
- Embedded apprt always returns `true` (can't check synchronously)

## Testing

1. Add `keybind = performable:ctrl+v=paste_from_clipboard` to config
2. Copy an image to clipboard
3. Open an application that handles image paste (e.g., `opencode`)
4. Press Ctrl+V
5. Image pastes successfully (app receives keypress and handles clipboard itself)

## Disclaimer

Most of the changes is done with Opus 4.5
