### PR TITLE
Refactor nautilus extension

### DIFF
--- a/dist/linux/ghostty_nautilus.py
+++ b/dist/linux/ghostty_nautilus.py
@@ -20,37 +20,39 @@
 from gi.repository import Nautilus, GObject, Gio
 
 
-class OpenInGhosttyAction(GObject.GObject, Nautilus.MenuProvider):
-    def _menu_item_activated(self, _menu, paths):
-        for path in paths:
-            cmd = ['ghostty', f'--working-directory={path}', '--gtk-single-instance=false']
-            Gio.Subprocess.new(cmd, Gio.SubprocessFlags.NONE)
+def open_in_ghostty_activated(_menu, paths):
+    for path in paths:
+        cmd = ['ghostty', f'--working-directory={path}', '--gtk-single-instance=false']
+        Gio.Subprocess.new(cmd, Gio.SubprocessFlags.NONE)
 
+
+def get_paths_to_open(files):
+    paths = []
+    for file in files:
+        location = file.get_location() if file.is_directory() else file.get_parent_location()
+        path = location.get_path()
+        if path and path not in paths:
+            paths.append(path)
+    if 10 < len(paths):
+        # Let's not open anything if the user selected a lot of directories,
+        # to avoid accidentally spamming their desktop with dozends of
+        # new windows or tabs.  Ten is a totally arbitrary limit :)
+        return []
+    else:
+        return paths
+
+
+class OpenInGhosttyAction(GObject.GObject, Nautilus.MenuProvider):
     def _make_item(self, name, paths):
         item = Nautilus.MenuItem(name=name, label='Open in Ghostty',
             icon='com.mitchellh.ghostty')
-        item.connect('activate', self._menu_item_activated, paths)
+        item.connect('activate', open_in_ghostty_activated, paths)
         return item
-
-    def _paths_to_open(self, files):
-        paths = []
-        for file in files:
-            location = file.get_location() if file.is_directory() else file.get_parent_location()
-            path = location.get_path()
-            if path and path not in paths:
-                paths.append(path)
-        if 10 < len(paths):
-            # Let's not open anything if the user selected a lot of directories,
-            # to avoid accidentally spamming their desktop with dozends of
-            # new windows or tabs.  Ten is a totally arbitrary limit :)
-            return []
-        else:
-            return paths
 
     def get_file_items(self, *args):
         # Nautilus 3.0 API passes args (window, files), 4.0 API just passes files
         files = args[0] if len(args) == 1 else args[1]
-        paths = self._paths_to_open(files)
+        paths = get_paths_to_open(files)
         if paths:
             return [self._make_item(name='GhosttyNautilus::open_in_ghostty', paths=paths)]
         else:
@@ -59,7 +61,7 @@ class OpenInGhosttyAction(GObject.GObject, Nautilus.MenuProvider):
     def get_background_items(self, *args):
         # Nautilus 3.0 API passes args (window, file), 4.0 API just passes file
         file = args[0] if len(args) == 1 else args[1]
-        paths = self._paths_to_open([file])
+        paths = get_paths_to_open([file])
         if paths:
             return [self._make_item(name='GhosttyNautilus::open_folder_in_ghostty', paths=paths)]
         else:

--- a/dist/linux/ghostty_nautilus.py
+++ b/dist/linux/ghostty_nautilus.py
@@ -54,12 +54,8 @@ def get_items_for_files(name, files):
 
 
 class GhosttyMenuProvider(GObject.GObject, Nautilus.MenuProvider):
-    def get_file_items(self, *args):
-        # Nautilus 3.0 API passes args (window, files), 4.0 API just passes files
-        files = args[0] if len(args) == 1 else args[1]
+    def get_file_items(self, files):
         return get_items_for_files('GhosttyNautilus::open_in_ghostty', files)
 
-    def get_background_items(self, *args):
-        # Nautilus 3.0 API passes args (window, file), 4.0 API just passes file
-        file = args[0] if len(args) == 1 else args[1]
+    def get_background_items(self, file):
         return get_items_for_files('GhosttyNautilus::open_folder_in_ghostty', [file])

