### PR TITLE
feat: adaptive power management for battery-aware rendering

### DIFF
--- a/docs/superpowers/plans/2026-03-26-adaptive-power-management.md
+++ b/docs/superpowers/plans/2026-03-26-adaptive-power-management.md
@@ -1,0 +1,1098 @@
+# Adaptive Power Management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add battery-aware power management to Ghostty that detects AC/battery/critical states and adjusts rendering parameters via the existing conditional config system.
+
+**Architecture:** Extend `conditional.zig`'s `State` struct with a `power` field. Add `src/os/power.zig` for cross-platform battery detection. Poll via timestamp check in `App.tick()`. Propagate state changes through the existing `changeConditionalState` → `reload_config` pipeline.
+
+**Tech Stack:** Zig, sysfs (Linux), IOKit/IOPowerSources (macOS), xev event loop
+
+**Spec:** `docs/superpowers/specs/2026-03-26-adaptive-power-management-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/os/power.zig` | **NEW** — Cross-platform power state detection (sysfs on Linux, IOKit on macOS, fallback for others) |
+| `src/os/main.zig` | Export `power` module |
+| `src/config/conditional.zig` | Add `Power` enum and `power` field to `State` |
+| `src/config/Config.zig` | Add `PowerMode` enum, `power-mode`, `power-critical-threshold`, `power-poll-interval`, `draw-interval` config options |
+| `src/App.zig` | Timestamp-gated power polling in `tick()`, state propagation via `config_conditional_state` |
+| `src/renderer/Thread.zig` | Replace `DRAW_INTERVAL` constant with `config.draw_interval_ms` in `DerivedConfig` |
+| `src/renderer/generic.zig` | No changes needed — `draw_interval_ms` lives in Thread's DerivedConfig, not renderer's |
+| `pkg/macos/build.zig` | Link `IOKit.framework` gated on `.macos` |
+
+---
+
+### Task 1: `src/os/power.zig` — Linux Power Detection with Tests
+
+**Files:**
+- Create: `src/os/power.zig`
+- Modify: `src/os/main.zig:1-81`
+
+- [ ] **Step 1: Write test cases for Linux sysfs power detection**
+
+Create `src/os/power.zig` with types, the testable `getPowerInfoFromPath` function signature, and all test cases. The tests create temporary directories mimicking sysfs structure.
+
+```zig
+const std = @import("std");
+const builtin = @import("builtin");
+const Allocator = std.mem.Allocator;
+
+pub const PowerState = enum { ac, battery, critical };
+
+pub const PowerInfo = struct {
+    state: PowerState,
+    battery_percent: ?u8,
+};
+
+/// Returns current power state. Pure function, no side effects.
+/// Never errors — returns .ac with null percent on any failure.
+pub fn getPowerInfo(critical_threshold: u8) PowerInfo {
+    if (comptime builtin.os.tag == .linux) {
+        return getPowerInfoFromPath("/sys/class/power_supply", critical_threshold);
+    }
+    // TODO: macOS implementation in Task 2
+    return .{ .state = .ac, .battery_percent = null };
+}
+
+/// Testable version that accepts a custom sysfs path.
+pub fn getPowerInfoFromPath(base_path: []const u8, critical_threshold: u8) PowerInfo {
+    _ = base_path;
+    _ = critical_threshold;
+    return .{ .state = .ac, .battery_percent = null };
+}
+
+/// Read a single-line sysfs file, trimming whitespace.
+fn readSysFile(dir: std.fs.Dir, name: []const u8, buf: []u8) ?[]const u8 {
+    _ = dir;
+    _ = name;
+    _ = buf;
+    return null;
+}
+
+// ── Helper for tests ──
+
+fn createMockSysfs(
+    tmp: *std.testing.TmpDir,
+    devices: []const struct {
+        name: []const u8,
+        type_val: []const u8,
+        files: []const struct { name: []const u8, value: []const u8 },
+    },
+) ![]const u8 {
+    for (devices) |device| {
+        try tmp.dir.makePath(device.name);
+        var dev_dir = try tmp.dir.openDir(device.name, .{});
+        defer dev_dir.close();
+
+        // Write "type" file
+        {
+            const f = try dev_dir.createFile("type", .{});
+            defer f.close();
+            try f.writeAll(device.type_val);
+        }
+
+        // Write additional files
+        for (device.files) |file| {
+            const f = try dev_dir.createFile(file.name, .{});
+            defer f.close();
+            try f.writeAll(file.value);
+        }
+    }
+
+    // Return the path as a slice we can pass to getPowerInfoFromPath
+    return try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+}
+
+test "power: ac power only" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try createMockSysfs(&tmp, &.{
+        .{ .name = "AC", .type_val = "Mains", .files = &.{
+            .{ .name = "online", .value = "1" },
+        } },
+    });
+    defer std.testing.allocator.free(path);
+
+    const info = getPowerInfoFromPath(path, 20);
+    try std.testing.expectEqual(PowerState.ac, info.state);
+    try std.testing.expect(info.battery_percent == null);
+}
+
+test "power: battery discharging at 50%" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try createMockSysfs(&tmp, &.{
+        .{ .name = "BAT0", .type_val = "Battery", .files = &.{
+            .{ .name = "status", .value = "Discharging" },
+            .{ .name = "capacity", .value = "50" },
+        } },
+    });
+    defer std.testing.allocator.free(path);
+
+    const info = getPowerInfoFromPath(path, 20);
+    try std.testing.expectEqual(PowerState.battery, info.state);
+    try std.testing.expectEqual(@as(?u8, 50), info.battery_percent);
+}
+
+test "power: battery critical at 15%" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try createMockSysfs(&tmp, &.{
+        .{ .name = "BAT0", .type_val = "Battery", .files = &.{
+            .{ .name = "status", .value = "Discharging" },
+            .{ .name = "capacity", .value = "15" },
+        } },
+    });
+    defer std.testing.allocator.free(path);
+
+    const info = getPowerInfoFromPath(path, 20);
+    try std.testing.expectEqual(PowerState.critical, info.state);
+    try std.testing.expectEqual(@as(?u8, 15), info.battery_percent);
+}
+
+test "power: battery charging reports ac" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try createMockSysfs(&tmp, &.{
+        .{ .name = "BAT0", .type_val = "Battery", .files = &.{
+            .{ .name = "status", .value = "Charging" },
+            .{ .name = "capacity", .value = "40" },
+        } },
+    });
+    defer std.testing.allocator.free(path);
+
+    const info = getPowerInfoFromPath(path, 20);
+    try std.testing.expectEqual(PowerState.ac, info.state);
+    try std.testing.expectEqual(@as(?u8, 40), info.battery_percent);
+}
+
+test "power: battery full reports ac" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try createMockSysfs(&tmp, &.{
+        .{ .name = "BAT0", .type_val = "Battery", .files = &.{
+            .{ .name = "status", .value = "Full" },
+            .{ .name = "capacity", .value = "100" },
+        } },
+    });
+    defer std.testing.allocator.free(path);
+
+    const info = getPowerInfoFromPath(path, 20);
+    try std.testing.expectEqual(PowerState.ac, info.state);
+    try std.testing.expectEqual(@as(?u8, 100), info.battery_percent);
+}
+
+test "power: no power supply directory" {
+    const info = getPowerInfoFromPath("/nonexistent/path/that/doesnt/exist", 20);
+    try std.testing.expectEqual(PowerState.ac, info.state);
+    try std.testing.expect(info.battery_percent == null);
+}
+
+test "power: malformed capacity file" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try createMockSysfs(&tmp, &.{
+        .{ .name = "BAT0", .type_val = "Battery", .files = &.{
+            .{ .name = "status", .value = "Discharging" },
+            .{ .name = "capacity", .value = "abc" },
+        } },
+    });
+    defer std.testing.allocator.free(path);
+
+    const info = getPowerInfoFromPath(path, 20);
+    try std.testing.expectEqual(PowerState.ac, info.state);
+    try std.testing.expect(info.battery_percent == null);
+}
+
+test "power: empty directory" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(path);
+
+    const info = getPowerInfoFromPath(path, 20);
+    try std.testing.expectEqual(PowerState.ac, info.state);
+    try std.testing.expect(info.battery_percent == null);
+}
+
+test "power: multiple batteries uses lowest capacity" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try createMockSysfs(&tmp, &.{
+        .{ .name = "BAT0", .type_val = "Battery", .files = &.{
+            .{ .name = "status", .value = "Discharging" },
+            .{ .name = "capacity", .value = "30" },
+        } },
+        .{ .name = "BAT1", .type_val = "Battery", .files = &.{
+            .{ .name = "status", .value = "Discharging" },
+            .{ .name = "capacity", .value = "60" },
+        } },
+    });
+    defer std.testing.allocator.free(path);
+
+    const info = getPowerInfoFromPath(path, 20);
+    try std.testing.expectEqual(PowerState.battery, info.state);
+    try std.testing.expectEqual(@as(?u8, 30), info.battery_percent);
+}
+
+test "power: ac online overrides battery discharging" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try createMockSysfs(&tmp, &.{
+        .{ .name = "AC", .type_val = "Mains", .files = &.{
+            .{ .name = "online", .value = "1" },
+        } },
+        .{ .name = "BAT0", .type_val = "Battery", .files = &.{
+            .{ .name = "status", .value = "Discharging" },
+            .{ .name = "capacity", .value = "45" },
+        } },
+    });
+    defer std.testing.allocator.free(path);
+
+    const info = getPowerInfoFromPath(path, 20);
+    try std.testing.expectEqual(PowerState.ac, info.state);
+    try std.testing.expectEqual(@as(?u8, 45), info.battery_percent);
+}
+
+test "power: threshold boundary - capacity equals threshold" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try createMockSysfs(&tmp, &.{
+        .{ .name = "BAT0", .type_val = "Battery", .files = &.{
+            .{ .name = "status", .value = "Discharging" },
+            .{ .name = "capacity", .value = "20" },
+        } },
+    });
+    defer std.testing.allocator.free(path);
+
+    const info = getPowerInfoFromPath(path, 20);
+    try std.testing.expectEqual(PowerState.critical, info.state);
+    try std.testing.expectEqual(@as(?u8, 20), info.battery_percent);
+}
+
+test "power: capacity at 0" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try createMockSysfs(&tmp, &.{
+        .{ .name = "BAT0", .type_val = "Battery", .files = &.{
+            .{ .name = "status", .value = "Discharging" },
+            .{ .name = "capacity", .value = "0" },
+        } },
+    });
+    defer std.testing.allocator.free(path);
+
+    const info = getPowerInfoFromPath(path, 20);
+    try std.testing.expectEqual(PowerState.critical, info.state);
+    try std.testing.expectEqual(@as(?u8, 0), info.battery_percent);
+}
+
+test "power: threshold 0 disables critical state" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try createMockSysfs(&tmp, &.{
+        .{ .name = "BAT0", .type_val = "Battery", .files = &.{
+            .{ .name = "status", .value = "Discharging" },
+            .{ .name = "capacity", .value = "5" },
+        } },
+    });
+    defer std.testing.allocator.free(path);
+
+    const info = getPowerInfoFromPath(path, 0);
+    try std.testing.expectEqual(PowerState.battery, info.state);
+    try std.testing.expectEqual(@as(?u8, 5), info.battery_percent);
+}
+
+test "power: capacity 100 while discharging" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try createMockSysfs(&tmp, &.{
+        .{ .name = "BAT0", .type_val = "Battery", .files = &.{
+            .{ .name = "status", .value = "Discharging" },
+            .{ .name = "capacity", .value = "100" },
+        } },
+    });
+    defer std.testing.allocator.free(path);
+
+    const info = getPowerInfoFromPath(path, 20);
+    try std.testing.expectEqual(PowerState.battery, info.state);
+    try std.testing.expectEqual(@as(?u8, 100), info.battery_percent);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/daaronch/src/legit/src/ghostty && zig build test -Dtest-filter="power" 2>&1 | head -30`
+Expected: Multiple FAIL results (stub implementation returns `.ac` for everything)
+
+- [ ] **Step 3: Implement `getPowerInfoFromPath` and `readSysFile`**
+
+Replace the stub implementations:
+
+```zig
+/// Read a single-line sysfs file, trimming whitespace.
+fn readSysFile(dir: std.fs.Dir, name: []const u8, buf: []u8) ?[]const u8 {
+    const file = dir.openFile(name, .{}) catch return null;
+    defer file.close();
+    const len = file.readAll(buf) catch return null;
+    return std.mem.trimRight(u8, buf[0..len], &std.ascii.whitespace);
+}
+
+/// Testable version that accepts a custom sysfs path.
+pub fn getPowerInfoFromPath(base_path: []const u8, critical_threshold: u8) PowerInfo {
+    var dir = std.fs.openDirAbsolute(base_path, .{ .iterate = true }) catch
+        return .{ .state = .ac, .battery_percent = null };
+    defer dir.close();
+
+    var ac_online = false;
+    var battery_charging = false;
+    var lowest_capacity: ?u8 = null;
+    var found_battery = false;
+
+    var buf: [256]u8 = undefined;
+
+    var iter = dir.iterate();
+    while (iter.next() catch null) |entry| {
+        if (entry.kind != .directory) continue;
+
+        var dev_dir = dir.openDir(entry.name, .{}) catch continue;
+        defer dev_dir.close();
+
+        const dev_type = readSysFile(dev_dir, "type", &buf) orelse continue;
+
+        if (std.mem.eql(u8, dev_type, "Mains")) {
+            const online = readSysFile(dev_dir, "online", &buf) orelse continue;
+            if (std.mem.eql(u8, online, "1")) {
+                ac_online = true;
+            }
+        } else if (std.mem.eql(u8, dev_type, "Battery")) {
+            found_battery = true;
+
+            const status = readSysFile(dev_dir, "status", &buf) orelse continue;
+            if (std.mem.eql(u8, status, "Charging") or std.mem.eql(u8, status, "Full")) {
+                battery_charging = true;
+            }
+
+            const cap_str = readSysFile(dev_dir, "capacity", &buf) orelse continue;
+            const capacity = std.fmt.parseInt(u8, cap_str, 10) catch continue;
+
+            if (lowest_capacity) |current| {
+                if (capacity < current) lowest_capacity = capacity;
+            } else {
+                lowest_capacity = capacity;
+            }
+        }
+    }
+
+    // Determine state
+    if (ac_online or battery_charging or !found_battery) {
+        return .{ .state = .ac, .battery_percent = lowest_capacity };
+    }
+
+    // On battery — check if critical
+    if (lowest_capacity) |cap| {
+        if (critical_threshold > 0 and cap <= critical_threshold) {
+            return .{ .state = .critical, .battery_percent = cap };
+        }
+        return .{ .state = .battery, .battery_percent = cap };
+    }
+
+    // Found battery but couldn't read capacity — treat as unknown/ac
+    return .{ .state = .ac, .battery_percent = null };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /home/daaronch/src/legit/src/ghostty && zig build test -Dtest-filter="power" 2>&1 | tail -5`
+Expected: All tests PASS
+
+- [ ] **Step 5: Export from `src/os/main.zig`**
+
+Add to the imports section (after line 18, `const kernel_info`):
+
+```zig
+const power = @import("power.zig");
+```
+
+Add to the `pub` exports section (after line 33, `pub const uri`):
+
+```zig
+pub const power = @import("power.zig");
+```
+
+Wait — the pattern is inconsistent. Some modules are imported as `const` and re-exported as functions, others are directly `pub const`. Looking at the file, `power` is a namespace module (like `shell`, `uri`), so use the direct pub pattern:
+
+Add after line 33 (`pub const uri = @import("uri.zig");`):
+```zig
+pub const power = @import("power.zig");
+```
+
+Add `power` to the test block at the bottom (inside `test {}`):
+```zig
+    if (comptime builtin.os.tag == .linux) {
+        _ = power;
+    }
+```
+
+(Inside the existing `if (comptime builtin.os.tag == .linux)` block, after `_ = kernel_info;`)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/os/power.zig src/os/main.zig
+git commit -m "feat: add power detection module with Linux sysfs support
+
+Cross-platform power state detection via os.power.getPowerInfo().
+Linux reads /sys/class/power_supply/ for battery status and capacity.
+Other platforms return .ac as fallback. Includes 14 unit tests with
+mock sysfs directories."
+```
+
+---
+
+### Task 2: Extend Conditional Config with `power` State
+
+**Files:**
+- Modify: `src/config/conditional.zig:9-16` (State struct)
+
+- [ ] **Step 1: Write failing test for power conditional matching**
+
+Add to `src/config/conditional.zig` after the existing test at line 94:
+
+```zig
+test "conditional power match" {
+    const testing = std.testing;
+    const state: State = .{ .power = .battery };
+    try testing.expect(state.match(.{
+        .key = .power,
+        .op = .eq,
+        .value = "battery",
+    }));
+    try testing.expect(!state.match(.{
+        .key = .power,
+        .op = .eq,
+        .value = "ac",
+    }));
+    try testing.expect(state.match(.{
+        .key = .power,
+        .op = .ne,
+        .value = "critical",
+    }));
+}
+
+test "conditional power and theme independence" {
+    const testing = std.testing;
+    const state: State = .{ .theme = .dark, .power = .critical };
+    try testing.expect(state.match(.{
+        .key = .theme,
+        .op = .eq,
+        .value = "dark",
+    }));
+    try testing.expect(state.match(.{
+        .key = .power,
+        .op = .eq,
+        .value = "critical",
+    }));
+
+    const state2: State = .{ .theme = .light, .power = .critical };
+    try testing.expect(state2.match(.{
+        .key = .theme,
+        .op = .eq,
+        .value = "light",
+    }));
+    try testing.expect(state2.match(.{
+        .key = .power,
+        .op = .eq,
+        .value = "critical",
+    }));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/daaronch/src/legit/src/ghostty && zig build test -Dtest-filter="conditional" 2>&1 | head -10`
+Expected: Compile error — `.power` field doesn't exist on `State`
+
+- [ ] **Step 3: Add `Power` enum and `power` field to `State`**
+
+In `src/config/conditional.zig`, modify the `State` struct (lines 9-16):
+
+```zig
+pub const State = struct {
+    /// The theme of the underlying OS desktop environment.
+    theme: Theme = .light,
+
+    /// The target OS of the current build.
+    os: std.Target.Os.Tag = builtin.target.os.tag,
+
+    /// The current power state of the machine.
+    power: Power = .ac,
+
+    pub const Theme = enum { light, dark };
+    pub const Power = enum { ac, battery, critical };
+```
+
+The `Key` enum is auto-generated from `State` fields at comptime (lines 40-54), so it automatically includes `.power`. The `match()` function uses `@tagName(raw)` on enum values (line 28), which works for `Power` since it's an enum. No other changes needed.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /home/daaronch/src/legit/src/ghostty && zig build test -Dtest-filter="conditional" 2>&1 | tail -5`
+Expected: All tests PASS (including original theme test + new power tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config/conditional.zig
+git commit -m "feat: add power state to conditional config system
+
+Add Power enum (ac/battery/critical) to conditional.State.
+The Key enum auto-generates to include .power. Existing match()
+logic works unchanged since Power is an enum like Theme."
+```
+
+---
+
+### Task 3: Add Config Options to `Config.zig`
+
+**Files:**
+- Modify: `src/config/Config.zig`
+
+- [ ] **Step 1: Add `PowerMode` enum**
+
+Find the config enums section (near line 5213 where `ConfirmCloseSurface` is defined). Add `PowerMode` nearby:
+
+```zig
+pub const PowerMode = enum {
+    /// Detect power state and apply conditional defaults.
+    auto,
+    /// Always use full performance settings (force power=ac).
+    performance,
+    /// Always use power-saving settings (force power=critical).
+    efficiency,
+    /// Disable power detection entirely.
+    off,
+};
+```
+
+- [ ] **Step 2: Add config fields**
+
+Add these fields to the Config struct. Place them near other rendering/performance options (near `@"window-vsync"` around line 2000):
+
+```zig
+/// Controls whether Ghostty adapts behavior based on power state.
+///
+/// `auto`: Detect power state via OS APIs and apply conditional defaults
+/// for reduced power consumption on battery. `performance`: Always use
+/// full performance settings regardless of power state. `efficiency`:
+/// Always use power-saving settings regardless of power state. `off`:
+/// Disable power detection entirely. No polling occurs. This is the
+/// default because desktop machines without batteries should not pay
+/// the cost of periodic polling.
+@"power-mode": PowerMode = .off,
+
+/// Battery percentage at or below which the power state transitions
+/// to "critical". Only relevant when power-mode is "auto".
+/// Set to 0 to disable the critical state entirely.
+@"power-critical-threshold": u8 = 20,
+
+/// How often to poll for power state changes, in seconds.
+/// Only relevant when power-mode is "auto".
+@"power-poll-interval": u16 = 30,
+
+/// Draw interval in milliseconds for animation frames.
+/// Lower values produce smoother animations but consume more power.
+/// Default: 8 (approximately 120 FPS).
+/// Common values: 16 (60 FPS), 32 (30 FPS).
+@"draw-interval": u16 = 8,
+```
+
+- [ ] **Step 3: Add validation in `finalize()`**
+
+In the `finalize()` function (starting at line 4491), add validation clamping:
+
+```zig
+    // Clamp power-related config values
+    self.@"power-critical-threshold" = @min(self.@"power-critical-threshold", 99);
+    self.@"power-poll-interval" = @max(5, @min(self.@"power-poll-interval", 300));
+    self.@"draw-interval" = @max(2, @min(self.@"draw-interval", 100));
+```
+
+- [ ] **Step 4: Run config tests**
+
+Run: `cd /home/daaronch/src/legit/src/ghostty && zig build test -Dtest-filter="Config" 2>&1 | tail -5`
+Expected: All existing tests pass (new fields have defaults, no breakage)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config/Config.zig
+git commit -m "feat: add power-mode, draw-interval, and related config options
+
+New config: power-mode (auto/performance/efficiency/off, default off),
+power-critical-threshold (0-99, default 20), power-poll-interval
+(5-300s, default 30), draw-interval (2-100ms, default 8).
+Includes validation clamping in finalize()."
+```
+
+---
+
+### Task 4: Replace `DRAW_INTERVAL` with Config-Driven Value in Renderer
+
+**Files:**
+- Modify: `src/renderer/Thread.zig:19,112-120,295-334,488-490,570-594`
+- Modify: `src/renderer/generic.zig:536+`
+
+- [ ] **Step 1: Add `draw_interval_ms` to Thread's `DerivedConfig`**
+
+In `src/renderer/Thread.zig`, modify `DerivedConfig` (lines 112-120):
+
+```zig
+pub const DerivedConfig = struct {
+    custom_shader_animation: configpkg.CustomShaderAnimation,
+    draw_interval_ms: u16,
+
+    pub fn init(config: *const configpkg.Config) DerivedConfig {
+        return .{
+            .custom_shader_animation = config.@"custom-shader-animation",
+            .draw_interval_ms = config.@"draw-interval",
+        };
+    }
+};
+```
+
+- [ ] **Step 2: Replace `DRAW_INTERVAL` constant usage in `syncDrawTimer`**
+
+In `src/renderer/Thread.zig`, line 329, change:
+```zig
+        DRAW_INTERVAL,
+```
+to:
+```zig
+        self.config.draw_interval_ms,
+```
+
+- [ ] **Step 3: Replace `DRAW_INTERVAL` constant usage in `drawCallback`**
+
+In `src/renderer/Thread.zig`, line 590, change:
+```zig
+        t.draw_h.run(&t.loop, &t.draw_c, DRAW_INTERVAL, Thread, t, drawCallback);
+```
+to:
+```zig
+        t.draw_h.run(&t.loop, &t.draw_c, t.config.draw_interval_ms, Thread, t, drawCallback);
+```
+
+- [ ] **Step 4: Remove the `DRAW_INTERVAL` constant**
+
+Delete line 19:
+```zig
+const DRAW_INTERVAL = 8; // 120 FPS
+```
+
+- [ ] **Step 5: Verify the renderer tests still pass**
+
+Run: `cd /home/daaronch/src/legit/src/ghostty && zig build test -Dtest-filter="Thread" 2>&1 | tail -5`
+Expected: All tests pass (or compile succeeds if there are no Thread-specific tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/Thread.zig
+git commit -m "feat: replace hardcoded DRAW_INTERVAL with config-driven draw_interval_ms
+
+Frame rate is now controlled by the draw-interval config option
+instead of a hardcoded 8ms constant. Both syncDrawTimer() and
+drawCallback() use the config value."
+```
+
+---
+
+### Task 5: Power Polling in `App.zig`
+
+**Files:**
+- Modify: `src/App.zig:40-70,89-103,126-132`
+
+- [ ] **Step 1: Add power polling fields to `App` struct**
+
+In `src/App.zig`, add after line 60 (`last_notification_digest`):
+
+```zig
+/// Timestamp of last power state check for polling.
+last_power_check: ?std.time.Instant = null,
+
+/// Last observed power state to detect transitions.
+last_power_state: ?configpkg.ConditionalState.Power = null,
+```
+
+- [ ] **Step 2: Initialize power state in `init()`**
+
+The `init()` function (line 89-103) initializes `config_conditional_state`. Power state initialization depends on `power-mode`, but `init()` doesn't have access to the config. The initial power state is set on the first `tick()` call via the polling mechanism, which is the right approach — it mirrors how `colorSchemeEvent` works (called after init by the apprt).
+
+No change needed in `init()`. The defaults (`.ac`, `null` for last_power fields) are correct.
+
+- [ ] **Step 3: Add `internal_os` import**
+
+`App.zig` does not currently import the OS module. Add near the top with other imports:
+
+```zig
+const internal_os = @import("os/main.zig");
+```
+
+- [ ] **Step 4: Add power polling to `tick()`**
+
+Modify `tick()` at line 129-132. Add the power poll after `drainMailbox`:
+
+```zig
+pub fn tick(self: *App, rt_app: *apprt.App) !void {
+    // Drain our mailbox
+    try self.drainMailbox(rt_app);
+
+    // Poll power state if auto mode is enabled.
+    // We check this on the config from the apprt since that's what
+    // determines our behavior.
+    try self.pollPowerState(rt_app);
+}
+```
+
+- [ ] **Step 5: Implement `pollPowerState`**
+
+Add after `tick()`:
+
+```zig
+/// Poll the power state and trigger a config reload if it changed.
+/// Only active when power-mode is .auto.
+fn pollPowerState(self: *App, rt_app: *apprt.App) !void {
+    const config = rt_app.config();
+    const power_mode = config.@"power-mode";
+
+    switch (power_mode) {
+        .off => return,
+        .performance => {
+            if (self.config_conditional_state.power != .ac) {
+                self.config_conditional_state.power = .ac;
+                _ = try rt_app.performAction(.app, .reload_config, .{ .soft = true });
+            }
+            return;
+        },
+        .efficiency => {
+            if (self.config_conditional_state.power != .critical) {
+                self.config_conditional_state.power = .critical;
+                _ = try rt_app.performAction(.app, .reload_config, .{ .soft = true });
+            }
+            return;
+        },
+        .auto => {},
+    }
+
+    // Check if enough time has elapsed since last poll
+    const now = std.time.Instant.now() catch return;
+    if (self.last_power_check) |last| {
+        const elapsed_ns = now.since(last);
+        const interval_ns: u64 = @as(u64, config.@"power-poll-interval") * std.time.ns_per_s;
+        if (elapsed_ns < interval_ns) return;
+    }
+    self.last_power_check = now;
+
+    // Poll power state
+    const info = internal_os.power.getPowerInfo(config.@"power-critical-threshold");
+    const new_state = info.state;
+
+    // Only trigger reload if state actually changed
+    if (self.last_power_state) |last_state| {
+        if (last_state == new_state) return;
+    }
+    self.last_power_state = new_state;
+    self.config_conditional_state.power = new_state;
+
+    _ = try rt_app.performAction(.app, .reload_config, .{ .soft = true });
+}
+```
+
+- [ ] **Step 6: Verify compilation**
+
+Run: `cd /home/daaronch/src/legit/src/ghostty && zig build 2>&1 | head -20`
+Expected: Clean compilation (or warnings about unused imports that we'll fix)
+
+Note: The `rt_app.config()` call and `performAction(.app, .reload_config, ...)` pattern need to match the actual apprt interface. Check the existing `colorSchemeEvent` call at line 426 for the exact signature and adjust accordingly.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/App.zig
+git commit -m "feat: add power state polling in App.tick()"
+```
+
+```bash
+git add src/App.zig
+git commit -m "feat: add power state polling in App.tick()
+
+Polls battery state every power-poll-interval seconds when
+power-mode=auto. Triggers config reload via existing
+changeConditionalState pipeline when state transitions between
+ac/battery/critical."
+```
+
+---
+
+### Task 6: Build System — Link IOKit on macOS
+
+**Files:**
+- Modify: `pkg/macos/build.zig:37-40`
+
+- [ ] **Step 1: Add IOKit framework linking**
+
+In `pkg/macos/build.zig`, after line 39 (`module.linkFramework("Carbon", .{});`), still inside the `if (target.result.os.tag == .macos)` block:
+
+```zig
+    if (target.result.os.tag == .macos) {
+        lib.linkFramework("Carbon");
+        module.linkFramework("Carbon", .{});
+        lib.linkFramework("IOKit");
+        module.linkFramework("IOKit", .{});
+    }
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add pkg/macos/build.zig
+git commit -m "build: link IOKit framework on macOS for power detection
+
+IOKit provides IOPowerSources API used by os.power module
+for battery state detection. Gated on .macos (not all Darwin)
+to match Carbon framework pattern."
+```
+
+---
+
+### Task 7: macOS Power Detection Implementation
+
+**Files:**
+- Modify: `src/os/power.zig`
+
+This task adds the macOS implementation using IOKit's IOPowerSources C API. It is compile-time gated so it only compiles on Darwin.
+
+- [ ] **Step 1: Add macOS extern declarations and implementation**
+
+In `src/os/power.zig`, update `getPowerInfo` and add macOS-specific code.
+
+**Note on pattern choice:** Ghostty's `src/os/macos.zig` uses extern function declarations (e.g., `extern fn pthread_set_qos_class_self_np(...)`) rather than `@cImport`. However, the IOPowerSources API involves extensive CoreFoundation types (`CFDictionaryRef`, `CFStringRef`, `CFArrayRef`) that are tedious to declare individually. Using `@cImport` here is pragmatic — if it causes issues during implementation, switch to extern declarations following the `macos.zig` pattern.
+
+```zig
+pub fn getPowerInfo(critical_threshold: u8) PowerInfo {
+    if (comptime builtin.os.tag == .linux) {
+        return getPowerInfoFromPath("/sys/class/power_supply", critical_threshold);
+    } else if (comptime builtin.os.tag == .macos) {
+        return getMacOSPowerInfo(critical_threshold);
+    }
+    return .{ .state = .ac, .battery_percent = null };
+}
+
+// ── macOS implementation ──
+
+fn getMacOSPowerInfo(critical_threshold: u8) PowerInfo {
+    if (comptime builtin.os.tag != .macos) unreachable;
+
+    const c = @cImport({
+        @cInclude("IOKit/ps/IOPowerSources.h");
+        @cInclude("IOKit/ps/IOPSKeys.h");
+    });
+
+    const info = c.IOPSCopyPowerSourcesInfo() orelse
+        return .{ .state = .ac, .battery_percent = null };
+    defer c.CFRelease(info);
+
+    const list = c.IOPSCopyPowerSourcesList(info) orelse
+        return .{ .state = .ac, .battery_percent = null };
+    defer c.CFRelease(list);
+
+    const count = c.CFArrayGetCount(list);
+    if (count == 0) return .{ .state = .ac, .battery_percent = null };
+
+    // Check providing power source type
+    const source_type = c.IOPSGetProvidingPowerSourceType(info);
+    const is_battery = if (source_type) |st|
+        c.CFStringCompare(st, c.CFSTR("Battery Power"), 0) == c.kCFCompareEqualTo
+    else
+        false;
+
+    // Get capacity from first power source
+    var battery_percent: ?u8 = null;
+    if (count > 0) {
+        const ps = c.CFArrayGetValueAtIndex(list, 0);
+        const desc = c.IOPSGetPowerSourceDescription(info, ps); // "Get" — do NOT CFRelease
+        if (desc) |d| {
+            const cap_key = c.CFSTR(c.kIOPSCurrentCapacityKey);
+            if (c.CFDictionaryGetValue(d, cap_key)) |cap_val| {
+                var cap: c_int = 0;
+                if (c.CFNumberGetValue(@ptrCast(cap_val), c.kCFNumberIntType, &cap)) {
+                    if (cap >= 0 and cap <= 100) {
+                        battery_percent = @intCast(@as(u32, @bitCast(cap)));
+                    }
+                }
+            }
+        }
+    }
+
+    if (!is_battery) {
+        return .{ .state = .ac, .battery_percent = battery_percent };
+    }
+
+    // On battery — check critical
+    if (battery_percent) |cap| {
+        if (critical_threshold > 0 and cap <= critical_threshold) {
+            return .{ .state = .critical, .battery_percent = cap };
+        }
+    }
+
+    return .{ .state = .battery, .battery_percent = battery_percent };
+}
+```
+
+- [ ] **Step 2: Verify compilation on Linux (macOS code is compile-time gated)**
+
+Run: `cd /home/daaronch/src/legit/src/ghostty && zig build 2>&1 | head -10`
+Expected: Clean compilation (macOS code not compiled on Linux)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/os/power.zig
+git commit -m "feat: add macOS power detection via IOKit IOPowerSources
+
+Uses IOPSCopyPowerSourcesInfo/IOPSGetProvidingPowerSourceType for
+AC vs battery detection, CFDictionary lookup for capacity percent.
+Compile-time gated to macOS only. Proper CFRelease memory management."
+```
+
+---
+
+### Task 8: Auto Mode Default Injection
+
+**Files:**
+- Modify: `src/config/Config.zig` (finalize function)
+
+This task injects synthetic conditional entries when `power-mode = auto` so users get sensible defaults without writing any `[conditional:power=...]` blocks.
+
+- [ ] **Step 1: Understand the replay mechanism**
+
+The `Replay.Step` union (line 5093 of `Config.zig`) already has a `conditional_arg` variant:
+
+```zig
+conditional_arg: struct {
+    conditions: []const Conditional,
+    arg: []const u8,
+},
+```
+
+This is exactly what we need. When `power-mode == .auto`, we inject `conditional_arg` replay steps with power conditions. These steps get replayed during `changeConditionalState()` (which calls `cloneEmpty` + `loadIter` with the replay steps), so the conditional values are applied correctly.
+
+The key insight: replay steps are appended to `_replay_steps` during config loading. To make auto-defaults *lower priority* than user config, we insert them at the **beginning** of `_replay_steps` in `finalize()`, so user-defined entries (which appear later) override them.
+
+- [ ] **Step 2: Implement auto-default injection in `finalize()`**
+
+In `finalize()`, after the existing validation clamping (added in Task 3), add:
+
+```zig
+    // Inject auto-mode power defaults as conditional replay steps.
+    // These are prepended so user-defined conditional blocks override them.
+    if (self.@"power-mode" == .auto) {
+        const arena_alloc = self._arena.?.allocator();
+
+        // Battery defaults
+        const battery_cond = try arena_alloc.dupe(conditional.Conditional, &.{
+            .{ .key = .power, .op = .eq, .value = "battery" },
+        });
+        // Critical defaults
+        const critical_cond = try arena_alloc.dupe(conditional.Conditional, &.{
+            .{ .key = .power, .op = .eq, .value = "critical" },
+        });
+
+        // Build the new steps to prepend
+        const auto_steps = &[_]Replay.Step{
+            .{ .conditional_arg = .{ .conditions = battery_cond, .arg = "draw-interval=16" } },
+            .{ .conditional_arg = .{ .conditions = battery_cond, .arg = "custom-shader-animation=false" } },
+            .{ .conditional_arg = .{ .conditions = critical_cond, .arg = "draw-interval=32" } },
+            .{ .conditional_arg = .{ .conditions = critical_cond, .arg = "custom-shader-animation=false" } },
+            .{ .conditional_arg = .{ .conditions = critical_cond, .arg = "cursor-style-blink=false" } },
+            .{ .conditional_arg = .{ .conditions = critical_cond, .arg = "background-blur=false" } },
+        };
+
+        // Prepend: insert auto_steps before existing replay steps
+        try self._replay_steps.insertSlice(arena_alloc, 0, auto_steps);
+
+        // Mark power as a used conditional key so changeConditionalState
+        // knows to re-evaluate when power state changes
+        self._conditional_set.insert(.power);
+    }
+```
+
+**Important:** The `_conditional_set` insertion is critical. Without it, `changeConditionalState()` would skip power state changes because it checks `self._conditional_set.contains(key)` (line 4327).
+
+- [ ] **Step 3: Verify compilation and existing tests**
+
+Run: `cd /home/daaronch/src/legit/src/ghostty && zig build test -Dtest-filter="Config" 2>&1 | tail -10`
+Expected: All existing tests still pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/config/Config.zig
+git commit -m "feat: inject auto-mode power defaults during config finalize
+
+When power-mode=auto, prepend default conditional entries for
+battery (draw-interval=16, no shader animation) and critical
+(draw-interval=32, no shader/blink/blur). User-defined
+conditional blocks override these defaults."
+```
+
+---
+
+### Task 9: End-to-End Verification
+
+**Files:**
+- No new files — verification only
+
+- [ ] **Step 1: Full build verification**
+
+Run: `cd /home/daaronch/src/legit/src/ghostty && zig build 2>&1 | head -20`
+Expected: Clean compilation with no errors
+
+- [ ] **Step 2: Run all unit tests**
+
+Run: `cd /home/daaronch/src/legit/src/ghostty && zig build test 2>&1 | tail -20`
+Expected: All tests pass
+
+- [ ] **Step 3: Test power module specifically**
+
+Run: `cd /home/daaronch/src/legit/src/ghostty && zig build test -Dtest-filter="power" 2>&1`
+Expected: All 14 power tests pass
+
+- [ ] **Step 4: Test conditional module specifically**
+
+Run: `cd /home/daaronch/src/legit/src/ghostty && zig build test -Dtest-filter="conditional" 2>&1`
+Expected: All conditional tests pass (original + new power tests)
+
+- [ ] **Step 5: Manual smoke test**
+
+Test `power-mode` config by creating a test config and verifying it parses:
+```bash
+echo 'power-mode = auto' | ghostty +validate-config -
+echo 'power-mode = performance' | ghostty +validate-config -
+echo 'draw-interval = 16' | ghostty +validate-config -
+echo 'power-critical-threshold = 10' | ghostty +validate-config -
+```
+Expected: All parse without errors
+
+- [ ] **Step 6: Final commit if any fixups needed**
+
+If any fixes were required during verification, stage only the changed files and commit:
+```bash
+git add <specific-files-that-changed>
+git commit -m "fix: address issues found during end-to-end verification"
+```

--- a/docs/superpowers/specs/2026-03-26-adaptive-power-management-design.md
+++ b/docs/superpowers/specs/2026-03-26-adaptive-power-management-design.md
@@ -1,0 +1,367 @@
+# Adaptive Power Management for Ghostty
+
+## Summary
+
+Add battery-aware power management to Ghostty. The system detects whether the machine is on AC power, battery, or critically low battery, and adjusts rendering parameters to reduce power consumption. Users can configure per-power-state overrides using the existing conditional config system.
+
+## Motivation
+
+Ghostty's renderer runs at 120 FPS for animations (`DRAW_INTERVAL = 8ms`), uses GPU-intensive features like background blur and custom shaders, and maintains a cursor blink timer — all of which consume power even when the user isn't actively interacting with the terminal. On laptops, this contributes to battery drain.
+
+No terminal emulator currently implements battery-adaptive rendering. This would be a differentiating feature.
+
+### Prior Art in Ghostty
+
+- **Issue #9263**: macOS attributes subprocess power usage to Ghostty (unfixable — OS behavior).
+- **Issue #8003**: Cursor blink timer wakes renderer unnecessarily (open).
+- **PR #9662**: RenderState refactor reduced critical render lock time 2-5x.
+- **PR #10668**: Draw timer now only activates when custom shaders are configured.
+- **PR #2586**: Renderer prefers integrated GPU on dual-GPU Macs.
+
+These fixes addressed specific regressions. This spec adds *proactive* power management.
+
+## Design
+
+### Approach: Extend Conditional Config
+
+Ghostty's conditional config system (`src/config/conditional.zig`) allows config values to change based on state. Currently it supports `theme` (light/dark) and `os`. We add `power` as a third conditional state dimension.
+
+This reuses the entire conditional infrastructure — parsing, matching, application, and config reload propagation — with minimal new code.
+
+### Power States
+
+Three states, represented as an enum:
+
+```
+ac       — plugged in or no battery detected
+battery  — on battery power, above critical threshold
+critical — on battery power, at or below critical threshold (default: 20%)
+```
+
+Desktops without batteries always report `ac`.
+
+## Components
+
+### 1. `src/os/power.zig` — Power Detection Module
+
+A new OS module following the pattern of `desktop.zig` and `flatpak.zig`. Exported via `src/os/main.zig`.
+
+**Public API:**
+
+```zig
+pub const PowerState = enum { ac, battery, critical };
+
+pub const PowerInfo = struct {
+    state: PowerState,
+    battery_percent: ?u8,  // null if no battery detected
+};
+
+/// Returns current power state. Pure function, no side effects.
+pub fn getPowerInfo(critical_threshold: u8) PowerInfo
+```
+
+**Platform implementations:**
+
+- **Linux:** Reads `/sys/class/power_supply/` sysfs interface.
+  - Iterates entries looking for `type == "Battery"` and `type == "Mains"`.
+  - Reads `status` (Charging/Discharging/Full/Not charging) and `capacity` (0-100).
+  - If any AC adapter has `online == 1` or battery status is `Charging`/`Full`, state is `.ac`.
+  - Otherwise state is `.battery` or `.critical` based on capacity vs threshold.
+  - Internal function `getPowerInfoFromPath(path, threshold)` takes a directory path for testability.
+  - For multiple batteries, uses the lowest capacity (most conservative/safest for triggering `critical`). This is a deliberate design choice — on multi-battery systems (e.g., ThinkPad with internal + external), the lowest battery is the one most likely to cause a shutdown.
+
+- **macOS:** Uses IOKit `IOPowerSources` C API via extern function declarations (matching the pattern in `src/os/macos.zig` which uses extern C functions like `pthread_set_qos_class_self_np`).
+  - `IOPSCopyPowerSourcesInfo()` → `IOPSGetProvidingPowerSourceType()` for AC vs battery.
+  - `IOPSGetPowerSourceDescription()` with `kIOPSCurrentCapacityKey` for battery percentage.
+  - Requires linking `IOKit.framework` (added to `pkg/macos/build.zig`).
+  - **CoreFoundation memory management:** `IOPSCopyPowerSourcesInfo()` returns a `CFTypeRef` that must be `CFRelease`d. Since `getPowerInfo()` is a synchronous function, it acquires and releases within the same call — no need for `CFReleaseThread`. The `IOPSGetPowerSourceDescription()` return value is a "Get" (not "Copy"), so it must NOT be released.
+
+- **Other platforms (Windows, FreeBSD, etc.):** Returns `PowerInfo{ .state = .ac, .battery_percent = null }`.
+
+**Design constraints:**
+- Pure function. No global state, no caching. Caller decides polling frequency.
+- Never errors. Returns `.ac` with `null` percent on any failure (file not found, parse error, API failure).
+- No libudev, no D-Bus, no netlink. Linux reads plain files. macOS uses a stable public C API.
+
+### 2. Config Options in `src/config/Config.zig`
+
+Three new configuration options:
+
+```zig
+/// Controls whether Ghostty adapts behavior based on power state.
+///
+/// `auto`: Detect power state via OS APIs and apply conditional defaults
+/// for reduced power consumption on battery.
+///
+/// `performance`: Always use full performance settings regardless of
+/// power state. Equivalent to forcing power=ac.
+///
+/// `efficiency`: Always use power-saving settings regardless of power
+/// state. Equivalent to forcing power=critical.
+///
+/// `off`: Disable power detection entirely. No polling occurs.
+/// This is the default because desktop machines without batteries
+/// should not pay the cost of periodic polling.
+@"power-mode": PowerMode = .off,
+
+/// Battery percentage at or below which the power state transitions
+/// to "critical". Only relevant when power-mode is "auto".
+/// Valid range: 0-99. Set to 0 to disable the critical state entirely.
+@"power-critical-threshold": u8 = 20,
+
+/// How often to poll for power state changes, in seconds.
+/// Only relevant when power-mode is "auto".
+/// Valid range: 5-300.
+@"power-poll-interval": u16 = 30,
+```
+
+**PowerMode enum:**
+
+```zig
+pub const PowerMode = enum {
+    auto,
+    performance,
+    efficiency,
+    off,
+};
+```
+
+**New overridable rendering config:**
+
+```zig
+/// Draw interval in milliseconds for animation frames.
+/// Lower values produce smoother animations but consume more power.
+/// Default: 8 (approximately 120 FPS).
+/// Common values: 16 (60 FPS), 32 (30 FPS).
+/// Valid range: 2-100.
+@"draw-interval": u16 = 8,
+```
+
+**Validation:** `draw-interval` is clamped to 2-100ms via `@min`/`@max` clamping in `finalize()`. Values below 2ms would oversaturate the event loop. Values above 100ms (< 10 FPS) would make the terminal feel broken. `power-poll-interval` and `power-critical-threshold` use the same clamping pattern in `finalize()`.
+
+This replaces the hardcoded `DRAW_INTERVAL` constant in `renderer/Thread.zig` and makes frame rate controllable via config — including via conditional power overrides.
+
+### 3. Conditional Config Extension in `src/config/conditional.zig`
+
+Add `power` to the `State` struct:
+
+```zig
+pub const State = struct {
+    theme: Theme = .light,
+    os: std.Target.Os.Tag = builtin.target.os.tag,
+    power: Power = .ac,
+
+    pub const Theme = enum { light, dark };
+    pub const Power = enum { ac, battery, critical };
+};
+```
+
+The `Key` enum is auto-generated from `State` fields via comptime reflection, so it automatically includes `.power`. The `match()` function already handles all enum fields generically — no changes needed.
+
+**Note:** `power` is only the second runtime-dynamic conditional key (after `theme`). The `os` key is set at compile time and never changes. The `changeConditionalState()` path in `Config.zig` (line 4315) iterates all conditional keys and checks if any relevant key changed, which handles multiple dynamic keys correctly. However, this path has only been tested with one dynamic key (`theme`). Integration tests should verify that independent changes to `theme` and `power` do not interfere with each other.
+
+This enables user config like:
+
+```
+[conditional:power=battery]
+draw-interval = 16
+custom-shader-animation = false
+
+[conditional:power=critical]
+draw-interval = 32
+custom-shader-animation = false
+cursor-style-blink = false
+background-blur = false
+```
+
+### 4. Power State Propagation via `src/App.zig`
+
+**Polling via `tick()` timestamp check:**
+
+`App.zig` does not own an xev event loop. It is a pure data/logic layer that gets `tick()`-ed by the apprt on every iteration. Theme changes propagate through `colorSchemeEvent()` called by the apprt, which triggers `performAction(.reload_config, .{ .soft = true })`.
+
+Power polling follows the same pattern using a timestamp check inside `tick()`:
+
+```zig
+// New fields on App:
+last_power_check: ?std.time.Instant = null,
+last_power_state: ?configpkg.ConditionalState.Power = null,
+```
+
+```
+App.init():
+  if power-mode == .performance → set config_conditional_state.power = .ac
+  if power-mode == .efficiency → set config_conditional_state.power = .critical
+  if power-mode == .off → no action (power stays at default .ac)
+  if power-mode == .auto → initial power check happens on first tick()
+
+App.tick(rt_app):
+  self.drainMailbox(rt_app);
+  if power-mode == .auto:
+    now = std.time.Instant.now()
+    if last_power_check is null OR now.since(last_power_check) >= power-poll-interval_ns:
+      last_power_check = now
+      info = os.power.getPowerInfo(critical_threshold)
+      new_state = info.state
+      if new_state != last_power_state:
+        last_power_state = new_state
+        config_conditional_state.power = new_state
+        rt_app.performAction(.reload_config, .{ .soft = true })
+```
+
+**Why this approach:** This mirrors how `colorSchemeEvent()` works — update `config_conditional_state`, then trigger a soft config reload. The `reload_config` path calls `updateConfig()` which applies conditionals via `changeConditionalState()` and pushes updates to all surfaces, renderers, and termio instances. The entire pipeline is reused.
+
+**Config reload handling:** If `power-mode` itself changes during a config reload (e.g., user switches from `auto` to `off`), `tick()` simply stops checking because the power-mode config will reflect the new value. If `power-poll-interval` changes, the next timestamp comparison uses the new interval. No timer cancellation needed.
+
+### 5. Renderer Integration in `src/renderer/Thread.zig`
+
+**`DerivedConfig` changes:**
+
+```zig
+pub const DerivedConfig = struct {
+    custom_shader_animation: configpkg.CustomShaderAnimation,
+    draw_interval_ms: u16,  // NEW: replaces DRAW_INTERVAL constant
+    // ... existing fields
+};
+```
+
+**`syncDrawTimer()` changes:**
+
+The draw timer uses `self.config.draw_interval_ms` instead of the hardcoded `DRAW_INTERVAL` constant. **Both call sites** must be updated:
+- `syncDrawTimer()` (initial arm, ~line 329): `self.draw_h.run(..., self.config.draw_interval_ms, ...)`
+- `drawCallback()` (re-arm, ~line 590): `t.draw_h.run(..., t.config.draw_interval_ms, ...)`
+
+The timer interval takes effect on the next re-arm cycle — no explicit cancellation needed.
+
+**`changeConfig()` must call `syncDrawTimer()`:** When a config change message arrives with a new `draw_interval_ms` value, the `changeConfig()` handler (line 488) must call `syncDrawTimer()` to ensure the draw timer state is re-evaluated. This already happens — the `change_config` message handler at line 456 calls `self.syncDrawTimer()` after `self.changeConfig()`.
+
+### 6. Auto Mode Defaults
+
+When `power-mode == .auto`, the system injects default conditional config entries during config `finalize()`. These are injected *before* user-defined conditional entries, so user overrides naturally take priority (later entries win in the config system).
+
+**Injected defaults:**
+
+| Conditional Block | Settings |
+|---|---|
+| `[conditional:power=battery]` | `draw-interval = 16`, `custom-shader-animation = false` |
+| `[conditional:power=critical]` | `draw-interval = 32`, `custom-shader-animation = false`, `cursor-style-blink = false`, `background-blur = false` |
+
+**Implementation:** During `Config.finalize()`, if `power-mode == .auto`, prepend synthetic conditional replay entries to the config's conditional set. These behave identically to user-written entries but appear earlier in the evaluation order, so any user-written `[conditional:power=battery]` block overrides them.
+
+This approach:
+- Requires no new tracking infrastructure (no "was this field explicitly set?" mechanism).
+- Uses the existing conditional application pipeline without modification.
+- Is transparent — the user's explicit config always wins.
+
+**Example:** If the user writes:
+```
+power-mode = auto
+
+[conditional:power=battery]
+draw-interval = 8  # I want full speed even on battery
+```
+
+The system injects `draw-interval = 16` first, then the user's `draw-interval = 8` overrides it. Result: 8ms on battery.
+
+## Testing Strategy
+
+### Unit Tests for `power.zig`
+
+The Linux implementation exposes `getPowerInfoFromPath(path, threshold)` for testing with mock sysfs directories.
+
+**Test cases:**
+
+1. **AC power only** — Directory contains `AC/type=Mains`, `AC/online=1`. No battery. Expect: `{ .ac, null }`.
+2. **Battery discharging at 50%** — `BAT0/type=Battery`, `BAT0/status=Discharging`, `BAT0/capacity=50`. Expect: `{ .battery, 50 }`.
+3. **Battery at critical (15%)** — Same as above with `capacity=15`, threshold 20. Expect: `{ .critical, 15 }`.
+4. **Battery charging** — `BAT0/status=Charging`, `BAT0/capacity=40`. Expect: `{ .ac, 40 }`.
+5. **Battery full** — `BAT0/status=Full`, `BAT0/capacity=100`. Expect: `{ .ac, 100 }`.
+6. **No power supply directory** — Path doesn't exist. Expect: `{ .ac, null }`.
+7. **Malformed capacity file** — `BAT0/capacity=abc`. Expect: `{ .ac, null }` (graceful degradation).
+8. **Empty directory** — Path exists but no entries. Expect: `{ .ac, null }`.
+9. **Multiple batteries** — `BAT0` discharging at 30%, `BAT1` discharging at 60%. Expect: uses lowest capacity (30%), state based on that.
+10. **AC online + battery discharging** — `AC/online=1` AND `BAT0/status=Discharging`. Expect: `{ .ac, <percent> }` (AC wins).
+11. **Threshold boundary** — Capacity exactly equal to threshold. Expect: `{ .critical, <threshold> }`.
+12. **Capacity at 0%** — Expect: `{ .critical, 0 }`.
+13. **Capacity at 100% while discharging** — Expect: `{ .battery, 100 }`.
+14. **Threshold at 0** — Critical disabled. Battery at 5%. Expect: `{ .battery, 5 }` (never critical).
+
+**macOS tests:** Compile-time gated. On non-Darwin, the macOS path is not compiled. On Darwin CI, test that `getPowerInfo()` returns a valid `PowerInfo` without crashing (the actual values depend on the machine).
+
+### Unit Tests for `conditional.zig`
+
+Extend the existing test:
+
+```zig
+test "conditional power match" {
+    const state: State = .{ .power = .battery };
+    try testing.expect(state.match(.{ .key = .power, .op = .eq, .value = "battery" }));
+    try testing.expect(!state.match(.{ .key = .power, .op = .eq, .value = "ac" }));
+    try testing.expect(state.match(.{ .key = .power, .op = .ne, .value = "critical" }));
+}
+
+test "conditional power and theme independence" {
+    const state: State = .{ .theme = .dark, .power = .critical };
+    // Power match should not affect theme match
+    try testing.expect(state.match(.{ .key = .theme, .op = .eq, .value = "dark" }));
+    try testing.expect(state.match(.{ .key = .power, .op = .eq, .value = "critical" }));
+    // Changing one should not affect the other
+    const state2: State = .{ .theme = .light, .power = .critical };
+    try testing.expect(state2.match(.{ .key = .theme, .op = .eq, .value = "light" }));
+    try testing.expect(state2.match(.{ .key = .power, .op = .eq, .value = "critical" }));
+}
+```
+
+### Unit Tests for Config
+
+1. **PowerMode parsing** — `"auto"`, `"performance"`, `"efficiency"`, `"off"` parse correctly.
+2. **Critical threshold validation** — Values 0-99 accepted, 100+ rejected.
+3. **Poll interval validation** — Values 5-300 accepted, below 5 rejected.
+4. **draw-interval default** — Default is 8, overridable.
+5. **draw-interval validation** — Values 2-100 accepted, 0, 1, and 101+ rejected.
+
+### Unit Tests for Auto Defaults
+
+1. **Auto mode applies defaults** — `power-mode=auto`, power=battery, no user conditionals. `draw-interval` resolves to 16.
+2. **User override wins** — `power-mode=auto`, power=battery, user writes `[conditional:power=battery] draw-interval=8`. `draw-interval` resolves to 8.
+3. **Performance mode** — `power-mode=performance`. Power conditional state forced to `ac` regardless of actual battery.
+4. **Efficiency mode** — `power-mode=efficiency`. Power conditional state forced to `critical`.
+5. **Off mode** — `power-mode=off`. No power polling, conditional state stays at default `.ac`.
+6. **Auto mode with threshold 0** — Critical state never reached, only ac/battery transitions.
+
+### Integration Tests
+
+1. **State transition propagation** — Simulate power state change from `ac` → `battery`. Verify renderer's `DerivedConfig` updates with new `draw_interval_ms`.
+2. **Config reload during power monitoring** — User reloads config while power polling is active. Verify new `power-poll-interval` is respected on next tick.
+3. **Power-mode change at runtime** — Change `power-mode` from `auto` to `off`. Verify polling stops (no more `getPowerInfo` calls).
+4. **Theme + power independence** — Change theme from light to dark while on battery. Verify both conditional dimensions apply correctly and don't interfere.
+
+## File Changes Summary
+
+| File | Change |
+|---|---|
+| `src/os/power.zig` | **NEW** — Power detection module |
+| `src/os/main.zig` | Export `power` module |
+| `src/config/Config.zig` | Add `power-mode`, `power-critical-threshold`, `power-poll-interval`, `draw-interval`, `PowerMode` enum |
+| `src/config/conditional.zig` | Add `power: Power` field and `Power` enum to `State` |
+| `src/App.zig` | Add timestamp-gated power check in `tick()`, propagate via `config_conditional_state` + soft reload |
+| `src/renderer/Thread.zig` | Replace `DRAW_INTERVAL` with `config.draw_interval_ms` in `DerivedConfig`, call `syncDrawTimer()` in `changeConfig()` |
+| `src/renderer/generic.zig` | Add `draw_interval_ms` to renderer `DerivedConfig` |
+| `pkg/macos/build.zig` | Link `IOKit.framework` gated on `target.result.os.tag == .macos` (matching Carbon framework pattern at lines 37-39) |
+
+## Out of Scope
+
+- **Event-driven notifications** (udev, IOPSNotification) — future enhancement, polling is sufficient for v1.
+- **Windows support** — returns `.ac` with `null` percent. Can be added later via `GetSystemPowerStatus()`.
+- **Per-surface power config** — all surfaces share the same power state.
+- **Power state in status bar / OSC** — exposing power info to shell programs.
+- **Fixing macOS process attribution** (Issue #9263) — unfixable at the terminal level.
+- **Wayland idle inhibitor interaction** — compositor idle detection behavior when Ghostty reduces frame rate on battery. Worth investigating in a follow-up.
+
+## Risks
+
+1. **Upstream acceptance** — `power-mode` defaults to `off`, so this is zero-impact for existing users. The conditional config extension is minimal. The `draw-interval` config has independent value even without power management.
+2. **Sysfs path variation** — Some Linux systems name batteries `BAT0`, others `battery`, others `CMB0`. The implementation iterates all entries and checks `type` files rather than hardcoding names.
+3. **IOKit framework availability** — IOKit is available on all macOS versions Ghostty supports. The API is stable and public (not private like `responsibility_spawnattrs_setdisclaim`).
+4. **Multiple dynamic conditionals** — `power` is only the second runtime-dynamic conditional key (after `theme`). The `changeConditionalState` code path handles this correctly in theory (iterates all keys), but has only been tested with one dynamic key. Integration tests must cover independent theme + power state changes.
+5. **tick() frequency** — `App.tick()` is called on every apprt loop iteration. The timestamp check adds one `std.time.Instant.now()` call per tick, which is a single `clock_gettime` syscall on Linux and `mach_absolute_time` on macOS — negligible overhead.

--- a/pkg/macos/build.zig
+++ b/pkg/macos/build.zig
@@ -37,6 +37,8 @@ pub fn build(b: *std.Build) !void {
     if (target.result.os.tag == .macos) {
         lib.linkFramework("Carbon");
         module.linkFramework("Carbon", .{});
+        lib.linkFramework("IOKit");
+        module.linkFramework("IOKit", .{});
     }
 
     if (target.result.os.tag.isDarwin()) {

--- a/src/App.zig
+++ b/src/App.zig
@@ -66,6 +66,10 @@ last_power_check: ?std.time.Instant = null,
 /// Last observed power state to detect transitions.
 last_power_state: ?configpkg.ConditionalState.Power = null,
 
+/// Power-related config cached from the last updateConfig call.
+/// Stored here because the apprt doesn't expose config directly.
+power_config: PowerConfig = .{},
+
 /// The conditional state of the configuration. See the equivalent field
 /// in the Surface struct for more information. In this case, this applies
 /// to the app-level config and as a default for new surfaces.
@@ -75,6 +79,12 @@ config_conditional_state: configpkg.ConditionalState,
 /// never goes true again. This can be used by surfaces to determine
 /// if they are the first surface.
 first: bool = true,
+
+pub const PowerConfig = struct {
+    power_mode: Config.PowerMode = .off,
+    critical_threshold: u8 = 20,
+    poll_interval: u16 = 30,
+};
 
 pub const CreateError = Allocator.Error || font.SharedGridSet.InitError;
 
@@ -140,10 +150,7 @@ pub fn tick(self: *App, rt_app: *apprt.App) !void {
 }
 
 fn pollPowerState(self: *App, rt_app: *apprt.App) !void {
-    const config = rt_app.config;
-    const power_mode = config.@"power-mode";
-
-    switch (power_mode) {
+    switch (self.power_config.power_mode) {
         .off => return,
         .performance => {
             if (self.config_conditional_state.power != .ac) {
@@ -166,13 +173,13 @@ fn pollPowerState(self: *App, rt_app: *apprt.App) !void {
     const now = std.time.Instant.now() catch return;
     if (self.last_power_check) |last| {
         const elapsed_ns = now.since(last);
-        const interval_ns: u64 = @as(u64, config.@"power-poll-interval") * std.time.ns_per_s;
+        const interval_ns: u64 = @as(u64, self.power_config.poll_interval) * std.time.ns_per_s;
         if (elapsed_ns < interval_ns) return;
     }
     self.last_power_check = now;
 
     // Poll power state
-    const info = internal_os.power.getPowerInfo(config.@"power-critical-threshold");
+    const info = internal_os.power.getPowerInfo(self.power_config.critical_threshold);
     const new_state: configpkg.ConditionalState.Power = switch (info.state) {
         .ac => .ac,
         .battery => .battery,
@@ -193,6 +200,13 @@ fn pollPowerState(self: *App, rt_app: *apprt.App) !void {
 /// called from the main thread. The caller owns the config memory. The
 /// memory can be freed immediately when this returns.
 pub fn updateConfig(self: *App, rt_app: *apprt.App, config: *const Config) !void {
+    // Cache power-related config for use in tick() polling.
+    self.power_config = .{
+        .power_mode = config.@"power-mode",
+        .critical_threshold = config.@"power-critical-threshold",
+        .poll_interval = config.@"power-poll-interval",
+    };
+
     // Go through and update all of the surface configurations.
     for (self.surfaces.items) |surface| {
         try surface.core().handleMessage(.{ .change_config = config });

--- a/src/App.zig
+++ b/src/App.zig
@@ -15,6 +15,7 @@ const Config = configpkg.Config;
 const BlockingQueue = @import("datastruct/main.zig").BlockingQueue;
 const renderer = @import("renderer.zig");
 const font = @import("font/main.zig");
+const internal_os = @import("os/main.zig");
 
 const log = std.log.scoped(.app);
 
@@ -58,6 +59,12 @@ font_grid_set: font.SharedGridSet,
 // will kill Ghostty.
 last_notification_time: ?std.time.Instant = null,
 last_notification_digest: u64 = 0,
+
+/// Timestamp of last power state check for polling.
+last_power_check: ?std.time.Instant = null,
+
+/// Last observed power state to detect transitions.
+last_power_state: ?configpkg.ConditionalState.Power = null,
 
 /// The conditional state of the configuration. See the equivalent field
 /// in the Surface struct for more information. In this case, this applies
@@ -129,6 +136,57 @@ pub fn destroy(self: *App) void {
 pub fn tick(self: *App, rt_app: *apprt.App) !void {
     // Drain our mailbox
     try self.drainMailbox(rt_app);
+    try self.pollPowerState(rt_app);
+}
+
+fn pollPowerState(self: *App, rt_app: *apprt.App) !void {
+    const config = rt_app.config;
+    const power_mode = config.@"power-mode";
+
+    switch (power_mode) {
+        .off => return,
+        .performance => {
+            if (self.config_conditional_state.power != .ac) {
+                self.config_conditional_state.power = .ac;
+                _ = try rt_app.performAction(.app, .reload_config, .{ .soft = true });
+            }
+            return;
+        },
+        .efficiency => {
+            if (self.config_conditional_state.power != .critical) {
+                self.config_conditional_state.power = .critical;
+                _ = try rt_app.performAction(.app, .reload_config, .{ .soft = true });
+            }
+            return;
+        },
+        .auto => {},
+    }
+
+    // Check if enough time has elapsed since last poll
+    const now = std.time.Instant.now() catch return;
+    if (self.last_power_check) |last| {
+        const elapsed_ns = now.since(last);
+        const interval_ns: u64 = @as(u64, config.@"power-poll-interval") * std.time.ns_per_s;
+        if (elapsed_ns < interval_ns) return;
+    }
+    self.last_power_check = now;
+
+    // Poll power state
+    const info = internal_os.power.getPowerInfo(config.@"power-critical-threshold");
+    const new_state: configpkg.ConditionalState.Power = switch (info.state) {
+        .ac => .ac,
+        .battery => .battery,
+        .critical => .critical,
+    };
+
+    // Only trigger reload if state actually changed
+    if (self.last_power_state) |last_state| {
+        if (last_state == new_state) return;
+    }
+    self.last_power_state = new_state;
+    self.config_conditional_state.power = new_state;
+
+    _ = try rt_app.performAction(.app, .reload_config, .{ .soft = true });
 }
 
 /// Update the configuration associated with the app. This can only be

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -4716,6 +4716,39 @@ pub fn finalize(self: *Config) !void {
     self.@"power-poll-interval" = @max(5, @min(self.@"power-poll-interval", 300));
     self.@"draw-interval" = @max(2, @min(self.@"draw-interval", 100));
 
+    // Inject auto-mode power defaults as conditional replay steps.
+    // Prepended so user-defined conditional blocks override them.
+    if (self.@"power-mode" == .auto) {
+        const arena_alloc = self._arena.?.allocator();
+
+        // Create condition slices for battery and critical states
+        const battery_conds: []const Conditional = try arena_alloc.dupe(
+            Conditional,
+            &.{.{ .key = .power, .op = .eq, .value = "battery" }},
+        );
+        const critical_conds: []const Conditional = try arena_alloc.dupe(
+            Conditional,
+            &.{.{ .key = .power, .op = .eq, .value = "critical" }},
+        );
+
+        // Build the default steps to prepend
+        const auto_steps: []const Replay.Step = &.{
+            .{ .conditional_arg = .{ .conditions = battery_conds, .arg = "draw-interval=16" } },
+            .{ .conditional_arg = .{ .conditions = battery_conds, .arg = "custom-shader-animation=false" } },
+            .{ .conditional_arg = .{ .conditions = critical_conds, .arg = "draw-interval=32" } },
+            .{ .conditional_arg = .{ .conditions = critical_conds, .arg = "custom-shader-animation=false" } },
+            .{ .conditional_arg = .{ .conditions = critical_conds, .arg = "cursor-style-blink=false" } },
+            .{ .conditional_arg = .{ .conditions = critical_conds, .arg = "background-blur=false" } },
+        };
+
+        // Prepend: insert auto_steps before existing replay steps
+        try self._replay_steps.insertSlice(arena_alloc, 0, auto_steps);
+
+        // Mark power as a used conditional key so changeConditionalState
+        // knows to re-evaluate when power state changes.
+        self._conditional_set.insert(.power);
+    }
+
     // Finalize key remapping set for efficient lookups
     self.@"key-remap".finalize();
 }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2012,6 +2012,32 @@ keybind: Keybinds = .{},
 /// This setting is only supported currently on macOS.
 @"window-vsync": bool = true,
 
+/// Controls whether Ghostty adapts behavior based on power state.
+///
+/// `auto`: Detect power state via OS APIs and apply conditional defaults
+/// for reduced power consumption on battery. `performance`: Always use
+/// full performance settings regardless of power state. `efficiency`:
+/// Always use power-saving settings regardless of power state. `off`:
+/// Disable power detection entirely. No polling occurs. This is the
+/// default because desktop machines without batteries should not pay
+/// the cost of periodic polling.
+@"power-mode": PowerMode = .off,
+
+/// Battery percentage at or below which the power state transitions
+/// to "critical". Only relevant when power-mode is "auto".
+/// Set to 0 to disable the critical state entirely.
+@"power-critical-threshold": u8 = 20,
+
+/// How often to poll for power state changes, in seconds.
+/// Only relevant when power-mode is "auto".
+@"power-poll-interval": u16 = 30,
+
+/// Draw interval in milliseconds for animation frames.
+/// Lower values produce smoother animations but consume more power.
+/// Default: 8 (approximately 120 FPS).
+/// Common values: 16 (60 FPS), 32 (30 FPS).
+@"draw-interval": u16 = 8,
+
 /// If true, new windows will inherit the working directory of the
 /// previously focused window. If no window was previously focused, the default
 /// working directory will be used (the `working-directory` option).
@@ -4685,6 +4711,11 @@ pub fn finalize(self: *Config) !void {
 
     self.@"faint-opacity" = std.math.clamp(self.@"faint-opacity", 0.0, 1.0);
 
+    // Clamp power-related config values
+    self.@"power-critical-threshold" = @min(self.@"power-critical-threshold", 99);
+    self.@"power-poll-interval" = @max(5, @min(self.@"power-poll-interval", 300));
+    self.@"draw-interval" = @max(2, @min(self.@"draw-interval", 100));
+
     // Finalize key remapping set for efficient lookups
     self.@"key-remap".finalize();
 }
@@ -5223,6 +5254,17 @@ pub const CustomShaderAnimation = enum(c_int) {
     false,
     true,
     always,
+};
+
+pub const PowerMode = enum {
+    /// Detect power state and apply conditional defaults.
+    auto,
+    /// Always use full performance settings (force power=ac).
+    performance,
+    /// Always use power-saving settings (force power=critical).
+    efficiency,
+    /// Disable power detection entirely.
+    off,
 };
 
 /// Valid values for macos-non-native-fullscreen

--- a/src/config/conditional.zig
+++ b/src/config/conditional.zig
@@ -13,7 +13,11 @@ pub const State = struct {
     /// The target OS of the current build.
     os: std.Target.Os.Tag = builtin.target.os.tag,
 
+    /// The power state of the device.
+    power: Power = .ac,
+
     pub const Theme = enum { light, dark };
+    pub const Power = enum { ac, battery, critical };
 
     /// Tests the conditional against the state and returns true if it matches.
     pub fn match(self: State, cond: Conditional) bool {
@@ -90,5 +94,52 @@ test "conditional enum match" {
         .key = .theme,
         .op = .ne,
         .value = "light",
+    }));
+}
+
+test "conditional power match" {
+    const testing = std.testing;
+    const state: State = .{ .power = .battery };
+    try testing.expect(state.match(.{
+        .key = .power,
+        .op = .eq,
+        .value = "battery",
+    }));
+    try testing.expect(!state.match(.{
+        .key = .power,
+        .op = .eq,
+        .value = "ac",
+    }));
+    try testing.expect(state.match(.{
+        .key = .power,
+        .op = .ne,
+        .value = "critical",
+    }));
+}
+
+test "conditional power and theme independence" {
+    const testing = std.testing;
+    const state: State = .{ .theme = .dark, .power = .critical };
+    try testing.expect(state.match(.{
+        .key = .theme,
+        .op = .eq,
+        .value = "dark",
+    }));
+    try testing.expect(state.match(.{
+        .key = .power,
+        .op = .eq,
+        .value = "critical",
+    }));
+
+    const state2: State = .{ .theme = .light, .power = .critical };
+    try testing.expect(state2.match(.{
+        .key = .theme,
+        .op = .eq,
+        .value = "light",
+    }));
+    try testing.expect(state2.match(.{
+        .key = .power,
+        .op = .eq,
+        .value = "critical",
     }));
 }

--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -31,6 +31,7 @@ pub const windows = @import("windows.zig");
 pub const macos = @import("macos.zig");
 pub const shell = @import("shell.zig");
 pub const uri = @import("uri.zig");
+pub const power = @import("power.zig");
 
 // Functions and types
 pub const CFReleaseThread = @import("cf_release_thread.zig");
@@ -74,6 +75,7 @@ test {
 
     if (comptime builtin.os.tag == .linux) {
         _ = kernel_info;
+        _ = power;
     } else if (comptime builtin.os.tag.isDarwin()) {
         _ = mach;
         _ = macos;

--- a/src/os/power.zig
+++ b/src/os/power.zig
@@ -1,0 +1,418 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+/// The power state of the system.
+pub const PowerState = enum { ac, battery, critical };
+
+/// Information about the current power state of the system.
+pub const PowerInfo = struct {
+    state: PowerState,
+    battery_percent: ?u8,
+};
+
+/// Get the current power info with a given critical threshold.
+/// On non-Linux platforms, always returns .ac with null battery.
+pub fn getPowerInfo(critical_threshold: u8) PowerInfo {
+    if (comptime builtin.os.tag != .linux) {
+        return .{ .state = .ac, .battery_percent = null };
+    }
+    return getPowerInfoFromPath("/sys/class/power_supply", critical_threshold);
+}
+
+/// Get power info by reading from a sysfs-like directory structure.
+/// Never errors — returns .ac with null on any failure.
+pub fn getPowerInfoFromPath(base_path: []const u8, critical_threshold: u8) PowerInfo {
+    const fallback: PowerInfo = .{ .state = .ac, .battery_percent = null };
+
+    var dir = std.fs.openDirAbsolute(base_path, .{ .iterate = true }) catch return fallback;
+    defer dir.close();
+
+    var it = dir.iterate();
+
+    var ac_online = false;
+    var battery_charging = false;
+    var found_battery = false;
+    var lowest_capacity: ?u8 = null;
+
+    while (it.next() catch return fallback) |entry| {
+        // Open the supply subdirectory
+        var supply_dir = dir.openDir(entry.name, .{}) catch continue;
+        defer supply_dir.close();
+
+        // Read the type file
+        var type_buf: [64]u8 = undefined;
+        const supply_type = readSysFile(supply_dir, "type", &type_buf) orelse continue;
+
+        if (std.mem.eql(u8, supply_type, "Mains")) {
+            // Check if AC adapter is online
+            var online_buf: [8]u8 = undefined;
+            const online = readSysFile(supply_dir, "online", &online_buf) orelse continue;
+            if (std.mem.eql(u8, online, "1")) {
+                ac_online = true;
+            }
+        } else if (std.mem.eql(u8, supply_type, "Battery")) {
+            found_battery = true;
+
+            // Read battery status
+            var status_buf: [32]u8 = undefined;
+            if (readSysFile(supply_dir, "status", &status_buf)) |status| {
+                if (std.mem.eql(u8, status, "Charging") or std.mem.eql(u8, status, "Full")) {
+                    battery_charging = true;
+                }
+            }
+
+            // Read battery capacity
+            var capacity_buf: [8]u8 = undefined;
+            if (readSysFile(supply_dir, "capacity", &capacity_buf)) |cap_str| {
+                const capacity = std.fmt.parseInt(u8, cap_str, 10) catch continue;
+                if (lowest_capacity == null or capacity < lowest_capacity.?) {
+                    lowest_capacity = capacity;
+                }
+            }
+        }
+    }
+
+    // Determine state
+    if (ac_online or battery_charging or !found_battery) {
+        return .{
+            .state = .ac,
+            .battery_percent = lowest_capacity,
+        };
+    }
+
+    const capacity = lowest_capacity orelse return fallback;
+
+    const state: PowerState = if (critical_threshold > 0 and capacity <= critical_threshold)
+        .critical
+    else
+        .battery;
+
+    return .{
+        .state = state,
+        .battery_percent = capacity,
+    };
+}
+
+/// Read a single-line sysfs file from the given directory, trimming whitespace.
+/// Returns null on any error or if buffer is too small.
+fn readSysFile(dir: std.fs.Dir, name: []const u8, buf: []u8) ?[]const u8 {
+    var file = dir.openFile(name, .{}) catch return null;
+    defer file.close();
+
+    const n = file.read(buf) catch return null;
+    if (n == 0) return null;
+
+    return std.mem.trim(u8, buf[0..n], &std.ascii.whitespace);
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+test "power: AC power only" {
+    if (comptime builtin.os.tag != .linux) return;
+
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(base);
+
+    // Create AC adapter entry
+    try tmp.dir.makeDir("AC0");
+    var ac_dir = try tmp.dir.openDir("AC0", .{});
+    defer ac_dir.close();
+    try writeFile(ac_dir, "type", "Mains\n");
+    try writeFile(ac_dir, "online", "1\n");
+
+    const info = getPowerInfoFromPath(base, 20);
+    try std.testing.expectEqual(PowerState.ac, info.state);
+    try std.testing.expectEqual(@as(?u8, null), info.battery_percent);
+}
+
+test "power: battery discharging at 50%" {
+    if (comptime builtin.os.tag != .linux) return;
+
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(base);
+
+    try tmp.dir.makeDir("BAT0");
+    var bat_dir = try tmp.dir.openDir("BAT0", .{});
+    defer bat_dir.close();
+    try writeFile(bat_dir, "type", "Battery\n");
+    try writeFile(bat_dir, "status", "Discharging\n");
+    try writeFile(bat_dir, "capacity", "50\n");
+
+    const info = getPowerInfoFromPath(base, 20);
+    try std.testing.expectEqual(PowerState.battery, info.state);
+    try std.testing.expectEqual(@as(?u8, 50), info.battery_percent);
+}
+
+test "power: battery critical at 15% (threshold 20)" {
+    if (comptime builtin.os.tag != .linux) return;
+
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(base);
+
+    try tmp.dir.makeDir("BAT0");
+    var bat_dir = try tmp.dir.openDir("BAT0", .{});
+    defer bat_dir.close();
+    try writeFile(bat_dir, "type", "Battery\n");
+    try writeFile(bat_dir, "status", "Discharging\n");
+    try writeFile(bat_dir, "capacity", "15\n");
+
+    const info = getPowerInfoFromPath(base, 20);
+    try std.testing.expectEqual(PowerState.critical, info.state);
+    try std.testing.expectEqual(@as(?u8, 15), info.battery_percent);
+}
+
+test "power: battery charging" {
+    if (comptime builtin.os.tag != .linux) return;
+
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(base);
+
+    try tmp.dir.makeDir("BAT0");
+    var bat_dir = try tmp.dir.openDir("BAT0", .{});
+    defer bat_dir.close();
+    try writeFile(bat_dir, "type", "Battery\n");
+    try writeFile(bat_dir, "status", "Charging\n");
+    try writeFile(bat_dir, "capacity", "40\n");
+
+    const info = getPowerInfoFromPath(base, 20);
+    try std.testing.expectEqual(PowerState.ac, info.state);
+    try std.testing.expectEqual(@as(?u8, 40), info.battery_percent);
+}
+
+test "power: battery full" {
+    if (comptime builtin.os.tag != .linux) return;
+
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(base);
+
+    try tmp.dir.makeDir("BAT0");
+    var bat_dir = try tmp.dir.openDir("BAT0", .{});
+    defer bat_dir.close();
+    try writeFile(bat_dir, "type", "Battery\n");
+    try writeFile(bat_dir, "status", "Full\n");
+    try writeFile(bat_dir, "capacity", "100\n");
+
+    const info = getPowerInfoFromPath(base, 20);
+    try std.testing.expectEqual(PowerState.ac, info.state);
+    try std.testing.expectEqual(@as(?u8, 100), info.battery_percent);
+}
+
+test "power: no power supply directory" {
+    if (comptime builtin.os.tag != .linux) return;
+
+    const info = getPowerInfoFromPath("/nonexistent/path/that/does/not/exist", 20);
+    try std.testing.expectEqual(PowerState.ac, info.state);
+    try std.testing.expectEqual(@as(?u8, null), info.battery_percent);
+}
+
+test "power: malformed capacity file" {
+    if (comptime builtin.os.tag != .linux) return;
+
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(base);
+
+    try tmp.dir.makeDir("BAT0");
+    var bat_dir = try tmp.dir.openDir("BAT0", .{});
+    defer bat_dir.close();
+    try writeFile(bat_dir, "type", "Battery\n");
+    try writeFile(bat_dir, "status", "Discharging\n");
+    try writeFile(bat_dir, "capacity", "not_a_number\n");
+
+    // Battery found but capacity couldn't be parsed → fallback
+    const info = getPowerInfoFromPath(base, 20);
+    try std.testing.expectEqual(PowerState.ac, info.state);
+    try std.testing.expectEqual(@as(?u8, null), info.battery_percent);
+}
+
+test "power: empty directory" {
+    if (comptime builtin.os.tag != .linux) return;
+
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(base);
+
+    const info = getPowerInfoFromPath(base, 20);
+    try std.testing.expectEqual(PowerState.ac, info.state);
+    try std.testing.expectEqual(@as(?u8, null), info.battery_percent);
+}
+
+test "power: multiple batteries uses lowest capacity" {
+    if (comptime builtin.os.tag != .linux) return;
+
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(base);
+
+    try tmp.dir.makeDir("BAT0");
+    var bat0_dir = try tmp.dir.openDir("BAT0", .{});
+    defer bat0_dir.close();
+    try writeFile(bat0_dir, "type", "Battery\n");
+    try writeFile(bat0_dir, "status", "Discharging\n");
+    try writeFile(bat0_dir, "capacity", "70\n");
+
+    try tmp.dir.makeDir("BAT1");
+    var bat1_dir = try tmp.dir.openDir("BAT1", .{});
+    defer bat1_dir.close();
+    try writeFile(bat1_dir, "type", "Battery\n");
+    try writeFile(bat1_dir, "status", "Discharging\n");
+    try writeFile(bat1_dir, "capacity", "30\n");
+
+    const info = getPowerInfoFromPath(base, 20);
+    try std.testing.expectEqual(PowerState.battery, info.state);
+    try std.testing.expectEqual(@as(?u8, 30), info.battery_percent);
+}
+
+test "power: AC online plus battery discharging" {
+    if (comptime builtin.os.tag != .linux) return;
+
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(base);
+
+    try tmp.dir.makeDir("AC0");
+    var ac_dir = try tmp.dir.openDir("AC0", .{});
+    defer ac_dir.close();
+    try writeFile(ac_dir, "type", "Mains\n");
+    try writeFile(ac_dir, "online", "1\n");
+
+    try tmp.dir.makeDir("BAT0");
+    var bat_dir = try tmp.dir.openDir("BAT0", .{});
+    defer bat_dir.close();
+    try writeFile(bat_dir, "type", "Battery\n");
+    try writeFile(bat_dir, "status", "Discharging\n");
+    try writeFile(bat_dir, "capacity", "45\n");
+
+    const info = getPowerInfoFromPath(base, 20);
+    try std.testing.expectEqual(PowerState.ac, info.state);
+    try std.testing.expectEqual(@as(?u8, 45), info.battery_percent);
+}
+
+test "power: threshold boundary (capacity == threshold)" {
+    if (comptime builtin.os.tag != .linux) return;
+
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(base);
+
+    try tmp.dir.makeDir("BAT0");
+    var bat_dir = try tmp.dir.openDir("BAT0", .{});
+    defer bat_dir.close();
+    try writeFile(bat_dir, "type", "Battery\n");
+    try writeFile(bat_dir, "status", "Discharging\n");
+    try writeFile(bat_dir, "capacity", "20\n");
+
+    const info = getPowerInfoFromPath(base, 20);
+    try std.testing.expectEqual(PowerState.critical, info.state);
+    try std.testing.expectEqual(@as(?u8, 20), info.battery_percent);
+}
+
+test "power: capacity at 0%" {
+    if (comptime builtin.os.tag != .linux) return;
+
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(base);
+
+    try tmp.dir.makeDir("BAT0");
+    var bat_dir = try tmp.dir.openDir("BAT0", .{});
+    defer bat_dir.close();
+    try writeFile(bat_dir, "type", "Battery\n");
+    try writeFile(bat_dir, "status", "Discharging\n");
+    try writeFile(bat_dir, "capacity", "0\n");
+
+    const info = getPowerInfoFromPath(base, 20);
+    try std.testing.expectEqual(PowerState.critical, info.state);
+    try std.testing.expectEqual(@as(?u8, 0), info.battery_percent);
+}
+
+test "power: threshold 0 disables critical" {
+    if (comptime builtin.os.tag != .linux) return;
+
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(base);
+
+    try tmp.dir.makeDir("BAT0");
+    var bat_dir = try tmp.dir.openDir("BAT0", .{});
+    defer bat_dir.close();
+    try writeFile(bat_dir, "type", "Battery\n");
+    try writeFile(bat_dir, "status", "Discharging\n");
+    try writeFile(bat_dir, "capacity", "5\n");
+
+    const info = getPowerInfoFromPath(base, 0);
+    try std.testing.expectEqual(PowerState.battery, info.state);
+    try std.testing.expectEqual(@as(?u8, 5), info.battery_percent);
+}
+
+test "power: capacity 100 while discharging" {
+    if (comptime builtin.os.tag != .linux) return;
+
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(base);
+
+    try tmp.dir.makeDir("BAT0");
+    var bat_dir = try tmp.dir.openDir("BAT0", .{});
+    defer bat_dir.close();
+    try writeFile(bat_dir, "type", "Battery\n");
+    try writeFile(bat_dir, "status", "Discharging\n");
+    try writeFile(bat_dir, "capacity", "100\n");
+
+    const info = getPowerInfoFromPath(base, 20);
+    try std.testing.expectEqual(PowerState.battery, info.state);
+    try std.testing.expectEqual(@as(?u8, 100), info.battery_percent);
+}
+
+// Helper to write a file in a directory
+fn writeFile(dir: std.fs.Dir, name: []const u8, content: []const u8) !void {
+    var file = try dir.createFile(name, .{});
+    defer file.close();
+    try file.writeAll(content);
+}

--- a/src/os/power.zig
+++ b/src/os/power.zig
@@ -11,12 +11,72 @@ pub const PowerInfo = struct {
 };
 
 /// Get the current power info with a given critical threshold.
-/// On non-Linux platforms, always returns .ac with null battery.
+/// On non-Linux/macOS platforms, always returns .ac with null battery.
 pub fn getPowerInfo(critical_threshold: u8) PowerInfo {
-    if (comptime builtin.os.tag != .linux) {
-        return .{ .state = .ac, .battery_percent = null };
+    if (comptime builtin.os.tag == .linux) {
+        return getPowerInfoFromPath("/sys/class/power_supply", critical_threshold);
+    } else if (comptime builtin.os.tag == .macos) {
+        return getMacOSPowerInfo(critical_threshold);
     }
-    return getPowerInfoFromPath("/sys/class/power_supply", critical_threshold);
+    return .{ .state = .ac, .battery_percent = null };
+}
+
+fn getMacOSPowerInfo(critical_threshold: u8) PowerInfo {
+    if (comptime builtin.os.tag != .macos) unreachable;
+
+    const c = @cImport({
+        @cInclude("IOKit/ps/IOPowerSources.h");
+        @cInclude("IOKit/ps/IOPSKeys.h");
+    });
+
+    const fallback: PowerInfo = .{ .state = .ac, .battery_percent = null };
+
+    const info = c.IOPSCopyPowerSourcesInfo() orelse return fallback;
+    defer c.CFRelease(info);
+
+    const list = c.IOPSCopyPowerSourcesList(info) orelse return fallback;
+    defer c.CFRelease(list);
+
+    const count = c.CFArrayGetCount(list);
+    if (count == 0) return fallback;
+
+    // Check providing power source type
+    const source_type = c.IOPSGetProvidingPowerSourceType(info);
+    const is_battery = if (source_type) |st|
+        c.CFStringCompare(st, c.CFSTR("Battery Power"), 0) == c.kCFCompareEqualTo
+    else
+        false;
+
+    // Get capacity from first power source
+    var battery_percent: ?u8 = null;
+    {
+        const ps = c.CFArrayGetValueAtIndex(list, 0);
+        const desc = c.IOPSGetPowerSourceDescription(info, ps); // "Get" — do NOT CFRelease
+        if (desc) |d| {
+            const cap_key = c.CFSTR(c.kIOPSCurrentCapacityKey);
+            if (c.CFDictionaryGetValue(d, cap_key)) |cap_val| {
+                var cap: c_int = 0;
+                if (c.CFNumberGetValue(@ptrCast(cap_val), c.kCFNumberIntType, &cap)) {
+                    if (cap >= 0 and cap <= 100) {
+                        battery_percent = @intCast(@as(u32, @bitCast(cap)));
+                    }
+                }
+            }
+        }
+    }
+
+    if (!is_battery) {
+        return .{ .state = .ac, .battery_percent = battery_percent };
+    }
+
+    // On battery — check critical threshold
+    if (battery_percent) |cap| {
+        if (critical_threshold > 0 and cap <= critical_threshold) {
+            return .{ .state = .critical, .battery_percent = cap };
+        }
+    }
+
+    return .{ .state = .battery, .battery_percent = battery_percent };
 }
 
 /// Get power info by reading from a sysfs-like directory structure.

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -16,7 +16,6 @@ const App = @import("../App.zig");
 const Allocator = std.mem.Allocator;
 const log = std.log.scoped(.renderer_thread);
 
-const DRAW_INTERVAL = 8; // 120 FPS
 const CURSOR_BLINK_INTERVAL = 600;
 
 /// Whether calls to `drawFrame` must be done from the app thread.
@@ -111,10 +110,12 @@ flags: packed struct {
 
 pub const DerivedConfig = struct {
     custom_shader_animation: configpkg.CustomShaderAnimation,
+    draw_interval_ms: u16,
 
     pub fn init(config: *const configpkg.Config) DerivedConfig {
         return .{
             .custom_shader_animation = config.@"custom-shader-animation",
+            .draw_interval_ms = config.@"draw-interval",
         };
     }
 };
@@ -326,7 +327,7 @@ fn syncDrawTimer(self: *Thread) void {
     self.draw_h.run(
         &self.loop,
         &self.draw_c,
-        DRAW_INTERVAL,
+        self.config.draw_interval_ms,
         Thread,
         self,
         drawCallback,
@@ -587,7 +588,7 @@ fn drawCallback(
 
     // Only continue if we're still active
     if (t.draw_active) {
-        t.draw_h.run(&t.loop, &t.draw_c, DRAW_INTERVAL, Thread, t, drawCallback);
+        t.draw_h.run(&t.loop, &t.draw_c, t.config.draw_interval_ms, Thread, t, drawCallback);
     }
 
     return .disarm;


### PR DESCRIPTION
## Summary

- Extends Ghostty's conditional config system with a `power` state (`ac` / `battery` / `critical`) for battery-aware rendering
- Adds cross-platform battery detection (Linux sysfs, macOS IOKit) with 14 unit tests
- Makes `DRAW_INTERVAL` configurable via `draw-interval` option (replaces hardcoded 8ms constant)
- Auto-mode provides sensible defaults (60fps on battery, 30fps on critical) that users can override with `[conditional:power=battery]` blocks

Closes #11928

## Changes

| File | Change |
|------|--------|
| `src/os/power.zig` | **New** — Cross-platform power detection module |
| `src/os/main.zig` | Export power module |
| `src/config/conditional.zig` | Add `Power` enum + `power` field to `State` |
| `src/config/Config.zig` | Add `power-mode`, `draw-interval`, threshold/interval options, auto-default injection via conditional replay steps |
| `src/App.zig` | Timestamp-gated power polling in `tick()`, cached `PowerConfig` |
| `src/renderer/Thread.zig` | Replace `DRAW_INTERVAL` constant with `config.draw_interval_ms` |
| `pkg/macos/build.zig` | Link `IOKit.framework` on macOS |

## Design

**Why extend conditional config?** The `Key` enum auto-generates from `State` struct fields via comptime reflection. Adding `power` required one struct field — the entire parsing, matching, and propagation pipeline works unchanged. Users get `[conditional:power=battery]` for free.

**Why poll in `tick()`?** Battery state changes on the order of minutes. A timestamp check in `App.tick()` avoids introducing timers or threads. When state changes, it triggers `performAction(.reload_config, .{ .soft = true })` — the same path as theme changes.

**Why `off` by default?** Desktops without batteries shouldn't pay polling cost. Users opt in with `power-mode = auto`.

**Auto-mode defaults** are injected as low-priority `conditional_arg` replay steps in `Config.finalize()`. User-written `[conditional:power=...]` blocks appear later and override them.

## Verification

- `zig build -Dapp-runtime=gtk` — Clean
- `zig build -Dapp-runtime=none` — Clean  
- `zig build test -Dapp-runtime=none` — All tests pass
- 14 unit tests for Linux power detection with mock sysfs directories
- macOS implementation compile-time gated (not testable on Linux CI)

## Test plan

- [ ] Verify `power-mode = auto` detects battery state correctly on macOS laptop
- [ ] Verify `power-mode = auto` detects battery state correctly on Linux laptop
- [ ] Verify `power-mode = off` (default) has zero behavior change
- [ ] Verify `power-mode = performance` forces full-speed rendering
- [ ] Verify `power-mode = efficiency` forces power-saving rendering
- [ ] Verify user `[conditional:power=battery]` overrides auto-mode defaults
- [ ] Verify `draw-interval` config works independently of power management
- [ ] Verify AC→battery→AC transitions update rendering in real-time
- [ ] Measure actual power draw reduction with `powermetrics` on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)