### PR TITLE
ci: update vouch to 1.3, create PRs instead of pushing to main

### DIFF
--- a/.github/workflows/vouch-check-issue.yml
+++ b/.github/workflows/vouch-check-issue.yml
@@ -12,7 +12,7 @@ jobs:
   check:
     runs-on: namespace-profile-ghostty-xsm
     steps:
-      - uses: mitchellh/vouch/action/check-issue@8c4f29bb7f2ddfa0b8dbc1bb6575e3f27c95d10a # v1.2.0
+      - uses: mitchellh/vouch/action/check-issue@0e11a71bba23218a284d3ecca162e75a110fd7e3 # v1.3.0
         with:
           issue-number: ${{ github.event.issue.number }}
           auto-close: true

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -12,7 +12,7 @@ jobs:
   check:
     runs-on: namespace-profile-ghostty-xsm
     steps:
-      - uses: mitchellh/vouch/action/check-pr@8c4f29bb7f2ddfa0b8dbc1bb6575e3f27c95d10a # v1.2.0
+      - uses: mitchellh/vouch/action/check-pr@0e11a71bba23218a284d3ecca162e75a110fd7e3 # v1.3.0
         with:
           pr-number: ${{ github.event.pull_request.number }}
           auto-close: true

--- a/.github/workflows/vouch-manage-by-discussion.yml
+++ b/.github/workflows/vouch-manage-by-discussion.yml
@@ -11,6 +11,7 @@ concurrency:
 permissions:
   contents: write
   discussions: write
+  pull-requests: write
 
 jobs:
   manage:
@@ -18,12 +19,14 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: mitchellh/vouch/action/manage-by-discussion@8c4f29bb7f2ddfa0b8dbc1bb6575e3f27c95d10a # v1.2.0
+      - uses: mitchellh/vouch/action/manage-by-discussion@0e11a71bba23218a284d3ecca162e75a110fd7e3 # v1.3.0
         with:
           discussion-number: ${{ github.event.discussion.number }}
           comment-node-id: ${{ github.event.comment.node_id }}
           vouch-keyword: "!vouch"
           denounce-keyword: "!denounce"
           unvouch-keyword: "!unvouch"
+          pull-request: "true"
+          merge-immediately: "true"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vouch-manage-by-issue.yml
+++ b/.github/workflows/vouch-manage-by-issue.yml
@@ -11,7 +11,7 @@ concurrency:
 permissions:
   contents: write
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   manage:
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: mitchellh/vouch/action/manage-by-issue@8c4f29bb7f2ddfa0b8dbc1bb6575e3f27c95d10a # v1.2.0
+      - uses: mitchellh/vouch/action/manage-by-issue@0e11a71bba23218a284d3ecca162e75a110fd7e3 # v1.3.0
         with:
           repo: ${{ github.repository }}
           issue-id: ${{ github.event.issue.number }}
@@ -27,5 +27,7 @@ jobs:
           vouch-keyword: "!vouch"
           denounce-keyword: "!denounce"
           unvouch-keyword: "!unvouch"
+          pull-request: "true"
+          merge-immediately: "true"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This will let us re-enable our main branch protection rules. :)