### PR TITLE
core: don't log redraw_surface or redraw_inspector app messages

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -237,7 +237,7 @@ pub fn needsConfirmQuit(self: *const App) bool {
 /// Drain the mailbox.
 fn drainMailbox(self: *App, rt_app: *apprt.App) !void {
     while (self.mailbox.pop()) |message| {
-        if (std.log.logEnabled(.debug, .app)) {
+        if (comptime std.log.logEnabled(.debug, .app)) {
             switch (message) {
                 // these tend to be way too verbose for normal debugging
                 .redraw_surface, .redraw_inspector => {},

--- a/src/App.zig
+++ b/src/App.zig
@@ -240,7 +240,7 @@ fn drainMailbox(self: *App, rt_app: *apprt.App) !void {
         switch (message) {
             // these tend to be way too verbose for normal debugging
             .redraw_surface, .redraw_inspector => {},
-            else => log.debug("mailbox message={s}", .{@tagName(message)}),
+            else => log.debug("mailbox message={t}", .{message}),
         }
         switch (message) {
             .open_config => try self.performAction(rt_app, .open_config),

--- a/src/App.zig
+++ b/src/App.zig
@@ -237,7 +237,11 @@ pub fn needsConfirmQuit(self: *const App) bool {
 /// Drain the mailbox.
 fn drainMailbox(self: *App, rt_app: *apprt.App) !void {
     while (self.mailbox.pop()) |message| {
-        log.debug("mailbox message={s}", .{@tagName(message)});
+        switch (message) {
+            // these tend to be way too verbose for normal debugging
+            .redraw_surface, .redraw_inspector => {},
+            else => log.debug("mailbox message={s}", .{@tagName(message)}),
+        }
         switch (message) {
             .open_config => try self.performAction(rt_app, .open_config),
             .new_window => |msg| try self.newWindow(rt_app, msg),

--- a/src/App.zig
+++ b/src/App.zig
@@ -237,10 +237,12 @@ pub fn needsConfirmQuit(self: *const App) bool {
 /// Drain the mailbox.
 fn drainMailbox(self: *App, rt_app: *apprt.App) !void {
     while (self.mailbox.pop()) |message| {
-        switch (message) {
-            // these tend to be way too verbose for normal debugging
-            .redraw_surface, .redraw_inspector => {},
-            else => log.debug("mailbox message={t}", .{message}),
+        if (std.log.logEnabled(.debug, .app)) {
+            switch (message) {
+                // these tend to be way too verbose for normal debugging
+                .redraw_surface, .redraw_inspector => {},
+                else => log.debug("mailbox message={t}", .{message}),
+            }
         }
         switch (message) {
             .open_config => try self.performAction(rt_app, .open_config),


### PR DESCRIPTION
They are _very_ verbose and make other debug logs difficult to read.