### PR TITLE
feat(macos): add quick-terminal-floating option for fullscreen overlay

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -472,10 +472,14 @@ class QuickTerminalController: BaseTerminalController {
                     return
                 }
 
-                // After animating in, we reset the window level to a value that
-                // is above other windows but not as high as popUpMenu. This allows
-                // things like IME dropdowns to appear properly.
-                window.level = .floating
+                // After animating in, we reset the window level. When floating mode
+                // is enabled, we use screenSaver level to appear above fullscreen apps.
+                // Otherwise, we use floating level which allows IME dropdowns to appear.
+                if self.derivedConfig.quickTerminalFloating {
+                    window.level = .screenSaver
+                } else {
+                    window.level = .floating
+                }
 
                 // Now that the window is visible, sync our appearance. This function
                 // requires the window is visible.
@@ -722,6 +726,7 @@ class QuickTerminalController: BaseTerminalController {
         let quickTerminalAnimationDuration: Double
         let quickTerminalAutoHide: Bool
         let quickTerminalSpaceBehavior: QuickTerminalSpaceBehavior
+        let quickTerminalFloating: Bool
         let quickTerminalSize: QuickTerminalSize
         let backgroundOpacity: Double
         let backgroundBlur: Ghostty.Config.BackgroundBlur
@@ -731,6 +736,7 @@ class QuickTerminalController: BaseTerminalController {
             self.quickTerminalAnimationDuration = 0.2
             self.quickTerminalAutoHide = true
             self.quickTerminalSpaceBehavior = .move
+            self.quickTerminalFloating = false
             self.quickTerminalSize = QuickTerminalSize()
             self.backgroundOpacity = 1.0
             self.backgroundBlur = .disabled
@@ -741,6 +747,7 @@ class QuickTerminalController: BaseTerminalController {
             self.quickTerminalAnimationDuration = config.quickTerminalAnimationDuration
             self.quickTerminalAutoHide = config.quickTerminalAutoHide
             self.quickTerminalSpaceBehavior = config.quickTerminalSpaceBehavior
+            self.quickTerminalFloating = config.quickTerminalFloating
             self.quickTerminalSize = config.quickTerminalSize
             self.backgroundOpacity = config.backgroundOpacity
             self.backgroundBlur = config.backgroundBlur

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -520,6 +520,14 @@ extension Ghostty {
             return QuickTerminalSpaceBehavior(fromGhosttyConfig: str) ?? .move
         }
 
+        var quickTerminalFloating: Bool {
+            guard let config = self.config else { return false }
+            var v = false
+            let key = "quick-terminal-floating"
+            _ = ghostty_config_get(config, &v, key, UInt(key.lengthOfBytes(using: .utf8)))
+            return v
+        }
+
         var quickTerminalSize: QuickTerminalSize {
             guard let config = self.config else { return QuickTerminalSize() }
             var v = ghostty_config_quick_terminal_size_s()

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2642,6 +2642,18 @@ keybind: Keybinds = .{},
 /// Available since: 1.1.0
 @"quick-terminal-space-behavior": QuickTerminalSpaceBehavior = .move,
 
+/// When enabled, the quick terminal window floats above all other windows,
+/// including fullscreen applications. This is similar to iTerm2's
+/// "Floating window" option for dedicated hotkey windows.
+///
+/// When this is set to `true`, the quick terminal will appear above
+/// fullscreen apps (e.g., a browser in fullscreen mode).
+///
+/// Only implemented on macOS.
+///
+/// Available since: 1.2.0
+@"quick-terminal-floating": bool = false,
+
 /// Determines under which circumstances that the quick terminal should receive
 /// keyboard input. See the corresponding [Wayland documentation](https://wayland.app/protocols/wlr-layer-shell-unstable-v1#zwlr_layer_surface_v1:enum:keyboard_interactivity)
 /// for a more detailed explanation of the behavior of each option.


### PR DESCRIPTION
Hi @mitchellh 👋

I've been a huge fan of iTerm2's **Dedicated Hotkey Window** feature — especially the "Floating window" option that lets the terminal appear above fullscreen apps. It's become an essential part of my workflow, and I was really hoping to have something similar in Ghostty.

So I went ahead and implemented it! I'd be grateful if you could take a look when you have time. Please let me know if there are any changes needed or if this approach aligns with Ghostty's design philosophy.

Thank you for creating such an amazing terminal emulator! 🙏

---

## Summary

- Add a new configuration option `quick-terminal-floating` that allows the quick terminal to appear above fullscreen applications on macOS
- When enabled, the quick terminal window level is set to `.screenSaver` instead of `.floating`
- This is similar to iTerm2's "Floating window" option for dedicated hotkey windows

## Motivation

Currently, the quick terminal cannot appear over fullscreen apps (e.g., a browser in fullscreen mode with Ctrl+Cmd+F). This is a common use case for users who want a system-wide terminal accessible via hotkey, similar to iTerm2's dedicated hotkey window feature.

## Configuration

```ini
# Enable floating mode to appear above fullscreen apps
quick-terminal-floating = true
```

## Implementation

- Added `quick-terminal-floating` bool option to `Config.zig`
- Added Swift binding in `Ghostty.Config.swift`
- Modified `QuickTerminalController.swift` to use `.screenSaver` window level when floating is enabled

## Test Plan

1. Set `quick-terminal-floating = true` in config
2. Open a browser in fullscreen mode (Ctrl+Cmd+F)
3. Press the quick terminal hotkey
4. Verify the quick terminal appears above the fullscreen app