### PR TITLE
feat: added rounded corners to quick terminal window

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalWindow.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalWindow.swift
@@ -21,10 +21,15 @@ class QuickTerminalWindow: NSPanel {
         // AeroSpace to treat the Quick Terminal as a floating window)
         self.setAccessibilitySubrole(.floatingWindow)
 
-        // Remove the title completely. This will make the window square. One
-        // downside is it also hides the cursor indications of resize but the
-        // window remains resizable.
-        self.styleMask.remove(.titled)
+        // Keep a titled window so macOS applies rounded corners, but hide the
+        // titlebar and traffic lights so it still feels borderless.
+        self.styleMask.insert(.titled)
+        self.styleMask.insert(.fullSizeContentView)
+        self.titleVisibility = .hidden
+        self.titlebarAppearsTransparent = true
+        self.standardWindowButton(.closeButton)?.isHidden = true
+        self.standardWindowButton(.miniaturizeButton)?.isHidden = true
+        self.standardWindowButton(.zoomButton)?.isHidden = true
 
         // We don't want to activate the owning app when quick terminal is triggered.
         self.styleMask.insert(.nonactivatingPanel)


### PR DESCRIPTION
This PR updates the appearance and behavior of the `QuickTerminalWindow` on macOS. This was discussed in https://github.com/ghostty-org/ghostty/discussions/8666

The main change is to retain the macOS window styling (including rounded corners) while hiding the titlebar and window controls, so the window appears borderless but still benefits from native system visuals

<img width="1517" height="935" alt="image" src="https://github.com/user-attachments/assets/1d9c2009-dfdd-4dc2-8a6a-30a27e1b2f94" />

P.S: Only after opening PR I saw that this is a sort of a duplicate of https://github.com/ghostty-org/ghostty/pull/9960. Feel free to close my PR if it's better to go with a configurable corner radius instead of setting rounded corners for all quick term windows