### PR TITLE
macOS: fix for Cmd+W window position/size restoration

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -253,7 +253,14 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
             // Only cascade if we aren't fullscreen.
             if let window = c.window {
                 if !window.styleMask.contains(.fullScreen) {
-                    Self.lastCascadePoint = window.cascadeTopLeft(from: Self.lastCascadePoint)
+                    let hasFixedPos = c.derivedConfig.windowPositionX != nil && c.derivedConfig.windowPositionY != nil
+                    let shouldCascade = !hasFixedPos && TerminalController.all.count > 1
+
+                    if shouldCascade {
+                        Self.lastCascadePoint = window.cascadeTopLeft(from: Self.lastCascadePoint)
+                    } else if !hasFixedPos {
+                        Self.lastCascadePoint = NSPoint(x: window.frame.minX, y: window.frame.maxY)
+                    }
                 }
             }
 
@@ -323,7 +330,14 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
                         window.setFrameTopLeftPoint(position)
                         window.constrainToScreen()
                     } else {
-                        Self.lastCascadePoint = window.cascadeTopLeft(from: Self.lastCascadePoint)
+                        let hasFixedPos = c.derivedConfig.windowPositionX != nil && c.derivedConfig.windowPositionY != nil
+                        let shouldCascade = !hasFixedPos && TerminalController.all.count > 1
+
+                        if shouldCascade {
+                            Self.lastCascadePoint = window.cascadeTopLeft(from: Self.lastCascadePoint)
+                        } else if !hasFixedPos {
+                            Self.lastCascadePoint = NSPoint(x: window.frame.minX, y: window.frame.maxY)
+                        }
                     }
                 }
             }
@@ -429,7 +443,14 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
             // Only cascade if we aren't fullscreen and are alone in the tab group.
             if !window.styleMask.contains(.fullScreen) &&
                 window.tabGroup?.windows.count ?? 1 == 1 {
-                Self.lastCascadePoint = window.cascadeTopLeft(from: Self.lastCascadePoint)
+                let hasFixedPos = controller.derivedConfig.windowPositionX != nil && controller.derivedConfig.windowPositionY != nil
+                let shouldCascade = !hasFixedPos && TerminalController.all.count > 1
+
+                if shouldCascade {
+                    Self.lastCascadePoint = window.cascadeTopLeft(from: Self.lastCascadePoint)
+                } else if !hasFixedPos {
+                    Self.lastCascadePoint = NSPoint(x: window.frame.minX, y: window.frame.maxY)
+                }
             }
 
             controller.showWindow(self)
@@ -1160,6 +1181,15 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         self.fixTabBar()
 
         // Whenever we move save our last position for the next start.
+        if let window {
+            LastWindowPosition.shared.save(window)
+        }
+    }
+
+    override func windowDidResize(_ notification: Notification) {
+        super.windowDidResize(notification)
+
+        // Whenever we resize save our last position and size for the next start.
         if let window {
             LastWindowPosition.shared.save(window)
         }

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -198,6 +198,16 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
     // of each other.
     private static var lastCascadePoint = NSPoint(x: 0, y: 0)
 
+    private static func applyCascade(to window: NSWindow, hasFixedPos: Bool) {
+        if hasFixedPos { return }
+
+        if all.count > 1 {
+            lastCascadePoint = window.cascadeTopLeft(from: lastCascadePoint)
+        } else {
+            lastCascadePoint = NSPoint(x: window.frame.minX, y: window.frame.maxY)
+        }
+    }
+
     // The preferred parent terminal controller.
     static var preferredParent: TerminalController? {
         all.first {
@@ -254,13 +264,7 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
             if let window = c.window {
                 if !window.styleMask.contains(.fullScreen) {
                     let hasFixedPos = c.derivedConfig.windowPositionX != nil && c.derivedConfig.windowPositionY != nil
-                    let shouldCascade = !hasFixedPos && TerminalController.all.count > 1
-
-                    if shouldCascade {
-                        Self.lastCascadePoint = window.cascadeTopLeft(from: Self.lastCascadePoint)
-                    } else if !hasFixedPos {
-                        Self.lastCascadePoint = NSPoint(x: window.frame.minX, y: window.frame.maxY)
-                    }
+                    Self.applyCascade(to: window, hasFixedPos: hasFixedPos)
                 }
             }
 
@@ -331,13 +335,7 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
                         window.constrainToScreen()
                     } else {
                         let hasFixedPos = c.derivedConfig.windowPositionX != nil && c.derivedConfig.windowPositionY != nil
-                        let shouldCascade = !hasFixedPos && TerminalController.all.count > 1
-
-                        if shouldCascade {
-                            Self.lastCascadePoint = window.cascadeTopLeft(from: Self.lastCascadePoint)
-                        } else if !hasFixedPos {
-                            Self.lastCascadePoint = NSPoint(x: window.frame.minX, y: window.frame.maxY)
-                        }
+                        Self.applyCascade(to: window, hasFixedPos: hasFixedPos)
                     }
                 }
             }
