### PR TITLE
macos: swiftlint 'no_fallthrough_only' rule

### DIFF
--- a/macos/.swiftlint.yml
+++ b/macos/.swiftlint.yml
@@ -11,6 +11,7 @@ disabled_rules:
   - function_body_length
   - line_length
   - nesting
+  - no_fallthrough_only
   - todo
   - trailing_comma
   - trailing_newline
@@ -20,7 +21,6 @@ disabled_rules:
   - for_where
   - force_cast
   - multiple_closures_with_trailing_closure
-  - no_fallthrough_only
   - switch_case_alignment
 
 identifier_name:

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -380,13 +380,7 @@ class AppDelegate: NSObject,
 
             if let why = event.attributeDescriptor(forKeyword: keyword) {
                 switch why.typeCodeValue {
-                case kAEShutDown:
-                    fallthrough
-
-                case kAERestart:
-                    fallthrough
-
-                case kAEReallyLogOut:
+                case kAEShutDown, kAERestart, kAEReallyLogOut:
                     return .terminateNow
 
                 default:


### PR DESCRIPTION
This rule is generally trying to be helpful, but it doesn't like a few places in our code base where we're intentionally listing out all of the well-known cases. Given that, just disable it.

https://realm.github.io/SwiftLint/no_fallthrough_only.html