### PR TITLE
splits: make resize_split and toggle_split_zoom non-performable with single pane

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -505,13 +505,13 @@ extension Ghostty {
                 return gotoWindow(app, target: target, direction: action.action.goto_window)
 
             case GHOSTTY_ACTION_RESIZE_SPLIT:
-                resizeSplit(app, target: target, resize: action.action.resize_split)
+                return resizeSplit(app, target: target, resize: action.action.resize_split)
 
             case GHOSTTY_ACTION_EQUALIZE_SPLITS:
                 equalizeSplits(app, target: target)
 
             case GHOSTTY_ACTION_TOGGLE_SPLIT_ZOOM:
-                toggleSplitZoom(app, target: target)
+                return toggleSplitZoom(app, target: target)
 
             case GHOSTTY_ACTION_INSPECTOR:
                 controlInspector(app, target: target, mode: action.action.inspector)
@@ -1244,16 +1244,21 @@ extension Ghostty {
         private static func resizeSplit(
             _ app: ghostty_app_t,
             target: ghostty_target_s,
-            resize: ghostty_action_resize_split_s) {
+            resize: ghostty_action_resize_split_s) -> Bool {
                 switch (target.tag) {
                 case GHOSTTY_TARGET_APP:
                     Ghostty.logger.warning("resize split does nothing with an app target")
-                    return
+                    return false
 
                 case GHOSTTY_TARGET_SURFACE:
-                    guard let surface = target.target.surface else { return }
-                    guard let surfaceView = self.surfaceView(from: surface) else { return }
-                    guard let resizeDirection = SplitResizeDirection.from(direction: resize.direction) else { return }
+                    guard let surface = target.target.surface else { return false }
+                    guard let surfaceView = self.surfaceView(from: surface) else { return false }
+                    guard let controller = surfaceView.window?.windowController as? BaseTerminalController else { return false }
+
+                    // If the window has no splits, the action is not performable
+                    guard controller.surfaceTree.isSplit else { return false }
+
+                    guard let resizeDirection = SplitResizeDirection.from(direction: resize.direction) else { return false }
                     NotificationCenter.default.post(
                         name: Notification.didResizeSplit,
                         object: surfaceView,
@@ -1262,9 +1267,11 @@ extension Ghostty {
                             Notification.ResizeSplitAmountKey: resize.amount,
                         ]
                     )
+                    return true
 
                 default:
                     assertionFailure()
+                    return false
                 }
         }
 
@@ -1292,23 +1299,30 @@ extension Ghostty {
 
         private static func toggleSplitZoom(
             _ app: ghostty_app_t,
-            target: ghostty_target_s) {
+            target: ghostty_target_s) -> Bool {
             switch (target.tag) {
             case GHOSTTY_TARGET_APP:
                 Ghostty.logger.warning("toggle split zoom does nothing with an app target")
-                return
+                return false
 
             case GHOSTTY_TARGET_SURFACE:
-                guard let surface = target.target.surface else { return }
-                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                guard let surface = target.target.surface else { return false }
+                guard let surfaceView = self.surfaceView(from: surface) else { return false }
+                guard let controller = surfaceView.window?.windowController as? BaseTerminalController else { return false }
+
+                // If the window has no splits, the action is not performable
+                guard controller.surfaceTree.isSplit else { return false }
+
                 NotificationCenter.default.post(
                     name: Notification.didToggleSplitZoom,
                     object: surfaceView
                 )
+                return true
 
 
             default:
                 assertionFailure()
+                return false
             }
         }
 

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -2406,7 +2406,7 @@ const Action = struct {
 
                 // If the tree has no splits (only one leaf), this action is not performable.
                 // This allows the key event to pass through to the terminal.
-                if (!tree.isSplit()) return false;
+                if (!tree.getIsSplit()) return false;
 
                 return tree.resize(
                     switch (value.direction) {
@@ -2564,7 +2564,7 @@ const Action = struct {
 
                 // If the tree has no splits (only one leaf), this action is not performable.
                 // This allows the key event to pass through to the terminal.
-                if (!tree.isSplit()) return false;
+                if (!tree.getIsSplit()) return false;
 
                 return surface.as(gtk.Widget).activateAction("split-tree.zoom", null) != 0;
             },

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -2400,9 +2400,13 @@ const Action = struct {
                     SplitTree,
                     surface.as(gtk.Widget),
                 ) orelse {
-                    log.warn("surface is not in a split tree, ignoring goto_split", .{});
+                    log.warn("surface is not in a split tree, ignoring resize_split", .{});
                     return false;
                 };
+
+                // If the tree has no splits (only one leaf), this action is not performable.
+                // This allows the key event to pass through to the terminal.
+                if (!tree.isSplit()) return false;
 
                 return tree.resize(
                     switch (value.direction) {
@@ -2550,6 +2554,18 @@ const Action = struct {
             .surface => |core| {
                 // TODO: pass surface ID when we have that
                 const surface = core.rt_surface.surface;
+                const tree = ext.getAncestor(
+                    SplitTree,
+                    surface.as(gtk.Widget),
+                ) orelse {
+                    log.warn("surface is not in a split tree, ignoring toggle_split_zoom", .{});
+                    return false;
+                };
+
+                // If the tree has no splits (only one leaf), this action is not performable.
+                // This allows the key event to pass through to the terminal.
+                if (!tree.isSplit()) return false;
+
                 return surface.as(gtk.Widget).activateAction("split-tree.zoom", null) != 0;
             },
         }

--- a/src/apprt/gtk/class/split_tree.zig
+++ b/src/apprt/gtk/class/split_tree.zig
@@ -561,7 +561,7 @@ pub const SplitTree = extern struct {
         ));
     }
 
-    fn getIsSplit(self: *Self) bool {
+    pub fn getIsSplit(self: *Self) bool {
         const tree: *const Surface.Tree = self.private().tree orelse &.empty;
         if (tree.isEmpty()) return false;
 

--- a/src/datastruct/split_tree.zig
+++ b/src/datastruct/split_tree.zig
@@ -794,6 +794,7 @@ pub fn SplitTree(comptime V: type) type {
             layout: Split.Layout,
             ratio: f16,
         ) Allocator.Error!Self {
+            assert(ratio >= -1 and ratio <= 1);
             assert(!std.math.isNan(ratio));
             assert(!std.math.isInf(ratio));
 

--- a/src/datastruct/split_tree.zig
+++ b/src/datastruct/split_tree.zig
@@ -1356,12 +1356,14 @@ test "SplitTree: isSplit" {
 
     // Split tree should be split
     var v2: TestView = .{ .label = "B" };
+    var tree2: TestTree = try TestTree.init(alloc, &v2);
+    defer tree2.deinit();
     var split = try single.split(
         alloc,
         .root,
         .right,
         0.5,
-        &v2,
+        &tree2,
     );
     defer split.deinit();
     try testing.expect(split.isSplit());


### PR DESCRIPTION
Refer to discussion #10000 

When a tab contains only a single split, resize_split and toggle_split_zoom actions now return false (not performed). This allows keybindings marked with `performable: true` to pass the event through to the terminal program.

The performable flag causes unperformed actions to be treated as if the binding didn't exist, so the key event is sent to the terminal instead of being consumed.

- Add isSplit() helper to SplitTree to detect single-pane vs split state
- Update GTK resizeSplit/toggleSplitZoom to return false when single pane
- Update macOS resizeSplit/toggleSplitZoom to return Bool and check isSplit
- Add unit test for isSplit method