### PR TITLE
macos: Ghostty.Shell.escape unit tests

### DIFF
--- a/macos/Tests/Ghostty/ShellTests.swift
+++ b/macos/Tests/Ghostty/ShellTests.swift
@@ -3,6 +3,34 @@ import Testing
 
 struct ShellTests {
     @Test(arguments: [
+        ("hello", "hello"),
+        ("", ""),
+        ("file name", "file\\ name"),
+        ("a\\b", "a\\\\b"),
+        ("(foo)", "\\(foo\\)"),
+        ("[bar]", "\\[bar\\]"),
+        ("{baz}", "\\{baz\\}"),
+        ("<qux>", "\\<qux\\>"),
+        ("say\"hi\"", "say\\\"hi\\\""),
+        ("it's", "it\\'s"),
+        ("`cmd`", "\\`cmd\\`"),
+        ("wow!", "wow\\!"),
+        ("#comment", "\\#comment"),
+        ("$HOME", "\\$HOME"),
+        ("a&b", "a\\&b"),
+        ("a;b", "a\\;b"),
+        ("a|b", "a\\|b"),
+        ("*.txt", "\\*.txt"),
+        ("file?.log", "file\\?.log"),
+        ("col1\tcol2", "col1\\\tcol2"),
+        ("$(echo 'hi')", "\\$\\(echo\\ \\'hi\\'\\)"),
+        ("/tmp/my file (1).txt", "/tmp/my\\ file\\ \\(1\\).txt"),
+    ])
+    func escape(input: String, expected: String) {
+        #expect(Ghostty.Shell.escape(input) == expected)
+    }
+
+    @Test(arguments: [
         ("", "''"),
         ("filename", "filename"),
         ("abcABC123@%_-+=:,./", "abcABC123@%_-+=:,./"),


### PR DESCRIPTION
*AI Disclosure:* These were written using the Claude Agent in Xcode 26.3, partly as an excuse to try out that latest integration.