### PR TITLE
renderer: drop opaque background for preedit cells

### DIFF
--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -2534,7 +2534,6 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     self.addPreeditCell(
                         cp,
                         .{ .x = x, .y = range.y },
-                        state.colors.background,
                         state.colors.foreground,
                     ) catch |err| {
                         log.warn("error building preedit cell, will be invalid x={} y={}, err={}", .{
@@ -3264,7 +3263,6 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             self: *Self,
             cp: renderer.State.Preedit.Codepoint,
             coord: terminal.Coordinate,
-            screen_bg: terminal.color.RGB,
             screen_fg: terminal.color.RGB,
         ) !void {
             // Render the glyph for our preedit text
@@ -3282,16 +3280,6 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 log.warn("failed to find font for preedit codepoint={X}", .{cp.codepoint});
                 return;
             };
-
-            // Add our opaque background cell
-            self.cells.bgCell(coord.y, coord.x).* = .{
-                screen_bg.r, screen_bg.g, screen_bg.b, 255,
-            };
-            if (cp.wide and coord.x < self.cells.size.columns - 1) {
-                self.cells.bgCell(coord.y, coord.x + 1).* = .{
-                    screen_bg.r, screen_bg.g, screen_bg.b, 255,
-                };
-            }
 
             // Add our text
             try self.cells.add(self.alloc, .text, .{


### PR DESCRIPTION
Discussed in https://github.com/ghostty-org/ghostty/discussions/10739

## Summary

Remove the hardcoded opaque background (alpha=255) from IME preedit cells so they respect `background-opacity` like all other cells.

When `background-opacity` is less than 1, preedit (composition) text was rendered with a fully opaque background, causing the text to appear highlighted and hard to read. This change removes the explicit per-cell background from `addPreeditCell`, letting preedit cells fall through to the global background. The underline indicator is preserved to mark the preedit region.

---

`background-opacity` が 1 未満のとき、IME入力中（preedit）のセルが完全不透明な背景で描画され、ハイライトされたように見えて読みづらくなる問題を修正しました。

`addPreeditCell` のセル背景描画を削除し、グローバル背景に委ねることで通常セルと同じ透過表示になります。
preedit領域のアンダーラインは維持されます。

## Test plan

- Set `background-opacity` to a value less than 1 (e.g. 0.5)
- Type Japanese (or other IME input) to trigger preedit
- Verify preedit text no longer appears highlighted
- Verify the underline indicator is still drawn under preedit text

AI disclosure: I used Claude Code to investigate the source code and generate code changes in this PR.