### PR TITLE
macos: disable Tahoe one-time codes

### DIFF
--- a/macos/Ghostty-Info.plist
+++ b/macos/Ghostty-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAutoFillRequiresTextContentTypeForOneTimeCodeOnMac</key>
+	<true/>
 	<key>NSDockTilePlugIn</key>
 	<string>DockTilePlugin.plugin</string>
 	<key>CFBundleDocumentTypes</key>


### PR DESCRIPTION
This disables all the automatic one-time code inputs in Ghostty. It'd be really neat to actually dynamically change this (not sure if it's possible with NSTextContext or how often thats cached) but for now we should just fully disable it.

Thanks to Ricky Mondello for the heads up on this.