### PR TITLE
build: libghostty-vt now depends on uucode directly

### DIFF
--- a/src/build/GhosttyZig.zig
+++ b/src/build/GhosttyZig.zig
@@ -73,6 +73,9 @@ fn initVt(
     // We always need unicode tables
     deps.unicode_tables.addModuleImport(vt);
 
+    // We need uucode for grapheme break support
+    deps.addUucode(b, vt, cfg.target, cfg.optimize);
+
     // If SIMD is enabled, add all our SIMD dependencies.
     if (cfg.simd) {
         try SharedDeps.addSimd(b, vt, null);

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -412,14 +412,7 @@ pub fn add(
     })) |dep| {
         step.root_module.addImport("z2d", dep.module("z2d"));
     }
-    if (b.lazyDependency("uucode", .{
-        .target = target,
-        .optimize = optimize,
-        .tables_path = self.uucode_tables,
-        .build_config_path = b.path("src/build/uucode_config.zig"),
-    })) |dep| {
-        step.root_module.addImport("uucode", dep.module("uucode"));
-    }
+    self.addUucode(b, step.root_module, target, optimize);
     if (b.lazyDependency("zf", .{
         .target = target,
         .optimize = optimize,
@@ -876,6 +869,23 @@ pub fn gtkNgDistResources(
             .generated = resources_h,
         },
     };
+}
+
+pub fn addUucode(
+    self: *const SharedDeps,
+    b: *std.Build,
+    module: *std.Build.Module,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+) void {
+    if (b.lazyDependency("uucode", .{
+        .target = target,
+        .optimize = optimize,
+        .tables_path = self.uucode_tables,
+        .build_config_path = b.path("src/build/uucode_config.zig"),
+    })) |dep| {
+        module.addImport("uucode", dep.module("uucode"));
+    }
 }
 
 // For dynamic linking, we prefer dynamic linking and to search by


### PR DESCRIPTION
This doesn't add any real weight to it, we only need it for a type definition. This fixes our example builds.

https://ampcode.com/threads/T-019bdc95-07bb-70c9-9db4-1218d41decb2