### PR TITLE
tripwire: change backing store from ArrayHashMap to EnumMap

### DIFF
--- a/src/font/Atlas.zig
+++ b/src/font/Atlas.zig
@@ -829,7 +829,7 @@ test "init error" {
     for (std.meta.tags(init_tw.FailPoint)) |tag| {
         const tw = init_tw;
         defer tw.end(.reset) catch unreachable;
-        try tw.errorAlways(tag, error.OutOfMemory);
+        tw.errorAlways(tag, error.OutOfMemory);
         try testing.expectError(
             error.OutOfMemory,
             init(testing.allocator, 32, .grayscale),
@@ -847,7 +847,7 @@ test "reserve error" {
         var atlas = try init(testing.allocator, 32, .grayscale);
         defer atlas.deinit(testing.allocator);
 
-        try tw.errorAlways(tag, error.OutOfMemory);
+        tw.errorAlways(tag, error.OutOfMemory);
         try testing.expectError(
             error.OutOfMemory,
             atlas.reserve(testing.allocator, 2, 2),
@@ -872,7 +872,7 @@ test "grow error" {
         const old_modified = atlas.modified.load(.monotonic);
         const old_resized = atlas.resized.load(.monotonic);
 
-        try tw.errorAlways(tag, error.OutOfMemory);
+        tw.errorAlways(tag, error.OutOfMemory);
         try testing.expectError(
             error.OutOfMemory,
             atlas.grow(testing.allocator, atlas.size + 1),

--- a/src/font/SharedGrid.zig
+++ b/src/font/SharedGrid.zig
@@ -484,7 +484,7 @@ test "renderGlyph error after cache insert rolls back cache entry" {
     // We use OutOfMemory as it's a valid error in the renderGlyph error set.
     const tw = renderGlyph_tw;
     defer tw.end(.reset) catch {};
-    try tw.errorAlways(.get_presentation, error.OutOfMemory);
+    tw.errorAlways(.get_presentation, error.OutOfMemory);
 
     // This should fail due to the tripwire
     try testing.expectError(
@@ -510,7 +510,7 @@ test "init error" {
     for (std.meta.tags(init_tw.FailPoint)) |tag| {
         const tw = init_tw;
         defer tw.end(.reset) catch unreachable;
-        try tw.errorAlways(tag, error.OutOfMemory);
+        tw.errorAlways(tag, error.OutOfMemory);
 
         // Create a resolver for testing - we need to set up a minimal one.
         // The caller is responsible for cleaning up the resolver if init fails.

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -5170,7 +5170,7 @@ test "PageList init error" {
     for (std.meta.tags(init_tw.FailPoint)) |tag| {
         const tw = init_tw;
         defer tw.end(.reset) catch unreachable;
-        try tw.errorAlways(tag, error.OutOfMemory);
+        tw.errorAlways(tag, error.OutOfMemory);
         try std.testing.expectError(
             error.OutOfMemory,
             init(
@@ -5187,7 +5187,7 @@ test "PageList init error" {
     for (std.meta.tags(initPages_tw.FailPoint)) |tag| {
         const tw = initPages_tw;
         defer tw.end(.reset) catch unreachable;
-        try tw.errorAlways(tag, error.OutOfMemory);
+        tw.errorAlways(tag, error.OutOfMemory);
 
         const cols: size.CellCountInt = if (tag == .page_buf_std) 80 else std_capacity.maxCols().? + 1;
         try std.testing.expectError(
@@ -5207,7 +5207,7 @@ test "PageList init error" {
     }) |tag| {
         const tw = initPages_tw;
         defer tw.end(.reset) catch unreachable;
-        try tw.errorAfter(tag, error.OutOfMemory, 1);
+        tw.errorAfter(tag, error.OutOfMemory, 1);
         try std.testing.expectError(
             error.OutOfMemory,
             init(

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -9493,7 +9493,7 @@ test "selectionString map allocation failure cleanup" {
 
     // Trigger allocation failure on toOwnedSlice
     var map: StringMap = undefined;
-    try selectionString_tw.errorAlways(.copy_map, error.OutOfMemory);
+    selectionString_tw.errorAlways(.copy_map, error.OutOfMemory);
     const result = s.selectionString(alloc, .{
         .sel = sel,
         .map = &map,

--- a/src/terminal/Tabstops.zig
+++ b/src/terminal/Tabstops.zig
@@ -261,7 +261,7 @@ test "Tabstops: resize alloc failure preserves state" {
     const original_cols = t.cols;
 
     // Trigger allocation failure when resizing beyond prealloc
-    try resize_tw.errorAlways(.dynamic_alloc, error.OutOfMemory);
+    resize_tw.errorAlways(.dynamic_alloc, error.OutOfMemory);
     const result = t.resize(testing.allocator, prealloc_columns * 2);
     try testing.expectError(error.OutOfMemory, result);
     try resize_tw.end(.reset);

--- a/src/terminal/search/screen.zig
+++ b/src/terminal/search/screen.zig
@@ -1460,7 +1460,7 @@ test "reloadActive partial history cleanup on appendSlice error" {
     // that need cleanup.
     const tw = reloadActive_tw;
     defer tw.end(.reset) catch unreachable;
-    try tw.errorAlways(.history_append_existing, error.OutOfMemory);
+    tw.errorAlways(.history_append_existing, error.OutOfMemory);
 
     // reloadActive is called by select(), which should trigger the error path.
     // If the bug exists, testing.allocator will report a memory leak
@@ -1507,7 +1507,7 @@ test "reloadActive partial history cleanup on loop append error" {
     // that needs cleanup.
     const tw = reloadActive_tw;
     defer tw.end(.reset) catch unreachable;
-    try tw.errorAfter(.history_append_new, error.OutOfMemory, 1);
+    tw.errorAfter(.history_append_new, error.OutOfMemory, 1);
 
     // reloadActive is called by select(), which should trigger the error path.
     // If the bug exists, testing.allocator will report a memory leak


### PR DESCRIPTION
This eliminates all allocation from Tripwire.

Thanks @pluiedev 