### PR TITLE
fix: Cmd+G / Cmd+Shift+G not working in search field

### DIFF
--- a/macos/GhosttyUITests/GhosttySearchUITests.swift
+++ b/macos/GhosttyUITests/GhosttySearchUITests.swift
@@ -1,0 +1,84 @@
+//
+//  GhosttySearchUITests.swift
+//  GhosttyUITests
+//
+
+import XCTest
+
+final class GhosttySearchUITests: GhosttyCustomConfigCase {
+
+    /// Verifies that Cmd+G (Find Next) navigates search results when the
+    /// search field is focused.
+    ///
+    /// This is a regression test for a bug where the NSTextView field editor
+    /// consumed Cmd+G via performKeyEquivalent before Ghostty could handle it.
+    /// Without the fix, the search match indicator never changes; with the fix,
+    /// pressing Cmd+G advances to the next match.
+    @MainActor
+    func testCmdGNavigatesSearchWhileSearchFieldFocused() async throws {
+        let app = try ghosttyApplication()
+        app.launch()
+
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 5), "Ghostty window should appear")
+
+        // Type repeated text so we have multiple search matches.
+        let terminalPane = window.groups["Terminal pane"]
+        XCTAssertTrue(terminalPane.waitForExistence(timeout: 5), "Terminal pane should exist")
+        terminalPane.typeText("echo hello && echo hello && echo hello\r")
+
+        // Wait for output to render.
+        try await Task.sleep(for: .seconds(1))
+
+        // Open search with Cmd+F. Focus should land in the search field.
+        app.typeKey("f", modifierFlags: .command)
+
+        // Find the search text field by its accessibility identifier.
+        let searchField = window.textFields["ghostty-search-field"]
+        XCTAssertTrue(searchField.waitForExistence(timeout: 3), "Search field should appear")
+
+        // Type a search term that will have multiple matches.
+        searchField.typeText("hello")
+
+        // Wait for search results to populate.
+        try await Task.sleep(for: .seconds(1))
+
+        // Find the match counter text (e.g. "1/3"). It's a staticText
+        // inside the search overlay whose value matches the N/M pattern.
+        let matchCounter = window.staticTexts.matching(
+            NSPredicate(format: "value MATCHES %@", "\\d+/\\d+")
+        ).firstMatch
+
+        // The counter should exist if there are matches.
+        guard matchCounter.waitForExistence(timeout: 3) else {
+            XCTFail("Match counter (e.g. '1/3') should appear after searching")
+            return
+        }
+
+        let initialCounter = matchCounter.value as? String
+        XCTAssertNotNil(initialCounter, "Match counter should have a string value")
+
+        // Press Cmd+G to navigate to the next match.
+        // WITHOUT the fix: the field editor consumes this and the counter doesn't change.
+        // WITH the fix: the search navigates and the counter updates.
+        app.typeKey("g", modifierFlags: .command)
+        try await Task.sleep(for: .seconds(0.5))
+
+        let afterNextCounter = matchCounter.value as? String
+        XCTAssertNotNil(afterNextCounter, "Match counter should still have a value after Cmd+G")
+        XCTAssertNotEqual(
+            initialCounter, afterNextCounter,
+            "Cmd+G should advance the search match (counter should change from \(initialCounter ?? "nil"))"
+        )
+
+        // Also verify Cmd+Shift+G goes back.
+        app.typeKey("g", modifierFlags: [.command, .shift])
+        try await Task.sleep(for: .seconds(0.5))
+
+        let afterPrevCounter = matchCounter.value as? String
+        XCTAssertEqual(
+            initialCounter, afterPrevCounter,
+            "Cmd+Shift+G should return to the original match"
+        )
+    }
+}

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -89,6 +89,15 @@ class BaseTerminalController: NSWindowController,
     /// Cancellable for aggregating bell state across all surfaces in this controller.
     private var bellStateCancellable: AnyCancellable?
 
