### PR TITLE
macOS: add pid and tty properties to AppleScript terminal class

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1080,6 +1080,8 @@ ghostty_surface_config_s ghostty_surface_inherited_config(ghostty_surface_t, gho
 void ghostty_surface_update_config(ghostty_surface_t, ghostty_config_t);
 bool ghostty_surface_needs_confirm_quit(ghostty_surface_t);
 bool ghostty_surface_process_exited(ghostty_surface_t);
+int64_t ghostty_surface_foreground_pid(ghostty_surface_t);
+const char* ghostty_surface_tty_name(ghostty_surface_t);
 void ghostty_surface_refresh(ghostty_surface_t);
 void ghostty_surface_draw(ghostty_surface_t);
 void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);

--- a/macos/Ghostty.sdef
+++ b/macos/Ghostty.sdef
@@ -90,6 +90,8 @@
         <cocoa key="title"/>
       </property>
       <property name="working directory" code="Gwdr" type="text" access="r" description="Current working directory for the terminal process."/>
+      <property name="pid" code="Gpid" type="integer" access="r" description="Foreground process group ID (PGID) for this terminal (result of tcgetpgrp). For a shell running a program this is the program&apos;s PID. Returns -1 if unavailable."/>
+      <property name="tty" code="Gtty" type="text" access="r" description="Slave pty device path for this terminal (e.g. /dev/ttys016). Empty string if unavailable."/>
       <responds-to command="split">
         <cocoa method="handleSplitCommand:"/>
       </responds-to>

--- a/macos/Sources/Features/AppleScript/ScriptTerminal.swift
+++ b/macos/Sources/Features/AppleScript/ScriptTerminal.swift
@@ -53,6 +53,31 @@ final class ScriptTerminal: NSObject {
         return surfaceView?.pwd ?? ""
     }
 
+    /// Exposed as the AppleScript `pid` property.
+    ///
+    /// Returns the foreground process group ID (result of `tcgetpgrp`) for
+    /// this terminal, or -1 if the process has exited or is unavailable.
+    /// For a shell running a program, this is typically the program's PID.
+    @objc(pid)
+    var pid: Int {
+        guard NSApp.isAppleScriptEnabled else { return -1 }
+        guard let surface = surfaceView?.surface else { return -1 }
+        return Int(ghostty_surface_foreground_pid(surface))
+    }
+
+    /// Exposed as the AppleScript `tty` property.
+    ///
+    /// Returns the slave pty device path (e.g. "/dev/ttys016"), or an empty
+    /// string if unavailable. Useful for uniquely identifying the terminal
+    /// device when correlating with process output from tools like `ps`.
+    @objc(tty)
+    var tty: String {
+        guard NSApp.isAppleScriptEnabled else { return "" }
+        guard let surface = surfaceView?.surface else { return "" }
+        guard let name = ghostty_surface_tty_name(surface) else { return "" }
+        return String(cString: name)
+    }
+
     /// Used by command handling (`perform action ... on <terminal>`).
     func perform(action: String) -> Bool {
         guard NSApp.isAppleScriptEnabled else { return false }

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -940,6 +940,27 @@ pub fn needsConfirmQuit(self: *Surface) bool {
     };
 }
 
