### PR TITLE
ci: add full zig test suite for Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,47 @@
+#--------------------------------------------------------------------
+# Line endings
+#--------------------------------------------------------------------
+# Source code - always LF
+*.zig text eol=lf
+*.c text eol=lf
+*.h text eol=lf
+*.cpp text eol=lf
+*.m text eol=lf
+*.swift text eol=lf
+*.py text eol=lf
+*.sh text eol=lf
+
+# Config/build files - always LF
+*.zon text eol=lf
+*.nix text eol=lf
+*.md text eol=lf
+*.json text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.toml text eol=lf
+CMakeLists.txt text eol=lf
+*.cmake text eol=lf
+Makefile text eol=lf
+
+# Text data files - always LF (embedded in Zig, parsed with \n split)
+*.txt text eol=lf
+
+# Windows resource files - preserve as-is (native Windows tooling)
+*.rc -text
+*.manifest -text
+
+# Binary files
+*.png binary
+*.ico binary
+*.icns binary
+*.ttf binary
+*.otf binary
+*.glsl binary
+*.blp binary
+
+#--------------------------------------------------------------------
+# Linguist
+#--------------------------------------------------------------------
 build.zig.zon.nix linguist-generated=true
 build.zig.zon.txt linguist-generated=true
 build.zig.zon.json linguist-generated=true
@@ -12,4 +56,3 @@ src/font/nerd_font_attributes.zig linguist-generated=true
 src/font/nerd_font_codepoint_tables.py linguist-generated=true
 src/font/res/** linguist-vendored
 src/terminal/res/** linguist-vendored
-src/terminal/res/rgb.txt -text

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,7 @@ jobs:
       - test-fuzz-libghostty
       - test-lib-vt
       - test-macos
+      - test-windows
       - pinact
       - prettier
       - swiftlint
@@ -1111,6 +1112,21 @@ jobs:
 
       - name: test
         run: nix develop -c zig build test --system ${{ steps.deps.outputs.deps }}
+
+  test-windows:
+    if: github.repository == 'ghostty-org/ghostty' && needs.skip.outputs.skip != 'true'
+    needs: skip
+    runs-on: windows-2025
+    timeout-minutes: 45
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+
+      - name: Test
+        run: zig build -Dapp-runtime=none test
 
   test-i18n:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1116,7 +1116,7 @@ jobs:
   test-windows:
     if: github.repository == 'ghostty-org/ghostty' && needs.skip.outputs.skip != 'true'
     needs: skip
-    runs-on: windows-2025
+    runs-on: namespace-profile-ghostty-windows
     timeout-minutes: 45
     steps:
       - name: Checkout code

--- a/src/font/sprite/draw/symbols_for_legacy_computing_supplement.zig
+++ b/src/font/sprite/draw/symbols_for_legacy_computing_supplement.zig
@@ -102,7 +102,14 @@ pub fn draw1CD00_1CDE5(
 
         const data = @embedFile("octants.txt");
         var it = std.mem.splitScalar(u8, data, '\n');
-        while (it.next()) |line| {
+        while (it.next()) |raw_line| {
+            // Trim \r so this works with both LF and CRLF line endings,
+            // since git may convert octants.txt to CRLF on Windows checkouts.
+            const line = if (raw_line.len > 0 and raw_line[raw_line.len - 1] == '\r')
+                raw_line[0 .. raw_line.len - 1]
+            else
+                raw_line;
+
             // Skip comments
             if (line.len == 0 or line[0] == '#') continue;
 


### PR DESCRIPTION
## Summary

This PR effectively enables testing for all the Windows related stuff that is coming soon. 

> [!IMPORTANT]
>This PR builds on top of #11782 which fixes the last (as we speak) bug that we have in the Windows pipeline. So it would be great to review that PR first and then work on this one. Then we'll have the real windows testing, basically achieving parity, infrastructurally, with the other platforms.

What it does:

- Add a `test-windows` job to the CI workflow that runs the full test suite (`zig build -Dapp-runtime=none test`) on Windows
- Add `test-windows` to the `required` checks list so it gates merges

## Context
The existing `build-libghostty-vt-windows` job only runs `zig build test-lib-vt` (the VT library subset). 
I realized that in  c5092b09d we removed the TODO comment in that job: "Work towards passing the full test suite on Windows." 
But effectively we weren't running tests in CI yet! 

The full test suite now passes on Windows (51/51 steps, 2654 tests, 23 skipped). This job mirrors what the other platforms do — Linux runs `zig build -Dapp-runtime=none test` via Nix, macOS runs `zig build test` via Nix. Windows runs the same command directly via `setup-zig` since there's no Nix on Windows.

## How
The new job follows the same pattern as the other Windows CI jobs:
- `runs-on: windows-2025` (same as `build-libghostty-vt-windows` and `build-examples-cmake-windows`)
- `timeout-minutes: 45` (same as other Windows jobs)
- `needs: skip` so it runs early in parallel (same as `test-macos` and the main `test` job), not gated behind other jobs
- Uses `mlugg/setup-zig` (same pinned version as other Windows jobs)
- Runs `zig build -Dapp-runtime=none test`

## Dependencies
This job will only pass once the following PRs are merged:
- PR #11782 -> backslash path handling in CommaSplitter/Theme
- PR #11807 -> freetype compilation fix
- PR #11810 -> ssize_t typedef for MSVC
- PR #11812 -> linkLibCpp skip + freetype enum signedness
- Others I have missed probably but they are merged already.

## Test plan
- The workflow YAML is valid (standard GitHub Actions syntax, matches existing job patterns)
- I will be ready to issue fix PRs if any issue related to this arises. I cannot reliably test GH actions locally unfortunately.
- Once dependencies land, the job should produce: 51/51 steps, ~2654 tests pass, 23 skipped
- No impact on existing Linux/macOS CI jobs

## What I Learnt
- GitHub Actions Windows runners don't have Nix, so Windows jobs use `setup-zig` directly while Linux/macOS jobs use `nix develop -c zig build ...`. The Nix wrapper ensures the exact same environment as the flake, but on Windows we get that consistency from the `setup-zig` action which reads the version from `build.zig.zon`.
- The `needs: skip` pattern allows a job to run in parallel with the main test job rather than waiting for it. The main `test` job is the gatekeeper for most build jobs (`needs: test`), but platform-specific test jobs like `test-macos` run in parallel since they're independent.
- The `required` job aggregates all needed jobs and uses a grep-based check to determine overall pass/fail, so adding a new job there means it becomes a merge blocker.