### PR TITLE
fix(tmux): viewer correctness for end-to-end control mode

### DIFF
--- a/src/terminal/tmux/control.zig
+++ b/src/terminal/tmux/control.zig
@@ -68,10 +68,19 @@ pub const Parser = struct {
                 isOctalDigit(data[read + 2]) and
                 isOctalDigit(data[read + 3]))
             {
-                data[write] = (@as(u8, data[read + 1] - '0') << 6) |
-                    (@as(u8, data[read + 2] - '0') << 3) |
+                // Compute the octal value using u16 to avoid overflow.
+                // Values above 255 (\400+) cannot represent a byte, so
+                // treat them as literal characters.
+                const val: u16 = (@as(u16, data[read + 1] - '0') << 6) |
+                    (@as(u16, data[read + 2] - '0') << 3) |
                     (data[read + 3] - '0');
-                read += 4;
+                if (val <= std.math.maxInt(u8)) {
+                    data[write] = @intCast(val);
+                    read += 4;
+                } else {
+                    data[write] = data[read];
+                    read += 1;
+                }
             } else {
                 data[write] = data[read];
                 read += 1;
@@ -915,6 +924,21 @@ test "unescape octal: backslash with non-octal digits" {
     try std.testing.expectEqualStrings("\\899", result);
 }
 
+test "unescape octal: value exceeding u8 treated as literal" {
+    // \400 = 256 which overflows u8, should pass through as literal
+    var data = "\\400".*;
+    const result = Parser.unescapeOctal(&data);
+    try std.testing.expectEqualStrings("\\400", result);
+}
+
+test "unescape octal: max u8 value" {
+    // \377 = 255, the maximum valid byte value
+    var data = "\\377".*;
+    const result = Parser.unescapeOctal(&data);
+    try std.testing.expectEqual(@as(u8, 0xFF), result[0]);
+    try std.testing.expectEqual(@as(usize, 1), result.len);
+}
+
 test "tmux output with octal escapes" {
     const testing = std.testing;
     const alloc = testing.allocator;
@@ -1047,6 +1071,19 @@ test "tmux exit notification" {
     var c: Parser = .{ .buffer = .init(alloc) };
     defer c.deinit();
     for ("%exit") |byte| try testing.expect(try c.put(byte) == null);
+    const n = (try c.put('\n')).?;
+    try testing.expect(n == .exit);
+}
+
+test "tmux exit notification with reason" {
+    // tmux sends "%exit lost-server" when the server dies.
+    // The reason string is ignored but must not break parsing.
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var c: Parser = .{ .buffer = .init(alloc) };
+    defer c.deinit();
+    for ("%exit lost-server") |byte| try testing.expect(try c.put(byte) == null);
     const n = (try c.put('\n')).?;
     try testing.expect(n == .exit);
 }

--- a/src/terminal/tmux/control.zig
+++ b/src/terminal/tmux/control.zig
@@ -56,6 +56,35 @@ pub const Parser = struct {
         self.buffer.deinit();
     }
 
+    /// Unescape tmux control mode octal escapes in-place.
+    /// tmux encodes bytes <32 and backslash as \NNN (3 octal digits).
+    /// Returns the decoded slice (which is a prefix of the input).
+    pub fn unescapeOctal(data: []u8) []u8 {
+        var read: usize = 0;
+        var write: usize = 0;
+        while (read < data.len) {
+            if (data[read] == '\\' and read + 3 < data.len and
+                isOctalDigit(data[read + 1]) and
+                isOctalDigit(data[read + 2]) and
+                isOctalDigit(data[read + 3]))
+            {
+                data[write] = (@as(u8, data[read + 1] - '0') << 6) |
+                    (@as(u8, data[read + 2] - '0') << 3) |
+                    (data[read + 3] - '0');
+                read += 4;
+            } else {
+                data[write] = data[read];
+                read += 1;
+            }
+            write += 1;
+        }
+        return data[0..write];
+    }
+
+    fn isOctalDigit(c: u8) bool {
+        return c >= '0' and c <= '7';
+    }
+
     // Handle a byte of input.
     //
     // If we reach our byte limit this will return OutOfMemory. It only
@@ -197,9 +226,15 @@ pub const Parser = struct {
                 line[@intCast(starts[1])..@intCast(ends[1])],
                 10,
             ) catch unreachable;
-            const data = line[@intCast(starts[2])..@intCast(ends[2])];
 
-            // Important: do not clear buffer here since name points to it
+            // tmux control mode encodes bytes <32 and backslash as octal
+            // escapes (\NNN) in %output data. Decode in-place — this is
+            // safe because the buffer is heap-allocated and we own it, and
+            // decoded output is always <= encoded length.
+            const raw = @constCast(line[@intCast(starts[2])..@intCast(ends[2])]);
+            const data = unescapeOctal(raw);
+
+            // Important: do not clear buffer here since data points to it
             self.state = .idle;
             return .{ .output = .{ .pane_id = id, .data = data } };
         } else if (std.mem.eql(u8, cmd, "%session-changed")) cmd: {
@@ -434,6 +469,78 @@ pub const Parser = struct {
             // Important: do not clear buffer here since client/name point to it
             self.state = .idle;
             return .{ .client_session_changed = .{ .client = client, .session_id = session_id, .name = name } };
+        } else if (std.mem.eql(u8, cmd, "%window-close")) cmd: {
+            var re = oni.Regex.init(
+                "^%window-close @([0-9]+)$",
+                .{ .capture_group = true },
+                oni.Encoding.utf8,
+                oni.Syntax.default,
+                null,
+            ) catch |err| {
+                log.warn("regex init failed error={}", .{err});
+                return error.RegexError;
+            };
+            defer re.deinit();
+
+            var region = re.search(line, .{}) catch |err| {
+                log.warn("failed to match notification cmd={s} line=\"{s}\" err={}", .{ cmd, line, err });
+                break :cmd;
+            };
+            defer region.deinit();
+            const starts = region.starts();
+            const ends = region.ends();
+
+            const id = std.fmt.parseInt(
+                usize,
+                line[@intCast(starts[1])..@intCast(ends[1])],
+                10,
+            ) catch unreachable;
+
+            self.buffer.clearRetainingCapacity();
+            self.state = .idle;
+            return .{ .window_close = .{ .id = id } };
+        } else if (std.mem.eql(u8, cmd, "%session-window-changed")) cmd: {
+            var re = oni.Regex.init(
+                "^%session-window-changed \\$([0-9]+) @([0-9]+)$",
+                .{ .capture_group = true },
+                oni.Encoding.utf8,
+                oni.Syntax.default,
+                null,
+            ) catch |err| {
+                log.warn("regex init failed error={}", .{err});
+                return error.RegexError;
+            };
+            defer re.deinit();
+
+            var region = re.search(line, .{}) catch |err| {
+                log.warn("failed to match notification cmd={s} line=\"{s}\" err={}", .{ cmd, line, err });
+                break :cmd;
+            };
+            defer region.deinit();
+            const starts = region.starts();
+            const ends = region.ends();
+
+            const session_id = std.fmt.parseInt(
+                usize,
+                line[@intCast(starts[1])..@intCast(ends[1])],
+                10,
+            ) catch unreachable;
+            const window_id = std.fmt.parseInt(
+                usize,
+                line[@intCast(starts[2])..@intCast(ends[2])],
+                10,
+            ) catch unreachable;
+
+            self.buffer.clearRetainingCapacity();
+            self.state = .idle;
+            return .{ .session_window_changed = .{ .session_id = session_id, .window_id = window_id } };
+        } else if (std.mem.eql(u8, cmd, "%exit")) {
+            // tmux sends %exit when the control mode client is exiting.
+            // Return the exit notification so the viewer and stream handler
+            // can perform proper cleanup.
+            self.buffer.clearRetainingCapacity();
+            self.state = .idle;
+            return .{ .exit = {} };
         } else {
             // Unknown notification, log it and return to idle state.
             log.warn("unknown tmux control mode notification={s}", .{cmd});
@@ -480,7 +587,7 @@ pub const Notification = union(enum) {
     /// Raw output from a pane.
     output: struct {
         pane_id: usize,
-        data: []const u8, // unescaped
+        data: []const u8, // unescaped (octal \NNN decoded in-place)
     },
 
     /// The client is now attached to the session with ID session-id, which is
@@ -517,6 +624,17 @@ pub const Notification = union(enum) {
     window_pane_changed: struct {
         window_id: usize,
         pane_id: usize,
+    },
+
+    /// The window with ID window-id was closed.
+    window_close: struct {
+        id: usize,
+    },
+
+    /// The session's current window changed to window-id in session-id.
+    session_window_changed: struct {
+        session_id: usize,
+        window_id: usize,
     },
 
     /// The client has detached.
@@ -722,4 +840,213 @@ test "tmux client-session-changed" {
     try testing.expectEqualStrings("/dev/pts/1", n.client_session_changed.client);
     try testing.expectEqual(2, n.client_session_changed.session_id);
     try testing.expectEqualStrings("mysession", n.client_session_changed.name);
+}
+
+test "unescape octal: no escapes passthrough" {
+    var data = "hello world".*;
+    const result = Parser.unescapeOctal(&data);
+    try std.testing.expectEqualStrings("hello world", result);
+}
+
+test "unescape octal: single ESC" {
+    // \033 = ESC (0x1B)
+    var data = "\\033".*;
+    const result = Parser.unescapeOctal(&data);
+    try std.testing.expectEqual(@as(usize, 1), result.len);
+    try std.testing.expectEqual(@as(u8, 0x1B), result[0]);
+}
+
+test "unescape octal: CR LF sequence" {
+    // \015\012 = CR LF
+    var data = "\\015\\012".*;
+    const result = Parser.unescapeOctal(&data);
+    try std.testing.expectEqual(@as(usize, 2), result.len);
+    try std.testing.expectEqual(@as(u8, 0x0D), result[0]);
+    try std.testing.expectEqual(@as(u8, 0x0A), result[1]);
+}
+
+test "unescape octal: escaped backslash" {
+    // \134 = backslash
+    var data = "\\134".*;
+    const result = Parser.unescapeOctal(&data);
+    try std.testing.expectEqual(@as(usize, 1), result.len);
+    try std.testing.expectEqual(@as(u8, '\\'), result[0]);
+}
+
+test "unescape octal: mixed escaped and literal" {
+    // "hello\033[31mworld" = "hello" + ESC + "[31mworld"
+    var data = "hello\\033[31mworld".*;
+    const result = Parser.unescapeOctal(&data);
+    try std.testing.expectEqual(@as(usize, 15), result.len);
+    try std.testing.expectEqualStrings("hello", result[0..5]);
+    try std.testing.expectEqual(@as(u8, 0x1B), result[5]);
+    try std.testing.expectEqualStrings("[31mworld", result[6..]);
+}
+
+test "unescape octal: multiple escapes in sequence" {
+    // \033\033 = ESC ESC
+    var data = "\\033\\033".*;
+    const result = Parser.unescapeOctal(&data);
+    try std.testing.expectEqual(@as(usize, 2), result.len);
+    try std.testing.expectEqual(@as(u8, 0x1B), result[0]);
+    try std.testing.expectEqual(@as(u8, 0x1B), result[1]);
+}
+
+test "unescape octal: backspace encoding from device" {
+    // \010ls = BS + "ls" (the exact pattern seen in device logs)
+    var data = "\\010ls".*;
+    const result = Parser.unescapeOctal(&data);
+    try std.testing.expectEqual(@as(usize, 3), result.len);
+    try std.testing.expectEqual(@as(u8, 0x08), result[0]);
+    try std.testing.expectEqualStrings("ls", result[1..]);
+}
+
+test "unescape octal: trailing backslash not enough digits" {
+    // Backslash at end without 3 digits should pass through
+    var data = "abc\\".*;
+    const result = Parser.unescapeOctal(&data);
+    try std.testing.expectEqualStrings("abc\\", result);
+}
+
+test "unescape octal: backslash with non-octal digits" {
+    // \8 is not octal, should pass through
+    var data = "\\899".*;
+    const result = Parser.unescapeOctal(&data);
+    try std.testing.expectEqualStrings("\\899", result);
+}
+
+test "tmux output with octal escapes" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // Simulate: %output %2 hello\033[31mworld
+    // tmux sends ESC as \033 in %output data
+    var c: Parser = .{ .buffer = .init(alloc) };
+    defer c.deinit();
+    for ("%output %2 hello\\033[31mworld") |byte| try testing.expect(try c.put(byte) == null);
+    const n = (try c.put('\n')).?;
+    try testing.expect(n == .output);
+    try testing.expectEqual(2, n.output.pane_id);
+    // Data should be decoded: "hello" + ESC + "[31mworld"
+    try testing.expectEqual(@as(usize, 15), n.output.data.len);
+    try testing.expectEqualStrings("hello", n.output.data[0..5]);
+    try testing.expectEqual(@as(u8, 0x1B), n.output.data[5]);
+    try testing.expectEqualStrings("[31mworld", n.output.data[6..]);
+}
+
+test "tmux output with escaped backslash" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // %output %5 path\\134file => "path\file"
+    var c: Parser = .{ .buffer = .init(alloc) };
+    defer c.deinit();
+    for ("%output %5 path\\134file") |byte| try testing.expect(try c.put(byte) == null);
+    const n = (try c.put('\n')).?;
+    try testing.expect(n == .output);
+    try testing.expectEqual(5, n.output.pane_id);
+    try testing.expectEqualStrings("path\\file", n.output.data);
+}
+
+test "tmux output with CR LF" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // %output %1 line1\015\012line2
+    var c: Parser = .{ .buffer = .init(alloc) };
+    defer c.deinit();
+    for ("%output %1 line1\\015\\012line2") |byte| try testing.expect(try c.put(byte) == null);
+    const n = (try c.put('\n')).?;
+    try testing.expect(n == .output);
+    try testing.expectEqual(1, n.output.pane_id);
+    try testing.expectEqual(@as(usize, 12), n.output.data.len);
+    try testing.expectEqualStrings("line1", n.output.data[0..5]);
+    try testing.expectEqual(@as(u8, 0x0D), n.output.data[5]);
+    try testing.expectEqual(@as(u8, 0x0A), n.output.data[6]);
+    try testing.expectEqualStrings("line2", n.output.data[7..]);
+}
+
+test "tmux output with raw UTF-8 box drawing" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // tmux sends UTF-8 bytes >= 0x80 raw (unescaped) in %output.
+    // \xe2\x94\x84 = U+2504 (box drawing light triple dash horizontal)
+    // \xe2\x80\xa2 = U+2022 (bullet)
+    // \xe2\x94\x81 = U+2501 (box drawing heavy horizontal)
+    // \xe2\x95\x90 = U+2550 (box drawing double horizontal)
+    var c: Parser = .{ .buffer = .init(alloc) };
+    defer c.deinit();
+
+    // Build the %output line with raw UTF-8 bytes
+    const prefix = "%output %3 ";
+    const box_chars = "\xe2\x94\x84\xe2\x80\xa2\xe2\x94\x81\xe2\x95\x90";
+    const line = prefix ++ box_chars;
+
+    for (line) |byte| try testing.expect(try c.put(byte) == null);
+    const n = (try c.put('\n')).?;
+    try testing.expect(n == .output);
+    try testing.expectEqual(3, n.output.pane_id);
+    // Data should be the raw UTF-8 bytes, unchanged
+    try testing.expectEqual(@as(usize, 12), n.output.data.len);
+    try testing.expectEqualStrings(box_chars, n.output.data);
+}
+
+test "tmux output with mixed UTF-8 and octal escapes" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // ESC[31m (octal-escaped ESC) + box drawing (raw UTF-8) + ESC[0m (octal-escaped ESC)
+    var c: Parser = .{ .buffer = .init(alloc) };
+    defer c.deinit();
+
+    const input = "%output %1 \\033[31m\xe2\x94\x84\\033[0m";
+    for (input) |byte| try testing.expect(try c.put(byte) == null);
+    const n = (try c.put('\n')).?;
+    try testing.expect(n == .output);
+    try testing.expectEqual(1, n.output.pane_id);
+    // Expected: ESC + "[31m" + e2 94 84 + ESC + "[0m"
+    // ESC=1 + [31m=4 + box=3 + ESC=1 + [0m=3 = 12 bytes
+    try testing.expectEqual(@as(usize, 12), n.output.data.len);
+    try testing.expectEqual(@as(u8, 0x1B), n.output.data[0]); // ESC
+    try testing.expectEqualStrings("[31m", n.output.data[1..5]);
+    try testing.expectEqualStrings("\xe2\x94\x84", n.output.data[5..8]); // box drawing
+    try testing.expectEqual(@as(u8, 0x1B), n.output.data[8]); // ESC
+    try testing.expectEqualStrings("[0m", n.output.data[9..12]);
+}
+
+test "tmux window-close" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var c: Parser = .{ .buffer = .init(alloc) };
+    defer c.deinit();
+    for ("%window-close @7") |byte| try testing.expect(try c.put(byte) == null);
+    const n = (try c.put('\n')).?;
+    try testing.expect(n == .window_close);
+    try testing.expectEqual(7, n.window_close.id);
+}
+
+test "tmux session-window-changed" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var c: Parser = .{ .buffer = .init(alloc) };
+    defer c.deinit();
+    for ("%session-window-changed $3 @5") |byte| try testing.expect(try c.put(byte) == null);
+    const n = (try c.put('\n')).?;
+    try testing.expect(n == .session_window_changed);
+    try testing.expectEqual(3, n.session_window_changed.session_id);
+    try testing.expectEqual(5, n.session_window_changed.window_id);
+}
+
+test "tmux exit notification" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var c: Parser = .{ .buffer = .init(alloc) };
+    defer c.deinit();
+    for ("%exit") |byte| try testing.expect(try c.put(byte) == null);
+    const n = (try c.put('\n')).?;
+    try testing.expect(n == .exit);
 }

