### PR TITLE
input: add prompt_window_title action

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -630,6 +630,7 @@ typedef struct {
 typedef enum {
   GHOSTTY_PROMPT_TITLE_SURFACE,
   GHOSTTY_PROMPT_TITLE_TAB,
+  GHOSTTY_PROMPT_TITLE_WINDOW,
 } ghostty_action_prompt_title_e;
 
 // apprt.action.Pwd.C

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -378,6 +378,37 @@ class BaseTerminalController: NSWindowController,
         }
     }
 
+    /// Prompt the user to change the window title.
+    func promptWindowTitle() {
+        guard let window else { return }
+
+        let alert = NSAlert()
+        alert.messageText = "Change Window Title"
+        alert.informativeText = "Leave blank to restore the default."
+        alert.alertStyle = .informational
+
+        let textField = NSTextField(frame: NSRect(x: 0, y: 0, width: 250, height: 24))
+        textField.stringValue = titleOverride ?? window.title
+        alert.accessoryView = textField
+
+        alert.addButton(withTitle: "OK")
+        alert.addButton(withTitle: "Cancel")
+
+        alert.window.initialFirstResponder = textField
+
+        alert.beginSheetModal(for: window) { [weak self] response in
+            guard let self else { return }
+            guard response == .alertFirstButtonReturn else { return }
+
+            let newTitle = textField.stringValue
+            if newTitle.isEmpty {
+                self.titleOverride = nil
+            } else {
+                self.titleOverride = newTitle
+            }
+        }
+    }
+
     /// Close a surface from a view.
     func closeSurface(
         _ view: Ghostty.SurfaceView,

--- a/macos/Sources/Ghostty/Ghostty.Action.swift
+++ b/macos/Sources/Ghostty/Ghostty.Action.swift
@@ -131,11 +131,14 @@ extension Ghostty.Action {
     enum PromptTitle {
         case surface
         case tab
+        case window
 
         init(_ c: ghostty_action_prompt_title_e) {
             switch c {
             case GHOSTTY_PROMPT_TITLE_TAB:
                 self = .tab
+            case GHOSTTY_PROMPT_TITLE_WINDOW:
+                self = .window
             default:
                 self = .surface
             }

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -1572,6 +1572,29 @@ extension Ghostty {
                     assertionFailure()
                     return false
                 }
+
+            case .window:
+                switch (target.tag) {
+                case GHOSTTY_TARGET_APP:
+                    guard let window = NSApp.mainWindow ?? NSApp.keyWindow,
+                          let controller = window.windowController as? BaseTerminalController
+                    else { return false }
+                    controller.promptWindowTitle()
+                    return true
+
+                case GHOSTTY_TARGET_SURFACE:
+                    guard let surface = target.target.surface else { return false }
+                    guard let surfaceView = self.surfaceView(from: surface) else { return false }
+                    guard let window = surfaceView.window,
+                          let controller = window.windowController as? BaseTerminalController
+                    else { return false }
+                    controller.promptWindowTitle()
+                    return true
+
+                default:
+                    assertionFailure()
+                    return false
+                }
             }
         }
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -5478,6 +5478,12 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             .tab,
         ),
 
+        .prompt_window_title => return try self.rt_app.performAction(
+            .{ .surface = self },
+            .prompt_title,
+            .window,
+        ),
+
         .clear_screen => {
             // This is a duplicate of some of the logic in termio.clearScreen
             // but we need to do this here so we can know the answer before

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -575,10 +575,11 @@ pub const MouseVisibility = enum(c_int) {
     hidden,
 };
 
-/// Whether to prompt for the surface title or tab title.
+/// Whether to prompt for the surface title, tab title, or window title.
 pub const PromptTitle = enum(c_int) {
     surface,
     tab,
+    window,
 };
 
 pub const MouseOverLink = struct {

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -2382,6 +2382,10 @@ const Action = struct {
                     },
                 }
             },
+            .window => {
+                // GTK does not yet support window title prompting
+                return false;
+            },
         }
     }
 

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -580,6 +580,11 @@ pub const Action = union(enum) {
     /// and persists across focus changes within the tab.
     prompt_tab_title,
 
+    /// Change the title of the current window via a pop-up prompt. The
+    /// title set via this prompt overrides any title set by the terminal
+    /// and persists across tab changes within the window.
+    prompt_window_title,
+
     /// Create a new split in the specified direction.
     ///
     /// Valid arguments:
@@ -1327,6 +1332,7 @@ pub const Action = union(enum) {
             .set_font_size,
             .prompt_surface_title,
             .prompt_tab_title,
+            .prompt_window_title,
             .clear_screen,
             .select_all,
             .scroll_to_top,

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -450,6 +450,12 @@ fn actionCommands(action: Action.Key) []const Command {
             .description = "Prompt for a new title for the current tab.",
         }},
 
+        .prompt_window_title => comptime &.{.{
+            .action = .prompt_window_title,
+            .title = "Change Window Title...",
+            .description = "Prompt for a new title for the current window.",
+        }},
+
         .new_split => comptime &.{
             .{
                 .action = .{ .new_split = .left },

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -440,19 +440,19 @@ fn actionCommands(action: Action.Key) []const Command {
 
         .prompt_surface_title => comptime &.{.{
             .action = .prompt_surface_title,
-            .title = "Change Terminal Title...",
+            .title = "Change Terminal Title\u{2026}",
             .description = "Prompt for a new title for the current terminal.",
         }},
 
         .prompt_tab_title => comptime &.{.{
             .action = .prompt_tab_title,
-            .title = "Change Tab Title...",
+            .title = "Change Tab Title\u{2026}",
             .description = "Prompt for a new title for the current tab.",
         }},
 
         .prompt_window_title => comptime &.{.{
             .action = .prompt_window_title,
-            .title = "Change Window Title...",
+            .title = "Change Window Title\u{2026}",
             .description = "Prompt for a new title for the current window.",
         }},
 

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -440,19 +440,19 @@ fn actionCommands(action: Action.Key) []const Command {
 
         .prompt_surface_title => comptime &.{.{
             .action = .prompt_surface_title,
-            .title = "Change Terminal Title\u{2026}",
+            .title = "Change Terminal Title…",
             .description = "Prompt for a new title for the current terminal.",
         }},
 
         .prompt_tab_title => comptime &.{.{
             .action = .prompt_tab_title,
-            .title = "Change Tab Title\u{2026}",
+            .title = "Change Tab Title…",
             .description = "Prompt for a new title for the current tab.",
         }},
 
         .prompt_window_title => comptime &.{.{
             .action = .prompt_window_title,
-            .title = "Change Window Title\u{2026}",
+            .title = "Change Window Title…",
             .description = "Prompt for a new title for the current window.",
         }},
 


### PR DESCRIPTION
## Summary

Adds a new `prompt_window_title` keybinding action that allows users to rename the current window via a pop-up prompt, similar to the existing `prompt_tab_title` and `prompt_surface_title` actions.

Closes #10469

## Changes

### Core (Zig)
- **[src/apprt/action.zig](cci:7://file:///Users/hello/Desktop/PCode/ghostty/src/apprt/action.zig:0:0-0:0)** — Added `window` variant to `PromptTitle` enum
- **[src/input/Binding.zig](cci:7://file:///Users/hello/Desktop/PCode/ghostty/src/input/Binding.zig:0:0-0:0)** — Added `prompt_window_title` action and its scope
- **[src/Surface.zig](cci:7://file:///Users/hello/Desktop/PCode/ghostty/src/Surface.zig:0:0-0:0)** — Added action dispatch (`.prompt_title`, `.window`)
- **[src/input/command.zig](cci:7://file:///Users/hello/Desktop/PCode/ghostty/src/input/command.zig:0:0-0:0)** — Added command palette entry: "Change Window Title..."
- **[include/ghostty.h](cci:7://file:///Users/hello/Desktop/PCode/ghostty/include/ghostty.h:0:0-0:0)** — Added `GHOSTTY_PROMPT_TITLE_WINDOW` to C API enum

### macOS (Swift)
- **[Ghostty.Action.swift](cci:7://file:///Users/hello/Desktop/PCode/ghostty/macos/Sources/Ghostty/Ghostty.Action.swift:0:0-0:0)** — Added `.window` case to `PromptTitle` Swift enum
- **[Ghostty.App.swift](cci:7://file:///Users/hello/Desktop/PCode/ghostty/macos/Sources/Ghostty/Ghostty.App.swift:0:0-0:0)** — Added `.window` dispatch in `promptTitle()`
- **[BaseTerminalController.swift](cci:7://file:///Users/hello/Desktop/PCode/ghostty/macos/Sources/Features/Terminal/BaseTerminalController.swift:0:0-0:0)** — Added `promptWindowTitle()` method

### GTK (Zig)
- **[application.zig](cci:7://file:///Users/hello/Desktop/PCode/ghostty/src/apprt/gtk/class/application.zig:0:0-0:0)** — Added `.window` case (returns false, not yet implemented — same as `.tab`)

## Testing

- `zig build` compiles with no errors
- `zig build test` passes all tests
- Tested on macOS via `zig build run`:
  - Command palette shows "Change Window Title..." entry
  - Dialog appears with "Change Window Title" header
  - Setting a title updates the window title
  - Clearing the title restores the default

## AI Assistance Notice

AI assistance was used in the development of this PR. I have reviewed all changes and understand the code.