+    /// Shared field editor for the search text field. Intercepts key
+    /// equivalents that match ghostty bindings (including performable ones)
+    /// and dispatches them directly to the surface.
+    private lazy var searchFieldEditor: GhosttySearchFieldEditor = {
+        let editor = GhosttySearchFieldEditor()
+        editor.isFieldEditor = true
+        return editor
+    }()
+
     /// An override title for the tab/window set by the user via prompt_tab_title.
     /// When set, this takes precedence over the computed title from the terminal.
     var titleOverride: String? {
@@ -1273,6 +1282,15 @@ class BaseTerminalController: NSWindowController,
         return appDelegate.undoManager
     }
 
+    func windowWillReturnFieldEditor(_ sender: NSWindow, to client: Any?) -> Any? {
+        if let textField = client as? NSTextField,
+           textField.accessibilityIdentifier() == Ghostty.searchFieldIdentifier {
+            searchFieldEditor.surfaceView = focusedSurface
+            return searchFieldEditor
+        }
+        return nil
+    }
+
     // MARK: First Responder
 
     @IBAction func close(_ sender: Any) {
@@ -1415,7 +1433,7 @@ class BaseTerminalController: NSWindowController,
     }
 
     @IBAction func findPrevious(_ sender: Any) {
-        focusedSurface?.findNext(sender)
+        focusedSurface?.findPrevious(sender)
     }
 
     @IBAction func findHide(_ sender: Any) {

--- a/macos/Sources/Ghostty/GhosttySearchFieldEditor.swift
+++ b/macos/Sources/Ghostty/GhosttySearchFieldEditor.swift
@@ -1,0 +1,52 @@
+#if canImport(AppKit)
+import AppKit
+import GhosttyKit
+
+/// Field editor for Ghostty's search field that intercepts key equivalents
+/// which are ghostty key bindings (including performable ones like
+/// navigate_search) and dispatches them directly to the surface.
+///
+/// This is necessary because:
+/// 1. NSTextView's default field editor consumes standard key equivalents
+///    (like Cmd+G for findNext:) via performKeyEquivalent before the app
+///    can handle them.
+/// 2. Ghostty's navigate_search bindings use `.performable = true`, which
+///    are intentionally excluded from the menu key equivalent reverse map.
+///    So even if we suppress the field editor, the menu system can't dispatch them.
+///
+/// The solution: check if the key event is a ghostty binding via
+/// ghostty_surface_key_is_binding, and if so, dispatch it directly.
+final class GhosttySearchFieldEditor: NSTextView {
+    /// The surface view to dispatch key bindings to.
+    weak var surfaceView: Ghostty.SurfaceView?
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        guard event.type == .keyDown else { return false }
+        guard let surface = surfaceView?.surface else {
+            return super.performKeyEquivalent(with: event)
+        }
+
+        // Build the ghostty key event from the NSEvent.
+        var ghosttyEvent = event.ghosttyKeyEvent(GHOSTTY_ACTION_PRESS)
+
+        // Check if this key event matches a ghostty binding.
+        let isBinding = (event.characters ?? "").withCString { ptr -> Bool in
+            ghosttyEvent.text = ptr
+            var flags = ghostty_binding_flags_e(0)
+            return ghostty_surface_key_is_binding(surface, ghosttyEvent, &flags)
+        }
+
+        if isBinding {
+            // Dispatch the key event to the surface, which will execute
+            // the bound action (e.g. navigate_search:next).
+            (event.characters ?? "").withCString { ptr in
+                ghosttyEvent.text = ptr
+                _ = ghostty_surface_key(surface, ghosttyEvent)
+            }
+            return true
+        }
+
+        return super.performKeyEquivalent(with: event)
+    }
+}
+#endif

