### PR TITLE
Add Linux platform support to the embedded apprt

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -38,6 +38,7 @@ typedef enum {
   GHOSTTY_PLATFORM_INVALID,
   GHOSTTY_PLATFORM_MACOS,
   GHOSTTY_PLATFORM_IOS,
+  GHOSTTY_PLATFORM_LINUX,
 } ghostty_platform_e;
 
 typedef enum {
@@ -426,9 +427,14 @@ typedef struct {
   void* uiview;
 } ghostty_platform_ios_s;
 
+typedef struct {
+  void* gtk_widget;
+} ghostty_platform_linux_s;
+
 typedef union {
   ghostty_platform_macos_s macos;
   ghostty_platform_ios_s ios;
+  ghostty_platform_linux_s gtk;
 } ghostty_platform_u;
 
 typedef enum {
@@ -1082,6 +1088,9 @@ bool ghostty_surface_needs_confirm_quit(ghostty_surface_t);
 bool ghostty_surface_process_exited(ghostty_surface_t);
 void ghostty_surface_refresh(ghostty_surface_t);
 void ghostty_surface_draw(ghostty_surface_t);
+void ghostty_surface_display_realized(ghostty_surface_t);
+void ghostty_surface_init_opengl(ghostty_surface_t);
+void ghostty_surface_draw_frame(ghostty_surface_t);
 void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);
 void ghostty_surface_set_focus(ghostty_surface_t, bool);
 void ghostty_surface_set_occlusion(ghostty_surface_t, bool);

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -343,6 +343,7 @@ pub const App = struct {
 pub const Platform = union(PlatformTag) {
     macos: MacOS,
     ios: IOS,
+    linux: Linux,
 
     // If our build target for libghostty is not darwin then we do
     // not include macos support at all.
@@ -356,6 +357,13 @@ pub const Platform = union(PlatformTag) {
         uiview: objc.Object,
     } else void;
 
+    pub const Linux = if (builtin.target.os.tag == .linux) struct {
+        /// A GtkGLArea widget pointer for OpenGL rendering.
+        /// The embedder must create and manage this widget.
+        /// Ghostty will use it to render terminal content via OpenGL.
+        gtk_widget: *anyopaque,
+    } else void;
+
     // The C ABI compatible version of this union. The tag is expected
     // to be stored elsewhere.
     pub const C = extern union {
@@ -365,6 +373,10 @@ pub const Platform = union(PlatformTag) {
 
         ios: extern struct {
             uiview: ?*anyopaque,
+        },
+
+        gtk: extern struct {
+            gtk_widget: ?*anyopaque,
         },
     };
 
@@ -385,6 +397,13 @@ pub const Platform = union(PlatformTag) {
                     break :ios error.UIViewMustBeSet);
                 break :ios .{ .ios = .{ .uiview = uiview } };
             } else error.UnsupportedPlatform,
+
+            .linux => if (Linux != void) linux: {
+                const config = c_platform.gtk;
+                const gtk_widget = config.gtk_widget orelse
+                    break :linux error.GtkWidgetMustBeSet;
+                break :linux .{ .linux = .{ .gtk_widget = gtk_widget } };
+            } else error.UnsupportedPlatform,
         };
     }
 };
@@ -395,6 +414,7 @@ pub const PlatformTag = enum(c_int) {
 
     macos = 1,
     ios = 2,
+    linux = 3,
 };
 
 pub const EnvVar = extern struct {
@@ -1688,6 +1708,38 @@ pub const CAPI = struct {
     /// call as soon as possible (NOW if possible).
     export fn ghostty_surface_draw(surface: *Surface) void {
         surface.draw();
+    }
+
+    /// Notify the surface that the display/GL context has been realized.
+    /// On Linux, this should be called from the GtkGLArea "realize" callback
+    /// after the GL context is current. This initializes the OpenGL function
+    /// pointers (GLAD) so the renderer can draw.
+    /// NOTE: Only call this for RE-realization (after displayUnrealized).
+    /// For first-time initialization, use ghostty_surface_init_opengl instead.
+    export fn ghostty_surface_display_realized(surface: *Surface) void {
+        surface.core_surface.renderer.displayRealized() catch {};
+    }
+
+    /// Initialize OpenGL function pointers for the surface.
+    /// Call this from a GtkGLArea "realize" callback when the GL context
+    /// is current for the first time. This loads GLAD so the renderer
+    /// can execute GL calls.
+    export fn ghostty_surface_init_opengl(_: *Surface) void {
+        const opengl = @import("../renderer/OpenGL.zig");
+        opengl.prepareContext(null) catch |err| {
+            log.warn("failed to prepare GL context err={}", .{err});
+        };
+    }
+
+    /// Draw a frame directly using the current GL context.
+    /// This should be called from a GtkGLArea "render" signal callback
+    /// where the GL context is already current. Unlike ghostty_surface_draw()
+    /// which schedules a draw on the render thread, this executes the
+    /// draw immediately on the calling thread.
+    export fn ghostty_surface_draw_frame(surface: *Surface) void {
+        surface.core_surface.renderer.drawFrame(true) catch |err| {
+            log.warn("failed to draw frame err={}", .{err});
+        };
     }
 
     /// Update the size of a surface. This will trigger resize notifications

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -130,7 +130,7 @@ fn glDebugMessageCallback(
 }
 
 /// Prepares the provided GL context, loading it with glad.
-fn prepareContext(getProcAddress: anytype) !void {
+pub fn prepareContext(getProcAddress: anytype) !void {
     const version = try gl.glad.load(getProcAddress);
     const major = gl.glad.versionMajor(@intCast(version));
     const minor = gl.glad.versionMinor(@intCast(version));
@@ -170,9 +170,12 @@ pub fn surfaceInit(surface: *apprt.Surface) !void {
         => try prepareContext(null),
 
         apprt.embedded => {
-            // TODO(mitchellh): this does nothing today to allow libghostty
-            // to compile for OpenGL targets but libghostty is strictly
-            // broken for rendering on this platforms.
+            // For embedded Linux (libghostty), the embedder provides a
+            // GtkGLArea whose GL context is already current. Initialize
+            // OpenGL the same way as the GTK apprt.
+            if (comptime builtin.target.os.tag == .linux) {
+                try prepareContext(null);
+            }
         },
     }
 
@@ -209,9 +212,12 @@ pub fn threadEnter(self: *const OpenGL, surface: *apprt.Surface) !void {
         },
 
         apprt.embedded => {
-            // TODO(mitchellh): this does nothing today to allow libghostty
-            // to compile for OpenGL targets but libghostty is strictly
-            // broken for rendering on this platforms.
+            // For embedded Linux, the GL context may not be current yet
+            // during threadEnter. Try loading GLAD here — if the context
+            // is current it will succeed, otherwise drawFrame will retry.
+            if (comptime builtin.target.os.tag == .linux) {
+                prepareContext(null) catch {};
+            }
         },
     }
 }
@@ -229,7 +235,8 @@ pub fn threadExit(self: *const OpenGL) void {
         },
 
         apprt.embedded => {
-            // TODO: see threadEnter
+            // For embedded Linux, same as GTK: no unloading needed
+            // since we may share global bindings.
         },
     }
 }
