### PR TITLE
ghostty.h: guard sys/types.h include for MSVC

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -15,11 +15,12 @@ extern "C" {
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <sys/types.h>
 
 #ifdef _MSC_VER
 #include <BaseTsd.h>
 typedef SSIZE_T ssize_t;
+#else
+#include <sys/types.h>
 #endif
 
 //-------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Move `sys/types.h` include into the `#else` branch of the existing `_MSC_VER` guard
- MSVC does not ship `sys/types.h` (POSIX header), and already gets `ssize_t` from `BaseTsd.h`

## Test plan

- [x] `zig build -Dapp-runtime=none` -- clean build
- [x] `zig build test -Dapp-runtime=none` on Windows (2606/2660 passed, 54 skipped)
- [x] `zig build test` on Linux (2658/2684 passed, 26 skipped)
- [x] `zig build test` on macOS (2658/2668 passed, 10 skipped)
- [x] `zig build test-lib-vt` on all 3 platforms
- [x] Zig examples build on all 3 platforms
- [x] CMake examples build on Windows (c-vt-cmake pass, c-vt-cmake-static pass)