### PR TITLE
fix: list-actions outputs without `--docs`

### DIFF
--- a/src/cli/list_actions.zig
+++ b/src/cli/list_actions.zig
@@ -46,6 +46,7 @@ pub fn run(alloc: Allocator) !u8 {
         opts.docs,
         std.heap.page_allocator,
     );
+    try stdout_writer.interface.flush();
 
     return 0;
 }


### PR DESCRIPTION
Explicitly flush the buffer once the generation is complete.

Resolves #11221