### PR TITLE
fix(formatter): preserve background colors on cells without text

### DIFF
--- a/src/terminal/formatter.zig
+++ b/src/terminal/formatter.zig
@@ -3427,7 +3427,9 @@ test "Page VT multi-line with styles" {
 
     try formatter.format(&builder.writer);
     const output = builder.writer.buffered();
-    try testing.expectEqualStrings("\x1b[0m\x1b[1mfirst\r\n\x1b[0m\x1b[3msecond\x1b[0m", output);
+    // Note: style is reset before newline to prevent background colors from
+    // bleeding to the next line's leading cells.
+    try testing.expectEqualStrings("\x1b[0m\x1b[1mfirst\x1b[0m\r\n\x1b[0m\x1b[3msecond\x1b[0m", output);
 
     // Verify point map matches output length
     try testing.expectEqual(output.len, point_map.items.len);

--- a/src/terminal/formatter.zig
+++ b/src/terminal/formatter.zig
@@ -1042,6 +1042,13 @@ pub const PageFormatter = struct {
             }
 
             if (blank_rows > 0) {
+                // Reset style before emitting newlines to prevent background
+                // colors from bleeding into the next line's leading cells.
+                if (!style.default()) {
+                    try self.formatStyleClose(writer);
+                    style = .{};
+                }
+
                 const sequence: []const u8 = switch (self.opts.emit) {
                     // Plaintext just uses standard newlines because newlines
                     // on their own usually move the cursor back in anywhere


### PR DESCRIPTION
The VT formatter was treating cells without text as blank and emitting
them as plain spaces, losing any background color styling. This caused
TUIs like htop to lose their background colors when rehydrating terminal
state (e.g., after detach/reattach in zmx).

For styled formats (VT/HTML), cells with background colors or `style_id`
are now emitted with proper SGR sequences and a space character instead
of being accumulated as unstyled blanks.

Adds handling for `bg_color_palette` and `bg_color_rgb` content tags which
were previously unreachable.

I used amp to construct the test case and the code to make the test pass.  Please see the amp thread.

I tested my branch against the test cases where it was previously broken (nvtop, htop, senpai).

Reference: https://ampcode.com/threads/T-019b7a35-c3f3-73fc-adfa-00bbe9dbda3c

## VT

### BEFORE

<img width="2256" height="552" alt="screenshot_1767373196" src="https://github.com/user-attachments/assets/32654801-35cb-4d94-8ebd-501cfe74b6b6" />

### AFTER

<img width="2256" height="632" alt="screenshot_1767373113" src="https://github.com/user-attachments/assets/f011260b-20ca-40a7-95b4-965c29b2eba3" />

## HTML

### BEFORE

<img width="1118" height="749" alt="screenshot_1767373647" src="https://github.com/user-attachments/assets/e4152640-8f1e-48f7-893c-d437d48629ef" />

### AFTER

<img width="1130" height="775" alt="screenshot_1767373657" src="https://github.com/user-attachments/assets/288423c8-d034-4dea-b976-506a7b95cc3c" />

