### PR TITLE
core/gtk: allow editing Ghostty config in a Ghostty window

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -689,6 +689,14 @@ typedef struct {
   const char* pwd;
 } ghostty_action_pwd_s;
 
+// apprt.action.OpenConfig
+typedef enum {
+  // Open the config in the OS default editor.
+  GHOSTTY_ACTION_OPEN_CONFIG_OS_OPEN,
+  // Open the config in a new window using $EDITOR or $VISUAL
+  GHOSTTY_ACTION_OPEN_CONFIG_NEW_WINDOW,
+} ghostty_action_open_config_e;
+
 // terminal.MouseShape
 typedef enum {
   GHOSTTY_MOUSE_SHAPE_DEFAULT,
@@ -1004,6 +1012,7 @@ typedef union {
   ghostty_action_search_total_s search_total;
   ghostty_action_search_selected_s search_selected;
   ghostty_action_readonly_e readonly;
+  ghostty_action_open_config_e open_config;
 } ghostty_action_u;
 
 typedef struct {

--- a/po/be.po
+++ b/po/be.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-04-14 00:00+0000\n"
 "Last-Translator: Illia Krauchanka <illiakrauchanka@gmail.com>\n"
 "Language-Team: Belarusian\n"
@@ -49,12 +49,12 @@ msgstr "Перазагрузіць канфігурацыю, каб паказа
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Скасаваць"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Закрыць"
@@ -63,7 +63,7 @@ msgstr "Закрыць"
 msgid "Configuration Errors"
 msgstr "Канфігурацыйныя памылкі"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -71,12 +71,12 @@ msgstr ""
 "Знойдзена адна або некалькі канфігурацыйных памылак. Прагледзьце памылкі "
 "ніжэй і альбо перазагрузіце канфігурацыю, альбо ігнаруйце гэтыя памылкі."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Ігнараваць"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Перазагрузіць канфігурацыю"
 
@@ -95,23 +95,23 @@ msgstr "Ghostty: інспектар тэрмінала"
 msgid "Find…"
 msgstr "Знайсці…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Папярэдняе супадзенне"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Наступнае супадзенне"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "Ой."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Не ўдалося атрымаць кантэкст OpenGL для адмалёўкі."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -121,103 +121,107 @@ msgstr ""
 "праглядаць, вылучаць і пракручваць змест, але ніякія падзеі ўводу не будуць "
 "адпраўлены ў запушчаную праграму."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Толькі для чытання"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Скапіяваць"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Уставіць"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Апавясціць пры завяршэнні наступнай каманды"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Ачысціць"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Скінуць"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Падзяліць"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Змяніць назву…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Падзяліць уверх"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Падзяліць уніз"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Падзяліць улева"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Падзяліць управа"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Укладка"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Змяніць назву ўкладкі…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Новая ўкладка"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Закрыць укладку"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Акно"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Новае акно"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Закрыць акно"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Налады"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Адкрыць канфігурацыю"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -227,31 +231,31 @@ msgstr "Пакіньце пустым, каб аднавіць назву па �
 msgid "OK"
 msgstr "ОК"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Новы падзел"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Паглядзець адкрытыя ўкладкі"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Галоўнае меню"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Палітра каманд"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Інспектар тэрмінала"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "Пра Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Выйсці"
 
@@ -259,24 +263,28 @@ msgstr "Выйсці"
 msgid "Execute a command…"
 msgstr "Выканаць каманду…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -339,16 +347,16 @@ msgstr "Усе сесіі тэрмінала ў гэтым акне будуць
 msgid "The currently running process in this split will be terminated."
 msgstr "Бягучы працэс у гэтым падзеле будзе завершаны."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Каманда завершана"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Каманда выканана паспяхова"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Каманда завершылася з памылкай"
@@ -361,19 +369,19 @@ msgstr "Змяніць назву тэрмінала"
 msgid "Change Tab Title"
 msgstr "Змяніць назву ўкладкі"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "Канфігурацыя перазагружана"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Скапіявана ў буфер абмену"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Буфер абмену ачышчаны"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Распрацоўшчыкі Ghostty"
 
@@ -931,150 +939,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/bg.po
+++ b/po/bg.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-02-09 22:07+0200\n"
 "Last-Translator: reo101 <pavel.atanasov2001@gmail.com>\n"
 "Language-Team: Bulgarian <dict@ludost.net>\n"
@@ -49,12 +49,12 @@ msgstr "За да покажеш това съобщение отново, пр�
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Отказ"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Затвори"
@@ -63,7 +63,7 @@ msgstr "Затвори"
 msgid "Configuration Errors"
 msgstr "Грешки в конфигурацията"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -71,12 +71,12 @@ msgstr ""
 "Открити са една или повече грешки в конфигурацията. Моля, прегледайте "
 "грешките по-долу и или презаредете конфигурацията си, или ги игнорирайте."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Игнорирай"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Презареди конфигурацията"
 
@@ -95,23 +95,23 @@ msgstr "Ghostty: Инспектор на терминала"
 msgid "Find…"
 msgstr "Намери…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Предишно съвпадение"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Следващо съвпадение"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "О, не."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Неуспешно придобиване на OpenGL контекст за рендиране."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -121,103 +121,107 @@ msgstr ""
 "селектирате и превъртате съдържанието, но към работещото приложение няма да "
 "бъдат изпращани входни събития."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Само за четене"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Копирай"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Постави"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Уведомяване при завършване на следващата команда"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Изчисти"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Нулирай"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Раздели"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Промени заглавие…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Раздели нагоре"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Раздели надолу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Раздели наляво"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Раздели надясно"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Раздел"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Смени името на таба…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Нов раздел"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Затвори раздел"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Прозорец"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Нов прозорец"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Затвори прозорец"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Конфигурация"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Отвори конфигурацията"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -227,31 +231,31 @@ msgstr "Оставете празно за възстановяване на з�
 msgid "OK"
 msgstr "ОК"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Ново разделяне"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Преглед на отворените раздели"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Главно меню"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Командна палитра"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Инспектор на терминала"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "За Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Изход"
 
@@ -259,24 +263,28 @@ msgstr "Изход"
 msgid "Execute a command…"
 msgstr "Изпълни команда…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -339,16 +347,16 @@ msgstr "Всички терминални сесии в този прозоре�
 msgid "The currently running process in this split will be terminated."
 msgstr "Текущият процес в това разделяне ще бъде прекратен."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Командата завърши"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Командата завърши успешно"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Командата завърши неуспешно"
@@ -361,19 +369,19 @@ msgstr "Промяна на заглавието на терминала"
 msgid "Change Tab Title"
 msgstr "Смени името на таба"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "Конфигурацията е презаредена"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Копирано в клипборда"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Клипбордът е изчистен"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Разработчици на Ghostty"
 
@@ -931,150 +939,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/ca.po
+++ b/po/ca.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2025-08-24 19:22+0200\n"
 "Last-Translator: Kristofer Soler "
 "<31729650+KristoferSoler@users.noreply.github.com>\n"
@@ -50,12 +50,12 @@ msgstr "Recarrega la configuració per tornar a mostrar aquest missatge"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Cancel·la"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Tanca"
@@ -64,7 +64,7 @@ msgstr "Tanca"
 msgid "Configuration Errors"
 msgstr "Errors de configuració"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -72,12 +72,12 @@ msgstr ""
 "S'han trobat un o més errors de configuració. Si us plau, revisa els errors "
 "a continuació i torna a carregar la configuració o ignora aquests errors."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Ignora"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Carrega la configuració"
 
@@ -97,23 +97,23 @@ msgstr "Ghostty: Inspector de terminal"
 msgid "Find…"
 msgstr "Cerca…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Coincidència anterior"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Coincidència següent"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "Oh, no."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "No s'ha pogut obtenir un context OpenGL per al renderitzat."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -123,103 +123,107 @@ msgstr ""
 "i desplaçar-te pel contingut, però no s'enviaran esdeveniments d'entrada a "
 "l'aplicació en execució."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Només lectura"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Copia"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Enganxa"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Notifica en finalitzar la propera comanda"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Neteja"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Reinicia"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Divideix"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Canvia el títol…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Divideix cap amunt"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Divideix cap avall"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Divideix a l'esquerra"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Divideix a la dreta"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Pestanya"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Canvia el títol de la pestanya…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Nova pestanya"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Tanca la pestanya"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Finestra"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Nova finestra"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Tanca la finestra"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Configuració"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Obre la configuració"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -229,31 +233,31 @@ msgstr "Deixa en blanc per restaurar el títol per defecte."
 msgid "OK"
 msgstr "D'acord"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Nova divisió"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Mostra les pestanyes obertes"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Menú principal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Paleta de comandes"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Inspector de terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "Sobre Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Surt"
 
@@ -261,24 +265,28 @@ msgstr "Surt"
 msgid "Execute a command…"
 msgstr "Executa una ordre…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -341,16 +349,16 @@ msgstr "Totes les sessions del terminal en aquesta finestra es tancaran."
 msgid "The currently running process in this split will be terminated."
 msgstr "El procés actualment en execució en aquesta divisió es tancarà."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Comanda finalitzada"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Comanda completada amb èxit"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Comanda fallida"
@@ -363,19 +371,19 @@ msgstr "Canvia el títol del terminal"
 msgid "Change Tab Title"
 msgstr "Canvia el títol de la pestanya"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "S'ha tornat a carregar la configuració"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Copiat al porta-retalls"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Porta-retalls netejat"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Desenvolupadors de Ghostty"
 
@@ -933,150 +941,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/com.mitchellh.ghostty.pot
+++ b/po/com.mitchellh.ghostty.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -48,12 +48,12 @@ msgstr ""
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr ""
@@ -62,18 +62,18 @@ msgstr ""
 msgid "Configuration Errors"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr ""
 
@@ -91,125 +91,129 @@ msgstr ""
 msgid "Find…"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
 "application."
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
@@ -220,31 +224,31 @@ msgstr ""
 msgid "OK"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr ""
 
@@ -252,24 +256,28 @@ msgstr ""
 msgid "Execute a command…"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -326,16 +334,16 @@ msgstr ""
 msgid "The currently running process in this split will be terminated."
 msgstr ""
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr ""
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr ""
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr ""
@@ -348,19 +356,19 @@ msgstr ""
 msgid "Change Tab Title"
 msgstr ""
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr ""
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr ""
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr ""
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr ""
 
@@ -918,150 +926,158 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-02-13 08:05+0100\n"
 "Last-Translator: Klaus Hipp <khipp@users.noreply.github.com>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
@@ -52,12 +52,12 @@ msgstr ""
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Abbrechen"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Schließen"
@@ -66,7 +66,7 @@ msgstr "Schließen"
 msgid "Configuration Errors"
 msgstr "Konfigurationsfehler"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -75,12 +75,12 @@ msgstr ""
 "untenstehenden Fehler und lade entweder deine Konfiguration erneut oder "
 "ignoriere die Fehler."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Ignorieren"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Konfiguration neu laden"
 
@@ -100,23 +100,23 @@ msgstr "Ghostty: Terminalinspektor"
 msgid "Find…"
 msgstr "Suchen…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Vorherige Übereinstimmung"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Nächste Übereinstimmung"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "Oh nein."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Es kann kein OpenGL-Kontext für das Rendering abgerufen werden."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -126,103 +126,107 @@ msgstr ""
 "Inhalt weiterhin anzeigen, auswählen und durchscrollen, es werden jedoch "
 "keine Eingabeereignisse an die laufende Anwendung gesendet."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Schreibgeschützt"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Kopieren"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Einfügen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Bei Abschluss des nächsten Befehls benachrichtigen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Leeren"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Zurücksetzen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Fenster teilen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Titel bearbeiten…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Fenster nach oben teilen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Fenster nach unten teilen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Fenter nach links teilen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Fenster nach rechts teilen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Tab"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Tab-Titel ändern…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Neuer Tab"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Tab schließen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Fenster"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Neues Fenster"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Fenster schließen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Konfiguration"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Konfiguration öffnen"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -232,31 +236,31 @@ msgstr "Leer lassen, um den Standardtitel wiederherzustellen."
 msgid "OK"
 msgstr "OK"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Neues geteiltes Fenster"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Offene Tabs einblenden"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Hauptmenü"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Befehlspalette"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Terminalinspektor"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "Über Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Beenden"
 
@@ -264,24 +268,28 @@ msgstr "Beenden"
 msgid "Execute a command…"
 msgstr "Einen Befehl ausführen…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -344,16 +352,16 @@ msgstr "Alle Terminalsitzungen in diesem Fenster werden beendet."
 msgid "The currently running process in this split will be terminated."
 msgstr "Der aktuell laufende Prozess in diesem geteilten Fenster wird beendet."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Befehl abgeschlossen"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Befehl erfolgreich"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Befehl fehlgeschlagen"
@@ -366,19 +374,19 @@ msgstr "Terminaltitel bearbeiten"
 msgid "Change Tab Title"
 msgstr "Tab-Titel ändern"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "Konfiguration wurde neu geladen"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "In die Zwischenablage kopiert"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Zwischenablage geleert"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Ghostty-Entwickler"
 
@@ -936,150 +944,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/es_AR.po
+++ b/po/es_AR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-02-19 13:34-0300\n"
 "Last-Translator: Alan Moyano <alanmoyano203@gmail.com>\n"
 "Language-Team: Argentinian <es@tp.org.es>\n"
@@ -48,12 +48,12 @@ msgstr "Recargar la configuración para volver a mostrar este mensaje"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Cancelar"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Cerrar"
@@ -62,7 +62,7 @@ msgstr "Cerrar"
 msgid "Configuration Errors"
 msgstr "Errores de configuración"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -70,12 +70,12 @@ msgstr ""
 "Se encontraron uno o más errores de configuración. Por favor revisá los "
 "errores a continuación, y recargá tu configuración o ignorá estos errores."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Ignorar"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Recargar configuración"
 
@@ -95,23 +95,23 @@ msgstr "Ghostty: Inspector de la terminal"
 msgid "Find…"
 msgstr "Buscar…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Coincidencia anterior"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Coincidencia siguiente"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "Uy, no."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "No se pudo obtener un contexto de OpenGL para el renderizado"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -121,103 +121,107 @@ msgstr ""
 "desplazarte por el contenido, pero no se enviarán los eventos de entrada a "
 "la aplicación en ejecución."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Solo lectura"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Pegar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Notificar al finalizar el siguiente comando"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Limpiar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Reiniciar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Dividir"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Cambiar título…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Dividir arriba"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Dividir abajo"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Dividir a la izquierda"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Dividir a la derecha"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Pestaña"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Cambiar título de la pestaña…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Nueva pestaña"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Cerrar pestaña"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Ventana"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Nueva ventana"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Cerrar ventana"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Configuración"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Abrir configuración"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -227,31 +231,31 @@ msgstr "Dejar en blanco para restaurar el título predeterminado."
 msgid "OK"
 msgstr "Aceptar"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Nueva división"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Ver pestañas abiertas"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Menú principal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Paleta de comandos"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Inspector de la terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "Acerca de Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Salir"
 
@@ -259,24 +263,28 @@ msgstr "Salir"
 msgid "Execute a command…"
 msgstr "Ejecutar un comando…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -339,16 +347,16 @@ msgstr "Todas las sesiones de terminal en esta ventana serán terminadas."
 msgid "The currently running process in this split will be terminated."
 msgstr "El proceso actualmente en ejecución en esta división será terminado."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Comando finalizado"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Comando ejecutado correctamente"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Comando fallido"
@@ -361,19 +369,19 @@ msgstr "Cambiar título de la terminal"
 msgid "Change Tab Title"
 msgstr "Cambiar título de la pestaña"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "Configuración recargada"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Copiado al portapapeles"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Portapapeles limpiado"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Desarrolladores de Ghostty"
 
@@ -931,150 +939,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/es_BO.po
+++ b/po/es_BO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-02-12 17:46+0200\n"
 "Last-Translator: Miguel Peredo <miguelp@quientienemail.com>\n"
 "Language-Team: Spanish <es@tp.org.es>\n"
@@ -48,12 +48,12 @@ msgstr "Recargar configuración para mostrar este aviso nuevamente"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Cancelar"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Cerrar"
@@ -62,7 +62,7 @@ msgstr "Cerrar"
 msgid "Configuration Errors"
 msgstr "Errores de configuración"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -70,12 +70,12 @@ msgstr ""
 "Se encontraron uno o más errores de configuración. Por favor revise los "
 "errores a continuación, y recargue su configuración o ignore estos errores."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Ignorar"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Recargar configuración"
 
@@ -95,23 +95,23 @@ msgstr "Ghostty: Inspector de la terminal"
 msgid "Find…"
 msgstr "Encontrar…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Resultado anterior"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Resultado siguiente"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "¡Epa!"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "No se puede iniciar OpenGL para rendering."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -121,103 +121,107 @@ msgstr ""
 "través del contenido, pero ninguna entrada (evento) va a ser enviada a la "
 "aplicación que se está ejecutando."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Solo lectura"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Pegar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Notificar cuando el próximo comando finalice"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Limpiar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Reiniciar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Dividir"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Cambiar título…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Dividir arriba"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Dividir abajo"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Dividir a la izquierda"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Dividir a la derecha"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Pestaña"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Cambiar el título de la pestaña…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Nueva pestaña"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Cerrar pestaña"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Ventana"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Nueva ventana"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Cerrar ventana"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Configuración"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Abrir configuración"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -227,31 +231,31 @@ msgstr "Dejar en blanco para restaurar el título predeterminado."
 msgid "OK"
 msgstr "Aceptar"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Nueva ventana dividida"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Ver pestañas abiertas"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Menú principal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Paleta de comandos"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Inspector de la terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "Acerca de Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Salir"
 
@@ -259,24 +263,28 @@ msgstr "Salir"
 msgid "Execute a command…"
 msgstr "Ejecutar comando…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -339,16 +347,16 @@ msgstr "Todas las sesiones de terminal en esta ventana serán terminadas."
 msgid "The currently running process in this split will be terminated."
 msgstr "El proceso actualmente en ejecución en esta división será terminado."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Comando finalizado"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Comando exitoso"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Comando fallido"
@@ -361,19 +369,19 @@ msgstr "Cambiar el título de la terminal"
 msgid "Change Tab Title"
 msgstr "Cambiar el título de la pestaña"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "Configuración recargada"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Copiado al portapapeles"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "El portapapeles está limpio"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Desarrolladores de Ghostty"
 
@@ -931,150 +939,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-02-18 10:57+0100\n"
 "Last-Translator: José Miguel Sarasola <alosarjos@gmail.com>\n"
 "Language-Team: \n"
@@ -49,12 +49,12 @@ msgstr "Recargar configuración para volver a mostrar este aviso"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Cancelar"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Cerrar"
@@ -63,7 +63,7 @@ msgstr "Cerrar"
 msgid "Configuration Errors"
 msgstr "Errores en la configuración"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -71,12 +71,12 @@ msgstr ""
 "Se detectaron uno o más errores de configuración. Por favor, revisa los "
 "errores más abajo y recarga la configuración o ignora estos errores."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Ignorar"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Recargar configuración"
 
@@ -96,23 +96,23 @@ msgstr "Ghostty: Inspector de terminal"
 msgid "Find…"
 msgstr "Buscar…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Resultado previo"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Resultado siguiente"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "Oh, no."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "No se pudo obtener un contexto de OpenGL para el renderizado."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -122,103 +122,107 @@ msgstr ""
 "scroll del contenido, pero no se enviarán eventos de entrada a la aplicación "
 "en ejecución."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Solo lectura"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Pegar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Notificar al finalizar el siguiente comando"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Limpiar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Reiniciar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Dividir"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Cambiar título…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Dividir arriba"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Dividir abajo"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Dividir a la izquierda"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Dividir a la derecha"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Pestaña"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Cambiar título de la pestaña…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Nueva pestaña"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Cerrar pestaña"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Ventana"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Nueva ventana"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Cerrar ventana"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Configuración"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Abrir configuración"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -228,31 +232,31 @@ msgstr "Dejar en blanco para restaurar el título predeterminado."
 msgid "OK"
 msgstr "Aceptar"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Nueva división"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Ver pestañas abiertas"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Menú principal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Paleta de comandos"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Inspector de terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "Acerca de Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Salir"
 
@@ -260,24 +264,28 @@ msgstr "Salir"
 msgid "Execute a command…"
 msgstr "Ejecutar un comando…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -340,16 +348,16 @@ msgstr "Todas las sesiones del terminal en esta ventana serán finalizadas."
 msgid "The currently running process in this split will be terminated."
 msgstr "El proceso ejecutándose en esta división será finalizado."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Comando finalizado"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Comando completado"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Comando fallido"
@@ -362,19 +370,19 @@ msgstr "Cambiar el título del terminal"
 msgid "Change Tab Title"
 msgstr "Cambiar el título de la pestaña"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "Configuración recargada"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Copiado al portapapeles"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Portapapeles vaciado"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Desarrolladores de Ghostty"
 
@@ -932,150 +940,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/eu.po
+++ b/po/eu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-05-01 12:56+0200\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: Language eu\n"
@@ -47,12 +47,12 @@ msgstr "Birkargatu konfigurazioa eta erakutsi hau berriz"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Utzi"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Itxi"
@@ -61,7 +61,7 @@ msgstr "Itxi"
 msgid "Configuration Errors"
 msgstr "Konfigurazio erroreak"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -69,12 +69,12 @@ msgstr ""
 "Konfigurazio erroreren bat aurkitu da. Begiratu erroreak azpian, eta "
 "birkargatu konfigurazioa edo baztertu erroreak."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Baztertu"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Birkargatu konfigurazioa"
 
@@ -94,23 +94,23 @@ msgstr "Ghostty: terminal ikuskatzailea"
 msgid "Find…"
 msgstr "Bilatu…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Aurreko bilaketa"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Hurrengo bilaketa"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "Oh, ez!"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Ezin izan da OpenGL kontestua erabili."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -119,103 +119,107 @@ msgstr ""
 "Terminal hau irakurtzeko moduan dago. Ikusi, aukeratu eta kontestuan zehar "
 "gora eta behera ibili zaitezke, baina ez da sarrera ekintzarik bidaliko."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Irakurtzeko-bakarrik"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Kopiatu"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Itsatsi"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Jakinarazi hurrengo komandoa amaitzean"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Garbitu"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Berrezarri"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Zatitu"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Aldatu izenburua…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Zatitu gorantz"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Zatitu beherantz"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Zatitu ezkerrera"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Zatitu eskumara"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Fitxa"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Aldatu fitxaren izenburua…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Fitxa berria"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Itxi fitxa"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Leihoa"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Leiho berria"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Itxi leihoa"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Konfigurazioa"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Ireki konfigurazioa"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -225,31 +229,31 @@ msgstr "Utzi hutsik defektuzko izenburua berrezartzeko"
 msgid "OK"
 msgstr "OK"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Zatitu"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Ikusi irekitako fitxak"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Menu nagusia"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Komando paleta"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Terminal ikuskatzailea"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "Ghosttyri buruz"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Irten"
 
@@ -257,24 +261,28 @@ msgstr "Irten"
 msgid "Execute a command…"
 msgstr "Exekutatu komando bat…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -336,16 +344,16 @@ msgstr "Leiho honetako terminal saio guztiak itxi egingo dira."
 msgid "The currently running process in this split will be terminated."
 msgstr "Zatikatze honetan martxan dagoen prozesua itxi egingo da."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Komandoa amaitu da"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Komandoa ondo amaitu da"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Komandoak huts egin du"
@@ -358,19 +366,19 @@ msgstr "Aldatu terminalaren izenburua"
 msgid "Change Tab Title"
 msgstr "Aldatu fitxaren izenburua"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "Konfigurazioa berriz kargatu da"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Arbelera kopiatu da"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Arbela garbitu da"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Ghostty garatzaileak"
 
@@ -928,150 +936,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-02-18 15:03+0200\n"
 "Last-Translator: Pangoraw <naydex.mc+github@gmail.com>\n"
 "Language-Team: French <traduc@traduc.org>\n"
@@ -48,12 +48,12 @@ msgstr "Recharger la configuration pour afficher à nouveau ce message"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Annuler"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Fermer"
@@ -62,7 +62,7 @@ msgstr "Fermer"
 msgid "Configuration Errors"
 msgstr "Erreurs de configuration"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -71,12 +71,12 @@ msgstr ""
 "les erreurs ci-dessous, et recharger votre configuration ou bien ignorer ces "
 "erreurs."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Ignorer"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Recharger la configuration"
 
@@ -96,23 +96,23 @@ msgstr "Ghostty: Inspecteur"
 msgid "Find…"
 msgstr "Chercher…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Résultat précédent"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Résultat suivant"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "Oh, non."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Impossible d'obtenir un contexte OpenGL pour le rendu."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -122,103 +122,107 @@ msgstr ""
 "sélectionner, et naviguer dans son contenu, mais aucune entrée ne sera "
 "envoyée à l'application en cours."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Lecture seule"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Copier"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Coller"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Notifier à la complétion de la prochaine commande"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Tout effacer"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Réinitialiser"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Créer panneau"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Changer le titre…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Panneau en haut"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Panneau en bas"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Panneau à gauche"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Panneau à droite"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Onglet"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Changer le titre de l'onglet…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Nouvel onglet"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Fermer l'onglet"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Fenêtre"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Nouvelle fenêtre"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Fermer la fenêtre"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Config"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Ouvrir la configuration"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -228,31 +232,31 @@ msgstr "Laisser vide pour restaurer le titre par défaut."
 msgid "OK"
 msgstr "OK"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Nouveau panneau"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Voir les onglets ouverts"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Menu principal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Palette de commandes"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Inspecteur de terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "À propos de Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Quitter"
 
@@ -260,24 +264,28 @@ msgstr "Quitter"
 msgid "Execute a command…"
 msgstr "Exécuter une commande…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -340,16 +348,16 @@ msgstr "Toutes les sessions de cette fenêtre vont être arrêtées."
 msgid "The currently running process in this split will be terminated."
 msgstr "Le processus en cours dans ce panneau va être arrêté."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Commande terminée"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Commande réussie"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "La commande a échoué"
@@ -362,19 +370,19 @@ msgstr "Changer le nom du terminal"
 msgid "Change Tab Title"
 msgstr "Changer le titre de l'onglet"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "Configuration rechargée"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Copié dans le presse-papiers"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Presse-papiers vidé"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Les développeurs de Ghostty"
 
@@ -932,150 +940,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/ga.po
+++ b/po/ga.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-02-18 14:32+0000\n"
 "Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@yahoo.com>\n"
 "Language-Team: Irish <gaeilge-gnulinux@lists.sourceforge.net>\n"
@@ -48,12 +48,12 @@ msgstr "Athlódáil an chumraíocht chun an teachtaireacht seo a thaispeáint ar
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Cealaigh"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Dún"
@@ -62,7 +62,7 @@ msgstr "Dún"
 msgid "Configuration Errors"
 msgstr "Earráidí cumraíochta"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -70,12 +70,12 @@ msgstr ""
 "Fuarthas earráid chumraíochta amháin nó níos mó. Athbhreithnigh na hearráidí "
 "thíos, agus athlódáil do chumraíocht nó déan neamhaird de na hearráidí seo."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Déan neamhaird de"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Athlódáil cumraíocht"
 
@@ -94,23 +94,23 @@ msgstr "Ghostty: Cigire teirminéil"
 msgid "Find…"
 msgstr "Cuardaigh…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "An toradh roimhe seo"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "An chéad toradh eile"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "Ó, fadbh."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Ní féidir comhthéacs OpenGL a fháil le haghaidh rindreála."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -120,103 +120,107 @@ msgstr ""
 "roghnú agus scroláil tríd an ábhar, ach ní seolfar aon teagmhais ionchuir "
 "chuig an bhfeidhmchlár atá ag rith."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Inléite amháin"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Cóipeáil"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Greamaigh"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Seol fógra nuair a chríochnaíonn an chéad ordú eile"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Glan"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Athshocraigh"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Scoilt"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Athraigh teideal…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Scoilt suas"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Scoilt síos"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Scoilt ar chlé"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Scoilt ar dheis"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Táb"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Athraigh teideal an táb…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Táb nua"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Dún táb"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Fuinneog"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Fuinneog nua"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Dún fuinneog"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Cumraíocht"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Oscail cumraíocht"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -226,31 +230,31 @@ msgstr "Fág bán chun an teideal réamhshocraithe a athbhunú."
 msgid "OK"
 msgstr "Ceart go leor"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Scoilt nua"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Féach ar na táib oscailte"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Príomh-Roghchlár"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Pailéad ordaithe"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Cigire teirminéil"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "Maidir le Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Scoir"
 
@@ -258,24 +262,28 @@ msgstr "Scoir"
 msgid "Execute a command…"
 msgstr "Rith ordú…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -339,16 +347,16 @@ msgid "The currently running process in this split will be terminated."
 msgstr ""
 "Cuirfear deireadh leis an bpróiseas atá ar siúl faoi láthair sa scoilt seo."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Ordú críochnaithe"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "D’éirigh leis an ordú"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Theip ar an ordú"
@@ -361,19 +369,19 @@ msgstr "Athraigh teideal teirminéil"
 msgid "Change Tab Title"
 msgstr "Athraigh teideal an táb"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "Tá an chumraíocht athlódáilte"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Cóipeáilte chuig an ghearrthaisce"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Gearrthaisce glanta"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Forbróirí Ghostty"
 
@@ -931,150 +939,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-02-18 18:14+0300\n"
 "Last-Translator: Sl (Shahaf Levi), Sl's Repository Ltd "
 "<ghostty@slsrepo.com>\n"
@@ -51,12 +51,12 @@ msgstr "טען/י את ההגדרות מחדש כדי להציג את הבקשה
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "ביטול"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "סגירה"
@@ -65,7 +65,7 @@ msgstr "סגירה"
 msgid "Configuration Errors"
 msgstr "שגיאות בהגדרות"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -73,12 +73,12 @@ msgstr ""
 "נמצאו אחת או יותר שגיאות בהגדרות. אנא בדוק/י את השגיאות המופיעות מטה ולאחר "
 "מכן טען/י את ההגדרות מחדש או התעלם/י מהשגיאות."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "התעלמות"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "טעינה מחדש של ההגדרות"
 
@@ -96,23 +96,23 @@ msgstr "Ghostty: בודק המסוף"
 msgid "Find…"
 msgstr "חפש/י…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "ההתאמה הקודמת"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "ההתאמה הבאה"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "אוי, לא"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "לא ניתן לקבל הקשר OpenGL לצורך רינדור."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -121,103 +121,107 @@ msgstr ""
 "מסוף זה נמצא במצב קריאה בלבד. עדיין תוכל/י לצפות, לבחור ולגלול בתוכן, אך לא "
 "יישלחו אירועי קלט לאפליקציה הפעילה."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "לקריאה בלבד"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "העתקה"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "הדבקה"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "תזכורת בסיום הפקודה הבאה"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "ניקוי"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "איפוס"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "פיצול"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "שינוי כותרת…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "פיצול למעלה"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "פיצול למטה"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "פיצול שמאלה"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "פיצול ימינה"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "כרטיסייה"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "שנה/י את כותרת הכרטיסייה…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "כרטיסייה חדשה"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "סגור/י כרטיסייה"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "חלון"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "חלון חדש"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "סגור/י חלון"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "הגדרות"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "פתיחת ההגדרות"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -227,31 +231,31 @@ msgstr "השאר/י ריק כדי לשחזר את כותרת ברירת המחד
 msgid "OK"
 msgstr "אישור"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "פיצול חדש"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "הצג/י כרטיסיות פתוחות"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "תפריט ראשי"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "לוח פקודות"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "בודק המסוף"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "אודות Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "יציאה"
 
@@ -259,24 +263,28 @@ msgstr "יציאה"
 msgid "Execute a command…"
 msgstr "הרץ/י פקודה…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -336,16 +344,16 @@ msgstr "כל הפעלות המסוף בחלון זה יסתיימו."
 msgid "The currently running process in this split will be terminated."
 msgstr "התהליך שרץ כרגע בפיצול זה יסתיים."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "הפקודה הסתיימה"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "הפקודה הצליחה"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "הפקודה נכשלה"
@@ -358,19 +366,19 @@ msgstr "שינוי כותרת המסוף"
 msgid "Change Tab Title"
 msgstr "שינוי כותרת הכרטיסייה"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "ההגדרות הוטענו מחדש"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "הועתק ללוח ההעתקה"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "לוח ההעתקה רוקן"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "המפתחים של Ghostty"
 
@@ -928,150 +936,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/hr.po
+++ b/po/hr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-02-18 21:00+0200\n"
 "Last-Translator: Filip7 <filipm7@protonmail.com>\n"
 "Language-Team: Croatian <lokalizacija@linux.hr>\n"
@@ -50,12 +50,12 @@ msgstr "Ponovno učitaj postavke za prikaz ovog upita"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Otkaži"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Zatvori"
@@ -64,7 +64,7 @@ msgstr "Zatvori"
 msgid "Configuration Errors"
 msgstr "Greške u postavkama"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -72,12 +72,12 @@ msgstr ""
 "Pronađena je greška (ili više njih) u postavkama. Pregledaj niže navedene "
 "greške te ponovno učitaj postavke ili zanemari ove greške."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Zanemari"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Ponovno učitaj postavke"
 
@@ -95,23 +95,23 @@ msgstr "Ghostty: inspektor terminala"
 msgid "Find…"
 msgstr "Pretraži…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Prethodno podudaranje"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Sljedeće podudaranje"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "Oh, ne."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Neuspjelo dohvaćanje OpenGL konteksta za renderiranje."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -121,103 +121,107 @@ msgstr ""
 "odabirati i skrolati kroz sadržaj, no unos neće biti poslan pokrenutoj "
 "aplikaciji."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Samo za čitanje"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Kopiraj"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Zalijepi"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Obavijesti kada iduća naredba završi"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Očisti"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Resetiraj"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Podijeli"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Promijeni naslov…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Podijeli gore"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Podijeli dolje"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Podijeli lijevo"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Podijeli desno"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Kartica"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Promijeni naslov kartice…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Nova kartica"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Zatvori karticu"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Prozor"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Novi prozor"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Zatvori prozor"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Postavke"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Otvori postavke"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -227,31 +231,31 @@ msgstr "Ostavi prazno za povratak zadanog naslova."
 msgid "OK"
 msgstr "OK"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Nova podjela"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Pregledaj otvorene kartice"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Glavni izbornik"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Paleta naredbi"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Inspektor terminala"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "O Ghosttyju"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Izađi"
 
@@ -259,24 +263,28 @@ msgstr "Izađi"
 msgid "Execute a command…"
 msgstr "Izvrši naredbu…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -339,16 +347,16 @@ msgstr "Sve sesije terminala u ovom prozoru će biti prekinute."
 msgid "The currently running process in this split will be terminated."
 msgstr "Pokrenuti procesi u ovoj podjeli će biti prekinuti."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Naredba je završena"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Naredba je uspjela"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Naredba nije uspjela"
@@ -361,19 +369,19 @@ msgstr "Promijeni naslov terminala"
 msgid "Change Tab Title"
 msgstr "Promijeni naslov kartice"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "Ponovno učitane postavke"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Kopirano u međuspremnik"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Očišćen međuspremnik"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Razvijatelji Ghosttyja"
 
@@ -931,150 +939,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-02-26 21:00+0100\n"
 "Last-Translator: Balázs Szücs <bszucs1209@gmail.com>\n"
 "Language-Team: Hungarian <translation-team-hu@lists.sourceforge.net>\n"
@@ -48,12 +48,12 @@ msgstr "Konfiguráció frissítése a kérdés újbóli megjelenítéséhez"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Mégse"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Bezárás"
@@ -62,7 +62,7 @@ msgstr "Bezárás"
 msgid "Configuration Errors"
 msgstr "Konfigurációs hibák"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -71,12 +71,12 @@ msgstr ""
 "hibákat, és frissítse a konfigurációt, vagy hagyja figyelmen kívül ezeket a "
 "hibákat."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Figyelmen kívül hagyás"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Konfiguráció frissítése"
 
@@ -95,23 +95,23 @@ msgstr "Ghostty: Terminálvizsgáló"
 msgid "Find…"
 msgstr "Keresés…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Előző találat"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Következő találat"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "Jaj, ne."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Nem sikerült OpenGL-környezetet létrehozni a megjelenítéshez."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -121,103 +121,107 @@ msgstr ""
 "megtekintheti, kijelölheti és görgetheti, de nem küld bemeneti eseményeket a "
 "futó alkalmazásnak."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Csak olvasható"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Másolás"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Beillesztés"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Értesítés a következő parancs befejezésekor"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Törlés"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Visszaállítás"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Felosztás"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Cím módosítása…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Felosztás felfelé"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Felosztás lefelé"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Felosztás balra"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Felosztás jobbra"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Fül"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Fül címének módosítása…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Új fül"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Fül bezárása"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Ablak"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Új ablak"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Ablak bezárása"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Konfiguráció"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Konfiguráció megnyitása"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -227,31 +231,31 @@ msgstr "Hagyja üresen az alapértelmezett cím visszaállításához."
 msgid "OK"
 msgstr "Rendben"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Új felosztás"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Megnyitott fülek megtekintése"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Főmenü"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Parancspaletta"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Terminálvizsgáló"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "A Ghostty névjegye"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Kilépés"
 
@@ -259,24 +263,28 @@ msgstr "Kilépés"
 msgid "Execute a command…"
 msgstr "Parancs végrehajtása…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -339,16 +347,16 @@ msgstr "Ebben az ablakban minden terminál munkamenet lezárul."
 msgid "The currently running process in this split will be terminated."
 msgstr "Ebben a felosztásban a jelenleg futó folyamat lezárul."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Parancs befejeződött"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Parancs sikeres"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Parancs sikertelen"
@@ -361,19 +369,19 @@ msgstr "Terminál címének módosítása"
 msgid "Change Tab Title"
 msgstr "Fül címének módosítása"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "Konfiguráció frissítve"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Vágólapra másolva"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Vágólap törölve"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Ghostty fejlesztők"
 
@@ -931,150 +939,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/id.po
+++ b/po/id.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-03-08 20:23+0700\n"
 "Last-Translator: Mikail Muzakki <mikailmmuzakki@gmail.com>\n"
 "Language-Team: Indonesian <translation-team-id@lists.sourceforge.net>\n"
@@ -49,12 +49,12 @@ msgstr "Muat ulang konfigurasi untuk menampilkan pesan ini lagi"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Batal"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Tutup"
@@ -63,7 +63,7 @@ msgstr "Tutup"
 msgid "Configuration Errors"
 msgstr "Kesalahan konfigurasi"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -71,12 +71,12 @@ msgstr ""
 "Ditemukan satu atau lebih kesalahan konfigurasi. Silakan tinjau kesalahan di "
 "bawah ini, dan muat ulang konfigurasi anda atau abaikan kesalahan ini."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Abaikan"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Muat ulang konfigurasi"
 
@@ -95,23 +95,23 @@ msgstr "Ghostty: Inspektur terminal"
 msgid "Find…"
 msgstr "Cari…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Hasil sebelumnya"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Hasil berikutnya"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "Oh, tidak."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Tidak dapat memperoleh konteks OpenGL untuk penampilan grafis."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -121,103 +121,107 @@ msgstr ""
 "memilih, dan menggulir konten, tetapi peristiwa input tidak akan dikirim ke "
 "aplikasi berjalan."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Hanya baca"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Salin"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Tempel"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Beri tahu saat perintah berikutnya selesai"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Bersihkan"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Atur ulang"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Belah"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Ubah judul…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Belah atas"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Belah bawah"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Belah kiri"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Belah kanan"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Tab"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Ubah judul tab…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Tab baru"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Tutup tab"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Jendela"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Jendela baru"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Tutup jendela"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Konfigurasi"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Buka konfigurasi"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -227,31 +231,31 @@ msgstr "Biarkan kosong untuk mengembalikan judul bawaan."
 msgid "OK"
 msgstr "OK"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Belahan baru"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Lihat tab terbuka"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Menu utama"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Palet perintah"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Inspektur terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "Tentang Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Keluar"
 
@@ -259,24 +263,28 @@ msgstr "Keluar"
 msgid "Execute a command…"
 msgstr "Eksekusi perintah…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -339,16 +347,16 @@ msgstr "Semua sesi terminal di jendela ini akan diakhiri."
 msgid "The currently running process in this split will be terminated."
 msgstr "Proses yang sedang berjalan dalam belahan ini akan diakhiri."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Perintah selesai"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Perintah berhasil"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Perintah gagal"
@@ -361,19 +369,19 @@ msgstr "Ubah judul terminal"
 msgid "Change Tab Title"
 msgstr "Ubah judul tab"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "Memuat ulang konfigurasi"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Disalin ke papan klip"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Papan klip dibersihkan"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Pengembang Ghostty"
 
@@ -931,150 +939,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2025-09-06 19:40+0200\n"
 "Last-Translator: Giacomo Bettini <giaco.bettini@gmail.com>\n"
 "Language-Team: Italian <tp@lists.linux.it>\n"
@@ -50,12 +50,12 @@ msgstr ""
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Annulla"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Chiudi"
@@ -64,7 +64,7 @@ msgstr "Chiudi"
 msgid "Configuration Errors"
 msgstr "Errori di configurazione"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -72,12 +72,12 @@ msgstr ""
 "Sono stati trovati uno o più errori di configurazione. Controlla gli errori "
 "seguenti, poi ricarica la tua configurazione o ignora quegli errori."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Ignora"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Ricarica configurazione"
 
@@ -96,23 +96,23 @@ msgstr "Ghostty: Ispettore del terminale"
 msgid "Find…"
 msgstr "Cerca…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Corrispondenza precedente"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Corrispondenza successiva"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "Oh no!"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Impossibile ottenere un contesto OpenGL per il rendering."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -122,103 +122,107 @@ msgstr ""
 "selezionare e scorrere il contenuto, ma non verrà inviato alcun evento di "
 "input all'applicazione in esecuzione."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Sola lettura"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Copia"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Incolla"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Notifica al termine del prossimo comando"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Pulisci"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Reimposta"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Divisione"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Cambia titolo…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Dividi in alto"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Dividi in basso"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Dividi a sinistra"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Dividi a destra"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Scheda"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Cambia titolo scheda…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Nuova scheda"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Chiudi scheda"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Finestra"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Nuova finestra"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Chiudi finestra"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Configurazione"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Apri configurazione"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -228,31 +232,31 @@ msgstr "Lasciare vuoto per ripristinare il titolo predefinito."
 msgid "OK"
 msgstr "OK"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Nuova divisione"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Vedi schede aperte"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Menù principale"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Riquadro comandi"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Ispettore del terminale"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "Informazioni su Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Chiudi"
 
@@ -260,24 +264,28 @@ msgstr "Chiudi"
 msgid "Execute a command…"
 msgstr "Esegui un comando…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -341,16 +349,16 @@ msgid "The currently running process in this split will be terminated."
 msgstr ""
 "Il processo attualmente in esecuzione in questa divisione sarà terminato."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Comando terminato"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Comando riuscito"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Comando fallito"
@@ -363,19 +371,19 @@ msgstr "Cambia il titolo del terminale"
 msgid "Change Tab Title"
 msgstr "Cambia il titolo della scheda"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "Configurazione ricaricata"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Copiato negli Appunti"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Appunti svuotati"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Sviluppatori di Ghostty"
 
@@ -933,150 +941,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-02-11 12:02+0900\n"
 "Last-Translator: Takayuki Nagatomi <tnagatomi@okweird.net>\n"
 "Language-Team: Japanese\n"
@@ -49,12 +49,12 @@ msgstr "このプロンプトを再び表示するには設定を再読み込み
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "キャンセル"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "閉じる"
@@ -63,7 +63,7 @@ msgstr "閉じる"
 msgid "Configuration Errors"
 msgstr "設定ファイルにエラーがあります"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -71,12 +71,12 @@ msgstr ""
 "設定ファイルにエラーがあります。以下のエラーを確認し、設定ファイルの再読み込"
 "みをするか、無視してください。"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "無視"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "設定ファイルの再読み込み"
 
@@ -95,23 +95,23 @@ msgstr "Ghostty: 端末インスペクター"
 msgid "Find…"
 msgstr "検索…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "前の一致"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "次の一致"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "おっと。"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "レンダリング用のOpenGLコンテキストを取得できませんでした。"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -120,103 +120,107 @@ msgstr ""
 "このターミナルは読み取り専用モードです。コンテンツの表示、選択、スクロールは"
 "可能ですが、入力イベントは実行中のアプリケーションに送信されません。"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "読み取り専用"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "コピー"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "貼り付け"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "次のコマンド実行終了時に通知する"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "クリア"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "リセット"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "分割"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "タイトルを変更…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "上に分割"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "下に分割"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "左に分割"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "右に分割"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "タブ"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "タブのタイトルを変更…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "新しいタブ"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "タブを閉じる"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "ウィンドウ"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "新しいウィンドウ"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "ウィンドウを閉じる"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "設定"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "設定ファイルを開く"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -226,31 +230,31 @@ msgstr "空白にした場合、デフォルトのタイトルを使用します
 msgid "OK"
 msgstr "OK"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "新しい分割"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "開いているすべてのタブを表示"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "メインメニュー"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "コマンドパレット"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "端末インスペクター"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "Ghostty について"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "終了"
 
@@ -258,24 +262,28 @@ msgstr "終了"
 msgid "Execute a command…"
 msgstr "コマンドを実行…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -338,16 +346,16 @@ msgstr "ウィンドウ内のすべてのターミナルセッションが終了
 msgid "The currently running process in this split will be terminated."
 msgstr "分割ウィンドウ内のすべてのプロセスが終了します。"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "コマンド実行終了"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "コマンド実行成功"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "コマンド実行失敗"
@@ -360,19 +368,19 @@ msgstr "ターミナルのタイトルを変更する"
 msgid "Change Tab Title"
 msgstr "タブのタイトルを変更する"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "設定を再読み込みしました"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "クリップボードにコピーしました"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "クリップボードを空にしました"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Ghostty 開発者"
 
@@ -930,150 +938,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/kk.po
+++ b/po/kk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-06-20 17:07+0500\n"
 "Last-Translator: AnmiTaliDev <anmitalidev@nuros.org>\n"
 "Language-Team: Kazakh <kk_KZ@googlegroups.com>\n"
@@ -50,12 +50,12 @@ msgstr "Бұл сұрауды қайта көрсету үшін конфигу�
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Бас тарту"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Жабу"
@@ -64,7 +64,7 @@ msgstr "Жабу"
 msgid "Configuration Errors"
 msgstr "Конфигурация қателері"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -72,12 +72,12 @@ msgstr ""
 "Бір немесе бірнеше конфигурация қатесі табылды. Төмендегі қателерді қарап "
 "шығып, конфигурацияны қайта жүктеңіз немесе бұл қателерді елемеңіз."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Елемеу"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Конфигурацияны қайта жүктеу"
 
@@ -97,23 +97,23 @@ msgstr "Ghostty: Терминал инспекторы"
 msgid "Find…"
 msgstr "Табу…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Алдыңғы сәйкестік"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Келесі сәйкестік"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "О, жоқ."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Рендеринг үшін OpenGL контекстін алу мүмкін емес."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -123,103 +123,107 @@ msgstr ""
 "жылжыта аласыз, бірақ іске қосылған қолданбаға ешқандай енгізу оқиғалары "
 "жіберілмейді."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Тек оқу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Көшіріп алу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Кірістіру"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Келесі команда аяқталғанда хабарлау"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Тазарту"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Тастау"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Бөлу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Тақырыпты өзгерту…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Жоғарыға бөлу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Төменге бөлу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Сол жаққа бөлу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Оң жаққа бөлу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr "Бөлуді жабу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Бет"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Бет атауын өзгерту…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Жаңа бет"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Бетті жабу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Терезе"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Жаңа терезе"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Терезені жабу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Конфигурация"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Конфигурацияны ашу"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -229,31 +233,31 @@ msgstr "Бастапқы атауды қалпына келтіру үшін б�
 msgid "OK"
 msgstr "ОК"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Жаңа бөлу"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Ашық беттерді көру"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Бас мәзір"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Командалар палитрасы"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Терминал инспекторы"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "Ghostty туралы"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Шығу"
 
@@ -261,24 +265,28 @@ msgstr "Шығу"
 msgid "Execute a command…"
 msgstr "Команданы орындау…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -341,16 +349,16 @@ msgstr "Осы терезедегі барлық терминал сессиял
 msgid "The currently running process in this split will be terminated."
 msgstr "Осы бөлудегі ағымдағы орындалып жатқан процесс тоқтатылады."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Команда аяқталды"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Команда сәтті орындалды"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Команда сәтсіз аяқталды"
@@ -363,19 +371,19 @@ msgstr "Терминал атауын өзгерту"
 msgid "Change Tab Title"
 msgstr "Бет атауын өзгерту"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "Конфигурация қайта жүктелді"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Алмасу буферіне көшірілді"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Алмасу буфері тазартылды"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Ghostty әзірлеушілері"
 
@@ -933,150 +941,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-02-11 12:50+0900\n"
 "Last-Translator: GyuYong Jung <obliviscence@gmail.com>\n"
 "Language-Team: Korean <translation-team-ko@googlegroups.com>\n"
@@ -48,12 +48,12 @@ msgstr "이 창을 다시 보려면 설정을 다시 불러오세요"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "취소"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "닫기"
@@ -62,7 +62,7 @@ msgstr "닫기"
 msgid "Configuration Errors"
 msgstr "설정 오류"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -70,12 +70,12 @@ msgstr ""
 "설정에 하나 이상의 문제가 발견되었습니다. 아래 오류를 확인한 후 설정을 다시 "
 "불러오거나 무시하세요."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "무시"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "설정 값 다시 불러오기"
 
@@ -93,23 +93,23 @@ msgstr "Ghostty: 터미널 인스펙터"
 msgid "Find…"
 msgstr "찾기…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "이전 결과"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "다음 결과"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "이런!"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "렌더링을 위한 OpenGL 컨텍스트를 가져올 수 없습니다."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -118,103 +118,107 @@ msgstr ""
 "이 터미널은 읽기 전용 모드입니다. 콘텐츠를 보고 선택하고 스크롤할 수는 있지"
 "만 실행 중인 애플리케이션으로 입력 이벤트가 전송되지 않습니다."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "읽기 전용"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "복사"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "붙여넣기"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "다음 명령 완료 시 알림"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "지우기"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "초기화"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "나누기"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "제목 변경…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "위로 창 나누기"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "아래로 창 나누기"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "왼쪽으로 창 나누기"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "오른쪽으로 창 나누기"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "탭"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "탭 제목 변경…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "새 탭"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "탭 닫기"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "창"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "새 창"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "창 닫기"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "설정"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "설정 열기"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -224,31 +228,31 @@ msgstr "제목란을 비워 두면 기본값으로 복원됩니다."
 msgid "OK"
 msgstr "확인"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "새 분할"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "열린 탭 보기"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "메인 메뉴"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "명령 팔레트"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "터미널 인스펙터"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "Ghostty 정보"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "종료"
 
@@ -256,24 +260,28 @@ msgstr "종료"
 msgid "Execute a command…"
 msgstr "명령을 실행하세요…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -336,16 +344,16 @@ msgstr "이 창의 모든 터미널 세션이 종료됩니다."
 msgid "The currently running process in this split will be terminated."
 msgstr "이 분할에서 현재 실행 중인 프로세스가 종료됩니다."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "명령 완료"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "명령 성공"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "명령 실패"
@@ -358,19 +366,19 @@ msgstr "터미널 제목 변경"
 msgid "Change Tab Title"
 msgstr "탭 제목 변경"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "설정값을 다시 불러왔습니다"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "클립보드에 복사됨"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "클립보드 지워짐"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Ghostty 개발자들"
 
@@ -928,150 +936,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/lt.po
+++ b/po/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-02-20 12:13+0100\n"
 "Last-Translator: Tadas Lotuzas <tdslot@gmail.com>\n"
 "Language-Team: Language LT\n"
@@ -49,12 +49,12 @@ msgstr "Iš naujo įkelkite konfigūraciją, kad vėl būtų rodoma ši užuomin
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Atšaukti"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Uždaryti"
@@ -63,7 +63,7 @@ msgstr "Uždaryti"
 msgid "Configuration Errors"
 msgstr "Konfigūracijos klaidos"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -72,12 +72,12 @@ msgstr ""
 "klaidas ir arba iš naujo įkelkite konfigūraciją, arba ignoruokite šias "
 "klaidas."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Ignoruoti"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Iš naujo įkelti konfigūraciją"
 
@@ -95,23 +95,23 @@ msgstr "Ghostty: terminalo inspektorius"
 msgid "Find…"
 msgstr "Rasti…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Ankstesnis atitikmuo"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Kitas atitikmuo"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "Oi, ne."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Nepavyko gauti OpenGL konteksto vaizdavimui."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -121,103 +121,107 @@ msgstr ""
 "slinkti per turinį, tačiau jokie įvesties įvykiai nebus siunčiami "
 "veikiančiai programai."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Tik skaitymui"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Kopijuoti"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Įklijuoti"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Pranešti apie sekančios komandos užbaigimą"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Išvalyti"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Atstatyti"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Padalinti"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Keisti pavadinimą…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Padalinti aukštyn"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Padalinti žemyn"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Padalinti kairėn"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Padalinti dešinėn"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Kortelė"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Keisti kortelės pavadinimą…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Nauja kortelė"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Uždaryti kortelę"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Langas"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Naujas langas"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Uždaryti langą"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Konfigūracija"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Atidaryti konfigūraciją"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -227,31 +231,31 @@ msgstr "Palikite tuščią, kad atkurtumėte numatytąjį pavadinimą."
 msgid "OK"
 msgstr "Gerai"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Naujas padalijimas"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Peržiūrėti atidarytas korteles"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Pagrindinis meniu"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Komandų paletė"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Terminalo inspektorius"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "Apie Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Išeiti"
 
@@ -259,24 +263,28 @@ msgstr "Išeiti"
 msgid "Execute a command…"
 msgstr "Vykdyti komandą…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -339,16 +347,16 @@ msgstr "Visos terminalo sesijos šiame lange bus nutrauktos."
 msgid "The currently running process in this split will be terminated."
 msgstr "Šiuo metu vykdomas procesas šiame padalijime bus nutrauktas."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Komanda užbaigta"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Komanda sėkminga"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Komanda nepavyko"
@@ -361,19 +369,19 @@ msgstr "Keisti terminalo pavadinimą"
 msgid "Change Tab Title"
 msgstr "Keisti kortelės pavadinimą"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "Konfigūracija įkelta iš naujo"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Nukopijuota į iškarpinę"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Iškarpinė išvalyta"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Ghostty kūrėjai"
 
@@ -931,150 +939,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-02-09 03:24+0200\n"
 "Last-Translator: Ēriks Remess <eriks@remess.lv>\n"
 "Language-Team: Latvian\n"
@@ -48,12 +48,12 @@ msgstr "Pārlādējiet konfigurāciju, lai šo uzvedni rādītu atkal"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Atcelt"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Aizvērt"
@@ -62,7 +62,7 @@ msgstr "Aizvērt"
 msgid "Configuration Errors"
 msgstr "Konfigurācijas kļūdas"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -70,12 +70,12 @@ msgstr ""
 "Tika atrasta viena vai vairākas konfigurācijas kļūdas. Lūdzu, pārskatiet "
 "zemāk redzamās kļūdas un pārlādējiet konfigurāciju vai ignorējiet tās."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Ignorēt"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Pārlādēt konfigurāciju"
 
@@ -93,23 +93,23 @@ msgstr "Ghostty: Termināļa inspektors"
 msgid "Find…"
 msgstr "Meklēt…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Iepriekšējā atbilstība"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Nākamā atbilstība"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "Ak, nē."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Neizdevās iegūt OpenGL kontekstu attēlošanai."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -118,103 +118,107 @@ msgstr ""
 "Šis terminālis ir tikai lasīšanas režīmā. Jūs joprojām varat skatīt, atlasīt "
 "un ritināt saturu, taču ievade netiks sūtīta palaistajai lietotnei."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Tikai lasīšanai"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Kopēt"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Ielīmēt"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Paziņot, kad nākamā komanda būs izpildīta"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Notīrīt"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Atiestatīt"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Sadalīt"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Mainīt virsrakstu…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Sadalīt uz augšu"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Sadalīt uz leju"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Sadalīt pa kreisi"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Sadalīt pa labi"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Cilne"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Mainīt cilnes virsrakstu…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Jauna cilne"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Aizvērt cilni"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Logs"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Jauns logs"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Aizvērt logu"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Konfigurācija"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Atvērt konfigurāciju"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -224,31 +228,31 @@ msgstr "Atstāj tukšu, lai atjaunotu noklusēto virsrakstu."
 msgid "OK"
 msgstr "Labi"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Jauns sadalījums"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Skatīt atvērtās cilnes"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Galvenā izvēlne"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Komandu palete"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Termināļa inspektors"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "Par Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Iziet"
 
@@ -256,24 +260,28 @@ msgstr "Iziet"
 msgid "Execute a command…"
 msgstr "Izpildīt komandu…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -336,16 +344,16 @@ msgstr "Visas termināļa sesijas šajā logā tiks pārtrauktas."
 msgid "The currently running process in this split will be terminated."
 msgstr "Pašlaik palaistais process šajā sadalījumā tiks pārtraukts."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Komanda izpildīta"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Komanda izdevās"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Komanda neizdevās"
@@ -358,19 +366,19 @@ msgstr "Mainīt termināļa virsrakstu"
 msgid "Change Tab Title"
 msgstr "Mainīt cilnes virsrakstu"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "Konfigurācija pārlādēta"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Nokopēts starpliktuvē"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Starpliktuve notīrīta"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Ghostty izstrādātāji"
 
@@ -928,150 +936,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/mk.po
+++ b/po/mk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-02-12 17:00+0100\n"
 "Last-Translator: Andrej Daskalov <andrej.daskalov@gmail.com>\n"
 "Language-Team: Macedonian\n"
@@ -48,12 +48,12 @@ msgstr "Одново вчитај конфигурација за да се по
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Откажи"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Затвори"
@@ -62,7 +62,7 @@ msgstr "Затвори"
 msgid "Configuration Errors"
 msgstr "Грешки во конфигурацијата"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -71,12 +71,12 @@ msgstr ""
 "грешките подолу и повторно вчитајте ја конфигурацијата или игнорирајте ги "
 "овие грешки."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Игнорирај"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Одново вчитај конфигурација"
 
@@ -95,23 +95,23 @@ msgstr "Ghostty: Инспектор на терминал"
 msgid "Find…"
 msgstr "Пронајди…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Претходно совпаѓање"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Следно совпаѓање"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "Упс."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Не може да се добие OpenGL контекст за рендерирање."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -121,103 +121,107 @@ msgstr ""
 "се движите низ содржината, но влезните настани нема да бидат испратени до "
 "апликацијата."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Само читање"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Копирај"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Вметни"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Извести по завршување на следната команда"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Исчисти"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Ресетирај"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Подели"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Промени наслов…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Подели нагоре"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Подели надолу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Подели налево"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Подели надесно"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Јазиче"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Промени наслов на јазиче…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Ново јазиче"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Затвори јазиче"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Прозор"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Нов прозор"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Затвори прозор"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Конфигурација"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Отвори конфигурација"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -227,31 +231,31 @@ msgstr "Оставете празно за враќање на стандарс�
 msgid "OK"
 msgstr "Во ред"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Нова поделба"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Прегледај отворени јазичиња"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Главно мени"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Командна палета"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Инспектор на терминал"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "За Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Излез"
 
@@ -259,24 +263,28 @@ msgstr "Излез"
 msgid "Execute a command…"
 msgstr "Изврши команда…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -339,16 +347,16 @@ msgstr "Сите сесии во овој прозорец ќе бидат пр�
 msgid "The currently running process in this split will be terminated."
 msgstr "Процесот кој моментално се извршува во оваа поделба ќе биде прекинат."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Командата заврши"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Командата успеа"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Командата не успеа"
@@ -361,19 +369,19 @@ msgstr "Промени наслов на терминал"
 msgid "Change Tab Title"
 msgstr "Промени наслов на јазиче"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "Конфигурацијата е одново вчитана"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Копирано во привремена меморија"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Исчистена привремена меморија"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Развивачи на Ghostty"
 
@@ -931,150 +939,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/nb.po
+++ b/po/nb.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-02-12 15:50+0000\n"
 "Last-Translator: Hanna Rose <me@hanna.lol>\n"
 "Language-Team: Norwegian Bokmal <l10n-no@lister.huftis.org>\n"
@@ -51,12 +51,12 @@ msgstr "Last inn konfigurasjonen på nytt for å vise denne meldingen igjen"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Avbryt"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Lukk"
@@ -65,7 +65,7 @@ msgstr "Lukk"
 msgid "Configuration Errors"
 msgstr "Konfigurasjonsfeil"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -73,12 +73,12 @@ msgstr ""
 "Én eller flere konfigurasjonsfeil ble funnet. Vennligst gjennomgå feilene "
 "under, og enten last konfigurasjonen din på nytt eller ignorer disse feilene."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Ignorer"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Last konfigurasjon på nytt"
 
@@ -96,23 +96,23 @@ msgstr "Ghostty: Terminalinspektør"
 msgid "Find…"
 msgstr "Finn…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Forrige treff"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Neste treff"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "Å, nei."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Kan ikke hente en OpenGL-kontekst for rendering."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -122,103 +122,107 @@ msgstr ""
 "bla gjennom innholdet, men ingen inndatahendelser vil bli sendt til den "
 "kjørende applikasjonen."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Skrivebeskyttet"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Kopier"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Lim inn"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Varsle når neste kommandoen fullføres"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Fjern"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Nullstill"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Del vindu"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Endre tittel…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Del oppover"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Del nedover"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Del til venstre"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Del til høyre"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Fane"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Endre fanetittel…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Ny fane"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Lukk fane"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Vindu"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Nytt vindu"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Lukk vindu"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Konfigurasjon"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Åpne konfigurasjon"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -228,31 +232,31 @@ msgstr "Blank verdi gjenoppretter standardtittelen."
 msgid "OK"
 msgstr "OK"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Del opp vindu"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Se åpne faner"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Hovedmeny"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Kommandopalett"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Terminalinspektør"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "Om Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Avslutt"
 
@@ -260,24 +264,28 @@ msgstr "Avslutt"
 msgid "Execute a command…"
 msgstr "Kjør en kommando…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -340,16 +348,16 @@ msgstr "Alle terminaløkter i dette vinduet vil bli avsluttet."
 msgid "The currently running process in this split will be terminated."
 msgstr "Den kjørende prosessen for denne splitten vil bli avsluttet."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Kommandoen fullført"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Kommandoen lyktes"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Kommandoen mislyktes"
@@ -362,19 +370,19 @@ msgstr "Endre terminaltittel"
 msgid "Change Tab Title"
 msgstr "Endre fanetittel"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "Konfigurasjonen ble lastet på nytt"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Kopiert til utklippstavlen"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Utklippstavle tømt"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Ghostty-utviklere"
 
@@ -932,150 +940,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-02-18 20:59+0100\n"
 "Last-Translator: Nico Geesink <geesinknico@gmail.com>\n"
 "Language-Team: Dutch <vertaling@vrijschrift.org>\n"
@@ -49,12 +49,12 @@ msgstr "Herlaad de configuratie om deze prompt opnieuw weer te geven"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Annuleren"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Afsluiten"
@@ -63,7 +63,7 @@ msgstr "Afsluiten"
 msgid "Configuration Errors"
 msgstr "Configuratiefouten"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -71,12 +71,12 @@ msgstr ""
 "Er zijn één of meer configuratiefouten gevonden. Bekijk de onderstaande "
 "fouten en herlaad je configuratie of negeer deze fouten."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Negeer"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Herlaad configuratie"
 
@@ -96,23 +96,23 @@ msgstr "Ghostty: terminalinspecteur"
 msgid "Find…"
 msgstr "Zoeken…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Vorige resultaat"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Volgende resultaat"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "Oh, nee."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "OpenGL-context voor rendering aanmaken mislukt."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -122,103 +122,107 @@ msgstr ""
 "bekijken en selecteren, maar er wordt geen invoer naar de applicatie "
 "verzonden."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Alleen-lezen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Kopiëren"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Plakken"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Meld wanneer het volgende commando is afgerond"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Leegmaken"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Herstellen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Splitsen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Wijzig titel…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Splits naar boven"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Splits naar beneden"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Splits naar links"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Splits naar rechts"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Tabblad"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Wijzig tabbladtitel…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Nieuw tabblad"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Sluit tabblad"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Venster"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Nieuw venster"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Sluit venster"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Configuratie"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Open configuratie"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -228,31 +232,31 @@ msgstr "Laat leeg om de standaardtitel te herstellen."
 msgid "OK"
 msgstr "OK"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Nieuwe splitsing"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Open tabbladen bekijken"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Hoofdmenu"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Opdrachtpalet"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Terminalinspecteur"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "Over Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Afsluiten"
 
@@ -260,24 +264,28 @@ msgstr "Afsluiten"
 msgid "Execute a command…"
 msgstr "Voer een commando uit…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -340,16 +348,16 @@ msgstr "Alle terminalsessies binnen dit venster zullen worden beëindigd."
 msgid "The currently running process in this split will be terminated."
 msgstr "Alle processen in deze splitsing zullen worden beëindigd."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Commando afgerond"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Commando succesvol afgerond"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Commando onsuccesvol afgerond"
@@ -362,19 +370,19 @@ msgstr "Titel van de terminal wijzigen"
 msgid "Change Tab Title"
 msgstr "Wijzig tabbladtitel"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "De configuratie is herladen"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Gekopieerd naar klembord"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Klembord geleegd"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Ghostty-ontwikkelaars"
 
@@ -932,150 +940,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/pl.po
+++ b/po/pl.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-02-11 14:12+0100\n"
 "Last-Translator: trag1c <dev@jakubr.me>\n"
 "Language-Team: Polish <translation-team-pl@lists.sourceforge.net>\n"
@@ -51,12 +51,12 @@ msgstr "Przeładuj konfigurację, by ponownie wyświetlić ten komunikat"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Anuluj"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Zamknij"
@@ -65,7 +65,7 @@ msgstr "Zamknij"
 msgid "Configuration Errors"
 msgstr "Błędy konfiguracji"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -73,12 +73,12 @@ msgstr ""
 "Znaleziono jeden lub więcej błędów konfiguracji. Sprawdź błędy wylistowane "
 "poniżej i przeładuj konfigurację lub zignoruj je."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Zignoruj"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Przeładuj konfigurację"
 
@@ -96,23 +96,23 @@ msgstr "Inspektor terminala Ghostty"
 msgid "Find…"
 msgstr "Znajdź…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Poprzednie dopasowanie"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Następne dopasowanie"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "O nie!"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Nie można uzyskać kontekstu OpenGL do renderowania."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -122,103 +122,107 @@ msgstr ""
 "przeglądać, zaznaczać i przewijać zawartość, ale wprowadzane dane nie będą "
 "przesyłane do wykonywanej aplikacji."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Tylko do odczytu"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Kopiuj"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Wklej"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Powiadom o ukończeniu następnej komendy"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Wyczyść"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Zresetuj"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Podział"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Zmień tytuł…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Podziel w górę"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Podziel w dół"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Podziel w lewo"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Podziel w prawo"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Karta"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Zmień tytuł karty…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Nowa karta"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Zamknij kartę"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Okno"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Nowe okno"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Zamknij okno"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Konfiguracja"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Otwórz konfigurację"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -228,31 +232,31 @@ msgstr "Pozostaw puste by przywrócić domyślny tytuł."
 msgid "OK"
 msgstr "OK"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Nowy podział"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Zobacz otwarte karty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Menu główne"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Paleta komend"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Inspektor terminala"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "O Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Zamknij"
 
@@ -260,24 +264,28 @@ msgstr "Zamknij"
 msgid "Execute a command…"
 msgstr "Wykonaj komendę…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -340,16 +348,16 @@ msgstr "Wszystkie sesje terminala w obecnym oknie zostaną zakończone."
 msgid "The currently running process in this split will be terminated."
 msgstr "Wszyskie trwające procesy w obecnym podziale zostaną zakończone."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Komenda zakończona"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Komenda wykonana pomyślnie"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Komenda nie powiodła się"
@@ -362,19 +370,19 @@ msgstr "Zmień tytuł terminala"
 msgid "Change Tab Title"
 msgstr "Zmień tytuł karty"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "Przeładowano konfigurację"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Skopiowano do schowka"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Wyczyszczono schowek"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Twórcy Ghostty"
 
@@ -932,150 +940,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-02-18 10:50-0300\n"
 "Last-Translator: Guilherme Tiscoski <github@guilhermetiscoski.com>\n"
 "Language-Team: Brazilian Portuguese <ldpbr-"
@@ -52,12 +52,12 @@ msgstr "Recarregue a configuração para mostrar este aviso novamente"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Cancelar"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Fechar"
@@ -66,7 +66,7 @@ msgstr "Fechar"
 msgid "Configuration Errors"
 msgstr "Erros de configuração"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -74,12 +74,12 @@ msgstr ""
 "Um ou mais erros de configuração encontrados. Por favor revise os erros "
 "abaixo, e ou recarregue sua configuração, ou ignore esses erros."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Ignorar"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Recarregar configuração"
 
@@ -98,23 +98,23 @@ msgstr "Ghostty: Inspetor do terminal"
 msgid "Find…"
 msgstr "Buscar…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Resultado anterior"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Próximo resultado"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "Ah, não."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Não foi possível obter um contexto OpenGL para renderização."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -124,103 +124,107 @@ msgstr ""
 "selecionar e rolar o conteúdo, mas nenhum evento de entrada será enviado "
 "para a aplicação em execução."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Somente leitura"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Colar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Notificar ao finalizar o próximo comando"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Limpar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Reiniciar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Dividir"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Mudar título…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Dividir para cima"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Dividir para baixo"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Dividir à esquerda"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Dividir à direita"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Aba"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Mudar título da aba…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Nova aba"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Fechar aba"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Janela"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Nova janela"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Fechar janela"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Configurar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Abrir configuração"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -230,31 +234,31 @@ msgstr "Deixe em branco para restaurar o título padrão."
 msgid "OK"
 msgstr "OK"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Nova divisão"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Visualizar abas abertas"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Menu Principal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Paleta de comandos"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Inspetor de terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "Sobre o Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Sair"
 
@@ -262,24 +266,28 @@ msgstr "Sair"
 msgid "Execute a command…"
 msgstr "Executar um comando…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -342,16 +350,16 @@ msgstr "Todas as sessões de terminal nessa janela serão finalizadas."
 msgid "The currently running process in this split will be terminated."
 msgstr "O processo atual rodando nessa divisão será finalizado."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Comando finalizado"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Comando bem-sucedido"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Comando falhou"
@@ -364,19 +372,19 @@ msgstr "Mudar título do Terminal"
 msgid "Change Tab Title"
 msgstr "Mudar título da aba"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "Configuração recarregada"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Copiado para a área de transferência"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Área de transferência limpa"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Desenvolvedores do Ghostty"
 
@@ -934,150 +942,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2025-02-18 10:20+0100\n"
 "Last-Translator: Ivan Bastrakov <bastaynav@proton.me>\n"
 "Language-Team: Russian <gnu@d07.ru>\n"
@@ -50,12 +50,12 @@ msgstr "Перезагрузите конфигурацию, чтобы снов
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Отмена"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Закрыть"
@@ -64,7 +64,7 @@ msgstr "Закрыть"
 msgid "Configuration Errors"
 msgstr "Ошибки конфигурации"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -72,12 +72,12 @@ msgstr ""
 "В конфигурации обнаружены перечисленные ниже ошибки. При необходимости "
 "исправьте их, а затем перезагрузите конфигурацию."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Игнорировать"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Перезагрузить конфигурацию"
 
@@ -97,23 +97,23 @@ msgstr "Ghostty: инспектор терминала"
 msgid "Find…"
 msgstr "Найти…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Предыдущий результат"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Следующий результат"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "Ой!"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Не удалось получить доступ к контексту OpenGL для отрисовки."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -123,103 +123,107 @@ msgstr ""
 "прокручивать и выделять, но запущенное приложение не будет получать события "
 "ввода."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Режим только для чтения"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Копировать"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Вставить"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Сообщить о завершении следующей команды"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Очистить"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Сброс"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Сплит"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Переименовать…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Сплит вверх"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Сплит вниз"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Сплит влево"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Сплит вправо"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Вкладка"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Переименовать вкладку…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Новая вкладка"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Закрыть вкладку"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Окно"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Новое окно"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Закрыть окно"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Конфигурация"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Открыть конфигурационный файл"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -229,31 +233,31 @@ msgstr "Оставьте поле пустым, чтобы вернуть наз
 msgid "OK"
 msgstr "ОК"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Новый сплит"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Просмотреть открытые вкладки"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Главное меню"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Палитра команд"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Инспектор терминала"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "О Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Выход"
 
@@ -261,24 +265,28 @@ msgstr "Выход"
 msgid "Execute a command…"
 msgstr "Выполнить команду…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -341,16 +349,16 @@ msgstr "Все сессии терминала в этом окне будут �
 msgid "The currently running process in this split will be terminated."
 msgstr "Процесс, работающий в этой сплит-области, будет остановлен."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Команда завершилась"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Команда выполнена успешно"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Команда завершилась с ошибкой"
@@ -363,19 +371,19 @@ msgstr "Переименовать терминал"
 msgid "Change Tab Title"
 msgstr "Переименовать вкладку"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "Конфигурация перезагружена"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Скопировано в буфер обмена"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Буфер обмена очищен"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Разработчики Ghostty"
 
@@ -933,150 +941,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-02-09 22:18+0300\n"
 "Last-Translator: Emir SARI <emir_sari@icloud.com>\n"
 "Language-Team: Turkish\n"
@@ -48,12 +48,12 @@ msgstr "Bu istemi tekrar göstermek için yapılandırmayı yeniden yükle"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "İptal"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Kapat"
@@ -62,7 +62,7 @@ msgstr "Kapat"
 msgid "Configuration Errors"
 msgstr "Yapılandırma Hataları"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -71,12 +71,12 @@ msgstr ""
 "gözden geçirin ve ardından ya yapılandırmanızı yeniden yükleyin ya da bu "
 "hataları yok sayın."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Yok Say"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Yapılandırmayı Yeniden Yükle"
 
@@ -96,23 +96,23 @@ msgstr "Ghostty: Uçbirim Denetçisi"
 msgid "Find…"
 msgstr "Bul…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Önceki Eşleşme"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Sonraki Eşleşme"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "Hayır, olamaz."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Görüntü oluşturma işlemi için OpenGL bağlamı elde edilemiyor."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -122,103 +122,107 @@ msgstr ""
 "kaydırabilirsiniz; ancak çalışan uygulamaya hiçbir giriş olayı "
 "gönderilmeyecektir."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Salt Okunur"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Kopyala"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Yapıştır"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Sonraki Komut Bittiğinde Bildir"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Temizle"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Sıfırla"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Böl"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Başlığı Değiştir…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Yukarı Doğru Böl"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Aşağı Doğru Böl"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Sola Doğru Böl"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Sağa Doğru Böl"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Sekme"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Sekme Başlığını Değiştir…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Yeni Sekme"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Sekmeyi Kapat"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Pencere"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Yeni Pencere"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Pencereyi Kapat"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Yapılandırma"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Yapılandırmayı Aç"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -228,31 +232,31 @@ msgstr "Öntanımlı başlığı geri yüklemek için boş bırakın."
 msgid "OK"
 msgstr "Tamam"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Yeni Bölme"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Açık Sekmeleri Görüntüle"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Ana Menü"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Komut Paleti"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Uçbirim Denetçisi"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "Ghostty Hakkında"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Çık"
 
@@ -260,24 +264,28 @@ msgstr "Çık"
 msgid "Execute a command…"
 msgstr "Bir komut çalıştır…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -340,16 +348,16 @@ msgstr "Bu penceredeki tüm uçbirim oturumları sonlandırılacaktır."
 msgid "The currently running process in this split will be terminated."
 msgstr "Bu bölmedeki şu anda çalışan süreç sonlandırılacaktır."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Komut Bitti"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Komut Başarılı"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Komut Başarısız"
@@ -362,19 +370,19 @@ msgstr "Uçbirim Başlığını Değiştir"
 msgid "Change Tab Title"
 msgstr "Sekme Başlığını Değiştir"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "Yapılandırma yeniden yüklendi"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Panoya kopyalandı"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Pano temizlendi"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Ghostty Geliştiricileri"
 
@@ -932,150 +940,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-02-18 13:14+0100\n"
 "Last-Translator: Volodymyr Chernetskyi "
 "<19735328+chernetskyi@users.noreply.github.com>\n"
@@ -50,12 +50,12 @@ msgstr "Перезавантажте налаштування, щоб показ
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Скасувати"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Закрити"
@@ -64,7 +64,7 @@ msgstr "Закрити"
 msgid "Configuration Errors"
 msgstr "Помилки налаштування"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -72,12 +72,12 @@ msgstr ""
 "Виявлено одну або декілька помилок налаштування. Будь ласка, перегляньте "
 "помилки нижче і або перезавантажте налаштування, або проігноруйте ці помилки."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Ігнорувати"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Перезавантажити налаштування"
 
@@ -96,23 +96,23 @@ msgstr "Ghostty: Інспектор терміналу"
 msgid "Find…"
 msgstr "Знайти…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Попередній збіг"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Наступний збіг"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "Халепа."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Не вдалося отримати контекст OpenGL для відображення."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -121,103 +121,107 @@ msgstr ""
 "Цей термінал працює в режимі читання. Можна переглядати, виділяти і гортати "
 "вміст, але ввід не буде передано до запущеної програми."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Тільки для читання"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Скопіювати"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Вставити"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Сповістити про завершення наступної команди"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Очистити"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Скинути"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Панель"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Змінити заголовок…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Нова панель зверху"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Нова панель знизу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Нова панель ліворуч"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Нова панель праворуч"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Вкладка"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Змінити заголовок вкладки…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Нова вкладка"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Закрити вкладку"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Вікно"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Нове вікно"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Закрити вікно"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Налаштування"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Відкрити налаштування"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -227,31 +231,31 @@ msgstr "Залиште порожнім, щоб відновити заголо�
 msgid "OK"
 msgstr "ОК"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Нова панель"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Переглянути відкриті вкладки"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Головне меню"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Палітра команд"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Інспектор терміналу"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "Про Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Завершити"
 
@@ -259,24 +263,28 @@ msgstr "Завершити"
 msgid "Execute a command…"
 msgstr "Виконати команду…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -339,16 +347,16 @@ msgstr "Всі сесії терміналу в цьому вікні будут
 msgid "The currently running process in this split will be terminated."
 msgstr "Процес, що виконується в цій панелі, буде завершено."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Команда завершилась"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Команда завершилась успішно"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Команда завершилась з помилкою"
@@ -361,19 +369,19 @@ msgstr "Змінити заголовок терміналу"
 msgid "Change Tab Title"
 msgstr "Змінити заголовок вкладки"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "Налаштування перезавантажено"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Скопійовано до буферa обміну"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Буфер обміну очищено"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Розробники Ghostty"
 
@@ -931,150 +939,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-03-04 09:32+0700\n"
 "Last-Translator: Anh Thang <buianhthang89@gmail.com>\n"
 "Language-Team: Vietnamese <translation-team-vi@lists.sourceforge.net>\n"
@@ -48,12 +48,12 @@ msgstr "Tải lại cấu hình để hiển thị lại thông báo này"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "Hủy"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Đóng"
@@ -62,7 +62,7 @@ msgstr "Đóng"
 msgid "Configuration Errors"
 msgstr "Lỗi cấu hình"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
@@ -70,12 +70,12 @@ msgstr ""
 "Phát hiện một hoặc nhiều lỗi cấu hình. Vui lòng xem xét các lỗi bên dưới, "
 "sau đó tải lại cấu hình hoặc bỏ qua các lỗi này."
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Bỏ qua"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "Tải lại cấu hình"
 
@@ -95,23 +95,23 @@ msgstr "Ghostty: Bộ kiểm tra Terminal"
 msgid "Find…"
 msgstr "Tìm kiếm…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "Kết quả trước"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "Kết quả tiếp theo"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "Ôi hỏng rồi."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Không thể lấy ngữ cảnh OpenGL để kết xuất đồ họa."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -120,103 +120,107 @@ msgstr ""
 "Terminal này đang ở chế độ chỉ đọc. Bạn vẫn có thể xem, chọn và cuộn nội "
 "dung, nhưng các sự kiện nhập liệu sẽ không được gửi đến ứng dụng."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "Chỉ đọc"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "Sao chép"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "Dán"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "Thông báo khi lệnh tiếp theo kết thúc"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "Xóa"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "Đặt lại"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "Chia màn hình"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "Đổi tiêu đề…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "Chia lên trên"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "Chia xuống dưới"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "Chia sang trái"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "Chia sang phải"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "Tab"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "Đổi tiêu đề Tab…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Tab mới"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "Đóng Tab"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "Cửa sổ"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "Cửa sổ mới"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "Đóng cửa sổ"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "Cấu hình"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "Mở tệp cấu hình"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -226,31 +230,31 @@ msgstr "Để trống để khôi phục tiêu đề mặc định."
 msgid "OK"
 msgstr "Đồng ý"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "Chia màn hình mới"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "Xem các Tab đang mở"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "Trình đơn chính"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "Bảng lệnh"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "Bộ kiểm tra Terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "Về Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "Thoát"
 
@@ -258,24 +262,28 @@ msgstr "Thoát"
 msgid "Execute a command…"
 msgstr "Chạy một lệnh…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -338,16 +346,16 @@ msgstr "Tất cả các phiên làm việc terminal trong cửa sổ này sẽ b
 msgid "The currently running process in this split will be terminated."
 msgstr "Tiến trình đang chạy trong phần chia này sẽ bị chấm dứt."
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "Lệnh đã kết thúc"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Lệnh thành công"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Lệnh thất bại"
@@ -360,19 +368,19 @@ msgstr "Đổi tiêu đề Terminal"
 msgid "Change Tab Title"
 msgstr "Đổi tiêu đề Tab"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "Đã tải lại cấu hình"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "Đã sao chép vào bảng tạm"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "Đã xóa sạch bảng tạm"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Các nhà phát triển Ghostty"
 
@@ -930,150 +938,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-02-12 01:56+0800\n"
 "Last-Translator: Leah <hi@pluie.me>\n"
 "Language-Team: Chinese (simplified) <i18n-zh@googlegroups.com>\n"
@@ -49,12 +49,12 @@ msgstr "本提示将在重载配置后再次出现"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "取消"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "关闭"
@@ -63,19 +63,19 @@ msgstr "关闭"
 msgid "Configuration Errors"
 msgstr "配置错误"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
 msgstr ""
 "加载配置时发现了以下错误。请仔细阅读错误信息，并选择忽略或重新加载配置文件。"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "忽略"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "重新加载配置"
 
@@ -93,23 +93,23 @@ msgstr "Ghostty 终端调试器"
 msgid "Find…"
 msgstr "查找…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "上一个匹配项"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "下一个匹配项"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "糟糕。"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "未能获取可用于渲染的 OpenGL 环境。"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -118,103 +118,107 @@ msgstr ""
 "本终端当前处于只读模式。你仍可浏览、选择、并滚动其中内容，但任何用户输入都不"
 "会传给运行中的程序。"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "只读"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "复制"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "粘贴"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "下条命令完成时发出提醒"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "清除屏幕"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "重置终端"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "分屏"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "更改标题…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "向上分屏"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "向下分屏"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "向左分屏"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "向右分屏"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr "关闭分屏"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "标签页"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "更改标签页标题…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "新建标签页"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "关闭标签页"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "窗口"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "新建窗口"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "关闭窗口"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "配置"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "打开配置文件"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -224,31 +228,31 @@ msgstr "留空以重置至默认标题。"
 msgid "OK"
 msgstr "确认"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "新建分屏"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "浏览标签页"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "主菜单"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "命令面板"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "终端调试器"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "关于 Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "退出"
 
@@ -256,24 +260,28 @@ msgstr "退出"
 msgid "Execute a command…"
 msgstr "选择要执行的命令…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -330,16 +338,16 @@ msgstr "窗口内所有运行中的进程将被终止。"
 msgid "The currently running process in this split will be terminated."
 msgstr "分屏内正在运行中的进程将被终止。"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "命令已完成"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "命令执行成功"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "命令执行失败"
@@ -352,19 +360,19 @@ msgstr "更改终端标题"
 msgid "Change Tab Title"
 msgstr "更改标签页标题"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "已重新加载配置"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "已复制至剪贴板"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "已清空剪贴板"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Ghostty 开发团队"
 
@@ -922,150 +930,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-05 20:27+0800\n"
+"POT-Creation-Date: 2026-08-09 12:08-0500\n"
 "PO-Revision-Date: 2026-02-18 13:58+0800\n"
 "Last-Translator: Yi-Jyun Pan <me@pan93.com>\n"
 "Language-Team: Chinese (traditional)\n"
@@ -48,12 +48,12 @@ msgstr "重新載入設定以再次顯示此提示"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2032
+#: src/apprt/gtk/class/application.zig:2262
 msgid "Cancel"
 msgstr "取消"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:85
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "關閉"
@@ -62,18 +62,18 @@ msgstr "關閉"
 msgid "Configuration Errors"
 msgstr "設定錯誤"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:7
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
 msgstr "發現有設定錯誤。請檢視以下錯誤，並重新載入設定或忽略這些錯誤。"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "忽略"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:434 src/apprt/gtk/ui/1.5/window.blp:313
 msgid "Reload Configuration"
 msgstr "重新載入設定"
 
@@ -91,23 +91,23 @@ msgstr "Ghostty：終端機檢查工具"
 msgid "Find…"
 msgstr "尋找…"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:64
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
 msgid "Previous Match"
 msgstr "上一筆符合"
 
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:74
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
 msgid "Next Match"
 msgstr "下一筆符合"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:6
+#: src/apprt/gtk/ui/1.2/surface.blp:7
 msgid "Oh, no."
 msgstr "噢不。"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:7
+#: src/apprt/gtk/ui/1.2/surface.blp:8
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "無法取得用於算繪的 OpenGL 上下文。"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:99
+#: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -116,103 +116,107 @@ msgstr ""
 "本終端機目前處於唯讀模式。您仍可查看、選取及捲動內容，但不會傳送任何輸入事件"
 "至執行中的應用程式。"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:109
+#: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
 msgstr "唯讀"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
 msgid "Copy"
 msgstr "複製"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
 msgid "Paste"
 msgstr "貼上"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:272
+#: src/apprt/gtk/ui/1.2/surface.blp:326
 msgid "Notify on Next Command Finish"
 msgstr "下個命令完成時通知"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:276
 msgid "Clear"
 msgstr "清除"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:281
 msgid "Reset"
 msgstr "重設"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Split"
 msgstr "分割"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:248
 msgid "Change Title…"
 msgstr "變更標題…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
-#: src/apprt/gtk/ui/1.5/window.blp:250 src/input/command.zig:481
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:253 src/input/command.zig:481
 msgid "Split Up"
 msgstr "向上分割"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
-#: src/apprt/gtk/ui/1.5/window.blp:255 src/input/command.zig:486
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:486
 msgid "Split Down"
 msgstr "向下分割"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
-#: src/apprt/gtk/ui/1.5/window.blp:260 src/input/command.zig:471
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:471
 msgid "Split Left"
 msgstr "向左分割"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
-#: src/apprt/gtk/ui/1.5/window.blp:265 src/input/command.zig:476
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:476
 msgid "Split Right"
 msgstr "向右分割"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:323
+#: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:329
+#: src/apprt/gtk/ui/1.2/surface.blp:383
 msgid "Tab"
 msgstr "分頁"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
-#: src/apprt/gtk/ui/1.5/window.blp:320 src/input/command.zig:464
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:227
+#: src/apprt/gtk/ui/1.5/window.blp:334 src/input/command.zig:464
 msgid "Change Tab Title…"
 msgstr "變更分頁標題…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
-#: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:232
 #: src/input/command.zig:427
 msgid "New Tab"
 msgstr "開新分頁"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
-#: src/input/command.zig:600
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:607
 msgid "Close Tab"
 msgstr "關閉分頁"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:349
+#: src/apprt/gtk/ui/1.2/surface.blp:403
 msgid "Window"
 msgstr "視窗"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
 #: src/input/command.zig:421
 msgid "New Window"
 msgstr "開新視窗"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
-#: src/input/command.zig:617
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:624
 msgid "Close Window"
 msgstr "關閉視窗"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:365
+#: src/apprt/gtk/ui/1.2/surface.blp:419 src/apprt/gtk/ui/1.5/window.blp:298
 msgid "Config"
 msgstr "設定"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
-msgid "Open Configuration"
-msgstr "開啟設定"
+#: src/apprt/gtk/ui/1.2/surface.blp:422 src/apprt/gtk/ui/1.5/window.blp:301
+msgid "Open Configuration in OS Editor"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:428 src/apprt/gtk/ui/1.5/window.blp:307
+msgid "Open Configuration in New Window"
+msgstr ""
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -222,31 +226,31 @@ msgstr "留空即可還原為預設標題。"
 msgid "OK"
 msgstr "確定"
 
-#: src/apprt/gtk/ui/1.5/window.blp:58 src/apprt/gtk/ui/1.5/window.blp:108
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
 msgid "New Split"
 msgstr "新增窗格"
 
-#: src/apprt/gtk/ui/1.5/window.blp:68 src/apprt/gtk/ui/1.5/window.blp:126
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
 msgid "View Open Tabs"
 msgstr "檢視已開啟的分頁"
 
-#: src/apprt/gtk/ui/1.5/window.blp:78 src/apprt/gtk/ui/1.5/window.blp:140
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
 msgid "Main Menu"
 msgstr "主選單"
 
-#: src/apprt/gtk/ui/1.5/window.blp:285
+#: src/apprt/gtk/ui/1.5/window.blp:288
 msgid "Command Palette"
 msgstr "命令面板"
 
-#: src/apprt/gtk/ui/1.5/window.blp:290
+#: src/apprt/gtk/ui/1.5/window.blp:293
 msgid "Terminal Inspector"
 msgstr "終端機檢查工具"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1908
+#: src/apprt/gtk/ui/1.5/window.blp:321 src/apprt/gtk/class/window.zig:1921
 msgid "About Ghostty"
 msgstr "關於 Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:312 src/input/command.zig:689
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/input/command.zig:696
 msgid "Quit"
 msgstr "結束"
 
@@ -254,24 +258,28 @@ msgstr "結束"
 msgid "Execute a command…"
 msgstr "執行命令…"
 
-#: src/apprt/gtk/class/application.zig:1714
+#: src/apprt/gtk/class/application.zig:1766
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1716
+#: src/apprt/gtk/class/application.zig:1768
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1727
+#: src/apprt/gtk/class/application.zig:1779
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2028
+#: src/apprt/gtk/class/application.zig:2258
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2031
+#: src/apprt/gtk/class/application.zig:2261
 msgid "Export"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2782
+msgid "Editing configuration file"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -328,16 +336,16 @@ msgstr "此視窗中的所有終端機工作階段都將被終止。"
 msgid "The currently running process in this split will be terminated."
 msgstr "此窗格中目前執行的處理程序將被終止。"
 
-#: src/apprt/gtk/class/surface.zig:1171
+#: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"
 msgstr "命令執行完成"
 
-#: src/apprt/gtk/class/surface.zig:1172
+#: src/apprt/gtk/class/surface.zig:1182
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "命令執行成功"
 
-#: src/apprt/gtk/class/surface.zig:1173
+#: src/apprt/gtk/class/surface.zig:1183
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "命令執行失敗"
@@ -350,19 +358,19 @@ msgstr "變更終端機標題"
 msgid "Change Tab Title"
 msgstr "變更分頁標題"
 
-#: src/apprt/gtk/class/window.zig:1122
+#: src/apprt/gtk/class/window.zig:1135
 msgid "Reloaded the configuration"
 msgstr "已重新載入設定"
 
-#: src/apprt/gtk/class/window.zig:1747
+#: src/apprt/gtk/class/window.zig:1760
 msgid "Copied to clipboard"
 msgstr "已複製到剪貼簿"
 
-#: src/apprt/gtk/class/window.zig:1749
+#: src/apprt/gtk/class/window.zig:1762
 msgid "Cleared clipboard"
 msgstr "已清除剪貼簿"
 
-#: src/apprt/gtk/class/window.zig:1889
+#: src/apprt/gtk/class/window.zig:1902
 msgid "Ghostty Developers"
 msgstr "Ghostty 開發者"
 
@@ -920,150 +928,159 @@ msgstr ""
 msgid "Show the on-screen keyboard if present."
 msgstr ""
 
-#: src/input/command.zig:581
-msgid "Open Config"
+#: src/input/command.zig:582
+msgid "Open Config Using OS editor"
 msgstr ""
 
-#: src/input/command.zig:582
-msgid "Open the config file."
+#: src/input/command.zig:583
+msgid "Open the config file with the OS's default editor."
 msgstr ""
 
 #: src/input/command.zig:587
-msgid "Reload Config"
+msgid "Open Config in New Terminal Window"
 msgstr ""
 
 #: src/input/command.zig:588
-msgid "Reload the config file."
-msgstr ""
-
-#: src/input/command.zig:593
-msgid "Close Terminal"
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
 msgstr ""
 
 #: src/input/command.zig:594
-msgid "Close the current terminal."
+msgid "Reload Config"
+msgstr ""
+
+#: src/input/command.zig:595
+msgid "Reload the config file."
+msgstr ""
+
+#: src/input/command.zig:600
+msgid "Close Terminal"
 msgstr ""
 
 #: src/input/command.zig:601
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:608
 msgid "Close the current tab."
 msgstr ""
 
-#: src/input/command.zig:605
+#: src/input/command.zig:612
 msgid "Close Other Tabs"
 msgstr ""
 
-#: src/input/command.zig:606
+#: src/input/command.zig:613
 msgid "Close all tabs in this window except the current one."
 msgstr ""
 
-#: src/input/command.zig:610
+#: src/input/command.zig:617
 msgid "Close Tabs to the Right"
 msgstr ""
 
-#: src/input/command.zig:611
+#: src/input/command.zig:618
 msgid "Close all tabs to the right of the current one."
 msgstr ""
 
-#: src/input/command.zig:618
+#: src/input/command.zig:625
 msgid "Close the current window."
 msgstr ""
 
-#: src/input/command.zig:623
+#: src/input/command.zig:630
 msgid "Close All Windows"
 msgstr ""
 
-#: src/input/command.zig:624
+#: src/input/command.zig:631
 msgid "Close all windows."
 msgstr ""
 
-#: src/input/command.zig:629
+#: src/input/command.zig:636
 msgid "Toggle Maximize"
 msgstr ""
 
-#: src/input/command.zig:630
+#: src/input/command.zig:637
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 
-#: src/input/command.zig:635
+#: src/input/command.zig:642
 msgid "Toggle Fullscreen"
 msgstr ""
 
-#: src/input/command.zig:636
+#: src/input/command.zig:643
 msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
-#: src/input/command.zig:641
+#: src/input/command.zig:648
 msgid "Toggle Window Decorations"
 msgstr ""
 
-#: src/input/command.zig:642
+#: src/input/command.zig:649
 msgid "Toggle the window decorations."
 msgstr ""
 
-#: src/input/command.zig:647
+#: src/input/command.zig:654
 msgid "Toggle Float on Top"
 msgstr ""
 
-#: src/input/command.zig:648
+#: src/input/command.zig:655
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 
-#: src/input/command.zig:653
+#: src/input/command.zig:660
 msgid "Toggle Secure Input"
 msgstr ""
 
-#: src/input/command.zig:654
+#: src/input/command.zig:661
 msgid "Toggle secure input mode."
 msgstr ""
 
-#: src/input/command.zig:659
+#: src/input/command.zig:666
 msgid "Toggle Mouse Reporting"
 msgstr ""
 
-#: src/input/command.zig:660
+#: src/input/command.zig:667
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
-#: src/input/command.zig:665
+#: src/input/command.zig:672
 msgid "Toggle Background Opacity"
 msgstr ""
 
-#: src/input/command.zig:666
+#: src/input/command.zig:673
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 
-#: src/input/command.zig:671
+#: src/input/command.zig:678
 msgid "Check for Updates"
 msgstr ""
 
-#: src/input/command.zig:672
+#: src/input/command.zig:679
 msgid "Check for updates to the application."
 msgstr ""
 
-#: src/input/command.zig:677
+#: src/input/command.zig:684
 msgid "Undo"
 msgstr ""
 
-#: src/input/command.zig:678
+#: src/input/command.zig:685
 msgid "Undo the last action."
 msgstr ""
 
-#: src/input/command.zig:683
+#: src/input/command.zig:690
 msgid "Redo"
 msgstr ""
 
-#: src/input/command.zig:684
+#: src/input/command.zig:691
 msgid "Redo the last undone action."
 msgstr ""
 
-#: src/input/command.zig:690
+#: src/input/command.zig:697
 msgid "Quit the application."
 msgstr ""
 
-#: src/input/command.zig:695
+#: src/input/command.zig:702
 msgid "Ghostty"
 msgstr ""
 
-#: src/input/command.zig:696
+#: src/input/command.zig:703
 msgid "Put a little Ghostty in your terminal."
 msgstr ""
+

--- a/src/App.zig
+++ b/src/App.zig
@@ -272,7 +272,15 @@ fn drainMailbox(self: *App, rt_app: *apprt.App) !void {
             }
         }
         switch (message) {
-            .open_config => try self.performAction(rt_app, .open_config),
+            .open_config => |v| try self.performAction(
+                rt_app,
+                .{
+                    .open_config = switch (v) {
+                        .os_open => .os_open,
+                        .new_window => .new_window,
+                    },
+                },
+            ),
             .new_window => |msg| try self.newWindow(rt_app, msg),
             .close => |surface| self.closeSurface(surface),
             .surface_message => |msg| try self.surfaceMessage(msg.surface, msg.message),
@@ -451,7 +459,14 @@ pub fn performAction(
         .ignore => {},
         .quit => _ = try rt_app.performAction(.app, .quit, {}),
         .new_window => _ = try self.newWindow(rt_app, .{ .parent = null }),
-        .open_config => _ = try rt_app.performAction(.app, .open_config, {}),
+        .open_config => |v| _ = try rt_app.performAction(
+            .app,
+            .open_config,
+            switch (v) {
+                .os_open => .os_open,
+                .new_window => .new_window,
+            },
+        ),
         .reload_config => _ = try rt_app.performAction(.app, .reload_config, .{}),
         .close_all_windows => _ = try rt_app.performAction(.app, .close_all_windows, {}),
         .toggle_quick_terminal => _ = try rt_app.performAction(.app, .toggle_quick_terminal, {}),
@@ -553,7 +568,7 @@ fn hasRtSurface(self: *const App, surface: *apprt.Surface) bool {
 /// The message types that can be sent to the app thread.
 pub const Message = union(enum) {
     // Open the configuration file
-    open_config: void,
+    open_config: OpenConfig,
 
     /// Create a new terminal window.
     new_window: NewWindow,
@@ -580,6 +595,13 @@ pub const Message = union(enum) {
     const NewWindow = struct {
         /// The parent surface
         parent: ?*Surface = null,
+    };
+
+    pub const OpenConfig = enum {
+        /// Open the config in the OS default editor.
+        os_open,
+        /// Open the config in a new window using $EDITOR or $VISUAL
+        new_window,
     };
 };
 

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -231,7 +231,7 @@ pub const Action = union(Key) {
     /// Open the Ghostty configuration. This is platform-specific about
     /// what it means; it can mean opening a dedicated UI or just opening
     /// a file in a text editor.
-    open_config,
+    open_config: OpenConfig,
 
     /// Called when there are no more surfaces and the app should quit
     /// after the configured delay.
@@ -1045,6 +1045,19 @@ pub const SearchSelected = struct {
         return .{
             .selected = if (self.selected) |s| @intCast(s) else -1,
         };
+    }
+};
+
+/// sync with ghostty_action_close_tab_mode_e in ghostty.h
+pub const OpenConfig = enum(c_int) {
+    /// Open the config in the OS default editor.
+    os_open,
+
+    /// Open the config in a new window using $EDITOR or $VISUAL
+    new_window,
+
+    test "ghostty.h OpenConfig" {
+        try lib.checkGhosttyHEnum(OpenConfig, "GHOSTTY_ACTION_OPEN_CONFIG_");
     }
 };
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1507,7 +1507,7 @@ pub const CAPI = struct {
 
     /// Open the configuration.
     export fn ghostty_app_open_config(v: *App) void {
-        _ = v.performAction(.app, .open_config, {}) catch |err| {
+        _ = v.performAction(.app, .open_config, .new_window) catch |err| {
             log.err("error reloading config err={}", .{err});
             return;
         };

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -738,7 +738,7 @@ pub const Application = extern struct {
                 .none,
             ),
 
-            .open_config => return Action.openConfig(self),
+            .open_config => return Action.openConfig(self, value),
 
             .open_url => Action.openUrl(self, value),
 
@@ -1203,7 +1203,8 @@ pub const Application = extern struct {
 
     fn syncActionAccelerators(self: *Self) void {
         self.syncActionAccelerator("app.quit", .{ .quit = {} });
-        self.syncActionAccelerator("app.open-config", .{ .open_config = {} });
+        self.syncActionAccelerator("app.open-config::os-open", .{ .open_config = .os_open });
+        self.syncActionAccelerator("app.open-config::new-window", .{ .open_config = .new_window });
         self.syncActionAccelerator("app.reload-config", .{ .reload_config = {} });
         self.syncActionAccelerator("win.toggle-inspector", .{ .inspector = .toggle });
         self.syncActionAccelerator("app.show-gtk-inspector", .show_gtk_inspector);
@@ -1480,11 +1481,14 @@ pub const Application = extern struct {
         const tas_variant_type = glib.VariantType.new("(tas)");
         defer tas_variant_type.free();
 
+        const s_variant_type = glib.ext.VariantType.newFor([:0]const u8);
+        defer s_variant_type.free();
+
         const actions = [_]ext.actions.Action(Self){
             .init("new-window", actionNewWindow, null),
             .init("new-window-command", actionNewWindow, as_variant_type),
             .init("new-tab", actionNewTab, tas_variant_type),
-            .init("open-config", actionOpenConfig, null),
+            .init("open-config", actionOpenConfig, s_variant_type),
             .init("present-surface", actionPresentSurface, t_variant_type),
             .init("quit", actionQuit, null),
             .init("reload-config", actionReloadConfig, null),
@@ -2037,10 +2041,42 @@ pub const Application = extern struct {
 
     pub fn actionOpenConfig(
         _: *gio.SimpleAction,
-        _: ?*glib.Variant,
+        parameter_: ?*glib.Variant,
         self: *Self,
     ) callconv(.c) void {
-        _ = self.core().mailbox.push(global.io(), .open_config, .forever);
+        const target: CoreApp.Message.OpenConfig = target: {
+            const target_map: std.StaticStringMap(CoreApp.Message.OpenConfig) = .initComptime(&.{
+                .{ "os-open", .os_open },
+                .{ "new-window", .new_window },
+            });
+
+            const parameter = parameter_ orelse {
+                log.warn("no parameter provided to app.open-config action", .{});
+                break :target .os_open;
+            };
+
+            const s_variant_type = glib.ext.VariantType.newFor([:0]const u8);
+            defer s_variant_type.free();
+
+            if (parameter.isOfType(s_variant_type) == 0) {
+                log.warn("parameter to app.open-config action is of type '{s}' not '{s}'", .{
+                    parameter.getTypeString(),
+                    s_variant_type.peekString()[0..s_variant_type.getStringLength()],
+                });
+                break :target .os_open;
+            }
+
+            var len: usize = undefined;
+            const buf = parameter.getString(&len);
+            const str = buf[0..len];
+
+            break :target target_map.get(str) orelse {
+                log.warn("'{s}' is not configured as a target for the app.open-config action", .{str});
+                break :target .os_open;
+            };
+        };
+
+        _ = self.core().mailbox.push(global.io(), .{ .open_config = target }, .forever);
     }
 
     fn actionPresentSurface(
@@ -2712,18 +2748,55 @@ const Action = struct {
         gtk.Window.present(win.as(gtk.Window));
     }
 
-    pub fn openConfig(self: *Application) bool {
-        // Get the config file path
+    pub fn openConfig(self: *Application, value: apprt.action.OpenConfig) bool {
         const alloc = self.allocator();
+
+        // Get the config file path
         const path = configpkg.edit.openPath(alloc) catch |err| {
-            log.warn("error getting config file path: {}", .{err});
+            log.warn("error getting config file path: {t}", .{err});
             return false;
         };
         defer alloc.free(path);
 
-        // Open it using openURL. "path" isn't actually a URL but
-        // at the time of writing that works just fine for GTK.
-        openUrl(self, .{ .kind = .text, .url = path });
+        switch (value) {
+            .os_open => {
+                // Open it using openUrl. "path" isn't actually a URL but
+                // at the time of writing that works just fine for GTK.
+                openUrl(self, .{ .kind = .text, .url = path });
+            },
+
+            .new_window => {
+                const cmd = internal_os.getConfigEditCommand(alloc, path, .default) catch |err| {
+                    log.warn("unable to get command to edit the config: {t}", .{err});
+                    return false;
+                };
+                defer alloc.free(cmd);
+
+                const command: configpkg.Command = .{
+                    .direct = &.{ "/bin/sh", "-c", cmd },
+                };
+
+                const title = std.fmt.allocPrintSentinel(
+                    alloc,
+                    "{s} {s}",
+                    .{ i18n._("Editing configuration file"), path },
+                    0,
+                ) catch |err| t: {
+                    log.warn("unable to format title: {t}", .{err});
+                    break :t null;
+                };
+                defer if (title) |t| alloc.free(t);
+
+                Action.newWindow(self, null, .{
+                    .command = command,
+                    .title = title,
+                }) catch |err| {
+                    log.warn("unable to create new window: {t}", .{err});
+                    return false;
+                };
+            },
+        }
+
         return true;
     }
 

--- a/src/apprt/gtk/ui/1.2/surface.blp
+++ b/src/apprt/gtk/ui/1.2/surface.blp
@@ -419,8 +419,15 @@ menu context_menu_model {
       label: _("Config");
 
       item {
-        label: _("Open Configuration");
+        label: _("Open Configuration in OS Editor");
         action: "app.open-config";
+        target: "os-open";
+      }
+
+      item {
+        label: _("Open Configuration in New Window");
+        action: "app.open-config";
+        target: "new-window";
       }
 
       item {

--- a/src/apprt/gtk/ui/1.5/window.blp
+++ b/src/apprt/gtk/ui/1.5/window.blp
@@ -294,14 +294,25 @@ menu main_menu {
       action: "win.toggle-inspector";
     }
 
-    item {
-      label: _("Open Configuration");
-      action: "app.open-config";
-    }
+    submenu {
+      label: _("Config");
 
-    item {
-      label: _("Reload Configuration");
-      action: "app.reload-config";
+      item {
+        label: _("Open Configuration in OS Editor");
+        action: "app.open-config";
+        target: "os-open";
+      }
+
+      item {
+        label: _("Open Configuration in New Window");
+        action: "app.open-config";
+        target: "new-window";
+      }
+
+      item {
+        label: _("Reload Configuration");
+        action: "app.reload-config";
+      }
     }
   }
 

--- a/src/cli/edit_config.zig
+++ b/src/cli/edit_config.zig
@@ -89,71 +89,44 @@ fn runInner(alloc: Allocator, stderr: *std.Io.Writer) !u8 {
             \\The `ghostty +edit-config` command is not supported on Windows.
             \\Please edit the configuration file manually at the following path:
             \\
-            \\{s}
-            \\
-        ,
-            .{path},
-        );
-        return 1;
-    }
-
-    // Get our editor
-    const editor = env: {
-        // VISUAL vs. EDITOR: https://unix.stackexchange.com/questions/4859/visual-vs-editor-what-s-the-difference
-        if (try global.environ().containsUnempty(alloc, "VISUAL")) {
-            break :env try global.environ().getAlloc(alloc, "VISUAL");
-        }
-
-        if (try global.environ().containsUnempty(alloc, "EDITOR")) {
-            break :env try global.environ().getAlloc(alloc, "EDITOR");
-        }
-
-        break :env "";
-    };
-    defer alloc.free(editor);
-
-    // If we don't have `$EDITOR` set then we can't do anything
-    // but we can still print a helpful message.
-    if (editor.len == 0) {
-        try stderr.print(
-            \\The $EDITOR or $VISUAL environment variable is not set or is empty.
-            \\This environment variable is required to edit the Ghostty configuration
-            \\via this CLI command.
-            \\
-            \\Please set the environment variable to your preferred terminal
-            \\text editor and try again.
-            \\
-            \\If you prefer to edit the configuration file another way,
-            \\you can find the configuration file at the following path:
-            \\
             \\
         ,
             .{},
         );
-
-        // Output the path using the OSC8 sequence so that it is linked.
-        try stderr.print(
-            "\x1b]8;;file://{s}\x1b\\{s}\x1b]8;;\x1b\\\n",
-            .{ path, path },
-        );
-
         return 1;
     }
 
-    // Build the command
-    const command = command: {
-        var buffer: std.Io.Writer.Allocating = .init(alloc);
-        defer buffer.deinit();
-        const writer = &buffer.writer;
-        try writer.writeAll(editor);
-        try writer.writeByte(' ');
-        {
-            var sh: internal_os.ShellEscapeWriter = .init(writer);
-            try sh.writer.writeAll(path);
-            try sh.writer.flush();
+    const command = internal_os.getConfigEditCommand(alloc, path, .{ .default_editor = .failure }) catch |err| {
+        switch (err) {
+            error.NoEditorConfigured => {
+                try stderr.print(
+                    \\The $EDITOR or $VISUAL environment variable is not set or is empty.
+                    \\This environment variable is required to edit the Ghostty configuration
+                    \\via this CLI command.
+                    \\
+                    \\Please set the environment variable to your preferred terminal
+                    \\text editor and try again.
+                    \\
+                    \\If you prefer to edit the configuration file another way,
+                    \\you can find the configuration file at the following path:
+                    \\
+                    \\
+                ,
+                    .{},
+                );
+
+                // Output the path using the OSC8 sequence so that it is linked.
+                try stderr.print(
+                    "\x1b]8;;file://{s}\x1b\\{s}\x1b]8;;\x1b\\\n",
+                    .{ path, path },
+                );
+
+                return 1;
+            },
+            error.WriteFailed,
+            error.OutOfMemory,
+            => |e| return e,
         }
-        try writer.flush();
-        break :command try buffer.toOwnedSliceSentinel(0);
     };
     defer alloc.free(command);
 
@@ -168,15 +141,22 @@ fn runInner(alloc: Allocator, stderr: *std.Io.Writer) !u8 {
 
     // If we reached this point then exec failed.
     try stderr.print(
-        \\Failed to execute the editor (E{s}).
+        \\Failed to execute the editor (E{t}).
         \\
         \\This is usually due to the executable path not existing, invalid
         \\permissions, or the shell environment not being set up
         \\correctly.
         \\
-        \\Editor: {s}
-        \\Path: {s}
+        \\Command: {s}
         \\
-    , .{ @tagName(err), editor, path });
+    , .{
+        err,
+        command,
+    });
+    // Output the path using the OSC8 sequence so that it is linked.
+    try stderr.print(
+        "Path: \x1b]8;;file://{s}\x1b\\{s}\x1b]8;;\x1b\\\n",
+        .{ path, path },
+    );
     return 1;
 }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -6519,7 +6519,7 @@ pub const Keybinds = struct {
         try self.set.put(
             alloc,
             .{ .key = .{ .unicode = ',' }, .mods = inputpkg.ctrlOrSuper(.{}) },
-            .{ .open_config = {} },
+            .{ .open_config = .default },
         );
 
         {

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -692,12 +692,14 @@ pub const Action = union(enum) {
     /// untested.
     show_on_screen_keyboard,
 
-    /// Open the configuration file in the default OS editor.
+    /// Open the configuration file in an editor.
     ///
-    /// If your default OS editor isn't configured then this will fail.
-    /// Currently, any failures to open the configuration will show up only in
-    /// the logs.
-    open_config,
+    /// * `os_open`: Use the OS's default editor to edit the configuration file.
+    ///   This is the default action. (Available since 1.4.0)
+    /// * `new_window`: Launch the editor specified in `$EDITOR` or `$VISUAL` in
+    ///   a new Ghostty window to edit the configuration file. GTK only. (Available
+    ///   since 1.4.0.)
+    open_config: OpenConfig,
 
     /// Reload the configuration.
     ///
@@ -1190,6 +1192,16 @@ pub const Action = union(enum) {
         right,
 
         pub const default: CloseTabMode = .this;
+    };
+
+    pub const OpenConfig = enum {
+        /// Open the config in the OS default editor.
+        os_open,
+
+        /// Open the config in a new window using $EDITOR or $VISUAL
+        new_window,
+
+        pub const default: OpenConfig = .os_open;
     };
 
     fn parseEnum(comptime T: type, value: []const u8) !T {

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -576,11 +576,18 @@ fn actionCommands(action: Action.Key) []const Command {
             .description = i18n.N_("Show the on-screen keyboard if present."),
         }},
 
-        .open_config => comptime &.{.{
-            .action = .open_config,
-            .title = i18n.N_("Open Config"),
-            .description = i18n.N_("Open the config file."),
-        }},
+        .open_config => comptime &.{
+            .{
+                .action = .{ .open_config = .os_open },
+                .title = i18n.N_("Open Config Using OS editor"),
+                .description = i18n.N_("Open the config file with the OS's default editor."),
+            },
+            .{
+                .action = .{ .open_config = .new_window },
+                .title = i18n.N_("Open Config in New Terminal Window"),
+                .description = i18n.N_("Open the config file in a new window using $EDITOR or $VISUAL."),
+            },
+        },
 
         .reload_config => comptime &.{.{
             .action = .reload_config,

--- a/src/os/edit.zig
+++ b/src/os/edit.zig
@@ -1,0 +1,69 @@
+const std = @import("std");
+
+const global = @import("../global.zig");
+const ShellEscapeWriter = @import("shell.zig").ShellEscapeWriter;
+
+const log = std.log.scoped(.os_edit);
+
+const Options = struct {
+    default_editor: enum {
+        /// Return an error if $EDITOR or $VISUAL is not defined.
+        failure,
+        /// Default to "vi" if $EDITOR or $VISUAL is not defined.
+        vi,
+        /// Default to "nano" if $EDITOR or $VISUAL is not defined.
+        nano,
+    } = .vi,
+
+    pub const default: Options = .{};
+};
+
+pub const Error = error{NoEditorConfigured};
+
+pub fn getConfigEditCommand(alloc: std.mem.Allocator, path: []const u8, options: Options) (Error || std.Io.Writer.Error || std.mem.Allocator.Error)![:0]const u8 {
+    const editor: []const u8 = editor: {
+        // VISUAL vs. EDITOR: https://unix.stackexchange.com/questions/4859/visual-vs-editor-what-s-the-difference
+        v: {
+            if (global.environ().containsUnempty(alloc, "VISUAL") catch break :v) {
+                break :editor global.environ().getAlloc(alloc, "VISUAL") catch break :v;
+            }
+        }
+
+        e: {
+            if (global.environ().containsUnempty(alloc, "EDITOR") catch break :e) {
+                break :editor global.environ().getAlloc(alloc, "EDITOR") catch break :e;
+            }
+        }
+
+        switch (options.default_editor) {
+            .failure => {
+                log.warn("$EDITOR or $VISUAL must be set to open config in a new window", .{});
+                return error.NoEditorConfigured;
+            },
+            .vi => {
+                log.warn("$EDITOR or $VISUAL not set, falling back to vi", .{});
+                break :editor try alloc.dupe(u8, "vi");
+            },
+            .nano => {
+                log.warn("$EDITOR or $VISUAL not set, falling back to nano", .{});
+                break :editor try alloc.dupe(u8, "nano");
+            },
+        }
+    };
+    defer alloc.free(editor);
+
+    var buffer: std.Io.Writer.Allocating = .init(alloc);
+    defer buffer.deinit();
+    const writer = &buffer.writer;
+
+    try writer.writeAll(editor);
+    try writer.writeByte(' ');
+    {
+        var sh: ShellEscapeWriter = .init(writer);
+        try sh.writer.writeAll(path);
+        try sh.writer.flush();
+    }
+    try writer.flush();
+
+    return try buffer.toOwnedSliceSentinel(0);
+}

--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -19,6 +19,7 @@ const kernel_info = @import("kernel_info.zig");
 
 // Namespaces
 pub const cgroup = @import("cgroup.zig");
+pub const edit = @import("edit.zig");
 pub const hostname = @import("hostname.zig");
 pub const i18n = @import("i18n.zig");
 pub const mach = @import("mach.zig");
@@ -55,10 +56,12 @@ pub const resourcesDir = resourcesdir.resourcesDir;
 pub const ResourcesDir = resourcesdir.ResourcesDir;
 pub const ShellEscapeWriter = shell.ShellEscapeWriter;
 pub const getKernelInfo = kernel_info.getKernelInfo;
+pub const getConfigEditCommand = edit.getConfigEditCommand;
 
 test {
     _ = file;
     _ = stderr;
+    _ = edit;
     _ = i18n;
     _ = path;
     _ = uri;


### PR DESCRIPTION
This PR extends the `open_config` keybind action to allow editing the Ghostty config in a new Ghostty window using the editor configured in `$EDITOR` or `$VISUAL`.