### PR TITLE
i18n: normalize LANGUAGE environment variable

### DIFF
--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -208,10 +208,9 @@ pub const Application = extern struct {
         /// Providers for loading custom stylesheets defined by user
         custom_css_providers: std.ArrayListUnmanaged(*gtk.CssProvider) = .empty,
 
-        /// A copy of the LANG environment variable that was provided to Ghostty
-        /// by the system. If this is null, the LANG environment variable did
-        /// not exist in Ghostty's environment variable.
-        saved_language: ?[:0]const u8 = null,
+        /// A map of saved locale environment variables (e.g., LANG, LANGUAGE) provided to Ghostty by the system.
+        /// If a key is missing, the environment variable did not exist in Ghostty's environment.
+        saved_locale_envs: std.StringHashMap(?[:0]const u8) = undefined,
 
         pub var offset: c_int = 0;
     };
@@ -266,17 +265,23 @@ pub const Application = extern struct {
         };
         defer config.deinit();
 
-        const saved_language: ?[:0]const u8 = saved_language: {
-            const old_language = old_language: {
-                const result = (internal_os.getenv(alloc, "LANG") catch break :old_language null) orelse break :old_language null;
+        var saved_locale_envs = std.StringHashMap(?[:0]const u8).init(alloc);
+        defer saved_locale_envs.deinit();
+
+        const locale_vars = [_][]const u8{ "LANG", "LANGUAGE" };
+        for (locale_vars) |env_name| {
+            const value = blk: {
+                const result = (internal_os.getenv(alloc, env_name) catch break :blk null) orelse break :blk null;
                 defer result.deinit(alloc);
-                break :old_language alloc.dupeZ(u8, result.value) catch break :old_language null;
+                break :blk alloc.dupeZ(u8, result.value) catch break :blk null;
             };
+            try saved_locale_envs.put(env_name, value);
+        }
 
-            if (config.language) |language| _ = internal_os.setenv("LANG", language);
-
-            break :saved_language old_language;
-        };
+        if (config.language) |language| {
+            _ = internal_os.setenv("LANG", language);
+            _ = internal_os.setenv("LANGUAGE", language);
+        }
 
         // Set gettext global domain to be our app so that our unqualified
         // translations map to our translations.
@@ -395,7 +400,7 @@ pub const Application = extern struct {
             .css_provider = css_provider,
             .custom_css_providers = .empty,
             .global_shortcuts = gobject.ext.newInstance(GlobalShortcuts, .{}),
-            .saved_language = saved_language,
+            .saved_locale_envs = try saved_locale_envs.clone(),
         };
 
         // Signals
@@ -432,7 +437,12 @@ pub const Application = extern struct {
         priv.config.unref();
         priv.winproto.deinit(alloc);
         priv.global_shortcuts.unref();
-        if (priv.saved_language) |language| alloc.free(language);
+        // Free saved_locale_envs values
+        var it = priv.saved_locale_envs.iterator();
+        while (it.next()) |entry| {
+            if (entry.value_ptr.*) |v| alloc.free(v);
+        }
+        priv.saved_locale_envs.deinit();
         if (gdk.Display.getDefault()) |display| {
             gtk.StyleContext.removeProviderForDisplay(
                 display,
@@ -461,7 +471,13 @@ pub const Application = extern struct {
     /// Get the original language that Ghostty was launched with. This returns a
     /// pointer to internal memory so it must be copied by callers.
     pub fn savedLanguage(self: *Self) ?[:0]const u8 {
-        return self.private().saved_language;
+        // Deprecated: Use savedLocaleEnvs instead
+        return self.private().saved_locale_envs.get("LANG") orelse null;
+    }
+
+    /// Get the saved locale environment variables map.
+    pub fn savedLocaleEnvs(self: *Self) std.StringHashMap(?[:0]const u8) {
+        return self.private().saved_locale_envs;
     }
 
     /// Run the application. This is a replacement for `gio.Application.run`

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -1530,10 +1530,17 @@ pub const Surface = extern struct {
         var env = try internal_os.getEnvMap(alloc);
         errdefer env.deinit();
 
-        if (app.savedLanguage()) |language| {
-            try env.put("LANG", language);
-        } else {
-            env.remove("LANG");
+        const locale_envs = [_][]const u8{ "LANG", "LANGUAGE" };
+        for (locale_envs) |locale_env| {
+            if (app.savedLocaleEnvs().get(locale_env)) |value| {
+                if (value) |v| {
+                    try env.put(locale_env, v);
+                } else {
+                    env.remove(locale_env);
+                }
+            } else {
+                env.remove(locale_env);
+            }
         }
 
         // Don't leak these GTK environment variables to child processes.

--- a/src/os/locale.zig
+++ b/src/os/locale.zig
@@ -32,41 +32,7 @@ pub fn ensureLocale(alloc: std.mem.Allocator) !void {
     if ((try internal_os.getenv(alloc, "LANGUAGE"))) |language| {
         defer language.deinit(alloc);
         if (language.value.len > 0) {
-            normalized: {
-                var locale_buf: [128]u8 = undefined;
-                var first = true;
-                // LANGUAGE might come as lv:en, without .UTF-8. Ordered by preference, we check one by one to find first valid locale.
-                var it = std.mem.splitScalar(u8, language.value, ':');
-                while (it.next()) |entry| {
-                    if (entry.len == 0) continue;
-                    defer first = false;
-
-                    // If the first preferred language is English (Ghostty's default), stop.
-                    if (first and std.mem.eql(u8, entry, "en")) {
-                        _ = internal_os.setenv("LANGUAGE", "en");
-                        break :normalized;
-                    }
-
-                    // If entry has no region (no "_*"), pick the first matching full locale.
-                    if (std.mem.indexOfScalar(u8, entry, '_') == null) {
-                        for (i18n_locales.locales) |locale| {
-                            if (!std.mem.startsWith(u8, locale, entry)) continue;
-                            if (locale.len <= entry.len) continue;
-                            if (locale[entry.len] != '_') continue;
-                            _ = internal_os.setenv("LANGUAGE", locale);
-                            break :normalized;
-                        }
-                    }
-
-                    // Normalize to {entry}.UTF-8 for LANGUAGE when supported by Ghostty.
-                    const locale = std.fmt.bufPrintZ(&locale_buf, "{s}.UTF-8", .{entry}) catch continue;
-                    for (i18n_locales.locales) |supported| {
-                        if (!std.mem.eql(u8, locale, supported)) continue;
-                        _ = internal_os.setenv("LANGUAGE", locale);
-                        break :normalized;
-                    }
-                }
-            }
+            preferredLanguage("LANGUAGE", language.value);
         }
     }
 
@@ -250,6 +216,44 @@ fn preferredLanguageFromCocoa(
     // reslice it with the null terminator.
     const slice = fbs.getWritten();
     return slice[0 .. slice.len - 1 :0];
+}
+
+fn preferredLanguage(key: [:0]const u8, language: []const u8) void {
+    var locale_buf: [128]u8 = undefined;
+    var first = true;
+
+    // LANGUAGE might come as lv:en, without .UTF-8. Ordered by preference,
+    // we check one by one to find first supported locale.
+    var it = std.mem.splitScalar(u8, language, ':');
+    while (it.next()) |entry| {
+        if (entry.len == 0) continue;
+        defer first = false;
+
+        // If the first preferred language is English (Ghostty's default), stop.
+        if (first and std.mem.eql(u8, entry, "en")) {
+            _ = internal_os.setenv(key, "en");
+            return;
+        }
+
+        // If entry has no region (no "_*"), pick the first matching full locale.
+        if (std.mem.indexOfScalar(u8, entry, '_') == null) {
+            for (i18n_locales.locales) |locale| {
+                if (!std.mem.startsWith(u8, locale, entry)) continue;
+                if (locale.len <= entry.len) continue;
+                if (locale[entry.len] != '_') continue;
+                _ = internal_os.setenv(key, locale);
+                return;
+            }
+        }
+
+        // Normalize to {entry}.UTF-8 for LANGUAGE when supported by Ghostty.
+        const locale = std.fmt.bufPrintZ(&locale_buf, "{s}.UTF-8", .{entry}) catch continue;
+        for (i18n_locales.locales) |supported| {
+            if (!std.mem.eql(u8, locale, supported)) continue;
+            _ = internal_os.setenv(key, locale);
+            return;
+        }
+    }
 }
 
 const LC_ALL: c_int = 6; // from locale.h

--- a/src/os/locale.zig
+++ b/src/os/locale.zig
@@ -29,22 +29,26 @@ pub fn ensureLocale(alloc: std.mem.Allocator) !void {
         }
     }
 
-    if ((try internal_os.getenv(alloc, "LANGUAGE"))) |language| {
-        defer language.deinit(alloc);
-        if (language.value.len > 0) {
-            var out: [11:0]u8 = undefined; // xx_YY.UTF-8 is exactly 11 bytes long
-            var writer: std.Io.Writer = .fixed(out[0..11]);
+    language: {
+        if ((try internal_os.getenv(alloc, "LANGUAGE"))) |language| {
+            defer language.deinit(alloc);
+
+            if (language.value.len <= 0) break :language;
+
+            var out: [64:0]u8 = undefined;
+            var writer: std.Io.Writer = .fixed(out[0..out.len]);
 
             const ok = preferredLanguage(&writer, language.value) catch false;
-            if (ok) {
-                const value = writer.buffered();
-                if (value.len == 11) {
-                    out[11] = 0;
-                    const preferred = out[0..11 :0];
-                    _ = internal_os.setenv("LANGUAGE", preferred);
-                    log.info("setlocale preferred locale from LANGUAGE {s}", .{preferred});
-                }
-            }
+
+            if (!ok) break :language;
+
+            writer.writeByte(0) catch break :language;
+
+            const value = writer.buffered();
+            const preferred = out[0 .. value.len - 1 :0];
+
+            log.info("setlocale preferred locale from LANGUAGE {s}", .{preferred});
+            _ = internal_os.setenv("LANGUAGE", preferred);
         }
     }
 
@@ -231,7 +235,7 @@ fn preferredLanguageFromCocoa(
 }
 
 fn preferredLanguage(writer: *std.Io.Writer, language: []const u8) !bool {
-    var locale_buf: [11]u8 = undefined;
+    var locale_buf: [64]u8 = undefined;
     var first = true;
 
     // LANGUAGE might come as lv:en, without .UTF-8. Ordered by preference,
@@ -293,7 +297,6 @@ test "preferredLanguage normalizes short language code" {
     const ok = try preferredLanguage(&buf.writer, "lv");
 
     try testing.expect(ok);
-    try testing.expectEqual(@as(usize, 11), buf.written().len);
     try testing.expectEqualStrings("lv_LV.UTF-8", buf.written());
 }
 
@@ -305,7 +308,7 @@ test "preferredLanguage keeps english when first and doesn't overwrite env" {
     const ok = try preferredLanguage(&buf.writer, "en:lv");
 
     try testing.expect(!ok); // ignores LANGUAGE and just continues
-    try testing.expectEqual(@as(usize, 0), buf.written().len);
+    try testing.expectEqual(0, buf.written().len);
     try testing.expectEqualStrings("", buf.written());
 }
 
@@ -317,7 +320,6 @@ test "preferredLanguage normalizes locale without encoding" {
     const ok = try preferredLanguage(&buf.writer, "it_IT");
 
     try testing.expect(ok);
-    try testing.expectEqual(@as(usize, 11), buf.written().len);
     try testing.expectEqualStrings("it_IT.UTF-8", buf.written());
 }
 
@@ -329,7 +331,6 @@ test "preferredLanguage keeps locale with encoding" {
     const ok = try preferredLanguage(&buf.writer, "pt_BR.UTF-8");
 
     try testing.expect(ok);
-    try testing.expectEqual(@as(usize, 11), buf.written().len);
     try testing.expectEqualStrings("pt_BR.UTF-8", buf.written());
 }
 
@@ -341,6 +342,6 @@ test "preferredLanguage returns false and writes nothing for completely invalid 
     const ok = try preferredLanguage(&buf.writer, "zz:qq_QQ:xx_YY.ISO-8859-1:__:@@@");
 
     try testing.expect(!ok);
-    try testing.expectEqual(@as(usize, 0), buf.written().len);
+    try testing.expectEqual(0, buf.written().len);
     try testing.expectEqualStrings("", buf.written());
 }

--- a/src/os/locale.zig
+++ b/src/os/locale.zig
@@ -29,27 +29,25 @@ pub fn ensureLocale(alloc: std.mem.Allocator) !void {
         }
     }
 
-    language: {
-        if ((try internal_os.getenv(alloc, "LANGUAGE"))) |language| {
-            defer language.deinit(alloc);
+    if ((try internal_os.getenv(alloc, "LANGUAGE"))) |language| language: {
+        defer language.deinit(alloc);
 
-            if (language.value.len <= 0) break :language;
+        if (language.value.len <= 0) break :language;
 
-            var out: [64:0]u8 = undefined;
-            var writer: std.Io.Writer = .fixed(out[0..out.len]);
+        var out: [64:0]u8 = undefined;
+        var writer: std.Io.Writer = .fixed(&out);
 
-            const ok = preferredLanguage(&writer, language.value) catch false;
+        const ok = preferredLanguage(&writer, language.value) catch false;
 
-            if (!ok) break :language;
+        if (!ok) break :language;
 
-            writer.writeByte(0) catch break :language;
+        writer.writeByte(0) catch break :language;
 
-            const value = writer.buffered();
-            const preferred = out[0 .. value.len - 1 :0];
+        const value = writer.buffered();
+        const preferred = out[0 .. value.len - 1 :0];
 
-            log.info("setlocale preferred locale from LANGUAGE {s}", .{preferred});
-            _ = internal_os.setenv("LANGUAGE", preferred);
-        }
+        log.info("setlocale preferred locale from LANGUAGE {s}", .{preferred});
+        _ = internal_os.setenv("LANGUAGE", preferred);
     }
 
     // Set the locale to whatever is set in env vars.

--- a/src/os/locale.zig
+++ b/src/os/locale.zig
@@ -32,7 +32,19 @@ pub fn ensureLocale(alloc: std.mem.Allocator) !void {
     if ((try internal_os.getenv(alloc, "LANGUAGE"))) |language| {
         defer language.deinit(alloc);
         if (language.value.len > 0) {
-            preferredLanguage("LANGUAGE", language.value);
+            var out: [11:0]u8 = undefined; // xx_YY.UTF-8 is 11 bytes long
+            var writer: std.Io.Writer = .fixed(out[0..out.len]);
+
+            const ok = preferredLanguage(&writer, language.value) catch false;
+            if (ok) {
+                const value = writer.buffered();
+                if (value.len == 11) {
+                    out[11] = 0;
+                    const preferred = out[0..11 :0];
+                    _ = internal_os.setenv("LANGUAGE", preferred);
+                    log.info("setlocale preferred locale from LANGUAGE {s}", .{preferred});
+                }
+            }
         }
     }
 
@@ -218,7 +230,7 @@ fn preferredLanguageFromCocoa(
     return slice[0 .. slice.len - 1 :0];
 }
 
-fn preferredLanguage(key: [:0]const u8, language: []const u8) void {
+fn preferredLanguage(writer: *std.Io.Writer, language: []const u8) !bool {
     var locale_buf: [128]u8 = undefined;
     var first = true;
 
@@ -233,15 +245,14 @@ fn preferredLanguage(key: [:0]const u8, language: []const u8) void {
         if (std.mem.endsWith(u8, entry, ".UTF-8")) {
             for (i18n_locales.locales) |supported| {
                 if (!std.mem.eql(u8, entry, supported)) continue;
-                _ = internal_os.setenv(key, supported);
-                return;
+                try writer.writeAll(supported);
+                return true;
             }
         }
 
         // If the first preferred language is English (Ghostty's default), stop.
         if (first and std.mem.eql(u8, entry, "en")) {
-            _ = internal_os.setenv(key, "en");
-            return;
+            return false;
         }
 
         // If entry has no region (no "_*"), pick the first matching full locale.
@@ -250,19 +261,21 @@ fn preferredLanguage(key: [:0]const u8, language: []const u8) void {
                 if (!std.mem.startsWith(u8, locale, entry)) continue;
                 if (locale.len <= entry.len) continue;
                 if (locale[entry.len] != '_') continue;
-                _ = internal_os.setenv(key, locale);
-                return;
+                try writer.writeAll(locale);
+                return true;
             }
         }
 
-        // Normalize to {entry}.UTF-8 for LANGUAGE when supported by Ghostty.
-        const locale = std.fmt.bufPrintZ(&locale_buf, "{s}.UTF-8", .{entry}) catch continue;
+        // Normalize to "{entry}.UTF-8" when supported.
+        const normalized = std.fmt.bufPrint(&locale_buf, "{s}.UTF-8", .{entry}) catch continue;
         for (i18n_locales.locales) |supported| {
-            if (!std.mem.eql(u8, locale, supported)) continue;
-            _ = internal_os.setenv(key, locale);
-            return;
+            if (!std.mem.eql(u8, normalized, supported)) continue;
+            try writer.writeAll(supported);
+            return true;
         }
     }
+
+    return false;
 }
 
 const LC_ALL: c_int = 6; // from locale.h
@@ -274,60 +287,60 @@ extern "c" fn freelocale(v: locale_t) void;
 
 test "preferredLanguage normalizes short language code" {
     const testing = std.testing;
-    const key: [:0]const u8 = "GHOSTTY_TEST_LANGUAGE_NORMALIZE_SHORT";
-    _ = internal_os.unsetenv(key);
-    defer _ = internal_os.unsetenv(key);
+    var buf: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer buf.deinit();
 
-    preferredLanguage(key, "lv:en");
+    const ok = try preferredLanguage(&buf.writer, "lv");
 
-    const got_opt = try internal_os.getenv(testing.allocator, key);
-    try testing.expect(got_opt != null);
-    const got = got_opt.?;
-    defer got.deinit(testing.allocator);
-    try testing.expectEqualStrings("lv_LV.UTF-8", got.value);
+    try testing.expect(ok);
+    try testing.expectEqual(@as(usize, 11), buf.written().len);
+    try testing.expectEqualStrings("lv_LV.UTF-8", buf.written());
 }
 
-test "preferredLanguage keeps english when first" {
+test "preferredLanguage keeps english when first and doesn't overwrite env" {
     const testing = std.testing;
-    const key: [:0]const u8 = "GHOSTTY_TEST_LANGUAGE_ENGLISH_FIRST";
-    _ = internal_os.unsetenv(key);
-    defer _ = internal_os.unsetenv(key);
+    var buf: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer buf.deinit();
 
-    preferredLanguage(key, "en:lv");
+    const ok = try preferredLanguage(&buf.writer, "en:lv");
 
-    const got_opt = try internal_os.getenv(testing.allocator, key);
-    try testing.expect(got_opt != null);
-    const got = got_opt.?;
-    defer got.deinit(testing.allocator);
-    try testing.expectEqualStrings("en", got.value);
+    try testing.expect(!ok); // ignores LANGUAGE and just continues
+    try testing.expectEqual(@as(usize, 0), buf.written().len);
+    try testing.expectEqualStrings("", buf.written());
 }
 
 test "preferredLanguage normalizes locale without encoding" {
     const testing = std.testing;
-    const key: [:0]const u8 = "GHOSTTY_TEST_LANGUAGE_NORMALIZE_ENCODING";
-    _ = internal_os.unsetenv(key);
-    defer _ = internal_os.unsetenv(key);
+    var buf: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer buf.deinit();
 
-    preferredLanguage(key, "it_IT");
+    const ok = try preferredLanguage(&buf.writer, "it_IT");
 
-    const got_opt = try internal_os.getenv(testing.allocator, key);
-    try testing.expect(got_opt != null);
-    const got = got_opt.?;
-    defer got.deinit(testing.allocator);
-    try testing.expectEqualStrings("it_IT.UTF-8", got.value);
+    try testing.expect(ok);
+    try testing.expectEqual(@as(usize, 11), buf.written().len);
+    try testing.expectEqualStrings("it_IT.UTF-8", buf.written());
 }
 
 test "preferredLanguage keeps locale with encoding" {
     const testing = std.testing;
-    const key: [:0]const u8 = "GHOSTTY_TEST_LANGUAGE_KEEP_ENCODING";
-    _ = internal_os.unsetenv(key);
-    defer _ = internal_os.unsetenv(key);
+    var buf: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer buf.deinit();
 
-    preferredLanguage(key, "pt_BR.UTF-8");
+    const ok = try preferredLanguage(&buf.writer, "pt_BR.UTF-8");
 
-    const got_opt = try internal_os.getenv(testing.allocator, key);
-    try testing.expect(got_opt != null);
-    const got = got_opt.?;
-    defer got.deinit(testing.allocator);
-    try testing.expectEqualStrings("pt_BR.UTF-8", got.value);
+    try testing.expect(ok);
+    try testing.expectEqual(@as(usize, 11), buf.written().len);
+    try testing.expectEqualStrings("pt_BR.UTF-8", buf.written());
+}
+
+test "preferredLanguage returns false and writes nothing for completely invalid LANGUAGE" {
+    const testing = std.testing;
+    var buf: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer buf.deinit();
+
+    const ok = try preferredLanguage(&buf.writer, "zz:qq_QQ:xx_YY.ISO-8859-1:__:@@@");
+
+    try testing.expect(!ok);
+    try testing.expectEqual(@as(usize, 0), buf.written().len);
+    try testing.expectEqualStrings("", buf.written());
 }

--- a/src/os/locale.zig
+++ b/src/os/locale.zig
@@ -32,8 +32,8 @@ pub fn ensureLocale(alloc: std.mem.Allocator) !void {
     if ((try internal_os.getenv(alloc, "LANGUAGE"))) |language| {
         defer language.deinit(alloc);
         if (language.value.len > 0) {
-            var out: [11:0]u8 = undefined; // xx_YY.UTF-8 is 11 bytes long
-            var writer: std.Io.Writer = .fixed(out[0..out.len]);
+            var out: [11:0]u8 = undefined; // xx_YY.UTF-8 is exactly 11 bytes long
+            var writer: std.Io.Writer = .fixed(out[0..11]);
 
             const ok = preferredLanguage(&writer, language.value) catch false;
             if (ok) {
@@ -231,7 +231,7 @@ fn preferredLanguageFromCocoa(
 }
 
 fn preferredLanguage(writer: *std.Io.Writer, language: []const u8) !bool {
-    var locale_buf: [128]u8 = undefined;
+    var locale_buf: [11]u8 = undefined;
     var first = true;
 
     // LANGUAGE might come as lv:en, without .UTF-8. Ordered by preference,


### PR DESCRIPTION
LANGUAGE can come as en, lv:en, pt_BR:en or as lv_LV.UTF-8. This PR normalizes LANGUAGE in a form that is supported by our translations.