### PR TITLE
fix(macos): enable cmd+c/x/v/a in rename tab dialog

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -364,7 +364,7 @@ class BaseTerminalController: NSWindowController,
         alert.informativeText = "Leave blank to restore the default."
         alert.alertStyle = .informational
 
-        let textField = NSTextField(frame: NSRect(x: 0, y: 0, width: 250, height: 24))
+        let textField = AlertTextFieldWithMenuSupport(frame: NSRect(x: 0, y: 0, width: 250, height: 24))
         textField.stringValue = titleOverride ?? window.title
         alert.accessoryView = textField
 
@@ -1536,6 +1536,41 @@ extension BaseTerminalController {
             // subscriptions for old/removed surfaces when the tree changes.
             .switchToLatest()
             .eraseToAnyPublisher()
+    }
+}
+
+// MARK: - AlertTextFieldWithMenuSupport
+
+/// A custom NSTextField that properly supports standard macOS text editing menu commands
+/// (cut, copy, paste) when used as an accessory view in NSAlert dialogs.
+/// This ensures cmd+c, cmd+x, and cmd+v work as expected in the rename tab dialog.
+private class AlertTextFieldWithMenuSupport: NSTextField {
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        // Handle standard macOS text editing commands through the responder chain.
+        // This allows cmd+c (copy), cmd+x (cut), cmd+v (paste), and cmd+a (select all)
+        // to work properly in alert accessory text fields.
+        if event.type == .keyDown {
+            let modifierFlags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            let isCommandKey = modifierFlags.contains(.command)
+
+            if isCommandKey {
+                let characters = event.characters ?? ""
+                switch characters {
+                case "c": // cmd+c (copy)
+                    return NSApp.sendAction(#selector(NSText.copy(_:)), to: nil, from: self)
+                case "x": // cmd+x (cut)
+                    return NSApp.sendAction(#selector(NSText.cut(_:)), to: nil, from: self)
+                case "v": // cmd+v (paste)
+                    return NSApp.sendAction(#selector(NSText.paste(_:)), to: nil, from: self)
+                case "a": // cmd+a (select all)
+                    return NSApp.sendAction(#selector(NSText.selectAll(_:)), to: nil, from: self)
+                default:
+                    break
+                }
+            }
+        }
+
+        return super.performKeyEquivalent(with: event)
     }
 }
 


### PR DESCRIPTION
## Summary
Fixes #10749 — The rename tab alert dialog on macOS did not support standard keyboard shortcuts (Cmd+C, Cmd+X, Cmd+V, Cmd+A).

## Root cause
NSAlert captures key events before they reach the text field responder chain, preventing standard text editing shortcuts from working.

## Fix
Add `AlertTextFieldWithMenuSupport` NSTextField subclass that overrides `performKeyEquivalent(with:)` to intercept Cmd+key events and dispatch them via `NSApp.sendAction`.

Supported shortcuts:
- Cmd+C (copy)
- Cmd+X (cut)
- Cmd+V (paste)
- Cmd+A (select all)

## Validation
- swiftlint: 0 findings
- periphery (dead code): 0 findings on new code
- cppcheck: 0 findings

## Test plan
- [ ] Open rename tab dialog (right-click tab > Rename)
- [ ] Cmd+A selects all text
- [ ] Cmd+C copies selected text
- [ ] Cmd+V pastes text
- [ ] Cmd+X cuts selected text
- [ ] Other key events still work normally

## AI usage
Claude Code used for implementation acceleration. Design decision (NSTextField subclass vs NSAlert override) made by contributor after reviewing AppKit responder chain architecture.