### PR TITLE
config: add progress-style option

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -1934,6 +1934,15 @@ extension Ghostty {
             case GHOSTTY_TARGET_SURFACE:
                 guard let surface = target.target.surface else { return }
                 guard let surfaceView = self.surfaceView(from: surface) else { return }
+                guard let config = (NSApplication.shared.delegate as? AppDelegate)?.ghostty.config else { return }
+
+                guard config.progressStyle else {
+                    Ghostty.logger.debug("progress_report action blocked by config")
+                    DispatchQueue.main.async {
+                        surfaceView.progressReport = nil
+                    }
+                    return
+                }
 
                 let progressReport = Ghostty.Action.ProgressReport(c: v)
                 DispatchQueue.main.async {

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -717,6 +717,14 @@ extension Ghostty {
             let buffer = UnsafeBufferPointer(start: v.commands, count: v.len)
             return buffer.map { Ghostty.Command(cValue: $0) }
         }
+
+        var progressStyle: Bool {
+            guard let config = self.config else { return true }
+            var v = true
+            let key = "progress-style"
+            _ = ghostty_config_get(config, &v, key, UInt(key.lengthOfBytes(using: .utf8)))
+            return v
+        }
     }
 }
 

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -1012,6 +1012,14 @@ pub const Surface = extern struct {
             priv.progress_bar_timer = null;
         }
 
+        if (priv.config) |config| {
+            if (!config.get().@"progress-style") {
+                log.debug("progress_report action blocked by config", .{});
+                priv.progress_bar_overlay.as(gtk.Widget).setVisible(@intFromBool(false));
+                return;
+            }
+        }
+
         const progress_bar = priv.progress_bar_overlay;
         switch (value.state) {
             // Remove the progress bar

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3636,6 +3636,11 @@ else
 /// notifications using certain escape sequences such as OSC 9 or OSC 777.
 @"desktop-notifications": bool = true,
 
+/// If `true` (default), applications running in the terminal can show
+/// graphical progress bars using the ConEmu OSC 9;4 escape sequence.
+/// If `false`, progress bar sequences are silently ignored.
+@"progress-style": bool = true,
+
 /// Modifies the color used for bold text in the terminal.
 ///
 /// This can be set to a specific color, using the same format as


### PR DESCRIPTION
Adds progress-style config to control OSC 9;4 progress bar visibility. Defaults to true, set false to hide.

Fixes #11241

AI Disclosure: Claude Code (Opus 4.6) used for codebase exploration, code review, and testing assistance. All code written and reviewed by hand.