### PR TITLE
Spanish (Bolivia) translation for 1.3 (ES_BO)

### DIFF
--- a/po/es_BO.UTF-8.po
+++ b/po/es_BO.UTF-8.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
 "POT-Creation-Date: 2026-02-05 10:23+0800\n"
-"PO-Revision-Date: 2025-08-23 17:46+0200\n"
+"PO-Revision-Date: 2026-02-12 17:46+0200\n"
 "Last-Translator: Miguel Peredo <miguelp@quientienemail.com>\n"
 "Language-Team: Spanish <es@tp.org.es>\n"
 "Language: es_BO\n"
@@ -307,15 +307,15 @@ msgstr "El proceso actualmente en ejecución en esta división será terminado."
 
 #: src/apprt/gtk/class/surface.zig:1108
 msgid "Command Finished"
-msgstr ""
+msgstr "Comando finalizado"
 
 #: src/apprt/gtk/class/surface.zig:1109
 msgid "Command Succeeded"
-msgstr ""
+msgstr "Comando exitoso"
 
 #: src/apprt/gtk/class/surface.zig:1110
 msgid "Command Failed"
-msgstr ""
+msgstr "Comando fallido"
 
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command succeeded"

--- a/po/es_BO.UTF-8.po
+++ b/po/es_BO.UTF-8.po
@@ -112,9 +112,9 @@ msgid ""
 "through the content, but no input events will be sent to the running "
 "application."
 msgstr ""
-"La terminal está en modo de lectura. Puedes ver, seleccionar, y desplazar"
-"a travez del contenido, pero ninguna entrada (evento) va a ser enviado"
-"a la aplicación que se está ejecutando"
+"La terminal está en modo de lectura. Puedes ver, seleccionar, y desplazar "
+"a través del contenido, pero ninguna entrada (evento) va a ser enviada "
+"a la aplicación que se está ejecutando."
 
 #: src/apprt/gtk/ui/1.2/surface.blp:107
 msgid "Read-only"
@@ -130,7 +130,7 @@ msgstr "Pegar"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:270
 msgid "Notify on Next Command Finish"
-msgstr "Notifcar cuando el próximo comando finalice"
+msgstr "Notificar cuando el próximo comando finalice"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:266
 msgid "Clear"

--- a/po/es_BO.UTF-8.po
+++ b/po/es_BO.UTF-8.po
@@ -88,7 +88,7 @@ msgstr "Ghostty: Inspector de la terminal"
 
 #: src/apprt/gtk/ui/1.2/search-overlay.blp:29
 msgid "Find…"
-msgstr "Encontrar..."
+msgstr "Encontrar…"
 
 #: src/apprt/gtk/ui/1.2/search-overlay.blp:64
 msgid "Previous Match"
@@ -118,7 +118,7 @@ msgstr ""
 
 #: src/apprt/gtk/ui/1.2/surface.blp:107
 msgid "Read-only"
-msgstr "Solo-lectura"
+msgstr "Solo lectura"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:198
 msgid "Copy"
@@ -243,7 +243,7 @@ msgstr "Salir"
 
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
-msgstr "Ejecutar comando..."
+msgstr "Ejecutar comando…"
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""

--- a/po/es_BO.UTF-8.po
+++ b/po/es_BO.UTF-8.po
@@ -88,23 +88,23 @@ msgstr "Ghostty: Inspector de la terminal"
 
 #: src/apprt/gtk/ui/1.2/search-overlay.blp:29
 msgid "Find…"
-msgstr ""
+msgstr "Encontrar..."
 
 #: src/apprt/gtk/ui/1.2/search-overlay.blp:64
 msgid "Previous Match"
-msgstr ""
+msgstr "Resultado anterior"
 
 #: src/apprt/gtk/ui/1.2/search-overlay.blp:74
 msgid "Next Match"
-msgstr ""
+msgstr "Resultado siguiente"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:6
 msgid "Oh, no."
-msgstr ""
+msgstr "¡Epa!"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Unable to acquire an OpenGL context for rendering."
-msgstr ""
+msgstr "No se puede iniciar OpenGL para rendering."
 
 #: src/apprt/gtk/ui/1.2/surface.blp:97
 msgid ""
@@ -112,10 +112,13 @@ msgid ""
 "through the content, but no input events will be sent to the running "
 "application."
 msgstr ""
+"La terminal está en modo de lectura. Puedes ver, seleccionar, y desplazar"
+"a travez del contenido, pero ninguna entrada (evento) va a ser enviado"
+"a la aplicación que se está ejecutando"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:107
 msgid "Read-only"
-msgstr ""
+msgstr "Solo-lectura"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:198
 msgid "Copy"
@@ -127,7 +130,7 @@ msgstr "Pegar"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:270
 msgid "Notify on Next Command Finish"
-msgstr ""
+msgstr "Notifcar cuando el próximo comando finalice"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:266
 msgid "Clear"


### PR DESCRIPTION
This pull request improves the Spanish (Bolivia) translation file by adding translations for several user interface strings related to terminal search, navigation, and read-only mode messages.

**Translation updates:**

* Added Spanish translations for search overlay actions such as "Find…", "Previous Match", and "Next Match" (`src/apprt/gtk/ui/1.2/search-overlay.blp`).
* Added translations for terminal state messages, including "Oh, no.", "Unable to acquire an OpenGL context for rendering.", and the read-only mode notification and label (`src/apprt/gtk/ui/1.2/surface.blp`).
* Added translation for "Notify on Next Command Finish" (`src/apprt/gtk/ui/1.2/surface.blp`).