### PR TITLE
Implement toggle_background_opacity keybinding action on linux

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2413,6 +2413,19 @@ pub fn setFontSize(self: *Surface, size: font.face.DesiredSize) !void {
     self.queueRender() catch unreachable;
 }
 
+/// Force the background to render as fully opaque, overriding the configured
+/// background-opacity. Pass false to restore normal opacity.
+pub fn setForceOpaqueBackground(self: *Surface, force: bool) void {
+    _ = self.renderer_thread.mailbox.push(
+        .{ .force_opaque_background = force },
+        .{ .forever = {} },
+    );
+    self.queueRender() catch |err| {
+        // Not a big deal if this fails, there will just be a noticeable delay.
+        log.warn("failed to notify renderer after setting force opaque background err={}", .{err});
+    };
+}
+
 /// This queues a render operation with the renderer thread. The render
 /// isn't guaranteed to happen immediately but it will happen as soon as
 /// practical.

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -761,6 +761,7 @@ pub const Application = extern struct {
             .toggle_window_decorations => return Action.toggleWindowDecorations(target),
             .toggle_command_palette => return Action.toggleCommandPalette(target),
             .toggle_split_zoom => return Action.toggleSplitZoom(target),
+            .toggle_background_opacity => return Action.toggleBackgroundOpacity(target),
             .show_on_screen_keyboard => return Action.showOnScreenKeyboard(target),
             .command_finished => return Action.commandFinished(target, value),
             .readonly => return Action.setReadonly(target, value),
@@ -775,7 +776,6 @@ pub const Application = extern struct {
             .close_all_windows,
             .float_window,
             .toggle_visibility,
-            .toggle_background_opacity,
             .cell_size,
             .render_inspector,
             .renderer_health,
@@ -2766,6 +2766,25 @@ const Action = struct {
                 };
 
                 window.toggleWindowDecorations();
+                return true;
+            },
+        }
+    }
+
+    pub fn toggleBackgroundOpacity(target: apprt.Target) bool {
+        switch (target) {
+            .app => return false,
+            .surface => |core| {
+                const surface = core.rt_surface.surface;
+                const window = ext.getAncestor(
+                    Window,
+                    surface.as(gtk.Widget),
+                ) orelse {
+                    log.warn("surface is not in a window, ignoring toggle_background_opacity", .{});
+                    return false;
+                };
+
+                window.toggleBackgroundOpacity();
                 return true;
             },
         }

--- a/src/apprt/gtk/class/window.zig
+++ b/src/apprt/gtk/class/window.zig
@@ -678,12 +678,26 @@ pub const Window = extern struct {
             );
         }
 
+        // Update all surfaces to reflect forced opaqueness value.
+        const numPages = priv.tab_view.getNPages();
+        for (0..@intCast(numPages)) |i| {
+            const pageChild = priv.tab_view
+                .getNthPage(@intCast(i))
+                .getChild();
+            const tab = gobject.ext.cast(Tab, pageChild) orelse continue;
+            const surfaceTree = tab.getSurfaceTree() orelse continue;
+            var it = surfaceTree.iterator();
+            while (it.next()) |entry| {
+                const surface = entry.view.core() orelse continue;
+                surface.setForceOpaqueBackground(priv.force_opaque_background);
+            }
+        }
+
         // Remainder uses the config
         const config = if (priv.config) |v| v.get() else return;
 
-        // TODO UPDATE
-        // Only add a solid background if we're opaque. This keeps GTK's
-        // understanding of the window in line with what's being rendered
+        // Only add the solid background class if we're opaque. This keeps
+        // GTK's understanding of the window in line with what's being rendered
         self.toggleCssClass("background", self.private().force_opaque_background or
             config.@"background-opacity" >= 1);
 
@@ -916,10 +930,6 @@ pub const Window = extern struct {
         const priv: *Private = self.private();
         priv.force_opaque_background = !priv.force_opaque_background;
         self.syncAppearance();
-    }
-
-    fn renderSurfaceOpaque(surface: *CoreSurface, force: bool) void {
-        surface.renderer_thread.mailbox.push(.{ .force_opaque = force }, .{ .forever = {} });
     }
 
     /// Set the window decoration override for this window. If this is null,

