### PR TITLE
bash: preserve existing PS0 value

### DIFF
--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -278,7 +278,9 @@ if (( BASH_VERSINFO[0] > 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 4) )
   __ghostty_hook() {
     builtin local ret=$?
     __ghostty_precmd "$ret"
-    PS0=$__ghostty_ps0
+    if [[ "$PS0" != *"$__ghostty_ps0"* ]]; then
+      PS0=$PS0"${__ghostty_ps0}"
+    fi
   }
 
   # Append our hook to PROMPT_COMMAND, preserving its existing type.


### PR DESCRIPTION
We were previously overwriting PS0 on every PROMPT_COMMAND. We now append to PS0, but only if it doesn't already contain our hook.

This is also more consistent with the bash-preexec behavior we maintain for older bash versions.