### PR TITLE
zsh: fix trailing '%' in PS1/PS2 combining with marks

### DIFF
--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -157,6 +157,11 @@ _ghostty_deferred_init() {
                 # unconditionally add mark1 and markB.
                 builtin local mark2=$'%{\e]133;P;k=s\a%}'
                 builtin local markB=$'%{\e]133;B\a%}'
+                # If PS1 ends with a bare '%', it combines with the '{'
+                # in markB to form a '%{' prompt escape, swallowing the
+                # marker and producing a visible '{'. Fix by doubling the
+                # trailing '%' so it becomes a literal '%%'.
+                [[ $PS1 == *[^%]% || $PS1 == % ]] && PS1=$PS1%
                 PS1=${mark1}${PS1}${markB}
 
                 # Handle multiline prompts by marking newline-separated
@@ -170,6 +175,7 @@ _ghostty_deferred_init() {
                 fi
 
                 # PS2 mark is needed when clearing the prompt on resize
+                [[ $PS2 == *[^%]% || $PS2 == % ]] && PS2=$PS2%
                 PS2=${mark2}${PS2}${markB}
 
                 # Save the marked PS1 so we can detect modifications


### PR DESCRIPTION
When PS1 ends with a bare '%' (e.g. `%3~ %`), concatenating our 133;B mark (`%{...%}`) directly after it causes zsh's prompt expansion to interpret the '%' + '{' result as a '%{' escape sequence. This swallows the 133;B mark and produces a visible '{' in the prompt.

Work around this by doubling a trailing '%' into '%%' before appending marks, so it expands to a literal '%' and won't merge with the `%{` token.