### PR TITLE
macOS: wrap goto_split spatial navigation at edges

### DIFF
--- a/macos/Sources/Features/Splits/SplitTree.swift
+++ b/macos/Sources/Features/Splits/SplitTree.swift
@@ -200,9 +200,9 @@ extension SplitTree {
             return allLeaves[index]
 
         case .spatial(let spatialDirection):
-            // Get spatial representation and find best candidate
+            // Get spatial representation and find best candidate (with wrapping)
             let spatial = root.spatial()
-            let nodes = spatial.slots(in: spatialDirection, from: currentNode)
+            let nodes = spatial.slotsWrapped(in: spatialDirection, from: currentNode)
 
             // If we have no nodes in the direction specified then we don't do
             // anything.
@@ -1101,6 +1101,72 @@ extension SplitTree.Spatial {
             slot.bounds.minX == overallBounds.minX
         case .right:
             slot.bounds.maxX == overallBounds.maxX
+        }
+    }
+
+    /// Like `slots(in:from:)` but wraps around spatially when there are no
+    /// direct neighbours in `direction`.
+    ///
+    /// If direct neighbours exist the call is equivalent to `slots(in:from:)`.
+    /// Otherwise the reference bounds are shifted by the full grid extent so
+    /// that slots on the far side become the nearest candidates, matching the
+    /// behaviour already implemented for GTK in PR #10811.
+    func slotsWrapped(in direction: Direction, from referenceNode: SplitTree.Node) -> [Slot] {
+        let direct = slots(in: direction, from: referenceNode)
+        if !direct.isEmpty { return direct }
+
+        guard let refSlot = slots.first(where: { $0.node == referenceNode }) else { return [] }
+        let overallBounds = slots.reduce(CGRect.null) { $0.union($1.bounds) }
+        guard !overallBounds.isEmpty else { return [] }
+
+        // Shift the reference rect by the full grid extent in the opposite
+        // direction so the "far" slots satisfy the same directional filter.
+        //
+        // Coordinate system: Y increases downward (standard screen/view coords),
+        // so "up" means smaller Y and "down" means larger Y.
+        let shiftedRef: CGRect
+        switch direction {
+        case .left:
+            shiftedRef = refSlot.bounds.offsetBy(dx: overallBounds.width, dy: 0)
+        case .right:
+            shiftedRef = refSlot.bounds.offsetBy(dx: -overallBounds.width, dy: 0)
+        case .up:
+            shiftedRef = refSlot.bounds.offsetBy(dx: 0, dy: overallBounds.height)
+        case .down:
+            shiftedRef = refSlot.bounds.offsetBy(dx: 0, dy: -overallBounds.height)
+        }
+
+        func distance(from rect1: CGRect, to rect2: CGRect) -> Double {
+            let dx = rect2.minX - rect1.minX
+            let dy = rect2.minY - rect1.minY
+            return sqrt(dx * dx + dy * dy)
+        }
+
+        switch direction {
+        case .left:
+            return slots.filter {
+                $0.node != referenceNode && $0.bounds.maxX <= shiftedRef.minX
+            }.sorted {
+                distance(from: shiftedRef, to: $0.bounds) < distance(from: shiftedRef, to: $1.bounds)
+            }
+        case .right:
+            return slots.filter {
+                $0.node != referenceNode && $0.bounds.minX >= shiftedRef.maxX
+            }.sorted {
+                distance(from: shiftedRef, to: $0.bounds) < distance(from: shiftedRef, to: $1.bounds)
+            }
+        case .up:
+            return slots.filter {
+                $0.node != referenceNode && $0.bounds.maxY <= shiftedRef.minY
+            }.sorted {
+                distance(from: shiftedRef, to: $0.bounds) < distance(from: shiftedRef, to: $1.bounds)
+            }
+        case .down:
+            return slots.filter {
+                $0.node != referenceNode && $0.bounds.minY >= shiftedRef.maxY
+            }.sorted {
+                distance(from: shiftedRef, to: $0.bounds) < distance(from: shiftedRef, to: $1.bounds)
+            }
         }
     }
 }

--- a/macos/Tests/Splits/SplitTreeTests.swift
+++ b/macos/Tests/Splits/SplitTreeTests.swift
@@ -618,6 +618,79 @@ struct SplitTreeTests {
         #expect(spatial.slots(in: .down, from: .leaf(view: view2)).isEmpty)
     }
 
