### PR TITLE
i18n: translation support for command palete

### DIFF
--- a/po/README_CONTRIBUTORS.md
+++ b/po/README_CONTRIBUTORS.md
@@ -44,6 +44,30 @@ else
 const label = gtk.Label.new(text);
 ```
 
+If a string must be stored untranslated and only translated later, use
+`i18n.N_` instead. This marks the string for extraction into the translation
+template but returns the original msgid unchanged. A common use case is
+compile-time or static metadata that is translated only when it is presented
+to the user.
+
+```zig
+const i18n = @import("i18n.zig");
+
+const Command = struct {
+    title: [:0]const u8,
+};
+
+const cmd = Command{
+    .title = i18n.N_("Reset Terminal"),
+};
+
+const label = gtk.Label.new(i18n._(cmd.title));
+```
+
+If `i18n._` is called at comptime, it returns the original msgid unchanged
+while still marking the string for translation. For strings that are stored
+untranslated and translated later, prefer `i18n.N_`.
+
 All translatable strings are extracted into the _translation template file_,
 located under `po/com.mitchellh.ghostty.pot`. **This file must stay in sync with
 the list of translatable strings present in source code or Blueprints at all times.**

--- a/po/be.po
+++ b/po/be.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-04-14 00:00+0000\n"
 "Last-Translator: Illia Krauchanka <illiakrauchanka@gmail.com>\n"
 "Language-Team: Belarusian\n"
@@ -154,22 +154,22 @@ msgid "Change Title…"
 msgstr "Змяніць назву…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Падзяліць уверх"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Падзяліць уніз"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Падзяліць улева"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Падзяліць управа"
 
@@ -182,16 +182,18 @@ msgid "Tab"
 msgstr "Укладка"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Змяніць назву ўкладкі…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Новая ўкладка"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Закрыць укладку"
 
@@ -200,10 +202,12 @@ msgid "Window"
 msgstr "Акно"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Новае акно"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Закрыць акно"
 
@@ -247,7 +251,7 @@ msgstr "Інспектар тэрмінала"
 msgid "About Ghostty"
 msgstr "Пра Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Выйсці"
 
@@ -335,16 +339,16 @@ msgstr "Усе сесіі тэрмінала ў гэтым акне будуць
 msgid "The currently running process in this split will be terminated."
 msgstr "Бягучы працэс у гэтым падзеле будзе завершаны."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Каманда завершана"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Каманда выканана паспяхова"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Каманда завершылася з памылкай"
@@ -373,4 +377,696 @@ msgstr "Буфер абмену ачышчаны"
 msgid "Ghostty Developers"
 msgstr "Распрацоўшчыкі Ghostty"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-02-09 22:07+0200\n"
 "Last-Translator: reo101 <pavel.atanasov2001@gmail.com>\n"
 "Language-Team: Bulgarian <dict@ludost.net>\n"
@@ -154,22 +154,22 @@ msgid "Change Title…"
 msgstr "Промени заглавие…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Раздели нагоре"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Раздели надолу"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Раздели наляво"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Раздели надясно"
 
@@ -182,16 +182,18 @@ msgid "Tab"
 msgstr "Раздел"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Смени името на таба…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Нов раздел"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Затвори раздел"
 
@@ -200,10 +202,12 @@ msgid "Window"
 msgstr "Прозорец"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Нов прозорец"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Затвори прозорец"
 
@@ -247,7 +251,7 @@ msgstr "Инспектор на терминала"
 msgid "About Ghostty"
 msgstr "За Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Изход"
 
@@ -335,16 +339,16 @@ msgstr "Всички терминални сесии в този прозоре�
 msgid "The currently running process in this split will be terminated."
 msgstr "Текущият процес в това разделяне ще бъде прекратен."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Командата завърши"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Командата завърши успешно"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Командата завърши неуспешно"
@@ -373,4 +377,696 @@ msgstr "Клипбордът е изчистен"
 msgid "Ghostty Developers"
 msgstr "Разработчици на Ghostty"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2025-08-24 19:22+0200\n"
 "Last-Translator: Kristofer Soler "
 "<31729650+KristoferSoler@users.noreply.github.com>\n"
@@ -156,22 +156,22 @@ msgid "Change Title…"
 msgstr "Canvia el títol…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Divideix cap amunt"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Divideix cap avall"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Divideix a l'esquerra"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Divideix a la dreta"
 
@@ -184,16 +184,18 @@ msgid "Tab"
 msgstr "Pestanya"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Canvia el títol de la pestanya…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Nova pestanya"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Tanca la pestanya"
 
@@ -202,10 +204,12 @@ msgid "Window"
 msgstr "Finestra"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Nova finestra"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Tanca la finestra"
 
@@ -249,7 +253,7 @@ msgstr "Inspector de terminal"
 msgid "About Ghostty"
 msgstr "Sobre Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Surt"
 
@@ -337,16 +341,16 @@ msgstr "Totes les sessions del terminal en aquesta finestra es tancaran."
 msgid "The currently running process in this split will be terminated."
 msgstr "El procés actualment en execució en aquesta divisió es tancarà."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Comanda finalitzada"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Comanda completada amb èxit"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Comanda fallida"
@@ -375,4 +379,696 @@ msgstr "Porta-retalls netejat"
 msgid "Ghostty Developers"
 msgstr "Desenvolupadors de Ghostty"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/com.mitchellh.ghostty.pot
+++ b/po/com.mitchellh.ghostty.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -147,22 +147,22 @@ msgid "Change Title…"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr ""
 
@@ -175,16 +175,18 @@ msgid "Tab"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr ""
 
@@ -193,10 +195,12 @@ msgid "Window"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr ""
 
@@ -240,7 +244,7 @@ msgstr ""
 msgid "About Ghostty"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr ""
 
@@ -322,16 +326,16 @@ msgstr ""
 msgid "The currently running process in this split will be terminated."
 msgstr ""
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr ""
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr ""
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr ""
@@ -358,4 +362,698 @@ msgstr ""
 
 #: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
+msgstr ""
+
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
+
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-02-13 08:05+0100\n"
 "Last-Translator: Klaus Hipp <khipp@users.noreply.github.com>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
@@ -159,22 +159,22 @@ msgid "Change Title…"
 msgstr "Titel bearbeiten…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Fenster nach oben teilen"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Fenster nach unten teilen"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Fenter nach links teilen"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Fenster nach rechts teilen"
 
@@ -187,16 +187,18 @@ msgid "Tab"
 msgstr "Tab"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Tab-Titel ändern…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Neuer Tab"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Tab schließen"
 
@@ -205,10 +207,12 @@ msgid "Window"
 msgstr "Fenster"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Neues Fenster"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Fenster schließen"
 
@@ -252,7 +256,7 @@ msgstr "Terminalinspektor"
 msgid "About Ghostty"
 msgstr "Über Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Beenden"
 
@@ -340,16 +344,16 @@ msgstr "Alle Terminalsitzungen in diesem Fenster werden beendet."
 msgid "The currently running process in this split will be terminated."
 msgstr "Der aktuell laufende Prozess in diesem geteilten Fenster wird beendet."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Befehl abgeschlossen"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Befehl erfolgreich"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Befehl fehlgeschlagen"
@@ -378,4 +382,696 @@ msgstr "Zwischenablage geleert"
 msgid "Ghostty Developers"
 msgstr "Ghostty-Entwickler"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/es_AR.po
+++ b/po/es_AR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-02-19 13:34-0300\n"
 "Last-Translator: Alan Moyano <alanmoyano203@gmail.com>\n"
 "Language-Team: Argentinian <es@tp.org.es>\n"
@@ -154,22 +154,22 @@ msgid "Change Title…"
 msgstr "Cambiar título…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Dividir arriba"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Dividir abajo"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Dividir a la izquierda"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Dividir a la derecha"
 
@@ -182,16 +182,18 @@ msgid "Tab"
 msgstr "Pestaña"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Cambiar título de la pestaña…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Nueva pestaña"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Cerrar pestaña"
 
@@ -200,10 +202,12 @@ msgid "Window"
 msgstr "Ventana"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Nueva ventana"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Cerrar ventana"
 
@@ -247,7 +251,7 @@ msgstr "Inspector de la terminal"
 msgid "About Ghostty"
 msgstr "Acerca de Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Salir"
 
@@ -335,16 +339,16 @@ msgstr "Todas las sesiones de terminal en esta ventana serán terminadas."
 msgid "The currently running process in this split will be terminated."
 msgstr "El proceso actualmente en ejecución en esta división será terminado."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Comando finalizado"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Comando ejecutado correctamente"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Comando fallido"
@@ -373,4 +377,696 @@ msgstr "Portapapeles limpiado"
 msgid "Ghostty Developers"
 msgstr "Desarrolladores de Ghostty"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/es_BO.po
+++ b/po/es_BO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-02-12 17:46+0200\n"
 "Last-Translator: Miguel Peredo <miguelp@quientienemail.com>\n"
 "Language-Team: Spanish <es@tp.org.es>\n"
@@ -154,22 +154,22 @@ msgid "Change Title…"
 msgstr "Cambiar título…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Dividir arriba"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Dividir abajo"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Dividir a la izquierda"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Dividir a la derecha"
 
@@ -182,16 +182,18 @@ msgid "Tab"
 msgstr "Pestaña"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Cambiar el título de la pestaña…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Nueva pestaña"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Cerrar pestaña"
 
@@ -200,10 +202,12 @@ msgid "Window"
 msgstr "Ventana"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Nueva ventana"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Cerrar ventana"
 
@@ -247,7 +251,7 @@ msgstr "Inspector de la terminal"
 msgid "About Ghostty"
 msgstr "Acerca de Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Salir"
 
@@ -335,16 +339,16 @@ msgstr "Todas las sesiones de terminal en esta ventana serán terminadas."
 msgid "The currently running process in this split will be terminated."
 msgstr "El proceso actualmente en ejecución en esta división será terminado."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Comando finalizado"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Comando exitoso"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Comando fallido"
@@ -373,4 +377,696 @@ msgstr "El portapapeles está limpio"
 msgid "Ghostty Developers"
 msgstr "Desarrolladores de Ghostty"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-02-18 10:57+0100\n"
 "Last-Translator: José Miguel Sarasola <alosarjos@gmail.com>\n"
 "Language-Team: \n"
@@ -155,22 +155,22 @@ msgid "Change Title…"
 msgstr "Cambiar título…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Dividir arriba"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Dividir abajo"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Dividir a la izquierda"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Dividir a la derecha"
 
@@ -183,16 +183,18 @@ msgid "Tab"
 msgstr "Pestaña"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Cambiar título de la pestaña…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Nueva pestaña"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Cerrar pestaña"
 
@@ -201,10 +203,12 @@ msgid "Window"
 msgstr "Ventana"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Nueva ventana"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Cerrar ventana"
 
@@ -248,7 +252,7 @@ msgstr "Inspector de terminal"
 msgid "About Ghostty"
 msgstr "Acerca de Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Salir"
 
@@ -336,16 +340,16 @@ msgstr "Todas las sesiones del terminal en esta ventana serán finalizadas."
 msgid "The currently running process in this split will be terminated."
 msgstr "El proceso ejecutándose en esta división será finalizado."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Comando finalizado"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Comando completado"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Comando fallido"
@@ -374,4 +378,696 @@ msgstr "Portapapeles vaciado"
 msgid "Ghostty Developers"
 msgstr "Desarrolladores de Ghostty"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/eu.po
+++ b/po/eu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-05-01 12:56+0200\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: Language eu\n"
@@ -152,22 +152,22 @@ msgid "Change Title…"
 msgstr "Aldatu izenburua…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Zatitu gorantz"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Zatitu beherantz"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Zatitu ezkerrera"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Zatitu eskumara"
 
@@ -180,16 +180,18 @@ msgid "Tab"
 msgstr "Fitxa"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Aldatu fitxaren izenburua…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Fitxa berria"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Itxi fitxa"
 
@@ -198,10 +200,12 @@ msgid "Window"
 msgstr "Leihoa"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Leiho berria"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Itxi leihoa"
 
@@ -245,7 +249,7 @@ msgstr "Terminal ikuskatzailea"
 msgid "About Ghostty"
 msgstr "Ghosttyri buruz"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Irten"
 
@@ -332,16 +336,16 @@ msgstr "Leiho honetako terminal saio guztiak itxi egingo dira."
 msgid "The currently running process in this split will be terminated."
 msgstr "Zatikatze honetan martxan dagoen prozesua itxi egingo da."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Komandoa amaitu da"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Komandoa ondo amaitu da"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Komandoak huts egin du"
@@ -370,4 +374,696 @@ msgstr "Arbela garbitu da"
 msgid "Ghostty Developers"
 msgstr "Ghostty garatzaileak"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-02-18 15:03+0200\n"
 "Last-Translator: Pangoraw <naydex.mc+github@gmail.com>\n"
 "Language-Team: French <traduc@traduc.org>\n"
@@ -155,22 +155,22 @@ msgid "Change Title…"
 msgstr "Changer le titre…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Panneau en haut"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Panneau en bas"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Panneau à gauche"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Panneau à droite"
 
@@ -183,16 +183,18 @@ msgid "Tab"
 msgstr "Onglet"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Changer le titre de l'onglet…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Nouvel onglet"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Fermer l'onglet"
 
@@ -201,10 +203,12 @@ msgid "Window"
 msgstr "Fenêtre"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Nouvelle fenêtre"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Fermer la fenêtre"
 
@@ -248,7 +252,7 @@ msgstr "Inspecteur de terminal"
 msgid "About Ghostty"
 msgstr "À propos de Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Quitter"
 
@@ -336,16 +340,16 @@ msgstr "Toutes les sessions de cette fenêtre vont être arrêtées."
 msgid "The currently running process in this split will be terminated."
 msgstr "Le processus en cours dans ce panneau va être arrêté."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Commande terminée"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Commande réussie"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "La commande a échoué"
@@ -374,4 +378,696 @@ msgstr "Presse-papiers vidé"
 msgid "Ghostty Developers"
 msgstr "Les développeurs de Ghostty"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/ga.po
+++ b/po/ga.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-02-18 14:32+0000\n"
 "Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@yahoo.com>\n"
 "Language-Team: Irish <gaeilge-gnulinux@lists.sourceforge.net>\n"
@@ -153,22 +153,22 @@ msgid "Change Title…"
 msgstr "Athraigh teideal…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Scoilt suas"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Scoilt síos"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Scoilt ar chlé"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Scoilt ar dheis"
 
@@ -181,16 +181,18 @@ msgid "Tab"
 msgstr "Táb"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Athraigh teideal an táb…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Táb nua"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Dún táb"
 
@@ -199,10 +201,12 @@ msgid "Window"
 msgstr "Fuinneog"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Fuinneog nua"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Dún fuinneog"
 
@@ -246,7 +250,7 @@ msgstr "Cigire teirminéil"
 msgid "About Ghostty"
 msgstr "Maidir le Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Scoir"
 
@@ -335,16 +339,16 @@ msgid "The currently running process in this split will be terminated."
 msgstr ""
 "Cuirfear deireadh leis an bpróiseas atá ar siúl faoi láthair sa scoilt seo."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Ordú críochnaithe"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "D’éirigh leis an ordú"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Theip ar an ordú"
@@ -373,4 +377,696 @@ msgstr "Gearrthaisce glanta"
 msgid "Ghostty Developers"
 msgstr "Forbróirí Ghostty"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-02-18 18:14+0300\n"
 "Last-Translator: Sl (Shahaf Levi), Sl's Repository Ltd "
 "<ghostty@slsrepo.com>\n"
@@ -154,22 +154,22 @@ msgid "Change Title…"
 msgstr "שינוי כותרת…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "פיצול למעלה"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "פיצול למטה"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "פיצול שמאלה"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "פיצול ימינה"
 
@@ -182,16 +182,18 @@ msgid "Tab"
 msgstr "כרטיסייה"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "שנה/י את כותרת הכרטיסייה…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "כרטיסייה חדשה"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "סגור/י כרטיסייה"
 
@@ -200,10 +202,12 @@ msgid "Window"
 msgstr "חלון"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "חלון חדש"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "סגור/י חלון"
 
@@ -247,7 +251,7 @@ msgstr "בודק המסוף"
 msgid "About Ghostty"
 msgstr "אודות Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "יציאה"
 
@@ -332,16 +336,16 @@ msgstr "כל הפעלות המסוף בחלון זה יסתיימו."
 msgid "The currently running process in this split will be terminated."
 msgstr "התהליך שרץ כרגע בפיצול זה יסתיים."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "הפקודה הסתיימה"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "הפקודה הצליחה"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "הפקודה נכשלה"
@@ -370,4 +374,696 @@ msgstr "לוח ההעתקה רוקן"
 msgid "Ghostty Developers"
 msgstr "המפתחים של Ghostty"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/hr.po
+++ b/po/hr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-02-18 21:00+0200\n"
 "Last-Translator: Filip7 <filipm7@protonmail.com>\n"
 "Language-Team: Croatian <lokalizacija@linux.hr>\n"
@@ -154,22 +154,22 @@ msgid "Change Title…"
 msgstr "Promijeni naslov…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Podijeli gore"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Podijeli dolje"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Podijeli lijevo"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Podijeli desno"
 
@@ -182,16 +182,18 @@ msgid "Tab"
 msgstr "Kartica"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Promijeni naslov kartice…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Nova kartica"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Zatvori karticu"
 
@@ -200,10 +202,12 @@ msgid "Window"
 msgstr "Prozor"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Novi prozor"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Zatvori prozor"
 
@@ -247,7 +251,7 @@ msgstr "Inspektor terminala"
 msgid "About Ghostty"
 msgstr "O Ghosttyju"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Izađi"
 
@@ -335,16 +339,16 @@ msgstr "Sve sesije terminala u ovom prozoru će biti prekinute."
 msgid "The currently running process in this split will be terminated."
 msgstr "Pokrenuti procesi u ovoj podjeli će biti prekinuti."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Naredba je završena"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Naredba je uspjela"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Naredba nije uspjela"
@@ -373,4 +377,696 @@ msgstr "Očišćen međuspremnik"
 msgid "Ghostty Developers"
 msgstr "Razvijatelji Ghosttyja"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-02-26 21:00+0100\n"
 "Last-Translator: Balázs Szücs <bszucs1209@gmail.com>\n"
 "Language-Team: Hungarian <translation-team-hu@lists.sourceforge.net>\n"
@@ -154,22 +154,22 @@ msgid "Change Title…"
 msgstr "Cím módosítása…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Felosztás felfelé"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Felosztás lefelé"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Felosztás balra"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Felosztás jobbra"
 
@@ -182,16 +182,18 @@ msgid "Tab"
 msgstr "Fül"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Fül címének módosítása…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Új fül"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Fül bezárása"
 
@@ -200,10 +202,12 @@ msgid "Window"
 msgstr "Ablak"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Új ablak"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Ablak bezárása"
 
@@ -247,7 +251,7 @@ msgstr "Terminálvizsgáló"
 msgid "About Ghostty"
 msgstr "A Ghostty névjegye"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Kilépés"
 
@@ -335,16 +339,16 @@ msgstr "Ebben az ablakban minden terminál munkamenet lezárul."
 msgid "The currently running process in this split will be terminated."
 msgstr "Ebben a felosztásban a jelenleg futó folyamat lezárul."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Parancs befejeződött"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Parancs sikeres"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Parancs sikertelen"
@@ -373,4 +377,696 @@ msgstr "Vágólap törölve"
 msgid "Ghostty Developers"
 msgstr "Ghostty fejlesztők"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-03-08 20:23+0700\n"
 "Last-Translator: Mikail Muzakki <mikailmmuzakki@gmail.com>\n"
 "Language-Team: Indonesian <translation-team-id@lists.sourceforge.net>\n"
@@ -154,22 +154,22 @@ msgid "Change Title…"
 msgstr "Ubah judul…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Belah atas"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Belah bawah"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Belah kiri"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Belah kanan"
 
@@ -182,16 +182,18 @@ msgid "Tab"
 msgstr "Tab"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Ubah judul tab…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Tab baru"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Tutup tab"
 
@@ -200,10 +202,12 @@ msgid "Window"
 msgstr "Jendela"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Jendela baru"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Tutup jendela"
 
@@ -247,7 +251,7 @@ msgstr "Inspektur terminal"
 msgid "About Ghostty"
 msgstr "Tentang Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Keluar"
 
@@ -335,16 +339,16 @@ msgstr "Semua sesi terminal di jendela ini akan diakhiri."
 msgid "The currently running process in this split will be terminated."
 msgstr "Proses yang sedang berjalan dalam belahan ini akan diakhiri."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Perintah selesai"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Perintah berhasil"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Perintah gagal"
@@ -373,4 +377,696 @@ msgstr "Papan klip dibersihkan"
 msgid "Ghostty Developers"
 msgstr "Pengembang Ghostty"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2025-09-06 19:40+0200\n"
 "Last-Translator: Giacomo Bettini <giaco.bettini@gmail.com>\n"
 "Language-Team: Italian <tp@lists.linux.it>\n"
@@ -155,22 +155,22 @@ msgid "Change Title…"
 msgstr "Cambia titolo…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Dividi in alto"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Dividi in basso"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Dividi a sinistra"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Dividi a destra"
 
@@ -183,16 +183,18 @@ msgid "Tab"
 msgstr "Scheda"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Cambia titolo scheda…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Nuova scheda"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Chiudi scheda"
 
@@ -201,10 +203,12 @@ msgid "Window"
 msgstr "Finestra"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Nuova finestra"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Chiudi finestra"
 
@@ -248,7 +252,7 @@ msgstr "Ispettore del terminale"
 msgid "About Ghostty"
 msgstr "Informazioni su Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Chiudi"
 
@@ -337,16 +341,16 @@ msgid "The currently running process in this split will be terminated."
 msgstr ""
 "Il processo attualmente in esecuzione in questa divisione sarà terminato."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Comando terminato"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Comando riuscito"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Comando fallito"
@@ -375,4 +379,696 @@ msgstr "Appunti svuotati"
 msgid "Ghostty Developers"
 msgstr "Sviluppatori di Ghostty"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-02-11 12:02+0900\n"
 "Last-Translator: Takayuki Nagatomi <tnagatomi@okweird.net>\n"
 "Language-Team: Japanese\n"
@@ -153,22 +153,22 @@ msgid "Change Title…"
 msgstr "タイトルを変更…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "上に分割"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "下に分割"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "左に分割"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "右に分割"
 
@@ -181,16 +181,18 @@ msgid "Tab"
 msgstr "タブ"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "タブのタイトルを変更…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "新しいタブ"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "タブを閉じる"
 
@@ -199,10 +201,12 @@ msgid "Window"
 msgstr "ウィンドウ"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "新しいウィンドウ"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "ウィンドウを閉じる"
 
@@ -246,7 +250,7 @@ msgstr "端末インスペクター"
 msgid "About Ghostty"
 msgstr "Ghostty について"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "終了"
 
@@ -334,16 +338,16 @@ msgstr "ウィンドウ内のすべてのターミナルセッションが終了
 msgid "The currently running process in this split will be terminated."
 msgstr "分割ウィンドウ内のすべてのプロセスが終了します。"
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "コマンド実行終了"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "コマンド実行成功"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "コマンド実行失敗"
@@ -372,4 +376,696 @@ msgstr "クリップボードを空にしました"
 msgid "Ghostty Developers"
 msgstr "Ghostty 開発者"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/kk.po
+++ b/po/kk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-06-20 17:07+0500\n"
 "Last-Translator: AnmiTaliDev <anmitalidev@nuros.org>\n"
 "Language-Team: Kazakh <kk_KZ@googlegroups.com>\n"
@@ -156,22 +156,22 @@ msgid "Change Title…"
 msgstr "Тақырыпты өзгерту…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Жоғарыға бөлу"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Төменге бөлу"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Сол жаққа бөлу"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Оң жаққа бөлу"
 
@@ -184,16 +184,18 @@ msgid "Tab"
 msgstr "Бет"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Бет атауын өзгерту…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Жаңа бет"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Бетті жабу"
 
@@ -202,10 +204,12 @@ msgid "Window"
 msgstr "Терезе"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Жаңа терезе"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Терезені жабу"
 
@@ -249,7 +253,7 @@ msgstr "Терминал инспекторы"
 msgid "About Ghostty"
 msgstr "Ghostty туралы"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Шығу"
 
@@ -337,16 +341,16 @@ msgstr "Осы терезедегі барлық терминал сессиял
 msgid "The currently running process in this split will be terminated."
 msgstr "Осы бөлудегі ағымдағы орындалып жатқан процесс тоқтатылады."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Команда аяқталды"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Команда сәтті орындалды"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Команда сәтсіз аяқталды"
@@ -375,4 +379,696 @@ msgstr "Алмасу буфері тазартылды"
 msgid "Ghostty Developers"
 msgstr "Ghostty әзірлеушілері"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-02-11 12:50+0900\n"
 "Last-Translator: GyuYong Jung <obliviscence@gmail.com>\n"
 "Language-Team: Korean <translation-team-ko@googlegroups.com>\n"
@@ -151,22 +151,22 @@ msgid "Change Title…"
 msgstr "제목 변경…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "위로 창 나누기"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "아래로 창 나누기"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "왼쪽으로 창 나누기"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "오른쪽으로 창 나누기"
 
@@ -179,16 +179,18 @@ msgid "Tab"
 msgstr "탭"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "탭 제목 변경…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "새 탭"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "탭 닫기"
 
@@ -197,10 +199,12 @@ msgid "Window"
 msgstr "창"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "새 창"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "창 닫기"
 
@@ -244,7 +248,7 @@ msgstr "터미널 인스펙터"
 msgid "About Ghostty"
 msgstr "Ghostty 정보"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "종료"
 
@@ -332,16 +336,16 @@ msgstr "이 창의 모든 터미널 세션이 종료됩니다."
 msgid "The currently running process in this split will be terminated."
 msgstr "이 분할에서 현재 실행 중인 프로세스가 종료됩니다."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "명령 완료"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "명령 성공"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "명령 실패"
@@ -370,4 +374,696 @@ msgstr "클립보드 지워짐"
 msgid "Ghostty Developers"
 msgstr "Ghostty 개발자들"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/lt.po
+++ b/po/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-02-20 12:13+0100\n"
 "Last-Translator: Tadas Lotuzas <tdslot@gmail.com>\n"
 "Language-Team: Language LT\n"
@@ -154,22 +154,22 @@ msgid "Change Title…"
 msgstr "Keisti pavadinimą…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Padalinti aukštyn"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Padalinti žemyn"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Padalinti kairėn"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Padalinti dešinėn"
 
@@ -182,16 +182,18 @@ msgid "Tab"
 msgstr "Kortelė"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Keisti kortelės pavadinimą…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Nauja kortelė"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Uždaryti kortelę"
 
@@ -200,10 +202,12 @@ msgid "Window"
 msgstr "Langas"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Naujas langas"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Uždaryti langą"
 
@@ -247,7 +251,7 @@ msgstr "Terminalo inspektorius"
 msgid "About Ghostty"
 msgstr "Apie Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Išeiti"
 
@@ -335,16 +339,16 @@ msgstr "Visos terminalo sesijos šiame lange bus nutrauktos."
 msgid "The currently running process in this split will be terminated."
 msgstr "Šiuo metu vykdomas procesas šiame padalijime bus nutrauktas."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Komanda užbaigta"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Komanda sėkminga"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Komanda nepavyko"
@@ -373,4 +377,696 @@ msgstr "Iškarpinė išvalyta"
 msgid "Ghostty Developers"
 msgstr "Ghostty kūrėjai"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-02-09 03:24+0200\n"
 "Last-Translator: Ēriks Remess <eriks@remess.lv>\n"
 "Language-Team: Latvian\n"
@@ -151,22 +151,22 @@ msgid "Change Title…"
 msgstr "Mainīt virsrakstu…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Sadalīt uz augšu"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Sadalīt uz leju"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Sadalīt pa kreisi"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Sadalīt pa labi"
 
@@ -179,16 +179,18 @@ msgid "Tab"
 msgstr "Cilne"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Mainīt cilnes virsrakstu…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Jauna cilne"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Aizvērt cilni"
 
@@ -197,10 +199,12 @@ msgid "Window"
 msgstr "Logs"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Jauns logs"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Aizvērt logu"
 
@@ -244,7 +248,7 @@ msgstr "Termināļa inspektors"
 msgid "About Ghostty"
 msgstr "Par Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Iziet"
 
@@ -332,16 +336,16 @@ msgstr "Visas termināļa sesijas šajā logā tiks pārtrauktas."
 msgid "The currently running process in this split will be terminated."
 msgstr "Pašlaik palaistais process šajā sadalījumā tiks pārtraukts."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Komanda izpildīta"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Komanda izdevās"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Komanda neizdevās"
@@ -370,4 +374,696 @@ msgstr "Starpliktuve notīrīta"
 msgid "Ghostty Developers"
 msgstr "Ghostty izstrādātāji"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/mk.po
+++ b/po/mk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-02-12 17:00+0100\n"
 "Last-Translator: Andrej Daskalov <andrej.daskalov@gmail.com>\n"
 "Language-Team: Macedonian\n"
@@ -154,22 +154,22 @@ msgid "Change Title…"
 msgstr "Промени наслов…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Подели нагоре"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Подели надолу"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Подели налево"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Подели надесно"
 
@@ -182,16 +182,18 @@ msgid "Tab"
 msgstr "Јазиче"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Промени наслов на јазиче…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Ново јазиче"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Затвори јазиче"
 
@@ -200,10 +202,12 @@ msgid "Window"
 msgstr "Прозор"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Нов прозор"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Затвори прозор"
 
@@ -247,7 +251,7 @@ msgstr "Инспектор на терминал"
 msgid "About Ghostty"
 msgstr "За Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Излез"
 
@@ -335,16 +339,16 @@ msgstr "Сите сесии во овој прозорец ќе бидат пр�
 msgid "The currently running process in this split will be terminated."
 msgstr "Процесот кој моментално се извршува во оваа поделба ќе биде прекинат."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Командата заврши"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Командата успеа"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Командата не успеа"
@@ -373,4 +377,696 @@ msgstr "Исчистена привремена меморија"
 msgid "Ghostty Developers"
 msgstr "Развивачи на Ghostty"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/nb.po
+++ b/po/nb.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-02-12 15:50+0000\n"
 "Last-Translator: Hanna Rose <me@hanna.lol>\n"
 "Language-Team: Norwegian Bokmal <l10n-no@lister.huftis.org>\n"
@@ -155,22 +155,22 @@ msgid "Change Title…"
 msgstr "Endre tittel…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Del oppover"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Del nedover"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Del til venstre"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Del til høyre"
 
@@ -183,16 +183,18 @@ msgid "Tab"
 msgstr "Fane"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Endre fanetittel…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Ny fane"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Lukk fane"
 
@@ -201,10 +203,12 @@ msgid "Window"
 msgstr "Vindu"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Nytt vindu"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Lukk vindu"
 
@@ -248,7 +252,7 @@ msgstr "Terminalinspektør"
 msgid "About Ghostty"
 msgstr "Om Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Avslutt"
 
@@ -336,16 +340,16 @@ msgstr "Alle terminaløkter i dette vinduet vil bli avsluttet."
 msgid "The currently running process in this split will be terminated."
 msgstr "Den kjørende prosessen for denne splitten vil bli avsluttet."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Kommandoen fullført"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Kommandoen lyktes"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Kommandoen mislyktes"
@@ -374,4 +378,696 @@ msgstr "Utklippstavle tømt"
 msgid "Ghostty Developers"
 msgstr "Ghostty-utviklere"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-02-18 20:59+0100\n"
 "Last-Translator: Nico Geesink <geesinknico@gmail.com>\n"
 "Language-Team: Dutch <vertaling@vrijschrift.org>\n"
@@ -155,22 +155,22 @@ msgid "Change Title…"
 msgstr "Wijzig titel…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Splits naar boven"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Splits naar beneden"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Splits naar links"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Splits naar rechts"
 
@@ -183,16 +183,18 @@ msgid "Tab"
 msgstr "Tabblad"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Wijzig tabbladtitel…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Nieuw tabblad"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Sluit tabblad"
 
@@ -201,10 +203,12 @@ msgid "Window"
 msgstr "Venster"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Nieuw venster"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Sluit venster"
 
@@ -248,7 +252,7 @@ msgstr "Terminalinspecteur"
 msgid "About Ghostty"
 msgstr "Over Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Afsluiten"
 
@@ -336,16 +340,16 @@ msgstr "Alle terminalsessies binnen dit venster zullen worden beëindigd."
 msgid "The currently running process in this split will be terminated."
 msgstr "Alle processen in deze splitsing zullen worden beëindigd."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Commando afgerond"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Commando succesvol afgerond"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Commando onsuccesvol afgerond"
@@ -374,4 +378,696 @@ msgstr "Klembord geleegd"
 msgid "Ghostty Developers"
 msgstr "Ghostty-ontwikkelaars"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-02-11 14:12+0100\n"
 "Last-Translator: trag1c <dev@jakubr.me>\n"
 "Language-Team: Polish <translation-team-pl@lists.sourceforge.net>\n"
@@ -155,22 +155,22 @@ msgid "Change Title…"
 msgstr "Zmień tytuł…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Podziel w górę"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Podziel w dół"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Podziel w lewo"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Podziel w prawo"
 
@@ -183,16 +183,18 @@ msgid "Tab"
 msgstr "Karta"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Zmień tytuł karty…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Nowa karta"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Zamknij kartę"
 
@@ -201,10 +203,12 @@ msgid "Window"
 msgstr "Okno"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Nowe okno"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Zamknij okno"
 
@@ -248,7 +252,7 @@ msgstr "Inspektor terminala"
 msgid "About Ghostty"
 msgstr "O Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Zamknij"
 
@@ -336,16 +340,16 @@ msgstr "Wszystkie sesje terminala w obecnym oknie zostaną zakończone."
 msgid "The currently running process in this split will be terminated."
 msgstr "Wszyskie trwające procesy w obecnym podziale zostaną zakończone."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Komenda zakończona"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Komenda wykonana pomyślnie"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Komenda nie powiodła się"
@@ -374,4 +378,696 @@ msgstr "Wyczyszczono schowek"
 msgid "Ghostty Developers"
 msgstr "Twórcy Ghostty"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-02-18 10:50-0300\n"
 "Last-Translator: Guilherme Tiscoski <github@guilhermetiscoski.com>\n"
 "Language-Team: Brazilian Portuguese <ldpbr-"
@@ -157,22 +157,22 @@ msgid "Change Title…"
 msgstr "Mudar título…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Dividir para cima"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Dividir para baixo"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Dividir à esquerda"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Dividir à direita"
 
@@ -185,16 +185,18 @@ msgid "Tab"
 msgstr "Aba"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Mudar título da aba…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Nova aba"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Fechar aba"
 
@@ -203,10 +205,12 @@ msgid "Window"
 msgstr "Janela"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Nova janela"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Fechar janela"
 
@@ -250,7 +254,7 @@ msgstr "Inspetor de terminal"
 msgid "About Ghostty"
 msgstr "Sobre o Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Sair"
 
@@ -338,16 +342,16 @@ msgstr "Todas as sessões de terminal nessa janela serão finalizadas."
 msgid "The currently running process in this split will be terminated."
 msgstr "O processo atual rodando nessa divisão será finalizado."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Comando finalizado"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Comando bem-sucedido"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Comando falhou"
@@ -376,4 +380,696 @@ msgstr "Área de transferência limpa"
 msgid "Ghostty Developers"
 msgstr "Desenvolvedores do Ghostty"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2025-02-18 10:20+0100\n"
 "Last-Translator: Ivan Bastrakov <bastaynav@proton.me>\n"
 "Language-Team: Russian <gnu@d07.ru>\n"
@@ -156,22 +156,22 @@ msgid "Change Title…"
 msgstr "Переименовать…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Сплит вверх"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Сплит вниз"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Сплит влево"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Сплит вправо"
 
@@ -184,16 +184,18 @@ msgid "Tab"
 msgstr "Вкладка"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Переименовать вкладку…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Новая вкладка"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Закрыть вкладку"
 
@@ -202,10 +204,12 @@ msgid "Window"
 msgstr "Окно"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Новое окно"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Закрыть окно"
 
@@ -249,7 +253,7 @@ msgstr "Инспектор терминала"
 msgid "About Ghostty"
 msgstr "О Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Выход"
 
@@ -337,16 +341,16 @@ msgstr "Все сессии терминала в этом окне будут �
 msgid "The currently running process in this split will be terminated."
 msgstr "Процесс, работающий в этой сплит-области, будет остановлен."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Команда завершилась"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Команда выполнена успешно"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Команда завершилась с ошибкой"
@@ -375,4 +379,696 @@ msgstr "Буфер обмена очищен"
 msgid "Ghostty Developers"
 msgstr "Разработчики Ghostty"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-02-09 22:18+0300\n"
 "Last-Translator: Emir SARI <emir_sari@icloud.com>\n"
 "Language-Team: Turkish\n"
@@ -155,22 +155,22 @@ msgid "Change Title…"
 msgstr "Başlığı Değiştir…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Yukarı Doğru Böl"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Aşağı Doğru Böl"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Sola Doğru Böl"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Sağa Doğru Böl"
 
@@ -183,16 +183,18 @@ msgid "Tab"
 msgstr "Sekme"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Sekme Başlığını Değiştir…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Yeni Sekme"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Sekmeyi Kapat"
 
@@ -201,10 +203,12 @@ msgid "Window"
 msgstr "Pencere"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Yeni Pencere"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Pencereyi Kapat"
 
@@ -248,7 +252,7 @@ msgstr "Uçbirim Denetçisi"
 msgid "About Ghostty"
 msgstr "Ghostty Hakkında"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Çık"
 
@@ -336,16 +340,16 @@ msgstr "Bu penceredeki tüm uçbirim oturumları sonlandırılacaktır."
 msgid "The currently running process in this split will be terminated."
 msgstr "Bu bölmedeki şu anda çalışan süreç sonlandırılacaktır."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Komut Bitti"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Komut Başarılı"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Komut Başarısız"
@@ -374,4 +378,696 @@ msgstr "Pano temizlendi"
 msgid "Ghostty Developers"
 msgstr "Ghostty Geliştiricileri"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-02-18 13:14+0100\n"
 "Last-Translator: Volodymyr Chernetskyi "
 "<19735328+chernetskyi@users.noreply.github.com>\n"
@@ -154,22 +154,22 @@ msgid "Change Title…"
 msgstr "Змінити заголовок…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Нова панель зверху"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Нова панель знизу"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Нова панель ліворуч"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Нова панель праворуч"
 
@@ -182,16 +182,18 @@ msgid "Tab"
 msgstr "Вкладка"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Змінити заголовок вкладки…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Нова вкладка"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Закрити вкладку"
 
@@ -200,10 +202,12 @@ msgid "Window"
 msgstr "Вікно"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Нове вікно"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Закрити вікно"
 
@@ -247,7 +251,7 @@ msgstr "Інспектор терміналу"
 msgid "About Ghostty"
 msgstr "Про Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Завершити"
 
@@ -335,16 +339,16 @@ msgstr "Всі сесії терміналу в цьому вікні будут
 msgid "The currently running process in this split will be terminated."
 msgstr "Процес, що виконується в цій панелі, буде завершено."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Команда завершилась"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Команда завершилась успішно"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Команда завершилась з помилкою"
@@ -373,4 +377,696 @@ msgstr "Буфер обміну очищено"
 msgid "Ghostty Developers"
 msgstr "Розробники Ghostty"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-03-04 09:32+0700\n"
 "Last-Translator: Anh Thang <buianhthang89@gmail.com>\n"
 "Language-Team: Vietnamese <translation-team-vi@lists.sourceforge.net>\n"
@@ -153,22 +153,22 @@ msgid "Change Title…"
 msgstr "Đổi tiêu đề…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "Chia lên trên"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "Chia xuống dưới"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "Chia sang trái"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "Chia sang phải"
 
@@ -181,16 +181,18 @@ msgid "Tab"
 msgstr "Tab"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "Đổi tiêu đề Tab…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Tab mới"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "Đóng Tab"
 
@@ -199,10 +201,12 @@ msgid "Window"
 msgstr "Cửa sổ"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Cửa sổ mới"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "Đóng cửa sổ"
 
@@ -246,7 +250,7 @@ msgstr "Bộ kiểm tra Terminal"
 msgid "About Ghostty"
 msgstr "Về Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "Thoát"
 
@@ -334,16 +338,16 @@ msgstr "Tất cả các phiên làm việc terminal trong cửa sổ này sẽ b
 msgid "The currently running process in this split will be terminated."
 msgstr "Tiến trình đang chạy trong phần chia này sẽ bị chấm dứt."
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "Lệnh đã kết thúc"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Lệnh thành công"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Lệnh thất bại"
@@ -372,4 +376,696 @@ msgstr "Đã xóa sạch bảng tạm"
 msgid "Ghostty Developers"
 msgstr "Các nhà phát triển Ghostty"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-02-12 01:56+0800\n"
 "Last-Translator: Leah <hi@pluie.me>\n"
 "Language-Team: Chinese (simplified) <i18n-zh@googlegroups.com>\n"
@@ -151,22 +151,22 @@ msgid "Change Title…"
 msgstr "更改标题…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "向上分屏"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "向下分屏"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "向左分屏"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "向右分屏"
 
@@ -179,16 +179,18 @@ msgid "Tab"
 msgstr "标签页"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "更改标签页标题…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "新建标签页"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "关闭标签页"
 
@@ -197,10 +199,12 @@ msgid "Window"
 msgstr "窗口"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "新建窗口"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "关闭窗口"
 
@@ -244,7 +248,7 @@ msgstr "终端调试器"
 msgid "About Ghostty"
 msgstr "关于 Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "退出"
 
@@ -326,16 +330,16 @@ msgstr "窗口内所有运行中的进程将被终止。"
 msgid "The currently running process in this split will be terminated."
 msgstr "分屏内正在运行中的进程将被终止。"
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "命令已完成"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "命令执行成功"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "命令执行失败"
@@ -364,4 +368,696 @@ msgstr "已清空剪贴板"
 msgid "Ghostty Developers"
 msgstr "Ghostty 开发团队"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-01 11:02-0500\n"
+"POT-Creation-Date: 2026-08-04 11:04+0300\n"
 "PO-Revision-Date: 2026-02-18 13:58+0800\n"
 "Last-Translator: Yi-Jyun Pan <me@pan93.com>\n"
 "Language-Team: Chinese (traditional)\n"
@@ -149,22 +149,22 @@ msgid "Change Title…"
 msgstr "變更標題…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250
+#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:475
 msgid "Split Up"
 msgstr "向上分割"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255
+#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:480
 msgid "Split Down"
 msgstr "向下分割"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260
+#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:465
 msgid "Split Left"
 msgstr "向左分割"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265
+#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:470
 msgid "Split Right"
 msgstr "向右分割"
 
@@ -177,16 +177,18 @@ msgid "Tab"
 msgstr "分頁"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320
+#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:458
 msgid "Change Tab Title…"
 msgstr "變更分頁標題…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "開新分頁"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/input/command.zig:594
 msgid "Close Tab"
 msgstr "關閉分頁"
 
@@ -195,10 +197,12 @@ msgid "Window"
 msgstr "視窗"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "開新視窗"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/input/command.zig:611
 msgid "Close Window"
 msgstr "關閉視窗"
 
@@ -242,7 +246,7 @@ msgstr "終端機檢查工具"
 msgid "About Ghostty"
 msgstr "關於 Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312
+#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:683
 msgid "Quit"
 msgstr "結束"
 
@@ -324,16 +328,16 @@ msgstr "此視窗中的所有終端機工作階段都將被終止。"
 msgid "The currently running process in this split will be terminated."
 msgstr "此窗格中目前執行的處理程序將被終止。"
 
-#: src/apprt/gtk/class/surface.zig:1170
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Finished"
 msgstr "命令執行完成"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1172
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "命令執行成功"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1173
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "命令執行失敗"
@@ -362,4 +366,696 @@ msgstr "已清除剪貼簿"
 msgid "Ghostty Developers"
 msgstr "Ghostty 開發者"
 
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr ""
 
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr ""
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr ""
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr ""
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr ""
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr ""
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr ""
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr ""
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr ""
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr ""
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr ""
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr ""
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr ""
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr ""
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr ""
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr ""
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr ""
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr ""
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr ""
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr ""
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr ""
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr ""
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr ""
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr ""
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr ""
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr ""
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr ""
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr ""
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr ""
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr ""
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr ""
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr ""
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr ""
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr ""
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr ""
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr ""
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr ""
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr ""
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr ""
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr ""
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr ""
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr ""
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr ""
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr ""
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr ""
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr ""
+
+#: src/input/command.zig:446
+msgid "Toggle Tab Overview"
+msgstr ""
+
+#: src/input/command.zig:447
+msgid "Toggle the tab overview."
+msgstr ""
+
+#: src/input/command.zig:452
+msgid "Change Terminal Title…"
+msgstr ""
+
+#: src/input/command.zig:453
+msgid "Prompt for a new title for the current terminal."
+msgstr ""
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current tab."
+msgstr ""
+
+#: src/input/command.zig:466
+msgid "Split the terminal to the left."
+msgstr ""
+
+#: src/input/command.zig:471
+msgid "Split the terminal to the right."
+msgstr ""
+
+#: src/input/command.zig:476
+msgid "Split the terminal up."
+msgstr ""
+
+#: src/input/command.zig:481
+msgid "Split the terminal down."
+msgstr ""
+
+#: src/input/command.zig:488
+msgid "Focus Split: Previous"
+msgstr ""
+
+#: src/input/command.zig:489
+msgid "Focus the previous split, if any."
+msgstr ""
+
+#: src/input/command.zig:493
+msgid "Focus Split: Next"
+msgstr ""
+
+#: src/input/command.zig:494
+msgid "Focus the next split, if any."
+msgstr ""
+
+#: src/input/command.zig:498
+msgid "Focus Split: Left"
+msgstr ""
+
+#: src/input/command.zig:499
+msgid "Focus the split to the left, if it exists."
+msgstr ""
+
+#: src/input/command.zig:503
+msgid "Focus Split: Right"
+msgstr ""
+
+#: src/input/command.zig:504
+msgid "Focus the split to the right, if it exists."
+msgstr ""
+
+#: src/input/command.zig:508
+msgid "Focus Split: Up"
+msgstr ""
+
+#: src/input/command.zig:509
+msgid "Focus the split above, if it exists."
+msgstr ""
+
+#: src/input/command.zig:513
+msgid "Focus Split: Down"
+msgstr ""
+
+#: src/input/command.zig:514
+msgid "Focus the split below, if it exists."
+msgstr ""
+
+#: src/input/command.zig:521
+msgid "Focus Window: Previous"
+msgstr ""
+
+#: src/input/command.zig:522
+msgid "Focus the previous window, if any."
+msgstr ""
+
+#: src/input/command.zig:526
+msgid "Focus Window: Next"
+msgstr ""
+
+#: src/input/command.zig:527
+msgid "Focus the next window, if any."
+msgstr ""
+
+#: src/input/command.zig:533
+msgid "Toggle Split Zoom"
+msgstr ""
+
+#: src/input/command.zig:534
+msgid "Toggle the zoom state of the current split."
+msgstr ""
+
+#: src/input/command.zig:539
+msgid "Toggle Read-Only Mode"
+msgstr ""
+
+#: src/input/command.zig:540
+msgid "Toggle read-only mode for the current surface."
+msgstr ""
+
+#: src/input/command.zig:545
+msgid "Equalize Splits"
+msgstr ""
+
+#: src/input/command.zig:546
+msgid "Equalize the size of all splits."
+msgstr ""
+
+#: src/input/command.zig:551
+msgid "Reset Window Size"
+msgstr ""
+
+#: src/input/command.zig:552
+msgid "Reset the window size to the default."
+msgstr ""
+
+#: src/input/command.zig:557
+msgid "Toggle Inspector"
+msgstr ""
+
+#: src/input/command.zig:558
+msgid "Toggle the inspector."
+msgstr ""
+
+#: src/input/command.zig:563
+msgid "Show the GTK Inspector"
+msgstr ""
+
+#: src/input/command.zig:564
+msgid "Show the GTK inspector."
+msgstr ""
+
+#: src/input/command.zig:569
+msgid "Show On-Screen Keyboard"
+msgstr ""
+
+#: src/input/command.zig:570
+msgid "Show the on-screen keyboard if present."
+msgstr ""
+
+#: src/input/command.zig:575
+msgid "Open Config"
+msgstr ""
+
+#: src/input/command.zig:576
+msgid "Open the config file."
+msgstr ""
+
+#: src/input/command.zig:581
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:582
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:587
+msgid "Close Terminal"
+msgstr ""
+
+#: src/input/command.zig:588
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Close the current tab."
+msgstr ""
+
+#: src/input/command.zig:599
+msgid "Close Other Tabs"
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:604
+msgid "Close Tabs to the Right"
+msgstr ""
+
+#: src/input/command.zig:605
+msgid "Close all tabs to the right of the current one."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Close the current window."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Close All Windows"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Close all windows."
+msgstr ""
+
+#: src/input/command.zig:623
+msgid "Toggle Maximize"
+msgstr ""
+
+#: src/input/command.zig:624
+msgid "Toggle the maximized state of the current window."
+msgstr ""
+
+#: src/input/command.zig:629
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/input/command.zig:630
+msgid "Toggle the fullscreen state of the current window."
+msgstr ""
+
+#: src/input/command.zig:635
+msgid "Toggle Window Decorations"
+msgstr ""
+
+#: src/input/command.zig:636
+msgid "Toggle the window decorations."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Toggle Float on Top"
+msgstr ""
+
+#: src/input/command.zig:642
+msgid "Toggle the float on top state of the current window."
+msgstr ""
+
+#: src/input/command.zig:647
+msgid "Toggle Secure Input"
+msgstr ""
+
+#: src/input/command.zig:648
+msgid "Toggle secure input mode."
+msgstr ""
+
+#: src/input/command.zig:653
+msgid "Toggle Mouse Reporting"
+msgstr ""
+
+#: src/input/command.zig:654
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr ""
+
+#: src/input/command.zig:659
+msgid "Toggle Background Opacity"
+msgstr ""
+
+#: src/input/command.zig:660
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:665
+msgid "Check for Updates"
+msgstr ""
+
+#: src/input/command.zig:666
+msgid "Check for updates to the application."
+msgstr ""
+
+#: src/input/command.zig:671
+msgid "Undo"
+msgstr ""
+
+#: src/input/command.zig:672
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:677
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:678
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:684
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:689
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:690
+msgid "Put a little Ghostty in your terminal."
+msgstr ""

--- a/src/build/GhosttyI18n.zig
+++ b/src/build/GhosttyI18n.zig
@@ -66,6 +66,7 @@ fn createUpdateStep(b: *std.Build) !*std.Build.Step {
         "--language=C", // Silence the "unknown extension" errors
         "--from-code=UTF-8",
         "--keyword=_",
+        "--keyword=N_",
         "--keyword=C_:1c,2",
     });
 
@@ -147,6 +148,11 @@ fn createUpdateStep(b: *std.Build) !*std.Build.Step {
             xgettext.addFileInput(b.path(path));
         }
     }
+
+    // For localization of command palette
+    const command_palette_path = "src/input/command.zig";
+    xgettext.addArg(command_palette_path);
+    xgettext.addFileInput(b.path(command_palette_path));
 
     // Add support for localizing our `nautilus` integration
     const xgettext_py = b.addSystemCommand(&.{

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -8746,8 +8746,13 @@ pub const RepeatableCommand = struct {
             self.value.deinit(alloc);
             self.value_c.deinit(alloc);
         }
-        try self.value.appendSlice(alloc, inputpkg.command.defaults);
-        try self.value_c.appendSlice(alloc, inputpkg.command.defaultsC);
+        try self.value.ensureUnusedCapacity(alloc, inputpkg.command.defaults.len);
+        try self.value_c.ensureUnusedCapacity(alloc, inputpkg.command.defaults.len);
+        for (inputpkg.command.defaults) |cmd| {
+            const translated = cmd.translated();
+            self.value.appendAssumeCapacity(translated);
+            self.value_c.appendAssumeCapacity(try translated.cval(alloc));
+        }
     }
 
     pub fn parseCLI(

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const assert = @import("../quirks.zig").inlineAssert;
 const Allocator = std.mem.Allocator;
 const Action = @import("Binding.zig").Action;
+const i18n = @import("../os/i18n.zig");
 
 /// A command is a named binding action that can be executed from
 /// something like a command palette.
@@ -76,6 +77,14 @@ pub const Command = struct {
         };
     }
 
+    pub fn translated(self: Command) Command {
+        return .{
+            .action = self.action,
+            .title = std.mem.span(i18n._(self.title)),
+            .description = std.mem.span(i18n._(self.description)),
+        };
+    }
+
     /// Implements a comparison function for std.mem.sortUnstable
     /// and similar functions. The sorting is defined by Ghostty
     /// to be what we prefer. If a caller wants some other sorting,
@@ -137,155 +146,155 @@ fn actionCommands(action: Action.Key) []const Command {
 
         .reset => comptime &.{.{
             .action = .reset,
-            .title = "Reset Terminal",
-            .description = "Reset the terminal to a clean state.",
+            .title = i18n.N_("Reset Terminal"),
+            .description = i18n.N_("Reset the terminal to a clean state."),
         }},
 
         .copy_to_clipboard => comptime &.{ .{
             .action = .{ .copy_to_clipboard = .mixed },
-            .title = "Copy to Clipboard",
-            .description = "Copy the selected text to the clipboard in both plain and styled formats.",
+            .title = i18n.N_("Copy to Clipboard"),
+            .description = i18n.N_("Copy the selected text to the clipboard in both plain and styled formats."),
         }, .{
             .action = .{ .copy_to_clipboard = .plain },
-            .title = "Copy Selection as Plain Text to Clipboard",
-            .description = "Copy the selected text as plain text to the clipboard.",
+            .title = i18n.N_("Copy Selection as Plain Text to Clipboard"),
+            .description = i18n.N_("Copy the selected text as plain text to the clipboard."),
         }, .{
             .action = .{ .copy_to_clipboard = .vt },
-            .title = "Copy Selection as ANSI Sequences to Clipboard",
-            .description = "Copy the selected text as ANSI escape sequences to the clipboard.",
+            .title = i18n.N_("Copy Selection as ANSI Sequences to Clipboard"),
+            .description = i18n.N_("Copy the selected text as ANSI escape sequences to the clipboard."),
         }, .{
             .action = .{ .copy_to_clipboard = .html },
-            .title = "Copy Selection as HTML to Clipboard",
-            .description = "Copy the selected text as HTML to the clipboard.",
+            .title = i18n.N_("Copy Selection as HTML to Clipboard"),
+            .description = i18n.N_("Copy the selected text as HTML to the clipboard."),
         } },
 
         .copy_url_to_clipboard => comptime &.{.{
             .action = .copy_url_to_clipboard,
-            .title = "Copy URL to Clipboard",
-            .description = "Copy the URL under the cursor to the clipboard.",
+            .title = i18n.N_("Copy URL to Clipboard"),
+            .description = i18n.N_("Copy the URL under the cursor to the clipboard."),
         }},
 
         .copy_title_to_clipboard => comptime &.{.{
             .action = .copy_title_to_clipboard,
-            .title = "Copy Terminal Title to Clipboard",
-            .description = "Copy the terminal title to the clipboard. If the terminal title is not set this has no effect.",
+            .title = i18n.N_("Copy Terminal Title to Clipboard"),
+            .description = i18n.N_("Copy the terminal title to the clipboard. If the terminal title is not set this has no effect."),
         }},
 
         .paste_from_clipboard => comptime &.{.{
             .action = .paste_from_clipboard,
-            .title = "Paste from Clipboard",
-            .description = "Paste the contents of the main clipboard.",
+            .title = i18n.N_("Paste from Clipboard"),
+            .description = i18n.N_("Paste the contents of the main clipboard."),
         }},
 
         .paste_from_selection => comptime &.{.{
             .action = .paste_from_selection,
-            .title = "Paste from Selection",
-            .description = "Paste the contents of the selection clipboard.",
+            .title = i18n.N_("Paste from Selection"),
+            .description = i18n.N_("Paste the contents of the selection clipboard."),
         }},
 
         .start_search => comptime &.{.{
             .action = .start_search,
-            .title = "Start Search",
-            .description = "Start a search if one isn't already active.",
+            .title = i18n.N_("Start Search"),
+            .description = i18n.N_("Start a search if one isn't already active."),
         }},
 
         .search_selection => comptime &.{.{
             .action = .search_selection,
-            .title = "Search Selection",
-            .description = "Start a search for the current text selection.",
+            .title = i18n.N_("Search Selection"),
+            .description = i18n.N_("Start a search for the current text selection."),
         }},
 
         .end_search => comptime &.{.{
             .action = .end_search,
-            .title = "End Search",
-            .description = "End the current search if any and hide any GUI elements.",
+            .title = i18n.N_("End Search"),
+            .description = i18n.N_("End the current search if any and hide any GUI elements."),
         }},
 
         .navigate_search => comptime &.{ .{
             .action = .{ .navigate_search = .next },
-            .title = "Next Search Result",
-            .description = "Navigate to the next search result, if any.",
+            .title = i18n.N_("Next Search Result"),
+            .description = i18n.N_("Navigate to the next search result, if any."),
         }, .{
             .action = .{ .navigate_search = .previous },
-            .title = "Previous Search Result",
-            .description = "Navigate to the previous search result, if any.",
+            .title = i18n.N_("Previous Search Result"),
+            .description = i18n.N_("Navigate to the previous search result, if any."),
         } },
 
         .increase_font_size => comptime &.{.{
             .action = .{ .increase_font_size = 1 },
-            .title = "Increase Font Size",
-            .description = "Increase the font size by 1 point.",
+            .title = i18n.N_("Increase Font Size"),
+            .description = i18n.N_("Increase the font size by 1 point."),
         }},
 
         .decrease_font_size => comptime &.{.{
             .action = .{ .decrease_font_size = 1 },
-            .title = "Decrease Font Size",
-            .description = "Decrease the font size by 1 point.",
+            .title = i18n.N_("Decrease Font Size"),
+            .description = i18n.N_("Decrease the font size by 1 point."),
         }},
 
         .reset_font_size => comptime &.{.{
             .action = .reset_font_size,
-            .title = "Reset Font Size",
-            .description = "Reset the font size to the default.",
+            .title = i18n.N_("Reset Font Size"),
+            .description = i18n.N_("Reset the font size to the default."),
         }},
 
         .clear_screen => comptime &.{.{
             .action = .clear_screen,
-            .title = "Clear Screen",
-            .description = "Clear the screen and scrollback.",
+            .title = i18n.N_("Clear Screen"),
+            .description = i18n.N_("Clear the screen and scrollback."),
         }},
 
         .select_all => comptime &.{.{
             .action = .select_all,
-            .title = "Select All",
-            .description = "Select all text on the screen.",
+            .title = i18n.N_("Select All"),
+            .description = i18n.N_("Select all text on the screen."),
         }},
 
         .scroll_to_top => comptime &.{.{
             .action = .scroll_to_top,
-            .title = "Scroll to Top",
-            .description = "Scroll to the top of the screen.",
+            .title = i18n.N_("Scroll to Top"),
+            .description = i18n.N_("Scroll to the top of the screen."),
         }},
 
         .scroll_to_bottom => comptime &.{.{
             .action = .scroll_to_bottom,
-            .title = "Scroll to Bottom",
-            .description = "Scroll to the bottom of the screen.",
+            .title = i18n.N_("Scroll to Bottom"),
+            .description = i18n.N_("Scroll to the bottom of the screen."),
         }},
 
         .scroll_to_selection => comptime &.{.{
             .action = .scroll_to_selection,
-            .title = "Scroll to Selection",
-            .description = "Scroll to the selected text.",
+            .title = i18n.N_("Scroll to Selection"),
+            .description = i18n.N_("Scroll to the selected text."),
         }},
 
         .scroll_page_up => comptime &.{.{
             .action = .scroll_page_up,
-            .title = "Scroll Page Up",
-            .description = "Scroll the screen up by a page.",
+            .title = i18n.N_("Scroll Page Up"),
+            .description = i18n.N_("Scroll the screen up by a page."),
         }},
 
         .scroll_page_down => comptime &.{.{
             .action = .scroll_page_down,
-            .title = "Scroll Page Down",
-            .description = "Scroll the screen down by a page.",
+            .title = i18n.N_("Scroll Page Down"),
+            .description = i18n.N_("Scroll the screen down by a page."),
         }},
 
         .write_screen_file => comptime &.{
             .{
                 .action = .{ .write_screen_file = .copy },
-                .title = "Copy Screen to Temporary File and Copy Path",
-                .description = "Copy the screen contents to a temporary file and copy the path to the clipboard.",
+                .title = i18n.N_("Copy Screen to Temporary File and Copy Path"),
+                .description = i18n.N_("Copy the screen contents to a temporary file and copy the path to the clipboard."),
             },
             .{
                 .action = .{ .write_screen_file = .paste },
-                .title = "Copy Screen to Temporary File and Paste Path",
-                .description = "Copy the screen contents to a temporary file and paste the path to the file.",
+                .title = i18n.N_("Copy Screen to Temporary File and Paste Path"),
+                .description = i18n.N_("Copy the screen contents to a temporary file and paste the path to the file."),
             },
             .{
                 .action = .{ .write_screen_file = .open },
-                .title = "Copy Screen to Temporary File and Open",
-                .description = "Copy the screen contents to a temporary file and open it.",
+                .title = i18n.N_("Copy Screen to Temporary File and Open"),
+                .description = i18n.N_("Copy the screen contents to a temporary file and open it."),
             },
 
             .{
@@ -293,24 +302,24 @@ fn actionCommands(action: Action.Key) []const Command {
                     .action = .copy,
                     .emit = .html,
                 } },
-                .title = "Copy Screen as HTML to Temporary File and Copy Path",
-                .description = "Copy the screen contents as HTML to a temporary file and copy the path to the clipboard.",
+                .title = i18n.N_("Copy Screen as HTML to Temporary File and Copy Path"),
+                .description = i18n.N_("Copy the screen contents as HTML to a temporary file and copy the path to the clipboard."),
             },
             .{
                 .action = .{ .write_screen_file = .{
                     .action = .paste,
                     .emit = .html,
                 } },
-                .title = "Copy Screen as HTML to Temporary File and Paste Path",
-                .description = "Copy the screen contents as HTML to a temporary file and paste the path to the file.",
+                .title = i18n.N_("Copy Screen as HTML to Temporary File and Paste Path"),
+                .description = i18n.N_("Copy the screen contents as HTML to a temporary file and paste the path to the file."),
             },
             .{
                 .action = .{ .write_screen_file = .{
                     .action = .open,
                     .emit = .html,
                 } },
-                .title = "Copy Screen as HTML to Temporary File and Open",
-                .description = "Copy the screen contents as HTML to a temporary file and open it.",
+                .title = i18n.N_("Copy Screen as HTML to Temporary File and Open"),
+                .description = i18n.N_("Copy the screen contents as HTML to a temporary file and open it."),
             },
 
             .{
@@ -318,42 +327,42 @@ fn actionCommands(action: Action.Key) []const Command {
                     .action = .copy,
                     .emit = .vt,
                 } },
-                .title = "Copy Screen as ANSI Sequences to Temporary File and Copy Path",
-                .description = "Copy the screen contents as ANSI escape sequences to a temporary file and copy the path to the clipboard.",
+                .title = i18n.N_("Copy Screen as ANSI Sequences to Temporary File and Copy Path"),
+                .description = i18n.N_("Copy the screen contents as ANSI escape sequences to a temporary file and copy the path to the clipboard."),
             },
             .{
                 .action = .{ .write_screen_file = .{
                     .action = .paste,
                     .emit = .vt,
                 } },
-                .title = "Copy Screen as ANSI Sequences to Temporary File and Paste Path",
-                .description = "Copy the screen contents as ANSI escape sequences to a temporary file and paste the path to the file.",
+                .title = i18n.N_("Copy Screen as ANSI Sequences to Temporary File and Paste Path"),
+                .description = i18n.N_("Copy the screen contents as ANSI escape sequences to a temporary file and paste the path to the file."),
             },
             .{
                 .action = .{ .write_screen_file = .{
                     .action = .open,
                     .emit = .vt,
                 } },
-                .title = "Copy Screen as ANSI Sequences to Temporary File and Open",
-                .description = "Copy the screen contents as ANSI escape sequences to a temporary file and open it.",
+                .title = i18n.N_("Copy Screen as ANSI Sequences to Temporary File and Open"),
+                .description = i18n.N_("Copy the screen contents as ANSI escape sequences to a temporary file and open it."),
             },
         },
 
         .write_selection_file => comptime &.{
             .{
                 .action = .{ .write_selection_file = .copy },
-                .title = "Copy Selection to Temporary File and Copy Path",
-                .description = "Copy the selection contents to a temporary file and copy the path to the clipboard.",
+                .title = i18n.N_("Copy Selection to Temporary File and Copy Path"),
+                .description = i18n.N_("Copy the selection contents to a temporary file and copy the path to the clipboard."),
             },
             .{
                 .action = .{ .write_selection_file = .paste },
-                .title = "Copy Selection to Temporary File and Paste Path",
-                .description = "Copy the selection contents to a temporary file and paste the path to the file.",
+                .title = i18n.N_("Copy Selection to Temporary File and Paste Path"),
+                .description = i18n.N_("Copy the selection contents to a temporary file and paste the path to the file."),
             },
             .{
                 .action = .{ .write_selection_file = .open },
-                .title = "Copy Selection to Temporary File and Open",
-                .description = "Copy the selection contents to a temporary file and open it.",
+                .title = i18n.N_("Copy Selection to Temporary File and Open"),
+                .description = i18n.N_("Copy the selection contents to a temporary file and open it."),
             },
 
             .{
@@ -361,24 +370,24 @@ fn actionCommands(action: Action.Key) []const Command {
                     .action = .copy,
                     .emit = .html,
                 } },
-                .title = "Copy Selection as HTML to Temporary File and Copy Path",
-                .description = "Copy the selection contents as HTML to a temporary file and copy the path to the clipboard.",
+                .title = i18n.N_("Copy Selection as HTML to Temporary File and Copy Path"),
+                .description = i18n.N_("Copy the selection contents as HTML to a temporary file and copy the path to the clipboard."),
             },
             .{
                 .action = .{ .write_selection_file = .{
                     .action = .paste,
                     .emit = .html,
                 } },
-                .title = "Copy Selection as HTML to Temporary File and Paste Path",
-                .description = "Copy the selection contents as HTML to a temporary file and paste the path to the file.",
+                .title = i18n.N_("Copy Selection as HTML to Temporary File and Paste Path"),
+                .description = i18n.N_("Copy the selection contents as HTML to a temporary file and paste the path to the file."),
             },
             .{
                 .action = .{ .write_selection_file = .{
                     .action = .open,
                     .emit = .html,
                 } },
-                .title = "Copy Selection as HTML to Temporary File and Open",
-                .description = "Copy the selection contents as HTML to a temporary file and open it.",
+                .title = i18n.N_("Copy Selection as HTML to Temporary File and Open"),
+                .description = i18n.N_("Copy the selection contents as HTML to a temporary file and open it."),
             },
 
             .{
@@ -386,299 +395,299 @@ fn actionCommands(action: Action.Key) []const Command {
                     .action = .copy,
                     .emit = .vt,
                 } },
-                .title = "Copy Selection as ANSI Sequences to Temporary File and Copy Path",
-                .description = "Copy the selection contents as ANSI escape sequences to a temporary file and copy the path to the clipboard.",
+                .title = i18n.N_("Copy Selection as ANSI Sequences to Temporary File and Copy Path"),
+                .description = i18n.N_("Copy the selection contents as ANSI escape sequences to a temporary file and copy the path to the clipboard."),
             },
             .{
                 .action = .{ .write_selection_file = .{
                     .action = .paste,
                     .emit = .vt,
                 } },
-                .title = "Copy Selection as ANSI Sequences to Temporary File and Paste Path",
-                .description = "Copy the selection contents as ANSI escape sequences to a temporary file and paste the path to the file.",
+                .title = i18n.N_("Copy Selection as ANSI Sequences to Temporary File and Paste Path"),
+                .description = i18n.N_("Copy the selection contents as ANSI escape sequences to a temporary file and paste the path to the file."),
             },
             .{
                 .action = .{ .write_selection_file = .{
                     .action = .open,
                     .emit = .vt,
                 } },
-                .title = "Copy Selection as ANSI Sequences to Temporary File and Open",
-                .description = "Copy the selection contents as ANSI escape sequences to a temporary file and open it.",
+                .title = i18n.N_("Copy Selection as ANSI Sequences to Temporary File and Open"),
+                .description = i18n.N_("Copy the selection contents as ANSI escape sequences to a temporary file and open it."),
             },
         },
 
         .new_window => comptime &.{.{
             .action = .new_window,
-            .title = "New Window",
-            .description = "Open a new window.",
+            .title = i18n.N_("New Window"),
+            .description = i18n.N_("Open a new window."),
         }},
 
         .new_tab => comptime &.{.{
             .action = .new_tab,
-            .title = "New Tab",
-            .description = "Open a new tab.",
+            .title = i18n.N_("New Tab"),
+            .description = i18n.N_("Open a new tab."),
         }},
 
         .move_tab => comptime &.{
             .{
                 .action = .{ .move_tab = -1 },
-                .title = "Move Tab Left",
-                .description = "Move the current tab to the left.",
+                .title = i18n.N_("Move Tab Left"),
+                .description = i18n.N_("Move the current tab to the left."),
             },
             .{
                 .action = .{ .move_tab = 1 },
-                .title = "Move Tab Right",
-                .description = "Move the current tab to the right.",
+                .title = i18n.N_("Move Tab Right"),
+                .description = i18n.N_("Move the current tab to the right."),
             },
         },
 
         .toggle_tab_overview => comptime &.{.{
             .action = .toggle_tab_overview,
-            .title = "Toggle Tab Overview",
-            .description = "Toggle the tab overview.",
+            .title = i18n.N_("Toggle Tab Overview"),
+            .description = i18n.N_("Toggle the tab overview."),
         }},
 
         .prompt_surface_title => comptime &.{.{
             .action = .prompt_surface_title,
-            .title = "Change Terminal Title…",
-            .description = "Prompt for a new title for the current terminal.",
+            .title = i18n.N_("Change Terminal Title…"),
+            .description = i18n.N_("Prompt for a new title for the current terminal."),
         }},
 
         .prompt_tab_title => comptime &.{.{
             .action = .prompt_tab_title,
-            .title = "Change Tab Title…",
-            .description = "Prompt for a new title for the current tab.",
+            .title = i18n.N_("Change Tab Title…"),
+            .description = i18n.N_("Prompt for a new title for the current tab."),
         }},
 
         .new_split => comptime &.{
             .{
                 .action = .{ .new_split = .left },
-                .title = "Split Left",
-                .description = "Split the terminal to the left.",
+                .title = i18n.N_("Split Left"),
+                .description = i18n.N_("Split the terminal to the left."),
             },
             .{
                 .action = .{ .new_split = .right },
-                .title = "Split Right",
-                .description = "Split the terminal to the right.",
+                .title = i18n.N_("Split Right"),
+                .description = i18n.N_("Split the terminal to the right."),
             },
             .{
                 .action = .{ .new_split = .up },
-                .title = "Split Up",
-                .description = "Split the terminal up.",
+                .title = i18n.N_("Split Up"),
+                .description = i18n.N_("Split the terminal up."),
             },
             .{
                 .action = .{ .new_split = .down },
-                .title = "Split Down",
-                .description = "Split the terminal down.",
+                .title = i18n.N_("Split Down"),
+                .description = i18n.N_("Split the terminal down."),
             },
         },
 
         .goto_split => comptime &.{
             .{
                 .action = .{ .goto_split = .previous },
-                .title = "Focus Split: Previous",
-                .description = "Focus the previous split, if any.",
+                .title = i18n.N_("Focus Split: Previous"),
+                .description = i18n.N_("Focus the previous split, if any."),
             },
             .{
                 .action = .{ .goto_split = .next },
-                .title = "Focus Split: Next",
-                .description = "Focus the next split, if any.",
+                .title = i18n.N_("Focus Split: Next"),
+                .description = i18n.N_("Focus the next split, if any."),
             },
             .{
                 .action = .{ .goto_split = .left },
-                .title = "Focus Split: Left",
-                .description = "Focus the split to the left, if it exists.",
+                .title = i18n.N_("Focus Split: Left"),
+                .description = i18n.N_("Focus the split to the left, if it exists."),
             },
             .{
                 .action = .{ .goto_split = .right },
-                .title = "Focus Split: Right",
-                .description = "Focus the split to the right, if it exists.",
+                .title = i18n.N_("Focus Split: Right"),
+                .description = i18n.N_("Focus the split to the right, if it exists."),
             },
             .{
                 .action = .{ .goto_split = .up },
-                .title = "Focus Split: Up",
-                .description = "Focus the split above, if it exists.",
+                .title = i18n.N_("Focus Split: Up"),
+                .description = i18n.N_("Focus the split above, if it exists."),
             },
             .{
                 .action = .{ .goto_split = .down },
-                .title = "Focus Split: Down",
-                .description = "Focus the split below, if it exists.",
+                .title = i18n.N_("Focus Split: Down"),
+                .description = i18n.N_("Focus the split below, if it exists."),
             },
         },
 
         .goto_window => comptime &.{
             .{
                 .action = .{ .goto_window = .previous },
-                .title = "Focus Window: Previous",
-                .description = "Focus the previous window, if any.",
+                .title = i18n.N_("Focus Window: Previous"),
+                .description = i18n.N_("Focus the previous window, if any."),
             },
             .{
                 .action = .{ .goto_window = .next },
-                .title = "Focus Window: Next",
-                .description = "Focus the next window, if any.",
+                .title = i18n.N_("Focus Window: Next"),
+                .description = i18n.N_("Focus the next window, if any."),
             },
         },
 
         .toggle_split_zoom => comptime &.{.{
             .action = .toggle_split_zoom,
-            .title = "Toggle Split Zoom",
-            .description = "Toggle the zoom state of the current split.",
+            .title = i18n.N_("Toggle Split Zoom"),
+            .description = i18n.N_("Toggle the zoom state of the current split."),
         }},
 
         .toggle_readonly => comptime &.{.{
             .action = .toggle_readonly,
-            .title = "Toggle Read-Only Mode",
-            .description = "Toggle read-only mode for the current surface.",
+            .title = i18n.N_("Toggle Read-Only Mode"),
+            .description = i18n.N_("Toggle read-only mode for the current surface."),
         }},
 
         .equalize_splits => comptime &.{.{
             .action = .equalize_splits,
-            .title = "Equalize Splits",
-            .description = "Equalize the size of all splits.",
+            .title = i18n.N_("Equalize Splits"),
+            .description = i18n.N_("Equalize the size of all splits."),
         }},
 
         .reset_window_size => comptime &.{.{
             .action = .reset_window_size,
-            .title = "Reset Window Size",
-            .description = "Reset the window size to the default.",
+            .title = i18n.N_("Reset Window Size"),
+            .description = i18n.N_("Reset the window size to the default."),
         }},
 
         .inspector => comptime &.{.{
             .action = .{ .inspector = .toggle },
-            .title = "Toggle Inspector",
-            .description = "Toggle the inspector.",
+            .title = i18n.N_("Toggle Inspector"),
+            .description = i18n.N_("Toggle the inspector."),
         }},
 
         .show_gtk_inspector => comptime &.{.{
             .action = .show_gtk_inspector,
-            .title = "Show the GTK Inspector",
-            .description = "Show the GTK inspector.",
+            .title = i18n.N_("Show the GTK Inspector"),
+            .description = i18n.N_("Show the GTK inspector."),
         }},
 
         .show_on_screen_keyboard => comptime &.{.{
             .action = .show_on_screen_keyboard,
-            .title = "Show On-Screen Keyboard",
-            .description = "Show the on-screen keyboard if present.",
+            .title = i18n.N_("Show On-Screen Keyboard"),
+            .description = i18n.N_("Show the on-screen keyboard if present."),
         }},
 
         .open_config => comptime &.{.{
             .action = .open_config,
-            .title = "Open Config",
-            .description = "Open the config file.",
+            .title = i18n.N_("Open Config"),
+            .description = i18n.N_("Open the config file."),
         }},
 
         .reload_config => comptime &.{.{
             .action = .reload_config,
-            .title = "Reload Config",
-            .description = "Reload the config file.",
+            .title = i18n.N_("Reload Config"),
+            .description = i18n.N_("Reload the config file."),
         }},
 
         .close_surface => comptime &.{.{
             .action = .close_surface,
-            .title = "Close Terminal",
-            .description = "Close the current terminal.",
+            .title = i18n.N_("Close Terminal"),
+            .description = i18n.N_("Close the current terminal."),
         }},
 
         .close_tab => comptime &.{
             .{
                 .action = .{ .close_tab = .this },
-                .title = "Close Tab",
-                .description = "Close the current tab.",
+                .title = i18n.N_("Close Tab"),
+                .description = i18n.N_("Close the current tab."),
             },
             .{
                 .action = .{ .close_tab = .other },
-                .title = "Close Other Tabs",
-                .description = "Close all tabs in this window except the current one.",
+                .title = i18n.N_("Close Other Tabs"),
+                .description = i18n.N_("Close all tabs in this window except the current one."),
             },
             .{
                 .action = .{ .close_tab = .right },
-                .title = "Close Tabs to the Right",
-                .description = "Close all tabs to the right of the current one.",
+                .title = i18n.N_("Close Tabs to the Right"),
+                .description = i18n.N_("Close all tabs to the right of the current one."),
             },
         },
 
         .close_window => comptime &.{.{
             .action = .close_window,
-            .title = "Close Window",
-            .description = "Close the current window.",
+            .title = i18n.N_("Close Window"),
+            .description = i18n.N_("Close the current window."),
         }},
 
         .close_all_windows => comptime &.{.{
             .action = .close_all_windows,
-            .title = "Close All Windows",
-            .description = "Close all windows.",
+            .title = i18n.N_("Close All Windows"),
+            .description = i18n.N_("Close all windows."),
         }},
 
         .toggle_maximize => comptime &.{.{
             .action = .toggle_maximize,
-            .title = "Toggle Maximize",
-            .description = "Toggle the maximized state of the current window.",
+            .title = i18n.N_("Toggle Maximize"),
+            .description = i18n.N_("Toggle the maximized state of the current window."),
         }},
 
         .toggle_fullscreen => comptime &.{.{
             .action = .toggle_fullscreen,
-            .title = "Toggle Fullscreen",
-            .description = "Toggle the fullscreen state of the current window.",
+            .title = i18n.N_("Toggle Fullscreen"),
+            .description = i18n.N_("Toggle the fullscreen state of the current window."),
         }},
 
         .toggle_window_decorations => comptime &.{.{
             .action = .toggle_window_decorations,
-            .title = "Toggle Window Decorations",
-            .description = "Toggle the window decorations.",
+            .title = i18n.N_("Toggle Window Decorations"),
+            .description = i18n.N_("Toggle the window decorations."),
         }},
 
         .toggle_window_float_on_top => comptime &.{.{
             .action = .toggle_window_float_on_top,
-            .title = "Toggle Float on Top",
-            .description = "Toggle the float on top state of the current window.",
+            .title = i18n.N_("Toggle Float on Top"),
+            .description = i18n.N_("Toggle the float on top state of the current window."),
         }},
 
         .toggle_secure_input => comptime &.{.{
             .action = .toggle_secure_input,
-            .title = "Toggle Secure Input",
-            .description = "Toggle secure input mode.",
+            .title = i18n.N_("Toggle Secure Input"),
+            .description = i18n.N_("Toggle secure input mode."),
         }},
 
         .toggle_mouse_reporting => comptime &.{.{
             .action = .toggle_mouse_reporting,
-            .title = "Toggle Mouse Reporting",
-            .description = "Toggle whether mouse events are reported to terminal applications.",
+            .title = i18n.N_("Toggle Mouse Reporting"),
+            .description = i18n.N_("Toggle whether mouse events are reported to terminal applications."),
         }},
 
         .toggle_background_opacity => comptime &.{.{
             .action = .toggle_background_opacity,
-            .title = "Toggle Background Opacity",
-            .description = "Toggle the background opacity of a window that started transparent.",
+            .title = i18n.N_("Toggle Background Opacity"),
+            .description = i18n.N_("Toggle the background opacity of a window that started transparent."),
         }},
 
         .check_for_updates => comptime &.{.{
             .action = .check_for_updates,
-            .title = "Check for Updates",
-            .description = "Check for updates to the application.",
+            .title = i18n.N_("Check for Updates"),
+            .description = i18n.N_("Check for updates to the application."),
         }},
 
         .undo => comptime &.{.{
             .action = .undo,
-            .title = "Undo",
-            .description = "Undo the last action.",
+            .title = i18n.N_("Undo"),
+            .description = i18n.N_("Undo the last action."),
         }},
 
         .redo => comptime &.{.{
             .action = .redo,
-            .title = "Redo",
-            .description = "Redo the last undone action.",
+            .title = i18n.N_("Redo"),
+            .description = i18n.N_("Redo the last undone action."),
         }},
 
         .quit => comptime &.{.{
             .action = .quit,
-            .title = "Quit",
-            .description = "Quit the application.",
+            .title = i18n.N_("Quit"),
+            .description = i18n.N_("Quit the application."),
         }},
 
         .text => comptime &.{.{
             .action = .{ .text = "👻" },
-            .title = "Ghostty",
-            .description = "Put a little Ghostty in your terminal.",
+            .title = i18n.N_("Ghostty"),
+            .description = i18n.N_("Put a little Ghostty in your terminal."),
         }},
 
         // No commands because they're parameterized and there

--- a/src/os/i18n.zig
+++ b/src/os/i18n.zig
@@ -67,6 +67,11 @@ pub fn _(msgid: [*:0]const u8) [*:0]const u8 {
     return dgettext(build_config.bundle_id, msgid);
 }
 
+/// Mark a string for translation without translating it immediately.
+pub fn N_(msgid: [:0]const u8) [:0]const u8 {
+    return msgid;
+}
+
 /// Canonicalize a locale name from a platform-specific value to
 /// a POSIX-compliant value. This is a thin layer over the unexported
 /// gnulib-lib function in gettext that does this already.

--- a/src/os/i18n.zig
+++ b/src/os/i18n.zig
@@ -62,8 +62,13 @@ pub fn initGlobalDomain() error{OutOfMemory}!void {
 }
 
 /// Translate a message for the Ghostty domain.
+///
+/// If this is called at comptime, the direct msgid is returned without
+/// translation. This still allows the string to be marked for translation
+/// while remaining usable in comptime contexts.
 pub fn _(msgid: [*:0]const u8) [*:0]const u8 {
     if (comptime !build_config.i18n) return msgid;
+    if (@inComptime()) return msgid;
     return dgettext(build_config.bundle_id, msgid);
 }
 
@@ -195,4 +200,11 @@ test "canonicalizeLocale darwin" {
     // canonicalizeLocale does not handle encodings and will turn them into
     // underscores. We should parse them out before calling this function.
     try testing.expectEqualStrings("en_US.UTF_8", try canonicalizeLocale(&buf, "en_US.UTF-8"));
+}
+
+test "_ returns msgid at comptime" {
+    const testing = std.testing;
+
+    const msgid = comptime @"_"("Ghostty");
+    try testing.expectEqualStrings("Ghostty", std.mem.span(msgid));
 }


### PR DESCRIPTION
Most obvious next step in translating Ghostty is the command palette.
Added support for i18n.N_ (https://docs.gtk.org/glib/i18n.html#macros).
Made a Latvian translation for the command palette to test. Codex did bulk of the translations but I verified them.