### PR TITLE
macOS: fix window position for the very first window

### DIFF
--- a/macos/GhosttyUITests/GhosttyWindowPositionUITests.swift
+++ b/macos/GhosttyUITests/GhosttyWindowPositionUITests.swift
@@ -128,12 +128,19 @@ final class GhosttyWindowPositionUITests: GhosttyCustomConfigCase {
         )
 
         let app = try ghosttyApplication()
+        // Suppress Restoration
+        app.launchArguments += ["-NSQuitAlwaysKeepsWindows", "NO"]
+        // Clean run
+        app.launchEnvironment["GHOSTTY_CLEAR_USER_DEFAULTS"] = "YES"
         app.launch()
 
         let window = app.windows.firstMatch
         XCTAssertTrue(window.waitForExistence(timeout: 5), "Window should appear")
 
         let firstFrame = window.frame
+        let screenFrame = NSScreen.main?.frame ?? .zero
+
+        XCTAssertEqual(firstFrame.midX, screenFrame.midX, accuracy: 5.0, "First window should be centered horizontally")
 
         // Close the window and open a new one — it should restore the same frame.
         app.typeKey("w", modifierFlags: [.command])

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -56,9 +56,6 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
     /// The notification cancellable for focused surface property changes.
     private var surfaceAppearanceCancellables: Set<AnyCancellable> = []
 
-    /// This will be set to the initial frame of the window from the xib on load.
-    private var initialFrame: NSRect?
-
     init(_ ghostty: Ghostty.App,
          withBaseConfig base: Ghostty.SurfaceConfiguration? = nil,
          withSurfaceTree tree: SplitTree<Ghostty.SurfaceView>? = nil,
@@ -1061,13 +1058,6 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
             }
         }
 
-
-        // Store our initial frame so we can know our default later. This MUST
-        // be after the defaultSize call above so that we don't re-apply our frame.
-        // Note: we probably want to set this on the first frame change or something
-        // so it respects cascade.
-        initialFrame = window.frame
-
         // In various situations, macOS automatically tabs new windows. Ghostty handles
         // its own tabbing so we DONT want this behavior. This detects this scenario and undoes
         // it.
@@ -1666,9 +1656,6 @@ extension TerminalController {
             // Initial size as requested by the configuration (e.g. `window-width`)
             // takes next priority.
             return .contentIntrinsicSize
-        } else if let initialFrame {
-            // The initial frame we had when we started otherwise.
-            return .frame(initialFrame)
         } else {
             return nil
         }

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -1061,22 +1061,6 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
             }
         }
 
-        // Set the initial window position. This must happen after the window
-        // is fully set up (content view, toolbar, default size) so that
-        // decorations added by subclass awakeFromNib (e.g. toolbar for tabs
-        // style) don't change the frame after the position is restored.
-        if let terminalWindow = window as? TerminalWindow {
-            terminalWindow.setInitialWindowPosition(
-                x: derivedConfig.windowPositionX,
-                y: derivedConfig.windowPositionY,
-            )
-        }
-
-        LastWindowPosition.shared.restore(
-            window,
-            origin: derivedConfig.windowPositionX == nil && derivedConfig.windowPositionY == nil,
-            size: defaultSize == nil,
-        )
 
         // Store our initial frame so we can know our default later. This MUST
         // be after the defaultSize call above so that we don't re-apply our frame.
@@ -1108,6 +1092,34 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         // apply this based on the root config but change it later based on surface
         // config (see focused surface change callback).
         syncAppearance(.init(config))
+    }
+
+    /// Setup correct window frame before showing the window
+    override func showWindow(_ sender: Any?) {
+        guard let terminalWindow = window as? TerminalWindow else { return }
+
+        // Set the initial window position. This must happen after the window
+        // is fully set up (content view, toolbar, default size) so that
+        // decorations added by subclass awakeFromNib (e.g. toolbar for tabs
+        // style) don't change the frame after the position is restored.
+        let originChanged = terminalWindow.setInitialWindowPosition(
+            x: derivedConfig.windowPositionX,
+            y: derivedConfig.windowPositionY,
+        )
+        let restored = LastWindowPosition.shared.restore(
+            terminalWindow,
+            origin: !originChanged,
+            size: defaultSize == nil,
+        )
+
+        // If nothing is changed for the frame,
+        // we should center the window
+        if !originChanged, !restored {
+            // This doesn't work in `windowDidLoad` somehow
+            terminalWindow.center()
+        }
+
+        super.showWindow(sender)
     }
 
     // Shows the "+" button in the tab bar, responds to that click.

--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -536,17 +536,15 @@ class TerminalWindow: NSWindow {
         terminalController?.updateColorSchemeForSurfaceTree()
     }
 
-    func setInitialWindowPosition(x: Int16?, y: Int16?) {
+    func setInitialWindowPosition(x: Int16?, y: Int16?) -> Bool {
         // If we don't have an X/Y then we try to use the previously saved window pos.
         guard let x = x, let y = y else {
-            center()
-            return
+            return false
         }
 
         // Prefer the screen our window is being placed on otherwise our primary screen.
         guard let screen = screen ?? NSScreen.screens.first else {
-            center()
-            return
+            return false
         }
 
         // Convert top-left coordinates to bottom-left origin using our utility extension
@@ -562,6 +560,7 @@ class TerminalWindow: NSWindow {
         safeOrigin.y = min(max(safeOrigin.y, vf.minY), vf.maxY - frame.height)
 
         setFrameOrigin(safeOrigin)
+        return true
     }
 
     private func hideWindowButtons() {

--- a/macos/Sources/Helpers/LastWindowPosition.swift
+++ b/macos/Sources/Helpers/LastWindowPosition.swift
@@ -50,7 +50,13 @@ class LastWindowPosition {
             newFrame.size.height = min(values[3], visibleFrame.height)
         }
 
-        if restoreOrigin, !visibleFrame.contains(newFrame.origin) {
+        // If the new frame is not constrained to the visible screen,
+        // we need to shift it a little bit before AppKit does this for us,
+        // so that we can save the correct size beforehand.
+        // This fixes restoration while running UI tests,
+        // where config is modified without switching apps,
+        // which will not trigger `windowDidBecomeMain`.
+        if restoreOrigin, !visibleFrame.contains(newFrame) {
             newFrame.origin.x = max(visibleFrame.minX, min(visibleFrame.maxX - newFrame.width, newFrame.origin.x))
             newFrame.origin.y = max(visibleFrame.minY, min(visibleFrame.maxY - newFrame.height, newFrame.origin.y))
         }


### PR DESCRIPTION
Depends on https://github.com/ghostty-org/ghostty/pull/11417

Moved positioning part from `windowDidLoad` to `showWindow` to make new users happy. Also deleted `initialFrame`, since we don't need it anymore.