### PR TITLE
feat: preserve tab characters when copying text in plain format

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2223,6 +2223,7 @@ fn copySelectionToClipboards(
         .background = self.io.terminal.colors.background.get(),
         .foreground = self.io.terminal.colors.foreground.get(),
         .palette = &self.io.terminal.colors.palette.current,
+        .tabstops = &self.io.terminal.tabstops,
     };
 
     const ScreenFormatter = terminal.formatter.ScreenFormatter;


### PR DESCRIPTION
Fixes #8426.

## Approach

The issue noted this task is "not contributor friendly" since core data structures don't track tab characters. Rather than modifying core data structures, this implementation leverages a semantic distinction that already exists in the cell data:

- **Empty cells** (codepoint 0): Created by tab expansion or cursor movement
- **Explicit spaces** (codepoint 0x20): Written directly by the application

The formatter reconstructs tabs by identifying runs of empty cells that end at tabstop positions.

**I'd appreciate feedback on whether this approach is acceptable, or if you'd prefer modifications to core data structures for correctness/future-proofing.**

## Implementation

- Add `tabstops` option to formatter `Options` struct
- Add `emitBlankCells()` helper that walks empty cell runs, emitting a tab at each tabstop boundary
- Buffer blank cells during accumulation to distinguish empty vs explicit space
- Pass terminal tabstops to formatter in `Surface.copySelectionToClipboards`
- Reset cell buffer at row boundaries (cross-row blanks fall back to spaces)

## XFCE Semantics

Implements XFCE behavior as requested in the issue:

| Case | Scenario | Output |
|------|----------|--------|
| a | Simple tab | `a\ta` |
| b | Space overwrites pos 1 | `b \tb` |
| c | Spaces overwrite pos 1-6 | `c      \tc` |
| d | All explicit spaces | `d       d` (no tab) |
| e | Char overwrites pos 3 | `e  x\te` |

## Testing

- 17 unit tests covering all XFCE cases, consecutive tabs, edge cases, and fallback behaviors
- Manual QA with verification script from #8426 - all 5 cases produce XFCE-matching output
- Tested tab preservation across terminal resize

## Trade-offs

- Uses fixed 512-cell buffer (matches `Tabstops.zig` prealloc) - overflow falls back to spaces
- Tab reconstruction disabled when `point_map` is set (byte-to-cell mapping requires 1:1)
- Cross-row blanks (wrap continuation) fall back to spaces for safety

---

Generated with the assistance of Claude Code.