### PR TITLE
bash: move __ghostty_preexec_hook into __ghostty_hook

### DIFF
--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -278,24 +278,20 @@ if (( BASH_VERSINFO[0] > 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 4) )
     [[ -n "$cmd" ]] && __ghostty_preexec "$cmd"
   }
 
-  # Use function substitution in 5.3+. Otherwise, use command substitution.
-  # Any output (including escape sequences) goes to the terminal.
-  # Only define if not already set (allows re-sourcing).
-  if [[ -z "${__ghostty_ps0+x}" ]]; then
-    if (( BASH_VERSINFO[0] > 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 3) )); then
-      # shellcheck disable=SC2016
-      builtin readonly __ghostty_ps0='${ __ghostty_preexec_hook; }'
-    else
-      # shellcheck disable=SC2016
-      builtin readonly __ghostty_ps0='$(__ghostty_preexec_hook >/dev/tty)'
-    fi
-  fi
-
   __ghostty_hook() {
     builtin local ret=$?
     __ghostty_precmd "$ret"
-    if [[ "$PS0" != *"$__ghostty_ps0"* ]]; then
-      PS0=$PS0"${__ghostty_ps0}"
+
+    # Append preexec hook to PS0 if not already present.
+    # Use function substitution in 5.3+, otherwise command substitution.
+    if [[ "$PS0" != *"__ghostty_preexec_hook"* ]]; then
+      if (( BASH_VERSINFO[0] > 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 3) )); then
+        # shellcheck disable=SC2016
+        PS0+='${ __ghostty_preexec_hook; }'
+      else
+        # shellcheck disable=SC2016
+        PS0+='$(__ghostty_preexec_hook >/dev/tty)'
+      fi
     fi
   }
 


### PR DESCRIPTION
We previously used a readonly variable (__ghostty_ps0) to define the best __ghostty_preexec_hook expansion for the current bash version.

This worked pretty well, but it had the downside of managing another variable (#11258).

We can instead simplify this a bit by moving this into __ghostty_hook. I didn't take that approach originally because I wanted to avoid the bash version check on each command, but slightly loosening our guard check to just look for "__ghostty_preexec_hook" (rather than the full expansion expression) means we can bury the bash version check to the cold path.

One small gap here is that we may not update PS0 to the correct syntax if we start switching between significantly different bash versions in interactive subshells, but that seems like a pretty rare case to handle given the benefits of this approach.