### PR TITLE
clickable file path fixes

### DIFF
--- a/src/config/url.zig
+++ b/src/config/url.zig
@@ -65,11 +65,11 @@ const non_dotted_path_lookahead =
 ;
 
 const dotted_path_space_segments =
-    \\(?:(?<!:) (?!\w+:\/\/)[\w\-.~:\/?#@!$&*+;=%]*[\/.])*
+    \\(?:(?<!:) (?!\w+:\/\/)(?!\.{0,2}\/)(?!~\/)[\w\-.~:\/?#@!$&*+;=%]*[\/.])*
 ;
 
 const any_path_space_segments =
-    \\(?:(?<!:) (?!\w+:\/\/)[\w\-.~:\/?#@!$&*+;=%]+)*
+    \\(?:(?<!:) (?!\w+:\/\/)(?!\.{0,2}\/)(?!~\/)[\w\-.~:\/?#@!$&*+;=%]+)*
 ;
 
 // Branch 1: URLs with explicit schemes (http, mailto, ftp, etc.).
@@ -358,6 +358,19 @@ test "url regex" {
         .{
             .input = "/tmp/test folder/file.txt",
             .expect = "/tmp/test folder/file.txt",
+        },
+        .{
+            .input = "/tmp/test  folder/file.txt",
+            .expect = "/tmp/test",
+        },
+        // Two space-separated absolute paths should match only the first
+        .{
+            .input = "/tmp/foo /tmp/bar",
+            .expect = "/tmp/foo",
+        },
+        .{
+            .input = "/tmp/foo.txt /tmp/bar.txt",
+            .expect = "/tmp/foo.txt",
         },
         // Bare relative file paths (no ./ or ../ prefix)
         .{

--- a/src/config/url.zig
+++ b/src/config/url.zig
@@ -110,7 +110,6 @@ const bare_relative_path_branch =
     dotted_path_lookahead ++
     bare_relative_path_prefix ++
     path_chars ++ "+" ++
-    dotted_path_space_segments ++
     no_trailing_colon ++
     trailing_spaces_at_eol;
 
@@ -362,6 +361,11 @@ test "url regex" {
         .{
             .input = "/tmp/test  folder/file.txt",
             .expect = "/tmp/test",
+        },
+        // unified diff lines
+        .{
+            .input = "diff --git a/src/font/shaper/harfbuzz.zig b/src/font/shaper/harfbuzz.zig",
+            .expect = "a/src/font/shaper/harfbuzz.zig",
         },
         // Two space-separated absolute paths should match only the first
         .{


### PR DESCRIPTION
- **url: improve space in path handling**
  The space-segment patterns in the path regex (dotted_path_space_segments
  and any_path_space_segments) greedily consume text after a space even
  when we know that the text is the start of a new independent path (e.g.,
  `/tmp/bar` in `/tmp/foo /tmp/bar`).
  
  Fix: Add two negative lookaheads after the space in both patterns:
  - `(?!\.{0,2}\/)` →  don't match if the next segment starts with `/`,
    `./`, or `../`
  - `(?!~\/)` →  don't match if the next segment starts with `~/`
  

- **url: fix regression with unified diff lines**
  Bare relative paths don't need space-continuation semantics.
  
  Fixes #10773
  