### PR TITLE
snap: fix handling of nonexistent last_revision file

### DIFF
--- a/snap/local/launcher
+++ b/snap/local/launcher
@@ -14,7 +14,14 @@ if [ -z "$XDG_DATA_HOME" ]; then
   export XDG_DATA_HOME="$SNAP_REAL_HOME/.local/share"
 fi
 
-source "$SNAP_USER_DATA/.last_revision" 2>/dev/null || true
+if [ -f "$SNAP_USER_DATA/.last_revision" ]; then
+  if ! source "$SNAP_USER_DATA/.last_revision" 2>/dev/null; then
+    # file exist but sourcing it fails, so it's likely
+    # not good anyway
+    rm -f "$SNAP_USER_DATA/.last_revision"
+  fi
+fi
+
 if [ "$LAST_REVISION" = "$SNAP_REVISION" ]; then
   needs_update=false
 else


### PR DESCRIPTION
Assuming /bin/sh is symlinked to bash, the handling of special builtin
'source' is slightly different between bash and bash-in-POSIX-mode (as a
result of being invoked through /bin/sh). Specifically errors in builtin
'source' cannot be masked with `|| true`. Compare

```
$ ls -l /bin/sh
lrwxrwxrwx 1 root root 4 Dec 11 11:00 /bin/sh -> bash
$ /bin/sh -c 'set -e ; source nofile || true; echo ok'
/bin/sh: line 1: source: nofile: file not found
$ /bin/bash -c 'set -e ; source nofile || true; echo ok'
/bin/bash: line 1: nofile: No such file or directory
ok
```

Thus ghostty from snap would not start at all when
$SNAP_USER_DATA/.last_revision does not exist causign the launcher
script to exit prematurely.