### PR TITLE
terminal: add word-level selection adjustment with opt+shift+arrow

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -5755,11 +5755,30 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             defer self.renderer_state.mutex.unlock();
 
             const screen: *terminal.Screen = self.io.terminal.screens.active;
-            const sel = if (screen.selection) |*sel| sel else {
-                // If we don't have a selection we do not perform this
-                // action, allowing the keybind to fall through to the
-                // terminal.
-                return false;
+            const sel = if (screen.selection) |*sel| sel else blk: {
+                // For word adjustments, create a new selection at the cursor
+                // position so the user can start selecting by word without
+                // needing an existing selection (matching macOS text editor
+                // behavior).
+                switch (direction) {
+                    .word_left, .word_right => {
+                        const cursor_pin = screen.cursor.page_pin.*;
+                        try screen.select(
+                            terminal.Selection.init(cursor_pin, cursor_pin, false),
+                        );
+                        break :blk &(screen.selection.?);
+                    },
+                    else => {
+                        // For non-word adjustments, we do not perform
+                        // this action, allowing the keybind to fall
+                        // through to the terminal.
+                        return false;
+                    },
+                }
+            };
+            const boundary: ?[]const u21 = switch (direction) {
+                .word_left, .word_right => self.config.selection_word_chars,
+                else => null,
             };
             sel.adjust(screen, switch (direction) {
                 .left => .left,
@@ -5772,7 +5791,9 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
                 .end => .end,
                 .beginning_of_line => .beginning_of_line,
                 .end_of_line => .end_of_line,
-            });
+                .word_left => .word_left,
+                .word_right => .word_right,
+            }, boundary);
 
             // If the selection endpoint is outside of the current viewpoint,
             // scroll it in to view. Note we always specifically use sel.end

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -6576,6 +6576,16 @@ pub const Keybinds = struct {
             .{ .adjust_selection = .end },
             .{ .performable = true },
         );
