### PR TITLE
macos: fix text editing shortcuts in modal sheet text fields

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1033,6 +1033,9 @@ bool ghostty_config_get(ghostty_config_t, void*, const char*, uintptr_t);
 ghostty_input_trigger_s ghostty_config_trigger(ghostty_config_t,
                                                const char*,
                                                uintptr_t);
+ghostty_input_trigger_s ghostty_config_trigger_menu(ghostty_config_t,
+                                                    const char*,
+                                                    uintptr_t);
 uint32_t ghostty_config_diagnostics_count(ghostty_config_t);
 ghostty_diagnostic_s ghostty_config_get_diagnostic(ghostty_config_t, uint32_t);
 ghostty_string_s ghostty_config_open_path(void);

--- a/macos/GhosttyUITests/GhosttyTabTitleDialogUITests.swift
+++ b/macos/GhosttyUITests/GhosttyTabTitleDialogUITests.swift
@@ -1,0 +1,60 @@
+//
+//  GhosttyTabTitleDialogUITests.swift
+//  GhosttyUITests
+//
+
+import XCTest
+
+final class GhosttyTabTitleDialogUITests: GhosttyCustomConfigCase {
+    /// https://github.com/ghostty-org/ghostty/discussions/10623
+    @MainActor
+    func testIssue10623() throws {
+        let app = try ghosttyApplication()
+        app.launch()
+
+        app.menuBarItems["View"].firstMatch.click()
+        app.menuItems["Change Tab Title..."].firstMatch.click()
+
+        let sheet = app.sheets.firstMatch
+        XCTAssertTrue(sheet.waitForExistence(timeout: 1), "Change Tab Title sheet should appear")
+
+        let textField = sheet.textFields.firstMatch
+        XCTAssertTrue(textField.waitForExistence(timeout: 1), "Change Tab Title text field should exist")
+
+        // Keep this deterministic and independent from prior pasteboard contents.
+        let expectedText = "ghostty-title-\(UUID().uuidString)"
+
+        textField.click()
+        textField.typeText(expectedText)
+
+        app.typeKey("a", modifierFlags: .command)
+        app.typeKey("c", modifierFlags: .command)
+        app.typeKey("a", modifierFlags: .command)
+        textField.typeText("x")
+        app.typeKey("a", modifierFlags: .command)
+        app.typeKey("v", modifierFlags: .command)
+
+        XCTAssertEqual(
+            textField.value as? String,
+            expectedText,
+            "Cmd+C should copy selected text from the sheet field"
+        )
+
+        app.typeKey("a", modifierFlags: .command)
+        app.typeKey("x", modifierFlags: .command)
+
+        XCTAssertEqual(
+            textField.value as? String,
+            "",
+            "Cmd+X should cut selected text from the sheet field"
+        )
+
+        app.typeKey("v", modifierFlags: .command)
+
+        XCTAssertEqual(
+            textField.value as? String,
+            expectedText,
+            "Cmd+V should paste the cut text back into the sheet field"
+        )
+    }
+}

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -693,6 +693,30 @@ class AppDelegate: NSObject,
         }
     }
 
+    /// For sheet text fields, route standard editing shortcuts to the text
+    /// system before terminal/menu shortcuts can consume them.
+    private func modalSheetTextEditingSelector(_ event: NSEvent) -> Selector? {
+        let relevantFlags = event.modifierFlags.intersection([.command, .control, .option, .shift])
+        guard relevantFlags == [.command] else { return nil }
+        guard let key = event.charactersIgnoringModifiers?.lowercased() else { return nil }
+
+        switch key {
+        case "a": return NSSelectorFromString("selectAll:")
+        case "c": return NSSelectorFromString("copy:")
+        case "x": return NSSelectorFromString("cut:")
+        case "v": return NSSelectorFromString("paste:")
+        default: return nil
+        }
+    }
+
+    private func dispatchModalSheetTextEditingShortcut(_ event: NSEvent) -> Bool {
+        guard let keyWindow = NSApp.keyWindow else { return false }
+        guard keyWindow.sheetParent != nil || NSApp.modalWindow != nil else { return false }
+        guard let firstResponder = keyWindow.firstResponder as? NSTextView else { return false }
+        guard let selector = modalSheetTextEditingSelector(event) else { return false }
+        return NSApp.sendAction(selector, to: nil, from: firstResponder)
+    }
+
     private func localEventKeyDown(_ event: NSEvent) -> NSEvent? {
         // If the tab overview is visible and escape is pressed, close it.
         // This can't POSSIBLY be right and is probably a FirstResponder problem
@@ -703,6 +727,11 @@ class AppDelegate: NSObject,
            let tabGroup = window.tabGroup,
            tabGroup.isOverviewVisible {
             window.toggleTabOverview(nil)
+            return nil
+        }
+
+        if dispatchModalSheetTextEditingShortcut(event) {
+            // We dispatched a standard text editing action (copy/cut/paste/select all).
             return nil
         }
 

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -693,28 +693,9 @@ class AppDelegate: NSObject,
         }
     }
 
