### PR TITLE
macos: remove tiny 1px gray border in non-native fullscreen

### DIFF
--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -468,9 +468,14 @@ class TerminalWindow: NSWindow {
         guard isVisible else { return }
         defer { updateColorSchemeForSurfaceTree() }
 
-        // Basic properties
         appearance = surfaceConfig.windowAppearance
-        hasShadow = surfaceConfig.macosWindowShadow
+
+        // In non-native fullscreen we force shadow off to avoid the 1px gray window border on macOS 26.
+        if let fs = terminalController?.fullscreenStyle, fs.isFullscreen, !styleMask.contains(.fullScreen) {
+            hasShadow = false
+        } else {
+            hasShadow = surfaceConfig.macosWindowShadow
+        }
 
         // Window transparency only takes effect if our window is not native fullscreen.
         // In native fullscreen we disable transparency/opacity because the background

--- a/macos/Sources/Helpers/Fullscreen.swift
+++ b/macos/Sources/Helpers/Fullscreen.swift
@@ -227,6 +227,10 @@ class NonNativeFullscreen: FullscreenBase, FullscreenStyle {
         // from the edges.
         window.styleMask.remove(.resizable)
 
+        // We don't need shadow in fullscreen and shadow causes macOS 26 to
+        // draw a tiny 1px gray border around the window so we disable it.
+        window.hasShadow = false
+
         // Focus window
         window.makeKeyAndOrderFront(nil)
 
@@ -267,6 +271,7 @@ class NonNativeFullscreen: FullscreenBase, FullscreenStyle {
 
         // Restore our saved state
         window.styleMask = savedState.styleMask
+        window.hasShadow = savedState.hasShadow
         window.setFrame(window.frameRect(forContentRect: savedState.contentFrame), display: true)
 
         // Removing the "titled" style also derefs all our accessory view controllers
@@ -397,6 +402,7 @@ class NonNativeFullscreen: FullscreenBase, FullscreenStyle {
         let styleMask: NSWindow.StyleMask
         let toolbar: NSToolbar?
         let toolbarStyle: NSWindow.ToolbarStyle
+        let hasShadow: Bool
         let titlebarAccessoryViewControllers: [NSTitlebarAccessoryViewController]
         let dock: Bool
         let menu: Bool
@@ -411,6 +417,7 @@ class NonNativeFullscreen: FullscreenBase, FullscreenStyle {
             self.styleMask = window.styleMask
             self.toolbar = window.toolbar
             self.toolbarStyle = window.toolbarStyle
+            self.hasShadow = window.hasShadow
             self.dock = window.screen?.hasDock ?? false
 
             self.titlebarAccessoryViewControllers = if window.hasTitleBar {


### PR DESCRIPTION
It seems macOS 26 draws a tiny 1px border around windows when window shadow is enabled. When shadow is disabled, the border is not drawn.

See https://github.com/ghostty-org/ghostty/discussions/9582#discussioncomment-16070472 for details.

Fixes https://github.com/ghostty-org/ghostty/discussions/9582

I've made initial discovery in https://ampcode.com/threads/T-019cd797-b49b-77ca-b702-ff18027fc6bf, then back and forth-ed a bit https://ampcode.com/threads/T-019cd7e2-87fa-71f8-8e45-3444e7b68676 and wrapped up the implementation.