### PR TITLE
windows: avoid fontconfig and ensure build compiles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -744,6 +744,10 @@ jobs:
           Write-Host "Zig installed."
           .\zig\zig.exe version
 
+      - name: Compile build
+        shell: pwsh
+        run: .\zig\zig.exe build --help
+
       - name: Generate build testing script
         shell: pwsh
         run: |

--- a/src/font/backend.zig
+++ b/src/font/backend.zig
@@ -40,6 +40,14 @@ pub const Backend = enum {
             };
         }
 
+        if (target.os.tag == .windows) {
+            // Avoid fontconfig on Windows because its libxml2 dependency
+            // may not unpack due to symlinks. Use plain freetype for now
+            // which means no font discovery. Full solution would likely use
+            // DirectWrite which has its own discovery API.
+            return .freetype;
+        }
+
         // macOS also supports "coretext_freetype" but there is no scenario
         // that is the default. It is only used by people who want to
         // self-compile Ghostty and prefer the freetype aesthetic.


### PR DESCRIPTION
This changes allows me to use ghostty as a zon dependency when building on windows (for windows). Fixes https://github.com/ghostty-org/ghostty/discussions/11697