### PR TITLE
editorconfig: 2-space indent for Nushell scripts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 root = true
 
-[*.{sh,bash,elv}]
+[*.{sh,bash,elv,nu}]
 indent_size = 2
 indent_style = space
 


### PR DESCRIPTION
This aligns with the Topiary format, which appears to be the most prominent community standard.

https://github.com/blindFS/topiary-nushell