### PR TITLE
macos: fix edit shortcuts in tab rename text field

### DIFF
--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -187,6 +187,32 @@ class TerminalWindow: NSWindow {
         super.sendEvent(event)
     }
 
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        // If the tab title editor is active, send the action directly to the
+        // field editor. The editor sits in the tab bar (outside the content
+        // view hierarchy), so the normal performKeyEquivalent walk through the
+        // content view never reaches it, and the menu dispatch does not reliably
+        // fire during this phase. Sending the action directly is both simpler
+        // and more reliable.
+        if let fieldEditor = tabTitleEditor.activeFieldEditor,
+           event.type == .keyDown,
+           event.modifierFlags.contains(.command) {
+            let action: Selector? = switch event.charactersIgnoringModifiers {
+            case "c": #selector(NSText.copy(_:))
+            case "x": #selector(NSText.cut(_:))
+            case "v": #selector(NSText.paste(_:))
+            case "a": #selector(NSText.selectAll(_:))
+            default: nil
+            }
+
+            if let action {
+                NSApp.sendAction(action, to: fieldEditor, from: nil)
+                return true
+            }
+        }
+        return super.performKeyEquivalent(with: event)
+    }
+
     override func close() {
         tabTitleEditor.finishEditing(commit: true)
         NotificationCenter.default.post(name: Self.terminalWillCloseNotification, object: self)

--- a/macos/Sources/Helpers/TabTitleEditor.swift
+++ b/macos/Sources/Helpers/TabTitleEditor.swift
@@ -343,6 +343,11 @@ final class TabTitleEditor: NSObject, NSTextFieldDelegate {
         }
     }
 
+    /// Returns the active field editor if inline editing is in progress, nil otherwise.
+    var activeFieldEditor: NSTextView? {
+        inlineTitleEditor?.currentEditor() as? NSTextView
+    }
+
     // MARK: NSTextFieldDelegate
 
     func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {


### PR DESCRIPTION
## Summary

Override `performKeyEquivalent` in `TerminalWindow` to route standard edit shortcuts (Cmd+C/X/V/A) to the field editor when inline tab title editing is active.

## Root cause

The inline tab title editor's `NSTextField` lives in the tab bar (titlebar area), outside the content view hierarchy. When AppKit dispatches `performKeyEquivalent`, it walks the content view tree and never reaches the field editor. The event falls through to `keyDown` on the field editor, but `interpretKeyEvents` has no key binding for `@v` (Cmd+V) - that mapping lives in the menu system, not the key binding dictionary. Result: beep.

## Changes

- **TerminalWindow.swift**: Added `performKeyEquivalent` override that checks if the tab title editor has an active field editor. For Cmd+C/X/V/A, maps to the standard `NSText` action selector and dispatches via `NSApp.sendAction`. All other keys fall through to `super.performKeyEquivalent`.
- **TabTitleEditor.swift**: Added `activeFieldEditor` computed property to expose the field editor state.

No `EditableTextField` subclass needed. No changes to any other file.

## Testing

1. Open Ghostty, create a new tab
2. Double-click the tab title to start editing
3. Cmd+V pastes from clipboard into the field
4. Cmd+A selects all text in the field
5. Cmd+C copies selected text
6. Cmd+X cuts selected text
7. Escape cancels, Enter commits
8. Terminal shortcuts (Cmd+T, Cmd+W) still work while editor is NOT active

Fixes #10749

This contribution was developed with AI assistance (Claude Code).