### PR TITLE
Lower unimplemented OSC from warning to debug

### DIFF
--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -2108,7 +2108,7 @@ pub fn Stream(comptime Handler: type) type {
                 .conemu_wait_input,
                 .conemu_guimacro,
                 => {
-                    log.warn("unimplemented OSC callback: {}", .{cmd});
+                    log.debug("unimplemented OSC callback: {}", .{cmd});
                 },
 
                 .invalid => {


### PR DESCRIPTION
The "unimplemented OSC command" warning is a frequent source of red herrings as there are many OSCs that we parse but deliberately do not implement. It's also a small drag on performance due to the function call overhead and the overhead of formatting and outputting the message. This PR lowers the message from warning to debug. Debug logs are compiled out of release builds so there should be less confusion from general users who will no longer see the message.