### PR TITLE
flake.nix: drop desc argument for runVM function

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -101,7 +101,7 @@
     formatter = forAllPlatforms (pkgs: pkgs.alejandra);
 
     apps = forBuildablePlatforms (pkgs: let
-      runVM = module: desc: let
+      runVM = module: let
         vm = import ./nix/vm/create.nix {
           inherit (pkgs.stdenv.hostPlatform) system;
           inherit module nixpkgs;


### PR DESCRIPTION
The current runVM function gets called only with a module and without a desc, resulting in an error when running `nix flake show` or similar commands.

This gets quite annoying when e.g. my language server starts evaluating all my flake inputs:
<img width="682" height="292" alt="image" src="https://github.com/user-attachments/assets/600accea-55b0-4290-9f09-d492f25123c2" />

This pr drops the `desc` argument to `runVM` and gets rid of that problem.