### PR TITLE
chore: sync with nixpkgs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -370,7 +370,7 @@ requirements for macOS are detailed below.
 ### Linux
 
 1. Check out the Ghostty source and change to the directory.
-2. Run `nix run .#check.<system>.<test-name>.driver`. `<system>` should be
+2. Run `nix run .#checks.<system>.<test-name>.driver`. `<system>` should be
    `x86_64-linux` or `aarch64-linux` (even on macOS, this launches a Linux
    VM, not a macOS one). `<test-name>` should be one of the tests defined in
    `nix/tests.nix`. The test will build and then launch. Depending on the speed

--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768068402,
-        "narHash": "sha256-bAXnnJZKJiF7Xr6eNW6+PhBf1lg2P1aFUO9+xgWkXfA=",
+        "lastModified": 1770586272,
+        "narHash": "sha256-Ucci8mu8QfxwzyfER2DQDbvW9t1BnTUJhBmY7ybralo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8bc5473b6bc2b6e1529a9c4040411e1199c43b4c",
+        "rev": "b1f916ba052341edc1f80d4b2399f1092a4873ca",
         "type": "github"
       },
       "original": {
@@ -56,11 +56,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768032153,
-        "narHash": "sha256-zvxtwlM8ZlulmZKyYCQAPpkm5dngSEnnHjmjV7Teloc=",
-        "rev": "3146c6aa9995e7351a398e17470e15305e6e18ff",
+        "lastModified": 1770537093,
+        "narHash": "sha256-XV30uo8tXuxdzuV8l3sojmlPRLd/8tpMsOp4lNzLGUo=",
+        "rev": "fef9403a3e4d31b0a23f0bacebbec52c248fbb51",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre925418.3146c6aa9995/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre942631.fef9403a3e4d/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",

--- a/flake.nix
+++ b/flake.nix
@@ -64,8 +64,8 @@
     forAllPlatforms = f: lib.genAttrs platforms (s: f legacyPackages.${s});
     forBuildablePlatforms = f: lib.genAttrs buildablePlatforms (s: f legacyPackages.${s});
   in {
-    devShell = forAllPlatforms (pkgs:
-      pkgs.callPackage ./nix/devShell.nix {
+    devShells = forAllPlatforms (pkgs: {
+      default = pkgs.callPackage ./nix/devShell.nix {
         zig = zig.packages.${pkgs.stdenv.hostPlatform.system}."0.15.2";
         wraptest = pkgs.callPackage ./nix/pkgs/wraptest.nix {};
         zon2nix = zon2nix;
@@ -77,7 +77,8 @@
             ucs-detect = pyfinal.callPackage ./nix/pkgs/ucs-detect.nix {};
           };
         };
-      });
+      };
+    });
 
     packages =
       forAllPlatforms (pkgs: {

--- a/nix/build-support/build-inputs.nix
+++ b/nix/build-support/build-inputs.nix
@@ -35,10 +35,10 @@
   pkgs.libadwaita
 ]
 ++ lib.optionals (stdenv.hostPlatform.isLinux && enableX11) [
-  pkgs.xorg.libX11
-  pkgs.xorg.libXcursor
-  pkgs.xorg.libXi
-  pkgs.xorg.libXrandr
+  pkgs.libx11
+  pkgs.libxcursor
+  pkgs.libxi
+  pkgs.libxrandr
 ]
 ++ lib.optionals (stdenv.hostPlatform.isLinux && enableWayland) [
   pkgs.gtk4-layer-shell

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -77,7 +77,6 @@ in
 
     buildInputs = buildInputs;
 
-    dontConfigure = true;
     dontStrip = !strip;
 
     GI_TYPELIB_PATH = gi_typelib_path;

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -91,6 +91,7 @@
           };
           programs.ssh = {
             enable = true;
+            enableDefaultConfig = false;
             extraOptionOverrides = {
               StrictHostKeyChecking = "accept-new";
               UserKnownHostsFile = "/dev/null";


### PR DESCRIPTION
updates nixpkgs and home-manager

X11 packages are now not in a shared namespace

the ZIG_GLOBAL_CACHE_DIR creation was moved to the configurePhase in the zig hook

moves nix shell from #devShell.\<system\> to #devshells.\<system\>.default

tested with `nix run` and `nix flake check` on x86-64_linux

no AI used