### PR TITLE
macOS: Make version in about dialog clickable

### DIFF
--- a/macos/Sources/Features/About/AboutView.swift
+++ b/macos/Sources/Features/About/AboutView.swift
@@ -15,9 +15,10 @@ struct AboutView: View {
         case stable(version: String, url: URL?)
         case tip
         case other(String)
+        case none
 
         init(version: String?, docsURL: URL?) {
-            guard let version else { self = .other(""); return }
+            guard let version else { self = .none; return }
             if version.range(of: #"^\d+\.\d+\.\d+$"#, options: .regularExpression) != nil {
                 let slug = version.replacingOccurrences(of: ".", with: "-")
                 self = .stable(version: version, url: docsURL?.appendingPathComponent("install/release-notes/\(slug)"))
@@ -88,9 +89,9 @@ struct AboutView: View {
                         PropertyRow(label: "Version", text: version, url: url)
                     case .tip:
                         PropertyRow(label: "Version", text: "Tip Release")
-                    case .other(let v) where !v.isEmpty:
+                    case .other(let v):
                         PropertyRow(label: "Version", text: v)
-                    default:
+                    case .none:
                         EmptyView()
                     }
                     if let build {

--- a/macos/Sources/Features/About/AboutView.swift
+++ b/macos/Sources/Features/About/AboutView.swift
@@ -20,19 +20,23 @@ struct AboutView: View {
         case tip
         /// Local dev build or unknown format.
         case other(String)
+
+        init(version: String?, docsURL: URL?) {
+            guard let version else { self = .other(""); return }
+            if version.range(of: #"^\d+\.\d+\.\d+$"#, options: .regularExpression) != nil {
+                let slug = version.replacingOccurrences(of: ".", with: "-")
+                self = .stable(url: docsURL?.appendingPathComponent("install/release-notes/\(slug)"))
+                return
+            }
+            if version.range(of: #"^[0-9a-f]{7,40}$"#, options: .regularExpression) != nil {
+                self = .tip
+                return
+            }
+            self = .other(version)
+        }
     }
 
-    private var versionConfig: VersionConfig {
-        guard let version else { return .other("") }
-        if version.range(of: #"^\d+\.\d+\.\d+$"#, options: .regularExpression) != nil {
-            let slug = version.replacingOccurrences(of: ".", with: "-")
-            return .stable(url: docsURL?.appendingPathComponent("install/release-notes/\(slug)"))
-        }
-        if version.range(of: #"^[0-9a-f]{7,40}$"#, options: .regularExpression) != nil {
-            return .tip
-        }
-        return .other(version)
-    }
+    private var versionConfig: VersionConfig { VersionConfig(version: version, docsURL: docsURL) }
 
     private var copyright: String? { Bundle.main.infoDictionary?["NSHumanReadableCopyright"] as? String }
 

--- a/macos/Sources/Features/About/AboutView.swift
+++ b/macos/Sources/Features/About/AboutView.swift
@@ -12,20 +12,15 @@ struct AboutView: View {
     private var version: String? { Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String }
 
     private enum VersionConfig {
-        /// Stable semver release (e.g. "1.3.1") with a link to release notes.
-        case stable(url: URL?)
-        /// Tip build: CI sets CFBundleShortVersionString to the raw short commit hash,
-        /// identical to GhosttyCommit. Show "Tip Release" text instead to avoid
-        /// duplicating the commit row.
+        case stable(version: String, url: URL?)
         case tip
-        /// Local dev build or unknown format.
         case other(String)
 
         init(version: String?, docsURL: URL?) {
             guard let version else { self = .other(""); return }
             if version.range(of: #"^\d+\.\d+\.\d+$"#, options: .regularExpression) != nil {
                 let slug = version.replacingOccurrences(of: ".", with: "-")
-                self = .stable(url: docsURL?.appendingPathComponent("install/release-notes/\(slug)"))
+                self = .stable(version: version, url: docsURL?.appendingPathComponent("install/release-notes/\(slug)"))
                 return
             }
             if version.range(of: #"^[0-9a-f]{7,40}$"#, options: .regularExpression) != nil {
@@ -89,8 +84,8 @@ struct AboutView: View {
 
                 VStack(spacing: 2) {
                     switch versionConfig {
-                    case .stable(let url):
-                        PropertyRow(label: "Version", text: version ?? "", url: url)
+                    case .stable(let version, let url):
+                        PropertyRow(label: "Version", text: version, url: url)
                     case .tip:
                         PropertyRow(label: "Version", text: "Tip Release")
                     case .other(let v) where !v.isEmpty:

--- a/macos/Sources/Features/About/AboutView.swift
+++ b/macos/Sources/Features/About/AboutView.swift
@@ -10,6 +10,30 @@ struct AboutView: View {
     private var build: String? { Bundle.main.infoDictionary?["CFBundleVersion"] as? String }
     private var commit: String? { Bundle.main.infoDictionary?["GhosttyCommit"] as? String }
     private var version: String? { Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String }
+
+    private enum VersionConfig {
+        /// Stable semver release (e.g. "1.3.1") with a link to release notes.
+        case stable(url: URL?)
+        /// Tip build: CI sets CFBundleShortVersionString to the raw short commit hash,
+        /// identical to GhosttyCommit. Show "Tip Release" text instead to avoid
+        /// duplicating the commit row.
+        case tip
+        /// Local dev build or unknown format.
+        case other(String)
+    }
+
+    private var versionConfig: VersionConfig {
+        guard let version else { return .other("") }
+        if version.range(of: #"^\d+\.\d+\.\d+$"#, options: .regularExpression) != nil {
+            let slug = version.replacingOccurrences(of: ".", with: "-")
+            return .stable(url: docsURL?.appendingPathComponent("install/release-notes/\(slug)"))
+        }
+        if version.range(of: #"^[0-9a-f]{7,40}$"#, options: .regularExpression) != nil {
+            return .tip
+        }
+        return .other(version)
+    }
+
     private var copyright: String? { Bundle.main.infoDictionary?["NSHumanReadableCopyright"] as? String }
 
     #if os(macOS)
@@ -60,8 +84,15 @@ struct AboutView: View {
                 .textSelection(.enabled)
 
                 VStack(spacing: 2) {
-                    if let version {
-                        PropertyRow(label: "Version", text: version)
+                    switch versionConfig {
+                    case .stable(let url):
+                        PropertyRow(label: "Version", text: version ?? "", url: url)
+                    case .tip:
+                        PropertyRow(label: "Version", text: "Tip Release")
+                    case .other(let v) where !v.isEmpty:
+                        PropertyRow(label: "Version", text: v)
+                    default:
+                        EmptyView()
                     }
                     if let build {
                         PropertyRow(label: "Build", text: build)

--- a/macos/Sources/Features/About/AboutView.swift
+++ b/macos/Sources/Features/About/AboutView.swift
@@ -12,27 +12,36 @@ struct AboutView: View {
     private var version: String? { Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String }
 
     private enum VersionConfig {
-        case stable(version: String, url: URL?)
-        case tip
+        case stable(version: String)
+        case tip(commit: String?)
         case other(String)
         case none
 
-        init(version: String?, docsURL: URL?) {
+        init(version: String?) {
             guard let version else { self = .none; return }
             if version.range(of: #"^\d+\.\d+\.\d+$"#, options: .regularExpression) != nil {
-                let slug = version.replacingOccurrences(of: ".", with: "-")
-                self = .stable(version: version, url: docsURL?.appendingPathComponent("install/release-notes/\(slug)"))
+                self = .stable(version: version)
                 return
             }
             if version.range(of: #"^[0-9a-f]{7,40}$"#, options: .regularExpression) != nil {
-                self = .tip
+                self = .tip(commit: version)
                 return
             }
             self = .other(version)
         }
+
+        var url: URL? {
+            switch self {
+            case .stable(let version):
+                let slug = version.replacingOccurrences(of: ".", with: "-")
+                return URL(string: "https://ghostty.org/docs/install/release-notes/\(slug)")
+            default:
+                return nil
+            }
+        }
     }
 
-    private var versionConfig: VersionConfig { VersionConfig(version: version, docsURL: docsURL) }
+    private var versionConfig: VersionConfig { VersionConfig(version: version) }
 
     private var copyright: String? { Bundle.main.infoDictionary?["NSHumanReadableCopyright"] as? String }
 
@@ -85,8 +94,8 @@ struct AboutView: View {
 
                 VStack(spacing: 2) {
                     switch versionConfig {
-                    case .stable(let version, let url):
-                        PropertyRow(label: "Version", text: version, url: url)
+                    case .stable(let version):
+                        PropertyRow(label: "Version", text: version, url: versionConfig.url)
                     case .tip:
                         PropertyRow(label: "Version", text: "Tip Release")
                     case .other(let v):


### PR DESCRIPTION
- Fixes: https://github.com/ghostty-org/ghostty/issues/11964

Made a private enum type `VersionConfig` to reference whether the release is a semver or tip, makes it easier for later in the view to `switch` between cases.

I do think there could be a better place for this enum or we can get rid of it, open to opinions. Right now version parsing is kind of duplicated between `AboutView` and `UpdateModalView` so we can also extract to a common helper if wanted.

Tested by manually setting `Marketing Version` in build settings to 

`1.3.1`
<img width="412" height="532" alt="Screenshot 2026-03-30 at 18 31 15" src="https://github.com/user-attachments/assets/285bb94d-138b-4169-bb66-684eb04b6ca3" />

`332b2aefc`
<img width="412" height="532" alt="Screenshot 2026-03-30 at 18 32 48" src="https://github.com/user-attachments/assets/fea30d39-bea7-4885-8221-1696e148f45e" />

### AI Disclosure
I used Sonnet 4.6 to understand where the version strings came from and in what format, it read release yml files to see what's going on. Then it proposed really bad code so I manually went in and cleaned up the view.
