### PR TITLE
macOS: close search bar if needed when it loses focus

### DIFF
--- a/macos/Sources/Ghostty/Surface View/SurfaceView.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView.swift
@@ -437,11 +437,10 @@ extension Ghostty {
                         }
                     }
 #if canImport(AppKit)
-                    .onExitCommand {
-                        if searchState.needle.isEmpty {
-                            onClose()
-                        } else {
-                            Ghostty.moveFocus(to: surfaceView)
+                    .onExitCommand(perform: onResignFirstResponder)
+                    .onChange(of: isSearchFieldFocused) {  newValue in
+                        if !newValue {
+                            onResignFirstResponder()
                         }
                     }
 #endif
@@ -520,7 +519,15 @@ extension Ghostty {
                 )
             }
         }
-
+#if canImport(AppKit)
+        private func onResignFirstResponder() {
+            if searchState.needle.isEmpty {
+                onClose()
+            } else {
+                Ghostty.moveFocus(to: surfaceView)
+            }
+        }
+#endif
         private var clipShape: some Shape {
             if #available(iOS 26.0, macOS 26.0, *) {
                 return ConcentricRectangle(corners: .concentric(minimum: 8), isUniform: true)

--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -660,6 +660,13 @@ extension Ghostty {
                 return event
             }
 
+            guard searchState == nil else {
+                // We don't want to process events that
+                // are supposed to be handled by SearchOverlay
+                // When clicking outside, SurfaceView will become first responder automatically
+                return event
+            }
+
             // We only want to process events that are on this window.
             guard let window,
                   event.window != nil,


### PR DESCRIPTION
This adds features like:

1. Clicking outside of search bar works like typing `escape`
2. Typing `tab` while search bar is focused also works like typing `escape`

https://github.com/user-attachments/assets/a51f1560-ed14-4002-81b4-96eb927b17ca

