### PR TITLE
add "Set Ghostty as Default Terminal App" on macOS

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -65,6 +65,7 @@ class AppDelegate: NSObject,
     @IBOutlet private var menuReturnToDefaultSize: NSMenuItem?
     @IBOutlet private var menuFloatOnTop: NSMenuItem?
     @IBOutlet private var menuUseAsDefault: NSMenuItem?
+    @IBOutlet private var menuSetAsDefaultTerminal: NSMenuItem?
 
     @IBOutlet private var menuIncreaseFontSize: NSMenuItem?
     @IBOutlet private var menuDecreaseFontSize: NSMenuItem?
@@ -1292,6 +1293,21 @@ extension AppDelegate {
             ud.removeObject(forKey: key)
         }
     }
+    
+    @IBAction func setAsDefaultTerminal(_ sender: NSMenuItem) {
+        do {
+            try NSWorkspace.shared.setGhosttyAsDefaultTerminal()
+            // Success - menu state will automatically update via validateMenuItem
+        } catch {
+            // Show error dialog
+            let alert = NSAlert()
+            alert.messageText = "Failed to Set Default Terminal"
+            alert.informativeText = "Ghostty could not be set as the default terminal application.\n\nError: \(error.localizedDescription)"
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "OK")
+            alert.runModal()
+        }
+    }
 }
 
 // MARK: NSMenuItemValidation
@@ -1299,6 +1315,12 @@ extension AppDelegate {
 extension AppDelegate: NSMenuItemValidation {
     func validateMenuItem(_ item: NSMenuItem) -> Bool {
         switch item.action {
+        case #selector(setAsDefaultTerminal(_:)):
+            // Check if Ghostty is already the default terminal
+            let isDefault = NSWorkspace.shared.isGhosttyDefaultTerminal
+            // Disable menu item if already default (option A)
+            return !isDefault
+            
         case #selector(floatOnTop(_:)),
             #selector(useAsDefault(_:)):
             // Float on top items only active if the key window is a primary

--- a/macos/Sources/App/macOS/MainMenu.xib
+++ b/macos/Sources/App/macOS/MainMenu.xib
@@ -60,6 +60,7 @@
                 <outlet property="menuSelectSplitRight" destination="upj-mc-L7X" id="nLY-o1-lky"/>
                 <outlet property="menuSelectionForSearch" destination="TDN-42-Bu7" id="M04-1K-vze"/>
                 <outlet property="menuServices" destination="aQe-vS-j8Q" id="uWQ-Wo-T1L"/>
+                <outlet property="menuSetAsDefaultTerminal" destination="ZXY-ST-DTA" id="IJK-LM-NOP"/>
                 <outlet property="menuSplitDown" destination="UDZ-4y-6xL" id="ptr-mj-Azh"/>
                 <outlet property="menuSplitLeft" destination="Ppv-GP-lQU" id="Xd5-Cd-Jut"/>
                 <outlet property="menuSplitRight" destination="VUR-Ld-nLx" id="RxO-Zw-ovb"/>
@@ -107,6 +108,12 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="toggleSecureInput:" target="bbz-4X-AYv" id="vWx-z8-5Sy"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Set Ghostty as Default Terminal App" id="ZXY-ST-DTA">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="setAsDefaultTerminal:" target="bbz-4X-AYv" id="ABC-DE-FGH"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="4je-JR-u6R"/>

--- a/macos/Sources/Helpers/Extensions/NSWorkspace+Extension.swift
+++ b/macos/Sources/Helpers/Extensions/NSWorkspace+Extension.swift
@@ -26,4 +26,34 @@ extension NSWorkspace {
         guard let uti = UTType(filenameExtension: ext) else { return nil}
         return defaultApplicationURL(forContentType: uti.identifier)
     }
+    
+    /// Checks if Ghostty is the default terminal application.
+    /// - Returns: True if Ghostty is the default application for handling public.unix-executable files.
+    var isGhosttyDefaultTerminal: Bool {
+        let ghosttyURL = Bundle.main.bundleURL
+        guard let defaultAppURL = defaultApplicationURL(forContentType: "public.unix-executable") else {
+            return false
+        }
+        // Compare bundle paths
+        return ghosttyURL.path == defaultAppURL.path
+    }
+    
+    /// Sets Ghostty as the default terminal application.
+    /// - Throws: An error if the application bundle cannot be located or if setting the default fails.
+    func setGhosttyAsDefaultTerminal() throws {
+        let ghosttyURL = Bundle.main.bundleURL
+        
+        // Create UTType for unix executables
+        guard let unixExecutableType = UTType("public.unix-executable") else {
+            throw NSError(
+                domain: "com.mitchellh.ghostty",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "Could not create UTType for public.unix-executable"]
+            )
+        }
+        
+        // Use NSWorkspace API to set the default application
+        // This API is available on macOS 12.0+, Ghostty supports 13.0+, so it's compatible
+        try setDefaultApplication(at: ghosttyURL, toOpen: unixExecutableType)
+    }
 }


### PR DESCRIPTION
This PR enables iTerm2-like one button "Set Ghostty as Default Terminal App" functionality on macOS, making it easier to open a directory in Ghostty, run shell scripts when mouse clicking, etc.