### PR TITLE
fix: zsh shell integration when `sudo` and `ssh` aliases are defined

### DIFF
--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -249,7 +249,7 @@ _ghostty_deferred_init() {
     # Sudo
     if [[ "$GHOSTTY_SHELL_FEATURES" == *"sudo"* ]] && [[ -n "$TERMINFO" ]]; then
       # Wrap `sudo` command to ensure Ghostty terminfo is preserved
-      sudo() {
+      function sudo() {
         builtin local sudo_has_sudoedit_flags="no"
         for arg in "$@"; do
           # Check if argument is '-e' or '--edit' (sudoedit flags)
@@ -272,7 +272,7 @@ _ghostty_deferred_init() {
 
     # SSH Integration
     if [[ "$GHOSTTY_SHELL_FEATURES" == *ssh-* ]]; then
-      ssh() {
+      function ssh() {
         emulate -L zsh
         setopt local_options no_glob_subst
 


### PR DESCRIPTION
I encountered an issue related to https://github.com/ghostty-org/ghostty/discussions/8641 and https://github.com/ghostty-org/ghostty/pull/8647, but in `zsh` instead of `bash`.

One of my aliases is:

```bash
alias sudo='sudo '
```

Which causes following error when sourcing the zsh shell integrations:

```shell
source /usr/share/ghostty/shell-integration/zsh/ghostty-integration
/usr/share/ghostty/shell-integration/zsh/ghostty-integration:149: defining function based on alias `sudo'
/usr/share/ghostty/shell-integration/zsh/ghostty-integration:233: parse error near `()'
```

