### PR TITLE
gtk: add extra keybinds to command palette for scrolling

### DIFF
--- a/src/apprt/gtk/ui/1.5/command-palette.blp
+++ b/src/apprt/gtk/ui/1.5/command-palette.blp
@@ -107,4 +107,8 @@ Adw.Dialog dialog {
       }
     }
   }
+
+  EventControllerKey {
+    key-pressed => $key_pressed();
+  }
 }


### PR DESCRIPTION
Adds `ctrl+n`, `ctrl+p`, `ctrl+j`, and `ctrl+k` keybinds to the GTK command palette for scrolling the list.

This is basically #7979 rebased for gtk-ng and adding `ctrl+j` and `ctrl+k`.

Fixes #7918