### PR TITLE
macOS: flash menu bar when using keyboard shortcuts

### DIFF
--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -1195,7 +1195,15 @@ extension Ghostty {
                 return false
             }
 
-            // If this event as-is would result in a key binding then we send it.
+            // Let the menu system handle this event if we're not in a key sequence or key table.
+            // This allows the menu bar to flash for shortcuts like Command+V.
+            if keySequence.isEmpty && keyTables.isEmpty {
+                if let menu = NSApp.mainMenu, menu.performKeyEquivalent(with: event) {
+                    return true
+                }
+            }
+
+            // If the menu didn't handle it, check Ghostty bindings for custom shortcuts.
             if let surface {
                 var ghosttyEvent = event.ghosttyKeyEvent(GHOSTTY_ACTION_PRESS)
                 let match = (event.characters ?? "").withCString { ptr in
@@ -2209,7 +2217,7 @@ extension Ghostty.SurfaceView {
 
         return NSAttributedString(string: plainString, attributes: attributes)
     }
-    
+
 }
 
 /// Caches a value for some period of time, evicting it automatically when that time expires.


### PR DESCRIPTION
When you press a keyboard shortcut that has a menu equivalent, the menu bar should flash briefly. This is standard macOS behavior.

This change calls `performKeyEquivalent` on the main menu before checking Ghostty bindings, so shortcuts with menu items get handled by the menu system first.

This works for most shortcuts - Cmd+V, Cmd+N, Cmd+T, etc. all flash now.

Won't flash for `performable: true` (like Cmd+C copy) -- excluded from menu: https://github.com/ghostty-org/ghostty/discussions/2811

The change skips menu handling when in a key sequence or key table, so those still work correctly.