### PR TITLE
i18n: update `de_DE` translations

### DIFF
--- a/po/de_DE.UTF-8.po
+++ b/po/de_DE.UTF-8.po
@@ -22,7 +22,7 @@ msgstr ""
 
 #: dist/linux/ghostty_nautilus.py:53
 msgid "Open in Ghostty"
-msgstr ""
+msgstr "In Ghostty öffnen"
 
 #: src/apprt/gtk/ui/1.0/clipboard-confirmation-dialog.blp:12
 #: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:12
@@ -184,7 +184,7 @@ msgstr "Tab"
 #: src/apprt/gtk/ui/1.2/surface.blp:325 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
-msgstr ""
+msgstr "Tab-Titel ändern…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
@@ -341,7 +341,7 @@ msgstr "Terminaltitel bearbeiten"
 
 #: src/apprt/gtk/class/title_dialog.zig:226
 msgid "Change Tab Title"
-msgstr ""
+msgstr "Tab-Titel ändern"
 
 #: src/apprt/gtk/class/window.zig:1007
 msgid "Reloaded the configuration"


### PR DESCRIPTION
This PR adds the missing translation strings for Ghostty 1.3.

Related to: #10632