### PR TITLE
feat(renderer): add iSurfaceOffset and iWindowResolution shader uniforms

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1091,6 +1091,8 @@ void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);
 void ghostty_surface_set_focus(ghostty_surface_t, bool);
 void ghostty_surface_set_occlusion(ghostty_surface_t, bool);
 void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t);
+void ghostty_surface_set_position(ghostty_surface_t, uint32_t, uint32_t,
+                                  uint32_t, uint32_t);
 ghostty_surface_size_s ghostty_surface_size(ghostty_surface_t);
 void ghostty_surface_set_color_scheme(ghostty_surface_t,
                                       ghostty_color_scheme_e);

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3257,6 +3257,26 @@ pub fn occlusionCallback(self: *Surface, visible: bool) !void {
     try self.queueRender();
 }
 
+/// Called by the apprt when the surface position within the window changes.
+/// This updates custom shader uniforms so effects can span the full window.
+pub fn surfacePositionCallback(
+    self: *Surface,
+    offset_x: u32,
+    offset_y: u32,
+    window_width: u32,
+    window_height: u32,
+) !void {
+    _ = self.renderer_thread.mailbox.push(.{
+        .surface_position = .{
+            .offset_x = offset_x,
+            .offset_y = offset_y,
+            .window_width = window_width,
+            .window_height = window_height,
+        },
+    }, .{ .forever = {} });
+    try self.queueRender();
+}
+
 pub fn focusCallback(self: *Surface, focused: bool) !void {
     // Crash metadata in case we crash in here
     crash.sentry.thread_state = self.crashThreadState();

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -810,6 +810,24 @@ pub const Surface = struct {
         };
     }
 
