### PR TITLE
deps: update wuffs package hash

### DIFF
--- a/build.zig.zon.json
+++ b/build.zig.zon.json
@@ -144,7 +144,7 @@
     "url": "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/archive/1.47/wayland-protocols-1.47.tar.gz",
     "hash": "sha256-3S3xSrX0EDgleq7cxLX7msDuAY8/D5SvkJcCjmDTMiM="
   },
-  "N-V-__8AAAzZywE3s51XfsLbP9eyEw57ae9swYB9aGB6fCMs": {
+  "N-V-__8AAEXUywEb8JCSytwiCVUsFb2CwHjOB59jhyRhOhsj": {
     "name": "wuffs",
     "url": "https://deps.files.ghostty.org/wuffs-122037b39d577ec2db3fd7b2130e7b69ef6cc1807d68607a7c232c958315d381b5cd.tar.gz",
     "hash": "sha256-nkzSCr6W5sTG7enDBXEIhgEm574uLD41UVR2wlC+HBM="

--- a/build.zig.zon.nix
+++ b/build.zig.zon.nix
@@ -315,7 +315,7 @@ in
       };
     }
     {
-      name = "N-V-__8AAAzZywE3s51XfsLbP9eyEw57ae9swYB9aGB6fCMs";
+      name = "N-V-__8AAEXUywEb8JCSytwiCVUsFb2CwHjOB59jhyRhOhsj";
       path = fetchZigArtifact {
         name = "wuffs";
         url = "https://deps.files.ghostty.org/wuffs-122037b39d577ec2db3fd7b2130e7b69ef6cc1807d68607a7c232c958315d381b5cd.tar.gz";

--- a/flatpak/zig-packages.json
+++ b/flatpak/zig-packages.json
@@ -176,7 +176,7 @@
   {
     "type": "archive",
     "url": "https://deps.files.ghostty.org/wuffs-122037b39d577ec2db3fd7b2130e7b69ef6cc1807d68607a7c232c958315d381b5cd.tar.gz",
-    "dest": "vendor/p/N-V-__8AAAzZywE3s51XfsLbP9eyEw57ae9swYB9aGB6fCMs",
+    "dest": "vendor/p/N-V-__8AAEXUywEb8JCSytwiCVUsFb2CwHjOB59jhyRhOhsj",
     "sha256": "9e4cd20abe96e6c4c6ede9c3057108860126e7be2e2c3e35515476c250be1c13"
   },
   {

--- a/pkg/wuffs/build.zig.zon
+++ b/pkg/wuffs/build.zig.zon
@@ -6,7 +6,7 @@
         // google/wuffs
         .wuffs = .{
             .url = "https://deps.files.ghostty.org/wuffs-122037b39d577ec2db3fd7b2130e7b69ef6cc1807d68607a7c232c958315d381b5cd.tar.gz",
-            .hash = "N-V-__8AAAzZywE3s51XfsLbP9eyEw57ae9swYB9aGB6fCMs",
+            .hash = "N-V-__8AAEXUywEb8JCSytwiCVUsFb2CwHjOB59jhyRhOhsj",
             .lazy = true,
         },
 


### PR DESCRIPTION
The hash from `deps.files.ghostty.org` differed from the value in `pkg/wuffs/build.zig.zon`, so it has been updated across all build configuration files. Package URL and contents are unchanged.

Affected files:
- pkg/wuffs/build.zig.zon
- build.zig.zon.json
- build.zig.zon.nix
- flatpak/zig-packages.json