### PR TITLE
ci: skip milestone workflow for bot-authored PRs

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -11,6 +11,9 @@ on:
 
 jobs:
   update-milestone:
+    # Ignore bot-authored pull requests (dependabot, app bots, etc)
+    # and CI-only PRs.
+    if: github.event_name == 'issues' || (github.event.pull_request.user.type != 'Bot' && !startsWith(github.event.pull_request.title, 'ci:'))
     runs-on: namespace-profile-ghostty-sm
     name: Milestone Update
     steps:


### PR DESCRIPTION
The milestone action currently runs for all merged pull_request_target close events, including PRs opened by bots such as dependabot and ghostty-vouch. That causes milestone binding to run on automated PRs that should be ignored.

Gate the update-milestone job so pull request events only run when the author is not a bot, while still allowing closed-issue events to run. This preserves existing issue milestone behavior and prevents bot PRs from triggering the workflow.