### PR TITLE
Misc inspector fixes

### DIFF
--- a/macos/Sources/Ghostty/Surface View/InspectorView.swift
+++ b/macos/Sources/Ghostty/Surface View/InspectorView.swift
@@ -269,16 +269,10 @@ extension Ghostty {
             // Builds up the "input.ScrollMods" bitmask
             var mods: Int32 = 0
 
-            var x = event.scrollingDeltaX
-            var y = event.scrollingDeltaY
+            let x = event.scrollingDeltaX
+            let y = event.scrollingDeltaY
             if event.hasPreciseScrollingDeltas {
                 mods = 1
-
-                // We do a 2x speed multiplier. This is subjective, it "feels" better to me.
-                x *= 2;
-                y *= 2;
-
-                // TODO(mitchellh): do we have to scale the x/y here by window scale factor?
             }
 
             // Determine our momentum value

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1205,10 +1205,11 @@ pub const Inspector = struct {
         // Determine our delta time
         const now = try std.time.Instant.now();
         io.DeltaTime = if (self.instant) |prev| delta: {
-            const since_ns = now.since(prev);
-            const since_s: f32 = @floatFromInt(since_ns / std.time.ns_per_s);
+            const since_ns: f64 = @floatFromInt(now.since(prev));
+            const ns_per_s: f64 = @floatFromInt(std.time.ns_per_s);
+            const since_s: f32 = @floatCast(since_ns / ns_per_s);
             break :delta @max(0.00001, since_s);
-        } else (1 / 60);
+        } else (1.0 / 60.0);
         self.instant = now;
     }
 };

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1133,15 +1133,18 @@ pub const Inspector = struct {
         yoff: f64,
         mods: input.ScrollMods,
     ) void {
-        _ = mods;
-
         self.queueRender();
         cimgui.c.ImGui_SetCurrentContext(self.ig_ctx);
         const io: *cimgui.c.ImGuiIO = cimgui.c.ImGui_GetIO();
+
+        // For precision scrolling (trackpads), the values are in pixels which
+        // scroll way too fast. Scale them down to approximate discrete wheel
+        // notches. imgui expects 1.0 to scroll ~5 lines of text.
+        const scale: f64 = if (mods.precision) 0.1 else 1.0;
         cimgui.c.ImGuiIO_AddMouseWheelEvent(
             io,
-            @floatCast(xoff),
-            @floatCast(yoff),
+            @floatCast(xoff * scale),
+            @floatCast(yoff * scale),
         );
     }
 

--- a/src/apprt/gtk/class/imgui_widget.zig
+++ b/src/apprt/gtk/class/imgui_widget.zig
@@ -131,21 +131,17 @@ pub const ImguiWidget = extern struct {
 
     /// Initialize the frame. Expects that the context is already current.
     fn newFrame(self: *Self) void {
-        // If we can't determine the time since the last frame we default to
-        // 1/60th of a second.
-        const default_delta_time = 1 / 60;
-
         const priv = self.private();
-
         const io: *cimgui.c.ImGuiIO = cimgui.c.ImGui_GetIO();
 
         // Determine our delta time
         const now = std.time.Instant.now() catch unreachable;
         io.DeltaTime = if (priv.instant) |prev| delta: {
-            const since_ns = now.since(prev);
-            const since_s: f32 = @floatFromInt(since_ns / std.time.ns_per_s);
+            const since_ns: f64 = @floatFromInt(now.since(prev));
+            const ns_per_s: f64 = @floatFromInt(std.time.ns_per_s);
+            const since_s: f32 = @floatCast(since_ns / ns_per_s);
             break :delta @max(0.00001, since_s);
-        } else default_delta_time;
+        } else (1.0 / 60.0);
 
         priv.instant = now;
     }

--- a/src/inspector/Inspector.zig
+++ b/src/inspector/Inspector.zig
@@ -583,10 +583,12 @@ fn renderModesWindow(self: *Inspector) void {
         const tag: terminal.modes.ModeTag = @bitCast(@as(terminal.modes.ModeTag.Backing, field.value));
 
         cimgui.c.ImGui_TableNextRow();
+        cimgui.c.ImGui_PushIDInt(@intCast(field.value));
+        defer cimgui.c.ImGui_PopID();
         {
             _ = cimgui.c.ImGui_TableSetColumnIndex(0);
             var value: bool = t.modes.get(@field(terminal.Mode, field.name));
-            _ = cimgui.c.ImGui_Checkbox("", &value);
+            _ = cimgui.c.ImGui_Checkbox("##checkbox", &value);
         }
         {
             _ = cimgui.c.ImGui_TableSetColumnIndex(1);


### PR DESCRIPTION
Inspector is getting some love! While working on some new functionality I found a bunch of bugs. Sending the bug fixes separately.

- Mode checkboxes didn't have a unique ID, causing Imgui warnings
- renderer: we keep a draw timer active while the inspector is visible, allowing animations to work
- GTK and macOS: we were always calculating a delta time of 0 since we converted to float after int math, making hover timers not work
- macOS: precision scrolling made scrolling way too fast, slow it down

No AI, just meat sticks