### PR TITLE
terminal: remove the ability to reuse a pool from PageList

### DIFF
--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -397,32 +397,15 @@ pub fn clone(
     top: point.Point,
     bot: ?point.Point,
 ) !Screen {
-    return try self.clonePool(alloc, null, top, bot);
-}
-
-/// Same as clone but you can specify a custom memory pool to use for
-/// the screen.
-pub fn clonePool(
-    self: *const Screen,
-    alloc: Allocator,
-    pool: ?*PageList.MemoryPool,
-    top: point.Point,
-    bot: ?point.Point,
-) !Screen {
     // Create a tracked pin remapper for our selection and cursor. Note
     // that we may want to expose this generally in the future but at the
     // time of doing this we don't need to.
     var pin_remap = PageList.Clone.TrackedPinsRemap.init(alloc);
     defer pin_remap.deinit();
 
-    var pages = try self.pages.clone(.{
+    var pages = try self.pages.clone(alloc, .{
         .top = top,
         .bot = bot,
-        .memory = if (pool) |p| .{
-            .pool = p,
-        } else .{
-            .alloc = alloc,
-        },
         .tracked_pins = &pin_remap,
     });
     errdefer pages.deinit();


### PR DESCRIPTION
This was an unused codepath and it complicates some things I'd like to do, such as resetting our pools during resize. It complicates those paths because if a user provides a pool we can't reset it (because other things might be in it). It's best to own the pools. And since we didn't reuse pools anyway, let's remove that.

Note this was previously used by our old render state mechanism (before `terminal.RenderState`) as a way for the renderer to speed up clones by having a preheated pool that was likely the right size before every frame. Since we changed methods, we don't need it.