### PR TITLE
Add missing plural forms

### DIFF
--- a/po/id.po
+++ b/po/id.po
@@ -16,6 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: dist/linux/ghostty_nautilus.py:53
 msgid "Open in Ghostty"

--- a/po/lt.po
+++ b/po/lt.po
@@ -15,6 +15,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #: dist/linux/ghostty_nautilus.py:53
 msgid "Open in Ghostty"


### PR DESCRIPTION
Supersedes #11529; I did not use their plural forms because I trust <kbd>ctrl</kbd>+<kbd>c</kbd> more than Claude Code.

`mk` and `zh_*` are still missing theirs, but neither [gettext's table] nor the [documentation it copied from] list them. That PR has them too, with values magicked from… somewhere? The [data they linked] is illegible to me.

[gettext's table]: https://cgit.git.savannah.gnu.org/cgit/gettext.git/tree/gettext-tools/src/plural-table.c?id=dbf9d71e0c4707ca1b14359256b3dcccecb8e837
[documentation it copied from]: https://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html
[data they linked]: https://www.unicode.org/cldr/charts/48/supplemental/language_plural_rules.html