### PR TITLE
terminfo: add support for SGR dim

### DIFF
--- a/src/terminfo/ghostty.zig
+++ b/src/terminfo/ghostty.zig
@@ -220,7 +220,7 @@ pub const ghostty: Source = .{
         .{ .name = "setaf", .value = .{ .string = "\\E[%?%p1%{8}%<%t3%p1%d%e%p1%{16}%<%t9%p1%{8}%-%d%e38;5;%p1%d%;m" } },
         .{ .name = "setrgbb", .value = .{ .string = "\\E[48:2:%p1%d:%p2%d:%p3%dm" } },
         .{ .name = "setrgbf", .value = .{ .string = "\\E[38:2:%p1%d:%p2%d:%p3%dm" } },
-        .{ .name = "sgr", .value = .{ .string = "%?%p9%t\\E(0%e\\E(B%;\\E[0%?%p6%t;1%;%?%p2%t;4%;%?%p1%p3%|%t;7%;%?%p4%t;5%;%?%p7%t;8%;m" } },
+        .{ .name = "sgr", .value = .{ .string = "%?%p9%t\\E(0%e\\E(B%;\\E[0%?%p6%t;1%;%?%p5%t;2%;%?%p2%t;4%;%?%p1%p3%|%t;7%;%?%p4%t;5%;%?%p7%t;8%;m" } },
         .{ .name = "sgr0", .value = .{ .string = "\\E(B\\E[m" } },
         .{ .name = "sitm", .value = .{ .string = "\\E[3m" } },
         .{ .name = "smacs", .value = .{ .string = "\\E(0" } },


### PR DESCRIPTION
This PR implements the fix discussed in https://github.com/ghostty-org/ghostty/discussions/11128.

Before:

<img width="818" height="96" alt="before" src="https://github.com/user-attachments/assets/788f981f-3d1b-4c60-bf85-0c297641cae7" />

After:

<img width="813" height="93" alt="after" src="https://github.com/user-attachments/assets/a530015a-053a-4680-9a85-812aa8df3d91" />