### PR TITLE
ci: update to Xcode 26.3

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -153,7 +153,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: XCode Select
-        run: sudo xcode-select -s /Applications/Xcode_26.2.app
+        run: sudo xcode-select -s /Applications/Xcode_26.3.app
 
       - name: Xcode Version
         run: xcodebuild -version

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -251,7 +251,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: XCode Select
-        run: sudo xcode-select -s /Applications/Xcode_26.2.app
+        run: sudo xcode-select -s /Applications/Xcode_26.3.app
 
       - name: Xcode Version
         run: xcodebuild -version
@@ -507,7 +507,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: XCode Select
-        run: sudo xcode-select -s /Applications/Xcode_26.2.app
+        run: sudo xcode-select -s /Applications/Xcode_26.3.app
 
       - name: Xcode Version
         run: xcodebuild -version
@@ -704,7 +704,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: XCode Select
-        run: sudo xcode-select -s /Applications/Xcode_26.2.app
+        run: sudo xcode-select -s /Applications/Xcode_26.3.app
 
       - name: Xcode Version
         run: xcodebuild -version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -469,7 +469,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Xcode Select
-        run: sudo xcode-select -s /Applications/Xcode_26.2.app
+        run: sudo xcode-select -s /Applications/Xcode_26.3.app
 
       - name: Build
         run: |
@@ -757,7 +757,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Xcode Select
-        run: sudo xcode-select -s /Applications/Xcode_26.2.app
+        run: sudo xcode-select -s /Applications/Xcode_26.3.app
 
       - name: Xcode Version
         run: xcodebuild -version
@@ -817,7 +817,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Xcode Select
-        run: sudo xcode-select -s /Applications/Xcode_26.2.app
+        run: sudo xcode-select -s /Applications/Xcode_26.3.app
 
       - name: Xcode Version
         run: xcodebuild -version
@@ -1057,7 +1057,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Xcode Select
-        run: sudo xcode-select -s /Applications/Xcode_26.2.app
+        run: sudo xcode-select -s /Applications/Xcode_26.3.app
 
       - name: Xcode Version
         run: xcodebuild -version


### PR DESCRIPTION
**WARNING:** We CANNOT upgrade to Xcode 26.4 with Zig 0.15 because: https://codeberg.org/ziglang/zig/issues/31658

We have to wait and see if Zig will backport that or if we just have to roll forward to Zig 0.16 when it comes out. At the time of this commit, no released Zig version has the fix for that issue.