### PR TITLE
macOS: Split drag to create new tabs

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -344,7 +344,9 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
     static func newTab(
         _ ghostty: Ghostty.App,
         from parent: NSWindow? = nil,
-        withBaseConfig baseConfig: Ghostty.SurfaceConfiguration? = nil
+        withBaseConfig baseConfig: Ghostty.SurfaceConfiguration? = nil,
+        tree: SplitTree<Ghostty.SurfaceView>? = nil,
+        confirmUndo: Bool = true,
     ) -> TerminalController? {
         // Making sure that we're dealing with a TerminalController. If not,
         // then we just create a new window.
@@ -367,7 +369,7 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         }
 
         // Create a new window and add it to the parent
-        let controller = TerminalController.init(ghostty, withBaseConfig: baseConfig)
+        let controller = TerminalController.init(ghostty, withBaseConfig: baseConfig, withSurfaceTree: tree)
         guard let window = controller.window else { return controller }
 
         // If the parent is miniaturized, then macOS exhibits really strange behaviors
@@ -444,7 +446,11 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
                 // https://github.com/ghostty-org/ghostty/pull/9512
                 DispatchQueue.main.async {
                     undoManager.disableUndoRegistration {
-                        target.closeTab(nil)
+                        if confirmUndo {
+                            target.closeTab(nil)
+                        } else {
+                            target.closeTabImmediately()
+                        }
                     }
                 }
 


### PR DESCRIPTION
Implements #10092 and updates cursor shape to indicate the drag action.


https://github.com/user-attachments/assets/53e8900c-f9b7-4ed4-9c5b-875eee1fa249


https://github.com/user-attachments/assets/59f38395-62cc-4a05-9f85-7eb54e8a2f41



We could also create the *second* tab when dragging the surface to the title bar, but Finder only accepts it on the New Tab button too.

> [!NOTE]
> AI proofread my comments
