### PR TITLE
feat: change `background_opacity_cells` option to work with opaque cells

### DIFF
--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1642,6 +1642,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     .uniforms = frame.uniforms.buffer,
                     .buffers = &.{ null, frame.cells_bg.buffer },
                     .draw = .{ .type = .triangle, .vertex_count = 3 },
+                    .is_cell_fill_pass = self.config.background_opacity_cells,
                 });
 
                 // Kitty images between cell backgrounds and text.

--- a/src/renderer/metal/Pipeline.zig
+++ b/src/renderer/metal/Pipeline.zig
@@ -127,8 +127,13 @@ pub fn init(comptime VertexAttributes: ?type, opts: Options) !Self {
         if (at.blending_enabled) {
             attachment.setProperty("rgbBlendOperation", @intFromEnum(mtl.MTLBlendOperation.add));
             attachment.setProperty("alphaBlendOperation", @intFromEnum(mtl.MTLBlendOperation.add));
-            attachment.setProperty("sourceRGBBlendFactor", @intFromEnum(mtl.MTLBlendFactor.one));
-            attachment.setProperty("sourceAlphaBlendFactor", @intFromEnum(mtl.MTLBlendFactor.one));
+            if (false) { // TODO: make this work with is_cell_fill_pass
+                attachment.setProperty("sourceRGBBlendFactor", @intFromEnum(mtl.MTLBlendFactor.one));
+                attachment.setProperty("sourceAlphaBlendFactor", @intFromEnum(mtl.MTLBlendFactor.one));
+            } else {
+                attachment.setProperty("sourceRGBBlendFactor", @intFromEnum(mtl.MTLBlendFactor.source_alpha));
+                attachment.setProperty("sourceAlphaBlendFactor", @intFromEnum(mtl.MTLBlendFactor.source_alpha));
+            }
             attachment.setProperty("destinationRGBBlendFactor", @intFromEnum(mtl.MTLBlendFactor.one_minus_source_alpha));
             attachment.setProperty("destinationAlphaBlendFactor", @intFromEnum(mtl.MTLBlendFactor.one_minus_source_alpha));
         }

--- a/src/renderer/metal/RenderPass.zig
+++ b/src/renderer/metal/RenderPass.zig
@@ -42,6 +42,7 @@ pub const Step = struct {
     /// of a fragment texture, set via setFragmentSamplerState(_:index:).
     samplers: []const ?Sampler = &.{},
     draw: Draw,
+    is_cell_fill_pass: bool = false,
 
     /// Describes the draw call for this step.
     pub const Draw = struct {

--- a/src/renderer/opengl/RenderPass.zig
+++ b/src/renderer/opengl/RenderPass.zig
@@ -34,6 +34,7 @@ pub const Step = struct {
     textures: []const ?Texture = &.{},
     samplers: []const ?Sampler = &.{},
     draw: Draw,
+    is_cell_fill_pass: bool = false,
 
     /// Describes the draw call for this step.
     pub const Draw = struct {
@@ -121,11 +122,16 @@ pub fn step(self: *Self, s: Step) void {
         };
     }
 
-    if (s.pipeline.blending_enabled) {
-        gl.enable(gl.c.GL_BLEND) catch return;
-        gl.blendFunc(gl.c.GL_ONE, gl.c.GL_ONE_MINUS_SRC_ALPHA) catch return;
+    if (!s.is_cell_fill_pass) {
+        if (s.pipeline.blending_enabled) {
+            gl.enable(gl.c.GL_BLEND) catch return;
+            gl.blendFunc(gl.c.GL_ONE, gl.c.GL_ONE_MINUS_SRC_ALPHA) catch return;
+        } else {
+            gl.disable(gl.c.GL_BLEND) catch return;
+        }
     } else {
-        gl.disable(gl.c.GL_BLEND) catch return;
+        gl.enable(gl.c.GL_BLEND) catch return;
+        gl.blendFunc(gl.c.GL_SRC_ALPHA, gl.c.GL_ONE_MINUS_SRC_ALPHA) catch return;
     }
 
     gl.drawArraysInstanced(


### PR DESCRIPTION
_Status - currently works, but I want to make sure I'm taking an acceptable approach before I continue._

This makes the `background_opacity_cells` option behave like Alacritty's `transparent_background_colors`, as discussed in #7957.

Currently, this is a bit hacky. To make it better, I would like to change all `blending_enabled` variables from booleans to enums and rename them to `blending_mode`, then translate all assignments of `false` to `none`, and `true` to `one`, then introduce a `src_alpha` enum member where the `is_cell_fill_pass` variable is used right now.

Also, the metal implementation is incomplete as of now, but I'm going to see if I can test it.

Resolves #7957