### PR TITLE
feat: add Manual termio backend for iOS SSH support

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -8,9 +8,9 @@
         // Zig libs
 
         .libxev = .{
-            // mitchellh/libxev
-            .url = "https://deps.files.ghostty.org/libxev-34fa50878aec6e5fa8f532867001ab3c36fae23e.tar.gz",
-            .hash = "libxev-0.0.0-86vtc4IcEwCqEYxEYoN_3KXmc6A9VLcm22aVImfvecYs",
+            // mitchellh/libxev - updated to include iOS mach_port fix (PR #204)
+            .url = "https://github.com/mitchellh/libxev/archive/46fa9b74bafb0b9c151a8035fdb6b01ec68581e4.tar.gz",
+            .hash = "libxev-0.0.0-86vtc0IbEwDsp-ljrhdEWhf2TYBvSrqqgNAPQwtfX8Eg",
             .lazy = true,
         },
         .vaxis = .{

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1079,6 +1079,7 @@ bool ghostty_surface_key_is_binding(ghostty_surface_t,
                                     ghostty_binding_flags_e*);
 void ghostty_surface_text(ghostty_surface_t, const char*, uintptr_t);
 void ghostty_surface_preedit(ghostty_surface_t, const char*, uintptr_t);
+void ghostty_surface_write_output(ghostty_surface_t, const char*, uintptr_t);
 bool ghostty_surface_mouse_captured(ghostty_surface_t);
 bool ghostty_surface_mouse_button(ghostty_surface_t,
                                   ghostty_input_mouse_state_e,

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1786,6 +1786,19 @@ pub const CAPI = struct {
         surface.preeditCallback(if (len == 0) null else ptr[0..len]);
     }
 
+    /// Write terminal output data directly to the surface. This is used when
+    /// the terminal output comes from an external source (e.g., SSH connection)
+    /// rather than a local PTY/command. The data is processed as if it came
+    /// from the terminal's output stream.
+    export fn ghostty_surface_write_output(
+        surface: *Surface,
+        ptr: [*]const u8,
+        len: usize,
+    ) void {
+        if (len == 0) return;
+        surface.core_surface.io.processOutput(ptr[0..len]);
+    }
+
     /// Returns true if the surface currently has mouse capturing
     /// enabled.
     export fn ghostty_surface_mouse_captured(surface: *Surface) bool {

--- a/src/termio.zig
+++ b/src/termio.zig
@@ -23,6 +23,7 @@ const message = @import("termio/message.zig");
 pub const backend = @import("termio/backend.zig");
 pub const mailbox = @import("termio/mailbox.zig");
 pub const Exec = @import("termio/Exec.zig");
+pub const Manual = @import("termio/Manual.zig");
 pub const Options = @import("termio/Options.zig");
 pub const Termio = @import("termio/Termio.zig");
 pub const Thread = @import("termio/Thread.zig");

--- a/src/termio/Manual.zig
+++ b/src/termio/Manual.zig
@@ -1,0 +1,128 @@
+//! Manual backend for terminal I/O that doesn't spawn a subprocess.
+//! This is used for scenarios where terminal output comes from an external
+//! source (e.g., SSH connection) rather than a local PTY.
+const Manual = @This();
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const renderer = @import("../renderer.zig");
+const terminal = @import("../terminal/main.zig");
+const termio = @import("../termio.zig");
+
+const log = std.log.scoped(.io_manual);
+
+// No state needed for manual backend
+_placeholder: u8 = 0,
+
+pub const Config = struct {
+    // No configuration needed
+};
+
+pub const ThreadData = struct {
+    // No thread data needed for manual backend
+
+    pub fn deinit(self: *ThreadData, alloc: Allocator) void {
+        _ = self;
+        _ = alloc;
+    }
+};
+
+pub fn init(
+    alloc: Allocator,
+    cfg: Config,
+) !Manual {
+    _ = alloc;
+    _ = cfg;
+    return .{};
+}
+
+pub fn deinit(self: *Manual) void {
+    _ = self;
+}
+
+pub fn initTerminal(self: *Manual, term: *terminal.Terminal) void {
+    _ = self;
+    _ = term;
+    // Nothing to initialize for manual backend
+}
+
+pub fn threadEnter(
+    self: *Manual,
+    alloc: Allocator,
+    io: *termio.Termio,
+    td: *termio.Termio.ThreadData,
+) !void {
+    _ = self;
+    _ = alloc;
+    _ = io;
+
+    // Set up thread data with manual backend data
+    td.backend = .{ .manual = .{} };
+
+    log.info("manual backend thread entered", .{});
+}
+
+pub fn threadExit(self: *Manual, td: *termio.Termio.ThreadData) void {
+    _ = self;
+    _ = td;
+    log.info("manual backend thread exited", .{});
+}
+
+pub fn focusGained(
+    self: *Manual,
+    td: *termio.Termio.ThreadData,
+    focused: bool,
+) !void {
+    _ = self;
+    _ = td;
+    _ = focused;
+    // Nothing to do for focus changes in manual mode
+}
+
+pub fn resize(
+    self: *Manual,
+    grid_size: renderer.GridSize,
+    screen_size: renderer.ScreenSize,
+) !void {
+    _ = self;
+    _ = grid_size;
+    _ = screen_size;
+    // Nothing to do for resize in manual mode
+    // The external application handles terminal size
+}
+
+pub fn queueWrite(
+    self: *Manual,
+    alloc: Allocator,
+    td: *termio.Termio.ThreadData,
+    data: []const u8,
+    linefeed: bool,
+) !void {
+    _ = self;
+    _ = alloc;
+    _ = td;
+    _ = linefeed;
+    // In manual mode, writes are handled externally
+    // The application should capture writes via a callback
+    log.debug("manual backend queueWrite called with {} bytes", .{data.len});
+}
+
+pub fn changeConfig(self: *Manual, config: *termio.DerivedConfig) void {
+    _ = self;
+    _ = config;
+}
+
+pub fn childExitedAbnormally(
+    self: *Manual,
+    gpa: Allocator,
+    t: *terminal.Terminal,
+    exit_code: u32,
+    runtime_ms: u64,
+) !void {
+    _ = self;
+    _ = gpa;
+    _ = t;
+    _ = exit_code;
+    _ = runtime_ms;
+    // No child process in manual mode
+}


### PR DESCRIPTION
Add a Manual backend for terminal I/O that doesn't spawn a subprocess. This enables iOS apps to feed terminal output from external sources like SSH connections.

Changes:
- Add Manual termio backend (src/termio/Manual.zig)
- Add ghostty_surface_write_output() API to embedded.zig
- Update Surface.zig to use Manual backend on iOS when no command
- Update build.zig.zon with libxev iOS mach_port fix
- Add Manual to backend union in backend.zig

The Manual backend implements all required Backend interface methods as no-ops, allowing the host application to:
1. Create a surface without spawning a subprocess
2. Write terminal output via ghostty_surface_write_output()
3. Capture keyboard input via existing ghostty_surface_key() API