### PR TITLE
macos: make undo/redo work for final split dragged out

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -945,12 +945,19 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
                 // Make it the key window
                 window.makeKeyAndOrderFront(nil)
             }
-
+            
             // Restore focus to the previously focused surface
             if let focusedUUID = undoState.focusedSurface,
                let focusTarget = surfaceTree.first(where: { $0.id == focusedUUID }) {
                 DispatchQueue.main.async {
                     Ghostty.moveFocus(to: focusTarget, from: nil)
+                }
+            } else if let focusedSurface = surfaceTree.first {
+                // No prior focused surface or we can't find it, let's focus
+                // the first.
+                self.focusedSurface = focusedSurface
+                DispatchQueue.main.async {
+                    Ghostty.moveFocus(to: focusedSurface, from: nil)
                 }
             }
         }


### PR DESCRIPTION
Fixes #10093