### PR TITLE
ci: deduplicate push and pull_request CI runs

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,8 +1,10 @@
-on: [push, pull_request]
+on:
+  push: {}
+  pull_request: {}
 name: Nix
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name != 'main' && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || (github.ref_name != 'main' && github.ref_name || github.run_id) }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,11 @@ on:
 name: Test
 
 # We only want the latest commit to test for any non-main ref.
+# Use head_ref (PR source branch) when available so that push and
+# pull_request events for the same branch share a concurrency group,
+# preventing duplicate CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name != 'main' && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || (github.ref_name != 'main' && github.ref_name || github.run_id) }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Previously, both the Test and Nix workflows triggered on push and pull_request events with different concurrency group keys for each event type. When pushing to a branch with an open PR, CI ran twice.

Fix the concurrency group to use github.head_ref (the PR source branch name) when available, so both events for the same branch share a group and cancel-in-progress deduplicates them. Pushes to branches without an open PR still trigger CI, and each push to main gets a unique group via run_id so merges are never cancelled.

I'm not totally sure if this is cursed and will mess up our required checks tests but... let's try.