### PR TITLE
gtk: add GSettings generic module and respect gtk-enable-primary-paste on gtk systems

### DIFF
--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -675,8 +675,7 @@ pub const Surface = extern struct {
         /// The context for this surface (window, tab, or split)
         context: apprt.surface.NewSurfaceContext = .window,
 
-        /// Whether primary paste (middle-click paste) is enabled via GNOME settings.
-        /// If true, middle-click paste is enabled. If false, it's disabled.
+        /// Whether primary paste (middle-click paste) is enabled.
         gtk_enable_primary_paste: bool = true,
 
         pub var offset: c_int = 0;
@@ -1770,12 +1769,8 @@ pub const Surface = extern struct {
         priv.im_composing = false;
         priv.im_len = 0;
 
-        // Read GNOME desktop interface settings for primary paste (middle-click)
-        // This is only relevant on Linux systems with GNOME settings available
-        priv.gtk_enable_primary_paste = gsettings.get(.@"gtk-enable-primary-paste") orelse blk: {
-            log.warn("gtk-enable-primary-paste was not set, using default value", .{});
-            break :blk false;
-        };
+        // Read GTK primary paste setting
+        priv.gtk_enable_primary_paste = gsettings.get(.@"gtk-enable-primary-paste") orelse true;
 
         // Set up to handle items being dropped on our surface. Files can be dropped
         // from Nautilus and strings can be dropped from many programs. The order
@@ -2696,8 +2691,6 @@ pub const Surface = extern struct {
         // Report the event
         const button = translateMouseButton(gesture.as(gtk.GestureSingle).getCurrentButton());
 
-        // Check if middle button paste should be disabled based on GNOME settings
-        // If gtk_enable_primary_paste is explicitly false, skip processing middle button
         if (button == .middle and !priv.gtk_enable_primary_paste) {
             return;
         }
@@ -2753,8 +2746,6 @@ pub const Surface = extern struct {
         const gtk_mods = event.getModifierState();
         const button = translateMouseButton(gesture.as(gtk.GestureSingle).getCurrentButton());
 
-        // Check if middle button paste should be disabled based on GNOME settings
-        // If gtk_enable_primary_paste is explicitly false, skip processing middle button
         if (button == .middle and !priv.gtk_enable_primary_paste) {
             return;
         }

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -677,7 +677,7 @@ pub const Surface = extern struct {
 
         /// Whether primary paste (middle-click paste) is enabled via GNOME settings.
         /// If true, middle-click paste is enabled. If false, it's disabled.
-        gtk_enable_primary_paste: ?bool = true,
+        gtk_enable_primary_paste: bool = true,
 
         pub var offset: c_int = 0;
     };
@@ -2698,7 +2698,7 @@ pub const Surface = extern struct {
 
         // Check if middle button paste should be disabled based on GNOME settings
         // If gtk_enable_primary_paste is explicitly false, skip processing middle button
-        if (button == .middle and !(priv.gtk_enable_primary_paste)) {
+        if (button == .middle and !priv.gtk_enable_primary_paste) {
             return;
         }
 
@@ -2755,7 +2755,7 @@ pub const Surface = extern struct {
 
         // Check if middle button paste should be disabled based on GNOME settings
         // If gtk_enable_primary_paste is explicitly false, skip processing middle button
-        if (button == .middle and !(priv.gtk_enable_primary_paste)) {
+        if (button == .middle and !priv.gtk_enable_primary_paste) {
             return;
         }
 

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -2756,7 +2756,7 @@ pub const Surface = extern struct {
 
         // Check if middle button paste should be disabled based on GNOME settings
         // If gtk_enable_primary_paste is explicitly false, skip processing middle button
-        if (button == .middle and !(priv.gtk_enable_primary_paste orelse false)) {
+        if (button == .middle and !(priv.gtk_enable_primary_paste orelse true)) {
             return;
         }
 

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -1516,7 +1516,7 @@ pub const Surface = extern struct {
         const xft_dpi_scale = xft_scale: {
             // gtk-xft-dpi is font DPI multiplied by 1024. See
             // https://docs.gtk.org/gtk4/property.Settings.gtk-xft-dpi.html
-            const gtk_xft_dpi = gsettings.get(.gtk_xft_dpi) orelse {
+            const gtk_xft_dpi = gsettings.get(.@"gtk-xft-dpi") orelse {
                 log.warn("gtk-xft-dpi was not set, using default value", .{});
                 break :xft_scale 1.0;
             };
@@ -1772,7 +1772,7 @@ pub const Surface = extern struct {
 
         // Read GNOME desktop interface settings for primary paste (middle-click)
         // This is only relevant on Linux systems with GNOME settings available
-        priv.gtk_enable_primary_paste = gsettings.get(.gtk_enable_primary_paste) orelse blk: {
+        priv.gtk_enable_primary_paste = gsettings.get(.@"gtk-enable-primary-paste") orelse blk: {
             log.warn("gtk-enable-primary-paste was not set, using default value", .{});
             break :blk false;
         };

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -676,9 +676,8 @@ pub const Surface = extern struct {
         context: apprt.surface.NewSurfaceContext = .window,
 
         /// Whether primary paste (middle-click paste) is enabled via GNOME settings.
-        /// If null, the setting could not be read (non-GNOME system or schema missing).
         /// If true, middle-click paste is enabled. If false, it's disabled.
-        gtk_enable_primary_paste: ?bool = null,
+        gtk_enable_primary_paste: ?bool = true,
 
         pub var offset: c_int = 0;
     };
@@ -2699,7 +2698,7 @@ pub const Surface = extern struct {
 
         // Check if middle button paste should be disabled based on GNOME settings
         // If gtk_enable_primary_paste is explicitly false, skip processing middle button
-        if (button == .middle and !(priv.gtk_enable_primary_paste orelse true)) {
+        if (button == .middle and !(priv.gtk_enable_primary_paste)) {
             return;
         }
 
@@ -2756,7 +2755,7 @@ pub const Surface = extern struct {
 
         // Check if middle button paste should be disabled based on GNOME settings
         // If gtk_enable_primary_paste is explicitly false, skip processing middle button
-        if (button == .middle and !(priv.gtk_enable_primary_paste orelse true)) {
+        if (button == .middle and !(priv.gtk_enable_primary_paste)) {
             return;
         }
 

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -2753,7 +2753,7 @@ pub const Surface = extern struct {
 
         // Check if middle button paste should be disabled based on GNOME settings
         // If gtk_enable_primary_paste is explicitly false, skip processing middle button
-        if (button == .middle and priv.gtk_enable_primary_paste == false) {
+        if (button == .middle and !priv.gtk_enable_primary_paste) {
             return;
         }
 

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -19,6 +19,7 @@ const terminal = @import("../../../terminal/main.zig");
 const CoreSurface = @import("../../../Surface.zig");
 const gresource = @import("../build/gresource.zig");
 const ext = @import("../ext.zig");
+const gsettings = @import("../gsettings.zig");
 const gtk_key = @import("../key.zig");
 const ApprtSurface = @import("../Surface.zig");
 const Common = @import("../class.zig").Common;
@@ -673,6 +674,11 @@ pub const Surface = extern struct {
 
         /// The context for this surface (window, tab, or split)
         context: apprt.surface.NewSurfaceContext = .window,
+
+        /// Whether primary paste (middle-click paste) is enabled via GNOME settings.
+        /// If null, the setting could not be read (non-GNOME system or schema missing).
+        /// If true, middle-click paste is enabled. If false, it's disabled.
+        gtk_enable_primary_paste: ?bool = null,
 
         pub var offset: c_int = 0;
     };
@@ -1511,12 +1517,10 @@ pub const Surface = extern struct {
         const xft_dpi_scale = xft_scale: {
             // gtk-xft-dpi is font DPI multiplied by 1024. See
             // https://docs.gtk.org/gtk4/property.Settings.gtk-xft-dpi.html
-            const settings = gtk.Settings.getDefault() orelse break :xft_scale 1.0;
-            var value = std.mem.zeroes(gobject.Value);
-            defer value.unset();
-            _ = value.init(gobject.ext.typeFor(c_int));
-            settings.as(gobject.Object).getProperty("gtk-xft-dpi", &value);
-            const gtk_xft_dpi = value.getInt();
+            const gtk_xft_dpi = gsettings.readSetting(c_int, "gtk-xft-dpi") orelse {
+                log.warn("gtk-xft-dpi was not set, using default value", .{});
+                break :xft_scale 1.0;
+            };
 
             // Use a value of 1.0 for the XFT DPI scale if the setting is <= 0
             // See:
@@ -1766,6 +1770,10 @@ pub const Surface = extern struct {
         priv.in_keyevent = .false;
         priv.im_composing = false;
         priv.im_len = 0;
+
+        // Read GNOME desktop interface settings for primary paste (middle-click)
+        // This is only relevant on Linux systems with GNOME settings available
+        priv.gtk_enable_primary_paste = gsettings.readSetting(bool, "gtk-enable-primary-paste");
 
         // Set up to handle items being dropped on our surface. Files can be dropped
         // from Nautilus and strings can be dropped from many programs. The order
@@ -2685,6 +2693,13 @@ pub const Surface = extern struct {
 
         // Report the event
         const button = translateMouseButton(gesture.as(gtk.GestureSingle).getCurrentButton());
+
+        // Check if middle button paste should be disabled based on GNOME settings
+        // If gtk_enable_primary_paste is explicitly false, skip processing middle button
+        if (button == .middle and priv.gtk_enable_primary_paste == false) {
+            return;
+        }
+
         const consumed = consumed: {
             const gtk_mods = event.getModifierState();
             const mods = gtk_key.translateMods(gtk_mods);
@@ -2735,6 +2750,12 @@ pub const Surface = extern struct {
         const surface = priv.core_surface orelse return;
         const gtk_mods = event.getModifierState();
         const button = translateMouseButton(gesture.as(gtk.GestureSingle).getCurrentButton());
+
+        // Check if middle button paste should be disabled based on GNOME settings
+        // If gtk_enable_primary_paste is explicitly false, skip processing middle button
+        if (button == .middle and priv.gtk_enable_primary_paste == false) {
+            return;
+        }
 
         const mods = gtk_key.translateMods(gtk_mods);
         const consumed = surface.mouseButtonCallback(

--- a/src/apprt/gtk/gsettings.zig
+++ b/src/apprt/gtk/gsettings.zig
@@ -3,32 +3,143 @@ const builtin = @import("builtin");
 const gtk = @import("gtk");
 const gobject = @import("gobject");
 
-/// Reads a GTK setting using the GTK Settings API.
+/// GTK Settings keys with well-defined types.
+pub const Key = enum {
+    gtk_enable_primary_paste,
+    gtk_xft_dpi,
+    gtk_font_name,
+
+    fn Type(comptime self: Key) type {
+        return switch (self) {
+            .gtk_enable_primary_paste => bool,
+            .gtk_xft_dpi => c_int,
+            .gtk_font_name => []const u8,
+        };
+    }
+
+    fn GValueType(comptime self: Key) type {
+        return switch (self) {
+            // Booleans are stored as integers in GTK's internal representation
+            .gtk_enable_primary_paste,
+            => c_int,
+
+            // Integer types
+            .gtk_xft_dpi,
+            => c_int,
+
+            // String types (returned as null-terminated C strings from GTK)
+            .gtk_font_name,
+            => ?[*:0]const u8,
+        };
+    }
+
+    fn propertyName(comptime self: Key) [*:0]const u8 {
+        return switch (self) {
+            .gtk_enable_primary_paste => "gtk-enable-primary-paste",
+            .gtk_xft_dpi => "gtk-xft-dpi",
+            .gtk_font_name => "gtk-font-name",
+        };
+    }
+
+    /// Returns true if this setting type requires memory allocation.
+    /// this is defensive: types that do not need allocation need to be
+    /// explicitly marked here
+    fn requiresAllocation(comptime self: Key) bool {
+        const T = self.Type();
+        return switch (T) {
+            bool, c_int => false,
+            else => true,
+        };
+    }
+};
+
+/// Reads a GTK setting using the GTK Settings API for non-allocating types.
 /// This automatically uses XDG Desktop Portal in Flatpak environments.
-/// Returns null if not on a GTK-supported platform or if the setting cannot be read.
 ///
-/// Supported platforms: Linux, FreeBSD
-/// Supported types: bool, c_int
+/// No allocator is required or used. Returns null if the setting is not available or cannot be read.
 ///
 /// Example usage:
-///   const enabled = readSetting(bool, "gtk-enable-primary-paste");
-///   const dpi = readSetting(c_int, "gtk-xft-dpi");
-pub fn readSetting(comptime T: type, key: [*:0]const u8) ?T {
-    // Only available on systems that use GTK (Linux, FreeBSD)
-    if (comptime builtin.os.tag != .linux and builtin.os.tag != .freebsd) return null;
-
+///   const enabled = get(.gtk_enable_primary_paste);
+///   const dpi = get(.gtk_xft_dpi);
+pub fn get(comptime key: Key) ?key.Type() {
+    comptime {
+        if (key.requiresAllocation()) {
+            @compileError("Allocating types require an allocator; use getAlloc() instead");
+        }
+    }
     const settings = gtk.Settings.getDefault() orelse return null;
+    return getImpl(settings, null, key) catch unreachable;
+}
 
-    // For bool and c_int, we use c_int as the underlying GObject type
-    // because GTK boolean properties are stored as integers
-    var value = gobject.ext.Value.new(c_int);
+/// Reads a GTK setting using the GTK Settings API, allocating if necessary.
+/// This automatically uses XDG Desktop Portal in Flatpak environments.
+///
+/// The caller must free any returned allocated memory with the provided allocator.
+/// Returns null if the setting is not available or cannot be read.
+/// May return an allocation error if memory allocation fails.
+///
+/// Example usage:
+///   const theme = try getAlloc(allocator, .gtk_theme_name);
+///   defer if (theme) |t| allocator.free(t);
+pub fn getAlloc(allocator: std.mem.Allocator, comptime key: Key) !?key.Type() {
+    const settings = gtk.Settings.getDefault() orelse return null;
+    return getImpl(settings, allocator, key);
+}
+
+/// Shared implementation for reading GTK settings.
+/// If allocator is null, only non-allocating types can be used.
+/// Note: When adding a new type, research if it requires allocation (strings and boxed types do)
+/// if allocation is NOT needed, list it inside the switch statement in the function requiresAllocation()
+fn getImpl(settings: *gtk.Settings, allocator: ?std.mem.Allocator, comptime key: Key) !?key.Type() {
+    const GValType = key.GValueType();
+    var value = gobject.ext.Value.new(GValType);
     defer value.unset();
 
-    settings.as(gobject.Object).getProperty(key, &value);
+    settings.as(gobject.Object).getProperty(key.propertyName(), &value);
 
-    return switch (T) {
-        bool => value.getInt() != 0,
-        c_int => value.getInt(),
-        else => @compileError("Unsupported type '" ++ @typeName(T) ++ "' for GTK setting. Supported types: bool, c_int"),
+    return switch (key) {
+        // Booleans are stored as integers in GTK, convert to bool
+        .gtk_enable_primary_paste,
+        => value.getInt() != 0,
+
+        // Integer types are returned directly
+        .gtk_xft_dpi,
+        => value.getInt(),
+
+        // Strings: GTK owns the GValue's pointer, so we must duplicate it
+        // before the GValue is destroyed by defer value.unset()
+        .gtk_font_name,
+        => blk: {
+            // This is defensive: we have already checked at compile-time that
+            // an allocator is provided for allocating types
+            const alloc = allocator.?;
+            const ptr = value.getString() orelse break :blk null;
+            const str = std.mem.span(ptr);
+            break :blk try alloc.dupe(u8, str);
+        },
     };
+}
+
+test "Key.Type returns correct types" {
+    try std.testing.expectEqual(bool, Key.gtk_enable_primary_paste.Type());
+    try std.testing.expectEqual(c_int, Key.gtk_xft_dpi.Type());
+    try std.testing.expectEqual([]const u8, Key.gtk_font_name.Type());
+}
+
+test "Key.requiresAllocation identifies allocating types" {
+    try std.testing.expectEqual(false, Key.gtk_enable_primary_paste.requiresAllocation());
+    try std.testing.expectEqual(false, Key.gtk_xft_dpi.requiresAllocation());
+    try std.testing.expectEqual(true, Key.gtk_font_name.requiresAllocation());
+}
+
+test "Key.GValueType returns correct GObject types" {
+    try std.testing.expectEqual(c_int, Key.gtk_enable_primary_paste.GValueType());
+    try std.testing.expectEqual(c_int, Key.gtk_xft_dpi.GValueType());
+    try std.testing.expectEqual(?[*:0]const u8, Key.gtk_font_name.GValueType());
+}
+
+test "Key.propertyName returns correct GTK property names" {
+    try std.testing.expectEqualSlices(u8, "gtk-enable-primary-paste", std.mem.span(Key.gtk_enable_primary_paste.propertyName()));
+    try std.testing.expectEqualSlices(u8, "gtk-xft-dpi", std.mem.span(Key.gtk_xft_dpi.propertyName()));
+    try std.testing.expectEqualSlices(u8, "gtk-font-name", std.mem.span(Key.gtk_font_name.propertyName()));
 }

--- a/src/apprt/gtk/gsettings.zig
+++ b/src/apprt/gtk/gsettings.zig
@@ -61,10 +61,8 @@ pub const Key = enum {
 ///   const enabled = get(.gtk_enable_primary_paste);
 ///   const dpi = get(.gtk_xft_dpi);
 pub fn get(comptime key: Key) ?key.Type() {
-    comptime {
-        if (key.requiresAllocation()) {
-            @compileError("Allocating types require an allocator; use getAlloc() instead");
-        }
+    if (comptime key.requiresAllocation()) {
+        @compileError("Allocating types require an allocator; use getAlloc() instead");
     }
     const settings = gtk.Settings.getDefault() orelse return null;
     return getImpl(settings, null, key) catch unreachable;

--- a/src/apprt/gtk/gsettings.zig
+++ b/src/apprt/gtk/gsettings.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const gtk = @import("gtk");
+const gobject = @import("gobject");
+
+/// Reads a GTK setting using the GTK Settings API.
+/// This automatically uses XDG Desktop Portal in Flatpak environments.
+/// Returns null if not on a GTK-supported platform or if the setting cannot be read.
+///
+/// Supported platforms: Linux, FreeBSD
+/// Supported types: bool, c_int
+///
+/// Example usage:
+///   const enabled = readSetting(bool, "gtk-enable-primary-paste");
+///   const dpi = readSetting(c_int, "gtk-xft-dpi");
+pub fn readSetting(comptime T: type, key: [*:0]const u8) ?T {
+    // Only available on systems that use GTK (Linux, FreeBSD)
+    if (comptime builtin.os.tag != .linux and builtin.os.tag != .freebsd) return null;
+
+    const settings = gtk.Settings.getDefault() orelse return null;
+
+    // For bool and c_int, we use c_int as the underlying GObject type
+    // because GTK boolean properties are stored as integers
+    var value = gobject.ext.Value.new(c_int);
+    defer value.unset();
+
+    settings.as(gobject.Object).getProperty(key, &value);
+
+    return switch (T) {
+        bool => value.getInt() != 0,
+        c_int => value.getInt(),
+        else => @compileError("Unsupported type '" ++ @typeName(T) ++ "' for GTK setting. Supported types: bool, c_int"),
+    };
+}

--- a/src/apprt/gtk/gsettings.zig
+++ b/src/apprt/gtk/gsettings.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const gtk = @import("gtk");
 const gobject = @import("gobject");
 


### PR DESCRIPTION
# Add GSettings Support for Primary Paste

Implements support for `org.gnome.desktop.interface gtk-enable-primary-paste` to allow users to disable middle-click paste. Also refactors GTK Settings access into a reusable generic module.

## Changes

- **NEW**: `src/apprt/gtk/gsettings.zig` - Generic GTK Settings reader supporting `bool` and `c_int` types, portal-aware for Flatpak/Snap
- **MODIFIED**: `src/apprt/gtk/class/surface.zig` - Reads primary paste setting and refactors gtk-xft-dpi to use new module

## Behavior
- Setting `false` → Middle-click paste blocked
- Setting `true` or unavailable → Middle-click paste works (default)
- Uses GTK Settings API which automatically uses XDG Desktop Portal in sandboxed environments

Note: No unit tests added as this is a thin wrapper around GTK Settings API that's already tested indirectly through surface.zig. Happy to add tests if desired, though they would require an active display environment and skip on most CI systems.