### PR TITLE
terminal/search: screen search prunes history for no-scrollback screens

### DIFF
--- a/src/terminal/highlight.zig
+++ b/src/terminal/highlight.zig
@@ -180,6 +180,15 @@ pub const Flattened = struct {
         };
     }
 
+    pub fn endPin(self: Flattened) Pin {
+        const slice = self.chunks.slice();
+        return .{
+            .node = slice.items(.node)[slice.len - 1],
+            .x = self.bot_x,
+            .y = slice.items(.end)[slice.len - 1] - 1,
+        };
+    }
+
     /// Convert to an Untracked highlight.
     pub fn untracked(self: Flattened) Untracked {
         // Note: we don't use startPin/endPin here because it is slightly


### PR DESCRIPTION
Fixes #10227

The big comment in `search/screen.zig` describes the solution well. The problem is that our search is discrete by page and a page can contain some amount of history as well. 

For zero-scrollback screens, we need to fully prune any history lines. For everyone else, everything in the PageList is scrollable and visible so we should search it.