### PR TITLE
elvish: improve shell integration instructions

### DIFF
--- a/src/shell-integration/README.md
+++ b/src/shell-integration/README.md
@@ -44,7 +44,7 @@ Elvish, on startup, searches for paths defined in `XDG_DATA_DIRS`
 variable for `./elvish/lib/*.elv` files and imports them. They are thus
 made available for use as modules by way of `use <filename>`.
 
-Ghostty launches Elvish, passing the environment with `XDG_DATA_DIRS`prepended
+Ghostty launches Elvish, passing the environment with `XDG_DATA_DIRS` prepended
 with `$GHOSTTY_RESOURCES_DIR/src/shell-integration`. It contains
 `./elvish/lib/ghostty-integration.elv`. The user can then import it
 by `use ghostty-integration` every time after shell startup or
@@ -57,7 +57,7 @@ of your `rc.elv` file:
 
 ```elvish
 if (eq $E:TERM "xterm-ghostty") {
-  use ghostty-integration
+  try { use ghostty-integration } catch { }
 }
 ```
 


### PR DESCRIPTION
Wrapping `use ghostty-integration` in a `try .. catch` here makes this suggestion more resilient to environments where we didn't inject our resource directory into XDG_DATA_DIRS (but are still running Ghostty).