### PR TITLE
Terminal: keep cross-boundary rows dirty in {insert,delete}Lines

### DIFF
--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1602,9 +1602,6 @@ pub fn insertLines(self: *Terminal, count: usize) void {
         const cur_rac = cur_p.rowAndCell();
         const cur_row: *Row = cur_rac.row;
 
-        // Mark the row as dirty
-        cur_p.markDirty();
-
         // If this is one of the lines we need to shift, do so
         if (y > adjusted_count) {
             const off_p = cur_p.up(adjusted_count).?;
@@ -1690,10 +1687,6 @@ pub fn insertLines(self: *Terminal, count: usize) void {
                     // Continue the loop to try handling this row again.
                     continue;
                 };
-
-                // The clone operation may overwrite the dirty flag, so make
-                // sure the row is still marked dirty.
-                dst_row.dirty = true;
             } else {
                 if (!left_right) {
                     // Swap the src/dst cells. This ensures that our dst gets the
@@ -1702,9 +1695,6 @@ pub fn insertLines(self: *Terminal, count: usize) void {
                     const dst = dst_row.*;
                     dst_row.* = src_row.*;
                     src_row.* = dst;
-
-                    // Make sure the row is marked as dirty though.
-                    dst_row.dirty = true;
 
                     // Ensure what we did didn't corrupt the page
                     cur_p.node.data.assertIntegrity();
@@ -1731,6 +1721,9 @@ pub fn insertLines(self: *Terminal, count: usize) void {
                 cells[self.scrolling_region.left .. self.scrolling_region.right + 1],
             );
         }
+
+        // Mark the row as dirty
+        cur_p.markDirty();
 
         // We have successfully processed a line.
         y -= 1;
@@ -1808,9 +1801,6 @@ pub fn deleteLines(self: *Terminal, count: usize) void {
     while (y < rem) {
         const cur_rac = cur_p.rowAndCell();
         const cur_row: *Row = cur_rac.row;
-
-        // Mark the row as dirty
-        cur_p.markDirty();
 
         // If this is one of the lines we need to shift, do so
         if (y < rem - adjusted_count) {
@@ -1892,10 +1882,6 @@ pub fn deleteLines(self: *Terminal, count: usize) void {
                     // Continue the loop to try handling this row again.
                     continue;
                 };
-
-                // The clone operation may overwrite the dirty flag, so make
-                // sure the row is still marked dirty.
-                dst_row.dirty = true;
             } else {
                 if (!left_right) {
                     // Swap the src/dst cells. This ensures that our dst gets the
@@ -1904,9 +1890,6 @@ pub fn deleteLines(self: *Terminal, count: usize) void {
                     const dst = dst_row.*;
                     dst_row.* = src_row.*;
                     src_row.* = dst;
-
-                    // Make sure the row is marked as dirty though.
-                    dst_row.dirty = true;
 
                     // Ensure what we did didn't corrupt the page
                     cur_p.node.data.assertIntegrity();
@@ -1933,6 +1916,9 @@ pub fn deleteLines(self: *Terminal, count: usize) void {
                 cells[self.scrolling_region.left .. self.scrolling_region.right + 1],
             );
         }
+
+        // Mark the row as dirty
+        cur_p.markDirty();
 
         // We have successfully processed a line.
         y += 1;

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1690,6 +1690,10 @@ pub fn insertLines(self: *Terminal, count: usize) void {
                     // Continue the loop to try handling this row again.
                     continue;
                 };
+
+                // The clone operation may overwrite the dirty flag, so make
+                // sure the row is still marked dirty.
+                dst_row.dirty = true;
             } else {
                 if (!left_right) {
                     // Swap the src/dst cells. This ensures that our dst gets the
@@ -1888,6 +1892,10 @@ pub fn deleteLines(self: *Terminal, count: usize) void {
                     // Continue the loop to try handling this row again.
                     continue;
                 };
+
+                // The clone operation may overwrite the dirty flag, so make
+                // sure the row is still marked dirty.
+                dst_row.dirty = true;
             } else {
                 if (!left_right) {
                     // Swap the src/dst cells. This ensures that our dst gets the


### PR DESCRIPTION
This fixes #10265 and thus also the remaining part of #9718 and likely #10250.

The issue was that when using `insertLines` and `deleteLines` to generate scrolling in a region that spans a page boundary, rows that are replaced by a row from a different page lose their dirty flags in the clone operation, since the flag is part of the data that gets cloned. The solution is to set the dirty flag again after the clone, just like the non-cloning branch does after the pointer swap.

**AI disclosure:** Amp is the MVP here. I prompted it with the hypothesis I developed in #10265 (that this happens when the scrolling region spans a page boundary), supplemented with insight I gained from perusing asciicast files (that the offending scrolling operations are always triggered by `CSI 1 L` or `CSI 1 M`, that is, `Terminal.insertLines` or `Terminal.deleteLines`). Amp figured out the rest and drafted the fix and tests. For free!

I cleaned up the tests and then pushed back a bit against the logic behind the fix, which led to a better understanding and what I think is a more appropriate fix. I can explain the details if there's interest, or people can just skim the thread here: https://ampcode.com/threads/T-019bb0d6-5334-744a-b78a-7c997ec1fade.