### PR TITLE
feat(macos): focus surface view if search box is manually closed

### DIFF
--- a/macos/Sources/Ghostty/Surface View/SurfaceView.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView.swift
@@ -190,7 +190,12 @@ extension Ghostty {
                     SurfaceSearchOverlay(
                         surfaceView: surfaceView,
                         searchState: searchState,
-                        onClose: { surfaceView.searchState = nil }
+                        onClose: {
+#if canImport(AppKit)
+                            Ghostty.moveFocus(to: surfaceView)
+#endif
+                            surfaceView.searchState = nil
+                        }
                     )
                 }
 
@@ -432,7 +437,6 @@ extension Ghostty {
 #if canImport(AppKit)
                     .onExitCommand {
                         if searchState.needle.isEmpty {
-                            Ghostty.moveFocus(to: surfaceView)
                             onClose()
                         } else {
                             Ghostty.moveFocus(to: surfaceView)


### PR DESCRIPTION
Currently, if a user clicks the "xmark" button to close the search box, the main interface does not regain focus until clicked again. This patch focuses the surface view upon closing.