### PR TITLE
fix(zsh): extend ZDOTDIR through startup to survive .zprofile exec (unblocks AWS Kiro)

### DIFF
--- a/src/shell-integration/zsh/.zprofile
+++ b/src/shell-integration/zsh/.zprofile
@@ -1,0 +1,33 @@
+# Based on (started as) a copy of Kitty's zsh integration. Kitty is
+# distributed under GPLv3, so this file is also distributed under GPLv3.
+# The license header is reproduced below:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# This wrapper is sourced because Ghostty extends ZDOTDIR control through
+# the zsh startup sequence (.zshenv -> .zprofile -> .zshrc). It sources
+# the user's .zprofile while keeping ZDOTDIR pointing to Ghostty's dir.
+#
+# We intentionally do NOT restore ZDOTDIR before sourcing so that if the
+# user's .zprofile replaces the shell process (e.g. Kiro/Fig's PTY wrapper
+# exec), the new shell inherits Ghostty's ZDOTDIR and integration loads.
+#
+# This file can get sourced with aliases enabled. To avoid alias expansion
+# we quote everything that can be quoted. Some aliases will still break us
+# though.
+
+# Source the user's .zprofile from their original ZDOTDIR.
+'builtin' 'typeset' _ghostty_file=${GHOSTTY_ZSH_ZDOTDIR-$HOME}"/.zprofile"
+[[ ! -r "$_ghostty_file" ]] || 'builtin' 'source' '--' "$_ghostty_file"
+'builtin' 'unset' '_ghostty_file'

--- a/src/shell-integration/zsh/.zprofile
+++ b/src/shell-integration/zsh/.zprofile
@@ -1,20 +1,3 @@
-# Based on (started as) a copy of Kitty's zsh integration. Kitty is
-# distributed under GPLv3, so this file is also distributed under GPLv3.
-# The license header is reproduced below:
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 # This wrapper is sourced because Ghostty extends ZDOTDIR control through
 # the zsh startup sequence (.zshenv -> .zprofile -> .zshrc). It sources
 # the user's .zprofile while keeping ZDOTDIR pointing to Ghostty's dir.
@@ -28,6 +11,9 @@
 # though.
 
 # Source the user's .zprofile from their original ZDOTDIR.
-'builtin' 'typeset' _ghostty_file=${GHOSTTY_ZSH_ZDOTDIR-$HOME}"/.zprofile"
-[[ ! -r "$_ghostty_file" ]] || 'builtin' 'source' '--' "$_ghostty_file"
-'builtin' 'unset' '_ghostty_file'
+{
+    'builtin' 'typeset' _ghostty_user_zprofile=${GHOSTTY_ZSH_ZDOTDIR-$HOME}"/.zprofile"
+    [[ ! -r "$_ghostty_user_zprofile" ]] || 'builtin' 'source' '--' "$_ghostty_user_zprofile"
+} always {
+    'builtin' 'unset' '_ghostty_user_zprofile'
+}

--- a/src/shell-integration/zsh/.zshenv
+++ b/src/shell-integration/zsh/.zshenv
@@ -23,11 +23,20 @@
 # we quote everything that can be quoted. Some aliases will still break us
 # though.
 
+# Save Ghostty's integration directory. We need this to set ZDOTDIR back
+# after sourcing the user's .zshenv so that our .zprofile and .zshrc
+# wrappers are loaded.
+'builtin' 'typeset' _ghostty_integ_dir="${${(%):-%x}:A:h}"
+
 # Restore the original ZDOTDIR value if GHOSTTY_ZSH_ZDOTDIR is set.
 # Otherwise, unset the ZDOTDIR that was set during shell injection.
+# For interactive shells, keep GHOSTTY_ZSH_ZDOTDIR set so that our
+# .zprofile and .zshrc wrappers can find the user's dot files.
 if [[ -n "${GHOSTTY_ZSH_ZDOTDIR+X}" ]]; then
     'builtin' 'export' ZDOTDIR="$GHOSTTY_ZSH_ZDOTDIR"
-    'builtin' 'unset' 'GHOSTTY_ZSH_ZDOTDIR'
+    if ! [[ -o 'interactive' ]]; then
+        'builtin' 'unset' 'GHOSTTY_ZSH_ZDOTDIR'
+    fi
 else
     'builtin' 'unset' 'ZDOTDIR'
 fi
