### PR TITLE
fix(build): add support for apple SDK paths to load system libraries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -252,6 +252,34 @@ jobs:
             -Dtarget=${{ matrix.target }} \
             -Dsimd=false
 
+  # lib-vt requires macOS runner for macOS/iOS builds becauase it requires the `apple_sdk` path
+  build-libghostty-vt-macos:
+    strategy:
+      matrix:
+        target: [aarch64-macos, x86_64-macos, aarch64-ios]
+    runs-on: namespace-profile-ghostty-macos-tahoe
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # TODO(tahoe): https://github.com/NixOS/nix/issues/13342
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          determinate: true
+      - uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # v16
+        with:
+          name: ghostty
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: Xcode Select
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app
+
+      - name: Build
+        run: |
+          nix develop -c zig build lib-vt \
+            -Dtarget=${{ matrix.target }}
+
   build-linux:
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
       - build-examples
       - build-flatpak
       - build-libghostty-vt
+      - build-libghostty-vt-macos
       - build-linux
       - build-linux-libghostty
       - build-nix

--- a/src/build/GhosttyLibVt.zig
+++ b/src/build/GhosttyLibVt.zig
@@ -1,6 +1,7 @@
 const GhosttyLibVt = @This();
 
 const std = @import("std");
+const builtin = @import("builtin");
 const assert = std.debug.assert;
 const RunStep = std.Build.Step.Run;
 const GhosttyZig = @import("GhosttyZig.zig");
@@ -61,9 +62,14 @@ pub fn initShared(
         .{ .include_extensions = &.{".h"} },
     );
 
+    if (lib.rootModuleTarget().os.tag.isDarwin()) {
+        lib.use_llvm = true;
+        lib.headerpad_max_install_names = true;
+    }
+
     // We always require the system SDK so that our system headers are available.
     // This makes things like `os/log.h` and iOS SDK available for cross-compiling.
-    if (lib.rootModuleTarget().os.tag.isDarwin()) {
+    if (builtin.os.tag.isDarwin() and lib.rootModuleTarget().os.tag.isDarwin()) {
         try @import("apple_sdk").addPaths(b, lib);
     }
 

--- a/src/build/GhosttyLibVt.zig
+++ b/src/build/GhosttyLibVt.zig
@@ -63,14 +63,16 @@ pub fn initShared(
     );
 
     if (lib.rootModuleTarget().os.tag.isDarwin()) {
+        // Self-hosted x86_64 doesn't work for darwin. It may not work
+        // for other platforms too but definitely darwin.
         lib.use_llvm = true;
-        lib.headerpad_max_install_names = true;
-    }
 
-    // We always require the system SDK so that our system headers are available.
-    // This makes things like `os/log.h` and iOS SDK available for cross-compiling.
-    if (builtin.os.tag.isDarwin() and lib.rootModuleTarget().os.tag.isDarwin()) {
-        try @import("apple_sdk").addPaths(b, lib);
+        // This is required for codesign and dynamic linking to work.
+        lib.headerpad_max_install_names = true;
+
+        // If we're not cross compiling then we try to find the Apple
+        // SDK using standard Apple tooling.
+        if (builtin.os.tag.isDarwin()) try @import("apple_sdk").addPaths(b, lib);
     }
 
     // Get our debug symbols

--- a/src/build/GhosttyLibVt.zig
+++ b/src/build/GhosttyLibVt.zig
@@ -61,6 +61,12 @@ pub fn initShared(
         .{ .include_extensions = &.{".h"} },
     );
 
+    // We always require the system SDK so that our system headers are available.
+    // This makes things like `os/log.h` and iOS SDK available for cross-compiling.
+    if (lib.rootModuleTarget().os.tag.isDarwin()) {
+        try @import("apple_sdk").addPaths(b, lib);
+    }
+
     // Get our debug symbols
     const dsymutil: ?std.Build.LazyPath = dsymutil: {
         if (!target.result.os.tag.isDarwin()) {


### PR DESCRIPTION
The PR addresses `lib-vt` iOS build issue caused by missing `apple_sdk` path. See #10663 for more details.