### PR TITLE
gtk: implement tab title renaming

### DIFF
--- a/src/apprt/gtk/build/gresource.zig
+++ b/src/apprt/gtk/build/gresource.zig
@@ -49,9 +49,9 @@ pub const blueprints: []const Blueprint = &.{
     .{ .major = 1, .minor = 5, .name = "split-tree-split" },
     .{ .major = 1, .minor = 2, .name = "surface" },
     .{ .major = 1, .minor = 5, .name = "surface-scrolled-window" },
-    .{ .major = 1, .minor = 5, .name = "surface-title-dialog" },
     .{ .major = 1, .minor = 3, .name = "surface-child-exited" },
     .{ .major = 1, .minor = 5, .name = "tab" },
+    .{ .major = 1, .minor = 5, .name = "title-dialog" },
     .{ .major = 1, .minor = 5, .name = "window" },
     .{ .major = 1, .minor = 5, .name = "command-palette" },
 };

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -35,6 +35,7 @@ const WeakRef = @import("../weak_ref.zig").WeakRef;
 const Config = @import("config.zig").Config;
 const Surface = @import("surface.zig").Surface;
 const SplitTree = @import("split_tree.zig").SplitTree;
+const Tab = @import("tab.zig").Tab;
 const Window = @import("window.zig").Window;
 const CloseConfirmationDialog = @import("close_confirmation_dialog.zig").CloseConfirmationDialog;
 const ConfigErrorsDialog = @import("config_errors_dialog.zig").ConfigErrorsDialog;
@@ -2330,9 +2331,17 @@ const Action = struct {
                     return true;
                 },
             },
-            .tab => {
-                // GTK does not yet support tab title prompting
-                return false;
+            .tab => switch (target) {
+                .app => return false,
+                .surface => |v| {
+                    // Get the tab from the surface's split tree ancestor
+                    const tab = ext.getAncestor(
+                        Tab,
+                        v.rt_surface.surface.as(gtk.Widget),
+                    ) orelse return false;
+                    tab.promptTitle();
+                    return true;
+                },
             },
         }
     }

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -30,7 +30,7 @@ const SearchOverlay = @import("search_overlay.zig").SearchOverlay;
 const KeyStateOverlay = @import("key_state_overlay.zig").KeyStateOverlay;
 const ChildExited = @import("surface_child_exited.zig").SurfaceChildExited;
 const ClipboardConfirmationDialog = @import("clipboard_confirmation_dialog.zig").ClipboardConfirmationDialog;
-const TitleDialog = @import("surface_title_dialog.zig").SurfaceTitleDialog;
+const TitleDialog = @import("title_dialog.zig").TitleDialog;
 const Window = @import("window.zig").Window;
 const InspectorWindow = @import("inspector_window.zig").InspectorWindow;
 const i18n = @import("../../../os/i18n.zig");
