### PR TITLE
core: add CApi to check whether trigger is unbound

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1078,6 +1078,8 @@ GHOSTTY_API bool ghostty_config_get(ghostty_config_t, void*, const char*, uintpt
 GHOSTTY_API ghostty_input_trigger_s ghostty_config_trigger(ghostty_config_t,
                                                               const char*,
                                                               uintptr_t);
+GHOSTTY_API bool ghostty_config_trigger_is_unbound(ghostty_config_t,
+                                                ghostty_input_trigger_s);
 GHOSTTY_API uint32_t ghostty_config_diagnostics_count(ghostty_config_t);
 GHOSTTY_API ghostty_diagnostic_s ghostty_config_get_diagnostic(ghostty_config_t, uint32_t);
 GHOSTTY_API ghostty_string_s ghostty_config_open_path(void);

--- a/src/config/CApi.zig
+++ b/src/config/CApi.zig
@@ -116,6 +116,10 @@ export fn ghostty_config_trigger_is_unbound(
     self: *Config,
     trigger: inputpkg.Binding.Trigger.C,
 ) bool {
+    if (self.keybind.cleared) {
+        // If all keybinds are cleared, then we treat any trigger as unbound
+        return true;
+    }
     const t = inputpkg.Binding.Trigger.evalC(trigger);
     return self.keybind.set.isUnbound(t);
 }

--- a/src/config/CApi.zig
+++ b/src/config/CApi.zig
@@ -112,6 +112,14 @@ export fn ghostty_config_trigger(
     };
 }
 
