### PR TITLE
bash: remove redundant out-of-band OSC 133;A

### DIFF
--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -198,7 +198,7 @@ function __ghostty_precmd() {
     # Marks. We need to do fresh line (A) at the beginning of the prompt
     # since if the cursor is not at the beginning of a line, the terminal
     # will emit a newline.
-    PS1='\[\e]133;A;redraw=last;cl=line\a\]'$PS1'\[\e]133;B\a\]'
+    PS1='\[\e]133;A;redraw=last;cl=line;aid='"$BASHPID"'\a\]'$PS1'\[\e]133;B\a\]'
     PS2='\[\e]133;A;k=s\a\]'$PS2'\[\e]133;B\a\]'
 
     # Bash doesn't redraw the leading lines in a multiline prompt so
@@ -236,8 +236,6 @@ function __ghostty_precmd() {
     builtin printf "\e]7;kitty-shell-cwd://%s%s\a" "$HOSTNAME" "$PWD"
   fi
 
-  # Fresh line and start of prompt.
-  builtin printf "\e]133;A;redraw=last;cl=line;aid=%s\a" "$BASHPID"
   _ghostty_executing=0
 }
 


### PR DESCRIPTION
The printf was part of the original script (9d6121245), and at the time, this was the only place we'd emit the 133;A mark.

A PS1-based 133;P;k=i mark was introduced in 2bf1f80f7, and then it become a full 133;A mark in aa47047a6, making the original printf line redundant (because bash will also redraw PS1 on SIGWINCH).

The PS1-based 133;A was only missing the aid= option, and with that added, it handles all of our cases (prompts, initial draw, and resizes).