### PR TITLE
ci: use local git commands for path-filter action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter_every
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ""
           predicate-quantifier: "every"
           filters: |
             code:
@@ -43,7 +43,7 @@ jobs:
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter_any
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ""
           filters: |
             macos:
               - '.swiftlint.yml'


### PR DESCRIPTION
Passing a `token` value causes this action to use the GitHub REST API, which is subject to rate limits. We can chew through that allowance quickly (1,000 requests/hour) given that we run two of these actions per workflow run.

`token` defaults to the workflow's token, but by setting it explicitly to an empty string, the action will instead use `git diff` to determine the modified paths. This works fine for our case because we're already running the checkout action, so we have an up-to-date repository view.

This also has the advantage of working around the 300 files GitHub REST API limit for listing changed files.

Ref: https://github.com/dorny/paths-filter