### PR TITLE
WIP: Make palette inversion opt-in

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -808,6 +808,12 @@ palette: Palette = .{},
 /// Available since: 1.3.0
 @"palette-generate": bool = true,
 
+/// Whether to invert generated light themes colors (see `palette-generate`).
+/// This helps give the 256-color palette more semantic meaning.
+/// 
+/// Available since: 1.3.0
+@"palette-harmonious": bool = false,
+
 /// The color of the cursor. If this is not set, a default will be chosen.
 ///
 /// Direct colors can be specified as either hex (`#RRGGBB` or `RRGGBB`)

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -808,9 +808,21 @@ palette: Palette = .{},
 /// Available since: 1.3.0
 @"palette-generate": bool = true,
 
-/// Whether to invert generated light themes colors (see `palette-generate`).
-/// This helps give the 256-color palette more semantic meaning.
-/// 
+/// Invert the palette colors generated when `palette-generate` is enabled,
+/// so that the colors go in reverse order. This allows palette-based
+/// applications to work well in both light and dark mode since the
+/// palettes are always relatively good colors.
+///
+/// This defaults to off because some legacy terminal applications
+/// hardcode the assumption that palette indices 16–231 are ordered from
+/// darkest to lightest, so enabling this would make them unreadable.
+/// This is not a generally good assumption and we encourage modern
+/// terminal applications to use the indices in a more semantic way.
+///
+/// This has no effect if `palette-generate` is disabled.
+///
+/// For more information see `palette-generate`.
+///
 /// Available since: 1.3.0
 @"palette-harmonious": bool = false,
 

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -189,6 +189,7 @@ pub const DerivedConfig = struct {
                     config.palette.mask,
                     config.background.toTerminalRGB(),
                     config.foreground.toTerminalRGB(),
+                    config.@"palette-harmonious"
                 );
             }
 

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -184,13 +184,7 @@ pub const DerivedConfig = struct {
                     break :generate;
                 }
 
-                break :palette terminalpkg.color.generate256Color(
-                    config.palette.value,
-                    config.palette.mask,
-                    config.background.toTerminalRGB(),
-                    config.foreground.toTerminalRGB(),
-                    config.@"palette-harmonious"
-                );
+                break :palette terminalpkg.color.generate256Color(config.palette.value, config.palette.mask, config.background.toTerminalRGB(), config.foreground.toTerminalRGB(), config.@"palette-harmonious");
             }
 
             break :palette config.palette.value;


### PR DESCRIPTION
From #10554

> I can see there being space for some kind of new sequence that tells the terminal that "hey, I want a semantic palette" or something, that is better adjusted to themes automatically. But, I don't think we should this by default.

> So my concrete proposal is to eliminate the inversion and bg => fg ramp and do a more typical dark => light ramp (still taking into account bg/fg, but keeping 16 black and 231 white). I think this is the only way we can really make this a default on feature. I think this would address all the negative reactions we've gotten to it.

This adds a new `palette-harmonious`, disabled by default, which allows generated light themes to be inverted.