### PR TITLE
inspector: redraw on timed updates rather than on-demand

### DIFF
--- a/macos/Sources/Ghostty/Surface View/InspectorView.swift
+++ b/macos/Sources/Ghostty/Surface View/InspectorView.swift
@@ -415,8 +415,6 @@ extension Ghostty {
         // MARK: MTKView
 
         override func draw(_ dirtyRect: NSRect) {
-            Ghostty.logger.warning("inspector draw at \(Date())")
-
             guard
               let commandBuffer = self.commandQueue.makeCommandBuffer(),
               let descriptor = self.currentRenderPassDescriptor else {

--- a/macos/Sources/Ghostty/Surface View/InspectorView.swift
+++ b/macos/Sources/Ghostty/Surface View/InspectorView.swift
@@ -120,9 +120,9 @@ extension Ghostty {
             self.commandQueue = commandQueue
             super.init(frame: frame, device: device)
 
-            // This makes it so renders only happen when we request
-            self.enableSetNeedsDisplay = true
-            self.isPaused = true
+            // Use timed updates mode. This is required for the inspector.
+            self.isPaused = false
+            self.preferredFramesPerSecond = 30
 
             // After initializing the parent we can set our own properties
             self.device = MTLCreateSystemDefaultDevice()
@@ -130,6 +130,13 @@ extension Ghostty {
 
             // Setup our tracking areas for mouse events
             updateTrackingAreas()
+
+            // Observe occlusion state to pause rendering when not visible
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(windowDidChangeOcclusionState),
+                name: NSWindow.didChangeOcclusionStateNotification,
+                object: nil)
         }
 
         required init(coder: NSCoder) {
@@ -141,27 +148,19 @@ extension Ghostty {
             NotificationCenter.default.removeObserver(self)
         }
 
+        @objc private func windowDidChangeOcclusionState(_ notification: NSNotification) {
+            guard let window = notification.object as? NSWindow,
+                  window == self.window else { return }
+            // Pause rendering when our window isn't visible.
+            isPaused = !window.occlusionState.contains(.visible)
+        }
+
         // MARK: Internal Inspector Funcs
 
         private func surfaceViewDidChange() {
-            let center = NotificationCenter.default
-            center.removeObserver(self)
-
-            guard let surfaceView = self.surfaceView else { return }
             guard let inspector = self.inspector else { return }
             guard let device = self.device else { return }
             _ = inspector.metalInit(device: device)
-
-            // Register an observer for render requests
-            center.addObserver(
-                self,
-                selector: #selector(didRequestRender),
-                name: Ghostty.Notification.inspectorNeedsDisplay,
-                object: surfaceView)
-        }
-
-        @objc private func didRequestRender(notification: SwiftUI.Notification) {
-            self.needsDisplay = true
         }
 
         private func updateSize() {
@@ -416,6 +415,8 @@ extension Ghostty {
         // MARK: MTKView
 
         override func draw(_ dirtyRect: NSRect) {
+            Ghostty.logger.warning("inspector draw at \(Date())")
+
             guard
               let commandBuffer = self.commandQueue.makeCommandBuffer(),
               let descriptor = self.currentRenderPassDescriptor else {

--- a/src/App.zig
+++ b/src/App.zig
@@ -240,7 +240,7 @@ fn drainMailbox(self: *App, rt_app: *apprt.App) !void {
         if (comptime std.log.logEnabled(.debug, .app)) {
             switch (message) {
                 // these tend to be way too verbose for normal debugging
-                .redraw_surface, .redraw_inspector => {},
+                .redraw_surface => {},
                 else => log.debug("mailbox message={t}", .{message}),
             }
         }
@@ -250,7 +250,6 @@ fn drainMailbox(self: *App, rt_app: *apprt.App) !void {
             .close => |surface| self.closeSurface(surface),
             .surface_message => |msg| try self.surfaceMessage(msg.surface, msg.message),
             .redraw_surface => |surface| try self.redrawSurface(rt_app, surface),
-            .redraw_inspector => |surface| self.redrawInspector(rt_app, surface),
 
             // If we're quitting, then we set the quit flag and stop
             // draining the mailbox immediately. This lets us defer
@@ -287,11 +286,6 @@ fn redrawSurface(
         .render,
         {},
     );
-}
-
-fn redrawInspector(self: *App, rt_app: *apprt.App, surface: *apprt.Surface) void {
-    if (!self.hasRtSurface(surface)) return;
-    rt_app.redrawInspector(surface);
 }
 
 /// Create a new window
@@ -564,10 +558,6 @@ pub const Message = union(enum) {
     /// wake up the renderer thread. The renderer thread will send this
     /// message if it needs to.
     redraw_surface: *apprt.Surface,
-
-    /// Redraw the inspector. This is called whenever some non-OS event
-    /// causes the inspector to need to be redrawn.
-    redraw_inspector: *apprt.Surface,
 
     const NewWindow = struct {
         /// The parent surface

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -294,9 +294,6 @@ fn setQosClass(self: *const Thread) void {
 
 fn syncDrawTimer(self: *Thread) void {
     skip: {
-        // If we have an inspector, we always run the draw timer.
-        if (self.flags.has_inspector) break :skip;
-
         // If our renderer supports animations and has them, then we
         // always have a draw timer.
         if (@hasDecl(rendererpkg.Renderer, "hasAnimations") and
@@ -479,9 +476,6 @@ fn drainMailbox(self: *Thread) !void {
 
             .inspector => |v| {
                 self.flags.has_inspector = v;
-                // Reset our draw timer state, which might change due
-                // to the inspector change.
-                self.syncDrawTimer();
             },
 
             .macos_display_id => |v| {
@@ -613,11 +607,6 @@ fn renderCallback(
         log.warn("render callback fired without data set", .{});
         return .disarm;
     };
-
-    // If we have an inspector, let the app know we want to rerender that.
-    if (t.flags.has_inspector) {
-        _ = t.app_mailbox.push(.{ .redraw_inspector = t.surface }, .{ .instant = {} });
-    }
 
     // Update our frame data
     t.renderer.updateFrame(


### PR DESCRIPTION
Fixes #10524 

This changes our inspector from being renderer-change driven to being FPS driven. Both macOS and GTK now draw the inspector at most at 30 FPS on a timer. Details between platforms are slightly different and covered later.

The motivation for this is that triggering an inspector redraw on frame update was causing _too many_ draws, leading to high CPU usage. Further, terminal change isn't a good proxy for all the state that the inspector shows, and tracking changes to all those to trigger a redraw is just a lot of complexity.

Instead, moving to a standard, game-like framerate driven redraw simplifies a lot. It does cost some CPU when idle, but actually lowers our CPU under normal usage since it's rendering less often (30 FPS isn't much for what we're doing).

**For macOS,** this uses CADisplayLink, so the refresh rate is variable. I've seen macOS drop it to 1fps when there isn't much happening, which is nice. We also setup an occlusion event so when the window is fully occluded we stop rendering entirely.

**For GTK,** the tools to control this are limited. We do a standard max-30 FPS tick redraw but can't support occlusion beyond what the window server supports. For Wayland, I believe we get it for free (occluded windows aren't drawn). 