### PR TITLE
macos: fix new tab crash

### DIFF
--- a/macos/Sources/Helpers/Extensions/NSView+Extension.swift
+++ b/macos/Sources/Helpers/Extensions/NSView+Extension.swift
@@ -65,7 +65,7 @@ extension NSView {
             return true
         }
 
-        for subview in subviews where contains(className: name) {
+        for subview in subviews where subview.contains(className: name) {
             return true
         }
 


### PR DESCRIPTION
It was introduced in 2a81d8cd2910b12fe007f0bc5fb5d6be57f0f0fe[0]. We lost the subview. prefix of from the contains() call.


Fixes: https://github.com/ghostty-org/ghostty/issues/10923
Link: https://github.com/ghostty-org/ghostty/commit/2a81d8cd2910b12fe007f0bc5fb5d6be57f0f0fe [0]