### PR TITLE
docs: fix backtick rendering in selection-word-chars default value

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -749,7 +749,7 @@ foreground: Color = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF },
 /// The null character (U+0000) is always treated as a boundary and does not
 /// need to be included in this configuration.
 ///
-/// Default: ` \t'"│`|:;,()[]{}<>$`
+/// Default: `` \t'"│`|:;,()[]{}<>$ ``
 ///
 /// To add or remove specific characters, you can set this to a custom value.
 /// For example, to treat semicolons as part of words:


### PR DESCRIPTION
## Summary
- The default value for `selection-word-chars` contains a literal backtick character, which broke inline code rendering on the website — the code span was prematurely closed, leaving part of the value outside the formatted block.
- Fixed by using double backtick delimiters which is the standard markdown way to include a backtick in inline code.