### PR TITLE
GTK: Don't apply unfocused options when searching

### DIFF
--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -822,11 +822,19 @@ pub const Surface = extern struct {
     /// Callback used to determine whether unfocused-split-fill / unfocused-split-opacity
     /// should be applied to the surface
     fn closureShouldUnfocusedSplitBeShown(
-        _: *Self,
+        self: *Self,
         focused: c_int,
         is_split: c_int,
     ) callconv(.c) c_int {
-        return @intFromBool(focused == 0 and is_split != 0);
+        const priv = self.private();
+        var val = gobject.ext.Value.new(bool);
+        defer val.unset();
+        gobject.Object.getProperty(
+            priv.search_overlay.as(gobject.Object),
+            SearchOverlay.properties.active.name,
+            &val,
+        );
+        return @intFromBool(val.getBoolean() == 0 and focused == 0 and is_split != 0);
     }
 
     pub fn toggleFullscreen(self: *Self) void {

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -822,19 +822,12 @@ pub const Surface = extern struct {
     /// Callback used to determine whether unfocused-split-fill / unfocused-split-opacity
     /// should be applied to the surface
     fn closureShouldUnfocusedSplitBeShown(
-        self: *Self,
+        _: *Self,
+        search_active: c_int,
         focused: c_int,
         is_split: c_int,
     ) callconv(.c) c_int {
-        const priv = self.private();
-        var val = gobject.ext.Value.new(bool);
-        defer val.unset();
-        gobject.Object.getProperty(
-            priv.search_overlay.as(gobject.Object),
-            SearchOverlay.properties.active.name,
-            &val,
-        );
-        return @intFromBool(val.getBoolean() == 0 and focused == 0 and is_split != 0);
+        return @intFromBool(search_active == 0 and focused == 0 and is_split != 0);
     }
 
     pub fn toggleFullscreen(self: *Self) void {

--- a/src/apprt/gtk/ui/1.2/surface.blp
+++ b/src/apprt/gtk/ui/1.2/surface.blp
@@ -203,7 +203,7 @@ Overlay terminal_page {
   // Apply unfocused-split-fill and unfocused-split-opacity to current surface
   // this is only applied when a tab has more than one surface
   Revealer {
-    reveal-child: bind $should_unfocused_split_be_shown(template.focused, template.is-split) as <bool>;
+    reveal-child: bind $should_unfocused_split_be_shown(search_overlay.active, template.focused, template.is-split) as <bool>;
     transition-duration: 0;
     // This is all necessary so that the Revealer itself doesn't override
     // any input events from the other overlays. Namely, if you don't have


### PR DESCRIPTION
If you have multiple splits and start searching naturally the focus transfers over to the search widget which would apply the unfocused options. This could make it difficult to view your matches from searching without re-focusing the surface.

This was discovered when I tested https://github.com/ghostty-org/ghostty/discussions/11218 (which is a different issue)