### PR TITLE
renderer: Metal and OpenGL shrink buffers when they're much smaller

### DIFF
--- a/src/renderer/metal/buffer.zig
+++ b/src/renderer/metal/buffer.zig
@@ -74,9 +74,11 @@ pub fn Buffer(comptime T: type) type {
         /// remaining data in the buffer is left untouched.
         pub fn sync(self: *Self, data: []const T) !void {
             // If we need more bytes than our buffer has, we need to reallocate.
+            // We also shrink if the buffer is more than 4x larger than needed
+            // to avoid holding onto excessive memory after temporary spikes.
             const req_bytes = data.len * @sizeOf(T);
             const avail_bytes = self.buffer.getProperty(c_ulong, "length");
-            if (req_bytes > avail_bytes) {
+            if (req_bytes > avail_bytes or (avail_bytes > 4 * req_bytes and req_bytes > 0)) {
                 // Deallocate previous buffer
                 self.buffer.msgSend(void, objc.sel("release"), .{});
 
@@ -131,9 +133,11 @@ pub fn Buffer(comptime T: type) type {
             }
 
             // If we need more bytes than our buffer has, we need to reallocate.
+            // We also shrink if the buffer is more than 4x larger than needed
+            // to avoid holding onto excessive memory after temporary spikes.
             const req_bytes = total_len * @sizeOf(T);
             const avail_bytes = self.buffer.getProperty(c_ulong, "length");
-            if (req_bytes > avail_bytes) {
+            if (req_bytes > avail_bytes or (avail_bytes > 4 * req_bytes and req_bytes > 0)) {
                 // Deallocate previous buffer
                 self.buffer.msgSend(void, objc.sel("release"), .{});
 

--- a/src/renderer/opengl/buffer.zig
+++ b/src/renderer/opengl/buffer.zig
@@ -78,7 +78,9 @@ pub fn Buffer(comptime T: type) type {
             defer binding.unbind();
 
             // If we need more space than our buffer has, we need to reallocate.
-            if (data.len > self.len) {
+            // We also shrink if the buffer is more than 4x larger than needed
+            // to avoid holding onto excessive memory after temporary spikes.
+            if (data.len > self.len or (self.len > 4 * data.len and data.len > 0)) {
                 // Reallocate the buffer to hold double what we require.
                 self.len = data.len * 2;
                 try binding.setDataNullManual(
@@ -103,7 +105,9 @@ pub fn Buffer(comptime T: type) type {
             }
 
             // If we need more space than our buffer has, we need to reallocate.
-            if (total_len > self.len) {
+            // We also shrink if the buffer is more than 4x larger than needed
+            // to avoid holding onto excessive memory after temporary spikes.
+            if (total_len > self.len or (self.len > 4 * total_len and total_len > 0)) {
                 // Reallocate the buffer to hold double what we require.
                 self.len = total_len * 2;
                 try binding.setDataNullManual(


### PR DESCRIPTION
Fixes the memory associated with #10352

Presently, our GPU buffers never shrink, they only grow. If the grid size grows very large, we have to allocate very large GPU buffers.

This commit introduces a little heuristic to shrink buffers when the size we're using is less than a quarter of the total size.

I don't love this so #10355 for the proper long term solution.