### PR TITLE
build: set zig optimize flag for CMake release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,15 @@ project(ghostty-vt VERSION 0.1.0 LANGUAGES C)
 
 set(GHOSTTY_ZIG_BUILD_FLAGS "" CACHE STRING "Additional flags to pass to zig build")
 
+# Map CMake build types to Zig optimization levels.
+if(CMAKE_BUILD_TYPE)
+    string(TOUPPER "${CMAKE_BUILD_TYPE}" _bt)
+    if(_bt STREQUAL "RELEASE" OR _bt STREQUAL "MINSIZEREL" OR _bt STREQUAL "RELWITHDEBINFO")
+        list(APPEND GHOSTTY_ZIG_BUILD_FLAGS "-Doptimize=ReleaseFast")
+    endif()
+    unset(_bt)
+endif()
+
 # --- Find Zig ----------------------------------------------------------------
 
 find_program(ZIG_EXECUTABLE zig REQUIRED)


### PR DESCRIPTION
Map CMake release build types (Release, MinSizeRel, RelWithDebInfo) to -Doptimize=ReleaseFast so that zig build automatically produces optimized builds when CMake is configured for a release variant. Debug builds remain unaffected, letting Zig use its default Debug optimization level.