### PR TITLE
GTK: Pass parent's computed default/min sizes to the new window

### DIFF
--- a/src/apprt/gtk/class/window.zig
+++ b/src/apprt/gtk/class/window.zig
@@ -383,6 +383,10 @@ pub const Window = extern struct {
             .config = priv.config,
         });
         if (parent_) |p| {
+            // For a new window's first tab, inherit the parent's initial size hints.
+            if (context == .window) {
+                surfaceInit(p.rt_surface.gobj(), self);
+            }
             tab.setParentWithContext(p, context);
         }
 


### PR DESCRIPTION
Fixes for #10532