### PR TITLE
feat: add macos-hush-login config option

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -642,6 +642,7 @@ pub fn init(
             .working_directory = if (config.@"working-directory") |wd| wd.value() else null,
             .resources_dir = global_state.resources_dir.host(),
             .term = config.term,
+            .hush_login = config.@"macos-hush-login",
             .rt_pre_exec_info = .init(config),
             .rt_post_fork_info = .init(config),
         });

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3365,6 +3365,17 @@ keybind: Keybinds = .{},
 /// The default is true.
 @"macos-applescript": bool = true,
 
+/// If true, Ghostty will suppress the "Last login" message when launching
+/// the shell. This is equivalent to creating a `~/.hushlogin` file, but
+/// only affects Ghostty and doesn't modify the user's home directory.
+///
+/// On macOS, terminal sessions launched through `login(1)` display the
+/// last login time by default. This can be distracting, especially for
+/// embedded terminal applications.
+///
+/// The default is false to match the default macOS terminal behavior.
+@"macos-hush-login": bool = false,
+
 /// Customize the macOS app icon.
 ///
 /// This only affects the icon that appears in the dock, application

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -566,6 +566,7 @@ pub const Config = struct {
     working_directory: ?[]const u8 = null,
     resources_dir: ?[]const u8,
     term: []const u8,
+    hush_login: bool = false,
 
     rt_pre_exec_info: Command.RtPreExecInfo,
     rt_post_fork_info: Command.RtPostForkInfo,
@@ -818,6 +819,7 @@ const Subprocess = struct {
             alloc,
             shell_command,
             internal_os.passwd,
+            cfg.hush_login,
         ) catch |err| switch (err) {
             // If we fail to allocate space for the command we want to
             // execute, we'd still like to try to run something so
@@ -1412,6 +1414,7 @@ fn execCommand(
     alloc: Allocator,
     command: configpkg.Command,
     comptime passwdpkg: type,
+    hush_login: bool,
 ) (Allocator.Error || error{SystemError})![]const [:0]const u8 {
     // If we're on macOS, we have to use `login(1)` to get all of
     // the proper environment variables set, a login shell, and proper
@@ -1427,7 +1430,7 @@ fn execCommand(
             break :darwin;
         };
 
-        const hush = if (passwd.home) |home| hush: {
+        const hush = hush_login or if (passwd.home) |home| hush: {
             var dir = std.fs.openDirAbsolute(home, .{}) catch |err| {
                 log.warn(
                     "failed to open home dir, not checking for hushlogin err={}",
@@ -1594,7 +1597,7 @@ test "execCommand darwin: shell command" {
                 .name = "testuser",
             };
         }
-    });
+    }, false);
 
     try testing.expectEqual(8, result.len);
     try testing.expectEqualStrings(result[0], "/usr/bin/login");
@@ -1624,7 +1627,7 @@ test "execCommand darwin: direct command" {
                 .name = "testuser",
             };
         }
-    });
+    }, false);
 
     try testing.expectEqual(5, result.len);
     try testing.expectEqualStrings(result[0], "/usr/bin/login");
@@ -1652,6 +1655,7 @@ test "execCommand: shell command, empty passwd" {
                 return .{};
             }
         },
+        false,
     );
 
     try testing.expectEqual(3, result.len);
@@ -1678,6 +1682,7 @@ test "execCommand: shell command, error passwd" {
                 return error.Fail;
             }
         },
+        false,
     );
 
     try testing.expectEqual(3, result.len);
@@ -1705,7 +1710,7 @@ test "execCommand: direct command, error passwd" {
             // login command and falls back to POSIX behavior.
             return error.Fail;
         }
-    });
+    }, false);
 
     try testing.expectEqual(2, result.len);
     try testing.expectEqualStrings(result[0], "foo");
@@ -1735,7 +1740,7 @@ test "execCommand: direct command, config freed" {
             // login command and falls back to POSIX behavior.
             return error.Fail;
         }
-    });
+    }, false);
 
     command_arena.deinit();
 


### PR DESCRIPTION
## Summary

- Adds a new boolean config option `macos-hush-login` (default: `false`) that suppresses the "Last login" message printed by `login(1)` on macOS
- When enabled, always passes `-q` to `login(1)`, equivalent to `~/.hushlogin` but scoped to Ghostty only
- The existing `~/.hushlogin` file check is preserved — either mechanism suppresses the message

## Motivation

Terminal sessions on macOS display "Last login: ..." by default. The standard workaround is `~/.hushlogin`, but this is a global setting that affects all terminal applications. Embedded terminal applications (libghostty embedders) have no clean way to suppress this without modifying the user's home directory.

This config option gives users and embedders a way to suppress the message within Ghostty only.

## Changes

- `src/config/Config.zig`: New `macos-hush-login` boolean option with documentation
- `src/termio/Exec.zig`: Thread the option through `execCommand()` to OR with the existing `~/.hushlogin` check
- `src/Surface.zig`: Pass the config value when initializing the subprocess
- All existing tests updated for the new parameter