### PR TITLE
build: add -fPIC for musl targets 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -217,6 +217,7 @@ jobs:
             x86_64-macos,
             aarch64-linux,
             x86_64-linux,
+            x86_64-linux-musl,
             x86_64-windows,
             wasm32-freestanding,
           ]

--- a/pkg/dcimgui/build.zig
+++ b/pkg/dcimgui/build.zig
@@ -64,7 +64,7 @@ pub fn build(b: *std.Build) !void {
             "-DIMGUI_IMPL_API=extern\t\"C\"",
         });
     }
-    if (target.result.os.tag == .freebsd) {
+    if (target.result.os.tag == .freebsd or target.result.abi == .musl) {
         try flags.append(b.allocator, "-fPIC");
     }
 

--- a/pkg/freetype/build.zig
+++ b/pkg/freetype/build.zig
@@ -90,7 +90,7 @@ fn buildLib(b: *std.Build, module: *std.Build.Module, options: anytype) !*std.Bu
         "-fno-sanitize=undefined",
     });
 
-    if (target.result.os.tag == .freebsd) {
+    if (target.result.os.tag == .freebsd or target.result.abi == .musl) {
         try flags.append(b.allocator, "-fPIC");
     }
 

--- a/pkg/glslang/build.zig
+++ b/pkg/glslang/build.zig
@@ -66,7 +66,7 @@ fn buildGlslang(
         "-fno-sanitize-trap=undefined",
     });
 
-    if (target.result.os.tag == .freebsd) {
+    if (target.result.os.tag == .freebsd or target.result.abi == .musl) {
         try flags.append(b.allocator, "-fPIC");
     }
 

--- a/pkg/highway/build.zig
+++ b/pkg/highway/build.zig
@@ -73,7 +73,7 @@ pub fn build(b: *std.Build) !void {
         "-fno-sanitize-trap=undefined",
     });
 
-    if (target.result.os.tag == .freebsd) {
+    if (target.result.os.tag == .freebsd or target.result.abi == .musl) {
         try flags.append(b.allocator, "-fPIC");
     }
 

--- a/pkg/simdutf/build.zig
+++ b/pkg/simdutf/build.zig
@@ -32,7 +32,7 @@ pub fn build(b: *std.Build) !void {
         "-fno-sanitize-trap=undefined",
     });
 
-    if (target.result.os.tag == .freebsd) {
+    if (target.result.os.tag == .freebsd or target.result.abi == .musl) {
         try flags.append(b.allocator, "-fPIC");
     }
 

--- a/pkg/spirv-cross/build.zig
+++ b/pkg/spirv-cross/build.zig
@@ -74,7 +74,7 @@ fn buildSpirvCross(
         "-fno-sanitize-trap=undefined",
     });
 
-    if (target.result.os.tag == .freebsd) {
+    if (target.result.os.tag == .freebsd or target.result.abi == .musl) {
         try flags.append(b.allocator, "-fPIC");
     }
 


### PR DESCRIPTION
Adds `-fPIC` flag for musl targets when building highway and simdutf C++ dependencies, matching the existing freebsd behavior.

## What is PIC?

Position Independent Code (PIC) generates machine code using relative addresses instead of absolute ones, allowing the code to be loaded at any memory address. This is required when linking static libraries into shared libraries (.so files).

## Why both freebsd and musl need it

Both freebsd and musl use strict relocation policies that reject non-PIC code in shared libraries. Without `-fPIC`, linking fails with errors like:

```
relocation R_X86_64_PC32 cannot be used against symbol '__cxa_begin_catch'
```

glibc is more permissive and handles these relocations at runtime, which is why linux-gnu targets work without this flag.

## Context

This enables cross-compiling ghostty-vt to musl/Alpine Linux targets. Discovered while integrating ghostty-vt into opentui: https://github.com/sst/opentui/pull/440

---

This PR was created with help from Claude Opus 4.5.