### PR TITLE
build,ci: add terminfo artifacts for releases and refactor terminfo build

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -102,10 +102,8 @@ jobs:
         run: |
           rm -rf zig-out/dist
           nix develop -c zig build distcheck
-          nix develop -c zig build terminfo
           cp zig-out/dist/ghostty-${GHOSTTY_VERSION}.tar.gz .
           cp zig-out/dist/ghostty-${GHOSTTY_VERSION}.tar.gz ghostty-source.tar.gz
-          cp zig-out/share/terminfo/ghostty.terminfo .
 
       - name: Sign Tarball
         run: |
@@ -123,6 +121,42 @@ jobs:
             ghostty-${{ env.GHOSTTY_VERSION }}.tar.gz.minisig
             ghostty-source.tar.gz
             ghostty-source.tar.gz.minisig
+
+  terminfo:
+    runs-on: namespace-profile-ghostty-xsm
+    needs: [setup]
+    env:
+      ZIG_LOCAL_CACHE_DIR: /zig/local-cache
+      ZIG_GLOBAL_CACHE_DIR: /zig/global-cache
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Cache
+        uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9 # v1.4.2
+        with:
+          path: |
+            /nix
+            /zig
+
+      - uses: cachix/install-nix-action@19effe9fe722874e6d46dd7182e4b8b7a43c4a99 # v31.10.0
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # v16
+        with:
+          name: ghostty
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: Build Terminfo
+        run: |
+          nix develop -c zig build terminfo
+          cp zig-out/share/terminfo/ghostty.terminfo .
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: terminfo
+          path: |-
             ghostty.terminfo
 
   build-macos:
@@ -367,7 +401,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' &&
         github.event.inputs.upload == 'true') ||
       github.event_name == 'push'
-    needs: [setup, source-tarball, build-macos, appcast]
+    needs: [setup, source-tarball, terminfo, build-macos, appcast]
     runs-on: namespace-profile-ghostty-sm
     env:
       GHOSTTY_VERSION: ${{ needs.setup.outputs.version }}
@@ -386,6 +420,11 @@ jobs:
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: source-tarball
+
+      - name: Download Terminfo Artifacts
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          name: terminfo
 
       # Upload all of our files EXCEPT the appcast. The appcast triggers
       # updates in clients and we don't want to do that until we're

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -102,8 +102,10 @@ jobs:
         run: |
           rm -rf zig-out/dist
           nix develop -c zig build distcheck
+          nix develop -c zig build terminfo
           cp zig-out/dist/ghostty-${GHOSTTY_VERSION}.tar.gz .
           cp zig-out/dist/ghostty-${GHOSTTY_VERSION}.tar.gz ghostty-source.tar.gz
+          cp zig-out/share/terminfo/ghostty.terminfo .
 
       - name: Sign Tarball
         run: |
@@ -121,6 +123,7 @@ jobs:
             ghostty-${{ env.GHOSTTY_VERSION }}.tar.gz.minisig
             ghostty-source.tar.gz
             ghostty-source.tar.gz.minisig
+            ghostty.terminfo
 
   build-macos:
     needs: [setup]
@@ -395,6 +398,7 @@ jobs:
           mv "ghostty-${GHOSTTY_VERSION}.tar.gz.minisig" blob/${GHOSTTY_VERSION}/ghostty-${GHOSTTY_VERSION}.tar.gz.minisig
           mv ghostty-source.tar.gz blob/${GHOSTTY_VERSION}/ghostty-source.tar.gz
           mv ghostty-source.tar.gz.minisig blob/${GHOSTTY_VERSION}/ghostty-source.tar.gz.minisig
+          mv ghostty.terminfo blob/${GHOSTTY_VERSION}/ghostty.terminfo
           mv ghostty-macos-universal.zip blob/${GHOSTTY_VERSION}/ghostty-macos-universal.zip
           mv ghostty-macos-universal-dsym.zip blob/${GHOSTTY_VERSION}/ghostty-macos-universal-dsym.zip
           mv Ghostty.dmg blob/${GHOSTTY_VERSION}/Ghostty.dmg

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -186,9 +186,7 @@ jobs:
         run: |
           rm -rf zig-out/dist
           nix develop -c zig build distcheck
