### PR TITLE
macOS: fix search bar losing focus unexpectedly

### DIFF
--- a/macos/GhosttyUITests/GhosttyMouseStateTests.swift
+++ b/macos/GhosttyUITests/GhosttyMouseStateTests.swift
@@ -49,5 +49,39 @@ final class GhosttyMouseStateTests: GhosttyCustomConfigCase {
 
         XCTAssertEqual(NSPasteboard.general.string(forType: .string), nil, "Moving mouse shouldn't select any texts")
     }
+
+    @MainActor func testSearchFocusState() async throws {
+        let app = try ghosttyApplication()
+        app.activate()
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 5), "New window should appear")
+        app.typeKey("f", modifierFlags: .command)
+
+        let textfield = app.textFields.firstMatch
+        XCTAssertTrue(textfield.waitForExistence(timeout: 5), "Search field should appear")
+        app.typeText("a")
+
+        XCTAssertTrue(textfield.stringValue == "a", "Search text should be `a`")
+
+        textfield.coordinate(withNormalizedOffset: .zero)
+            .withOffset(.init(dx: textfield.frame.width * 0.5, dy: 0))
+            .click()
+
+        app.typeText("b")
+
+        XCTAssertTrue(textfield.stringValue == "ab", "Search text should be `ab`")
+
+        // resign
+        app.typeKey(.escape, modifierFlags: [])
+
+        // dismiss
+        app.typeKey(.escape, modifierFlags: [])
+
+        XCTAssertTrue(textfield.waitForNonExistence(timeout: 5), "Search field should disappear")
+    }
 }
 
+private extension XCUIElement {
+    var stringValue: String? {
+        (value as? String)
+    }
+}

--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -667,7 +667,9 @@ extension Ghostty {
 
             // The clicked location in this window should be this view.
             let location = convert(event.locationInWindow, from: nil)
-            guard hitTest(location) == self else { return event }
+            // We should use window to perform hitTest here,
+            // because there could be some other overlays on top, like search bar
+            guard window.contentView?.hitTest(location) == self else { return event }
 
             // We always assume that we're resetting our mouse suppression
             // unless we see the specific scenario below to set it.


### PR DESCRIPTION
A regression caused by 3ee8ef4f650f550698ee1e8e81e591511e195bf4.

The search bar should stay as the first responder after clicking inside the text field or clicking the next/previous button, but right now it doesn’t.