### PR TITLE
fix(macos): fix fullscreen tab bar disappearing after monitor disconnect

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -534,9 +534,29 @@ class BaseTerminalController: NSWindowController,
         guard let window else { return }
         guard window.isVisible else { return }
 
-        // We ignore fullscreen windows because macOS automatically resizes
-        // those back to the fullscreen bounds.
-        guard !window.styleMask.contains(.fullScreen) else { return }
+        // For fullscreen windows with tabs, force a relayout on all tabs.
+        // After a monitor disconnect, the window frames become stale. Cycling
+        // through tabs fixes this, so we simulate that by changing the selected tab.
+        if window.styleMask.contains(.fullScreen) {
+            if let tabGroup = window.tabGroup, tabGroup.windows.count > 1 {
+                DispatchQueue.main.async {
+                    // Remember the current selected window
+                    let originalSelected = tabGroup.selectedWindow
+
+                    // Briefly select each tab to trigger layout recalculation
+                    // Only cycle through tabs that have the fullscreen style mask
+                    for tabWindow in tabGroup.windows where tabWindow != originalSelected && tabWindow.styleMask.contains(.fullScreen) {
+                        tabGroup.selectedWindow = tabWindow
+                    }
+
+                    // Restore the original selection
+                    if let originalSelected {
+                        tabGroup.selectedWindow = originalSelected
+                    }
+                }
+            }
+            return
+        }
 
         guard let screen = window.screen else { return }
         let visibleFrame = screen.visibleFrame


### PR DESCRIPTION
# Issue Description

On macOS Sequoia 15.x, when using Ghostty in native fullscreen mode with multiple tabs, disconnecting an external monitor causes the tab bar to disappear and show desktop background through a gap at the top of the window.

Affected `macos-titlebar-style` options: "native", "transparent", and "tabs"

# Reproduction Steps

- Open Ghostty with multiple tabs in fullscreen mode
- Connect an external monitor to computer
- Close the laptop lid (using external monitor only)
- Cycle through all tabs
- Open the laptop lid
- Unplug the external monitor
- Switch to a different tab

**Expected:** Tab bar remains visible with the new tab selected
**Actual:** Tab bar disappears, gap at top shows desktop background instead of terminal content

https://github.com/user-attachments/assets/a0d507cb-48be-4122-aee8-3a8c31c28e7b

# Root Cause

In native fullscreen with tabs, each tab is a separate NSWindow managed by an NSWindowTabGroup. When the display configuration changes (monitor disconnect), macOS sends didChangeScreenParametersNotification. However, only the currently visible tab's window updates its frame geometry to match the new screen. Background tabs retain stale frame data from the old monitor configuration.

When switching to a background tab after the screen change, AppKit restores the tab's stale geometry, which doesn't match the new screen dimensions. This causes the toolbar window (NSToolbarFullScreenWindow) containing the tab bar to be positioned incorrectly - pushed off the top of the screen.

# Solution

The fix programmatically cycles through all tabs when screen parameters change, briefly making each tab key to trigger AppKit's internal layout recalculation. This updates all tabs' geometry to match the new screen configuration before the user switches tabs.

I used ampcode (AI) to help me:
- Debug the issue
- Figure out root cause
- Come up with a strategy to fix it
- Apply the code changes

My primary job was to:
- QA all code changes against all `macos-titlebar-style` options on mac os
- Review code changes
- Submit report and PR

Reference: https://github.com/ghostty-org/ghostty/discussions/5389