### PR TITLE
macos: ignore swiftlint 'line_length' rule

### DIFF
--- a/macos/.swiftlint.yml
+++ b/macos/.swiftlint.yml
@@ -6,6 +6,7 @@ disabled_rules:
   - cyclomatic_complexity
   - file_length
   - function_body_length
+  - line_length
   - nesting
   - todo
   - trailing_comma
@@ -16,8 +17,6 @@ disabled_rules:
   - deployment_target
   - for_where
   - force_cast
-  - line_length
-  - mark
   - multiple_closures_with_trailing_closure
   - no_fallthrough_only
   - switch_case_alignment


### PR DESCRIPTION
Also, there are no more outstanding 'mark' issues.