### PR TITLE
fix: use flush instead of end on stdout in code generators for Windows compatibility

### DIFF
--- a/src/unicode/props_uucode.zig
+++ b/src/unicode/props_uucode.zig
@@ -87,7 +87,10 @@ pub fn main() !void {
     var buf: [4096]u8 = undefined;
     var stdout = std.fs.File.stdout().writer(&buf);
     try t.writeZig(&stdout.interface);
-    try stdout.end();
+    // Use flush instead of end to avoid Windows issue where stdout.end()
+    // tries to truncate the console handle which is not supported.
+    // See: https://github.com/ghostty-org/ghostty/issues/10147
+    try stdout.interface.flush();
 
     // Uncomment when manually debugging to see our table sizes.
     // std.log.warn("stage1={} stage2={} stage3={}", .{

--- a/src/unicode/symbols_uucode.zig
+++ b/src/unicode/symbols_uucode.zig
@@ -34,7 +34,10 @@ pub fn main() !void {
     var buf: [4096]u8 = undefined;
     var stdout = std.fs.File.stdout().writer(&buf);
     try t.writeZig(&stdout.interface);
-    try stdout.end();
+    // Use flush instead of end to avoid Windows issue where stdout.end()
+    // tries to truncate the console handle which is not supported.
+    // See: https://github.com/ghostty-org/ghostty/issues/10147
+    try stdout.interface.flush();
 
     // Uncomment when manually debugging to see our table sizes.
     // std.log.warn("stage1={} stage2={} stage3={}", .{


### PR DESCRIPTION
This fixes the Windows build failure reported in https://github.com/ghostty-org/ghostty/issues/10147

When building ghostty (or projects that use ghostty as a dependency) on Windows, the `symbols-unigen` and `props-unigen` code generators crash with `error.FileTooBig` because they call `stdout.end()`.

The issue is that `stdout.end()` internally calls `setEndPos()` to truncate the output to the actual bytes written. This works for regular files, but on Windows stdout is typically a pipe (when captured by the build system via `captureStdOut()`) or a console handle. Windows does not support `SetEndOfFile` on pipes or console handles - it returns `ERROR_INVALID_PARAMETER`, which Zig maps to `error.FileTooBig`.

Using `flush()` instead of `end()` is the correct fix for stdout because:

1. The purpose of `end()` is to flush buffered data AND truncate the file to remove any leftover bytes from a previous write. This is useful when overwriting an existing file that might be larger than the new content.

2. For stdout (especially when captured as a pipe), truncation is not needed and not possible. We're writing sequentially to a fresh pipe - there's no "old content" to truncate. The pipe simply receives bytes as they're written.

3. `flush()` ensures all buffered data is sent to the pipe, which is all that's needed for the build system to capture the complete output.

You can see a successful Windows native build using this fix in the opentui project CI: https://github.com/remorses/opentui/actions/runs/20671299561/job/59352503875

The build completes successfully and runs 2879 tests (with only 4 unrelated Windows-specific test failures due to timing differences).

Files changed:
- src/unicode/symbols_uucode.zig
- src/unicode/props_uucode.zig