### PR TITLE
macOS: copy_title_to_clipboard respects user-set title override

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1104,6 +1104,8 @@ bool ghostty_surface_read_text(ghostty_surface_t,
                                ghostty_selection_s,
                                ghostty_text_s*);
 void ghostty_surface_free_text(ghostty_surface_t, ghostty_text_s*);
+const char* ghostty_surface_get_display_title(ghostty_surface_t);
+void ghostty_surface_set_title_override(ghostty_surface_t, const char*);
 
 #ifdef __APPLE__
 void ghostty_surface_set_display_id(ghostty_surface_t, uint32_t);

--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -574,10 +574,18 @@ extension Ghostty {
                     let prevTitle = titleFromTerminal ?? "👻"
                     titleFromTerminal = nil
                     setTitle(prevTitle)
+                    // Clear the title override so copy_title_to_clipboard uses terminal title
+                    if let surface = self.surface {
+                        ghostty_surface_set_title_override(surface, nil)
+                    }
                 } else {
                     // Set the title and prevent it from being changed automatically
                     titleFromTerminal = title
                     title = newTitle
+                    // Set the title override so copy_title_to_clipboard uses user's title
+                    if let surface = self.surface {
+                        ghostty_surface_set_title_override(surface, newTitle)
+                    }
                 }
             }
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -5382,7 +5382,7 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
         },
 
         .copy_title_to_clipboard => {
-            const title = self.rt_surface.getTitle() orelse return false;
+            const title = self.rt_surface.getDisplayTitle() orelse return false;
             if (title.len == 0) return false;
 
             self.rt_surface.setClipboard(.standard, &.{.{


### PR DESCRIPTION
## Summary
  - When using "Change Terminal Title..." to set a custom title, `copy_title_to_clipboard` now copies the user-set title instead of
  the original terminal title
  - Adds `getDisplayTitle()` method that returns `title_override` if set, otherwise falls back to the terminal-set title

  ## Test plan
  - [x] Set custom title via "Change Terminal Title..."
  - [x] Use "Copy Terminal Title to Clipboard" → copies custom title
  - [x] Clear custom title (leave empty)
  - [x] Use "Copy Terminal Title to Clipboard" → copies original terminal title

  **Note:** GTK implementation is not included per CONTRIBUTING.md guidelines (macOS-only machine).

AI Disclosure: This PR was written with Claude Code assistance. I tested all changes on macOS.

  Ref #10345