### PR TITLE
build(libghostty): export function table for wasm to allow host callbacks

### DIFF
--- a/src/build/GhosttyLibVt.zig
+++ b/src/build/GhosttyLibVt.zig
@@ -47,6 +47,9 @@ pub fn initWasm(
     // There is no entrypoint for this wasm module.
     exe.entry = .disabled;
 
+    // Export the function table so the host can add callback entries.
+    exe.export_table = true;
+
     return .{
         .step = &exe.step,
         .artifact = b.addInstallArtifact(exe, .{}),


### PR DESCRIPTION
Export function table for wasm module to allow host callbacks (effects).