### PR TITLE
Rewritten semantic prompt state management (OSC 133)

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4295,7 +4295,7 @@ fn clickMoveCursor(self: *Surface, to: terminal.Pin) !void {
     // This flag is only set if we've seen at least one semantic prompt
     // OSC sequence. If we've never seen that sequence, we can't possibly
     // move the cursor so we can fast path out of here.
-    if (!t.flags.shell_redraws_prompt) return;
+    if (!t.screens.active.flags.semantic_content) return;
 
     // Get our path
     const from = t.screens.active.cursor.page_pin.*;

--- a/src/inspector/widgets/renderer.zig
+++ b/src/inspector/widgets/renderer.zig
@@ -48,24 +48,76 @@ pub const Info = struct {
     ) void {
         if (!open) return;
 
-        cimgui.c.ImGui_SeparatorText("Overlays");
+        cimgui.c.ImGui_SetNextItemOpen(true, cimgui.c.ImGuiCond_Once);
+        if (!cimgui.c.ImGui_CollapsingHeader("Overlays", cimgui.c.ImGuiTreeNodeFlags_None)) return;
 
-        // Hyperlinks
-        {
-            var hyperlinks: bool = self.features.contains(.highlight_hyperlinks);
-            _ = cimgui.c.ImGui_Checkbox("Overlay Hyperlinks", &hyperlinks);
-            cimgui.c.ImGui_SameLine();
-            widgets.helpMarker("When enabled, highlights OSC8 hyperlinks.");
+        cimgui.c.ImGui_SeparatorText("Hyperlinks");
+        self.overlayHyperlinks(alloc);
+        cimgui.c.ImGui_SeparatorText("Semantic Prompts");
+        self.overlaySemanticPrompts(alloc);
+    }
 
-            if (!hyperlinks) {
-                _ = self.features.swapRemove(.highlight_hyperlinks);
-            } else {
-                self.features.put(
-                    alloc,
-                    .highlight_hyperlinks,
-                    .highlight_hyperlinks,
-                ) catch log.warn("error enabling hyperlink overlay feature", .{});
-            }
+    fn overlayHyperlinks(self: *Info, alloc: Allocator) void {
+        var hyperlinks: bool = self.features.contains(.highlight_hyperlinks);
+        _ = cimgui.c.ImGui_Checkbox("Overlay Hyperlinks", &hyperlinks);
+        cimgui.c.ImGui_SameLine();
+        widgets.helpMarker("When enabled, highlights OSC8 hyperlinks.");
+
+        if (!hyperlinks) {
+            _ = self.features.swapRemove(.highlight_hyperlinks);
+        } else {
+            self.features.put(
+                alloc,
+                .highlight_hyperlinks,
+                .highlight_hyperlinks,
+            ) catch log.warn("error enabling hyperlink overlay feature", .{});
         }
+    }
+
+    fn overlaySemanticPrompts(self: *Info, alloc: Allocator) void {
+        var semantic_prompts: bool = self.features.contains(.semantic_prompts);
+        _ = cimgui.c.ImGui_Checkbox("Overlay Semantic Prompts", &semantic_prompts);
+        cimgui.c.ImGui_SameLine();
+        widgets.helpMarker("When enabled, highlights OSC 133 semantic prompts.");
+
+        // Handle the checkbox results
+        if (!semantic_prompts) {
+            _ = self.features.swapRemove(.semantic_prompts);
+        } else {
+            self.features.put(
+                alloc,
+                .semantic_prompts,
+                .semantic_prompts,
+            ) catch log.warn("error enabling semantic prompt overlay feature", .{});
+        }
+
+        // Help
+        cimgui.c.ImGui_Indent();
+        defer cimgui.c.ImGui_Unindent();
+
+        cimgui.c.ImGui_TextDisabled("Colors:");
+
+        const prompt_rgb = renderer.Overlay.Color.semantic_prompt.rgb();
+        const input_rgb = renderer.Overlay.Color.semantic_input.rgb();
+        const prompt_col: cimgui.c.ImVec4 = .{
+            .x = @as(f32, @floatFromInt(prompt_rgb.r)) / 255.0,
+            .y = @as(f32, @floatFromInt(prompt_rgb.g)) / 255.0,
+            .z = @as(f32, @floatFromInt(prompt_rgb.b)) / 255.0,
+            .w = 1.0,
+        };
+        const input_col: cimgui.c.ImVec4 = .{
+            .x = @as(f32, @floatFromInt(input_rgb.r)) / 255.0,
+            .y = @as(f32, @floatFromInt(input_rgb.g)) / 255.0,
+            .z = @as(f32, @floatFromInt(input_rgb.b)) / 255.0,
+            .w = 1.0,
+        };
+
+        _ = cimgui.c.ImGui_ColorButton("##prompt_color", prompt_col, cimgui.c.ImGuiColorEditFlags_NoTooltip);
+        cimgui.c.ImGui_SameLine();
+        cimgui.c.ImGui_Text("Prompt");
+
+        _ = cimgui.c.ImGui_ColorButton("##input_color", input_col, cimgui.c.ImGuiColorEditFlags_NoTooltip);
+        cimgui.c.ImGui_SameLine();
+        cimgui.c.ImGui_Text("Input");
     }
 };

--- a/src/inspector/widgets/screen.zig
+++ b/src/inspector/widgets/screen.zig
@@ -57,7 +57,7 @@ pub const Info = struct {
 
             if (cimgui.c.ImGui_CollapsingHeader(
                 "Cursor",
-                cimgui.c.ImGuiTreeNodeFlags_None,
+                cimgui.c.ImGuiTreeNodeFlags_DefaultOpen,
             )) {
                 cursorTable(&screen.cursor);
                 cimgui.c.ImGui_Separator();
@@ -69,7 +69,7 @@ pub const Info = struct {
 
             if (cimgui.c.ImGui_CollapsingHeader(
                 "Keyboard",
-                cimgui.c.ImGuiTreeNodeFlags_None,
+                cimgui.c.ImGuiTreeNodeFlags_DefaultOpen,
             )) keyboardTable(
                 screen,
                 data.modify_other_keys_2,
@@ -77,13 +77,13 @@ pub const Info = struct {
 
             if (cimgui.c.ImGui_CollapsingHeader(
                 "Kitty Graphics",
-                cimgui.c.ImGuiTreeNodeFlags_None,
+                cimgui.c.ImGuiTreeNodeFlags_DefaultOpen,
             )) kittyGraphicsTable(&screen.kitty_images);
 
             if (cimgui.c.ImGui_CollapsingHeader(
-                "Internal Terminal State",
-                cimgui.c.ImGuiTreeNodeFlags_None,
-            )) internalStateTable(&screen.pages);
+                "Other Screen State",
+                cimgui.c.ImGuiTreeNodeFlags_DefaultOpen,
+            )) internalStateTable(screen);
         }
 
         // Cell window
@@ -327,8 +327,10 @@ pub fn kittyGraphicsTable(
 
 /// Render internal terminal state table.
 pub fn internalStateTable(
-    pages: *const terminal.PageList,
+    screen: *const terminal.Screen,
 ) void {
+    const pages = &screen.pages;
+
     if (!cimgui.c.ImGui_BeginTable(
         "##terminal_state",
         2,
@@ -347,9 +349,21 @@ pub fn internalStateTable(
     cimgui.c.ImGui_Text("Memory Limit");
     _ = cimgui.c.ImGui_TableSetColumnIndex(1);
     cimgui.c.ImGui_Text("%d bytes (%d KiB)", pages.maxSize(), units.toKibiBytes(pages.maxSize()));
+
     cimgui.c.ImGui_TableNextRow();
     _ = cimgui.c.ImGui_TableSetColumnIndex(0);
     cimgui.c.ImGui_Text("Viewport Location");
     _ = cimgui.c.ImGui_TableSetColumnIndex(1);
     cimgui.c.ImGui_Text("%s", @tagName(pages.viewport).ptr);
+
+    {
+        cimgui.c.ImGui_TableNextRow();
+        _ = cimgui.c.ImGui_TableSetColumnIndex(0);
+        cimgui.c.ImGui_Text("Semantic Content");
+        cimgui.c.ImGui_SameLine();
+        widgets.helpMarker("Whether semantic prompt markers (OSC 133) have been seen.");
+        _ = cimgui.c.ImGui_TableSetColumnIndex(1);
+        var value: bool = screen.flags.semantic_content;
+        _ = cimgui.c.ImGui_Checkbox("##semantic_content", &value);
+    }
 }

--- a/src/inspector/widgets/surface.zig
+++ b/src/inspector/widgets/surface.zig
@@ -25,6 +25,7 @@ pub const Inspector = struct {
     terminal_info: widgets.terminal.Info,
     vt_stream: widgets.termio.Stream,
     renderer_info: widgets.renderer.Info,
+    show_demo_window: bool,
 
     pub fn init(alloc: Allocator) !Inspector {
         return .{
@@ -33,6 +34,7 @@ pub const Inspector = struct {
             .terminal_info = .empty,
             .vt_stream = try .init(alloc),
             .renderer_info = .empty,
+            .show_demo_window = true,
         };
     }
 
@@ -51,13 +53,6 @@ pub const Inspector = struct {
         // then it is a first render.
         const dockspace_id = cimgui.c.ImGui_GetID("Main Dockspace");
         const first_render = createDockSpace(dockspace_id);
-
-        // In debug we show the ImGui demo window so we can easily view
-        // available widgets and such.
-        if (comptime builtin.mode == .Debug) {
-            var show: bool = true; // Always show it
-            cimgui.c.ImGui_ShowDemoWindow(&show);
-        }
 
         // Draw everything that requires the terminal state mutex.
         {
@@ -136,6 +131,14 @@ pub const Inspector = struct {
             }
         }
 
+        // In debug we show the ImGui demo window so we can easily view
+        // available widgets and such.
+        if (comptime builtin.mode == .Debug) {
+            if (self.show_demo_window) {
+                cimgui.c.ImGui_ShowDemoWindow(&self.show_demo_window);
+            }
+        }
+
         if (first_render) {
             // On first render, setup our initial focus state. We only
             // do this on first render so that we can let the user change
@@ -171,12 +174,12 @@ pub const Inspector = struct {
             // this is the point we'd pre-split and so on for the initial
             // layout.
             const dock_id_main: cimgui.c.ImGuiID = dockspace_id;
+            cimgui.ImGui_DockBuilderDockWindow(window_imgui_demo, dock_id_main);
             cimgui.ImGui_DockBuilderDockWindow(window_terminal, dock_id_main);
             cimgui.ImGui_DockBuilderDockWindow(window_surface, dock_id_main);
             cimgui.ImGui_DockBuilderDockWindow(window_keyboard, dock_id_main);
             cimgui.ImGui_DockBuilderDockWindow(window_termio, dock_id_main);
             cimgui.ImGui_DockBuilderDockWindow(window_renderer, dock_id_main);
-            cimgui.ImGui_DockBuilderDockWindow(window_imgui_demo, dock_id_main);
             cimgui.ImGui_DockBuilderFinish(dockspace_id);
         }
 

--- a/src/renderer/row.zig
+++ b/src/renderer/row.zig
@@ -15,7 +15,7 @@ pub fn neverExtendBg(
     // Any semantic prompts should not have their background extended
     // because prompts often contain special formatting (such as
     // powerline) that looks bad when extended.
-    switch (row.semantic_prompt2) {
+    switch (row.semantic_prompt) {
         .prompt, .prompt_continuation => return true,
         .no_prompt => {},
     }

--- a/src/renderer/row.zig
+++ b/src/renderer/row.zig
@@ -15,9 +15,9 @@ pub fn neverExtendBg(
     // Any semantic prompts should not have their background extended
     // because prompts often contain special formatting (such as
     // powerline) that looks bad when extended.
-    switch (row.semantic_prompt) {
-        .prompt, .prompt_continuation, .input => return true,
-        .unknown, .command => {},
+    switch (row.semantic_prompt2) {
+        .prompt, .prompt_continuation => return true,
+        .no_prompt => {},
     }
 
     for (0.., cells) |x, *cell| {

--- a/src/renderer/row.zig
+++ b/src/renderer/row.zig
@@ -17,7 +17,7 @@ pub fn neverExtendBg(
     // powerline) that looks bad when extended.
     switch (row.semantic_prompt) {
         .prompt, .prompt_continuation => return true,
-        .no_prompt => {},
+        .none => {},
     }
 
     for (0.., cells) |x, *cell| {

--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # We need to be in interactive mode to proceed.
-if [[ "$-" != *i* ]] ; then builtin return; fi
+if [[ "$-" != *i* ]]; then builtin return; fi
 
 # When automatic shell integration is active, we were started in POSIX
 # mode and need to manually recreate the bash startup sequence.
@@ -49,7 +49,10 @@ if [ -n "$GHOSTTY_BASH_INJECT" ]; then
     if [[ $__ghostty_bash_flags != *"--noprofile"* ]]; then
       [ -r /etc/profile ] && builtin source "/etc/profile"
       for __ghostty_rcfile in "$HOME/.bash_profile" "$HOME/.bash_login" "$HOME/.profile"; do
-        [ -r "$__ghostty_rcfile" ] && { builtin source "$__ghostty_rcfile"; break; }
+        [ -r "$__ghostty_rcfile" ] && {
+          builtin source "$__ghostty_rcfile"
+          break
+        }
       done
     fi
   else
@@ -61,7 +64,10 @@ if [ -n "$GHOSTTY_BASH_INJECT" ]; then
       #  Void Linux uses /etc/bash/bashrc
       #  Nixos uses /etc/bashrc
       for __ghostty_rcfile in /etc/bash.bashrc /etc/bash/bashrc /etc/bashrc; do
-        [ -r "$__ghostty_rcfile" ] && { builtin source "$__ghostty_rcfile"; break; }
+        [ -r "$__ghostty_rcfile" ] && {
+          builtin source "$__ghostty_rcfile"
+          break
+        }
       done
       if [[ -z "$GHOSTTY_BASH_RCFILE" ]]; then GHOSTTY_BASH_RCFILE="$HOME/.bashrc"; fi
       [ -r "$GHOSTTY_BASH_RCFILE" ] && builtin source "$GHOSTTY_BASH_RCFILE"
@@ -101,9 +107,9 @@ if [[ "$GHOSTTY_SHELL_FEATURES" == *"sudo"* && -n "$TERMINFO" ]]; then
       fi
     done
     if [[ "$sudo_has_sudoedit_flags" == "yes" ]]; then
-      builtin command sudo "$@";
+      builtin command sudo "$@"
     else
-      builtin command sudo --preserve-env=TERMINFO "$@";
+      builtin command sudo --preserve-env=TERMINFO "$@"
     fi
   }
 fi
@@ -127,8 +133,8 @@ if [[ "$GHOSTTY_SHELL_FEATURES" == *ssh-* ]]; then
 
       while IFS=' ' read -r ssh_key ssh_value; do
         case "$ssh_key" in
-          user) ssh_user="$ssh_value" ;;
-          hostname) ssh_hostname="$ssh_value" ;;
+        user) ssh_user="$ssh_value" ;;
+        hostname) ssh_hostname="$ssh_value" ;;
         esac
         [[ -n "$ssh_user" && -n "$ssh_hostname" ]] && break
       done < <(builtin command ssh -G "$@" 2>/dev/null)
@@ -187,66 +193,71 @@ _ghostty_executing=""
 _ghostty_last_reported_cwd=""
 
 function __ghostty_precmd() {
-    local ret="$?"
-    if test "$_ghostty_executing" != "0"; then
-      _GHOSTTY_SAVE_PS1="$PS1"
-      _GHOSTTY_SAVE_PS2="$PS2"
+  local ret="$?"
+  if test "$_ghostty_executing" != "0"; then
+    _GHOSTTY_SAVE_PS1="$PS1"
+    _GHOSTTY_SAVE_PS2="$PS2"
 
-      # Marks
-      PS1=$PS1'\[\e]133;B\a\]'
-      PS2=$PS2'\[\e]133;B\a\]'
+    # Marks. We need to do fresh line (A) at the beginning of the prompt
+    # since if the cursor is not at the beginning of a line, the terminal
+    # will emit a newline.
+    PS1='\[\e]133;A\a\]'$PS1'\[\e]133;B\a\]'
+    PS2='\[\e]133;A;k=s\a\]'$PS2'\[\e]133;B\a\]'
 
-      # bash doesn't redraw the leading lines in a multiline prompt so
-      # mark the last line as a secondary prompt (k=s) to prevent the
-      # preceding lines from being erased by ghostty after a resize.
-      if [[ "${PS1}" == *"\n"* || "${PS1}" == *$'\n'* ]]; then
-        PS1=$PS1'\[\e]133;A;k=s\a\]'
-      fi
-
-      # Cursor
-      if [[ "$GHOSTTY_SHELL_FEATURES" == *"cursor"* ]]; then
-        [[ "$PS1" != *'\[\e[5 q\]'* ]] && PS1=$PS1'\[\e[5 q\]' # input
-        [[ "$PS0" != *'\[\e[0 q\]'* ]] && PS0=$PS0'\[\e[0 q\]' # reset
-      fi
-
-      # Title (working directory)
-      if [[ "$GHOSTTY_SHELL_FEATURES" == *"title"* ]]; then
-        PS1=$PS1'\[\e]2;\w\a\]'
-      fi
+    # Bash doesn't redraw the leading lines in a multiline prompt so
+    # we mark the start of each line (after each newline) as a secondary
+    # prompt. This correctly handles multiline prompts by setting the first
+    # to primary and the subsequent lines to secondary.
+    if [[ "${PS1}" == *"\n"* || "${PS1}" == *$'\n'* ]]; then
+      builtin local __ghostty_mark=$'\\[\\e]133;A;k=s\\a\\]'
+      PS1="${PS1//$'\n'/$'\n'$__ghostty_mark}"
+      PS1="${PS1//\\n/\\n$__ghostty_mark}"
     fi
 
-    if test "$_ghostty_executing" != ""; then
-      # End of current command. Report its status.
-      builtin printf "\e]133;D;%s;aid=%s\a" "$ret" "$BASHPID"
+    # Cursor
+    if [[ "$GHOSTTY_SHELL_FEATURES" == *"cursor"* ]]; then
+      [[ "$PS1" != *'\[\e[5 q\]'* ]] && PS1=$PS1'\[\e[5 q\]' # input
+      [[ "$PS0" != *'\[\e[0 q\]'* ]] && PS0=$PS0'\[\e[0 q\]' # reset
     fi
 
-    # unfortunately bash provides no hooks to detect cwd changes
-    # in particular this means cwd reporting will not happen for a
-    # command like cd /test && cat. PS0 is evaluated before cd is run.
-    if [[ "$_ghostty_last_reported_cwd" != "$PWD" ]]; then
-      _ghostty_last_reported_cwd="$PWD"
-      builtin printf "\e]7;kitty-shell-cwd://%s%s\a" "$HOSTNAME" "$PWD"
+    # Title (working directory)
+    if [[ "$GHOSTTY_SHELL_FEATURES" == *"title"* ]]; then
+      PS1=$PS1'\[\e]2;\w\a\]'
     fi
+  fi
 
-    # Fresh line and start of prompt.
-    builtin printf "\e]133;A;aid=%s\a" "$BASHPID"
-    _ghostty_executing=0
+  if test "$_ghostty_executing" != ""; then
+    # End of current command. Report its status.
+    builtin printf "\e]133;D;%s;aid=%s\a" "$ret" "$BASHPID"
+  fi
+
+  # unfortunately bash provides no hooks to detect cwd changes
+  # in particular this means cwd reporting will not happen for a
+  # command like cd /test && cat. PS0 is evaluated before cd is run.
+  if [[ "$_ghostty_last_reported_cwd" != "$PWD" ]]; then
+    _ghostty_last_reported_cwd="$PWD"
+    builtin printf "\e]7;kitty-shell-cwd://%s%s\a" "$HOSTNAME" "$PWD"
+  fi
+
+  # Fresh line and start of prompt.
+  builtin printf "\e]133;A;aid=%s\a" "$BASHPID"
+  _ghostty_executing=0
 }
 
 function __ghostty_preexec() {
-    builtin local cmd="$1"
+  builtin local cmd="$1"
 
-    PS1="$_GHOSTTY_SAVE_PS1"
-    PS2="$_GHOSTTY_SAVE_PS2"
+  PS1="$_GHOSTTY_SAVE_PS1"
+  PS2="$_GHOSTTY_SAVE_PS2"
 
-    # Title (current command)
-    if [[ -n $cmd && "$GHOSTTY_SHELL_FEATURES" == *"title"* ]]; then
-      builtin printf "\e]2;%s\a" "${cmd//[[:cntrl:]]}"
-    fi
+  # Title (current command)
+  if [[ -n $cmd && "$GHOSTTY_SHELL_FEATURES" == *"title"* ]]; then
+    builtin printf "\e]2;%s\a" "${cmd//[[:cntrl:]]/}"
+  fi
 
-    # End of input, start of output.
-    builtin printf "\e]133;C;\a"
-    _ghostty_executing=1
+  # End of input, start of output.
+  builtin printf "\e]133;C;\a"
+  _ghostty_executing=1
 }
 
 preexec_functions+=(__ghostty_preexec)

--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -201,7 +201,7 @@ function __ghostty_precmd() {
     # Marks. We need to do fresh line (A) at the beginning of the prompt
     # since if the cursor is not at the beginning of a line, the terminal
     # will emit a newline.
-    PS1='\[\e]133;A\a\]'$PS1'\[\e]133;B\a\]'
+    PS1='\[\e]133;A;redraw=last\a\]'$PS1'\[\e]133;B\a\]'
     PS2='\[\e]133;A;k=s\a\]'$PS2'\[\e]133;B\a\]'
 
     # Bash doesn't redraw the leading lines in a multiline prompt so
@@ -240,7 +240,7 @@ function __ghostty_precmd() {
   fi
 
   # Fresh line and start of prompt.
-  builtin printf "\e]133;A;aid=%s\a" "$BASHPID"
+  builtin printf "\e]133;A;redraw=last;aid=%s\a" "$BASHPID"
   _ghostty_executing=0
 }
 

--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -132,6 +132,7 @@ _ghostty_deferred_init() {
                 # asynchronously from a `zle -F` handler might still remove our
                 # marks. Oh well.
                 builtin local mark2=$'%{\e]133;A;k=s\a%}'
+                builtin local markB=$'%{\e]133;B\a%}'
                 # Add marks conditionally to avoid a situation where we have
                 # several marks in place. These conditions can have false
                 # positives and false negatives though.
@@ -139,8 +140,17 @@ _ghostty_deferred_init() {
                 # - False positive (with prompt_percent): PS1="%(?.$mark1.)"
                 # - False negative (with prompt_subst):   PS1='$mark1'
                 [[ $PS1 == *$mark1* ]] || PS1=${mark1}${PS1}
+                [[ $PS1 == *$markB* ]] || PS1=${PS1}${markB}
+                # Handle multiline prompts by marking continuation lines as 
+                # secondary by replacing newlines with being prefixed
+                # with k=s
+                if [[ $PS1 == *$'\n'* ]]; then
+                    PS1=${PS1//$'\n'/$'\n'${mark2}}
+                fi
+
                 # PS2 mark is needed when clearing the prompt on resize
                 [[ $PS2 == *$mark2* ]] || PS2=${mark2}${PS2}
+                [[ $PS2 == *$markB* ]] || PS2=${PS2}${markB}
                 (( _ghostty_state = 2 ))
             else
                 # If our precmd hook is not the last, we cannot rely on prompt
@@ -179,7 +189,10 @@ _ghostty_deferred_init() {
         # top. We cannot force prompt_subst on the user though, so we would
         # still need this code for the no_prompt_subst case.
         PS1=${PS1//$'%{\e]133;A\a%}'}
+        PS1=${PS1//$'%{\e]133;A;k=s\a%}'}
+        PS1=${PS1//$'%{\e]133;B\a%}'}
         PS2=${PS2//$'%{\e]133;A;k=s\a%}'}
+        PS2=${PS2//$'%{\e]133;B\a%}'}
 
         # This will work incorrectly in the presence of a preexec hook that
         # prints. For example, if MichaelAquilina/zsh-you-should-use installs

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -1229,7 +1229,7 @@ const ReflowCursor = struct {
 
             // If the row has a semantic prompt then the blank row is meaningful
             // so we just consider pretend the first cell of the row isn't empty.
-            if (cols_len == 0 and src_row.semantic_prompt != .unknown) cols_len = 1;
+            if (cols_len == 0 and src_row.semantic_prompt2 != .no_prompt) cols_len = 1;
         }
 
         // Handle tracked pin adjustments.
@@ -1973,13 +1973,13 @@ const ReflowCursor = struct {
 
         // If the row has a semantic prompt then the blank row is meaningful
         // so we always return all but one so that the row is drawn.
-        if (self.page_row.semantic_prompt != .unknown) return len - 1;
+        if (self.page_row.semantic_prompt2 != .no_prompt) return len - 1;
 
         return len;
     }
 
     fn copyRowMetadata(self: *ReflowCursor, other: *const Row) void {
-        self.page_row.semantic_prompt = other.semantic_prompt;
+        self.page_row.semantic_prompt2 = other.semantic_prompt2;
     }
 };
 
@@ -10254,7 +10254,7 @@ test "PageList resize reflow more cols no reflow preserves semantic prompt" {
         try testing.expect(s.pages.first == s.pages.last);
         const page = &s.pages.first.?.data;
         const rac = page.getRowAndCell(0, 1);
-        rac.row.semantic_prompt = .prompt;
+        rac.row.semantic_prompt2 = .prompt;
     }
 
     // Resize
@@ -10266,7 +10266,7 @@ test "PageList resize reflow more cols no reflow preserves semantic prompt" {
         try testing.expect(s.pages.first == s.pages.last);
         const page = &s.pages.first.?.data;
         const rac = page.getRowAndCell(0, 1);
-        try testing.expect(rac.row.semantic_prompt == .prompt);
+        try testing.expect(rac.row.semantic_prompt2 == .prompt);
     }
 }
 
@@ -10829,7 +10829,7 @@ test "PageList resize reflow less cols no reflow preserves semantic prompt" {
         const page = &s.pages.first.?.data;
         {
             const rac = page.getRowAndCell(0, 1);
-            rac.row.semantic_prompt = .prompt;
+            rac.row.semantic_prompt2 = .prompt;
         }
         for (0..s.cols) |x| {
             const rac = page.getRowAndCell(x, 1);
@@ -10851,12 +10851,12 @@ test "PageList resize reflow less cols no reflow preserves semantic prompt" {
             const p = s.pin(.{ .active = .{ .y = 1 } }).?;
             const rac = p.rowAndCell();
             try testing.expect(rac.row.wrap);
-            try testing.expect(rac.row.semantic_prompt == .prompt);
+            try testing.expect(rac.row.semantic_prompt2 == .prompt);
         }
         {
             const p = s.pin(.{ .active = .{ .y = 2 } }).?;
             const rac = p.rowAndCell();
-            try testing.expect(rac.row.semantic_prompt == .prompt);
+            try testing.expect(rac.row.semantic_prompt2 == .prompt);
         }
     }
 }
@@ -10871,7 +10871,7 @@ test "PageList resize reflow less cols no reflow preserves semantic prompt on fi
         try testing.expect(s.pages.first == s.pages.last);
         const page = &s.pages.first.?.data;
         const rac = page.getRowAndCell(0, 0);
-        rac.row.semantic_prompt = .prompt;
+        rac.row.semantic_prompt2 = .prompt;
     }
 
     // Resize
@@ -10883,7 +10883,7 @@ test "PageList resize reflow less cols no reflow preserves semantic prompt on fi
         try testing.expect(s.pages.first == s.pages.last);
         const page = &s.pages.first.?.data;
         const rac = page.getRowAndCell(0, 0);
-        try testing.expect(rac.row.semantic_prompt == .prompt);
+        try testing.expect(rac.row.semantic_prompt2 == .prompt);
     }
 }
 
@@ -10897,7 +10897,7 @@ test "PageList resize reflow less cols wrap preserves semantic prompt" {
         try testing.expect(s.pages.first == s.pages.last);
         const page = &s.pages.first.?.data;
         const rac = page.getRowAndCell(0, 0);
-        rac.row.semantic_prompt = .prompt;
+        rac.row.semantic_prompt2 = .prompt;
     }
 
     // Resize
@@ -10909,7 +10909,7 @@ test "PageList resize reflow less cols wrap preserves semantic prompt" {
         try testing.expect(s.pages.first == s.pages.last);
         const page = &s.pages.first.?.data;
         const rac = page.getRowAndCell(0, 0);
-        try testing.expect(rac.row.semantic_prompt == .prompt);
+        try testing.expect(rac.row.semantic_prompt2 == .prompt);
     }
 }
 

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -1229,7 +1229,7 @@ const ReflowCursor = struct {
 
             // If the row has a semantic prompt then the blank row is meaningful
             // so we just consider pretend the first cell of the row isn't empty.
-            if (cols_len == 0 and src_row.semantic_prompt != .no_prompt) cols_len = 1;
+            if (cols_len == 0 and src_row.semantic_prompt != .none) cols_len = 1;
         }
 
         // Handle tracked pin adjustments.
@@ -1973,7 +1973,7 @@ const ReflowCursor = struct {
 
         // If the row has a semantic prompt then the blank row is meaningful
         // so we always return all but one so that the row is drawn.
-        if (self.page_row.semantic_prompt != .no_prompt) return len - 1;
+        if (self.page_row.semantic_prompt != .none) return len - 1;
 
         return len;
     }
@@ -4405,7 +4405,7 @@ pub const PromptIterator = struct {
             const rac = p.rowAndCell();
             switch (rac.row.semantic_prompt) {
                 // This row isn't a prompt. Keep looking.
-                .no_prompt => if (at_limit) break,
+                .none => if (at_limit) break,
 
                 // This is a prompt line or continuation line. In either
                 // case we consider the first line the prompt, and then
@@ -4427,7 +4427,7 @@ pub const PromptIterator = struct {
                                 if (limit.eql(next_pin)) break;
                             },
 
-                            .prompt, .no_prompt => {
+                            .prompt, .none => {
                                 self.current = next_pin;
                                 return p.left(p.x);
                             },
@@ -4458,7 +4458,7 @@ pub const PromptIterator = struct {
             const rac = p.rowAndCell();
             switch (rac.row.semantic_prompt) {
                 // This row isn't a prompt. Keep looking.
-                .no_prompt => if (at_limit) break,
+                .none => if (at_limit) break,
 
                 // This is a prompt line.
                 .prompt => {
@@ -4485,7 +4485,7 @@ pub const PromptIterator = struct {
 
                         switch (prior.rowAndCell().row.semantic_prompt) {
                             // No prompt. That means our last pin is good!
-                            .no_prompt => {
+                            .none => {
                                 self.current = prior;
                                 return end_pin.left(end_pin.x);
                             },

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1683,7 +1683,7 @@ pub inline fn resize(
     // If our cursor is on a prompt line, then we clear the prompt so
     // the shell can redraw it. This works with OSC133 semantic prompts.
     if (opts.prompt_redraw and
-        self.cursor.page_row.semantic_prompt2 != .no_prompt)
+        self.cursor.page_row.semantic_prompt != .no_prompt)
     prompt: {
         const start = start: {
             var it = self.cursor.page_pin.promptIterator(
@@ -2342,7 +2342,7 @@ pub fn cursorSetSemanticContent(self: *Screen, t: union(enum) {
             self.flags.semantic_content = true;
             cursor.semantic_content = .prompt;
             cursor.semantic_content_clear_eol = false;
-            cursor.page_row.semantic_prompt2 = switch (kind) {
+            cursor.page_row.semantic_prompt = switch (kind) {
                 .initial, .right => .prompt,
                 .continuation, .secondary => .prompt_continuation,
             };
@@ -2920,7 +2920,7 @@ pub fn promptPath(
 } {
     // Verify "from" is on a prompt row before calling highlightSemanticContent.
     // highlightSemanticContent asserts the starting point is a prompt.
-    switch (from.rowAndCell().row.semantic_prompt2) {
+    switch (from.rowAndCell().row.semantic_prompt) {
         .prompt, .prompt_continuation => {},
         .no_prompt => return .{ .x = 0, .y = 0 },
     }
@@ -3043,7 +3043,7 @@ pub fn testWriteString(self: *Screen, text: []const u8) !void {
                 self.cursorSetSemanticContent(.output);
             } else switch (self.cursor.semantic_content) {
                 .input, .output => {},
-                .prompt => self.cursor.page_row.semantic_prompt2 = .prompt_continuation,
+                .prompt => self.cursor.page_row.semantic_prompt = .prompt_continuation,
             }
             continue;
         }
@@ -3079,7 +3079,7 @@ pub fn testWriteString(self: *Screen, text: []const u8) !void {
             self.cursor.page_row.wrap_continuation = true;
             switch (self.cursor.semantic_content) {
                 .input, .output => {},
-                .prompt => self.cursor.page_row.semantic_prompt2 = .prompt_continuation,
+                .prompt => self.cursor.page_row.semantic_prompt = .prompt_continuation,
             }
         }
 
@@ -6088,15 +6088,15 @@ test "Screen: resize more cols no reflow preserves semantic prompt" {
     // Our one row should still be a semantic prompt, the others should not.
     {
         const list_cell = s.pages.getCell(.{ .active = .{ .x = 0, .y = 0 } }).?;
-        try testing.expect(list_cell.row.semantic_prompt2 == .no_prompt);
+        try testing.expect(list_cell.row.semantic_prompt == .no_prompt);
     }
     {
         const list_cell = s.pages.getCell(.{ .active = .{ .x = 0, .y = 1 } }).?;
-        try testing.expect(list_cell.row.semantic_prompt2 == .prompt);
+        try testing.expect(list_cell.row.semantic_prompt == .prompt);
     }
     {
         const list_cell = s.pages.getCell(.{ .active = .{ .x = 0, .y = 2 } }).?;
-        try testing.expect(list_cell.row.semantic_prompt2 == .no_prompt);
+        try testing.expect(list_cell.row.semantic_prompt == .no_prompt);
     }
 }
 
@@ -8474,7 +8474,7 @@ test "Screen: promptPath" {
     // Row 2: prompt (with prompt cells) and input
     {
         const rac = page.getRowAndCell(0, 2);
-        rac.row.semantic_prompt2 = .prompt;
+        rac.row.semantic_prompt = .prompt;
         // First 3 cols are prompt
         for (0..3) |x| {
             const cell = page.getRowAndCell(x, 2).cell;
@@ -8497,7 +8497,7 @@ test "Screen: promptPath" {
     // Row 3: continuation line with input cells (same prompt block)
     {
         const rac = page.getRowAndCell(0, 3);
-        rac.row.semantic_prompt2 = .prompt_continuation;
+        rac.row.semantic_prompt = .prompt_continuation;
         for (0..6) |x| {
             const cell = page.getRowAndCell(x, 3).cell;
             cell.* = .{
@@ -8510,7 +8510,7 @@ test "Screen: promptPath" {
     // Row 6: next prompt + input on same line
     {
         const rac = page.getRowAndCell(0, 6);
-        rac.row.semantic_prompt2 = .prompt;
+        rac.row.semantic_prompt = .prompt;
         for (0..2) |x| {
             const cell = page.getRowAndCell(x, 6).cell;
             cell.* = .{

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -6187,9 +6187,12 @@ test "Screen: resize more cols no reflow preserves semantic prompt" {
     defer s.deinit();
 
     // Set one of the rows to be a prompt
-    try s.testWriteSemanticString("1ABCD\n", .unknown);
-    try s.testWriteSemanticString("2EFGH\n", .prompt);
-    try s.testWriteSemanticString("3IJKL", .unknown);
+    s.cursorSetSemanticContent(.output);
+    try s.testWriteString("1ABCD\n");
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("2EFGH");
+    s.cursorSetSemanticContent(.output);
+    try s.testWriteString("\n3IJKL");
 
     try s.resize(.{ .cols = 10, .rows = 3, .reflow = false });
 
@@ -6208,15 +6211,15 @@ test "Screen: resize more cols no reflow preserves semantic prompt" {
     // Our one row should still be a semantic prompt, the others should not.
     {
         const list_cell = s.pages.getCell(.{ .active = .{ .x = 0, .y = 0 } }).?;
-        try testing.expect(list_cell.row.semantic_prompt == .unknown);
+        try testing.expect(list_cell.row.semantic_prompt2 == .no_prompt);
     }
     {
         const list_cell = s.pages.getCell(.{ .active = .{ .x = 0, .y = 1 } }).?;
-        try testing.expect(list_cell.row.semantic_prompt == .prompt);
+        try testing.expect(list_cell.row.semantic_prompt2 == .prompt);
     }
     {
         const list_cell = s.pages.getCell(.{ .active = .{ .x = 0, .y = 2 } }).?;
-        try testing.expect(list_cell.row.semantic_prompt == .unknown);
+        try testing.expect(list_cell.row.semantic_prompt2 == .no_prompt);
     }
 }
 

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -134,6 +134,10 @@ pub const Cursor = struct {
     /// because its most likely null.
     hyperlink: ?*hyperlink.Hyperlink = null,
 
+    /// The current semantic content type for the cursor that will be
+    /// applied to any newly written cells.
+    semantic_content: pagepkg.Cell.SemanticContent = .output,
+
     /// The pointers into the page list where the cursor is currently
     /// located. This makes it faster to move the cursor.
     page_pin: *PageList.Pin,

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -3095,6 +3095,10 @@ pub fn testWriteString(self: *Screen, text: []const u8) !void {
             try self.cursorDownOrScroll();
             self.cursorHorizontalAbsolute(0);
             self.cursor.page_row.wrap_continuation = true;
+            switch (self.cursor.semantic_content) {
+                .input, .output => {},
+                .prompt => self.cursor.page_row.semantic_prompt2 = .prompt_continuation,
+            }
         }
 
         assert(width == 1 or width == 2);

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -137,6 +137,7 @@ pub const Cursor = struct {
     /// The current semantic content type for the cursor that will be
     /// applied to any newly written cells.
     semantic_content: pagepkg.Cell.SemanticContent = .output,
+    semantic_content_clear_eol: bool = false,
 
     /// The pointers into the page list where the cursor is currently
     /// located. This makes it faster to move the cursor.

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1683,7 +1683,7 @@ pub inline fn resize(
     // If our cursor is on a prompt line, then we clear the prompt so
     // the shell can redraw it. This works with OSC133 semantic prompts.
     if (opts.prompt_redraw and
-        self.cursor.page_row.semantic_prompt != .no_prompt)
+        self.cursor.page_row.semantic_prompt != .none)
     prompt: {
         const start = start: {
             var it = self.cursor.page_pin.promptIterator(
@@ -2922,7 +2922,7 @@ pub fn promptPath(
     // highlightSemanticContent asserts the starting point is a prompt.
     switch (from.rowAndCell().row.semantic_prompt) {
         .prompt, .prompt_continuation => {},
-        .no_prompt => return .{ .x = 0, .y = 0 },
+        .none => return .{ .x = 0, .y = 0 },
     }
 
     // Get our prompt bounds assuming "from" is at a prompt.
@@ -6088,7 +6088,7 @@ test "Screen: resize more cols no reflow preserves semantic prompt" {
     // Our one row should still be a semantic prompt, the others should not.
     {
         const list_cell = s.pages.getCell(.{ .active = .{ .x = 0, .y = 0 } }).?;
-        try testing.expect(list_cell.row.semantic_prompt == .no_prompt);
+        try testing.expect(list_cell.row.semantic_prompt == .none);
     }
     {
         const list_cell = s.pages.getCell(.{ .active = .{ .x = 0, .y = 1 } }).?;
@@ -6096,7 +6096,7 @@ test "Screen: resize more cols no reflow preserves semantic prompt" {
     }
     {
         const list_cell = s.pages.getCell(.{ .active = .{ .x = 0, .y = 2 } }).?;
-        try testing.expect(list_cell.row.semantic_prompt == .no_prompt);
+        try testing.expect(list_cell.row.semantic_prompt == .none);
     }
 }
 

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -776,7 +776,7 @@ fn printWrap(self: *Terminal) !void {
     cursor.semantic_content_clear_eol = old_semantic_clear;
     switch (old_semantic) {
         .output, .input => {},
-        .prompt => cursor.page_row.semantic_prompt2 = .prompt_continuation,
+        .prompt => cursor.page_row.semantic_prompt = .prompt_continuation,
     }
 
     if (mark_wrap) {
@@ -1200,7 +1200,7 @@ pub fn cursorIsAtPrompt(self: *Terminal) bool {
 
     // If our page row is a prompt then we're always at a prompt
     const cursor: *const Screen.Cursor = &self.screens.active.cursor;
-    if (cursor.page_row.semantic_prompt2 != .no_prompt) return true;
+    if (cursor.page_row.semantic_prompt != .no_prompt) return true;
 
     // Otherwise, determine our cursor state
     return switch (cursor.semantic_content) {
@@ -2347,7 +2347,7 @@ pub fn eraseDisplay(
                 );
                 while (it.next()) |p| {
                     const row = p.rowAndCell().row;
-                    switch (row.semantic_prompt2) {
+                    switch (row.semantic_prompt) {
                         // If we're at a prompt or input area, then we are at a prompt.
                         .prompt,
                         .prompt_continuation,
@@ -4328,11 +4328,11 @@ test "Terminal: soft wrap with semantic prompt" {
     for ("hello") |c| try t.print(c);
     {
         const list_cell = t.screens.active.pages.getCell(.{ .screen = .{ .x = 0, .y = 0 } }).?;
-        try testing.expectEqual(.prompt, list_cell.row.semantic_prompt2);
+        try testing.expectEqual(.prompt, list_cell.row.semantic_prompt);
     }
     {
         const list_cell = t.screens.active.pages.getCell(.{ .screen = .{ .x = 0, .y = 1 } }).?;
-        try testing.expectEqual(.prompt_continuation, list_cell.row.semantic_prompt2);
+        try testing.expectEqual(.prompt_continuation, list_cell.row.semantic_prompt);
     }
 }
 
@@ -11302,7 +11302,7 @@ test "Terminal: semantic prompt" {
         try testing.expectEqual(.prompt, cell.semantic_content);
 
         const row = list_cell.row;
-        try testing.expectEqual(.prompt, row.semantic_prompt2);
+        try testing.expectEqual(.prompt, row.semantic_prompt);
     }
 
     // Start input but end it on EOL
@@ -11323,7 +11323,7 @@ test "Terminal: semantic prompt" {
         try testing.expectEqual(.output, cell.semantic_content);
 
         const row = list_cell.row;
-        try testing.expectEqual(.no_prompt, row.semantic_prompt2);
+        try testing.expectEqual(.no_prompt, row.semantic_prompt);
     }
 }
 
@@ -11346,7 +11346,7 @@ test "Terminal: semantic prompt continuations" {
         try testing.expectEqual(.prompt, cell.semantic_content);
 
         const row = list_cell.row;
-        try testing.expectEqual(.prompt, row.semantic_prompt2);
+        try testing.expectEqual(.prompt, row.semantic_prompt);
     }
 
     // Start input but end it on EOL
@@ -11370,7 +11370,7 @@ test "Terminal: semantic prompt continuations" {
         try testing.expectEqual(.prompt, cell.semantic_content);
 
         const row = list_cell.row;
-        try testing.expectEqual(.prompt_continuation, row.semantic_prompt2);
+        try testing.expectEqual(.prompt_continuation, row.semantic_prompt);
     }
 }
 

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1189,19 +1189,6 @@ pub const SemanticPrompt = enum {
     command,
 };
 
-/// Mark the current semantic prompt information. Current escape sequences
-/// (OSC 133) only allow setting this for wherever the current active cursor
-/// is located.
-pub fn markSemanticPrompt(self: *Terminal, p: SemanticPrompt) void {
-    //log.debug("semantic_prompt y={} p={}", .{ self.screens.active.cursor.y, p });
-    self.screens.active.cursor.page_row.semantic_prompt = switch (p) {
-        .prompt => .prompt,
-        .prompt_continuation => .prompt_continuation,
-        .input => .input,
-        .command => .command,
-    };
-}
-
 /// Returns true if the cursor is currently at a prompt. Another way to look
 /// at this is it returns false if the shell is currently outputting something.
 /// This requires shell integration (semantic prompt integration).
@@ -2360,19 +2347,15 @@ pub fn eraseDisplay(
                 );
                 while (it.next()) |p| {
                     const row = p.rowAndCell().row;
-                    switch (row.semantic_prompt) {
+                    switch (row.semantic_prompt2) {
                         // If we're at a prompt or input area, then we are at a prompt.
                         .prompt,
                         .prompt_continuation,
-                        .input,
                         => break,
 
                         // If we have command output, then we're most certainly not
                         // at a prompt.
-                        .command => break :at_prompt,
-
-                        // If we don't know, we keep searching.
-                        .unknown => {},
+                        .no_prompt => break :at_prompt,
                     }
                 } else break :at_prompt;
 

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1093,6 +1093,19 @@ pub fn semanticPrompt(
             // command but we don't yet handle these in any meaningful way.
         },
 
+        .new_command => {
+            // Same as OSC "133;A" but may first implicitly terminate a
+            // previous command: if the options specify an aid and there
+            // is an active (open) command with matching aid, finish the
+            // innermost such command (as well as any other commands
+            // nested more deeply). If no aid is specified, treat as an
+            // aid whose value is the empty string.
+            try self.semanticPrompt(.{
+                .action = .fresh_line_new_prompt,
+                .options_unvalidated = cmd.options_unvalidated,
+            });
+        },
+
         .prompt_start => {
             // Explicit start of prompt. Optional after an A or N command.
             // The k (kind) option specifies the type of prompt:

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1077,7 +1077,7 @@ pub fn semanticPrompt(
 
             // "Subsequent text (until a OSC "133;B" or OSC "133;I" command)
             // is a prompt string (as if followed by OSC 133;P;k=i\007)."
-            self.screens.active.cursor.setSemanticContent(.{
+            self.screens.active.cursorSetSemanticContent(.{
                 .prompt = cmd.readOption(.prompt_kind) orelse .initial,
             });
 
@@ -1109,7 +1109,7 @@ pub fn semanticPrompt(
             // The k (kind) option specifies the type of prompt:
             // regular primary prompt (k=i or default),
             // right-side prompts (k=r), or prompts for continuation lines (k=c or k=s).
-            self.screens.active.cursor.setSemanticContent(.{
+            self.screens.active.cursorSetSemanticContent(.{
                 .prompt = cmd.readOption(.prompt_kind) orelse .initial,
             });
         },
@@ -1117,21 +1117,21 @@ pub fn semanticPrompt(
         .end_prompt_start_input => {
             // End of prompt and start of user input, terminated by a OSC
             // "133;C" or another prompt (OSC "133;P").
-            self.screens.active.cursor.setSemanticContent(.{
+            self.screens.active.cursorSetSemanticContent(.{
                 .input = .clear_explicit,
             });
         },
 
         .end_prompt_start_input_terminate_eol => {
             // End of prompt and start of user input, terminated by end-of-line.
-            self.screens.active.cursor.setSemanticContent(.{
+            self.screens.active.cursorSetSemanticContent(.{
                 .input = .clear_eol,
             });
         },
 
         .end_input_start_output => {
             // "End of input, and start of output."
-            self.screens.active.cursor.setSemanticContent(.output);
+            self.screens.active.cursorSetSemanticContent(.output);
         },
 
         .end_command => {
@@ -1139,7 +1139,7 @@ pub fn semanticPrompt(
             // anything. Other terminals appear to do nothing here. I think
             // its reasonable at this point to reset our semantic content
             // state but the spec doesn't really say what to do.
-            self.screens.active.cursor.setSemanticContent(.output);
+            self.screens.active.cursorSetSemanticContent(.output);
         },
     }
 }

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -2685,16 +2685,18 @@ pub fn resize(
     {
         primary.clearPrompt();
     }
-    if (self.modes.get(.wraparound)) {
-        try primary.resize(cols, rows);
-    } else {
-        try primary.resizeWithoutReflow(cols, rows);
-    }
+    try primary.resize(.{
+        .cols = cols,
+        .rows = rows,
+        .reflow = self.modes.get(.wraparound),
+    });
 
     // Alternate screen, if it exists, doesn't reflow
-    if (self.screens.get(.alternate)) |alt| {
-        try alt.resizeWithoutReflow(cols, rows);
-    }
+    if (self.screens.get(.alternate)) |alt| try alt.resize(.{
+        .cols = cols,
+        .rows = rows,
+        .reflow = false,
+    });
 
     // Whenever we resize we just mark it as a screen clear
     self.flags.dirty.clear = true;

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1076,7 +1076,17 @@ pub fn semanticPrompt(
 
             // "Subsequent text (until a OSC "133;B" or OSC "133;I" command)
             // is a prompt string (as if followed by OSC 133;P;k=i\007)."
-            // TODO
+
+            // Implementation note: we don't yet differentiate between
+            // the prompt types (k=) because it isn't of value to us
+            // currently. This may change in the future.
+            self.screens.active.cursor.semantic_content = .prompt;
+
+            // This is a kitty-specific flag that notes that the shell
+            // is capable of redraw.
+            if (cmd.readOption(.redraw)) |v| {
+                self.flags.shell_redraws_prompt = v;
+            }
 
             // The "aid" and "cl" options are also valid for this
             // command but we don't yet handle these in any meaningful way.

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1070,6 +1070,7 @@ pub fn semanticPrompt(
 ) !void {
     switch (cmd.action) {
         .fresh_line => try self.semanticPromptFreshLine(),
+
         .fresh_line_new_prompt => {
             // "First do a fresh-line."
             try self.semanticPromptFreshLine();
@@ -1090,6 +1091,12 @@ pub fn semanticPrompt(
 
             // The "aid" and "cl" options are also valid for this
             // command but we don't yet handle these in any meaningful way.
+        },
+
+        .end_prompt_start_input => {
+            // End of prompt and start of user input, terminated by a OSC
+            // "133;C" or another prompt (OSC "133;P").
+            self.screens.active.cursor.semantic_content = .input;
         },
 
         else => {},

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1093,10 +1093,33 @@ pub fn semanticPrompt(
             // command but we don't yet handle these in any meaningful way.
         },
 
+        .prompt_start => {
+            // Explicit start of prompt. Optional after an A or N command.
+            // The k (kind) option specifies the type of prompt:
+            // regular primary prompt (k=i or default),
+            // right-side prompts (k=r), or prompts for continuation lines (k=c or k=s).
+
+            // As noted above, we don't currently utilize the prompt type.
+            self.screens.active.cursor.semantic_content = .prompt;
+        },
+
         .end_prompt_start_input => {
             // End of prompt and start of user input, terminated by a OSC
             // "133;C" or another prompt (OSC "133;P").
             self.screens.active.cursor.semantic_content = .input;
+        },
+
+        .end_input_start_output => {
+            // "End of input, and start of output."
+            self.screens.active.cursor.semantic_content = .output;
+        },
+
+        .end_command => {
+            // From a terminal state perspective, this doesn't really do
+            // anything. Other terminals appear to do nothing here. I think
+            // its reasonable at this point to reset our semantic content
+            // state but the spec doesn't really say what to do.
+            self.screens.active.cursor.semantic_content = .output;
         },
 
         else => {},

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -711,6 +711,7 @@ fn printCell(
         .style_id = self.screens.active.cursor.style_id,
         .wide = wide,
         .protected = self.screens.active.cursor.protected,
+        .semantic_content = self.screens.active.cursor.semantic_content,
     };
 
     if (style_changed) {
@@ -11236,6 +11237,7 @@ test "Terminal: fullReset with a non-empty pen" {
 
     try t.setAttribute(.{ .direct_color_fg = .{ .r = 0xFF, .g = 0, .b = 0x7F } });
     try t.setAttribute(.{ .direct_color_bg = .{ .r = 0xFF, .g = 0, .b = 0x7F } });
+    t.screens.active.cursor.semantic_content = .input;
     t.fullReset();
 
     {
@@ -11248,6 +11250,7 @@ test "Terminal: fullReset with a non-empty pen" {
     }
 
     try testing.expectEqual(@as(style.Id, 0), t.screens.active.cursor.style_id);
+    try testing.expectEqual(.output, t.screens.active.cursor.semantic_content);
 }
 
 test "Terminal: fullReset hyperlink" {

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1200,7 +1200,7 @@ pub fn cursorIsAtPrompt(self: *Terminal) bool {
 
     // If our page row is a prompt then we're always at a prompt
     const cursor: *const Screen.Cursor = &self.screens.active.cursor;
-    if (cursor.page_row.semantic_prompt != .no_prompt) return true;
+    if (cursor.page_row.semantic_prompt != .none) return true;
 
     // Otherwise, determine our cursor state
     return switch (cursor.semantic_content) {
@@ -2355,7 +2355,7 @@ pub fn eraseDisplay(
 
                         // If we have command output, then we're most certainly not
                         // at a prompt.
-                        .no_prompt => break :at_prompt,
+                        .none => break :at_prompt,
                     }
                 } else break :at_prompt;
 
@@ -11323,7 +11323,7 @@ test "Terminal: semantic prompt" {
         try testing.expectEqual(.output, cell.semantic_content);
 
         const row = list_cell.row;
-        try testing.expectEqual(.no_prompt, row.semantic_prompt);
+        try testing.expectEqual(.none, row.semantic_prompt);
     }
 }
 

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -83,7 +83,7 @@ flags: packed struct {
     // This supports a Kitty extension where programs using semantic
     // prompts (OSC133) can annotate their new prompts with `redraw=0` to
     // disable clearing the prompt on resize.
-    shell_redraws_prompt: bool = true,
+    shell_redraws_prompt: osc.semantic_prompt.Redraw = .true,
 
     // This is set via ESC[4;2m. Any other modify key mode just sets
     // this to false and we act in mode 1 by default.

--- a/src/terminal/osc.zig
+++ b/src/terminal/osc.zig
@@ -17,6 +17,7 @@ const parsers = @import("osc/parsers.zig");
 const encoding = @import("osc/encoding.zig");
 
 pub const color = parsers.color;
+pub const semantic_prompt = parsers.semantic_prompt;
 
 const log = std.log.scoped(.osc);
 

--- a/src/terminal/osc/parsers/semantic_prompt.zig
+++ b/src/terminal/osc/parsers/semantic_prompt.zig
@@ -47,6 +47,7 @@ pub const Option = enum {
     cl,
     prompt_kind,
     err,
+
     // https://sw.kovidgoyal.net/kitty/shell-integration/#notes-for-shell-developers
     // Kitty supports a "redraw" option for prompt_start. I can't find
     // this documented anywhere but can see in the code that this is used

--- a/src/terminal/osc/parsers/semantic_prompt.zig
+++ b/src/terminal/osc/parsers/semantic_prompt.zig
@@ -49,10 +49,8 @@ pub const Option = enum {
     err,
 
     // https://sw.kovidgoyal.net/kitty/shell-integration/#notes-for-shell-developers
-    // Kitty supports a "redraw" option for prompt_start. I can't find
-    // this documented anywhere but can see in the code that this is used
-    // by shell environments to tell the terminal that the shell will NOT
-    // redraw the prompt so we should attempt to resize it.
+    // Kitty supports a "redraw" option for prompt_start. This is extended
+    // by Ghostty with the "last" option. See Redraw the type for more details.
     redraw,
 
     // Use a special key instead of arrow keys to move the cursor on
@@ -82,7 +80,7 @@ pub const Option = enum {
             .cl => Click,
             .prompt_kind => PromptKind,
             .err => []const u8,
-            .redraw => bool,
+            .redraw => Redraw,
             .special_key => bool,
             .click_events => bool,
             .exit_code => i32,
@@ -170,7 +168,15 @@ pub const Option = enum {
                 .cl => std.meta.stringToEnum(Click, value),
                 .prompt_kind => if (value.len == 1) PromptKind.init(value[0]) else null,
                 .err => value,
-                .redraw, .special_key, .click_events => if (value.len == 1) switch (value[0]) {
+                .redraw => if (std.mem.eql(u8, value, "0"))
+                    .false
+                else if (std.mem.eql(u8, value, "1"))
+                    .true
+                else if (std.mem.eql(u8, value, "last"))
+                    .last
+                else
+                    null,
+                .special_key, .click_events => if (value.len == 1) switch (value[0]) {
                     '0' => false,
                     '1' => true,
                     else => null,
@@ -207,6 +213,29 @@ pub const PromptKind = enum {
             else => null,
         };
     }
+};
+
+/// The values for the `redraw` extension to OSC133. This was
+/// started by Kitty[1] and extended by Ghostty (the "last" option).
+///
+/// [1]: https://sw.kovidgoyal.net/kitty/shell-integration/#notes-for-shell-developers
+pub const Redraw = enum(u2) {
+    /// The shell supports redrawing the full prompt and all continuations.
+    /// This is the default value, it does not need to be explicitly set
+    /// unless it is to reset a prior other value.
+    true,
+
+    /// The shell does NOT support redrawing. In this case, Ghostty will NOT
+    /// clear any prompt lines on resize.
+    false,
+
+    /// The shell supports redrawing only the LAST line of the prompt.
+    /// Ghostty will only clear the last line of the prompt on resize.
+    ///
+    /// This is specifically introduced because Bash only redraws the last
+    /// line. It is literally the only shell that does this and it does this
+    /// because its bad and they should feel bad. Don't be like Bash.
+    last,
 };
 
 /// Parse OSC 133, semantic prompts
@@ -514,7 +543,7 @@ test "OSC 133: fresh_line_new_prompt with redraw=0" {
     const cmd = p.end(null).?.*;
     try testing.expect(cmd == .semantic_prompt);
     try testing.expect(cmd.semantic_prompt.action == .fresh_line_new_prompt);
-    try testing.expect(cmd.semantic_prompt.readOption(.redraw).? == false);
+    try testing.expect(cmd.semantic_prompt.readOption(.redraw).? == .false);
 }
 
 test "OSC 133: fresh_line_new_prompt with redraw=1" {
@@ -528,7 +557,7 @@ test "OSC 133: fresh_line_new_prompt with redraw=1" {
     const cmd = p.end(null).?.*;
     try testing.expect(cmd == .semantic_prompt);
     try testing.expect(cmd.semantic_prompt.action == .fresh_line_new_prompt);
-    try testing.expect(cmd.semantic_prompt.readOption(.redraw).? == true);
+    try testing.expect(cmd.semantic_prompt.readOption(.redraw).? == .true);
 }
 
 test "OSC 133: fresh_line_new_prompt with invalid redraw" {
@@ -871,8 +900,9 @@ test "Option.read err" {
 
 test "Option.read redraw" {
     const testing = std.testing;
-    try testing.expect(Option.redraw.read("redraw=1").? == true);
-    try testing.expect(Option.redraw.read("redraw=0").? == false);
+    try testing.expect(Option.redraw.read("redraw=1").? == .true);
+    try testing.expect(Option.redraw.read("redraw=0").? == .false);
+    try testing.expect(Option.redraw.read("redraw=last").? == .last);
     try testing.expect(Option.redraw.read("redraw=2") == null);
     try testing.expect(Option.redraw.read("redraw=10") == null);
     try testing.expect(Option.redraw.read("redraw=") == null);

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -1898,10 +1898,6 @@ pub const Row = packed struct(u64) {
     /// false negatives. This is used to optimize hyperlink operations.
     hyperlink: bool = false,
 
-    /// The semantic prompt type for this row as specified by the
-    /// running program, or "unknown" if it was never set.
-    semantic_prompt: SemanticPrompt = .unknown,
-
     /// The semantic prompt state for this row.
     ///
     /// This is ONLY meant to note if there are ANY cells in this
@@ -1933,9 +1929,9 @@ pub const Row = packed struct(u64) {
     /// screen.
     dirty: bool = false,
 
-    _padding: u20 = 0,
+    _padding: u23 = 0,
 
-    /// The semantic prompt state of the row. See `semantic_prompt`.
+    /// The semantic prompt state of the row. See `semantic_prompt2`.
     pub const SemanticPrompt2 = enum(u2) {
         /// No prompt cells in this row.
         no_prompt = 0,
@@ -1944,29 +1940,6 @@ pub const Row = packed struct(u64) {
         /// Prompt cells exist in this row that had k=c set (continuation)
         /// line. This is used as a way to
         prompt_continuation = 2,
-    };
-
-    /// Semantic prompt type.
-    pub const SemanticPrompt = enum(u3) {
-        /// Unknown, the running application didn't tell us for this line.
-        unknown = 0,
-
-        /// This is a prompt line, meaning it only contains the shell prompt.
-        /// For poorly behaving shells, this may also be the input.
-        prompt = 1,
-        prompt_continuation = 2,
-
-        /// This line contains the input area. We don't currently track
-        /// where this actually is in the line, so we just assume it is somewhere.
-        input = 3,
-
-        /// This line is the start of command output.
-        command = 4,
-
-        /// True if this is a prompt or input line.
-        pub fn promptOrInput(self: SemanticPrompt) bool {
-            return self == .prompt or self == .prompt_continuation or self == .input;
-        }
     };
 
     /// Returns true if this row has any managed memory outside of the

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -1907,7 +1907,7 @@ pub const Row = packed struct(u64) {
     /// This may contain false positives but never false negatives. If
     /// this is set, you should still check individual cells to see if they
     /// have prompt semantics.
-    semantic_prompt2: SemanticPrompt2 = .no_prompt,
+    semantic_prompt: SemanticPrompt = .no_prompt,
 
     /// True if this row contains a virtual placeholder for the Kitty
     /// graphics protocol. (U+10EEEE)
@@ -1931,8 +1931,8 @@ pub const Row = packed struct(u64) {
 
     _padding: u23 = 0,
 
-    /// The semantic prompt state of the row. See `semantic_prompt2`.
-    pub const SemanticPrompt2 = enum(u2) {
+    /// The semantic prompt state of the row. See `semantic_prompt`.
+    pub const SemanticPrompt = enum(u2) {
         /// No prompt cells in this row.
         no_prompt = 0,
         /// Prompt cells exist in this row.

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -1902,6 +1902,17 @@ pub const Row = packed struct(u64) {
     /// running program, or "unknown" if it was never set.
     semantic_prompt: SemanticPrompt = .unknown,
 
+    /// The semantic prompt state for this row.
+    ///
+    /// This is ONLY meant to note if there are ANY cells in this
+    /// row that are part of a prompt. This is an optimization for more
+    /// efficiently implementing jump-to-prompt operations.
+    ///
+    /// This may contain false positives but never false negatives. If
+    /// this is set, you should still check individual cells to see if they
+    /// have prompt semantics.
+    semantic_prompt2: SemanticPrompt2 = .no_prompt,
+
     /// True if this row contains a virtual placeholder for the Kitty
     /// graphics protocol. (U+10EEEE)
     // Note: We keep this as memory-using even if the kitty graphics
@@ -1922,7 +1933,18 @@ pub const Row = packed struct(u64) {
     /// screen.
     dirty: bool = false,
 
-    _padding: u22 = 0,
+    _padding: u20 = 0,
+
+    /// The semantic prompt state of the row. See `semantic_prompt`.
+    pub const SemanticPrompt2 = enum(u2) {
+        /// No prompt cells in this row.
+        no_prompt = 0,
+        /// Prompt cells exist in this row.
+        prompt = 1,
+        /// Prompt cells exist in this row that had k=c set (continuation)
+        /// line. This is used as a way to
+        prompt_continuation = 2,
+    };
 
     /// Semantic prompt type.
     pub const SemanticPrompt = enum(u3) {

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -1907,7 +1907,7 @@ pub const Row = packed struct(u64) {
     /// This may contain false positives but never false negatives. If
     /// this is set, you should still check individual cells to see if they
     /// have prompt semantics.
-    semantic_prompt: SemanticPrompt = .no_prompt,
+    semantic_prompt: SemanticPrompt = .none,
 
     /// True if this row contains a virtual placeholder for the Kitty
     /// graphics protocol. (U+10EEEE)
@@ -1934,11 +1934,16 @@ pub const Row = packed struct(u64) {
     /// The semantic prompt state of the row. See `semantic_prompt`.
     pub const SemanticPrompt = enum(u2) {
         /// No prompt cells in this row.
-        no_prompt = 0,
-        /// Prompt cells exist in this row.
+        none = 0,
+        /// Prompt cells exist in this row and this is a primary prompt
+        /// line. A primary prompt line is one that is not a continuation
+        /// and is the beginning of a prompt.
         prompt = 1,
         /// Prompt cells exist in this row that had k=c set (continuation)
-        /// line. This is used as a way to
+        /// line. This is used as a way to detect when a line should
+        /// be considered part of some prior prompt. If no prior prompt
+        /// is found, the last (most historical) prompt continuation line is
+        /// considered the prompt.
         prompt_continuation = 2,
     };
 

--- a/src/terminal/stream_readonly.zig
+++ b/src/terminal/stream_readonly.zig
@@ -933,3 +933,18 @@ test "semantic prompt fresh line new prompt" {
     try s.nextSlice("\x1b]133;A;redraw=1\x07");
     try testing.expect(t.flags.shell_redraws_prompt);
 }
+
+test "semantic prompt end prompt start input" {
+    var t: Terminal = try .init(testing.allocator, .{ .cols = 10, .rows = 10 });
+    defer t.deinit(testing.allocator);
+
+    var s: Stream = .initAlloc(testing.allocator, .init(&t));
+    defer s.deinit();
+
+    // Write some text and then send OSC 133;A (fresh_line_new_prompt)
+    try s.nextSlice("Hello");
+    try s.nextSlice("\x1b]133;A\x07");
+    try s.nextSlice("prompt$ ");
+    try s.nextSlice("\x1b]133;B\x07");
+    try testing.expectEqual(.input, t.screens.active.cursor.semantic_content);
+}

--- a/src/terminal/stream_readonly.zig
+++ b/src/terminal/stream_readonly.zig
@@ -999,3 +999,19 @@ test "semantic prompt new_command at column zero" {
     try testing.expectEqual(@as(usize, 0), t.screens.active.cursor.y);
     try testing.expectEqual(.prompt, t.screens.active.cursor.semantic_content);
 }
+
+test "semantic prompt end_prompt_start_input_terminate_eol clears on linefeed" {
+    var t: Terminal = try .init(testing.allocator, .{ .cols = 10, .rows = 10 });
+    defer t.deinit(testing.allocator);
+
+    var s: Stream = .initAlloc(testing.allocator, .init(&t));
+    defer s.deinit();
+
+    // Set input terminated by EOL
+    try s.nextSlice("\x1b]133;I\x07");
+    try testing.expectEqual(.input, t.screens.active.cursor.semantic_content);
+
+    // Linefeed should reset semantic content to output
+    try s.nextSlice("\n");
+    try testing.expectEqual(.output, t.screens.active.cursor.semantic_content);
+}

--- a/src/terminal/stream_readonly.zig
+++ b/src/terminal/stream_readonly.zig
@@ -904,7 +904,7 @@ test "semantic prompt fresh line new prompt" {
     // Test with redraw option
     try s.nextSlice("prompt$ ");
     try s.nextSlice("\x1b]133;A;redraw=1\x07");
-    try testing.expect(t.flags.shell_redraws_prompt);
+    try testing.expect(t.flags.shell_redraws_prompt == .true);
 }
 
 test "semantic prompt end of input, then start output" {

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -610,8 +610,9 @@ pub fn clearScreen(self: *Termio, td: *ThreadData, history: bool) !void {
         // send a FF (0x0C) to the shell so that it can repaint the screen.
         // Mark the current row as a not a prompt so we can properly
         // clear the full screen in the next eraseDisplay call.
-        self.terminal.markSemanticPrompt(.command);
-        assert(!self.terminal.cursorIsAtPrompt());
+        // TODO: fix this
+        // self.terminal.markSemanticPrompt(.command);
+        // assert(!self.terminal.cursorIsAtPrompt());
         self.terminal.eraseDisplay(.complete, false);
     }
 

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1071,26 +1071,10 @@ pub const StreamHandler = struct {
         cmd: Stream.Action.SemanticPrompt,
     ) !void {
         switch (cmd.action) {
-            .fresh_line_new_prompt => {
-                const kind = cmd.readOption(.prompt_kind) orelse .initial;
-                switch (kind) {
-                    .initial, .right => {
-                        self.terminal.markSemanticPrompt(.prompt);
-                        if (cmd.readOption(.redraw)) |redraw| {
-                            self.terminal.flags.shell_redraws_prompt = redraw;
-                        }
-                    },
-                    .continuation, .secondary => {
-                        self.terminal.markSemanticPrompt(.prompt_continuation);
-                    },
-                }
-            },
-
-            .end_prompt_start_input => self.terminal.markSemanticPrompt(.input),
             .end_input_start_output => {
-                self.terminal.markSemanticPrompt(.command);
                 self.surfaceMessageWriter(.start_command);
             },
+
             .end_command => {
                 // The specification seems to not specify the type but
                 // other terminals accept 32-bits, but exit codes are really
@@ -1103,12 +1087,11 @@ pub const StreamHandler = struct {
                 self.surfaceMessageWriter(.{ .stop_command = code });
             },
 
-            // All of these commands weren't previously handled by our
-            // semantic prompt code. I am PR-ing the parser separate from the
-            // handling so we just ignore these like we did before, even
-            // though we should handle them eventually.
+            // Handled by Terminal, no special handling by us
+            .end_prompt_start_input,
             .end_prompt_start_input_terminate_eol,
             .fresh_line,
+            .fresh_line_new_prompt,
             .new_command,
             .prompt_start,
             => {},

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -320,7 +320,7 @@ pub const StreamHandler = struct {
             .progress_report => self.progressReport(value),
             .start_hyperlink => try self.startHyperlink(value.uri, value.id),
             .clipboard_contents => try self.clipboardContents(value.kind, value.data),
-            .semantic_prompt => self.semanticPrompt(value),
+            .semantic_prompt => try self.semanticPrompt(value),
             .mouse_shape => try self.setMouseShape(value),
             .configure_charset => self.configureCharset(value.slot, value.charset),
             .set_attribute => {
@@ -1069,7 +1069,7 @@ pub const StreamHandler = struct {
     fn semanticPrompt(
         self: *StreamHandler,
         cmd: Stream.Action.SemanticPrompt,
-    ) void {
+    ) !void {
         switch (cmd.action) {
             .fresh_line_new_prompt => {
                 const kind = cmd.readOption(.prompt_kind) orelse .initial;
@@ -1113,6 +1113,10 @@ pub const StreamHandler = struct {
             .prompt_start,
             => {},
         }
+
+        // We do this last so failures are still processed correctly
+        // above.
+        try self.terminal.semanticPrompt(cmd);
     }
 
     fn reportPwd(self: *StreamHandler, url: []const u8) !void {


### PR DESCRIPTION
Fixes #5932 

This updates our core terminal internals to track [semantic prompts (OSC133)](https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md) in a way that can enable us to fully implement the specification. This PR makes our terminal state fully handle all specified sequences properly, but we still ignore some noted options (`aid`, `cl`, etc.) that are not critical to functionality.

I took a look at our shell integrations and they should still be accurate and correct with regards to their OSC133 usage.

This doesn't introduce any new functionality, but should result in existing functionality being more correct, more robust, and gives us the groundwork to do more with semantic prompts in the future.

> [!NOTE]
>
> This PR description is **fully human written.** I realize its layout and use of headers may trigger AI smells. But it's all me, I promise. :)

## Extensions

I kept support for the Kitty `redraw=0` extension: if an OSC133A command sets `redraw=0` then we will NOT clear the prompt on resize (assuming the shell can NOT redraw the prompt). I don't actually know any scripts that utilize this, so we may want to just throw it away, but we had support before and it's cheap to keep around and it's tested.

## Limitations, Missing Features

* We don't currently respect `aid` so nested semantic zones can break things. This would require significant rework since aids are arbitrary strings. It'd require managed memory on pages to store the aids. Fwiw, in my brief survey of popular mainstream terminals, I wasn't able to find any that respect this. Maybe Warp does since semantic prompts are so core to their product but its not OSS for me to verify.

## Internal Changes

### `terminal.Page`

The internal state now tracks the current _semantic content type_ via a 2-bit flag on each `Cell`:

* `output` (zero value) - Command output
* `input` - Prompt input, typed by the user
* `prompt` - Prompt itself, e.g. `user@host $`

In addition to this, each `Row` also has a 2-bit flag. This flag _only tracks if the row might contain a prompt_:

* `no_prompt` (zero value) - No prompt cells
* `prompt` - Prompt cells exist and this started the prompt (OSC133 A)
* `prompt_continuation` - Prompt cells exist and this continued a prior prompt (OSC 133 A `k=s` or `k=c`)

The row flags server two functions:

1. An optimization to make prompt scanning faster
2. The only place the existence of continuation vs primary prompt is stored since cells themselves only store `prompt`

### `terminal.PageList`

The PageList has two new functions:

* `promptIterator` - An iterator that yields `Pin` values that map to the _first line_ of a prompt.
* `highlightSemanticContent` - Returns a highlight (pin range) to map to specific semantic content for a given prompt pin. This lets you quickly grab stuff like the prompt lines, content lines, etc.

### `terminal.Screen`

* The Screen now has a flag that tracks whether we've seen any row trigger a semantic prompt. This can be used as a fast path to avoid expensive semantic prompt operations if we know our screen can't possibly contain any. We don't currently use this but I plan to.

* **Big one: clearing the prompt lines is now built-in to resize.** This makes our resize aware of semantic prompts which makes it work _so much better_ already.

### `terminal.Terminal`

* A new function `semanticPrompt` for handling all the semantic prompt operations.

**AI Disclosure:** AI was used in various ways throughout this. It is by no means 100% AI-written, it's mostly human written. I reviewed everything. AI was used mostly for some assistance on rote tasks.