+/// Returns the foreground process group ID for this terminal, or -1 if
+/// the process has exited or the PID cannot be determined.
+///
+/// Note: on POSIX this returns the result of tcgetpgrp() on the master pty
+/// fd, which is the PGID of the foreground process group. For a shell
+/// running a program, this is the PID of that program (the group leader),
+/// not the shell's PID.
+pub fn foregroundPid(self: *Surface) i64 {
+    if (self.child_exited) return -1;
+    return self.io.backend.foregroundPid();
+}
+
+/// Returns the slave pty device path for this terminal (e.g. "/dev/ttys016"),
+/// or null if the process has exited or the path is unavailable.
+///
+/// The returned pointer is valid for the lifetime of the surface.
+pub fn ttyName(self: *Surface) ?[*:0]const u8 {
+    if (self.child_exited) return null;
+    return self.io.backend.ttyName();
+}
+
 /// Called from the app thread to handle mailbox messages to our specific
 /// surface.
 pub fn handleMessage(self: *Surface, msg: Message) !void {

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1598,6 +1598,19 @@ pub const CAPI = struct {
         return surface.core_surface.child_exited;
     }
 
+    /// Returns the foreground process group ID for the terminal, or -1 if
+    /// the process has exited or the PID cannot be determined.
+    export fn ghostty_surface_foreground_pid(surface: *Surface) i64 {
+        return surface.core_surface.foregroundPid();
+    }
+
+    /// Returns a null-terminated string with the slave pty device path
+    /// (e.g. "/dev/ttys016"), or NULL if unavailable. The pointer is valid
+    /// for the lifetime of the surface.
+    export fn ghostty_surface_tty_name(surface: *Surface) ?[*:0]const u8 {
+        return surface.core_surface.ttyName();
+    }
+
     /// Returns true if the surface has a selection.
     export fn ghostty_surface_has_selection(surface: *Surface) bool {
         return surface.core_surface.hasSelection();

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -265,6 +265,16 @@ pub fn resize(
     return try self.subprocess.resize(grid_size, screen_size);
 }
 
+/// See Subprocess.foregroundPid.
+pub fn foregroundPid(self: *Exec) i64 {
+    return self.subprocess.foregroundPid();
+}
+
+/// See Subprocess.ttyName.
+pub fn ttyName(self: *Exec) ?[*:0]const u8 {
+    return self.subprocess.ttyName();
+}
+
 fn processExitCommon(td: *termio.Termio.ThreadData, exit_code: u32) void {
     assert(td.backend == .exec);
     const execdata = &td.backend.exec;
@@ -575,6 +585,7 @@ const Subprocess = struct {
     const c = @cImport({
         @cInclude("errno.h");
         @cInclude("signal.h");
+        @cInclude("stdlib.h");
         @cInclude("unistd.h");
     });
 
@@ -586,6 +597,11 @@ const Subprocess = struct {
     screen_size: renderer.ScreenSize,
     pty: ?Pty = null,
     process: ?Process = null,
+
+    /// The slave pty device name (e.g. "/dev/ttys016"), captured at subprocess
+    /// start so callers can query it without holding any pty fd open.
+    /// Null on Windows or if the pty wasn't opened yet.
+    tty_name: ?[:0]const u8 = null,
 
     rt_pre_exec_info: Command.RtPreExecInfo,
     rt_post_fork_info: Command.RtPostForkInfo,
@@ -908,7 +924,23 @@ const Subprocess = struct {
 
             pty.deinit();
             self.pty = null;
+            self.tty_name = null;
         };
+
+        // Capture the slave device name from the master fd while we still
+        // hold both fds. We copy into the arena so the string outlives the
+        // pty.slave fd, which is closed once the child is up.
+        // Use ptsname_r (the re-entrant variant) for thread safety when
+        // multiple terminals open simultaneously.
+        if (comptime builtin.os.tag != .windows) {
+            var tty_buf: [1024:0]u8 = undefined;
+            if (c.ptsname_r(pty.master, &tty_buf, tty_buf.len) == 0) {
+                self.tty_name = self.arena.allocator().dupeZ(
+                    u8,
+                    std.mem.sliceTo(&tty_buf, 0),
+                ) catch null;
+            }
+        }
 
         // Cleanup we only run in our parent when we successfully start
         // the process.
@@ -1127,6 +1159,23 @@ const Subprocess = struct {
                 .ws_ypixel = std.math.cast(u16, screen_size.height) orelse std.math.maxInt(u16),
             });
         }
+    }
+
+    /// Returns the process group ID of the foreground process running in this
+    /// terminal, or -1 if it cannot be determined (pty not open, process
+    /// exited, or unsupported platform).
+    pub fn foregroundPid(self: *Subprocess) i64 {
+        if (comptime builtin.os.tag == .windows) return -1;
+        const pty = self.pty orelse return -1;
+        const pgid = c.tcgetpgrp(pty.master);
+        return if (pgid < 0) -1 else @intCast(pgid);
+    }
+
+    /// Returns the slave pty device path (e.g. "/dev/ttys016"), or null if
+    /// unavailable. The pointer is valid for the lifetime of this Subprocess.
+    pub fn ttyName(self: *Subprocess) ?[*:0]const u8 {
+        const name = self.tty_name orelse return null;
+        return name.ptr;
     }
 
     /// Kill the underlying subprocess. This sends a SIGHUP to the child

--- a/src/termio/backend.zig
+++ b/src/termio/backend.zig
@@ -100,6 +100,22 @@ pub const Backend = union(Kind) {
             ),
         }
     }
+
+    /// Returns the foreground process group ID for the terminal, or -1 if
+    /// unavailable. See Exec.foregroundPid for details.
+    pub fn foregroundPid(self: *Backend) i64 {
+        return switch (self.*) {
+            .exec => |*exec| exec.foregroundPid(),
+        };
+    }
+
+    /// Returns the slave pty device path, or null if unavailable.
+    /// See Exec.ttyName for details.
+    pub fn ttyName(self: *Backend) ?[*:0]const u8 {
+        return switch (self.*) {
+            .exec => |*exec| exec.ttyName(),
+        };
+    }
 };
 
 /// Termio thread data. See termio.ThreadData for docs.


### PR DESCRIPTION
## Summary
- Expose foreground process group ID (`pid`) and slave pty device path (`tty`) on the AppleScript `terminal` class
- Enables scripts to reliably correlate a terminal with a known process even when multiple terminals share the same working directory
- Uses `ptsname_r(3)` (thread-safe) to capture the tty name at pty open time; `tcgetpgrp()` for the foreground PGID

## Changes
- **Zig C API**: `ghostty_surface_foreground_pid()` / `ghostty_surface_tty_name()` through Exec → Backend → Surface → embedded
- **Swift**: two `@objc` getters on `ScriptTerminal.swift`
- **sdef**: `pid` (code `Gpid`) and `tty` (code `Gtty`) read-only properties

Closes #11592