### PR TITLE
macos: add support for middle-click tab close for `macos-titlebar-style = tabs`

### DIFF
--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -840,3 +840,29 @@ extension TerminalWindow: TabTitleEditorDelegate {
         makeFirstResponder(focusedSurface)
     }
 }
+
+// MARK: - Tab Clicks
+
+extension TerminalWindow {
+    /// Handles a middle-click event to close the tab under the cursor
+    ///
+    /// Returns true if the event was handled and should be consumed
+    func handleTabBarMiddleClick(_ event: NSEvent) -> Bool {
+        // Require middle click
+        guard event.type == .otherMouseDown && event.buttonNumber == 2 else { return false }
+
+        // Require tab hit
+        let screenPoint = convertPoint(toScreen: event.locationInWindow)
+        guard let hit = tabButtonHit(atScreenPoint: screenPoint) else { return false }
+
+        // Require we have tabs and the index is valid
+        guard let tabbedWindows = tabbedWindows,
+              hit.index < tabbedWindows.count else { return false }
+
+        // Find the controller and close it
+        let targetWindow = tabbedWindows[hit.index]
+        guard let controller = targetWindow.windowController as? TerminalController else { return false }
+        controller.closeTab(nil)
+        return true
+    }
+}

--- a/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
@@ -76,6 +76,9 @@ class TitlebarTabsTahoeTerminalWindow: TransparentTitlebarTerminalWindow, NSTool
             return
         }
 
+        // Handle middle-click to close tabs if configured
+        if handleTabBarMiddleClick(event) { return }
+
         let isRightClick =
             event.type == .rightMouseDown ||
             (event.type == .otherMouseDown && event.buttonNumber == 2) ||

--- a/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsVenturaTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsVenturaTerminalWindow.swift
@@ -69,6 +69,11 @@ class TitlebarTabsVenturaTerminalWindow: TerminalWindow {
         tab.attributedTitle = attributedTitle
     }
 
+    override func sendEvent(_ event: NSEvent) {
+        if tabBarView != nil && handleTabBarMiddleClick(event) { return }
+        super.sendEvent(event)
+    }
+
 	override func layoutIfNeeded() {
 		super.layoutIfNeeded()
 


### PR DESCRIPTION
Fixes #11962

### Summary
This PR implements a fix for: https://github.com/ghostty-org/ghostty/discussions/10264

This allows the `macos-titlebar-style` setting `tabs` to behave the same way other titlebar style options do with middle click handling.

### AI Disclosure
I used claude code (Sonnet 4.6) to identify the best place to start when implementing this change, as well as for general Swift questions. The code within this PR is written by me.