### PR TITLE
fix: use flush instead of end on stdout in code generators for Windows compatibility

### DIFF
--- a/src/unicode/props_uucode.zig
+++ b/src/unicode/props_uucode.zig
@@ -88,7 +88,8 @@ pub fn main() !void {
     var stdout = std.fs.File.stdout().writer(&buf);
     try t.writeZig(&stdout.interface);
     // Use flush instead of end because stdout is a pipe when captured by
-    // the build system, and pipes cannot be truncated (especially on Windows).
+    // the build system, and pipes cannot be truncated (Windows returns
+    // INVALID_PARAMETER, Linux returns EINVAL).
     try stdout.interface.flush();
 
     // Uncomment when manually debugging to see our table sizes.

--- a/src/unicode/props_uucode.zig
+++ b/src/unicode/props_uucode.zig
@@ -87,7 +87,9 @@ pub fn main() !void {
     var buf: [4096]u8 = undefined;
     var stdout = std.fs.File.stdout().writer(&buf);
     try t.writeZig(&stdout.interface);
-    try stdout.end();
+    // Use flush instead of end because stdout is a pipe when captured by
+    // the build system, and pipes cannot be truncated (especially on Windows).
+    try stdout.interface.flush();
 
     // Uncomment when manually debugging to see our table sizes.
     // std.log.warn("stage1={} stage2={} stage3={}", .{

--- a/src/unicode/symbols_uucode.zig
+++ b/src/unicode/symbols_uucode.zig
@@ -34,7 +34,9 @@ pub fn main() !void {
     var buf: [4096]u8 = undefined;
     var stdout = std.fs.File.stdout().writer(&buf);
     try t.writeZig(&stdout.interface);
-    try stdout.end();
+    // Use flush instead of end because stdout is a pipe when captured by
+    // the build system, and pipes cannot be truncated (especially on Windows).
+    try stdout.interface.flush();
 
     // Uncomment when manually debugging to see our table sizes.
     // std.log.warn("stage1={} stage2={} stage3={}", .{

--- a/src/unicode/symbols_uucode.zig
+++ b/src/unicode/symbols_uucode.zig
@@ -35,7 +35,8 @@ pub fn main() !void {
     var stdout = std.fs.File.stdout().writer(&buf);
     try t.writeZig(&stdout.interface);
     // Use flush instead of end because stdout is a pipe when captured by
-    // the build system, and pipes cannot be truncated (especially on Windows).
+    // the build system, and pipes cannot be truncated (Windows returns
+    // INVALID_PARAMETER, Linux returns EINVAL).
     try stdout.interface.flush();
 
     // Uncomment when manually debugging to see our table sizes.


### PR DESCRIPTION
This fixes the Windows build failure discussed in https://github.com/ghostty-org/ghostty/discussions/10148

When building on Windows, `symbols-unigen` and `props-unigen` crash with `error.FileTooBig` because `stdout.end()` calls `setEndPos()` to truncate the output. Windows does not support `SetEndOfFile` on pipes or console handles - it returns `ERROR_INVALID_PARAMETER`, which Zig maps to `error.FileTooBig`.

Using `flush()` instead of `end()` is correct here because:

1. `end()` flushes AND truncates - useful when overwriting files that might have leftover content
2. For stdout captured as a pipe, there's nothing to truncate - we're writing sequentially to a fresh pipe
3. `flush()` ensures all buffered data is sent, which is all that's needed

CI before fix was failing with FileTooBig, after fix builds successfully: https://github.com/remorses/opentui/actions/runs/20671299561/job/59352503875