### PR TITLE
Update es_AR.po translation for "Unable to acquire an OpenGL context for rendering."

### DIFF
--- a/po/es_AR.po
+++ b/po/es_AR.po
@@ -108,7 +108,7 @@ msgstr "Uy, no."
 
 #: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Unable to acquire an OpenGL context for rendering."
-msgstr "No se puedo obtener un contexto de OpenGL para el renderizado"
+msgstr "No se puede obtener un contexto de OpenGL para el renderizado"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:97
 msgid ""
@@ -116,7 +116,9 @@ msgid ""
 "through the content, but no input events will be sent to the running "
 "application."
 msgstr ""
-"Esta terminal está en modo solo lectura. Aún puedes ver, seleccionar y "
+"/es_AR.po
+
+Ésta terminal está en modo solo lectura. Aún puedes ver, seleccionar y "
 "desplazarte por el contenido, pero no se enviarán los eventos de entrada a "
 "la aplicación en ejecución."
 

--- a/po/es_AR.po
+++ b/po/es_AR.po
@@ -108,7 +108,7 @@ msgstr "Uy, no."
 
 #: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Unable to acquire an OpenGL context for rendering."
-msgstr "No se puede obtener un contexto de OpenGL para el renderizado"
+msgstr "No se pudo obtener un contexto de OpenGL para el renderizado"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:97
 msgid ""

--- a/po/es_AR.po
+++ b/po/es_AR.po
@@ -116,9 +116,7 @@ msgid ""
 "through the content, but no input events will be sent to the running "
 "application."
 msgstr ""
-"/es_AR.po
-
-Esta terminal está en modo solo lectura. Aún puedes ver, seleccionar y "
+"Esta terminal está en modo solo lectura. Aún puedes ver, seleccionar y "
 "desplazarte por el contenido, pero no se enviarán los eventos de entrada a "
 "la aplicación en ejecución."
 

--- a/po/es_AR.po
+++ b/po/es_AR.po
@@ -118,7 +118,7 @@ msgid ""
 msgstr ""
 "/es_AR.po
 
-Ésta terminal está en modo solo lectura. Aún puedes ver, seleccionar y "
+Esta terminal está en modo solo lectura. Aún puedes ver, seleccionar y "
 "desplazarte por el contenido, pero no se enviarán los eventos de entrada a "
 "la aplicación en ejecución."
 


### PR DESCRIPTION
- "Unable to acquire an OpenGL context for rendering."
 This could be translated to "No se puede" or "No se pudo", depends on the context of the message.
If the message is showing a current intent the translation should be "No se puede", if the message is communicating that Ghostty failed to acquire the OpenGL then the translation should be "No se pudo", here I need more context.
Either case the wording "No se puedo" is incorrect.