### PR TITLE
Add NSUserDefaults settings store infrastructure

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1028,6 +1028,8 @@ void ghostty_config_load_file(ghostty_config_t, const char*);
 void ghostty_config_load_default_files(ghostty_config_t);
 void ghostty_config_load_recursive_files(ghostty_config_t);
 void ghostty_config_finalize(ghostty_config_t);
+void ghostty_config_set(ghostty_config_t, const char*, uintptr_t, const char*, uintptr_t);
+bool ghostty_config_key_equal(ghostty_config_t, ghostty_config_t, const char*, uintptr_t);
 bool ghostty_config_get(ghostty_config_t, void*, const char*, uintptr_t);
 ghostty_input_trigger_s ghostty_config_trigger(ghostty_config_t,
                                                const char*,

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -98,6 +98,9 @@ class AppDelegate: NSObject,
     /// The ghostty global state. Only one per process.
     let ghostty: Ghostty.App
 
+    /// The platform settings store for reading/writing config values via NSUserDefaults.
+    let settingsStore: UserDefaultsSettingsStore
+
     /// The global undo manager for app-level state such as window restoration.
     lazy var undoManager = ExpiringUndoManager()
 
@@ -155,10 +158,11 @@ class AppDelegate: NSObject,
     @Published private(set) var appIcon: NSImage? = nil
 
     override init() {
+        settingsStore = UserDefaultsSettingsStore()
 #if DEBUG
-        ghostty = Ghostty.App(configPath: ProcessInfo.processInfo.environment["GHOSTTY_CONFIG_PATH"])
+        ghostty = Ghostty.App(configPath: ProcessInfo.processInfo.environment["GHOSTTY_CONFIG_PATH"], settingsStore: settingsStore)
 #else
-        ghostty = Ghostty.App()
+        ghostty = Ghostty.App(settingsStore: settingsStore)
 #endif
         super.init()
 

--- a/macos/Sources/Helpers/UserDefaultsSettingsStore.swift
+++ b/macos/Sources/Helpers/UserDefaultsSettingsStore.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Source of a configuration value.
+enum ConfigValueSource {
+    /// Value was set in a config file or via CLI args.
+    case file
+    /// Value was set in the platform settings store (e.g. NSUserDefaults).
+    case settingsStore
+    /// Neither file nor settings store set this value; it is the default.
+    case `default`
+}
+
+/// A resolved configuration value with its source.
+struct ConfigValue<T> {
+    let value: T
+    let source: ConfigValueSource
+}
+
+/// NSUserDefaults-backed settings store for Ghostty configuration.
+///
+/// All values are string-based because every Ghostty config value can be
+/// expressed as a string (same format as config files). This avoids
+/// duplicating the ~200+ field type system in Swift and allows values to
+/// be fed directly into the Zig config parser.
+///
+/// Keys are namespaced with a prefix to avoid collisions with existing
+/// app-state UserDefaults keys (SecureInput, CustomGhosttyIcon, etc.).
+final class UserDefaultsSettingsStore {
+    private let defaults: UserDefaults
+
+    /// The prefix applied to all Ghostty config keys stored in UserDefaults.
+    static let keyPrefix = "ghostty.config."
+
+    /// Create a store backed by the given UserDefaults instance.
+    /// - Parameter defaults: The UserDefaults to use. Defaults to `.standard`.
+    ///   Pass a custom suite for testing.
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    /// Read all string values for a Ghostty config key.
+    /// Returns nil if no value is stored.
+    /// Repeatable keys (e.g. font-family) may have multiple values.
+    func strings(forKey key: String) -> [String]? {
+        let stored = defaults.object(forKey: Self.keyPrefix + key)
+        if let array = stored as? [String] {
+            return array.isEmpty ? nil : array
+        }
+        if let single = stored as? String {
+            return [single]
+        }
+        return nil
+    }
+
+    /// Read the first (or only) string value for a key.
+    func string(forKey key: String) -> String? {
+        strings(forKey: key)?.first
+    }
+
+    /// Write string values for a Ghostty config key.
+    /// Pass multiple values for repeatable keys (e.g. font-family).
+    func set(_ values: [String], forKey key: String) {
+        defaults.set(values, forKey: Self.keyPrefix + key)
+    }
+
+    /// Write a single string value for a key.
+    func set(_ value: String, forKey key: String) {
+        set([value], forKey: key)
+    }
+
+    /// Remove the value for a Ghostty config key.
+    func removeValue(forKey key: String) {
+        defaults.removeObject(forKey: Self.keyPrefix + key)
+    }
+
+    /// Remove all stored settings values, resetting to defaults.
+    func resetAll() {
+        for key in allKeys {
+            removeValue(forKey: key)
+        }
+    }
+
+    /// All Ghostty config keys that have stored values.
+    var allKeys: [String] {
+        defaults.dictionaryRepresentation().keys
+            .filter { $0.hasPrefix(Self.keyPrefix) }
+            .map { String($0.dropFirst(Self.keyPrefix.count)) }
+    }
+}

--- a/macos/Tests/Settings/ConfigSourceTrackingTests.swift
+++ b/macos/Tests/Settings/ConfigSourceTrackingTests.swift
@@ -1,0 +1,71 @@
+import Testing
+import Foundation
+@testable import Ghostty
+
+struct ConfigSourceTrackingTests {
+    /// Create a settings store backed by an isolated UserDefaults suite.
+    private func makeStore() -> (UserDefaultsSettingsStore, UserDefaults) {
+        let suite = "com.mitchellh.ghostty.test.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        let store = UserDefaultsSettingsStore(defaults: defaults)
+        return (store, defaults)
+    }
+
+    @Test func settingsStoreSourceWhenKeyPresent() {
+        let (store, defaults) = makeStore()
+        defer { defaults.removePersistentDomain(forName: defaults.suiteName!) }
+
+        store.set("16", forKey: "font-size")
+
+        // Without a real Ghostty config (nil), the method should still
+        // detect the settings store source since that check comes first.
+        let config = Ghostty.Config(config: nil)
+        let source = config.resolvedSource(
+            forKey: "font-size",
+            settingsStore: store,
+            defaultConfig: nil
+        )
+        #expect(source == .settingsStore)
+    }
+
+    @Test func defaultSourceWhenNoStoreAndNoConfig() {
+        let (store, defaults) = makeStore()
+        defer { defaults.removePersistentDomain(forName: defaults.suiteName!) }
+
+        // No value in store, no config to compare -> default
+        let config = Ghostty.Config(config: nil)
+        let source = config.resolvedSource(
+            forKey: "font-size",
+            settingsStore: store,
+            defaultConfig: nil
+        )
+        #expect(source == .default)
+    }
+
+    @Test func defaultSourceWithNilStore() {
+        let config = Ghostty.Config(config: nil)
+        let source = config.resolvedSource(
+            forKey: "font-size",
+            settingsStore: nil,
+            defaultConfig: nil
+        )
+        #expect(source == .default)
+    }
+
+    @Test func settingsStoreCheckTakesPrecedence() {
+        let (store, defaults) = makeStore()
+        defer { defaults.removePersistentDomain(forName: defaults.suiteName!) }
+
+        // Even with nil configs (so file vs default can't be determined),
+        // a settings store value should return .settingsStore
+        store.set("JetBrains Mono", forKey: "font-family")
+
+        let config = Ghostty.Config(config: nil)
+        let source = config.resolvedSource(
+            forKey: "font-family",
+            settingsStore: store,
+            defaultConfig: nil
+        )
+        #expect(source == .settingsStore)
+    }
+}

--- a/macos/Tests/Settings/UserDefaultsSettingsStoreTests.swift
+++ b/macos/Tests/Settings/UserDefaultsSettingsStoreTests.swift
@@ -1,0 +1,119 @@
+import Testing
+import Foundation
+@testable import Ghostty
+
+struct UserDefaultsSettingsStoreTests {
+    /// Create a store backed by an isolated UserDefaults suite.
+    private func makeStore() -> (UserDefaultsSettingsStore, UserDefaults) {
+        let suite = "com.mitchellh.ghostty.test.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        let store = UserDefaultsSettingsStore(defaults: defaults)
+        return (store, defaults)
+    }
+
+    @Test func setAndGetSingleValue() {
+        let (store, defaults) = makeStore()
+        defer { defaults.removePersistentDomain(forName: defaults.suiteName!) }
+
+        store.set("14", forKey: "font-size")
+        #expect(store.string(forKey: "font-size") == "14")
+        #expect(store.strings(forKey: "font-size") == ["14"])
+    }
+
+    @Test func setAndGetMultipleValues() {
+        let (store, defaults) = makeStore()
+        defer { defaults.removePersistentDomain(forName: defaults.suiteName!) }
+
+        store.set(["JetBrains Mono", "Noto Color Emoji"], forKey: "font-family")
+        #expect(store.strings(forKey: "font-family") == ["JetBrains Mono", "Noto Color Emoji"])
+        // string(forKey:) returns the first value
+        #expect(store.string(forKey: "font-family") == "JetBrains Mono")
+    }
+
+    @Test func nilForUnsetKey() {
+        let (store, defaults) = makeStore()
+        defer { defaults.removePersistentDomain(forName: defaults.suiteName!) }
+
+        #expect(store.string(forKey: "nonexistent") == nil)
+        #expect(store.strings(forKey: "nonexistent") == nil)
+    }
+
+    @Test func nilForEmptyArray() {
+        let (store, defaults) = makeStore()
+        defer { defaults.removePersistentDomain(forName: defaults.suiteName!) }
+
+        store.set([], forKey: "font-family")
+        #expect(store.strings(forKey: "font-family") == nil)
+    }
+
+    @Test func allKeysReturnsOnlyPrefixedKeys() {
+        let (store, defaults) = makeStore()
+        defer { defaults.removePersistentDomain(forName: defaults.suiteName!) }
+
+        // Set an unrelated key directly on the same defaults suite
+        defaults.set("unrelated", forKey: "SomeOtherKey")
+        store.set("14", forKey: "font-size")
+        store.set("true", forKey: "font-thicken")
+
+        #expect(store.allKeys.count == 2)
+        #expect(store.allKeys.contains("font-size"))
+        #expect(store.allKeys.contains("font-thicken"))
+    }
+
+    @Test func removeValue() {
+        let (store, defaults) = makeStore()
+        defer { defaults.removePersistentDomain(forName: defaults.suiteName!) }
+
+        store.set("14", forKey: "font-size")
+        store.removeValue(forKey: "font-size")
+        #expect(store.string(forKey: "font-size") == nil)
+    }
+
+    @Test func resetAllClearsOnlyPrefixedKeys() {
+        let (store, defaults) = makeStore()
+        defer { defaults.removePersistentDomain(forName: defaults.suiteName!) }
+
+        // Set a non-prefixed key that should survive resetAll
+        defaults.set("keep-this", forKey: "SecureInput")
+        store.set("14", forKey: "font-size")
+        store.set("true", forKey: "font-thicken")
+
+        store.resetAll()
+
+        #expect(store.allKeys.isEmpty)
+        #expect(defaults.string(forKey: "SecureInput") == "keep-this")
+    }
+
+    @Test func overwriteExistingValue() {
+        let (store, defaults) = makeStore()
+        defer { defaults.removePersistentDomain(forName: defaults.suiteName!) }
+
+        store.set("14", forKey: "font-size")
+        store.set("16", forKey: "font-size")
+        #expect(store.string(forKey: "font-size") == "16")
+    }
+
+    @Test func keyPrefixIsApplied() {
+        let (store, defaults) = makeStore()
+        defer { defaults.removePersistentDomain(forName: defaults.suiteName!) }
+
+        store.set("14", forKey: "font-size")
+
+        // The underlying UserDefaults key should be prefixed
+        #expect(defaults.array(forKey: "ghostty.config.font-size") as? [String] == ["14"])
+        // And the unprefixed key should not exist
+        #expect(defaults.object(forKey: "font-size") == nil)
+    }
+
+    @Test func legacySingleStringMigration() {
+        let (store, defaults) = makeStore()
+        defer { defaults.removePersistentDomain(forName: defaults.suiteName!) }
+
+        // Simulate a plain string stored directly (e.g. from `defaults write`)
+        defaults.set("14", forKey: "ghostty.config.font-size")
+
+        // strings(forKey:) should still work, wrapping it in an array
+        #expect(store.strings(forKey: "font-size") == ["14"])
+        #expect(store.string(forKey: "font-size") == "14")
+    }
+}

--- a/src/config/c_get.zig
+++ b/src/config/c_get.zig
@@ -103,7 +103,7 @@ fn getValue(ptr_raw: *anyopaque, value: anytype) bool {
 }
 
 /// Get a value from the config by key.
-fn fieldByKey(self: *const Config, comptime k: Key) Value(k) {
+pub fn fieldByKey(self: *const Config, comptime k: Key) Value(k) {
     const field = comptime field: {
         const fields = std.meta.fields(Config);
         for (fields) |field| {


### PR DESCRIPTION
Working towards a preference pane for macOS [as discussed here](https://github.com/ghostty-org/ghostty/discussions/2354). This PR was AI-assisted; [here's my conversation](https://agentexports.com/g/1945f4191af012d4d45f8d27be2d51ff). There may be some gaps as my agent died a couple times.

Add a settings store that injects NSUserDefaults values into Ghostty's config system. Values are fed directly through the Zig parser via a new ghostty_config_set() C API, so the replay system for theme/conditional rebuilds works automatically without intermediate files.

Zig side:
- ghostty_config_set(cfg, key, key_len, val, val_len) to inject a single key-value pair through loadIter, recording replay steps
- ghostty_config_key_equal(a, b, key, len) to compare a key across two configs, used for source tracking (file vs default detection)
- Make c_get.fieldByKey public so CApi can access it

Swift side:
- UserDefaultsSettingsStore: concrete class backed by NSUserDefaults, keys prefixed with ghostty.config., supports repeatable keys (arrays) and legacy single-string values from `defaults write`
- ConfigValueSource enum and Config.resolvedSource() for determining value provenance (settingsStore vs file vs default)
- Config.loadConfig() injects store values after file/CLI config but before finalize (highest precedence)
- AppDelegate owns the store, passes it through to Ghostty.App