### PR TITLE
GTK: Toggle background opacity keybind

### DIFF
--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -765,12 +765,13 @@ pub const Application = extern struct {
             .search_total => Action.searchTotal(target, value),
             .search_selected => Action.searchSelected(target, value),
 
+            .toggle_background_opacity => return Action.toggleBackgroundOpacity(target),
+
             // Unimplemented
             .secure_input,
             .close_all_windows,
             .float_window,
             .toggle_visibility,
-            .toggle_background_opacity,
             .cell_size,
             .render_inspector,
             .renderer_health,
@@ -2736,6 +2737,25 @@ const Action = struct {
                 };
 
                 window.toggleWindowDecorations();
+                return true;
+            },
+        }
+    }
+
+    pub fn toggleBackgroundOpacity(target: apprt.Target) bool {
+        switch (target) {
+            .app => return false,
+            .surface => |core| {
+                const surface = core.rt_surface.surface;
+                const window = ext.getAncestor(
+                    Window,
+                    surface.as(gtk.Widget),
+                ) orelse {
+                    log.warn("surface is not in a window, ignoring toggle_background_opacity", .{});
+                    return false;
+                };
+
+                window.toggleBackgroundOpacity();
                 return true;
             },
         }

--- a/src/apprt/gtk/class/window.zig
+++ b/src/apprt/gtk/class/window.zig
@@ -735,6 +735,11 @@ pub const Window = extern struct {
             widget.removeCssClass(class.ptr);
     }
 
+    fn hasCssClass(self: *Self, class: [:0]const u8) bool {
+        const widget = self.as(gtk.Widget);
+        return widget.hasCssClass(class.ptr) == 1;
+    }
+
     /// Perform a binding action on the window's active surface.
     fn performBindingAction(
         self: *Self,
@@ -907,6 +912,17 @@ pub const Window = extern struct {
             // Anything non-none to none
             .auto, .client, .server => .none,
         });
+    }
+
+    /// Toggle background opacity for this window
+    pub fn toggleBackgroundOpacity(self: *Self) void {
+        const priv = self.private();
+
+        const config = if (priv.config) |v| v.get() else return;
+        if (config.@"background-opacity" < 1) {
+            const val = self.hasCssClass("background");
+            self.toggleCssClass("background", !val);
+        }
     }
 
     /// Set the window decoration override for this window. If this is null,

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -824,8 +824,6 @@ pub const Action = union(enum) {
     ///
     /// When `background-opacity` is less than 1, this action will either make
     /// the window transparent or not depending on its current transparency state.
-    ///
-    /// Only implemented on macOS.
     toggle_background_opacity,
 
     /// Check for updates.


### PR DESCRIPTION
Closes: https://github.com/ghostty-org/ghostty/issues/5047

And supersedes https://github.com/ghostty-org/ghostty/pull/11881 as it shouldn't need to touch the renderer at all


https://github.com/user-attachments/assets/976c3d73-d7f0-4b8e-94ad-32c0cdd453ed