### PR TITLE
gtk: auto-fallback to software GL on context failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ See the [download page](https://ghostty.org/download) on the Ghostty website.
 
 See the [documentation](https://ghostty.org/docs) on the Ghostty website.
 
+On Linux (GTK), Ghostty will automatically retry with software rendering if
+an OpenGL context cannot be created. This behavior is configurable via
+`gtk-opengl-auto-fallback`.
+
 ## Contributing and Developing
 
 If you have any ideas, issues, etc. regarding Ghostty, or would like to

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -3093,6 +3093,8 @@ pub const Surface = extern struct {
             log.warn("failed to make GL context current: {s}", .{err.f_message orelse "(no message)"});
             log.warn("this error is almost always due to a library, driver, or GTK issue", .{});
             log.warn("this is a common cause of this issue: https://ghostty.org/docs/help/gtk-opengl-context", .{});
+            log.warn("you can try restarting with software rendering (LIBGL_ALWAYS_SOFTWARE=1)", .{});
+            if (self.tryRelaunchWithSoftwareRendering()) return;
             self.setError(true);
             return;
         }
@@ -3393,6 +3395,10 @@ pub const Surface = extern struct {
         _ = self.private().gl_area.as(gtk.Widget).grabFocus();
     }
 
+    fn errorRetrySoftware(_: *gtk.Button, self: *Self) callconv(.c) void {
+        _ = self.tryRelaunchWithSoftwareRendering();
+    }
+
     fn searchChanged(_: *SearchOverlay, needle: ?[*:0]const u8, self: *Self) callconv(.c) void {
         const surface = self.core() orelse return;
         _ = surface.performBindingAction(.{ .search = std.mem.sliceTo(needle orelse "", 0) }) catch |err| {
@@ -3412,6 +3418,67 @@ pub const Surface = extern struct {
         _ = surface.performBindingAction(.{ .navigate_search = .previous }) catch |err| {
             log.warn("unable to perform navigate_search action err={}", .{err});
         };
+    }
+
+    const software_env_name = "LIBGL_ALWAYS_SOFTWARE";
+    const software_relaunch_env_name = "GHOSTTY_GL_SOFTWARE_RELAUNCH";
+
+    fn tryRelaunchWithSoftwareRendering(self: *Self) bool {
+        _ = self;
+
+        if (std.posix.getenv(software_env_name) != null) {
+            log.warn("software rendering already requested ({} set)", .{software_env_name});
+            return false;
+        }
+        if (std.posix.getenv(software_relaunch_env_name) != null) {
+            log.warn("software rendering relaunch already attempted", .{});
+            return false;
+        }
+
+        const alloc = Application.default().allocator();
+        var env = std.process.getEnvMap(alloc) catch |err| {
+            log.warn("failed to get environment for relaunch err={}", .{err});
+            return false;
+        };
+        defer env.deinit();
+
+        env.put(software_env_name, "1") catch |err| {
+            log.warn("failed to set {s} for relaunch err={}", .{ software_env_name, err });
+            return false;
+        };
+        env.put(software_relaunch_env_name, "1") catch |err| {
+            log.warn("failed to set {s} for relaunch err={}", .{ software_relaunch_env_name, err });
+            return false;
+        };
+
+        var args_iter = std.process.argsWithAllocator(alloc) catch |err| {
+            log.warn("failed to read argv for relaunch err={}", .{err});
+            return false;
+        };
+        defer args_iter.deinit();
+
+        var args = std.ArrayList([]const u8).init(alloc);
+        defer args.deinit();
+        while (args_iter.next()) |arg| {
+            args.append(arg) catch |err| {
+                log.warn("failed to build argv for relaunch err={}", .{err});
+                return false;
+            };
+        }
+        if (args.items.len == 0) {
+            log.warn("no argv available to relaunch", .{});
+            return false;
+        }
+
+        var child = std.process.Child.init(args.items, alloc);
+        child.env_map = &env;
+        child.spawn() catch |err| {
+            log.warn("failed to relaunch Ghostty with software rendering err={}", .{err});
+            return false;
+        };
+
+        log.info("relaunching Ghostty with software rendering enabled", .{});
+        std.process.exit(0);
     }
 
     const C = Common(Self, Private);
@@ -3492,6 +3559,7 @@ pub const Surface = extern struct {
             class.bindTemplateCallback("search_changed", &searchChanged);
             class.bindTemplateCallback("search_next_match", &searchNextMatch);
             class.bindTemplateCallback("search_previous_match", &searchPreviousMatch);
+            class.bindTemplateCallback("error_retry_software", &errorRetrySoftware);
 
             // Properties
             gobject.ext.registerProperties(class, &.{

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -3424,7 +3424,13 @@ pub const Surface = extern struct {
     const software_relaunch_env_name = "GHOSTTY_GL_SOFTWARE_RELAUNCH";
 
     fn tryRelaunchWithSoftwareRendering(self: *Self) bool {
-        _ = self;
+        if (self.private().config) |config| {
+            const cfg = config.get();
+            if (!cfg.@"gtk-opengl-auto-fallback") {
+                log.info("software rendering auto-fallback disabled by config", .{});
+                return false;
+            }
+        }
 
         if (std.posix.getenv(software_env_name) != null) {
             log.warn("software rendering already requested ({} set)", .{software_env_name});

--- a/src/apprt/gtk/ui/1.2/surface.blp
+++ b/src/apprt/gtk/ui/1.2/surface.blp
@@ -6,9 +6,20 @@ Adw.StatusPage error_page {
   title: _("Oh, no.");
   description: _("Unable to acquire an OpenGL context for rendering.");
 
-  child: LinkButton {
-    label: "https://ghostty.org/docs/help/gtk-opengl-context";
-    uri: "https://ghostty.org/docs/help/gtk-opengl-context";
+  child: Box {
+    orientation: vertical;
+    spacing: 6;
+    halign: center;
+
+    LinkButton {
+      label: "https://ghostty.org/docs/help/gtk-opengl-context";
+      uri: "https://ghostty.org/docs/help/gtk-opengl-context";
+    }
+
+    Button {
+      label: _("Restart with software rendering");
+      clicked => $error_retry_software();
+    }
   };
 }
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3414,6 +3414,13 @@ else
 /// Available since: 1.1.0
 @"gtk-opengl-debug": bool = builtin.mode == .Debug,
 
+/// If `true`, Ghostty will automatically relaunch once with software rendering
+/// when GTK fails to create an OpenGL context. This helps older or broken
+/// drivers recover without manual intervention.
+///
+/// Available since: 1.6.0
+@"gtk-opengl-auto-fallback": bool = true,
+
 /// If `true`, the Ghostty GTK application will run in single-instance mode:
 /// each new `ghostty` process launched will result in a new window if there is
 /// already a running process.


### PR DESCRIPTION
## Summary
- auto-relaunch Ghostty once with software rendering when GTK fails to create an OpenGL context
- add a manual "Restart with software rendering" action on the error page
- add `gtk-opengl-auto-fallback` config (default true) to opt out of auto fallback

## Testing
- Not run (local environment)
