### PR TITLE
windows: skip expandHomeUnix test on Windows

### DIFF
--- a/src/os/homedir.zig
+++ b/src/os/homedir.zig
@@ -149,6 +149,8 @@ fn expandHomeUnix(path: []const u8, buf: []u8) ExpandError![]const u8 {
 }
 
 test "expandHomeUnix" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
     const testing = std.testing;
     const allocator = testing.allocator;
     var buf: [std.fs.max_path_bytes]u8 = undefined;


### PR DESCRIPTION
## What

Skip the `expandHomeUnix` test on Windows with `SkipZigTest`.

`expandHomeUnix` is a Unix-internal function that is never called on Windows. The public `expandHome` already returns the path unchanged on Windows (added upstream in cccdb0d2a). But the unit test calls `expandHomeUnix` directly, which invokes `home()` and expects Unix-style forward-slash separators, so it fails on Windows.

## How

Two lines:

```zig
if (builtin.os.tag == .windows) return error.SkipZigTest;

```

## Verified

- `zig build test-lib-vt` passes on Windows (exit 0)
- No behavior change on Linux/macOS

## What I Learnt

- When upstream adds a platform dispatch for production code (like `expandHome` returning unchanged on Windows), the unit tests for internal platform-specific functions (like `expandHomeUnix`) may still need a skip guard. 
- Zig doesn't have something like Go's `//go:build` but damn... comptime is insane, like supercharged C# `#if`



