### PR TITLE
macos: add AppleScript front window and focused terminal properties

### DIFF
--- a/macos/Ghostty.sdef
+++ b/macos/Ghostty.sdef
@@ -9,6 +9,9 @@
       <property name="frontmost" code="pisf" type="boolean" access="r" description="Is this the active application?">
         <cocoa key="isActive"/>
       </property>
+      <property name="front window" code="GFWn" type="window" access="r" description="The frontmost Ghostty window.">
+        <cocoa key="frontWindow"/>
+      </property>
       <property name="version" code="vers" type="text" access="r" description="The version number of the application."/>
       <responds-to command="perform action">
         <cocoa method="handlePerformActionScriptCommand:"/>
@@ -66,6 +69,9 @@
       </property>
       <property name="index" code="pidx" type="integer" access="r" description="1-based index of this tab in its window."/>
       <property name="selected" code="GTsl" type="boolean" access="r" description="Whether this tab is selected in its window."/>
+      <property name="focused terminal" code="GTfT" type="terminal" access="r" description="The currently focused terminal surface in this tab.">
+        <cocoa key="focusedTerminal"/>
+      </property>
       <responds-to command="select tab">
         <cocoa method="handleSelectTabCommand:"/>
       </responds-to>

--- a/macos/Sources/Features/AppleScript/AppDelegate+AppleScript.swift
+++ b/macos/Sources/Features/AppleScript/AppDelegate+AppleScript.swift
@@ -57,6 +57,16 @@ extension NSApplication {
         return result
     }
 
+    /// Exposed as the AppleScript `front window` property.
+    ///
+    /// `scriptWindows` is already ordered front-to-back, so the first item is
+    /// the frontmost logical Ghostty window.
+    @objc(frontWindow)
+    var frontWindow: ScriptWindow? {
+        guard isAppleScriptEnabled else { return nil }
+        return scriptWindows.first
+    }
+
     /// Enables AppleScript unique-ID lookup for window references.
     ///
     /// Required selector name pattern for element key `scriptWindows`:

--- a/macos/Sources/Features/AppleScript/ScriptTab.swift
+++ b/macos/Sources/Features/AppleScript/ScriptTab.swift
@@ -67,6 +67,20 @@ final class ScriptTab: NSObject {
         return window?.tabIsSelected(controller) ?? false
     }
 
+    /// Exposed as the AppleScript `focused terminal` property.
+    ///
+    /// Uses the currently focused surface for this tab.
+    @objc(focusedTerminal)
+    var focusedTerminal: ScriptTerminal? {
+        guard NSApp.isAppleScriptEnabled else { return nil }
+        guard let controller else { return nil }
+        guard let surface = controller.focusedSurface,
+              controller.surfaceTree.contains(surface)
+        else { return nil }
+
+        return ScriptTerminal(surfaceView: surface)
+    }
+
     /// Best-effort native window containing this tab.
     var parentWindow: NSWindow? {
         guard NSApp.isAppleScriptEnabled else { return nil }


### PR DESCRIPTION
This adds two new propeties to make it easy to get the frontmost (main) window and the focused terminal within a tab. We already had a property to get the selected tab of a tab group.

## Examples

### Send Input to Focused Terminal

```AppleScript
tell application "Ghostty"
  set term to focused terminal of selected tab of front window
  input text "pwd\n" to term
end tell
```

### Split the Focused Terminal

```applescript
tell application "Ghostty"
  set currentTerm to focused terminal of selected tab of front window
  set newTerm to split currentTerm direction right
  input text "echo split-ready\n" to newTerm
end tell
```