### PR TITLE
Reset stale mouse reporting on semantic prompts

### DIFF
--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1164,6 +1164,20 @@ pub fn semanticPrompt(
     cmd: osc.Command.SemanticPrompt,
 ) !void {
     switch (cmd.action) {
+        .fresh_line_new_prompt,
+        .new_command,
+        .prompt_start,
+        .end_prompt_start_input,
+        .end_prompt_start_input_terminate_eol,
+        => self.resetMouseReporting(),
+
+        .fresh_line,
+        .end_input_start_output,
+        .end_command,
+        => {},
+    }
+
+    switch (cmd.action) {
         .fresh_line => try self.semanticPromptFreshLine(),
 
         .fresh_line_new_prompt => {
@@ -1279,6 +1293,20 @@ pub fn semanticPrompt(
             self.screens.active.cursorSetSemanticContent(.output);
         },
     }
+}
+
+fn resetMouseReporting(self: *Terminal) void {
+    self.flags.mouse_event = .none;
+    self.flags.mouse_format = .x10;
+
+    self.modes.set(.mouse_event_x10, false);
+    self.modes.set(.mouse_event_normal, false);
+    self.modes.set(.mouse_event_button, false);
+    self.modes.set(.mouse_event_any, false);
+    self.modes.set(.mouse_format_utf8, false);
+    self.modes.set(.mouse_format_sgr, false);
+    self.modes.set(.mouse_format_urxvt, false);
+    self.modes.set(.mouse_format_sgr_pixels, false);
 }
 
 // OSC 133;L
@@ -12017,6 +12045,30 @@ test "Terminal: semantic prompt" {
         const row = list_cell.row;
         try testing.expectEqual(.none, row.semantic_prompt);
     }
+}
+
+test "Terminal: semantic prompt resets mouse reporting state" {
+    const alloc = testing.allocator;
+    var t = try init(alloc, .{ .cols = 10, .rows = 5 });
+    defer t.deinit(alloc);
+
+    t.flags.mouse_event = .any;
+    t.flags.mouse_format = .sgr;
+    t.modes.set(.mouse_event_any, true);
+    t.modes.set(.mouse_format_sgr, true);
+
+    try t.semanticPrompt(.init(.fresh_line_new_prompt));
+
+    try testing.expectEqual(.none, t.flags.mouse_event);
+    try testing.expectEqual(.x10, t.flags.mouse_format);
+    try testing.expect(!t.modes.get(.mouse_event_x10));
+    try testing.expect(!t.modes.get(.mouse_event_normal));
+    try testing.expect(!t.modes.get(.mouse_event_button));
+    try testing.expect(!t.modes.get(.mouse_event_any));
+    try testing.expect(!t.modes.get(.mouse_format_utf8));
+    try testing.expect(!t.modes.get(.mouse_format_sgr));
+    try testing.expect(!t.modes.get(.mouse_format_urxvt));
+    try testing.expect(!t.modes.get(.mouse_format_sgr_pixels));
 }
 
 test "Terminal: semantic prompt continuations" {

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1163,19 +1163,7 @@ pub fn semanticPrompt(
     self: *Terminal,
     cmd: osc.Command.SemanticPrompt,
 ) !void {
-    switch (cmd.action) {
-        .fresh_line_new_prompt,
-        .new_command,
-        .prompt_start,
-        .end_prompt_start_input,
-        .end_prompt_start_input_terminate_eol,
-        => self.resetMouseReporting(),
-
-        .fresh_line,
-        .end_input_start_output,
-        .end_command,
-        => {},
-    }
+    if (cmd.action.resetsMouse()) self.resetMouseReporting();
 
     switch (cmd.action) {
         .fresh_line => try self.semanticPromptFreshLine(),

--- a/src/terminal/osc/parsers/semantic_prompt.zig
+++ b/src/terminal/osc/parsers/semantic_prompt.zig
@@ -28,6 +28,22 @@ pub const Command = struct {
         end_prompt_start_input_terminate_eol, // 'I'
         end_input_start_output, // 'C'
         end_command, // 'D'
+
+        pub fn resetsMouse(self: Action) bool {
+            return switch (self) {
+                .fresh_line_new_prompt,
+                .new_command,
+                .prompt_start,
+                .end_prompt_start_input,
+                .end_prompt_start_input_terminate_eol,
+                => true,
+
+                .fresh_line,
+                .end_input_start_output,
+                .end_command,
+                => false,
+            };
+        }
     };
 
     pub fn init(action: Action) Command {

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1075,20 +1075,6 @@ pub const StreamHandler = struct {
         self: *StreamHandler,
         cmd: Stream.Action.SemanticPrompt,
     ) !void {
-        const reset_mouse = switch (cmd.action) {
-            .fresh_line_new_prompt,
-            .new_command,
-            .prompt_start,
-            .end_prompt_start_input,
-            .end_prompt_start_input_terminate_eol,
-            => true,
-
-            .fresh_line,
-            .end_input_start_output,
-            .end_command,
-            => false,
-        };
-
         switch (cmd.action) {
             .end_input_start_output => {
                 self.surfaceMessageWriter(.start_command);
@@ -1120,7 +1106,7 @@ pub const StreamHandler = struct {
         // above.
         try self.terminal.semanticPrompt(cmd);
 
-        if (reset_mouse) try self.setMouseShape(.text);
+        if (cmd.action.resetsMouse()) try self.setMouseShape(.text);
     }
 
     fn reportPwd(self: *StreamHandler, url: []const u8) !void {

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1075,6 +1075,20 @@ pub const StreamHandler = struct {
         self: *StreamHandler,
         cmd: Stream.Action.SemanticPrompt,
     ) !void {
+        const reset_mouse = switch (cmd.action) {
+            .fresh_line_new_prompt,
+            .new_command,
+            .prompt_start,
+            .end_prompt_start_input,
+            .end_prompt_start_input_terminate_eol,
+            => true,
+
+            .fresh_line,
+            .end_input_start_output,
+            .end_command,
+            => false,
+        };
+
         switch (cmd.action) {
             .end_input_start_output => {
                 self.surfaceMessageWriter(.start_command);
@@ -1105,6 +1119,8 @@ pub const StreamHandler = struct {
         // We do this last so failures are still processed correctly
         // above.
         try self.terminal.semanticPrompt(cmd);
+
+        if (reset_mouse) try self.setMouseShape(.text);
     }
 
     fn reportPwd(self: *StreamHandler, url: []const u8) !void {


### PR DESCRIPTION
## Summary
- reset stale mouse reporting state when shell integration marks a prompt via OSC 133
- restore the terminal mouse shape to text after prompt transitions handled by the stream handler
- add a VT test covering stale mouse reporting cleanup on semantic prompt entry

## Why
When a remote app such as `ssh` disconnects without sending the usual mouse-mode reset sequences, Ghostty can keep reporting mouse events after control returns to the local shell prompt. Resetting mouse reporting on semantic prompt transitions prevents those stale mouse escape sequences from leaking into the shell.

## Testing
- `zig build test-lib-vt -Demit-xcframework=false -Demit-macos-app=false`
- `zig build test-lib-vt -Demit-xcframework=false -Demit-macos-app=false -Dtest-filter="semantic prompt resets mouse reporting state"`
- `zig build test-lib-vt -Demit-xcframework=false -Demit-macos-app=false -Dtest-filter="Terminal: semantic prompt"`

## Notes
- I did not run the full macOS app build in this environment because this machine only has Command Line Tools installed and lacks the full Xcode `metal` toolchain.