### PR TITLE
fix(macos): quick terminal ignores configured size when initial-window=false

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalPosition.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalPosition.swift
@@ -86,7 +86,7 @@ enum QuickTerminalPosition : String {
                 y: round(screen.visibleFrame.origin.y + (screen.visibleFrame.height - window.frame.height) / 2))
 
         case .center:
-            return .init(x: round(screen.visibleFrame.origin.x + (screen.visibleFrame.width - window.frame.width) / 2), y:  screen.visibleFrame.height - window.frame.width)
+            return .init(x: round(screen.visibleFrame.origin.x + (screen.visibleFrame.width - window.frame.width) / 2), y: screen.visibleFrame.maxY)
         }
     }
 

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalWindow.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalWindow.swift
@@ -5,18 +5,18 @@ class QuickTerminalWindow: NSPanel {
     // still become key/main and receive events.
     override var canBecomeKey: Bool { return true }
     override var canBecomeMain: Bool { return true }
-    
+
     override func awakeFromNib() {
         super.awakeFromNib()
 
         // Note: almost all of this stuff can be done in the nib/xib directly
         // but I prefer to do it programmatically because the properties we
         // care about are less hidden.
-        
+
         // Add a custom identifier so third party apps can use the Accessibility
-        // API to apply special rules to the quick terminal. 
+        // API to apply special rules to the quick terminal.
         self.identifier = .init(rawValue: "com.mitchellh.ghostty.quickTerminal")
-        
+
         // Set the correct AXSubrole of kAXFloatingWindowSubrole (allows
         // AeroSpace to treat the Quick Terminal as a floating window)
         self.setAccessibilitySubrole(.floatingWindow)
@@ -30,18 +30,24 @@ class QuickTerminalWindow: NSPanel {
         self.styleMask.insert(.nonactivatingPanel)
     }
 
-    /// This is set to the frame prior to setting `contentView`. This is purely a hack to workaround
-    /// bugs in older macOS versions (Ventura): https://github.com/ghostty-org/ghostty/pull/8026
-    var initialFrame: NSRect? = nil
-    
+    /// When set, any setFrame call from SwiftUI layout will have its size
+    /// replaced with this locked size. This prevents SwiftUI's NSHostingView
+    /// from corrupting the window dimensions during content setup and animation.
+    /// The origin is still allowed to change (for animation positioning).
+    ///
+    /// This is especially important when initial-window=false because the quick
+    /// terminal is the first window in the process and SwiftUI's initial layout
+    /// can be more aggressive about resizing.
+    var lockedSize: NSSize? = nil
+
     override func setFrame(_ frameRect: NSRect, display flag: Bool) {
-        // Upon first adding this Window to its host view, older SwiftUI
-        // seems to have a "hiccup" and corrupts the frameRect,
-        // sometimes setting the size to zero, sometimes corrupting it.
-        // If we find we have cached the "initial" frame, use that instead
-        // the propagated one through the framework
-        //
-        // https://github.com/ghostty-org/ghostty/pull/8026
-        super.setFrame(initialFrame ?? frameRect, display: flag)
+        if let lockedSize {
+            // Allow origin changes but enforce the locked size. This lets
+            // animation positioning work while preventing SwiftUI from
+            // corrupting the window dimensions.
+            super.setFrame(NSRect(origin: frameRect.origin, size: lockedSize), display: flag)
+        } else {
+            super.setFrame(frameRect, display: flag)
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Quick terminal ignores `quick-terminal-size` when `initial-window=false`, opening with a tiny width regardless of config
- Root cause: SwiftUI's NSHostingView corrupts the window frame during multiple layout passes (contentView setup, surfaceTree population via `@Published`, `makeKeyAndOrderFront`). The previous `initialFrame` hack (PR #8026) was cleared too early — before `animateIn()` triggers these layout passes
- Fix: replace `initialFrame` (locked entire NSRect) with `lockedSize` (locks only dimensions, allows origin changes for animation). Lock held from `windowDidLoad` through the full animate-in sequence, released after animation completes
- Also fixes center position's `initialOrigin` using `window.frame.width` instead of `screen.visibleFrame.maxY` for the Y coordinate

## Context

I (@alexisceballosc) hit this bug for months using quick terminal exclusively. I have zero experience with Swift/SwiftUI/AppKit but I know my way around code. Used Claude Code (Opus 4.6) to diagnose and write the fix, then compiled and verified it myself on a MacBook Pro M4 Max (36 GB), macOS 26.2 (build 25C56), Xcode 26.2, Zig 0.15.2. The fix works.

I can't guarantee this follows every Swift/AppKit idiom perfectly, but it works. At the very least it should serve as a solid starting point for anyone addressing this bug.

<details>
<summary>Relevant config used for testing (theme/visual settings excluded)</summary>

```
command = /opt/homebrew/bin/tmux new-session -A -s main
initial-window = false
macos-hidden = always
confirm-close-surface = false
macos-option-as-alt = true
keybind = global:cmd+grave_accent=toggle_quick_terminal
keybind = cmd+f=toggle_fullscreen
quick-terminal-position = center
quick-terminal-size = 90%, 90%
quick-terminal-animation-duration = 0.08
quick-terminal-space-behavior = remain
window-padding-x = 10
window-padding-y = 10
window-padding-balance = true
```

</details>

## Test plan

- [ ] Open Ghostty with `initial-window=false` and trigger quick terminal — should respect `quick-terminal-size`
- [ ] Toggle quick terminal closed and open again — dimensions should persist
- [ ] Run `exit` in terminal, reopen quick terminal — should recreate surface with correct size
- [ ] Test with `initial-window=true` — should work as before (no regression)
- [ ] Test with different `quick-terminal-position` values (top, bottom, left, right, center)
- [ ] Manually resize quick terminal, close and reopen — should remember resized dimensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)