### PR TITLE
Lots of duplicate word typos + typo

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4968,14 +4968,14 @@ fn mouseSelection(
         break :ebs drag_pin.before(click_pin);
     };
 
-    // Whether or not the the click pin cell
+    // Whether or not the click pin cell
     // should be included in the selection.
     const include_click_cell = if (end_before_start)
         click_x_frac >= threshold_point
     else
         click_x_frac < threshold_point;
 
-    // Whether or not the the drag pin cell
+    // Whether or not the drag pin cell
     // should be included in the selection.
     const include_drag_cell = if (end_before_start)
         drag_x_frac < threshold_point

--- a/src/apprt/gtk/class/command_palette.zig
+++ b/src/apprt/gtk/class/command_palette.zig
@@ -353,7 +353,7 @@ pub const CommandPalette = extern struct {
         // Regular command - emit trigger signal
         const action = cmd.getAction() orelse return;
 
-        // Signal that an an action has been selected. Signals are synchronous
+        // Signal that an action has been selected. Signals are synchronous
         // so we shouldn't need to worry about cloning the action.
         signals.trigger.impl.emit(
             self,

--- a/src/apprt/gtk/winproto/x11.zig
+++ b/src/apprt/gtk/winproto/x11.zig
@@ -48,7 +48,7 @@ pub const App = struct {
         else
             "ghostty";
 
-        // Set the X11 window class property (WM_CLASS) if are are on an X11
+        // Set the X11 window class property (WM_CLASS) if we are on an X11
         // display.
         //
         // Note that we also set the program name here using g_set_prgname.

--- a/src/config/url.zig
+++ b/src/config/url.zig
@@ -17,7 +17,7 @@ const oni = @import("oniguruma");
 /// 2. Do not match regexes ending with ), except for ones which contain a (
 ///    without a subsequent )
 ///
-/// Rule 2 means that that we handle the following two cases:
+/// Rule 2 means that we handle the following two cases:
 ///
 ///   "https://en.wikipedia.org/wiki/Rust_(video_game)" (include parens)
 ///   "(https://example.com)" (do not include the parens)

--- a/src/font/nerd_font_codegen.py
+++ b/src/font/nerd_font_codegen.py
@@ -460,10 +460,9 @@ def generate_zig_switch_arms(
                         # scaled and aligned position would span the line height
                         # plus overlap. Thus, we can use any other stretched
                         # glyph with overlap as stand-in to get the vertical
-                        # bounds, such as as 0xE0B0 (powerline left hard
-                        # divider). We don't worry about the horizontal bounds,
-                        # as they by design should not affect the group's
-                        # bounding box.
+                        # bounds, such as 0xE0B0 (powerline left hard divider).
+                        # We don't worry about the horizontal bounds, as they by
+                        # design should not affect the group's bounding box.
                         if (
                             patch_set_name == "Progress Indicators"
                             and cp_original == 0xEDFF

--- a/src/font/shape.zig
+++ b/src/font/shape.zig
@@ -34,8 +34,8 @@ pub const Shaper = switch (options.backend) {
     .web_canvas => web_canvas.Shaper,
 };
 
-/// A cell is a single single within a terminal that should be rendered
-/// for a shaping call. Note all terminal cells may be present; only
+/// A cell is a single glyph within a terminal that should be rendered
+/// for a shaping call. Not all terminal cells may be present; only
 /// cells that have a glyph that needs to be rendered.
 pub const Cell = struct {
     /// The X position of this shaper cell relative to the offset of the

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -104,7 +104,7 @@ pub const Shaper = struct {
     }
 
     /// Returns an iterator that returns one text run at a time for the
-    /// given terminal row. Note that text runs are are only valid one at a time
+    /// given terminal row. Note that text runs are only valid one at a time
     /// for a Shaper struct since they share state.
     ///
     /// The selection must be a row-only selection (height = 1). See

--- a/src/font/shaper/web_canvas.zig
+++ b/src/font/shaper/web_canvas.zig
@@ -58,7 +58,7 @@ pub const Shaper = struct {
     }
 
     /// Returns an iterator that returns one text run at a time for the
-    /// given terminal row. Note that text runs are are only valid one at a time
+    /// given terminal row. Note that text runs are only valid one at a time
     /// for a Shaper struct since they share state.
     pub fn runIterator(
         self: *Shaper,

--- a/src/font/sprite/draw/box.zig
+++ b/src/font/sprite/draw/box.zig
@@ -845,7 +845,7 @@ fn dashHorizontal(
         }
         hline(canvas, x, x1, y, thick_px);
         // Advance by the width of the dash we drew and the width
-        // of a gap to get the the start of the next dash.
+        // of a gap to get the start of the next dash.
         x = x1 + gap_width;
     }
 }
@@ -923,7 +923,7 @@ fn dashVertical(
         }
         vline(canvas, y, y1, x, thick_px);
         // Advance by the height of the dash we drew and the height
-        // of a gap to get the the start of the next dash.
+        // of a gap to get the start of the next dash.
         y = y1 + gap_height;
     }
 }

--- a/src/input/key_encode.zig
+++ b/src/input/key_encode.zig
@@ -159,7 +159,7 @@ fn kitty(
             switch (event.key) {
                 else => {},
                 inline .enter, .backspace => |tag| {
-                    // See legacy for why we handle this this way.
+                    // See legacy for why we handle this way.
                     if (isControlUtf8(event.utf8)) break :utf8;
                     if (comptime tag == .backspace) return;
                     return try writer.writeAll(event.utf8);

--- a/src/input/keycodes.zig
+++ b/src/input/keycodes.zig
@@ -40,7 +40,7 @@ pub const Entry = struct {
 };
 
 /// A map from code to key. This isn't meant to be used at runtime
-/// (though it could), so it isn't exported. It it used to build the
+/// (though it could), so it isn't exported. It used to build the
 /// key value for Entry.
 const code_to_key = code_to_key: {
     @setEvalBranchQuota(5000);

--- a/src/terminal/hash_map.zig
+++ b/src/terminal/hash_map.zig
@@ -104,8 +104,8 @@ pub fn OffsetHashMap(
     };
 }
 
-/// Fork of stdlib.HashMap as of Zig 0.12 modified to to use offsets
-/// for the key/values pointer. The metadata is still a pointer to limit
+/// Fork of stdlib.HashMap as of Zig 0.12 modified to use offsets for
+/// the key/values pointer. The metadata is still a pointer to limit
 /// the amount of arithmetic required to access it. See the file comment
 /// for full details.
 fn HashMapUnmanaged(

--- a/src/terminal/render.zig
+++ b/src/terminal/render.zig
@@ -740,7 +740,7 @@ pub const RenderState = struct {
     /// we can adjust this later.
     ///
     /// NOTE: There is a limitation in that wrapped lines before/after
-    /// the the top/bottom line of the viewport are not included, since
+    /// the top/bottom line of the viewport are not included, since
     /// the render state cuts them off.
     pub fn string(
         self: *const RenderState,

--- a/src/termio/Options.zig
+++ b/src/termio/Options.zig
@@ -30,7 +30,7 @@ mailbox: termio.Mailbox,
 /// terminal implementation.)
 renderer_state: *renderer.State,
 
-/// A handle to wake up the renderer. This hints to the renderer that that
+/// A handle to wake up the renderer. This hints to the renderer that
 /// a repaint should happen.
 renderer_wakeup: xev.Async,
 

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -42,7 +42,7 @@ terminal: terminalpkg.Terminal,
 /// The shared render state
 renderer_state: *renderer.State,
 
-/// A handle to wake up the renderer. This hints to the renderer that that
+/// A handle to wake up the renderer. This hints to the renderer that
 /// a repaint should happen.
 renderer_wakeup: xev.Async,
 
@@ -391,8 +391,8 @@ pub fn threadExit(self: *Termio, data: *ThreadData) void {
     self.backend.threadExit(data);
 }
 
-/// Send a message to the the mailbox. Depending on the mailbox type in
-/// use this may process now or it may just enqueue and process later.
+/// Send a message to the mailbox. Depending on the mailbox type in use
+/// this may process now or it may just enqueue and process later.
 ///
 /// This will also notify the mailbox thread to process the message. If
 /// you're sending a lot of messages, it may be more efficient to use
@@ -609,7 +609,7 @@ pub fn clearScreen(self: *Termio, td: *ThreadData, history: bool) !void {
             // Clear all Kitty graphics state for this screen. This copies
             // Kitty's behavior when Cmd+K deletes all Kitty graphics. I
             // didn't spend time researching whether it only deletes Kitty
-            // graphics that are placed baove the cursor or if it deletes
+            // graphics that are placed above the cursor or if it deletes
             // all of them. We delete all of them for now but if this behavior
             // isn't fully correct we should fix this later.
             self.terminal.screens.active.kitty_images.delete(

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -36,7 +36,7 @@ pub const StreamHandler = struct {
     /// The mailbox for notifying the renderer of things.
     renderer_mailbox: *renderer.Thread.Mailbox,
 
-    /// A handle to wake up the renderer. This hints to the renderer that that
+    /// A handle to wake up the renderer. This hints to the renderer that
     /// a repaint should happen.
     renderer_wakeup: xev.Async,
 
@@ -1038,7 +1038,7 @@ pub const StreamHandler = struct {
         self: *StreamHandler,
         shape: terminal.MouseShape,
     ) !void {
-        // Avoid changing the shape it it is already set to avoid excess
+        // Avoid changing the shape if it is already set to avoid excess
         // cross-thread messaging.
         if (self.terminal.mouse_shape == shape) return;
 


### PR DESCRIPTION
TL;DR: this description is (intentionally) nonsense but I ran `\b(\w+)\s\1\b` over `src` and stole a singular typo fix from #11528.

Replacement of #11528 with 100% less slop and 99% less AI; I didn't feel like saying no to free(ish) typo checking. Note that many of the fixes there were outright incorrect (and clearly had no review from sentient lifeforms, contrary to its—sorry, it's—description). A lot of extra double words were caught with a handy `rg --pcre2 '\b(\w+)\s+\1\b' src`; you could say this PR was “ripgrep-assisted” the way that one was “AI-assisted”. Rather ironic since that PR also claims to have used grep via Claude Code, but missed a lot of them.

The its → it's changes from that PR were elided; I decided to run a `rg "\bit'?s\b" src`, but someone REALLY likes their its, so I reverted my changes as there were an extremely large number of changes (probably a hundred files with multiple hundred cases). The only other change was “baout” → “about”.

# AI Usage

Claude Code was used by proxy for finding baout. Claude Code was used by proxy for realizing that the correct spelling is about. Claude Code was not used for fixing it. Oh my god it was so difficult to fix, the original PR had it so easy. I had to type out the file name (fish's AI sorry I mean autocomplete helped though) and like, type /baout, press R, press ab, then save and exit. This is so difficult you know we should use an AI for this, like this is so hard I don't know how people manage.

All changes were verified by me: I consulted the dictionary to delve into double-checkment of “in existence; being in evidence; apparent.” Uhhh insert assorted other AI impersonation here maybe? THE LLM IN ME WANTS TO ESCAPE PLEASE HELP