### PR TITLE
fix: correct typos and duplicate words in comments

### DIFF
--- a/pkg/opengl/glad.zig
+++ b/pkg/opengl/glad.zig
@@ -4,7 +4,7 @@ const c = @import("c.zig").c;
 pub const Context = c.GladGLContext;
 
 /// This is the current context. Set this var manually prior to calling
-/// any of this package's functions. I know its nasty to have a global but
+/// any of this package's functions. I know it's nasty to have a global but
 /// this makes it match OpenGL API styles where it also operates on a
 /// threadlocal global.
 pub threadlocal var context: Context = undefined;

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4968,14 +4968,14 @@ fn mouseSelection(
         break :ebs drag_pin.before(click_pin);
     };
 
-    // Whether or not the the click pin cell
+    // Whether or not the click pin cell
     // should be included in the selection.
     const include_click_cell = if (end_before_start)
         click_x_frac >= threshold_point
     else
         click_x_frac < threshold_point;
 
-    // Whether or not the the drag pin cell
+    // Whether or not the drag pin cell
     // should be included in the selection.
     const include_drag_cell = if (end_before_start)
         drag_x_frac < threshold_point

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1972,12 +1972,12 @@ pub const CAPI = struct {
     ) bool {
         const action_str = action_ptr[0..action_len];
         const action = input.Binding.Action.parse(action_str) catch |err| {
-            log.err("error parsing binding action action={s} err={}", .{ action_str, err });
+            log.err("error parsing binding action={s} err={}", .{ action_str, err });
             return false;
         };
 
         return ptr.core_surface.performBindingAction(action) catch |err| {
-            log.err("error performing binding action action={f} err={}", .{ action, err });
+            log.err("error performing binding action={f} err={}", .{ action, err });
             return false;
         };
     }

