### PR TITLE
fix: remove progress bar on reset terminal

### DIFF
--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -952,6 +952,9 @@ pub const StreamHandler = struct {
 
         // Reset resets our palette so we report it for mode 2031.
         self.surfaceMessageWriter(.{ .report_color_scheme = false });
+
+        // Clear the progress bar
+        self.progressReport(.{ .state = .remove });
     }
 
     pub fn queryKittyKeyboard(self: *StreamHandler) !void {


### PR DESCRIPTION
closes #10168

ai disclosure: i fully used claude code to generate this pr, but change seems straightforward enough and have manually tested it.