### PR TITLE
bash: handle PROMPT_COMMAND ending in a newline

### DIFF
--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -303,7 +303,7 @@ if (( BASH_VERSINFO[0] > 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 4) )
     elif [[ $(builtin declare -p PROMPT_COMMAND 2>/dev/null) == "declare -a "* ]]; then
       PROMPT_COMMAND+=(__ghostty_hook)
     else
-      [[ "${PROMPT_COMMAND}" =~ \;[[:space:]]*$ ]] || PROMPT_COMMAND+=";"
+      [[ "${PROMPT_COMMAND}" =~ (\;[[:space:]]*|$'\n')$ ]] || PROMPT_COMMAND+=";"
       PROMPT_COMMAND+=" __ghostty_hook"
     fi
   fi


### PR DESCRIPTION
We need to handle on more case: when an existing PROMPT_COMMAND ends in a newline, we don't want to append a ; because that already counts as a command separator.

We now handle all of these PROMPT_COMMAND cases:

- Ends with ; — no ; added
- Ends with \n or other whitespace — no ; added
- Ends with a command name — ; added as separator

See: #11245