### PR TITLE
renderer: kitty image update requires draw_mutex

### DIFF
--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1226,6 +1226,10 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // kitty state on every frame because any cell change can move
                 // an image.
                 if (self.images.kittyRequiresUpdate(state.terminal)) {
+                    // We need to grab the draw mutex since this updates
+                    // our image state that drawFrame uses.
+                    self.draw_mutex.lock();
+                    defer self.draw_mutex.unlock();
                     self.images.kittyUpdate(
                         self.alloc,
                         state.terminal,

--- a/src/renderer/image.zig
+++ b/src/renderer/image.zig
@@ -844,7 +844,7 @@ pub const Image = union(enum) {
     /// Converts the image data to a format that can be uploaded to the GPU.
     /// If the data is already in a format that can be uploaded, this is a
     /// no-op.
-    pub fn convert(self: *Image, alloc: Allocator) wuffs.Error!void {
+    fn convert(self: *Image, alloc: Allocator) wuffs.Error!void {
         const p = self.getPendingPointer().?;
         // As things stand, we currently convert all images to RGBA before
         // uploading to the GPU. This just makes things easier. In the future
@@ -867,7 +867,7 @@ pub const Image = union(enum) {
 
     /// Prepare the pending image data for upload to the GPU.
     /// This doesn't need GPU access so is safe to call any time.
-    pub fn prepForUpload(self: *Image, alloc: Allocator) wuffs.Error!void {
+    fn prepForUpload(self: *Image, alloc: Allocator) wuffs.Error!void {
         assert(self.isPending());
         try self.convert(alloc);
     }


### PR DESCRIPTION
Fixes #10680

The image state is used for drawing, so when we update it, we need to acquire the draw mutex. All our other state updates already acquire the draw mutex but Kitty images are odd in that they happen in the critical area (due to their size).