### PR TITLE
apprt/embedded: fix ghostty_surface_free_text parameter mismatch

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1675,7 +1675,7 @@ pub const CAPI = struct {
         return true;
     }
 
-    export fn ghostty_surface_free_text(ptr: *Text) void {
+    export fn ghostty_surface_free_text(_: *Surface, ptr: *Text) void {
         ptr.deinit();
     }
 


### PR DESCRIPTION
Fixes #12020

The C header declared ghostty_surface_free_text with both a ghostty_surface_t and ghostty_text_s* parameter, but the Zig implementation only accepted a *Text parameter. This caused the surface pointer to be interpreted as the text pointer, so the actual text allocation was never freed.

I opted to keep the surface parameter to minimize the diff here. I'm not sure why I thought I would need access to that surface pointer but just want to fix the leak first.