+    pub fn updateSurfacePosition(
+        self: *Surface,
+        offset_x: u32,
+        offset_y: u32,
+        window_width: u32,
+        window_height: u32,
+    ) void {
+        self.core_surface.surfacePositionCallback(
+            offset_x,
+            offset_y,
+            window_width,
+            window_height,
+        ) catch |err| {
+            log.err("error in surface position callback err={}", .{err});
+            return;
+        };
+    }
+
     pub fn colorSchemeCallback(self: *Surface, scheme: apprt.ColorScheme) void {
         self.core_surface.colorSchemeCallback(scheme) catch |err| {
             log.err("error setting color scheme err={}", .{err});
@@ -1694,6 +1712,18 @@ pub const CAPI = struct {
     /// to the pty and the renderer.
     export fn ghostty_surface_set_size(surface: *Surface, w: u32, h: u32) void {
         surface.updateSize(w, h);
+    }
+
+    /// Update the position of a surface within its parent window.
+    /// Used for custom shaders that need window-global coordinates.
+    export fn ghostty_surface_set_position(
+        surface: *Surface,
+        offset_x: u32,
+        offset_y: u32,
+        window_width: u32,
+        window_height: u32,
+    ) void {
+        surface.updateSurfacePosition(offset_x, offset_y, window_width, window_height);
     }
 
     /// Return the size information a surface has.

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -1557,6 +1557,20 @@ pub const Surface = extern struct {
         return priv.size;
     }
 
+    /// Notify the core surface of this widget's position within the window.
+    /// This enables custom shaders to compute window-global coordinates.
+    ///
+    /// TODO: Use gtk_widget_compute_point or gtk_widget_compute_bounds to
+    /// determine the exact position of this surface within the window.
+    /// For now, we report (0,0) offset which means shaders fall back to
+    /// per-surface coordinates (same as before this feature).
+    fn updateSurfacePosition(self: *Self, surface: *CoreSurface) void {
+        _ = self;
+        surface.surfacePositionCallback(0, 0, 0, 0) catch |err| {
+            log.warn("error in surface position callback err={}", .{err});
+        };
+    }
+
     pub fn getCursorPos(self: *Self) apprt.CursorPos {
         return self.private().cursor_pos;
     }
@@ -3308,6 +3322,9 @@ pub const Surface = extern struct {
             surface.sizeCallback(priv.size) catch |err| {
                 log.warn("error in size callback err={}", .{err});
             };
+
+            // Update surface position within the window for custom shaders.
+            self.updateSurfacePosition(surface);
 
             // Setup our resize overlay if configured
             self.resizeOverlaySchedule();

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -445,6 +445,13 @@ fn drainMailbox(self: *Thread) !void {
 
             .resize => |v| self.renderer.setScreenSize(v),
 
+            .surface_position => |v| self.renderer.setSurfacePosition(
+                v.offset_x,
+                v.offset_y,
+                v.window_width,
+                v.window_height,
+            ),
+
             .change_config => |config| {
                 defer config.alloc.destroy(config.thread);
                 defer config.alloc.destroy(config.impl);

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -112,6 +112,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// The size of everything.
         size: renderer.Size,
 
+        /// Position of this surface within the window, in pixels.
+        /// Set by the apprt when the surface is repositioned (e.g. splits).
+        surface_offset: [2]u32 = .{ 0, 0 },
+
+        /// Total window size in pixels. When 0, defaults to surface size.
+        window_size: [2]u32 = .{ 0, 0 },
+
         /// True if the window is focused
         focused: bool,
 
@@ -769,6 +776,8 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     .cursor_text = @splat(0),
                     .selection_background_color = @splat(0),
                     .selection_foreground_color = @splat(0),
+                    .surface_offset = .{ 0, 0, 0, 0 },
+                    .window_resolution = .{ 0, 0, 1, 0 },
                 },
                 .bg_image_buffer = undefined,
 
@@ -1915,6 +1924,21 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             }
         }
 
+        /// Update the position of this surface within its parent window.
+        /// This is used by custom shaders to compute window-global coordinates.
+        pub fn setSurfacePosition(
+            self: *Self,
+            offset_x: u32,
+            offset_y: u32,
+            window_width: u32,
+            window_height: u32,
+        ) void {
+            self.draw_mutex.lock();
+            defer self.draw_mutex.unlock();
+            self.surface_offset = .{ offset_x, offset_y };
+            self.window_size = .{ window_width, window_height };
+        }
+
         /// Resize the screen.
         pub fn setScreenSize(
             self: *Self,
@@ -2133,6 +2157,24 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             uniforms.channel_resolution[0] = .{
                 @floatFromInt(screen.width),
                 @floatFromInt(screen.height),
+                1,
+                0,
+            };
+
+            // Surface position within the window. Defaults to (0,0) offset
+            // and surface resolution as window resolution when the apprt
+            // does not provide position information.
+            uniforms.surface_offset = .{
+                @floatFromInt(self.surface_offset[0]),
+                @floatFromInt(self.surface_offset[1]),
+                0,
+                0,
+            };
+            const win_w = self.window_size[0];
+            const win_h = self.window_size[1];
+            uniforms.window_resolution = .{
+                if (win_w > 0) @floatFromInt(win_w) else @floatFromInt(screen.width),
+                if (win_h > 0) @floatFromInt(win_h) else @floatFromInt(screen.height),
                 1,
                 0,
             };

--- a/src/renderer/message.zig
+++ b/src/renderer/message.zig
@@ -45,6 +45,15 @@ pub const Message = union(enum) {
     /// Changes the size. The screen size might change, padding, grid, etc.
     resize: renderer.Size,
 
+    /// Updates the position of this surface within its parent window.
+    /// Used by custom shaders to compute window-global coordinates.
+    surface_position: struct {
+        offset_x: u32,
+        offset_y: u32,
+        window_width: u32,
+        window_height: u32,
+    },
+
     /// The derived configuration to update the renderer with.
     change_config: struct {
         alloc: Allocator,

--- a/src/renderer/shaders/shadertoy_prefix.glsl
+++ b/src/renderer/shaders/shadertoy_prefix.glsl
@@ -28,6 +28,8 @@ layout(binding = 1, std140) uniform Globals {
     uniform vec3  iCursorText;
     uniform vec3  iSelectionForegroundColor;
     uniform vec3  iSelectionBackgroundColor;
+    uniform vec4  iSurfaceOffset;
+    uniform vec4  iWindowResolution;
 };
 
 #define CURSORSTYLE_BLOCK        0

--- a/src/renderer/shadertoy.zig
+++ b/src/renderer/shadertoy.zig
@@ -37,6 +37,8 @@ pub const Uniforms = extern struct {
     cursor_text: [4]f32 align(16),
     selection_background_color: [4]f32 align(16),
     selection_foreground_color: [4]f32 align(16),
+    surface_offset: [4]f32 align(16),
+    window_resolution: [4]f32 align(16),
 };
 
 /// The target to load shaders for.


### PR DESCRIPTION
## Summary

Custom shaders currently have no way to know where their surface sits within the window. Each split gets its own coordinate space starting at `(0,0)` with `iResolution` set to its own dimensions. This makes it impossible to create effects that span the full window (gradients, vignettes, CRT curvature) — they get duplicated per split instead.

This PR adds two new Shadertoy uniforms:

- **`iSurfaceOffset`** (`vec4`) — `.xy` = pixel position of this surface's top-left corner within the window
- **`iWindowResolution`** (`vec4`) — `.xyz` = total window size in pixels (same convention as `iResolution`)

With these, shaders can compute window-global UVs:

```glsl
vec2 globalUV = (fragCoord.xy + iSurfaceOffset.xy) / iWindowResolution.xy;
```

### Changes

- **Shader interface**: 2 new uniforms in `shadertoy.zig` + `shadertoy_prefix.glsl`
- **Renderer**: new `surface_offset` / `window_size` fields, populated per-frame, with safe defaults (offset=0, window=surface size)
- **Message system**: new `surface_position` message for thread-safe updates
- **Core Surface**: new `surfacePositionCallback` for apprts to report position
- **Embedded (macOS)**: new C API `ghostty_surface_set_position()` for the Swift host to call on split layout changes
- **GTK**: plumbing in place, calls the callback on every resize. Position computation is stubbed with a TODO — needs `gtk_widget_compute_point` / `gtk_widget_compute_bounds` for the actual offset

### Backward compatibility

Fully backward-compatible. Defaults (`offset=0,0`, `window_resolution=iResolution`) mean existing shaders behave identically. No existing code paths are modified.

### Related

- Closes the shader aspect of #10053 (unified background across splits)
- Enables window-spanning effects for the custom shader ecosystem (gradients, vignettes, unified CRT, etc.)