### PR TITLE
macOS: show keyboard shortcuts in command palette

### DIFF
--- a/macos/Sources/Features/Command Palette/TerminalCommandPalette.swift
+++ b/macos/Sources/Features/Command Palette/TerminalCommandPalette.swift
@@ -123,9 +123,11 @@ struct TerminalCommandPaletteView: View {
         return appDelegate.ghostty.config.commandPaletteEntries
             .filter(\.isSupported)
             .map { c in
-                CommandOption(
+                let symbols = appDelegate.ghostty.config.keyboardShortcut(for: c.action)?.keyList
+                return CommandOption(
                     title: c.title,
-                    description: c.description
+                    description: c.description,
+                    symbols: symbols
                 ) {
                     onAction(c.action)
                 }


### PR DESCRIPTION
Closes #10718

## Summary
- Populates the `symbols` field on `CommandOption` by looking up keybindings via the existing `keyboardShortcut(for:)` API
- All the UI rendering (`ShortcutSymbolsView`) and the keybinding lookup were already in place, this just wires them together

## AI Disclosure
Claude Code was used to assist with codebase exploration and drafting the change. The implementation was manually verified by building and testing locally on macOS with Xcode 26.2.

## Test plan
- [x] Built with `xcodebuild` on Xcode 26.1 and 26.2
- [x] Launched app, opened command palette, confirmed shortcuts appear next to commands that have keybindings
- [x] Confirmed commands without keybindings show no shortcuts
<img width="912" height="744" alt="Screenshot 2026-02-14 at 12 55 42 PM" src="https://github.com/user-attachments/assets/b988015c-21b6-4a17-9883-e23c87c6934b" />


