### PR TITLE
elvish: improve OSC 133 semantic prompt support

### DIFF
--- a/src/shell-integration/elvish/lib/ghostty-integration.elv
+++ b/src/shell-integration/elvish/lib/ghostty-integration.elv
@@ -11,15 +11,16 @@
   # List of enabled shell integration features
   var features = [(str:split ',' $E:GHOSTTY_SHELL_FEATURES)]
 
-  # helper used by `mark-*` functions
+  # State tracking for semantic prompt sequences
+  # Values: 'prompt-start', 'pre-exec', 'post-exec'
   fn set-prompt-state {|new| set-env __ghostty_prompt_state $new }
 
   fn mark-prompt-start {
-    if (not-eq prompt-start (constantly $E:__ghostty_prompt_state)) {
-      printf "\e]133;D\a"
+    if (not-eq $E:__ghostty_prompt_state 'prompt-start') {
+      printf "\e]133;D;aid="$pid"\a"
     }
     set-prompt-state 'prompt-start'
-    printf "\e]133;A\a"
+    printf "\e]133;A;aid="$pid"\a"
   }
 
   fn mark-output-start {|_|
@@ -44,8 +45,14 @@
       }
     }
 
-    printf "\e]133;D;"$exit-status"\a"
+    printf "\e]133;D;"$exit-status";aid="$pid"\a"
   }
+
+  # NOTE: OSC 133;B (end of prompt, start of input) cannot be reliably
+  # implemented at the script level in Elvish. The prompt function's output is
+  # escaped, and writing to /dev/tty has timing issues because Elvish renders
+  # its prompts on a background thread. Full semantic prompt support requires a
+  # native implementation: https://github.com/elves/elvish/pull/1917
 
   fn sudo-with-terminfo {|@args|
     var sudoedit = $false


### PR DESCRIPTION
Add `aid=$pid` to 133;A and 133;D for nested shell tracking, and fix the state comparison which was incorrectly using `constantly` (comparing a string to a function, which always evaluated to true).

OSC 133;B (input start) and 133;P;k=r (right prompt) cannot be reliably implemented at the script level because Elvish escapes control characters in prompt function output, and writing directly to /dev/tty has timing issues because Elvish renders its prompts on a background thread. Full semantic prompt support requires a native implementation: https://github.com/elves/elvish/pull/1917

See: #10523