### PR TITLE
macos: fix quick terminal glassy background

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -625,6 +625,8 @@ class QuickTerminalController: BaseTerminalController {
             window.isOpaque = true
             window.backgroundColor = .windowBackgroundColor
         }
+
+        terminalViewContainer?.ghosttyConfigDidChange(ghostty.config, preferredBackgroundColor: nil)
     }
 
     private func showNoNewTabAlert() {

--- a/macos/Sources/Features/Terminal/TerminalViewContainer.swift
+++ b/macos/Sources/Features/Terminal/TerminalViewContainer.swift
@@ -62,13 +62,6 @@ class TerminalViewContainer: NSView {
         updateGlassEffectTopInsetIfNeeded()
     }
 
-    @objc private func ghosttyConfigDidChange(_ notification: Notification) {
-        guard let config = notification.userInfo?[
-            Notification.Name.GhosttyConfigChangeKey
-        ] as? Ghostty.Config else { return }
-        ghosttyConfigDidChange(config, preferredBackgroundColor: (window as? TerminalWindow)?.preferredBackgroundColor)
-    }
-
     func ghosttyConfigDidChange(_ config: Ghostty.Config, preferredBackgroundColor: NSColor?) {
         let newValue = DerivedConfig(config: config, preferredBackgroundColor: preferredBackgroundColor, cornerRadius: windowCornerRadius)
         guard newValue != derivedConfig else { return }


### PR DESCRIPTION
Fixes a regression from [#9032096](https://github.com/ghostty-org/ghostty/commit/9032096) 🥲 and clean some dead code

On first launch of the quick terminal window, the container style is not properly updated; you'll have to reload the config to show the background.

<img width="571" height="312" alt="IMG_4783" src="https://github.com/user-attachments/assets/c5d920ea-9ad8-494d-98c0-c560e36c4a31" />
