### PR TITLE
macos: workaround for `TabTitleEditor` alignment issue

### DIFF
--- a/macos/Sources/Helpers/TabTitleEditor.swift
+++ b/macos/Sources/Helpers/TabTitleEditor.swift
@@ -226,7 +226,9 @@ final class TabTitleEditor: NSObject, NSTextFieldDelegate {
 
         if let sourceLabel {
             let labelFrame = tabButton.convert(sourceLabel.bounds, from: sourceLabel)
-            frame.origin.y = labelFrame.minY
+            /// The `labelFrame.minY` value changes unexpectedly after the first use,
+            /// I don't know exactly why, but `tabButton.bounds` appears stable enough to calculate the correct position reliably.
+            frame.origin.y = bounds.midY - labelFrame.height * 0.5
             frame.size.height = labelFrame.height
         }
 


### PR DESCRIPTION
Fixes #10993


https://github.com/user-attachments/assets/666803f9-05aa-4c86-ab4a-7a183d471e33

