### PR TITLE
appintents: expose PID and TTY on TerminalEntity

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1085,6 +1085,8 @@ ghostty_surface_config_s ghostty_surface_inherited_config(ghostty_surface_t, gho
 void ghostty_surface_update_config(ghostty_surface_t, ghostty_config_t);
 bool ghostty_surface_needs_confirm_quit(ghostty_surface_t);
 bool ghostty_surface_process_exited(ghostty_surface_t);
+uint64_t ghostty_surface_child_pid(ghostty_surface_t);
+const char* ghostty_surface_tty_name(ghostty_surface_t);
 void ghostty_surface_refresh(ghostty_surface_t);
 void ghostty_surface_draw(ghostty_surface_t);
 void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);

--- a/macos/Sources/Features/App Intents/Entities/TerminalEntity.swift
+++ b/macos/Sources/Features/App Intents/Entities/TerminalEntity.swift
@@ -14,6 +14,12 @@ struct TerminalEntity: AppEntity {
     @Property(title: "Kind")
     var kind: Kind
 
+    @Property(title: "PID")
+    var pid: Int?
+
+    @Property(title: "TTY")
+    var tty: String?
+
     var screenshot: NSImage?
 
     static var typeDisplayRepresentation: TypeDisplayRepresentation {
@@ -49,6 +55,8 @@ struct TerminalEntity: AppEntity {
         self.id = view.id
         self.title = view.title
         self.workingDirectory = view.pwd
+        self.pid = view.surfaceModel?.childPID
+        self.tty = view.surfaceModel?.ttyName
         if let nsImage = ImageRenderer(content: view.screenshot()).nsImage {
             self.screenshot = nsImage
         }

--- a/macos/Sources/Features/App Intents/GetTerminalDetailsIntent.swift
+++ b/macos/Sources/Features/App Intents/GetTerminalDetailsIntent.swift
@@ -35,6 +35,8 @@ struct GetTerminalDetailsIntent: AppIntent {
         switch detail {
         case .title: return .result(value: terminal.title)
         case .workingDirectory: return .result(value: terminal.workingDirectory)
+        case .pid: return .result(value: terminal.pid.map { String($0) })
+        case .tty: return .result(value: terminal.tty)
         case .allContents:
             guard let view = terminal.surfaceView else { throw GhosttyIntentError.surfaceNotFound }
             return .result(value: view.cachedScreenContents.get())
@@ -53,6 +55,8 @@ struct GetTerminalDetailsIntent: AppIntent {
 enum TerminalDetail: String {
     case title
     case workingDirectory
+    case pid
+    case tty
     case allContents
     case selectedText
     case visibleText
@@ -64,6 +68,8 @@ extension TerminalDetail: AppEnum {
     static var caseDisplayRepresentations: [Self: DisplayRepresentation] = [
         .title: .init(title: "Title"),
         .workingDirectory: .init(title: "Working Directory"),
+        .pid: .init(title: "PID"),
+        .tty: .init(title: "TTY"),
         .allContents: .init(title: "Full Contents"),
         .selectedText: .init(title: "Selected Text"),
         .visibleText: .init(title: "Visible Text"),

--- a/macos/Sources/Ghostty/Ghostty.Surface.swift
+++ b/macos/Sources/Ghostty/Ghostty.Surface.swift
@@ -82,6 +82,20 @@ extension Ghostty {
             event.withCValue { keyIsBinding($0) }
         }
 
+        /// The PID of the foreground process, or nil if not available.
+        @MainActor
+        var childPID: Int? {
+            let pid = ghostty_surface_child_pid(surface)
+            return pid != 0 ? Int(pid) : nil
+        }
+
+        /// The TTY device name (e.g. "/dev/ttys003"), or nil if not available.
+        @MainActor
+        var ttyName: String? {
+            guard let ptr = ghostty_surface_tty_name(surface) else { return nil }
+            return String(cString: ptr)
+        }
+
         /// Whether the terminal has captured mouse input.
         ///
         /// When the mouse is captured, the terminal application is receiving mouse events

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1598,6 +1598,19 @@ pub const CAPI = struct {
         return surface.core_surface.child_exited;
     }
 
+    /// Returns the PID of the foreground process running in the surface,
+    /// or 0 if the process is not available.
+    export fn ghostty_surface_child_pid(surface: *Surface) u64 {
+        return surface.core_surface.getProcessInfo(.foreground_pid) orelse 0;
+    }
+
+    /// Returns the TTY device name of the surface (e.g. "/dev/ttys003"),
+    /// or null if not available.
+    export fn ghostty_surface_tty_name(surface: *Surface) ?[*:0]const u8 {
+        const name = surface.core_surface.getProcessInfo(.tty_name) orelse return null;
+        return name.ptr;
+    }
+
     /// Returns true if the surface has a selection.
     export fn ghostty_surface_has_selection(surface: *Surface) bool {
         return surface.core_surface.hasSelection();


### PR DESCRIPTION
This is a re-submission of #10983. Vouched in #11287.

Add child process PID and TTY device name as queryable properties on
TerminalEntity for App Intents. This enables external applications and
Shortcuts to identify and filter terminals by their PID or TTY device.

Closes #10756

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
