### PR TITLE
Add clipboard-paste-bracketed-safe-newline config option

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -301,6 +301,7 @@ const DerivedConfig = struct {
     clipboard_trim_trailing_spaces: bool,
     clipboard_paste_protection: bool,
     clipboard_paste_bracketed_safe: bool,
+    clipboard_paste_bracketed_safe_newline: bool,
     clipboard_codepoint_map: configpkg.Config.RepeatableClipboardCodepointMap,
     copy_on_select: configpkg.CopyOnSelect,
     right_click_action: configpkg.RightClickAction,
@@ -379,6 +380,7 @@ const DerivedConfig = struct {
             .clipboard_trim_trailing_spaces = config.@"clipboard-trim-trailing-spaces",
             .clipboard_paste_protection = config.@"clipboard-paste-protection",
             .clipboard_paste_bracketed_safe = config.@"clipboard-paste-bracketed-safe",
+            .clipboard_paste_bracketed_safe_newline = config.@"clipboard-paste-bracketed-safe-newline",
             .clipboard_codepoint_map = try config.@"clipboard-codepoint-map".clone(alloc),
             .copy_on_select = config.@"copy-on-select",
             .right_click_action = config.@"right-click-action",
@@ -6027,7 +6029,8 @@ fn completeClipboardPaste(
     const encode_opts: input.paste.Options = encode_opts: {
         self.renderer_state.mutex.lock();
         defer self.renderer_state.mutex.unlock();
-        const opts: input.paste.Options = .fromTerminal(&self.io.terminal);
+        var opts: input.paste.Options = .fromTerminal(&self.io.terminal);
+        opts.bracketed_safe_newline = self.config.clipboard_paste_bracketed_safe_newline;
 
         // If we have paste protection enabled, we detect unsafe pastes and return
         // an error. The error approach allows apprt to attempt to complete the paste

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2376,6 +2376,12 @@ keybind: Keybinds = .{},
 /// program, not the terminal emulator).
 @"clipboard-paste-bracketed-safe": bool = true,
 
+/// If true, convert newlines to carriage returns in bracketed paste mode.
+/// This matches Terminal.app's "Paste newlines as carriage returns" behavior.
+/// When disabled, newlines are preserved as-is in bracketed paste mode
+/// (default xterm behavior).
+@"clipboard-paste-bracketed-safe-newline": bool = false,
+
 /// Enables or disabled title reporting (CSI 21 t). This escape sequence
 /// allows the running program to query the terminal title. This is a common
 /// security issue and is disabled by default.

--- a/src/input/paste.zig
+++ b/src/input/paste.zig
@@ -5,6 +5,9 @@ pub const Options = struct {
     /// True if bracketed paste mode is on.
     bracketed: bool,
 
+    /// True to convert newlines in bracketed paste mode.
+    bracketed_safe_newline: bool = false,
+
     /// Return the encoding options based on the current terminal state.
     pub fn fromTerminal(t: *const Terminal) Options {
         return .{
@@ -90,17 +93,25 @@ pub fn encode(
         }
     }
 
-    // Bracketed paste mode (mode 2004) wraps pasted data in
-    // fenceposts so that the terminal can ignore things like newlines.
+    // Bracketed paste mode (mode 2004) wraps pasted data in fenceposts
     if (opts.bracketed) {
         result[0] = "\x1b[200~";
         result[2] = "\x1b[201~";
+
+        // Optionally convert newlines in bracketed mode (for macOS
+        // Terminal.app matching behavior)
+        if (opts.bracketed_safe_newline) {
+            if (comptime mutable) {
+                std.mem.replaceScalar(u8, data, '\n', '\r');
+            } else if (std.mem.indexOfScalar(u8, data, '\n') != null) {
+                return Error.MutableRequired;
+            }
+        }
+
         return result;
     }
 
-    // Non-bracketed. We have to replace newline with `\r`. This matches
-    // the behavior of xterm and other terminals. For `\r\n` this will
-    // result in `\r\r` which does match xterm.
+    // Non-bracketed: always convert LF to CR (xterm behavior)
     if (comptime mutable) {
         std.mem.replaceScalar(u8, data, '\n', '\r');
     } else if (std.mem.indexOfScalar(u8, data, '\n') != null) {
@@ -149,6 +160,27 @@ test "encode bracketed" {
     );
     try testing.expectEqualStrings("\x1b[200~", result[0]);
     try testing.expectEqualStrings("hello", result[1]);
+    try testing.expectEqualStrings("\x1b[201~", result[2]);
+}
+
+test "encode bracketed with newlines (default)" {
+    const testing = std.testing;
+    const result = try encode(
+        @as([]const u8, "hello\nworld"),
+        .{ .bracketed = true },
+    );
+    try testing.expectEqualStrings("\x1b[200~", result[0]);
+    try testing.expectEqualStrings("hello\nworld", result[1]);
+    try testing.expectEqualStrings("\x1b[201~", result[2]);
+}
+
+test "encode bracketed with newlines (safe_newline enabled)" {
+    const testing = std.testing;
+    const data: []u8 = try testing.allocator.dupe(u8, "hello\nworld");
+    defer testing.allocator.free(data);
+    const result = encode(data, .{ .bracketed = true, .bracketed_safe_newline = true });
+    try testing.expectEqualStrings("\x1b[200~", result[0]);
+    try testing.expectEqualStrings("hello\rworld", result[1]);
     try testing.expectEqualStrings("\x1b[201~", result[2]);
 }
 


### PR DESCRIPTION
This rebases @kitknox's work from Discussion #9592 onto the latest main.

## Problem

Every major terminal emulator (Terminal.app, iTerm2, VS Code Terminal, 
Termius, Warp) converts LF to CR in bracketed paste mode or forces 
bracketed paste regardless of shell state. Ghostty preserves LF in 
bracketed mode and requires the shell to explicitly request bracketed 
paste via readline.

This causes multi-line paste to break on remote servers running bash 
where `enable-bracketed-paste` is not set in inputrc. The same paste 
works perfectly in every other terminal.

## Solution

Add a `clipboard-paste-bracketed-safe-newline` config option (default: false).
When enabled, LF is converted to CR in bracketed paste mode, matching 
Terminal.app's "Paste newlines as carriage returns" behavior.

## Changes

- `src/config/Config.zig`: Add new config option
- `src/input/paste.zig`: Add newline conversion in bracketed mode
- `src/Surface.zig`: Wire config to paste options

Original work by @kitknox in commit fc4c528.