### PR TITLE
apprt: show title override in command palette jump commands

### DIFF
--- a/macos/Sources/Features/Command Palette/TerminalCommandPalette.swift
+++ b/macos/Sources/Features/Command Palette/TerminalCommandPalette.swift
@@ -143,8 +143,15 @@ struct TerminalCommandPaletteView: View {
             let displayColor = color != TerminalTabColor.none ? color : nil
 
             return controller.surfaceTree.map { surface in
-                let title = surface.title.isEmpty ? window.title : surface.title
-                let displayTitle = title.isEmpty ? "Untitled" : title
+                let terminalTitle = surface.title.isEmpty ? window.title : surface.title
+                let displayTitle: String
+                if let override = controller.titleOverride, !override.isEmpty {
+                    displayTitle = override
+                } else if !terminalTitle.isEmpty {
+                    displayTitle = terminalTitle
+                } else {
+                    displayTitle = "Untitled"
+                }
                 let pwd = surface.pwd?.abbreviatedPath
                 let subtitle: String? = if let pwd, !displayTitle.contains(pwd) {
                     pwd

--- a/macos/Sources/Features/Command Palette/TerminalCommandPalette.swift
+++ b/macos/Sources/Features/Command Palette/TerminalCommandPalette.swift
@@ -143,12 +143,11 @@ struct TerminalCommandPaletteView: View {
             let displayColor = color != TerminalTabColor.none ? color : nil
 
             return controller.surfaceTree.map { surface in
-                let terminalTitle = surface.title.isEmpty ? window.title : surface.title
                 let displayTitle: String
                 if let override = controller.titleOverride, !override.isEmpty {
                     displayTitle = override
                 } else if !terminalTitle.isEmpty {
-                    displayTitle = terminalTitle
+                    displayTitle = surface.title.isEmpty ? window.title : surface.title
                 } else {
                     displayTitle = "Untitled"
                 }

--- a/macos/Sources/Features/Command Palette/TerminalCommandPalette.swift
+++ b/macos/Sources/Features/Command Palette/TerminalCommandPalette.swift
@@ -143,11 +143,12 @@ struct TerminalCommandPaletteView: View {
             let displayColor = color != TerminalTabColor.none ? color : nil
 
             return controller.surfaceTree.map { surface in
+                let terminalTitle = surface.title.isEmpty ? window.title : surface.title
                 let displayTitle: String
                 if let override = controller.titleOverride, !override.isEmpty {
                     displayTitle = override
                 } else if !terminalTitle.isEmpty {
-                    displayTitle = surface.title.isEmpty ? window.title : surface.title
+                    displayTitle = terminalTitle
                 } else {
                     displayTitle = "Untitled"
                 }

--- a/src/apprt/gtk/class/command_palette.zig
+++ b/src/apprt/gtk/class/command_palette.zig
@@ -691,12 +691,12 @@ const Command = extern struct {
                 defer surface.unref();
 
                 const alloc = priv.arena.allocator();
-                const surface_title = surface.getTitle() orelse "Untitled";
+                const effective_title = surface.getTitleOverride() orelse surface.getTitle() orelse "Untitled";
 
                 j.title = std.fmt.allocPrintSentinel(
                     alloc,
                     "Focus: {s}",
-                    .{surface_title},
+                    .{effective_title},
                     0,
                 ) catch null;
 
@@ -717,8 +717,7 @@ const Command = extern struct {
                 defer surface.unref();
 
                 const alloc = priv.arena.allocator();
-
-                const title = surface.getTitle() orelse "Untitled";
+                const title = surface.getTitleOverride() orelse surface.getTitle() orelse "Untitled";
                 const pwd = surface.getPwd();
 
                 if (pwd) |p| {

--- a/src/apprt/gtk/class/command_palette.zig
+++ b/src/apprt/gtk/class/command_palette.zig
@@ -691,7 +691,7 @@ const Command = extern struct {
                 defer surface.unref();
 
                 const alloc = priv.arena.allocator();
-                const effective_title = surface.getTitleOverride() orelse surface.getTitle() orelse "Untitled";
+                const effective_title = surface.getEffectiveTitle() orelse "Untitled";
 
                 j.title = std.fmt.allocPrintSentinel(
                     alloc,
@@ -717,7 +717,7 @@ const Command = extern struct {
                 defer surface.unref();
 
                 const alloc = priv.arena.allocator();
-                const title = surface.getTitleOverride() orelse surface.getTitle() orelse "Untitled";
+                const title = surface.getEffectiveTitle() orelse "Untitled";
                 const pwd = surface.getPwd();
 
                 if (pwd) |p| {


### PR DESCRIPTION
Relates to https://github.com/ghostty-org/ghostty/discussions/3709

When a surface has a title override set (via `prompt_surface_title`), the command palette's "Focus:" jump commands now display the override instead of the terminal title.

**No title override:**
<img width="515" height="265" alt="Screenshot 2026-01-26 at 6 11 56 PM" src="https://github.com/user-attachments/assets/55f49878-87fd-498d-be4e-098ea42b7aaf" />

**With title override**
<img width="519" height="270" alt="Screenshot 2026-01-26 at 6 11 30 PM" src="https://github.com/user-attachments/assets/e2a293ef-0c29-4fab-94ff-b6b357193321" />

**AI DISCLAIMER**

I leveraged Claude Code to understand the codebase, make a plan and write the first draft of the code. I reviewed and edited the code written by claude and manually tested the change on iOS.