--- a/src/terminal/tmux/output.zig
+++ b/src/terminal/tmux/output.zig
@@ -356,7 +356,7 @@ test "parse window layout" {
     try testing.expectEqualStrings("a]b,c{d}e(f)", try Variable.parse(.window_layout, "a]b,c{d}e(f)"));
 }
 
-test "parse window_name" {
+test "parse window name" {
     try testing.expectEqualStrings("bash", try Variable.parse(.window_name, "bash"));
     try testing.expectEqualStrings("vim", try Variable.parse(.window_name, "vim"));
     try testing.expectEqualStrings("", try Variable.parse(.window_name, ""));

--- a/src/terminal/tmux/output.zig
+++ b/src/terminal/tmux/output.zig
@@ -167,6 +167,8 @@ pub const Variable = enum {
     /// encodes pane dimensions as `WxH,X,Y[,ID]` with `{...}` for horizontal
     /// splits and `[...]` for vertical splits.
     window_layout,
+    /// Name of the window (e.g., "bash", "vim").
+    window_name,
     /// Pane wrap flag.
     wrap_flag,
 
@@ -217,6 +219,7 @@ pub const Variable = enum {
             .pane_tabs,
             .version,
             .window_layout,
+            .window_name,
             => value,
         };
     }
@@ -258,6 +261,7 @@ pub const Variable = enum {
             .pane_tabs,
             .version,
             .window_layout,
+            .window_name,
             => []const u8,
         };
     }
@@ -350,6 +354,13 @@ test "parse window layout" {
     try testing.expectEqualStrings("abc123", try Variable.parse(.window_layout, "abc123"));
     try testing.expectEqualStrings("", try Variable.parse(.window_layout, ""));
     try testing.expectEqualStrings("a]b,c{d}e(f)", try Variable.parse(.window_layout, "a]b,c{d}e(f)"));
+}
+
+test "parse window_name" {
+    try testing.expectEqualStrings("bash", try Variable.parse(.window_name, "bash"));
+    try testing.expectEqualStrings("vim", try Variable.parse(.window_name, "vim"));
+    try testing.expectEqualStrings("", try Variable.parse(.window_name, ""));
+    try testing.expectEqualStrings("my window", try Variable.parse(.window_name, "my window"));
 }
 
 test "parse cursor_flag" {

--- a/src/terminal/tmux/viewer.zig
+++ b/src/terminal/tmux/viewer.zig
@@ -555,12 +555,6 @@ pub const Viewer = struct {
             // track this but acknowledge the notification to avoid warnings.
             .session_window_changed => {},
 
-            // A window was closed or a session-window link changed.
-            // These are currently no-ops; proper handling is pending
-            // viewer correctness work.
-            .window_close => {},
-            .session_window_changed => {},
-
             // This is for other clients, which we don't do anything about.
             // For us, we'll get `exit` or `session_changed`, respectively.
             .client_detached,
@@ -679,7 +673,7 @@ pub const Viewer = struct {
 
         // Replace the old name with the new one.
         if (window.name.len > 0) self.alloc.free(window.name);
-        window.name = try self.alloc.dupe(u8, new_name);
+        window.name = if (new_name.len > 0) try self.alloc.dupe(u8, new_name) else "";
 
         // Notify the caller that windows changed so it can refresh.
         var arena = self.action_arena.promote(self.alloc);
@@ -988,7 +982,7 @@ pub const Viewer = struct {
                 .height = data.window_height,
                 .layout_arena = arena.state,
                 .layout = layout,
-                .name = try self.alloc.dupe(u8, data.window_name),
+                .name = if (data.window_name.len > 0) try self.alloc.dupe(u8, data.window_name) else "",
             });
         }
 
@@ -1236,6 +1230,13 @@ pub const Viewer = struct {
         // Swap in persistent parser state from the pane.
         stream.parser = pane.vt_parser;
         stream.utf8decoder = pane.vt_utf8decoder;
+        // Restore the OSC allocator: pane.vt_parser was created via
+        // VTParser.init() which sets osc_parser.alloc to null. The
+        // stream created above by vtStream/initAlloc had a valid
+        // allocator, but we just overwrote the parser. Without this,
+        // OSC sequences in %output (window titles, semantic prompts)
+        // are silently dropped.
+        stream.parser.osc_parser.alloc = self.alloc;
         defer {
             // DCS/OSC/APC sequences within %output data that span to
             // the end of a message are passthrough sequences meant for
@@ -1614,7 +1615,7 @@ const Format = struct {
             .window_id,
             .window_width,
             .window_height,
-            .window_name,
+            .window_name, // Must not contain the delimiter (';').
             .window_layout,
         },
     };
@@ -2978,4 +2979,115 @@ test "exit notification in command_queue state" {
             }).check,
         },
     });
