### PR TITLE
vt: add color_palette and color_rgb cell data types

### DIFF
--- a/include/ghostty/vt/screen.h
+++ b/include/ghostty/vt/screen.h
@@ -9,6 +9,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <ghostty/vt/color.h>
 #include <ghostty/vt/types.h>
 
 #ifdef __cplusplus
@@ -184,6 +185,22 @@ typedef enum {
    * Output type: GhosttyCellSemanticContent *
    */
   GHOSTTY_CELL_DATA_SEMANTIC_CONTENT = 9,
+
+  /**
+   * The palette index for the cell's background color.
+   * Only valid when content_tag is GHOSTTY_CELL_CONTENT_BG_COLOR_PALETTE.
+   *
+   * Output type: GhosttyColorPaletteIndex *
+   */
+  GHOSTTY_CELL_DATA_COLOR_PALETTE = 10,
+
+  /**
+   * The RGB value for the cell's background color.
+   * Only valid when content_tag is GHOSTTY_CELL_CONTENT_BG_COLOR_RGB.
+   *
+   * Output type: GhosttyColorRgb *
+   */
+  GHOSTTY_CELL_DATA_COLOR_RGB = 11,
 } GhosttyCellData;
 
 /**

--- a/src/terminal/c/cell.zig
+++ b/src/terminal/c/cell.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const testing = std.testing;
 const page = @import("../page.zig");
 const Cell = page.Cell;
+const color = @import("../color.zig");
 const style_c = @import("style.zig");
 const Result = @import("result.zig").Result;
 
@@ -71,6 +72,16 @@ pub const CellData = enum(c_int) {
     /// Output type: GhosttyCellSemanticContent *
     semantic_content = 9,
 
+    /// The palette index for the cell's background color.
+    /// Only valid when content_tag is bg_color_palette.
+    /// Output type: GhosttyColorPaletteIndex *
+    color_palette = 10,
+
+    /// The RGB value for the cell's background color.
+    /// Only valid when content_tag is bg_color_rgb.
+    /// Output type: GhosttyColorRgb *
+    color_rgb = 11,
+
     /// Output type expected for querying the data of the given kind.
     pub fn OutType(comptime self: CellData) type {
         return switch (self) {
@@ -81,6 +92,8 @@ pub const CellData = enum(c_int) {
             .has_text, .has_styling, .has_hyperlink, .protected => bool,
             .style_id => u16,
             .semantic_content => SemanticContent,
+            .color_palette => u8,
+            .color_rgb => color.RGB.C,
         };
     }
 };
@@ -122,6 +135,11 @@ fn getTyped(
         .has_hyperlink => out.* = cell.hyperlink,
         .protected => out.* = cell.protected,
         .semantic_content => out.* = @enumFromInt(@intFromEnum(cell.semantic_content)),
+        .color_palette => out.* = cell.content.color_palette,
+        .color_rgb => {
+            const rgb = cell.content.color_rgb;
+            out.* = .{ .r = rgb.r, .g = rgb.g, .b = rgb.b };
+        },
     }
 
     return .success;


### PR DESCRIPTION
Add two new CellData variants to extract background color values directly from cells. color_palette (10) returns the palette index as a GhosttyColorPaletteIndex and color_rgb (11) returns the RGB components as a GhosttyColorRgb. Both reuse the existing color types from color.h rather than introducing new ones.

These are only valid when the cell content_tag is
bg_color_palette or bg_color_rgb respectively; querying them with a mismatched tag reads from the wrong union member.

Found via Ghostling.