@@ -48,14 +57,25 @@ fi
     [[ ! -r "$_ghostty_file" ]] || 'builtin' 'source' '--' "$_ghostty_file"
 } always {
     if [[ -o 'interactive' ]]; then
-        # ${(%):-%x} is the path to the current file.
-        # On top of it we add :A:h to get the directory.
-        'builtin' 'typeset' _ghostty_file="${${(%):-%x}:A:h}"/ghostty-integration
+        # Update GHOSTTY_ZSH_ZDOTDIR to reflect any ZDOTDIR changes the
+        # user's .zshenv may have made (e.g. setting ZDOTDIR for XDG layout).
+        # Our .zprofile and .zshrc wrappers use this to find user files.
+        if [[ -n "${ZDOTDIR+X}" ]]; then
+            'builtin' 'export' GHOSTTY_ZSH_ZDOTDIR="$ZDOTDIR"
+        else
+            'builtin' 'unset' 'GHOSTTY_ZSH_ZDOTDIR'
+        fi
+
+        # Set ZDOTDIR back to Ghostty's dir so our .zprofile and .zshrc
+        # wrappers are sourced instead of the user's files directly.
+        'builtin' 'export' ZDOTDIR="$_ghostty_integ_dir"
+
+        'builtin' 'typeset' _ghostty_file="${_ghostty_integ_dir}"/ghostty-integration
         if [[ -r "$_ghostty_file" ]]; then
             'builtin' 'autoload' '-Uz' '--' "$_ghostty_file"
             "${_ghostty_file:t}"
             'builtin' 'unfunction' '--' "${_ghostty_file:t}"
         fi
     fi
-    'builtin' 'unset' '_ghostty_file'
+    'builtin' 'unset' '_ghostty_file' '_ghostty_integ_dir'
 }

--- a/src/shell-integration/zsh/.zshenv
+++ b/src/shell-integration/zsh/.zshenv
@@ -26,7 +26,7 @@
 # Save Ghostty's integration directory. We need this to set ZDOTDIR back
 # after sourcing the user's .zshenv so that our .zprofile and .zshrc
 # wrappers are loaded.
-'builtin' 'typeset' _ghostty_integ_dir="${${(%):-%x}:A:h}"
+'builtin' 'typeset' _ghostty_integration_dir="${${(%):-%x}:A:h}"
 
 # Restore the original ZDOTDIR value if GHOSTTY_ZSH_ZDOTDIR is set.
 # Otherwise, unset the ZDOTDIR that was set during shell injection.
@@ -51,10 +51,10 @@ fi
     #
     # Use typeset in case we are in a function with warn_create_global in
     # effect. Unlikely but better safe than sorry.
-    'builtin' 'typeset' _ghostty_file=${ZDOTDIR-$HOME}"/.zshenv"
+    'builtin' 'typeset' _ghostty_user_zshenv=${ZDOTDIR-$HOME}"/.zshenv"
     # Zsh ignores unreadable rc files. We do the same.
     # Zsh ignores rc files that are directories, and so does source.
-    [[ ! -r "$_ghostty_file" ]] || 'builtin' 'source' '--' "$_ghostty_file"
+    [[ ! -r "$_ghostty_user_zshenv" ]] || 'builtin' 'source' '--' "$_ghostty_user_zshenv"
 } always {
     if [[ -o 'interactive' ]]; then
         # Update GHOSTTY_ZSH_ZDOTDIR to reflect any ZDOTDIR changes the
@@ -68,14 +68,14 @@ fi
 
         # Set ZDOTDIR back to Ghostty's dir so our .zprofile and .zshrc
         # wrappers are sourced instead of the user's files directly.
-        'builtin' 'export' ZDOTDIR="$_ghostty_integ_dir"
+        'builtin' 'export' ZDOTDIR="$_ghostty_integration_dir"
 
-        'builtin' 'typeset' _ghostty_file="${_ghostty_integ_dir}"/ghostty-integration
-        if [[ -r "$_ghostty_file" ]]; then
-            'builtin' 'autoload' '-Uz' '--' "$_ghostty_file"
-            "${_ghostty_file:t}"
-            'builtin' 'unfunction' '--' "${_ghostty_file:t}"
+        'builtin' 'typeset' _ghostty_integration="${_ghostty_integration_dir}"/ghostty-integration
+        if [[ -r "$_ghostty_integration" ]]; then
+            'builtin' 'autoload' '-Uz' '--' "$_ghostty_integration"
+            "${_ghostty_integration:t}"
+            'builtin' 'unfunction' '--' "${_ghostty_integration:t}"
         fi
     fi
-    'builtin' 'unset' '_ghostty_file' '_ghostty_integ_dir'
+    'builtin' 'unset' '_ghostty_user_zshenv' '_ghostty_integration' '_ghostty_integration_dir'
 }

--- a/src/shell-integration/zsh/.zshrc
+++ b/src/shell-integration/zsh/.zshrc
@@ -1,20 +1,3 @@
-# Based on (started as) a copy of Kitty's zsh integration. Kitty is
-# distributed under GPLv3, so this file is also distributed under GPLv3.
-# The license header is reproduced below:
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 # This wrapper is sourced because Ghostty extends ZDOTDIR control through
 # the zsh startup sequence (.zshenv -> .zprofile -> .zshrc). It permanently
 # restores the user's ZDOTDIR, sources their .zshrc, and re-verifies that
