### PR TITLE
apprt: add Windows platform to embedded runtime

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -152,8 +152,13 @@ pub fn build(b: *std.Build) !void {
         // build on macOS this way ironically so we need to fix that.
         if (!config.target.result.os.tag.isDarwin()) {
             lib_shared.installHeader(); // Only need one header
-            lib_shared.install("libghostty.so");
-            lib_static.install("libghostty.a");
+            if (config.target.result.os.tag == .windows) {
+                lib_shared.install("ghostty.dll");
+                lib_static.install("ghostty-static.lib");
+            } else {
+                lib_shared.install("libghostty.so");
+                lib_static.install("libghostty.a");
+            }
         }
     }
 

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -43,6 +43,7 @@ typedef enum {
   GHOSTTY_PLATFORM_INVALID,
   GHOSTTY_PLATFORM_MACOS,
   GHOSTTY_PLATFORM_IOS,
+  GHOSTTY_PLATFORM_WINDOWS,
 } ghostty_platform_e;
 
 typedef enum {
@@ -431,9 +432,14 @@ typedef struct {
   void* uiview;
 } ghostty_platform_ios_s;
 
+typedef struct {
+  void* hwnd;
+} ghostty_platform_windows_s;
+
 typedef union {
   ghostty_platform_macos_s macos;
   ghostty_platform_ios_s ios;
+  ghostty_platform_windows_s windows;
 } ghostty_platform_u;
 
 typedef enum {

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -343,6 +343,7 @@ pub const App = struct {
 pub const Platform = union(PlatformTag) {
     macos: MacOS,
     ios: IOS,
+    windows: Windows,
 
     // If our build target for libghostty is not darwin then we do
     // not include macos support at all.
@@ -356,6 +357,11 @@ pub const Platform = union(PlatformTag) {
         uiview: objc.Object,
     } else void;
 
+    pub const Windows = if (builtin.target.os.tag == .windows) struct {
+        /// The window handle for the surface.
+        hwnd: std.os.windows.HWND,
+    } else void;
+
     // The C ABI compatible version of this union. The tag is expected
     // to be stored elsewhere.
     pub const C = extern union {
@@ -365,6 +371,10 @@ pub const Platform = union(PlatformTag) {
 
         ios: extern struct {
             uiview: ?*anyopaque,
+        },
+
+        windows: extern struct {
+            hwnd: ?*anyopaque,
         },
     };
 
@@ -385,6 +395,14 @@ pub const Platform = union(PlatformTag) {
                     break :ios error.UIViewMustBeSet);
                 break :ios .{ .ios = .{ .uiview = uiview } };
             } else error.UnsupportedPlatform,
+
+            .windows => if (Windows != void) windows: {
+                const config = c_platform.windows;
+                const hwnd: std.os.windows.HWND = @ptrCast(
+                    config.hwnd orelse break :windows error.HWNDMustBeSet,
+                );
+                break :windows .{ .windows = .{ .hwnd = hwnd } };
+            } else error.UnsupportedPlatform,
         };
     }
 };
@@ -395,6 +413,7 @@ pub const PlatformTag = enum(c_int) {
 
     macos = 1,
     ios = 2,
+    windows = 3,
 };
 
 pub const EnvVar = extern struct {

--- a/src/build/GhosttyLib.zig
+++ b/src/build/GhosttyLib.zig
@@ -39,6 +39,12 @@ pub fn initStatic(
     lib.bundle_compiler_rt = true;
     lib.bundle_ubsan_rt = true;
 
+    if (deps.config.target.result.os.tag == .windows) {
+        // Zig's ubsan emits /exclude-symbols linker directives that
+        // are incompatible with the MSVC linker (LNK4229).
+        lib.bundle_ubsan_rt = false;
+    }
+
     // Add our dependencies. Get the list of all static deps so we can
     // build a combined archive if necessary.
     var lib_list = try deps.add(lib);

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -99,6 +99,7 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !Metal {
             .view = switch (opts.rt_surface.platform) {
                 .macos => |v| v.nsview,
                 .ios => |v| v.uiview,
+                .windows => unreachable,
             },
         },
 


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is stacked!
> - This PR
> - #11840 
> - #11782 <- **start here and bubble up**
>
> (still figuring out how to best present stacking without thinking about crypto and tiramisu and lasagna, sorry it's dinner time)

## Summary

- Add `GHOSTTY_PLATFORM_WINDOWS` to the C API platform enum in `ghostty.h`
- Add `ghostty_platform_windows_s` struct with a `void* hwnd` field and corresponding union member
- Add the matching Zig `PlatformTag.windows` and `Platform.Windows` type in `embedded.zig`
- The `Windows` type is a real struct on Windows builds and `void` on other platforms, following the same pattern as `MacOS` and `IOS`
- Add `.windows => unreachable` to the Metal renderer's platform switch since Metal only runs on Apple platforms
- Add `HWNDMustBeSet` error for when Windows surfaces are created without a valid window handle

This is the plumbing needed so that a Windows GUI wrapper (C# WinUI 3) can pass a window handle when creating surfaces via libghostty. The `hwnd` field is a placeholder. The exact handle type (HWND, IDXGISwapChain, etc.) will be determined by the SwapChainPanel integration spike (doing some research on the side).

## Test results

| Platform | Result | Steps | Tests Passed | Skipped |
|----------|--------|-------|-------------|---------|
| Windows | PASS | 51/51 | 2604/2657 | 53 |
| Linux | PASS | 86/86 | 2615/2638 | 23 |
| Mac | PASS | 160/160 | 2619/2626 | 7 |

Luckily I ran multi-platform tests because I got something I was not expecting.

Initial Mac test caught a missing `.windows` arm in `Metal.zig:99` (exhaustive switch on platform). Fixed by adding `.windows => unreachable` since Metal only targets Apple platforms.

## What I Learnt

- Adding a new variant to a tagged union in Zig breaks all exhaustive switches across the codebase, which is exactly the point - the compiler forces you to handle the new case everywhere. The Metal renderer was the only place that switched on the platform tag directly. Pretty cool, I guess stuff like this helps you catch errors sooner.
- The Platform type uses comptime conditional types (`if (builtin.target.os.tag == .windows) struct { ... } else void`) so Windows-specific fields are zero-cost on other platforms. Yeah, comptime makes me think at the build flag shenanigans I did in go for years and now I think: that was cute.
- Stressing this: Cross-platform testing is essential when touching enums/unions in Zig. The Windows and Linux builds passed fine, but Mac failed because Metal.zig has an exhaustive switch that only gets compiled on Darwin. Each platform compiles different code paths (Metal on Mac, OpenGL on Linux, future DirectX on Windows), so a change that looks safe on one platform can break another. Always test all three before PRing.