### PR TITLE
nix: add systems input and fix zig follows

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,6 +54,7 @@
         "flake-compat": "flake-compat",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
+        "systems": "systems",
         "zig": "zig",
         "zon2nix": "zon2nix"
       }
@@ -82,7 +83,9 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems"
+        "systems": [
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1773145353,

--- a/flake.nix
+++ b/flake.nix
@@ -17,11 +17,17 @@
       flake = false;
     };
 
+    systems = {
+      url = "github:nix-systems/default";
+      flake = false;
+    };
+
     zig = {
       url = "github:mitchellh/zig-overlay";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-compat.follows = "flake-compat";
+        systems.follows = "systems";
       };
     };
 


### PR DESCRIPTION
Currently I have to use [this unusual syntax](https://github.com/luisnquin/nixos-config/blob/6e1c9f32e0f35bc3423af3b895c10a8fe97e7e18/flake.nix#L137) in my flake inputs to ensure that I don't have systems repeated in my flake.lock file. This will make more obvious the fact that you have to do follows to that hidden input.