### PR TITLE
i18n: update uk_UA translation for 1.3

### DIFF
--- a/po/uk_UA.UTF-8.po
+++ b/po/uk_UA.UTF-8.po
@@ -2,14 +2,13 @@
 # Copyright (C) 2025 Mitchell Hashimoto, Ghostty contributors
 # This file is distributed under the same license as the com.mitchellh.ghostty package.
 # Danylo Zalizchuk <danilmail0110@gmail.com>, 2025.
-# Volodymyr Chernetskyi <19735328+chernetskyi@users.noreply.github.com>, 2025.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
 "POT-Creation-Date: 2026-02-05 10:23+0800\n"
-"PO-Revision-Date: 2025-08-25 19:59+0100\n"
+"PO-Revision-Date: 2026-02-09 21:03+0100\n"
 "Last-Translator: Volodymyr Chernetskyi "
 "<19735328+chernetskyi@users.noreply.github.com>\n"
 "Language-Team: Ukrainian <trans-uk@lists.fedoraproject.org>\n"
@@ -90,23 +89,23 @@ msgstr "Ghostty: Інспектор терміналу"
 
 #: src/apprt/gtk/ui/1.2/search-overlay.blp:29
 msgid "Find…"
-msgstr ""
+msgstr "Знайти…"
 
 #: src/apprt/gtk/ui/1.2/search-overlay.blp:64
 msgid "Previous Match"
-msgstr ""
+msgstr "Попередній збіг"
 
 #: src/apprt/gtk/ui/1.2/search-overlay.blp:74
 msgid "Next Match"
-msgstr ""
+msgstr "Наступний збіг"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:6
 msgid "Oh, no."
-msgstr ""
+msgstr "Халепа."
 
 #: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Unable to acquire an OpenGL context for rendering."
-msgstr ""
+msgstr "Не вдалося отримати контекст OpenGL для відображення."
 
 #: src/apprt/gtk/ui/1.2/surface.blp:97
 msgid ""
@@ -114,10 +113,12 @@ msgid ""
 "through the content, but no input events will be sent to the running "
 "application."
 msgstr ""
+"Цей термінал працює в режимі читання. Можна переглядати, виділяти і гортати "
+"вміст, але ввід не буде передано до запущеної програми."
 
 #: src/apprt/gtk/ui/1.2/surface.blp:107
 msgid "Read-only"
-msgstr ""
+msgstr "Тільки для читання"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:198
 msgid "Copy"
@@ -129,7 +130,7 @@ msgstr "Вставити"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:270
 msgid "Notify on Next Command Finish"
-msgstr ""
+msgstr "Сповістити про завершення наступної команди"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:266
 msgid "Clear"
@@ -306,15 +307,15 @@ msgstr "Процес, що виконується в цій панелі, буд
 
 #: src/apprt/gtk/class/surface.zig:1108
 msgid "Command Finished"
-msgstr ""
+msgstr "Команда завершилась"
 
 #: src/apprt/gtk/class/surface.zig:1109
 msgid "Command Succeeded"
-msgstr ""
+msgstr "Команда завершилась успішно"
 
 #: src/apprt/gtk/class/surface.zig:1110
 msgid "Command Failed"
-msgstr ""
+msgstr "Команда завершилась з помилкою"
 
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command succeeded"


### PR DESCRIPTION
Adding missing Ukrainian translations, as asked for in https://github.com/ghostty-org/ghostty/issues/10632.

@danulqua @gmile @gordonbondon 