### PR TITLE
Add navigate_command_palette binding action

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -547,6 +547,12 @@ typedef enum {
   GHOSTTY_SPLIT_DIRECTION_UP,
 } ghostty_action_split_direction_e;
 
+// input.Binding.Action.NavigateCommandPalette
+typedef enum {
+  GHOSTTY_NAVIGATE_COMMAND_PALETTE_PREVIOUS,
+  GHOSTTY_NAVIGATE_COMMAND_PALETTE_NEXT,
+} ghostty_action_navigate_command_palette_e;
+
 // apprt.action.GotoSplit
 typedef enum {
   GHOSTTY_GOTO_SPLIT_PREVIOUS,
@@ -868,6 +874,7 @@ typedef enum {
   GHOSTTY_ACTION_TOGGLE_WINDOW_DECORATIONS,
   GHOSTTY_ACTION_TOGGLE_QUICK_TERMINAL,
   GHOSTTY_ACTION_TOGGLE_COMMAND_PALETTE,
+  GHOSTTY_ACTION_NAVIGATE_COMMAND_PALETTE,
   GHOSTTY_ACTION_TOGGLE_VISIBILITY,
   GHOSTTY_ACTION_TOGGLE_BACKGROUND_OPACITY,
   GHOSTTY_ACTION_MOVE_TAB,
@@ -925,6 +932,7 @@ typedef enum {
 
 typedef union {
   ghostty_action_split_direction_e new_split;
+  ghostty_action_navigate_command_palette_e navigate_command_palette;
   ghostty_action_fullscreen_e toggle_fullscreen;
   ghostty_action_move_tab_s move_tab;
   ghostty_action_goto_tab_e goto_tab;

--- a/macos/Sources/Features/Command Palette/CommandPalette.swift
+++ b/macos/Sources/Features/Command Palette/CommandPalette.swift
@@ -191,6 +191,20 @@ struct CommandPaletteView: View {
                 query = ""
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .ghosttyCommandPaletteNavigate)) { notification in
+            guard isPresented else { return }
+            guard let direction = notification.userInfo?["direction"] as? Int else { return }
+            if filteredOptions.isEmpty { return }
+            if direction > 0 {
+                // Next
+                let current = selectedIndex ?? UInt.max
+                selectedIndex = (current >= UInt(filteredOptions.count - 1)) ? 0 : current + 1
+            } else {
+                // Previous
+                let current = selectedIndex ?? UInt(filteredOptions.count)
+                selectedIndex = (current == 0) ? UInt(filteredOptions.count - 1) : current - 1
+            }
+        }
         .task {
             // Grab focus on the first appearance.
             // This happens right after onAppear,

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -581,6 +581,9 @@ extension Ghostty {
             case GHOSTTY_ACTION_TOGGLE_COMMAND_PALETTE:
                 toggleCommandPalette(app, target: target)
 
+            case GHOSTTY_ACTION_NAVIGATE_COMMAND_PALETTE:
+                navigateCommandPalette(app, target: target, v: action.action.navigate_command_palette)
+
             case GHOSTTY_ACTION_TOGGLE_MAXIMIZE:
                 toggleMaximize(app, target: target)
 
@@ -1004,6 +1007,33 @@ extension Ghostty {
                 NotificationCenter.default.post(
                     name: .ghosttyCommandPaletteDidToggle,
                     object: surfaceView
+                )
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        private static func navigateCommandPalette(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s,
+            v: ghostty_action_navigate_command_palette_e) {
+            switch target.tag {
+            case GHOSTTY_TARGET_APP:
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                let direction: Int = switch v {
+                case GHOSTTY_NAVIGATE_COMMAND_PALETTE_NEXT: 1
+                case GHOSTTY_NAVIGATE_COMMAND_PALETTE_PREVIOUS: -1
+                default: 0
+                }
+                NotificationCenter.default.post(
+                    name: .ghosttyCommandPaletteNavigate,
+                    object: surfaceView,
+                    userInfo: ["direction": direction]
                 )
 
             default:

--- a/macos/Sources/Ghostty/GhosttyPackage.swift
+++ b/macos/Sources/Ghostty/GhosttyPackage.swift
@@ -364,6 +364,7 @@ extension Notification.Name {
     static let ghosttyDidChangeReadonly = Notification.Name("com.mitchellh.ghostty.didChangeReadonly")
     static let ReadonlyKey = ghosttyDidChangeReadonly.rawValue + ".readonly"
     static let ghosttyCommandPaletteDidToggle = Notification.Name("com.mitchellh.ghostty.commandPaletteDidToggle")
+    static let ghosttyCommandPaletteNavigate = Notification.Name("com.mitchellh.ghostty.commandPaletteNavigate")
 
     /// Toggle maximize of current window
     static let ghosttyMaximizeDidToggle = Notification.Name("com.mitchellh.ghostty.maximizeDidToggle")

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -5604,6 +5604,12 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             {},
         ),
 
+        .navigate_command_palette => |nav| return try self.rt_app.performAction(
+            .{ .surface = self },
+            .navigate_command_palette,
+            nav,
+        ),
+
         .toggle_background_opacity => return try self.rt_app.performAction(
             .{ .surface = self },
             .toggle_background_opacity,

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -117,6 +117,9 @@ pub const Action = union(Key) {
     /// Toggle the command palette.
     toggle_command_palette,
 
+    /// Navigate the command palette selection up or down.
+    navigate_command_palette: input.Binding.Action.NavigateCommandPalette,
+
     /// Toggle the visibility of all Ghostty terminal windows.
     toggle_visibility,
 
@@ -357,6 +360,7 @@ pub const Action = union(Key) {
         toggle_window_decorations,
         toggle_quick_terminal,
         toggle_command_palette,
+        navigate_command_palette,
         toggle_visibility,
         toggle_background_opacity,
         move_tab,

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -755,6 +755,7 @@ pub const Application = extern struct {
             .toggle_tab_overview => return Action.toggleTabOverview(target),
             .toggle_window_decorations => return Action.toggleWindowDecorations(target),
             .toggle_command_palette => return Action.toggleCommandPalette(target),
+            .navigate_command_palette => |v| return Action.navigateCommandPalette(target, v),
             .toggle_split_zoom => return Action.toggleSplitZoom(target),
             .show_on_screen_keyboard => return Action.showOnScreenKeyboard(target),
             .command_finished => return Action.commandFinished(target, value),
@@ -2746,6 +2747,21 @@ const Action = struct {
             .app => return false,
             .surface => |surface| {
                 return surface.rt_surface.gobj().toggleCommandPalette();
+            },
+        }
+    }
+
+    pub fn navigateCommandPalette(
+        target: apprt.Target,
+        direction: input.Binding.Action.NavigateCommandPalette,
+    ) bool {
+        switch (target) {
+            .app => return false,
+            .surface => |surface| {
+                const widget = surface.rt_surface.gobj().as(gtk.Widget);
+                const window = ext.getAncestor(Window, widget) orelse return false;
+                window.navigateCommandPalette(direction);
+                return true;
             },
         }
     }

--- a/src/apprt/gtk/class/command_palette.zig
+++ b/src/apprt/gtk/class/command_palette.zig
@@ -325,6 +325,21 @@ pub const CommandPalette = extern struct {
         _ = priv.search.as(gtk.Widget).grabFocus();
     }
 
+    /// Move the selection in the command palette by one item in the given
+    /// direction. Wraps around at list boundaries.
+    pub fn navigate(self: *CommandPalette, direction: input.Binding.Action.NavigateCommandPalette) void {
+        const priv = self.private();
+        const n_items = priv.model.as(gio.ListModel).getNItems();
+        if (n_items == 0) return;
+
+        const current = priv.model.getSelected();
+        const new_pos: c_uint = switch (direction) {
+            .next => if (current + 1 >= n_items) 0 else current + 1,
+            .previous => if (current == 0) n_items - 1 else current - 1,
+        };
+        priv.model.setSelected(new_pos);
+    }
+
     /// Helper function to send a signal containing the action that should be
     /// performed.
     fn activated(self: *CommandPalette, pos: c_uint) void {

--- a/src/apprt/gtk/class/window.zig
+++ b/src/apprt/gtk/class/window.zig
@@ -2017,6 +2017,15 @@ pub const Window = extern struct {
         self.performBindingAction(action.*);
     }
 
+    /// Navigate the command palette selection. If the command palette is not
+    /// currently open, this is a no-op.
+    pub fn navigateCommandPalette(self: *Window, direction: input.Binding.Action.NavigateCommandPalette) void {
+        const priv = self.private();
+        const command_palette = priv.command_palette.get() orelse return;
+        defer command_palette.unref();
+        command_palette.navigate(direction);
+    }
+
     /// React to a GTK action requesting that the command palette be toggled.
     fn actionToggleCommandPalette(
         _: *gio.SimpleAction,

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -757,6 +757,10 @@ pub const Action = union(enum) {
     /// version can be found by running `ghostty +version`.
     toggle_command_palette,
 
+    /// Navigate the command palette results list. If the command palette
+    /// is not open, this is not performed.
+    navigate_command_palette: NavigateCommandPalette,
+
     /// Toggle the quick terminal.
     ///
     /// The quick terminal, also known as the "Quake-style" or drop-down
@@ -977,6 +981,11 @@ pub const Action = union(enum) {
     };
 
     pub const NavigateSearch = enum {
+        previous,
+        next,
+    };
+
+    pub const NavigateCommandPalette = enum {
         previous,
         next,
     };
@@ -1361,6 +1370,7 @@ pub const Action = union(enum) {
             .toggle_secure_input,
             .toggle_mouse_reporting,
             .toggle_command_palette,
+            .navigate_command_palette,
             .toggle_background_opacity,
             .show_on_screen_keyboard,
             .reset_window_size,

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -711,6 +711,7 @@ fn actionCommands(action: Action.Key) []const Command {
         // No commands because I'm not sure they make sense in a command
         // palette context.
         .toggle_command_palette,
+        .navigate_command_palette,
         .toggle_quick_terminal,
         .toggle_visibility,
         .previous_tab,


### PR DESCRIPTION
## Summary
- New keybindable action `navigate_command_palette` with `previous`/`next` values
- Makes command palette navigation configurable via the normal keybinding system

## Changes
- **Core**: `NavigateCommandPalette` enum + action in `Binding.zig`, dispatch in `Surface.zig`, apprt `Action` union
- **C API**: `ghostty_action_navigate_command_palette_e` enum + action tag
- **GTK**: `CommandPalette.navigate()` moves `SingleSelection`, routed through window
- **macOS**: notification dispatch, `CommandPaletteView` handles via `.onReceive`

Closes #10799