### PR TITLE
macOS: Clear badge icon when no surfaces have an active bell

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,13 +18,6 @@ A file for [guiding coding agents](https://agents.md/).
 - macOS app: `macos/`
 - GTK (Linux and FreeBSD) app: `src/apprt/gtk`
 
-## macOS App
-
-- Do not use `xcodebuild`
-- Use `zig build` to build the macOS app and any shared Zig code
-- Use `zig build run` to build and run the macOS app
-- Run Xcode tests using `zig build test`
-
 ## Issue and PR Guidelines
 
 - Never create an issue.

--- a/macos/AGENTS.md
+++ b/macos/AGENTS.md
@@ -1,3 +1,9 @@
 # macOS Ghostty Application
 
 - Use `swiftlint` for formatting and linting Swift code.
+- If code outside of this directory is modified, use
+  `zig build -Demit-macos-app=false` before building the macOS app to update
+  the underlying Ghostty library.
+- Use `xcodebuild` to build the macOS app, do not use `zig build`
+  (except to build the underlying library as mentioned above).
+- Run unit tests directly with `xcodebuild`

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -799,7 +799,7 @@ class AppDelegate: NSObject,
                         self.setDockBadge()
                     }
                 }
-                
+
             case .notDetermined:
                 // Not determined yet, request authorization for badge
                 center.requestAuthorization(options: [.badge]) { granted, error in
@@ -807,7 +807,7 @@ class AppDelegate: NSObject,
                         Self.logger.warning("Error requesting badge authorization: \(error)")
                         return
                     }
-                    
+
                     if granted {
                         // Permission granted, set the badge
                         DispatchQueue.main.async {
@@ -815,11 +815,11 @@ class AppDelegate: NSObject,
                         }
                     }
                 }
-                
+
             case .denied, .provisional, .ephemeral:
                 // In these known non-authorized states, do not attempt to set the badge.
                 break
-                
+
             @unknown default:
                 // Handle future unknown states by doing nothing.
                 break
@@ -896,7 +896,7 @@ class AppDelegate: NSObject,
         // Config could change keybindings, so update everything that depends on that
         syncMenuShortcuts(config)
         TerminalController.all.forEach { $0.relabelTabs() }
-        
+
         // Update our badge since config can change what we show.
         syncDockBadge()
 

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -848,11 +848,11 @@ class AppDelegate: NSObject,
     }
 
     private func setDockBadge() {
-        let anyBell = NSApp.windows
+        let bellCount = NSApp.windows
             .compactMap { $0.windowController as? BaseTerminalController }
-            .contains { $0.bell }
-        let wantsBadge = ghostty.config.bellFeatures.contains(.attention) && anyBell
-        let label = wantsBadge ? "•" : nil
+            .reduce(0) { $0 + ($1.bell ? 1 : 0) }
+        let wantsBadge = ghostty.config.bellFeatures.contains(.attention) && bellCount > 0
+        let label = wantsBadge ? (bellCount > 99 ? "99+" : String(bellCount)) : nil
         NSApp.dockTile.badgeLabel = label
         NSApp.dockTile.display()
     }

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -477,7 +477,9 @@ pub fn add(
         .freetype = true,
         .@"backend-metal" = target.result.os.tag.isDarwin(),
         .@"backend-osx" = target.result.os.tag == .macos,
-        .@"backend-opengl3" = target.result.os.tag != .macos,
+        // OpenGL3 backend should only be built on non-Apple targets.
+        // Apple platforms use Metal (and macOS may also use the OSX backend).
+        .@"backend-opengl3" = !target.result.os.tag.isDarwin(),
     })) |dep| {
         step.root_module.addImport("dcimgui", dep.module("dcimgui"));
         step.linkLibrary(dep.artifact("dcimgui"));


### PR DESCRIPTION
Fixes #8487

I did this by setting up a publisher on `BaseTerminalController` for any bell state change on any surfaces in the tree (including removing surfaces). By listening to this event at AppDelegate and reinspecting all our windows, we can reliably set the badge. 

**This also includes a change to show the number of terminals with an active bell!** We can now determine the number, so we show it!