--- a/macos/Sources/Ghostty/Surface View/GhosttySearchField.swift
+++ b/macos/Sources/Ghostty/Surface View/GhosttySearchField.swift
@@ -1,0 +1,115 @@
+#if canImport(AppKit)
+import SwiftUI
+import AppKit
+import GhosttyKit
+
+extension Ghostty {
+    /// The accessibility identifier used to tag the search NSTextField so that
+    /// `windowWillReturnFieldEditor(_:to:)` can vend our custom field editor.
+    static let searchFieldIdentifier = "ghostty-search-field"
+
+    /// NSViewRepresentable wrapper around NSTextField for the search field.
+    ///
+    /// This gives us a guaranteed NSTextField reference that we can tag with
+    /// an accessibility identifier directly, rather than relying on SwiftUI's
+    /// internal propagation of accessibility identifiers to the underlying
+    /// AppKit view (which is an implementation detail).
+    struct GhosttySearchField: NSViewRepresentable {
+        @Binding var text: String
+        let surfaceView: SurfaceView
+        let onClose: () -> Void
+
+        /// Whether the field should become first responder. Set via onAppear/notification.
+        /// Callers should toggle this false→true to re-trigger focus.
+        @Binding var isFocused: Bool
+
+        func makeNSView(context: Context) -> NSTextField {
+            let field = NSTextField()
+            field.placeholderString = "Search"
+            field.setAccessibilityIdentifier(Ghostty.searchFieldIdentifier)
+            field.delegate = context.coordinator
+            field.isBordered = false
+            field.drawsBackground = false
+            field.focusRingType = .none
+            field.font = .systemFont(ofSize: NSFont.systemFontSize)
+            field.cell?.sendsActionOnEndEditing = false
+            return field
+        }
+
+        func updateNSView(_ field: NSTextField, context: Context) {
+            // Update text only if it differs to avoid cursor jumps
+            if field.stringValue != text {
+                field.stringValue = text
+            }
+
+            // Update coordinator references
+            context.coordinator.parent = self
+
+            // Handle focus requests on rising edge, then reset the flag
+            // so subsequent true→false→true transitions re-trigger focus.
+            if isFocused, let window = field.window {
+                window.makeFirstResponder(field)
+                DispatchQueue.main.async {
+                    isFocused = false
+                }
+            }
+        }
+
+        func makeCoordinator() -> Coordinator {
+            Coordinator(self)
+        }
+
+        class Coordinator: NSObject, NSTextFieldDelegate {
+            var parent: GhosttySearchField
+
+            init(_ parent: GhosttySearchField) {
+                self.parent = parent
+            }
+
+            func controlTextDidChange(_ obj: Foundation.Notification) {
+                guard let field = obj.object as? NSTextField else { return }
+                parent.text = field.stringValue
+            }
+
+            func control(
+                _ control: NSControl,
+                textView: NSTextView,
+                doCommandBy commandSelector: Selector
+            ) -> Bool {
+                // Don't intercept during IME composition — Return should commit
+                // the marked text and Escape should cancel composition.
+                if textView.hasMarkedText() {
+                    return false
+                }
+
+                if commandSelector == #selector(NSResponder.insertNewline(_:)) {
+                    // Enter key: navigate search
+                    guard let surface = parent.surfaceView.surface else { return true }
+
+                    let shiftPressed = NSApp.currentEvent?.modifierFlags.contains(.shift) ?? false
+                    let action = shiftPressed
+                        ? "navigate_search:previous"
+                        : "navigate_search:next"
+                    ghostty_surface_binding_action(
+                        surface, action,
+                        UInt(action.lengthOfBytes(using: .utf8))
+                    )
+                    return true
+                }
+
+                if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
+                    // Escape key: close search if empty, otherwise move focus back
+                    if parent.text.isEmpty {
+                        parent.onClose()
+                    } else {
+                        Ghostty.moveFocus(to: parent.surfaceView)
+                    }
+                    return true
+                }
+
+                return false
+            }
+        }
+    }
+}
+#endif

