### PR TITLE
fix(gtk): restore middle-click paste when scrollbar is enabled

### DIFF
--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -2713,6 +2713,18 @@ pub const Surface = extern struct {
         };
     }
 
+    /// Public method to forward mouse down events from parent widgets
+    /// (e.g., ScrolledWindow capturing middle-clicks).
+    pub fn forwardMouseDown(
+        self: *Self,
+        gesture: *gtk.GestureClick,
+        n_press: c_int,
+        x: f64,
+        y: f64,
+    ) void {
+        gcMouseDown(gesture, n_press, x, y, self);
+    }
+
     fn gcMouseDown(
         gesture: *gtk.GestureClick,
         _: c_int,

--- a/src/apprt/gtk/ui/1.5/surface-scrolled-window.blp
+++ b/src/apprt/gtk/ui/1.5/surface-scrolled-window.blp
@@ -7,5 +7,12 @@ template $GhostttySurfaceScrolledWindow: Adw.Bin {
   Gtk.ScrolledWindow {
     hscrollbar-policy: never;
     vscrollbar-policy: bind $scrollbar_policy(template.config) as <Gtk.PolicyType>;
+    kinetic-scrolling: false;
+
+    GestureClick {
+      pressed => $scrolled_window_mouse_down();
+      button: 2;
+      propagation-phase: capture;
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Fixes middle-click paste (primary selection) not working when GTK scrollbars are enabled
- The `GtkScrolledWindow` was intercepting middle-click events before they reached the terminal Surface

## Solution

- Added a `GestureClick` with `propagation-phase: capture` to the ScrolledWindow that intercepts middle-clicks and forwards them to the Surface
- The gesture is claimed after handling to prevent double-paste when the scrollbar is not visible
- Also disabled `kinetic-scrolling` on the ScrolledWindow as it uses middle-click for autoscroll

## Test plan

- [x] Enable scrollbars (`scrollbar = system` in config)
- [x] Select text in another application to populate primary selection
- [x] Middle-click in Ghostty terminal - should paste once
- [x] Run `seq 1 80` to make scrollbar visible
- [x] Middle-click again - should still paste once

Fixes #10613

🤖 Generated with [Claude Code](https://claude.ai/code)