### PR TITLE
input: send composed text in kitty keyboard protocol

### DIFF
--- a/src/input/key_encode.zig
+++ b/src/input/key_encode.zig
@@ -214,7 +214,13 @@ fn kitty(
         }
     }
 
-    const entry = entry_ orelse return;
+    const entry = entry_ orelse {
+        // No entry found. If we have UTF-8 text this is a pure text event
+        // (e.g. composed/IME text), so send it as-is so programs can
+        // still receive it.
+        if (event.utf8.len > 0) return try writer.writeAll(event.utf8);
+        return;
+    };
 
     // If this is just a modifier we require "report all" to send the sequence.
     if (entry.modifier and !opts.kitty_flags.report_all) return;
@@ -1441,6 +1447,25 @@ test "kitty: composing with modifier" {
         .kitty_flags = .{ .disambiguate = true, .report_all = true },
     });
     try testing.expectEqualStrings("\x1b[57441;2u", writer.buffered());
+}
+
+test "kitty: composed text with report all" {
+    var buf: [128]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    try kitty(&writer, .{
+        .key = .unidentified,
+        .mods = .{},
+        .utf8 = "\xc3\xbb", // û
+    }, .{
+        .kitty_flags = .{
+            .disambiguate = true,
+            .report_events = true,
+            .report_alternates = true,
+            .report_all = true,
+            .report_associated = true,
+        },
+    });
+    try testing.expectEqualStrings("\xc3\xbb", writer.buffered());
 }
 
 test "kitty: shift+a on US keyboard" {


### PR DESCRIPTION
When the kitty keyboard protocol "report all keys as escape codes" mode was active, composed/IME text (e.g. from dead keys or compose sequences) was silently dropped. 

This happened because the composed text is sent within our GTK apprt with key=unidentified and no unshifted_codepoint, so no kitty entry was found and the encoder returned without producing any output. The plain-text fallback was also skipped because report_all bypasses it.

Send composed text as raw UTF-8 when no kitty entry is found, matching the behavior of Kitty on Linux for me.

Fixes #10049