### PR TITLE
i18n: Update Hebrew (he_IL) translations for 1.3 (3 new strings)

### DIFF
--- a/po/he_IL.UTF-8.po
+++ b/po/he_IL.UTF-8.po
@@ -179,7 +179,7 @@ msgstr "כרטיסייה"
 #: src/apprt/gtk/ui/1.2/surface.blp:325 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
-msgstr "שנה/י את כותרת הכרטיסיה…"
+msgstr "שנה/י את כותרת הכרטיסייה…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
@@ -333,7 +333,7 @@ msgstr "שינוי כותרת המסוף"
 
 #: src/apprt/gtk/class/title_dialog.zig:226
 msgid "Change Tab Title"
-msgstr "שינוי כותרת הכרטיסיה"
+msgstr "שינוי כותרת הכרטיסייה"
 
 #: src/apprt/gtk/class/window.zig:1007
 msgid "Reloaded the configuration"

--- a/po/he_IL.UTF-8.po
+++ b/po/he_IL.UTF-8.po
@@ -247,8 +247,8 @@ msgid "Quit"
 msgstr "יציאה"
 
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
-msgid "Execute a command"
-msgstr "הרץ/י פקודה"
+msgid "Execute a command…"
+msgstr "הרץ/י פקודה…"
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""

--- a/po/he_IL.UTF-8.po
+++ b/po/he_IL.UTF-8.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
 "POT-Creation-Date: 2026-02-17 23:16+0100\n"
-"PO-Revision-Date: 2026-02-11 22:45+0300\n"
+"PO-Revision-Date: 2026-02-18 18:14+0300\n"
 "Last-Translator: Sl (Shahaf Levi), Sl's Repository Ltd "
 "<ghostty@slsrepo.com>\n"
 "Language-Team: Hebrew <he_IL@lists.sourceforge.net>\n"
@@ -22,7 +22,7 @@ msgstr ""
 
 #: dist/linux/ghostty_nautilus.py:53
 msgid "Open in Ghostty"
-msgstr ""
+msgstr "פתח/י בGhostty"
 
 #: src/apprt/gtk/ui/1.0/clipboard-confirmation-dialog.blp:12
 #: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:12
@@ -179,7 +179,7 @@ msgstr "כרטיסייה"
 #: src/apprt/gtk/ui/1.2/surface.blp:325 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
-msgstr ""
+msgstr "שנה/י את כותרת הכרטיסיה…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
@@ -247,8 +247,8 @@ msgid "Quit"
 msgstr "יציאה"
 
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
-msgid "Execute a command…"
-msgstr "הרץ/י פקודה…"
+msgid "Execute a command"
+msgstr "הרץ/י פקודה"
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -333,7 +333,7 @@ msgstr "שינוי כותרת המסוף"
 
 #: src/apprt/gtk/class/title_dialog.zig:226
 msgid "Change Tab Title"
-msgstr ""
+msgstr "שינוי כותרת הכרטיסיה"
 
 #: src/apprt/gtk/class/window.zig:1007
 msgid "Reloaded the configuration"


### PR DESCRIPTION
Addressing the three newer strings requested by [Kat](https://github.com/ghostty-org/ghostty/issues/10632#issuecomment-3919649650) in #10632.