### PR TITLE
cmd + left/right to switch tabs by default

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -6299,6 +6299,16 @@ pub const Keybinds = struct {
             .{ .key = .{ .physical = .tab }, .mods = .{ .ctrl = true } },
             .{ .next_tab = {} },
         );
+        try self.set.put(
+            alloc,
+            .{ .key = .{ .physical = .arrow_left }, .mods = .{ .super = true } },
+            .{ .previous_tab = {} },
+        );
+        try self.set.put(
+            alloc,
+            .{ .key = .{ .physical = .arrow_right }, .mods = .{ .super = true } },
+            .{ .next_tab = {} },
+        );
 
         // Windowing
         if (comptime !builtin.target.os.tag.isDarwin()) {


### PR DESCRIPTION
I believe this is the default in iTerm (I could be wrong!), but it's a feature that makes a lot of sense to me.

Currently, I have this setup, but maybe it makes sense to enable it with zero-config?

```bash
$ cat ~/.config/ghostty/config
keybind = super+left=previous_tab
keybind = super+right=next_tab
```