### PR TITLE
Add OSC 8 links to +show-config output.

### DIFF
--- a/src/cli/list_keybinds.zig
+++ b/src/cli/list_keybinds.zig
@@ -75,7 +75,7 @@ pub fn run(alloc: Allocator) !u8 {
         return prettyPrint(arena.allocator(), config.keybind);
     } else {
         try config.keybind.formatEntryDocs(
-            configpkg.entryFormatter("keybind", writer),
+            configpkg.entryFormatter("keybind", writer, false),
             opts.docs,
         );
     }

--- a/src/cli/show_config.zig
+++ b/src/cli/show_config.zig
@@ -4,6 +4,7 @@ const Allocator = std.mem.Allocator;
 const Action = @import("ghostty.zig").Action;
 const configpkg = @import("../config.zig");
 const Config = configpkg.Config;
+const tui = @import("tui.zig");
 
 pub const Options = struct {
     /// If true, do not load the user configuration, only load the defaults.
@@ -16,6 +17,12 @@ pub const Options = struct {
     /// If true print the documentation above each option as a comment,
     /// if available.
     docs: bool = false,
+
+    /// If `true`, print without formatting even if printing to a tty
+    plain: bool = false,
+
+    /// Force links even if not a TTY
+    @"force-links": bool = false,
 
     pub fn deinit(self: Options) void {
         _ = self;
@@ -55,6 +62,12 @@ pub const Options = struct {
 ///   * `--docs`: Print the documentation above each option as a comment,
 ///     This is very noisy but is very useful to learn about available
 ///     options, especially paired with `--default`.
+///
+///   * `--plain`: Will disable formatting and make the output more friendly for
+///     Unix tooling. This is default when not printing to a TTY.
+///
+///   * `--force-links`: Force the use of OSC 8 links even if not printing to
+///     a TTY.
 pub fn run(alloc: Allocator) !u8 {
     var opts: Options = .{};
     defer opts.deinit();
@@ -68,16 +81,19 @@ pub fn run(alloc: Allocator) !u8 {
     var config = if (opts.default) try Config.default(alloc) else try Config.load(alloc);
     defer config.deinit();
 
+    // For some reason `std.fmt.format` isn't working here but it works in
+    // tests so we just do configfmt.format.
+    var stdout: std.fs.File = .stdout();
+
+    const links = opts.@"force-links" or (tui.can_pretty_print and !opts.plain and stdout.isTty());
     const configfmt: configpkg.FileFormatter = .{
         .alloc = alloc,
         .config = &config,
         .changed = !opts.default and opts.@"changes-only",
         .docs = opts.docs,
+        .links = links,
     };
 
-    // For some reason `std.fmt.format` isn't working here but it works in
-    // tests so we just do configfmt.format.
-    var stdout: std.fs.File = .stdout();
     var buffer: [4096]u8 = undefined;
     var stdout_writer = stdout.writer(&buffer);
     try configfmt.format(&stdout_writer.interface);

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -5348,7 +5348,7 @@ pub const Color = struct {
         defer buf.deinit();
 
         var color: Color = .{ .r = 10, .g = 11, .b = 12 };
-        try color.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try color.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = #0a0b0c\n", buf.written());
     }
 
@@ -5426,7 +5426,7 @@ pub const TerminalColor = union(enum) {
         defer buf.deinit();
 
         var sc: TerminalColor = .@"cell-foreground";
-        try sc.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try sc.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try testing.expectEqualSlices(u8, "a = cell-foreground\n", buf.written());
     }
 };
@@ -5478,7 +5478,7 @@ pub const BoldColor = union(enum) {
         defer buf.deinit();
 
         var sc: BoldColor = .bright;
-        try sc.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try sc.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try testing.expectEqualSlices(u8, "a = bright\n", buf.written());
     }
 };
@@ -5615,7 +5615,7 @@ pub const ColorList = struct {
 
         var p: Self = .{};
         try p.parseCLI(alloc, "black,white");
-        try p.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try p.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = #000000,#ffffff\n", buf.written());
     }
 
@@ -5769,7 +5769,7 @@ pub const Palette = struct {
         defer buf.deinit();
 
         var list: Self = .{};
-        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = 0=#1d1f21\n", buf.written()[0..14]);
     }
 
@@ -5920,7 +5920,7 @@ pub const RepeatableString = struct {
         defer buf.deinit();
 
         var list: Self = .{};
-        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = \n", buf.written());
     }
 
@@ -5935,7 +5935,7 @@ pub const RepeatableString = struct {
 
         var list: Self = .{};
         try list.parseCLI(alloc, "A");
-        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = A\n", buf.written());
     }
 
@@ -5951,7 +5951,7 @@ pub const RepeatableString = struct {
         var list: Self = .{};
         try list.parseCLI(alloc, "A");
         try list.parseCLI(alloc, "B");
-        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = A\na = B\n", buf.written());
     }
 };
@@ -6227,7 +6227,7 @@ pub const RepeatableFontVariation = struct {
 
         var list: Self = .{};
         try list.parseCLI(alloc, "wght = 200");
-        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = wght=200\n", buf.written());
     }
 };
@@ -7287,7 +7287,7 @@ pub const Keybinds = struct {
 
         var list: Keybinds = .{};
         try list.parseCLI(alloc, "shift+a=csi:hello");
-        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = shift+a=csi:hello\n", buf.written());
     }
 
@@ -7304,7 +7304,7 @@ pub const Keybinds = struct {
         var list: Keybinds = .{};
         try list.parseCLI(alloc, "ctrl+z>1=goto_tab:1");
         try list.parseCLI(alloc, "ctrl+z>2=goto_tab:2");
-        try list.formatEntry(formatterpkg.entryFormatter("keybind", &buf.writer));
+        try list.formatEntry(formatterpkg.entryFormatter("keybind", &buf.writer, false));
 
         // Note they turn into translated keys because they match
         // their ASCII mapping.
@@ -7330,7 +7330,7 @@ pub const Keybinds = struct {
         try list.parseCLI(alloc, "ctrl+a>ctrl+b>w=close_window");
         try list.parseCLI(alloc, "ctrl+a>ctrl+c>t=new_tab");
         try list.parseCLI(alloc, "ctrl+b>ctrl+d>a=previous_tab");
-        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
 
         // NB: This does not currently retain the order of the keybinds.
         const want =
@@ -7706,7 +7706,7 @@ pub const Keybinds = struct {
 
         var keybinds: Keybinds = .{};
         try keybinds.parseCLI(alloc, "foo/shift+a=csi:hello");
-        try keybinds.formatEntry(formatterpkg.entryFormatter("keybind", &buf.writer));
+        try keybinds.formatEntry(formatterpkg.entryFormatter("keybind", &buf.writer, false));
 
         try testing.expectEqualStrings("keybind = foo/shift+a=csi:hello\n", buf.written());
     }
@@ -7723,7 +7723,7 @@ pub const Keybinds = struct {
         var keybinds: Keybinds = .{};
         try keybinds.parseCLI(alloc, "shift+b=csi:world");
         try keybinds.parseCLI(alloc, "foo/shift+a=csi:hello");
-        try keybinds.formatEntry(formatterpkg.entryFormatter("keybind", &buf.writer));
+        try keybinds.formatEntry(formatterpkg.entryFormatter("keybind", &buf.writer, false));
 
         const output = buf.written();
         try testing.expect(std.mem.indexOf(u8, output, "keybind = shift+b=csi:world\n") != null);
@@ -8008,7 +8008,7 @@ pub const RepeatableCodepointMap = struct {
 
         var list: Self = .{};
         try list.parseCLI(alloc, "U+ABCD=Comic Sans");
-        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = U+ABCD=Comic Sans\n", buf.written());
     }
 
@@ -8023,7 +8023,7 @@ pub const RepeatableCodepointMap = struct {
 
         var list: Self = .{};
         try list.parseCLI(alloc, "U+0001 - U+0005=Verdana");
-        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = U+0001-U+0005=Verdana\n", buf.written());
     }
 
@@ -8038,7 +8038,7 @@ pub const RepeatableCodepointMap = struct {
 
         var list: Self = .{};
         try list.parseCLI(alloc, "U+0006-U+0009, U+ABCD=Courier");
-        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8,
             \\a = U+0006-U+0009=Courier
             \\a = U+ABCD=Courier
@@ -8214,7 +8214,7 @@ pub const RepeatableClipboardCodepointMap = struct {
 
         var list: Self = .{};
         try list.parseCLI(alloc, "U+2500=U+002D");
-        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = U+2500=U+002D\n", buf.written());
     }
 
@@ -8229,7 +8229,7 @@ pub const RepeatableClipboardCodepointMap = struct {
 
         var list: Self = .{};
         try list.parseCLI(alloc, "U+03A3=SUM");
-        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = U+03A3=SUM\n", buf.written());
     }
 };
@@ -8323,7 +8323,7 @@ pub const FontStyle = union(enum) {
 
         var p: Self = .{ .default = {} };
         try p.parseCLI(alloc, "default");
-        try p.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try p.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = default\n", buf.written());
     }
 
@@ -8338,7 +8338,7 @@ pub const FontStyle = union(enum) {
 
         var p: Self = .{ .default = {} };
         try p.parseCLI(alloc, "false");
-        try p.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try p.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = false\n", buf.written());
     }
 
@@ -8353,7 +8353,7 @@ pub const FontStyle = union(enum) {
 
         var p: Self = .{ .default = {} };
         try p.parseCLI(alloc, "bold");
-        try p.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try p.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = bold\n", buf.written());
     }
 };
@@ -8638,7 +8638,7 @@ pub const RepeatableCommand = struct {
         defer buf.deinit();
 
         var list: RepeatableCommand = .{};
-        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = \n", buf.written());
     }
 
@@ -8653,7 +8653,7 @@ pub const RepeatableCommand = struct {
 
         var list: RepeatableCommand = .{};
         try list.parseCLI(alloc, "title:Bobr, action:text:Bober");
-        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = title:\"Bobr\",action:\"text:Bober\"\n", buf.written());
     }
 
@@ -8669,7 +8669,7 @@ pub const RepeatableCommand = struct {
         var list: RepeatableCommand = .{};
         try list.parseCLI(alloc, "title:Bobr, action:text:kurwa");
         try list.parseCLI(alloc, "title:Ja,   description: pierdole,  action:text:jakie bydle");
-        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = title:\"Bobr\",action:\"text:kurwa\"\na = title:\"Ja\",description:\"pierdole\",action:\"text:jakie bydle\"\n", buf.written());
     }
 
@@ -8988,7 +8988,7 @@ pub const MouseScrollMultiplier = struct {
         defer buf.deinit();
 
         var args: Self = .{ .precision = 1.5, .discrete = 2.5 };
-        try args.formatEntry(formatterpkg.entryFormatter("mouse-scroll-multiplier", &buf.writer));
+        try args.formatEntry(formatterpkg.entryFormatter("mouse-scroll-multiplier", &buf.writer, false));
         try testing.expectEqualSlices(u8, "mouse-scroll-multiplier = precision:1.5,discrete:2.5\n", buf.written());
     }
 };
@@ -10102,7 +10102,7 @@ test "test entryFormatter" {
     defer buf.deinit();
 
     var p: Duration = .{ .duration = std.math.maxInt(u64) };
-    try p.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+    try p.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
     try std.testing.expectEqualStrings("a = 584y 49w 23h 34m 33s 709ms 551µs 615ns\n", buf.written());
 }
 

--- a/src/config/RepeatableStringMap.zig
+++ b/src/config/RepeatableStringMap.zig
@@ -150,7 +150,7 @@ test "RepeatableStringMap: formatConfig empty" {
     defer buf.deinit();
 
     var list: RepeatableStringMap = .{};
-    try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+    try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
     try std.testing.expectEqualSlices(u8, "a = \n", buf.written());
 }
 
@@ -166,7 +166,7 @@ test "RepeatableStringMap: formatConfig single item" {
         defer buf.deinit();
         var map: RepeatableStringMap = .{};
         try map.parseCLI(alloc, "A=B");
-        try map.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try map.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = A=B\n", buf.written());
     }
     {
@@ -174,7 +174,7 @@ test "RepeatableStringMap: formatConfig single item" {
         defer buf.deinit();
         var map: RepeatableStringMap = .{};
         try map.parseCLI(alloc, " A = B ");
-        try map.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try map.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = A=B\n", buf.written());
     }
 }
@@ -192,7 +192,7 @@ test "RepeatableStringMap: formatConfig multiple items" {
         var list: RepeatableStringMap = .{};
         try list.parseCLI(alloc, "A=B");
         try list.parseCLI(alloc, "B = C");
-        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = A=B\na = B=C\n", buf.written());
     }
 }

