### PR TITLE
macOS: refactor MenuShortcutManager

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -1153,8 +1153,13 @@ extension AppDelegate {
     @MainActor private func syncMenuShortcuts(_ config: Ghostty.Config) {
         guard ghostty.readiness == .ready else { return }
 
-        menuShortcutManager.reset()
+        menuShortcutManager.resetRegisteredGhosttyActions()
 
+        registerGhosttyActions(config)
+        menuShortcutManager.updateShortcut(in: NSApp.mainMenu, config: config)
+    }
+
+    @MainActor private func registerGhosttyActions(_ config: Ghostty.Config) {
         syncMenuShortcut(config, action: "check_for_updates", menuItem: self.menuCheckForUpdates)
         syncMenuShortcut(config, action: "open_config", menuItem: self.menuOpenConfig)
         syncMenuShortcut(config, action: "reload_config", menuItem: self.menuReloadConfig)
@@ -1221,7 +1226,7 @@ extension AppDelegate {
     }
 
     @MainActor private func syncMenuShortcut(_ config: Ghostty.Config, action: String, menuItem: NSMenuItem?) {
-        menuShortcutManager.syncMenuShortcut(config, action: action, menuItem: menuItem)
+        menuShortcutManager.register(action: action, menuItem: menuItem)
     }
 
     @MainActor func performGhosttyBindingMenuKeyEquivalent(with event: NSEvent) -> Bool {

--- a/macos/Sources/Ghostty/Ghostty.Input.swift
+++ b/macos/Sources/Ghostty/Ghostty.Input.swift
@@ -84,6 +84,8 @@ extension Ghostty {
     /// A map from the Ghostty key enum to the keyEquivalent string for shortcuts. Note that
     /// not all ghostty key enum values are represented here because not all of them can be
     /// mapped to a KeyEquivalent.
+    ///
+    /// - Important: `KeyEquivalent` here should NOT be uppercased by any means
     static let keyToEquivalent: [ghostty_input_key_e: KeyEquivalent] = [
         // Function keys
         GHOSTTY_KEY_ARROW_UP: .upArrow,

--- a/macos/Sources/Ghostty/Ghostty.MenuShortcutManager.swift
+++ b/macos/Sources/Ghostty/Ghostty.MenuShortcutManager.swift
@@ -37,45 +37,45 @@ extension Ghostty {
 }
 
 extension Ghostty.MenuShortcutManager {
-        /// Attempts to perform a menu key equivalent only for menu items that represent
-        /// Ghostty keybind actions. This is important because it lets our surface dispatch
-        /// bindings through the menu so they flash but also lets our surface override macOS built-ins
-        /// like Cmd+H.
-        func performGhosttyBindingMenuKeyEquivalent(with event: NSEvent) -> Bool {
-            // Convert this event into the same normalized lookup key we use when
-            // syncing menu shortcuts from configuration.
-            guard let key = MenuShortcutKey(event: event) else {
-                return false
-            }
-
-            // If we don't have an entry for this key combo, no Ghostty-owned
-            // menu shortcut exists for this event.
-            guard let action = configuredShortcuts[key] else {
-                return false
-            }
-
-            guard let item = NSApp.mainMenu?.findItem(with: action) else {
-                return false
-            }
-
-            guard let parentMenu = item.menu else {
-                return false
-            }
-
-            // Keep enablement state fresh in case menu validation hasn't run yet.
-            parentMenu.update()
-            guard item.isEnabled else {
-                return false
-            }
-
-            let index = parentMenu.index(of: item)
-            guard index >= 0 else {
-                return false
-            }
-
-            parentMenu.performActionForItem(at: index)
-            return true
+    /// Attempts to perform a menu key equivalent only for menu items that represent
+    /// Ghostty keybind actions. This is important because it lets our surface dispatch
+    /// bindings through the menu so they flash but also lets our surface override macOS built-ins
+    /// like Cmd+H.
+    func performGhosttyBindingMenuKeyEquivalent(with event: NSEvent) -> Bool {
+        // Convert this event into the same normalized lookup key we use when
+        // syncing menu shortcuts from configuration.
+        guard let key = MenuShortcutKey(event: event) else {
+            return false
         }
+
+        // If we don't have an entry for this key combo, no Ghostty-owned
+        // menu shortcut exists for this event.
+        guard let action = configuredShortcuts[key] else {
+            return false
+        }
+
+        guard let item = NSApp.mainMenu?.findItem(with: action) else {
+            return false
+        }
+
+        guard let parentMenu = item.menu else {
+            return false
+        }
+
+        // Keep enablement state fresh in case menu validation hasn't run yet.
+        parentMenu.update()
+        guard item.isEnabled else {
+            return false
+        }
+
+        let index = parentMenu.index(of: item)
+        guard index >= 0 else {
+            return false
+        }
+
+        parentMenu.performActionForItem(at: index)
+        return true
+    }
 }
 
 // MARK: - Recursively process all of the menu items

--- a/macos/Sources/Ghostty/Ghostty.MenuShortcutManager.swift
+++ b/macos/Sources/Ghostty/Ghostty.MenuShortcutManager.swift
@@ -37,35 +37,6 @@ extension Ghostty {
 }
 
 extension Ghostty.MenuShortcutManager {
-        /// Syncs a single menu shortcut for the given action. The action string is the same
-        /// action string used for the Ghostty configuration.
-        private func syncMenuShortcutFrom(_ config: Ghostty.Config, action: String, menuItem menu: NSMenuItem) -> Bool {
-
-            guard let shortcut = config.keyboardShortcut(for: action) else {
-                return false
-            }
-
-            let keyEquivalent = shortcut.key.character.description
-            let modifierMask = NSEvent.ModifierFlags(swiftUIFlags: shortcut.modifiers)
-            // Build a direct lookup for key-equivalent dispatch so we don't need to
-            // linearly walk the full menu hierarchy at event time.
-            guard let key = MenuShortcutKey(
-                // We don't want to check missing `shift` for Ghostty configured shortcuts,
-                // because we know it's there when it needs to be
-                keyEquivalent: keyEquivalent.lowercased(),
-                modifiers: modifierMask
-            ) else {
-                return false
-            }
-
-            menu.keyEquivalent = keyEquivalent
-            menu.keyEquivalentModifierMask = modifierMask
-
-            // Later registrations intentionally override earlier ones for the same key.
-            configuredShortcuts[key] = menu.action
-            return true
-        }
-
         /// Attempts to perform a menu key equivalent only for menu items that represent
         /// Ghostty keybind actions. This is important because it lets our surface dispatch
         /// bindings through the menu so they flash but also lets our surface override macOS built-ins
@@ -145,6 +116,35 @@ private extension Ghostty.MenuShortcutManager {
                 item.keyEquivalentModifierMask = []
             }
         }
+    }
+
+    /// Syncs a single menu shortcut for the given action. The action string is the same
+    /// action string used for the Ghostty configuration.
+    func syncMenuShortcutFrom(_ config: Ghostty.Config, action: String, menuItem menu: NSMenuItem) -> Bool {
+
+        guard let shortcut = config.keyboardShortcut(for: action) else {
+            return false
+        }
+
+        let keyEquivalent = shortcut.key.character.description
+        let modifierMask = NSEvent.ModifierFlags(swiftUIFlags: shortcut.modifiers)
+        // Build a direct lookup for key-equivalent dispatch so we don't need to
+        // linearly walk the full menu hierarchy at event time.
+        guard let key = MenuShortcutKey(
+            // We don't want to check missing `shift` for Ghostty configured shortcuts,
+            // because we know it's there when it needs to be
+            keyEquivalent: keyEquivalent.lowercased(),
+            modifiers: modifierMask
+        ) else {
+            return false
+        }
+
+        menu.keyEquivalent = keyEquivalent
+        menu.keyEquivalentModifierMask = modifierMask
+
+        // Later registrations intentionally override earlier ones for the same key.
+        configuredShortcuts[key] = menu.action
+        return true
     }
 }
 

--- a/macos/Sources/Ghostty/Ghostty.MenuShortcutManager.swift
+++ b/macos/Sources/Ghostty/Ghostty.MenuShortcutManager.swift
@@ -1,4 +1,5 @@
 import AppKit
+import SwiftUI
 
 extension Ghostty {
     /// The manager that's responsible for updating shortcuts of Ghostty's app menu
@@ -126,21 +127,14 @@ private extension Ghostty.MenuShortcutManager {
             return false
         }
 
-        let keyEquivalent = shortcut.key.character.description
-        let modifierMask = NSEvent.ModifierFlags(swiftUIFlags: shortcut.modifiers)
         // Build a direct lookup for key-equivalent dispatch so we don't need to
         // linearly walk the full menu hierarchy at event time.
-        guard let key = MenuShortcutKey(
-            // We don't want to check missing `shift` for Ghostty configured shortcuts,
-            // because we know it's there when it needs to be
-            keyEquivalent: keyEquivalent.lowercased(),
-            modifiers: modifierMask
-        ) else {
+        guard let key = MenuShortcutKey(shortcut) else {
             return false
         }
 
-        menu.keyEquivalent = keyEquivalent
-        menu.keyEquivalentModifierMask = modifierMask
+        menu.keyEquivalent = key.keyEquivalent
+        menu.keyEquivalentModifierMask = key.modifierFlags
 
         // Later registrations intentionally override earlier ones for the same key.
         configuredShortcuts[key] = menu.action
@@ -154,7 +148,11 @@ extension Ghostty.MenuShortcutManager {
         private static let shortcutModifiers: NSEvent.ModifierFlags = [.shift, .control, .option, .command]
 
         let keyEquivalent: String
-        let modifiersRawValue: UInt
+        private let modifiersRawValue: UInt
+
+        var modifierFlags: NSEvent.ModifierFlags {
+            NSEvent.ModifierFlags(rawValue: modifiersRawValue)
+        }
 
         init?(keyEquivalent: String, modifiers: NSEvent.ModifierFlags) {
             let normalized = keyEquivalent.lowercased()
@@ -174,6 +172,31 @@ extension Ghostty.MenuShortcutManager {
         init?(event: NSEvent) {
             guard let keyEquivalent = event.charactersIgnoringModifiers else { return nil }
             self.init(keyEquivalent: keyEquivalent, modifiers: event.modifierFlags)
+        }
+
+        /// Create from a `NSMenuItem`
+        ///
+        /// - Important: This will check whether the `keyEquivalent` is uppercased by `.shift` modifier.
+        init?(_ menuItem: NSMenuItem) {
+            self.init(
+                keyEquivalent: menuItem.keyEquivalent,
+                modifiers: menuItem.keyEquivalentModifierMask,
+            )
+        }
+
+        /// Create from a swiftUI `KeyboardShortcut`
+        init?(_ shortcut: KeyboardShortcut) {
+            let keyEquivalent = shortcut.key.character.description
+            let modifierMask = NSEvent.ModifierFlags(swiftUIFlags: shortcut.modifiers)
+            self.init(keyEquivalent: keyEquivalent, modifiers: modifierMask)
+        }
+
+        var swiftUIShortcut: KeyboardShortcut? {
+            guard let character = keyEquivalent.first else { return nil }
+            return KeyboardShortcut(
+                KeyEquivalent(character),
+                modifiers: .init(nsFlags: modifierFlags)
+            )
         }
     }
 }

--- a/macos/Sources/Ghostty/Ghostty.MenuShortcutManager.swift
+++ b/macos/Sources/Ghostty/Ghostty.MenuShortcutManager.swift
@@ -4,36 +4,49 @@ extension Ghostty {
     /// The manager that's responsible for updating shortcuts of Ghostty's app menu
     @MainActor
     class MenuShortcutManager {
-
-        /// Ghostty menu items indexed by their normalized shortcut. This avoids traversing
+        /// Ghostty action indexed by the action of their belonging menu item
+        private var ghosttyActionsBySelector: [Selector: String] = [:]
+        /// Ghostty menu action indexed by their normalized shortcut. This avoids traversing
         /// the entire menu tree on every key equivalent event.
         ///
-        /// We store a weak reference so this cache can never be the owner of menu items.
-        /// If multiple items map to the same shortcut, the most recent one wins.
-        private var menuItemsByShortcut: [MenuShortcutKey: Weak<NSMenuItem>] = [:]
+        /// If multiple action map to the same shortcut, the most recent one wins.
+        private var configuredShortcuts: [MenuShortcutKey: Selector] = [:]
 
         /// Reset our shortcut index since we're about to rebuild all menu bindings.
-        func reset() {
-            menuItemsByShortcut.removeAll(keepingCapacity: true)
+        func resetRegisteredGhosttyActions() {
+            ghosttyActionsBySelector.removeAll(keepingCapacity: true)
         }
 
+        /// Registers a single menu shortcut for the given action. The action string is the same
+        /// action string used for the Ghostty configuration.
+        func register(action ghosttyAction: String?, menuItem: NSMenuItem?) {
+            guard let selector = menuItem?.action else {
+                return
+            }
+            ghosttyActionsBySelector[selector] = ghosttyAction
+        }
+
+        /// Map the keyboard shortcut of every menu item (including submenu's) in this menu based on previously register action
+        func updateShortcut(in menu: NSMenu?, config: Ghostty.Config) {
+            /// Reset our shortcut index since we're about to rebuild all menu bindings.
+            configuredShortcuts.removeAll()
+
+            updateShortcutRecursively(in: menu, config: config)
+        }
+    }
+}
+
+extension Ghostty.MenuShortcutManager {
         /// Syncs a single menu shortcut for the given action. The action string is the same
         /// action string used for the Ghostty configuration.
-        func syncMenuShortcut(_ config: Ghostty.Config, action: String?, menuItem: NSMenuItem?) {
-            guard let menu = menuItem else { return }
+        private func syncMenuShortcutFrom(_ config: Ghostty.Config, action: String, menuItem menu: NSMenuItem) -> Bool {
 
-            guard let action, let shortcut = config.keyboardShortcut(for: action) else {
-                // No shortcut, clear the menu item
-                menu.keyEquivalent = ""
-                menu.keyEquivalentModifierMask = []
-                return
+            guard let shortcut = config.keyboardShortcut(for: action) else {
+                return false
             }
 
             let keyEquivalent = shortcut.key.character.description
             let modifierMask = NSEvent.ModifierFlags(swiftUIFlags: shortcut.modifiers)
-            menu.keyEquivalent = keyEquivalent
-            menu.keyEquivalentModifierMask = modifierMask
-
             // Build a direct lookup for key-equivalent dispatch so we don't need to
             // linearly walk the full menu hierarchy at event time.
             guard let key = MenuShortcutKey(
@@ -42,11 +55,15 @@ extension Ghostty {
                 keyEquivalent: keyEquivalent.lowercased(),
                 modifiers: modifierMask
             ) else {
-                return
+                return false
             }
 
+            menu.keyEquivalent = keyEquivalent
+            menu.keyEquivalentModifierMask = modifierMask
+
             // Later registrations intentionally override earlier ones for the same key.
-            menuItemsByShortcut[key] = .init(menu)
+            configuredShortcuts[key] = menu.action
+            return true
         }
 
         /// Attempts to perform a menu key equivalent only for menu items that represent
@@ -62,13 +79,11 @@ extension Ghostty {
 
             // If we don't have an entry for this key combo, no Ghostty-owned
             // menu shortcut exists for this event.
-            guard let weakItem = menuItemsByShortcut[key] else {
+            guard let action = configuredShortcuts[key] else {
                 return false
             }
 
-            // Weak references can be nil if a menu item was deallocated after sync.
-            guard let item = weakItem.value else {
-                menuItemsByShortcut.removeValue(forKey: key)
+            guard let item = NSApp.mainMenu?.findItem(with: action) else {
                 return false
             }
 
@@ -89,6 +104,46 @@ extension Ghostty {
 
             parentMenu.performActionForItem(at: index)
             return true
+        }
+}
+
+// MARK: - Recursively process all of the menu items
+
+private extension Ghostty.MenuShortcutManager {
+    /// Map the keyboard shortcut of every menu item recursively in this menu based on previously register action
+    func updateShortcutRecursively(in menu: NSMenu?, config: Ghostty.Config) {
+        guard let menu else {
+            return
+        }
+
+        for item in menu.items {
+            updateItemShortcut(item: item, config: config)
+            updateShortcutRecursively(in: item.submenu, config: config)
+        }
+        menu.update()
+    }
+}
+
+// MARK: - Process a single menu item
+
+private extension Ghostty.MenuShortcutManager {
+    /// Update shortcuts in the following order
+    ///
+    /// 1. Ghostty configuration
+    /// 2. Xib
+    /// 3. Remove unbound defined in Ghostty configuration
+    /// 4. Check conflicts between xib and Ghostty configuration
+    func updateItemShortcut(item: NSMenuItem, config: Ghostty.Config) {
+        guard let selector = item.action else {
+            return
+        }
+
+        if let action = ghosttyActionsBySelector[selector] {
+            if !syncMenuShortcutFrom(config, action: action, menuItem: item) {
+                // No shortcut, clear the menu item
+                item.keyEquivalent = ""
+                item.keyEquivalentModifierMask = []
+            }
         }
     }
 }
@@ -120,5 +175,20 @@ extension Ghostty.MenuShortcutManager {
             guard let keyEquivalent = event.charactersIgnoringModifiers else { return nil }
             self.init(keyEquivalent: keyEquivalent, modifiers: event.modifierFlags)
         }
+    }
+}
+
+private extension NSMenu {
+    /// Expensive operation, but it will be deleted later
+    func findItem(with action: Selector) -> NSMenuItem? {
+        for item in items {
+            if item.action == action {
+                return item
+            }
+            if let item = item.submenu?.findItem(with: action) {
+                return item
+            }
+        }
+        return nil
     }
 }

--- a/macos/Tests/Ghostty/MenuShortcutManagerTests.swift
+++ b/macos/Tests/Ghostty/MenuShortcutManagerTests.swift
@@ -8,19 +8,26 @@ struct MenuShortcutManagerTests {
     func unbindShouldDiscardDefault() async throws {
         let config = try TemporaryConfig("keybind = super+d=unbind")
 
+        let menu = NSMenu()
         let item = NSMenuItem(title: "Split Right", action: #selector(BaseTerminalController.splitRight(_:)), keyEquivalent: "d")
         item.keyEquivalentModifierMask = .command
+        menu.addItem(item)
+
         let manager = await Ghostty.MenuShortcutManager()
-        await manager.reset()
-        await manager.syncMenuShortcut(config, action: "new_split:right", menuItem: item)
+        await manager.resetRegisteredGhosttyActions()
+        await manager.register(action: "new_split:right", menuItem: item)
+
+        await manager.updateShortcut(in: menu, config: config)
 
         #expect(item.keyEquivalent.isEmpty)
         #expect(item.keyEquivalentModifierMask.isEmpty)
 
         try config.reload("")
 
-        await manager.reset()
-        await manager.syncMenuShortcut(config, action: "new_split:right", menuItem: item)
+        await manager.resetRegisteredGhosttyActions()
+        await manager.register(action: "new_split:right", menuItem: item)
+
+        await manager.updateShortcut(in: menu, config: config)
 
         #expect(item.keyEquivalent == "d")
         #expect(item.keyEquivalentModifierMask == .command)
@@ -35,14 +42,46 @@ struct MenuShortcutManagerTests {
 
         let goToLeftItem = NSMenuItem(title: "Select Split Left", action: "splitMoveFocusLeft:", keyEquivalent: "")
 
-        let manager = await Ghostty.MenuShortcutManager()
-        await manager.reset()
+        let menu = NSMenu()
+        [hideItem, goToLeftItem].forEach(menu.addItem)
 
-        await manager.syncMenuShortcut(config, action: nil, menuItem: hideItem)
-        await manager.syncMenuShortcut(config, action: "goto_split:left", menuItem: goToLeftItem)
+        let manager = await Ghostty.MenuShortcutManager()
+        await manager.resetRegisteredGhosttyActions()
+
+        await manager.register(action: "dummy", menuItem: hideItem)
+        await manager.register(action: "goto_split:left", menuItem: goToLeftItem)
+
+        await manager.updateShortcut(in: menu, config: config)
 
         #expect(hideItem.keyEquivalent.isEmpty)
         #expect(hideItem.keyEquivalentModifierMask.isEmpty)
+
+        #expect(goToLeftItem.keyEquivalent == "h")
+        #expect(goToLeftItem.keyEquivalentModifierMask == .command)
+    }
+
+    @Test
+    func unreferencedItemShouldNOTBeChanged() async throws {
+        let config = try TemporaryConfig("keybind=super+h=goto_split:left")
+
+        let hideItem = NSMenuItem(title: "Hide Ghostty", action: "hide:", keyEquivalent: "h")
+        hideItem.keyEquivalentModifierMask = .command
+
+        let goToLeftItem = NSMenuItem(title: "Select Split Left", action: "splitMoveFocusLeft:", keyEquivalent: "")
+
+        let menu = NSMenu()
+        [hideItem, goToLeftItem].forEach(menu.addItem)
+
+        let manager = await Ghostty.MenuShortcutManager()
+
+        await manager.resetRegisteredGhosttyActions()
+        await manager.register(action: "goto_split:left", menuItem: goToLeftItem)
+
+        await manager.updateShortcut(in: menu, config: config)
+
+        // hideItem is not register, so it should stays the same
+        #expect(hideItem.keyEquivalent == "h")
+        #expect(hideItem.keyEquivalentModifierMask == .command)
 
         #expect(goToLeftItem.keyEquivalent == "h")
         #expect(goToLeftItem.keyEquivalentModifierMask == .command)

--- a/macos/Tests/Ghostty/NormalizedMenuShortcutKeyTests.swift
+++ b/macos/Tests/Ghostty/NormalizedMenuShortcutKeyTests.swift
@@ -28,28 +28,28 @@ struct NormalizedMenuShortcutKeyTests {
     @Test func preservesShortcutModifiers() {
         let key = Key(keyEquivalent: "c", modifiers: [.shift, .control, .option, .command])
         let allMods: NSEvent.ModifierFlags = [.shift, .control, .option, .command]
-        #expect(key?.modifiersRawValue == allMods.rawValue)
+        #expect(key?.modifierFlags == allMods)
     }
 
     @Test func uppercaseLetterInsertsShift() {
         // "A" is uppercase and case-sensitive, so .shift should be added
         let key = Key(keyEquivalent: "A", modifiers: .command)
-        let expected = NSEvent.ModifierFlags([.command, .shift]).rawValue
-        #expect(key?.modifiersRawValue == expected)
+        let expected = NSEvent.ModifierFlags([.command, .shift])
+        #expect(key?.modifierFlags == expected)
     }
 
     @Test func lowercaseLetterDoesNotInsertShift() {
         let key = Key(keyEquivalent: "a", modifiers: .command)
-        let expected = NSEvent.ModifierFlags.command.rawValue
-        #expect(key?.modifiersRawValue == expected)
+        let expected = NSEvent.ModifierFlags.command
+        #expect(key?.modifierFlags == expected)
     }
 
     @Test func nonCaseSensitiveCharacterDoesNotInsertShift() {
         // "1" is not case-sensitive (uppercased == lowercased is false for digits,
         // but "1".uppercased() == "1".lowercased() == "1" so isCaseSensitive is false)
         let key = Key(keyEquivalent: "1", modifiers: .command)
-        let expected = NSEvent.ModifierFlags.command.rawValue
-        #expect(key?.modifiersRawValue == expected)
+        let expected = NSEvent.ModifierFlags.command
+        #expect(key?.modifierFlags == expected)
     }
 
     // MARK: - Equality / Hashing


### PR DESCRIPTION
The structure is now nearly the same for upcoming changes. Although it goes through every single menu item in Ghostty’s main menu, it currently still resets menu items registered in `AppDelegate`, but **will not change the ones not linked, like "Hide Others"**.

The last two commits adjust code style to reduce review headache in the first one😵‍💫