+export fn ghostty_config_trigger_is_unbound(
+    self: *Config,
+    trigger: inputpkg.Binding.Trigger.C,
+) bool {
+    const t = inputpkg.Binding.Trigger.evalC(trigger);
+    return self.keybind.set.isUnbound(t);
+}
+
 fn config_trigger_(
     self: *Config,
     str: []const u8,

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -6414,6 +6414,9 @@ pub const Keybinds = struct {
         table: []const u8,
     } = .root,
 
+    /// Whether all keybinds are cleared
+    cleared: bool = false,
+
     pub fn init(self: *Keybinds, alloc: Allocator) !void {
         // We don't clear the memory because it's in the arena and unlikely
         // to be free-able anyways (since arenas can only clear the last
@@ -7206,6 +7209,7 @@ pub const Keybinds = struct {
             self.set = .{};
             self.tables = .empty;
             self.chain_target = .root;
+            self.cleared = true;
             return;
         }
 
@@ -7291,6 +7295,7 @@ pub const Keybinds = struct {
         return .{
             .set = try self.set.clone(alloc),
             .tables = tables,
+            .cleared = self.cleared,
         };
     }
 
@@ -7307,7 +7312,7 @@ pub const Keybinds = struct {
             if (!equalSet(entry.value_ptr, &other_set)) return false;
         }
 
-        return true;
+        return self.cleared == other.cleared;
     }
 
     fn equalSet(
@@ -7911,6 +7916,7 @@ pub const Keybinds = struct {
 
         try testing.expectEqual(1, keybinds.set.bindings.count());
         try testing.expectEqual(2, keybinds.tables.count());
+        try testing.expectEqual(false, keybinds.cleared);
 
         // Clear all keybinds
         try keybinds.parseCLI(alloc, "clear");
@@ -7918,6 +7924,7 @@ pub const Keybinds = struct {
         // Both root set and tables should be cleared
         try testing.expectEqual(0, keybinds.set.bindings.count());
         try testing.expectEqual(0, keybinds.tables.count());
+        try testing.expectEqual(true, keybinds.cleared);
     }
 
     test "parseCLI reset clears tables" {

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -1983,6 +1983,17 @@ pub const Trigger = struct {
         };
     }
 
+    pub fn evalC(c: C) Trigger {
+        return .{
+            .key = switch (c.tag) {
+                .physical => .{ .physical = c.key.physical },
+                .unicode => .{ .unicode = @as(u21, @intCast(@as(u32, c.key.unicode))) },
+                .catch_all => .catch_all,
+            },
+            .mods = c.mods,
+        };
+    }
+
     /// Format implementation for fmt package.
     pub fn format(
         self: Trigger,
@@ -1999,6 +2010,22 @@ pub const Trigger = struct {
             .physical => |k| try writer.print("{t}", .{k}),
             .unicode => |c| try writer.print("{u}", .{c}),
             .catch_all => try writer.writeAll("catch_all"),
+        }
+    }
+
+    test "evalC roundtrip" {
+        const cases = [_]struct { input: []const u8, mods: key.Mods }{
+            .{ .input = "a", .mods = .{} },
+            .{ .input = "ctrl+a", .mods = .{ .ctrl = true } },
+            .{ .input = "shift+up", .mods = .{ .shift = true } },
+            .{ .input = "super+c", .mods = .{ .super = true } },
+        };
+
+        inline for (cases) |case| {
+            const zig = try Trigger.parse(case.input);
+            const c = zig.cval();
+            const back = evalC(c);
+            try std.testing.expectEqual(zig, back);
         }
     }
 };
@@ -2023,6 +2050,14 @@ pub const Set = struct {
 
     /// The set of bindings.
     bindings: HashMap = .{},
+
+    /// The set of triggers that have been unbound.
+    unbound_triggers: std.ArrayHashMapUnmanaged(
+        Trigger,
+        void,
+        Context(Trigger),
+        true,
+    ) = .{},
 
     /// The reverse mapping of action to binding. Note that multiple
     /// bindings can map to the same action and this map will only have
@@ -2252,6 +2287,7 @@ pub const Set = struct {
         };
 
         self.bindings.deinit(alloc);
+        self.unbound_triggers.deinit(alloc);
         self.reverse.deinit(alloc);
         self.* = undefined;
     }
@@ -2432,6 +2468,11 @@ pub const Set = struct {
             .binding => |b| switch (b.action) {
                 .unbind => {
                     set.remove(alloc, b.trigger);
+                    // move it to unbound_triggers if this is a root
+                    if (set == root) {
+                        try set.unbound_triggers.put(alloc, b.trigger, {});
+                    }
+                    // then return pervious error
                     return error.SequenceUnbind;
                 },
 
@@ -2478,6 +2519,8 @@ pub const Set = struct {
     ) Allocator.Error!void {
         // unbind should never go into the set, it should be handled prior
         assert(action != .unbind);
+        // Remove previous unbinds
+        _ = self.unbound_triggers.swapRemove(t);
 
         // This is true if we're going to track this entry as
         // a reverse mapping. There are certain scenarios we don't.
@@ -2604,6 +2647,11 @@ pub const Set = struct {
     /// Get a binding for a given trigger.
     pub fn get(self: Set, t: Trigger) ?Entry {
         return self.bindings.getEntry(t);
+    }
+
+    /// Returns true if the given trigger has been unbound.
+    pub fn isUnbound(self: Set, t: Trigger) bool {
+        return self.unbound_triggers.contains(t);
     }
 
     /// Get a trigger for the given action. An action can have multiple
@@ -2748,6 +2796,7 @@ pub const Set = struct {
     pub fn clone(self: *const Set, alloc: Allocator) !Set {
         var result: Set = .{
             .bindings = try self.bindings.clone(alloc),
+            .unbound_triggers = try self.unbound_triggers.clone(alloc),
             .reverse = try self.reverse.clone(alloc),
         };
 
@@ -3549,7 +3598,7 @@ test "set: parseAndPut unconsumed binding" {
     }
 }
 
-test "set: parseAndPut removed binding" {
+test "set: parseAndPut move unbind to disabled" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
@@ -3568,6 +3617,9 @@ test "set: parseAndPut removed binding" {
 
     // Sets up the chain parent properly
     try testing.expect(s.chain_parent == null);
+
+    // unbound_triggers should be set
+    try testing.expect(s.isUnbound(.{ .key = .{ .unicode = 'a' } }));
 }
 
 test "set: put sets chain_parent" {
@@ -3688,6 +3740,9 @@ test "set: sequence unbind clears chain_parent" {
 
     // After unbind, chain_parent should be cleared
     try testing.expect(s.chain_parent == null);
+
+    // unbound_triggers should NOT be set
+    try testing.expect(s.unbound_triggers.count() == 0);
 }
 
 test "set: sequence unbind with remaining leaves clears chain_parent" {
@@ -3709,6 +3764,9 @@ test "set: sequence unbind with remaining leaves clears chain_parent" {
     try testing.expect(a_entry.value_ptr.* == .leader);
     const inner_set = a_entry.value_ptr.*.leader;
     try testing.expect(inner_set.get(.{ .key = .{ .unicode = 'c' } }) != null);
+
+    // unbound_triggers should NOT be set
+    try testing.expect(s.unbound_triggers.count() == 0);
 }
 
 test "set: direct remove clears chain_parent" {
@@ -3945,6 +4003,9 @@ test "set: parseAndPut unbind sequence unbinds leader" {
         const t: Trigger = .{ .key = .{ .unicode = 'a' } };
         try testing.expect(current.get(t) == null);
     }
+
+    // unbound_triggers should NOT be set
+    try testing.expect(s.unbound_triggers.count() == 0);
 }
 
 test "set: parseAndPut unbind sequence unbinds leader if not set" {
@@ -3960,6 +4021,9 @@ test "set: parseAndPut unbind sequence unbinds leader if not set" {
         const t: Trigger = .{ .key = .{ .unicode = 'a' } };
         try testing.expect(current.get(t) == null);
     }
+
+    // unbound_triggers should NOT be set
+    try testing.expect(s.unbound_triggers.count() == 0);
 }
 
 test "set: parseAndPut sequence preserves reverse mapping" {
@@ -4241,6 +4305,43 @@ test "set: parseAndPut chain with unbind is error" {
     const entry = s.get(.{ .key = .{ .unicode = 'a' } }).?.value_ptr.*;
     try testing.expect(entry == .leaf);
     try testing.expect(entry.leaf.action == .new_window);
+}
+
+test "set: save and clone unbind triggers" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s: Set = .{};
+    defer s.deinit(alloc);
+
+    try s.parseAndPut(alloc, "a=unbind");
+    try s.parseAndPut(alloc, "a=new_window");
+    try s.parseAndPut(alloc, "b=unbind");
+    try s.parseAndPut(alloc, "super+c=unbind");
+
+    // New binding should still exist
+    const entry = s.get(.{ .key = .{ .unicode = 'a' } }).?.value_ptr.*;
+    try testing.expect(entry == .leaf);
+    try testing.expect(entry.leaf.action == .new_window);
+
+    // unbound_triggers should be set
+
+    try testing.expect(s.unbound_triggers.count() == 2);
+
+    try testing.expect(s.isUnbound(.{ .key = .{ .unicode = 'b' } }));
+
+    try testing.expect(s.isUnbound(.{ .key = .{ .unicode = 'c' }, .mods = .{ .super = true } }));
+
+    var cloned = try s.clone(alloc);
+    defer cloned.deinit(alloc);
+
+    // Clone should have the same result
+
+    try testing.expect(cloned.unbound_triggers.count() == 2);
+
+    try testing.expect(cloned.isUnbound(.{ .key = .{ .unicode = 'b' } }));
+
+    try testing.expect(cloned.isUnbound(.{ .key = .{ .unicode = 'c' }, .mods = .{ .super = true } }));
 }
 
 test "set: getEvent physical" {


### PR DESCRIPTION
Preparing a better solution to fix https://github.com/ghostty-org/ghostty/issues/779, which caused a lot of workarounds along the way to make the menu behave as it's supposed to.

## AI Disclosure

Perplexity helped me to write `evalC` and to add test cases for it.
Claude reviewed it and did some renaming. I manually reviewed it and added some test cases on the ~~Swift side~~(Separated into another pr).