### PR TITLE
zsh: update PS1 substitution to include 'cl=line'

### DIFF
--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -188,7 +188,7 @@ _ghostty_deferred_init() {
         # our own prompt, user prompt, and our own prompt with user additions on
         # top. We cannot force prompt_subst on the user though, so we would
         # still need this code for the no_prompt_subst case.
-        PS1=${PS1//$'%{\e]133;A\a%}'}
+        PS1=${PS1//$'%{\e]133;A;cl=line\a%}'}
         PS1=${PS1//$'%{\e]133;A;k=s\a%}'}
         PS1=${PS1//$'%{\e]133;B\a%}'}
         PS2=${PS2//$'%{\e]133;A;k=s\a%}'}


### PR DESCRIPTION
Our PS1 cleanup code (where we remove any markers we added) was still looking for the previous 133;A form. Update it to include 'cl=line', which was added in 8595558.