-    /// For sheet text fields, route standard editing shortcuts to the text
-    /// system before terminal/menu shortcuts can consume them.
-    private func modalSheetTextEditingSelector(_ event: NSEvent) -> Selector? {
-        let relevantFlags = event.modifierFlags.intersection([.command, .control, .option, .shift])
-        guard relevantFlags == [.command] else { return nil }
-        guard let key = event.charactersIgnoringModifiers?.lowercased() else { return nil }
-
-        switch key {
-        case "a": return NSSelectorFromString("selectAll:")
-        case "c": return NSSelectorFromString("copy:")
-        case "x": return NSSelectorFromString("cut:")
-        case "v": return NSSelectorFromString("paste:")
-        default: return nil
-        }
-    }
-
-    private func dispatchModalSheetTextEditingShortcut(_ event: NSEvent) -> Bool {
+    private func modalSheetIsActive() -> Bool {
         guard let keyWindow = NSApp.keyWindow else { return false }
-        guard keyWindow.sheetParent != nil || NSApp.modalWindow != nil else { return false }
-        guard let firstResponder = keyWindow.firstResponder as? NSTextView else { return false }
-        guard let selector = modalSheetTextEditingSelector(event) else { return false }
-        return NSApp.sendAction(selector, to: nil, from: firstResponder)
+        return keyWindow.sheetParent != nil || NSApp.modalWindow != nil
     }
 
     private func localEventKeyDown(_ event: NSEvent) -> NSEvent? {
@@ -730,9 +711,11 @@ class AppDelegate: NSObject,
             return nil
         }
 
-        if dispatchModalSheetTextEditingShortcut(event) {
-            // We dispatched a standard text editing action (copy/cut/paste/select all).
-            return nil
+        // If a modal sheet/dialog is active, do not process app-level
+        // shortcuts in the local monitor. Let normal AppKit dispatch handle
+        // responder-chain key equivalents and keyDown behavior.
+        if modalSheetIsActive() {
+            return event
         }
 
         // If we have a main window then we don't process any of the keys

--- a/macos/Sources/App/macOS/MainMenu.xib
+++ b/macos/Sources/App/macOS/MainMenu.xib
@@ -228,6 +228,11 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="4O9-zO-zB9"/>
+                            <menuItem title="Cut" keyEquivalent="x" id="u9x-X1-ctT">
+                                <connections>
+                                    <action selector="cut:" target="-1" id="k2Z-yc-1fN"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Copy" id="Jqf-pv-Zcu">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -115,7 +115,7 @@ extension Ghostty {
         func keyboardShortcut(for action: String) -> KeyboardShortcut? {
             guard let cfg = self.config else { return nil }
 
-            let trigger = ghostty_config_trigger(cfg, action, UInt(action.lengthOfBytes(using: .utf8)))
+            let trigger = ghostty_config_trigger_menu(cfg, action, UInt(action.lengthOfBytes(using: .utf8)))
             return Ghostty.keyboardShortcut(for: trigger)
         }
 #endif

--- a/src/config/CApi.zig
+++ b/src/config/CApi.zig
@@ -111,12 +111,32 @@ export fn ghostty_config_trigger(
     };
 }
 
+export fn ghostty_config_trigger_menu(
+    self: *Config,
+    str: [*]const u8,
+    len: usize,
+) inputpkg.Binding.Trigger.C {
+    return config_trigger_menu_(self, str[0..len]) catch |err| err: {
+        log.err("error finding menu trigger err={}", .{err});
+        break :err .{};
+    };
+}
+
 fn config_trigger_(
     self: *Config,
     str: []const u8,
 ) !inputpkg.Binding.Trigger.C {
     const action = try inputpkg.Binding.Action.parse(str);
     const trigger: inputpkg.Binding.Trigger = self.keybind.set.getTrigger(action) orelse .{};
+    return trigger.cval();
+}
+
+fn config_trigger_menu_(
+    self: *Config,
+    str: []const u8,
+) !inputpkg.Binding.Trigger.C {
+    const action = try inputpkg.Binding.Action.parse(str);
+    const trigger: inputpkg.Binding.Trigger = self.keybind.set.getTriggerForMenu(action) orelse .{};
     return trigger.cval();
 }
 

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -2603,6 +2603,62 @@ pub const Set = struct {
         return self.reverse.get(a);
     }
 
+    /// Get a trigger suitable for GUI shortcut display and key-equivalent
+    /// routing. This prefers representable triggers and falls back to
+    /// performable mappings when needed.
+    pub fn getTriggerForMenu(self: Set, a: Action) ?Trigger {
+        if (self.getTrigger(a)) |trigger| {
+            if (triggerIsMenuRepresentable(trigger)) return trigger;
+        }
+
+        var fallback_nonperformable: ?Trigger = null;
+        var fallback_performable: ?Trigger = null;
+        var it = self.bindings.iterator();
+        while (it.next()) |entry| {
+            const leaf = switch (entry.value_ptr.*) {
+                .leaf => |leaf| leaf,
+                .leader, .leaf_chained => continue,
+            };
+
+            if (!std.meta.eql(leaf.action, a)) continue;
+            const trigger = entry.key_ptr.*;
+            if (!triggerIsMenuRepresentable(trigger)) continue;
+
+            if (leaf.flags.performable) {
+                if (fallback_performable == null) fallback_performable = trigger;
+            } else if (fallback_nonperformable == null) {
+                fallback_nonperformable = trigger;
+            }
+        }
+
+        return fallback_nonperformable orelse fallback_performable;
+    }
+
+    fn triggerIsMenuRepresentable(trigger: Trigger) bool {
+        return switch (trigger.key) {
+            .unicode => true,
+            .catch_all => false,
+            .physical => |physical_key| switch (physical_key) {
+                .arrow_up,
+                .arrow_down,
+                .arrow_left,
+                .arrow_right,
+                .home,
+                .end,
+                .delete,
+                .page_up,
+                .page_down,
+                .escape,
+                .enter,
+                .tab,
+                .backspace,
+                .space,
+                => true,
+                else => false,
+            },
+        };
+    }
+
     /// Get an entry for the given key event. This will attempt to find
     /// a binding using multiple parts of the event in the following order:
     ///
@@ -4038,6 +4094,40 @@ test "set: performable is not part of reverse mappings" {
     {
         const trigger = s.getTrigger(.{ .new_window = {} }).?;
         try testing.expect(trigger.key.unicode == 'a');
+    }
+}
+
+test "set: getTriggerForMenu prefers representable performable over non-representable" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s: Set = .{};
+    defer s.deinit(alloc);
+
+    // Non-performable physical copy key is not representable in macOS menu
+    // key equivalents.
+    try s.put(
+        alloc,
+        .{ .key = .{ .physical = .copy } },
+        .{ .copy_to_clipboard = .mixed },
+    );
+    // Performable unicode mapping should be selected for menu/display.
+    try s.putFlags(
+        alloc,
+        .{ .key = .{ .unicode = 'c' }, .mods = .{ .super = true } },
+        .{ .copy_to_clipboard = .mixed },
+        .{ .performable = true },
+    );
+
+    {
+        const reverse = s.getTrigger(.{ .copy_to_clipboard = .mixed }).?;
+        try testing.expect(reverse.key == .physical);
+        try testing.expect(reverse.key.physical == .copy);
+    }
+    {
+        const menu = s.getTriggerForMenu(.{ .copy_to_clipboard = .mixed }).?;
+        try testing.expect(menu.key == .unicode);
+        try testing.expectEqual(@as(u21, 'c'), menu.key.unicode);
     }
 }
 


### PR DESCRIPTION
Route Cmd+A/C/X/V to the text system when a modal sheet or dialog is active, preventing terminal or menu shortcuts from consuming them.

Fix #10749 

AI Use Note: The tests were initially created in full by Claude Opus 4.6. The fix was reviewed and improved with its help as well. All code is read by a human.