### PR TITLE
terminal/screen: optionally preserve whitespaces in selectLine

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4139,7 +4139,7 @@ pub fn mouseButtonCallback(
                 const sel_ = if (mods.ctrlOrSuper())
                     self.io.terminal.screens.active.selectOutput(pin.*)
                 else
-                    self.io.terminal.screens.active.selectLine(.{ .pin = pin.* });
+                    self.io.terminal.screens.active.selectLine(.{ .pin = pin.*, .leading_whitespace = null });
                 if (sel_) |sel| {
                     try self.io.terminal.screens.active.select(sel);
                     try self.queueRender();
@@ -4438,7 +4438,8 @@ fn linkAtPin(
     const screen: *terminal.Screen = self.renderer_state.terminal.screens.active;
     const line = screen.selectLine(.{
         .pin = mouse_pin,
-        .whitespace = null,
+        .leading_whitespace = null,
+        .trailing_whitespace = null,
         .semantic_prompt_boundary = false,
     }) orelse return null;
 
@@ -4863,13 +4864,13 @@ fn dragLeftClickTriple(
 
     // Get the line selection under our current drag point. If there isn't a
     // line, do nothing.
-    const line = screen.selectLine(.{ .pin = drag_pin }) orelse return;
+    const line = screen.selectLine(.{ .pin = drag_pin, .leading_whitespace = null }) orelse return;
 
     // Get the selection under our click point. We first try to trim
     // whitespace if we've selected a word. But if no word exists then
     // we select the blank line.
-    const sel_ = screen.selectLine(.{ .pin = click_pin }) orelse
-        screen.selectLine(.{ .pin = click_pin, .whitespace = null });
+    const sel_ = screen.selectLine(.{ .pin = click_pin, .leading_whitespace = null }) orelse
+        screen.selectLine(.{ .pin = click_pin, .leading_whitespace = null, .trailing_whitespace = null });
 
     var sel = sel_ orelse return;
     if (drag_pin.before(click_pin)) {

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -2495,12 +2495,18 @@ pub fn selectionString(
 }
 
 pub const SelectLine = struct {
+    const default_whitespace: []const u21 = &.{ 0, ' ', '\t' };
+
     /// The pin of some part of the line to select.
     pin: Pin,
 
-    /// These are the codepoints to consider whitespace to trim
-    /// from the ends of the selection.
-    whitespace: ?[]const u21 = &.{ 0, ' ', '\t' },
+    /// Codepoints to trim from the start of the selection.
+    /// Set to null to preserve leading whitespace, e.g. for
+    /// triple-click line selection.
+    leading_whitespace: ?[]const u21 = default_whitespace,
+
+    /// Codepoints to trim from the end of the selection.
+    trailing_whitespace: ?[]const u21 = default_whitespace,
 
     /// If true, line selection will consider semantic prompt
     /// state changing a boundary. State changing is ANY state
@@ -2629,7 +2635,7 @@ pub fn selectLine(self: *const Screen, opts: SelectLine) ?Selection {
 
     // Go forward from the start to find the first non-whitespace character.
     const start: Pin = start: {
-        const whitespace = opts.whitespace orelse break :start start_pin;
+        const whitespace = opts.leading_whitespace orelse break :start start_pin;
         var it = start_pin.cellIterator(.right_down, end_pin);
         while (it.next()) |p| {
             const cell = p.rowAndCell().cell;
@@ -2651,7 +2657,7 @@ pub fn selectLine(self: *const Screen, opts: SelectLine) ?Selection {
 
     // Go backward from the end to find the first non-whitespace character.
     const end: Pin = end: {
-        const whitespace = opts.whitespace orelse break :end end_pin;
+        const whitespace = opts.trailing_whitespace orelse break :end end_pin;
         var it = end_pin.cellIterator(.left_up, start_pin);
         while (it.next()) |p| {
             const cell = p.rowAndCell().cell;
@@ -2921,7 +2927,8 @@ pub const LineIterator = struct {
         const current = self.current orelse return null;
         const result = self.screen.selectLine(.{
             .pin = current,
-            .whitespace = null,
+            .leading_whitespace = null,
+            .trailing_whitespace = null,
             .semantic_prompt_boundary = false,
         }) orelse {
             self.current = null;
@@ -7637,6 +7644,87 @@ test "Screen: selectLine" {
     }
 }
 
+test "Screen: selectLine optionally preserves whitespaces" {
+    // Regression test for https://github.com/ghostty-org/ghostty/issues/11463
+    //
+    // selectLine can optionally keep leading or trailing whitespaces.
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, .{ .cols = 20, .rows = 10 });
+    defer s.deinit();
+    // "   indented line  " (3 leading, 2 trailing spaces)
+    try s.testWriteString("   indented line  ");
+
+    // default: leading trimmed, trailing trimmed
+    {
+        var sel = s.selectLine(.{
+            .pin = s.pages.pin(.{ .active = .{ .x = 5, .y = 0 } }).?,
+        }).?;
+        defer sel.deinit(&s);
+        try testing.expectEqual(point.Point{ .screen = .{
+            .x = 3,
+            .y = 0,
+        } }, s.pages.pointFromPin(.screen, sel.start()).?);
+        try testing.expectEqual(point.Point{ .screen = .{
+            .x = 15,
+            .y = 0,
+        } }, s.pages.pointFromPin(.screen, sel.end()).?);
+    }
+
+    // leading_whitespace = null: leading preserved, trailing trimmed
+    {
+        var sel = s.selectLine(.{
+            .pin = s.pages.pin(.{ .active = .{ .x = 5, .y = 0 } }).?,
+            .leading_whitespace = null,
+        }).?;
+        defer sel.deinit(&s);
+        try testing.expectEqual(point.Point{ .screen = .{
+            .x = 0,
+            .y = 0,
+        } }, s.pages.pointFromPin(.screen, sel.start()).?);
+        try testing.expectEqual(point.Point{ .screen = .{
+            .x = 15,
+            .y = 0,
+        } }, s.pages.pointFromPin(.screen, sel.end()).?);
+    }
+
+    // trailing_whitespace = null: leading trimmed, trailing preserved
+    {
+        var sel = s.selectLine(.{
+            .pin = s.pages.pin(.{ .active = .{ .x = 5, .y = 0 } }).?,
+            .trailing_whitespace = null,
+        }).?;
+        defer sel.deinit(&s);
+        try testing.expectEqual(point.Point{ .screen = .{
+            .x = 3,
+            .y = 0,
+        } }, s.pages.pointFromPin(.screen, sel.start()).?);
+        try testing.expectEqual(point.Point{ .screen = .{
+            .x = 19,
+            .y = 0,
+        } }, s.pages.pointFromPin(.screen, sel.end()).?);
+    }
+
+    // both leading preserved and trailing preserved
+    {
+        var sel = s.selectLine(.{
+            .pin = s.pages.pin(.{ .active = .{ .x = 5, .y = 0 } }).?,
+            .leading_whitespace = null,
+            .trailing_whitespace = null,
+        }).?;
+        defer sel.deinit(&s);
+        try testing.expectEqual(point.Point{ .screen = .{
+            .x = 0,
+            .y = 0,
+        } }, s.pages.pointFromPin(.screen, sel.start()).?);
+        try testing.expectEqual(point.Point{ .screen = .{
+            .x = 19,
+            .y = 0,
+        } }, s.pages.pointFromPin(.screen, sel.end()).?);
+    }
+}
+
 test "Screen: selectLine across soft-wrap" {
     const testing = std.testing;
     const alloc = testing.allocator;
@@ -7763,7 +7851,8 @@ test "Screen: selectLine disabled whitespace trimming" {
                 .x = 1,
                 .y = 0,
             } }).?,
-            .whitespace = null,
+            .leading_whitespace = null,
+            .trailing_whitespace = null,
         }).?;
         defer sel.deinit(&s);
         try testing.expectEqual(point.Point{ .screen = .{
@@ -7783,7 +7872,8 @@ test "Screen: selectLine disabled whitespace trimming" {
                 .x = 1,
                 .y = 3,
             } }).?,
-            .whitespace = null,
+            .leading_whitespace = null,
+            .trailing_whitespace = null,
         }).?;
         defer sel.deinit(&s);
         try testing.expectEqual(point.Point{ .screen = .{


### PR DESCRIPTION
Relates to https://github.com/ghostty-org/ghostty/issues/11463

selectLine has a whitespace filter to control trimming of whitespaces both leading and trailing any line but the filter applies to both. However, for use cases such as triple clicking or dragging, preserving the leading whitespaces and dropping the trailing ones is useful to preserve the indentation of the lines.

This PR extends selectLine with two control filters to facilitate this behavior. There is now `leading_whitespace` and `trailing_whitespace` and both can be disabled or modified for any usecase.

Default behavior remains the same. Only in the case of triple clicking and dragging we're modifying it preserving the leading whitespaces.

Added a unitary test to test all the cases for the gates.

Note: I considered using a boolean gate instead called `trim_leading`. The call to the method would look very similar but it felt unnecessary since we already had the existing `whitespace` filter. However I could not come with a way to use a single filter so this is why i aded one for leading and one for trailing whitespaces. 