### PR TITLE
ci: Run build-macos-freetype with coretext_freetype for Harfbuzz tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -511,11 +511,11 @@ jobs:
 
       - name: Test All
         run: |
-          nix develop -c zig build test --system ${{ steps.deps.outputs.deps }} -Drenderer=metal -Dfont-backend=freetype
+          nix develop -c zig build test --system ${{ steps.deps.outputs.deps }} -Drenderer=metal -Dfont-backend=coretext_freetype
 
       - name: Build All
         run: |
-          nix develop -c zig build --system ${{ steps.deps.outputs.deps }} -Demit-macos-app=false -Drenderer=metal -Dfont-backend=freetype
+          nix develop -c zig build --system ${{ steps.deps.outputs.deps }} -Demit-macos-app=false -Drenderer=metal -Dfont-backend=coretext_freetype
 
   build-windows:
     runs-on: windows-2022


### PR DESCRIPTION
As mentioned in https://github.com/ghostty-org/ghostty/pull/10332#issuecomment-3800353166, the Harfbuzz shaping tests that depend on specific fonts (that are on macOS, but not whatever linux distro we use for CI) aren't being checked in CI. The `build-macos-freetype` CI check is primarily to make sure Freetype can build on Mac, but if we switch to the `coretext_freetype` backend, we still use Freetype for rendering, but then we get Coretext for font discovery which then enables these tests to run.