### PR TITLE
docs: add clarification for pre-vouching contributors 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,13 @@ on a system of trust, and AI has unfortunately made it so we can no
 longer trust-by-default because it makes it too trivial to generate
 plausible-looking but actually low-quality contributions.
 
+## Pre-Vouching Contributors
+
+If you have already contributed to Ghostty prior to the introduction 
+of the vouching system and wish to continue contributing, you will not
+automatically be vouched. You will be required to follow the same
+vouching process as a first-time contributor.
+
 ## Denouncement System
 
 If you repeatedly break the rules of this document or repeatedly

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ plausible-looking but actually low-quality contributions.
 ## Contributors Prior to the Vouch System
 
 If you contributed to Ghostty prior to the introduction
-of the vouch system and wish to continue contributing, you are not
+of the vouch system and wish to continue contributing, you were not
 automatically added to the [list of vouched users](.github/VOUCHED.td). You will need to follow the same
 process as a first-time contributor to be vouched.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ plausible-looking but actually low-quality contributions.
 ## Contributors Prior to the Vouch System
 
 If you contributed to Ghostty prior to the introduction
-of the vouch system and wish to continue contributing, you were not
+of the vouch system and wish to continue contributing, you are not
 automatically added to the [list of vouched users](.github/VOUCHED.td). You will need to follow the same
 process as a first-time contributor to be vouched.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ plausible-looking but actually low-quality contributions.
 ## Contributors Prior to the Vouch System
 
 If you contributed to Ghostty prior to the introduction
-of the vouching system and wish to continue contributing, you are not
+of the vouch system and wish to continue contributing, you were not
 automatically vouched. You are required to follow the same
 vouching process as a first-time contributor.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ plausible-looking but actually low-quality contributions.
 
 ## Contributors Prior to the Vouch System
 
-If you have already contributed to Ghostty prior to the introduction
+If you contributed to Ghostty prior to the introduction
 of the vouching system and wish to continue contributing, you are not
 automatically vouched. You are required to follow the same
 vouching process as a first-time contributor.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,11 +47,11 @@ on a system of trust, and AI has unfortunately made it so we can no
 longer trust-by-default because it makes it too trivial to generate
 plausible-looking but actually low-quality contributions.
 
-## Pre-Vouching Contributors
+## Contributors Prior to the Vouch System
 
 If you have already contributed to Ghostty prior to the introduction 
-of the vouching system and wish to continue contributing, you will not
-automatically be vouched. You will be required to follow the same
+of the vouching system and wish to continue contributing, you are not
+automatically vouched. You are required to follow the same
 vouching process as a first-time contributor.
 
 ## Denouncement System

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ plausible-looking but actually low-quality contributions.
 
 If you contributed to Ghostty prior to the introduction
 of the vouch system and wish to continue contributing, you were not
-automatically vouched. You are required to follow the same
+automatically added to the [list of vouched users](.github/VOUCHED.td). You will need to follow the same
 vouching process as a first-time contributor.
 
 ## Denouncement System

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ plausible-looking but actually low-quality contributions.
 If you contributed to Ghostty prior to the introduction
 of the vouch system and wish to continue contributing, you were not
 automatically added to the [list of vouched users](.github/VOUCHED.td). You will need to follow the same
-vouching process as a first-time contributor.
+process as a first-time contributor to be vouched.
 
 ## Denouncement System
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ plausible-looking but actually low-quality contributions.
 
 ## Contributors Prior to the Vouch System
 
-If you have already contributed to Ghostty prior to the introduction 
+If you have already contributed to Ghostty prior to the introduction
 of the vouching system and wish to continue contributing, you are not
 automatically vouched. You are required to follow the same
 vouching process as a first-time contributor.


### PR DESCRIPTION
If this PR is accepted, it will add a clarification to the contribution guidelines to inform pre-vouching contributors that they are still required to apply for vouching as would a first-time contributor.