### PR TITLE
macos: handle global keybinds when active

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1060,6 +1060,7 @@ void* ghostty_app_userdata(ghostty_app_t);
 void ghostty_app_set_focus(ghostty_app_t, bool);
 bool ghostty_app_key(ghostty_app_t, ghostty_input_key_s);
 bool ghostty_app_key_is_binding(ghostty_app_t, ghostty_input_key_s);
+bool ghostty_app_key_is_global_binding(ghostty_app_t, ghostty_input_key_s);
 void ghostty_app_keyboard_changed(ghostty_app_t);
 void ghostty_app_open_config(ghostty_app_t);
 void ghostty_app_update_config(ghostty_app_t, ghostty_config_t);

--- a/macos/Sources/Features/Global Keybinds/GlobalEventTap.swift
+++ b/macos/Sources/Features/Global Keybinds/GlobalEventTap.swift
@@ -128,11 +128,6 @@ private func cgEventFlagsChangedHandler(
     // We only care about keydown events
     guard type == .keyDown else { return result }
 
-    // If our app is currently active then we don't process the key event.
-    // This is because we already have a local event handler in AppDelegate
-    // that processes all local events.
-    guard !NSApp.isActive else { return result }
-
     // We need an app delegate to get the Ghostty app instance
     guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return result }
     guard let ghostty = appDelegate.ghostty.app else { return result }
@@ -142,6 +137,17 @@ private func cgEventFlagsChangedHandler(
 
     // Build our event input and call ghostty
     let key_ev = event.ghosttyKeyEvent(GHOSTTY_ACTION_PRESS)
+
+    // If our app is currently active then we only process global keybinds.
+    // Non-global keybinds are handled by the local event handler in AppDelegate
+    // and the surface's key event handling. Global keybinds (e.g. toggle_visibility)
+    // must still be processed here because the local event handler skips processing
+    // when a main window exists, and the surface handler doesn't handle app-level
+    // global actions.
+    if NSApp.isActive {
+        guard ghostty_app_key_is_global_binding(ghostty, key_ev) else { return result }
+    }
+
     if ghostty_app_key(ghostty, key_ev) {
         GlobalEventTap.logger.info("global key event handled event=\(event)")
         return nil

--- a/src/App.zig
+++ b/src/App.zig
@@ -334,6 +334,31 @@ pub fn keyEventIsBinding(
     return rt_app.config.keybind.set.getEvent(event) != null;
 }
 
+/// Returns true if the given key event would trigger a global
+/// keybinding. This is used by the apprt to determine if a key
+/// event should be processed even when the app is focused, since
+/// global keybinds should work regardless of focus state.
+pub fn keyEventIsGlobalBinding(
+    self: *App,
+    rt_app: *apprt.App,
+    event: input.KeyEvent,
+) bool {
+    _ = self;
+
+    switch (event.action) {
+        .release => return false,
+        .press, .repeat => {},
+    }
+
+    const entry = rt_app.config.keybind.set.getEvent(event) orelse return false;
+    const leaf: input.Binding.Set.GenericLeaf = switch (entry.value_ptr.*) {
+        .leader => return false,
+        inline .leaf, .leaf_chained => |leaf| leaf.generic(),
+    };
+
+    return leaf.flags.global;
+}
+
 /// Handle a key event at the app-scope. If this key event is used,
 /// this will return true and the caller shouldn't continue processing
 /// the event. If the event is not used, this will return false.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1466,6 +1466,21 @@ pub const CAPI = struct {
         return app.core_app.keyEventIsBinding(app, core_event);
     }
 
+    /// Returns true if the given key event would trigger a global
+    /// binding. Unlike ghostty_app_key_is_binding, this only matches
+    /// bindings with the global flag set.
+    export fn ghostty_app_key_is_global_binding(
+        app: *App,
+        event: KeyEvent,
+    ) bool {
+        const core_event = event.keyEvent().core() orelse {
+            log.warn("error processing key event", .{});
+            return false;
+        };
+
+        return app.core_app.keyEventIsGlobalBinding(app, core_event);
+    }
+
     /// Notify the app that the keyboard was changed. This causes the
     /// keyboard layout to be reloaded from the OS.
     export fn ghostty_app_keyboard_changed(v: *App) void {


### PR DESCRIPTION
This fixes an issue where global keybinds (such as toggle_visibility) were not correctly handled when Ghostty was the active application on macOS.

This occurs because the GlobalEventTap was returning early when the app was active, and the local event handler in AppDelegate skips processing when a main window exists.

We now allow the GlobalEventTap to process events when the app is active, but ONLY if the event triggers a global binding.

discussion: https://github.com/ghostty-org/ghostty/discussions/11255