### PR TITLE
macos: select tab applescript command should not activate application

### DIFF
--- a/macos/Sources/Features/AppleScript/ScriptTab.swift
+++ b/macos/Sources/Features/AppleScript/ScriptTab.swift
@@ -126,7 +126,6 @@ final class ScriptTab: NSObject {
         }
 
         tabContainerWindow.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
         return nil
     }
 


### PR DESCRIPTION
Related to #11457