### PR TITLE
Revert "build: link to the system FontConfig by default

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -38,15 +38,6 @@ here:
 | `zig build dist`                | Builds a source tarball                                                                                                |
 | `zig build distcheck`           | Builds and validates a source tarball                                                                                  |
 
-## FontConfig and GTK
-
-Because of the global shared state that FontConfig maintains, FontConfig must
-be linked dynamically to the same system FontConfig shared library that GTK
-uses. Ghostty's default has been changed to always link to the system FontConfig
-library. If that is overridden (by specifying `-fno-sys=fontconfig` during the
-build) Ghostty may crash when trying to locate glyphs that are not available in
-the default font.
-
 ## Extra Dependencies
 
 Building Ghostty from a Git checkout on Linux requires some additional

--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -424,19 +424,6 @@ pub fn init(b: *std.Build, appVersion: []const u8) !Config {
     // show up properly in `--help`.
 
     {
-        // These should default to `true` except on macOS because linking them
-        // to Ghostty statically when GTK is dynamically linked to them can
-        // cause crashes.
-        for (&[_][]const u8{
-            "fontconfig",
-        }) |dep| {
-            _ = b.systemIntegrationOption(
-                dep,
-                .{
-                    .default = if (target.result.os.tag.isDarwin()) false else true,
-                },
-            );
-        }
         // These dependencies we want to default false if we're on macOS.
         // On macOS we don't want to use system libraries because we
         // generally want a fat binary. This can be overridden with the
@@ -444,6 +431,7 @@ pub fn init(b: *std.Build, appVersion: []const u8) !Config {
         for (&[_][]const u8{
             "freetype",
             "harfbuzz",
+            "fontconfig",
             "libpng",
             "zlib",
             "oniguruma",

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -200,13 +200,6 @@ pub fn add(
             if (b.systemIntegrationOption("fontconfig", .{})) {
                 step.linkSystemLibrary2("fontconfig", dynamic_link_opts);
             } else {
-                if (self.config.app_runtime == .gtk)
-                    std.debug.print(
-                        \\WARNING: Statically linking FontConfig when using the GTK app runtime is known
-                        \\to cause crashes! It is HIGHLY recommended that Ghostty be dynamically linked
-                        \\to the system FontConfig library.
-                        \\
-                    , .{});
                 step.linkLibrary(fontconfig_dep.artifact("fontconfig"));
                 try static_libs.append(
                     b.allocator,


### PR DESCRIPTION
This reverts commit ee4c6f88c5517d242b73427f66da4d54d41e35a8.

This breaks standard `zig build run` from a dev shell in Nix/NixOS. I think we need to rethink some of the protections here, possibly only to apply to packaging/release modes or something.

cc @jcollie 