--- a/src/apprt/gtk/class/command_palette.zig
+++ b/src/apprt/gtk/class/command_palette.zig
@@ -353,7 +353,7 @@ pub const CommandPalette = extern struct {
         // Regular command - emit trigger signal
         const action = cmd.getAction() orelse return;
 
-        // Signal that an an action has been selected. Signals are synchronous
+        // Signal that an action has been selected. Signals are synchronous
         // so we shouldn't need to worry about cloning the action.
         signals.trigger.impl.emit(
             self,

--- a/src/apprt/gtk/winproto/x11.zig
+++ b/src/apprt/gtk/winproto/x11.zig
@@ -48,7 +48,7 @@ pub const App = struct {
         else
             "ghostty";
 
-        // Set the X11 window class property (WM_CLASS) if are are on an X11
+        // Set the X11 window class property (WM_CLASS) if we are on an X11
         // display.
         //
         // Note that we also set the program name here using g_set_prgname.

--- a/src/benchmark/Benchmark.zig
+++ b/src/benchmark/Benchmark.zig
@@ -38,9 +38,9 @@ pub fn run(
     // Our result accumulator. This will be returned at the end of the run.
     var result: RunResult = .{};
 
-    // If we're on macOS, we setup signposts so its easier to find
+    // If we're on macOS, we setup signposts so it's easier to find
     // the results in Instruments. There's a lot of nasty comptime stuff
-    // here but its just to ensure this does nothing on other platforms.
+    // here but it's just to ensure this does nothing on other platforms.
     const signpost_name = "ghostty";
     const signpost: if (builtin.target.os.tag.isDarwin()) struct {
         log: *macos.os.Log,

--- a/src/build_config.zig
+++ b/src/build_config.zig
@@ -32,7 +32,7 @@ pub const mode_string = mode: {
 pub const artifact = Artifact.detect();
 
 /// Our build configuration. We re-export a lot of these back at the
-/// top-level so its a bit cleaner to use throughout the code. See the doc
+/// top-level so it's a bit cleaner to use throughout the code. See the doc
 /// comments in BuildConfig for details on each.
 const config = BuildConfig.fromOptions();
 pub const exe_entrypoint = config.exe_entrypoint;

--- a/src/config/url.zig
+++ b/src/config/url.zig
@@ -17,7 +17,7 @@ const oni = @import("oniguruma");
 /// 2. Do not match regexes ending with ), except for ones which contain a (
 ///    without a subsequent )
 ///
-/// Rule 2 means that that we handle the following two cases:
+/// Rule 2 means that we handle the following two cases:
 ///
 ///   "https://en.wikipedia.org/wiki/Rust_(video_game)" (include parens)
 ///   "(https://example.com)" (do not include the parens)

--- a/src/font/sprite/draw/box.zig
+++ b/src/font/sprite/draw/box.zig
@@ -845,7 +845,7 @@ fn dashHorizontal(
         }
         hline(canvas, x, x1, y, thick_px);
         // Advance by the width of the dash we drew and the width
-        // of a gap to get the the start of the next dash.
+        // of a gap to get the start of the next dash.
         x = x1 + gap_width;
     }
 }
@@ -923,7 +923,7 @@ fn dashVertical(
         }
         vline(canvas, y, y1, x, thick_px);
         // Advance by the height of the dash we drew and the height
-        // of a gap to get the the start of the next dash.
+        // of a gap to get the start of the next dash.
         y = y1 + gap_height;
     }
 }

--- a/src/quirks.zig
+++ b/src/quirks.zig
@@ -18,7 +18,7 @@ pub fn disableDefaultFontFeatures(face: *const font.Face) bool {
     // This function used to do something, but we integrated the logic
     // we checked for directly into our shaping algorithm. It's likely
     // there are other broken fonts for other reasons so I'm keeping this
-    // around so its easy to add more checks in the future.
+    // around so it's easy to add more checks in the future.
     return false;
 
     // var buf: [64]u8 = undefined;

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1929,7 +1929,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
             self.updateScreenSizeUniforms();
 
-            log.debug("screen size size={}", .{size});
+            log.debug("screen size={}", .{size});
         }
 
         /// Update uniforms that are based on the screen size.

--- a/src/terminal/render.zig
+++ b/src/terminal/render.zig
@@ -740,7 +740,7 @@ pub const RenderState = struct {
     /// we can adjust this later.
     ///
     /// NOTE: There is a limitation in that wrapped lines before/after
-    /// the the top/bottom line of the viewport are not included, since
+    /// the top/bottom line of the viewport are not included, since
     /// the render state cuts them off.
     pub fn string(
         self: *const RenderState,

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -108,7 +108,7 @@ pub fn threadEnter(
         ),
 
         // If we're executing via Flatpak then we can't do
-        // traditional process watching (its implemented
+        // traditional process watching (it's implemented
         // as a special case in os/flatpak.zig) since the
         // command is on the host.
         .flatpak => null,
@@ -494,7 +494,7 @@ pub const ThreadData = struct {
     // enough to satisfy most write requests. It must be a power of 2.
     const WRITE_REQ_PREALLOC = std.math.pow(usize, 2, 5);
 
-    /// Process start time and boolean of whether its already exited.
+    /// Process start time and boolean of whether it's already exited.
     start: std.time.Instant,
     exited: bool = false,
 
@@ -1187,7 +1187,7 @@ const Subprocess = struct {
 
     fn getpgid(pid: c.pid_t) ?c.pid_t {
         // Get our process group ID. Before the child pid calls setsid
-        // the pgid will be ours because we forked it. Its possible that
+        // the pgid will be ours because we forked it. It's possible that
         // we may be calling this before setsid if we are killing a surface
         // VERY quickly after starting it.
         const my_pgid = c.getpgid(0);
@@ -1205,7 +1205,7 @@ const Subprocess = struct {
                 continue;
             }
 
-            // Don't know why it would be zero but its not a valid pid
+            // Don't know why it would be zero but it's not a valid pid
             if (pgid == 0) return null;
 
             // If the pid doesn't exist then... we're done!
@@ -1478,7 +1478,7 @@ fn execCommand(
         // There is another issue: `login(1)` on macOS 14.3 and earlier
         // checked for ".hushlogin" in the working directory. This means
         // that if we specify "-l" then we won't get hushlogin honored
-        // if its in the home directory (which is standard). To get
+        // if it's in the home directory (which is standard). To get
         // around this, we check for hushlogin ourselves and if present
         // specify the "-q" flag to login(1).
         //

--- a/src/termio/Options.zig
+++ b/src/termio/Options.zig
@@ -30,7 +30,7 @@ mailbox: termio.Mailbox,
 /// terminal implementation.)
 renderer_state: *renderer.State,
 
-/// A handle to wake up the renderer. This hints to the renderer that that
+/// A handle to wake up the renderer. This hints to the renderer that
 /// a repaint should happen.
 renderer_wakeup: xev.Async,
 

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -67,7 +67,7 @@ terminal_stream: StreamHandler.Stream,
 last_cursor_reset: ?std.time.Instant = null,
 
 /// State we have for thread enter. This may be null if we don't need
-/// to keep track of any state or if its already been freed.
+/// to keep track of any state or if it's already been freed.
 thread_enter_state: ?*ThreadEnterState = null,
 
 /// The state we need to keep around only until we enter the IO
@@ -391,7 +391,7 @@ pub fn threadExit(self: *Termio, data: *ThreadData) void {
     self.backend.threadExit(data);
 }
 
-/// Send a message to the the mailbox. Depending on the mailbox type in
+/// Send a message to the mailbox. Depending on the mailbox type in
 /// use this may process now or it may just enqueue and process later.
 ///
 /// This will also notify the mailbox thread to process the message. If
@@ -609,7 +609,7 @@ pub fn clearScreen(self: *Termio, td: *ThreadData, history: bool) !void {
             // Clear all Kitty graphics state for this screen. This copies
             // Kitty's behavior when Cmd+K deletes all Kitty graphics. I
             // didn't spend time researching whether it only deletes Kitty
-            // graphics that are placed baove the cursor or if it deletes
+            // graphics that are placed above the cursor or if it deletes
             // all of them. We delete all of them for now but if this behavior
             // isn't fully correct we should fix this later.
             self.terminal.screens.active.kitty_images.delete(

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -42,7 +42,7 @@ terminal: terminalpkg.Terminal,
 /// The shared render state
 renderer_state: *renderer.State,
 
-/// A handle to wake up the renderer. This hints to the renderer that that
+/// A handle to wake up the renderer. This hints to the renderer that
 /// a repaint should happen.
 renderer_wakeup: xev.Async,
 

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -1,6 +1,6 @@
 //! Represents the "writer" thread for terminal IO. The reader side is
 //! handled by the Termio struct itself and dependent on the underlying
-//! implementation (i.e. if its a pty, manual, etc.).
+//! implementation (i.e. if it's a pty, manual, etc.).
 //!
 //! The writer thread does handle writing bytes to the pty but also handles
 //! different events such as starting synchronized output, changing some
@@ -474,7 +474,7 @@ fn startScrollTimer(self: *Thread, cb: *CallbackData) void {
     switch (self.scroll_c.state()) {
         // If it is already active, e.g. startScrollTimer is called multiple
         // times, then we just return. We can't simply check `scroll_active`
-        // because its possible that `stopScrollTimer` was called but there
+        // because it's possible that `stopScrollTimer` was called but there
         // was no loop tick between then and now to halt out completion.
         .active => return,
 

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -162,7 +162,7 @@ pub const StreamHandler = struct {
         defer self.renderer_state.mutex.lock();
         self.renderer_wakeup.notify() catch |err| {
             // This is an EXTREMELY unlikely case. We still don't return
-            // and attempt to send the message because its most likely
+            // and attempt to send the message because it's most likely
             // that everything is fine, but log in case a freeze happens.
             log.warn(
                 "failed to notify renderer, may deadlock err={}",

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -36,7 +36,7 @@ pub const StreamHandler = struct {
     /// The mailbox for notifying the renderer of things.
     renderer_mailbox: *renderer.Thread.Mailbox,
 
-    /// A handle to wake up the renderer. This hints to the renderer that that
+    /// A handle to wake up the renderer. This hints to the renderer that
     /// a repaint should happen.
     renderer_wakeup: xev.Async,
 


### PR DESCRIPTION
## Summary

Fix 30 typos and grammar issues across 16 source files. All changes are in code comments and log messages only — zero functional impact.

### Categories

**Duplicate words (16 fixes)**:
- `"that that"` → `"that"` (4 occurrences in termio/, config/)
- `"the the"` → `"the"` (6 occurrences in Surface.zig, font/sprite/, terminal/)
- `"action action="` → `"action="` (2 in apprt/embedded.zig)
- `"screen size size="` → `"screen size="` (1 in renderer/)
- `"an an"` → `"an"` (1 in apprt/gtk/)
- `"if are are"` → `"if we are"` (1 in apprt/gtk/)
- `"to the the"` → `"to the"` (1 in termio/)

**Grammar — its/it's (13 fixes)**:
- `"its"` → `"it's"` where contraction is correct (possessive → contraction)
- Files: termio/Exec.zig, termio/Thread.zig, termio/stream_handler.zig, build_config.zig, quirks.zig, pkg/opengl/glad.zig, benchmark/Benchmark.zig

**Spelling (1 fix)**:
- `"baove"` → `"above"` (termio/Termio.zig)

### Files changed

`src/termio/Termio.zig`, `src/termio/stream_handler.zig`, `src/termio/Options.zig`, `src/termio/Exec.zig`, `src/termio/Thread.zig`, `src/config/url.zig`, `src/renderer/generic.zig`, `src/apprt/embedded.zig`, `src/apprt/gtk/winproto/x11.zig`, `src/apprt/gtk/class/command_palette.zig`, `src/Surface.zig`, `src/font/sprite/draw/box.zig`, `src/terminal/render.zig`, `src/build_config.zig`, `src/quirks.zig`, `pkg/opengl/glad.zig`, `src/benchmark/Benchmark.zig`

## Test plan

- [ ] `zig build` compiles without errors
- [ ] All changes are in comments/log strings — no logic changes
- [ ] Grep confirms no remaining `"that that"`, `"the the"`, `"an an"` duplicates

## AI disclosure

Typos were identified using pattern-based search (grep for duplicate words, its/it's confusion) with Claude Code (Anthropic). Each fix was manually verified in context to ensure correctness.