### PR TITLE
Nix pkgs pin dependencies

### DIFF
--- a/nix/pkgs/blessed.nix
+++ b/nix/pkgs/blessed.nix
@@ -7,9 +7,9 @@
   six,
   wcwidth,
 }:
-buildPythonPackage {
+buildPythonPackage (finalAttrs: {
   pname = "blessed";
-  version = "unstable-1.31";
+  version = "1.31";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -17,7 +17,7 @@ buildPythonPackage {
   src = fetchFromGitHub {
     owner = "jquast";
     repo = "blessed";
-    rev = "9d2580b5f800a26a19cebe7119163be5e9ae58e9"; # tag 1.31
+    tag = finalAttrs.version;
     hash = "sha256-Nn+aiDk0Qwk9xAvAqtzds/WlrLAozjPL1eSVNU75tJA=";
   };
 
@@ -37,4 +37,4 @@ buildPythonPackage {
     maintainers = [];
     license = licenses.mit;
   };
-}
+})

--- a/nix/pkgs/blessed.nix
+++ b/nix/pkgs/blessed.nix
@@ -9,7 +9,7 @@
 }:
 buildPythonPackage {
   pname = "blessed";
-  version = "unstable-2026-02-23";
+  version = "unstable-1.31";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -17,8 +17,8 @@ buildPythonPackage {
   src = fetchFromGitHub {
     owner = "jquast";
     repo = "blessed";
-    rev = "master";
-    hash = "sha256-ROd/O9pfqnF5DHXqoz+tkl1jQJSZad3Ta1h+oC3+gvY=";
+    rev = "9d2580b5f800a26a19cebe7119163be5e9ae58e9"; # tag 1.31
+    hash = "sha256-Nn+aiDk0Qwk9xAvAqtzds/WlrLAozjPL1eSVNU75tJA=";
   };
 
   build-system = [flit-core];

--- a/nix/pkgs/ucs-detect.nix
+++ b/nix/pkgs/ucs-detect.nix
@@ -11,9 +11,9 @@
   prettytable,
   requests,
 }:
-buildPythonPackage {
+buildPythonPackage (finalAttrs: {
   pname = "ucs-detect";
-  version = "unstable-2.0.2";
+  version = "2.0.2";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -21,7 +21,7 @@ buildPythonPackage {
   src = fetchFromGitHub {
     owner = "jquast";
     repo = "ucs-detect";
-    rev = "44884c9581b57ed17d514b54adca07986576c2bf"; # tag 2.0.2
+    tag = finalAttrs.version;
     hash = "sha256-pCJNrJN+SO0pGveNJuISJbzOJYyxP9Tbljp8PwqbgYU=";
   };
 
@@ -44,4 +44,4 @@ buildPythonPackage {
     license = licenses.mit;
     maintainers = [];
   };
-}
+})

--- a/nix/pkgs/ucs-detect.nix
+++ b/nix/pkgs/ucs-detect.nix
@@ -13,7 +13,7 @@
 }:
 buildPythonPackage {
   pname = "ucs-detect";
-  version = "unstable-2026-02-23";
+  version = "unstable-2.0.2";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -21,8 +21,8 @@ buildPythonPackage {
   src = fetchFromGitHub {
     owner = "jquast";
     repo = "ucs-detect";
-    rev = "master";
-    hash = "sha256-x7BD14n1/mP9bzjM6DPqc5R1Fk/HLLycl4o41KV+xAE=";
+    rev = "44884c9581b57ed17d514b54adca07986576c2bf"; # tag 2.0.2
+    hash = "sha256-pCJNrJN+SO0pGveNJuISJbzOJYyxP9Tbljp8PwqbgYU=";
   };
 
   dependencies = [


### PR DESCRIPTION
pinning these to the master branch was leading to derivation errors since new commits have recently happened.

I didn't pin them to the original commits rather the latest release tags I can do that if required, I don't think any major functionality changed from what I can see mostly new test results

I was getting hash mismatch errors because it was pulling in new commits
```
error: hash mismatch in fixed-output derivation '/nix/store/8hf2d85msqrb78cvb09cwvnginmznkkf-source.drv':
         specified: sha256-ROd/O9pfqnF5DHXqoz+tkl1jQJSZad3Ta1h+oC3+gvY=
            got:    sha256-ZpxrSI2vEH7KXNBiRQFlkI0+vtZIRqy2w7x1eJIEnlw=
error: Cannot build '/nix/store/0l8kzy1dbhjyrypixy9alivpdvhcg7yi-python3.13-blessed-unstable-2026-02-23.drv'.
```