### PR TITLE
core: restructure args parsing to allow `+`-prefixed args after `-e`

### DIFF
--- a/src/benchmark/cli.zig
+++ b/src/benchmark/cli.zig
@@ -14,6 +14,8 @@ pub const Action = enum {
     @"is-symbol",
     @"osc-parser",
 
+    pub const ParseResult = cli.action.ActionParser(@This());
+
     /// Returns the struct associated with the action. The struct
     /// should have a few decls:
     ///
@@ -38,15 +40,19 @@ pub const Action = enum {
 /// An entrypoint for the benchmark CLI.
 pub fn main() !void {
     const alloc = std.heap.c_allocator;
-    const action_ = try cli.action.detectArgs(Action, alloc);
-    const action = action_ orelse return error.NoAction;
-    try mainAction(alloc, action, .cli);
+    // Eventually this will be replaced with the args from the "juicy" main.
+    var iter = try std.process.argsWithAllocator(alloc);
+    defer iter.deinit();
+    const result: Action.ParseResult = try .parse(alloc, &iter);
+    defer result.deinit(alloc);
+    const action = result.action orelse return error.NoAction;
+    try mainAction(alloc, action, .{ .cli = result.args });
 }
 
 /// Arguments that can be passed to the benchmark.
 pub const Args = union(enum) {
     /// The arguments passed to the CLI via argc/argv.
-    cli,
+    cli: []const [:0]const u8,
 
     /// Simple string arguments, parsed via std.process.ArgIteratorGeneral.
     string: []const u8,
@@ -75,8 +81,8 @@ fn mainActionImpl(
     var opts: Options = .{};
     defer if (@hasDecl(Options, "deinit")) opts.deinit();
     switch (args) {
-        .cli => {
-            var iter = try cli.args.argsIterator(alloc);
+        .cli => |a| {
+            var iter = try cli.args.argsIterator(alloc, a);
             defer iter.deinit();
             try cli.args.parse(Options, alloc, &opts, &iter);
         },

--- a/src/cli/action.zig
+++ b/src/cli/action.zig
@@ -1,101 +1,173 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
-pub const DetectError = error{
-    /// Multiple actions were detected. You can specify at most one
-    /// action on the CLI otherwise the behavior desired is ambiguous.
-    MultipleActions,
-
-    /// An unknown action was specified.
-    InvalidAction,
-};
-
-/// Detect the action from CLI args.
-pub fn detectArgs(comptime E: type, alloc: Allocator) !?E {
-    var iter = try std.process.argsWithAllocator(alloc);
-    defer iter.deinit();
-    return try detectIter(E, &iter);
-}
-
-/// Detect the action from any iterator. Each iterator value should yield
-/// a CLI argument such as "--foo".
+/// Build a type to handle parsing CLI args for an action. The `parse`
+/// function of the resulting type will parse the CLI args (given by a
+/// std.process.argsWithAllocator-compatible iterator) looking for an action
+/// and filtering the found action from the list of arguments, making subsequent
+/// processing steps easier.
 ///
 /// The comptime type E must be an enum with the available actions.
 /// If the type E has a decl `detectSpecialCase`, then it will be called
 /// for each argument to allow handling of special cases. The function
 /// signature for `detectSpecialCase` should be:
 ///
-///   fn detectSpecialCase(arg: []const u8) ?SpecialCase(E)
+///   fn detectSpecialCase(arg: []const u8) ?ActionParser(E).SpecialCase
 ///
-pub fn detectIter(
-    comptime E: type,
-    iter: anytype,
-) DetectError!?E {
-    var fallback: ?E = null;
-    var pending: ?E = null;
-    while (iter.next()) |arg| {
-        // Allow handling of special cases.
-        if (@hasDecl(E, "detectSpecialCase")) special: {
-            const special = E.detectSpecialCase(arg) orelse break :special;
-            switch (special) {
-                .action => |a| return a,
-                .fallback => |a| fallback = a,
-                .abort_if_no_action => if (pending == null) return null,
+pub fn ActionParser(comptime E: type) type {
+    return struct {
+        pub const Self = @This();
+
+        action: ?E,
+        args: []const [:0]const u8,
+
+        pub const Error = error{
+            /// Multiple actions were detected. You can specify at most one action on
+            /// the CLI otherwise the behavior desired is ambiguous.
+            MultipleActions,
+
+            /// Multiple fallback actions were detected. You can specify at most one
+            /// fallback action on the CLI otherwise the behavior desired is ambiguous.
+            MultipleFallbackActions,
+
+            /// An unknown action was specified.
+            InvalidAction,
+        };
+
+        /// The action enum E can implement the decl `detectSpecialCase` to
+        /// return this enum in order to perform various special case actions.
+        pub const SpecialCase = union(enum) {
+            /// Immediately return this action.
+            action: E,
+
+            /// Return this action if no other action is found.
+            fallback: E,
+
+            /// Stop processing arguments looking for actions. This is kind of weird
+            /// but is a special case to allow "-e" in Ghostty.
+            abort,
+        };
+
+        /// Detect the action from any iterator. Each iterator value should yield
+        /// a CLI argument such as "--foo".
+        pub fn parse(
+            alloc: Allocator,
+            iter: anytype,
+        ) (Allocator.Error || Error)!Self {
+            var args: std.ArrayList([:0]const u8) = .empty;
+            errdefer {
+                for (args.items) |arg| alloc.free(arg);
+                args.deinit(alloc);
             }
+
+            const action = action: {
+                var fallback: ?struct {
+                    /// The action to fall back to.
+                    action: E,
+                    /// If we fall back to this action, use this position to remove it
+                    /// from the cached list of arguments.
+                    pos: usize,
+                } = null;
+                var pending: ?E = null;
+
+                while (iter.next()) |arg| {
+                    // Allow handling of special cases.
+                    if (@hasDecl(E, "detectSpecialCase")) special: {
+                        const special = E.detectSpecialCase(arg) orelse break :special;
+                        switch (special) {
+                            .action => |a| {
+                                break :action a;
+                            },
+                            .fallback => |a| {
+                                if (fallback != null) return error.MultipleFallbackActions;
+                                try args.append(alloc, try alloc.dupeZ(u8, arg));
+                                fallback = .{
+                                    .action = a,
+                                    .pos = args.items.len - 1,
+                                };
+                                continue;
+                            },
+                            .abort => {
+                                try args.append(alloc, try alloc.dupeZ(u8, arg));
+                                break :action pending;
+                            },
+                        }
+                    }
+
+                    // Commands must start with "+"
+                    if (arg.len == 0 or arg[0] != '+') {
+                        try args.append(alloc, try alloc.dupeZ(u8, arg));
+                        continue;
+                    }
+                    if (pending != null) return Error.MultipleActions;
+                    pending = std.meta.stringToEnum(E, arg[1..]) orelse
+                        return Error.InvalidAction;
+                }
+
+                // If we have an action, we always return that action, even if we've
+                // seen "--help" or "-h" because the action may have its own help text.
+                if (pending != null) break :action pending;
+
+                // If we have no action but we have a fallback, then we return that.
+                if (fallback) |a| {
+                    // Remove the argument that created the fallback
+                    const arg = args.orderedRemove(a.pos);
+                    alloc.free(arg);
+                    break :action a.action;
+                }
+
+                break :action null;
+            };
+
+            while (iter.next()) |arg| {
+                try args.append(alloc, try alloc.dupeZ(u8, arg));
+            }
+
+            return .{
+                .action = action,
+                .args = try args.toOwnedSlice(alloc),
+            };
         }
 
-        // Commands must start with "+"
-        if (arg.len == 0 or arg[0] != '+') continue;
-        if (pending != null) return DetectError.MultipleActions;
-        pending = std.meta.stringToEnum(E, arg[1..]) orelse
-            return DetectError.InvalidAction;
-    }
-
-    // If we have an action, we always return that action, even if we've
-    // seen "--help" or "-h" because the action may have its own help text.
-    if (pending != null) return pending;
-
-    // If we have no action but we have a fallback, then we return that.
-    if (fallback) |a| return a;
-
-    return null;
-}
-
-/// The action enum E can implement the decl `detectSpecialCase` to
-/// return this enum in order to perform various special case actions.
-pub fn SpecialCase(comptime E: type) type {
-    return union(enum) {
-        /// Immediately return this action.
-        action: E,
-
-        /// Return this action if no other action is found.
-        fallback: E,
-
-        /// If there is no pending action (we haven't seen an action yet)
-        /// then we should return no action. This is kind of weird but is
-        /// a special case to allow "-e" in Ghostty.
-        abort_if_no_action,
+        pub fn deinit(self: *const Self, alloc: Allocator) void {
+            for (self.args) |arg| alloc.free(arg);
+            alloc.free(self.args);
+        }
     };
 }
 
 test "detect direct match" {
     const testing = std.testing;
     const alloc = testing.allocator;
-    const Enum = enum { foo, bar, baz };
+    const Enum = enum {
+        foo,
+        bar,
+        baz,
+
+        const ParseResult = ActionParser(@This());
+    };
 
     var iter = try std.process.ArgIteratorGeneral(.{}).init(
         alloc,
         "+foo",
     );
     defer iter.deinit();
-    const result = try detectIter(Enum, &iter);
-    try testing.expectEqual(Enum.foo, result.?);
+    const result: Enum.ParseResult = try .parse(alloc, &iter);
+    defer result.deinit(alloc);
+    try testing.expectEqual(Enum.foo, result.action.?);
+    try testing.expectEqual(0, result.args.len);
 }
 
 test "detect invalid match" {
     const testing = std.testing;
     const alloc = testing.allocator;
-    const Enum = enum { foo, bar, baz };
+    const Enum = enum {
+        foo,
+        bar,
+        baz,
+
+        const ParseResult = ActionParser(@This());
+    };
 
     var iter = try std.process.ArgIteratorGeneral(.{}).init(
         alloc,
@@ -103,15 +175,21 @@ test "detect invalid match" {
     );
     defer iter.deinit();
     try testing.expectError(
-        DetectError.InvalidAction,
-        detectIter(Enum, &iter),
+        error.InvalidAction,
+        Enum.ParseResult.parse(alloc, &iter),
     );
 }
 
 test "detect multiple actions" {
     const testing = std.testing;
     const alloc = testing.allocator;
-    const Enum = enum { foo, bar, baz };
+    const Enum = enum {
+        foo,
+        bar,
+        baz,
+
+        const ParseResult = ActionParser(@This());
+    };
 
     var iter = try std.process.ArgIteratorGeneral(.{}).init(
         alloc,
@@ -119,23 +197,32 @@ test "detect multiple actions" {
     );
     defer iter.deinit();
     try testing.expectError(
-        DetectError.MultipleActions,
-        detectIter(Enum, &iter),
+        error.MultipleActions,
+        Enum.ParseResult.parse(alloc, &iter),
     );
 }
 
 test "detect no match" {
     const testing = std.testing;
     const alloc = testing.allocator;
-    const Enum = enum { foo, bar, baz };
+    const Enum = enum {
+        foo,
+        bar,
+        baz,
+
+        const ParseResult = ActionParser(@This());
+    };
 
     var iter = try std.process.ArgIteratorGeneral(.{}).init(
         alloc,
         "--some-flag",
     );
     defer iter.deinit();
-    const result = try detectIter(Enum, &iter);
-    try testing.expect(result == null);
+    const result: Enum.ParseResult = try .parse(alloc, &iter);
+    defer result.deinit(alloc);
+    try testing.expect(result.action == null);
+    try testing.expectEqual(1, result.args.len);
+    try testing.expectEqualStrings("--some-flag", result.args[0]);
 }
 
 test "detect special case action" {
@@ -145,7 +232,9 @@ test "detect special case action" {
         foo,
         bar,
 
-        fn detectSpecialCase(arg: []const u8) ?SpecialCase(@This()) {
+        const ParseResult = ActionParser(@This());
+
+        fn detectSpecialCase(arg: []const u8) ?ParseResult.SpecialCase {
             return if (std.mem.eql(u8, arg, "--special"))
                 .{ .action = .foo }
             else
@@ -159,8 +248,11 @@ test "detect special case action" {
             "--special +bar",
         );
         defer iter.deinit();
-        const result = try detectIter(Enum, &iter);
-        try testing.expectEqual(Enum.foo, result.?);
+        const result: Enum.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expectEqual(Enum.foo, result.action.?);
+        try testing.expectEqual(1, result.args.len);
+        try testing.expectEqualStrings("+bar", result.args[0]);
     }
 
     {
@@ -169,8 +261,10 @@ test "detect special case action" {
             "+bar --special",
         );
         defer iter.deinit();
-        const result = try detectIter(Enum, &iter);
-        try testing.expectEqual(Enum.foo, result.?);
+        const result: Enum.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expectEqual(Enum.foo, result.action.?);
+        try testing.expectEqual(0, result.args.len);
     }
 
     {
@@ -179,8 +273,10 @@ test "detect special case action" {
             "+bar",
         );
         defer iter.deinit();
-        const result = try detectIter(Enum, &iter);
-        try testing.expectEqual(Enum.bar, result.?);
+        const result: Enum.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expectEqual(Enum.bar, result.action.?);
+        try testing.expectEqual(0, result.args.len);
     }
 }
 
@@ -190,10 +286,15 @@ test "detect special case fallback" {
     const Enum = enum {
         foo,
         bar,
+        baz,
 
-        fn detectSpecialCase(arg: []const u8) ?SpecialCase(@This()) {
+        pub const ParseResult = ActionParser(@This());
+
+        fn detectSpecialCase(arg: []const u8) ?ParseResult.SpecialCase {
             return if (std.mem.eql(u8, arg, "--special"))
                 .{ .fallback = .foo }
+            else if (std.mem.eql(u8, arg, "--super-special"))
+                .{ .fallback = .baz }
             else
                 null;
         }
@@ -205,8 +306,10 @@ test "detect special case fallback" {
             "--special",
         );
         defer iter.deinit();
-        const result = try detectIter(Enum, &iter);
-        try testing.expectEqual(Enum.foo, result.?);
+        const result: Enum.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expectEqual(Enum.foo, result.action.?);
+        try testing.expectEqual(0, result.args.len);
     }
 
     {
@@ -215,8 +318,11 @@ test "detect special case fallback" {
             "+bar --special",
         );
         defer iter.deinit();
-        const result = try detectIter(Enum, &iter);
-        try testing.expectEqual(Enum.bar, result.?);
+        const result: Enum.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expectEqual(Enum.bar, result.action.?);
+        try testing.expectEqual(1, result.args.len);
+        try testing.expectEqualStrings("--special", result.args[0]);
     }
 
     {
@@ -225,21 +331,110 @@ test "detect special case fallback" {
             "--special +bar",
         );
         defer iter.deinit();
-        const result = try detectIter(Enum, &iter);
-        try testing.expectEqual(Enum.bar, result.?);
+        const result: Enum.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expectEqual(Enum.bar, result.action.?);
+        try testing.expectEqual(1, result.args.len);
+        try testing.expectEqualStrings("--special", result.args[0]);
+    }
+
+    {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(
+            alloc,
+            "--a=42 --special --b=67",
+        );
+        defer iter.deinit();
+        const result: Enum.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expectEqual(Enum.foo, result.action.?);
+        try testing.expectEqual(2, result.args.len);
+        try testing.expectEqualStrings("--a=42", result.args[0]);
+        try testing.expectEqualStrings("--b=67", result.args[1]);
+    }
+
+    {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(
+            alloc,
+            "--special --super-special",
+        );
+        defer iter.deinit();
+        try testing.expectError(error.MultipleFallbackActions, Enum.ParseResult.parse(alloc, &iter));
+    }
+
+    {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(
+            alloc,
+            "+bar --special --super-special",
+        );
+        defer iter.deinit();
+        try testing.expectError(error.MultipleFallbackActions, Enum.ParseResult.parse(alloc, &iter));
+    }
+
+    {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(
+            alloc,
+            "+bar --super-special",
+        );
+        defer iter.deinit();
+        const result: Enum.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expectEqual(Enum.bar, result.action.?);
+        try testing.expectEqual(1, result.args.len);
+        try testing.expectEqualStrings("--super-special", result.args[0]);
+    }
+
+    {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(
+            alloc,
+            "--super-special --a=42",
+        );
+        defer iter.deinit();
+        const result: Enum.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expectEqual(Enum.baz, result.action.?);
+        try testing.expectEqual(1, result.args.len);
+        try testing.expectEqualStrings("--a=42", result.args[0]);
+    }
+
+    {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(
+            alloc,
+            "--super-special",
+        );
+        defer iter.deinit();
+        const result: Enum.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expectEqual(Enum.baz, result.action.?);
+        try testing.expectEqual(0, result.args.len);
+    }
+
+    {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(
+            alloc,
+            "--b=67 --super-special --a=42",
+        );
+        defer iter.deinit();
+        const result: Enum.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expectEqual(Enum.baz, result.action.?);
+        try testing.expectEqual(2, result.args.len);
+        try testing.expectEqualStrings("--b=67", result.args[0]);
+        try testing.expectEqualStrings("--a=42", result.args[1]);
     }
 }
 
-test "detect special case abort_if_no_action" {
+test "detect special case abort" {
     const testing = std.testing;
     const alloc = testing.allocator;
     const Enum = enum {
         foo,
         bar,
 
-        fn detectSpecialCase(arg: []const u8) ?SpecialCase(@This()) {
+        pub const ParseResult = ActionParser(@This());
+
+        fn detectSpecialCase(arg: []const u8) ?ParseResult.SpecialCase {
             return if (std.mem.eql(u8, arg, "-e"))
-                .abort_if_no_action
+                .abort
             else
                 null;
         }
@@ -251,8 +446,11 @@ test "detect special case abort_if_no_action" {
             "-e",
         );
         defer iter.deinit();
-        const result = try detectIter(Enum, &iter);
-        try testing.expect(result == null);
+        const result: Enum.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expect(result.action == null);
+        try testing.expectEqual(1, result.args.len);
+        try testing.expectEqualStrings("-e", result.args[0]);
     }
 
     {
@@ -261,8 +459,11 @@ test "detect special case abort_if_no_action" {
             "+foo -e",
         );
         defer iter.deinit();
-        const result = try detectIter(Enum, &iter);
-        try testing.expectEqual(Enum.foo, result.?);
+        const result: Enum.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expectEqual(Enum.foo, result.action.?);
+        try testing.expectEqual(1, result.args.len);
+        try testing.expectEqualStrings("-e", result.args[0]);
     }
 
     {
@@ -271,7 +472,25 @@ test "detect special case abort_if_no_action" {
             "-e +bar",
         );
         defer iter.deinit();
-        const result = try detectIter(Enum, &iter);
-        try testing.expect(result == null);
+        const result: Enum.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expect(result.action == null);
+        try testing.expectEqual(2, result.args.len);
+        try testing.expectEqualStrings("-e", result.args[0]);
+        try testing.expectEqualStrings("+bar", result.args[1]);
+    }
+
+    {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(
+            alloc,
+            "+bar -e +bar",
+        );
+        defer iter.deinit();
+        const result: Enum.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expectEqual(Enum.bar, result.action.?);
+        try testing.expectEqual(2, result.args.len);
+        try testing.expectEqualStrings("-e", result.args[0]);
+        try testing.expectEqualStrings("+bar", result.args[1]);
     }
 }

--- a/src/cli/args.zig
+++ b/src/cli/args.zig
@@ -1322,9 +1322,6 @@ test "parseIntoField: tagged union missing tag" {
 /// An iterator that considers its location to be CLI args. It
 /// iterates through an underlying iterator and increments a counter
 /// to track the current CLI arg index.
-///
-/// This also ignores any argument that starts with `+`. It assumes that
-/// actions were parsed out before this iterator was created.
 pub fn ArgsIterator(comptime Iterator: type) type {
     return struct {
         const Self = @This();
@@ -1343,14 +1340,9 @@ pub fn ArgsIterator(comptime Iterator: type) type {
             }
         }
 
-        pub fn next(self: *Self) ?[]const u8 {
+        pub fn next(self: *Self) ?[:0]const u8 {
             const value = self.iterator.next() orelse return null;
             self.index += 1;
-
-            // We ignore any argument that starts with "+". This is used
-            // to indicate actions and are expected to be parsed out before
-            // this iterator is created.
-            if (value.len > 0 and value[0] == '+') return self.next();
 
             return value;
         }
@@ -1363,8 +1355,8 @@ pub fn ArgsIterator(comptime Iterator: type) type {
 }
 
 /// Create an args iterator for the process args. This will skip argv0.
-pub fn argsIterator(alloc_gpa: Allocator) internal_os.args.ArgIterator.InitError!ArgsIterator(internal_os.args.ArgIterator) {
-    var iter = try internal_os.args.iterator(alloc_gpa);
+pub fn argsIterator(alloc_gpa: Allocator, args: ?[]const [:0]const u8) internal_os.args.ArgIterator.InitError!ArgsIterator(internal_os.args.ArgIterator) {
+    var iter = try internal_os.args.iterator(alloc_gpa, args);
     errdefer iter.deinit();
     _ = iter.next(); // skip argv0
     return .{ .iterator = iter };
@@ -1382,6 +1374,7 @@ test "ArgsIterator" {
     defer iter.deinit();
 
     try testing.expectEqualStrings("--what", iter.next().?);
+    try testing.expectEqualStrings("+list-things", iter.next().?);
     try testing.expectEqualStrings("--a=42", iter.next().?);
     try testing.expectEqual(@as(?[]const u8, null), iter.next());
     try testing.expectEqual(@as(?[]const u8, null), iter.next());

--- a/src/cli/boo.zig
+++ b/src/cli/boo.zig
@@ -4,6 +4,7 @@ const args = @import("args.zig");
 const Action = @import("ghostty.zig").Action;
 const Allocator = std.mem.Allocator;
 const vaxis = @import("vaxis");
+const global_state = &(@import("../global.zig")).state;
 
 const framedata = @import("framedata").compressed;
 
@@ -183,7 +184,7 @@ pub fn run(gpa: Allocator) !u8 {
     defer opts.deinit();
 
     {
-        var iter = try args.argsIterator(gpa);
+        var iter = try args.argsIterator(gpa, global_state.results.args);
         defer iter.deinit();
         try args.parse(Options, gpa, &opts, &iter);
     }

--- a/src/cli/crash_report.zig
+++ b/src/cli/crash_report.zig
@@ -4,6 +4,7 @@ const args = @import("args.zig");
 const Action = @import("ghostty.zig").Action;
 const Config = @import("../config.zig").Config;
 const crash = @import("../crash/main.zig");
+const global_state = &(@import("../global.zig")).state;
 
 pub const Options = struct {
     pub fn deinit(self: Options) void {
@@ -33,7 +34,7 @@ pub fn run(alloc_gpa: Allocator) !u8 {
     defer opts.deinit();
 
     {
-        var iter = try args.argsIterator(alloc_gpa);
+        var iter = try args.argsIterator(alloc_gpa, global_state.results.args);
         defer iter.deinit();
         try args.parse(Options, alloc_gpa, &opts, &iter);
     }

--- a/src/cli/edit_config.zig
+++ b/src/cli/edit_config.zig
@@ -7,6 +7,7 @@ const Action = @import("ghostty.zig").Action;
 const configpkg = @import("../config.zig");
 const internal_os = @import("../os/main.zig");
 const Config = configpkg.Config;
+const global_state = &(@import("../global.zig")).state;
 
 pub const Options = struct {
     pub fn deinit(self: Options) void {
@@ -55,7 +56,7 @@ pub fn run(alloc: Allocator) !u8 {
     defer opts.deinit();
 
     {
-        var iter = try args.argsIterator(alloc);
+        var iter = try args.argsIterator(alloc, global_state.results.args);
         defer iter.deinit();
         try args.parse(Options, alloc, &opts, &iter);
     }

--- a/src/cli/explain_config.zig
+++ b/src/cli/explain_config.zig
@@ -7,6 +7,7 @@ const Config = @import("../config/Config.zig");
 const ConfigKey = @import("../config/key.zig").Key;
 const KeybindAction = @import("../input/Binding.zig").Action;
 const Pager = @import("Pager.zig");
+const global_state = &(@import("../global.zig")).state;
 
 pub const Options = struct {
     /// The config option to explain. For example:
@@ -51,7 +52,7 @@ pub fn run(alloc: Allocator) !u8 {
     var positional: ?[]const u8 = null;
     var no_pager: bool = false;
 
-    var iter = try args.argsIterator(alloc);
+    var iter = try args.argsIterator(alloc, global_state.results.args);
     defer iter.deinit();
     defer if (option_name) |s| alloc.free(s);
     defer if (keybind_name) |s| alloc.free(s);

--- a/src/cli/ghostty.zig
+++ b/src/cli/ghostty.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const help_strings = @import("help_strings");
 const actionpkg = @import("action.zig");
-const SpecialCase = actionpkg.SpecialCase;
+const ActionParser = actionpkg.ActionParser;
 
 const list_fonts = @import("list_fonts.zig");
 const help = @import("help.zig");
@@ -73,13 +73,13 @@ pub const Action = enum {
     // Use IPC to tell the running Ghostty to open a new window.
     @"new-window",
 
-    pub fn detectSpecialCase(arg: []const u8) ?SpecialCase(Action) {
+    pub const ParseResult = ActionParser(@This());
+
+    pub fn detectSpecialCase(arg: []const u8) ?ParseResult.SpecialCase {
         // If we see a "-e" and we haven't seen a command yet, then
         // we are done looking for commands. This special case enables
-        // `ghostty -e ghostty +command`. If we've seen a command we
-        // still want to keep looking because
-        // `ghostty +command -e +command` is invalid.
-        if (std.mem.eql(u8, arg, "-e")) return .abort_if_no_action;
+        // `ghostty -e ghostty +command`.
+        if (std.mem.eql(u8, arg, "-e")) return .abort;
 
         // Special case, --version always outputs the version no
         // matter what, no matter what other args exist.
@@ -206,8 +206,13 @@ test "parse action none" {
         "--a=42 --b --b-f=false",
     );
     defer iter.deinit();
-    const action = try actionpkg.detectIter(Action, &iter);
-    try testing.expect(action == null);
+    const result: Action.ParseResult = try .parse(alloc, &iter);
+    defer result.deinit(alloc);
+    try testing.expect(result.action == null);
+    try testing.expectEqual(3, result.args.len);
+    try testing.expectEqualStrings("--a=42", result.args[0]);
+    try testing.expectEqualStrings("--b", result.args[1]);
+    try testing.expectEqualStrings("--b-f=false", result.args[2]);
 }
 
 test "parse action version" {
@@ -220,8 +225,13 @@ test "parse action version" {
             "--a=42 --b --b-f=false --version",
         );
         defer iter.deinit();
-        const action = try actionpkg.detectIter(Action, &iter);
-        try testing.expect(action.? == .version);
+        const result: Action.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expect(result.action.? == .version);
+        try testing.expectEqual(3, result.args.len);
+        try testing.expectEqualStrings("--a=42", result.args[0]);
+        try testing.expectEqualStrings("--b", result.args[1]);
+        try testing.expectEqualStrings("--b-f=false", result.args[2]);
     }
 
     {
@@ -230,18 +240,35 @@ test "parse action version" {
             "--version --a=42 --b --b-f=false",
         );
         defer iter.deinit();
-        const action = try actionpkg.detectIter(Action, &iter);
-        try testing.expect(action.? == .version);
+        const result: Action.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expect(result.action.? == .version);
+        try testing.expectEqual(3, result.args.len);
+        try testing.expectEqualStrings("--a=42", result.args[0]);
+        try testing.expectEqualStrings("--b", result.args[1]);
+        try testing.expectEqualStrings("--b-f=false", result.args[2]);
     }
 
     {
+        var args: std.ArrayList([:0]const u8) = .empty;
+        defer {
+            for (args.items) |arg| alloc.free(arg);
+            args.deinit(alloc);
+        }
         var iter = try std.process.ArgIteratorGeneral(.{}).init(
             alloc,
             "--c=84 --d --version --a=42 --b --b-f=false",
         );
         defer iter.deinit();
-        const action = try actionpkg.detectIter(Action, &iter);
-        try testing.expect(action.? == .version);
+        const result: Action.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expect(result.action.? == .version);
+        try testing.expectEqual(5, result.args.len);
+        try testing.expectEqualStrings("--c=84", result.args[0]);
+        try testing.expectEqualStrings("--d", result.args[1]);
+        try testing.expectEqualStrings("--a=42", result.args[2]);
+        try testing.expectEqualStrings("--b", result.args[3]);
+        try testing.expectEqualStrings("--b-f=false", result.args[4]);
     }
 }
 
@@ -255,8 +282,13 @@ test "parse action plus" {
             "--a=42 --b --b-f=false +version",
         );
         defer iter.deinit();
-        const action = try actionpkg.detectIter(Action, &iter);
-        try testing.expect(action.? == .version);
+        const result: Action.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expect(result.action.? == .version);
+        try testing.expectEqual(3, result.args.len);
+        try testing.expectEqualStrings("--a=42", result.args[0]);
+        try testing.expectEqualStrings("--b", result.args[1]);
+        try testing.expectEqualStrings("--b-f=false", result.args[2]);
     }
 
     {
@@ -265,8 +297,13 @@ test "parse action plus" {
             "+version --a=42 --b --b-f=false",
         );
         defer iter.deinit();
-        const action = try actionpkg.detectIter(Action, &iter);
-        try testing.expect(action.? == .version);
+        const result: Action.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expect(result.action.? == .version);
+        try testing.expectEqual(3, result.args.len);
+        try testing.expectEqualStrings("--a=42", result.args[0]);
+        try testing.expectEqualStrings("--b", result.args[1]);
+        try testing.expectEqualStrings("--b-f=false", result.args[2]);
     }
 
     {
@@ -275,8 +312,15 @@ test "parse action plus" {
             "--c=84 --d +version --a=42 --b --b-f=false",
         );
         defer iter.deinit();
-        const action = try actionpkg.detectIter(Action, &iter);
-        try testing.expect(action.? == .version);
+        const result: Action.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expect(result.action.? == .version);
+        try testing.expectEqual(5, result.args.len);
+        try testing.expectEqualStrings("--c=84", result.args[0]);
+        try testing.expectEqualStrings("--d", result.args[1]);
+        try testing.expectEqualStrings("--a=42", result.args[2]);
+        try testing.expectEqualStrings("--b", result.args[3]);
+        try testing.expectEqualStrings("--b-f=false", result.args[4]);
     }
 }
 
@@ -290,8 +334,13 @@ test "parse action plus ignores -e" {
             "--a=42 -e +version",
         );
         defer iter.deinit();
-        const action = try actionpkg.detectIter(Action, &iter);
-        try testing.expect(action == null);
+        const result: Action.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expect(result.action == null);
+        try testing.expectEqual(3, result.args.len);
+        try testing.expectEqualStrings("--a=42", result.args[0]);
+        try testing.expectEqualStrings("-e", result.args[1]);
+        try testing.expectEqualStrings("+version", result.args[2]);
     }
 
     {
@@ -300,9 +349,69 @@ test "parse action plus ignores -e" {
             "+list-fonts --a=42 -e +version",
         );
         defer iter.deinit();
-        try testing.expectError(
-            actionpkg.DetectError.MultipleActions,
-            actionpkg.detectIter(Action, &iter),
+        const result: Action.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expectEqual(Action.@"list-fonts", result.action.?);
+        try testing.expectEqual(3, result.args.len);
+        try testing.expectEqualStrings("--a=42", result.args[0]);
+        try testing.expectEqualStrings("-e", result.args[1]);
+        try testing.expectEqualStrings("+version", result.args[2]);
+    }
+
+    {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(
+            alloc,
+            "+list-fonts --a=42 +version -e hello",
         );
+        defer iter.deinit();
+        try testing.expectError(error.MultipleActions, Action.ParseResult.parse(alloc, &iter));
+    }
+}
+
+test "parse action help" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(
+            alloc,
+            "--help",
+        );
+        defer iter.deinit();
+        const result: Action.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expectEqual(Action.help, result.action.?);
+        try testing.expectEqual(0, result.args.len);
+    }
+
+    {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(
+            alloc,
+            "+list-fonts --help",
+        );
+        defer iter.deinit();
+        const result: Action.ParseResult = try .parse(alloc, &iter);
+        defer result.deinit(alloc);
+        try testing.expectEqual(Action.@"list-fonts", result.action.?);
+        try testing.expectEqual(1, result.args.len);
+        try testing.expectEqualStrings("--help", result.args[0]);
+    }
+
+    {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(
+            alloc,
+            "+list-fonts --help +version",
+        );
+        defer iter.deinit();
+        try testing.expectError(error.MultipleActions, Action.ParseResult.parse(alloc, &iter));
+    }
+
+    {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(
+            alloc,
+            "+list-fonts --help --help",
+        );
+        defer iter.deinit();
+        try testing.expectError(error.MultipleFallbackActions, Action.ParseResult.parse(alloc, &iter));
     }
 }

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const args = @import("args.zig");
 const Action = @import("ghostty.zig").Action;
+const global_state = &(@import("../global.zig")).state;
 
 // Note that this options struct doesn't implement the `help` decl like other
 // actions. That is because the help command is special and wants to handle its
@@ -25,7 +26,7 @@ pub fn run(alloc: Allocator) !u8 {
     defer opts.deinit();
 
     {
-        var iter = try args.argsIterator(alloc);
+        var iter = try args.argsIterator(alloc, global_state.results.args);
         defer iter.deinit();
         try args.parse(Options, alloc, &opts, &iter);
     }

--- a/src/cli/list_actions.zig
+++ b/src/cli/list_actions.zig
@@ -3,6 +3,7 @@ const args = @import("args.zig");
 const Action = @import("ghostty.zig").Action;
 const Allocator = std.mem.Allocator;
 const helpgen_actions = @import("../input/helpgen_actions.zig");
+const global_state = &(@import("../global.zig")).state;
 
 pub const Options = struct {
     /// If `true`, print out documentation about the action associated with the
@@ -32,7 +33,7 @@ pub fn run(alloc: Allocator) !u8 {
     defer opts.deinit();
 
     {
-        var iter = try args.argsIterator(alloc);
+        var iter = try args.argsIterator(alloc, global_state.results.args);
         defer iter.deinit();
         try args.parse(Options, alloc, &opts, &iter);
     }

--- a/src/cli/list_colors.zig
+++ b/src/cli/list_colors.zig
@@ -6,6 +6,7 @@ const args = @import("args.zig");
 const x11_color = @import("../terminal/main.zig").x11_color;
 const vaxis = @import("vaxis");
 const tui = @import("tui.zig");
+const global_state = &(@import("../global.zig")).state;
 
 pub const Options = struct {
     pub fn deinit(self: Options) void {
@@ -34,7 +35,7 @@ pub fn run(alloc: Allocator) !u8 {
     defer opts.deinit();
 
     {
-        var iter = try args.argsIterator(alloc);
+        var iter = try args.argsIterator(alloc, global_state.results.args);
         defer iter.deinit();
         try args.parse(Options, alloc, &opts, &iter);
     }

--- a/src/cli/list_fonts.zig
+++ b/src/cli/list_fonts.zig
@@ -4,6 +4,7 @@ const ArenaAllocator = std.heap.ArenaAllocator;
 const Action = @import("ghostty.zig").Action;
 const args = @import("args.zig");
 const font = @import("../font/main.zig");
+const global_state = &(@import("../global.zig")).state;
 
 const log = std.log.scoped(.list_fonts);
 
@@ -60,7 +61,7 @@ pub const Options = struct {
 ///     is identical to the `font-family` set of Ghostty configuration values, so
 ///     this can be used to debug why your desired font may not be loading.
 pub fn run(alloc: Allocator) !u8 {
-    var iter = try args.argsIterator(alloc);
+    var iter = try args.argsIterator(alloc, global_state.results.args);
     defer iter.deinit();
     return try runArgs(alloc, &iter);
 }

--- a/src/cli/list_keybinds.zig
+++ b/src/cli/list_keybinds.zig
@@ -10,6 +10,7 @@ const vaxis = @import("vaxis");
 const input = @import("../input.zig");
 const tui = @import("tui.zig");
 const Binding = input.Binding;
+const global_state = &(@import("../global.zig")).state;
 
 pub const Options = struct {
     /// If `true`, print out the default keybinds instead of the ones configured
@@ -56,7 +57,7 @@ pub fn run(alloc: Allocator) !u8 {
     defer opts.deinit();
 
     {
-        var iter = try args.argsIterator(alloc);
+        var iter = try args.argsIterator(alloc, global_state.results.args);
         defer iter.deinit();
         try args.parse(Options, alloc, &opts, &iter);
     }

--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -108,7 +108,7 @@ pub fn run(gpa_alloc: std.mem.Allocator) !u8 {
     defer opts.deinit();
 
     {
-        var iter = try args.argsIterator(gpa_alloc);
+        var iter = try args.argsIterator(gpa_alloc, global_state.results.args);
         defer iter.deinit();
         try args.parse(Options, gpa_alloc, &opts, &iter);
     }

--- a/src/cli/new_window.zig
+++ b/src/cli/new_window.zig
@@ -7,6 +7,7 @@ const args = @import("args.zig");
 const diagnostics = @import("diagnostics.zig");
 const lib = @import("../lib/main.zig");
 const homedir = @import("../os/homedir.zig");
+const global_state = &(@import("../global.zig")).state;
 
 pub const Options = struct {
     /// This is set by the CLI parser for deinit.
@@ -147,7 +148,7 @@ pub const Options = struct {
 ///
 /// Available since: 1.2.0
 pub fn run(alloc: Allocator) !u8 {
-    var iter = try args.argsIterator(alloc);
+    var iter = try args.argsIterator(alloc, global_state.results.args);
     defer iter.deinit();
 
     var buffer: [1024]u8 = undefined;

--- a/src/cli/show_config.zig
+++ b/src/cli/show_config.zig
@@ -5,6 +5,7 @@ const Action = @import("ghostty.zig").Action;
 const configpkg = @import("../config.zig");
 const Config = configpkg.Config;
 const Pager = @import("Pager.zig");
+const global_state = &(@import("../global.zig")).state;
 
 pub const Options = struct {
     /// If true, do not load the user configuration, only load the defaults.
@@ -66,7 +67,7 @@ pub fn run(alloc: Allocator) !u8 {
     defer opts.deinit();
 
     {
-        var iter = try args.argsIterator(alloc);
+        var iter = try args.argsIterator(alloc, global_state.results.args);
         defer iter.deinit();
         try args.parse(Options, alloc, &opts, &iter);
     }

--- a/src/cli/show_face.zig
+++ b/src/cli/show_face.zig
@@ -7,6 +7,7 @@ const diagnostics = @import("diagnostics.zig");
 const font = @import("../font/main.zig");
 const configpkg = @import("../config.zig");
 const Config = configpkg.Config;
+const global_state = &(@import("../global.zig")).state;
 
 pub const Options = struct {
     /// This is set by the CLI parser for deinit.
@@ -62,7 +63,7 @@ pub const Options = struct {
 ///     style. Valid options are `text` and `emoji`. If unset, the presentation
 ///     style of a codepoint will be inferred from the Unicode standard.
 pub fn run(alloc: Allocator) !u8 {
-    var iter = try args.argsIterator(alloc);
+    var iter = try args.argsIterator(alloc, global_state.results.args);
     defer iter.deinit();
 
     var stdout_buffer: [1024]u8 = undefined;

--- a/src/cli/ssh_cache.zig
+++ b/src/cli/ssh_cache.zig
@@ -5,6 +5,7 @@ const args = @import("args.zig");
 const Action = @import("ghostty.zig").Action;
 pub const Entry = @import("ssh-cache/Entry.zig");
 pub const DiskCache = @import("ssh-cache/DiskCache.zig");
+const global_state = &(@import("../global.zig")).state;
 
 pub const Options = struct {
     clear: bool = false,
@@ -55,7 +56,7 @@ pub fn run(alloc_gpa: Allocator) !u8 {
     defer opts.deinit();
 
     {
-        var iter = try args.argsIterator(alloc_gpa);
+        var iter = try args.argsIterator(alloc_gpa, global_state.results.args);
         defer iter.deinit();
         try args.parse(Options, alloc_gpa, &opts, &iter);
     }

--- a/src/cli/validate_config.zig
+++ b/src/cli/validate_config.zig
@@ -3,6 +3,7 @@ const Allocator = std.mem.Allocator;
 const args = @import("args.zig");
 const Action = @import("ghostty.zig").Action;
 const Config = @import("../config.zig").Config;
+const global_state = &(@import("../global.zig")).state;
 
 pub const Options = struct {
     /// The path of the config file to validate. If this isn't specified,
@@ -34,7 +35,7 @@ pub fn run(alloc: std.mem.Allocator) !u8 {
     defer opts.deinit();
 
     {
-        var iter = try args.argsIterator(alloc);
+        var iter = try args.argsIterator(alloc, global_state.results.args);
         defer iter.deinit();
         try args.parse(Options, alloc, &opts, &iter);
     }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -4155,7 +4155,7 @@ pub fn loadCliArgs(self: *Config, alloc_gpa: Allocator) !void {
     }
 
     // Initialize our CLI iterator.
-    var iter = try cli.args.argsIterator(alloc_gpa);
+    var iter = try cli.args.argsIterator(alloc_gpa, global_state.results.args);
     defer iter.deinit();
     try self.loadIter(alloc_gpa, &iter);
 

--- a/src/global.zig
+++ b/src/global.zig
@@ -30,9 +30,11 @@ pub const GlobalState = struct {
 
     gpa: ?GPA,
     alloc: std.mem.Allocator,
-    action: ?cli.ghostty.Action,
     logging: Logging,
     rlimits: ResourceLimits = .{},
+
+    /// Results of parsing CLI arguments for actions.
+    results: cli.ghostty.Action.ParseResult,
 
     /// The app resources directory, equivalent to zig-out/share when we build
     /// from source. This is null if we can't detect it.
@@ -64,10 +66,10 @@ pub const GlobalState = struct {
         self.* = .{
             .gpa = null,
             .alloc = undefined,
-            .action = null,
             .logging = .{},
             .rlimits = .{},
             .resources_dir = .{},
+            .results = undefined,
         };
         errdefer self.deinit();
 
@@ -95,16 +97,18 @@ pub const GlobalState = struct {
         else
             unreachable;
 
+        // Eventually this will be replaced with the args passed on from the
+        // "juicy" main.
+        var iter = try std.process.argsWithAllocator(self.alloc);
+        defer iter.deinit();
+
         // We first try to parse any action that we may be executing.
-        self.action = try cli.action.detectArgs(
-            cli.ghostty.Action,
-            self.alloc,
-        );
+        self.results = try .parse(self.alloc, &iter);
 
         // If we have an action executing, we disable logging by default
         // since we write to stderr we don't want logs messing up our
         // output.
-        if (self.action != null) self.logging.stderr = false;
+        if (self.results.action != null) self.logging.stderr = false;
 
         // I don't love the env var name but I don't have it in my heart
         // to parse CLI args 3 times (once for actions, once for config,
@@ -183,6 +187,7 @@ pub const GlobalState = struct {
     /// Cleans up the global state. This doesn't _need_ to be called but
     /// doing so in dev modes will check for memory leaks.
     pub fn deinit(self: *GlobalState) void {
+        self.results.deinit(self.alloc);
         self.resources_dir.deinit(self.alloc);
 
         // Flush our crash logs

--- a/src/main_build_data.zig
+++ b/src/main_build_data.zig
@@ -25,12 +25,18 @@ pub const Action = enum {
 
     // Other
     terminfo,
+
+    pub const ParseResults = cli.action.ActionParser(@This());
 };
 
 pub fn main() !void {
     const alloc = std.heap.c_allocator;
-    const action_ = try cli.action.detectArgs(Action, alloc);
-    const action = action_ orelse return error.NoAction;
+    // Eventually this will be replaced with the args from the "juicy" main.
+    var iter = try std.process.argsWithAllocator(alloc);
+    defer iter.deinit();
+    const results: Action.ParseResults = try .parse(alloc, &iter);
+    defer results.deinit(alloc);
+    const action = results.action orelse return error.NoAction;
 
     // Our output always goes to stdout.
     var buffer: [1024]u8 = undefined;

--- a/src/main_c.zig
+++ b/src/main_c.zig
@@ -117,7 +117,7 @@ pub export fn ghostty_init(argc: usize, argv: [*][*:0]u8) c_int {
 /// Runs an action if it is specified. If there is no action this returns
 /// false. If there is an action then this doesn't return.
 pub export fn ghostty_cli_try_action() void {
-    const action = state.action orelse return;
+    const action = state.results.action orelse return;
     std.log.info("executing CLI action={}", .{action});
     posix.exit(action.run(state.alloc) catch |err| {
         std.log.err("CLI action failed error={}", .{err});

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -62,7 +62,7 @@ pub fn main() !MainReturn {
     }
 
     // Execute our action if we have one
-    if (state.action) |action| {
+    if (state.results.action) |action| {
         std.log.info("executing CLI action={}", .{action});
         posix.exit(action.run(alloc) catch |err| err: {
             std.log.err("CLI action failed error={}", .{err});

--- a/src/os/args.zig
+++ b/src/os/args.zig
@@ -9,26 +9,46 @@ const macos = @import("macos");
 ///
 /// For Zig-aware readers: this is the same as std.process.argsWithAllocator
 /// but handles macOS using NSProcessInfo instead of libc argc/argv.
-pub fn iterator(allocator: Allocator) ArgIterator.InitError!ArgIterator {
+pub fn iterator(allocator: Allocator, args: ?[]const [:0]const u8) ArgIterator.InitError!ArgIterator {
     //if (true) return try std.process.argsWithAllocator(allocator);
-    return .initWithAllocator(allocator);
+    return .initWithAllocator(allocator, args);
 }
 
-/// Duck-typed to std.process.ArgIterator
 pub const ArgIterator = switch (builtin.os.tag) {
     .macos => IteratorMacOS,
-    else => std.process.ArgIterator,
+    else => IteratorArgs,
 };
 
-/// This is an ArgIterator (duck-typed for std.process.ArgIterator) for
-/// NSApplicationMain-based applications on macOS. It uses NSProcessInfo to
-/// get the command line arguments since libc argc/argv pointers are not
-/// valid.
+const IteratorArgs = struct {
+    args: []const [:0]const u8,
+    index: usize,
+
+    pub const InitError = Allocator.Error;
+
+    pub fn initWithAllocator(_: Allocator, args: ?[]const [:0]const u8) InitError!IteratorArgs {
+        return .{
+            .args = args orelse &.{},
+            .index = 0,
+        };
+    }
+
+    pub fn next(self: *IteratorArgs) ?[:0]const u8 {
+        if (self.index >= self.args.len) return null;
+        defer self.index += 1;
+        return self.args[self.index];
+    }
+
+    pub fn deinit(_: *const IteratorArgs) void {}
+};
+
+/// This is an ArgIterator for NSApplicationMain-based applications on macOS.
+/// It uses NSProcessInfo to get the command line arguments since libc argc/argv
+/// pointers are not valid.
 ///
 /// I believe this should work for all macOS applications even if
-/// NSApplicationMain is not used, but I haven't tested that so I'm not
-/// sure. If/when libghostty is ever used outside of NSApplicationMain
-/// then we can revisit this.
+/// NSApplicationMain is not used, but I haven't tested that so I'm not sure.
+/// If/when libghostty is ever used outside of NSApplicationMain then we can
+/// revisit this.
 const IteratorMacOS = struct {
     alloc: Allocator,
     index: usize,
@@ -38,7 +58,7 @@ const IteratorMacOS = struct {
 
     pub const InitError = Allocator.Error;
 
-    pub fn initWithAllocator(alloc: Allocator) InitError!IteratorMacOS {
+    pub fn initWithAllocator(alloc: Allocator, _: ?[]const [:0]const u8) InitError!IteratorMacOS {
         const NSProcessInfo = objc.getClass("NSProcessInfo").?;
         const info = NSProcessInfo.msgSend(objc.Object, objc.sel("processInfo"), .{});
         const args = info.getProperty(objc.Object, "arguments");
@@ -124,7 +144,7 @@ test "args" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
-    var iter = try iterator(alloc);
+    var iter = try iterator(alloc, &.{"hello"});
     defer iter.deinit();
     try testing.expect(iter.next().?.len > 0);
 }

--- a/src/synthetic/cli.zig
+++ b/src/synthetic/cli.zig
@@ -10,6 +10,8 @@ pub const Action = enum {
     osc,
     utf8,
 
+    pub const ParseResult = cli.action.ActionParser(@This());
+
     /// Returns the struct associated with the action. The struct
     /// should have a few decls:
     ///
@@ -30,14 +32,18 @@ pub const Action = enum {
 /// An entrypoint for the synthetic generator CLI.
 pub fn main() !void {
     const alloc = std.heap.c_allocator;
-    const action_ = try cli.action.detectArgs(Action, alloc);
-    const action = action_ orelse return error.NoAction;
-    try mainAction(alloc, action, .cli);
+    // Eventually this will be replaced with the args from the "juicy" main.
+    var iter = try std.process.argsWithAllocator(alloc);
+    defer iter.deinit();
+    const result: Action.ParseResult = try .parse(alloc, &iter);
+    defer result.deinit(alloc);
+    const action = result.action orelse return error.NoAction;
+    try mainAction(alloc, action, .{ .cli = result.args });
 }
 
 pub const Args = union(enum) {
     /// The arguments passed to the CLI via argc/argv.
-    cli,
+    cli: []const [:0]const u8,
 
     /// Simple string arguments, parsed via std.process.ArgIteratorGeneral.
     string: []const u8,
@@ -66,8 +72,8 @@ fn mainActionImpl(
     var opts: Options = .{};
     defer if (@hasDecl(Options, "deinit")) opts.deinit();
     switch (args) {
-        .cli => {
-            var iter = try cli.args.argsIterator(alloc);
+        .cli => |a| {
+            var iter = try cli.args.argsIterator(alloc, a);
             defer iter.deinit();
             try cli.args.parse(Options, alloc, &opts, &iter);
         },


### PR DESCRIPTION
Previously, the argument parser would not allow `+`-prefixed args after `-e`. Depending on the situation, it would either raise an error about multiple actions found, or it would just skip the argument as if it wasn't there. In practice, it made commands like the following impossible:

```
ghostty -e hx +10 src/main.zig
```
```
ghostty +new-window -e vim src/main.zig '+normal!10Gvz5'
```

This PR changes argument parsing so that it stops looking for actions once an argument like `-e` has been seen. It also stores a copy of the arguments with the action filtered out so that subsequent operations that parse the CLI arguments again (like individual actions do) do not need to worry about filtering out actions.

This also parepares Ghostty for 0.16 a bit where the CLI arguments aren't available "at will" just by calling `std.process.argsWithAllocator`.

Fixes #11937