+        try self.set.put(
+            alloc,
+            .{ .key = .{ .physical = .arrow_left }, .mods = .{ .shift = true, .alt = true } },
+            .{ .adjust_selection = .word_left },
+        );
+        try self.set.put(
+            alloc,
+            .{ .key = .{ .physical = .arrow_right }, .mods = .{ .shift = true, .alt = true } },
+            .{ .adjust_selection = .word_right },
+        );
 
         // Tabs common to all platforms
         try self.set.put(

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -480,6 +480,11 @@ pub const Action = union(enum) {
     ///     Adjust the selection to the beginning or the end of the line
     ///     respectively.
     ///
+    ///   - `word_left`, `word_right`
+    ///
+    ///     Adjust the selection one word to the left or right respectively,
+    ///     using the configured `selection-word-chars` for word boundaries.
+    ///
     adjust_selection: AdjustSelection,
 
     /// Jump the viewport forward or back by the given number of prompts.
@@ -992,6 +997,8 @@ pub const Action = union(enum) {
         end,
         beginning_of_line,
         end_of_line,
+        word_left,
+        word_right,
     };
 
     pub const SplitDirection = enum {

--- a/src/terminal/Selection.zig
+++ b/src/terminal/Selection.zig
@@ -400,6 +400,8 @@ pub const Adjustment = enum {
     page_down,
     beginning_of_line,
     end_of_line,
+    word_left,
+    word_right,
 };
 
 /// Adjust the selection by some given adjustment. An adjustment allows
@@ -408,6 +410,7 @@ pub fn adjust(
     self: *Selection,
     s: *const Screen,
     adjustment: Adjustment,
+    boundary_codepoints: ?[]const u21,
 ) void {
     // Note that we always adjust "end" because end always represents
     // the last point of the selection by mouse, not necessarily the
@@ -418,7 +421,7 @@ pub fn adjust(
         .up => if (end_pin.up(1)) |new_end| {
             end_pin.* = new_end;
         } else {
-            self.adjust(s, .beginning_of_line);
+            self.adjust(s, .beginning_of_line, null);
         },
 
         .down => {
@@ -433,7 +436,7 @@ pub fn adjust(
                 }
             } else {
                 // If we're at the bottom, just go to the end of the line
-                self.adjust(s, .end_of_line);
+                self.adjust(s, .end_of_line, null);
             }
         },
 
@@ -466,13 +469,13 @@ pub fn adjust(
         .page_up => if (end_pin.up(s.pages.rows)) |new_end| {
             end_pin.* = new_end;
         } else {
-            self.adjust(s, .home);
+            self.adjust(s, .home, null);
         },
 
         .page_down => if (end_pin.down(s.pages.rows)) |new_end| {
             end_pin.* = new_end;
         } else {
-            self.adjust(s, .end);
+            self.adjust(s, .end, null);
         },
 
         .home => end_pin.* = s.pages.pin(.{ .screen = .{
@@ -500,6 +503,118 @@ pub fn adjust(
         .beginning_of_line => end_pin.x = 0,
 
         .end_of_line => end_pin.x = end_pin.node.data.size.cols - 1,
+
+        .word_left => {
+            const codepoints = boundary_codepoints orelse return;
+            var it = end_pin.cellIterator(.left_up, null);
+            _ = it.next(); // skip current cell
+
+            // Phase 1: skip boundary characters (whitespace/punctuation) going left.
+            // Empty cells and hard line breaks (non-wrapped rows) are treated
+            // as hard boundaries, consistent with selectWord in Screen.zig.
+            var last_non_boundary: ?Pin = null;
+            while (it.next()) |next| {
+                const rac = next.rowAndCell();
+                const cell = rac.cell;
+
+                // Stop at hard line breaks (landing on last col of a non-wrapped row)
+                if (next.x == next.node.data.size.cols - 1 and !rac.row.wrap) break;
+
+                // Empty cells are hard boundaries
+                if (!cell.hasText()) break;
+
+                const is_boundary = std.mem.indexOfAny(
+                    u21,
+                    codepoints,
+                    &[_]u21{cell.content.codepoint},
+                ) != null;
+                if (!is_boundary) {
+                    last_non_boundary = next;
+                    break;
+                }
+            }
+
+            // Phase 2: skip non-boundary characters (word body) going left
+            // to find the start of the word.
+            if (last_non_boundary != null) {
+                while (it.next()) |next| {
+                    const rac = next.rowAndCell();
+                    const cell = rac.cell;
+
+                    // Stop at hard line breaks
+                    if (next.x == next.node.data.size.cols - 1 and !rac.row.wrap) break;
+
+                    if (!cell.hasText()) break;
+                    const is_boundary = std.mem.indexOfAny(
+                        u21,
+                        codepoints,
+                        &[_]u21{cell.content.codepoint},
+                    ) != null;
+                    if (is_boundary) break;
+                    last_non_boundary = next;
+                }
+            }
+
+            if (last_non_boundary) |pos| {
+                end_pin.* = pos;
+            }
+        },
+
+        .word_right => {
+            const codepoints = boundary_codepoints orelse return;
+            var it = end_pin.cellIterator(.right_down, null);
+            _ = it.next(); // skip current cell
+
+            // Phase 1: skip boundary characters (whitespace/punctuation) going right.
+            // Empty cells and hard line breaks (non-wrapped rows) are treated
+            // as hard boundaries, consistent with selectWord in Screen.zig.
+            var last_non_boundary: ?Pin = null;
+            while (it.next()) |next| {
+                const rac = next.rowAndCell();
+                const cell = rac.cell;
+
+                // Stop at hard line breaks
+                if (next.x == next.node.data.size.cols - 1 and !rac.row.wrap) break;
+
+                // Empty cells are hard boundaries
+                if (!cell.hasText()) break;
+
+                const is_boundary = std.mem.indexOfAny(
+                    u21,
+                    codepoints,
+                    &[_]u21{cell.content.codepoint},
+                ) != null;
+                if (!is_boundary) {
+                    last_non_boundary = next;
+                    break;
+                }
+            }
+
+            // Phase 2: skip non-boundary characters (word body) going right
+            // to find the end of the word.
+            if (last_non_boundary != null) {
+                while (it.next()) |next| {
+                    const rac = next.rowAndCell();
+                    const cell = rac.cell;
+
+                    // Stop at hard line breaks
+                    if (next.x == next.node.data.size.cols - 1 and !rac.row.wrap) break;
+
+                    if (!cell.hasText()) break;
+                    const is_boundary = std.mem.indexOfAny(
+                        u21,
+                        codepoints,
+                        &[_]u21{cell.content.codepoint},
+                    ) != null;
+                    if (is_boundary) break;
+                    last_non_boundary = next;
+                }
+            }
+
+            if (last_non_boundary) |pos| {
+                end_pin.* = pos;
+            }
+        },
     }
 }
 
@@ -517,7 +632,7 @@ test "Selection: adjust right" {
             false,
         );
         defer sel.deinit(&s);
-        sel.adjust(&s, .right);
+        sel.adjust(&s, .right, null);
 
         try testing.expectEqual(point.Point{ .screen = .{
             .x = 5,
@@ -537,7 +652,7 @@ test "Selection: adjust right" {
             false,
         );
         defer sel.deinit(&s);
-        sel.adjust(&s, .right);
+        sel.adjust(&s, .right, null);
 
         try testing.expectEqual(point.Point{ .screen = .{
             .x = 4,
@@ -557,7 +672,7 @@ test "Selection: adjust right" {
             false,
         );
         defer sel.deinit(&s);
-        sel.adjust(&s, .right);
+        sel.adjust(&s, .right, null);
 
         try testing.expectEqual(point.Point{ .screen = .{
             .x = 5,
@@ -584,7 +699,7 @@ test "Selection: adjust left" {
             false,
         );
         defer sel.deinit(&s);
-        sel.adjust(&s, .left);
+        sel.adjust(&s, .left, null);
 
         // Start line
         try testing.expectEqual(point.Point{ .screen = .{
@@ -605,7 +720,7 @@ test "Selection: adjust left" {
             false,
         );
         defer sel.deinit(&s);
-        sel.adjust(&s, .left);
+        sel.adjust(&s, .left, null);
 
         // Start line
         try testing.expectEqual(point.Point{ .screen = .{
@@ -633,7 +748,7 @@ test "Selection: adjust left skips blanks" {
             false,
         );
         defer sel.deinit(&s);
-        sel.adjust(&s, .left);
+        sel.adjust(&s, .left, null);
 
         // Start line
         try testing.expectEqual(point.Point{ .screen = .{
@@ -654,7 +769,7 @@ test "Selection: adjust left skips blanks" {
             false,
         );
         defer sel.deinit(&s);
-        sel.adjust(&s, .left);
+        sel.adjust(&s, .left, null);
 
         // Start line
         try testing.expectEqual(point.Point{ .screen = .{
@@ -682,7 +797,7 @@ test "Selection: adjust up" {
             false,
         );
         defer sel.deinit(&s);
-        sel.adjust(&s, .up);
+        sel.adjust(&s, .up, null);
 
         try testing.expectEqual(point.Point{ .screen = .{
             .x = 5,
@@ -702,7 +817,7 @@ test "Selection: adjust up" {
             false,
         );
         defer sel.deinit(&s);
-        sel.adjust(&s, .up);
+        sel.adjust(&s, .up, null);
 
         try testing.expectEqual(point.Point{ .screen = .{
             .x = 5,
@@ -729,7 +844,7 @@ test "Selection: adjust down" {
             false,
         );
         defer sel.deinit(&s);
-        sel.adjust(&s, .down);
+        sel.adjust(&s, .down, null);
 
         try testing.expectEqual(point.Point{ .screen = .{
             .x = 5,
@@ -749,7 +864,7 @@ test "Selection: adjust down" {
             false,
         );
         defer sel.deinit(&s);
-        sel.adjust(&s, .down);
+        sel.adjust(&s, .down, null);
 
         try testing.expectEqual(point.Point{ .screen = .{
             .x = 4,
@@ -776,7 +891,7 @@ test "Selection: adjust down with not full screen" {
             false,
         );
         defer sel.deinit(&s);
-        sel.adjust(&s, .down);
+        sel.adjust(&s, .down, null);
 
         // Start line
         try testing.expectEqual(point.Point{ .screen = .{
@@ -804,7 +919,7 @@ test "Selection: adjust home" {
             false,
         );
         defer sel.deinit(&s);
-        sel.adjust(&s, .home);
+        sel.adjust(&s, .home, null);
 
         // Start line
         try testing.expectEqual(point.Point{ .screen = .{
@@ -832,7 +947,7 @@ test "Selection: adjust end with not full screen" {
             false,
         );
         defer sel.deinit(&s);
-        sel.adjust(&s, .end);
+        sel.adjust(&s, .end, null);
 
         // Start line
         try testing.expectEqual(point.Point{ .screen = .{
@@ -860,7 +975,7 @@ test "Selection: adjust beginning of line" {
             false,
         );
         defer sel.deinit(&s);
-        sel.adjust(&s, .beginning_of_line);
+        sel.adjust(&s, .beginning_of_line, null);
 
         // Start line
         try testing.expectEqual(point.Point{ .screen = .{
@@ -881,7 +996,7 @@ test "Selection: adjust beginning of line" {
             false,
         );
         defer sel.deinit(&s);
-        sel.adjust(&s, .beginning_of_line);
+        sel.adjust(&s, .beginning_of_line, null);
 
         // Start line
         try testing.expectEqual(point.Point{ .screen = .{
@@ -902,7 +1017,7 @@ test "Selection: adjust beginning of line" {
             false,
         );
         defer sel.deinit(&s);
-        sel.adjust(&s, .beginning_of_line);
+        sel.adjust(&s, .beginning_of_line, null);
 
         // Start line
         try testing.expectEqual(point.Point{ .screen = .{
@@ -930,7 +1045,7 @@ test "Selection: adjust end of line" {
             false,
         );
         defer sel.deinit(&s);
-        sel.adjust(&s, .end_of_line);
+        sel.adjust(&s, .end_of_line, null);
 
         try testing.expectEqual(point.Point{ .screen = .{
             .x = 1,
@@ -950,7 +1065,7 @@ test "Selection: adjust end of line" {
             false,
         );
         defer sel.deinit(&s);
-        sel.adjust(&s, .end_of_line);
+        sel.adjust(&s, .end_of_line, null);
 
         try testing.expectEqual(point.Point{ .screen = .{
             .x = 1,
@@ -970,7 +1085,7 @@ test "Selection: adjust end of line" {
             false,
         );
         defer sel.deinit(&s);
-        sel.adjust(&s, .end_of_line);
+        sel.adjust(&s, .end_of_line, null);
 
         // Start line
         try testing.expectEqual(point.Point{ .screen = .{
@@ -979,6 +1094,187 @@ test "Selection: adjust end of line" {
         } }, s.pages.pointFromPin(.screen, sel.start()).?);
         try testing.expectEqual(point.Point{ .screen = .{
             .x = 7,
+            .y = 0,
+        } }, s.pages.pointFromPin(.screen, sel.end()).?);
+    }
+}
+
+test "Selection: adjust word_right" {
+    const testing = std.testing;
+    var s = try Screen.init(testing.allocator, .{ .cols = 20, .rows = 10, .max_scrollback = 0 });
+    defer s.deinit();
+    try s.testWriteString("hello world foo bar");
+
+    const boundary = &[_]u21{ ' ', '\t' };
+
+    // word_right from middle of "hello" -> end of "hello"
+    {
+        var sel = Selection.init(
+            s.pages.pin(.{ .screen = .{ .x = 0, .y = 0 } }).?,
+            s.pages.pin(.{ .screen = .{ .x = 2, .y = 0 } }).?,
+            false,
+        );
+        defer sel.deinit(&s);
+        sel.adjust(&s, .word_right, boundary);
+
+        try testing.expectEqual(point.Point{ .screen = .{
+            .x = 4,
+            .y = 0,
+        } }, s.pages.pointFromPin(.screen, sel.end()).?);
+    }
+
+    // word_right from end of "hello" -> end of "world"
+    {
+        var sel = Selection.init(
+            s.pages.pin(.{ .screen = .{ .x = 0, .y = 0 } }).?,
+            s.pages.pin(.{ .screen = .{ .x = 4, .y = 0 } }).?,
+            false,
+        );
+        defer sel.deinit(&s);
+        sel.adjust(&s, .word_right, boundary);
+
+        try testing.expectEqual(point.Point{ .screen = .{
+            .x = 10,
+            .y = 0,
+        } }, s.pages.pointFromPin(.screen, sel.end()).?);
+    }
+
+    // word_right from last word "bar" -> end of "bar"
+    {
+        var sel = Selection.init(
+            s.pages.pin(.{ .screen = .{ .x = 0, .y = 0 } }).?,
+            s.pages.pin(.{ .screen = .{ .x = 16, .y = 0 } }).?,
+            false,
+        );
+        defer sel.deinit(&s);
+        sel.adjust(&s, .word_right, boundary);
+
+        try testing.expectEqual(point.Point{ .screen = .{
+            .x = 18,
+            .y = 0,
+        } }, s.pages.pointFromPin(.screen, sel.end()).?);
+    }
+}
+
+test "Selection: adjust word_right with multiple spaces" {
+    const testing = std.testing;
+    var s = try Screen.init(testing.allocator, .{ .cols = 20, .rows = 10, .max_scrollback = 0 });
+    defer s.deinit();
+    try s.testWriteString("hello   world");
+
+    const boundary = &[_]u21{ ' ', '\t' };
+
+    // word_right from middle of "hello" -> end of "hello"
+    {
+        var sel = Selection.init(
+            s.pages.pin(.{ .screen = .{ .x = 0, .y = 0 } }).?,
+            s.pages.pin(.{ .screen = .{ .x = 2, .y = 0 } }).?,
+            false,
+        );
+        defer sel.deinit(&s);
+        sel.adjust(&s, .word_right, boundary);
+
+        try testing.expectEqual(point.Point{ .screen = .{
+            .x = 4,
+            .y = 0,
+        } }, s.pages.pointFromPin(.screen, sel.end()).?);
+    }
+}
+
+test "Selection: adjust word_left" {
+    const testing = std.testing;
+    var s = try Screen.init(testing.allocator, .{ .cols = 20, .rows = 10, .max_scrollback = 0 });
+    defer s.deinit();
+    try s.testWriteString("hello world foo bar");
+
+    const boundary = &[_]u21{ ' ', '\t' };
+
+    // word_left from middle of "world" -> start of "world"
+    {
+        var sel = Selection.init(
+            s.pages.pin(.{ .screen = .{ .x = 0, .y = 0 } }).?,
+            s.pages.pin(.{ .screen = .{ .x = 8, .y = 0 } }).?,
+            false,
+        );
+        defer sel.deinit(&s);
+        sel.adjust(&s, .word_left, boundary);
+
+        try testing.expectEqual(point.Point{ .screen = .{
+            .x = 6,
+            .y = 0,
+        } }, s.pages.pointFromPin(.screen, sel.end()).?);
+    }
+
+    // word_left from start of "world" -> start of "hello"
+    {
+        var sel = Selection.init(
+            s.pages.pin(.{ .screen = .{ .x = 10, .y = 0 } }).?,
+            s.pages.pin(.{ .screen = .{ .x = 6, .y = 0 } }).?,
+            false,
+        );
+        defer sel.deinit(&s);
+        sel.adjust(&s, .word_left, boundary);
+
+        try testing.expectEqual(point.Point{ .screen = .{
+            .x = 0,
+            .y = 0,
+        } }, s.pages.pointFromPin(.screen, sel.end()).?);
+    }
+
+    // word_left from start of "hello" -> stays put (no previous word)
+    {
+        var sel = Selection.init(
+            s.pages.pin(.{ .screen = .{ .x = 5, .y = 0 } }).?,
+            s.pages.pin(.{ .screen = .{ .x = 0, .y = 0 } }).?,
+            false,
+        );
+        defer sel.deinit(&s);
+        sel.adjust(&s, .word_left, boundary);
+
+        // Should stay at x=0 since there's no previous word
+        try testing.expectEqual(point.Point{ .screen = .{
+            .x = 0,
+            .y = 0,
+        } }, s.pages.pointFromPin(.screen, sel.end()).?);
+    }
+}
+
+test "Selection: adjust word_left with multiple spaces" {
+    const testing = std.testing;
+    var s = try Screen.init(testing.allocator, .{ .cols = 20, .rows = 10, .max_scrollback = 0 });
+    defer s.deinit();
+    try s.testWriteString("hello   world");
+
+    const boundary = &[_]u21{ ' ', '\t' };
+
+    // word_left from middle of "world" -> start of "world" (skips within word)
+    {
+        var sel = Selection.init(
+            s.pages.pin(.{ .screen = .{ .x = 12, .y = 0 } }).?,
+            s.pages.pin(.{ .screen = .{ .x = 10, .y = 0 } }).?,
+            false,
+        );
+        defer sel.deinit(&s);
+        sel.adjust(&s, .word_left, boundary);
+
+        try testing.expectEqual(point.Point{ .screen = .{
+            .x = 8,
+            .y = 0,
+        } }, s.pages.pointFromPin(.screen, sel.end()).?);
+    }
+
+    // word_left from start of "world" -> start of "hello" (skips multiple spaces)
+    {
+        var sel = Selection.init(
+            s.pages.pin(.{ .screen = .{ .x = 12, .y = 0 } }).?,
+            s.pages.pin(.{ .screen = .{ .x = 8, .y = 0 } }).?,
+            false,
+        );
+        defer sel.deinit(&s);
+        sel.adjust(&s, .word_left, boundary);
+
+        try testing.expectEqual(point.Point{ .screen = .{
+            .x = 0,
             .y = 0,
         } }, s.pages.pointFromPin(.screen, sel.end()).?);
     }


### PR DESCRIPTION
[#1208](https://github.com/ghostty-org/ghostty/issues/1208)

Add word_left and word_right directions to the selection adjustment system, bound to Opt+Shift+Left and Opt+Shift+Right by default. This allows selecting text word-by-word, matching macOS text editor behavior. Previously, adjust_selection only supported character, line, page, and screen-boundary movements. Word movement uses the existing selection-word-chars configuration for boundary detection, consistent with double-click word selection. Empty cells and hard line breaks (non wrapped rows) are treated as hard boundaries, matching selectWord in Screen.zig.

Unlike the other selection adjustment bindings, the word bindings are not marked performable. When no selection exists, they create a new zero-width selection at the cursor position and immediately adjust it, so the user can start selecting by word without first click-dragging. word_left moves to the start of the current/previous word and word_right moves to the end of the current/next word.