### PR TITLE
bash: only define $__ghostty_ps0 when unset

### DIFF
--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -268,12 +268,15 @@ if (( BASH_VERSINFO[0] > 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 4) )
 
   # Use function substitution in 5.3+. Otherwise, use command substitution.
   # Any output (including escape sequences) goes to the terminal.
-  if (( BASH_VERSINFO[0] > 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 3) )); then
-    # shellcheck disable=SC2016
-    builtin readonly __ghostty_ps0='${ __ghostty_preexec_hook; }'
-  else
-    # shellcheck disable=SC2016
-    builtin readonly __ghostty_ps0='$(__ghostty_preexec_hook >/dev/tty)'
+  # Only define if not already set (allows re-sourcing).
+  if [[ -z "${__ghostty_ps0+x}" ]]; then
+    if (( BASH_VERSINFO[0] > 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 3) )); then
+      # shellcheck disable=SC2016
+      builtin readonly __ghostty_ps0='${ __ghostty_preexec_hook; }'
+    else
+      # shellcheck disable=SC2016
+      builtin readonly __ghostty_ps0='$(__ghostty_preexec_hook >/dev/tty)'
+    fi
   fi
 
   __ghostty_hook() {


### PR DESCRIPTION
This fixes an error if the script was sourced a second time:

    bash: __ghostty_ps0: readonly variable

Because this is a non-exported variable, this would only happen if the script was sourced multiple times in the same bash session.