### PR TITLE
gtk: clean up title renaming and fix a small leak

### DIFF
--- a/src/apprt/gtk/class/tab.zig
+++ b/src/apprt/gtk/class/tab.zig
@@ -330,6 +330,10 @@ pub const Tab = extern struct {
             glib.free(@ptrCast(@constCast(v)));
             priv.title = null;
         }
+        if (priv.title_override) |v| {
+            glib.free(@ptrCast(@constCast(v)));
+            priv.title_override = null;
+        }
 
         gobject.Object.virtual_methods.finalize.call(
             Class.parent,

--- a/src/apprt/gtk/class/window.zig
+++ b/src/apprt/gtk/class/window.zig
@@ -339,6 +339,7 @@ pub const Window = extern struct {
             .init("close-tab", actionCloseTab, s_variant_type),
             .init("new-tab", actionNewTab, null),
             .init("new-window", actionNewWindow, null),
+            .init("prompt-surface-title", actionPromptSurfaceTitle, null),
             .init("prompt-tab-title", actionPromptTabTitle, null),
             .init("prompt-context-tab-title", actionPromptContextTabTitle, null),
             .init("ring-bell", actionRingBell, null),
@@ -1801,6 +1802,14 @@ pub const Window = extern struct {
         const child = page.getChild();
         const tab = gobject.ext.cast(Tab, child) orelse return;
         tab.promptTabTitle();
+    }
+
+    fn actionPromptSurfaceTitle(
+        _: *gio.SimpleAction,
+        _: ?*glib.Variant,
+        self: *Window,
+    ) callconv(.c) void {
+        self.performBindingAction(.prompt_surface_title);
     }
 
     fn actionPromptTabTitle(

--- a/src/apprt/gtk/ui/1.5/window.blp
+++ b/src/apprt/gtk/ui/1.5/window.blp
@@ -243,7 +243,7 @@ menu main_menu {
 
       item {
         label: _("Change Title…");
-        action: "win.prompt-title";
+        action: "win.prompt-surface-title";
       }
 
       item {

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -570,12 +570,9 @@ pub const Action = union(enum) {
     toggle_tab_overview,
 
     /// Change the title of the current focused surface via a pop-up prompt.
-    ///
-    /// This requires libadwaita 1.5 or newer on Linux. The current libadwaita
-    /// version can be found by running `ghostty +version`.
     prompt_surface_title,
 
-    /// Change the title of the current tab/window via a pop-up prompt. The
+    /// Change the title of the current tab via a pop-up prompt. The
     /// title set via this prompt overrides any title set by the terminal
     /// and persists across focus changes within the tab.
     prompt_tab_title,

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -440,13 +440,13 @@ fn actionCommands(action: Action.Key) []const Command {
 
         .prompt_surface_title => comptime &.{.{
             .action = .prompt_surface_title,
-            .title = "Change Terminal Title...",
+            .title = "Change Terminal Title…",
             .description = "Prompt for a new title for the current terminal.",
         }},
 
         .prompt_tab_title => comptime &.{.{
             .action = .prompt_tab_title,
-            .title = "Change Tab Title...",
+            .title = "Change Tab Title…",
             .description = "Prompt for a new title for the current tab.",
         }},
 


### PR DESCRIPTION
Also enables the "Change Title…" item in the main menu.