### PR TITLE
ci: add build-cmake job to test cmake build of libghostty-vt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,6 +87,7 @@ jobs:
       - build-dist
       - build-examples-zig
       - build-examples-cmake
+      - build-cmake
       - build-flatpak
       - build-libghostty-vt
       - build-libghostty-vt-android
@@ -260,6 +261,44 @@ jobs:
           cd example/${{ matrix.dir }}
           nix develop -c cmake -B build -DFETCHCONTENT_SOURCE_DIR_GHOSTTY=${{ github.workspace }}
           nix develop -c cmake --build build
+
+  build-cmake:
+    runs-on: namespace-profile-ghostty-sm
+    needs: test
+    env:
+      ZIG_LOCAL_CACHE_DIR: /zig/local-cache
+      ZIG_GLOBAL_CACHE_DIR: /zig/global-cache
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Cache
+        uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9 # v1.4.2
+        with:
+          path: |
+            /nix
+            /zig
+
+      # Install Nix and use that to run our tests so our environment matches exactly.
+      - uses: cachix/install-nix-action@1ca7d21a94afc7c957383a2d217460d980de4934 # v31.10.1
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+        with:
+          name: ghostty
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: Build
+        run: |
+          nix develop -c cmake -B build
+          nix develop -c cmake --build build
+
+      - name: Verify artifacts
+        run: |
+          test -f zig-out/lib/libghostty-vt.so.0.1.0
+          test -d zig-out/include/ghostty
+          ls -la zig-out/lib/
+          ls -la zig-out/include/ghostty/
 
   build-flatpak:
     strategy:


### PR DESCRIPTION
Add a new CI job that builds the root CMakeLists.txt to ensure the cmake wrapper for libghostty-vt works. 

This isn't the recommend way to build libghostty-vt, but its how downstream CMake projects would consume it so we gotta keep it working.