### PR TITLE
zsh: fix ssh-terminfo shell integration to not interpret escape characters

### DIFF
--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -315,7 +315,7 @@ _ghostty_deferred_init() {
                 ssh_cpath_dir=$(mktemp -d "/tmp/ghostty-ssh-$ssh_user.XXXXXX" 2>/dev/null) || ssh_cpath_dir="/tmp/ghostty-ssh-$ssh_user.$$"
                 ssh_cpath="$ssh_cpath_dir/socket"
 
-                if print "$ssh_terminfo" | command ssh "${ssh_opts[@]}" -o ControlMaster=yes -o ControlPath="$ssh_cpath" -o ControlPersist=60s "$@" '
+                if builtin print -r "$ssh_terminfo" | command ssh "${ssh_opts[@]}" -o ControlMaster=yes -o ControlPath="$ssh_cpath" -o ControlPersist=60s "$@" '
                   infocmp xterm-ghostty >/dev/null 2>&1 && exit 0
                   command -v tic >/dev/null 2>&1 || exit 1
                   mkdir -p ~/.terminfo 2>/dev/null && tic -x - 2>/dev/null && exit 0


### PR DESCRIPTION
With zsh, when installing the ghostty terminfo on a server via the ssh-terminfo shell integration, parts of the terminfo get mangled. In particular, the newline escape sequence in 
```
> infocmp -0 -x xterm-ghostty | grep ind=
 ...,ind=\n,indn=...
 ```
gets interpreted by `print` as a literal newline, which then just gets ignored / does not have the intended effect.

Documentation for the `-r` flag of `print` used in the fix is [here](https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#:~:text=Ignore%20the%20escape%20conventions%20of%20echo.).

### Testing locally
You can directly demonstrate this locally. This outputs a host of warning messages:
```
ssh_terminfo=$(infocmp -0 -x xterm-ghostty 2>/dev/null)
print "$ssh_terminfo" | tic -x -
```
Whereas
```print -r "$ssh_terminfo" | tic -x -```
or
```infocmp -0 -x xterm-ghostty | tic -x -```
work without issue.

### Testing remotely
The most visible way is to observe the output of `htop` before and after the change.

More directly, the output of `infocmp -x xterm-ghostty | grep " ind="` should be
```ich=\E[%p1%d@, ich1=\E[@, il=\E[%p1%dL, il1=\E[L, ind=\n,```
instead of 
```ich=\E[%p1%d@, ich1=\E[@, il=\E[%p1%dL, il1=\E[L, ind=,```

---

Discussed in #11031.

---
AI disclosure: I used Claude for parts of figuring out what was going on. The fix itself and the rest was written and tested by myself.