### PR TITLE
Fix: correct "Open Ghostty Here" Dolphin action for Plasma

### DIFF
--- a/dist/linux/ghostty_dolphin.desktop
+++ b/dist/linux/ghostty_dolphin.desktop
@@ -7,5 +7,4 @@ Actions=RunGhosttyDir
 [Desktop Action RunGhosttyDir]
 Name=Open Ghostty Here
 Icon=com.mitchellh.ghostty
-Exec=ghostty --working-directory=%F --gtk-single-instance=false
-
+Exec=ghostty --working-directory=%F +new-window

--- a/dist/linux/ghostty_dolphin.desktop
+++ b/dist/linux/ghostty_dolphin.desktop
@@ -7,4 +7,4 @@ Actions=RunGhosttyDir
 [Desktop Action RunGhosttyDir]
 Name=Open Ghostty Here
 Icon=com.mitchellh.ghostty
-Exec=ghostty --working-directory=%F +new-window
+Exec=ghostty +new-window --working-directory=%F


### PR DESCRIPTION
See #11594

The change allows "Open Ghostty Here" Dolphin action to launch new ghostty window with gtk single instance.
