### PR TITLE
replace CIELAB with OKLCH for 256-color palette interpolation

### DIFF
--- a/src/terminal/color.zig
+++ b/src/terminal/color.zig
@@ -63,7 +63,7 @@ pub const PaletteMask = std.StaticBitSet(@typeInfo(Palette).array.len);
 /// own theme configuration, and light/dark switching works automatically.
 ///
 /// The 216-color cube (indices 16–231) is built via trilinear
-/// interpolation in CIELAB space over the 8 base colors. The base16
+/// interpolation in Oklch space over the 8 base colors. The base16
 /// palette maps to the 8 corners of a 6×6×6 RGB cube as follows:
 ///
 ///   R=0 edge: bg      → base[1] (red)
@@ -74,11 +74,12 @@ pub const PaletteMask = std.StaticBitSet(@typeInfo(Palette).array.len);
 /// For each R slice, four corner colors (c0–c3) are interpolated along
 /// the R axis, then for each G row two edge colors (c4–c5) are
 /// interpolated along G, and finally each B cell is interpolated along B
-/// to produce the final color. CIELAB interpolation ensures perceptually
-/// uniform brightness transitions across different hues.
+/// to produce the final color. Oklch interpolation ensures perceptually
+/// uniform brightness transitions across different hues, with natural
+/// hue blending along the shortest arc.
 ///
 /// The 24-step grayscale ramp (indices 232–255) is a simple linear
-/// interpolation in CIELAB from the background to the foreground,
+/// interpolation in Oklch from the background to the foreground,
 /// excluding pure black and white (available in the cube at (0,0,0)
 /// and (5,5,5)). The interpolation parameter runs from 1/25 to 24/25.
 ///