@@ -444,13 +442,7 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
             if !window.styleMask.contains(.fullScreen) &&
                 window.tabGroup?.windows.count ?? 1 == 1 {
                 let hasFixedPos = controller.derivedConfig.windowPositionX != nil && controller.derivedConfig.windowPositionY != nil
-                let shouldCascade = !hasFixedPos && TerminalController.all.count > 1
-
-                if shouldCascade {
-                    Self.lastCascadePoint = window.cascadeTopLeft(from: Self.lastCascadePoint)
-                } else if !hasFixedPos {
-                    Self.lastCascadePoint = NSPoint(x: window.frame.minX, y: window.frame.maxY)
-                }
+                Self.applyCascade(to: window, hasFixedPos: hasFixedPos)
             }
 
             controller.showWindow(self)

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -204,7 +204,7 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         if all.count > 1 {
             lastCascadePoint = window.cascadeTopLeft(from: lastCascadePoint)
         } else {
-            lastCascadePoint = NSPoint(x: window.frame.minX, y: window.frame.maxY)
+            lastCascadePoint = window.cascadeTopLeft(from: NSPoint(x: window.frame.minX, y: window.frame.maxY))
         }
     }
 

--- a/macos/Sources/Helpers/LastWindowPosition.swift
+++ b/macos/Sources/Helpers/LastWindowPosition.swift
@@ -7,22 +7,28 @@ class LastWindowPosition {
     private let positionKey = "NSWindowLastPosition"
 
     func save(_ window: NSWindow) {
-        let origin = window.frame.origin
-        let point = [origin.x, origin.y]
-        UserDefaults.standard.set(point, forKey: positionKey)
+        let frame = window.frame
+        let rect = [frame.origin.x, frame.origin.y, frame.size.width, frame.size.height]
+        UserDefaults.standard.set(rect, forKey: positionKey)
     }
 
     func restore(_ window: NSWindow) -> Bool {
-        guard let points = UserDefaults.standard.array(forKey: positionKey) as? [Double],
-              points.count == 2 else { return false }
+        guard let values = UserDefaults.standard.array(forKey: positionKey) as? [Double],
+              values.count >= 2 else { return false }
 
-        let lastPosition = CGPoint(x: points[0], y: points[1])
+        let lastPosition = CGPoint(x: values[0], y: values[1])
 
         guard let screen = window.screen ?? NSScreen.main else { return false }
         let visibleFrame = screen.visibleFrame
 
         var newFrame = window.frame
         newFrame.origin = lastPosition
+
+        if values.count >= 4 {
+            newFrame.size.width = min(values[2], visibleFrame.width)
+            newFrame.size.height = min(values[3], visibleFrame.height)
+        }
+
         if !visibleFrame.contains(newFrame.origin) {
             newFrame.origin.x = max(visibleFrame.minX, min(visibleFrame.maxX - newFrame.width, newFrame.origin.x))
             newFrame.origin.y = max(visibleFrame.minY, min(visibleFrame.maxY - newFrame.height, newFrame.origin.y))


### PR DESCRIPTION
I'd like to contribute a fix for an issue I found regarding how macOS window restoration works when a window is closed via Cmd+W (leaving the app active).

Currently, the position cascades down and to the right on every reopen, and size explicitly resets. Also, explicit `window-position-x/y` configs get ignored on first launch.

I've diagnosed the issues:
1. In `TerminalWindow.swift`, `setInitialWindowPosition` relies on the `TerminalController` which isn't present during `awakeFromNib`. I moved the `screen.origin` calculation directly into the window class to ensure fixed coordinates are respected immediately.
2. In `TerminalController.swift`, I consolidated the window spawning cascade logic into a new `applyCascade(to:hasFixedPos:)` helper. It now only calls `cascadeTopLeft` if `TerminalController.all.count > 1` (meaning another window is active) and fixed coords aren't set. If it's the only window, it anchors exactly where `LastWindowPosition` placed it.
3. In `LastWindowPosition.swift`, I updated the `save` and `restore` logic to persist the full `window.frame` (origin + size) instead of just the origin.

*Disclosure: I used Cursor (Tab) to assist in navigating the codebase and formatting the Swift code, but I fully understand the AppKit lifecycle changes and edge cases I'm proposing.*

I have the commit locally formatted with `swiftlint` and ready to push!