### PR TITLE
build: fix libghostty shared lib install for Windows

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -152,8 +152,13 @@ pub fn build(b: *std.Build) !void {
         // build on macOS this way ironically so we need to fix that.
         if (!config.target.result.os.tag.isDarwin()) {
             lib_shared.installHeader(); // Only need one header
-            lib_shared.install("libghostty.so");
-            lib_static.install("libghostty.a");
+            if (config.target.result.os.tag == .windows) {
+                lib_shared.install("ghostty.dll");
+                lib_static.install("ghostty-static.lib");
+            } else {
+                lib_shared.install("libghostty.so");
+                lib_static.install("libghostty.a");
+            }
         }
     }
 

--- a/src/build/GhosttyLib.zig
+++ b/src/build/GhosttyLib.zig
@@ -39,6 +39,12 @@ pub fn initStatic(
     lib.bundle_compiler_rt = true;
     lib.bundle_ubsan_rt = true;
 
+    if (deps.config.target.result.os.tag == .windows) {
+        // Zig's ubsan emits /exclude-symbols linker directives that
+        // are incompatible with the MSVC linker (LNK4229).
+        lib.bundle_ubsan_rt = false;
+    }
+
     // Add our dependencies. Get the list of all static deps so we can
     // build a combined archive if necessary.
     var lib_list = try deps.add(lib);


### PR DESCRIPTION
## Summary

- On Windows, install the shared lib as `ghostty.dll` and the static lib as `ghostty-static.lib` instead of `libghostty.so` and `libghostty.a`
- The `-static` suffix on the static lib avoids collision with the import lib that the DLL produces (same pattern as `ghostty-vt-static.lib`)
- Guard `bundle_ubsan_rt` in `GhosttyLib.zig` `initStatic` for Windows, since Zig's ubsan emits `/exclude-symbols` linker directives that are incompatible with the MSVC linker (LNK4229). Matches the existing pattern in `GhosttyLibVt.zig`

Also includes a cherry-pick of PR #11782 (backslash path handling) to keep the Windows test suite fully passing on this branch.

## Discussion

- Is this better? This is me starting to question Claude's training/output.

```zig
// Zig's ubsan emits /exclude-symbols linker directives that
// are incompatible with the MSVC linker (LNK4229).
lib.bundle_ubsan_rt = deps.config.target.result.os.tag != .windows;
```

More concise, still preserves the comment. Not sure which is preferred here. The set-then-override matches `GhosttyLibVt.zig` exactly, but the boolean is maybe cleaner? Open to either. Curious about your preference.

## Test results

Tested before/after on all three platforms:

| | Windows | Linux | Mac |
|---|---|---|---|
| **BEFORE** (upstream/main) | FAIL (pre-existing, fixed by PR 11782) | PASS | PASS |
| **AFTER** (this branch) | PASS - 51/51 steps, 2604/2657 tests, 53 skipped | PASS | PASS |

No regressions on any platform.

## What I Learnt

- Zig's build system automatically generates an import `.lib` alongside a `.dll` on Windows, so the static lib needs a distinct name to avoid collision. 
- The ubsan runtime emits MSVC-incompatible linker directives