### PR TITLE
feat: add scrollback-clear-allowed config option

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2806,6 +2806,19 @@ keybind: Keybinds = .{},
 /// need KAM, you don't need it.
 @"vt-kam-allowed": bool = false,
 
+/// If false, prevents applications from clearing the scrollback buffer
+/// using the CSI 3 J escape sequence (ED with parameter 3). This is useful
+/// if you want to preserve your scrollback history even when applications
+/// (such as shells on logout, or programs like `clear`) attempt to clear it.
+///
+/// When set to false, CSI 3 J will be silently ignored and the scrollback
+/// buffer will remain intact. The visible screen can still be cleared
+/// normally.
+///
+/// This is similar to iTerm2's "Prevent CSI 3 J from clearing scrollback
+/// history" option.
+@"scrollback-clear-allowed": bool = true,
+
 /// Custom shaders to run after the default shaders. This is a file path
 /// to a GLSL-syntax shader for all platforms.
 ///

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -166,6 +166,7 @@ pub const DerivedConfig = struct {
     clipboard_write: configpkg.ClipboardAccess,
     enquiry_response: []const u8,
     conditional_state: configpkg.ConditionalState,
+    scrollback_clear_allowed: bool,
 
     pub fn init(
         alloc_gpa: Allocator,
@@ -187,6 +188,7 @@ pub const DerivedConfig = struct {
             .clipboard_write = config.@"clipboard-write",
             .enquiry_response = try alloc.dupe(u8, config.@"enquiry-response"),
             .conditional_state = config._conditional_state,
+            .scrollback_clear_allowed = config.@"scrollback-clear-allowed",
 
             // This has to be last so that we copy AFTER the arena allocations
             // above happen (Zig assigns in order).
@@ -281,6 +283,7 @@ pub fn init(self: *Termio, alloc: Allocator, opts: termio.Options) !void {
         .enquiry_response = opts.config.enquiry_response,
         .default_cursor_style = opts.config.cursor_style,
         .default_cursor_blink = opts.config.cursor_blink,
+        .scrollback_clear_allowed = opts.config.scrollback_clear_allowed,
     };
 
     const thread_enter_state = try ThreadEnterState.create(

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -56,6 +56,9 @@ pub const StreamHandler = struct {
     /// The clipboard write access configuration.
     clipboard_write: configpkg.ClipboardAccess,
 
+    /// Whether applications are allowed to clear the scrollback buffer.
+    scrollback_clear_allowed: bool,
+
     //---------------------------------------------------------------
     // Internal state
 
@@ -112,6 +115,7 @@ pub const StreamHandler = struct {
         self.enquiry_response = config.enquiry_response;
         self.default_cursor_style = config.cursor_style;
         self.default_cursor_blink = config.cursor_blink;
+        self.scrollback_clear_allowed = config.scrollback_clear_allowed;
 
         // If our cursor is the default, then we update it immediately.
         if (self.default_cursor) self.setCursorStyle(.default) catch |err| {
@@ -235,7 +239,9 @@ pub const StreamHandler = struct {
                 try self.terminal.scrollViewport(.{ .bottom = {} });
                 self.terminal.eraseDisplay(.complete, value);
             },
-            .erase_display_scrollback => self.terminal.eraseDisplay(.scrollback, value),
+            .erase_display_scrollback => if (self.scrollback_clear_allowed) {
+                self.terminal.eraseDisplay(.scrollback, value);
+            },
             .erase_display_scroll_complete => self.terminal.eraseDisplay(.scroll_complete, value),
             .erase_line_right => self.terminal.eraseLine(.right, value),
             .erase_line_left => self.terminal.eraseLine(.left, value),


### PR DESCRIPTION
## Summary
- Adds a new `scrollback-clear-allowed` configuration option (default: `true`)
- When set to `false`, CSI 3 J (ED with parameter 3) is silently ignored
- Preserves scrollback history when applications attempt to clear it

## Motivation
Some terminal applications clear the scrollback buffer on exit or during certain operations. Users who rely on scrollback history (e.g., for reviewing build logs, debugging sessions, or preserving context) may want to prevent this behavior.

This is similar to iTerm2's "Prevent CSI 3 J from clearing scrollback history" option.

## Use Cases
- Development workflows where preserving terminal history is important
- AI coding assistants that may clear scrollback during context management
- Build and deployment pipelines where logs should remain accessible

## Changes
- `src/config/Config.zig`: Added `scrollback-clear-allowed` config option with documentation
- `src/termio/Termio.zig`: Pass config to stream handler
- `src/termio/stream_handler.zig`: Conditionally handle CSI 3 J based on config

## Test plan
1. Set `scrollback-clear-allowed = false` in config
2. Run a command that generates scrollback (e.g., `for i in {1..50}; do echo "Line $i"; done`)
3. Run `printf '\033[3J'` or `clear`
4. Verify scrollback is preserved when scrolling up

🤖 Generated with [Claude Code](https://claude.ai/code)