--- a/macos/Sources/Ghostty/Surface View/SurfaceView.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView.swift
@@ -405,22 +405,25 @@ extension Ghostty {
         @State private var corner: Corner = .topRight
         @State private var dragOffset: CGSize = .zero
         @State private var barSize: CGSize = .zero
-        @FocusState private var isSearchFieldFocused: Bool
+        @State private var isSearchFieldFocused: Bool = false
 
         private let padding: CGFloat = 8
 
         var body: some View {
             GeometryReader { geo in
                 HStack(spacing: 4) {
-                    TextField("Search", text: $searchState.needle)
-                    .textFieldStyle(.plain)
+                    GhosttySearchField(
+                        text: $searchState.needle,
+                        surfaceView: surfaceView,
+                        onClose: onClose,
+                        isFocused: $isSearchFieldFocused
+                    )
                     .frame(width: 180)
                     .padding(.leading, 8)
                     .padding(.trailing, 50)
                     .padding(.vertical, 6)
                     .background(Color.primary.opacity(0.1))
                     .cornerRadius(6)
-                    .focused($isSearchFieldFocused)
                     .overlay(alignment: .trailing) {
                         if let selected = searchState.selected {
                             Text("\(selected + 1)/\(searchState.total, default: "?")")
@@ -435,23 +438,6 @@ extension Ghostty {
                                 .monospacedDigit()
                                 .padding(.trailing, 8)
                         }
-                    }
-#if canImport(AppKit)
-                    .onExitCommand {
-                        if searchState.needle.isEmpty {
-                            onClose()
-                        } else {
-                            Ghostty.moveFocus(to: surfaceView)
-                        }
-                    }
-#endif
-                    .backport.onKeyPress(.return) { modifiers in
-                        if modifiers.contains(.shift) {
-                            _ = surfaceView.navigateSearchToPrevious()
-                        } else {
-                            _ = surfaceView.navigateSearchToNext()
-                        }
-                        return .handled
                     }
 
                     Button(action: {

--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -1604,11 +1604,19 @@ extension Ghostty {
         }
 
         @IBAction func findNext(_ sender: Any?) {
-            _ = self.navigateSearchToNext()
+            guard let surface = self.surface else { return }
+            let action = "navigate_search:next"
+            if !ghostty_surface_binding_action(surface, action, UInt(action.lengthOfBytes(using: .utf8))) {
+                AppDelegate.logger.warning("action failed action=\(action)")
+            }
         }
 
         @IBAction func findPrevious(_ sender: Any?) {
-            _ = navigateSearchToPrevious()
+            guard let surface = self.surface else { return }
+            let action = "navigate_search:previous"
+            if !ghostty_surface_binding_action(surface, action, UInt(action.lengthOfBytes(using: .utf8))) {
+                AppDelegate.logger.warning("action failed action=\(action)")
+            }
         }
 
         @IBAction func findHide(_ sender: Any?) {


### PR DESCRIPTION
When the search field is focused, Cmd+G (Find Next) and Cmd+Shift+G (Find Previous) were consumed by the NSTextView field editor's performKeyEquivalent before Ghostty could handle them. Additionally, navigate_search bindings use .performable, which are intentionally excluded from the menu key equivalent reverse map, so menu-based dispatch could never work.

Fix: introduce a custom field editor (GhosttySearchFieldEditor) that intercepts performKeyEquivalent, checks if the key event matches a ghostty binding via ghostty_surface_key_is_binding, and dispatches it directly via ghostty_surface_key. This is fully config-driven — no hardcoded key equivalents.

Also replace the SwiftUI TextField with an NSViewRepresentable (GhosttySearchField) to guarantee accessibility identifier propagation for the windowWillReturnFieldEditor hook.

Additional fixes included:
- AppDelegate: correct action strings (search:next → navigate_search:next)
- BaseTerminalController: fix findPrevious calling findNext (copy-paste bug)
- GhosttySearchField: guard IME composition (hasMarkedText) for Enter/Escape
- Shared searchFieldIdentifier constant

Includes UI test verifying Cmd+G advances the match counter.