### PR TITLE
nix: update nixpkgs, remove zig.hook, and remove x11-gnome 

### DIFF
--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -64,7 +64,7 @@ jobs:
           mkdir blob
           mv appcast.xml blob/appcast.xml
       - name: Upload Appcast to R2
-        uses: ryand56/r2-upload-action@b801a390acbdeb034c5e684ff5e1361c06639e7c # v1
+        uses: ryand56/r2-upload-action@b801a390acbdeb034c5e684ff5e1361c06639e7c # v1.4
         with:
           r2-account-id: ${{ secrets.CF_R2_RELEASE_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.CF_R2_RELEASE_AWS_KEY }}

--- a/flake.lock
+++ b/flake.lock
@@ -125,17 +125,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1758405547,
-        "narHash": "sha256-WgaDgvIZMPvlZcZrpPMjkaalTBnGF2lTG+62znXctWM=",
+        "lastModified": 1768231828,
+        "narHash": "sha256-wL/8Iij4T2OLkhHcc4NieOjf7YeJffaUYbCiCqKv/+0=",
         "owner": "jcollie",
         "repo": "zon2nix",
-        "rev": "bf983aa90ff169372b9fa8c02e57ea75e0b42245",
+        "rev": "c28e93f3ba133d4c1b1d65224e2eebede61fd071",
         "type": "github"
       },
       "original": {
         "owner": "jcollie",
         "repo": "zon2nix",
-        "rev": "bf983aa90ff169372b9fa8c02e57ea75e0b42245",
+        "rev": "c28e93f3ba133d4c1b1d65224e2eebede61fd071",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -41,27 +41,26 @@
         ]
       },
       "locked": {
-        "lastModified": 1755776884,
-        "narHash": "sha256-CPM7zm6csUx7vSfKvzMDIjepEJv1u/usmaT7zydzbuI=",
+        "lastModified": 1768068402,
+        "narHash": "sha256-bAXnnJZKJiF7Xr6eNW6+PhBf1lg2P1aFUO9+xgWkXfA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4fb695d10890e9fc6a19deadf85ff79ffb78da86",
+        "rev": "8bc5473b6bc2b6e1529a9c4040411e1199c43b4c",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.05",
         "repo": "home-manager",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1763191728,
-        "narHash": "sha256-gI9PpaoX4/f28HkjcTbFVpFhtOxSDtOEdFaHZrdETe0=",
-        "rev": "1d4c88323ac36805d09657d13a5273aea1b34f0c",
+        "lastModified": 1768032153,
+        "narHash": "sha256-zvxtwlM8ZlulmZKyYCQAPpkm5dngSEnnHjmjV7Teloc=",
+        "rev": "3146c6aa9995e7351a398e17470e15305e6e18ff",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.11pre896415.1d4c88323ac3/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre925418.3146c6aa9995/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
     };
 
     zon2nix = {
-      url = "github:jcollie/zon2nix?rev=bf983aa90ff169372b9fa8c02e57ea75e0b42245";
+      url = "github:jcollie/zon2nix?rev=c28e93f3ba133d4c1b1d65224e2eebede61fd071";
       inputs = {
         nixpkgs.follows = "nixpkgs";
       };

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
     };
 
     home-manager = {
-      url = "github:nix-community/home-manager?ref=release-25.05";
+      url = "github:nix-community/home-manager";
       inputs = {
         nixpkgs.follows = "nixpkgs";
       };
@@ -117,7 +117,6 @@
             wayland-gnome = runVM ./nix/vm/wayland-gnome.nix;
             wayland-plasma6 = runVM ./nix/vm/wayland-plasma6.nix;
             x11-cinnamon = runVM ./nix/vm/x11-cinnamon.nix;
-            x11-gnome = runVM ./nix/vm/x11-gnome.nix;
             x11-plasma6 = runVM ./nix/vm/x11-plasma6.nix;
             x11-xfce = runVM ./nix/vm/x11-xfce.nix;
           };

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -26,6 +26,7 @@
   wasmtime,
   wraptest,
   zig,
