### PR TITLE
termio: don't auto-generate palette if user didn't customize any

### DIFF
--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -175,15 +175,25 @@ pub const DerivedConfig = struct {
         errdefer arena.deinit();
         const alloc = arena.allocator();
 
-        const palette: terminalpkg.color.Palette = if (config.@"palette-generate")
-            terminalpkg.color.generate256Color(
-                config.palette.value,
-                config.palette.mask,
-                config.background.toTerminalRGB(),
-                config.foreground.toTerminalRGB(),
-            )
-        else
-            config.palette.value;
+        const palette: terminalpkg.color.Palette = palette: {
+            if (config.@"palette-generate") generate: {
+                if (config.palette.mask.findFirstSet() == null) {
+                    // If the user didn't set any values manually, then
+                    // we're using the default palette and we don't need
+                    // to apply the generation code to it.
+                    break :generate;
+                }
+
+                break :palette terminalpkg.color.generate256Color(
+                    config.palette.value,
+                    config.palette.mask,
+                    config.background.toTerminalRGB(),
+                    config.foreground.toTerminalRGB(),
+                );
+            }
+
+            break :palette config.palette.value;
+        };
 
         return .{
             .palette = palette,


### PR DESCRIPTION
This fixes the issue where our palette generation was changing our default palette. The default palette is based on some well known values chosen from various terminals and it was a bit jarring to have it change.

We now only auto-generate the palette if the user has customized at least one entry.