### PR TITLE
Fix Windows test in src/Command.zig

### DIFF
--- a/src/Command.zig
+++ b/src/Command.zig
@@ -725,6 +725,11 @@ test "Command: redirect stdout to file" {
         .path = "C:\\Windows\\System32\\whoami.exe",
         .args = &.{"C:\\Windows\\System32\\whoami.exe"},
         .stdout = stdout,
+        .os_pre_exec = null,
+        .rt_pre_exec = null,
+        .rt_post_fork = null,
+        .rt_pre_exec_info = undefined,
+        .rt_post_fork_info = undefined,
     } else .{
         .path = "/bin/sh",
         .args = &.{ "/bin/sh", "-c", "echo hello" },


### PR DESCRIPTION
This was introduced in #10611. This doesn't fix all of the current Windows build problems, but at least fixes one that I introduced.