--- a/src/apprt/gtk/class/window.zig
+++ b/src/apprt/gtk/class/window.zig
@@ -225,6 +225,9 @@ pub const Window = extern struct {
         /// config on a per-window basis.
         window_decoration: ?configpkg.WindowDecoration = null,
 
+        /// Whether background opacity has been toggled to be forced opaque.
+        force_opaque_background: bool = false,
+
         /// Binding group for our active tab.
         tab_bindings: *gobject.BindingGroup,
 
@@ -678,11 +681,11 @@ pub const Window = extern struct {
         // Remainder uses the config
         const config = if (priv.config) |v| v.get() else return;
 
-        // Only add a solid background if we're opaque.
-        self.toggleCssClass(
-            "background",
-            config.@"background-opacity" >= 1,
-        );
+        // TODO UPDATE
+        // Only add a solid background if we're opaque. This keeps GTK's
+        // understanding of the window in line with what's being rendered
+        self.toggleCssClass("background", self.private().force_opaque_background or
+            config.@"background-opacity" >= 1);
 
         // Apply class to color headerbar if window-theme is set to `ghostty` and
         // GTK version is before 4.16. The conditional is because above 4.16
@@ -907,6 +910,16 @@ pub const Window = extern struct {
             // Anything non-none to none
             .auto, .client, .server => .none,
         });
+    }
+
+    pub fn toggleBackgroundOpacity(self: *Self) void {
+        const priv: *Private = self.private();
+        priv.force_opaque_background = !priv.force_opaque_background;
+        self.syncAppearance();
+    }
+
+    fn renderSurfaceOpaque(surface: *CoreSurface, force: bool) void {
+        surface.renderer_thread.mailbox.push(.{ .force_opaque = force }, .{ .forever = {} });
     }
 
     /// Set the window decoration override for this window. If this is null,

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -476,6 +476,10 @@ fn drainMailbox(self: *Thread) !void {
                 self.flags.has_inspector = v;
             },
 
+            .force_opaque_background => |v| {
+                self.renderer.force_opaque_background = v;
+            },
+
             .macos_display_id => |v| {
                 if (@hasDecl(rendererpkg.Renderer, "setMacOSDisplayID")) {
                     try self.renderer.setMacOSDisplayID(v);

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -216,7 +216,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// Whether or not we have custom shaders.
         has_custom_shaders: bool = false,
 
-        /// TODO
+        /// Force the background to be opaque, regardless of the value in config.
         force_opaque_background: bool = false,
 
         /// Our shader pipelines.

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1388,13 +1388,15 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     self.scrollbar_dirty = true;
                 }
 
+                // Opacity from 0 to 1.
+                const opacity = if (self.force_opaque_background) 1 else self.config.background_opacity;
+
                 // Update our background color
                 self.uniforms.bg_color = .{
                     self.terminal_state.colors.background.r,
                     self.terminal_state.colors.background.g,
                     self.terminal_state.colors.background.b,
-                    self.force_opaque_background or
-                        @intFromFloat(@round(self.config.background_opacity * 255.0)),
+                    @intFromFloat(@round(opacity * 255.0)),
                 };
 
                 // If we're on macOS and have glass styles, we remove

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -216,6 +216,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// Whether or not we have custom shaders.
         has_custom_shaders: bool = false,
 
+        /// TODO
+        force_opaque_background: bool = false,
+
         /// Our shader pipelines.
         shaders: Shaders,
 
@@ -1390,7 +1393,8 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     self.terminal_state.colors.background.r,
                     self.terminal_state.colors.background.g,
                     self.terminal_state.colors.background.b,
-                    @intFromFloat(@round(self.config.background_opacity * 255.0)),
+                    self.force_opaque_background or
+                        @intFromFloat(@round(self.config.background_opacity * 255.0)),
                 };
 
                 // If we're on macOS and have glass styles, we remove

--- a/src/renderer/message.zig
+++ b/src/renderer/message.zig
@@ -64,6 +64,9 @@ pub const Message = union(enum) {
     /// Activate or deactivate the inspector.
     inspector: bool,
 
+    /// Force the background to be fully opaque, overriding configuration.
+    force_opaque_background: bool,
+
     /// The macOS display ID has changed for the window.
     macos_display_id: u32,
 


### PR DESCRIPTION
Closes #5047 

It's unfortunate that the GTK implementation touches the renderer pipeline directly while the SwiftUI one doesn't. SwiftUI's pipeline is simpler than GTK's, as it allows just telling the compositor to render a surface without an alpha component straight up. The problem is GTK's scene graph composition; it will let you draw semi-transparent pixels on to the GLArea, and take it upon itself to blend it with the background layer. The only solution I could think of is overriding opacity at the render step, so the GLArea is opaque and nothing can be blended. 
Not super clean, but it seems to be just a limitation of GTK and this would close a long-standing issue.

--
AI Usage: Used Claude to explain some Zig concepts as I'm not familiar with the language