### PR TITLE
elvish: improve the sudoedit detection code

### DIFF
--- a/src/shell-integration/elvish/lib/ghostty-integration.elv
+++ b/src/shell-integration/elvish/lib/ghostty-integration.elv
@@ -50,16 +50,19 @@
   fn sudo-with-terminfo {|@args|
     var sudoedit = $false
     for arg $args {
-      use str
-      if (str:has-prefix $arg -) {
-        if (has-value [e -edit] $arg[1..]) {
+      if (str:has-prefix $arg --) {
+        if (eq $arg --edit) {
           set sudoedit = $true
           break
         }
-        continue
+      } elif (str:has-prefix $arg -) {
+        if (str:contains (str:trim-prefix $arg -) e) {
+          set sudoedit = $true
+          break
+        }
+      } elif (not (str:contains $arg =)) {
+        break
       }
-
-      if (not (has-value $arg =)) { break }
     }
 
     if (not $sudoedit) { set args = [ --preserve-env=TERMINFO $@args ] }


### PR DESCRIPTION
The previous logic didn't detect the `e` option when it was combined with other flags (e.g. `-ie`). This change also attempts to improve the general readability of this code to be a bit more explicit.