### PR TITLE
macOS: Dragging a split outside of window creates a new window

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -734,7 +734,9 @@ class BaseTerminalController: NSWindowController,
         // it is already a single split.
         guard surfaceTree.isSplit else { return }
         
-        // If we are removing our focused surface then we move it.
+        // If we are removing our focused surface then we move it. We need to
+        // keep track of our old one so undo sends focus back to the right place.
+        let oldFocusedSurface = focusedSurface
         if focusedSurface == target {
             focusedSurface = findNextFocusTargetAfterClosing(node: targetNode)
         }
@@ -752,11 +754,12 @@ class BaseTerminalController: NSWindowController,
             undoManager?.endUndoGrouping()
         }
         
-        replaceSurfaceTree(removedTree, moveFocusFrom: focusedSurface)
+        replaceSurfaceTree(removedTree, moveFocusFrom: oldFocusedSurface)
         _ = TerminalController.newWindow(
             ghostty,
             tree: newTree,
-            position: notification.userInfo?[Notification.Name.ghosttySurfaceDragEndedNoTargetPointKey] as? NSPoint)
+            position: notification.userInfo?[Notification.Name.ghosttySurfaceDragEndedNoTargetPointKey] as? NSPoint,
+            confirmUndo: false)
     }
 
     // MARK: Local Events

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -734,6 +734,9 @@ class BaseTerminalController: NSWindowController,
         // it is already a single split.
         guard surfaceTree.isSplit else { return }
 
+        // Extract the drop position from the notification
+        let dropPoint = notification.userInfo?[Notification.Name.ghosttySurfaceDragEndedNoTargetPointKey] as? NSPoint
+
         // Remove the surface from our tree
         let removedTree = surfaceTree.remove(targetNode)
 
@@ -748,7 +751,7 @@ class BaseTerminalController: NSWindowController,
         }
         
         replaceSurfaceTree(removedTree, moveFocusFrom: focusedSurface)
-        _ = TerminalController.newWindow(ghostty, tree: newTree)
+        _ = TerminalController.newWindow(ghostty, tree: newTree, position: dropPoint)
     }
 
     // MARK: Local Events

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -285,7 +285,8 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
     static func newWindow(
         _ ghostty: Ghostty.App,
         tree: SplitTree<Ghostty.SurfaceView>,
-        position: NSPoint? = nil
+        position: NSPoint? = nil,
+        confirmUndo: Bool = true,
     ) -> TerminalController {
         let c = TerminalController.init(ghostty, withSurfaceTree: tree)
 
@@ -321,7 +322,11 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
                 expiresAfter: c.undoExpiration
             ) { target in
                 undoManager.disableUndoRegistration {
-                    target.closeWindow(nil)
+                    if confirmUndo {
+                        target.closeWindow(nil)
+                    } else {
+                        target.closeWindowImmediately()
+                    }
                 }
 
                 undoManager.registerUndo(

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -277,9 +277,15 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
 
     /// Create a new window with an existing split tree.
     /// The window will be sized to match the tree's current view bounds if available.
+    /// - Parameters:
+    ///   - ghostty: The Ghostty app instance.
+    ///   - tree: The split tree to use for the new window.
+    ///   - position: Optional screen position (top-left corner) for the new window.
+    ///               If nil, the window will cascade from the last cascade point.
     static func newWindow(
         _ ghostty: Ghostty.App,
-        tree: SplitTree<Ghostty.SurfaceView>
+        tree: SplitTree<Ghostty.SurfaceView>,
+        position: NSPoint? = nil
     ) -> TerminalController {
         let c = TerminalController.init(ghostty, withSurfaceTree: tree)
 
@@ -295,7 +301,12 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
                 }
 
                 if !window.styleMask.contains(.fullScreen) {
-                    Self.lastCascadePoint = window.cascadeTopLeft(from: Self.lastCascadePoint)
+                    if let position {
+                        window.setFrameTopLeftPoint(position)
+                        window.constrainToScreen()
+                    } else {
+                        Self.lastCascadePoint = window.cascadeTopLeft(from: Self.lastCascadePoint)
+                    }
                 }
             }
 

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -275,6 +275,56 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         return c
     }
 
