### PR TITLE
macos: finish editing tab title when the window resigns as key window

### DIFF
--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -202,6 +202,7 @@ class TerminalWindow: NSWindow {
     override func resignKey() {
         super.resignKey()
         resetZoomTabButton.contentTintColor = .secondaryLabelColor
+        tabTitleEditor.finishEditing(commit: true)
     }
 
     override func becomeMain() {

--- a/macos/Sources/Helpers/TabTitleEditor.swift
+++ b/macos/Sources/Helpers/TabTitleEditor.swift
@@ -226,7 +226,7 @@ final class TabTitleEditor: NSObject, NSTextFieldDelegate {
 
         if let sourceLabel {
             let labelFrame = tabButton.convert(sourceLabel.bounds, from: sourceLabel)
-            /// The `labelFrame.minY` value changes unexpectedly after the first use,
+            /// The `labelFrame.minY` value changes unexpectedly after double clicking selected text,
             /// I don't know exactly why, but `tabButton.bounds` appears stable enough to calculate the correct position reliably.
             frame.origin.y = bounds.midY - labelFrame.height * 0.5
             frame.size.height = labelFrame.height


### PR DESCRIPTION
This fixes #11146 and also #10993. Updated the comments added in #11052.

> After finishing editing when the window resigns as the key window, using `labelFrame.minY` is fine with the same usage as #10993, but when double-clicking with text selected it will move up again 🤷🏻‍♂️.

This makes focus state more accurate with cursor shape on the surface, when editing the title for a tab in another window group.

[Incorrect example](https://github.com/user-attachments/assets/c3c4e774-a683-44e7-9bb6-3be79ac72ec2)
