### PR TITLE
GTK: add 'move' to the drop target actions

### DIFF
--- a/src/apprt/gtk/ui/1.2/surface.blp
+++ b/src/apprt/gtk/ui/1.2/surface.blp
@@ -221,7 +221,7 @@ Overlay terminal_page {
 
   DropTarget drop_target {
     drop => $drop();
-    actions: copy;
+    actions: copy | move;
   }
 }
 


### PR DESCRIPTION
Fixes #11175