+    /// Create a new window with an existing split tree.
+    /// The window will be sized to match the tree's current view bounds if available.
+    static func newWindow(
+        _ ghostty: Ghostty.App,
+        tree: SplitTree<Ghostty.SurfaceView>
+    ) -> TerminalController {
+        let c = TerminalController.init(ghostty, withSurfaceTree: tree)
+
+        // Calculate the target frame based on the tree's view bounds
+        let treeSize: CGSize? = tree.root?.viewBounds()
+
+        DispatchQueue.main.async {
+            if let window = c.window {
+                // If we have a tree size, resize the window's content to match
+                if let treeSize, treeSize.width > 0, treeSize.height > 0 {
+                    window.setContentSize(treeSize)
+                    window.constrainToScreen()
+                }
+
+                if !window.styleMask.contains(.fullScreen) {
+                    Self.lastCascadePoint = window.cascadeTopLeft(from: Self.lastCascadePoint)
+                }
+            }
+
+            c.showWindow(self)
+        }
+
+        // Setup our undo
+        if let undoManager = c.undoManager {
+            undoManager.setActionName("New Window")
+            undoManager.registerUndo(
+                withTarget: c,
+                expiresAfter: c.undoExpiration
+            ) { target in
+                undoManager.disableUndoRegistration {
+                    target.closeWindow(nil)
+                }
+
+                undoManager.registerUndo(
+                    withTarget: ghostty,
+                    expiresAfter: target.undoExpiration
+                ) { ghostty in
+                    _ = TerminalController.newWindow(ghostty, tree: tree)
+                }
+            }
+        }
+
+        return c
+    }
+
     static func newTab(
         _ ghostty: Ghostty.App,
         from parent: NSWindow? = nil,
@@ -397,7 +447,7 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
 
         return controller
     }
-
+    
     //MARK: - Methods
 
     @objc private func ghosttyConfigDidChange(_ notification: Notification) {

--- a/macos/Sources/Ghostty/Surface View/SurfaceDragSource.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceDragSource.swift
@@ -177,7 +177,11 @@ extension Ghostty {
             }
             
             onDragStateChanged?(true)
-            beginDraggingSession(with: [item], event: event, source: self)
+            let session = beginDraggingSession(with: [item], event: event, source: self)
+            
+            // We need to disable this so that endedAt happens immediately for our
+            // drags outside of any targets.
+            session.animatesToStartingPositionsOnCancelOrFail = false
         }
         
         // MARK: NSDraggingSource
@@ -229,7 +233,8 @@ extension Ghostty {
                 if !endsInWindow {
                     NotificationCenter.default.post(
                         name: .ghosttySurfaceDragEndedNoTarget,
-                        object: surfaceView
+                        object: surfaceView,
+                        userInfo: [Foundation.Notification.Name.ghosttySurfaceDragEndedNoTargetPointKey: screenPoint]
                     )
                 }
             }
@@ -245,4 +250,7 @@ extension Notification.Name {
     /// released outside a valid drop target) and was not cancelled by the user
     /// pressing escape. The notification's object is the SurfaceView that was dragged.
     static let ghosttySurfaceDragEndedNoTarget = Notification.Name("ghosttySurfaceDragEndedNoTarget")
+    
+    /// Key for the screen point where the drag ended in the userInfo dictionary.
+    static let ghosttySurfaceDragEndedNoTargetPointKey = "endedAtPoint"
 }


### PR DESCRIPTION
Fixes #10091 

Includes undo/redo.

https://github.com/user-attachments/assets/e533425f-4329-4cce-baac-1c9fadfc3641

