### PR TITLE
fix(macos): support pasting clipboard images as temp file paths

### DIFF
--- a/macos/Sources/Helpers/Extensions/NSPasteboard+Extension.swift
+++ b/macos/Sources/Helpers/Extensions/NSPasteboard+Extension.swift
@@ -35,6 +35,8 @@ extension NSPasteboard {
     /// Gets the contents of the pasteboard as a string following a specific set of semantics.
     /// Does these things in order:
     /// - Tries to get the absolute filesystem path of the file in the pasteboard if there is one and ensures the file path is properly escaped.
+    /// - Tries to get image data from the pasteboard (e.g. screenshots captured to clipboard),
+    ///   writes it to a temp file, and returns the escaped path.
     /// - Tries to get any string from the pasteboard.
     /// If all of the above fail, returns None.
     func getOpinionatedStringContents() -> String? {
@@ -43,6 +45,29 @@ extension NSPasteboard {
             return urls
                 .map { $0.isFileURL ? Ghostty.Shell.escape($0.path) : $0.absoluteString }
                 .joined(separator: " ")
+        }
+
+        // Check for image data in the clipboard (e.g. macOS screenshot to clipboard
+        // via Cmd+Shift+Ctrl+4). Write to a temp file and return the escaped path
+        // so that terminal applications like Claude Code can consume it.
+        if let imageData = self.data(forType: .png) ?? self.data(forType: .tiff) {
+            let fileName = "ghostty-paste-\(UUID().uuidString).png"
+            let tempURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(fileName)
+            do {
+                // If we got TIFF data, convert to PNG for broader compatibility
+                if self.data(forType: .png) == nil,
+                   let tiffImage = NSImage(data: imageData),
+                   let tiffData = tiffImage.tiffRepresentation,
+                   let bitmap = NSBitmapImageRep(data: tiffData),
+                   let pngData = bitmap.representation(using: .png, properties: [:]) {
+                    try pngData.write(to: tempURL)
+                } else {
+                    try imageData.write(to: tempURL)
+                }
+                return Ghostty.Shell.escape(tempURL.path)
+            } catch {
+                // Fall through to string fallback
+            }
         }
 
         return self.string(forType: .string)


### PR DESCRIPTION
## Summary

When a screenshot is captured directly to the clipboard via Cmd+Shift+Ctrl+4, the pasteboard contains raw PNG/TIFF image data rather than a file URL. `getOpinionatedStringContents()` only handled file URLs and strings, silently ignoring image data.

This adds a check for image data between the URL and string fallback branches. When image data is found, it writes it to a temp file and returns the escaped path. TIFF data (macOS native screenshot format) is converted to PNG for broader compatibility.

**Before:** Cmd+V after clipboard screenshot does nothing.
**After:** Cmd+V writes the image to a temp file and pastes the escaped path (e.g. `/tmp/ghostty-paste-UUID.png`).

This enables tools like Claude Code to receive pasted screenshots, matching the behavior of iTerm2 and Warp.

## The change

One file: `macos/Sources/Helpers/Extensions/NSPasteboard+Extension.swift`

Added a ~20 line branch to `getOpinionatedStringContents()` that:
1. Checks for PNG or TIFF data in the pasteboard
2. Converts TIFF to PNG if needed (broader compatibility)
3. Writes to a temp file with a UUID filename
4. Returns the shell-escaped path using the existing `Ghostty.Shell.escape()`

The check sits between the existing URL handler and the string fallback, so existing behavior is unchanged for file copies and text pastes.

## Related

- Discussion #10478 (feature request for clipboard screenshot paste)
- Discussion #10117 (can't paste images into Claude Code)