### PR TITLE
macOS: fix incorrect delete symbol mapping

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.Input.swift
+++ b/macos/Sources/Ghostty/Ghostty.Input.swift
@@ -89,7 +89,7 @@ extension Ghostty {
         GHOSTTY_KEY_ARROW_RIGHT: .rightArrow,
         GHOSTTY_KEY_HOME: .home,
         GHOSTTY_KEY_END: .end,
-        GHOSTTY_KEY_DELETE: .delete,
+        GHOSTTY_KEY_DELETE: .deleteForward,
         GHOSTTY_KEY_PAGE_UP: .pageUp,
         GHOSTTY_KEY_PAGE_DOWN: .pageDown,
         GHOSTTY_KEY_ESCAPE: .escape,

--- a/macos/Sources/Helpers/Extensions/KeyboardShortcut+Extension.swift
+++ b/macos/Sources/Helpers/Extensions/KeyboardShortcut+Extension.swift
@@ -22,6 +22,7 @@ extension KeyboardShortcut: @retroactive CustomStringConvertible {
         case .return: keyString = "⏎"
         case .escape: keyString = "⎋"
         case .delete: keyString = "⌫"
+        case .deleteForward: keyString = "⌦"
         case .space: keyString = "␣"
         case .tab: keyString = "⇥"
         case .upArrow: keyString = "▲"


### PR DESCRIPTION
`GHOSTTY_KEY_DELETE` should be mapped to `KeyEquivalent.deleteForward`. This fixes the correct symbol showing in the menu. Previously, both `GHOSTTY_KEY_DELETE` and `GHOSTTY_KEY_BACKSPACE` were showing `⌫`, but `GHOSTTY_KEY_DELETE` only worked for `fn+delete`.

Add the following keybind and observe the symbol in the menu:
```
keybind=delete=new_tab
```

<img width="535" height="318" alt="image" src="https://github.com/user-attachments/assets/67ed7b5d-f848-42ee-a382-fe364d86cb2c" />
