### PR TITLE
macOS: bug fixes for moving splits to different trees

### DIFF
--- a/macos/Sources/Features/Global Keybinds/GlobalEventTap.swift
+++ b/macos/Sources/Features/Global Keybinds/GlobalEventTap.swift
@@ -128,10 +128,12 @@ fileprivate func cgEventFlagsChangedHandler(
     // We only care about keydown events
     guard type == .keyDown else { return result }
 
-    // If our app is currently active then we don't process the key event.
-    // This is because we already have a local event handler in AppDelegate
+    // If our app is currently active and not dragging surface,
+    // then we don't process the key event.
+    // This is because we already have a valid local event handler in AppDelegate
     // that processes all local events.
-    guard !NSApp.isActive else { return result }
+    // See `https://developer.apple.com/documentation/appkit/nsevent/addlocalmonitorforevents(matching:handler:)#Discussion`
+    guard (!NSApp.isActive || Ghostty.isDraggingSurface) else { return result }
 
     // We need an app delegate to get the Ghostty app instance
     guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return result }

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -304,7 +304,7 @@ class QuickTerminalController: BaseTerminalController {
         // If its the root, we check if the process exited. If it did,
         // then we do empty the tree.
         if surface.processExited {
-            surfaceTree = .init()
+            resetSurfaceTree()
             return
         }
 
@@ -314,6 +314,10 @@ class QuickTerminalController: BaseTerminalController {
     }
 
     // MARK: Methods
+
+    func resetSurfaceTree() {
+        surfaceTree = .init()
+    }
 
     func toggle() {
         if (visible) {

--- a/macos/Sources/Features/Splits/SplitTree.swift
+++ b/macos/Sources/Features/Splits/SplitTree.swift
@@ -121,10 +121,10 @@ extension SplitTree {
 
     /// Insert a new view at the given view point by creating a split in the given direction.
     /// This will always reset the zoomed state of the tree.
-    func insert(view: ViewType, at: ViewType, direction: NewDirection) throws -> Self {
+    func inserting(view: ViewType, at: ViewType, direction: NewDirection) throws -> Self {
         guard let root else { throw SplitError.viewNotFound }
         return .init(
-            root: try root.insert(view: view, at: at, direction: direction),
+            root: try root.inserting(view: view, at: at, direction: direction),
             zoomed: nil)
     }
     /// Find a node containing a view with the specified ID.
@@ -137,7 +137,7 @@ extension SplitTree {
 
     /// Remove a node from the tree. If the node being removed is part of a split,
     /// the sibling node takes the place of the parent split.
-    func remove(_ target: Node) -> Self {
+    func removing(_ target: Node) -> Self {
         guard let root else { return self }
 
         // If we're removing the root itself, return an empty tree
@@ -155,7 +155,7 @@ extension SplitTree {
     }
 
     /// Replace a node in the tree with a new node.
-    func replace(node: Node, with newNode: Node) throws -> Self {
+    func replacing(node: Node, with newNode: Node) throws -> Self {
         guard let root else { throw SplitError.viewNotFound }
 
         // Get the path to the node we want to replace
@@ -164,7 +164,7 @@ extension SplitTree {
         }
 
         // Replace the node
-        let newRoot = try root.replaceNode(at: path, with: newNode)
+        let newRoot = try root.replacingNode(at: path, with: newNode)
 
         // Update zoomed if it was the replaced node
         let newZoomed = (zoomed == node) ? newNode : zoomed
@@ -232,7 +232,7 @@ extension SplitTree {
 
     /// Equalize all splits in the tree so that each split's ratio is based on the
     /// relative weight (number of leaves) of its children.
-    func equalize() -> Self {
+    func equalized() -> Self {
         guard let root else { return self }
         let newRoot = root.equalize()
         return .init(root: newRoot, zoomed: zoomed)
@@ -255,7 +255,7 @@ extension SplitTree {
     ///   - bounds: The bounds used to construct the spatial tree representation
     /// - Returns: A new SplitTree with the adjusted split ratios
     /// - Throws: SplitError.viewNotFound if the node is not found in the tree or no suitable parent split exists
-    func resize(node: Node, by pixels: UInt16, in direction: Spatial.Direction, with bounds: CGRect) throws -> Self {
+    func resizing(node: Node, by pixels: UInt16, in direction: Spatial.Direction, with bounds: CGRect) throws -> Self {
         guard let root else { throw SplitError.viewNotFound }
 
         // Find the path to the target node
@@ -327,7 +327,7 @@ extension SplitTree {
         )
 
         // Replace the split node with the new one
-        let newRoot = try root.replaceNode(at: splitPath, with: .split(newSplit))
+        let newRoot = try root.replacingNode(at: splitPath, with: .split(newSplit))
         return .init(root: newRoot, zoomed: nil)
     }
 
@@ -508,7 +508,7 @@ extension SplitTree.Node {
     ///
     /// - Note: If the existing view (`at`) is not found in the tree, this method does nothing. We should
     /// maybe throw instead but at the moment we just do nothing.
-    func insert(view: ViewType, at: ViewType, direction: NewDirection) throws -> Self {
+    func inserting(view: ViewType, at: ViewType, direction: NewDirection) throws -> Self {
         // Get the path to our insertion point. If it doesn't exist we do
         // nothing.
         guard let path = path(to: .leaf(view: at)) else {
@@ -544,11 +544,11 @@ extension SplitTree.Node {
         ))
 
         // Replace the node at the path with the new split
-        return try replaceNode(at: path, with: newSplit)
+        return try replacingNode(at: path, with: newSplit)
     }
 
     /// Helper function to replace a node at the given path from the root
-    func replaceNode(at path: Path, with newNode: Self) throws -> Self {
+    func replacingNode(at path: Path, with newNode: Self) throws -> Self {
         // If path is empty, replace the root
         if path.isEmpty {
             return newNode
@@ -635,7 +635,7 @@ extension SplitTree.Node {
     /// Resize a split node to the specified ratio.
     /// For leaf nodes, this returns the node unchanged.
     /// For split nodes, this creates a new split with the updated ratio.
-    func resize(to ratio: Double) -> Self {
+    func resizing(to ratio: Double) -> Self {
         switch self {
         case .leaf:
             // Leaf nodes don't have a ratio to resize

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -953,6 +953,8 @@ class BaseTerminalController: NSWindowController,
             // to do this.
             if let c = sourceController as? TerminalController {
                 c.closeTabImmediately()
+            } else if let qc = sourceController as? QuickTerminalController {
+                qc.resetSurfaceTree()
             } else {
                 // Not a TerminalController so we always undo into a new window.
                 _ = TerminalController.newWindow(

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -240,7 +240,7 @@ class BaseTerminalController: NSWindowController,
         // Do the split
         let newTree: SplitTree<Ghostty.SurfaceView>
         do {
-            newTree = try surfaceTree.insert(
+            newTree = try surfaceTree.inserting(
                 view: newView,
                 at: oldView,
                 direction: direction)
@@ -450,7 +450,7 @@ class BaseTerminalController: NSWindowController,
         }
 
         replaceSurfaceTree(
-            surfaceTree.remove(node),
+            surfaceTree.removing(node),
             moveFocusTo: nextFocus,
             moveFocusFrom: focusedSurface,
             undoAction: "Close Terminal"
@@ -614,7 +614,7 @@ class BaseTerminalController: NSWindowController,
         guard surfaceTree.contains(target) else { return }
         
         // Equalize the splits
-        surfaceTree = surfaceTree.equalize()
+        surfaceTree = surfaceTree.equalized()
     }
     
     @objc private func ghosttyDidFocusSplit(_ notification: Notification) {
@@ -704,7 +704,7 @@ class BaseTerminalController: NSWindowController,
         
         // Perform the resize using the new SplitTree resize method
         do {
-            surfaceTree = try surfaceTree.resize(node: targetNode, by: amount, in: spatialDirection, with: bounds)
+            surfaceTree = try surfaceTree.resizing(node: targetNode, by: amount, in: spatialDirection, with: bounds)
         } catch {
             Ghostty.logger.warning("failed to resize split: \(error)")
         }
@@ -742,7 +742,7 @@ class BaseTerminalController: NSWindowController,
         }
 
         // Remove the surface from our tree
-        let removedTree = surfaceTree.remove(targetNode)
+        let removedTree = surfaceTree.removing(targetNode)
 
         // Create a new tree with the dragged surface and open a new window
         let newTree = SplitTree<Ghostty.SurfaceView>(view: target)
@@ -868,9 +868,9 @@ class BaseTerminalController: NSWindowController,
     }
 
     private func splitDidResize(node: SplitTree<Ghostty.SurfaceView>.Node, to newRatio: Double) {
-        let resizedNode = node.resize(to: newRatio)
+        let resizedNode = node.resizing(to: newRatio)
         do {
-            surfaceTree = try surfaceTree.replace(node: node, with: resizedNode)
+            surfaceTree = try surfaceTree.replacing(node: node, with: resizedNode)
         } catch {
             Ghostty.logger.warning("failed to replace node during split resize: \(error)")
         }
@@ -892,10 +892,10 @@ class BaseTerminalController: NSWindowController,
         // Check if source is in our tree
         if let sourceNode = surfaceTree.root?.node(view: source) {
             // Source is in our tree - same window move
-            let treeWithoutSource = surfaceTree.remove(sourceNode)
+            let treeWithoutSource = surfaceTree.removing(sourceNode)
             let newTree: SplitTree<Ghostty.SurfaceView>
             do {
-                newTree = try treeWithoutSource.insert(view: source, at: destination, direction: direction)
+                newTree = try treeWithoutSource.inserting(view: source, at: destination, direction: direction)
             } catch {
                 Ghostty.logger.warning("failed to insert surface during drop: \(error)")
                 return
@@ -930,10 +930,10 @@ class BaseTerminalController: NSWindowController,
         // Remove from source controller's tree and add it to our tree.
         // We do this first because if there is an error then we can
         // abort.
-        let sourceTreeWithoutNode = sourceController.surfaceTree.remove(sourceNode)
+        let sourceTreeWithoutNode = sourceController.surfaceTree.removing(sourceNode)
         let newTree: SplitTree<Ghostty.SurfaceView>
         do {
-            newTree = try surfaceTree.insert(view: source, at: destination, direction: direction)
+            newTree = try surfaceTree.inserting(view: source, at: destination, direction: direction)
         } catch {
             Ghostty.logger.warning("failed to insert surface during cross-window drop: \(error)")
             return

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -961,10 +961,9 @@ class BaseTerminalController: NSWindowController,
                     confirmUndo: false)
             }
         } else {
-            // The source isn't empty so we can do a simple replace which will handle
+            // The source isn't empty so we can do a simple remove which will handle
             // the undo properly.
-            sourceController.replaceSurfaceTree(
-                sourceTreeWithoutNode)
+            sourceController.removeSurfaceNode(sourceNode)
         }
         
         // Add in the surface to our tree

--- a/macos/Sources/Ghostty/Surface View/SurfaceDragSource.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceDragSource.swift
@@ -2,6 +2,12 @@ import AppKit
 import SwiftUI
 
 extension Ghostty {
+    /// This is only true when the user is dragging the surface.
+    ///
+    /// We need this to allow global events when the surface
+    /// can't receive events callback when dragging
+    private(set) static var isDraggingSurface = false
+
     /// A preference key that propagates the ID of the SurfaceView currently being dragged,
     /// or nil if no surface is being dragged.
     struct DraggingSurfaceKey: PreferenceKey {
@@ -189,6 +195,7 @@ extension Ghostty {
             }
             
             onDragStateChanged?(true)
+            Ghostty.isDraggingSurface = true
             let session = beginDraggingSession(with: [item], event: event, source: self)
             
             // We need to disable this so that endedAt happens immediately for our
@@ -253,6 +260,7 @@ extension Ghostty {
 
             isTracking = false
             onDragStateChanged?(false)
+            Ghostty.isDraggingSurface = false
         }
     }
 }


### PR DESCRIPTION
This pr contains 3 fixes as explained in the commit message. 

The first commit contains only some renaming to distinguish mutating and non-mutating functions, like `sort/sorted` of `Array`.

I didn't figure out good away to detect in `GlobalEventTap.swift` whether a surface is being dragged, so another global variable was created under `Ghostty`, if you have a better way to do this, pleas lemme know.