### PR TITLE
appintents: expose PID and TTY on TerminalEntity

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1072,6 +1072,8 @@ ghostty_surface_config_s ghostty_surface_inherited_config(ghostty_surface_t, gho
 void ghostty_surface_update_config(ghostty_surface_t, ghostty_config_t);
 bool ghostty_surface_needs_confirm_quit(ghostty_surface_t);
 bool ghostty_surface_process_exited(ghostty_surface_t);
+int32_t ghostty_surface_child_pid(ghostty_surface_t);
+const char* ghostty_surface_tty_name(ghostty_surface_t);
 void ghostty_surface_refresh(ghostty_surface_t);
 void ghostty_surface_draw(ghostty_surface_t);
 void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);

--- a/macos/Sources/Features/App Intents/Entities/TerminalEntity.swift
+++ b/macos/Sources/Features/App Intents/Entities/TerminalEntity.swift
@@ -14,6 +14,12 @@ struct TerminalEntity: AppEntity {
     @Property(title: "Kind")
     var kind: Kind
 
+    @Property(title: "PID")
+    var pid: Int?
+
+    @Property(title: "TTY")
+    var tty: String?
+
     var screenshot: NSImage?
 
     static var typeDisplayRepresentation: TypeDisplayRepresentation {
@@ -49,6 +55,8 @@ struct TerminalEntity: AppEntity {
         self.id = view.id
         self.title = view.title
         self.workingDirectory = view.pwd
+        self.pid = view.childPID.map { Int($0) }
+        self.tty = view.ttyName
         if let nsImage = ImageRenderer(content: view.screenshot()).nsImage {
             self.screenshot = nsImage
         }

--- a/macos/Sources/Features/App Intents/GetTerminalDetailsIntent.swift
+++ b/macos/Sources/Features/App Intents/GetTerminalDetailsIntent.swift
@@ -35,6 +35,8 @@ struct GetTerminalDetailsIntent: AppIntent {
         switch detail {
         case .title: return .result(value: terminal.title)
         case .workingDirectory: return .result(value: terminal.workingDirectory)
+        case .pid: return .result(value: terminal.pid.map { String($0) })
+        case .tty: return .result(value: terminal.tty)
         case .allContents:
             guard let view = terminal.surfaceView else { throw GhosttyIntentError.surfaceNotFound }
             return .result(value: view.cachedScreenContents.get())
@@ -53,6 +55,8 @@ struct GetTerminalDetailsIntent: AppIntent {
 enum TerminalDetail: String {
     case title
     case workingDirectory
+    case pid
+    case tty
     case allContents
     case selectedText
     case visibleText
@@ -64,6 +68,8 @@ extension TerminalDetail: AppEnum {
     static var caseDisplayRepresentations: [Self: DisplayRepresentation] = [
         .title: .init(title: "Title"),
         .workingDirectory: .init(title: "Working Directory"),
+        .pid: .init(title: "PID"),
+        .tty: .init(title: "TTY"),
         .allContents: .init(title: "Full Contents"),
         .selectedText: .init(title: "Selected Text"),
         .visibleText: .init(title: "Visible Text"),

--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -178,6 +178,20 @@ extension Ghostty {
             return ghostty_surface_process_exited(surface)
         }
 
+        // Returns the PID of the child process, or nil if not available.
+        var childPID: Int32? {
+            guard let surface = self.surface else { return nil }
+            let pid = ghostty_surface_child_pid(surface)
+            return pid >= 0 ? pid : nil
+        }
+
+        // Returns the TTY device name (e.g. "/dev/ttys003"), or nil if not available.
+        var ttyName: String? {
+            guard let surface = self.surface else { return nil }
+            guard let ptr = ghostty_surface_tty_name(surface) else { return nil }
+            return String(cString: ptr)
+        }
+
         // Returns the inspector instance for this surface, or nil if the
         // surface has been closed or no inspector is active.
         var inspector: Ghostty.Inspector? {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -936,6 +936,26 @@ pub fn needsConfirmQuit(self: *Surface) bool {
     };
 }
 
+/// Returns the PID of the child process, or -1 if not available.
+pub fn childPid(self: *Surface) i32 {
+    switch (self.io.backend) {
+        .exec => |*exec| {
+            const process = exec.subprocess.process orelse return -1;
+            switch (process) {
+                .fork_exec => |cmd| return if (cmd.pid) |p| @intCast(p) else -1,
+                .flatpak => return -1,
+            }
+        },
+    }
+}
+
+/// Returns the TTY device name (e.g. "/dev/ttys003"), or null if not available.
+pub fn ttyName(self: *Surface) ?[*:0]const u8 {
+    switch (self.io.backend) {
+        .exec => |*exec| return exec.subprocess.tty_name,
+    }
+}
+
 /// Called from the app thread to handle mailbox messages to our specific
 /// surface.
 pub fn handleMessage(self: *Surface, msg: Message) !void {

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1574,6 +1574,18 @@ pub const CAPI = struct {
         return surface.core_surface.child_exited;
     }
 
+    /// Returns the PID of the child process running in the surface,
+    /// or -1 if the process is not available.
+    export fn ghostty_surface_child_pid(surface: *Surface) i32 {
+        return surface.core_surface.childPid();
+    }
+
+    /// Returns the TTY device name of the surface (e.g. "/dev/ttys003"),
+    /// or null if not available.
+    export fn ghostty_surface_tty_name(surface: *Surface) ?[*:0]const u8 {
+        return surface.core_surface.ttyName();
+    }
+
     /// Returns true if the surface has a selection.
     export fn ghostty_surface_has_selection(surface: *Surface) bool {
         return surface.core_surface.hasSelection();

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -586,6 +586,7 @@ const Subprocess = struct {
     screen_size: renderer.ScreenSize,
     pty: ?Pty = null,
     process: ?Process = null,
+    tty_name: ?[*:0]const u8 = null,
 
     rt_pre_exec_info: Command.RtPreExecInfo,
     rt_post_fork_info: Command.RtPostForkInfo,
@@ -914,6 +915,17 @@ const Subprocess = struct {
         // the process.
         defer if (!in_child and self.process != null) {
             if (comptime builtin.os.tag != .windows) {
+                // Save the tty name before closing the slave fd.
+                // Use ttyname_r (reentrant) for thread safety since
+                // ttyname uses a static buffer.
+                self.tty_name = tty_name: {
+                    var tty_buf: [256]u8 = undefined;
+                    if (c.ttyname_r(pty.slave, &tty_buf, tty_buf.len) != 0) break :tty_name null;
+                    const len = std.mem.indexOfScalar(u8, &tty_buf, 0) orelse break :tty_name null;
+                    const duped = self.arena.allocator().dupeZ(u8, tty_buf[0..len]) catch break :tty_name null;
+                    break :tty_name duped;
+                };
+
                 // Once our subcommand is started we can close the slave
                 // side. This prevents the slave fd from being leaked to
                 // future children.


### PR DESCRIPTION
## Summary

- Add `pid` (child process PID) and `tty` (TTY device name, e.g. `/dev/ttys003`) as `@Property` fields on `TerminalEntity`
- Expose both as queryable details via `GetTerminalDetailsIntent`
- Add C API functions `ghostty_surface_child_pid` and `ghostty_surface_tty_name` bridging Zig core to Swift

This enables external applications and Shortcuts to identify and filter terminals by their PID or TTY device, as requested in #10756.

## Implementation

**Zig core → C API → Swift → App Intents** pipeline for both properties:

| Layer | File | Change |
|-------|------|--------|
| Subprocess | `src/termio/Exec.zig` | Store `tty_name` via `ttyname_r()` before closing slave fd |
| Surface | `src/Surface.zig` | Add `childPid()` and `ttyName()` methods |
| C API | `src/apprt/embedded.zig`, `include/ghostty.h` | Export `ghostty_surface_child_pid`, `ghostty_surface_tty_name` |
| Swift | `SurfaceView_AppKit.swift` | Add `childPID` and `ttyName` computed properties |
| App Intents | `TerminalEntity.swift`, `GetTerminalDetailsIntent.swift` | Add `pid` and `tty` as `@Property` and `TerminalDetail` cases |

### Notes
- Uses `ttyname_r` (reentrant) instead of `ttyname` for thread safety
- TTY name string is duped into the subprocess arena allocator for stable lifetime
- PID returns `-1` / `nil` for Flatpak or unavailable processes
- TTY returns `null` / `nil` on Windows or when not available

## Test plan

- [ ] Build succeeds on macOS with `zig build -Doptimize=ReleaseFast`
- [ ] Launch built Ghostty.app, open terminal tabs
- [ ] Use Shortcuts app: "Get Details of Terminal" → select "PID" → verify valid PID returned
- [ ] Use Shortcuts app: "Get Details of Terminal" → select "TTY" → verify TTY path returned (e.g. `/dev/ttys003`)
- [ ] Verify PID matches `ps` output for the shell process in that tab
- [ ] Verify TTY matches `tty` command output in that tab

Closes #10756

🤖 Generated with [Claude Code](https://claude.com/claude-code)