@@ -92,11 +93,11 @@ pub fn generate256Color(
     fg: RGB,
 ) Palette {
     // Convert the background, foreground, and 8 base theme colors into
-    // CIELAB space so that all interpolation is perceptually uniform.
-    const bg_lab: LAB = .fromRgb(bg);
-    const fg_lab: LAB = .fromRgb(fg);
-    const base8_lab: [8]LAB = base8: {
-        var base8: [8]LAB = undefined;
+    // Oklch space so that all interpolation is perceptually uniform.
+    const bg_lch: Oklch = .fromRgb(bg);
+    const fg_lch: Oklch = .fromRgb(fg);
+    const base8_lch: [8]Oklch = base8: {
+        var base8: [8]Oklch = undefined;
         for (0..8) |i| base8[i] = .fromRgb(base[i]);
         break :base8 base8;
     };
@@ -105,7 +106,7 @@ pub fn generate256Color(
     var result = base;
 
     // Build the 216-color cube (indices 16–231) via trilinear interpolation
-    // in CIELAB. The three nested loops correspond to the R, G, and B axes
+    // in Oklch. The three nested loops correspond to the R, G, and B axes
     // of a 6×6×6 cube. For each R slice, four corner colors (c0–c3) are
     // interpolated along R from the 8 base colors, mapping the cube corners
     // to theme-aware anchors (see doc comment for the mapping). Then for
@@ -115,19 +116,19 @@ pub fn generate256Color(
     for (0..6) |ri| {
         // R-axis corners: blend base colors along the red dimension.
         const tr = @as(f32, @floatFromInt(ri)) / 5.0;
-        const c0: LAB = .lerp(tr, bg_lab, base8_lab[1]);
-        const c1: LAB = .lerp(tr, base8_lab[2], base8_lab[3]);
-        const c2: LAB = .lerp(tr, base8_lab[4], base8_lab[5]);
-        const c3: LAB = .lerp(tr, base8_lab[6], fg_lab);
+        const c0: Oklch = .lerp(tr, bg_lch, base8_lch[1]);
+        const c1: Oklch = .lerp(tr, base8_lch[2], base8_lch[3]);
+        const c2: Oklch = .lerp(tr, base8_lch[4], base8_lch[5]);
+        const c3: Oklch = .lerp(tr, base8_lch[6], fg_lch);
         for (0..6) |gi| {
             // G-axis edges: blend the R-interpolated corners along green.
             const tg = @as(f32, @floatFromInt(gi)) / 5.0;
-            const c4: LAB = .lerp(tg, c0, c1);
-            const c5: LAB = .lerp(tg, c2, c3);
+            const c4: Oklch = .lerp(tg, c0, c1);
+            const c5: Oklch = .lerp(tg, c2, c3);
             for (0..6) |bi| {
                 // B-axis: final interpolation along blue, then convert back to RGB.
                 if (!skip.isSet(idx)) {
-                    const c6: LAB = .lerp(
+                    const c6: Oklch = .lerp(
                         @as(f32, @floatFromInt(bi)) / 5.0,
                         c4,
                         c5,
@@ -141,13 +142,13 @@ pub fn generate256Color(
     }
 
     // Build the 24-step grayscale ramp (indices 232–255) by linearly
-    // interpolating in CIELAB from background to foreground. The parameter
+    // interpolating in Oklch from background to foreground. The parameter
     // runs from 1/25 to 24/25, excluding the endpoints which are already
     // available in the cube at (0,0,0) and (5,5,5).
     for (0..24) |i| {
         const t = @as(f32, @floatFromInt(i + 1)) / 25.0;
         if (!skip.isSet(idx)) {
-            const c: LAB = .lerp(t, bg_lab, fg_lab);
+            const c: Oklch = .lerp(t, bg_lch, fg_lch);
             result[idx] = c.toRgb();
         }
         idx += 1;
@@ -626,14 +627,25 @@ pub const RGB = packed struct(u24) {
     }
 };
 
-/// LAB color space
-const LAB = struct {
+/// Oklch color space (Lightness, Chroma, Hue).
+///
+/// Oklch is the cylindrical form of Oklab, a perceptually uniform color
+/// space designed by Björn Ottosson. Compared to CIELAB, Oklab has better
+/// perceptual uniformity (especially for blues) and a simpler, more
+/// accurate conversion from/to sRGB. The cylindrical LCH form enables
+/// natural hue interpolation along the shortest arc.
+///
+/// Reference: https://bottosson.github.io/posts/oklab/
+const Oklch = struct {
+    /// Perceived lightness (0 = black, 1 = white).
     l: f32,
-    a: f32,
-    b: f32,
+    /// Chroma (colorfulness), 0 for achromatic grays.
+    c: f32,
+    /// Hue angle in radians.
+    h: f32,
 
-    /// RGB to LAB
-    pub fn fromRgb(rgb: RGB) LAB {
+    /// Convert an sRGB color to Oklch.
+    pub fn fromRgb(rgb: RGB) Oklch {
         // Step 1: Normalize sRGB channels from [0, 255] to [0.0, 1.0].
         var r: f32 = @as(f32, @floatFromInt(rgb.r)) / 255.0;
         var g: f32 = @as(f32, @floatFromInt(rgb.g)) / 255.0;
@@ -647,60 +659,57 @@ const LAB = struct {
         g = if (g > 0.04045) std.math.pow(f32, (g + 0.055) / 1.055, 2.4) else g / 12.92;
         b = if (b > 0.04045) std.math.pow(f32, (b + 0.055) / 1.055, 2.4) else b / 12.92;
 
-        // Step 3: Convert linear RGB to CIE XYZ using the sRGB to XYZ
-        // transformation matrix (D65 illuminant). The X and Z values are
-        // normalized by the D65 white point reference values (Xn=0.95047,
-        // Zn=1.08883; Yn=1.0 is implicit).
-        var x = (r * 0.4124564 + g * 0.3575761 + b * 0.1804375) / 0.95047;
-        var y = r * 0.2126729 + g * 0.7151522 + b * 0.0721750;
-        var z = (r * 0.0193339 + g * 0.1191920 + b * 0.9503041) / 1.08883;
+        // Step 3: Linear RGB to LMS (Oklab M1 matrix).
+        const l_lms = 0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b;
+        const m_lms = 0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b;
+        const s_lms = 0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b;
 
-        // Step 4: Apply the CIE f(t) nonlinear transform to each XYZ
-        // component. Above the threshold (epsilon ≈ 0.008856) the cube
-        // root is used; below it, a linear approximation avoids numerical
-        // instability near zero.
-        x = if (x > 0.008856) std.math.cbrt(x) else 7.787 * x + 16.0 / 116.0;
-        y = if (y > 0.008856) std.math.cbrt(y) else 7.787 * y + 16.0 / 116.0;
-        z = if (z > 0.008856) std.math.cbrt(z) else 7.787 * z + 16.0 / 116.0;
+        // Step 4: Cube root (nonlinear compression).
+        const l_ = std.math.cbrt(l_lms);
+        const m_ = std.math.cbrt(m_lms);
+        const s_ = std.math.cbrt(s_lms);
 
-        // Step 5: Compute the final CIELAB values from the transformed XYZ.
-        // L* is lightness (0–100), a* is green–red, b* is blue–yellow.
-        return .{ .l = 116.0 * y - 16.0, .a = 500.0 * (x - y), .b = 200.0 * (y - z) };
+        // Step 5: LMS to Oklab (M2 matrix).
+        const lab_l = 0.2104542553 * l_ + 0.7936177850 * m_ - 0.0040720468 * s_;
+        const lab_a = 1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_;
+        const lab_b = 0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_;
+
+        // Step 6: Oklab rectangular (L, a, b) to cylindrical (L, C, h).
+        const c = @sqrt(lab_a * lab_a + lab_b * lab_b);
+        const h = std.math.atan2(lab_b, lab_a);
+
+        return .{ .l = lab_l, .c = c, .h = h };
     }
 
-    /// LAB to RGB
-    pub fn toRgb(self: LAB) RGB {
-        // Step 1: Recover the intermediate f(Y), f(X), f(Z) values from
-        // L*a*b* by inverting the CIELAB formulas.
-        const y = (self.l + 16.0) / 116.0;
-        const x = self.a / 500.0 + y;
-        const z = y - self.b / 200.0;
+    /// Convert Oklch back to sRGB.
+    pub fn toRgb(self: Oklch) RGB {
+        // Step 1: Oklch cylindrical to Oklab rectangular.
+        const lab_a = self.c * @cos(self.h);
+        const lab_b = self.c * @sin(self.h);
 
-        // Step 2: Apply the inverse CIE f(t) transform to get back to
-        // XYZ. Above epsilon (≈0.008856) the cube is used; below it the
-        // linear segment is inverted. Results are then scaled by the D65
-        // white point reference values (Xn=0.95047, Zn=1.08883; Yn=1.0).
-        const x3 = x * x * x;
-        const y3 = y * y * y;
-        const z3 = z * z * z;
-        const xf = (if (x3 > 0.008856) x3 else (x - 16.0 / 116.0) / 7.787) * 0.95047;
-        const yf = if (y3 > 0.008856) y3 else (y - 16.0 / 116.0) / 7.787;
-        const zf = (if (z3 > 0.008856) z3 else (z - 16.0 / 116.0) / 7.787) * 1.08883;
+        // Step 2: Oklab to LMS (inverse M2 matrix).
+        const l_ = self.l + 0.3963377774 * lab_a + 0.2158037573 * lab_b;
+        const m_ = self.l - 0.1055613458 * lab_a - 0.0638541728 * lab_b;
+        const s_ = self.l - 0.0894841775 * lab_a - 1.2914855480 * lab_b;
 
-        // Step 3: Convert CIE XYZ back to linear RGB using the XYZ to sRGB
-        // matrix (inverse of the sRGB to XYZ matrix, D65 illuminant).
-        var r = xf * 3.2404542 - yf * 1.5371385 - zf * 0.4985314;
-        var g = -xf * 0.9692660 + yf * 1.8760108 + zf * 0.0415560;
-        var b = xf * 0.0556434 - yf * 0.2040259 + zf * 1.0572252;
+        // Step 3: Undo cube root.
+        const l_lms = l_ * l_ * l_;
+        const m_lms = m_ * m_ * m_;
+        const s_lms = s_ * s_ * s_;
 
-        // Step 4: Apply sRGB companding (gamma correction) to convert from
+        // Step 4: LMS to linear RGB (inverse M1 matrix).
+        var r = 4.0767416621 * l_lms - 3.3077115913 * m_lms + 0.2309699292 * s_lms;
+        var g = -1.2684380046 * l_lms + 2.6097574011 * m_lms - 0.3413193965 * s_lms;
+        var b = -0.0041960863 * l_lms - 0.7034186147 * m_lms + 1.7076147010 * s_lms;
+
+        // Step 5: Apply sRGB companding (gamma correction) to convert from
         // linear RGB back to sRGB. This is the forward sRGB transfer
         // function with the same two-segment split as the inverse.
         r = if (r > 0.0031308) 1.055 * std.math.pow(f32, r, 1.0 / 2.4) - 0.055 else 12.92 * r;
         g = if (g > 0.0031308) 1.055 * std.math.pow(f32, g, 1.0 / 2.4) - 0.055 else 12.92 * g;
         b = if (b > 0.0031308) 1.055 * std.math.pow(f32, b, 1.0 / 2.4) - 0.055 else 12.92 * b;
 
-        // Step 5: Clamp to [0.0, 1.0], scale to [0, 255], and round to
+        // Step 6: Clamp to [0.0, 1.0], scale to [0, 255], and round to
         // the nearest integer to produce the final 8-bit sRGB values.
         return .{
             .r = @intFromFloat(@min(@max(r, 0.0), 1.0) * 255.0 + 0.5),
@@ -709,14 +718,33 @@ const LAB = struct {
         };
     }
 
-    /// Linearly interpolate between two LAB colors component-wise.
-    /// `t` is the interpolation factor in [0, 1]: t=0 returns `a`,
-    /// t=1 returns `b`, and values in between blend proportionally.
-    pub fn lerp(t: f32, a: LAB, b: LAB) LAB {
+    /// Interpolate between two Oklch colors.
+    ///
+    /// Lightness and chroma are linearly interpolated. Hue is interpolated
+    /// along the shortest arc. When either endpoint is achromatic (chroma
+    /// near zero), its hue is treated as missing and replaced with the
+    /// other endpoint's hue.
+    ///
+    /// References:
+    ///   Shorter hue interpolation: https://www.w3.org/TR/css-color-4/#hue-shorter
+    ///   Powerless hue component:   https://www.w3.org/TR/css-color-4/#powerless
+    pub fn lerp(t: f32, a: Oklch, b: Oklch) Oklch {
+        // Determine effective hues, handling achromatic endpoints.
+        const achromatic_threshold = 1e-4;
+        const a_achromatic = a.c < achromatic_threshold;
+        const b_achromatic = b.c < achromatic_threshold;
+        const ha = if (a_achromatic) b.h else a.h;
+        const hb = if (b_achromatic) a.h else b.h;
+
+        // Shortest-arc hue interpolation.
+        var dh = hb - ha;
+        if (dh > std.math.pi) dh -= 2.0 * std.math.pi;
+        if (dh < -std.math.pi) dh += 2.0 * std.math.pi;
+
         return .{
             .l = a.l + t * (b.l - a.l),
-            .a = a.a + t * (b.a - a.a),
-            .b = a.b + t * (b.b - a.b),
+            .c = a.c + t * (b.c - a.c),
+            .h = ha + t * dh,
         };
     }
 };
@@ -886,39 +914,37 @@ test "DynamicPalette: changeDefault with multiple changes" {
     try testing.expectEqual(@as(usize, 3), p.mask.count());
 }
 
-test "LAB.fromRgb" {
+test "Oklch.fromRgb" {
     const testing = std.testing;
-    const epsilon = 0.5;
+    const epsilon = 0.005;
 
-    // White (255, 255, 255) -> L*=100, a*=0, b*=0
-    const white = LAB.fromRgb(.{ .r = 255, .g = 255, .b = 255 });
-    try testing.expectApproxEqAbs(@as(f32, 100.0), white.l, epsilon);
-    try testing.expectApproxEqAbs(@as(f32, 0.0), white.a, epsilon);
-    try testing.expectApproxEqAbs(@as(f32, 0.0), white.b, epsilon);
+    // White (255, 255, 255) -> L≈1.0, C≈0, H=any
+    const white = Oklch.fromRgb(.{ .r = 255, .g = 255, .b = 255 });
+    try testing.expectApproxEqAbs(@as(f32, 1.0), white.l, epsilon);
+    try testing.expectApproxEqAbs(@as(f32, 0.0), white.c, epsilon);
 
-    // Black (0, 0, 0) -> L*=0, a*=0, b*=0
-    const black = LAB.fromRgb(.{ .r = 0, .g = 0, .b = 0 });
+    // Black (0, 0, 0) -> L≈0, C≈0, H=any
+    const black = Oklch.fromRgb(.{ .r = 0, .g = 0, .b = 0 });
     try testing.expectApproxEqAbs(@as(f32, 0.0), black.l, epsilon);
-    try testing.expectApproxEqAbs(@as(f32, 0.0), black.a, epsilon);
-    try testing.expectApproxEqAbs(@as(f32, 0.0), black.b, epsilon);
+    try testing.expectApproxEqAbs(@as(f32, 0.0), black.c, epsilon);
 
-    // Pure red (255, 0, 0) -> L*≈53.23, a*≈80.11, b*≈67.22
-    const red = LAB.fromRgb(.{ .r = 255, .g = 0, .b = 0 });
-    try testing.expectApproxEqAbs(@as(f32, 53.23), red.l, epsilon);
-    try testing.expectApproxEqAbs(@as(f32, 80.11), red.a, epsilon);
-    try testing.expectApproxEqAbs(@as(f32, 67.22), red.b, epsilon);
+    // Pure red (255, 0, 0) -> L≈0.6279, C≈0.2577, H≈29.23° (0.5101 rad)
+    const red = Oklch.fromRgb(.{ .r = 255, .g = 0, .b = 0 });
+    try testing.expectApproxEqAbs(@as(f32, 0.6279), red.l, epsilon);
+    try testing.expectApproxEqAbs(@as(f32, 0.2577), red.c, epsilon);
+    try testing.expectApproxEqAbs(@as(f32, 0.5101), red.h, 0.01);
 
-    // Pure green (0, 128, 0) -> L*≈46.23, a*≈-51.70, b*≈49.90
-    const green = LAB.fromRgb(.{ .r = 0, .g = 128, .b = 0 });
-    try testing.expectApproxEqAbs(@as(f32, 46.23), green.l, epsilon);
-    try testing.expectApproxEqAbs(@as(f32, -51.70), green.a, epsilon);
-    try testing.expectApproxEqAbs(@as(f32, 49.90), green.b, epsilon);
+    // Pure green (0, 128, 0) -> L≈0.5195, C≈0.1768, H≈142.50° (2.487 rad)
+    const green = Oklch.fromRgb(.{ .r = 0, .g = 128, .b = 0 });
+    try testing.expectApproxEqAbs(@as(f32, 0.5195), green.l, epsilon);
+    try testing.expectApproxEqAbs(@as(f32, 0.1768), green.c, epsilon);
+    try testing.expectApproxEqAbs(@as(f32, 2.487), green.h, 0.01);
 
-    // Pure blue (0, 0, 255) -> L*≈32.30, a*≈79.20, b*≈-107.86
-    const blue = LAB.fromRgb(.{ .r = 0, .g = 0, .b = 255 });
-    try testing.expectApproxEqAbs(@as(f32, 32.30), blue.l, epsilon);
-    try testing.expectApproxEqAbs(@as(f32, 79.20), blue.a, epsilon);
-    try testing.expectApproxEqAbs(@as(f32, -107.86), blue.b, epsilon);
+    // Pure blue (0, 0, 255) -> L≈0.4520, C≈0.3132, H≈264.05° (-1.674 rad)
+    const blue = Oklch.fromRgb(.{ .r = 0, .g = 0, .b = 255 });
+    try testing.expectApproxEqAbs(@as(f32, 0.4520), blue.l, epsilon);
+    try testing.expectApproxEqAbs(@as(f32, 0.3132), blue.c, epsilon);
+    try testing.expectApproxEqAbs(@as(f32, -1.674), blue.h, 0.01);
 }
 
 test "generate256Color: base16 preserved" {
@@ -986,10 +1012,10 @@ test "generate256Color: skip mask preserves original colors" {
     try testing.expect(!palette[21].eql(default[21]));
 }
 
-test "LAB.toRgb" {
+test "Oklch.toRgb" {
     const testing = std.testing;
 
-    // Round-trip: RGB -> LAB -> RGB should recover the original values.
+    // Round-trip: RGB -> Oklch -> RGB should recover the original values.
     const cases = [_]RGB{
         .{ .r = 255, .g = 255, .b = 255 },
         .{ .r = 0, .g = 0, .b = 0 },
@@ -1001,8 +1027,8 @@ test "LAB.toRgb" {
     };
 
     for (cases) |expected| {
-        const lab = LAB.fromRgb(expected);
-        const actual = lab.toRgb();
+        const lch = Oklch.fromRgb(expected);
+        const actual = lch.toRgb();
         try testing.expectEqual(expected.r, actual.r);
         try testing.expectEqual(expected.g, actual.g);
         try testing.expectEqual(expected.b, actual.b);


### PR DESCRIPTION
OKLCH (cylindrical Oklab) provides better perceptual uniformity than CIELAB, especially for blue hues, and enables natural hue interpolation along the shortest arc. This improves the quality of generated 256-color palettes when blending between base16 theme colors.

See https://github.com/ghostty-org/ghostty/pull/10554#issuecomment-3918793903