### PR TITLE
Zig 0.16 prep: "juicy" main environment variables

### DIFF
--- a/pkg/android-ndk/build.zig
+++ b/pkg/android-ndk/build.zig
@@ -118,7 +118,7 @@ pub fn addPaths(b: *std.Build, step: *std.Build.Step.Compile) !void {
 
 fn findNDKPath(b: *std.Build) ?[]const u8 {
     // Check if user has set the environment variable for the NDK path.
-    if (std.process.getEnvVarOwned(b.allocator, "ANDROID_NDK_HOME") catch null) |value| {
+    if (b.graph.env_map.get("ANDROID_NDK_HOME")) |value| {
         if (value.len == 0) return null;
         var dir = std.fs.openDirAbsolute(value, .{}) catch return null;
         defer dir.close();
@@ -127,7 +127,7 @@ fn findNDKPath(b: *std.Build) ?[]const u8 {
 
     // Check the common environment variables for the Android SDK path and look for the NDK inside it.
     inline for (.{ "ANDROID_HOME", "ANDROID_SDK_ROOT" }) |env| {
-        if (std.process.getEnvVarOwned(b.allocator, env) catch null) |sdk| {
+        if (b.graph.env_map.get(env)) |sdk| {
             if (sdk.len > 0) {
                 if (findLatestNDK(b, sdk)) |ndk| return ndk;
             }
@@ -135,10 +135,9 @@ fn findNDKPath(b: *std.Build) ?[]const u8 {
     }
 
     // As a fallback, we assume the most common/default SDK path based on the OS.
-    const home = std.process.getEnvVarOwned(
-        b.allocator,
+    const home = b.graph.env_map.get(
         if (builtin.os.tag == .windows) "LOCALAPPDATA" else "HOME",
-    ) catch return null;
+    ) orelse return null;
 
     const default_sdk_path = b.pathJoin(
         &.{

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -269,9 +269,8 @@ pub const Application = extern struct {
 
         const saved_language: ?[:0]const u8 = saved_language: {
             const old_language = old_language: {
-                const result = (internal_os.getenv(alloc, "LANG") catch break :old_language null) orelse break :old_language null;
-                defer result.deinit(alloc);
-                break :old_language alloc.dupeZ(u8, result.value) catch break :old_language null;
+                const result = internal_os.getenv("LANG") orelse break :old_language null;
+                break :old_language alloc.dupeZ(u8, result) catch break :old_language null;
             };
 
             if (config.language) |language| _ = internal_os.setenv("LANG", language);

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -1551,9 +1551,10 @@ pub const Surface = extern struct {
         return self.private().cursor_pos;
     }
 
-    pub fn defaultTermioEnv(self: *Self) !std.process.EnvMap {
+    pub fn defaultTermioEnv(self: *Self) Allocator.Error!std.process.EnvMap {
         const app = Application.default();
         const alloc = app.allocator();
+
         var env = try internal_os.getEnvMap(alloc);
         errdefer env.deinit();
 

--- a/src/apprt/gtk/winproto.zig
+++ b/src/apprt/gtk/winproto.zig
@@ -141,7 +141,7 @@ pub const Window = union(Protocol) {
         };
     }
 
-    pub fn addSubprocessEnv(self: *Window, env: *std.process.EnvMap) !void {
+    pub fn addSubprocessEnv(self: *Window, env: *std.process.EnvMap) Allocator.Error!void {
         switch (self.*) {
             inline else => |*v| try v.addSubprocessEnv(env),
         }

--- a/src/apprt/gtk/winproto/noop.zig
+++ b/src/apprt/gtk/winproto/noop.zig
@@ -69,7 +69,7 @@ pub const Window = struct {
         return true;
     }
 
-    pub fn addSubprocessEnv(_: *Window, _: *std.process.EnvMap) !void {}
+    pub fn addSubprocessEnv(_: *Window, _: *std.process.EnvMap) error{}!void {}
 
     pub fn setUrgent(_: *Window, _: bool) !void {}
 };

--- a/src/apprt/gtk/winproto/wayland.zig
+++ b/src/apprt/gtk/winproto/wayland.zig
@@ -339,7 +339,7 @@ pub const Window = struct {
         };
     }
 
-    pub fn addSubprocessEnv(self: *Window, env: *std.process.EnvMap) !void {
+    pub fn addSubprocessEnv(self: *Window, env: *std.process.EnvMap) error{}!void {
         _ = self;
         _ = env;
     }

--- a/src/apprt/gtk/winproto/x11.zig
+++ b/src/apprt/gtk/winproto/x11.zig
@@ -341,13 +341,15 @@ pub const Window = struct {
         self.last_applied_decoration_hints = hints;
     }
 
-    pub fn addSubprocessEnv(self: *Window, env: *std.process.EnvMap) !void {
+    pub fn addSubprocessEnv(self: *Window, env: *std.process.EnvMap) Allocator.Error!void {
         var buf: [64]u8 = undefined;
-        const window_id = try std.fmt.bufPrint(
+        const window_id = std.fmt.bufPrint(
             &buf,
             "{}",
             .{self.x11_surface.getXid()},
-        );
+        ) catch |err| switch (err) {
+            error.NoSpaceLeft => return error.OutOfMemory,
+        };
 
         try env.put("WINDOWID", window_id);
     }

--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -11,7 +11,6 @@ const RendererBackend = @import("../renderer/backend.zig").Backend;
 const TerminalBuildOptions = @import("../terminal/build_options.zig").Options;
 const XCFrameworkTarget = @import("xcframework.zig").Target;
 const WasmTarget = @import("../os/wasm/target.zig").Target;
-const expandPath = @import("../os/path.zig").expand;
 
 const gtk = @import("gtk.zig");
 const GitVersion = @import("GitVersion.zig");
@@ -101,15 +100,11 @@ pub fn init(b: *std.Build, appVersion: []const u8) !Config {
     // defaults.
     const gtk_targets = gtk.targets(b);
 
-    // We use env vars throughout the build so we grab them immediately here.
-    var env = try std.process.getEnvMap(b.allocator);
-    errdefer env.deinit();
-
     var config: Config = .{
         .optimize = optimize,
         .target = target,
         .wasm_target = wasm_target,
-        .env = env,
+        .env = b.graph.env_map,
     };
 
     //---------------------------------------------------------------
@@ -291,8 +286,8 @@ pub fn init(b: *std.Build, appVersion: []const u8) !Config {
 
         // If we're in a nix shell we default to doing this.
         // Note: we purposely never deinit envmap because we leak the strings
-        if (env.get("IN_NIX_SHELL") == null) break :patch_rpath null;
-        break :patch_rpath env.get("LD_LIBRARY_PATH");
+        if (b.graph.env_map.get("IN_NIX_SHELL") == null) break :patch_rpath null;
+        break :patch_rpath b.graph.env_map.get("LD_LIBRARY_PATH");
     };
 
     config.pie = b.option(
@@ -358,10 +353,8 @@ pub fn init(b: *std.Build, appVersion: []const u8) !Config {
         if (system_package) break :emit_docs true;
 
         // We only default to true if we can find pandoc.
-        const path = expandPath(b.allocator, "pandoc") catch
-            break :emit_docs false;
-        defer if (path) |p| b.allocator.free(p);
-        break :emit_docs path != null;
+        _ = b.findProgram(&.{"pandoc"}, &.{}) catch break :emit_docs false;
+        break :emit_docs true;
     };
 
     config.emit_terminfo = b.option(

--- a/src/build/GhosttyXcodebuild.zig
+++ b/src/build/GhosttyXcodebuild.zig
@@ -48,7 +48,6 @@ pub fn init(
         },
     };
 
-    const env = try std.process.getEnvMap(b.allocator);
     const app_path = b.fmt("macos/build/{s}/Ghostty.app", .{xc_config});
 
     // Our step to build the Ghostty macOS app.
@@ -57,7 +56,7 @@ pub fn init(
         // we create a new empty environment.
         const env_map = try b.allocator.create(std.process.EnvMap);
         env_map.* = .init(b.allocator);
-        if (env.get("PATH")) |v| try env_map.put("PATH", v);
+        if (b.graph.env_map.get("PATH")) |v| try env_map.put("PATH", v);
 
         const step = RunStep.create(b, "xcodebuild");
         step.has_side_effects = true;
@@ -93,7 +92,7 @@ pub fn init(
     const xctest = xctest: {
         const env_map = try b.allocator.create(std.process.EnvMap);
         env_map.* = .init(b.allocator);
-        if (env.get("PATH")) |v| try env_map.put("PATH", v);
+        if (b.graph.env_map.get("PATH")) |v| try env_map.put("PATH", v);
 
         const step = RunStep.create(b, "xcodebuild test");
         step.has_side_effects = true;

--- a/src/cli/edit_config.zig
+++ b/src/cli/edit_config.zig
@@ -91,26 +91,13 @@ fn runInner(alloc: Allocator, stderr: *std.Io.Writer) !u8 {
     }
 
     // Get our editor
-    const get_env_: ?internal_os.GetEnvResult = env: {
+    const editor = env: {
         // VISUAL vs. EDITOR: https://unix.stackexchange.com/questions/4859/visual-vs-editor-what-s-the-difference
-        if (try internal_os.getenv(alloc, "VISUAL")) |v| {
-            if (v.value.len > 0) break :env v;
-            v.deinit(alloc);
-        }
+        if (internal_os.getenvNotEmpty("VISUAL")) |v| break :env v;
+        if (internal_os.getenvNotEmpty("EDITOR")) |v| break :env v;
 
-        if (try internal_os.getenv(alloc, "EDITOR")) |v| {
-            if (v.value.len > 0) break :env v;
-            v.deinit(alloc);
-        }
-
-        break :env null;
-    };
-    defer if (get_env_) |v| v.deinit(alloc);
-    const editor: []const u8 = if (get_env_) |v| v.value else "";
-
-    // If we don't have `$EDITOR` set then we can't do anything
-    // but we can still print a helpful message.
-    if (editor.len == 0) {
+        // If we don't have `$VISUAL` or `$EDITOR` set then we can't do anything
+        // but we can still print a helpful message.
         try stderr.print(
             \\The $EDITOR or $VISUAL environment variable is not set or is empty.
             \\This environment variable is required to edit the Ghostty configuration
@@ -122,34 +109,32 @@ fn runInner(alloc: Allocator, stderr: *std.Io.Writer) !u8 {
             \\If you prefer to edit the configuration file another way,
             \\you can find the configuration file at the following path:
             \\
+            \\{c}]8;;file://{s}{c}{c}{s}{c}]8;;{c}{c}
             \\
         ,
-            .{},
-        );
-
-        // Output the path using the OSC8 sequence so that it is linked.
-        try stderr.print(
-            "\x1b]8;;file://{s}\x1b\\{s}\x1b]8;;\x1b\\\n",
-            .{ path, path },
+            .{ '\x1b', path, '\x1b', '\\', path, '\x1b', '\x1b', '\\' },
         );
 
         return 1;
-    }
-
-    // We require libc because we want to use std.c.environ for envp
-    // and not have to build that ourselves. We can remove this
-    // limitation later but Ghostty already heavily requires libc
-    // so this is not a big deal.
-    comptime assert(builtin.link_libc);
+    };
 
     const editorZ = try alloc.dupeZ(u8, editor);
     defer alloc.free(editorZ);
+
     const pathZ = try alloc.dupeZ(u8, path);
     defer alloc.free(pathZ);
+
+    const env = try internal_os.createPosixBlock(alloc);
+    defer {
+        var i: usize = 0;
+        while (env[i]) |e| : (i += 1) alloc.free(std.mem.span(e));
+        alloc.free(env);
+    }
+
     const err = std.posix.execvpeZ(
         editorZ,
         &.{ editorZ, pathZ },
-        std.c.environ,
+        env,
     );
 
     // If we reached this point then exec failed.
@@ -161,8 +146,8 @@ fn runInner(alloc: Allocator, stderr: *std.Io.Writer) !u8 {
         \\correctly.
         \\
         \\Editor: {s}
-        \\Path: {s}
+        \\Path: {c}]8;;file://{s}{c}{c}{s}{c}]8;;{c}{c}
         \\
-    , .{ err, editor, path });
+    , .{ err, editor, '\x1b', path, '\x1b', '\\', path, '\x1b', '\x1b', '\\' });
     return 1;
 }

--- a/src/cli/ssh-cache/DiskCache.zig
+++ b/src/cli/ssh-cache/DiskCache.zig
@@ -369,6 +369,21 @@ test "disk cache default path" {
     const testing = std.testing;
     const alloc = std.testing.allocator;
 
+    // Partially initialize global state
+    const global = &@import("../../global.zig").state;
+    global.* = .{
+        .gpa = null,
+        .logging = undefined,
+        .resources_dir = undefined,
+        .action = null,
+        .alloc = alloc,
+        .environ_map = try std.process.getEnvMap(alloc),
+    };
+    defer {
+        global.environ_map.deinit();
+        global.* = undefined;
+    }
+
     const path = try DiskCache.defaultPath(alloc, "ghostty");
     defer alloc.free(path);
     try testing.expect(path.len > 0);
@@ -377,6 +392,21 @@ test "disk cache default path" {
 test "disk cache clear" {
     const testing = std.testing;
     const alloc = testing.allocator;
+
+    // Partially initialize global state
+    const global = &@import("../../global.zig").state;
+    global.* = .{
+        .gpa = null,
+        .logging = undefined,
+        .resources_dir = undefined,
+        .action = null,
+        .alloc = alloc,
+        .environ_map = try std.process.getEnvMap(alloc),
+    };
+    defer {
+        global.environ_map.deinit();
+        global.* = undefined;
+    }
 
     // Create our path
     var tmp = testing.tmpDir(.{});
@@ -405,6 +435,21 @@ test "disk cache clear" {
 test "disk cache operations" {
     const testing = std.testing;
     const alloc = testing.allocator;
+
+    // Partially initialize global state
+    const global = &@import("../../global.zig").state;
+    global.* = .{
+        .gpa = null,
+        .logging = undefined,
+        .resources_dir = undefined,
+        .action = null,
+        .alloc = alloc,
+        .environ_map = try std.process.getEnvMap(alloc),
+    };
+    defer {
+        global.environ_map.deinit();
+        global.* = undefined;
+    }
 
     // Create our path
     var tmp = testing.tmpDir(.{});
@@ -453,6 +498,21 @@ test "disk cache operations" {
 test "disk cache cleans up temp files" {
     const testing = std.testing;
     const alloc = testing.allocator;
+
+    // Partially initialize global state
+    const global = &@import("../../global.zig").state;
+    global.* = .{
+        .gpa = null,
+        .logging = undefined,
+        .resources_dir = undefined,
+        .action = null,
+        .alloc = alloc,
+        .environ_map = try std.process.getEnvMap(alloc),
+    };
+    defer {
+        global.environ_map.deinit();
+        global.* = undefined;
+    }
 
     var tmp = testing.tmpDir(.{ .iterate = true });
     defer tmp.cleanup();

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -4522,7 +4522,7 @@ pub fn finalize(self: *Config) !void {
                 // read from SHELL if we're in a probable CLI environment.
                 if (!probable_cli) break :shell_env;
 
-                if (std.process.getEnvVarOwned(alloc, "SHELL")) |value| {
+                if (internal_os.getenv("SHELL")) |value| {
                     log.info("default shell source=env value={s}", .{value});
 
                     const copy = try alloc.dupeZ(u8, value);
@@ -4530,7 +4530,7 @@ pub fn finalize(self: *Config) !void {
 
                     // If we don't need the working directory, then we can exit now.
                     if (!wd_home) break :command;
-                } else |_| {}
+                }
             }
 
             switch (builtin.os.tag) {
@@ -5031,9 +5031,7 @@ fn probableCliEnvironment() bool {
 
     // If we have TERM_PROGRAM set to a non-empty value, we assume
     // a graphical terminal environment.
-    if (std.posix.getenv("TERM_PROGRAM")) |v| {
-        if (v.len > 0) return true;
-    }
+    if (internal_os.getenvNotEmpty("TERM_PROGRAM")) |_| return true;
 
     // CLI arguments makes things probable
     if (std.os.argv.len > 1) return true;

--- a/src/crash/sentry.zig
+++ b/src/crash/sentry.zig
@@ -118,7 +118,7 @@ fn initThread(gpa: Allocator) !void {
         // a more idiomatic macOS application. But if XDG env vars are set
         // we will respect them.
         if (comptime builtin.os.tag == .macos) macos: {
-            if (std.posix.getenv("XDG_CACHE_HOME") != null) break :macos;
+            if (internal_os.getenv("XDG_CACHE_HOME") != null) break :macos;
             break :cache_dir try internal_os.macos.cacheDir(
                 alloc,
                 "sentry",

--- a/src/global.zig
+++ b/src/global.zig
@@ -33,6 +33,7 @@ pub const GlobalState = struct {
     action: ?cli.ghostty.Action,
     logging: Logging,
     rlimits: ResourceLimits = .{},
+    environ_map: std.process.EnvMap,
 
     /// The app resources directory, equivalent to zig-out/share when we build
     /// from source. This is null if we can't detect it.
@@ -68,6 +69,7 @@ pub const GlobalState = struct {
             .logging = .{},
             .rlimits = .{},
             .resources_dir = .{},
+            .environ_map = undefined,
         };
         errdefer self.deinit();
 
@@ -95,6 +97,11 @@ pub const GlobalState = struct {
         else
             unreachable;
 
+        // Get a copy of the environment variables. This is in preparation for
+        // Zig 0.16 where environment variables are no longer accessible except
+        // from the "juicy main".
+        self.environ_map = try std.process.getEnvMap(self.alloc);
+
         // We first try to parse any action that we may be executing.
         self.action = try cli.action.detectArgs(
             cli.ghostty.Action,
@@ -111,9 +118,8 @@ pub const GlobalState = struct {
         // maybe once for logging) so for now this is an easy way to do
         // this. Env vars are useful for logging too because they are
         // easy to set.
-        if ((try internal_os.getenv(self.alloc, "GHOSTTY_LOG"))) |v| {
-            defer v.deinit(self.alloc);
-            self.logging = cli.args.parsePackedStruct(Logging, v.value) catch .{};
+        if ((internal_os.getenv("GHOSTTY_LOG"))) |v| {
+            self.logging = cli.args.parsePackedStruct(Logging, v) catch .{};
         }
 
         // Setup our signal handlers before logging
@@ -161,7 +167,7 @@ pub const GlobalState = struct {
 
         // We need to make sure the process locale is set properly. Locale
         // affects a lot of behaviors in a shell.
-        try internal_os.ensureLocale(self.alloc);
+        internal_os.ensureLocale();
 
         // Initialize glslang for shader compilation
         try glslang.init();
@@ -184,6 +190,7 @@ pub const GlobalState = struct {
     /// doing so in dev modes will check for memory leaks.
     pub fn deinit(self: *GlobalState) void {
         self.resources_dir.deinit(self.alloc);
+        self.environ_map.deinit();
 
         // Flush our crash logs
         crash.deinit();

--- a/src/os/TempDir.zig
+++ b/src/os/TempDir.zig
@@ -5,8 +5,8 @@ const TempDir = @This();
 const std = @import("std");
 const testing = std.testing;
 const Dir = std.fs.Dir;
-const allocTmpDir = @import("file.zig").allocTmpDir;
-const freeTmpDir = @import("file.zig").freeTmpDir;
+const getTmpDir = @import("file.zig").getTmpDir;
+// const freeTmpDir = @import("file.zig").freeTmpDir;
 
 const log = std.log.scoped(.tempdir);
 
@@ -31,8 +31,7 @@ pub fn init() !TempDir {
 
     const dir = dir: {
         const cwd = std.fs.cwd();
-        const tmp_dir = allocTmpDir(std.heap.page_allocator) orelse break :dir cwd;
-        defer freeTmpDir(std.heap.page_allocator, tmp_dir);
+        const tmp_dir = getTmpDir() orelse break :dir cwd;
         break :dir try cwd.openDir(tmp_dir, .{});
     };
 

--- a/src/os/dbus.zig
+++ b/src/os/dbus.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
+const getenv = @import("env.zig").getenv;
+
 /// Returns true if the program was launched by D-Bus activation.
 ///
 /// On Linux GTK, this returns true if the program was launched using D-Bus
@@ -12,8 +14,8 @@ pub fn launchedByDbusActivation() bool {
         // On Linux, D-Bus activation sets `DBUS_STARTER_ADDRESS` and
         // `DBUS_STARTER_BUS_TYPE`. If these environment variables are present
         // (no matter the value) we were launched by D-Bus activation.
-        .linux => std.posix.getenv("DBUS_STARTER_ADDRESS") != null and
-            std.posix.getenv("DBUS_STARTER_BUS_TYPE") != null,
+        .linux => getenv("DBUS_STARTER_ADDRESS") != null and
+            getenv("DBUS_STARTER_BUS_TYPE") != null,
 
         // No other system supports D-Bus so always return false.
         else => false,

--- a/src/os/desktop.zig
+++ b/src/os/desktop.zig
@@ -115,45 +115,55 @@ pub fn desktopEnvironment() DesktopEnvironment {
 
 test "desktop environment" {
     const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // partially initialize global state
+    const global = &@import("../global.zig").state;
+    global.* = .{
+        .gpa = null,
+        .logging = undefined,
+        .resources_dir = undefined,
+        .action = null,
+        .alloc = alloc,
+        .environ_map = try std.process.getEnvMap(alloc),
+    };
+    defer {
+        global.environ_map.deinit();
+        global.* = undefined;
+    }
 
     switch (builtin.os.tag) {
         .macos => try testing.expectEqual(.macos, desktopEnvironment()),
         .windows => try testing.expectEqual(.windows, desktopEnvironment()),
         .linux, .freebsd => {
-            const setenv = @import("env.zig").setenv;
-            const unsetenv = @import("env.zig").unsetenv;
+            global.environ_map.remove("XDG_SESSION_DESKTOP");
+            global.environ_map.remove("XDG_CURRENT_DESKTOP");
 
-            const xdg_current_desktop = getenv("XDG_CURRENT_DESKTOP");
-            defer if (xdg_current_desktop) |v| {
-                _ = setenv("XDG_CURRENT_DESKTOP", v);
-            } else {
-                _ = unsetenv("XDG_CURRENT_DESKTOP");
-            };
-            _ = unsetenv("XDG_CURRENT_DESKTOP");
-
-            const xdg_session_desktop = getenv("XDG_SESSION_DESKTOP");
-            defer if (xdg_session_desktop) |v| {
-                _ = setenv("XDG_SESSION_DESKTOP", v);
-            } else {
-                _ = unsetenv("XDG_SESSION_DESKTOP");
-            };
-            _ = unsetenv("XDG_SESSION_DESKTOP");
-
-            _ = setenv("XDG_SESSION_DESKTOP", "gnome");
+            try global.environ_map.put("XDG_SESSION_DESKTOP", "gnome");
             try testing.expectEqual(.gnome, desktopEnvironment());
-            _ = setenv("XDG_SESSION_DESKTOP", "gnome-xorg");
+
+            try global.environ_map.put("XDG_SESSION_DESKTOP", "gnome-xorg");
             try testing.expectEqual(.gnome, desktopEnvironment());
-            _ = setenv("XDG_SESSION_DESKTOP", "foobar");
+
+            try global.environ_map.put("XDG_SESSION_DESKTOP", "foobar");
             try testing.expectEqual(.other, desktopEnvironment());
 
-            _ = unsetenv("XDG_SESSION_DESKTOP");
+            global.environ_map.remove("XDG_SESSION_DESKTOP");
             try testing.expectEqual(.other, desktopEnvironment());
 
-            _ = setenv("XDG_CURRENT_DESKTOP", "GNOME");
+            try global.environ_map.put("XDG_CURRENT_DESKTOP", "GNOME");
             try testing.expectEqual(.gnome, desktopEnvironment());
-            _ = setenv("XDG_CURRENT_DESKTOP", "FOOBAR");
+
+            try global.environ_map.put("XDG_CURRENT_DESKTOP", "GNOME:BOBR");
+            try testing.expectEqual(.gnome, desktopEnvironment());
+
+            try global.environ_map.put("XDG_CURRENT_DESKTOP", "BOBR:GNOME");
             try testing.expectEqual(.other, desktopEnvironment());
-            _ = unsetenv("XDG_CURRENT_DESKTOP");
+
+            try global.environ_map.put("XDG_CURRENT_DESKTOP", "FOOBAR");
+            try testing.expectEqual(.other, desktopEnvironment());
+
+            global.environ_map.remove("XDG_CURRENT_DESKTOP");
             try testing.expectEqual(.other, desktopEnvironment());
         },
         else => try testing.expectEqual(.other, DesktopEnvironment()),

--- a/src/os/desktop.zig
+++ b/src/os/desktop.zig
@@ -3,6 +3,8 @@ const builtin = @import("builtin");
 const build_config = @import("../build_config.zig");
 const posix = std.posix;
 
+const getenv = @import("env.zig").getenv;
+
 const c = @cImport({
     @cInclude("unistd.h");
 });
@@ -26,7 +28,7 @@ pub fn launchedFromDesktop() bool {
             // was launched from the desktop.
             if (build_config.artifact == .lib) lib: {
                 const env = "GHOSTTY_MAC_LAUNCH_SOURCE";
-                const source = posix.getenv(env) orelse break :lib;
+                const source = getenv(env) orelse break :lib;
 
                 // Source can be "app", "cli", or "zig_run". We assume
                 // its the desktop only if its "app". We may want to do
@@ -44,7 +46,7 @@ pub fn launchedFromDesktop() bool {
         // another terminal was launched from a desktop file and then launches
         // Ghostty and Ghostty inherits the env.
         .linux, .freebsd => ul: {
-            const gio_pid_str = posix.getenv("GIO_LAUNCHED_DESKTOP_FILE_PID") orelse
+            const gio_pid_str = getenv("GIO_LAUNCHED_DESKTOP_FILE_PID") orelse
                 break :ul false;
 
             const pid = c.getpid();
@@ -89,7 +91,7 @@ pub fn desktopEnvironment() DesktopEnvironment {
 
             // Use $XDG_SESSION_DESKTOP to determine what DE we are using on Linux
             // https://www.freedesktop.org/software/systemd/man/latest/pam_systemd.html#desktop=
-            if (posix.getenv("XDG_SESSION_DESKTOP")) |sd| {
+            if (getenv("XDG_SESSION_DESKTOP")) |sd| {
                 if (std.ascii.eqlIgnoreCase("gnome", sd)) break :de .gnome;
                 if (std.ascii.eqlIgnoreCase("gnome-xorg", sd)) break :de .gnome;
             }
@@ -99,7 +101,7 @@ pub fn desktopEnvironment() DesktopEnvironment {
             // colon-separated list of up to three desktop names, although we
             // only look at the first.
             // https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html
-            if (posix.getenv("XDG_CURRENT_DESKTOP")) |cd| {
+            if (getenv("XDG_CURRENT_DESKTOP")) |cd| {
                 var cd_it = std.mem.splitScalar(u8, cd, ':');
                 const cd_first = cd_it.first();
                 if (std.ascii.eqlIgnoreCase(cd_first, "gnome")) break :de .gnome;
@@ -118,7 +120,6 @@ test "desktop environment" {
         .macos => try testing.expectEqual(.macos, desktopEnvironment()),
         .windows => try testing.expectEqual(.windows, desktopEnvironment()),
         .linux, .freebsd => {
-            const getenv = std.posix.getenv;
             const setenv = @import("env.zig").setenv;
             const unsetenv = @import("env.zig").unsetenv;
 

--- a/src/os/env.zig
+++ b/src/os/env.zig
@@ -106,17 +106,28 @@ pub fn getenvNotEmpty(key: []const u8) ?[]const u8 {
     return result;
 }
 
-pub fn setenv(key: [:0]const u8, value: [:0]const u8) c_int {
+pub fn setenv(key: []const u8, value: []const u8) c_int {
+    const keyZ = global.state.alloc.dupeZ(u8, key) catch return -1;
+    defer global.state.alloc.free(keyZ);
+
+    const valueZ = global.state.alloc.dupeZ(u8, value) catch return -1;
+    defer global.state.alloc.free(valueZ);
+
+    global.state.environ_map.put(key, value) catch return -1;
+
     return switch (builtin.os.tag) {
-        .windows => c._putenv_s(key.ptr, value.ptr),
-        else => c.setenv(key.ptr, value.ptr, 1),
+        .windows => c._putenv_s(keyZ.ptr, valueZ.ptr),
+        else => c.setenv(keyZ.ptr, valueZ.ptr, 1),
     };
 }
 
-pub fn unsetenv(key: [:0]const u8) c_int {
+pub fn unsetenv(key: []const u8) c_int {
+    const keyZ = global.state.alloc.dupeZ(u8, key) catch return -1;
+    defer global.state.alloc.free(keyZ);
+
     return switch (builtin.os.tag) {
-        .windows => c._putenv_s(key.ptr, ""),
-        else => c.unsetenv(key.ptr),
+        .windows => c._putenv_s(keyZ.ptr, ""),
+        else => c.unsetenv(keyZ.ptr),
     };
 }
 

--- a/src/os/env.zig
+++ b/src/os/env.zig
@@ -3,15 +3,39 @@ const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const posix = std.posix;
 const isFlatpak = @import("flatpak.zig").isFlatpak;
+const global = @import("../global.zig");
 
 pub const Error = Allocator.Error;
 
 /// Get the environment map.
-pub fn getEnvMap(alloc: Allocator) !std.process.EnvMap {
-    return if (isFlatpak())
-        std.process.EnvMap.init(alloc)
-    else
-        try std.process.getEnvMap(alloc);
+pub fn getEnvMap(alloc: Allocator) Error!std.process.EnvMap {
+    var new: std.process.EnvMap = .init(alloc);
+    var it = global.state.environ_map.iterator();
+    while (it.next()) |kv| {
+        try new.put(kv.key_ptr.*, kv.value_ptr.*);
+    }
+    return new;
+}
+
+/// This is basically a clone of `std.process.EnvironMap.Map.createPosixBlock`
+/// from Zig 0.16. This can be removed once Ghostty is ported to Zig 0.16.
+pub fn createPosixBlock(alloc: Allocator) Error![:null]?[*:0]u8 {
+    var blk = try alloc.allocSentinel(?[*:0]u8, global.state.environ_map.count(), null);
+    var i: usize = 0;
+    errdefer {
+        for (0..i) |j| alloc.free(std.mem.span(blk[j].?));
+        alloc.free(blk);
+    }
+    var it = global.state.environ_map.iterator();
+    while (it.next()) |kv| : (i += 1) {
+        blk[i] = try std.fmt.allocPrintSentinel(
+            alloc,
+            "{s}={s}",
+            .{ kv.key_ptr.*, kv.value_ptr.* },
+            0,
+        );
+    }
+    return blk;
 }
 
 /// Append a value to an environment variable such as PATH.
@@ -62,52 +86,24 @@ pub fn prependEnv(
     });
 }
 
-/// The result of getenv, with a shared deinit to properly handle allocation
-/// on Windows.
-pub const GetEnvResult = struct {
-    value: []const u8,
-
-    pub fn deinit(self: GetEnvResult, alloc: Allocator) void {
-        switch (builtin.os.tag) {
-            .windows => alloc.free(self.value),
-            else => {},
-        }
-    }
-};
+/// Gets the value of an environment variable, or null if not found.
+/// The returned value should not be modified or freed.
+pub fn getenv(key: []const u8) ?[]const u8 {
+    return global.state.environ_map.get(key);
+}
 
 /// Gets the value of an environment variable, or null if not found.
-/// This will allocate on Windows but not on other platforms. The returned
-/// value should have deinit called to do the proper cleanup no matter what
-/// platform you are on.
-pub fn getenv(alloc: Allocator, key: []const u8) Error!?GetEnvResult {
-    return switch (builtin.os.tag) {
-        // Non-Windows doesn't need to allocate
-        else => if (posix.getenv(key)) |v| .{ .value = v } else null,
-
-        // Windows needs to allocate
-        .windows => if (std.process.getEnvVarOwned(alloc, key)) |v| .{
-            .value = v,
-        } else |err| switch (err) {
-            error.EnvironmentVariableNotFound => null,
-            error.InvalidWtf8 => null,
-            else => |e| e,
-        },
-    };
+/// The returned value is owned by the caller and must be freed.
+pub fn getenvOwned(alloc: Allocator, key: []const u8) Error!?[]const u8 {
+    return try alloc.dupe(u8, global.state.environ_map.get(key) orelse return null);
 }
 
 /// Gets the value of an environment variable. Returns null if not found or the
-/// value is empty. This will allocate on Windows but not on other platforms.
-/// The returned value should have deinit called to do the proper cleanup no
-/// matter what platform you are on.
-pub fn getenvNotEmpty(alloc: Allocator, key: []const u8) !?GetEnvResult {
-    const result_ = try getenv(alloc, key);
-    if (result_) |result| {
-        if (result.value.len == 0) {
-            result.deinit(alloc);
-            return null;
-        }
-    }
-    return result_;
+/// value is empty. The returned value should not be freed or modified.
+pub fn getenvNotEmpty(key: []const u8) ?[]const u8 {
+    const result = global.state.environ_map.get(key) orelse return null;
+    if (result.len == 0) return null;
+    return result;
 }
 
 pub fn setenv(key: [:0]const u8, value: [:0]const u8) c_int {

--- a/src/os/file.zig
+++ b/src/os/file.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const builtin = @import("builtin");
 const posix = std.posix;
 
+const getenv = @import("env.zig").getenv;
+
 const log = std.log.scoped(.os);
 
 pub const rlimit = if (@hasDecl(posix.system, "rlimit")) posix.rlimit else struct {};
@@ -53,27 +55,15 @@ pub fn restoreMaxFiles(lim: rlimit) void {
     posix.setrlimit(.NOFILE, lim) catch {};
 }
 
-/// Return the recommended path for temporary files.
-/// This may not actually allocate memory, use freeTmpDir to properly
-/// free the memory when applicable.
-pub fn allocTmpDir(allocator: std.mem.Allocator) ?[]const u8 {
+/// Return the recommended path for temporary files. The string
+/// should not be freed.
+pub fn getTmpDir() ?[]const u8 {
     if (builtin.os.tag == .windows) {
         // TODO: what is a good fallback path on windows?
-        const v = std.process.getenvW(std.unicode.utf8ToUtf16LeStringLiteral("TMP")) orelse return null;
-        return std.unicode.utf16LeToUtf8Alloc(allocator, v) catch |e| {
-            log.warn("failed to convert temp dir path from windows string: {}", .{e});
-            return null;
-        };
+        if (getenv("TMP")) |v| return v;
+        return null;
     }
-    if (posix.getenv("TMPDIR")) |v| return v;
-    if (posix.getenv("TMP")) |v| return v;
+    if (getenv("TMPDIR")) |v| return v;
+    if (getenv("TMP")) |v| return v;
     return "/tmp";
-}
-
-/// Free a path returned by tmpDir if it allocated memory.
-/// This is a "no-op" for all platforms except windows.
-pub fn freeTmpDir(allocator: std.mem.Allocator, dir: []const u8) void {
-    if (builtin.os.tag == .windows) {
-        allocator.free(dir);
-    }
 }

--- a/src/os/homedir.zig
+++ b/src/os/homedir.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 const passwd = @import("passwd.zig");
 const posix = std.posix;
 const objc = @import("objc");
+const getenv = @import("env.zig").getenv;
 
 const Error = error{
     /// The buffer used for output is not large enough to store the value.
@@ -25,7 +26,7 @@ pub inline fn home(buf: []u8) !?[]const u8 {
 
 fn homeUnix(buf: []u8) !?[]const u8 {
     // First: if we have a HOME env var, then we use that.
-    if (posix.getenv("HOME")) |result| {
+    if (getenv("HOME")) |result| {
         if (buf.len < result.len) return Error.BufferTooSmall;
         @memcpy(buf[0..result.len], result);
         return buf[0..result.len];
@@ -76,29 +77,18 @@ fn homeUnix(buf: []u8) !?[]const u8 {
     return null;
 }
 
-fn homeWindows(buf: []u8) !?[]const u8 {
+fn homeWindows(buf: []u8) Error!?[]const u8 {
     const drive_len = blk: {
-        var fba_instance = std.heap.FixedBufferAllocator.init(buf);
-        const fba = fba_instance.allocator();
-        const drive = std.process.getEnvVarOwned(fba, "HOMEDRIVE") catch |err| switch (err) {
-            error.OutOfMemory => return Error.BufferTooSmall,
-            error.InvalidWtf8, error.EnvironmentVariableNotFound => return null,
-        };
-        // could shift the contents if this ever happens
-        if (drive.ptr != buf.ptr) @panic("codebug");
+        const drive = getenv("HOMEDRIVE") orelse return null;
+        if (drive.len > buf.len) return error.BufferTooSmall;
+        @memcpy(buf[0..drive.len], drive);
         break :blk drive.len;
     };
 
     const path_len = blk: {
-        const path_buf = buf[drive_len..];
-        var fba_instance = std.heap.FixedBufferAllocator.init(buf[drive_len..]);
-        const fba = fba_instance.allocator();
-        const homepath = std.process.getEnvVarOwned(fba, "HOMEPATH") catch |err| switch (err) {
-            error.OutOfMemory => return Error.BufferTooSmall,
-            error.InvalidWtf8, error.EnvironmentVariableNotFound => return null,
-        };
-        // could shift the contents if this ever happens
-        if (homepath.ptr != path_buf.ptr) @panic("codebug");
+        const homepath = getenv("HOMEPATH") orelse return null;
+        if (drive_len + homepath.len > buf.len) return error.BufferTooSmall;
+        @memcpy(buf[drive_len .. drive_len + homepath.len], homepath);
         break :blk homepath.len;
     };
 

--- a/src/os/homedir.zig
+++ b/src/os/homedir.zig
@@ -134,7 +134,23 @@ fn expandHomeUnix(path: []const u8, buf: []u8) ExpandError![]const u8 {
 
 test "expandHomeUnix" {
     const testing = std.testing;
-    const allocator = testing.allocator;
+    const alloc = testing.allocator;
+
+    // partially initialize global state
+    const global = &@import("../global.zig").state;
+    global.* = .{
+        .gpa = null,
+        .logging = undefined,
+        .resources_dir = undefined,
+        .action = null,
+        .alloc = alloc,
+        .environ_map = try std.process.getEnvMap(alloc),
+    };
+    defer {
+        global.environ_map.deinit();
+        global.* = undefined;
+    }
+
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const home_dir = try expandHomeUnix("~/", &buf);
     // Joining the home directory `~` with the path `/`
@@ -142,8 +158,8 @@ test "expandHomeUnix" {
     try testing.expect(home_dir[home_dir.len - 1] == std.fs.path.sep);
 
     const downloads = try expandHomeUnix("~/Downloads/shader.glsl", &buf);
-    const expected_downloads = try std.mem.concat(allocator, u8, &[_][]const u8{ home_dir, "Downloads/shader.glsl" });
-    defer allocator.free(expected_downloads);
+    const expected_downloads = try std.mem.concat(alloc, u8, &[_][]const u8{ home_dir, "Downloads/shader.glsl" });
+    defer alloc.free(expected_downloads);
     try testing.expectEqualStrings(expected_downloads, downloads);
 
     try testing.expectEqualStrings("~", try expandHomeUnix("~", &buf));
@@ -153,8 +169,8 @@ test "expandHomeUnix" {
 
     // Expect an error if the buffer is large enough to hold the home directory,
     // but not the expanded path
-    var small_buf = try allocator.alloc(u8, home_dir.len);
-    defer allocator.free(small_buf);
+    var small_buf = try alloc.alloc(u8, home_dir.len);
+    defer alloc.free(small_buf);
     try testing.expectError(error.BufferTooSmall, expandHomeUnix(
         "~/Downloads",
         small_buf[0..],
@@ -163,6 +179,22 @@ test "expandHomeUnix" {
 
 test {
     const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // partially initialize global state
+    const global = &@import("../global.zig").state;
+    global.* = .{
+        .gpa = null,
+        .logging = undefined,
+        .resources_dir = undefined,
+        .action = null,
+        .alloc = alloc,
+        .environ_map = try std.process.getEnvMap(alloc),
+    };
+    defer {
+        global.environ_map.deinit();
+        global.* = undefined;
+    }
 
     var buf: [1024]u8 = undefined;
     const result = try home(&buf);

--- a/src/os/locale.zig
+++ b/src/os/locale.zig
@@ -9,13 +9,12 @@ const i18n = internal_os.i18n;
 const log = std.log.scoped(.os_locale);
 
 /// Ensure that the locale is set.
-pub fn ensureLocale(alloc: std.mem.Allocator) !void {
+pub fn ensureLocale() void {
     assert(builtin.link_libc);
 
     // Get our LANG env var. We use this many times but we also need
     // the original value later.
-    const lang = try internal_os.getenv(alloc, "LANG");
-    defer if (lang) |v| v.deinit(alloc);
+    const lang = internal_os.getenv("LANG");
 
     // On macOS, pre-populate the LANG env var with system preferences.
     // When launching the .app, LANG is not set so we must query it from the
@@ -23,7 +22,7 @@ pub fn ensureLocale(alloc: std.mem.Allocator) !void {
     // process.
     if (comptime builtin.target.os.tag.isDarwin()) {
         // Set the lang if it is not set or if its empty.
-        if (lang == null or lang.?.value.len == 0) {
+        if (lang == null or lang.?.len == 0) {
             setLangFromCocoa();
         }
     }
@@ -37,9 +36,8 @@ pub fn ensureLocale(alloc: std.mem.Allocator) !void {
     // setlocale failed. This is probably because the LANG env var is
     // invalid. Try to set it without the LANG var set to use the system
     // default.
-    if ((try internal_os.getenv(alloc, "LANG"))) |old_lang| {
-        defer old_lang.deinit(alloc);
-        if (old_lang.value.len > 0) {
+    if ((internal_os.getenv("LANG"))) |old_lang| {
+        if (old_lang.len > 0) {
             // We don't need to do both of these things but we do them
             // both to be sure that lang is either empty or unset completely.
             _ = internal_os.setenv("LANG", "");

--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -35,12 +35,13 @@ pub const uri = @import("uri.zig");
 // Functions and types
 pub const CFReleaseThread = @import("cf_release_thread.zig");
 pub const TempDir = @import("TempDir.zig");
-pub const GetEnvResult = env.GetEnvResult;
 pub const getEnvMap = env.getEnvMap;
+pub const createPosixBlock = env.createPosixBlock;
 pub const appendEnv = env.appendEnv;
 pub const appendEnvAlways = env.appendEnvAlways;
 pub const prependEnv = env.prependEnv;
 pub const getenv = env.getenv;
+pub const getenvNotEmpty = env.getenvNotEmpty;
 pub const setenv = env.setenv;
 pub const unsetenv = env.unsetenv;
 pub const launchedFromDesktop = desktop.launchedFromDesktop;

--- a/src/os/path.zig
+++ b/src/os/path.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const testing = std.testing;
+const getenv = @import("env.zig").getenv;
 
 /// Search for "cmd" in the PATH and return the absolute path. This will
 /// always allocate if there is a non-null result. The caller must free the
@@ -13,15 +14,7 @@ pub fn expand(alloc: Allocator, cmd: []const u8) !?[]u8 {
         return try alloc.dupe(u8, cmd);
     }
 
-    const PATH = switch (builtin.os.tag) {
-        .windows => blk: {
-            const win_path = std.process.getenvW(std.unicode.utf8ToUtf16LeStringLiteral("PATH")) orelse return null;
-            const path = try std.unicode.utf16LeToUtf8Alloc(alloc, win_path);
-            break :blk path;
-        },
-        else => std.posix.getenvZ("PATH") orelse return null,
-    };
-    defer if (builtin.os.tag == .windows) alloc.free(PATH);
+    const PATH = getenv("PATH") orelse return null;
 
     var path_buf: [std.fs.max_path_bytes]u8 = undefined;
     var it = std.mem.tokenizeScalar(u8, PATH, std.fs.path.delimiter);

--- a/src/os/path.zig
+++ b/src/os/path.zig
@@ -64,6 +64,23 @@ fn isExecutable(mode: std.fs.File.Mode) bool {
 
 // `uname -n` is the *nix equivalent of `hostname.exe` on Windows
 test "expand: hostname" {
+    const alloc = std.testing.allocator;
+
+    // partially initialize global state
+    const global = &@import("../global.zig").state;
+    global.* = .{
+        .gpa = null,
+        .logging = undefined,
+        .resources_dir = undefined,
+        .action = null,
+        .alloc = alloc,
+        .environ_map = try std.process.getEnvMap(alloc),
+    };
+    defer {
+        global.environ_map.deinit();
+        global.* = undefined;
+    }
+
     const executable = if (builtin.os.tag == .windows) "hostname.exe" else "uname";
     const path = (try expand(testing.allocator, executable)).?;
     defer testing.allocator.free(path);
@@ -71,11 +88,45 @@ test "expand: hostname" {
 }
 
 test "expand: does not exist" {
+    const alloc = std.testing.allocator;
+
+    // partially initialize global state
+    const global = &@import("../global.zig").state;
+    global.* = .{
+        .gpa = null,
+        .logging = undefined,
+        .resources_dir = undefined,
+        .action = null,
+        .alloc = alloc,
+        .environ_map = try std.process.getEnvMap(alloc),
+    };
+    defer {
+        global.environ_map.deinit();
+        global.* = undefined;
+    }
+
     const path = try expand(testing.allocator, "thisreallyprobablydoesntexist123");
     try testing.expect(path == null);
 }
 
 test "expand: slash" {
+    const alloc = std.testing.allocator;
+
+    // partially initialize global state
+    const global = &@import("../global.zig").state;
+    global.* = .{
+        .gpa = null,
+        .logging = undefined,
+        .resources_dir = undefined,
+        .action = null,
+        .alloc = alloc,
+        .environ_map = try std.process.getEnvMap(alloc),
+    };
+    defer {
+        global.environ_map.deinit();
+        global.* = undefined;
+    }
+
     const path = (try expand(testing.allocator, "foo/env")).?;
     defer testing.allocator.free(path);
     try testing.expect(path.len == 7);

--- a/src/os/resourcesdir.zig
+++ b/src/os/resourcesdir.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 
+const getenvNotEmpty = @import("env.zig").getenvNotEmpty;
+
 pub const ResourcesDir = struct {
     /// Avoid accessing these directly, use the app() and host() methods instead.
     app_path: ?[]const u8 = null,
@@ -44,15 +46,9 @@ pub fn resourcesDir(alloc: Allocator) !ResourcesDir {
     // if debug Ghostty is launched by an older version of Ghostty, it
     // would inherit the old, stale resources of older Ghostty instead of the
     // freshly built ones under zig-out/share/ghostty.
-    //
-    // Note: we ALWAYS want to allocate here because the result is always
-    // freed, do not try to use internal_os.getenv or posix getenv.
     if (comptime builtin.mode != .Debug) {
-        if (std.process.getEnvVarOwned(alloc, "GHOSTTY_RESOURCES_DIR")) |dir| {
-            if (dir.len > 0) return .{ .app_path = dir };
-        } else |err| switch (err) {
-            error.EnvironmentVariableNotFound => {},
-            else => return err,
+        if (getenvNotEmpty("GHOSTTY_RESOURCES_DIR")) |dir| {
+            return .{ .app_path = try alloc.dupe(u8, dir) };
         }
     }
 
@@ -102,11 +98,8 @@ pub fn resourcesDir(alloc: Allocator) !ResourcesDir {
     // If terminfo detection failed in debug builds (somehow),
     // fallback and use the provided resources dir.
     if (comptime builtin.mode == .Debug) {
-        if (std.process.getEnvVarOwned(alloc, "GHOSTTY_RESOURCES_DIR")) |dir| {
-            if (dir.len > 0) return .{ .app_path = dir };
-        } else |err| switch (err) {
-            error.EnvironmentVariableNotFound => {},
-            else => return err,
+        if (getenvNotEmpty("GHOSTTY_RESOURCES_DIR")) |dir| {
+            return .{ .app_path = try alloc.dupe(u8, dir) };
         }
     }
 

--- a/src/os/systemd.zig
+++ b/src/os/systemd.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
+const getenv = @import("env.zig").getenv;
+
 const log = std.log.scoped(.systemd);
 
 /// Returns true if the program was launched as a systemd service.
@@ -16,8 +18,8 @@ pub fn launchedBySystemd() bool {
             // `JOURNAL_STREAM` (v231+) environment variables. If these
             // environment variables are not present we were not launched by
             // systemd.
-            if (std.posix.getenv("INVOCATION_ID") == null) break :linux false;
-            if (std.posix.getenv("JOURNAL_STREAM") == null) break :linux false;
+            if (getenv("INVOCATION_ID") == null) break :linux false;
+            if (getenv("JOURNAL_STREAM") == null) break :linux false;
 
             // If `INVOCATION_ID` and `JOURNAL_STREAM` are present, check to make sure
             // that our parent process is actually `systemd`, not some other terminal
@@ -91,7 +93,7 @@ pub const notify = struct {
         if (comptime builtin.os.tag != .linux) return;
 
         // Get the socket address that should receive notifications.
-        const socket_path = std.posix.getenv("NOTIFY_SOCKET") orelse return;
+        const socket_path = getenv("NOTIFY_SOCKET") orelse return;
 
         // If the socket address is an empty string return.
         if (socket_path.len == 0) return;

--- a/src/os/xdg.zig
+++ b/src/os/xdg.zig
@@ -6,7 +6,10 @@ const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const posix = std.posix;
 const homedir = @import("homedir.zig");
-const env_os = @import("env.zig");
+const getenv = @import("env.zig").getenv;
+const getenvNotEmpty = @import("env.zig").getenvNotEmpty;
+const setenv = @import("env.zig").setenv;
+const unsetenv = @import("env.zig").unsetenv;
 
 pub const Options = struct {
     /// Subdirectories to join to the base. This avoids extra allocations
@@ -70,22 +73,21 @@ fn dir(
     // First check the env var. On Windows we have to allocate so this tracks
     // both whether we have the env var and whether we own it.
     // on Windows we treat `LOCALAPPDATA` as a fallback for `XDG_CONFIG_HOME`
-    const env_ = try env_os.getenvNotEmpty(alloc, internal_opts.env) orelse switch (builtin.os.tag) {
+    const env_ = getenvNotEmpty(internal_opts.env) orelse switch (builtin.os.tag) {
         else => null,
-        .windows => try env_os.getenvNotEmpty(alloc, internal_opts.windows_env),
+        .windows => getenvNotEmpty(internal_opts.windows_env),
     };
-    defer if (env_) |env| env.deinit(alloc);
 
     if (env_) |env| {
         // If we have a subdir, then we use the env as-is to avoid a copy.
         if (opts.subdir) |subdir| {
             return try std.fs.path.join(alloc, &[_][]const u8{
-                env.value,
+                env,
                 subdir,
             });
         }
 
-        return try alloc.dupe(u8, env.value);
+        return try alloc.dupe(u8, env);
     }
 
     // Get our home dir
@@ -161,19 +163,19 @@ test "fallback when xdg env empty" {
     const alloc = std.testing.allocator;
 
     const saved_home = home: {
-        const home = std.posix.getenv("HOME") orelse break :home null;
+        const home = getenv("HOME") orelse break :home null;
         break :home try alloc.dupeZ(u8, home);
     };
     defer env: {
         const home = saved_home orelse {
-            _ = env_os.unsetenv("HOME");
+            _ = unsetenv("HOME");
             break :env;
         };
-        _ = env_os.setenv("HOME", home);
+        _ = setenv("HOME", home);
         std.testing.allocator.free(home);
     }
     const temp_home = "/tmp/ghostty-test-home";
-    _ = env_os.setenv("HOME", temp_home);
+    _ = setenv("HOME", temp_home);
 
     const DirCase = struct {
         name: [:0]const u8,
@@ -190,15 +192,15 @@ test "fallback when xdg env empty" {
     inline for (cases) |case| {
         // Save and restore each environment variable
         const saved_env = blk: {
-            const value = std.posix.getenv(case.name) orelse break :blk null;
+            const value = getenv(case.name) orelse break :blk null;
             break :blk try alloc.dupeZ(u8, value);
         };
         defer env: {
             const value = saved_env orelse {
-                _ = env_os.unsetenv(case.name);
+                _ = unsetenv(case.name);
                 break :env;
             };
-            _ = env_os.setenv(case.name, value);
+            _ = setenv(case.name, value);
             alloc.free(value);
         }
 
@@ -209,7 +211,7 @@ test "fallback when xdg env empty" {
         defer alloc.free(expected);
 
         // Test with empty string - should fallback to home
-        _ = env_os.setenv(case.name, "");
+        _ = setenv(case.name, "");
         const actual = try case.func(alloc, .{});
         defer alloc.free(actual);
 
@@ -220,7 +222,6 @@ test "fallback when xdg env empty" {
 test "fallback when xdg env empty and subdir" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
 
-    const env = @import("env.zig");
     const alloc = std.testing.allocator;
 
     const saved_home = home: {
@@ -229,15 +230,15 @@ test "fallback when xdg env empty and subdir" {
     };
     defer env: {
         const home = saved_home orelse {
-            _ = env.unsetenv("HOME");
+            _ = unsetenv("HOME");
             break :env;
         };
-        _ = env.setenv("HOME", home);
+        _ = setenv("HOME", home);
         std.testing.allocator.free(home);
     }
 
     const temp_home = "/tmp/ghostty-test-home";
-    _ = env.setenv("HOME", temp_home);
+    _ = setenv("HOME", temp_home);
 
     const DirCase = struct {
         name: [:0]const u8,
@@ -259,10 +260,10 @@ test "fallback when xdg env empty and subdir" {
         };
         defer env: {
             const value = saved_env orelse {
-                _ = env.unsetenv(case.name);
+                _ = unsetenv(case.name);
                 break :env;
             };
-            _ = env.setenv(case.name, value);
+            _ = setenv(case.name, value);
             alloc.free(value);
         }
 
@@ -274,7 +275,7 @@ test "fallback when xdg env empty and subdir" {
         defer alloc.free(expected);
 
         // Test with empty string - should fallback to home
-        _ = env.setenv(case.name, "");
+        _ = setenv(case.name, "");
         const actual = try case.func(alloc, .{ .subdir = "ghostty" });
         defer alloc.free(actual);
 

--- a/src/os/xdg.zig
+++ b/src/os/xdg.zig
@@ -225,7 +225,7 @@ test "fallback when xdg env empty and subdir" {
     const alloc = std.testing.allocator;
 
     const saved_home = home: {
-        const home = std.posix.getenv("HOME") orelse break :home null;
+        const home = getenv("HOME") orelse break :home null;
         break :home try alloc.dupeZ(u8, home);
     };
     defer env: {
@@ -255,7 +255,7 @@ test "fallback when xdg env empty and subdir" {
     inline for (cases) |case| {
         // Save and restore each environment variable
         const saved_env = blk: {
-            const value = std.posix.getenv(case.name) orelse break :blk null;
+            const value = getenv(case.name) orelse break :blk null;
             break :blk try alloc.dupeZ(u8, value);
         };
         defer env: {

--- a/src/os/xdg.zig
+++ b/src/os/xdg.zig
@@ -8,8 +8,6 @@ const posix = std.posix;
 const homedir = @import("homedir.zig");
 const getenv = @import("env.zig").getenv;
 const getenvNotEmpty = @import("env.zig").getenvNotEmpty;
-const setenv = @import("env.zig").setenv;
-const unsetenv = @import("env.zig").unsetenv;
 
 pub const Options = struct {
     /// Subdirectories to join to the base. This avoids extra allocations
@@ -136,6 +134,21 @@ test "cache directory paths" {
     const alloc = testing.allocator;
     const mock_home = "/Users/test";
 
+    // Partially initialize global state
+    const global = &@import("../global.zig").state;
+    global.* = .{
+        .gpa = null,
+        .logging = undefined,
+        .resources_dir = undefined,
+        .action = null,
+        .alloc = alloc,
+        .environ_map = try std.process.getEnvMap(alloc),
+    };
+    defer {
+        global.environ_map.deinit();
+        global.* = undefined;
+    }
+
     // Test when XDG_CACHE_HOME is not set
     {
         // Test base path
@@ -162,21 +175,6 @@ test "fallback when xdg env empty" {
 
     const alloc = std.testing.allocator;
 
-    const saved_home = home: {
-        const home = getenv("HOME") orelse break :home null;
-        break :home try alloc.dupeZ(u8, home);
-    };
-    defer env: {
-        const home = saved_home orelse {
-            _ = unsetenv("HOME");
-            break :env;
-        };
-        _ = setenv("HOME", home);
-        std.testing.allocator.free(home);
-    }
-    const temp_home = "/tmp/ghostty-test-home";
-    _ = setenv("HOME", temp_home);
-
     const DirCase = struct {
         name: [:0]const u8,
         func: fn (Allocator, Options) anyerror![]u8,
@@ -190,19 +188,23 @@ test "fallback when xdg env empty" {
     };
 
     inline for (cases) |case| {
-        // Save and restore each environment variable
-        const saved_env = blk: {
-            const value = getenv(case.name) orelse break :blk null;
-            break :blk try alloc.dupeZ(u8, value);
+        // Partially initialize global state
+        const global = &@import("../global.zig").state;
+        global.* = .{
+            .gpa = null,
+            .logging = undefined,
+            .resources_dir = undefined,
+            .action = null,
+            .alloc = alloc,
+            .environ_map = try std.process.getEnvMap(alloc),
         };
-        defer env: {
-            const value = saved_env orelse {
-                _ = unsetenv(case.name);
-                break :env;
-            };
-            _ = setenv(case.name, value);
-            alloc.free(value);
+        defer {
+            global.environ_map.deinit();
+            global.* = undefined;
         }
+
+        const temp_home = "/tmp/ghostty-test-home";
+        try global.environ_map.put("HOME", temp_home);
 
         const expected = try std.fs.path.join(alloc, &[_][]const u8{
             temp_home,
@@ -211,7 +213,8 @@ test "fallback when xdg env empty" {
         defer alloc.free(expected);
 
         // Test with empty string - should fallback to home
-        _ = setenv(case.name, "");
+        try global.environ_map.put(case.name, "");
+
         const actual = try case.func(alloc, .{});
         defer alloc.free(actual);
 
@@ -224,22 +227,6 @@ test "fallback when xdg env empty and subdir" {
 
     const alloc = std.testing.allocator;
 
-    const saved_home = home: {
-        const home = getenv("HOME") orelse break :home null;
-        break :home try alloc.dupeZ(u8, home);
-    };
-    defer env: {
-        const home = saved_home orelse {
-            _ = unsetenv("HOME");
-            break :env;
-        };
-        _ = setenv("HOME", home);
-        std.testing.allocator.free(home);
-    }
-
-    const temp_home = "/tmp/ghostty-test-home";
-    _ = setenv("HOME", temp_home);
-
     const DirCase = struct {
         name: [:0]const u8,
         func: fn (Allocator, Options) anyerror![]u8,
@@ -253,19 +240,24 @@ test "fallback when xdg env empty and subdir" {
     };
 
     inline for (cases) |case| {
-        // Save and restore each environment variable
-        const saved_env = blk: {
-            const value = getenv(case.name) orelse break :blk null;
-            break :blk try alloc.dupeZ(u8, value);
+        // Partially initialize global state
+        const global = &@import("../global.zig").state;
+        global.* = .{
+            .gpa = null,
+            .logging = undefined,
+            .resources_dir = undefined,
+            .action = null,
+            .alloc = alloc,
+            .environ_map = try std.process.getEnvMap(alloc),
         };
-        defer env: {
-            const value = saved_env orelse {
-                _ = unsetenv(case.name);
-                break :env;
-            };
-            _ = setenv(case.name, value);
-            alloc.free(value);
+        defer {
+            global.environ_map.deinit();
+            global.* = undefined;
         }
+
+        // Set a known home directory
+        const temp_home = "/tmp/ghostty-test-home";
+        try global.environ_map.put("HOME", temp_home);
 
         const expected = try std.fs.path.join(alloc, &[_][]const u8{
             temp_home,
@@ -275,7 +267,8 @@ test "fallback when xdg env empty and subdir" {
         defer alloc.free(expected);
 
         // Test with empty string - should fallback to home
-        _ = setenv(case.name, "");
+        try global.environ_map.put(case.name, "");
+
         const actual = try case.func(alloc, .{ .subdir = "ghostty" });
         defer alloc.free(actual);
 

--- a/src/terminal/kitty/graphics_image.zig
+++ b/src/terminal/kitty/graphics_image.zig
@@ -12,8 +12,9 @@ const wuffs = @import("wuffs");
 
 const temp_dir = struct {
     const TempDir = @import("../../os/TempDir.zig");
-    const allocTmpDir = @import("../../os/file.zig").allocTmpDir;
-    const freeTmpDir = @import("../../os/file.zig").freeTmpDir;
+    const getTmpDir = @import("../../os/file.zig").getTmpDir;
+
+    // const freeTmpDir = @import("../../os/file.zig").freeTmpDir;
 };
 
 const log = std.log.scoped(.kitty_gfx);
@@ -281,8 +282,7 @@ pub const LoadingImage = struct {
     fn isPathInTempDir(path: []const u8) bool {
         if (std.mem.startsWith(u8, path, "/tmp")) return true;
         if (std.mem.startsWith(u8, path, "/dev/shm")) return true;
-        if (temp_dir.allocTmpDir(std.heap.page_allocator)) |dir| {
-            defer temp_dir.freeTmpDir(std.heap.page_allocator, dir);
+        if (temp_dir.getTmpDir()) |dir| {
             if (std.mem.startsWith(u8, path, dir)) return true;
 
             // The temporary dir is sometimes a symlink. On macOS for

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1548,11 +1548,10 @@ fn execCommand(
 
                 // Note we don't free any of the memory below since it is
                 // allocated in the arena.
-                const windir = std.process.getEnvVarOwned(
-                    alloc,
+                const windir = internal_os.getenv(
                     "WINDIR",
-                ) catch |err| {
-                    log.warn("failed to get WINDIR, cannot run shell command err={}", .{err});
+                ) orelse {
+                    log.warn("failed to get WINDIR, cannot run shell command", .{});
                     return error.SystemError;
                 };
                 const cmd = try std.fs.path.joinZ(alloc, &[_][]const u8{


### PR DESCRIPTION
Zig 0.16 will eliminate the ability to directly access environment variables (using `std.posix.getenv` or related APIs). Instead environment variables will be passed to a program's `main` function if it has the signature `pub fn main(init: std.process.Init)`. The environment variables will need to be cached somewhere accessible to the rest of Ghostty.

This adds the environment variables to Ghostty's `global.state` variable and then provides convenience APIs for accessing the enviroment variables that are similar to the APIs previously available.

Similar changes are made in the build system - the environment variables are available in the `b.graph.env_map` variable.

See:

https://github.com/ziglang/zig/issues/24510
https://codeberg.org/ziglang/zig/pulls/30644