### PR TITLE
macos: add vertical tab sidebar on macOS

### DIFF
--- a/macos/Ghostty.xcodeproj/project.pbxproj
+++ b/macos/Ghostty.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 				"Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift",
 				"Features/Terminal/Window Styles/TitlebarTabsVenturaTerminalWindow.swift",
 				"Features/Terminal/Window Styles/TransparentTitlebarTerminalWindow.swift",
+				"Features/Terminal/Window Styles/VerticalTabSidebar.swift",
 				Features/Update/UpdateBadge.swift,
 				Features/Update/UpdateController.swift,
 				Features/Update/UpdateDelegate.swift,

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -140,7 +140,8 @@ class QuickTerminalController: BaseTerminalController {
         window.contentView = TerminalViewContainer(
             ghostty: self.ghostty,
             viewModel: self,
-            delegate: self
+            delegate: self,
+            windowController: self
         )
         
         // Clear out our frame at this point, the fixup from above is complete.

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -1033,6 +1033,7 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
             ghostty: self.ghostty,
             viewModel: self,
             delegate: self,
+            windowController: self
         )
 
         // If we have a default size, we want to apply it.

--- a/macos/Sources/Features/Terminal/TerminalViewContainer.swift
+++ b/macos/Sources/Features/Terminal/TerminalViewContainer.swift
@@ -11,12 +11,13 @@ class TerminalViewContainer<ViewModel: TerminalViewModel>: NSView {
     private var glassTopConstraint: NSLayoutConstraint?
     private var derivedConfig: DerivedConfig
 
-    init(ghostty: Ghostty.App, viewModel: ViewModel, delegate: (any TerminalViewDelegate)? = nil) {
+    init(ghostty: Ghostty.App, viewModel: ViewModel, delegate: (any TerminalViewDelegate)? = nil, windowController: BaseTerminalController? = nil) {
         self.derivedConfig = DerivedConfig(config: ghostty.config)
         self.terminalView = NSHostingView(rootView: TerminalView(
             ghostty: ghostty,
             viewModel: viewModel,
-            delegate: delegate
+            delegate: delegate,
+            windowController: windowController
         ))
         super.init(frame: .zero)
         setup()

--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -218,14 +218,21 @@ class TerminalWindow: NSWindow {
     }
 
     override func addTitlebarAccessoryViewController(_ childViewController: NSTitlebarAccessoryViewController) {
-        super.addTitlebarAccessoryViewController(childViewController)
-
         // Tab bar is attached as a titlebar accessory view controller (layout bottom). We
         // can detect when it is shown or hidden by overriding add/remove and searching for
         // it. This has been verified to work on macOS 12 to 26
         if isTabBar(childViewController) {
+            // When using vertical tabs or hidden mode, don't add the tab bar at all
+            if derivedConfig.macosTabsLocation != .native {
+                // Don't call super - this prevents the tab bar from being added
+                return
+            }
+            
             childViewController.identifier = Self.tabBarIdentifier
+            super.addTitlebarAccessoryViewController(childViewController)
             tabBarDidAppear()
+        } else {
+            super.addTitlebarAccessoryViewController(childViewController)
         }
     }
 
@@ -555,6 +562,7 @@ class TerminalWindow: NSWindow {
         let macosWindowButtons: Ghostty.MacOSWindowButtons
         let macosTitlebarStyle: String
         let windowCornerRadius: CGFloat
+        let macosTabsLocation: Ghostty.MacOSTabsLocation
 
         init() {
             self.title = nil
@@ -564,6 +572,7 @@ class TerminalWindow: NSWindow {
             self.backgroundBlur = .disabled
             self.macosTitlebarStyle = "transparent"
             self.windowCornerRadius = 16
+            self.macosTabsLocation = .native
         }
 
         init(_ config: Ghostty.Config) {
@@ -583,6 +592,7 @@ class TerminalWindow: NSWindow {
             default:
                 self.windowCornerRadius = 16
             }
+            self.macosTabsLocation = config.macosTabsLocation
         }
     }
 }

--- a/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
@@ -102,6 +102,13 @@ class TitlebarTabsTahoeTerminalWindow: TransparentTitlebarTerminalWindow, NSTool
     // This is called by macOS for native tabbing in order to add the tab bar. We hook into
     // this, detect the tab bar being added, and override its behavior.
     override func addTitlebarAccessoryViewController(_ childViewController: NSTitlebarAccessoryViewController) {
+        // When using vertical tabs or hidden mode, skip the titlebar tabs processing
+        // and let the base class handle hiding the tab bar
+        guard derivedConfig.macosTabsLocation == .native else {
+            super.addTitlebarAccessoryViewController(childViewController)
+            return
+        }
+        
         // If this is the tab bar then we need to set it up for the titlebar
         guard isTabBar(childViewController) else {
             // After dragging a tab into a new window, `hasTabBar` needs to be

--- a/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsVenturaTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsVenturaTerminalWindow.swift
@@ -357,6 +357,13 @@ class TitlebarTabsVenturaTerminalWindow: TerminalWindow {
     // This is called by macOS for native tabbing in order to add the tab bar. We hook into
     // this, detect the tab bar being added, and override its behavior.
     override func addTitlebarAccessoryViewController(_ childViewController: NSTitlebarAccessoryViewController) {
+        // When using vertical tabs or hidden mode, skip the titlebar tabs processing
+        // and let the base class handle hiding the tab bar
+        guard derivedConfig.macosTabsLocation == .native else {
+            super.addTitlebarAccessoryViewController(childViewController)
+            return
+        }
+        
         let isTabBar = self.titlebarTabs && isTabBar(childViewController)
 
         if (isTabBar) {

--- a/macos/Sources/Features/Terminal/Window Styles/VerticalTabSidebar.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/VerticalTabSidebar.swift
@@ -1,0 +1,434 @@
+import SwiftUI
+import Cocoa
+
+/// A vertical tab sidebar that displays tabs in a vertical list.
+/// This provides an alternative to the native horizontal tab bar.
+struct VerticalTabSidebar: View {
+    /// The window controller that manages the tabs
+    weak var windowController: BaseTerminalController?
+    
+    /// Whether the sidebar is on the right side (affects resize handle position)
+    var isRightSide: Bool = false
+    
+    /// The tab data model that tracks all tabs
+    @StateObject private var tabModel = TabModel()
+    
+    /// Timer for refreshing the tab list
+    @State private var refreshTimer: Timer?
+    
+    /// For the rename dialog
+    @State private var isShowingRenameDialog: Bool = false
+    @State private var renameText: String = ""
+    @State private var windowToRename: NSWindow? = nil
+    
+    /// Sidebar width - persisted in UserDefaults
+    @AppStorage("verticalTabSidebarWidth") private var sidebarWidth: Double = 200
+    
+    /// Whether we're currently resizing
+    @State private var isResizing: Bool = false
+    
+    /// Minimum and maximum width constraints
+    private let minWidth: CGFloat = 120
+    private let maxWidth: CGFloat = 400
+    
+    var body: some View {
+        HStack(spacing: 0) {
+            // Resize handle on the left if sidebar is on the right
+            if isRightSide {
+                resizeHandle
+            }
+            
+            // Main sidebar content
+            VStack(spacing: 0) {
+                // Tab list
+                ScrollView {
+                    LazyVStack(spacing: 2) {
+                        ForEach(tabModel.tabs) { tab in
+                            TabRow(
+                                title: tab.title,
+                                isSelected: tab.isSelected,
+                                keyEquivalent: tab.index < 9 ? "\(tab.index + 1)" : nil,
+                                hasCustomTitle: tabModel.getCustomTitle(for: tab.window) != nil,
+                                onSelect: {
+                                    selectTab(tab.window)
+                                },
+                                onClose: {
+                                    closeTab(tab.window)
+                                },
+                                onRename: {
+                                    windowToRename = tab.window
+                                    renameText = tabModel.getCustomTitle(for: tab.window) ?? tab.title
+                                    isShowingRenameDialog = true
+                                },
+                                onClearCustomTitle: {
+                                    tabModel.clearCustomTitle(for: tab.window)
+                                    refreshTabs()
+                                }
+                            )
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+                
+                Divider()
+                
+                // Footer with new tab button
+                HStack(spacing: 8) {
+                    Button(action: createNewTab) {
+                        Image(systemName: "plus")
+                            .font(.system(size: 14))
+                    }
+                    .buttonStyle(.plain)
+                    .help("New Tab")
+                    
+                    Spacer()
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+            }
+            .frame(width: sidebarWidth)
+            .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+            
+            // Resize handle on the right if sidebar is on the left
+            if !isRightSide {
+                resizeHandle
+            }
+        }
+        .onAppear {
+            refreshTabs()
+            startRefreshTimer()
+        }
+        .onDisappear {
+            stopRefreshTimer()
+        }
+        .sheet(isPresented: $isShowingRenameDialog) {
+            RenameTabSheet(
+                title: $renameText,
+                isPresented: $isShowingRenameDialog,
+                onSave: {
+                    if let window = windowToRename {
+                        tabModel.setCustomTitle(renameText.isEmpty ? nil : renameText, for: window)
+                        refreshTabs()
+                    }
+                }
+            )
+        }
+    }
+    
+    /// The resize handle view
+    private var resizeHandle: some View {
+        ZStack {
+            // Subtle border line
+            Rectangle()
+                .fill(Color(nsColor: .separatorColor))
+                .frame(width: 1)
+                .frame(maxHeight: .infinity)
+            
+            // Wider invisible hit area for dragging
+            Rectangle()
+                .fill(isResizing ? Color.accentColor.opacity(0.3) : Color.clear)
+                .frame(width: 6)
+        }
+        .frame(width: 6)
+        .contentShape(Rectangle())
+        .onHover { hovering in
+            if hovering {
+                NSCursor.resizeLeftRight.push()
+            } else {
+                NSCursor.pop()
+            }
+        }
+        .gesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { value in
+                    isResizing = true
+                    let delta = isRightSide ? -value.translation.width : value.translation.width
+                    let newWidth = sidebarWidth + delta
+                    sidebarWidth = min(maxWidth, max(minWidth, newWidth))
+                }
+                .onEnded { _ in
+                    isResizing = false
+                }
+        )
+    }
+    
+    // MARK: - Rename Sheet
+    
+    struct RenameTabSheet: View {
+        @Binding var title: String
+        @Binding var isPresented: Bool
+        let onSave: () -> Void
+        
+        var body: some View {
+            VStack(spacing: 16) {
+                Text("Rename Tab")
+                    .font(.headline)
+                
+                TextField("Tab title", text: $title)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 250)
+                
+                Text("Leave empty to use automatic title")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                
+                HStack(spacing: 12) {
+                    Button("Cancel") {
+                        isPresented = false
+                    }
+                    .keyboardShortcut(.escape)
+                    
+                    Button("Save") {
+                        onSave()
+                        isPresented = false
+                    }
+                    .keyboardShortcut(.return)
+                    .buttonStyle(.borderedProminent)
+                }
+            }
+            .padding(20)
+            .frame(minWidth: 300)
+        }
+    }
+    
+    // MARK: - Tab Data Model
+    
+    /// Represents a single tab's data
+    struct TabData: Identifiable {
+        let id: String  // Unique ID combining window hash and title for proper updates
+        let window: NSWindow
+        let title: String
+        let index: Int
+        let isSelected: Bool
+        
+        init(window: NSWindow, index: Int, isSelected: Bool, customTitles: [ObjectIdentifier: String], resolvedTitle: String) {
+            self.window = window
+            self.index = index
+            self.isSelected = isSelected
+            
+            // Use custom title if set, otherwise use resolved title (based on tab-title-mode)
+            let windowId = ObjectIdentifier(window)
+            if let customTitle = customTitles[windowId], !customTitle.isEmpty {
+                self.title = customTitle
+                self.id = "\(windowId.hashValue)-custom-\(customTitle)"
+            } else {
+                self.title = resolvedTitle
+                self.id = "\(windowId.hashValue)-\(resolvedTitle)"
+            }
+        }
+    }
+    
+    /// Observable model that holds the tab list and custom titles
+    class TabModel: ObservableObject {
+        @Published var tabs: [TabData] = []
+        /// Custom titles set by the user (keyed by window ObjectIdentifier)
+        var customTitles: [ObjectIdentifier: String] = [:]
+        
+        func setCustomTitle(_ title: String?, for window: NSWindow) {
+            let id = ObjectIdentifier(window)
+            if let title = title, !title.isEmpty {
+                customTitles[id] = title
+            } else {
+                customTitles.removeValue(forKey: id)
+            }
+        }
+        
+        func getCustomTitle(for window: NSWindow) -> String? {
+            return customTitles[ObjectIdentifier(window)]
+        }
+        
+        func clearCustomTitle(for window: NSWindow) {
+            customTitles.removeValue(forKey: ObjectIdentifier(window))
+        }
+    }
+    
+    /// Get the title for a window
+    private func resolveTitle(for window: NSWindow, controller: BaseTerminalController?) -> String {
+        return window.title
+    }
+    
+    // MARK: - Tab Row
+    
+    struct TabRow: View {
+        let title: String
+        let isSelected: Bool
+        let keyEquivalent: String?
+        let hasCustomTitle: Bool
+        let onSelect: () -> Void
+        let onClose: () -> Void
+        let onRename: () -> Void
+        let onClearCustomTitle: () -> Void
+        
+        @State private var isHovering: Bool = false
+        
+        var body: some View {
+            HStack(spacing: 6) {
+                // Key equivalent badge
+                if let keyEquiv = keyEquivalent {
+                    Text("⌘\(keyEquiv)")
+                        .font(.system(size: 10, weight: .medium, design: .monospaced))
+                        .foregroundColor(.secondary)
+                        .frame(width: 28)
+                }
+                
+                // Custom title indicator
+                if hasCustomTitle {
+                    Image(systemName: "pencil.circle.fill")
+                        .font(.system(size: 10))
+                        .foregroundColor(.accentColor.opacity(0.7))
+                }
+                
+                // Tab title
+                Text(title.isEmpty ? "Ghostty" : title)
+                    .font(.system(size: 12))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .foregroundColor(isSelected ? .primary : .secondary)
+                
+                Spacer()
+                
+                // Close button (shown on hover)
+                if isHovering {
+                    Button(action: onClose) {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundColor(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Close Tab")
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isSelected ? Color.accentColor.opacity(0.2) : (isHovering ? Color.primary.opacity(0.05) : Color.clear))
+            )
+            .contentShape(Rectangle())
+            .onTapGesture {
+                onSelect()
+            }
+            .onHover { hovering in
+                isHovering = hovering
+            }
+            .contextMenu {
+                Button("Rename Tab...") {
+                    onRename()
+                }
+                if hasCustomTitle {
+                    Button("Clear Custom Title") {
+                        onClearCustomTitle()
+                    }
+                }
+                Divider()
+                Button("Close Tab") {
+                    onClose()
+                }
+            }
+            .padding(.horizontal, 4)
+        }
+    }
+    
+    // MARK: - Actions
+    
+    private func refreshTabs() {
+        guard let window = windowController?.window else {
+            tabModel.tabs = []
+            return
+        }
+        
+        // Get all tabbed windows and the selected one
+        let windows: [NSWindow]
+        let selectedWindow: NSWindow?
+        
+        if let tabGroup = window.tabGroup {
+            windows = tabGroup.windows
+            selectedWindow = tabGroup.selectedWindow
+        } else {
+            windows = [window]
+            selectedWindow = window
+        }
+        
+        // Build the tab data with current titles (using custom titles if set)
+        let newTabs = windows.enumerated().map { index, win in
+            // Get the controller for this window to resolve title based on config
+            let controller = win.windowController as? BaseTerminalController
+            let resolvedTitle = resolveTitle(for: win, controller: controller)
+            
+            return TabData(
+                window: win,
+                index: index,
+                isSelected: win == selectedWindow,
+                customTitles: tabModel.customTitles,
+                resolvedTitle: resolvedTitle
+            )
+        }
+        
+        // Check if anything changed (IDs or selection state)
+        let newIds = newTabs.map { $0.id }
+        let oldIds = tabModel.tabs.map { $0.id }
+        let newSelection = newTabs.map { $0.isSelected }
+        let oldSelection = tabModel.tabs.map { $0.isSelected }
+        
+        if newIds != oldIds || newSelection != oldSelection {
+            tabModel.tabs = newTabs
+        }
+    }
+    
+    private func selectTab(_ window: NSWindow) {
+        window.makeKeyAndOrderFront(nil)
+        refreshTabs()
+    }
+    
+    private func closeTab(_ window: NSWindow) {
+        // If this is the only tab, close the window
+        if tabModel.tabs.count <= 1 {
+            window.close()
+            return
+        }
+        
+        // Otherwise just close this tab
+        window.close()
+        
+        // Refresh after a short delay
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            refreshTabs()
+        }
+    }
+    
+    private func createNewTab() {
+        guard let surface = windowController?.focusedSurface?.surface else { return }
+        windowController?.ghostty.newTab(surface: surface)
+        
+        // Refresh after a short delay
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            refreshTabs()
+        }
+    }
+    
+    // MARK: - Timer
+    
+    private func startRefreshTimer() {
+        // Refresh tabs periodically to catch changes
+        refreshTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { _ in
+            refreshTabs()
+        }
+    }
+    
+    private func stopRefreshTimer() {
+        refreshTimer?.invalidate()
+        refreshTimer = nil
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+struct VerticalTabSidebar_Previews: PreviewProvider {
+    static var previews: some View {
+        VerticalTabSidebar(windowController: nil)
+            .frame(height: 400)
+    }
+}
+#endif
+

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -289,6 +289,17 @@ extension Ghostty {
             return String(cString: ptr)
         }
 
+        var macosTabsLocation: Ghostty.MacOSTabsLocation {
+            let defaultValue = Ghostty.MacOSTabsLocation.native
+            guard let config = self.config else { return defaultValue }
+            var v: UnsafePointer<Int8>? = nil
+            let key = "macos-tabs-location"
+            guard ghostty_config_get(config, &v, key, UInt(key.lengthOfBytes(using: .utf8))) else { return defaultValue }
+            guard let ptr = v else { return defaultValue }
+            let str = String(cString: ptr)
+            return Ghostty.MacOSTabsLocation(rawValue: str) ?? defaultValue
+        }
+
         var macosTitlebarProxyIcon: MacOSTitlebarProxyIcon {
             let defaultValue = MacOSTitlebarProxyIcon.visible
             guard let config = self.config else { return defaultValue }

--- a/macos/Sources/Ghostty/Package.swift
+++ b/macos/Sources/Ghostty/Package.swift
@@ -373,6 +373,15 @@ extension Ghostty {
         case tip
         case stable
     }
+    
+    /// Enum for macos-tabs-location config option
+    enum MacOSTabsLocation: String {
+        case native   // Use native macOS tab bar (default)
+        case left     // Vertical tabs on the left
+        case right    // Vertical tabs on the right
+        case hidden   // No tab UI (use keybinds only)
+    }
+
 }
 
 // MARK: Surface Notification

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3126,6 +3126,30 @@ keybind: Keybinds = .{},
 /// Changing this option at runtime only applies to new windows.
 @"macos-titlebar-style": MacTitlebarStyle = .transparent,
 
+/// The location of the tab bar on macOS. This controls where tabs are
+/// displayed in the window.
+///
+/// Valid values are:
+///
+///   * `native` - Use the native macOS tab bar (horizontal, in the titlebar
+///     area). This is the default.
+///   * `left` - Display tabs in a vertical sidebar on the left side of the
+///     window.
+///   * `right` - Display tabs in a vertical sidebar on the right side of the
+///     window.
+///   * `hidden` - Hide the tab bar completely. Use keybinds to switch between
+///     tabs.
+///
+/// When using `left` or `right`, the native macOS tab bar will be hidden and
+/// replaced with a custom vertical tab sidebar.
+///
+/// The default value is `native`.
+///
+/// Changing this option at runtime only applies to new windows.
+///
+/// Available since: 1.3.0
+@"macos-tabs-location": MacTabsLocation = .native,
+
 /// Whether the proxy icon in the macOS titlebar is visible. The proxy icon
 /// is the icon that represents the folder of the current working directory.
 /// You can see this very clearly in the macOS built-in Terminal.app
@@ -8499,6 +8523,14 @@ pub const MacTitlebarStyle = enum {
     native,
     transparent,
     tabs,
+    hidden,
+};
+
+/// See macos-tabs-location
+pub const MacTabsLocation = enum {
+    native,
+    left,
+    right,
     hidden,
 };
 


### PR DESCRIPTION
https://github.com/ghostty-org/ghostty/discussions/2549

- Add a vertical tab sidebar for Terminal windows
- Sync vertical and top tab titles on rename
- Hide the top tab bar when vertical tabs are enabled
- Make the vertical tab sidebar resizable

This was written mostly by Cursor AI, with some tweaks by me, since cursor did AI type things. I have been running this on my machine, M3 Mac, Tahoe 26.2 for over a month, with zero crashes. I tried to stay out of any Linux pieces intentionally, since I can't test this on linux, but AI did initially add gtk changes, which I tried to rip out. 