### PR TITLE
Clear key state overlay on "ignore" action

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2973,6 +2973,9 @@ fn maybeHandleBinding(
         // If our action was "ignore" then we return the special input
         // effect of "ignored".
         for (actions) |action| if (action == .ignore) {
+            // If we're in a sequence, clear it.
+            self.endKeySequence(.drop, .retain);
+
             return .ignored;
         };
     }


### PR DESCRIPTION
This fixes a bug in the key state sequence overlay.

## Demo

In my ghostty config, I have

    keybind = ctrl+space>escape=ignore
    keybind = ctrl+space>p=toggle_command_palette
    ...

because I use `ctrl+space>` sequences for most things and so hitting `esc` is my way to bail out of the sequence if I change my mind.

I just switched to tip and got the new GTK key sequence overlay. Here's what I saw. In these screen recordings, the sequence of keys I press is

    ctrl+space, escape, ctrl+space, escape, ctrl+space, escape, ctrl+space, p

https://github.com/user-attachments/assets/4a37bc7e-b75c-4bd1-99de-f21f4211b5b5

after the fix:

https://github.com/user-attachments/assets/023be88e-1299-4219-920c-1b1134b2888c

## Notes

I believe this was also a leak, since the queued keys wouldn't be deinited.

**AI usage:** Claude Code suggested the fix, then I read enough code to convince myself that it makes sense.