### PR TITLE
config: add link-url-modifier option for modifier-free URL clicking

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -331,6 +331,7 @@ const DerivedConfig = struct {
     title_report: bool,
     links: []DerivedConfig.Link,
     link_previews: configpkg.LinkPreviews,
+    link_url_modifier: configpkg.LinkUrlModifier,
     scroll_to_bottom: configpkg.Config.ScrollToBottom,
     notify_on_command_finish: configpkg.Config.NotifyOnCommandFinish,
     notify_on_command_finish_action: configpkg.Config.NotifyOnCommandFinishAction,
@@ -409,6 +410,7 @@ const DerivedConfig = struct {
             .title_report = config.@"title-report",
             .links = links,
             .link_previews = config.@"link-previews",
+            .link_url_modifier = config.@"link-url-modifier",
             .scroll_to_bottom = config.@"scroll-to-bottom",
             .notify_on_command_finish = config.@"notify-on-command-finish",
             .notify_on_command_finish_action = config.@"notify-on-command-finish-action",
@@ -1563,6 +1565,12 @@ fn mouseRefreshLinks(
     // isn't a link OR if we shouldn't be showing links for some reason
     // (see further comments for cases).
     const link_: ?apprt.action.MouseOverLink, const preview: bool = link: {
+        // Selection-oriented mouse modifier states take precedence over
+        // actionable link hover so users can still access those gestures
+        // without links taking over the cursor.
+        if (SurfaceMouse.shouldSuppressLinkHover(self.mouse.mods))
+            break :link .{ null, false };
+
         // If we clicked and our mouse moved cells then we never
         // highlight links until the mouse is unclicked. This follows
         // standard macOS and Linux behavior where a click and drag cancels
@@ -4243,8 +4251,9 @@ fn linkAtPos(
     // Get our comparison mods
     const mouse_mods = self.mouseModsWithCapture(self.mouse.mods);
 
-    // If we have the proper modifiers set then we can check for OSC8 links.
-    if (mouse_mods.equal(input.ctrlOrSuper(.{}))) hyperlink: {
+    // OSC8 hyperlinks follow the same modifier behavior as the built-in URL
+    // matcher.
+    if (self.config.link_url_modifier.matches(mouse_mods)) hyperlink: {
         const rac = mouse_pin.rowAndCell();
         const cell = rac.cell;
         if (!cell.hyperlink) break :hyperlink;

--- a/src/config.zig
+++ b/src/config.zig
@@ -44,6 +44,7 @@ pub const WindowPaddingColor = Config.WindowPaddingColor;
 pub const BackgroundImagePosition = Config.BackgroundImagePosition;
 pub const BackgroundImageFit = Config.BackgroundImageFit;
 pub const LinkPreviews = Config.LinkPreviews;
+pub const LinkUrlModifier = Config.LinkUrlModifier;
 pub const WorkingDirectory = Config.WorkingDirectory;
 
 // Alternate APIs

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1414,13 +1414,27 @@ scrollbar: Scrollbar = .system,
 /// TODO: This can't currently be set!
 link: RepeatableLink = .{},
 
-/// Enable URL matching. URLs are matched on hover with control (Linux) or
-/// command (macOS) pressed and open using the default system application for
-/// the linked URL.
+/// Enable URL matching. URLs are matched on hover and open using the default
+/// system application for the linked URL.
+///
+/// The modifier required to make matched URLs actionable is controlled by
+/// `link-url-modifier`. By default this requires control (Linux) or command
+/// (macOS).
 ///
 /// The URL matcher is always lowest priority of any configured links (see
 /// `link`). If you want to customize URL matching, use `link` and disable this.
 @"link-url": bool = true,
+
+/// Which modifier, if any, is required before URLs become clickable with the
+/// mouse.
+///
+/// This applies to both automatically detected URLs and OSC 8 hyperlinks.
+///
+/// Possible values are:
+///
+///   * `ctrl-or-super` - Require control on Linux and command on macOS.
+///   * `none` - No modifier is required.
+@"link-url-modifier": LinkUrlModifier = .@"ctrl-or-super",
 
 /// Show link previews for a matched URL.
 ///
@@ -3851,7 +3865,7 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
     try result.link.links.append(alloc, .{
         .regex = url.regex,
         .action = .{ .open = {} },
-        .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+        .highlight = result.@"link-url-modifier".highlight(),
     });
 
     return result;
@@ -4659,9 +4673,12 @@ pub fn finalize(self: *Config) !void {
     if (self.@"window-width" > 0) self.@"window-width" = @max(10, self.@"window-width");
     if (self.@"window-height" > 0) self.@"window-height" = @max(4, self.@"window-height");
 
-    // If URLs are disabled, cut off the first link. The first link is
-    // always the URL matcher.
-    if (!self.@"link-url") self.link.links.items = self.link.links.items[1..];
+    // The first link is always our built-in URL matcher, which can be
+    // disabled entirely or have its hover requirements updated here.
+    if (self.link.links.items.len > 0) {
+        self.link.links.items[0].highlight = self.@"link-url-modifier".highlight();
+        if (!self.@"link-url") self.link.links.items = self.link.links.items[1..];
+    }
 
     // We warn when the quit-after-last-window-closed-delay is set to a very
     // short value because it can cause Ghostty to quit before the first
@@ -5265,6 +5282,25 @@ pub const LinkPreviews = enum {
     false,
     true,
     osc8,
+};
+
+pub const LinkUrlModifier = enum {
+    none,
+    @"ctrl-or-super",
+
+    pub fn highlight(self: LinkUrlModifier) inputpkg.Link.Highlight {
+        return switch (self) {
+            .none => .{ .hover = {} },
+            .@"ctrl-or-super" => .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+        };
+    }
+
+    pub fn matches(self: LinkUrlModifier, mods: inputpkg.Mods) bool {
+        return switch (self) {
+            .none => true,
+            .@"ctrl-or-super" => mods.equal(inputpkg.ctrlOrSuper(.{})),
+        };
+    }
 };
 
 /// See working-directory
@@ -10873,4 +10909,66 @@ test "compatibility: window new-window" {
             cfg.@"macos-dock-drop-behavior",
         );
     }
+}
+
+test "LinkUrlModifier matches and highlight" {
+    const testing = std.testing;
+    const required_mods = inputpkg.ctrlOrSuper(.{});
+    const wrong_mods: inputpkg.Mods = if (required_mods.ctrl)
+        .{ .super = true }
+    else
+        .{ .ctrl = true };
+
+    try testing.expect(LinkUrlModifier.none.matches(.{}));
+    try testing.expect(LinkUrlModifier.none.matches(required_mods));
+    try testing.expect(!LinkUrlModifier.@"ctrl-or-super".matches(.{}));
+    try testing.expect(LinkUrlModifier.@"ctrl-or-super".matches(required_mods));
+    try testing.expect(!LinkUrlModifier.@"ctrl-or-super".matches(wrong_mods));
+
+    switch (LinkUrlModifier.none.highlight()) {
+        .hover => {},
+        else => return error.TestUnexpectedResult,
+    }
+
+    switch (LinkUrlModifier.@"ctrl-or-super".highlight()) {
+        .hover_mods => |mods| try testing.expect(mods.equal(inputpkg.ctrlOrSuper(.{}))),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "link-url-modifier updates built-in url matcher" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var cfg = try Config.default(alloc);
+    defer cfg.deinit();
+
+    var it: TestIterator = .{ .data = &.{
+        "--link-url-modifier=none",
+    } };
+    try cfg.loadIter(alloc, &it);
+    try cfg.finalize();
+
+    // The first built-in link is the default URL matcher.
+    switch (cfg.link.links.items[0].highlight) {
+        .hover => {},
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "link-url-modifier with link-url disabled" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var cfg = try Config.default(alloc);
+    defer cfg.deinit();
+
+    var it: TestIterator = .{ .data = &.{
+        "--link-url=false",
+        "--link-url-modifier=none",
+    } };
+    try cfg.loadIter(alloc, &it);
+    try cfg.finalize();
+
+    try testing.expectEqual(@as(usize, 0), cfg.link.links.items.len);
 }

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1249,10 +1249,8 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     // If our mouse isn't hovering, we have no links.
                     const vp = state.mouse.point orelse break :osc8 .empty;
 
-                    // If the right mods aren't pressed, then we can't match.
-                    if (!state.mouse.mods.equal(inputpkg.ctrlOrSuper(.{})))
-                        break :osc8 .empty;
-
+                    // The surface only sets mouse.point when the hovered link
+                    // is actionable, so we can use it directly here.
                     break :osc8 self.terminal_state.linkCells(
                         arena_alloc,
                         vp,

--- a/src/surface_mouse.zig
+++ b/src/surface_mouse.zig
@@ -125,6 +125,12 @@ pub fn isRectangleSelectState(mods: input.Mods) bool {
         mods.ctrlOrSuper() and mods.alt;
 }
 
+/// Returns true if the current mouse modifier state should suppress
+/// actionable link hover so selection-oriented mouse states keep precedence.
+pub fn shouldSuppressLinkHover(mods: input.Mods) bool {
+    return isRectangleSelectState(mods);
+}
+
 test "keyToMouseShape" {
     const testing = std.testing;
 
@@ -333,4 +339,13 @@ test "keyToMouseShape" {
         const got = m.keyToMouseShape();
         try testing.expect(want == got);
     }
+}
+
+test "shouldSuppressLinkHover" {
+    const testing = std.testing;
+
+    try testing.expect(!shouldSuppressLinkHover(.{}));
+    try testing.expect(!shouldSuppressLinkHover(.{ .shift = true }));
+    try testing.expect(!shouldSuppressLinkHover(.{ .shift = true, .super = true }));
+    try testing.expect(shouldSuppressLinkHover(.{ .ctrl = true, .alt = true }));
 }


### PR DESCRIPTION
## Summary

This adds a new `link-url-modifier` config option to control whether URLs require a modifier before they become clickable.

By default, behavior is unchanged: Ghostty still requires Ctrl on Linux and Cmd on macOS.

With `link-url-modifier = none`, matched URLs become actionable on plain hover/click instead.

This applies to both:
- the built-in URL matcher from `link-url`
- OSC 8 hyperlinks

## Why

This is an opt-in way to address the behavior discussed in #4917 without changing Ghostty’s default mouse/link UX.

The goal here is narrow:
- keep the current default
- allow people who want it to enable modifier-free hover/click for links
- keep URL matching and OSC 8 behavior consistent

## Notes

A couple of interaction details were important here:

- Dragging after a click still cancels link hover, so drag-to-select continues to work.
- Existing shift-override behavior in mouse-capture apps is preserved.
- Rectangle-select modifier states still take precedence over actionable link hover.

## Testing

Tested with:

- `zig build test -Dtest-filter=LinkUrlModifier`
- `zig build test -Dtest-filter=shouldSuppressLinkHover`
- `zig build test`
- `zig build`
