### PR TITLE
ci(release-tip): track optional triggering PRs and retain URLs

### DIFF
--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -428,12 +428,21 @@ jobs:
           source-dir: blob
           destination-dir: ./
 
-      - name: Echo Release URLs
+      - name: Show and Save Release URLs
         run: |
-          echo "Release URLs:"
-          echo "  App Bundle: https://tip.files.ghostty.org/${GHOSTTY_COMMIT_LONG}/ghostty-macos-universal.zip"
-          echo "  Debug Symbols: https://tip.files.ghostty.org/${GHOSTTY_COMMIT_LONG}/ghostty-macos-universal-dsym.zip"
-          echo "  DMG: https://tip.files.ghostty.org/${GHOSTTY_COMMIT_LONG}/Ghostty.dmg"
+          cat << EOF | tee release-urls.txt
+          Release URLs:
+            App Bundle: https://tip.files.ghostty.org/${GHOSTTY_COMMIT_LONG}/ghostty-macos-universal.zip
+            Debug Symbols: https://tip.files.ghostty.org/${GHOSTTY_COMMIT_LONG}/ghostty-macos-universal-dsym.zip
+            DMG: https://tip.files.ghostty.org/${GHOSTTY_COMMIT_LONG}/Ghostty.dmg
+          EOF
+
+      - name: Upload Release URLs
+        uses: actions/upload-artifact@47309c993abb98030a35d55ef7ff34b7fa1074b5 # v6.0
+        with:
+          name: release-urls-${{ inputs.pr || '0' }}
+          path: release-urls.txt
+          retention-days: 2
 
   build-macos-debug-slow:
     needs: [setup]

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -4,7 +4,11 @@ on:
     types: [completed]
     branches: [main]
 
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      pr:
+        type: number
+        required: false
 
 name: Release Tip
 


### PR DESCRIPTION
Based on some prior private discussion -- this is needed for the GitHub bot to correctly dispatch, track, and collect workflow runs based on the triggering PR.

I'm not sure if covering only `build-macos` is enough and if outputs from other jobs (like `build-macos-debug-slow`) are also useful here. I went with just `build-macos` since it's the only one to also link a DMG (and it sounds the most basic of course).