### PR TITLE
Improve local path link detection and local file open normalization

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2063,6 +2063,147 @@ fn resolvePathForOpening(
     return null;
 }
 
+/// Returns true if the text has a non-local URL scheme and therefore should
+/// not be validated against the local filesystem.
+fn isNonLocalUrl(text: []const u8) bool {
+    const prefixes = [_][]const u8{
+        "http://",
+        "https://",
+        "mailto:",
+        "ftp://",
+        "ssh:",
+        "git://",
+        "ssh://",
+        "tel:",
+        "magnet:",
+        "ipfs://",
+        "ipns://",
+        "gemini://",
+        "gopher://",
+        "news:",
+    };
+    for (prefixes) |prefix| {
+        if (std.ascii.startsWithIgnoreCase(text, prefix)) return true;
+    }
+
+    return false;
+}
+
+/// Trim a trailing `:line` or `:line:column` suffix if present.
+fn trimLineColumnSuffix(text: []const u8) []const u8 {
+    var end = text.len;
+    var removed: u2 = 0;
+    while (removed < 2) : (removed += 1) {
+        if (end == 0) break;
+
+        var i = end;
+        while (i > 0 and std.ascii.isDigit(text[i - 1])) i -= 1;
+        if (i == end or i == 0 or text[i - 1] != ':') break;
+        end = i - 1;
+    }
+
+    return if (removed > 0) text[0..end] else text;
+}
+
+fn expandLeadingEnvVar(
+    path: []const u8,
+    buf: []u8,
+) ?[]const u8 {
+    if (path.len < 2 or path[0] != '$') return path;
+    if (!(std.ascii.isAlphabetic(path[1]) or path[1] == '_')) return null;
+
+    var i: usize = 2;
+    while (i < path.len and (std.ascii.isAlphanumeric(path[i]) or path[i] == '_')) {
+        i += 1;
+    }
+
+    // We only support the `$VAR/...` style path prefix.
+    if (i < path.len and path[i] != '/') return null;
+
+    const value = std.posix.getenv(path[1..i]) orelse return null;
+    const rest = path[i..];
+    if (value.len + rest.len > buf.len) return null;
+
+    @memcpy(buf[0..value.len], value);
+    @memcpy(buf[value.len .. value.len + rest.len], rest);
+    return buf[0 .. value.len + rest.len];
+}
+
+fn localPathExists(
+    self: *Surface,
+    path: []const u8,
+) bool {
+    var path_buf_home: [std.fs.max_path_bytes]u8 = undefined;
+    var path_buf_env: [std.fs.max_path_bytes]u8 = undefined;
+    var path_buf_resolved: [std.fs.max_path_bytes]u8 = undefined;
+
+    var candidate = std.mem.trimRight(u8, path, " ");
+    if (candidate.len == 0) return false;
+
+    candidate = internal_os.expandHome(candidate, &path_buf_home) catch
+        return false;
+    candidate = expandLeadingEnvVar(candidate, &path_buf_env) orelse
+        return false;
+
+    if (std.fs.path.isAbsolute(candidate)) {
+        std.fs.accessAbsolute(candidate, .{}) catch return false;
+        return true;
+    }
+
+    const terminal_pwd = self.io.terminal.getPwd() orelse return false;
+    var resolve_fba = std.heap.FixedBufferAllocator.init(&path_buf_resolved);
+    const resolved = std.fs.path.resolve(
+        resolve_fba.allocator(),
+        &.{ terminal_pwd, candidate },
+    ) catch return false;
+
+    std.fs.accessAbsolute(resolved, .{}) catch return false;
+    return true;
+}
+
+/// Return the local path target that exists on disk, optionally stripping
+/// a trailing `:line[:column]` suffix when needed.
+fn existingLocalPathTarget(
+    self: *Surface,
+    target: []const u8,
+) ?[]const u8 {
+    const trimmed = std.mem.trimRight(u8, target, " ");
+    if (trimmed.len == 0) return null;
+
+    if (self.localPathExists(trimmed)) return trimmed;
+
+    const no_lc = trimLineColumnSuffix(trimmed);
+    if (!std.mem.eql(u8, no_lc, trimmed) and self.localPathExists(no_lc)) return no_lc;
+
+    return null;
+}
+
+fn linkTargetExists(
+    self: *Surface,
+    target: []const u8,
+) bool {
+    const trimmed = std.mem.trimRight(u8, target, " ");
+    if (trimmed.len == 0) return false;
+
+    // Non-local URLs should remain linkable regardless of filesystem state.
+    if (isNonLocalUrl(trimmed)) return true;
+
+    // `file:` URLs are local by definition, so validate their local path.
+    if (std.mem.startsWith(u8, trimmed, "file:")) {
+        const uri = internal_os.uri.parse(trimmed, .{
+            .mac_address = true,
+            .raw_path = true,
+        }) catch return false;
+        if (!std.mem.eql(u8, uri.scheme, "file")) return false;
+
+        var raw_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const path = uri.path.toRaw(&raw_buf) catch return false;
+        return self.localPathExists(path);
+    }
+
+    return self.existingLocalPathTarget(trimmed) != null;
+}
+
 /// Returns the x/y coordinate of where the IME (Input Method Editor)
 /// keyboard should be rendered.
 pub fn imePoint(self: *const Surface) apprt.IMEPos {
@@ -4463,6 +4604,17 @@ fn linkAtPin(
             defer match.deinit();
             const sel = match.selection();
             if (!sel.contains(screen, mouse_pin)) continue;
+
+            // Local filesystem paths should only be linkable if they exist.
+            if (link.action == .open) {
+                const target = try self.io.terminal.screens.active.selectionString(self.alloc, .{
+                    .sel = sel,
+                    .trim = false,
+                });
+                defer self.alloc.free(target);
+                if (!self.linkTargetExists(target)) continue;
+            }
+
             return .{
                 .action = link.action,
                 .selection = sel,
@@ -4506,10 +4658,25 @@ fn processLinks(self: *Surface, pos: apprt.CursorPos) !bool {
             });
             defer self.alloc.free(str);
 
-            const resolved_path = try self.resolvePathForOpening(str);
+            const open_target = blk: {
+                const trimmed = std.mem.trimRight(u8, str, " ");
+
+                // Keep non-local URLs and file URLs intact; they aren't path-only
+                // strings and may include characters that are significant.
+                if (isNonLocalUrl(trimmed)) break :blk trimmed;
+                if (std.mem.startsWith(u8, trimmed, "file:")) break :blk trimmed;
+
+                // For local file references like `foo.zig:12:5`, open the
+                // underlying existing path (`foo.zig`) instead of the suffix form.
+                if (self.existingLocalPathTarget(trimmed)) |local| break :blk local;
+
+                break :blk trimmed;
+            };
+
+            const resolved_path = try self.resolvePathForOpening(open_target);
             defer if (resolved_path) |p| self.alloc.free(p);
 
-            const url_to_open = resolved_path orelse str;
+            const url_to_open = resolved_path orelse open_target;
             try self.openUrl(.{ .kind = .unknown, .url = url_to_open });
         },
 

--- a/src/config/url.zig
+++ b/src/config/url.zig
@@ -69,7 +69,7 @@ const dotted_path_space_segments =
 ;
 
 const any_path_space_segments =
-    \\(?:(?<!:) (?!\w+:\/\/)(?!\.{0,2}\/)(?!~\/)[\w\-.~:\/?#@!$&*+;=%]+)*
+    \\(?:(?<!:) (?!\w+:\/\/)(?!\.{0,2}\/)(?!~\/)(?:[\w\-.~:\/?#@!$&*+;=%]*[\/.][\w\-.~:\/?#@!$&*+;=%]*|[\w\-.~:\/?#@!$&*+;=%]+(?=[,:]| *$)))*
 ;
 
 // Branch 1: URLs with explicit schemes (http, mailto, ftp, etc.).
@@ -113,12 +113,35 @@ const bare_relative_path_branch =
     no_trailing_colon ++
     trailing_spaces_at_eol;
 
+// Branch 4: Bare filenames with an extension and optional `:line[:column]`
+// suffix, e.g. `build.zig`, `main.rs:42`, `mod.swift:10:3`.
+//
+// We exclude matches that are clearly inside paths (`/`, `~/`, `$VAR/`) by
+// requiring a non-path prefix via lookbehind.
+const bare_filename_branch =
+    \\(?<![\w\/~$.,-])(?>[\w][\w\-.]*\.[\w\-.]+)(?::\d+(?::\d+)?)?(?!:)
+;
+
+// Branch 5: `ls -l` line entries where the path appears as a plain trailing
+// name (e.g. `build.zig`, `macos`) without any slash prefix.
+//
+// We use `\K` so only the filename/directory token is returned as the match.
+// This intentionally treats the entry as a non-space token to avoid matching
+// terminal row padding spaces.
+const ls_long_listing_branch =
+    \\(?:^|[\r\n])(?:[-bcdlps][rwx-]{9}[@+]? +\d+ +\S+ +\S+ +\d+ +\S+ +\d{1,2} +(?:\d{2}:\d{2}|\d{4}) +)\K[^\s\x00]+(?:(?= +-> +)|(?=[\r\n]|$))
+;
+
 pub const regex =
     scheme_url_branch ++
     "|" ++
     rooted_or_relative_path_branch ++
     "|" ++
-    bare_relative_path_branch;
+    bare_relative_path_branch ++
+    "|" ++
+    bare_filename_branch ++
+    "|" ++
+    ls_long_listing_branch;
 
 test "url regex" {
     const testing = std.testing;
@@ -417,6 +440,34 @@ test "url regex" {
         .{
             .input = "directory: ~/src/ghostty-org/ghostty",
             .expect = "~/src/ghostty-org/ghostty",
+        },
+        .{
+            .input = "(base) foo@bar|~/Documents/proj on main!?",
+            .expect = "~/Documents/proj",
+        },
+        .{
+            .input = "-rw-r--r--@  1 user  staff   11213 Mar  4 22:42 build.zig",
+            .expect = "build.zig",
+        },
+        .{
+            .input = "-rw-r--r--@  1 user  staff   11213 Mar  4 22:42 build.zig                                      ",
+            .expect = "build.zig",
+        },
+        .{
+            .input = "-rw-r--r--@  1 user  staff   11213 Mar  4 22:42 build.zig\x00\x00\x00",
+            .expect = "build.zig",
+        },
+        .{
+            .input = "drwxr-xr-x@ 16 user  staff     512 Mar  5 11:03 macos",
+            .expect = "macos",
+        },
+        .{
+            .input = "echo build.zig",
+            .expect = "build.zig",
+        },
+        .{
+            .input = "build.zig:12:5",
+            .expect = "build.zig:12:5",
         },
         .{
             .input = "$HOME/src/config/url.zig",


### PR DESCRIPTION
Fix:
- Path overmatch in prompts: text like "(base) foo@bar|~/Documents/proj on main!?" was matched as one path.
- Missing local file link detection, for example, ls -l output and the file name/path that appear in the console could be clickable and openable.


Reference discussion: https://github.com/ghostty-org/ghostty/discussions/11184