### PR TITLE
i18n: update `de_DE` translations

### DIFF
--- a/po/de_DE.UTF-8.po
+++ b/po/de_DE.UTF-8.po
@@ -4,14 +4,15 @@
 # This file is distributed under the same license as the com.mitchellh.ghostty package.
 # Robin Pfäffle <r@rpfaeffle.com>, 2025.
 # Jan Klass <kissaki@posteo.de>, 2026.
+# Klaus Hipp <khipp@users.noreply.github.com>, 2026.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
 "POT-Creation-Date: 2026-02-05 10:23+0800\n"
-"PO-Revision-Date: 2026-01-06 10:25+0100\n"
-"Last-Translator: Jan Klass <kissaki@posteo.de>\n"
+"PO-Revision-Date: 2026-02-13 08:05+0100\n"
+"Last-Translator: Klaus Hipp <khipp@users.noreply.github.com>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
@@ -92,23 +93,23 @@ msgstr "Ghostty: Terminalinspektor"
 
 #: src/apprt/gtk/ui/1.2/search-overlay.blp:29
 msgid "Find…"
-msgstr ""
+msgstr "Suchen…"
 
 #: src/apprt/gtk/ui/1.2/search-overlay.blp:64
 msgid "Previous Match"
-msgstr ""
+msgstr "Vorherige Übereinstimmung"
 
 #: src/apprt/gtk/ui/1.2/search-overlay.blp:74
 msgid "Next Match"
-msgstr ""
+msgstr "Nächste Übereinstimmung"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:6
 msgid "Oh, no."
-msgstr ""
+msgstr "Oh nein."
 
 #: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Unable to acquire an OpenGL context for rendering."
-msgstr ""
+msgstr "Es kann kein OpenGL-Kontext für das Rendering abgerufen werden."
 
 #: src/apprt/gtk/ui/1.2/surface.blp:97
 msgid ""
@@ -116,10 +117,13 @@ msgid ""
 "through the content, but no input events will be sent to the running "
 "application."
 msgstr ""
+"Dieses Terminal befindet sich im schreibgeschützten Modus. Du kannst den "
+"Inhalt weiterhin anzeigen, auswählen und durchscrollen, es werden jedoch "
+"keine Eingabeereignisse an die laufende Anwendung gesendet."
 
 #: src/apprt/gtk/ui/1.2/surface.blp:107
 msgid "Read-only"
-msgstr ""
+msgstr "Schreibgeschützt"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:198
 msgid "Copy"
@@ -131,7 +135,7 @@ msgstr "Einfügen"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:270
 msgid "Notify on Next Command Finish"
-msgstr ""
+msgstr "Bei Abschluss des nächsten Befehls benachrichtigen"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:266
 msgid "Clear"
@@ -204,7 +208,7 @@ msgstr "Konfiguration öffnen"
 
 #: src/apprt/gtk/ui/1.5/surface-title-dialog.blp:5
 msgid "Change Terminal Title"
-msgstr "Terminal-Titel bearbeiten"
+msgstr "Terminaltitel bearbeiten"
 
 #: src/apprt/gtk/ui/1.5/surface-title-dialog.blp:6
 msgid "Leave blank to restore the default title."
@@ -308,15 +312,15 @@ msgstr "Der aktuell laufende Prozess in diesem geteilten Fenster wird beendet."
 
 #: src/apprt/gtk/class/surface.zig:1108
 msgid "Command Finished"
-msgstr ""
+msgstr "Befehl abgeschlossen"
 
 #: src/apprt/gtk/class/surface.zig:1109
 msgid "Command Succeeded"
-msgstr ""
+msgstr "Befehl erfolgreich"
 
 #: src/apprt/gtk/class/surface.zig:1110
 msgid "Command Failed"
-msgstr ""
+msgstr "Befehl fehlgeschlagen"
 
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command succeeded"


### PR DESCRIPTION
This PR adds the missing translations for Ghostty 1.3 and aligns the existing translation of "Terminal Title" with similar instances, such as "Terminalinspektor" and "Terminalsitzungen".

Related to: #10632