### PR TITLE
🐛 Prevent git log output with signature information

### DIFF
--- a/src/build/GitVersion.zig
+++ b/src/build/GitVersion.zig
@@ -39,7 +39,7 @@ pub fn detect(b: *std.Build) !Version {
 
     const short_hash = short_hash: {
         const output = b.runAllowFail(
-            &[_][]const u8{ "git", "-C", b.build_root.path orelse ".", "log", "--pretty=format:%h", "-n", "1" },
+            &[_][]const u8{ "git", "-C", b.build_root.path orelse ".", "-c", "log.showSignature=false", "log", "--pretty=format:%h", "-n", "1" },
             &code,
             .Ignore,
         ) catch |err| switch (err) {


### PR DESCRIPTION
When users have something like

[log]
        showSignature = true

in their .gitconfig files, invocations of the log or show git sub-command emit additional information about signatures.  This additional output disturbs the generation of short_hash in GitVersion.zig, the additional text is copied verbatim into the string and then shown in the CSI >q output.

To fix it always suppress the output of the signature information.  This has no effects when the setting is disabled anyway.