@@ -1401,6 +1401,7 @@ pub const Surface = extern struct {
             TitleDialog,
             .{
                 .@"initial-value" = priv.title_override orelse priv.title,
+                .heading = "Change Terminal Title",
             },
         );
         _ = TitleDialog.signals.set.connect(

--- a/src/apprt/gtk/class/title_dialog.zig
+++ b/src/apprt/gtk/class/title_dialog.zig
@@ -9,14 +9,14 @@ const gresource = @import("../build/gresource.zig");
 const ext = @import("../ext.zig");
 const Common = @import("../class.zig").Common;
 
-const log = std.log.scoped(.gtk_ghostty_surface_title_dialog);
+const log = std.log.scoped(.gtk_ghostty_title_dialog);
 
-pub const SurfaceTitleDialog = extern struct {
+pub const TitleDialog = extern struct {
     const Self = @This();
     parent_instance: Parent,
     pub const Parent = adw.AlertDialog;
     pub const getGObjectType = gobject.ext.defineClass(Self, .{
-        .name = "GhosttySurfaceTitleDialog",
+        .name = "GhosttyTitleDialog",
         .instanceInit = &init,
         .classInit = &Class.init,
         .parent_class = &Class.parent,
@@ -35,6 +35,21 @@ pub const SurfaceTitleDialog = extern struct {
                 .{
                     .default = null,
                     .accessor = C.privateStringFieldAccessor("initial_value"),
+                },
+            );
+        };
+
+        pub const heading = struct {
+            pub const name = "heading";
+            pub const get = impl.get;
+            pub const set = impl.set;
+            const impl = gobject.ext.defineProperty(
+                name,
+                Self,
+                ?[:0]const u8,
+                .{
+                    .default = null,
+                    .accessor = C.privateStringFieldAccessor("heading"),
                 },
             );
         };
@@ -57,6 +72,9 @@ pub const SurfaceTitleDialog = extern struct {
     const Private = struct {
         /// The initial value of the entry field.
         initial_value: ?[:0]const u8 = null,
+
+        /// The dialog heading text.
+        heading: ?[:0]const u8 = null,
 
         // Template bindings
         entry: *gtk.Entry,
@@ -87,6 +105,11 @@ pub const SurfaceTitleDialog = extern struct {
         const priv = self.private();
         if (priv.initial_value) |v| {
             priv.entry.getBuffer().setText(v, -1);
+        }
+
+        // Set the heading if one was provided
+        if (priv.heading) |h| {
+            self.as(adw.AlertDialog).setHeading(h);
         }
 
         // Show it. We could also just use virtual methods to bind to
@@ -138,6 +161,10 @@ pub const SurfaceTitleDialog = extern struct {
             glib.free(@ptrCast(@constCast(v)));
             priv.initial_value = null;
         }
+        if (priv.heading) |v| {
+            glib.free(@ptrCast(@constCast(v)));
+            priv.heading = null;
+        }
 
         gobject.Object.virtual_methods.finalize.call(
             Class.parent,
@@ -162,7 +189,7 @@ pub const SurfaceTitleDialog = extern struct {
                 comptime gresource.blueprint(.{
                     .major = 1,
                     .minor = 5,
-                    .name = "surface-title-dialog",
+                    .name = "title-dialog",
                 }),
             );
 
@@ -175,6 +202,7 @@ pub const SurfaceTitleDialog = extern struct {
             // Properties
             gobject.ext.registerProperties(class, &.{
                 properties.@"initial-value".impl,
+                properties.heading.impl,
             });
 
             // Virtual methods

--- a/src/apprt/gtk/ui/1.5/tab.blp
+++ b/src/apprt/gtk/ui/1.5/tab.blp
@@ -8,7 +8,7 @@ template $GhosttyTab: Box {
   orientation: vertical;
   hexpand: true;
   vexpand: true;
-  title: bind $computed_title(template.config, split_tree.active-surface as <$GhosttySurface>.title, split_tree.active-surface as <$GhosttySurface>.title-override, split_tree.is-zoomed, split_tree.active-surface as <$GhosttySurface>.bell-ringing) as <string>;
+  title: bind $computed_title(template.config, split_tree.active-surface as <$GhosttySurface>.title, split_tree.active-surface as <$GhosttySurface>.title-override, template.title-override, split_tree.is-zoomed, split_tree.active-surface as <$GhosttySurface>.bell-ringing) as <string>;
   tooltip: bind split_tree.active-surface as <$GhosttySurface>.pwd;
 
   $GhosttySplitTree split_tree {

--- a/src/apprt/gtk/ui/1.5/title-dialog.blp
+++ b/src/apprt/gtk/ui/1.5/title-dialog.blp
@@ -1,8 +1,8 @@
 using Gtk 4.0;
 using Adw 1;
 
-template $GhosttySurfaceTitleDialog: Adw.AlertDialog {
-  heading: _("Change Terminal Title");
+template $GhosttyTitleDialog: Adw.AlertDialog {
+  heading: _("Change Title");
   body: _("Leave blank to restore the default title.");
 
   responses [


### PR DESCRIPTION
## Summary

This PR implements tab title renaming for the GTK platform, following the same pattern as the macOS implementation from PR #9879.

### Changes

- Add `title-override` property to Tab class for storing user-set tab titles
- Rename `SurfaceTitleDialog` to `TitleDialog` and make it reusable with configurable heading
- Both surface and tab title prompts now use the same `TitleDialog` class with different headings
- Implement `promptTitle` method on Tab to display the rename dialog
- Update `closureComputedTitle` to prioritize tab title override
- Route `prompt_title` action to Tab.promptTitle() for the `.tab` case

The tab title override takes precedence over:
1. Surface title override
2. Terminal title
3. Config title
4. Default "Ghostty" title

Leaving the dialog empty restores the default title behavior.

### Refactoring per maintainer feedback

Per [feedback on PR #9904](https://github.com/ghostty-org/ghostty/pull/9904#discussion_r2027376541), 
`SurfaceTitleDialog` has been renamed to `TitleDialog` and made reusable with a configurable 
`heading` property. This avoids code duplication between surface and tab title dialogs.

## Test plan

- [x] All unit tests pass (`zig build test`)

### Manual GTK testing (requires Linux environment)

The following manual tests require a Linux environment with GTK. I developed this on macOS 
and cannot run the GTK apprt locally. Reviewers with Linux access are encouraged to verify:

- Build the GTK apprt with `zig build -Dapp-runtime=gtk`
- Run Ghostty and open multiple tabs
- Use the `prompt_tab_title` binding (or add one via config) to rename a tab
- Verify the tab title changes and persists across focus changes
- Verify leaving the input empty restores the default title
- Verify tab title override takes priority over surface title override

## AI Disclosure

This PR was developed with assistance from Claude Code (Claude Opus 4.5). The implementation 
follows patterns established in the existing codebase (macOS implementation, existing 
SurfaceTitleDialog). All code changes have been reviewed and the automated test suite passes.

Closes #9880