### PR TITLE
fix(macOS): pass through paste keybind when clipboard has no text

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -965,6 +965,7 @@ typedef void (*ghostty_runtime_write_clipboard_cb)(void*,
                                                    const ghostty_clipboard_content_s*,
                                                    size_t,
                                                    bool);
+typedef bool (*ghostty_runtime_clipboard_has_text_cb)(void*, ghostty_clipboard_e);
 typedef void (*ghostty_runtime_close_surface_cb)(void*, bool);
 typedef bool (*ghostty_runtime_action_cb)(ghostty_app_t,
                                           ghostty_target_s,
@@ -978,6 +979,7 @@ typedef struct {
   ghostty_runtime_read_clipboard_cb read_clipboard_cb;
   ghostty_runtime_confirm_read_clipboard_cb confirm_read_clipboard_cb;
   ghostty_runtime_write_clipboard_cb write_clipboard_cb;
+  ghostty_runtime_clipboard_has_text_cb clipboard_has_text_cb;
   ghostty_runtime_close_surface_cb close_surface_cb;
 } ghostty_runtime_config_s;
 

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -66,6 +66,7 @@ extension Ghostty {
                 confirm_read_clipboard_cb: { userdata, str, state, request in App.confirmReadClipboard(userdata, string: str, state: state, request: request ) },
                 write_clipboard_cb: { userdata, loc, content, len, confirm in
                     App.writeClipboard(userdata, location: loc, content: content, len: len, confirm: confirm) },
+                clipboard_has_text_cb: { userdata, loc in App.clipboardHasText(userdata, location: loc) },
                 close_surface_cb: { userdata, processAlive in App.closeSurface(userdata, processAlive: processAlive) }
             )
 
@@ -286,6 +287,10 @@ extension Ghostty {
             confirm: Bool
         ) {}
 
+        static func clipboardHasText(_ userdata: UnsafeMutableRawPointer?, location: ghostty_clipboard_e) -> Bool {
+            return true
+        }
+
         static func closeSurface(_ userdata: UnsafeMutableRawPointer?, processAlive: Bool) {}
         #endif
 
@@ -320,6 +325,11 @@ extension Ghostty {
             NotificationCenter.default.post(name: Notification.ghosttyCloseSurface, object: surface, userInfo: [
                 "process_alive": processAlive,
             ])
+        }
+
+        static func clipboardHasText(_ userdata: UnsafeMutableRawPointer?, location: ghostty_clipboard_e) -> Bool {
+            guard let pasteboard = NSPasteboard.ghostty(location) else { return false }
+            return pasteboard.getOpinionatedStringContents() != nil
         }
 
         static func readClipboard(_ userdata: UnsafeMutableRawPointer?, location: ghostty_clipboard_e, state: UnsafeMutableRawPointer?) {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -6074,10 +6074,11 @@ pub const Keybinds = struct {
                 .{ .key = .{ .physical = .copy } },
                 .{ .copy_to_clipboard = .mixed },
             );
-            try self.set.put(
+            try self.set.putFlags(
                 alloc,
                 .{ .key = .{ .physical = .paste } },
                 .paste_from_clipboard,
+                .{ .performable = true },
             );
 
             // On non-MacOS desktop envs (Windows, KDE, Gnome, Xfce), ctrl+insert is an
@@ -6092,10 +6093,11 @@ pub const Keybinds = struct {
                     .{ .key = .{ .physical = .insert }, .mods = .{ .ctrl = true } },
                     .{ .copy_to_clipboard = .mixed },
                 );
-                try self.set.put(
+                try self.set.putFlags(
                     alloc,
                     .{ .key = .{ .physical = .insert }, .mods = .{ .shift = true } },
                     .{ .paste_from_clipboard = {} },
+                    .{ .performable = true },
                 );
             }
 
@@ -6112,10 +6114,11 @@ pub const Keybinds = struct {
                 .{ .copy_to_clipboard = .mixed },
                 .{ .performable = true },
             );
-            try self.set.put(
+            try self.set.putFlags(
                 alloc,
                 .{ .key = .{ .unicode = 'v' }, .mods = mods },
                 .{ .paste_from_clipboard = {} },
+                .{ .performable = true },
             );
         }
 


### PR DESCRIPTION
## Summary

When pressing Cmd+V on macOS with only image data in the clipboard (no text), Ghostty intercepts the keybind, finds no text to paste, and silently swallows the keypress. Applications like Claude Code never receive the key event and can't handle image paste via native macOS APIs.

Two issues combine to cause this:

1. **`embedded.zig:clipboardRequest()` always returned `true`**, meaning the keybind was always consumed — even when the clipboard had no text. GTK already has a synchronous check that returns `false` when clipboard has no text.

2. **The default paste bindings were not `performable`**. Even if `clipboardRequest` returned `false`, without the `performable` flag the key was still consumed by the binding system.

## Changes

- **`src/apprt/embedded.zig`** — Add optional `clipboard_has_text` callback to `Options` struct. Modify `clipboardRequest()` to check it for paste requests and return `false` when clipboard has no text, giving the embedded apprt parity with GTK.
- **`include/ghostty.h`** — Add `ghostty_runtime_clipboard_has_text_cb` typedef and field to `ghostty_runtime_config_s`.
- **`macos/Sources/Ghostty/Ghostty.App.swift`** — Implement `clipboardHasText` using existing `getOpinionatedStringContents()`. Wire callback into runtime config. Add iOS stub (returns `true`).
- **`src/config/Config.zig`** — Make default paste bindings (`physical:paste`, `shift+insert`, `super+v`/`ctrl+shift+v`) `performable` so the key passes through when the action returns `false`.

## How it works

1. User presses Cmd+V with image in clipboard
2. Binding system matches `performable:super+v=paste_from_clipboard`
3. `performAction()` → `startClipboardRequest()` → `clipboardRequest()`
4. `clipboardRequest()` checks `clipboard_has_text` callback → macOS reports no text → returns `false`
5. Since binding is `performable` and action returned `false`, key passes through (`Surface.zig:2987-2993`)
6. Application receives the keypress and handles image paste natively

## Test plan

- [ ] Copy an image to clipboard, open a terminal app (e.g., Claude Code) in Ghostty, press Cmd+V — the keypress should now reach the app
- [ ] Copy text to clipboard, press Cmd+V — normal paste behavior should be unchanged
- [ ] Copy a file in Finder, press Cmd+V — file path paste should work unchanged
- [ ] Verify Shift+Insert paste works on Linux builds
- [ ] Verify physical paste key (dedicated keyboard key) works

## References

- Issue #10549 — "Implement Kitty Clipboard Protocol (OSC 5522)"
- Discussion #10099 — Root cause analysis of image paste failure
- Discussion #10117 — "Can't paste images into claude code"

## AI Disclosure

This PR was authored with AI assistance (Claude Code) per `AI_POLICY.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)