+  zig_0_15,
   zip,
   llvmPackages_latest,
   bzip2,

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -20,16 +20,6 @@
   wayland-scanner,
   pkgs,
 }: let
-  # The Zig hook has no way to select the release type without actual
-  # overriding of the default flags.
-  #
-  # TODO: Once
-  # https://github.com/ziglang/zig/issues/14281#issuecomment-1624220653 is
-  # ultimately acted on and has made its way to a nixpkgs implementation, this
-  # can probably be removed in favor of that.
-  zig_hook = zig_0_15.hook.overrideAttrs {
-    zig_default_flags = "-Dcpu=baseline -Doptimize=${optimize} --color off";
-  };
   gi_typelib_path = import ./build-support/gi-typelib-path.nix {
     inherit pkgs lib stdenv;
   };
@@ -73,7 +63,7 @@ in
         ncurses
         pandoc
         pkg-config
-        zig_hook
+        zig_0_15
         gobject-introspection
         wrapGAppsHook4
         blueprint-compiler
@@ -92,12 +82,16 @@ in
 
     GI_TYPELIB_PATH = gi_typelib_path;
 
+    dontSetZigDefaultFlags = true;
+
     zigBuildFlags = [
       "--system"
       "${finalAttrs.deps}"
       "-Dversion-string=${finalAttrs.version}-${revision}-nix"
       "-Dgtk-x11=${lib.boolToString enableX11}"
       "-Dgtk-wayland=${lib.boolToString enableWayland}"
+      "-Dcpu=baseline"
+      "-Doptimize=${optimize}"
       "-Dstrip=${lib.boolToString strip}"
     ];
 

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -274,7 +274,7 @@ in {
           client.succeed("${su "${ghostty} +new-window"}")
           client.wait_until_succeeds("${wm_class} | grep -q 'com.mitchellh.ghostty-debug'")
 
-      with subtest("SSH from client to server and verify that the Ghostty terminfo is copied.")
+      with subtest("SSH from client to server and verify that the Ghostty terminfo is copied."):
           client.sleep(2)
           client.send_chars("ssh ghostty@server\n")
           server.wait_for_file("${user.home}/.terminfo/x/xterm-ghostty", timeout=30)

--- a/nix/vm/common-gnome.nix
+++ b/nix/vm/common-gnome.nix
@@ -8,7 +8,7 @@
     ./common.nix
   ];
 
-  services.xserver = {
+  services = {
     displayManager = {
       gdm = {
         enable = true;

--- a/nix/vm/x11-gnome.nix
+++ b/nix/vm/x11-gnome.nix
@@ -1,9 +1,0 @@
-{...}: {
-  imports = [
-    ./common-gnome.nix
-  ];
-
-  services.displayManager = {
-    defaultSession = "gnome-xorg";
-  };
-}

--- a/src/extra/bash.zig
+++ b/src/extra/bash.zig
@@ -296,7 +296,7 @@ fn writeBashCompletions(writer: *std.Io.Writer) !void {
         \\  else                    prev="${COMP_WORDS[COMP_CWORD-1]}"
         \\  fi
         \\
-        \\  # current completion is double quoted add a space so the curor progresses
+        \\  # current completion is double quoted add a space so the cursor progresses
         \\  if [[ "$2" == \"*\" ]]; then
         \\    COMPREPLY=( "$cur " );
         \\    return;

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -1641,7 +1641,7 @@ pub fn Stream(comptime Handler: type) type {
                                     },
                                 },
                                 else => {
-                                    log.warn("invalid set curor style command: {f}", .{input});
+                                    log.warn("invalid set cursor style command: {f}", .{input});
                                     return;
                                 },
                             };


### PR DESCRIPTION
As of NixOS/nixpkgs#473413, `zig.hook` no longer supports `zig_default_flags`, and now they can and must be provided in `zigBuildFlags` instead.

Updating also requires removing gnome-xorg since it has been removed from nixpkgs.

`nix flake check` succeeds on my system (x86_64-linux), with a couple deprecation warnings that I believe aren't important.