--- a/src/config/command.zig
+++ b/src/config/command.zig
@@ -305,7 +305,7 @@ pub const Command = union(enum) {
 
         var v: Self = undefined;
         try v.parseCLI(alloc, "echo hello");
-        try v.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try v.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = echo hello\n", buf.written());
     }
 
@@ -320,7 +320,7 @@ pub const Command = union(enum) {
 
         var v: Self = undefined;
         try v.parseCLI(alloc, "direct: echo hello");
-        try v.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try v.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = direct:echo hello\n", buf.written());
     }
 };

--- a/src/config/formatter.zig
+++ b/src/config/formatter.zig
@@ -9,14 +9,20 @@ const Key = @import("key.zig").Key;
 pub fn entryFormatter(
     name: []const u8,
     writer: *std.Io.Writer,
+    links: bool,
 ) EntryFormatter {
-    return .{ .name = name, .writer = writer };
+    return .{
+        .name = name,
+        .writer = writer,
+        .links = links,
+    };
 }
 
 /// The entry formatter type for a given writer.
 pub const EntryFormatter = struct {
     name: []const u8,
     writer: *std.Io.Writer,
+    links: bool,
 
     pub fn formatEntry(
         self: @This(),
@@ -27,6 +33,7 @@ pub const EntryFormatter = struct {
             T,
             self.name,
             value,
+            self.links,
             self.writer,
         );
     }
@@ -37,26 +44,45 @@ pub fn formatEntry(
     comptime T: type,
     name: []const u8,
     value: T,
+    links: bool,
     writer: *std.Io.Writer,
 ) !void {
+    var linkstart_buf: [128]u8 = undefined;
+    var linkend_buf: [16]u8 = undefined;
+
+    const linkstart, const linkend = l: {
+        if (!links) break :l .{ "", "" };
+        const linkstart = std.fmt.bufPrint(
+            &linkstart_buf,
+            "\x1b]8;;https://ghostty.org/docs/config/reference#{s}\x1b\\",
+            .{name},
+        ) catch break :l .{ "", "" };
+        const linkend = std.fmt.bufPrint(
+            &linkend_buf,
+            "\x1b]8;;\x1b\\",
+            .{},
+        ) catch break :l .{ "", "" };
+        break :l .{ linkstart, linkend };
+    };
+
     switch (@typeInfo(T)) {
         .bool, .int => {
-            try writer.print("{s} = {}\n", .{ name, value });
+            try writer.print("{s}{s}{s} = {}\n", .{ linkstart, name, linkend, value });
             return;
         },
 
         .float => {
-            try writer.print("{s} = {d}\n", .{ name, value });
+            try writer.print("{s}{s}{s} = {d}\n", .{ linkstart, name, linkend, value });
             return;
         },
 
         .@"enum" => {
-            try writer.print("{s} = {t}\n", .{ name, value });
+            try writer.print("{s}{s}{s} = {t}\n", .{ linkstart, name, linkend, value });
             return;
         },
 
         .void => {
-            try writer.print("{s} = \n", .{name});
+            try writer.print("{s}{s}{s} = \n", .{ linkstart, name, linkend });
             return;
         },
 
@@ -66,10 +92,11 @@ pub fn formatEntry(
                     info.child,
                     name,
                     inner,
+                    links,
                     writer,
                 );
             } else {
-                try writer.print("{s} = \n", .{name});
+                try writer.print("{s}{s}{s} = \n", .{ linkstart, name, linkend });
             }
 
             return;
@@ -79,7 +106,7 @@ pub fn formatEntry(
             []const u8,
             [:0]const u8,
             => {
-                try writer.print("{s} = {s}\n", .{ name, value });
+                try writer.print("{s}{s}{s} = {s}\n", .{ linkstart, name, linkend, value });
                 return;
             },
 
@@ -92,12 +119,12 @@ pub fn formatEntry(
         // call BACK to our formatEntry to write each primitive
         // value.
         .@"struct" => |info| if (@hasDecl(T, "formatEntry")) {
-            try value.formatEntry(entryFormatter(name, writer));
+            try value.formatEntry(entryFormatter(name, writer, links));
             return;
         } else switch (info.layout) {
             // Packed structs we special case.
             .@"packed" => {
-                try writer.print("{s} = ", .{name});
+                try writer.print("{s}{s}{s} = ", .{ linkstart, name, linkend });
                 inline for (info.fields, 0..) |field, i| {
                     if (i > 0) try writer.print(",", .{});
                     try writer.print("{s}{s}", .{
@@ -113,7 +140,7 @@ pub fn formatEntry(
         },
 
         .@"union" => if (@hasDecl(T, "formatEntry")) {
-            try value.formatEntry(entryFormatter(name, writer));
+            try value.formatEntry(entryFormatter(name, writer, links));
             return;
         },
 
@@ -137,6 +164,9 @@ pub const FileFormatter = struct {
 
     /// Only include changed values from the default.
     changed: bool = false,
+
+    /// Use OSC 8 to link to the online documentation.
+    links: bool = false,
 
     /// Implements std.fmt so it can be used directly with std.fmt.
     pub fn format(
@@ -176,6 +206,7 @@ pub const FileFormatter = struct {
                     field.type,
                     field.name,
                     value,
+                    self.links,
                     writer,
                 ) catch return error.WriteFailed;
 
@@ -231,14 +262,14 @@ test "formatEntry bool" {
     {
         var buf: std.Io.Writer.Allocating = .init(testing.allocator);
         defer buf.deinit();
-        try formatEntry(bool, "a", true, &buf.writer);
+        try formatEntry(bool, "a", true, false, &buf.writer);
         try testing.expectEqualStrings("a = true\n", buf.written());
     }
 
     {
         var buf: std.Io.Writer.Allocating = .init(testing.allocator);
         defer buf.deinit();
-        try formatEntry(bool, "a", false, &buf.writer);
+        try formatEntry(bool, "a", false, false, &buf.writer);
         try testing.expectEqualStrings("a = false\n", buf.written());
     }
 }
@@ -249,7 +280,7 @@ test "formatEntry int" {
     {
         var buf: std.Io.Writer.Allocating = .init(testing.allocator);
         defer buf.deinit();
-        try formatEntry(u8, "a", 123, &buf.writer);
+        try formatEntry(u8, "a", 123, false, &buf.writer);
         try testing.expectEqualStrings("a = 123\n", buf.written());
     }
 }
@@ -260,7 +291,7 @@ test "formatEntry float" {
     {
         var buf: std.Io.Writer.Allocating = .init(testing.allocator);
         defer buf.deinit();
-        try formatEntry(f64, "a", 0.7, &buf.writer);
+        try formatEntry(f64, "a", 0.7, false, &buf.writer);
         try testing.expectEqualStrings("a = 0.7\n", buf.written());
     }
 }
@@ -272,7 +303,7 @@ test "formatEntry enum" {
     {
         var buf: std.Io.Writer.Allocating = .init(testing.allocator);
         defer buf.deinit();
-        try formatEntry(Enum, "a", .two, &buf.writer);
+        try formatEntry(Enum, "a", .two, false, &buf.writer);
         try testing.expectEqualStrings("a = two\n", buf.written());
     }
 }
@@ -283,7 +314,7 @@ test "formatEntry void" {
     {
         var buf: std.Io.Writer.Allocating = .init(testing.allocator);
         defer buf.deinit();
-        try formatEntry(void, "a", {}, &buf.writer);
+        try formatEntry(void, "a", {}, false, &buf.writer);
         try testing.expectEqualStrings("a = \n", buf.written());
     }
 }
@@ -294,14 +325,14 @@ test "formatEntry optional" {
     {
         var buf: std.Io.Writer.Allocating = .init(testing.allocator);
         defer buf.deinit();
-        try formatEntry(?bool, "a", null, &buf.writer);
+        try formatEntry(?bool, "a", null, false, &buf.writer);
         try testing.expectEqualStrings("a = \n", buf.written());
     }
 
     {
         var buf: std.Io.Writer.Allocating = .init(testing.allocator);
         defer buf.deinit();
-        try formatEntry(?bool, "a", false, &buf.writer);
+        try formatEntry(?bool, "a", false, false, &buf.writer);
         try testing.expectEqualStrings("a = false\n", buf.written());
     }
 }
@@ -312,7 +343,7 @@ test "formatEntry string" {
     {
         var buf: std.Io.Writer.Allocating = .init(testing.allocator);
         defer buf.deinit();
-        try formatEntry([]const u8, "a", "hello", &buf.writer);
+        try formatEntry([]const u8, "a", "hello", false, &buf.writer);
         try testing.expectEqualStrings("a = hello\n", buf.written());
     }
 }
@@ -327,7 +358,18 @@ test "formatEntry packed struct" {
     {
         var buf: std.Io.Writer.Allocating = .init(testing.allocator);
         defer buf.deinit();
-        try formatEntry(Value, "a", .{}, &buf.writer);
+        try formatEntry(Value, "a", .{}, false, &buf.writer);
         try testing.expectEqualStrings("a = one,no-two\n", buf.written());
+    }
+}
+
+test "formatEntry links" {
+    const testing = std.testing;
+
+    {
+        var buf: std.Io.Writer.Allocating = .init(testing.allocator);
+        defer buf.deinit();
+        try formatEntry(void, "a", {}, true, &buf.writer);
+        try testing.expectEqualStrings("\x1b]8;;https://ghostty.org/docs/config/reference#a\x1b\\a\x1b]8;;\x1b\\ = \n", buf.written());
     }
 }

--- a/src/config/io.zig
+++ b/src/config/io.zig
@@ -147,7 +147,7 @@ pub const ReadableIO = union(enum) {
 
         var v: Self = undefined;
         try v.parseCLI(alloc, "raw:foo");
-        try v.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try v.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = raw:foo\n", buf.written());
     }
 };

--- a/src/config/path.zig
+++ b/src/config/path.zig
@@ -331,7 +331,7 @@ pub const Path = union(enum) {
 
         var item: Path = undefined;
         try item.parseCLI(alloc, "A");
-        try item.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try item.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = A\n", buf.written());
     }
 
@@ -347,7 +347,7 @@ pub const Path = union(enum) {
         var item: Path = undefined;
         try item.parseCLI(alloc, "A");
         try item.parseCLI(alloc, "?B");
-        try item.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try item.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = ?B\n", buf.written());
     }
 };
@@ -473,7 +473,7 @@ pub const RepeatablePath = struct {
         defer buf.deinit();
 
         var list: RepeatablePath = .{};
-        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = \n", buf.written());
     }
 
@@ -488,7 +488,7 @@ pub const RepeatablePath = struct {
 
         var list: RepeatablePath = .{};
         try list.parseCLI(alloc, "A");
-        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = A\n", buf.written());
     }
 
@@ -504,7 +504,7 @@ pub const RepeatablePath = struct {
         var list: RepeatablePath = .{};
         try list.parseCLI(alloc, "A");
         try list.parseCLI(alloc, "?B");
-        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer));
+        try list.formatEntry(formatterpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = A\na = ?B\n", buf.written());
     }
 };

--- a/src/font/Metrics.zig
+++ b/src/font/Metrics.zig
@@ -566,7 +566,7 @@ pub const Modifier = union(enum) {
         defer buf.deinit();
 
         const p = try parseCLI("24%");
-        try p.formatEntry(configpkg.entryFormatter("a", &buf.writer));
+        try p.formatEntry(configpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = 24%\n", buf.written());
     }
 
@@ -577,7 +577,7 @@ pub const Modifier = union(enum) {
         defer buf.deinit();
 
         const p = try parseCLI("-30");
-        try p.formatEntry(configpkg.entryFormatter("a", &buf.writer));
+        try p.formatEntry(configpkg.entryFormatter("a", &buf.writer, false));
         try std.testing.expectEqualSlices(u8, "a = -30\n", buf.written());
     }
 };

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -4734,7 +4734,7 @@ test "set: formatEntries leaf_chained" {
 
     // Write the trigger first (as formatEntry in Config.zig does)
     try entry.key_ptr.format(&writer);
-    try entry.value_ptr.formatEntries(&writer, formatterpkg.entryFormatter("keybind", &output.writer));
+    try entry.value_ptr.formatEntries(&writer, formatterpkg.entryFormatter("keybind", &output.writer, false));
 
     const expected =
         \\keybind = a=new_window
@@ -4770,7 +4770,7 @@ test "set: formatEntries leaf_chained multiple chains" {
     var writer: std.Io.Writer = .fixed(&buf);
 
     try entry.key_ptr.format(&writer);
-    try entry.value_ptr.formatEntries(&writer, formatterpkg.entryFormatter("keybind", &output.writer));
+    try entry.value_ptr.formatEntries(&writer, formatterpkg.entryFormatter("keybind", &output.writer, false));
 
     const expected =
         \\keybind = ctrl+a=new_window
@@ -4802,7 +4802,7 @@ test "set: formatEntries leaf_chained with text action" {
 
     const entry = s.get(.{ .key = .{ .unicode = 'a' } }).?;
     try entry.key_ptr.format(&writer);
-    try entry.value_ptr.formatEntries(&writer, formatterpkg.entryFormatter("keybind", &output.writer));
+    try entry.value_ptr.formatEntries(&writer, formatterpkg.entryFormatter("keybind", &output.writer, false));
 
     const expected =
         \\keybind = a=text:hello

--- a/src/input/key_mods.zig
+++ b/src/input/key_mods.zig
@@ -855,7 +855,7 @@ test "RemapSet: formatEntry empty" {
     defer buf.deinit();
 
     const set: RemapSet = .empty;
-    try set.formatEntry(formatterpkg.entryFormatter("key-remap", &buf.writer));
+    try set.formatEntry(formatterpkg.entryFormatter("key-remap", &buf.writer, false));
     try testing.expectEqualSlices(u8, "key-remap = \n", buf.written());
 }
 
@@ -872,7 +872,7 @@ test "RemapSet: formatEntry single sided" {
     try set.parse(testing.allocator, "left_ctrl=super");
     set.finalize();
 
-    try set.formatEntry(formatterpkg.entryFormatter("key-remap", &buf.writer));
+    try set.formatEntry(formatterpkg.entryFormatter("key-remap", &buf.writer, false));
     try testing.expectEqualSlices(u8, "key-remap = left_ctrl=left_super\n", buf.written());
 }
 
@@ -889,7 +889,7 @@ test "RemapSet: formatEntry unsided creates two entries" {
     try set.parse(testing.allocator, "ctrl=super");
     set.finalize();
 
-    try set.formatEntry(formatterpkg.entryFormatter("key-remap", &buf.writer));
+    try set.formatEntry(formatterpkg.entryFormatter("key-remap", &buf.writer, false));
     // Unsided creates both left and right mappings
     const written = buf.written();
     try testing.expect(std.mem.indexOf(u8, written, "left_ctrl=left_super") != null);
@@ -909,6 +909,6 @@ test "RemapSet: formatEntry right sided" {
     try set.parse(testing.allocator, "left_alt=right_ctrl");
     set.finalize();
 
-    try set.formatEntry(formatterpkg.entryFormatter("key-remap", &buf.writer));
+    try set.formatEntry(formatterpkg.entryFormatter("key-remap", &buf.writer, false));
     try testing.expectEqualSlices(u8, "key-remap = left_alt=right_ctrl\n", buf.written());
 }


### PR DESCRIPTION
When enabled, OSC 8 hyperlinks will be embedded in the `+show-config` output linking to the online configuration reference.

Will be disabled by default if `stdout` is not a TTY. Can be overridden with a combination of `--plain` or `--force-links` flags.