### PR TITLE
zsh: use OSC 133;P;k=s for secondary prompts

### DIFF
--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -155,27 +155,18 @@ _ghostty_deferred_init() {
                 # Add our marks. Since we always start from a clean PS1
                 # (either restored above or freshly set by a theme), we can
                 # unconditionally add mark1 and markB.
-                builtin local mark2=$'%{\e]133;A;k=s\a%}'
+                builtin local mark2=$'%{\e]133;P;k=s\a%}'
                 builtin local markB=$'%{\e]133;B\a%}'
                 PS1=${mark1}${PS1}${markB}
 
                 # Handle multiline prompts by marking newline-separated
-                # continuation lines with k=s (mark2). We skip the newline
-                # immediately after mark1 to avoid introducing a double
-                # newline due to OSC 133;A's fresh-line behavior.
+                # continuation lines with k=s (mark2).
                 #
                 # We skip this when PS1 changed because injecting marks into
                 # newlines can break pattern matching in themes that
                 # strip/rebuild the prompt dynamically (e.g., Pure).
                 if (( ! ps1_changed )) && [[ $PS1 == *$'\n'* ]]; then
-                    if [[ $PS1 == ${mark1}$'\n'* ]]; then
-                        builtin local rest=${PS1#${mark1}$'\n'}
-                        if [[ $rest == *$'\n'* ]]; then
-                            PS1=${mark1}$'\n'${rest//$'\n'/$'\n'${mark2}}
-                        fi
-                    else
-                        PS1=${PS1//$'\n'/$'\n'${mark2}}
-                    fi
+                    PS1=${PS1//$'\n'/$'\n'${mark2}}
                 fi
 
                 # PS2 mark is needed when clearing the prompt on resize


### PR DESCRIPTION
This is consistent with our bash prompt handling and also lets us simplify our multiline prompt logic (because it no longer needs to work around 133;A's fresh-line behavior).