@@ -32,8 +15,8 @@ else
 fi
 
 {
-    'builtin' 'typeset' _ghostty_file=${ZDOTDIR-$HOME}"/.zshrc"
-    [[ ! -r "$_ghostty_file" ]] || 'builtin' 'source' '--' "$_ghostty_file"
+    'builtin' 'typeset' _ghostty_user_zshrc=${ZDOTDIR-$HOME}"/.zshrc"
+    [[ ! -r "$_ghostty_user_zshrc" ]] || 'builtin' 'source' '--' "$_ghostty_user_zshrc"
 } always {
     # Re-add _ghostty_deferred_init to precmd_functions if it was removed
     # during startup. Tools like Kiro/Fig may replace precmd_functions in
@@ -44,5 +27,5 @@ fi
         precmd_functions+=(_ghostty_deferred_init)
     fi
     'builtin' 'unset' 'GHOSTTY_ZSH_ZDOTDIR'
-    'builtin' 'unset' '_ghostty_file'
+    'builtin' 'unset' '_ghostty_user_zshrc'
 }

--- a/src/shell-integration/zsh/.zshrc
+++ b/src/shell-integration/zsh/.zshrc
@@ -7,6 +7,11 @@
 # we quote everything that can be quoted. Some aliases will still break us
 # though.
 
+# Fix HISTFILE if /etc/zshrc misdirected it to Ghostty's dir.
+# On macOS, /etc/zshrc sets HISTFILE=${ZDOTDIR:-$HOME}/.zsh_history but
+# ZDOTDIR was still Ghostty's integration dir when that ran.
+[[ "${HISTFILE:-}" == "${ZDOTDIR}"/* ]] && HISTFILE="${GHOSTTY_ZSH_ZDOTDIR:-$HOME}/.zsh_history"
+
 # Permanently restore the user's ZDOTDIR.
 if [[ -n "${GHOSTTY_ZSH_ZDOTDIR+X}" ]]; then
     'builtin' 'export' ZDOTDIR="$GHOSTTY_ZSH_ZDOTDIR"

--- a/src/shell-integration/zsh/.zshrc
+++ b/src/shell-integration/zsh/.zshrc
@@ -1,0 +1,48 @@
+# Based on (started as) a copy of Kitty's zsh integration. Kitty is
+# distributed under GPLv3, so this file is also distributed under GPLv3.
+# The license header is reproduced below:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# This wrapper is sourced because Ghostty extends ZDOTDIR control through
+# the zsh startup sequence (.zshenv -> .zprofile -> .zshrc). It permanently
+# restores the user's ZDOTDIR, sources their .zshrc, and re-verifies that
+# shell integration hooks are still in place.
+#
+# This file can get sourced with aliases enabled. To avoid alias expansion
+# we quote everything that can be quoted. Some aliases will still break us
+# though.
+
+# Permanently restore the user's ZDOTDIR.
+if [[ -n "${GHOSTTY_ZSH_ZDOTDIR+X}" ]]; then
+    'builtin' 'export' ZDOTDIR="$GHOSTTY_ZSH_ZDOTDIR"
+else
+    'builtin' 'unset' 'ZDOTDIR'
+fi
+
+{
+    'builtin' 'typeset' _ghostty_file=${ZDOTDIR-$HOME}"/.zshrc"
+    [[ ! -r "$_ghostty_file" ]] || 'builtin' 'source' '--' "$_ghostty_file"
+} always {
+    # Re-add _ghostty_deferred_init to precmd_functions if it was removed
+    # during startup. Tools like Kiro/Fig may replace precmd_functions in
+    # .zprofile or .zshrc, silently removing our deferred init hook.
+    if (( $+functions[_ghostty_deferred_init] )) &&
+       [[ ${precmd_functions[(I)_ghostty_deferred_init]} -eq 0 ]]; then
+        'builtin' 'typeset' -ag precmd_functions
+        precmd_functions+=(_ghostty_deferred_init)
+    fi
+    'builtin' 'unset' 'GHOSTTY_ZSH_ZDOTDIR'
+    'builtin' 'unset' '_ghostty_file'
+}


### PR DESCRIPTION
Demo of `inherit-working-directory` working with AWS Kiro





https://github.com/user-attachments/assets/99526b43-2d40-4fc3-b7b5-9e076bc486c3




Tools like AWS Kiro (formerly Fig/CodeWhisperer) exec their PTY wrapper from .zprofile, replacing the shell process entirely. Since Ghostty previously restored ZDOTDIR in .zshenv and never controlled .zprofile or .zshrc, the new shell spawned by the PTY wrapper had no Ghostty ZDOTDIR and all shell integration (OSC 7, OSC 133, cursor shape, etc.) was silently lost.

Fix by extending Ghostty's ZDOTDIR control through .zprofile and .zshrc:

- .zshenv: keep ZDOTDIR pointing to Ghostty's dir for interactive shells after sourcing user's .zshenv and loading integration
- .zprofile (new): source user's .zprofile WITHOUT restoring ZDOTDIR, so exec'd processes inherit Ghostty's ZDOTDIR and integration loads in the new shell
- .zshrc (new): permanently restore ZDOTDIR, source user's .zshrc, then re-verify _ghostty_deferred_init is still in precmd_functions


LLM Disclosure, Code and Diagnostic was done by Opus 4.6 with me the human in the full loop and real testing
