### PR TITLE
fix(completions.fish): add +help and +version to completions

### DIFF
--- a/src/extra/bash.zig
+++ b/src/extra/bash.zig
@@ -158,9 +158,6 @@ fn writeBashCompletions(writer: *std.Io.Writer) !void {
     );
 
     for (@typeInfo(Action).@"enum".fields) |field| {
-        if (std.mem.eql(u8, "help", field.name)) continue;
-        if (std.mem.eql(u8, "version", field.name)) continue;
-
         const options = @field(Action, field.name).options();
         // assumes options will never be created with only <_name> members
         if (@typeInfo(options).@"struct".fields.len == 0) continue;
@@ -194,9 +191,6 @@ fn writeBashCompletions(writer: *std.Io.Writer) !void {
     );
 
     for (@typeInfo(Action).@"enum".fields) |field| {
-        if (std.mem.eql(u8, "help", field.name)) continue;
-        if (std.mem.eql(u8, "version", field.name)) continue;
-
         const options = @field(Action, field.name).options();
         if (@typeInfo(options).@"struct".fields.len == 0) continue;
 
@@ -272,9 +266,6 @@ fn writeBashCompletions(writer: *std.Io.Writer) !void {
     );
 
     for (@typeInfo(Action).@"enum".fields) |field| {
-        if (std.mem.eql(u8, "help", field.name)) continue;
-        if (std.mem.eql(u8, "version", field.name)) continue;
-
         try writer.writeAll(pad1 ++ "topLevel+=\" +" ++ field.name ++ "\"\n");
     }
 

--- a/src/extra/fish.zig
+++ b/src/extra/fish.zig
@@ -28,8 +28,6 @@ fn writeCompletions(writer: *std.Io.Writer) !void {
         try writer.writeAll("set -l commands \"");
         var count: usize = 0;
         for (@typeInfo(Action).@"enum".fields) |field| {
-            if (std.mem.eql(u8, "help", field.name)) continue;
-            if (std.mem.eql(u8, "version", field.name)) continue;
             if (count > 0) try writer.writeAll(" ");
             try writer.writeAll("+");
             try writer.writeAll(field.name);
@@ -98,8 +96,6 @@ fn writeCompletions(writer: *std.Io.Writer) !void {
         try writer.writeAll("complete -c ghostty -n \"string match -q -- '+*' (commandline -pt)\" -f -a \"");
         var count: usize = 0;
         for (@typeInfo(Action).@"enum".fields) |field| {
-            if (std.mem.eql(u8, "help", field.name)) continue;
-            if (std.mem.eql(u8, "version", field.name)) continue;
             if (count > 0) try writer.writeAll(" ");
             try writer.writeAll("+");
             try writer.writeAll(field.name);

--- a/src/extra/zsh.zig
+++ b/src/extra/zsh.zig
@@ -139,9 +139,6 @@ fn writeZshCompletions(writer: *std.Io.Writer) !void {
         var count: usize = 0;
         const padding = "        ";
         for (@typeInfo(Action).@"enum".fields) |field| {
-            if (std.mem.eql(u8, "help", field.name)) continue;
-            if (std.mem.eql(u8, "version", field.name)) continue;
-
             try writer.writeAll(padding ++ "'+");
             try writer.writeAll(field.name);
             try writer.writeAll("'\n");
@@ -168,9 +165,6 @@ fn writeZshCompletions(writer: *std.Io.Writer) !void {
     {
         const padding = "        ";
         for (@typeInfo(Action).@"enum".fields) |field| {
-            if (std.mem.eql(u8, "help", field.name)) continue;
-            if (std.mem.eql(u8, "version", field.name)) continue;
-
             const options = @field(Action, field.name).options();
             // assumes options will never be created with only <_name> members
             if (@typeInfo(options).@"struct".fields.len == 0) continue;


### PR DESCRIPTION
`+help` and `+version` is missing from completions, even though they are working actions and are referenced in discussion template [here](https://github.com/ghostty-org/ghostty/pull/7012). This PR adds the completion for fish (as that is the shell that I use).
