### PR TITLE
feat(macos): add two-finger swipe gesture for tab navigation

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -319,6 +319,14 @@ extension Ghostty {
             return v
         }
 
+        var macosTabSwipeNavigation: Bool {
+            guard let config = self.config else { return true }
+            var v = true;
+            let key = "macos-tab-swipe-navigation"
+            _ = ghostty_config_get(config, &v, key, UInt(key.lengthOfBytes(using: .utf8)))
+            return v
+        }
+
         var macosIcon: MacOSIcon {
             let defaultValue = MacOSIcon.official
             guard let config = self.config else { return defaultValue }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3201,6 +3201,13 @@ keybind: Keybinds = .{},
 /// find false more visually appealing.
 @"macos-window-shadow": bool = true,
 
+/// Whether to enable two-finger swipe gestures for navigating between tabs.
+/// When enabled, swiping left or right with two fingers on a trackpad will
+/// switch to the next or previous tab, similar to iTerm2.
+///
+/// The default value is true.
+@"macos-tab-swipe-navigation": bool = true,
+
 /// If true, the macOS icon in the dock and app switcher will be hidden. This is
 /// mainly intended for those primarily using the quick-terminal mode.
 ///


### PR DESCRIPTION
## Summary
- Adds two-finger horizontal swipe gesture support for switching between tabs on macOS
- Similar to iTerm2's tab navigation behavior
- Configurable via `macos-tab-swipe-navigation` option (enabled by default)

## Implementation
- Uses `NSEvent.addLocalMonitorForEvents` to capture scroll wheel events
- Detects horizontal swipe gestures by tracking scroll delta accumulation
- Triggers tab switch when horizontal threshold is exceeded and gesture ends
- Only activates for predominantly horizontal gestures (deltaX > deltaY * 1.5)

## Changes
- `src/config/Config.zig`: Added `macos-tab-swipe-navigation` configuration option
- `macos/Sources/Ghostty/Ghostty.Config.swift`: Added Swift accessor for the config
- `macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift`: Implemented swipe detection and tab switching

## Test plan
- [x] Open Ghostty with multiple tabs
- [x] Two-finger swipe left → switches to next tab
- [x] Two-finger swipe right → switches to previous tab
- [x] Vertical scrolling in terminal still works normally
- [x] Set `macos-tab-swipe-navigation = false` → swipe gestures disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)