### PR TITLE
👻 : Add Support For Use of Apple's New API - Core Audio Tap API `CATap`

### DIFF
--- a/macos/Ghostty.xcodeproj/project.pbxproj
+++ b/macos/Ghostty.xcodeproj/project.pbxproj
@@ -623,6 +623,7 @@
 				INFOPLIST_KEY_NSLocationUsageDescription = "A program running within Ghostty would like to access your location information.";
 				INFOPLIST_KEY_NSMainNibFile = MainMenu;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "A program running within Ghostty would like to use your microphone.";
+				INFOPLIST_KEY_NSAudioCaptureUsageDescription = "A program running within Ghostty would like to access your system's audio.";
 				INFOPLIST_KEY_NSMotionUsageDescription = "A program running within Ghostty would like to access motion data.";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "A program running within Ghostty would like to access your Photo Library.";
 				INFOPLIST_KEY_NSRemindersUsageDescription = "A program running within Ghostty would like to access your reminders.";


### PR DESCRIPTION
#### [Core Audio Tap API](https://github.com/insidegui/AudioCap)

There's a new NS permission needed for macos (>14.x) to capture system audio with the `Core Audio Tap API`. Previously desktop-audio capture was handled by a different permissions API with GUI & preferences. Both APIs continue to exist but this newer one has a NS permission we should include. The "geniuses" have spoken and this API doesn't have public methods for querying the permissions state. As a strong side-effect of this "feature", failures due to lack of NS permissions are likely to be handled poorly by software makers.

---

I've spent [the last 5 days](https://github.com/electron/electron/issues/49607) reviewing C++/Objective-C Chromium source to hone in on why my DesktopAudioCapture broke on an electron version update. It is in-fact chromium [started using](source.chromium.org/chromium/chromium/src/+/ad17e8f8b93d5f34891b06085d373a668918255e) this new `Core Audio Tap API` and has no fallback to the old API if the new one fails.

Should be your easiest code-review of the week. Shoutout to the maintainers/creator, big fan of this Zig based terminal with good shader support.