### PR TITLE
Add terminfo as downloadable release artifact

### DIFF
--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -51,6 +51,7 @@ jobs:
           curl -I -s -o /dev/null -w "%{http_code}" "${BASE}/ghostty-macos-universal.zip" | grep -q "^200$" || exit 1
           curl -I -s -o /dev/null -w "%{http_code}" "${BASE}/ghostty-macos-universal-dsym.zip" | grep -q "^200$" || exit 1
           curl -I -s -o /dev/null -w "%{http_code}" "${BASE}/Ghostty.dmg" | grep -q "^200$" || exit 1
+          curl -I -s -o /dev/null -w "%{http_code}" "${BASE}/ghostty.terminfo" | grep -q "^200$" || exit 1
           curl -I -s -o /dev/null -w "%{http_code}" "${BASE}/appcast-staged.xml" | grep -q "^200$" || exit 1
 
       - name: Download Staged Appcast

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -105,6 +105,11 @@ jobs:
           cp zig-out/dist/ghostty-${GHOSTTY_VERSION}.tar.gz .
           cp zig-out/dist/ghostty-${GHOSTTY_VERSION}.tar.gz ghostty-source.tar.gz
 
+      - name: Generate Terminfo
+        run: |
+          nix develop -c zig build -Demit-terminfo=true
+          cp zig-out/share/terminfo/ghostty.terminfo .
+
       - name: Sign Tarball
         run: |
           echo -n "${{ secrets.MINISIGN_KEY }}" > minisign.key
@@ -121,6 +126,7 @@ jobs:
             ghostty-${{ env.GHOSTTY_VERSION }}.tar.gz.minisig
             ghostty-source.tar.gz
             ghostty-source.tar.gz.minisig
+            ghostty.terminfo
 
   build-macos:
     needs: [setup]
@@ -166,6 +172,7 @@ jobs:
             zig build \
             -Doptimize=ReleaseFast \
             -Demit-macos-app=false \
+            -Demit-terminfo=true \
             -Dversion-string=${GHOSTTY_VERSION}
 
       # The native app is built with native XCode tooling. This also does
@@ -385,6 +392,7 @@ jobs:
           mv ghostty-macos-universal.zip blob/${GHOSTTY_VERSION}/ghostty-macos-universal.zip
           mv ghostty-macos-universal-dsym.zip blob/${GHOSTTY_VERSION}/ghostty-macos-universal-dsym.zip
           mv Ghostty.dmg blob/${GHOSTTY_VERSION}/Ghostty.dmg
