### PR TITLE
config: add quick-terminal-background-opacity option

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -610,7 +610,8 @@ class QuickTerminalController: BaseTerminalController {
 
         // If we have window transparency then set it transparent. Otherwise set it opaque.
         // Also check if the user has overridden transparency to be fully opaque.
-        if !isBackgroundOpaque && (self.derivedConfig.backgroundOpacity < 1 || derivedConfig.backgroundBlur.isGlassStyle) {
+        // effectiveBackgroundOpacity accounts for quick-terminal-background-opacity.
+        if !isBackgroundOpaque && (derivedConfig.effectiveBackgroundOpacity < 1 || derivedConfig.backgroundBlur.isGlassStyle) {
             window.isOpaque = false
 
             // This is weird, but we don't use ".clear" because this creates a look that
@@ -728,7 +729,9 @@ class QuickTerminalController: BaseTerminalController {
         let quickTerminalAutoHide: Bool
         let quickTerminalSpaceBehavior: QuickTerminalSpaceBehavior
         let quickTerminalSize: QuickTerminalSize
-        let backgroundOpacity: Double
+        /// Effective background opacity for the quick terminal. Uses
+        /// quick-terminal-background-opacity if set, otherwise background-opacity.
+        let effectiveBackgroundOpacity: Double
         let backgroundBlur: Ghostty.Config.BackgroundBlur
 
         init() {
@@ -737,7 +740,7 @@ class QuickTerminalController: BaseTerminalController {
             self.quickTerminalAutoHide = true
             self.quickTerminalSpaceBehavior = .move
             self.quickTerminalSize = QuickTerminalSize()
-            self.backgroundOpacity = 1.0
+            self.effectiveBackgroundOpacity = 1.0
             self.backgroundBlur = .disabled
         }
 
@@ -747,7 +750,7 @@ class QuickTerminalController: BaseTerminalController {
             self.quickTerminalAutoHide = config.quickTerminalAutoHide
             self.quickTerminalSpaceBehavior = config.quickTerminalSpaceBehavior
             self.quickTerminalSize = config.quickTerminalSize
-            self.backgroundOpacity = config.backgroundOpacity
+            self.effectiveBackgroundOpacity = config.quickTerminalBackgroundOpacity ?? config.backgroundOpacity
             self.backgroundBlur = config.backgroundBlur
         }
     }

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -602,6 +602,14 @@ extension Ghostty {
             guard ghostty_config_get(config, &v, key, UInt(key.lengthOfBytes(using: .utf8))) else { return QuickTerminalSize() }
             return QuickTerminalSize(from: v)
         }
+
+        var quickTerminalBackgroundOpacity: Double? {
+            guard let config = self.config else { return nil }
+            var v: Double = 0
+            let key = "quick-terminal-background-opacity"
+            guard ghostty_config_get(config, &v, key, UInt(key.lengthOfBytes(using: .utf8))) else { return nil }
+            return v
+        }
         #endif
 
         var resizeOverlay: ResizeOverlay {

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -419,6 +419,11 @@ pub const Surface = struct {
     /// that getTitle works without the implementer needing to save it.
     title: ?[:0]const u8 = null,
 
+    /// True if this surface belongs to a quick terminal window. When true,
+    /// quick-terminal-background-opacity overrides background-opacity in the
+    /// renderer config if the setting is present.
+    is_quick_terminal: bool = false,
+
     /// Surface initialization options.
     pub const Options = extern struct {
         /// The platform that this surface is being initialized for and
@@ -571,6 +576,18 @@ pub const Surface = struct {
         // Wait after command
         if (opts.wait_after_command) {
             config.@"wait-after-command" = true;
+        }
+
+        // Detect quick terminal surfaces from the GHOSTTY_QUICK_TERMINAL
+        // env var set by the apprt (e.g. Swift, GTK). Override
+        // background-opacity with quick-terminal-background-opacity if set.
+        if (config.env.map.get("GHOSTTY_QUICK_TERMINAL")) |val| {
+            if (std.mem.eql(u8, val, "1")) {
+                self.is_quick_terminal = true;
+                if (app.config.@"quick-terminal-background-opacity") |opacity| {
+                    config.@"background-opacity" = opacity;
+                }
+            }
         }
 
         // Initialize our surface right away. We're given a view that is
@@ -1582,6 +1599,19 @@ pub const CAPI = struct {
         surface: *Surface,
         config: *const Config,
     ) void {
+        // For quick terminal surfaces, override background-opacity with
+        // quick-terminal-background-opacity if the setting is present.
+        if (surface.is_quick_terminal) {
+            if (config.@"quick-terminal-background-opacity") |opacity| {
+                var modified = config.*;
+                modified.@"background-opacity" = opacity;
+                surface.core_surface.updateConfig(&modified) catch |err| {
+                    log.err("error updating config err={}", .{err});
+                };
+                return;
+            }
+        }
+
         surface.core_surface.updateConfig(config) catch |err| {
             log.err("error updating config err={}", .{err});
             return;

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2703,6 +2703,18 @@ keybind: Keybinds = .{},
 /// Only implemented on macOS.
 @"quick-terminal-animation-duration": f64 = 0.2,
 
+/// The opacity level (opposite of transparency) of the background for the
+/// quick terminal. A value of 1 is fully opaque and a value of 0 is fully
+/// transparent. A value less than 0 or greater than 1 will be clamped to
+/// the nearest valid value.
+///
+/// This behaves identically to `background-opacity` but applies only to the
+/// quick terminal window. When set, it overrides `background-opacity` for the
+/// quick terminal. When unset, the quick terminal uses `background-opacity`.
+///
+/// Only implemented on macOS.
+@"quick-terminal-background-opacity": ?f64 = null,
+
 /// Automatically hide the quick terminal when focus shifts to another window.
 /// Set it to false for the quick terminal to remain open even when it loses focus.
 ///


### PR DESCRIPTION
I want to add background opacity to quick terminal view -- so my dropdown overlay config is different than my main window config. This is critical for me so I can see my windows underneath my terminal while I'm typing commands. At the same time, I don't want to have normal ghostty windows show my desktop beneath them (or other windows)

Relevant discussions:

* https://github.com/ghostty-org/ghostty/discussions/10047
* https://github.com/ghostty-org/ghostty/discussions/3524
* https://github.com/ghostty-org/ghostty/issues/2331

Disclosures:

* yes I have read all ghostty policies
* yes I used AI assistance for this feature (Claude Code, Opus 4.6)
* yes I have read and reviewed all code
* yes I have tested that it actually works on my machine

Caveat: this is my first PR, so this may be the "wrong way" of doing it. the main thing I'm unsure of is how to correlate `is_quick_terminal`; right now I'm reusing `GHOSTTY_QUICK_TERMINAL`
