### PR TITLE
feat(macos): if the search box is empty directly close the box

### DIFF
--- a/macos/Sources/Ghostty/Surface View/SurfaceView.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView.swift
@@ -431,7 +431,12 @@ extension Ghostty {
                     }
 #if canImport(AppKit)
                     .onExitCommand {
-                        Ghostty.moveFocus(to: surfaceView)
+                        if searchState.needle.isEmpty {
+                            Ghostty.moveFocus(to: surfaceView)
+                            onClose()
+                        } else {
+                            Ghostty.moveFocus(to: surfaceView)
+                        }
                     }
 #endif
                     .backport.onKeyPress(.return) { modifiers in


### PR DESCRIPTION
referring to the discussion: https://github.com/ghostty-org/ghostty/discussions/9814

This is a very small change addressing the behavior for closing the search bar. This removes an extra step when closing the search bar if the query is empty