### PR TITLE
Update zh_TW Traditional Chinese locale, cc #10632

### DIFF
--- a/po/zh_TW.UTF-8.po
+++ b/po/zh_TW.UTF-8.po
@@ -169,7 +169,7 @@ msgstr "分頁"
 #: src/apprt/gtk/ui/1.2/surface.blp:325 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
-msgstr ""
+msgstr "變更分頁標題…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
@@ -320,7 +320,7 @@ msgstr "變更終端機標題"
 
 #: src/apprt/gtk/class/title_dialog.zig:226
 msgid "Change Tab Title"
-msgstr ""
+msgstr "變更分頁標題"
 
 #: src/apprt/gtk/class/window.zig:1007
 msgid "Reloaded the configuration"


### PR DESCRIPTION
GitHub Copilot pull request summary:

> This pull request updates the Traditional Chinese (zh_TW) translations for the "Change Tab Title" strings in the application. These updates provide accurate translations for UI elements related to changing tab titles.
> 
> **Translation updates:**
> 
> * Added the Traditional Chinese translation for the "Change Tab Title…" menu item in `po/zh_TW.UTF-8.po`
> * Added the Traditional Chinese translation for the "Change Tab Title" dialog label in `po/zh_TW.UTF-8.po`