### PR TITLE
build: make sure CMake can clean up after libghostty-vt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,11 @@ add_custom_target(zig_build_lib_vt ALL
     DEPENDS "${GHOSTTY_VT_SHARED_LIBRARY}" "${GHOSTTY_VT_STATIC_LIBRARY}"
 )
 
+# Tell CMake's clean target to also remove Zig's output directory.
+set_property(DIRECTORY APPEND PROPERTY
+    ADDITIONAL_CLEAN_FILES "${ZIG_OUT_DIR}"
+)
+
 # --- IMPORTED library targets ------------------------------------------------
 
 # Shared


### PR DESCRIPTION
Fixes `cmake --build build --target clean`

Currently:

```
[1/1] Cleaning all built files...
FAILED: clean
ninja  -t clean
Cleaning... ninja: error: remove(_deps/ghostty-src/zig-out/lib): Directory not empty
ninja: error: remove(/...ghostling/build/_deps/ghostty-src/zig-out/lib): Directory not empty
33 files.
ninja: build stopped: subcommand failed.
```