+    // MARK: - slotsWrapped tests
+
+    /// Horizontal split: going left from left pane wraps to the right pane.
+    @Test func slotsWrappedHorizontalLeftFromLeftEdge() throws {
+        let (tree, view1, view2) = try makeHorizontalSplit()
+        let spatial = tree.root!.spatial(within: CGSize(width: 1000, height: 500))
+        let wrapped = spatial.slotsWrapped(in: .left, from: .leaf(view: view1))
+        #expect(wrapped.contains { $0.node == .leaf(view: view2) })
+    }
+
+    /// Horizontal split: going right from right pane wraps to the left pane.
+    @Test func slotsWrappedHorizontalRightFromRightEdge() throws {
+        let (tree, view1, view2) = try makeHorizontalSplit()
+        let spatial = tree.root!.spatial(within: CGSize(width: 1000, height: 500))
+        let wrapped = spatial.slotsWrapped(in: .right, from: .leaf(view: view2))
+        #expect(wrapped.contains { $0.node == .leaf(view: view1) })
+    }
+
+    /// Vertical split: going up from the top pane wraps to the bottom pane.
+    @Test func slotsWrappedVerticalUpFromTopEdge() throws {
+        let view1 = MockView()
+        let view2 = MockView()
+        var tree = SplitTree<MockView>(view: view1)
+        tree = try tree.inserting(view: view2, at: view1, direction: .down)
+        let spatial = tree.root!.spatial(within: CGSize(width: 1000, height: 500))
+        // view1 is at the top (minY=0); going up should wrap to view2 (bottom)
+        let wrapped = spatial.slotsWrapped(in: .up, from: .leaf(view: view1))
+        #expect(wrapped.contains { $0.node == .leaf(view: view2) })
+    }
+
+    /// Vertical split: going down from the bottom pane wraps to the top pane.
+    @Test func slotsWrappedVerticalDownFromBottomEdge() throws {
+        let view1 = MockView()
+        let view2 = MockView()
+        var tree = SplitTree<MockView>(view: view1)
+        tree = try tree.inserting(view: view2, at: view1, direction: .down)
+        let spatial = tree.root!.spatial(within: CGSize(width: 1000, height: 500))
+        // view2 is at the bottom (maxY = height); going down wraps to view1 (top)
+        let wrapped = spatial.slotsWrapped(in: .down, from: .leaf(view: view2))
+        #expect(wrapped.contains { $0.node == .leaf(view: view1) })
+    }
+
+    /// When direct neighbours exist, slotsWrapped behaves identically to slots.
+    @Test func slotsWrappedReturnsSameAsSlotWhenNeighbourExists() throws {
+        let (tree, view1, view2) = try makeHorizontalSplit()
+        let spatial = tree.root!.spatial(within: CGSize(width: 1000, height: 500))
+        let direct = spatial.slots(in: .right, from: .leaf(view: view1))
+        let wrapped = spatial.slotsWrapped(in: .right, from: .leaf(view: view1))
+        #expect(direct.map(\.node) == wrapped.map(\.node))
+    }
+
+    /// 2x2 grid: going left from the left column wraps to the spatially nearest
+    /// pane in the right column (same row, not the one diagonally far).
+    @Test func slotsWrappedGridSpatialAwareness() throws {
+        // Layout:  view1 | view2
+        //          view3 | view4
+        let view1 = MockView()
+        let view2 = MockView()
+        let view3 = MockView()
+        let view4 = MockView()
+        var tree = SplitTree<MockView>(view: view1)
+        tree = try tree.inserting(view: view2, at: view1, direction: .right)
+        tree = try tree.inserting(view: view3, at: view1, direction: .down)
+        tree = try tree.inserting(view: view4, at: view2, direction: .down)
+        let spatial = tree.root!.spatial(within: CGSize(width: 1000, height: 800))
+
+        // From view1 (top-left), going left wraps to the top-right column.
+        // view2 should be the nearest (same row), not view4 (different row).
+        let wrappedLeft = spatial.slotsWrapped(in: .left, from: .leaf(view: view1))
+        let leafNodes = wrappedLeft.filter { if case .leaf = $0.node { return true }; return false }
+        #expect(leafNodes.first?.node == .leaf(view: view2))
+    }
+
     // Set/Dictionary usage is the only path that exercises StructuralIdentity.hash(into:)
     @Test func structuralIdentityHashableBehavior() throws {
         let (tree, _, _) = try makeHorizontalSplit()


### PR DESCRIPTION
## Summary
- When navigating past the edge of the split grid with a spatial direction (`goto_split:up/down/left/right`), focus now wraps to the opposite side
- Matches the GTK behaviour added in PR #10811
- Wrapping is spatially aware: picks the nearest pane on the far side (e.g. in a 2×2 grid, going left from top-left wraps to top-right, not bottom-right)

## Changes
- `SplitTree.Spatial.slotsWrapped(in:from:)` — shifts reference rect by full grid extent, reuses directional filter and distance sort
- `focusTarget()` now calls `slotsWrapped` instead of `slots` for spatial directions
- Unit tests for all four wrap directions plus 2×2 grid spatial awareness

Closes #8406