### PR TITLE
vt: Allow building libghostty-vt as a static library

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -91,20 +91,28 @@ pub fn build(b: *std.Build) !void {
     }
 
     // libghostty-vt
-    const libghostty_vt_shared = shared: {
-        if (config.target.result.cpu.arch.isWasm()) {
-            break :shared try buildpkg.GhosttyLibVt.initWasm(
-                b,
-                &mod,
-            );
-        }
-
-        break :shared try buildpkg.GhosttyLibVt.initShared(
+    if (config.emit_lib_vt_static) {
+        const libghostty_vt_static = try buildpkg.GhosttyLibVt.initStatic(
             b,
             &mod,
         );
-    };
-    libghostty_vt_shared.install(b.getInstallStep());
+        libghostty_vt_static.install(b.getInstallStep());
+    } else {
+        const libghostty_vt_shared = shared: {
+            if (config.target.result.cpu.arch.isWasm()) {
+                break :shared try buildpkg.GhosttyLibVt.initWasm(
+                    b,
+                    &mod,
+                );
+            }
+
+            break :shared try buildpkg.GhosttyLibVt.initShared(
+                b,
+                &mod,
+            );
+        };
+        libghostty_vt_shared.install(b.getInstallStep());
+    }
 
     // Helpgen
     if (config.emit_helpgen) deps.help_strings.install();
@@ -116,7 +124,7 @@ pub fn build(b: *std.Build) !void {
             resources.install();
             if (i18n) |v| v.install();
         }
-    } else if (!config.emit_lib_vt) {
+    } else if (!config.emit_lib_vt and !config.emit_lib_vt_static) {
         // The macOS Ghostty Library
         //
         // This is NOT libghostty (even though its named that for historical

--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -52,6 +52,7 @@ emit_docs: bool = false,
 emit_exe: bool = false,
 emit_helpgen: bool = false,
 emit_lib_vt: bool = false,
+emit_lib_vt_static: bool = false,
 emit_macos_app: bool = false,
 emit_terminfo: bool = false,
 emit_termcap: bool = false,
@@ -321,11 +322,17 @@ pub fn init(b: *std.Build, appVersion: []const u8) !Config {
         "Set defaults for a libghostty-vt-only build (disables xcframework, macOS app, and docs).",
     ) orelse false;
 
+    config.emit_lib_vt_static = b.option(
+        bool,
+        "emit-lib-vt-static",
+        "Set defaults for a static libghostty-vt-only build (disables xcframework, macOS app, and docs).",
+    ) orelse false;
+
     config.emit_exe = b.option(
         bool,
         "emit-exe",
         "Build and install main executables with 'build'",
-    ) orelse !config.emit_lib_vt;
+    ) orelse !(config.emit_lib_vt or config.emit_lib_vt_static);
 
     config.emit_test_exe = b.option(
         bool,
@@ -360,7 +367,8 @@ pub fn init(b: *std.Build, appVersion: []const u8) !Config {
         if (config.emit_bench or
             config.emit_test_exe or
             config.emit_helpgen or
-            config.emit_lib_vt) break :emit_docs false;
+            config.emit_lib_vt or
+            config.emit_lib_vt_static) break :emit_docs false;
 
         // We always emit docs in system package mode.
         if (system_package) break :emit_docs true;
@@ -410,6 +418,7 @@ pub fn init(b: *std.Build, appVersion: []const u8) !Config {
         "emit-xcframework",
         "Build and install the xcframework for the macOS library.",
     ) orelse !config.emit_lib_vt and
+        !config.emit_lib_vt_static and
         builtin.target.os.tag.isDarwin() and
         target.result.os.tag == .macos and
         config.app_runtime == .none and
@@ -421,7 +430,9 @@ pub fn init(b: *std.Build, appVersion: []const u8) !Config {
         bool,
         "emit-macos-app",
         "Build and install the macOS app bundle.",
-    ) orelse !config.emit_lib_vt and config.emit_xcframework;
+    ) orelse !config.emit_lib_vt and
+        !config.emit_lib_vt_static and
+        config.emit_xcframework;
 
     //---------------------------------------------------------------
     // System Packages

--- a/src/build/GhosttyLibVt.zig
+++ b/src/build/GhosttyLibVt.zig
@@ -45,6 +45,30 @@ pub fn initWasm(
     };
 }
 
+pub fn initStatic(
+    b: *std.Build,
+    zig: *const GhosttyZig,
+) !GhosttyLibVt {
+    const lib = b.addLibrary(.{
+        .name = "ghostty-vt",
+        .root_module = zig.vt_c,
+        .version = std.SemanticVersion{ .major = 0, .minor = 1, .patch = 0 },
+    });
+    lib.installHeadersDirectory(
+        b.path("include/ghostty"),
+        "ghostty",
+        .{ .include_extensions = &.{".h"} },
+    );
+
+    return .{
+        .step = &lib.step,
+        .artifact = b.addInstallArtifact(lib, .{}),
+        .output = lib.getEmittedBin(),
+        .dsym = null,
+        .pkg_config = pkgConfig(b),
+    };
+}
+
 pub fn initShared(
     b: *std.Build,
     zig: *const GhosttyZig,
@@ -97,29 +121,29 @@ pub fn initShared(
     };
 
     // pkg-config
-    const pc: std.Build.LazyPath = pc: {
-        const wf = b.addWriteFiles();
-        break :pc wf.add("libghostty-vt.pc", b.fmt(
-            \\prefix={s}
-            \\includedir=${{prefix}}/include
-            \\libdir=${{prefix}}/lib
-            \\
-            \\Name: libghostty-vt
-            \\URL: https://github.com/ghostty-org/ghostty
-            \\Description: Ghostty VT library
-            \\Version: 0.1.0
-            \\Cflags: -I${{includedir}}
-            \\Libs: -L${{libdir}} -lghostty-vt
-        , .{b.install_prefix}));
-    };
-
     return .{
         .step = &lib.step,
         .artifact = b.addInstallArtifact(lib, .{}),
         .output = lib.getEmittedBin(),
         .dsym = dsymutil,
-        .pkg_config = pc,
+        .pkg_config = pkgConfig(b),
     };
+}
+
+fn pkgConfig(b: *std.Build) std.Build.LazyPath {
+    const wf = b.addWriteFiles();
+    return wf.add("libghostty-vt.pc", b.fmt(
+        \\prefix={s}
+        \\includedir=${{prefix}}/include
+        \\libdir=${{prefix}}/lib
+        \\
+        \\Name: libghostty-vt
+        \\URL: https://github.com/ghostty-org/ghostty
+        \\Description: Ghostty VT library
+        \\Version: 0.1.0
+        \\Cflags: -I${{includedir}}
+        \\Libs: -L${{libdir}} -lghostty-vt
+    , .{b.install_prefix}));
 }
 
 pub fn install(


### PR DESCRIPTION
Add a new option `-Demit-lib-vt-static`, which allows building libghostty-vt as a static library, similar to how #11716 added `-Demit-lib-vt`