+}
+
+test "OSC sequences in output are processed with allocator" {
+    // Regression test: pane.vt_parser was initialized via VTParser.init()
+    // which sets osc_parser.alloc to null. When receivedOutput() swaps
+    // this parser into the stream, multi-field OSC sequences (which need
+    // the allocator to set up their writer) were silently discarded.
+    var viewer = try Viewer.init(testing.allocator);
+    defer viewer.deinit();
+
+    try testViewer(&viewer, &.{
+        // Standard initialization
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{
+            .input = .{ .tmux = .{ .session_changed = .{
+                .id = 0,
+                .name = "test",
+            } } },
+            .contains_command = "display-message",
+        },
+        .{
+            .input = .{ .tmux = .{ .block_end = "3.5a" } },
+            .contains_command = "list-windows",
+        },
+        // Single pane layout (100x50, pane 0)
+        .{
+            .input = .{ .tmux = .{
+                .block_end =
+                \\$0;@0;100;50;bash;ac7d,100x50,0,0,0
+                ,
+            } },
+            .contains_tags = &.{ .windows, .command },
+        },
+        // Drain capture-pane (4) + pane_state (1)
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        // Send OSC 4 (set palette color 0 to red) via %output.
+        // OSC 4 requires the allocator for its multi-field parsing.
+        // Without the allocator fix, ensureAllocator() returns false
+        // and the sequence is silently discarded.
+        .{
+            .input = .{ .tmux = .{ .output = .{ .pane_id = 0, .data = "\x1b]4;0;rgb:ff/00/00\x07" } } },
+            .check = (struct {
+                fn check(v: *Viewer, _: []const Viewer.Action) anyerror!void {
+                    const pane: *Viewer.Pane = v.panes.getEntry(0).?.value_ptr;
+                    const t: *Terminal = &pane.terminal;
+                    try testing.expectEqual(@as(u8, 0xff), t.colors.palette.current[0].r);
+                    try testing.expectEqual(@as(u8, 0x00), t.colors.palette.current[0].g);
+                    try testing.expectEqual(@as(u8, 0x00), t.colors.palette.current[0].b);
+                }
+            }).check,
+        },
+        .{
+            .input = .{ .tmux = .exit },
+            .contains_tags = &.{.exit},
+        },
+    });
+}
+
+test "empty window name does not leak on deinit" {
+    // Regression test: receivedListWindows() called alloc.dupe(u8, "")
+    // for empty window names, producing a zero-length allocated slice.
+    // Window.deinit() guards free with `if (name.len > 0)`, so the
+    // allocation was never freed. Now we store "" literal when empty.
+    var viewer = try Viewer.init(testing.allocator);
+    defer viewer.deinit();
+
+    try testViewer(&viewer, &.{
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{
+            .input = .{ .tmux = .{ .session_changed = .{
+                .id = 0,
+                .name = "test",
+            } } },
+            .contains_command = "display-message",
+        },
+        .{
+            .input = .{ .tmux = .{ .block_end = "3.5a" } },
+            .contains_command = "list-windows",
+        },
+        // Window with empty name (field between the two ';' delimiters is empty)
+        .{
+            .input = .{ .tmux = .{
+                .block_end =
+                \\$0;@0;100;50;;ac7d,100x50,0,0,0
+                ,
+            } },
+            .contains_tags = &.{ .windows, .command },
+            .check = (struct {
+                fn check(v: *Viewer, _: []const Viewer.Action) anyerror!void {
+                    try testing.expectEqual(1, v.windows.items.len);
+                    try testing.expectEqualStrings("", v.windows.items[0].name);
+                }
+            }).check,
+        },
+        // Drain capture-pane (4) + pane_state (1)
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{
+            .input = .{ .tmux = .exit },
+            .contains_tags = &.{.exit},
+        },
+    });
+    // If the empty name was incorrectly duped, testing.allocator
+    // will report a memory leak and fail this test.
 }

