### PR TITLE
gtk: add two-finger left/right scroll to switch tab pages

### DIFF
--- a/src/apprt/gtk/ui/1.2/surface.blp
+++ b/src/apprt/gtk/ui/1.2/surface.blp
@@ -53,10 +53,15 @@ Overlay terminal_page {
     }
 
     EventControllerScroll {
-      scroll => $scroll();
-      scroll-begin => $scroll_begin();
-      scroll-end => $scroll_end();
-      flags: both_axes;
+      scroll => $scroll_vertical();
+      scroll-begin => $scroll_vertical_begin();
+      scroll-end => $scroll_vertical_end();
+      flags: vertical;
+    }
+
+    EventControllerScroll {
+      scroll => $scroll_horizontal();
+      flags: horizontal;
     }
 
     EventControllerMotion {


### PR DESCRIPTION
This adds the ability to use two fingers on a touchpad to scroll left or right on a Ghostty window to change tab pages. Uses the same basic machinery as scrolling up and down the scrollback buffer. Scrolling pages does not wrap around at the start or end of the tabs.

