### PR TITLE
gtk: fix +new-window `--working-directory` inferrence.

### DIFF
--- a/src/cli/new_window.zig
+++ b/src/cli/new_window.zig
@@ -198,7 +198,8 @@ fn runArgs(
         const cwd: std.fs.Dir = std.fs.cwd();
         var buf: [std.fs.max_path_bytes]u8 = undefined;
         const wd = try cwd.realpath(".", &buf);
-        try opts._arguments.append(alloc, try std.fmt.allocPrintSentinel(alloc, "--working-directory={s}", .{wd}, 0));
+        // This should be inserted at the beginning of the list, just in case `-e` was used.
+        try opts._arguments.insert(alloc, 0, try std.fmt.allocPrintSentinel(alloc, "--working-directory={s}", .{wd}, 0));
     }
 
     var arena = ArenaAllocator.init(alloc_gpa);


### PR DESCRIPTION
If the CLI argument `--working-directory` is not used with `+new-window`, the current working directory that `ghostty +new-window` is run from will be appended to the list of configuration data sent to the main Ghostty process. If `-e` _was_ used on the CLI, the `--working-directory` that was appended will be interpreted as part of the command to be executed, likely causing it to fail.

Instead, insert `--working-directory` at the beginning of the list of configuration that it sent to the main Ghostty process.

Fixes #11356