### PR TITLE
cmake: add import library to custom command OUTPUT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ file(MAKE_DIRECTORY "${ZIG_OUT_DIR}/include")
 
 # Custom command: run zig build -Demit-lib-vt (produces both shared and static)
 add_custom_command(
-    OUTPUT "${GHOSTTY_VT_SHARED_LIBRARY}" "${GHOSTTY_VT_STATIC_LIBRARY}"
+    OUTPUT "${GHOSTTY_VT_SHARED_LIBRARY}" "${GHOSTTY_VT_STATIC_LIBRARY}" "${ZIG_OUT_DIR}/lib/${GHOSTTY_VT_IMPLIB}"
     COMMAND "${ZIG_EXECUTABLE}" build -Demit-lib-vt ${GHOSTTY_ZIG_BUILD_FLAGS}
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     COMMENT "Building libghostty-vt via zig build..."


### PR DESCRIPTION
# What 

PR #11756 added IMPORTED_IMPLIB pointing to the .lib import library, but the
import library is not listed in the OUTPUT directive of the `add_custom_command`
that runs zig build. The file is produced as a side-effect of the build.

This works with the Visual Studio generator (which is lenient about undeclared outputs) but fails with Ninja:

ninja: error: 'zig-out/lib/ghostty-vt.lib', needed by 'ghostling', missing and no known rule to make it

The fix adds "${ZIG_OUT_DIR}/lib/${GHOSTTY_VT_IMPLIB}" to the OUTPUT list. No
behavioral change. The file was already being built, Ninja just needs to know
about it.

## but_why.gif

I am cleaning up https://github.com/ghostty-org/ghostling/pull/6 and I realise that in order to get rid of the CMake workarounds we had before #11756, this change is necessary.

# POC

I set up a branch pointing at my fork with a POC and it builds, this is the cleaned up CMakeList https://github.com/deblasis/winghostling/blob/test/cmake-implib-no-workaround/CMakeLists.txt

