### PR TITLE
shellcheck: move common directives to .shellcheckrc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -978,8 +978,6 @@ jobs:
             --check-sourced \
             --color=always \
             --severity=warning \
-            --shell=bash \
-            --external-sources \
             $(find . \( -name "*.sh" -o -name "*.bash" \) -type f ! -path "./zig-out/*" ! -path "./macos/build/*" ! -path "./.git/*" | sort)
 
   translations:

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,8 @@
+# ShellCheck <https://www.shellcheck.net/>
+# https://github.com/koalaman/shellcheck/wiki/Directive#shellcheckrc-file
+
+# Allow opening any 'source'd file, even if not specified as input
+external-sources=true
+
+# Assume bash by default
+shell=bash

--- a/HACKING.md
+++ b/HACKING.md
@@ -164,6 +164,28 @@ alejandra .
 
 Make sure your Alejandra version matches the version of Alejandra in [devShell.nix](https://github.com/ghostty-org/ghostty/blob/main/nix/devShell.nix).
 
+### ShellCheck
+
+Bash scripts are checked with [ShellCheck](https://www.shellcheck.net/) in CI.
+
+Nix users can use the following command to run ShellCheck over all of our scripts:
+
+```
+nix develop -c shellcheck \
+    --check-sourced \
+    --severity=warning \
+    $(find . \( -name "*.sh" -o -name "*.bash" \) -type f ! -path "./zig-out/*" ! -path "./macos/build/*" ! -path "./.git/*" | sort)
+```
+
+Non-Nix users can [install ShellCheck](https://github.com/koalaman/shellcheck#user-content-installing) and then run:
+
+```
+shellcheck \
+    --check-sourced \
+    --severity=warning \
+    $(find . \( -name "*.sh" -o -name "*.bash" \) -type f ! -path "./zig-out/*" ! -path "./macos/build/*" ! -path "./.git/*" | sort)
+```
+
 ### Updating the Zig Cache Fixed-Output Derivation Hash
 
 The Nix package depends on a [fixed-output


### PR DESCRIPTION
This simplifies our CI command line and makes it easier to document expected usage (in HACKING.md).

There unfortunately isn't a way to set --checked-sourced or our default warning level in .shellcheckrc, and our `find` command is still a bit unwieldy, but this is still a net improvement.