### PR TITLE
feat(i18n): add Portuguese (pt_PT) translation file

### DIFF
--- a/po/pt_PT.UTF-8.po
+++ b/po/pt_PT.UTF-8.po
@@ -1,0 +1,354 @@
+# Portuguese translations for com.mitchellh.ghostty package
+# Traduções em português europeu para o pacote com.mitchellh.ghostty.
+# Copyright (C) 2025 Mitchell Hashimoto, Ghostty contributors
+# This file is distributed under the same license as the com.mitchellh.ghostty package.
+# Marcelo Borges <git@marceloborges.dev>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: com.mitchellh.ghostty\n"
+"Report-Msgid-Bugs-To: m@mitchellh.com\n"
+"POT-Creation-Date: 2026-02-17 23:16+0100\n"
+"PO-Revision-Date: 2026-02-24 09:15+0000\n"
+"Last-Translator: Marcelo Borges <me@marceloborges.dev>\n"
+"Language-Team: Portuguese <translation-team-pt@lists.sourceforge.net>\n"
+"Language: pt_PT\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: dist/linux/ghostty_nautilus.py:53
+msgid "Open in Ghostty"
+msgstr "Abrir no Ghostty"
+
+#: src/apprt/gtk/ui/1.0/clipboard-confirmation-dialog.blp:12
+#: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:12
+#: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:197
+#: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:201
+msgid "Authorize Clipboard Access"
+msgstr "Autorizar acesso à área de transferência"
+
+#: src/apprt/gtk/ui/1.0/clipboard-confirmation-dialog.blp:17
+#: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:17
+msgid "Deny"
+msgstr "Negar"
+
+#: src/apprt/gtk/ui/1.0/clipboard-confirmation-dialog.blp:18
+#: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:18
+msgid "Allow"
+msgstr "Permitir"
+
+#: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:92
+msgid "Remember choice for this split"
+msgstr "Lembrar escolha para esta divisão"
+
+#: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:93
+msgid "Reload configuration to show this prompt again"
+msgstr "Recarregar a configuração para mostrar este aviso novamente"
+
+#: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
+#: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
+msgid "Close"
+msgstr "Fechar"
+
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:6
+msgid "Configuration Errors"
+msgstr "Erros de configuração"
+
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+msgid ""
+"One or more configuration errors were found. Please review the errors below, "
+"and either reload your configuration or ignore these errors."
+msgstr ""
+"Foram encontrados um ou mais erros de configuração. Por favor, reveja os erros "
+"abaixo e recarregue a sua configuração ou ignore esses erros."
+
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+msgid "Ignore"
+msgstr "Ignorar"
+
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
+#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:300
+msgid "Reload Configuration"
+msgstr "Recarregar configuração"
+
+#: src/apprt/gtk/ui/1.2/debug-warning.blp:7
+#: src/apprt/gtk/ui/1.3/debug-warning.blp:6
+msgid ""
+"⚠️ You're running a debug build of Ghostty! Performance will be degraded."
+msgstr ""
+"⚠️ Está a executar uma versão de depuração do Ghostty! O desempenho será afetado."
+
+#: src/apprt/gtk/ui/1.5/inspector-window.blp:5
+msgid "Ghostty: Terminal Inspector"
+msgstr "Ghostty: Inspetor do terminal"
+
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:29
+msgid "Find…"
+msgstr "Procurar…"
+
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+msgid "Previous Match"
+msgstr "Correspondência anterior"
+
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+msgid "Next Match"
+msgstr "Próxima correspondência"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:6
+msgid "Oh, no."
+msgstr "Oh, não."
+
+#: src/apprt/gtk/ui/1.2/surface.blp:7
+msgid "Unable to acquire an OpenGL context for rendering."
+msgstr "Não foi possível obter um contexto OpenGL para renderização."
+
+#: src/apprt/gtk/ui/1.2/surface.blp:97
+msgid ""
+"This terminal is in read-only mode. You can still view, select, and scroll "
+"through the content, but no input events will be sent to the running "
+"application."
+msgstr ""
+"Este terminal está no modo só de leitura. Pode visualizar, selecionar e percorrer "
+"o conteúdo, mas nenhum evento de entrada será enviado para a aplicação em execução."
+
+#: src/apprt/gtk/ui/1.2/surface.blp:107
+msgid "Read-only"
+msgstr "Só de leitura"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+msgid "Copy"
+msgstr "Copiar"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+msgid "Paste"
+msgstr "Colar"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:270
+msgid "Notify on Next Command Finish"
+msgstr "Notificar ao terminar o próximo comando"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+msgid "Clear"
+msgstr "Limpar"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+msgid "Reset"
+msgstr "Repor"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+msgid "Split"
+msgstr "Dividir"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+msgid "Change Title…"
+msgstr "Mudar título…"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.5/window.blp:250
+msgid "Split Up"
+msgstr "Dividir para cima"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.5/window.blp:255
+msgid "Split Down"
+msgstr "Dividir para baixo"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.5/window.blp:260
+msgid "Split Left"
+msgstr "Dividir à esquerda"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.5/window.blp:265
+msgid "Split Right"
+msgstr "Dividir à direita"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:322
+msgid "Tab"
+msgstr "Separador"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:325 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.5/window.blp:320
+msgid "Change Tab Title…"
+msgstr "Alterar título do separador…"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+msgid "New Tab"
+msgstr "Novo separador"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:234
+msgid "Close Tab"
+msgstr "Fechar separador"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:342
+msgid "Window"
+msgstr "Janela"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:212
+msgid "New Window"
+msgstr "Nova janela"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:217
+msgid "Close Window"
+msgstr "Fechar janela"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:358
+msgid "Config"
+msgstr "Configuração"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:361 src/apprt/gtk/ui/1.5/window.blp:295
+msgid "Open Configuration"
+msgstr "Abrir configuração"
+
+#: src/apprt/gtk/ui/1.5/title-dialog.blp:5
+msgid "Leave blank to restore the default title."
+msgstr "Deixe em branco para restaurar o título predefinido."
+
+#: src/apprt/gtk/ui/1.5/title-dialog.blp:9
+msgid "OK"
+msgstr "OK"
+
+#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+msgid "New Split"
+msgstr "Nova divisão"
+
+#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+msgid "View Open Tabs"
+msgstr "Visualizar separadores abertos"
+
+#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+msgid "Main Menu"
+msgstr "Menu principal"
+
+#: src/apprt/gtk/ui/1.5/window.blp:285
+msgid "Command Palette"
+msgstr "Paleta de comandos"
+
+#: src/apprt/gtk/ui/1.5/window.blp:290
+msgid "Terminal Inspector"
+msgstr "Inspetor de terminal"
+
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1727
+msgid "About Ghostty"
+msgstr "Sobre o Ghostty"
+
+#: src/apprt/gtk/ui/1.5/window.blp:312
+msgid "Quit"
+msgstr "Sair"
+
+#: src/apprt/gtk/ui/1.5/command-palette.blp:17
+msgid "Execute a command…"
+msgstr "Executar um comando…"
+
+#: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
+msgid ""
+"An application is attempting to write to the clipboard. The current "
+"clipboard contents are shown below."
+msgstr ""
+"Uma aplicação está a tentar escrever na área de transferência. O conteúdo "
+"atual da área de transferência é exibido abaixo."
+
+#: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:202
+msgid ""
+"An application is attempting to read from the clipboard. The current "
+"clipboard contents are shown below."
+msgstr ""
+"Uma aplicação está a tentar ler da área de transferência. O conteúdo atual "
+"da área de transferência é exibido abaixo."
+
+#: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:205
+msgid "Warning: Potentially Unsafe Paste"
+msgstr "Aviso: Colagem potencialmente insegura"
+
+#: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:206
+msgid ""
+"Pasting this text into the terminal may be dangerous as it looks like some "
+"commands may be executed."
+msgstr ""
+"Colar este texto no terminal pode ser perigoso, pois parece que alguns "
+"comandos podem ser executados."
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:184
+msgid "Quit Ghostty?"
+msgstr "Sair do Ghostty?"
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:185
+msgid "Close Tab?"
+msgstr "Fechar separador?"
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:186
+msgid "Close Window?"
+msgstr "Fechar janela?"
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:187
+msgid "Close Split?"
+msgstr "Fechar divisão?"
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:193
+msgid "All terminal sessions will be terminated."
+msgstr "Todas as sessões de terminal serão terminadas."
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:194
+msgid "All terminal sessions in this tab will be terminated."
+msgstr "Todas as sessões de terminal neste separador serão terminadas."
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:195
+msgid "All terminal sessions in this window will be terminated."
+msgstr "Todas as sessões de terminal nesta janela serão terminadas."
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:196
+msgid "The currently running process in this split will be terminated."
+msgstr "O processo em execução nesta divisão será terminado."
+
+#: src/apprt/gtk/class/surface.zig:1108
+msgid "Command Finished"
+msgstr "Comando concluído"
+
+#: src/apprt/gtk/class/surface.zig:1109
+msgid "Command Succeeded"
+msgstr "Comando concluído com sucesso"
+
+#: src/apprt/gtk/class/surface.zig:1110
+msgid "Command Failed"
+msgstr "O comando falhou"
+
+#: src/apprt/gtk/class/surface_child_exited.zig:109
+msgid "Command succeeded"
+msgstr "Comando concluído com sucesso"
+
+#: src/apprt/gtk/class/surface_child_exited.zig:113
+msgid "Command failed"
+msgstr "O comando falhou"
+
+#: src/apprt/gtk/class/title_dialog.zig:225
+msgid "Change Terminal Title"
+msgstr "Alterar título do terminal"
+
+#: src/apprt/gtk/class/title_dialog.zig:226
+msgid "Change Tab Title"
+msgstr "Alterar título do separador"
+
+#: src/apprt/gtk/class/window.zig:1007
+msgid "Reloaded the configuration"
+msgstr "Configuração recarregada"
+
+#: src/apprt/gtk/class/window.zig:1566
+msgid "Copied to clipboard"
+msgstr "Copiado para a área de transferência"
+
+#: src/apprt/gtk/class/window.zig:1568
+msgid "Cleared clipboard"
+msgstr "Área de transferência limpa"
+
+#: src/apprt/gtk/class/window.zig:1708
+msgid "Ghostty Developers"
+msgstr "Programadores do Ghostty"


### PR DESCRIPTION
  Adds a new pt_PT.UTF-8.po file with European Portuguese translations
  for the Ghostty interface and messages. This allows users to use the
  application in Portuguese, improving accessibility and localization.