### PR TITLE
config: add clipboard-trim-leading-spaces option

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -298,6 +298,7 @@ const DerivedConfig = struct {
     clipboard_read: configpkg.ClipboardAccess,
     clipboard_write: configpkg.ClipboardAccess,
     clipboard_trim_trailing_spaces: bool,
+    clipboard_trim_leading_spaces: bool,
     clipboard_paste_protection: bool,
     clipboard_paste_bracketed_safe: bool,
     clipboard_codepoint_map: configpkg.Config.RepeatableClipboardCodepointMap,
@@ -376,6 +377,7 @@ const DerivedConfig = struct {
             .clipboard_read = config.@"clipboard-read",
             .clipboard_write = config.@"clipboard-write",
             .clipboard_trim_trailing_spaces = config.@"clipboard-trim-trailing-spaces",
+            .clipboard_trim_leading_spaces = config.@"clipboard-trim-leading-spaces",
             .clipboard_paste_protection = config.@"clipboard-paste-protection",
             .clipboard_paste_bracketed_safe = config.@"clipboard-paste-bracketed-safe",
             .clipboard_codepoint_map = try config.@"clipboard-codepoint-map".clone(alloc),
@@ -2202,6 +2204,7 @@ fn copySelectionToClipboards(
         .emit = .plain, // We'll override this below
         .unwrap = true,
         .trim = self.config.clipboard_trim_trailing_spaces,
+        .trim_leading = self.config.clipboard_trim_leading_spaces,
         .codepoint_map = self.config.clipboard_codepoint_map.map.list,
         .background = self.io.terminal.colors.background.get(),
         .foreground = self.io.terminal.colors.foreground.get(),

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2364,6 +2364,12 @@ keybind: Keybinds = .{},
 /// Completely blank lines always have their whitespace trimmed.
 @"clipboard-trim-trailing-spaces": bool = true,
 
+/// Trims leading whitespace on data that is copied to the clipboard. This does
+/// not affect data sent to the clipboard via `clipboard-write`. This only
+/// applies to leading whitespace on lines that have other characters.
+/// Completely blank lines are unaffected.
+@"clipboard-trim-leading-spaces": bool = false,
+
 /// Require confirmation before pasting text that appears unsafe. This helps
 /// prevent a "copy/paste attack" where a user may accidentally execute unsafe
 /// commands by pasting text with newlines.

--- a/src/terminal/formatter.zig
+++ b/src/terminal/formatter.zig
@@ -97,6 +97,12 @@ pub const Options = struct {
     /// is currently only space characters (0x20).
     trim: bool = true,
 
+    /// Trim leading whitespace on lines with other text. This only affects
+    /// leading whitespace on rows that have at least one other cell with text.
+    /// Completely blank lines are unaffected. Whitespace is currently only
+    /// space characters (0x20).
+    trim_leading: bool = false,
+
     /// Replace matching Unicode codepoints with some other values.
     /// This will use the last matching range found in the list.
     codepoint_map: ?std.MultiArrayList(CodepointMap) = .{},
@@ -882,6 +888,7 @@ pub const PageFormatter = struct {
     ) std.Io.Writer.Error!TrailingState {
         var blank_rows: usize = 0;
         var blank_cells: usize = 0;
+        var leading_done: bool = false;
 
         // Continue our prior trailing state if we have it, but only if we're
         // starting from the beginning (start_y and start_x are both 0).
@@ -1114,7 +1121,10 @@ pub const PageFormatter = struct {
 
             // If the row doesn't continue a wrap then we need to reset
             // our blank cell count.
-            if (!row.wrap_continuation or !self.opts.unwrap) blank_cells = 0;
+            if (!row.wrap_continuation or !self.opts.unwrap) {
+                blank_cells = 0;
+                leading_done = false;
+            }
 
             // Go through each cell and print it
             for (cells_subset, row_start_x..) |*cell, x_usize| {
@@ -1125,6 +1135,12 @@ pub const PageFormatter = struct {
                 switch (cell.wide) {
                     .narrow, .wide => {},
                     .spacer_head, .spacer_tail => continue,
+                }
+
+                // Skip leading spaces when trim_leading is enabled.
+                if (!leading_done and self.opts.trim_leading) {
+                    if (cell.codepoint() == ' ') continue;
+                    leading_done = true;
                 }
 
                 // If we have a zero value, then we accumulate a counter. We
@@ -6278,4 +6294,117 @@ test "Page HTML hyperlink point map maps closing to previous cell" {
     for (closing_idx..closing_idx + "</a>".len) |i| {
         try testing.expectEqual(expected_coord, point_map.items[i]);
     }
+}
+
+test "Page plain trim_leading" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var builder: std.Io.Writer.Allocating = .init(alloc);
+    defer builder.deinit();
+
+    var t = try Terminal.init(alloc, .{
+        .cols = 80,
+        .rows = 24,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+
+    s.nextSlice("   hello\r\n   world");
+
+    const pages = &t.screens.active.pages;
+    try testing.expect(pages.pages.first != null);
+    try testing.expect(pages.pages.first == pages.pages.last);
+
+    const page = &pages.pages.last.?.data;
+    var formatter: PageFormatter = .init(page, .{
+        .emit = .plain,
+        .trim_leading = true,
+    });
+
+    _ = try formatter.formatWithState(&builder.writer);
+    const output = builder.writer.buffered();
+    try testing.expectEqualStrings("hello\nworld", output);
+}
+
+test "Page plain trim_leading disabled by default" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var builder: std.Io.Writer.Allocating = .init(alloc);
+    defer builder.deinit();
+
+    var t = try Terminal.init(alloc, .{
+        .cols = 80,
+        .rows = 24,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+
+    s.nextSlice("   hello\r\n   world");
+
+    const pages = &t.screens.active.pages;
+    try testing.expect(pages.pages.first != null);
+    try testing.expect(pages.pages.first == pages.pages.last);
+
+    const page = &pages.pages.last.?.data;
+    var formatter: PageFormatter = .init(page, .plain);
+
+    _ = try formatter.formatWithState(&builder.writer);
+    const output = builder.writer.buffered();
+    try testing.expectEqualStrings("   hello\n   world", output);
+}
+
+test "Page plain trim_leading preserves wrap continuation spaces" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var builder: std.Io.Writer.Allocating = .init(alloc);
+    defer builder.deinit();
+
+    // Use small cols so the text wraps
+    var t = try Terminal.init(alloc, .{
+        .cols = 10,
+        .rows = 24,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+
+    // "hello     world" is 15 chars. With 10 cols:
+    // row 0: "hello     " (wrap=true)
+    // row 1: "world" (wrap_continuation=true)
+    // But we want leading spaces on the continuation row.
+    // Let's use: "hello  " + "   world" which is 13 chars.
+    // row 0: "hello     " (10 chars, wrap=true) -- 5 chars + 5 spaces
+    // row 1: "   world" (wrap_continuation=true) -- 3 spaces + 5 chars
+    // Actually the terminal writes sequentially, so "hello        world" (13 chars):
+    // row 0 gets "hello     " (fills 10 cols) -> wraps
+    // row 1 gets "   world"
+    s.nextSlice("hello        world");
+
+    const pages = &t.screens.active.pages;
+    try testing.expect(pages.pages.first != null);
+    try testing.expect(pages.pages.first == pages.pages.last);
+
+    const page = &pages.pages.last.?.data;
+    var formatter: PageFormatter = .init(page, .{
+        .emit = .plain,
+        .unwrap = true,
+        .trim_leading = true,
+    });
+
+    _ = try formatter.formatWithState(&builder.writer);
+    const output = builder.writer.buffered();
+    // With unwrap=true, the continuation row's leading spaces are mid-line
+    // content and should NOT be trimmed. The leading spaces on row 0 (the
+    // start of the logical line) should be trimmed though -- but row 0 starts
+    // with "hello" so there are no leading spaces to trim there.
+    // Result: "hello        world" unwrapped as one line, no leading trim needed.
+    try testing.expectEqualStrings("hello        world", output);
 }

--- a/src/terminal/formatter.zig
+++ b/src/terminal/formatter.zig
@@ -1139,9 +1139,12 @@ pub const PageFormatter = struct {
                     .spacer_head, .spacer_tail => continue,
                 }
 
-                // Skip leading spaces when trim_leading is enabled.
+                // Skip leading whitespace when trim_leading is enabled.
+                // This includes both space characters (0x20) and empty cells
+                // (codepoint 0), which some programs use for indentation via
+                // cursor positioning.
                 if (!leading_done and self.opts.trim_leading) {
-                    if (cell.codepoint() == ' ') continue;
+                    if (cell.codepoint() == ' ' or !cell.hasText()) continue;
                     leading_done = true;
                     blank_cells = 0;
                 }

--- a/src/terminal/formatter.zig
+++ b/src/terminal/formatter.zig
@@ -855,6 +855,7 @@ pub const PageFormatter = struct {
     pub const TrailingState = struct {
         rows: usize = 0,
         cells: usize = 0,
+        leading_done: bool = false,
 
         pub const empty: TrailingState = .{ .rows = 0, .cells = 0 };
     };
@@ -897,21 +898,22 @@ pub const PageFormatter = struct {
             if (self.start_y == 0 and self.start_x == 0) {
                 blank_rows = state.rows;
                 blank_cells = state.cells;
+                leading_done = state.leading_done;
             }
         }
 
         // Setup our starting column and perform some validation for overflows.
         // Note: start_x only applies to the first row, end_x only applies to the last row.
         const start_x: size.CellCountInt = self.start_x;
-        if (start_x >= self.page.size.cols) return .{ .rows = blank_rows, .cells = blank_cells };
+        if (start_x >= self.page.size.cols) return .{ .rows = blank_rows, .cells = blank_cells, .leading_done = leading_done };
         const end_x_unclamped: size.CellCountInt = self.end_x orelse self.page.size.cols - 1;
         var end_x = @min(end_x_unclamped, self.page.size.cols - 1);
 
         // Setup our starting row and perform some validation for overflows.
         const start_y: size.CellCountInt = self.start_y;
-        if (start_y >= self.page.size.rows) return .{ .rows = blank_rows, .cells = blank_cells };
+        if (start_y >= self.page.size.rows) return .{ .rows = blank_rows, .cells = blank_cells, .leading_done = leading_done };
         const end_y_unclamped: size.CellCountInt = self.end_y orelse self.page.size.rows - 1;
-        if (start_y > end_y_unclamped) return .{ .rows = blank_rows, .cells = blank_cells };
+        if (start_y > end_y_unclamped) return .{ .rows = blank_rows, .cells = blank_cells, .leading_done = leading_done };
         var end_y = @min(end_y_unclamped, self.page.size.rows - 1);
 
         // Edge case: if our end x/y falls on a spacer head AND we're unwrapping,
@@ -939,7 +941,7 @@ pub const PageFormatter = struct {
 
         // If we only have a single row, validate that start_x <= end_x
         if (start_y == end_y and start_x > end_x) {
-            return .{ .rows = blank_rows, .cells = blank_cells };
+            return .{ .rows = blank_rows, .cells = blank_cells, .leading_done = leading_done };
         }
 
         // Wrap HTML output in monospace font styling
@@ -1141,6 +1143,7 @@ pub const PageFormatter = struct {
                 if (!leading_done and self.opts.trim_leading) {
                     if (cell.codepoint() == ' ') continue;
                     leading_done = true;
+                    blank_cells = 0;
                 }
 
                 // If we have a zero value, then we accumulate a counter. We
@@ -1376,7 +1379,7 @@ pub const PageFormatter = struct {
             }
         }
 
-        return .{ .rows = blank_rows, .cells = blank_cells };
+        return .{ .rows = blank_rows, .cells = blank_cells, .leading_done = leading_done };
     }
 
     fn writeCell(


### PR DESCRIPTION
Adds a `clipboard-trim-leading-spaces` config option (default `false`) that strips leading whitespace from each line when copying to the clipboard. This is the counterpart to `clipboard-trim-trailing-spaces`.

## Motivation

Common terminal output — `ps aux`, log files, columnar data, and CLI tools that indent output — uses leading spaces for alignment. When pasted elsewhere, that padding is noise. With this option enabled, only semantically meaningful leading content is copied.

## Implementation

- `trim_leading: bool = false` added to `formatter.Options`
- Per-row `leading_done` flag tracks whether we've passed the first non-whitespace cell on the current logical line
- Leading space characters (`0x20`) and empty cells (codepoint 0, used by programs that indent via cursor positioning) are skipped until the first content cell
- Guard: `!row.wrap_continuation || !opts.unwrap` ensures spaces at the start of soft-wrapped continuation rows are never stripped — they are mid-line content, not line-start whitespace
- `leading_done` persists across pages via `TrailingState` for correct behavior on long selections
- Default `false` means zero behavior change for existing users

## Files changed

- `src/config/Config.zig` — new config field
- `src/Surface.zig` — `DerivedConfig` wiring + formatter opts in `copySelectionToClipboards()`
- `src/terminal/formatter.zig` — `Options.trim_leading`, `TrailingState.leading_done`, cell loop logic, 3 unit tests

## Not changed

`selectionString()` path (used for primary-selection and URL copy) — leading-space trimming is not appropriate for those use cases.

## Test plan

- [x] `zig build test` — all tests pass
- [x] Manual testing: `printf "   hello\n"` with option enabled → clipboard contains `hello`
- [x] Manual testing: soft-wrapped continuation rows preserve mid-line spaces
- [x] Manual testing: default `false` preserves existing behavior