### PR TITLE
Add iTimeFocus shader uniform to track time since focus

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2783,6 +2783,22 @@ keybind: Keybinds = .{},
 ///    the same time as the `iTime` uniform, allowing you to compute the
 ///    time since the change by subtracting this from `iTime`.
 ///
+///  * `float iTimeFocus` - Timestamp when the surface last gained iFocus.
+///
+///    When the surface gains focus, this is set to the current value of
+///    `iTime`, similar to how `iTimeCursorChange` works. This allows you
+///    to compute the time since focus was gained or lost by calculating
+///    `iTime - iTimeFocus`. Use this to create animations that restart
+///    when the terminal regains focus.
+///
+///  * `int iFocus` - Current focus state of the surface.
+///
+///    Set to 1.0 when the surface is focused, 0.0 when unfocused. This
+///    allows shaders to detect unfocused state and avoid animation artifacts
+///    from large time deltas caused by infrequent "deceptive frames"
+///    (e.g., modifier key presses, link hover events in unfocused split panes).
+///    Check `iFocus > 0` to determine if the surface is currently focused.
+///
 /// If the shader fails to compile, the shader will be ignored. Any errors
 /// related to shader compilation will not show up as configuration errors
 /// and only show up in the log, since shader compilation happens after

--- a/src/renderer/shaders/shadertoy_prefix.glsl
+++ b/src/renderer/shaders/shadertoy_prefix.glsl
@@ -16,6 +16,8 @@ layout(binding = 1, std140) uniform Globals {
     uniform vec4  iCurrentCursorColor;
     uniform vec4  iPreviousCursorColor;
     uniform float iTimeCursorChange;
+    uniform float iTimeFocus;
+    uniform int iFocus;
 };
 
 layout(binding = 0) uniform sampler2D iChannel0;

--- a/src/renderer/shaders/test_shadertoy_focus.glsl
+++ b/src/renderer/shaders/test_shadertoy_focus.glsl
@@ -1,0 +1,41 @@
+// Test shader for iTimeFocus and iFocus
+// Shows border when focused, green fade that restarts on each focus gain
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = fragCoord / iResolution.xy;
+
+    // Sample the terminal content
+    vec4 terminal = texture2D(iChannel0, uv);
+    vec3 color = terminal.rgb;
+
+    if (iFocus > 0) {
+        // FOCUSED: Add border and fading green overlay
+
+        // Calculate time since focus was gained
+        float timeSinceFocus = iTime - iTimeFocus;
+
+        // Green fade: starts at 1.0 (full green), fades to 0.0 over 3 seconds
+        float fadeOut = max(0.0, 1.0 - (timeSinceFocus / 3.0));
+
+        // Add green overlay that fades out
+        color = mix(color, vec3(0.0, 1.0, 0.0), fadeOut * 0.4);
+
+        // Add border (5 pixels)
+        float borderSize = 5.0;
+        vec2 pixelCoord = fragCoord;
+        bool isBorder = pixelCoord.x < borderSize ||
+                       pixelCoord.x > iResolution.x - borderSize ||
+                       pixelCoord.y < borderSize ||
+                       pixelCoord.y > iResolution.y - borderSize;
+
+        if (isBorder) {
+            // Bright cyan border that pulses subtly
+            float pulse = sin(timeSinceFocus * 2.0) * 0.1 + 0.9;
+            color = vec3(0.0, 1.0, 1.0) * pulse;
+        }
+    } else {
+        // UNFOCUSED: Solid red overlay (no border)
+        color = mix(color, vec3(1.0, 0.0, 0.0), 0.3);
+    }
+
+    fragColor = vec4(color, 1.0);
+}

--- a/src/renderer/shadertoy.zig
+++ b/src/renderer/shadertoy.zig
@@ -25,6 +25,8 @@ pub const Uniforms = extern struct {
     current_cursor_color: [4]f32 align(16),
     previous_cursor_color: [4]f32 align(16),
     cursor_change_time: f32 align(4),
+    time_focus: f32 align(4),
+    focus: i32 align(4),
 };
 
 /// The target to load shaders for.
@@ -412,3 +414,4 @@ test "shadertoy to glsl" {
 
 const test_crt = @embedFile("shaders/test_shadertoy_crt.glsl");
 const test_invalid = @embedFile("shaders/test_shadertoy_invalid.glsl");
+const test_focus = @embedFile("shaders/test_shadertoy_focus.glsl");


### PR DESCRIPTION
When using split panes with custom shaders, unfocused panes receive frame re-draws when mod keys are held or when the mouse hovers over a link. This behavior is desirable in general, but shaders have no way to detect when the frames they are drawing are "real" or a momentary glitch frame.

Fixes #8456 indirectly, by allowing the shader to be updated to handle this situation.

This PR adds two new shadertoy uniforms:

```glsl
float iTimeFocus
```

- Timestamp of when the surface last gained focus (set to current iTime, similar to iTimeCursorChange timestamp)
- Allows calculating time since focus: iTime - iTimeFocus
- Resets on each focus gain, enabling "focus trigger" animations
- Uses the same focus state signal that changes unfocused-split-fill config option

```glsl
float iFocus
```

- Current focus state: 1.0 when focused, 0.0 when unfocused
- Simple boolean check: if (iFocus == 1.0)
- This indicates that the frame being rendered is a defocused frame (for example, upon leaving the surface, or when a mod key is held or an OSC8 link is hovered), allowing shaders to apply consistently instead of flashing.

## Example

This does nothing, but it does show the two costumes and how you might use them

```glsl
  void mainImage(out vec4 fragColor, in vec2 fragCoord) {
      if (iFocus == 1.0) {
          // Focused: animate based on time since focus
          float timeSinceFocus = iTime - iTimeFocus;
          // Resume normal animation
      } else {
          // Unfocused: dim or hide effects
      }
  }
```

Here's the included example shader being applied to this test build:

https://github.com/user-attachments/assets/4932e12f-6a1c-42dd-81f3-19da9a551c95

And here's a [more exciting shader](https://github.com/martinemde/dotfiles/blob/22d97c6888874564e92083b761b13a1ad593b187/home/dot_config/ghostty/focus_vignette.glsl) that locates your cursor upon switching to a surface, renders a fade/zoom in of the cursor on focus, and applies a shadow vignette to the defocused surfaces.

https://github.com/user-attachments/assets/32b98956-59f0-4e4b-9c2f-ab79b147205f

AI disclosure: I used claude code to generate everything is this PR, but I reviewed it, understand what it is doing, tested it manually, and believe it is correct. I also tested by directly creating shadertoys that use the new costumes (shown above) and have uploaded the examples here showing that it works.