### PR TITLE
i18n: add missing Plural-Forms metadata to 5 translation files

### DIFF
--- a/po/id.po
+++ b/po/id.po
@@ -16,6 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #: dist/linux/ghostty_nautilus.py:53
 msgid "Open in Ghostty"

--- a/po/lt.po
+++ b/po/lt.po
@@ -15,6 +15,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 &&"
+" (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #: dist/linux/ghostty_nautilus.py:53
 msgid "Open in Ghostty"

--- a/po/mk.po
+++ b/po/mk.po
@@ -16,6 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n % 10 == 1 && n % 100 != 11) ? 0 :"
+" 1;\n"
 
 #: dist/linux/ghostty_nautilus.py:53
 msgid "Open in Ghostty"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -16,6 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #: dist/linux/ghostty_nautilus.py:53
 msgid "Open in Ghostty"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -15,6 +15,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #: dist/linux/ghostty_nautilus.py:53
 msgid "Open in Ghostty"


### PR DESCRIPTION
## Summary

Add missing `Plural-Forms` header to 5 `.po` translation files that were lacking this GNU gettext metadata.

### Changes

| File | Language | Plural-Forms added |
|------|----------|--------------------|
| `po/id.po` | Indonesian | `nplurals=1; plural=0;` |
| `po/zh_CN.po` | Chinese (Simplified) | `nplurals=1; plural=0;` |
| `po/zh_TW.po` | Chinese (Traditional) | `nplurals=1; plural=0;` |
| `po/lt.po` | Lithuanian | `nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 \|\| n%100>=20) ? 1 : 2);` |
| `po/mk.po` | Macedonian | `nplurals=2; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : 1;` |

### Rationale

- **GNU gettext best practice**: Every `.po` file should include `Plural-Forms` in its metadata header. Without it, gettext falls back to the default formula (`nplurals=2; plural=(n != 1);`), which is incorrect for languages like Indonesian, Chinese, and Lithuanian.
- **Consistency**: The other 24 translation files in `po/` already have correct `Plural-Forms` headers.
- **References**: Plural formulas sourced from [GNU gettext documentation](https://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html) and [Unicode CLDR](https://cldr.unicode.org/index/cldr-spec/plural-rules).

## Test plan

- [ ] `zig build update-translations` runs without errors
- [ ] `msgfmt --check` validates each modified `.po` file
- [ ] No functional change if the project doesn't currently use plural forms, but ensures correctness for future plural strings

## AI disclosure

Missing Plural-Forms headers were identified by auditing all 29 `.po` files against the GNU gettext specification using Claude Code (Anthropic). Plural formulas were sourced from official GNU gettext and Unicode CLDR documentation.