### PR TITLE
Fix Palette.C array size typo: [265] → [256]

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -5645,7 +5645,7 @@ pub const Palette = struct {
 
     /// ghostty_config_palette_s
     pub const C = extern struct {
-        colors: [265]Color.C,
+        colors: [256]Color.C,
     };
 
     pub fn cval(self: Self) Palette.C {


### PR DESCRIPTION
The C struct Palette.C declared colors as [265]Color.C, but the terminal palette is 256 colors (terminal.color.Palette = [256]RGB) and the C header ghostty_config_palette_s correctly uses colors[256].

The mismatch causes ghostty_config_get to write 265×3 = 795 bytes through a pointer sized for 256×3 = 768 bytes, producing a 27-byte buffer overflow. On macOS Release builds with stack protector enabled, this triggers __stack_chk_fail → SIGABRT on launch.

Discovered this while working on https://github.com/markhuot/watchtower. Builds were succeeding but the app was crashing on launch because we use the new C bindings to get the foreground/background colors to set window theming like "selection" color.