### PR TITLE
fix: calculate cell size before presenting gtk window

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -46,8 +46,8 @@ const Renderer = rendererpkg.Renderer;
 /// being resized to a size that is too small to be useful. These defaults
 /// are chosen to match the default size of Mac's Terminal.app, but is
 /// otherwise somewhat arbitrary.
-const min_window_width_cells: u32 = 10;
-const min_window_height_cells: u32 = 4;
+pub const min_window_width_cells: u32 = 10;
+pub const min_window_height_cells: u32 = 4;
 
 /// The maximum number of key tables that can be active at any
 /// given time. `activate_key_table` calls after this are ignored.

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -2182,10 +2182,10 @@ const Action = struct {
         // Create a new tab with window context (first tab in new window)
         win.newTabForWindow(parent);
 
-        // Compute the initial window size before presenting so the window
+        // Estimate the initial window size before presenting so the window
         // manager can position it correctly.
         if (win.getActiveSurface()) |surface| {
-            surface.computeInitialSize();
+            surface.estimateInitialSize();
             if (surface.getDefaultSize()) |size| {
                 win.as(gtk.Window).setDefaultSize(
                     @intCast(size.width),

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -2182,6 +2182,18 @@ const Action = struct {
         // Create a new tab with window context (first tab in new window)
         win.newTabForWindow(parent);
 
+        // Compute the initial window size before presenting so the window
+        // manager can position it correctly.
+        if (win.getActiveSurface()) |surface| {
+            surface.computeInitialSize();
+            if (surface.getDefaultSize()) |size| {
+                win.as(gtk.Window).setDefaultSize(
+                    @intCast(size.width),
+                    @intCast(size.height),
+                );
+            }
+        }
+
         // Show the window
         gtk.Window.present(win.as(gtk.Window));
     }

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -2005,11 +2005,12 @@ pub const Surface = extern struct {
         self.as(gobject.Object).notifyByPspec(properties.@"default-size".impl.param_spec);
     }
 
-    /// Compute and set the initial window size from config and font metrics.
+    /// Estimate and set the initial window size from config and font metrics.
     /// This can be called before the core surface exists to set up the window
-    /// size before presenting.
-    pub fn computeInitialSize(self: *Self) void {
-        const priv = self.private();
+    /// size before presenting. This is an estimate because it does not take
+    /// into account any padding that may need to be added to the window.
+    pub fn estimateInitialSize(self: *Self) void {
+        const priv: *Private = self.private();
         const config_obj = priv.config orelse return;
         const config = config_obj.get();
 
@@ -2042,11 +2043,8 @@ pub const Surface = extern struct {
 
         const cell = font_grid.cellSize();
 
-        // Calculate size: "best guess"; Padding unavailable pre-init.
-        // We do not need to @max here because the surface init will set
-        // size_limit which enforces minimums defined in src/Surface.zig
-        const width = config.@"window-width" * cell.width;
-        const height = config.@"window-height" * cell.height;
+        const width = @max(CoreSurface.min_window_width_cells, config.@"window-width") * cell.width;
+        const height = @max(CoreSurface.min_window_height_cells, config.@"window-height") * cell.height;
         const width_f32: f32 = @floatFromInt(width);
         const height_f32: f32 = @floatFromInt(height);
 

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -2042,9 +2042,11 @@ pub const Surface = extern struct {
 
         const cell = font_grid.cellSize();
 
-        // Calculate size (matching recomputeInitialSize logic)
-        const width = @max(config.@"window-width", 10) * cell.width;
-        const height = @max(config.@"window-height", 4) * cell.height;
+        // Calculate size: "best guess"; Padding unavailable pre-init.
+        // We do not need to @max here because the surface init will set
+        // size_limit which enforces minimums defined in src/Surface.zig
+        const width = config.@"window-width" * cell.width;
+        const height = config.@"window-height" * cell.height;
         const width_f32: f32 = @floatFromInt(width);
         const height_f32: f32 = @floatFromInt(height);
 


### PR DESCRIPTION
Fixes #7937

Added `computeInitialSize` to GTK `Surface` and call it in GTK `Application` before the first `present()`, so the window manager centers the correct size on initial show.

The issue occurs because the core `Surface.recomputeInitialSize()` runs only after the renderer is initialized. In GTK, the `GLArea` isn’t realized until after `present()`, so the initial size arrives too late for WM centering.

**Limitations**:  when we precompute size before `present()` we do not have access to padding, so the sizing will be very slightly off... but since it is only off a few pixels I was unable to tell visually that it wasn't perfectly centered.

**Other thoughts**: I was hesitant to make changes to core `Surface` because the issue is Linux-specific, but it may make sense to extract a helper from `recomputeInitialSize` to avoid duplicating the sizing math.

**AI Disclosure:** I used AI to explore the project, help with any language / API questions (I've never used zig before and rarely use gtk), and make implementation suggestions.