### PR TITLE
gtk: only trigger resize callbacks and overlay when size actually changes

### DIFF
--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -3292,10 +3292,13 @@ pub const Surface = extern struct {
 
         // Store our cached size
         const priv = self.private();
-        priv.size = .{
+
+        const new_size: apprt.SurfaceSize = .{
             .width = @intCast(width),
             .height = @intCast(height),
         };
+        const changed = !priv.size.eql(&new_size);
+        priv.size = new_size;
 
         // If our surface is realize, we send callbacks.
         if (priv.core_surface) |surface| {
@@ -3305,12 +3308,13 @@ pub const Surface = extern struct {
                 log.warn("error in content scale callback err={}", .{err});
             };
 
-            surface.sizeCallback(priv.size) catch |err| {
-                log.warn("error in size callback err={}", .{err});
-            };
-
-            // Setup our resize overlay if configured
-            self.resizeOverlaySchedule();
+            if (changed) {
+                surface.sizeCallback(new_size) catch |err| {
+                    log.warn("error in size callback err={}", .{err});
+                };
+                // Setup our resize overlay if configured
+                self.resizeOverlaySchedule();
+            }
 
             return;
         }

--- a/src/apprt/gtk/ui/1.2/resize-overlay.blp
+++ b/src/apprt/gtk/ui/1.2/resize-overlay.blp
@@ -4,6 +4,10 @@ using Adw 1;
 // type in zig-gobject.
 template $GhosttyResizeOverlay: Adw.Bin {
   visible: false;
+  can-focus: false;
+  can-target: false;
+  focusable: false;
+  focus-on-click: false;
   duration: 750;
   first-delay: 250;
   overlay-halign: center;
@@ -16,10 +20,12 @@ template $GhosttyResizeOverlay: Adw.Bin {
         "resize-overlay",
       ]
 
+      can-focus: false;
+      can-target: false;
       focusable: false;
       focus-on-click: false;
-      justify: center;
       selectable: false;
+      justify: center;
       halign: bind template.overlay-halign;
       valign: bind template.overlay-valign;
     }

--- a/src/apprt/structs.zig
+++ b/src/apprt/structs.zig
@@ -12,6 +12,10 @@ pub const ContentScale = struct {
 pub const SurfaceSize = struct {
     width: u32,
     height: u32,
+
+    pub fn eql(self: *const SurfaceSize, other: *const SurfaceSize) bool {
+        return self.width == other.width and self.height == other.height;
+    }
 };
 
 /// The position of the cursor in pixels.


### PR DESCRIPTION
Fixes #11970

Also fixes problem that resize overlay would intercept mouse activity while active.