### PR TITLE
build: define ssize_t for MSVC in ghostty.h

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -17,6 +17,11 @@ extern "C" {
 #include <stdint.h>
 #include <sys/types.h>
 
+#ifdef _MSC_VER
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 //-------------------------------------------------------------------
 // Macros
 

--- a/pkg/freetype/build.zig
+++ b/pkg/freetype/build.zig
@@ -84,11 +84,14 @@ fn buildLib(b: *std.Build, module: *std.Build.Module, options: anytype) !*std.Bu
 
         "-DFT_CONFIG_OPTION_SYSTEM_ZLIB=1",
 
-        "-DHAVE_UNISTD_H",
-        "-DHAVE_FCNTL_H",
-
         "-fno-sanitize=undefined",
     });
+    if (target.result.os.tag != .windows) {
+        try flags.appendSlice(b.allocator, &.{
+            "-DHAVE_UNISTD_H",
+            "-DHAVE_FCNTL_H",
+        });
+    }
 
     if (target.result.os.tag == .freebsd or target.result.abi == .musl) {
         try flags.append(b.allocator, "-fPIC");


### PR DESCRIPTION
> [!WARNING]
> Review/approve this AFTER #11807 (this PR includes its commits)

92% progress with the fixes!

## Summary
- Add a conditional `ssize_t` typedef for MSVC in `include/ghostty.h`
- MSVC's `<sys/types.h>` does not define `ssize_t` (it is a POSIX type), which causes the `translate-c` build step to fail when translating `ghostty.h` on Windows
- Uses `SSIZE_T` from `<BaseTsd.h>`, the standard Windows SDK equivalent

## Context
The `translate-c` step translates `ghostty.h` to Zig for test compilation. On MSVC, it fails with 3 errors on `ssize_t` (used in `ghostty_action_move_tab_s`, `ghostty_action_search_total_s`, `ghostty_action_search_selected_s`).

The `#ifdef _MSC_VER` guard means this only affects MSVC builds. `BaseTsd.h` is a standard Windows SDK header and `SSIZE_T` is a signed pointer-sized integer, matching POSIX `ssize_t` and Zig's `isize`. This pattern is used by libuv, curl, and other cross-platform C projects.

## Test plan

### Cross-platform results (`zig build test` / `zig build -Dapp-runtime=none test` on Windows)

| | Windows | Linux | Mac |
|---|---|---|---|
| **BEFORE** (d5aef6e84) | FAIL - 47/51 steps, 1 failed | PASS - 86/86, 2655/2678 tests, 23 skipped | PASS - 160/160, 2655/2662 tests, 7 skipped |
| **AFTER** (a35f84db3) | FAIL - 48/51 steps, 1 failed | PASS - 86/86, 2655/2678 tests, 23 skipped | PASS - 160/160, 2655/2662 tests, 7 skipped |

### Windows: what changed (47 -> 48 steps, translate-c fixed)

**Fixed by this PR:**
- `translate-c` - was `3 errors` (unknown type name 'ssize_t' at lines 582, 842, 847) -> `success`

**Remaining failure (pre-existing, unrelated):**
- `compile test ghostty-test` - 3 errors in libcxxabi (`std::get_new_handler` not found, `type_info` redefinition). This is Zig's bundled libc++ ABI conflicting with MSVC headers when compiling the test binary. It was previously masked by the translate-c failure blocking this step.

### Linux/macOS: no regressions
Identical pass counts and test results before and after.

## What Have I Learnt
- I tried fixing this issue the old way, googling and stuff, I eventually figured out but it took me way more than I am prepared to share. Yikes. 
