### PR TITLE
snap: Don't leak LD_LIBRARY_PATH set by the snap launcher

### DIFF
--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
+const build_config = @import("../build_config.zig");
 const apprt = @import("../apprt.zig");
 
 const log = std.log.scoped(.@"os-open");
@@ -47,6 +48,17 @@ pub fn open(
     // This must be set before spawning the process.
     exe.stdout_behavior = .Pipe;
     exe.stderr_behavior = .Pipe;
+
+    // In the snap on Linux the launcher exports LD_LIBRARY_PATH pointing at
+    // the snap's bundled libraries. Leaking this into child process can
+    // can be problematic, so let's drop it from the env
+    var snap_env: std.process.EnvMap = if (comptime build_config.snap) blk: {
+        var env = try std.process.getEnvMap(alloc);
+        env.remove("LD_LIBRARY_PATH");
+        break :blk env;
+    } else undefined;
+    defer if (comptime build_config.snap) snap_env.deinit();
+    if (comptime build_config.snap) exe.env_map = &snap_env;
 
     // Spawn the process on our same thread so we can detect failure
     // quickly.


### PR DESCRIPTION
LD_LIBRARY_PATH was being leaked which could break some apps launched from ghostty, such as opening configuration in a text editor.