### PR TITLE
macos: opacity-toggle setting persists between tabs in a window and to a newly created window

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -767,7 +767,7 @@ class BaseTerminalController: NSWindowController,
             tree: newTree,
             position: notification.userInfo?[Notification.Name.ghosttySurfaceDragEndedNoTargetPointKey] as? NSPoint,
             confirmUndo: false,
-            inheritBackgroundOpacityFrom: self as? TerminalController)
+            inheritBackgroundOpacity: isBackgroundOpaque)
     }
 
     // MARK: Local Events
@@ -991,11 +991,15 @@ class BaseTerminalController: NSWindowController,
         // Do nothing if in fullscreen (transparency doesn't apply in fullscreen)
         guard let window, !window.styleMask.contains(.fullScreen) else { return }
 
-        // Toggle between transparent and opaque
-        isBackgroundOpaque.toggle()
+        let newValue = !isBackgroundOpaque
+        let controllers = NSApplication.shared.windows.compactMap {
+            $0.windowController as? BaseTerminalController
+        }
 
-        // Update our appearance
-        syncAppearance()
+        for controller in controllers {
+            controller.isBackgroundOpaque = newValue
+            controller.syncAppearance()
+        }
     }
 
     /// Override this to resync any appearance related properties. This will be called automatically

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -766,7 +766,8 @@ class BaseTerminalController: NSWindowController,
             ghostty,
             tree: newTree,
             position: notification.userInfo?[Notification.Name.ghosttySurfaceDragEndedNoTargetPointKey] as? NSPoint,
-            confirmUndo: false)
+            confirmUndo: false,
+            inheritBackgroundOpacityFrom: self as? TerminalController)
     }
 
     // MARK: Local Events

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -316,11 +316,11 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         tree: SplitTree<Ghostty.SurfaceView>,
         position: NSPoint? = nil,
         confirmUndo: Bool = true,
-        inheritBackgroundOpacityFrom parentController: TerminalController? = nil
+        inheritBackgroundOpacity: Bool? = nil
     ) -> TerminalController {
         let c = TerminalController.init(ghostty, withSurfaceTree: tree)
-        if let parentController {
-            c.isBackgroundOpaque = parentController.isBackgroundOpaque
+        if let inheritBackgroundOpacity {
+            c.isBackgroundOpaque = inheritBackgroundOpacity
         }
 
         // Calculate the target frame based on the tree's view bounds
@@ -369,7 +369,7 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
                     _ = TerminalController.newWindow(
                         ghostty,
                         tree: tree,
-                        inheritBackgroundOpacityFrom: parentController
+                        inheritBackgroundOpacity: inheritBackgroundOpacity
                     )
                 }
             }
@@ -501,30 +501,6 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         }
 
         return controller
-    }
-
-    override func toggleBackgroundOpacity() {
-        // Do nothing if config is already fully opaque
-        guard ghostty.config.backgroundOpacity < 1 else { return }
-
-        // Do nothing if in fullscreen (transparency doesn't apply in fullscreen)
-        guard let window, !window.styleMask.contains(.fullScreen) else { return }
-
-        let newValue = !isBackgroundOpaque
-        let controllers: [TerminalController]
-
-        if let tabGroup = window.tabGroup {
-            controllers = tabGroup.windows.compactMap {
-                $0.windowController as? TerminalController
-            }
-        } else {
-            controllers = [self]
-        }
-
-        for controller in controllers {
-            controller.isBackgroundOpaque = newValue
-            controller.syncAppearance()
-        }
     }
 
     // MARK: - Methods

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -230,6 +230,9 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         // Get our parent. Our parent is the one explicitly given to us,
         // otherwise the focused terminal, otherwise an arbitrary one.
         let parent: NSWindow? = explicitParent ?? preferredParent?.window
+        if let parentController = parent?.windowController as? TerminalController {
+            c.isBackgroundOpaque = parentController.isBackgroundOpaque
+        }
 
         if let parent, parent.styleMask.contains(.fullScreen) {
             // If our previous window was fullscreen then we want our new window to
@@ -313,8 +316,12 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         tree: SplitTree<Ghostty.SurfaceView>,
         position: NSPoint? = nil,
         confirmUndo: Bool = true,
+        inheritBackgroundOpacityFrom parentController: TerminalController? = nil
     ) -> TerminalController {
         let c = TerminalController.init(ghostty, withSurfaceTree: tree)
+        if let parentController {
+            c.isBackgroundOpaque = parentController.isBackgroundOpaque
+        }
 
         // Calculate the target frame based on the tree's view bounds
         let treeSize: CGSize? = tree.root?.viewBounds()
@@ -359,7 +366,11 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
                     withTarget: ghostty,
                     expiresAfter: target.undoExpiration
                 ) { ghostty in
-                    _ = TerminalController.newWindow(ghostty, tree: tree)
+                    _ = TerminalController.newWindow(
+                        ghostty,
+                        tree: tree,
+                        inheritBackgroundOpacityFrom: parentController
+                    )
                 }
             }
         }
@@ -394,6 +405,7 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
 
         // Create a new window and add it to the parent
         let controller = TerminalController.init(ghostty, withBaseConfig: baseConfig)
+        controller.isBackgroundOpaque = parentController.isBackgroundOpaque
         guard let window = controller.window else { return controller }
 
         // If the parent is miniaturized, then macOS exhibits really strange behaviors
@@ -489,6 +501,30 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         }
 
         return controller
+    }
+
+    override func toggleBackgroundOpacity() {
+        // Do nothing if config is already fully opaque
+        guard ghostty.config.backgroundOpacity < 1 else { return }
+
+        // Do nothing if in fullscreen (transparency doesn't apply in fullscreen)
+        guard let window, !window.styleMask.contains(.fullScreen) else { return }
+
+        let newValue = !isBackgroundOpaque
+        let controllers: [TerminalController]
+
+        if let tabGroup = window.tabGroup {
+            controllers = tabGroup.windows.compactMap {
+                $0.windowController as? TerminalController
+            }
+        } else {
+            controllers = [self]
+        }
+
+        for controller in controllers {
+            controller.isBackgroundOpaque = newValue
+            controller.syncAppearance()
+        }
     }
 
     // MARK: - Methods


### PR DESCRIPTION
Conversion of https://github.com/ghostty-org/ghostty/discussions/11041 into a PR. My vouch request doubles as an Issue so I don't think I need to make a new issue in Issue Triage.

The opacity toggle setting is now reflected amongst all tabs. So now when you press the keybinding for toggle_background_opacity, all existing tabs and all new tabs created will have the same toggle setting.

There is also logic in `BaseTerminalController.swift` that makes a new window inherit the current window's toggle state. There is no logic that changes the toggle state between all windows as I think the toggle logic should be per-window. This is a subjective design choice so let me know if you disagree. 

A suggestion for the future, if the user wants more fine-tuned control over the scope, maybe a configuration option like 

`toggle_background_opacity_scope` 

and have the options be 

`global, window, tab`

 could be useful but I think that might be too complex for a small issue like this.

_edit:_ I just stumbled upon this post https://github.com/ghostty-org/ghostty/discussions/4817. If this were to be implemented (themes at a tab or window level) then the design of this pr would have to rethought.

AI usage disclosure:
I used OpenAI Codex (GPT-5.3-Codex) for AI-assisted code editing and text drafting and for code review.
Extent: initial implementation and wording assistance.
I manually reviewed and edited the code and I understand how the changes work in `TerminalController.swift` and `BaseTerminalController.swift`