--- a/dist/linux/ghostty_nautilus.py
+++ b/dist/linux/ghostty_nautilus.py
@@ -42,27 +42,24 @@ def get_paths_to_open(files):
         return paths
 
 
-class OpenInGhosttyAction(GObject.GObject, Nautilus.MenuProvider):
-    def _make_item(self, name, paths):
+def get_items_for_files(name, files):
+    paths = get_paths_to_open(files)
+    if paths:
         item = Nautilus.MenuItem(name=name, label='Open in Ghostty',
             icon='com.mitchellh.ghostty')
         item.connect('activate', open_in_ghostty_activated, paths)
-        return item
+        return [item]
+    else:
+        return []
 
+
+class OpenInGhosttyAction(GObject.GObject, Nautilus.MenuProvider):
     def get_file_items(self, *args):
         # Nautilus 3.0 API passes args (window, files), 4.0 API just passes files
         files = args[0] if len(args) == 1 else args[1]
-        paths = get_paths_to_open(files)
-        if paths:
-            return [self._make_item(name='GhosttyNautilus::open_in_ghostty', paths=paths)]
-        else:
-            return []
+        return get_items_for_files('GhosttyNautilus::open_in_ghostty', files)
 
     def get_background_items(self, *args):
         # Nautilus 3.0 API passes args (window, file), 4.0 API just passes file
         file = args[0] if len(args) == 1 else args[1]
-        paths = get_paths_to_open([file])
-        if paths:
-            return [self._make_item(name='GhosttyNautilus::open_folder_in_ghostty', paths=paths)]
-        else:
-            return []
+        return get_items_for_files('GhosttyNautilus::open_folder_in_ghostty', [file])

--- a/dist/linux/ghostty_nautilus.py
+++ b/dist/linux/ghostty_nautilus.py
@@ -21,13 +21,10 @@ from gi.repository import Nautilus, GObject, Gio
 
 
 class OpenInGhosttyAction(GObject.GObject, Nautilus.MenuProvider):
-    def _open_terminal(self, path):
-        cmd = ['ghostty', f'--working-directory={path}', '--gtk-single-instance=false']
-        Gio.Subprocess.new(cmd, Gio.SubprocessFlags.NONE)
-
     def _menu_item_activated(self, _menu, paths):
         for path in paths:
-            self._open_terminal(path)
+            cmd = ['ghostty', f'--working-directory={path}', '--gtk-single-instance=false']
+            Gio.Subprocess.new(cmd, Gio.SubprocessFlags.NONE)
 
     def _make_item(self, name, paths):
         item = Nautilus.MenuItem(name=name, label='Open in Ghostty',

--- a/dist/linux/ghostty_nautilus.py
+++ b/dist/linux/ghostty_nautilus.py
@@ -53,7 +53,7 @@ def get_items_for_files(name, files):
         return []
 
 
-class OpenInGhosttyAction(GObject.GObject, Nautilus.MenuProvider):
+class GhosttyMenuProvider(GObject.GObject, Nautilus.MenuProvider):
     def get_file_items(self, *args):
         # Nautilus 3.0 API passes args (window, files), 4.0 API just passes files
         files = args[0] if len(args) == 1 else args[1]


### PR DESCRIPTION
Following #10082 I took the opportunity to clean up the code in the nautilus extension a little.   Specifically, this pull request

- turns methods that weren't using `self` into functions,
- inlines a helper method that was trivial after #10082,
- extracts duplicate code in both menu item callbacks into a new helper function, and
- removes the compatibility hack for the Nautilus 3.0 API, i.e. GNOME 42 and older.

I'm not that sure about the last point, as it's not clear to me what the support baseline is here: GNOME 43 (the first version to support the Nautilus 4.0 API) was released in Sep 2022, i.e. is almost as old as Ghostty itself.  The previous Debian stable release already included GNOME 43, but Ubuntu 22.04 (the LTS before the current 24.04 LTS) still includes GNOME 42.  Does Ghostty support a system that old?  If so, I'll drop the corresponding commit from this PR.