### PR TITLE
input: paste encoding replaces unsafe control characters with spaces

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -40,6 +40,8 @@ extend-ignore-re = [
   "kHOM\\d*",
   # Ignore "typos" in sprite font draw fn names
   "draw[0-9A-F]+(_[0-9A-F]+)?\\(",
+  # Ignore test data in src/input/paste.zig
+  "\"hel\\\\x",
 ]
 
 [default.extend-words]


### PR DESCRIPTION
For a hardcoded set of control characters, replace them with spaces when encoding pasted text. This is to prevent unsafe control characters from being pasted which could trick a user into executing commands unexpectedly.

This happens regardless of bracketed paste mode, because certain characters processed by the kernel pty line discipline can break bracketed paste (source from zsh: 
https://zsh-workers.zsh.narkive.com/Kd3evJ7t/bracketed-paste-mode-in-xterm-and-urxvt).

This behavior is based on xterm's behavior (https://github.com/ThomasDickey/xterm-snapshots/blob/caac5c35a22d116ed09a54c962fce3ee7a7f99d2/button.c#L2578-L2595), including the list of characters. Note that as a comment in the code says, we should be sourcing some of these from a tcgetattr call instead of hardcoding them, but this is a good start.