### PR TITLE
feat(macos): add dedicated 'Reopen Closed Tab' menu item (Cmd+Shift+T)

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -37,6 +37,7 @@ class AppDelegate: NSObject,
     @IBOutlet private var menuCloseTab: NSMenuItem?
     @IBOutlet private var menuCloseWindow: NSMenuItem?
     @IBOutlet private var menuCloseAllWindows: NSMenuItem?
+    @IBOutlet private var menuReopenClosedTab: NSMenuItem?
 
     @IBOutlet private var menuUndo: NSMenuItem?
     @IBOutlet private var menuRedo: NSMenuItem?
@@ -1207,6 +1208,14 @@ class AppDelegate: NSObject,
         undoManager.redo()
     }
 
+    /// Reopens the last closed tab or window. This explicitly uses the app-level
+    /// undo manager to restore closed surfaces, unlike the standard undo action
+    /// which may act on text in the focused surface.
+    @IBAction func reopenClosedTab(_ sender: Any?) {
+        guard undoManager.canUndo else { return }
+        undoManager.undo()
+    }
+
     private struct DerivedConfig {
         let initialWindow: Bool
         let shouldQuitAfterLastWindowClosed: Bool
@@ -1320,6 +1329,15 @@ extension AppDelegate: NSMenuItemValidation {
                 item.title = "Redo"
             }
             return undoManager.canRedo
+
+        case #selector(reopenClosedTab(_:)):
+            // Show what will be restored in the menu title
+            if undoManager.canUndo {
+                item.title = "Reopen \(undoManager.undoActionName)"
+            } else {
+                item.title = "Reopen Closed Tab"
+            }
+            return undoManager.canUndo
 
         default:
             return true

--- a/macos/Sources/App/macOS/MainMenu.xib
+++ b/macos/Sources/App/macOS/MainMenu.xib
@@ -22,6 +22,7 @@
                 <outlet property="menuClose" destination="DVo-aG-piG" id="R3t-0C-aSU"/>
                 <outlet property="menuCloseAllWindows" destination="yKr-Vi-Yqw" id="Zet-Ir-zbm"/>
                 <outlet property="menuCloseTab" destination="Obb-Mk-j8J" id="Gda-L0-gdz"/>
+                <outlet property="menuReopenClosedTab" destination="rCT-4x-7Pm" id="rCT-oL-7Pm"/>
                 <outlet property="menuCloseWindow" destination="W5w-UZ-crk" id="6ff-BT-ENV"/>
                 <outlet property="menuCommandPalette" destination="et6-de-Mh7" id="53t-cu-dm5"/>
                 <outlet property="menuCopy" destination="Jqf-pv-Zcu" id="bKd-1C-oy9"/>
@@ -206,6 +207,13 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="closeAllWindows:" target="-1" id="hrz-eb-l5t"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="sR2-mT-9Kx"/>
+                            <menuItem title="Reopen Closed Tab" keyEquivalent="T" id="rCT-4x-7Pm">
+                                <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                <connections>
+                                    <action selector="reopenClosedTab:" target="bbz-4X-AYv" id="pRT-5c-2Lm"/>
                                 </connections>
                             </menuItem>
                         </items>


### PR DESCRIPTION
## Summary

Adds a dedicated "Reopen Closed Tab" menu item to the File menu on macOS, providing a browser-like experience for restoring accidentally closed tabs and windows.

## Changes

- New menu item "Reopen Closed Tab" in File menu (after "Close All Windows")
- Keyboard shortcut: **Cmd+Shift+T** (standard browser convention)
- Menu item dynamically updates to show what will be restored (e.g., "Reopen Close Tab")
- Disabled state when nothing can be restored
- Uses the app-level undo manager directly, bypassing the responder chain

## Why This Matters

The existing `Edit > Undo` menu item operates through the responder chain, which means:
- If a terminal has text focus, undo may act on text operations
- Users need to know that "undo" also handles window restoration
- It's not immediately discoverable for users coming from browsers

The new dedicated menu item:
- Provides familiar browser-like UX (Cmd+Shift+T)
- Always restores closed surfaces regardless of current focus
- Is clearly labeled for its purpose
- Makes session recovery more discoverable

## Screenshots

The menu item appears in the File menu:

```
File
├── New Window
├── New Tab
├── ─────────
├── Split Right/Left/Down/Up
├── ─────────
├── Close
├── Close Tab
├── Close Window
├── Close All Windows
├── ─────────           ← NEW separator
└── Reopen Closed Tab   ← NEW (Cmd+Shift+T)
```

## Testing

- [x] Menu item appears correctly in File menu
- [x] Cmd+Shift+T triggers the action
- [x] Menu is disabled when undo stack is empty
- [x] Menu title updates to show what will be restored
- [x] Restoring works for closed tabs, windows, and splits

## Related

This PR complements the existing undo-timeout configuration option and window-save-state functionality by making session recovery more accessible.

Related issue: #10584

---

🤖 Generated with [Claude Code](https://claude.ai/code)