### PR TITLE
fix: enable cursor blinking mode by default

### DIFF
--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -191,6 +191,7 @@ pub const SavedCursor = struct {
     protected: bool,
     pending_wrap: bool,
     origin: bool,
+    cursor_blinking: bool,
     charset: CharsetState,
 };
 

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1094,6 +1094,7 @@ pub fn saveCursor(self: *Terminal) void {
         .protected = self.screens.active.cursor.protected,
         .pending_wrap = self.screens.active.cursor.pending_wrap,
         .origin = self.modes.get(.origin),
+        .cursor_blinking = self.modes.get(.cursor_blinking),
         .charset = self.screens.active.charset,
     };
 }
@@ -1109,6 +1110,7 @@ pub fn restoreCursor(self: *Terminal) void {
         .style = .{},
         .protected = false,
         .pending_wrap = false,
+        .cursor_blinking = true,
         .origin = false,
         .charset = .{},
     };
@@ -1128,6 +1130,7 @@ pub fn restoreCursor(self: *Terminal) void {
 
     self.screens.active.charset = saved.charset;
     self.modes.set(.origin, saved.origin);
+    self.modes.set(.cursor_blinking, saved.cursor_blinking);
     self.screens.active.cursor.pending_wrap = saved.pending_wrap;
     self.screens.active.cursor.protected = saved.protected;
     self.screens.active.cursorAbsolute(

--- a/src/terminal/modes.zig
+++ b/src/terminal/modes.zig
@@ -202,7 +202,7 @@ const entries: []const ModeEntry = &.{
     .{ .name = "wraparound", .value = 7, .default = true },
     .{ .name = "autorepeat", .value = 8 },
     .{ .name = "mouse_event_x10", .value = 9 },
-    .{ .name = "cursor_blinking", .value = 12 },
+    .{ .name = "cursor_blinking", .value = 12, .default = true },
     .{ .name = "cursor_visible", .value = 25, .default = true },
     .{ .name = "enable_mode_3", .value = 40 },
     .{ .name = "reverse_wrap", .value = 45 },

--- a/src/terminal/stream_readonly.zig
+++ b/src/terminal/stream_readonly.zig
@@ -87,8 +87,8 @@ pub const Handler = struct {
             ),
             .cursor_style => {
                 const blink = switch (value) {
-                    .default, .steady_block, .steady_bar, .steady_underline => false,
-                    .blinking_block, .blinking_bar, .blinking_underline => true,
+                    .steady_block, .steady_bar, .steady_underline => false,
+                    .default, .blinking_block, .blinking_bar, .blinking_underline => true,
                 };
                 const style: Screen.CursorStyle = switch (value) {
                     .default, .blinking_block, .steady_block => .block,


### PR DESCRIPTION
Ghostty already defaults to blinking mode and behavior should be maintained in core to provide consistent and [standard](https://vt100.net/docs/vt510-rm/DECSCUSR.html) defaults.