-          nix develop -c zig build terminfo
           cp zig-out/dist/*.tar.gz ghostty-source.tar.gz
-          cp zig-out/share/terminfo/ghostty.terminfo .
 
       - name: Sign Tarball
         run: |
@@ -206,7 +204,51 @@ jobs:
           files: |
             ghostty-source.tar.gz
             ghostty-source.tar.gz.minisig
-            ghostty.terminfo
+          token: ${{ secrets.GH_RELEASE_TOKEN }}
+
+  terminfo:
+    needs: [setup]
+    if: |
+      needs.setup.outputs.should_skip != 'true' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.repository_owner == 'ghostty-org' &&
+          github.ref_name == 'main'
+        )
+      )
+    runs-on: namespace-profile-ghostty-xsm
+    env:
+      ZIG_LOCAL_CACHE_DIR: /zig/local-cache
+      ZIG_GLOBAL_CACHE_DIR: /zig/global-cache
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Cache
+        uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9 # v1.4.2
+        with:
+          path: |
+            /nix
+            /zig
+      - uses: cachix/install-nix-action@19effe9fe722874e6d46dd7182e4b8b7a43c4a99 # v31.10.0
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # v16
+        with:
+          name: ghostty
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - name: Build Terminfo
+        run: |
+          nix develop -c zig build terminfo
+          cp zig-out/share/terminfo/ghostty.terminfo ghostty.terminfo
+
+      - name: Update Release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        with:
+          name: 'Ghostty Tip ("Nightly")'
+          prerelease: true
+          tag_name: tip
+          target_commitish: ${{ github.sha }}
+          files: ghostty.terminfo
           token: ${{ secrets.GH_RELEASE_TOKEN }}
 
   build-macos:

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -186,7 +186,9 @@ jobs:
         run: |
           rm -rf zig-out/dist
           nix develop -c zig build distcheck
+          nix develop -c zig build terminfo
           cp zig-out/dist/*.tar.gz ghostty-source.tar.gz
+          cp zig-out/share/terminfo/ghostty.terminfo .
 
       - name: Sign Tarball
         run: |
@@ -204,6 +206,7 @@ jobs:
           files: |
             ghostty-source.tar.gz
             ghostty-source.tar.gz.minisig
+            ghostty.terminfo
           token: ${{ secrets.GH_RELEASE_TOKEN }}
 
   build-macos:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,7 @@ jobs:
       - skip
       - build-bench
       - build-dist
+      - build-terminfo
       - build-examples
       - build-flatpak
       - build-libghostty-vt
@@ -562,6 +563,36 @@ jobs:
           name: source-tarball
           path: |-
             ghostty-source.tar.gz
+
+  build-terminfo:
+    runs-on: namespace-profile-ghostty-xsm
+    needs: test
+    env:
+      ZIG_LOCAL_CACHE_DIR: /zig/local-cache
+      ZIG_GLOBAL_CACHE_DIR: /zig/global-cache
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Cache
+        uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9 # v1.4.2
+        with:
+          path: |
+            /nix
+            /zig
+
+      # Install Nix and use that to run our tests so our environment matches exactly.
+      - uses: cachix/install-nix-action@19effe9fe722874e6d46dd7182e4b8b7a43c4a99 # v31.10.0
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # v16
+        with:
+          name: ghostty
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: Build Terminfo
+        run: |
+          nix develop -c zig build terminfo
 
   trigger-snap:
     if: github.event_name != 'pull_request'

--- a/build.zig
+++ b/build.zig
@@ -54,11 +54,11 @@ pub fn build(b: *std.Build) !void {
         "update-translations",
         "Update translation files",
     );
-
     const terminfo_step = b.step(
         "terminfo",
         "Build Ghostty terminfo source files",
     );
+
     // Ghostty resources like terminfo, shell integration, themes, etc.
     const resources = try buildpkg.GhosttyResources.init(b, &config, &deps);
     const i18n = if (config.i18n) try buildpkg.GhosttyI18n.init(b, &config) else null;

--- a/build.zig
+++ b/build.zig
@@ -55,6 +55,10 @@ pub fn build(b: *std.Build) !void {
         "Update translation files",
     );
 
+    const terminfo_step = b.step(
+        "terminfo",
+        "Build Ghostty terminfo source files",
+    );
     // Ghostty resources like terminfo, shell integration, themes, etc.
     const resources = try buildpkg.GhosttyResources.init(b, &config, &deps);
     const i18n = if (config.i18n) try buildpkg.GhosttyI18n.init(b, &config) else null;
@@ -91,6 +95,20 @@ pub fn build(b: *std.Build) !void {
         check_step.dependOn(dist.install_step);
     }
 
+    // Ghostty terminfo source artifacts
+    const terminfo = try buildpkg.GhosttyTerminfo.init(b, &deps);
+    {
+        terminfo_step.dependOn(terminfo.installTerminfoSource(
+            b,
+            &config,
+        ));
+        if (terminfo.installTermcapSource(
+            b,
+            &config,
+        )) |cap_step| {
+            terminfo_step.dependOn(cap_step);
+        }
+    }
     // libghostty (internal, big)
     const libghostty_shared = try buildpkg.GhosttyLib.initShared(
         b,
@@ -290,7 +308,6 @@ pub fn build(b: *std.Build) !void {
         });
         if (config.emit_test_exe) b.installArtifact(test_exe);
         _ = try deps.add(test_exe);
-
         // Verify our internal libghostty header.
         const ghostty_h = b.addTranslateC(.{
             .root_source_file = b.path("include/ghostty.h"),

--- a/src/build/GhosttyResources.zig
+++ b/src/build/GhosttyResources.zig
@@ -3,12 +3,16 @@ const GhosttyResources = @This();
 const std = @import("std");
 const assert = std.debug.assert;
 const Config = @import("Config.zig");
-const RunStep = std.Build.Step.Run;
+const GhosttyTerminfo = @import("GhosttyTerminfo.zig");
 const SharedDeps = @import("SharedDeps.zig");
 
 steps: []*std.Build.Step,
 
-pub fn init(b: *std.Build, cfg: *const Config, deps: *const SharedDeps) !GhosttyResources {
+pub fn init(
+    b: *std.Build,
+    cfg: *const Config,
+    deps: *const SharedDeps,
+) !GhosttyResources {
     var steps: std.ArrayList(*std.Build.Step) = .empty;
     errdefer steps.deinit(b.allocator);
 
@@ -28,90 +32,25 @@ pub fn init(b: *std.Build, cfg: *const Config, deps: *const SharedDeps) !Ghostty
     deps.help_strings.addImport(build_data_exe);
 
     // Terminfo
-    terminfo: {
-        const os_tag = cfg.target.result.os.tag;
-        const terminfo_share_dir = if (os_tag == .freebsd)
-            "site-terminfo"
-        else
-            "terminfo";
-
-        // Encode our terminfo
-        const run = b.addRunArtifact(build_data_exe);
-        run.addArg("+terminfo");
-        const wf = b.addWriteFiles();
-        const source = wf.addCopyFile(run.captureStdOut(), "ghostty.terminfo");
-
+    {
+        const terminfo_data = try GhosttyTerminfo.init(b, deps);
         if (cfg.emit_terminfo) {
-            const source_install = b.addInstallFile(
-                source,
-                if (os_tag == .freebsd)
-                    "share/site-terminfo/ghostty.terminfo"
-                else
-                    "share/terminfo/ghostty.terminfo",
-            );
-
-            try steps.append(b.allocator, &source_install.step);
-        }
-
-        // Windows doesn't have the binaries below.
-        if (os_tag == .windows) break :terminfo;
-
-        // Convert to termcap source format if thats helpful to people and
-        // install it. The resulting value here is the termcap source in case
-        // that is used for other commands.
-        if (cfg.emit_termcap) {
-            const run_step = RunStep.create(b, "infotocap");
-            run_step.addArg("infotocap");
-            run_step.addFileArg(source);
-            const out_source = run_step.captureStdOut();
-            _ = run_step.captureStdErr(); // so we don't see stderr
-
-            const cap_install = b.addInstallFile(
-                out_source,
-                if (os_tag == .freebsd)
-                    "share/site-terminfo/ghostty.termcap"
-                else
-                    "share/terminfo/ghostty.termcap",
-            );
-
-            try steps.append(b.allocator, &cap_install.step);
-        }
-
-        // Compile the terminfo source into a terminfo database
-        {
-            const run_step = RunStep.create(b, "tic");
-            run_step.addArgs(&.{ "tic", "-x", "-o" });
-            const path = run_step.addOutputFileArg(terminfo_share_dir);
-
-            run_step.addFileArg(source);
-            _ = run_step.captureStdErr(); // so we don't see stderr
-
-            // Ensure that `share/terminfo` is a directory, otherwise the `cp
-            // -R` will create a file named `share/terminfo`
-            const mkdir_step = RunStep.create(b, "make share/terminfo directory");
-            switch (cfg.target.result.os.tag) {
-                // windows mkdir shouldn't need "-p"
-                .windows => mkdir_step.addArgs(&.{"mkdir"}),
-                else => mkdir_step.addArgs(&.{ "mkdir", "-p" }),
-            }
-
-            mkdir_step.addArg(b.fmt(
-                "{s}/share/{s}",
-                .{ b.install_path, terminfo_share_dir },
+            try steps.append(b.allocator, terminfo_data.installTerminfoSource(
+                b,
+                cfg,
             ));
-
-            try steps.append(b.allocator, &mkdir_step.step);
-
-            // Use cp -R instead of Step.InstallDir because we need to preserve
-            // symlinks in the terminfo database. Zig's InstallDir step doesn't
-            // handle symlinks correctly yet.
-            const copy_step = RunStep.create(b, "copy terminfo db");
-            copy_step.addArgs(&.{ "cp", "-R" });
-            copy_step.addFileArg(path);
-            copy_step.addArg(b.fmt("{s}/share", .{b.install_path}));
-            copy_step.step.dependOn(&mkdir_step.step);
-            try steps.append(b.allocator, &copy_step.step);
         }
+
+        if (cfg.emit_termcap) {
+            if (terminfo_data.installTermcapSource(
+                b,
+                cfg,
+            )) |cap_step| {
+                try steps.append(b.allocator, cap_step);
+            }
+        }
+
+        try terminfo_data.installCompiled(b, cfg, &steps);
     }
 
     // Shell-integration

--- a/src/build/GhosttyTerminfo.zig
+++ b/src/build/GhosttyTerminfo.zig
@@ -1,0 +1,119 @@
+//! GhosttyTerminfo builds terminfo source artifacts from Ghostty's Zig terminfo definition.
+const GhosttyTerminfo = @This();
+
+const std = @import("std");
+const Config = @import("Config.zig");
+const SharedDeps = @import("SharedDeps.zig");
+const RunStep = std.Build.Step.Run;
+
+terminfo_source: std.Build.LazyPath,
+termcap_source: ?std.Build.LazyPath,
+
+pub fn init(
+    b: *std.Build,
+    deps: *const SharedDeps,
+) !GhosttyTerminfo {
+    const build_data_exe = b.addExecutable(.{
+        .name = "ghostty-build-data",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main_build_data.zig"),
+            .target = b.graph.host,
+            .strip = false,
+            .omit_frame_pointer = false,
+            .unwind_tables = .sync,
+        }),
+    });
+    build_data_exe.linkLibC();
+    deps.help_strings.addImport(build_data_exe);
+
+    const run = b.addRunArtifact(build_data_exe);
+    run.addArg("+terminfo");
+    const wf = b.addWriteFiles();
+    const terminfo_source = wf.addCopyFile(run.captureStdOut(), "ghostty.terminfo");
+
+    var termcap_source: ?std.Build.LazyPath = null;
+    if (b.graph.host.result.os.tag != .windows) {
+        const run_step = RunStep.create(b, "infotocap");
+        run_step.addArg("infotocap");
+        run_step.addFileArg(terminfo_source);
+        termcap_source = run_step.captureStdOut();
+        _ = run_step.captureStdErr(); // suppress noise
+    }
+
+    return .{
+        .terminfo_source = terminfo_source,
+        .termcap_source = termcap_source,
+    };
+}
+
+pub fn installTerminfoSource(
+    self: *const GhosttyTerminfo,
+    b: *std.Build,
+    cfg: *const Config,
+) *std.Build.Step {
+    const os_tag = cfg.target.result.os.tag;
+    const dest = switch (os_tag) {
+        .freebsd => "share/site-terminfo/ghostty.terminfo",
+        else => "share/terminfo/ghostty.terminfo",
+    };
+    const source_install = b.addInstallFile(self.terminfo_source, dest);
+    return &source_install.step;
+}
+
+pub fn installTermcapSource(
+    self: *const GhosttyTerminfo,
+    b: *std.Build,
+    cfg: *const Config,
+) ?*std.Build.Step {
+    const os_tag = cfg.target.result.os.tag;
+    const dest = switch (os_tag) {
+        .freebsd => "share/site-terminfo/ghostty.termcap",
+        else => "share/terminfo/ghostty.termcap",
+    };
+    if (self.termcap_source) |source| {
+        const cap_install = b.addInstallFile(source, dest);
+        return &cap_install.step;
+    }
+    return null;
+}
+
+/// Compiles and installs a terminfo database under share/terminfo (or
+/// share/site-terminfo on FreeBSD), preserving symlinks in the output.
+pub fn installCompiled(
+    self: *const GhosttyTerminfo,
+    b: *std.Build,
+    cfg: *const Config,
+    steps: *std.ArrayList(*std.Build.Step),
+) !void {
+    const os_tag = cfg.target.result.os.tag;
+
+    const terminfo_share_dir = switch (os_tag) {
+        .windows => return, // we don't support terminfo on Windows
+        .freebsd => "site-terminfo",
+        else => "terminfo",
+    };
+
+    const run_step = RunStep.create(b, "tic");
+    run_step.addArgs(&.{ "tic", "-x", "-o" });
+    const path = run_step.addOutputFileArg(terminfo_share_dir);
+    run_step.addFileArg(self.terminfo_source);
+    _ = run_step.captureStdErr(); // so we don't see stderr
+
+    // Ensure that `share/terminfo` is a directory, otherwise `cp -R`
+    // may create a file named `share/terminfo`.
+    const mkdir_step = RunStep.create(b, "make share/terminfo directory");
+    mkdir_step.addArgs(&.{ "mkdir", "-p" });
+    mkdir_step.addArg(b.fmt(
+        "{s}/share/{s}",
+        .{ b.install_path, terminfo_share_dir },
+    ));
+    try steps.append(b.allocator, &mkdir_step.step);
+
+    // Use cp -R because InstallDir doesn't preserve symlinks for this tree.
+    const copy_step = RunStep.create(b, "copy terminfo db");
+    copy_step.addArgs(&.{ "cp", "-R" });
+    copy_step.addFileArg(path);
+    copy_step.addArg(b.fmt("{s}/share", .{b.install_path}));
+    copy_step.step.dependOn(&mkdir_step.step);
+    try steps.append(b.allocator, &copy_step.step);
+}

--- a/src/build/main.zig
+++ b/src/build/main.zig
@@ -15,6 +15,7 @@ pub const GhosttyFrameData = @import("GhosttyFrameData.zig");
 pub const GhosttyLib = @import("GhosttyLib.zig");
 pub const GhosttyLibVt = @import("GhosttyLibVt.zig");
 pub const GhosttyResources = @import("GhosttyResources.zig");
+pub const GhosttyTerminfo = @import("GhosttyTerminfo.zig");
 pub const GhosttyI18n = @import("GhosttyI18n.zig");
 pub const GhosttyXcodebuild = @import("GhosttyXcodebuild.zig");
 pub const GhosttyXCFramework = @import("GhosttyXCFramework.zig");


### PR DESCRIPTION
Closes #9917
# Summary
- refactor terminfo generation/DB compilation out of GhosttyResources internals into dedicated GhosttyTerminfo file
- add `zig build terminfo` step to only output terminfo and termcap source files
- publish ghostty.terminfo in tagged and tip release workflows
- document how to build/fetch and install terminfo in README

# AI Disclosure
gpt-5.3-codex in Codex cli was used to iterate on an approach and reviewed at each step. All code is understood.