+          mv ghostty.terminfo blob/${GHOSTTY_VERSION}/ghostty.terminfo
           mv appcast.xml blob/${GHOSTTY_VERSION}/appcast-staged.xml
       - name: Upload to R2
         uses: ryand56/r2-upload-action@b801a390acbdeb034c5e684ff5e1361c06639e7c # v1.4

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -179,6 +179,11 @@ jobs:
           nix develop -c zig build distcheck
           cp zig-out/dist/*.tar.gz ghostty-source.tar.gz
 
+      - name: Generate Terminfo
+        run: |
+          nix develop -c zig build -Demit-terminfo=true
+          cp zig-out/share/terminfo/ghostty.terminfo .
+
       - name: Sign Tarball
         run: |
           echo -n "${{ secrets.MINISIGN_KEY }}" > minisign.key
@@ -195,6 +200,7 @@ jobs:
           files: |
             ghostty-source.tar.gz
             ghostty-source.tar.gz.minisig
+            ghostty.terminfo
           token: ${{ secrets.GH_RELEASE_TOKEN }}
 
   build-macos:
@@ -251,7 +257,7 @@ jobs:
       # GhosttyKit is the framework that is built from Zig for our native
       # Mac app to access. Build this in release mode.
       - name: Build GhosttyKit
-        run: nix develop -c zig build -Doptimize=ReleaseFast -Demit-macos-app=false
+        run: nix develop -c zig build -Doptimize=ReleaseFast -Demit-macos-app=false -Demit-terminfo=true
 
       # The native app is built with native XCode tooling. This also does
       # codesigning. IMPORTANT: this must NOT run in a Nix environment.
@@ -485,7 +491,7 @@ jobs:
       # GhosttyKit is the framework that is built from Zig for our native
       # Mac app to access. Build this in release mode.
       - name: Build GhosttyKit
-        run: nix develop -c zig build -Doptimize=Debug -Demit-macos-app=false
+        run: nix develop -c zig build -Doptimize=Debug -Demit-macos-app=false -Demit-terminfo=true
 
       # The native app is built with native XCode tooling. This also does
       # codesigning. IMPORTANT: this must NOT run in a Nix environment.
@@ -669,7 +675,7 @@ jobs:
       # GhosttyKit is the framework that is built from Zig for our native
       # Mac app to access. Build this in release mode.
       - name: Build GhosttyKit
-        run: nix develop -c zig build -Doptimize=ReleaseSafe -Demit-macos-app=false
+        run: nix develop -c zig build -Doptimize=ReleaseSafe -Demit-macos-app=false -Demit-terminfo=true
 
       # The native app is built with native XCode tooling. This also does
       # codesigning. IMPORTANT: this must NOT run in a Nix environment.

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -20,7 +20,10 @@ at `release.files.ghostty.org` in the following URL format where
 ```
 https://release.files.ghostty.org/VERSION/ghostty-VERSION.tar.gz
 https://release.files.ghostty.org/VERSION/ghostty-VERSION.tar.gz.minisig
+https://release.files.ghostty.org/VERSION/ghostty.terminfo
 ```
+
+The `ghostty.terminfo` file is the generated terminfo source for the release.
 
 Signature files are signed with
 [minisign](https://jedisct1.github.io/minisign/)
@@ -83,7 +86,8 @@ zig build \
   --prefix /usr \
   --system /tmp/offline-cache/p \
   -Doptimize=ReleaseFast \
-  -Dcpu=baseline
+  -Dcpu=baseline \
+  -Demit-terminfo=true
 ```
 
 The build options are covered in the next section, but this will build
@@ -117,6 +121,11 @@ relevant to package maintainers:
 - `-Dcpu=baseline`: Build for the "baseline" CPU of the target architecture.
   This avoids building for newer CPU features that may not be available on
   all target machines.
+
+- `-Demit-terminfo=true`: Install the Ghostty terminfo source file to
+  `share/terminfo/ghostty.terminfo` (or `share/site-terminfo` on FreeBSD).
+  Release builds default to false, so enable this if your package ships
+  terminfo.
 
 - `-Dtarget=$arch-$os-$abi`: Build for a specific target triple. This is
   often necessary for system packages to specify a specific minimum Linux

--- a/flatpak/com.mitchellh.ghostty.yml
+++ b/flatpak/com.mitchellh.ghostty.yml
@@ -41,6 +41,7 @@ modules:
         -Dcpu=baseline
         -Dflatpak=true
         -Dstrip=false
+        -Demit-terminfo=true
         -fno-sys=oniguruma
         --prefix /app
         --search-prefix /app

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -96,6 +96,7 @@ in
       "--system"
       "${finalAttrs.deps}"
       "-Dversion-string=${finalAttrs.version}-${revision}-nix"
+      "-Demit-terminfo=true"
       "-Dgtk-x11=${lib.boolToString enableX11}"
       "-Dgtk-wayland=${lib.boolToString enableWayland}"
       "-Dstrip=${lib.boolToString strip}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -84,6 +84,7 @@ parts:
         -Dpatch-rpath=\$ORIGIN/../usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:/snap/core24/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR \
         -Doptimize=ReleaseFast \
         -Dcpu=baseline \
+        -Demit-terminfo=true \
         -fno-sys=gtk4-layer-shell
       cp -rp zig-out/* $CRAFT_PART_INSTALL/
       sed -i 's|Icon=com.mitchellh.ghostty|Icon=${SNAP}/share/icons/hicolor/512x512/apps/com.mitchellh.ghostty.png|g' $CRAFT_PART_INSTALL/share/applications/com.mitchellh.ghostty.desktop


### PR DESCRIPTION
## Summary

This PR makes the Ghostty terminfo source file available as a downloadable artifact in releases. Users who SSH into remote servers often encounter rendering issues because the server lacks Ghostty's terminfo definition. Currently, obtaining the terminfo requires cloning the entire repository, which is cumbersome. With this change, users can download the terminfo file directly and compile it with tic.

Changes:
- Generate ghostty.terminfo during tagged and nightly release builds
- Upload terminfo to R2 for tagged releases and to GitHub Release assets for nightly builds
- Add terminfo validation to publish-tag workflow to catch missing files before publishing
- Enable terminfo generation in flatpak, nix, and snap package builds
- Document the terminfo flag and download location in PACKAGING.md

Closes #9917

## Test Plan

Local verification completed on macOS:

- YAML syntax validation passed for all modified workflow and package files
- Terminfo generation tested with both minimal and full builds (with Metal toolchain)
- Generated terminfo file validated for correct header and capabilities (Tc, Su, colors)
- Terminfo source successfully compiled with tic to produce valid database
- Nix package build tested via Docker to confirm flag integration in zigBuildFlags

CI/CD verification will occur post-merge:
- Tagged release: ghostty.terminfo uploaded to R2 at /{VERSION}/ghostty.terminfo
- Nightly release: ghostty.terminfo appears in GitHub Release assets

## AI Disclosure

This PR was developed with assistance from Claude Code. All changes were reviewed, tested locally, and verified by the submitter.