### PR TITLE
ci: milestone workflow should use our vouch app token

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -9,18 +9,26 @@ on:
   pull_request_target:
     types: [closed]
 
+permissions: {}
+
 jobs:
   update-milestone:
     runs-on: namespace-profile-ghostty-sm
     name: Milestone Update
     steps:
+      - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: app-token
+        with:
+          app-id: ${{ secrets.VOUCH_APP_ID }}
+          private-key: ${{ secrets.VOUCH_APP_PRIVATE_KEY }}
+
       - name: Set Milestone for PR
         uses: hustcer/milestone-action@ebed8d5daafd855a600d7e665c1b130f06d24130 # v3.1
         if: github.event.pull_request.merged == true
         with:
           action: bind-pr # `bind-pr` is the default action
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       # Bind milestone to closed issue that has a merged PR fix
       - name: Set Milestone for Issue
@@ -29,4 +37,4 @@ jobs:
         with:
           action: bind-issue
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
This increases our rate limits and the vouch app already has the permissions required for the milestone workflow.

cc @trag1c 