### PR TITLE
fix(shell): fallback TERM for su login sessions

### DIFF
--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -112,6 +112,38 @@ if [[ "$GHOSTTY_SHELL_FEATURES" == *"sudo"* && -n "$TERMINFO" ]]; then
       builtin command sudo --preserve-env=TERMINFO "$@"
     fi
   }
+
+fi
+
+# su
+if [[ -n "$TERMINFO" && "$(type -t su 2>/dev/null)" == "file" ]]; then
+  # Wrap `su` login shells so they don't inherit xterm-ghostty without TERMINFO.
+  # Login `su` usually drops TERMINFO, which breaks readline key handling.
+  function su {
+    builtin local su_login_shell="no"
+    builtin local arg
+    for arg in "$@"; do
+      case "$arg" in
+      -|--login|-l|-[^-]*l[^-]*)
+        su_login_shell="yes"
+        ;;
+      --)
+        builtin break
+        ;;
+      -*)
+        ;;
+      *)
+        builtin break
+        ;;
+      esac
+    done
+
+    if [[ "$su_login_shell" == "yes" ]]; then
+      TERM="xterm-256color" builtin command su "$@"
+    else
+      builtin command su "$@"
+    fi
+  }
 fi
 
 # SSH Integration

--- a/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
+++ b/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
@@ -119,6 +119,34 @@ function __ghostty_setup --on-event fish_prompt -d "Setup ghostty integration"
         end
     end
 
+    # Ensure $TERMINFO is set and `su` is not already a function or alias
+    if test -n "$TERMINFO"; and test file = (type -t su 2> /dev/null; or echo "x")
+        # Wrap `su` login shells so TERM is compatible when TERMINFO is dropped
+        function su -d "Wrap su login shells for terminfo fallback"
+            set --function su_login_shell no
+
+            for arg in $argv
+                if test "$arg" = "-"; or test "$arg" = "--login"; or string match -r -q -- '^-[^-]*l[^-]*$' "$arg"
+                    set su_login_shell yes
+                end
+
+                if test "$arg" = "--"
+                    break
+                end
+
+                if not string match -r -q -- '^-' "$arg"
+                    break
+                end
+            end
+
+            if test "$su_login_shell" = yes
+                TERM=xterm-256color command su $argv
+            else
+                command su $argv
+            end
+        end
+    end
+
     # SSH Integration
     set -l features (string split ',' -- "$GHOSTTY_SHELL_FEATURES")
     if contains ssh-env $features; or contains ssh-terminfo $features

--- a/src/shell-integration/nushell/vendor/autoload/ghostty.nu
+++ b/src/shell-integration/nushell/vendor/autoload/ghostty.nu
@@ -99,6 +99,33 @@ export module ghostty {
 
     ^sudo ...$sudo_args
   }
+
+  # Wrap `su` login shells to use a compatible TERM when TERMINFO is dropped
+  export def --wrapped su [...args] {
+    mut su_login_shell = false
+
+    for arg in $args {
+      if ($arg == "-" or $arg == "--login" or ($arg =~ '^-[^-]*l[^-]*$')) {
+        $su_login_shell = true
+      }
+
+      if ($arg == "--") {
+        break
+      }
+
+      if not ($arg | str starts-with "-") {
+        break
+      }
+    }
+
+    if (($env.TERMINFO? | default "") | is-not-empty) and $su_login_shell {
+      with-env {TERM: "xterm-256color"} {
+        ^su ...$args
+      }
+    } else {
+      ^su ...$args
+    }
+  }
 }
 
 # Clean up XDG_DATA_DIRS by removing GHOSTTY_SHELL_INTEGRATION_XDG_DIR

--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -268,6 +268,38 @@ _ghostty_deferred_init() {
           builtin command sudo --preserve-env=TERMINFO "$@";
         fi
       }
+
+    fi
+
+    # su
+    if [[ -n "$TERMINFO" ]] && (( $+commands[su] )) && (( ! $+functions[su] )) && (( ! $+aliases[su] )); then
+      # Wrap `su` login shells so they don't inherit xterm-ghostty without TERMINFO.
+      # Login `su` usually drops TERMINFO, which breaks readline key handling.
+      su() {
+        builtin local su_login_shell="no"
+        builtin local arg
+        for arg in "$@"; do
+          case "$arg" in
+            -|--login|-l|-[^-]*l[^-]*)
+              su_login_shell="yes"
+              ;;
+            --)
+              builtin break
+              ;;
+            -*)
+              ;;
+            *)
+              builtin break
+              ;;
+          esac
+        done
+
+        if [[ "$su_login_shell" == "yes" ]]; then
+          TERM="xterm-256color" builtin command su "$@"
+        else
+          builtin command su "$@"
+        fi
+      }
     fi
 
     # SSH Integration


### PR DESCRIPTION
## Summary
- Fixes broken line editing in login-style `su` sessions (`su - <user>`) where arrow-key navigation/cursor behavior becomes incorrect.
- Root cause: login `su` can drop `TERMINFO` while inheriting `TERM=xterm-ghostty`, leaving the child shell with mismatched terminal capabilities.
- Adds shell-integration wrappers for `su` (bash, zsh, fish, nushell) to detect login-style invocation and run only that command with `TERM=xterm-256color`.

## Behavior Notes
- This change affects only login-style `su` invocations (`-`, `--login`, `-l`, or combined short options containing `l`).
- Non-login `su` behavior is unchanged.
- Existing `sudo` terminfo-preservation behavior remains unchanged.

## Validation
- `bash -n src/shell-integration/bash/ghostty.bash`
- `zsh -n src/shell-integration/zsh/ghostty-integration`
- `zig build test -Dtest-filter=shell_integration`
- Manual reproduction in app:
  1. `su - Admin`
  2. Edit a long command with left/right arrows
  3. Confirm cursor movement and line rendering behave correctly

## Related
- Issue triage discussion: #11075