### PR TITLE
feat(i18n): complete Lithuanian (lt_LT) translation for v1.3

### DIFF
--- a/po/lt_LT.UTF-8.po
+++ b/po/lt_LT.UTF-8.po
@@ -128,7 +128,7 @@ msgstr "Įklijuoti"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:270
 msgid "Notify on Next Command Finish"
-msgstr "Pranešti apie kitos komandos užbaigimą"
+msgstr "Pranešti apie sekančios komandos užbaigimą"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:266
 msgid "Clear"

--- a/po/lt_LT.UTF-8.po
+++ b/po/lt_LT.UTF-8.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
 "POT-Creation-Date: 2026-02-05 10:23+0800\n"
-"PO-Revision-Date: 2025-09-17 13:27+0200\n"
+"PO-Revision-Date: 2026-02-10 08:14+0100\n"
 "Last-Translator: Tadas Lotuzas <tdslot@gmail.com>\n"
 "Language-Team: Language LT\n"
 "Language: LT\n"
@@ -86,23 +86,23 @@ msgstr "Ghostty: terminalo inspektorius"
 
 #: src/apprt/gtk/ui/1.2/search-overlay.blp:29
 msgid "Find…"
-msgstr ""
+msgstr "Rasti…"
 
 #: src/apprt/gtk/ui/1.2/search-overlay.blp:64
 msgid "Previous Match"
-msgstr ""
+msgstr "Ankstesnis atitikmuo"
 
 #: src/apprt/gtk/ui/1.2/search-overlay.blp:74
 msgid "Next Match"
-msgstr ""
+msgstr "Kitas atitikmuo"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:6
 msgid "Oh, no."
-msgstr ""
+msgstr "Oi, ne."
 
 #: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Unable to acquire an OpenGL context for rendering."
-msgstr ""
+msgstr "Nepavyko gauti OpenGL konteksto vaizdavimui."
 
 #: src/apprt/gtk/ui/1.2/surface.blp:97
 msgid ""
@@ -110,10 +110,13 @@ msgid ""
 "through the content, but no input events will be sent to the running "
 "application."
 msgstr ""
+"Šis terminalas yra tik skaitymui. Vis tiek galite peržiūrėti, pasirinkti ir "
+"slinkti per turinį, tačiau jokių įvesties įvykių nebus siunčiama veikiančiai "
+"programai."
 
 #: src/apprt/gtk/ui/1.2/surface.blp:107
 msgid "Read-only"
-msgstr ""
+msgstr "Tik skaitymui"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:198
 msgid "Copy"
@@ -125,7 +128,7 @@ msgstr "Įklijuoti"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:270
 msgid "Notify on Next Command Finish"
-msgstr ""
+msgstr "Pranešti apie kitos komandos užbaigimą"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:266
 msgid "Clear"
@@ -302,15 +305,15 @@ msgstr "Šiuo metu vykdomas procesas šiame padalijime bus nutrauktas."
 
 #: src/apprt/gtk/class/surface.zig:1108
 msgid "Command Finished"
-msgstr ""
+msgstr "Komanda užbaigta"
 
 #: src/apprt/gtk/class/surface.zig:1109
 msgid "Command Succeeded"
-msgstr ""
+msgstr "Komanda sėkminga"
 
 #: src/apprt/gtk/class/surface.zig:1110
 msgid "Command Failed"
-msgstr ""
+msgstr "Komanda nepavyko"
 
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command succeeded"

--- a/po/lt_LT.UTF-8.po
+++ b/po/lt_LT.UTF-8.po
@@ -111,7 +111,7 @@ msgid ""
 "application."
 msgstr ""
 "Šis terminalas yra tik skaitymui. Vis tiek galite peržiūrėti, pasirinkti ir "
-"slinkti per turinį, tačiau jokių įvesties įvykių nebus siunčiama veikiančiai "
+"slinkti per turinį, tačiau jokie įvesties įvykiai nebus siunčiami veikiančiai "
 "programai."
 
 #: src/apprt/gtk/ui/1.2/surface.blp:107


### PR DESCRIPTION
- Added translations for 10 previously untranslated strings
- Translated search overlay messages (Find, Previous Match, Next Match)
- Translated error messages (OpenGL context, read-only mode)
- Translated notification messages (Command Finished, Command Succeeded, Command Failed)
- Updated PO-Revision-Date to 2026-02-10

All 71 messages are now fully translated in Lithuanian.