### PR TITLE
vt: also build static libghostty-vt for wasm

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -106,27 +106,23 @@ pub fn build(b: *std.Build) !void {
     };
     libghostty_vt_shared.install(b.getInstallStep());
 
-    // libghostty-vt static lib. We don't build this for wasm since wasm has
-    // no concept of static vs shared and we put the wasm binary up in
-    // our shared handling.
-    if (!config.target.result.cpu.arch.isWasm()) {
-        const libghostty_vt_static = try buildpkg.GhosttyLibVt.initStatic(
-            b,
-            &mod,
-        );
+    // libghostty-vt static lib
+    const libghostty_vt_static = try buildpkg.GhosttyLibVt.initStatic(
+        b,
+        &mod,
+    );
 
-        if (config.is_dep) {
-            // If we're a dependency, we need to install everything as-is
-            // so that dep.artifact("ghostty-vt-static") works.
-            libghostty_vt_static.install(b.getInstallStep());
-        } else {
-            // If we're not a dependency, we rename the static lib to
-            // be idiomatic.
-            b.getInstallStep().dependOn(&b.addInstallLibFile(
-                libghostty_vt_static.output,
-                "libghostty-vt.a",
-            ).step);
-        }
+    if (config.is_dep) {
+        // If we're a dependency, we need to install everything as-is
+        // so that dep.artifact("ghostty-vt-static") works.
+        libghostty_vt_static.install(b.getInstallStep());
+    } else {
+        // If we're not a dependency, we rename the static lib to
+        // be idiomatic.
+        b.getInstallStep().dependOn(&b.addInstallLibFile(
+            libghostty_vt_static.output,
+            "libghostty-vt.a",
+        ).step);
     }
 
     // Helpgen


### PR DESCRIPTION
A static libghostty-vt is also useful for wasm targets, as that allows linking with an application into a larger wasm module.

See https://github.com/ghostty-org/ghostty/pull/11729#issuecomment-4106589379