### PR TITLE
i18n: update ja_JP translation

### DIFF
--- a/po/ja_JP.UTF-8.po
+++ b/po/ja_JP.UTF-8.po
@@ -20,7 +20,7 @@ msgstr ""
 
 #: dist/linux/ghostty_nautilus.py:53
 msgid "Open in Ghostty"
-msgstr ""
+msgstr "Ghosttyで開く"
 
 #: src/apprt/gtk/ui/1.0/clipboard-confirmation-dialog.blp:12
 #: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:12
@@ -178,7 +178,7 @@ msgstr "タブ"
 #: src/apprt/gtk/ui/1.2/surface.blp:325 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
-msgstr ""
+msgstr "タブのタイトルを変更…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
@@ -335,7 +335,7 @@ msgstr "ターミナルのタイトルを変更する"
 
 #: src/apprt/gtk/class/title_dialog.zig:226
 msgid "Change Tab Title"
-msgstr ""
+msgstr "タブのタイトルを変更する"
 
 #: src/apprt/gtk/class/window.zig:1007
 msgid "Reloaded the configuration"


### PR DESCRIPTION
as requested in https://github.com/ghostty-org/ghostty/issues/10632#issuecomment-3919649650

for Japanese reviewers:

既存の以下に合わせ、

```
msgid "Change Title…"
msgstr "タイトルを変更…"

msgid "Change Terminal Title"
msgstr "ターミナルのタイトルを変更する"
```

以下の2つでは末尾の表現を変えました。

```
msgid "Change Tab Title…"
msgstr "タブのタイトルを変更…"

msgid "Change Tab Title"
msgstr "タブのタイトルを変更する"
```