@@ -238,14 +245,14 @@ pub fn displayRealized(self: *const OpenGL) void {
     _ = self;
 
     switch (apprt.runtime) {
-        apprt.gtk => prepareContext(null) catch |err| {
+        apprt.gtk, apprt.embedded => prepareContext(null) catch |err| {
             log.warn(
                 "Error preparing GL context in displayRealized, err={}",
                 .{err},
             );
         },
 
-        else => @compileError("only GTK should be calling displayRealized"),
+        else => @compileError("only GTK or embedded should be calling displayRealized"),
     }
 }
 
@@ -278,8 +285,10 @@ pub fn initShaders(
 /// Get the current size of the runtime surface.
 pub fn surfaceSize(self: *const OpenGL) !struct { width: u32, height: u32 } {
     _ = self;
+    // GLAD may not be loaded yet (e.g. embedded Linux before GL context is current)
+    const getIntegerv = gl.glad.context.GetIntegerv orelse return error.OpenGLNotLoaded;
     var viewport: [4]gl.c.GLint = undefined;
-    gl.glad.context.GetIntegerv.?(gl.c.GL_VIEWPORT, &viewport);
+    getIntegerv(gl.c.GL_VIEWPORT, &viewport);
     return .{
         .width = @intCast(viewport[2]),
         .height = @intCast(viewport[3]),


### PR DESCRIPTION
## Summary

This adds `GHOSTTY_PLATFORM_LINUX` to the embedded apprt so that libghostty can be used as a terminal rendering library on Linux. This is the same pattern that cmux uses on macOS with `GHOSTTY_PLATFORM_MACOS`, but for GTK4 on Linux.

The embedder creates a GtkGLArea widget, passes it to `ghostty_surface_new()` via the new platform variant, and ghostty handles everything else. PTY management, VT parsing, OpenGL rendering. Works on both Wayland and X11 through GTK4.

## What changed

**ghostty.h**
- Added `GHOSTTY_PLATFORM_LINUX = 3` to the platform enum
- Added `ghostty_platform_linux_s` struct with a `gtk_widget` pointer
- The union field is named `gtk` because `linux` is a predefined macro in C
- Added `ghostty_surface_init_opengl()` to load GLAD on first GtkGLArea realize
- Added `ghostty_surface_draw_frame()` to draw directly on the calling thread, for use inside GTK render callbacks where the GL context is current

**embedded.zig**
- Added `linux = 3` to `PlatformTag`
- Added `Linux` struct (conditional on `os.tag == .linux`) holding the `gtk_widget` pointer
- `Platform.init()` handles the `.linux` case
- New C API exports for `init_opengl` and `draw_frame`

**OpenGL.zig**
- `prepareContext` is now public so the embedded apprt can call it
- `surfaceInit` initializes OpenGL for embedded Linux
- `surfaceSize` returns an error instead of panicking when GLAD functions are not loaded yet
- `threadEnter`, `threadExit`, `displayRealized` handle the embedded apprt properly

## Proof of concept

A minimal working example is at https://github.com/patcito/testty. It embeds a fully functional ghostty terminal in a GTK4 window on Wayland. About 300 lines of Zig. Keyboard input goes through GtkIMContext, rendering uses GtkGLArea with `drawFrame` called from the render signal.

## Test plan

- Build with `zig build -Dapp-runtime=none` on Linux, verify it compiles clean
- Run the testty example, verify terminal renders and accepts keyboard input
- Verify existing macOS embedded builds are not affected (the Linux additions are behind `os.tag == .linux` comptime checks)