### PR TITLE
visionos: add xros target support and visionOS XCFramework slices

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -471,6 +471,10 @@ jobs:
       - name: Build GhosttyKit
         run: nix develop -c zig build --system ${{ steps.deps.outputs.deps }} -Demit-macos-app=false
 
+      # Build an XCFramework that includes visionOS slices.
+      - name: Build GhosttyKit visionOS slices
+        run: nix develop -c ./scripts/build-visionos-xcframework.sh --system ${{ steps.deps.outputs.deps }}
+
       # The native app is built with native Xcode tooling. This also does
       # codesigning. IMPORTANT: this must NOT run in a Nix environment.
       # Nix breaks xcodebuild so this has to be run outside.

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 zig-cache/
 .zig-cache/
 zig-out/
+.toolchains/
 /result*
 /.nixos-test-history
 example/*.wasm

--- a/VISIONOS_FORKS.md
+++ b/VISIONOS_FORKS.md
@@ -1,0 +1,34 @@
+# VisionOS Fork Stack
+
+This repository is configured to build visionOS with forked upstream dependencies.
+
+## Forked dependencies
+
+- `libxev`
+  - Fork: `https://github.com/douglance/libxev`
+  - Commit: `3726043b4942d5ad88f33f6b1ed0e9a60548f5a0`
+  - Purpose: add `.visionos` mapping to the kqueue backend selection.
+
+- `zig` stdlib for visionOS builds
+  - Fork: `https://github.com/douglance/zig`
+  - Branch: `fix/visionos-std-coverage-0.15x`
+  - Commit: `34470b281dec31c254a11571f8d3c81ea0755dcc`
+  - Purpose: backport `std.fs` and Darwin AArch64 debug context visionOS coverage to `0.15.x`.
+
+## Build commands
+
+Use the wrapper for visionOS builds so Zig uses the forked stdlib:
+
+```bash
+./scripts/zig-visionos.sh prepare
+./scripts/zig-visionos.sh build lib-vt -Dtarget=aarch64-visionos -Doptimize=ReleaseFast
+./scripts/build-visionos-xcframework.sh
+```
+
+`build-visionos-xcframework.sh` produces `macos/GhosttyKit.xcframework` with `xros` slices.
+
+The wrapper downloads the Zig fork tarball once into `.toolchains/zig-visionos` and then runs:
+
+```bash
+zig --zig-lib-dir <forked-zig-lib> ...
+```

--- a/build.zig
+++ b/build.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const builtin = @import("builtin");
 const buildpkg = @import("src/build/main.zig");
+const TerminalBuildOptions = @import("src/terminal/build_options.zig").Options;
 
 const appVersion = @import("build.zig.zon").version;
 const minimumZigVersion = @import("build.zig.zon").minimum_zig_version;
@@ -60,7 +61,11 @@ pub fn build(b: *std.Build) !void {
     const i18n = if (config.i18n) try buildpkg.GhosttyI18n.init(b, &config) else null;
 
     // Ghostty executable, the actual runnable Ghostty program.
-    const exe = try buildpkg.GhosttyExe.init(b, &config, &deps);
+    // Skip exe init for platforms that don't support it (e.g., visionOS).
+    const exe = if (config.app_runtime != .none)
+        try buildpkg.GhosttyExe.init(b, &config, &deps)
+    else
+        null;
 
     // Ghostty docs
     const docs = try buildpkg.GhosttyDocs.init(b, &deps);
@@ -118,13 +123,23 @@ pub fn build(b: *std.Build) !void {
     libghostty_vt_shared.install(libvt_step);
     libghostty_vt_shared.install(b.getInstallStep());
 
+    // libghostty-vt static
+    const libvt_static_step = b.step("lib-vt-static", "Build libghostty-vt static library");
+    if (!config.target.result.cpu.arch.isWasm()) {
+        const libghostty_vt_static = try buildpkg.GhosttyLibVt.initStatic(
+            b,
+            &mod,
+        );
+        libghostty_vt_static.install(libvt_static_step);
+    }
+
     // Helpgen
     if (config.emit_helpgen) deps.help_strings.install();
 
     // Runtime "none" is libghostty, anything else is an executable.
     if (config.app_runtime != .none) {
         if (config.emit_exe) {
-            exe.install();
+            if (exe) |e| e.install();
             resources.install();
             if (i18n) |v| v.install();
         }
@@ -182,7 +197,7 @@ pub fn build(b: *std.Build) !void {
     // Run step
     run: {
         if (config.app_runtime != .none) {
-            const run_cmd = b.addRunArtifact(exe.exe);
+            const run_cmd = b.addRunArtifact((exe orelse break :run).exe);
             if (b.args) |args| run_cmd.addArgs(args);
 
             // Set the proper resources dir so things like shell integration
@@ -256,16 +271,59 @@ pub fn build(b: *std.Build) !void {
 
     // Zig module tests
     {
+        const mkVtTestModule = struct {
+            fn create(
+                b_: *std.Build,
+                config_: *const buildpkg.Config,
+                deps_: *const buildpkg.SharedDeps,
+                c_abi_: bool,
+            ) !*std.Build.Module {
+                var vt_options: TerminalBuildOptions = config_.terminalOptions();
+                vt_options.artifact = .lib;
+                vt_options.oniguruma = false;
+                vt_options.c_abi = c_abi_;
+
+                const module = b_.createModule(.{
+                    .root_source_file = b_.path("src/lib_vt.zig"),
+                    .target = config_.target,
+                    .optimize = config_.optimize,
+                    .link_libc = if (config_.simd) true else null,
+                    .link_libcpp = if (config_.simd) true else null,
+                });
+
+                const general_options = b_.addOptions();
+                try config_.addOptions(general_options);
+                module.addOptions("build_options", general_options);
+                vt_options.add(b_, module);
+
+                deps_.unicode_tables.addModuleImport(module);
+                deps_.addUucode(b_, module, config_.target, config_.optimize);
+                if (config_.simd) try buildpkg.SharedDeps.addSimd(b_, module, null);
+
+                return module;
+            }
+        }.create;
+
         const mod_vt_test = b.addTest(.{
-            .root_module = mod.vt,
+            .root_module = try mkVtTestModule(b, &config, &deps, false),
             .filters = test_filters,
+        });
+        _ = try deps.addWith(mod_vt_test, .{
+            .include_build_options = false,
+            .include_terminal_options = false,
+            .include_simd = false,
         });
         const mod_vt_test_run = b.addRunArtifact(mod_vt_test);
         test_lib_vt_step.dependOn(&mod_vt_test_run.step);
 
         const mod_vt_c_test = b.addTest(.{
-            .root_module = mod.vt_c,
+            .root_module = try mkVtTestModule(b, &config, &deps, true),
             .filters = test_filters,
+        });
+        _ = try deps.addWith(mod_vt_c_test, .{
+            .include_build_options = false,
+            .include_terminal_options = false,
+            .include_simd = false,
         });
         const mod_vt_c_test_run = b.addRunArtifact(mod_vt_c_test);
         test_lib_vt_step.dependOn(&mod_vt_c_test_run.step);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -8,9 +8,9 @@
         // Zig libs
 
         .libxev = .{
-            // mitchellh/libxev
-            .url = "https://deps.files.ghostty.org/libxev-34fa50878aec6e5fa8f532867001ab3c36fae23e.tar.gz",
-            .hash = "libxev-0.0.0-86vtc4IcEwCqEYxEYoN_3KXmc6A9VLcm22aVImfvecYs",
+            // douglance/libxev (visionOS kqueue backend support)
+            .url = "https://github.com/douglance/libxev/archive/3726043b4942d5ad88f33f6b1ed0e9a60548f5a0.tar.gz",
+            .hash = "libxev-0.0.0-86vtc3kbEwBykzpSo2s87dYDs1G0fPxn__T4tG5AipAN",
             .lazy = true,
         },
         .vaxis = .{

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -38,6 +38,7 @@ typedef enum {
   GHOSTTY_PLATFORM_INVALID,
   GHOSTTY_PLATFORM_MACOS,
   GHOSTTY_PLATFORM_IOS,
+  GHOSTTY_PLATFORM_VISIONOS,
 } ghostty_platform_e;
 
 typedef enum {
@@ -426,9 +427,14 @@ typedef struct {
   void* uiview;
 } ghostty_platform_ios_s;
 
+typedef struct {
+  void* uiview;
+} ghostty_platform_visionos_s;
+
 typedef union {
   ghostty_platform_macos_s macos;
   ghostty_platform_ios_s ios;
+  ghostty_platform_visionos_s visionos;
 } ghostty_platform_u;
 
 typedef enum {

--- a/macos/Sources/Ghostty/Surface View/SurfaceView.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView.swift
@@ -705,6 +705,12 @@ extension Ghostty {
             // probably set this to some default, then modify the scale factor through
             // libghostty APIs when a UIView is attached to a window/scene. TODO.
             config.scale_factor = UIScreen.main.scale
+#elseif os(visionOS)
+            config.platform_tag = GHOSTTY_PLATFORM_VISIONOS
+            config.platform = ghostty_platform_u(visionos: ghostty_platform_visionos_s(
+                uiview: Unmanaged.passUnretained(view).toOpaque()
+            ))
+            config.scale_factor = UIScreen.main.scale
 #else
 #error("unsupported target")
 #endif

--- a/pkg/apple-sdk/build.zig
+++ b/pkg/apple-sdk/build.zig
@@ -96,6 +96,7 @@ pub fn addPaths(
         // It costs us nothing in the build script to return something better.
         .macos => error.XcodeMacOSSDKNotFound,
         .ios => error.XcodeiOSSDKNotFound,
+        .visionos => error.XcodeVisionOSSDKNotFound,
         .tvos => error.XcodeTVOSSDKNotFound,
         .watchos => error.XcodeWatchOSSDKNotFound,
         else => error.XcodeAppleSDKNotFound,

--- a/scripts/build-visionos-xcframework.sh
+++ b/scripts/build-visionos-xcframework.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+./scripts/zig-visionos.sh prepare
+
+exec ./scripts/zig-visionos.sh build \
+    -Dtarget=aarch64-macos \
+    -Demit-exe=false \
+    -Demit-macos-app=false \
+    -Demit-xcframework=true \
+    -Dxcframework-visionos=true \
+    -Demit-docs=false \
+    -Demit-webdata=false \
+    -Doptimize=ReleaseFast \
+    "$@"

--- a/scripts/zig-visionos.sh
+++ b/scripts/zig-visionos.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORK_COMMIT="34470b281dec31c254a11571f8d3c81ea0755dcc"
+FORK_URL="https://github.com/douglance/zig/archive/${FORK_COMMIT}.tar.gz"
+TOOLCHAIN_DIR="${ROOT_DIR}/.toolchains/zig-visionos"
+STD_SRC_DIR="${TOOLCHAIN_DIR}/zig-${FORK_COMMIT}"
+STD_LIB_DIR="${STD_SRC_DIR}/lib"
+
+ensure_stdlib() {
+    if [[ -f "${STD_LIB_DIR}/std/std.zig" ]]; then
+        return
+    fi
+
+    mkdir -p "${TOOLCHAIN_DIR}"
+    local tmp_dir
+    tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/zig-visionos.XXXXXX")"
+    local archive_path="${tmp_dir}/zig.tar.gz"
+
+    curl --fail --location --silent --show-error "${FORK_URL}" --output "${archive_path}"
+    tar -xzf "${archive_path}" -C "${tmp_dir}"
+
+    local extracted
+    extracted="$(find "${tmp_dir}" -mindepth 1 -maxdepth 1 -type d -name "zig-*" | head -n1)"
+    if [[ -z "${extracted}" ]]; then
+        echo "failed to extract zig fork archive from ${FORK_URL}" >&2
+        exit 1
+    fi
+
+    if [[ ! -d "${STD_SRC_DIR}" ]]; then
+        mv "${extracted}" "${STD_SRC_DIR}"
+    fi
+
+    if [[ ! -f "${STD_LIB_DIR}/std/std.zig" ]]; then
+        echo "failed to locate Zig stdlib in ${STD_LIB_DIR}" >&2
+        exit 1
+    fi
+}
+
+if [[ "${1:-}" == "prepare" ]]; then
+    ensure_stdlib
+    echo "Prepared ${STD_LIB_DIR}"
+    exit 0
+fi
+
+if [[ "${1:-}" == "--print-lib-dir" ]]; then
+    ensure_stdlib
+    echo "${STD_LIB_DIR}"
+    exit 0
+fi
+
+ensure_stdlib
+
+if [[ "$#" -eq 0 ]]; then
+    echo "usage: $0 <zig-command> [args...]" >&2
+    echo "example: $0 build -Dtarget=aarch64-visionos" >&2
+    exit 1
+fi
+
+zig_command="$1"
+shift
+exec zig "${zig_command}" --zig-lib-dir "${STD_LIB_DIR}" "$@"

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -347,7 +347,7 @@ fn setupFd(src: File.Handle, target: i32) !void {
                 }
             }
         },
-        .freebsd, .ios, .macos => {
+        .freebsd, .ios, .visionos, .macos => {
             // Mac doesn't support dup3 so we use dup2. We purposely clear
             // CLO_ON_EXEC for this fd.
             const flags = try posix.fcntl(src, posix.F.GETFD, 0);

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -342,6 +342,7 @@ pub const App = struct {
 pub const Platform = union(PlatformTag) {
     macos: MacOS,
     ios: IOS,
+    visionos: VisionOS,
 
     // If our build target for libghostty is not darwin then we do
     // not include macos support at all.
@@ -355,6 +356,11 @@ pub const Platform = union(PlatformTag) {
         uiview: objc.Object,
     } else void;
 
+    pub const VisionOS = if (builtin.target.os.tag.isDarwin()) struct {
+        /// The view to render the surface on.
+        uiview: objc.Object,
+    } else void;
+
     // The C ABI compatible version of this union. The tag is expected
     // to be stored elsewhere.
     pub const C = extern union {
@@ -363,6 +369,10 @@ pub const Platform = union(PlatformTag) {
         },
 
         ios: extern struct {
+            uiview: ?*anyopaque,
+        },
+
+        visionos: extern struct {
             uiview: ?*anyopaque,
         },
     };
@@ -384,6 +394,13 @@ pub const Platform = union(PlatformTag) {
                     break :ios error.UIViewMustBeSet);
                 break :ios .{ .ios = .{ .uiview = uiview } };
             } else error.UnsupportedPlatform,
+
+            .visionos => if (VisionOS != void) visionos: {
+                const config = c_platform.visionos;
+                const uiview = objc.Object.fromId(config.uiview orelse
+                    break :visionos error.UIViewMustBeSet);
+                break :visionos .{ .visionos = .{ .uiview = uiview } };
+            } else error.UnsupportedPlatform,
         };
     }
 };
@@ -394,6 +411,7 @@ pub const PlatformTag = enum(c_int) {
 
     macos = 1,
     ios = 2,
+    visionos = 3,
 };
 
 pub const EnvVar = extern struct {

--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -20,6 +20,7 @@ const GitVersion = @import("GitVersion.zig");
 optimize: std.builtin.OptimizeMode,
 target: std.Build.ResolvedTarget,
 xcframework_target: XCFrameworkTarget = .universal,
+xcframework_visionos: bool = false,
 wasm_target: WasmTarget,
 
 /// Comptime interfaces
@@ -120,6 +121,12 @@ pub fn init(b: *std.Build, appVersion: []const u8) !Config {
         "The target for the xcframework.",
     ) orelse .universal;
 
+    config.xcframework_visionos = b.option(
+        bool,
+        "xcframework-visionos",
+        "Include visionOS slices in GhosttyKit.xcframework.",
+    ) orelse false;
+
     //---------------------------------------------------------------
     // Comptime Interfaces
     config.font_backend = b.option(
@@ -174,6 +181,10 @@ pub fn init(b: *std.Build, appVersion: []const u8) !Config {
         "simd",
         "Build with SIMD-accelerated code paths. Results in significant performance improvements.",
     ) orelse simd: {
+        // Zig's current visionOS C++ toolchain path is not reliable enough
+        // for our SIMD C++ dependencies yet.
+        if (target.result.os.tag == .visionos) break :simd false;
+
         // We can't build our SIMD dependencies for Wasm. Note that we may
         // still use SIMD features in the Wasm-builds.
         if (target.result.cpu.arch.isWasm()) break :simd false;
@@ -585,6 +596,13 @@ pub fn osVersionMin(tag: std.Target.Os.Tag) ?std.Target.Query.OsVersion {
             .patch = 0,
         } },
 
+        // visionOS 1 is the earliest supported baseline.
+        .visionos => .{ .semver = .{
+            .major = 1,
+            .minor = 0,
+            .patch = 0,
+        } },
+
         // This should never happen currently. If we add a new target then
         // we should add a new case here.
         else => null,
@@ -634,3 +652,10 @@ pub const ReleaseChannel = enum {
     /// Stable tagged releases.
     stable,
 };
+
+test "osVersionMin visionos" {
+    const testing = std.testing;
+    const version = osVersionMin(.visionos);
+    try testing.expect(version != null);
+    try testing.expectEqual(@as(u32, 1), version.?.semver.major);
+}

--- a/src/build/GhosttyLib.zig
+++ b/src/build/GhosttyLib.zig
@@ -37,7 +37,7 @@ pub fn initStatic(
     // These must be bundled since we're compiling into a static lib.
     // Otherwise, you get undefined symbol errors.
     lib.bundle_compiler_rt = true;
-    lib.bundle_ubsan_rt = true;
+    lib.bundle_ubsan_rt = deps.config.target.result.os.tag != .visionos;
 
     // Add our dependencies. Get the list of all static deps so we can
     // build a combined archive if necessary.

--- a/src/build/GhosttyLibVt.zig
+++ b/src/build/GhosttyLibVt.zig
@@ -60,6 +60,9 @@ pub fn initShared(
         "ghostty",
         .{ .include_extensions = &.{".h"} },
     );
+    if (target.result.os.tag.isDarwin()) {
+        try @import("apple_sdk").addPaths(b, lib);
+    }
 
     // Get our debug symbols
     const dsymutil: ?std.Build.LazyPath = dsymutil: {
@@ -98,6 +101,37 @@ pub fn initShared(
         .output = lib.getEmittedBin(),
         .dsym = dsymutil,
         .pkg_config = pc,
+    };
+}
+
+pub fn initStatic(
+    b: *std.Build,
+    zig: *const GhosttyZig,
+) !GhosttyLibVt {
+    const target = zig.vt.resolved_target.?;
+    const lib = b.addLibrary(.{
+        .name = "ghostty-vt",
+        .linkage = .static,
+        .root_module = zig.vt_c,
+        .version = std.SemanticVersion{ .major = 0, .minor = 1, .patch = 0 },
+    });
+    lib.installHeadersDirectory(
+        b.path("include/ghostty"),
+        "ghostty",
+        .{ .include_extensions = &.{".h"} },
+    );
+    if (target.result.os.tag.isDarwin()) {
+        try @import("apple_sdk").addPaths(b, lib);
+    }
+    lib.bundle_compiler_rt = true;
+    lib.bundle_ubsan_rt = target.result.os.tag != .visionos;
+
+    return .{
+        .step = &lib.step,
+        .artifact = b.addInstallArtifact(lib, .{}),
+        .output = lib.getEmittedBin(),
+        .dsym = null,
+        .pkg_config = null,
     };
 }
 

--- a/src/build/GhosttyXCFramework.zig
+++ b/src/build/GhosttyXCFramework.zig
@@ -15,6 +15,8 @@ pub fn init(
     deps: *const SharedDeps,
     target: Target,
 ) !GhosttyXCFramework {
+    const include_visionos = deps.config.xcframework_visionos;
+
     // Universal macOS build
     const macos_universal = try GhosttyLib.initMacOSUniversal(b, deps);
 
@@ -53,37 +55,105 @@ pub fn init(
         }),
     ));
 
+    const visionos = if (include_visionos)
+        try GhosttyLib.initStatic(b, &try deps.retarget(
+            b,
+            b.resolveTargetQuery(.{
+                .cpu_arch = .aarch64,
+                .os_tag = .visionos,
+                .os_version_min = Config.osVersionMin(.visionos),
+                .abi = null,
+            }),
+        ))
+    else
+        null;
+
+    const visionos_sim = if (include_visionos)
+        try GhosttyLib.initStatic(b, &try deps.retarget(
+            b,
+            b.resolveTargetQuery(.{
+                .cpu_arch = .aarch64,
+                .os_tag = .visionos,
+                .os_version_min = Config.osVersionMin(.visionos),
+                .abi = .simulator,
+                .cpu_model = .{ .explicit = &std.Target.aarch64.cpu.apple_a17 },
+            }),
+        ))
+    else
+        null;
+
     // The xcframework wraps our ghostty library so that we can link
     // it to the final app built with Swift.
-    const xcframework = XCFrameworkStep.create(b, .{
-        .name = "GhosttyKit",
-        .out_path = "macos/GhosttyKit.xcframework",
-        .libraries = switch (target) {
-            .universal => &.{
-                .{
-                    .library = macos_universal.output,
-                    .headers = b.path("include"),
-                    .dsym = macos_universal.dsym,
+    const xcframework = if (include_visionos)
+        XCFrameworkStep.create(b, .{
+            .name = "GhosttyKit",
+            .out_path = "macos/GhosttyKit.xcframework",
+            .libraries = switch (target) {
+                .universal => &.{
+                    .{
+                        .library = macos_universal.output,
+                        .headers = b.path("include"),
+                        .dsym = macos_universal.dsym,
+                    },
+                    .{
+                        .library = ios.output,
+                        .headers = b.path("include"),
+                        .dsym = ios.dsym,
+                    },
+                    .{
+                        .library = ios_sim.output,
+                        .headers = b.path("include"),
+                        .dsym = ios_sim.dsym,
+                    },
+                    .{
+                        .library = visionos.?.output,
+                        .headers = b.path("include"),
+                        .dsym = visionos.?.dsym,
+                    },
+                    .{
+                        .library = visionos_sim.?.output,
+                        .headers = b.path("include"),
+                        .dsym = visionos_sim.?.dsym,
+                    },
                 },
-                .{
-                    .library = ios.output,
-                    .headers = b.path("include"),
-                    .dsym = ios.dsym,
-                },
-                .{
-                    .library = ios_sim.output,
-                    .headers = b.path("include"),
-                    .dsym = ios_sim.dsym,
-                },
-            },
 
-            .native => &.{.{
-                .library = macos_native.output,
-                .headers = b.path("include"),
-                .dsym = macos_native.dsym,
-            }},
-        },
-    });
+                .native => &.{.{
+                    .library = macos_native.output,
+                    .headers = b.path("include"),
+                    .dsym = macos_native.dsym,
+                }},
+            },
+        })
+    else
+        XCFrameworkStep.create(b, .{
+            .name = "GhosttyKit",
+            .out_path = "macos/GhosttyKit.xcframework",
+            .libraries = switch (target) {
+                .universal => &.{
+                    .{
+                        .library = macos_universal.output,
+                        .headers = b.path("include"),
+                        .dsym = macos_universal.dsym,
+                    },
+                    .{
+                        .library = ios.output,
+                        .headers = b.path("include"),
+                        .dsym = ios.dsym,
+                    },
+                    .{
+                        .library = ios_sim.output,
+                        .headers = b.path("include"),
+                        .dsym = ios_sim.dsym,
+                    },
+                },
+
+                .native => &.{.{
+                    .library = macos_native.output,
+                    .headers = b.path("include"),
+                    .dsym = macos_native.dsym,
+                }},
+            },
+        });
 
     return .{
         .xcframework = xcframework,

--- a/src/build/MetallibStep.zig
+++ b/src/build/MetallibStep.zig
@@ -30,6 +30,10 @@ pub fn create(b: *std.Build, opts: Options) ?*MetallibStep {
             .simulator => "iphoneos",
             else => "iphoneos",
         },
+        .visionos => switch (opts.target.result.abi) {
+            .simulator => "xrsimulator",
+            else => "xros",
+        },
         else => return null,
     };
     const platform_version_arg = switch (opts.target.result.os.tag) {
@@ -38,6 +42,7 @@ pub fn create(b: *std.Build, opts: Options) ?*MetallibStep {
             .simulator => "-mios-simulator-version-min",
             else => "-mios-version-min",
         },
+        .visionos => null,
         else => null,
     };
 
@@ -48,6 +53,7 @@ pub fn create(b: *std.Build, opts: Options) ?*MetallibStep {
     else switch (opts.target.result.os.tag) {
         .macos => "10.14",
         .ios => "11.0",
+        .visionos => "1.0",
         else => unreachable,
     };
 

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -21,6 +21,11 @@ uucode_tables: std.Build.LazyPath,
 
 /// Used to keep track of a list of file sources.
 pub const LazyPathList = std.ArrayList(std.Build.LazyPath);
+pub const AddOptions = struct {
+    include_build_options: bool = true,
+    include_terminal_options: bool = true,
+    include_simd: bool = true,
+};
 
 pub fn init(b: *std.Build, cfg: *const Config) !SharedDeps {
     const uucode_tables = blk: {
@@ -93,6 +98,14 @@ fn initTarget(
     const config = try b.allocator.create(Config);
     config.* = self.config.*;
     config.target = target;
+
+    // Some build options are target-dependent but inherited during retarget.
+    // Normalize visionOS to the supported subset.
+    if (target.result.os.tag == .visionos) {
+        config.sentry = false;
+        config.simd = false;
+    }
+
     self.config = config;
 
     // Setup our shared build options
@@ -103,6 +116,14 @@ fn initTarget(
 pub fn add(
     self: *const SharedDeps,
     step: *std.Build.Step.Compile,
+) !LazyPathList {
+    return self.addWith(step, .{});
+}
+
+pub fn addWith(
+    self: *const SharedDeps,
+    step: *std.Build.Step.Compile,
+    add_options: AddOptions,
 ) !LazyPathList {
     const b = step.step.owner;
 
@@ -129,11 +150,17 @@ pub fn add(
         return static_libs;
     }
 
-    // Every exe gets build options populated
-    step.root_module.addOptions("build_options", self.options);
+    // Every exe gets build options populated.
+    // Some shared modules (e.g. lib-vt test modules) already own these options
+    // and must not be overridden in-place.
+    if (add_options.include_build_options) {
+        step.root_module.addOptions("build_options", self.options);
+    }
 
     // Every exe needs the terminal options
-    self.config.terminalOptions().add(b, step.root_module);
+    if (add_options.include_terminal_options) {
+        self.config.terminalOptions().add(b, step.root_module);
+    }
 
     // Freetype. We always include this even if our font backend doesn't
     // use it because Dear Imgui uses Freetype.
@@ -332,7 +359,7 @@ pub fn add(
     }
 
     // Simd
-    if (self.config.simd) try addSimd(
+    if (self.config.simd and add_options.include_simd) try addSimd(
         b,
         step.root_module,
         &static_libs,
@@ -380,11 +407,12 @@ pub fn add(
     if (step.rootModuleTarget().os.tag.isDarwin()) {
         try @import("apple_sdk").addPaths(b, step);
 
-        const metallib = self.metallib.?;
-        metallib.output.addStepDependencies(&step.step);
-        step.root_module.addAnonymousImport("ghostty_metallib", .{
-            .root_source_file = metallib.output,
-        });
+        if (self.metallib) |metallib| {
+            metallib.output.addStepDependencies(&step.step);
+            step.root_module.addAnonymousImport("ghostty_metallib", .{
+                .root_source_file = metallib.output,
+            });
+        }
     }
 
     // Other dependencies, mostly pure Zig

--- a/src/build/zig.zig
+++ b/src/build/zig.zig
@@ -6,10 +6,7 @@ pub fn requireZig(comptime required_zig: []const u8) void {
     // Fail compilation if the current Zig version doesn't meet requirements.
     const current_vsn = builtin.zig_version;
     const required_vsn = std.SemanticVersion.parse(required_zig) catch unreachable;
-    if (current_vsn.major != required_vsn.major or
-        current_vsn.minor != required_vsn.minor or
-        current_vsn.patch < required_vsn.patch)
-    {
+    if (current_vsn.order(required_vsn) == .lt) {
         @compileError(std.fmt.comptimePrint(
             "Your Zig version v{f} does not meet the required build version of v{f}",
             .{ current_vsn, required_vsn },

--- a/src/config/theme.zig
+++ b/src/config/theme.zig
@@ -38,7 +38,7 @@ pub const Location = enum {
                     // error set since some platforms don't support some
                     // error types.
                     const Error = @TypeOf(err) || switch (builtin.os.tag) {
-                        .ios => error{BufferTooSmall},
+                        .ios, .visionos => error{BufferTooSmall},
                         else => error{},
                     };
 

--- a/src/font/shaper/run.zig
+++ b/src/font/shaper/run.zig
@@ -7,6 +7,13 @@ const terminal = @import("../../terminal/main.zig");
 const autoHash = std.hash.autoHash;
 const Hasher = std.hash.Wyhash;
 
+fn kittyGraphicsPlaceholder() u21 {
+    return if (comptime @hasDecl(terminal.kitty.graphics, "unicode"))
+        terminal.kitty.graphics.unicode.placeholder
+    else
+        0;
+}
+
 /// A single text run. A text run is only valid for one Shaper instance and
 /// until the next run is created. A text run never goes across multiple
 /// rows in a terminal, so it is guaranteed to always be one line.
@@ -262,7 +269,7 @@ pub const RunIterator = struct {
             }
 
             // If we're a Kitty unicode placeholder then we add a blank.
-            if (cell.codepoint() == terminal.kitty.graphics.unicode.placeholder) {
+            if (cell.codepoint() == kittyGraphicsPlaceholder()) {
                 try self.addCodepoint(&hasher, ' ', @intCast(cluster));
                 continue;
             }
@@ -325,7 +332,7 @@ pub const RunIterator = struct {
     ) !?font.Collection.Index {
         if (cell.isEmpty() or
             cell.codepoint() == 0 or
-            cell.codepoint() == terminal.kitty.graphics.unicode.placeholder)
+            cell.codepoint() == kittyGraphicsPlaceholder())
         {
             return try self.opts.grid.getIndex(
                 alloc,

--- a/src/input/keycodes.zig
+++ b/src/input/keycodes.zig
@@ -9,7 +9,7 @@ const Key = @import("key.zig").Key;
 /// The full list of entries for the current platform.
 pub const entries: []const Entry = entries: {
     const native_idx = switch (builtin.os.tag) {
-        .ios, .macos => 4, // mac
+        .ios, .visionos, .macos => 4, // mac
         .windows => 3, // win
         .freebsd, .linux => 2, // xkb
         else => @compileError("unsupported platform"),

--- a/src/os/desktop.zig
+++ b/src/os/desktop.zig
@@ -60,8 +60,8 @@ pub fn launchedFromDesktop() bool {
         // TODO: This should have some logic to detect this. Perhaps std.builtin.subsystem
         .windows => false,
 
-        // iPhone/iPad is always launched from the "desktop"
-        .ios => true,
+        // iOS and visionOS apps are always launched by the system shell.
+        .ios, .visionos => true,
 
         else => @compileError("unsupported platform"),
     };

--- a/src/os/homedir.zig
+++ b/src/os/homedir.zig
@@ -16,8 +16,8 @@ pub inline fn home(buf: []u8) !?[]const u8 {
         inline .linux, .freebsd, .macos => try homeUnix(buf),
         .windows => try homeWindows(buf),
 
-        // iOS doesn't have a user-writable home directory
-        .ios => null,
+        // iOS/visionOS don't expose a standard user home directory model.
+        .ios, .visionos => null,
 
         else => @compileError("unimplemented"),
     };
@@ -122,7 +122,7 @@ pub const ExpandError = error{
 pub fn expandHome(path: []const u8, buf: []u8) ExpandError![]const u8 {
     return switch (builtin.os.tag) {
         .linux, .freebsd, .macos => try expandHomeUnix(path, buf),
-        .ios => return path,
+        .ios, .visionos => return path,
         else => @compileError("unimplemented"),
     };
 }

--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -39,7 +39,7 @@ pub fn open(
             alloc,
         ),
 
-        .ios => return error.Unimplemented,
+        .ios, .visionos => return error.Unimplemented,
         else => @compileError("unsupported OS"),
     };
 

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -17,7 +17,7 @@ pub const winsize = extern struct {
 
 pub const Pty = switch (builtin.os.tag) {
     .windows => WindowsPty,
-    .ios => NullPty,
+    .ios, .visionos => NullPty,
     else => PosixPty,
 };
 

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -63,7 +63,7 @@ autorelease_pool: ?*objc.AutoreleasePool = null,
 
 pub fn init(alloc: Allocator, opts: rendererpkg.Options) !Metal {
     comptime switch (builtin.os.tag) {
-        .macos, .ios => {},
+        .macos, .ios, .visionos => {},
         else => @compileError("unsupported platform for Metal"),
     };
 
@@ -78,7 +78,7 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !Metal {
     // Grab metadata about the device.
     const default_storage_mode: mtl.MTLResourceOptions.StorageMode = switch (comptime builtin.os.tag) {
         // manage mode is not supported by iOS
-        .ios => .shared,
+        .ios, .visionos => .shared,
         else => if (device.getProperty(bool, "hasUnifiedMemory")) .shared else .managed,
     };
     const max_texture_size = queryMaxTextureSize(device);
@@ -99,6 +99,7 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !Metal {
             .view = switch (opts.rt_surface.platform) {
                 .macos => |v| v.nsview,
                 .ios => |v| v.uiview,
+                .visionos => |v| v.uiview,
             },
         },
 
@@ -125,7 +126,7 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !Metal {
             info.view.setProperty("wantsLayer", true);
         },
 
-        .ios => {
+        .ios, .visionos => {
             const view_layer = objc.Object.fromId(info.view.getProperty(?*anyopaque, "layer"));
             view_layer.msgSend(void, objc.sel("addSublayer:"), .{layer.layer.value});
         },
@@ -427,7 +428,7 @@ fn chooseDevice() error{NoMetalDevice}!objc.Object {
                     device.getProperty(bool, "isLowPower")) break;
             }
         },
-        .ios => {
+        .ios, .visionos => {
             chosen_device = objc.Object.fromId(mtl.MTLCreateSystemDefaultDevice());
         },
         else => @compileError("unsupported target for Metal"),

--- a/src/terminal/osc/parsers/semantic_prompt.zig
+++ b/src/terminal/osc/parsers/semantic_prompt.zig
@@ -26,10 +26,27 @@ pub const Command = struct {
         end_command, // 'D'
     };
 
+    pub const C = extern struct {
+        action: c_int,
+        options_unvalidated: [*c]const u8,
+        options_unvalidated_len: usize,
+    };
+
     pub fn init(action: Action) Command {
         return .{
             .action = action,
             .options_unvalidated = "",
+        };
+    }
+
+    pub fn cval(self: Command) C {
+        return .{
+            .action = @intFromEnum(self.action),
+            .options_unvalidated = if (self.options_unvalidated.len > 0)
+                self.options_unvalidated.ptr
+            else
+                null,
+            .options_unvalidated_len = self.options_unvalidated.len,
         };
     }
 


### PR DESCRIPTION
## Summary
- add visionOS platform wiring for embedded/libghostty surfaces ( +  bridge)
- add xros/xrsimulator build plumbing in Zig build graph and Metal shader compilation
- add optional visionOS slices to  via 
- add visionOS-target build wrapper scripts and docs for reproducible local builds
- isolate  test modules so test dependency wiring does not mutate production  modules (fixes wasm  build regression)

## Validation
- 
- Prepared /Users/douglance/Developer/lv/ghostty/.toolchains/zig-visionos/zig-34470b281dec31c254a11571f8d3c81ea0755dcc/lib
- 
- 

## Notes
- this includes temporary fork pinning in  for  visionOS coverage
- release-fast  still hits existing  assertion behavior and is not introduced by this patch