### PR TITLE
fix(zsh): strip control characters from window title

### DIFF
--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -204,8 +204,10 @@ _ghostty_deferred_init() {
       # Enable terminal title changes.
       functions[_ghostty_precmd]+="
           builtin print -rnu $_ghostty_fd \$'\\e]2;'\"\${(%):-%(4~|…/%3~|%~)}\"\$'\\a'"
+      # Strip control characters from the command to avoid displaying escape
+      # sequences like \n in the title.
       functions[_ghostty_preexec]+="
-          builtin print -rnu $_ghostty_fd \$'\\e]2;'\"\${(V)1}\"\$'\\a'"
+          builtin print -rnu $_ghostty_fd \$'\\e]2;'\"\${1//[[:cntrl:]]}\"\$'\\a'"
     fi
 
     if [[ "$GHOSTTY_SHELL_FEATURES" == *"cursor"* ]]; then

--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -201,11 +201,9 @@ _ghostty_deferred_init() {
     _ghostty_report_pwd
 
     if [[ "$GHOSTTY_SHELL_FEATURES" == *"title"* ]]; then
-      # Enable terminal title changes.
+      # Enable terminal title changes, formatted for user-friendly display.
       functions[_ghostty_precmd]+="
           builtin print -rnu $_ghostty_fd \$'\\e]2;'\"\${(%):-%(4~|…/%3~|%~)}\"\$'\\a'"
-      # Strip control characters from the command to avoid displaying escape
-      # sequences like \n in the title.
       functions[_ghostty_preexec]+="
           builtin print -rnu $_ghostty_fd \$'\\e]2;'\"\${1//[[:cntrl:]]}\"\$'\\a'"
     fi


### PR DESCRIPTION
## Summary
- Fix literal \n appearing in window titles when running commands in zsh

## Description
The zsh shell integration was using ${(V)1} parameter expansion to set the window title. The (V) flag converts control characters to their visible escape sequence representations, causing commands ending with a newline to display as command\n in the title bar.

Changed to use ${1//[[:cntrl:]]} which strips control characters entirely, matching the behavior of the bash integration.

<img width="231" height="47" alt="image" src="https://github.com/user-attachments/assets/356c77a1-32da-47b0-bf86-29735cc67e90" />

## Test

  - Open Ghostty with zsh shell integration enabled
  - Run a command (e.g., cargo install trunk)

  ---
  AI Disclosure: This PR was written primarily by Claude Code. (Opus 4.5)