### PR TITLE
gtk: disable kinetic scrolling for trackpads until 4.20.1

### DIFF
--- a/src/apprt/gtk/class/surface_scrolled_window.zig
+++ b/src/apprt/gtk/class/surface_scrolled_window.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const adw = @import("adw");
 const gobject = @import("gobject");
 const gtk = @import("gtk");
+const gtk_version = @import("../gtk_version.zig");
 
 const gresource = @import("../build/gresource.zig");
 const Common = @import("../class.zig").Common;
@@ -59,11 +60,29 @@ pub const SurfaceScrolledWindow = extern struct {
         config: ?*Config = null,
         config_binding: ?*gobject.Binding = null,
         surface: ?*Surface = null,
+        scrolled_window: *gtk.ScrolledWindow,
         pub var offset: c_int = 0;
     };
 
     fn init(self: *Self, _: *Class) callconv(.c) void {
         gtk.Widget.initTemplate(self.as(gtk.Widget));
+        if (gtk_version.runtimeUntil(4, 20, 1)) self.disableKineticScroll();
+    }
+
+    fn disableKineticScroll(self: *Self) void {
+        // Until gtk 4.20.1 trackpads have kinetic scrolling behavior regardless
+        // of `Gtk.ScrolledWindow.kinetic_scrolling`. As a workaround, disable
+        // EventControllerScroll.kinetic
+        const controllers = self.private().scrolled_window.as(gtk.Widget).observeControllers();
+        defer controllers.unref();
+        var i: c_uint = 0;
+        while (controllers.getObject(i)) |obj| : (i += 1) {
+            defer obj.unref();
+            const controller = gobject.ext.cast(gtk.EventControllerScroll, obj) orelse continue;
+            var flags = controller.getFlags();
+            flags.kinetic = false;
+            controller.setFlags(flags);
+        }
     }
 
     fn dispose(self: *Self) callconv(.c) void {
@@ -189,6 +208,7 @@ pub const SurfaceScrolledWindow = extern struct {
             // Bindings
             class.bindTemplateCallback("scrollbar_policy", &closureScrollbarPolicy);
             class.bindTemplateCallback("notify_surface", &propSurface);
+            class.bindTemplateChildPrivate("scrolled_window", .{});
 
             // Properties
             gobject.ext.registerProperties(class, &.{

--- a/src/apprt/gtk/ui/1.5/surface-scrolled-window.blp
+++ b/src/apprt/gtk/ui/1.5/surface-scrolled-window.blp
@@ -4,7 +4,7 @@ using Adw 1;
 template $GhostttySurfaceScrolledWindow: Adw.Bin {
   notify::surface => $notify_surface();
 
-  Gtk.ScrolledWindow {
+  Gtk.ScrolledWindow scrolled_window {
     hscrollbar-policy: never;
     vscrollbar-policy: bind $scrollbar_policy(template.config) as <Gtk.PolicyType>;
   }


### PR DESCRIPTION
Until gtk 4.20.1 trackpads have kinetic scrolling behavior regardless of `Gtk.ScrolledWindow.kinetic_scrolling`. As a workaround, set EventControllerScroll.kinetic to false on all controllers.

`observeControllers()` has this warning:
> Calling this function will enable extra internal bookkeeping to track controllers and emit signals on the returned listmodel. It may slow down operations a lot.
> Applications should try hard to avoid calling this function because of the slowdowns.

but judging from the [source](https://github.com/GNOME/gtk/blob/5301a91f1c74764facb4d60f40ab8621dd7af198/gtk/gtkwidget.c#L12375-L12383) this is a one time penalty since we free the result immediately afterwards.

Fixes https://github.com/ghostty-org/ghostty/discussions/11460.

### AI usage
Zed + Opus 4.5 generated the first pass, but it missed freeing the result of `observeControllers()` and conveniently binding `scrolled_window` to the blueprint. Figuring out what was going on also took a lot of [human debugging](https://github.com/ghostty-org/ghostty/discussions/11460#discussioncomment-16245664).