### PR TITLE
nix: update ucs-detect to latest master

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,7 @@
           packageOverrides = pyfinal: pyprev: {
             blessed = pyfinal.callPackage ./nix/pkgs/blessed.nix {};
             ucs-detect = pyfinal.callPackage ./nix/pkgs/ucs-detect.nix {};
+            wcwidth = pyfinal.callPackage ./nix/pkgs/wcwidth.nix {};
           };
         };
       };

--- a/nix/pkgs/blessed.nix
+++ b/nix/pkgs/blessed.nix
@@ -1,22 +1,24 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   pythonOlder,
   flit-core,
   six,
   wcwidth,
 }:
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "blessed";
-  version = "1.23.0";
+  version = "unstable-2026-02-23";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-VlkaMpZvcE9hMfFACvQVHZ6PX0FEEzpcoDQBl2Pe53s=";
+  src = fetchFromGitHub {
+    owner = "jquast";
+    repo = "blessed";
+    rev = "master";
+    hash = "sha256-ROd/O9pfqnF5DHXqoz+tkl1jQJSZad3Ta1h+oC3+gvY=";
   };
 
   build-system = [flit-core];
@@ -27,6 +29,7 @@ buildPythonPackage rec {
   ];
 
   doCheck = false;
+  dontCheckRuntimeDeps = true;
 
   meta = with lib; {
     homepage = "https://github.com/jquast/blessed";

--- a/nix/pkgs/ucs-detect.nix
+++ b/nix/pkgs/ucs-detect.nix
@@ -1,36 +1,42 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   pythonOlder,
-  setuptools,
+  hatchling,
   # Dependencies
   blessed,
   wcwidth,
   pyyaml,
+  prettytable,
+  requests,
 }:
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "ucs-detect";
-  version = "1.0.8";
+  version = "unstable-2026-02-23";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
-  src = fetchPypi {
-    inherit version;
-    pname = "ucs_detect";
-    hash = "sha256-ihB+tZCd6ykdeXYxc6V1Q6xALQ+xdCW5yqSL7oppqJc=";
+  src = fetchFromGitHub {
+    owner = "jquast";
+    repo = "ucs-detect";
+    rev = "master";
+    hash = "sha256-x7BD14n1/mP9bzjM6DPqc5R1Fk/HLLycl4o41KV+xAE=";
   };
 
   dependencies = [
     blessed
     wcwidth
     pyyaml
+    prettytable
+    requests
   ];
 
-  nativeBuildInputs = [setuptools];
+  nativeBuildInputs = [hatchling];
 
   doCheck = false;
+  dontCheckRuntimeDeps = true;
 
   meta = with lib; {
     description = "Measures number of Terminal column cells of wide-character codes";

--- a/nix/pkgs/wcwidth.nix
+++ b/nix/pkgs/wcwidth.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+}:
+buildPythonPackage rec {
+  pname = "wcwidth";
+  version = "0.6.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-zcTkJi1u+aGlfgGDhMvrEgjYq7xkF2An4sJFXIExMVk=";
+  };
+
+  build-system = [hatchling];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Measures the displayed width of unicode strings in a terminal";
+    homepage = "https://github.com/jquast/wcwidth";
+    license = licenses.mit;
+    maintainers = [];
+  };
+}


### PR DESCRIPTION
This updates [ucs-detect](https://github.com/jquast/ucs-detect) to the latest `master` version from 2/7/2026.

AI disclaimer: this was done almost entirely with the help of AI, with this thread here: https://ampcode.com/threads/T-019c8ac5-e8ab-738d-93a6-06ec5b20f5e2