--- a/src/terminal/tmux/viewer.zig
+++ b/src/terminal/tmux/viewer.zig
@@ -518,6 +518,12 @@ pub const Viewer = struct {
             // We don't use window names for anything, currently.
             .window_renamed => {},
 
+            // A window was closed or a session-window link changed.
+            // These are currently no-ops; proper handling is pending
+            // viewer correctness work.
+            .window_close => {},
+            .session_window_changed => {},
+
             // This is for other clients, which we don't do anything about.
             // For us, we'll get `exit` or `session_changed`, respectively.
             .client_detached,

--- a/src/terminal/tmux/viewer.zig
+++ b/src/terminal/tmux/viewer.zig
@@ -8,7 +8,9 @@ const CircBuf = @import("../../datastruct/main.zig").CircBuf;
 const CursorStyle = @import("../cursor.zig").Style;
 const Screen = @import("../Screen.zig");
 const ScreenSet = @import("../ScreenSet.zig");
+const VTParser = @import("../Parser.zig");
 const Terminal = @import("../Terminal.zig");
+const UTF8Decoder = @import("../UTF8Decoder.zig");
 const Layout = @import("layout.zig").Layout;
 const control = @import("control.zig");
 const output = @import("output.zig");
@@ -247,8 +249,12 @@ pub const Viewer = struct {
         height: usize,
         layout_arena: ArenaAllocator.State,
         layout: Layout,
+        /// The window name (e.g., "bash", "vim"). Owned by the Viewer's
+        /// allocator (duped from tmux output). Empty string if unknown.
+        name: []const u8,
 
         pub fn deinit(self: *Window, alloc: Allocator) void {
+            if (self.name.len > 0) alloc.free(self.name);
             self.layout_arena.promote(alloc).deinit();
         }
     };
@@ -256,7 +262,14 @@ pub const Viewer = struct {
     pub const Pane = struct {
         terminal: Terminal,
 
+        /// Persistent VT parser state for %output processing.
+        /// Without this, CSI sequences split across %output messages
+        /// lose parser state and render as literal text.
+        vt_parser: VTParser = .init(),
+        vt_utf8decoder: UTF8Decoder = .{},
+
         pub fn deinit(self: *Pane, alloc: Allocator) void {
+            self.vt_parser.deinit();
             self.terminal.deinit(alloc);
         }
     };
@@ -515,8 +528,32 @@ pub const Viewer = struct {
             // care.
             .sessions_changed => {},
 
-            // We don't use window names for anything, currently.
-            .window_renamed => {},
+            // Window was renamed. Update our stored name and notify the caller.
+            .window_renamed => |info| {
+                self.windowRenamed(
+                    &actions,
+                    info.id,
+                    info.name,
+                ) catch {
+                    log.warn("failed to handle window rename, becoming defunct", .{});
+                    return self.defunct();
+                };
+            },
+
+            // Window was closed. Remove it and any orphaned panes.
+            .window_close => |info| {
+                self.windowClose(
+                    &actions,
+                    info.id,
+                ) catch {
+                    log.warn("failed to handle window close, becoming defunct", .{});
+                    return self.defunct();
+                };
+            },
+
+            // The active window in our session changed. We don't currently
+            // track this but acknowledge the notification to avoid warnings.
+            .session_window_changed => {},
 
             // A window was closed or a session-window link changed.
             // These are currently no-ops; proper handling is pending
@@ -624,6 +661,61 @@ pub const Viewer = struct {
 
         // Queue list-windows to get the updated window list
         try self.queueCommands(&.{.list_windows});
+    }
+
+    /// When a window is renamed, update the stored name and notify callers.
+    fn windowRenamed(
+        self: *Viewer,
+        actions: *std.ArrayList(Action),
+        window_id: usize,
+        new_name: []const u8,
+    ) !void {
+        const window: *Window = window: for (self.windows.items) |*w| {
+            if (w.id == window_id) break :window w;
+        } else {
+            log.info("window rename for unknown window id={}", .{window_id});
+            return;
+        };
+
+        // Replace the old name with the new one.
+        if (window.name.len > 0) self.alloc.free(window.name);
+        window.name = try self.alloc.dupe(u8, new_name);
+
+        // Notify the caller that windows changed so it can refresh.
+        var arena = self.action_arena.promote(self.alloc);
+        defer self.action_arena = arena.state;
+        try actions.append(arena.allocator(), .{ .windows = self.windows.items });
+    }
+
+    /// When a window is closed, remove it from our list, prune any panes
+    /// that are no longer referenced by any remaining window layout, and
+    /// emit a `.windows` action.
+    fn windowClose(
+        self: *Viewer,
+        actions: *std.ArrayList(Action),
+        window_id: usize,
+    ) !void {
+        // Find and remove the window.
+        const idx: ?usize = idx: for (self.windows.items, 0..) |*w, i| {
+            if (w.id == window_id) break :idx i;
+        } else null;
+
+        if (idx) |i| {
+            var window = self.windows.orderedRemove(i);
+            window.deinit(self.alloc);
+        } else {
+            log.info("window close for unknown window id={}", .{window_id});
+            return;
+        }
+
+        // Sync layouts to prune orphaned panes. This re-evaluates which
+        // panes are still referenced by remaining windows.
+        try self.syncLayouts(self.windows.items);
+
+        // Notify the caller.
+        var arena = self.action_arena.promote(self.alloc);
+        defer self.action_arena = arena.state;
+        try actions.append(arena.allocator(), .{ .windows = self.windows.items });
     }
 
     fn syncLayouts(
@@ -786,7 +878,7 @@ pub const Viewer = struct {
             ),
         } else {
             // If we have no pending commands, this is unexpected.
-            log.info("unexpected block output err={}", .{is_err});
+            log.debug("unexpected block output err={}", .{is_err});
             return;
         };
         self.command_queue.deleteOldest(1);
@@ -896,12 +988,17 @@ pub const Viewer = struct {
                 .height = data.window_height,
                 .layout_arena = arena.state,
                 .layout = layout,
+                .name = try self.alloc.dupe(u8, data.window_name),
             });
         }
 
         // Setup our windows action so the caller can process GUI
-        // window changes.
-        try actions.append(arena_alloc, .{ .windows = windows.items });
+        // window changes. We must dupe into the arena because `windows`
+        // is a local ArrayList whose backing memory is freed by defer
+        // when this function returns. Without the dupe, the action
+        // would hold a dangling pointer (use-after-free).
+        const arena_windows = try arena_alloc.dupe(Window, windows.items);
+        try actions.append(arena_alloc, .{ .windows = arena_windows });
 
         // Sync up our layouts. This will populate unknown panes, prune, etc.
         try self.syncLayouts(windows.items);
@@ -935,6 +1032,13 @@ pub const Viewer = struct {
 
             // Determine which screen to use based on alternate_on
             const screen_key: ScreenSet.Key = if (data.alternate_on) .alternate else .primary;
+
+            // Switch the terminal to the correct active screen. The capture-pane
+            // sequence leaves the terminal on the alternate screen (because it
+            // captures alternate last), so we must restore the correct screen here.
+            // Without this, the renderer would show the alternate screen (blank for
+            // a normal shell), and subsequent %output would write to the wrong screen.
+            _ = try t.switchScreen(screen_key);
 
             // Set cursor position on the appropriate screen (tmux uses 0-based)
             if (t.screens.get(screen_key)) |screen| {
@@ -1121,8 +1225,58 @@ pub const Viewer = struct {
         const pane: *Pane = entry.value_ptr;
         const t: *Terminal = &pane.terminal;
 
+        // Use pane's persistent parser state to handle CSI sequences
+        // that span multiple %output messages. We start with the
+        // standard vtStream() (which produces a correctly-initialized
+        // ReadonlyStream with a fresh parser in ground state), then
+        // swap in the pane's saved parser/utf8decoder. After processing
+        // we save the parser state back and hand deinit a fresh parser
+        // so it only frees that throw-away instance.
         var stream = t.vtStream();
-        defer stream.deinit();
+        // Swap in persistent parser state from the pane.
+        stream.parser = pane.vt_parser;
+        stream.utf8decoder = pane.vt_utf8decoder;
+        defer {
+            // DCS/OSC/APC sequences within %output data that span to
+            // the end of a message are passthrough sequences meant for
+            // the outer terminal, not for this pane. The ReadonlyStream
+            // handler ignores them anyway, but the parser would remain
+            // trapped in an absorbing state across messages if we
+            // persisted it as-is (dcs_passthrough in particular can
+            // only be exited by the 8-bit C1 ST, which tmux never
+            // sends in 7-bit control mode). Reset to ground so the
+            // next message starts clean.
+            //
+            // CSI/escape states are safe to persist: they are
+            // short-lived and exit on the next final byte, which is
+            // the exact split-sequence case we need to handle.
+            switch (stream.parser.state) {
+                .dcs_passthrough,
+                .dcs_entry,
+                .dcs_param,
+                .dcs_intermediate,
+                .dcs_ignore,
+                .sos_pm_apc_string,
+                => {
+                    stream.parser.state = .ground;
+                    stream.parser.clear();
+                },
+                .osc_string => {
+                    stream.parser.osc_parser.reset();
+                    stream.parser.state = .ground;
+                    stream.parser.clear();
+                },
+                else => {},
+            }
+
+            // Save updated parser state back to the pane.
+            pane.vt_parser = stream.parser;
+            pane.vt_utf8decoder = stream.utf8decoder;
+            // Give deinit a fresh parser to clean up (prevents it
+            // from freeing the parser we just saved to the pane).
+            stream.parser = .init();
+            stream.deinit();
+        }
         stream.nextSlice(data) catch |err| {
             log.info("failed to process output for pane id={}: {}", .{ id, err });
             return err;
@@ -1158,15 +1312,62 @@ pub const Viewer = struct {
                 // so just copy it over.
                 if (panes_old.getEntry(id)) |entry| {
                     gop.value_ptr.* = entry.value_ptr.*;
+
+                    // Resize the pane terminal if tmux assigned it new
+                    // dimensions (e.g. after refresh-client -C). Without
+                    // this, the pane's Terminal grid stays at its old size
+                    // and output is rendered with the wrong dimensions.
+                    const new_cols: size.CellCountInt = std.math.cast(
+                        size.CellCountInt,
+                        layout.width,
+                    ) orelse {
+                        log.warn("pane {} layout width {} overflows CellCountInt, skipping", .{ id, layout.width });
+                        _ = panes_new.swapRemove(gop.key_ptr.*);
+                        break :pane;
+                    };
+                    const new_rows: size.CellCountInt = std.math.cast(
+                        size.CellCountInt,
+                        layout.height,
+                    ) orelse {
+                        log.warn("pane {} layout height {} overflows CellCountInt, skipping", .{ id, layout.height });
+                        _ = panes_new.swapRemove(gop.key_ptr.*);
+                        break :pane;
+                    };
+                    if (gop.value_ptr.terminal.cols != new_cols or
+                        gop.value_ptr.terminal.rows != new_rows)
+                    {
+                        try gop.value_ptr.terminal.resize(
+                            gpa_alloc,
+                            new_cols,
+                            new_rows,
+                        );
+                    }
+
                     break :pane;
                 }
 
-                // TODO: We need to gracefully handle overflow of our
-                // max cols/width here. In practice we shouldn't hit this
-                // so we cast but its not safe.
+                // Validate layout dimensions fit in CellCountInt before
+                // creating the terminal. Oversized dimensions from a
+                // corrupted or adversarial layout would panic on @intCast.
+                const cols: size.CellCountInt = std.math.cast(
+                    size.CellCountInt,
+                    layout.width,
+                ) orelse {
+                    log.warn("pane {} layout width {} overflows CellCountInt, skipping", .{ id, layout.width });
+                    _ = panes_new.swapRemove(gop.key_ptr.*);
+                    break :pane;
+                };
+                const rows: size.CellCountInt = std.math.cast(
+                    size.CellCountInt,
+                    layout.height,
+                ) orelse {
+                    log.warn("pane {} layout height {} overflows CellCountInt, skipping", .{ id, layout.height });
+                    _ = panes_new.swapRemove(gop.key_ptr.*);
+                    break :pane;
+                };
                 var t: Terminal = try .init(gpa_alloc, .{
-                    .cols = @intCast(layout.width),
-                    .rows = @intCast(layout.height),
+                    .cols = cols,
+                    .rows = rows,
                 });
                 errdefer t.deinit(gpa_alloc);
 
@@ -1407,12 +1608,13 @@ const Format = struct {
     };
 
     const list_windows: Format = .{
-        .delim = ' ',
+        .delim = ';',
         .vars = &.{
             .session_id,
             .window_id,
             .window_width,
             .window_height,
+            .window_name,
             .window_layout,
         },
     };
@@ -1551,7 +1753,7 @@ test "session changed resets state" {
         .{
             .input = .{ .tmux = .{
                 .block_end =
-                \\$1 @0 83 44 027b,83x44,0,0[83x20,0,0,0,83x23,0,21,1]
+                \\$1;@0;83;44;bash;027b,83x44,0,0[83x20,0,0,0,83x23,0,21,1]
                 ,
             } },
             .contains_tags = &.{ .windows, .command },
@@ -1598,7 +1800,7 @@ test "session changed resets state" {
         .{
             .input = .{ .tmux = .{
                 .block_end =
-                \\$2 @1 83 44 027b,83x44,0,0[83x20,0,0,0,83x23,0,21,1]
+                \\$2;@1;83;44;bash;027b,83x44,0,0[83x20,0,0,0,83x23,0,21,1]
                 ,
             } },
             .contains_tags = &.{ .windows, .command },
@@ -1650,7 +1852,7 @@ test "initial flow" {
         .{
             .input = .{ .tmux = .{
                 .block_end =
-                \\$0 @0 83 44 027b,83x44,0,0[83x20,0,0,0,83x23,0,21,1]
+                \\$0;@0;83;44;bash;027b,83x44,0,0[83x20,0,0,0,83x23,0,21,1]
                 ,
             } },
             .contains_tags = &.{ .windows, .command },
@@ -1823,7 +2025,7 @@ test "layout change" {
         .{
             .input = .{ .tmux = .{
                 .block_end =
-                \\$0 @0 83 44 b7dd,83x44,0,0,0
+                \\$0;@0;83;44;bash;b7dd,83x44,0,0,0
                 ,
             } },
             .contains_tags = &.{ .windows, .command },
@@ -1894,7 +2096,7 @@ test "layout_change does not return command when queue not empty" {
         .{
             .input = .{ .tmux = .{
                 .block_end =
-                \\$0 @0 83 44 b7dd,83x44,0,0,0
+                \\$0;@0;83;44;bash;b7dd,83x44,0,0,0
                 ,
             } },
             .contains_tags = &.{ .windows, .command },
@@ -1955,7 +2157,7 @@ test "layout_change returns command when queue was empty" {
         .{
             .input = .{ .tmux = .{
                 .block_end =
-                \\$0 @0 83 44 b7dd,83x44,0,0,0
+                \\$0;@0;83;44;bash;b7dd,83x44,0,0,0
                 ,
             } },
             .contains_tags = &.{ .windows, .command },
@@ -2022,7 +2224,7 @@ test "window_add queues list_windows when queue empty" {
         .{
             .input = .{ .tmux = .{
                 .block_end =
-                \\$0 @0 83 44 b7dd,83x44,0,0,0
+                \\$0;@0;83;44;bash;b7dd,83x44,0,0,0
                 ,
             } },
             .contains_tags = &.{ .windows, .command },
@@ -2083,7 +2285,7 @@ test "window_add queues list_windows when queue not empty" {
         .{
             .input = .{ .tmux = .{
                 .block_end =
-                \\$0 @0 83 44 b7dd,83x44,0,0,0
+                \\$0;@0;83;44;bash;b7dd,83x44,0,0,0
                 ,
             } },
             .contains_tags = &.{ .windows, .command },
@@ -2145,7 +2347,7 @@ test "two pane flow with pane state" {
         .{
             .input = .{ .tmux = .{
                 .block_end =
-                \\$0 @0 165 79 ca97,165x79,0,0[165x40,0,0,0,165x38,0,41,4]
+                \\$0;@0;165;79;bash;ca97,165x79,0,0[165x40,0,0,0,165x38,0,41,4]
                 ,
             } },
             .contains_tags = &.{ .windows, .command },
@@ -2293,6 +2495,487 @@ test "two pane flow with pane state" {
         .{
             .input = .{ .tmux = .exit },
             .contains_tags = &.{.exit},
+        },
+    });
+}
+
+test "window name from list-windows" {
+    var viewer = try Viewer.init(testing.allocator);
+    defer viewer.deinit();
+
+    try testViewer(&viewer, &.{
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{
+            .input = .{ .tmux = .{ .session_changed = .{
+                .id = 1,
+                .name = "test",
+            } } },
+            .contains_command = "display-message",
+        },
+        .{
+            .input = .{ .tmux = .{ .block_end = "3.5a" } },
+            .contains_command = "list-windows",
+        },
+        // list-windows output with window name "vim"
+        .{
+            .input = .{ .tmux = .{
+                .block_end =
+                \\$1;@0;83;44;vim;b7dd,83x44,0,0,0
+                ,
+            } },
+            .contains_tags = &.{ .windows, .command },
+            .check = (struct {
+                fn check(v: *Viewer, _: []const Viewer.Action) anyerror!void {
+                    try testing.expectEqual(1, v.windows.items.len);
+                    const window = v.windows.items[0];
+                    try testing.expectEqualStrings("vim", window.name);
+                }
+            }).check,
+        },
+        .{
+            .input = .{ .tmux = .exit },
+            .contains_tags = &.{.exit},
+        },
+    });
+}
+
+test "window_renamed updates name" {
+    var viewer = try Viewer.init(testing.allocator);
+    defer viewer.deinit();
+
+    try testViewer(&viewer, &.{
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{
+            .input = .{ .tmux = .{ .session_changed = .{
+                .id = 1,
+                .name = "test",
+            } } },
+            .contains_command = "display-message",
+        },
+        .{
+            .input = .{ .tmux = .{ .block_end = "3.5a" } },
+            .contains_command = "list-windows",
+        },
+        .{
+            .input = .{ .tmux = .{
+                .block_end =
+                \\$1;@0;83;44;bash;b7dd,83x44,0,0,0
+                ,
+            } },
+            .contains_tags = &.{ .windows, .command },
+        },
+        // Drain capture-pane commands (4 per pane) + pane_state
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        // Now rename the window
+        .{
+            .input = .{ .tmux = .{ .window_renamed = .{
+                .id = 0,
+                .name = "vim",
+            } } },
+            .contains_tags = &.{.windows},
+            .check = (struct {
+                fn check(v: *Viewer, _: []const Viewer.Action) anyerror!void {
+                    try testing.expectEqual(1, v.windows.items.len);
+                    try testing.expectEqualStrings("vim", v.windows.items[0].name);
+                }
+            }).check,
+        },
+        .{
+            .input = .{ .tmux = .exit },
+            .contains_tags = &.{.exit},
+        },
+    });
+}
+
+test "window_close removes window and orphaned panes" {
+    var viewer = try Viewer.init(testing.allocator);
+    defer viewer.deinit();
+
+    try testViewer(&viewer, &.{
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{
+            .input = .{ .tmux = .{ .session_changed = .{
+                .id = 1,
+                .name = "test",
+            } } },
+            .contains_command = "display-message",
+        },
+        .{
+            .input = .{ .tmux = .{ .block_end = "3.5a" } },
+            .contains_command = "list-windows",
+        },
+        // Two windows: @0 with pane 0, @1 with pane 2
+        .{
+            .input = .{ .tmux = .{
+                .block_end =
+                \\$1;@0;83;44;bash;b7dd,83x44,0,0,0
+                \\$1;@1;83;44;vim;b7df,83x44,0,0,2
+                ,
+            } },
+            .contains_tags = &.{ .windows, .command },
+            .check = (struct {
+                fn check(v: *Viewer, _: []const Viewer.Action) anyerror!void {
+                    try testing.expectEqual(2, v.windows.items.len);
+                    try testing.expectEqual(2, v.panes.count());
+                    try testing.expect(v.panes.contains(0));
+                    try testing.expect(v.panes.contains(2));
+                }
+            }).check,
+        },
+        // Drain capture-pane commands (4 per pane * 2 panes + 1 pane_state = 9)
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        // Close window @1, which should remove pane 2
+        .{
+            .input = .{ .tmux = .{ .window_close = .{ .id = 1 } } },
+            .contains_tags = &.{.windows},
+            .check = (struct {
+                fn check(v: *Viewer, _: []const Viewer.Action) anyerror!void {
+                    try testing.expectEqual(1, v.windows.items.len);
+                    try testing.expectEqual(0, v.windows.items[0].id);
+                    // Pane 0 still exists, pane 2 was pruned
+                    try testing.expectEqual(1, v.panes.count());
+                    try testing.expect(v.panes.contains(0));
+                    try testing.expect(!v.panes.contains(2));
+                }
+            }).check,
+        },
+        .{
+            .input = .{ .tmux = .exit },
+            .contains_tags = &.{.exit},
+        },
+    });
+}
+
+test "split CSI across output messages persists parser state" {
+    // Regression test: receivedOutput() used to create a fresh VT parser
+    // on every %output message. When tmux splits a CSI sequence across
+    // two messages (e.g., ESC[32 | mX), the second message's leading 'm'
+    // was printed as literal text instead of completing the SGR sequence.
+    var viewer = try Viewer.init(testing.allocator);
+    defer viewer.deinit();
+
+    try testViewer(&viewer, &.{
+        // Standard initialization
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{
+            .input = .{ .tmux = .{ .session_changed = .{
+                .id = 0,
+                .name = "test",
+            } } },
+            .contains_command = "display-message",
+        },
+        .{
+            .input = .{ .tmux = .{ .block_end = "3.5a" } },
+            .contains_command = "list-windows",
+        },
+        // Single pane layout (83x44, pane 0)
+        .{
+            .input = .{ .tmux = .{
+                .block_end =
+                \\$0;@0;83;44;bash;b7dd,83x44,0,0,0
+                ,
+            } },
+            .contains_tags = &.{ .windows, .command },
+        },
+        // Drain capture-pane (4) + pane_state (1)
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        // First %output: ESC[32  (incomplete CSI — continues in next message)
+        .{
+            .input = .{ .tmux = .{ .output = .{ .pane_id = 0, .data = "\x1b[32" } } },
+            .check = (struct {
+                fn check(_: *Viewer, actions: []const Viewer.Action) anyerror!void {
+                    try testing.expectEqual(0, actions.len);
+                }
+            }).check,
+        },
+        // Second %output: mX  (completes ESC[32m = SGR green, then prints 'X')
+        .{
+            .input = .{ .tmux = .{ .output = .{ .pane_id = 0, .data = "mX" } } },
+            .check = (struct {
+                fn check(v: *Viewer, _: []const Viewer.Action) anyerror!void {
+                    const pane: *Viewer.Pane = v.panes.getEntry(0).?.value_ptr;
+                    const screen: *Screen = pane.terminal.screens.active;
+                    // The cell at (0,0) should contain 'X'
+                    const str = try screen.dumpStringAlloc(
+                        testing.allocator,
+                        .{ .active = .{} },
+                    );
+                    defer testing.allocator.free(str);
+                    try testing.expect(std.mem.startsWith(u8, str, "X"));
+                    // Verify 'X' has green foreground (SGR 32 = palette index 2)
+                    const list_cell = screen.pages.getCell(.{ .active = .{ .x = 0, .y = 0 } }).?;
+                    const cell_style = list_cell.style();
+                    try testing.expectEqual(
+                        @as(@TypeOf(cell_style.fg_color), .{ .palette = 2 }),
+                        cell_style.fg_color,
+                    );
+                    // The literal 'm' should NOT be on screen
+                    try testing.expect(!std.mem.startsWith(u8, str, "m"));
+                }
+            }).check,
+        },
+        .{
+            .input = .{ .tmux = .exit },
+            .contains_tags = &.{.exit},
+        },
+    });
+}
+
+test "pane resize on layout change" {
+    var viewer = try Viewer.init(testing.allocator);
+    defer viewer.deinit();
+
+    try testViewer(&viewer, &.{
+        // Standard initialization
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{
+            .input = .{ .tmux = .{ .session_changed = .{
+                .id = 1,
+                .name = "test",
+            } } },
+            .contains_command = "display-message",
+        },
+        .{
+            .input = .{ .tmux = .{ .block_end = "3.5a" } },
+            .contains_command = "list-windows",
+        },
+        // Initial layout: 83x44
+        .{
+            .input = .{ .tmux = .{
+                .block_end =
+                \\$1;@0;83;44;bash;b7dd,83x44,0,0,0
+                ,
+            } },
+            .contains_tags = &.{ .windows, .command },
+            .check = (struct {
+                fn check(v: *Viewer, _: []const Viewer.Action) anyerror!void {
+                    const pane: *Viewer.Pane = v.panes.getEntry(0).?.value_ptr;
+                    try testing.expectEqual(83, pane.terminal.cols);
+                    try testing.expectEqual(44, pane.terminal.rows);
+                }
+            }).check,
+        },
+        // Drain capture-pane (4) + pane_state (1)
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        // Layout change: resize to 100x50
+        .{
+            .input = .{ .tmux = .{ .layout_change = .{
+                .window_id = 0,
+                .layout = "ac7d,100x50,0,0,0",
+                .visible_layout = "ac7d,100x50,0,0,0",
+                .raw_flags = "*",
+            } } },
+            .contains_tags = &.{.windows},
+            .check = (struct {
+                fn check(v: *Viewer, _: []const Viewer.Action) anyerror!void {
+                    const pane: *Viewer.Pane = v.panes.getEntry(0).?.value_ptr;
+                    try testing.expectEqual(100, pane.terminal.cols);
+                    try testing.expectEqual(50, pane.terminal.rows);
+                }
+            }).check,
+        },
+        .{
+            .input = .{ .tmux = .exit },
+            .contains_tags = &.{.exit},
+        },
+    });
+}
+
+test "pane state switches to correct screen" {
+    // After capture-pane fills both primary and alternate screens,
+    // the terminal is left on the alternate screen (captured last).
+    // receivedPaneState should switch to the correct active screen
+    // based on the alternate_on flag.
+    var viewer = try Viewer.init(testing.allocator);
+    defer viewer.deinit();
+
+    try testViewer(&viewer, &.{
+        // Standard initialization
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{
+            .input = .{ .tmux = .{ .session_changed = .{
+                .id = 0,
+                .name = "test",
+            } } },
+            .contains_command = "display-message",
+        },
+        .{
+            .input = .{ .tmux = .{ .block_end = "3.5a" } },
+            .contains_command = "list-windows",
+        },
+        // Single pane
+        .{
+            .input = .{ .tmux = .{
+                .block_end =
+                \\$0;@0;83;44;bash;b7dd,83x44,0,0,0
+                ,
+            } },
+            .contains_tags = &.{ .windows, .command },
+        },
+        // Drain capture-pane (4) — feed some content to primary visible
+        .{ .input = .{ .tmux = .{ .block_end = "" } } }, // primary history
+        .{
+            .input = .{ .tmux = .{
+                .block_end =
+                \\primary content
+                ,
+            } },
+        }, // primary visible
+        .{ .input = .{ .tmux = .{ .block_end = "" } } }, // alternate history
+        .{
+            .input = .{ .tmux = .{
+                .block_end =
+                \\alternate content
+                ,
+            } },
+        }, // alternate visible
+        // pane_state: alternate_on=0 means primary is active
+        .{
+            .input = .{ .tmux = .{
+                .block_end =
+                \\%0;0;0;0;;;;0;4294967295;4294967295;0;1;0;0;0;0;0;0;0;0;0;;;0;24;
+                ,
+            } },
+            .check = (struct {
+                fn check(v: *Viewer, _: []const Viewer.Action) anyerror!void {
+                    const pane: *Viewer.Pane = v.panes.getEntry(0).?.value_ptr;
+                    const t: *Terminal = &pane.terminal;
+                    // After pane_state with alternate_on=0, active screen
+                    // should be primary
+                    try testing.expectEqual(ScreenSet.Key.primary, t.screens.active_key);
+                }
+            }).check,
+        },
+        .{
+            .input = .{ .tmux = .exit },
+            .contains_tags = &.{.exit},
+        },
+    });
+}
+
+test "session_window_changed is handled without error" {
+    var viewer = try Viewer.init(testing.allocator);
+    defer viewer.deinit();
+
+    try testViewer(&viewer, &.{
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{
+            .input = .{ .tmux = .{ .session_changed = .{
+                .id = 1,
+                .name = "test",
+            } } },
+            .contains_command = "display-message",
+        },
+        .{
+            .input = .{ .tmux = .{ .block_end = "3.5a" } },
+            .contains_command = "list-windows",
+        },
+        .{
+            .input = .{ .tmux = .{
+                .block_end =
+                \\$1;@0;83;44;bash;b7dd,83x44,0,0,0
+                ,
+            } },
+            .contains_tags = &.{ .windows, .command },
+        },
+        // Drain capture-pane (4) + pane_state (1)
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        // session_window_changed should be handled without error
+        .{
+            .input = .{ .tmux = .{ .session_window_changed = .{
+                .session_id = 1,
+                .window_id = 0,
+            } } },
+            .check = (struct {
+                fn check(v: *Viewer, actions: []const Viewer.Action) anyerror!void {
+                    // Should not produce any actions and viewer should
+                    // still be operational (not defunct)
+                    try testing.expectEqual(0, actions.len);
+                    try testing.expect(v.state == .command_queue);
+                }
+            }).check,
+        },
+        .{
+            .input = .{ .tmux = .exit },
+            .contains_tags = &.{.exit},
+        },
+    });
+}
+
+test "exit notification in command_queue state" {
+    var viewer = try Viewer.init(testing.allocator);
+    defer viewer.deinit();
+
+    try testViewer(&viewer, &.{
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{
+            .input = .{ .tmux = .{ .session_changed = .{
+                .id = 1,
+                .name = "test",
+            } } },
+            .contains_command = "display-message",
+        },
+        .{
+            .input = .{ .tmux = .{ .block_end = "3.5a" } },
+            .contains_command = "list-windows",
+        },
+        .{
+            .input = .{ .tmux = .{
+                .block_end =
+                \\$1;@0;83;44;bash;b7dd,83x44,0,0,0
+                ,
+            } },
+            .contains_tags = &.{ .windows, .command },
+        },
+        // Drain capture-pane (4) + pane_state (1)
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        .{ .input = .{ .tmux = .{ .block_end = "" } } },
+        // Now in command_queue state with no pending commands.
+        // Exit should transition to defunct and emit .exit action.
+        .{
+            .input = .{ .tmux = .exit },
+            .contains_tags = &.{.exit},
+            .check = (struct {
+                fn check(v: *Viewer, _: []const Viewer.Action) anyerror!void {
+                    try testing.expect(v.state == .defunct);
+                }
+            }).check,
+        },
+        // After defunct, further inputs produce no actions.
+        .{
+            .input = .{ .tmux = .exit },
+            .check = (struct {
+                fn check(_: *Viewer, actions: []const Viewer.Action) anyerror!void {
+                    try testing.expectEqual(0, actions.len);
+                }
+            }).check,
         },
     });
 }


### PR DESCRIPTION
## Summary

Multiple correctness fixes for the tmux control mode viewer that are necessary for end-to-end operation: persistent VT parser state across `%output` messages, window name tracking, screen restoration after capture-pane, pane resizing on layout changes, and handlers for `%window-renamed`, `%window-close`, and `%session-window-changed` notifications.

> **Depends on PR #11217** (`fix/tmux-control-mode-parsing`) for `Notification` variants (`window_close`, `session_window_changed`, `exit`), `Parser.unescapeOctal()`, and `Variable.window_name`.

## Changes

**Persistent VT parser state:**
- Add `vt_parser` and `vt_utf8decoder` fields to `Pane` struct so parser state persists across `%output` messages
- `receivedOutput` swaps in the pane's parser before processing and saves state back in `defer`
- Resets DCS/OSC/APC absorbing states to ground between messages (CSI/escape states are safe to persist)
- Without this, tmux splitting a CSI sequence across two `%output` messages (e.g. `ESC[32` | `mX`) caused the second message's `m` to print as literal text instead of completing the SGR

**Window name tracking:**
- Add `name` field to `Window` struct, parsed from `list-windows` output
- Update `list-windows` format to use semicolon delimiter and include `window_name` variable
- Add `windowRenamed` handler: updates stored name, emits `.windows` action
- Update all existing test data strings to match new 6-field semicolon-delimited format

**Window close handling:**
- Add `windowClose` handler: finds and removes window by ID, calls `syncLayouts` to prune orphaned panes, emits `.windows` action

**Screen restoration:**
- `receivedPaneState` now calls `switchScreen()` based on the `alternate_on` flag
- The capture-pane sequence leaves the terminal on the alternate screen (captured last); without switching back, the renderer shows a blank alternate screen for normal shell panes

**Pane resize:**
- `initLayout` now calls `terminal.resize()` when an existing pane's dimensions change
- Replace `@intCast` with `std.math.cast` for safe overflow handling (graceful skip instead of panic)

**Other:**
- Handle `session_window_changed` as acknowledged no-op (prevents "unexpected notification" warnings)
- Use arena-duped window slice in `receivedListWindows` to prevent use-after-free (same fix as #11213, needed here since this branch doesn't include that commit)
- Change "unexpected block output" log level from `info` to `debug`

## Tests

8 new tests:

| Test | What it verifies |
|---|---|
| `window name from list-windows` | Window name parsed from semicolon-delimited format |
| `window_renamed updates name` | Handler updates stored name, emits `.windows` |
| `window_close removes window and orphaned panes` | Two windows → close one → remaining window and panes correct |
| `split CSI across output messages persists parser state` | `ESC[32` + `mX` across two `%output` → SGR green applied, no literal `m` |
| `pane resize on layout change` | 83×44 → layout_change to 100×50 → terminal resized |
| `pane state switches to correct screen` | After capture-pane, `alternate_on=0` → primary screen active |
| `session_window_changed is handled without error` | Notification processed without viewer becoming defunct |
| `exit notification in command_queue state` | `%exit` during normal operation → defunct + `.exit` action |

All existing viewer tests continue to pass.

## Context

Found while building tmux control mode support in [Geistty](https://github.com/daiimus/geistty), an iOS SSH terminal using Ghostty as its rendering engine ([fork](https://github.com/daiimus/ghostty/tree/ios-external-backend)). These fixes were discovered by connecting the viewer to a real GUI and observing the failures: blank screens (wrong active screen), garbled SGR colors (parser state lost between messages), and unhandled notifications causing the viewer to go defunct.

This is a prerequisite for #1935 (tmux control mode support).

## AI Disclosure

Fix was developed with Claude Code assistance. I understand the changes: the persistent parser fix stores `VTParser` and `UTF8Decoder` on the `Pane` struct and swaps them into `receivedOutput`'s local processing loop, saving state back via `defer`. The absorbing-state reset (DCS/OSC/APC → ground) is necessary because these states accumulate unbounded data and would leak across messages, while CSI/escape states are bounded and safe to persist. The `windowClose` handler calls `syncLayouts` to diff the layout's pane set against the live pane map, which handles cascading cleanup of panes that belonged to the closed window. The screen switch in `receivedPaneState` is needed because the capture-pane command sequence captures alternate last, leaving the terminal's active screen set to alternate regardless of what the pane was actually using.