### PR TITLE
Fix IME Preedit characters getting thicker when idle

### DIFF
--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -2629,6 +2629,12 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             const row_selection = row_data.items(.selection);
             const row_highlights = row_data.items(.highlights);
 
+            // Get preedit range only if its row is dirty or full rebuild.
+            const dirty_preedit_range = if (preedit_range) |range|
+                if (rebuild or row_dirty[range.y]) preedit_range else null
+            else
+                null;
+
             // If our cell contents buffer is shorter than the screen viewport,
             // we render the rows that fit, starting from the bottom. If instead
             // the viewport is shorter than the cell contents buffer, we align
@@ -2811,9 +2817,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 }
             }
 
-            // Setup our preedit text.
-            if (preedit) |preedit_v| {
-                const range = preedit_range.?;
+            // Rebuild our preedit text only when its row is dirty.
+            if (dirty_preedit_range) |range| {
+                const preedit_v = preedit.?;
                 var x = range.x[0];
                 for (preedit_v.codepoints[range.cp_offset..]) |cp| {
                     self.addPreeditCell(


### PR DESCRIPTION
Fixes https://github.com/ghostty-org/ghostty/issues/10424

When preedit text is marked as dirty by user input,
it is the case of "full rebuild" and there is no problem.

When it is not the full rebuild case, only the dirty rows are cleared,
but preedit text is always rendered additively.
This causes preedit text to get thicker when idle.

To avoid this, I changed preedit text to be rendered only during full rebuild or when its row is dirty.

I tested on macOS.

Before
[![Image from Gyazo](https://i.gyazo.com/5775fda5466abc6bff812f8426dedef9.gif)](https://gyazo.com/5775fda5466abc6bff812f8426dedef9)


After
[![Image from Gyazo](https://i.gyazo.com/643b62e9702daeda5fd00dc9d96c0c86.gif)](https://gyazo.com/643b62e9702daeda5fd00dc9d96c0c86)


AI disclosure: I used Claude Code to investigate the source code and generate code changes in this PR.