### PR TITLE
macos: add root-level .swiftlint.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           filters: |
             macos:
+              - '.swiftlint.yml'
               - 'macos/**'
 
   required:
@@ -963,7 +964,7 @@ jobs:
           useDaemon: false # sometimes fails on short jobs
 
       - name: swiftlint check
-        run: nix develop -c swiftlint lint --strict macos
+        run: nix develop -c swiftlint lint --strict
 
   alejandra:
     if: github.repository == 'ghostty-org/ghostty'

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,2 @@
+included: macos
+child_config: macos/.swiftlint.yml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ A file for [guiding coding agents](https://agents.md/).
 - **Test (Zig):** `zig build test`
 - **Test filter (Zig)**: `zig build test -Dtest-filter=<test name>`
 - **Formatting (Zig)**: `zig fmt .`
-- **Formatting (Swift)**: `swiftlint lint --fix macos`
+- **Formatting (Swift)**: `swiftlint lint --fix`
 - **Formatting (other)**: `prettier -w .`
 
 ## Directory Structure

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -137,6 +137,7 @@
 /dist/macos/ @ghostty-org/macos
 /pkg/apple-sdk/ @ghostty-org/macos
 /pkg/macos/ @ghostty-org/macos
+/.swiftlint.yml @ghostty-org/macos
 
 # Renderer
 /src/renderer.zig @ghostty-org/renderer

--- a/HACKING.md
+++ b/HACKING.md
@@ -194,7 +194,7 @@ are modifying Swift code, you may want to install it locally and run this from
 the repo root before you commit:
 
 ```
-swiftlint lint --fix macos
+swiftlint lint --fix
 ```
 
 Make sure your SwiftLint version matches the version in [devShell.nix](https://github.com/ghostty-org/ghostty/blob/main/nix/devShell.nix).
@@ -202,13 +202,13 @@ Make sure your SwiftLint version matches the version in [devShell.nix](https://g
 Nix users can use the following command to format with SwiftLint:
 
 ```
-nix develop -c swiftlint lint --fix macos
+nix develop -c swiftlint lint --fix
 ```
 
 To check for violations without auto-fixing:
 
 ```
-nix develop -c swiftlint lint --strict macos
+nix develop -c swiftlint lint --strict
 ```
 
 ### Updating the Zig Cache Fixed-Output Derivation Hash

--- a/macos/.swiftlint.yml
+++ b/macos/.swiftlint.yml
@@ -2,6 +2,9 @@
 #
 check_for_updates: false
 
+excluded:
+  - build
+
 disabled_rules:
   - cyclomatic_complexity
   - file_length
@@ -13,7 +16,6 @@ disabled_rules:
   - type_body_length
 
   # TODO
-  - deployment_target
   - for_where
   - force_cast
   - line_length

--- a/macos/Ghostty.xcodeproj/project.pbxproj
+++ b/macos/Ghostty.xcodeproj/project.pbxproj
@@ -509,7 +509,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "[[ -z \"$GITHUB_ACTIONS\" ]] || exit 0;\n\nSWIFTLINT=\"\"\nif command -v swiftlint >/dev/null 2>&1; then\n    SWIFTLINT=\"$(command -v swiftlint)\"\nelif [[ -f \"/opt/homebrew/bin/swiftlint\" ]]; then\n    SWIFTLINT=\"/opt/homebrew/bin/swiftlint\"\nfi\n\nif [[ -n \"$SWIFTLINT\" ]]; then\n    \"$SWIFTLINT\" lint --quiet \"$SRCROOT\"\nfi\n";
+			shellScript = "[[ -z \"$GITHUB_ACTIONS\" ]] || exit 0;\n\nSWIFTLINT=\"\"\nif command -v swiftlint >/dev/null 2>&1; then\n    SWIFTLINT=\"$(command -v swiftlint)\"\nelif [[ -f \"/opt/homebrew/bin/swiftlint\" ]]; then\n    SWIFTLINT=\"/opt/homebrew/bin/swiftlint\"\nfi\n\nif [[ -n \"$SWIFTLINT\" ]]; then\n    \"$SWIFTLINT\" lint --quiet\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */


### PR DESCRIPTION
In order to support running from both the repository root and from within Xcode project, and to keep things generally organized, our primary .swiftlint.yml configuration file lives under macos/.

This change introduces a root-level .swiftlint.yml which limits the file scope to macos/ and then includes macos/.swiftlint.yml for the rest of the directives.

This unlocks a few benefits:

- We no longer need to pass an explicit `macos` path argument in any of our invocations. SwiftLint will do the right thing when run either from the repository root or from within the macos/ directory.
- It lets us easily exclude the macos/build/ directory (and re-enable the 'deployment_target' rule). In the previous setup, this was more challenging than you'd expect due to SwiftLint's path resolution rules and required passing even more arguments like `--working-directory`.

The only downside is adding a new file to the repository root, but that feels like the right trade-off given the benefits and conveniences.