### PR TITLE
macOS: remove redundant tab event overrides

### DIFF
--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -184,6 +184,10 @@ class TerminalWindow: NSWindow {
             return
         }
 
+        if tabTitleEditor.handleRightMouseDown(event) {
+            return
+        }
+
         super.sendEvent(event)
     }
 

--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -840,29 +840,3 @@ extension TerminalWindow: TabTitleEditorDelegate {
         makeFirstResponder(focusedSurface)
     }
 }
-
-// MARK: - Tab Clicks
-
-extension TerminalWindow {
-    /// Handles a middle-click event to close the tab under the cursor
-    ///
-    /// Returns true if the event was handled and should be consumed
-    func handleTabBarMiddleClick(_ event: NSEvent) -> Bool {
-        // Require middle click
-        guard event.type == .otherMouseDown && event.buttonNumber == 2 else { return false }
-
-        // Require tab hit
-        let screenPoint = convertPoint(toScreen: event.locationInWindow)
-        guard let hit = tabButtonHit(atScreenPoint: screenPoint) else { return false }
-
-        // Require we have tabs and the index is valid
-        guard let tabbedWindows = tabbedWindows,
-              hit.index < tabbedWindows.count else { return false }
-
-        // Find the controller and close it
-        let targetWindow = tabbedWindows[hit.index]
-        guard let controller = targetWindow.windowController as? TerminalController else { return false }
-        controller.closeTab(nil)
-        return true
-    }
-}

--- a/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
@@ -67,42 +67,6 @@ class TitlebarTabsTahoeTerminalWindow: TransparentTitlebarTerminalWindow, NSTool
 
         viewModel.isMainWindow = false
     }
-
-    /// On our Tahoe titlebar tabs, we need to fix up right click events because they don't work
-    /// naturally due to whatever mess we made.
-    override func sendEvent(_ event: NSEvent) {
-        guard viewModel.hasTabBar else {
-            super.sendEvent(event)
-            return
-        }
-
-        let isRightClick =
-            event.type == .rightMouseDown ||
-            (event.type == .otherMouseDown && event.buttonNumber == 2) ||
-            (event.type == .leftMouseDown && event.modifierFlags.contains(.control))
-        guard isRightClick else {
-            super.sendEvent(event)
-            return
-        }
-
-        guard let tabBarView else {
-            super.sendEvent(event)
-            return
-        }
-
-        guard !tabTitleEditor.handleRightMouseDown(event) else {
-            return
-        }
-
-        let locationInTabBar = tabBarView.convert(event.locationInWindow, from: nil)
-        guard tabBarView.bounds.contains(locationInTabBar) else {
-            super.sendEvent(event)
-            return
-        }
-
-        tabBarView.rightMouseDown(with: event)
-    }
-
     // This is called by macOS for native tabbing in order to add the tab bar. We hook into
     // this, detect the tab bar being added, and override its behavior.
     override func addTitlebarAccessoryViewController(_ childViewController: NSTitlebarAccessoryViewController) {

--- a/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
@@ -76,9 +76,6 @@ class TitlebarTabsTahoeTerminalWindow: TransparentTitlebarTerminalWindow, NSTool
             return
         }
 
-        // Handle middle-click to close tabs if configured
-        if handleTabBarMiddleClick(event) { return }
-
         let isRightClick =
             event.type == .rightMouseDown ||
             (event.type == .otherMouseDown && event.buttonNumber == 2) ||

--- a/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsVenturaTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsVenturaTerminalWindow.swift
@@ -69,11 +69,6 @@ class TitlebarTabsVenturaTerminalWindow: TerminalWindow {
         tab.attributedTitle = attributedTitle
     }
 
-    override func sendEvent(_ event: NSEvent) {
-        if tabBarView != nil && handleTabBarMiddleClick(event) { return }
-        super.sendEvent(event)
-    }
-
 	override func layoutIfNeeded() {
 		super.layoutIfNeeded()
 

--- a/macos/Sources/Helpers/TabTitleEditor.swift
+++ b/macos/Sources/Helpers/TabTitleEditor.swift
@@ -125,6 +125,7 @@ final class TabTitleEditor: NSObject, NSTextFieldDelegate {
     ///
     /// If this returns true then the event was handled by the coordinator.
     func handleRightMouseDown(_ event: NSEvent) -> Bool {
+        guard event.type == .rightMouseDown else { return false }
         if isMouseEventWithinEditor(event) {
             inlineTitleEditor?.rightMouseDown(with: event)
             return true


### PR DESCRIPTION
- Revert 5540f5f249db0f5e8c1e5f47ee9339f4fe1786f0, middle click comes out of box with native tabbing, but we override it wrong previous.
- Reverts 894e8d91ba43e88fcff33f011dbb9f52618725c5, I check it the commit right before it and all the way back to ffe4afe5383ae322987ba1861df16103e9d66da8, right mouse down on tab bar works well without any issue
- Add back reverted handling in #11150

https://github.com/user-attachments/assets/8660368e-05ae-45b0-aa81-6196f3434daf

