### PR TITLE
terminal: default render state foreground to white

### DIFF
--- a/src/terminal/render.zig
+++ b/src/terminal/render.zig
@@ -98,8 +98,8 @@ pub const RenderState = struct {
         .rows = 0,
         .cols = 0,
         .colors = .{
-            .background = .{},
-            .foreground = .{},
+            .background = .{ .r = 0, .g = 0, .b = 0 },
+            .foreground = .{ .r = 0xff, .g = 0xff, .b = 0xff },
             .cursor = null,
             .palette = color.default,
         },


### PR DESCRIPTION
Fixes #11704

The RenderState empty initializer set both background and foreground to the default RGB value of black (0, 0, 0), making text unreadable when a caller has not explicitly configured terminal colors via DynamicRGB. This is the common case for libghostty consumers.

Default the foreground to white so that the initial render state provides readable white-on-black text out of the box.

Long term we also need to expose setting the default colors for a Terminal instance but this is a workable fix in the mean time.