### PR TITLE
terminal: implement kitty clipboard protocol read path (OSC 5522)

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -81,6 +81,8 @@ typedef enum {
   GHOSTTY_CLIPBOARD_REQUEST_PASTE,
   GHOSTTY_CLIPBOARD_REQUEST_OSC_52_READ,
   GHOSTTY_CLIPBOARD_REQUEST_OSC_52_WRITE,
+  GHOSTTY_CLIPBOARD_REQUEST_KITTY_MIME_LIST,
+  GHOSTTY_CLIPBOARD_REQUEST_KITTY_MIME_READ,
 } ghostty_clipboard_request_e;
 
 typedef enum {
@@ -1152,6 +1154,8 @@ GHOSTTY_API void ghostty_surface_complete_clipboard_request(ghostty_surface_t,
                                                                const char*,
                                                                void*,
                                                                bool);
+GHOSTTY_API ghostty_clipboard_request_e ghostty_clipboard_request_type(void*);
+GHOSTTY_API const char* ghostty_clipboard_request_mime(void*);
 GHOSTTY_API bool ghostty_surface_has_selection(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_read_selection(ghostty_surface_t, ghostty_text_s*);
 GHOSTTY_API bool ghostty_surface_read_text(ghostty_surface_t,

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -334,6 +334,27 @@ extension Ghostty {
             // Get our pasteboard
             guard let pasteboard = NSPasteboard.ghostty(location) else { return false }
 
+            // Check the request type to handle kitty clipboard protocol
+            switch ghostty_clipboard_request_type(state) {
+            case GHOSTTY_CLIPBOARD_REQUEST_KITTY_MIME_LIST:
+                let mimes = pasteboard.availableMimeTypes()
+                guard !mimes.isEmpty else { return false }
+                completeClipboardRequest(surface, data: mimes.joined(separator: "\n"), state: state)
+                return true
+
+            case GHOSTTY_CLIPBOARD_REQUEST_KITTY_MIME_READ:
+                guard let mimePtr = ghostty_clipboard_request_mime(state),
+                      let mime = String(cString: mimePtr, encoding: .utf8),
+                      let data = pasteboard.data(forMimeType: mime) else {
+                    return false
+                }
+                completeClipboardRequest(surface, data: data.base64EncodedString(), state: state)
+                return true
+
+            default:
+                break
+            }
+
             // Return false if there is no text-like clipboard content so
             // performable paste bindings can pass through to the terminal.
             guard let str = pasteboard.getOpinionatedStringContents() else { return false }

--- a/macos/Sources/Helpers/Extensions/NSPasteboard+Extension.swift
+++ b/macos/Sources/Helpers/Extensions/NSPasteboard+Extension.swift
@@ -26,11 +26,34 @@ extension NSPasteboard.PasteboardType {
     }
 }
 
+extension NSPasteboard.PasteboardType {
+    /// Convert a pasteboard type to a MIME type string.
+    var mimeType: String? {
+        UTType(rawValue)?.preferredMIMEType
+    }
+}
+
 extension NSPasteboard {
     /// The pasteboard to used for Ghostty selection.
     static var ghosttySelection: NSPasteboard = {
         NSPasteboard(name: .init("com.mitchellh.ghostty.selection"))
     }()
+
+    /// Get all available MIME types on this pasteboard.
+    func availableMimeTypes() -> [String] {
+        var mimes: [String] = []
+        for type in types ?? [] {
+            guard let mime = type.mimeType, !mimes.contains(mime) else { continue }
+            mimes.append(mime)
+        }
+        return mimes
+    }
+
+    /// Get the raw data for a specific MIME type.
+    func data(forMimeType mime: String) -> Data? {
+        guard let type = PasteboardType(mimeType: mime) else { return nil }
+        return data(forType: type)
+    }
 
     /// Gets the contents of the pasteboard as a string following a specific set of semantics.
     /// Does these things in order:

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -169,6 +169,33 @@ search: ?Search = null,
 /// Used to rate limit BEL handling.
 last_bell_time: ?std.time.Instant = null,
 
+/// Kitty clipboard protocol paste state (mode 5522). Set when a paste
+/// event triggers an unsolicited MIME list, cleared on use or timeout.
+kitty_paste: ?KittyPaste = null,
+
+/// State for a pending kitty clipboard protocol paste event.
+const KittyPaste = struct {
+    /// Single-use password for this paste event. Raw bytes, base64-encoded
+    /// when sent in OSC sequences.
+    password: [16]u8,
+
+    /// The clipboard location that was pasted from.
+    clipboard: apprt.Clipboard,
+
+    /// When this password was issued. Per spec, passwords MUST be
+    /// invalidated after a short timeout to prevent a stashed password
+    /// from authorizing reads of future clipboard contents.
+    issued_at: std.time.Instant,
+
+    /// Password validity window. Long enough for interactive app response,
+    /// short enough to bound exposure if the app stashes the password.
+    pub const timeout_ns = 5 * std.time.ns_per_s;
+
+    pub fn expired(self: KittyPaste, now: std.time.Instant) bool {
+        return now.since(self.issued_at) > timeout_ns;
+    }
+};
+
 /// The effect of an input event. This can be used by callers to take
 /// the appropriate action after an input event. For example, key
 /// input can be forwarded to the OS for further processing if it
@@ -1042,6 +1069,11 @@ pub fn handleMessage(self: *Surface, msg: Message) !void {
                 defer v.alloc.free(v.data);
                 try self.clipboardWrite(v.data, w.clipboard_type);
             },
+        },
+
+        .kitty_clipboard_read => |v| {
+            defer v.alloc.free(v.metadata);
+            try self.handleKittyClipboardRead(v.metadata);
         },
 
         .pwd_change => |w| {
@@ -5986,6 +6018,16 @@ pub fn completeClipboardRequest(
             .mime = "text/plain",
             .data = data,
         }}, !confirmed),
+
+        .kitty_mime_list => |clipboard| try self.completeKittyMimeList(
+            data,
+            clipboard,
+        ),
+
+        .kitty_mime_read => |v| try self.completeKittyMimeRead(
+            data,
+            std.mem.sliceTo(&v.mime, 0),
+        ),
     }
 }
 
@@ -6001,7 +6043,25 @@ fn startClipboardRequest(
     req: apprt.ClipboardRequest,
 ) !bool {
     switch (req) {
-        .paste => {}, // always allowed
+        .paste => {
+            // If kitty clipboard protocol mode (5522) is enabled, paste
+            // events send an unsolicited MIME type list instead of the
+            // actual paste data. The app then requests specific MIME types.
+            const kitty_mode = kitty_mode: {
+                self.renderer_state.mutex.lock();
+                defer self.renderer_state.mutex.unlock();
+                break :kitty_mode self.io.terminal.modes.get(.kitty_clipboard_protocol);
+            };
+            if (kitty_mode) {
+                // If the apprt doesn't support MIME listing (returns false),
+                // fall through to normal paste rather than silently dropping.
+                if (try self.rt_surface.clipboardRequest(
+                    loc,
+                    .{ .kitty_mime_list = loc },
+                )) return true;
+            }
+        },
+
         .osc_52_read => if (self.config.clipboard_read == .deny) {
             log.info(
                 "application attempted to read clipboard, but 'clipboard-read' is set to deny",
@@ -6009,6 +6069,8 @@ fn startClipboardRequest(
             );
             return false;
         },
+
+        .kitty_mime_list, .kitty_mime_read => {},
 
         // No clipboard write code paths travel through this function
         .osc_52_write => unreachable,
@@ -6139,6 +6201,162 @@ fn completeClipboardReadOSC52(
         self.alloc,
         buf,
     ), .unlocked);
+}
+
+/// Complete a kitty MIME list request by sending an unsolicited OSC 5522
+/// MIME type listing with a single-use password.
+fn completeKittyMimeList(
+    self: *Surface,
+    data: []const u8,
+    clipboard: apprt.Clipboard,
+) !void {
+    var password: [16]u8 = undefined;
+    std.crypto.random.bytes(&password);
+    self.kitty_paste = .{
+        .password = password,
+        .clipboard = clipboard,
+        .issued_at = std.time.Instant.now() catch {
+            // Platforms without a monotonic clock can't safely implement
+            // the spec's MUST-timeout requirement, so don't issue a password.
+            self.kitty_paste = null;
+            return;
+        },
+    };
+
+    const buf = try input.kitty_clipboard.encodeMimeList(
+        self.alloc,
+        &password,
+        data,
+    );
+    self.queueIo(.{ .write_alloc = .{ .alloc = self.alloc, .data = buf } }, .unlocked);
+}
+
+/// Complete a kitty MIME read request by sending OSC 5522 data packets.
+/// The data is already base64-encoded by the apprt.
+fn completeKittyMimeRead(
+    self: *Surface,
+    data: []const u8,
+    mime: []const u8,
+) !void {
+    // write_alloc takes ownership — avoids the dupe-then-free that
+    // writeReq would do for MB-scale image payloads.
+    const buf = try input.kitty_clipboard.encodeMimeData(
+        self.alloc,
+        mime,
+        data,
+    );
+    self.queueIo(.{ .write_alloc = .{ .alloc = self.alloc, .data = buf } }, .unlocked);
+}
+
+/// Handle an OSC 5522 read request from the application. Validates the
+/// password against a pending paste event and initiates a clipboard read
+/// for the requested MIME type.
+fn handleKittyClipboardRead(
+    self: *Surface,
+    metadata: []const u8,
+) !void {
+    const osc = terminal.osc;
+    const KCP = osc.Command.KittyClipboardProtocol;
+    const req: KCP = .{
+        .metadata = metadata,
+        .payload = null,
+        .terminator = .st,
+    };
+
+    const kc = input.kitty_clipboard;
+
+    const op = req.readOption(.type) orelse {
+        self.queueIo(.{ .write_stable = kc.encodeError(.EINVAL) }, .unlocked);
+        return;
+    };
+
+    // We only handle read requests; write operations aren't supported yet.
+    if (op != .read) {
+        self.queueIo(.{ .write_stable = kc.encodeError(.ENOSYS) }, .unlocked);
+        return;
+    }
+
+    // Decode the requested MIME type first. If this fails, the password
+    // is not consumed — the app can retry with a different MIME.
+    const b64 = std.base64.standard;
+    const mime_b64 = req.readOption(.mime) orelse {
+        self.queueIo(.{ .write_stable = kc.encodeError(.EINVAL) }, .unlocked);
+        return;
+    };
+    comptime assert(kc.mime_max_len == apprt.ClipboardRequest.KittyMimeRead.mime_max_len);
+    var mime_buf: [kc.mime_max_len]u8 = undefined;
+    const mime_len = b64.Decoder.calcSizeForSlice(mime_b64) catch {
+        self.queueIo(.{ .write_stable = kc.encodeError(.EINVAL) }, .unlocked);
+        return;
+    };
+    if (mime_len > mime_buf.len) {
+        self.queueIo(.{ .write_stable = kc.encodeError(.EINVAL) }, .unlocked);
+        return;
+    }
+    b64.Decoder.decode(mime_buf[0..mime_len], mime_b64) catch {
+        self.queueIo(.{ .write_stable = kc.encodeError(.EINVAL) }, .unlocked);
+        return;
+    };
+    const mime = mime_buf[0..mime_len];
+
+    // Validate the password against a pending paste event. Without a
+    // valid password, treat this like a regular clipboard read (subject
+    // to clipboard-read policy).
+    const paste: KittyPaste = paste: {
+        const p = self.kitty_paste orelse break :paste null;
+        const now = std.time.Instant.now() catch break :paste null;
+        if (p.expired(now)) {
+            self.kitty_paste = null;
+            break :paste null;
+        }
+        break :paste p;
+    } orelse {
+        if (self.config.clipboard_read == .deny) {
+            self.queueIo(.{ .write_stable = kc.encodeError(.EPERM) }, .unlocked);
+            return;
+        }
+        // TODO: implement non-password-authenticated reads with user prompt
+        self.queueIo(.{ .write_stable = kc.encodeError(.ENOSYS) }, .unlocked);
+        return;
+    };
+
+    const pw_b64 = req.readOption(.password) orelse req.readOption(.pw) orelse {
+        self.queueIo(.{ .write_stable = kc.encodeError(.EPERM) }, .unlocked);
+        return;
+    };
+
+    var pw_decoded: [16]u8 = undefined;
+    const pw_len = b64.Decoder.calcSizeForSlice(pw_b64) catch {
+        self.queueIo(.{ .write_stable = kc.encodeError(.EPERM) }, .unlocked);
+        return;
+    };
+    if (pw_len != 16) {
+        self.queueIo(.{ .write_stable = kc.encodeError(.EPERM) }, .unlocked);
+        return;
+    }
+    b64.Decoder.decode(&pw_decoded, pw_b64) catch {
+        self.queueIo(.{ .write_stable = kc.encodeError(.EPERM) }, .unlocked);
+        return;
+    };
+    if (!std.crypto.timing_safe.eql([16]u8, pw_decoded, paste.password)) {
+        self.queueIo(.{ .write_stable = kc.encodeError(.EPERM) }, .unlocked);
+        return;
+    }
+
+    // Password and MIME both validated. Invalidate the password (single-use).
+    self.kitty_paste = null;
+
+    const started = self.rt_surface.clipboardRequest(
+        paste.clipboard,
+        .{ .kitty_mime_read = .init(paste.clipboard, mime) },
+    ) catch |err| {
+        log.warn("failed to start kitty MIME read err={}", .{err});
+        self.queueIo(.{ .write_stable = kc.encodeError(.EIO) }, .unlocked);
+        return;
+    };
+    if (!started) {
+        self.queueIo(.{ .write_stable = kc.encodeError(.EIO) }, .unlocked);
+    }
 }
 
 fn showDesktopNotification(self: *Surface, title: [:0]const u8, body: [:0]const u8) !void {
@@ -6636,4 +6854,65 @@ test "Surface: rectangle selection logic" {
         9, 2, // expected end
         true, //rectangle selection
     );
+}
+
+test "KittyPaste: timeout constant is 5 seconds" {
+    // The spec says passwords MUST be invalidated after a short timeout.
+    // 5s was chosen as long enough for an interactive app to respond, short
+    // enough to bound the window where a stashed password could authorize
+    // reads of future clipboard contents. Pinned so a change trips a test.
+    try std.testing.expectEqual(5 * std.time.ns_per_s, KittyPaste.timeout_ns);
+}
+
+test "KittyPaste: expiry boundary" {
+    const now = std.time.Instant.now() catch return error.SkipZigTest;
+
+    // std.time.Instant is opaque per-platform but we can reach into the
+    // timestamp on each one: posix has timespec{sec,nsec}, windows/wasi/uefi
+    // have a u64. Construct issued-ago Instants by subtracting whole seconds.
+    const secondsAgo = struct {
+        fn f(base: std.time.Instant, secs: u64) std.time.Instant {
+            var past = base;
+            switch (@import("builtin").os.tag) {
+                .windows => {
+                    // QPC ticks; QPF varies but is at least 10MHz. Subtracting
+                    // secs * 10MHz undershoots on faster clocks — past appears
+                    // *less* old, which is the conservative direction for the
+                    // 5min/10min cases below. Skip the tight 4s/6s boundary.
+                    past.timestamp -= secs * 10_000_000;
+                },
+                .wasi, .uefi => past.timestamp -= secs * std.time.ns_per_s,
+                else => past.timestamp.sec -= @intCast(secs),
+            }
+            return past;
+        }
+    }.f;
+
+    const make = struct {
+        fn p(at: std.time.Instant) KittyPaste {
+            return .{
+                .password = [_]u8{0} ** 16,
+                .clipboard = .standard,
+                .issued_at = at,
+            };
+        }
+    }.p;
+
+    // Fresh: not expired
+    try std.testing.expect(!make(now).expired(now));
+
+    // 5 minutes ago: well past timeout
+    try std.testing.expect(make(secondsAgo(now, 300)).expired(now));
+
+    // 10 minutes ago: definitely expired
+    try std.testing.expect(make(secondsAgo(now, 600)).expired(now));
+
+    // The tight boundary depends on second-granularity arithmetic, so it's
+    // posix-only where we have direct timespec.sec control.
+    if (@import("builtin").os.tag != .windows) {
+        // 4s ago: under the 5s timeout
+        try std.testing.expect(!make(secondsAgo(now, 4)).expired(now));
+        // 6s ago: over
+        try std.testing.expect(make(secondsAgo(now, 6)).expired(now));
+    }
 }

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1982,6 +1982,26 @@ pub const CAPI = struct {
         };
     }
 
+    /// Get the request type for a clipboard request state pointer. This
+    /// lets embedders branch on the request type to handle kitty clipboard
+    /// protocol requests differently.
+    export fn ghostty_clipboard_request_type(
+        state: *apprt.ClipboardRequest,
+    ) apprt.ClipboardRequestType {
+        return state.*;
+    }
+
+    /// Get the MIME type for a kitty_mime_read clipboard request. Returns
+    /// null for other request types.
+    export fn ghostty_clipboard_request_mime(
+        state: *apprt.ClipboardRequest,
+    ) ?[*:0]const u8 {
+        return switch (state.*) {
+            .kitty_mime_read => |*v| &v.mime,
+            else => null,
+        };
+    }
+
     /// Complete a clipboard read request started via the read callback.
     /// This can only be called once for a given request. Once it is called
     /// with a request the request pointer will be invalidated.

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -3774,6 +3774,14 @@ const Clipboard = struct {
         clipboard_type: apprt.Clipboard,
         state: apprt.ClipboardRequest,
     ) Allocator.Error!bool {
+        // Kitty clipboard protocol MIME requests are not yet implemented
+        // on GTK. Return false so the caller falls back to normal paste.
+        // TODO: implement via gdk.Clipboard.getFormats() + readAsync()
+        switch (state) {
+            .kitty_mime_list, .kitty_mime_read => return false,
+            else => {},
+        }
+
         // Get our requested clipboard
         const clipboard = get(
             self.private().gl_area.as(gtk.Widget),
@@ -3876,7 +3884,7 @@ const Clipboard = struct {
                 .request = &req,
                 .@"can-remember" = switch (req) {
                     .osc_52_read, .osc_52_write => true,
-                    .paste => false,
+                    .paste, .kitty_mime_list, .kitty_mime_read => false,
                 },
                 .@"clipboard-contents" = contents_buf,
             },
@@ -3913,7 +3921,7 @@ const Clipboard = struct {
         if (remember) switch (req.*) {
             .osc_52_read => surface.config.clipboard_read = .allow,
             .osc_52_write => surface.config.clipboard_write = .allow,
-            .paste => {},
+            .paste, .kitty_mime_list, .kitty_mime_read => {},
         };
 
         // Get our text
@@ -3952,7 +3960,10 @@ const Clipboard = struct {
         if (remember) switch (req.*) {
             .osc_52_read => surface.config.clipboard_read = .deny,
             .osc_52_write => surface.config.clipboard_write = .deny,
-            .paste => @panic("paste should not be able to be remembered"),
+            .paste,
+            .kitty_mime_list,
+            .kitty_mime_read,
+            => @panic("should not be able to be remembered"),
         };
     }
 

--- a/src/apprt/structs.zig
+++ b/src/apprt/structs.zig
@@ -67,6 +67,8 @@ pub const ClipboardRequestType = enum(u8) {
     paste,
     osc_52_read,
     osc_52_write,
+    kitty_mime_list,
+    kitty_mime_read,
 };
 
 /// Clipboard request. This is used to request clipboard contents and must
@@ -80,6 +82,81 @@ pub const ClipboardRequest = union(ClipboardRequestType) {
 
     /// A request to write clipboard contents via OSC 52.
     osc_52_write: Clipboard,
+
+    /// A request to list available MIME types on the clipboard for the
+    /// kitty clipboard protocol (OSC 5522, mode 5522). The apprt should
+    /// complete this request with a newline-separated list of MIME types.
+    kitty_mime_list: Clipboard,
+
+    /// A request to read a specific MIME type from the clipboard for the
+    /// kitty clipboard protocol. The apprt should complete this request
+    /// with the base64-encoded data for the requested MIME type.
+    kitty_mime_read: KittyMimeRead,
+
+    pub const KittyMimeRead = struct {
+        pub const mime_max_len = 256;
+
+        clipboard: Clipboard,
+        /// The requested MIME type, null-terminated.
+        mime: [mime_max_len:0]u8,
+
+        pub fn init(clipboard: Clipboard, mime: []const u8) KittyMimeRead {
+            var result: KittyMimeRead = .{
+                .clipboard = clipboard,
+                .mime = [_:0]u8{0} ** mime_max_len,
+            };
+            const len = @min(mime.len, mime_max_len);
+            @memcpy(result.mime[0..len], mime[0..len]);
+            return result;
+        }
+
+        test init {
+            const testing = @import("std").testing;
+            const mem = @import("std").mem;
+
+            // Basic MIME type
+            {
+                const r = KittyMimeRead.init(.standard, "text/plain");
+                try testing.expectEqual(Clipboard.standard, r.clipboard);
+                try testing.expectEqualStrings("text/plain", mem.sliceTo(&r.mime, 0));
+            }
+
+            // Image MIME type
+            {
+                const r = KittyMimeRead.init(.standard, "image/png");
+                try testing.expectEqualStrings("image/png", mem.sliceTo(&r.mime, 0));
+            }
+
+            // Empty MIME
+            {
+                const r = KittyMimeRead.init(.standard, "");
+                try testing.expectEqualStrings("", mem.sliceTo(&r.mime, 0));
+            }
+
+            // Exactly at the limit (boundary)
+            {
+                const long = "a" ** mime_max_len;
+                const r = KittyMimeRead.init(.standard, long);
+                try testing.expectEqualStrings(long, mem.sliceTo(&r.mime, 0));
+                try testing.expectEqual(@as(u8, 0), r.mime[mime_max_len]);
+            }
+
+            // Over the limit (truncation)
+            {
+                const overlong = "x" ** (mime_max_len + 50);
+                const r = KittyMimeRead.init(.standard, overlong);
+                try testing.expectEqual(@as(usize, mime_max_len), mem.sliceTo(&r.mime, 0).len);
+                try testing.expectEqual(@as(u8, 0), r.mime[mime_max_len]);
+            }
+
+            // Real Office MIME types fit
+            {
+                const xlsx = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+                const r = KittyMimeRead.init(.standard, xlsx);
+                try testing.expectEqualStrings(xlsx, mem.sliceTo(&r.mime, 0));
+            }
+        }
+    };
 
     /// Make this a valid gobject if we're in a GTK environment.
     pub const getGObjectType = switch (build_config.app_runtime) {

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -37,6 +37,13 @@ pub const Message = union(enum) {
         req: WriteReq,
     },
 
+    /// Handle a kitty clipboard protocol read request (OSC 5522).
+    /// The metadata is allocated and must be freed by the receiver.
+    kitty_clipboard_read: struct {
+        alloc: std.mem.Allocator,
+        metadata: []const u8,
+    },
+
     /// Change the configuration to the given configuration. The pointer is
     /// not valid after receiving this message so any config must be used
     /// and derived immediately.

--- a/src/input.zig
+++ b/src/input.zig
@@ -12,6 +12,7 @@ pub const function_keys = @import("input/function_keys.zig");
 pub const keycodes = @import("input/keycodes.zig");
 pub const key_encode = @import("input/key_encode.zig");
 pub const kitty = @import("input/kitty.zig");
+pub const kitty_clipboard = @import("input/kitty_clipboard.zig");
 pub const mouse_encode = @import("input/mouse_encode.zig");
 pub const paste = @import("input/paste.zig");
 

--- a/src/input/kitty_clipboard.zig
+++ b/src/input/kitty_clipboard.zig
@@ -1,0 +1,856 @@
+//! Kitty clipboard protocol (OSC 5522) paste encoding helpers.
+//! Spec: https://rockorager.dev/misc/bracketed-paste-mime/
+//!
+//! When mode 5522 is enabled, paste events send an unsolicited MIME
+//! type listing with a single-use password. The application then
+//! requests specific MIME data using the password.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const parsers = @import("../terminal/osc/parsers/kitty_clipboard_protocol.zig");
+pub const Status = parsers.Status;
+
+/// Maximum raw payload size per DATA packet (before base64 encoding).
+/// The spec limits payload to 4096 bytes pre-encoding.
+pub const chunk_raw_max = 4096;
+
+/// Chunk size in base64 characters. We slice a pre-encoded base64 stream,
+/// so middle chunks have no padding: N chars decode to N/4*3 raw bytes.
+/// To stay at or under 4096 raw bytes: (4096/3)*4 = 5460 chars → 4095 bytes.
+pub const chunk_b64_max = (chunk_raw_max / 3) * 4;
+
+comptime {
+    std.debug.assert(chunk_b64_max % 4 == 0);
+    std.debug.assert(chunk_b64_max / 4 * 3 <= chunk_raw_max);
+}
+
+/// Maximum raw MIME type length. Must match apprt.ClipboardRequest.KittyMimeRead
+/// so we never advertise a MIME type the reader can't accept back.
+/// 256 covers all IANA-registered types including the OpenXML Office types
+/// (65-73 bytes) with comfortable headroom.
+pub const mime_max_len = 256;
+
+/// Encode an unsolicited MIME type listing for a paste event.
+/// This is sent by the terminal when the user pastes and mode 5522 is enabled.
+///
+/// The `mimes` argument is a newline-separated list of MIME types.
+/// The `password` is raw bytes that will be base64-encoded.
+pub fn encodeMimeList(
+    alloc: Allocator,
+    password: []const u8,
+    mimes: []const u8,
+) Allocator.Error![]u8 {
+    const b64 = std.base64.standard.Encoder;
+
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(alloc);
+
+    var pw_buf: [64]u8 = undefined;
+    const pw_size = b64.calcSize(password.len);
+    std.debug.assert(pw_size <= pw_buf.len);
+    const pw_b64 = b64.encode(pw_buf[0..pw_size], password);
+
+    try buf.writer(alloc).print(
+        "\x1b]5522;type=read:status=OK:password={s}\x1b\\",
+        .{pw_b64},
+    );
+
+    var it = std.mem.tokenizeScalar(u8, mimes, '\n');
+    while (it.next()) |mime| {
+        const trimmed = std.mem.trim(u8, mime, &std.ascii.whitespace);
+        if (trimmed.len == 0) continue;
+        if (trimmed.len > mime_max_len) continue;
+
+        var mime_buf: [b64.calcSize(mime_max_len)]u8 = undefined;
+        const mime_b64 = b64.encode(mime_buf[0..b64.calcSize(trimmed.len)], trimmed);
+
+        try buf.writer(alloc).print(
+            "\x1b]5522;type=read:status=DATA:mime={s}\x1b\\",
+            .{mime_b64},
+        );
+    }
+
+    try buf.appendSlice(alloc, "\x1b]5522;type=read:status=DONE\x1b\\");
+
+    return buf.toOwnedSlice(alloc);
+}
+
+/// Encode a MIME data response. The `data` is already base64-encoded
+/// (typically by the apprt). Data is chunked into DATA packets.
+pub fn encodeMimeData(
+    alloc: Allocator,
+    mime: []const u8,
+    data: []const u8,
+) Allocator.Error![]u8 {
+    const b64 = std.base64.standard.Encoder;
+
+    std.debug.assert(mime.len <= mime_max_len);
+    var mime_buf: [b64.calcSize(mime_max_len)]u8 = undefined;
+    const mime_b64 = b64.encode(mime_buf[0..b64.calcSize(mime.len)], mime);
+
+    // Per-chunk overhead is ~60 bytes of OSC framing plus the MIME echo.
+    // Pre-size to avoid O(log n) reallocs when encoding multi-MB images.
+    const chunks = (data.len + chunk_b64_max - 1) / chunk_b64_max;
+    const per_chunk_overhead = 64 + mime_b64.len;
+    const cap = data.len + chunks * per_chunk_overhead + 128;
+
+    var buf: std.ArrayList(u8) = try .initCapacity(alloc, cap);
+    errdefer buf.deinit(alloc);
+
+    try buf.appendSlice(alloc, "\x1b]5522;type=read:status=OK\x1b\\");
+
+    var offset: usize = 0;
+    while (offset < data.len) {
+        const end = @min(offset + chunk_b64_max, data.len);
+        try buf.writer(alloc).print(
+            "\x1b]5522;type=read:status=DATA:mime={s};{s}\x1b\\",
+            .{ mime_b64, data[offset..end] },
+        );
+        offset = end;
+    }
+
+    try buf.appendSlice(alloc, "\x1b]5522;type=read:status=DONE\x1b\\");
+
+    return buf.toOwnedSlice(alloc);
+}
+
+/// Encode an error response. Using the Status enum gives compile-time
+/// drift detection against the OSC parser.
+pub fn encodeError(comptime status: Status) []const u8 {
+    return "\x1b]5522;type=read:status=" ++ @tagName(status) ++ "\x1b\\";
+}
+
+test "encodeMimeList: single text/plain" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const result = try encodeMimeList(alloc, "secret123456789a", "text/plain");
+    defer alloc.free(result);
+
+    try testing.expect(std.mem.startsWith(u8, result, "\x1b]5522;type=read:status=OK:password="));
+    try testing.expect(std.mem.indexOf(u8, result, "status=DATA:mime=dGV4dC9wbGFpbg==") != null);
+    try testing.expect(std.mem.endsWith(u8, result, "\x1b]5522;type=read:status=DONE\x1b\\"));
+    try testing.expectEqual(@as(usize, 3), std.mem.count(u8, result, "\x1b\\"));
+}
+
+test "encodeMimeList: multiple MIME types" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const result = try encodeMimeList(
+        alloc,
+        "pw",
+        "text/plain\nimage/png\ntext/html",
+    );
+    defer alloc.free(result);
+
+    try testing.expectEqual(@as(usize, 5), std.mem.count(u8, result, "\x1b\\"));
+    try testing.expect(std.mem.indexOf(u8, result, "dGV4dC9wbGFpbg==") != null);
+    try testing.expect(std.mem.indexOf(u8, result, "aW1hZ2UvcG5n") != null);
+    try testing.expect(std.mem.indexOf(u8, result, "dGV4dC9odG1s") != null);
+}
+
+test "encodeMimeList: empty MIME list" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const result = try encodeMimeList(alloc, "pw", "");
+    defer alloc.free(result);
+
+    try testing.expectEqual(@as(usize, 2), std.mem.count(u8, result, "\x1b\\"));
+    try testing.expect(std.mem.indexOf(u8, result, "status=DATA") == null);
+}
+
+test "encodeMimeList: whitespace-only MIME entries skipped" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const result = try encodeMimeList(alloc, "pw", "text/plain\n   \n\t\nimage/png");
+    defer alloc.free(result);
+
+    try testing.expectEqual(@as(usize, 4), std.mem.count(u8, result, "\x1b\\"));
+}
+
+test "encodeMimeList: overlong MIME type skipped" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // Exactly at the limit: included
+    {
+        const at_limit = "x" ** mime_max_len;
+        const result = try encodeMimeList(alloc, "pw", at_limit);
+        defer alloc.free(result);
+        try testing.expectEqual(@as(usize, 3), std.mem.count(u8, result, "\x1b\\"));
+    }
+
+    // One byte over: skipped. Prevents advertising a MIME the reader
+    // can't accept back through the fixed-size request struct.
+    {
+        const over = "x" ** (mime_max_len + 1);
+        const result = try encodeMimeList(alloc, "pw", over);
+        defer alloc.free(result);
+        try testing.expectEqual(@as(usize, 2), std.mem.count(u8, result, "\x1b\\"));
+    }
+}
+
+test "encodeMimeList: Office MIME types pass through" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // 65-73 bytes — well under mime_max_len. Someone might actually want
+    // to paste an .xlsx into a TUI editor.
+    const office_types =
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet\n" ++
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document\n" ++
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation\n" ++
+        "text/plain";
+
+    const result = try encodeMimeList(alloc, "pw", office_types);
+    defer alloc.free(result);
+
+    // All four MIME types advertised + OK + DONE = 6 packets
+    try testing.expectEqual(@as(usize, 6), std.mem.count(u8, result, "\x1b\\"));
+}
+
+test "encodeMimeList: password base64 round-trip" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const pw = [_]u8{ 0x00, 0xFF, 0x42, 0x13, 0x37, 0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE, 0x12, 0x34, 0x56 };
+    const result = try encodeMimeList(alloc, &pw, "text/plain");
+    defer alloc.free(result);
+
+    const prefix = "password=";
+    const start = std.mem.indexOf(u8, result, prefix).? + prefix.len;
+    const end = std.mem.indexOfScalarPos(u8, result, start, '\x1b').?;
+    const pw_b64 = result[start..end];
+
+    var decoded: [16]u8 = undefined;
+    try std.base64.standard.Decoder.decode(&decoded, pw_b64);
+    try testing.expectEqualSlices(u8, &pw, &decoded);
+}
+
+test "encodeMimeData: small payload single chunk" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const result = try encodeMimeData(alloc, "text/plain", "SGVsbG8=");
+    defer alloc.free(result);
+
+    try testing.expectEqual(@as(usize, 3), std.mem.count(u8, result, "\x1b\\"));
+    try testing.expect(std.mem.indexOf(u8, result, ";SGVsbG8=\x1b") != null);
+}
+
+test "encodeMimeData: empty payload" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const result = try encodeMimeData(alloc, "text/plain", "");
+    defer alloc.free(result);
+
+    try testing.expectEqual(@as(usize, 2), std.mem.count(u8, result, "\x1b\\"));
+}
+
+test "encodeMimeData: large payload chunked" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const data = try alloc.alloc(u8, chunk_b64_max * 3 + 100);
+    defer alloc.free(data);
+    @memset(data, 'A');
+
+    const result = try encodeMimeData(alloc, "image/png", data);
+    defer alloc.free(result);
+
+    try testing.expectEqual(@as(usize, 6), std.mem.count(u8, result, "\x1b\\"));
+    try testing.expectEqual(@as(usize, 4), std.mem.count(u8, result, "status=DATA"));
+}
+
+test "chunk_b64_max decodes to <= 4096 raw bytes" {
+    const testing = std.testing;
+    const decoded = chunk_b64_max / 4 * 3;
+    try testing.expect(decoded <= chunk_raw_max);
+    try testing.expectEqual(@as(usize, 5460), chunk_b64_max);
+    try testing.expectEqual(@as(usize, 4095), decoded);
+}
+
+test "encodeMimeData: chunk boundary exact multiple" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const data = try alloc.alloc(u8, chunk_b64_max * 2);
+    defer alloc.free(data);
+    @memset(data, 'B');
+
+    const result = try encodeMimeData(alloc, "image/png", data);
+    defer alloc.free(result);
+
+    try testing.expectEqual(@as(usize, 2), std.mem.count(u8, result, "status=DATA"));
+}
+
+test "encodeMimeData: chunks preserve data integrity" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const b64_alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    const data = try alloc.alloc(u8, chunk_b64_max + 500);
+    defer alloc.free(data);
+    for (data, 0..) |*b, i| b.* = b64_alphabet[i % 64];
+
+    const result = try encodeMimeData(alloc, "text/plain", data);
+    defer alloc.free(result);
+
+    var reassembled: std.ArrayList(u8) = .empty;
+    defer reassembled.deinit(alloc);
+
+    var it = std.mem.splitSequence(u8, result, "\x1b\\");
+    while (it.next()) |seq| {
+        if (std.mem.indexOf(u8, seq, "status=DATA") == null) continue;
+        const sep = std.mem.lastIndexOfScalar(u8, seq, ';') orelse continue;
+        try reassembled.appendSlice(alloc, seq[sep + 1 ..]);
+    }
+
+    try testing.expectEqualSlices(u8, data, reassembled.items);
+}
+
+test "encodeError: all error status codes" {
+    const testing = std.testing;
+    inline for (.{ .EINVAL, .EIO, .ENOSYS, .EPERM, .EBUSY }) |status| {
+        const result = encodeError(status);
+        try testing.expect(std.mem.startsWith(u8, result, "\x1b]5522;type=read:status="));
+        try testing.expect(std.mem.endsWith(u8, result, "\x1b\\"));
+        try testing.expect(std.mem.indexOf(u8, result, @tagName(status)) != null);
+    }
+}
+
+// Roundtrip tests: verify our encoder output can be parsed back by the
+// OSC parser. Catches encoder/parser drift.
+
+const terminal = @import("../terminal/main.zig");
+
+test "roundtrip: encodeMimeList output parses correctly" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const password = [_]u8{ 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10 };
+    const encoded = try encodeMimeList(alloc, &password, "text/plain\nimage/png");
+    defer alloc.free(encoded);
+
+    var packets: std.ArrayList(struct {
+        type: ?[]const u8,
+        status: ?[]const u8,
+        mime: ?[]const u8,
+        password: ?[]const u8,
+    }) = .empty;
+    defer {
+        for (packets.items) |p| {
+            if (p.type) |v| alloc.free(v);
+            if (p.status) |v| alloc.free(v);
+            if (p.mime) |v| alloc.free(v);
+            if (p.password) |v| alloc.free(v);
+        }
+        packets.deinit(alloc);
+    }
+
+    var offset: usize = 0;
+    while (offset < encoded.len) {
+        const osc_start = std.mem.indexOfPos(u8, encoded, offset, "\x1b]") orelse break;
+        const st = std.mem.indexOfPos(u8, encoded, osc_start, "\x1b\\") orelse break;
+
+        var p: terminal.osc.Parser = .init(alloc);
+        defer p.deinit();
+        for (encoded[osc_start + 2 .. st]) |ch| p.next(ch);
+        const cmd = p.end('\x1b') orelse return error.ParseFailed;
+
+        try testing.expect(cmd.* == .kitty_clipboard_protocol);
+        const kcp = cmd.kitty_clipboard_protocol;
+
+        try packets.append(alloc, .{
+            .type = if (kcp.readOption(.type)) |v| try alloc.dupe(u8, @tagName(v)) else null,
+            .status = if (kcp.readOption(.status)) |v| try alloc.dupe(u8, @tagName(v)) else null,
+            .mime = if (kcp.readOption(.mime)) |v| try alloc.dupe(u8, v) else null,
+            .password = if (kcp.readOption(.password)) |v| try alloc.dupe(u8, v) else null,
+        });
+
+        offset = st + 2;
+    }
+
+    // OK → DATA(text/plain) → DATA(image/png) → DONE
+    try testing.expectEqual(@as(usize, 4), packets.items.len);
+
+    try testing.expectEqualStrings("read", packets.items[0].type.?);
+    try testing.expectEqualStrings("OK", packets.items[0].status.?);
+    try testing.expect(packets.items[0].password != null);
+
+    try testing.expectEqualStrings("DATA", packets.items[1].status.?);
+    try testing.expectEqualStrings("dGV4dC9wbGFpbg==", packets.items[1].mime.?);
+
+    try testing.expectEqualStrings("DATA", packets.items[2].status.?);
+    try testing.expectEqualStrings("aW1hZ2UvcG5n", packets.items[2].mime.?);
+
+    try testing.expectEqualStrings("DONE", packets.items[3].status.?);
+
+    var pw_decoded: [16]u8 = undefined;
+    try std.base64.standard.Decoder.decode(&pw_decoded, packets.items[0].password.?);
+    try testing.expectEqualSlices(u8, &password, &pw_decoded);
+}
+
+test "roundtrip: encodeMimeData chunks parse correctly" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const raw_data = try alloc.alloc(u8, chunk_b64_max + 200);
+    defer alloc.free(raw_data);
+    @memset(raw_data, 'Q');
+
+    const encoded = try encodeMimeData(alloc, "image/png", raw_data);
+    defer alloc.free(encoded);
+
+    var reassembled: std.ArrayList(u8) = .empty;
+    defer reassembled.deinit(alloc);
+
+    var packet_count: usize = 0;
+    var offset: usize = 0;
+    while (offset < encoded.len) {
+        const osc_start = std.mem.indexOfPos(u8, encoded, offset, "\x1b]") orelse break;
+        const st = std.mem.indexOfPos(u8, encoded, osc_start, "\x1b\\") orelse break;
+
+        var p: terminal.osc.Parser = .init(alloc);
+        defer p.deinit();
+        for (encoded[osc_start + 2 .. st]) |ch| p.next(ch);
+        const cmd = p.end('\x1b') orelse return error.ParseFailed;
+
+        try testing.expect(cmd.* == .kitty_clipboard_protocol);
+        const kcp = cmd.kitty_clipboard_protocol;
+        packet_count += 1;
+
+        if (kcp.readOption(.status) == .DATA) {
+            try testing.expectEqualStrings("aW1hZ2UvcG5n", kcp.readOption(.mime).?);
+            const payload = kcp.payload orelse return error.MissingPayload;
+            try reassembled.appendSlice(alloc, payload);
+        }
+
+        offset = st + 2;
+    }
+
+    try testing.expectEqual(@as(usize, 4), packet_count);
+    try testing.expectEqualSlices(u8, raw_data, reassembled.items);
+}
+
+test "roundtrip: encodeError parses correctly" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    inline for (.{ Status.EPERM, .EINVAL, .EIO, .ENOSYS }) |status| {
+        const encoded = encodeError(status);
+
+        var p: terminal.osc.Parser = .init(alloc);
+        defer p.deinit();
+        for (encoded[2 .. encoded.len - 2]) |ch| p.next(ch);
+        const cmd = p.end('\x1b') orelse return error.ParseFailed;
+
+        try testing.expect(cmd.* == .kitty_clipboard_protocol);
+        const kcp = cmd.kitty_clipboard_protocol;
+        try testing.expectEqual(parsers.Operation.read, kcp.readOption(.type).?);
+        try testing.expectEqual(status, kcp.readOption(.status).?);
+    }
+}
+
+// Allocation failure: every alloc point in the encoders is a leak vector if
+// errdefer is wrong. This walks a failing allocator through every index.
+
+test "encodeMimeList: no leaks under allocation failure" {
+    const testing = std.testing;
+
+    // checkAllAllocationFailures runs the function once per allocation site,
+    // failing at index 0, then 1, then 2, etc. testing.allocator catches any
+    // un-freed bytes when an error path returns. If errdefer buf.deinit() is
+    // missing or fires on the wrong scope, this fails.
+    const TestFn = struct {
+        fn run(alloc: Allocator) !void {
+            const result = try encodeMimeList(
+                alloc,
+                "0123456789abcdef",
+                // Multiple MIME types means multiple writer.print() allocations
+                "text/plain\ntext/html\nimage/png\napplication/json",
+            );
+            alloc.free(result);
+        }
+    };
+    try testing.checkAllAllocationFailures(testing.allocator, TestFn.run, .{});
+}
+
+test "encodeMimeData: no leaks under allocation failure with large multi-chunk payload" {
+    const testing = std.testing;
+
+    const TestFn = struct {
+        fn run(alloc: Allocator) !void {
+            // Three full chunks plus a remainder — exercises the loop body's
+            // writer.print() allocation for each chunk separately.
+            var data: [chunk_b64_max * 3 + 100]u8 = undefined;
+            @memset(&data, 'X');
+            const result = try encodeMimeData(alloc, "image/png", &data);
+            alloc.free(result);
+        }
+    };
+    try testing.checkAllAllocationFailures(testing.allocator, TestFn.run, .{});
+}
+
+// Spec wire-format compliance: every byte we emit is read by an application
+// expecting exact framing. A single off-by-one in delimiters breaks the peer.
+
+test "encodeMimeData: every chunk respects the 4096-byte raw limit" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // 5 full chunks plus a partial. The spec says "no more than 4096 bytes
+    // before encoding" — if a single chunk exceeds that, kitty (or anything
+    // following the spec) is allowed to reject the whole transfer.
+    const data = try alloc.alloc(u8, chunk_b64_max * 5 + 1000);
+    defer alloc.free(data);
+    @memset(data, 'A');
+
+    const result = try encodeMimeData(alloc, "application/octet-stream", data);
+    defer alloc.free(result);
+
+    var it = std.mem.splitSequence(u8, result, "\x1b\\");
+    while (it.next()) |seq| {
+        if (std.mem.indexOf(u8, seq, "status=DATA") == null) continue;
+        const sep = std.mem.lastIndexOfScalar(u8, seq, ';') orelse continue;
+        const payload = seq[sep + 1 ..];
+
+        // Middle chunks (no padding): N chars decode to N/4*3 bytes.
+        // Final chunk may have padding which decodes to fewer bytes —
+        // either way the upper bound is N/4*3.
+        const decoded_max = payload.len / 4 * 3;
+        try testing.expect(decoded_max <= chunk_raw_max);
+    }
+}
+
+test "encodeMimeData: capacity estimate covers actual output (no realloc growth)" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // The encoder pre-sizes the buffer to avoid O(log n) reallocs on big
+    // images. If the estimate is too low, the buffer grows mid-encode —
+    // that's a perf bug (silent ~2x memory churn on a 10MB image), and
+    // it means the per_chunk_overhead constant is wrong.
+    //
+    // We can't directly observe reallocs from outside ArrayList, but we
+    // can re-derive the estimate and assert the final size fits.
+    const cases = [_]struct { mime: []const u8, data_len: usize }{
+        .{ .mime = "text/plain", .data_len = 0 },
+        .{ .mime = "text/plain", .data_len = 1 },
+        .{ .mime = "text/plain", .data_len = chunk_b64_max },
+        .{ .mime = "text/plain", .data_len = chunk_b64_max + 1 },
+        .{ .mime = "image/png", .data_len = chunk_b64_max * 10 },
+        // Longest MIME we accept — overhead estimate must account for it
+        .{ .mime = "x" ** mime_max_len, .data_len = chunk_b64_max * 3 },
+    };
+
+    for (cases) |c| {
+        const data = try alloc.alloc(u8, c.data_len);
+        defer alloc.free(data);
+        @memset(data, 'Z');
+
+        const result = try encodeMimeData(alloc, c.mime, data);
+        defer alloc.free(result);
+
+        // Mirror the encoder's estimate
+        const b64 = std.base64.standard.Encoder;
+        const mime_b64_len = b64.calcSize(c.mime.len);
+        const chunks = if (c.data_len == 0) 0 else (c.data_len + chunk_b64_max - 1) / chunk_b64_max;
+        const per_chunk_overhead = 64 + mime_b64_len;
+        const cap = c.data_len + chunks * per_chunk_overhead + 128;
+
+        try testing.expect(result.len <= cap);
+    }
+}
+
+test "encodeMimeData: payload bytes are reproduced exactly with no foreign bytes between chunks" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // Unique byte at every position. If chunk N's last bytes leak into
+    // chunk N+1's first bytes (or vice versa), or if the slicing skips/
+    // duplicates bytes at boundaries, the reassembled stream won't match.
+    // This is the data-bleed test: a single dropped, repeated, or foreign
+    // byte fails byte-exact comparison.
+    const b64_alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    const sizes = [_]usize{
+        chunk_b64_max - 1, // just under one chunk
+        chunk_b64_max, // exactly one chunk
+        chunk_b64_max + 1, // one byte into chunk 2
+        chunk_b64_max * 2, // exactly two chunks
+        chunk_b64_max * 7 + 333, // 8 chunks, last one weird size
+    };
+
+    for (sizes) |size| {
+        const data = try alloc.alloc(u8, size);
+        defer alloc.free(data);
+        for (data, 0..) |*b, i| b.* = b64_alphabet[i % 64];
+
+        const result = try encodeMimeData(alloc, "image/png", data);
+        defer alloc.free(result);
+
+        var reassembled: std.ArrayList(u8) = .empty;
+        defer reassembled.deinit(alloc);
+
+        var it = std.mem.splitSequence(u8, result, "\x1b\\");
+        while (it.next()) |seq| {
+            if (std.mem.indexOf(u8, seq, "status=DATA") == null) continue;
+            const sep = std.mem.lastIndexOfScalar(u8, seq, ';') orelse continue;
+            try reassembled.appendSlice(alloc, seq[sep + 1 ..]);
+        }
+
+        try testing.expectEqualSlices(u8, data, reassembled.items);
+    }
+}
+
+test "encodeMimeData: MIME echo is identical in every DATA packet" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // The spec sends the MIME in every DATA packet for self-describing
+    // chunks. If the encoder cached it once and accidentally reused a
+    // stack buffer, packets after the first could carry garbage.
+    const data = try alloc.alloc(u8, chunk_b64_max * 4);
+    defer alloc.free(data);
+    @memset(data, 'M');
+
+    const result = try encodeMimeData(alloc, "text/html", data);
+    defer alloc.free(result);
+
+    const expected_mime = "dGV4dC9odG1s"; // base64("text/html")
+    var data_packet_count: usize = 0;
+
+    var it = std.mem.splitSequence(u8, result, "\x1b\\");
+    while (it.next()) |seq| {
+        if (std.mem.indexOf(u8, seq, "status=DATA") == null) continue;
+        data_packet_count += 1;
+
+        const mime_start = std.mem.indexOf(u8, seq, "mime=") orelse
+            return error.MissingMime;
+        const mime_field = seq[mime_start + 5 ..];
+        const mime_end = std.mem.indexOfScalar(u8, mime_field, ';') orelse mime_field.len;
+
+        try testing.expectEqualStrings(expected_mime, mime_field[0..mime_end]);
+    }
+
+    try testing.expectEqual(@as(usize, 4), data_packet_count);
+}
+
+test "encodeMimeList: packet ordering is OK first, DATA*, DONE last" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // The spec requires this exact ordering. An app reading our output
+    // is a state machine: if DONE appears before DATA, or DATA before OK,
+    // it's a protocol violation.
+    const result = try encodeMimeList(
+        alloc,
+        "secretsecretsecr",
+        "text/plain\nimage/png\ntext/html\napplication/json",
+    );
+    defer alloc.free(result);
+
+    var seen_ok = false;
+    var seen_done = false;
+    var data_after_ok: usize = 0;
+
+    var it = std.mem.splitSequence(u8, result, "\x1b\\");
+    while (it.next()) |seq| {
+        if (seq.len == 0) continue;
+
+        if (std.mem.indexOf(u8, seq, "status=OK") != null) {
+            try testing.expect(!seen_ok); // exactly one OK
+            try testing.expect(!seen_done);
+            seen_ok = true;
+        } else if (std.mem.indexOf(u8, seq, "status=DATA") != null) {
+            try testing.expect(seen_ok);
+            try testing.expect(!seen_done);
+            data_after_ok += 1;
+        } else if (std.mem.indexOf(u8, seq, "status=DONE") != null) {
+            try testing.expect(seen_ok);
+            try testing.expect(!seen_done); // exactly one DONE
+            seen_done = true;
+        }
+    }
+
+    try testing.expect(seen_ok);
+    try testing.expect(seen_done);
+    try testing.expectEqual(@as(usize, 4), data_after_ok);
+}
+
+test "encodeMimeList: output contains no naked ESC outside ST" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // A stray 0x1b that isn't part of "\x1b]" (OSC) or "\x1b\\" (ST)
+    // would corrupt any terminal parser. This checks we don't accidentally
+    // emit one — e.g., if the password contains 0x1b.
+    const password = [_]u8{ 0x1b, 0x5d, 0x5c, 0x07, 0x00, 0xff, 0x1b, 0x1b, 0x5c, 0x5c, 0x5c, 0x5c, 0x5c, 0x5c, 0x5c, 0x5c };
+    const result = try encodeMimeList(alloc, &password, "text/plain");
+    defer alloc.free(result);
+
+    var i: usize = 0;
+    while (i < result.len) : (i += 1) {
+        if (result[i] != 0x1b) continue;
+        // Every ESC must be followed by ']' (OSC start) or '\' (ST end)
+        try testing.expect(i + 1 < result.len);
+        const next = result[i + 1];
+        try testing.expect(next == ']' or next == '\\');
+    }
+}
+
+// Spec example reproduction: the spec gives byte-exact examples. Our encoder
+// should produce them. If these tests fail, we're not interoperable.
+
+test "spec example: text/plain paste with password 'secret123'" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // From https://rockorager.dev/misc/bracketed-paste-mime/ — the spec's
+    // first example shows password "secret123" base64 → "c2VjcmV0MTIz".
+    // Our encoder takes raw bytes, so the password input is the literal
+    // string "secret123" (9 bytes, not 16 — the spec doesn't fix length,
+    // we chose 16 for entropy).
+    const result = try encodeMimeList(alloc, "secret123", "text/plain");
+    defer alloc.free(result);
+
+    // Spec's exact output:
+    // T: \x1b]5522;type=read:status=OK:password=c2VjcmV0MTIz\x1b\\
+    // T: \x1b]5522;type=read:status=DATA:mime=dGV4dC9wbGFpbg==\x1b\\
+    // T: \x1b]5522;type=read:status=DONE\x1b\\
+    const expected =
+        "\x1b]5522;type=read:status=OK:password=c2VjcmV0MTIz\x1b\\" ++
+        "\x1b]5522;type=read:status=DATA:mime=dGV4dC9wbGFpbg==\x1b\\" ++
+        "\x1b]5522;type=read:status=DONE\x1b\\";
+
+    try testing.expectEqualStrings(expected, result);
+}
+
+test "spec example: data response 'Hello, world!' as text/plain" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // Spec shows: SGVsbG8sIHdvcmxkIQ== which is base64("Hello, world!")
+    // Our encoder takes pre-encoded base64 (the apprt encodes), so we
+    // pass the b64 string directly.
+    const result = try encodeMimeData(alloc, "text/plain", "SGVsbG8sIHdvcmxkIQ==");
+    defer alloc.free(result);
+
+    const expected =
+        "\x1b]5522;type=read:status=OK\x1b\\" ++
+        "\x1b]5522;type=read:status=DATA:mime=dGV4dC9wbGFpbg==;SGVsbG8sIHdvcmxkIQ==\x1b\\" ++
+        "\x1b]5522;type=read:status=DONE\x1b\\";
+
+    try testing.expectEqualStrings(expected, result);
+}
+
+test "spec example: HTML data response '<b>Bold text</b>'" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // Spec: PGI+Qm9sZCB0ZXh0PC9iPg== = base64("<b>Bold text</b>")
+    const result = try encodeMimeData(alloc, "text/html", "PGI+Qm9sZCB0ZXh0PC9iPg==");
+    defer alloc.free(result);
+
+    const expected =
+        "\x1b]5522;type=read:status=OK\x1b\\" ++
+        "\x1b]5522;type=read:status=DATA:mime=dGV4dC9odG1s;PGI+Qm9sZCB0ZXh0PC9iPg==\x1b\\" ++
+        "\x1b]5522;type=read:status=DONE\x1b\\";
+
+    try testing.expectEqualStrings(expected, result);
+}
+
+// Adversarial inputs: an apprt could pass us anything. These should be
+// handled gracefully, not crash or corrupt the output.
+
+test "encodeMimeList: MIME containing colon doesn't break OSC option parsing" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // ":" is the OSC metadata separator. A MIME like "text/plain:v2"
+    // (not standard but the apprt could send anything) gets base64'd,
+    // so the colon is encoded away. Verify the output parses cleanly.
+    const result = try encodeMimeList(alloc, "pw", "text/plain:v2");
+    defer alloc.free(result);
+
+    var p: terminal.osc.Parser = .init(alloc);
+    defer p.deinit();
+
+    // Find the DATA packet
+    const data_start = std.mem.indexOf(u8, result, "status=DATA").?;
+    const osc_start = std.mem.lastIndexOfScalar(u8, result[0..data_start], 0x1b).?;
+    const st = std.mem.indexOfPos(u8, result, data_start, "\x1b\\").?;
+
+    for (result[osc_start + 2 .. st]) |ch| p.next(ch);
+    const cmd = p.end('\x1b').?;
+
+    const mime_b64 = cmd.kitty_clipboard_protocol.readOption(.mime).?;
+    var decoded: [32]u8 = undefined;
+    const len = try std.base64.standard.Decoder.calcSizeForSlice(mime_b64);
+    try std.base64.standard.Decoder.decode(decoded[0..len], mime_b64);
+
+    try testing.expectEqualStrings("text/plain:v2", decoded[0..len]);
+}
+
+test "encodeMimeList: MIME with trailing newline doesn't produce empty DATA packet" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // tokenizeScalar correctly skips empty tokens, but a regression to
+    // splitScalar would produce an empty entry. Belt and suspenders.
+    const result = try encodeMimeList(alloc, "pw", "text/plain\n");
+    defer alloc.free(result);
+
+    try testing.expectEqual(@as(usize, 1), std.mem.count(u8, result, "status=DATA"));
+}
+
+test "encodeMimeList: 100 MIME types — no quadratic behavior" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var mimes: std.ArrayList(u8) = .empty;
+    defer mimes.deinit(alloc);
+    var i: usize = 0;
+    while (i < 100) : (i += 1) {
+        try mimes.writer(alloc).print("application/x-type-{d}\n", .{i});
+    }
+
+    const result = try encodeMimeList(alloc, "pw", mimes.items);
+    defer alloc.free(result);
+
+    try testing.expectEqual(@as(usize, 100), std.mem.count(u8, result, "status=DATA"));
+    // Each entry adds <100 bytes of output. Anything wildly above that
+    // means the encoder is doing something quadratic (like re-encoding
+    // the password per entry).
+    try testing.expect(result.len < 100 * 100 + 200);
+}
+
+test "encodeMimeData: payload that LOOKS like an OSC sequence is preserved literally" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // The data is opaque base64 to us. If the apprt's base64 happens to
+    // produce a substring like "5522;type=" (entirely possible — base64
+    // uses [A-Za-z0-9+/=] but the surrounding context could line up),
+    // the encoder must NOT interpret it. The chunk goes between ';' and
+    // ST, so it's payload, not metadata.
+    //
+    // This particular string doesn't decode to anything meaningful but
+    // it stress-tests the framing.
+    const sneaky = "ABCD]5522;type=read:status=EVILpasswordEFGH";
+    const result = try encodeMimeData(alloc, "text/plain", sneaky);
+    defer alloc.free(result);
+
+    // The sneaky string appears exactly once, in the payload position
+    try testing.expectEqual(@as(usize, 1), std.mem.count(u8, result, sneaky));
+    // And it's framed correctly — preceded by ';', followed by ST
+    const idx = std.mem.indexOf(u8, result, sneaky).?;
+    try testing.expectEqual(@as(u8, ';'), result[idx - 1]);
+    try testing.expectEqual(@as(u8, 0x1b), result[idx + sneaky.len]);
+    try testing.expectEqual(@as(u8, '\\'), result[idx + sneaky.len + 1]);
+}

--- a/src/terminal/c/terminal.zig
+++ b/src/terminal/c/terminal.zig
@@ -265,6 +265,7 @@ fn new_(
         .color_scheme = &Effects.colorSchemeTrampoline,
         .device_attributes = &Effects.deviceAttributesTrampoline,
         .enquiry = &Effects.enquiryTrampoline,
+        .kitty_clipboard = null,
         .xtversion = &Effects.xtversionTrampoline,
         .title_changed = &Effects.titleChangedTrampoline,
         .size = &Effects.sizeTrampoline,

--- a/src/terminal/modes.zig
+++ b/src/terminal/modes.zig
@@ -292,6 +292,7 @@ const entries: []const ModeEntry = &.{
     .{ .name = "grapheme_cluster", .value = 2027 },
     .{ .name = "report_color_scheme", .value = 2031 },
     .{ .name = "in_band_size_reports", .value = 2048 },
+    .{ .name = "kitty_clipboard_protocol", .value = 5522 },
 };
 
 test {
@@ -304,6 +305,8 @@ test modeFromInt {
     try testing.expect(modeFromInt(9, true) == null);
     try testing.expect(modeFromInt(9, false).? == .mouse_event_x10);
     try testing.expect(modeFromInt(14, true) == null);
+    try testing.expect(modeFromInt(5522, false).? == .kitty_clipboard_protocol);
+    try testing.expect(modeFromInt(5522, true) == null);
 }
 
 test ModeState {

--- a/src/terminal/osc/parsers/kitty_clipboard_protocol.zig
+++ b/src/terminal/osc/parsers/kitty_clipboard_protocol.zig
@@ -700,3 +700,106 @@ test "OSC: 5522: example 15" {
     try testing.expectEqual(.OK, cmd.kitty_clipboard_protocol.readOption(.status).?);
     try testing.expectEqual(.read, cmd.kitty_clipboard_protocol.readOption(.type).?);
 }
+
+// Adversarial tests for malformed input that an attacker might send
+
+test "OSC: 5522: malformed - option with no equals" {
+    const testing = std.testing;
+    const req: OSC = .{ .metadata = "type", .payload = null, .terminator = .st };
+    try testing.expect(req.readOption(.type) == null);
+}
+
+test "OSC: 5522: malformed - option with only colon separator" {
+    const testing = std.testing;
+    const req: OSC = .{ .metadata = ":::", .payload = null, .terminator = .st };
+    try testing.expect(req.readOption(.type) == null);
+    try testing.expect(req.readOption(.mime) == null);
+}
+
+test "OSC: 5522: malformed - embedded null bytes in metadata" {
+    const testing = std.testing;
+    const req: OSC = .{
+        .metadata = "type=read\x00:password=evil",
+        .payload = null,
+        .terminator = .st,
+    };
+    // Null byte makes value "read\x00" which won't match "read" exactly
+    try testing.expect(req.readOption(.type) == null);
+}
+
+test "OSC: 5522: malformed - duplicate keys takes first" {
+    const testing = std.testing;
+    const req: OSC = .{
+        .metadata = "type=read:type=write",
+        .payload = null,
+        .terminator = .st,
+    };
+    try testing.expectEqual(Operation.read, req.readOption(.type).?);
+}
+
+test "OSC: 5522: malformed - whitespace-only value" {
+    const testing = std.testing;
+    const req: OSC = .{
+        .metadata = "type=   ",
+        .payload = null,
+        .terminator = .st,
+    };
+    try testing.expect(req.readOption(.type) == null);
+}
+
+test "OSC: 5522: malformed - key prefix collision" {
+    const testing = std.testing;
+    // "pwfoo" must not match key "pw" — next char after "pw" is 'f', not '='
+    const req: OSC = .{
+        .metadata = "pwfoo=bar",
+        .payload = null,
+        .terminator = .st,
+    };
+    try testing.expect(req.readOption(.pw) == null);
+}
+
+test "OSC: 5522: very long metadata" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var p: Parser = .init(alloc);
+    defer p.deinit();
+
+    var input: std.ArrayList(u8) = .empty;
+    defer input.deinit(alloc);
+    try input.appendSlice(alloc, "5522;type=read:mime=");
+    try input.appendNTimes(alloc, 'A', 10000);
+    for (input.items) |ch| p.next(ch);
+
+    const cmd = p.end('\x1b').?.*;
+    try testing.expect(cmd == .kitty_clipboard_protocol);
+    try testing.expectEqual(Operation.read, cmd.kitty_clipboard_protocol.readOption(.type).?);
+    const mime = cmd.kitty_clipboard_protocol.readOption(.mime).?;
+    try testing.expectEqual(@as(usize, 10000), mime.len);
+}
+
+test "OSC: 5522: password with all valid base64 chars" {
+    const testing = std.testing;
+    const req: OSC = .{
+        .metadata = "password=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/==",
+        .payload = null,
+        .terminator = .st,
+    };
+    try testing.expectEqualStrings(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/==",
+        req.readOption(.password).?,
+    );
+}
+
+test "OSC: 5522: injection attempt - terminator in metadata" {
+    const testing = std.testing;
+    // Metadata with embedded ST — downstream base64 decode will reject,
+    // but the option parser itself returns the raw value including escapes
+    const req: OSC = .{
+        .metadata = "type=read:password=abc\x1b\\evil",
+        .payload = null,
+        .terminator = .st,
+    };
+    const pw = req.readOption(.password).?;
+    try testing.expect(std.mem.indexOf(u8, pw, "\x1b") != null);
+}

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -119,6 +119,7 @@ pub const Action = union(Key) {
     progress_report: osc.Command.ProgressReport,
     start_hyperlink: StartHyperlink,
     clipboard_contents: ClipboardContents,
+    kitty_clipboard: KittyClipboard,
     mouse_shape: MouseShape,
     configure_charset: ConfigureCharset,
     set_attribute: sgr.Attribute,
@@ -216,6 +217,7 @@ pub const Action = union(Key) {
             "progress_report",
             "start_hyperlink",
             "clipboard_contents",
+            "kitty_clipboard",
             "mouse_shape",
             "configure_charset",
             "set_attribute",
@@ -379,6 +381,17 @@ pub const Action = union(Key) {
                 .kind = self.kind,
                 .data = .init(self.data),
             };
+        }
+    };
+
+    pub const KittyClipboard = struct {
+        metadata: []const u8,
+        payload: ?[]const u8,
+
+        pub const C = void;
+
+        pub fn cval(_: KittyClipboard) KittyClipboard.C {
+            return {};
         }
     };
 
@@ -2057,10 +2070,16 @@ pub fn Stream(comptime H: type) type {
                 .conemu_output_environment_variable,
                 .conemu_run_process,
                 .kitty_text_sizing,
-                .kitty_clipboard_protocol,
                 .context_signal,
                 => {
                     log.debug("unimplemented OSC callback: {}", .{cmd});
+                },
+
+                .kitty_clipboard_protocol => |v| {
+                    self.handler.vt(.kitty_clipboard, .{
+                        .metadata = v.metadata,
+                        .payload = v.payload,
+                    });
                 },
 
                 .invalid => {
@@ -3446,4 +3465,102 @@ test "stream: tab clear with overflowing param" {
     // This is the exact input from the fuzz crash (minus the mode byte):
     // CSI with a huge numeric param that saturates to 65535, followed by 'g'.
     s.nextSlice("\x1b[388888888888888888888888888888888888g\x1b[0m");
+}
+
+test "stream: OSC 5522 kitty clipboard dispatch" {
+    const H = struct {
+        metadata: ?[]const u8 = null,
+        payload: ?[]const u8 = null,
+
+        pub fn vt(
+            self: *@This(),
+            comptime action: Action.Tag,
+            value: Action.Value(action),
+        ) void {
+            switch (action) {
+                .kitty_clipboard => {
+                    self.metadata = value.metadata;
+                    self.payload = value.payload;
+                },
+                else => {},
+            }
+        }
+    };
+
+    const alloc = testing.allocator;
+    var s: Stream(H) = .init(.{});
+    s.parser.osc_parser = .init(alloc);
+    defer s.parser.osc_parser.deinit();
+
+    // Basic read request with MIME and password
+    s.nextSlice("\x1b]5522;type=read:mime=dGV4dC9wbGFpbg==:password=c2VjcmV0\x1b\\");
+    try testing.expect(s.handler.metadata != null);
+    try testing.expectEqualStrings("type=read:mime=dGV4dC9wbGFpbg==:password=c2VjcmV0", s.handler.metadata.?);
+    try testing.expect(s.handler.payload == null);
+}
+
+test "stream: OSC 5522 kitty clipboard with payload" {
+    const H = struct {
+        metadata: ?[]const u8 = null,
+        payload: ?[]const u8 = null,
+
+        pub fn vt(
+            self: *@This(),
+            comptime action: Action.Tag,
+            value: Action.Value(action),
+        ) void {
+            switch (action) {
+                .kitty_clipboard => {
+                    self.metadata = value.metadata;
+                    self.payload = value.payload;
+                },
+                else => {},
+            }
+        }
+    };
+
+    const alloc = testing.allocator;
+    var s: Stream(H) = .init(.{});
+    s.parser.osc_parser = .init(alloc);
+    defer s.parser.osc_parser.deinit();
+
+    s.nextSlice("\x1b]5522;type=wdata:mime=aW1hZ2UvcG5n;SGVsbG8=\x1b\\");
+    try testing.expect(s.handler.metadata != null);
+    try testing.expectEqualStrings("type=wdata:mime=aW1hZ2UvcG5n", s.handler.metadata.?);
+    try testing.expectEqualStrings("SGVsbG8=", s.handler.payload.?);
+}
+
+test "stream: DECSET/DECRST mode 5522" {
+    const H = struct {
+        mode: ?modes.Mode = null,
+        set: bool = false,
+
+        pub fn vt(
+            self: *@This(),
+            comptime action: Action.Tag,
+            value: Action.Value(action),
+        ) void {
+            switch (action) {
+                .set_mode => {
+                    self.mode = value.mode;
+                    self.set = true;
+                },
+                .reset_mode => {
+                    self.mode = value.mode;
+                    self.set = false;
+                },
+                else => {},
+            }
+        }
+    };
+
+    var s: Stream(H) = .init(.{});
+
+    s.nextSlice("\x1b[?5522h");
+    try testing.expectEqual(modes.Mode.kitty_clipboard_protocol, s.handler.mode.?);
+    try testing.expect(s.handler.set);
+
+    s.nextSlice("\x1b[?5522l");
+    try testing.expectEqual(modes.Mode.kitty_clipboard_protocol, s.handler.mode.?);
+    try testing.expect(!s.handler.set);
 }

--- a/src/terminal/stream_terminal.zig
+++ b/src/terminal/stream_terminal.zig
@@ -76,6 +76,16 @@ pub const Handler = struct {
         /// is 256 bytes; longer strings will be silently ignored.
         xtversion: ?*const fn (*Handler) []const u8,
 
+        /// Called when an OSC 5522 (kitty clipboard protocol) sequence
+        /// is received. The metadata and payload slices are only valid
+        /// during the call. Implementers should use the OSC readOption
+        /// helpers to parse the metadata.
+        kitty_clipboard: ?*const fn (
+            *Handler,
+            metadata: []const u8,
+            payload: ?[]const u8,
+        ) void,
+
         /// No effects means that the stream effectively becomes readonly
         /// that only affects pure terminal state and ignores all side
         /// effects beyond that.
@@ -84,6 +94,7 @@ pub const Handler = struct {
             .color_scheme = null,
             .device_attributes = null,
             .enquiry = null,
+            .kitty_clipboard = null,
             .size = null,
             .title_changed = null,
             .write_pty = null,
@@ -255,6 +266,10 @@ pub const Handler = struct {
             .apc_end,
             .apc_put,
             => {},
+
+            .kitty_clipboard => if (self.effects.kitty_clipboard) |f| {
+                f(self, value.metadata, value.payload);
+            },
 
             // Have no terminal-modifying effect
             .report_pwd,
@@ -2068,4 +2083,127 @@ test "device attributes: custom response" {
 
     s.nextSlice("\x1B[>c");
     try testing.expectEqualStrings("\x1b[>41;100;0c", S.written.?);
+}
+
+test "kitty_clipboard effects callback" {
+    var t: Terminal = try .init(testing.allocator, .{ .cols = 80, .rows = 24 });
+    defer t.deinit(testing.allocator);
+
+    // Without callback: OSC 5522 is silently ignored
+    {
+        var s: Stream = .initAlloc(testing.allocator, .init(&t));
+        defer s.deinit();
+        s.nextSlice("\x1b]5522;type=read:mime=dGV4dC9wbGFpbg==\x1b\\");
+    }
+
+    t.fullReset();
+
+    // With callback: metadata and payload are delivered
+    {
+        const S = struct {
+            var last_metadata: ?[]const u8 = null;
+            var last_payload: ?[]const u8 = null;
+
+            fn kittyClipboard(
+                _: *Handler,
+                metadata: []const u8,
+                payload: ?[]const u8,
+            ) void {
+                if (last_metadata) |m| testing.allocator.free(m);
+                if (last_payload) |p| testing.allocator.free(p);
+                last_metadata = testing.allocator.dupe(u8, metadata) catch @panic("OOM");
+                last_payload = if (payload) |p|
+                    testing.allocator.dupe(u8, p) catch @panic("OOM")
+                else
+                    null;
+            }
+        };
+        S.last_metadata = null;
+        S.last_payload = null;
+        defer {
+            if (S.last_metadata) |m| testing.allocator.free(m);
+            if (S.last_payload) |p| testing.allocator.free(p);
+        }
+
+        var handler: Handler = .init(&t);
+        handler.effects.kitty_clipboard = &S.kittyClipboard;
+
+        var s: Stream = .initAlloc(testing.allocator, handler);
+        defer s.deinit();
+
+        // Read request (no payload)
+        s.nextSlice("\x1b]5522;type=read:mime=dGV4dC9wbGFpbg==:password=c2VjcmV0\x1b\\");
+        try testing.expectEqualStrings(
+            "type=read:mime=dGV4dC9wbGFpbg==:password=c2VjcmV0",
+            S.last_metadata.?,
+        );
+        try testing.expect(S.last_payload == null);
+
+        // Write with payload
+        s.nextSlice("\x1b]5522;type=wdata:mime=aW1hZ2UvcG5n;SGVsbG8=\x1b\\");
+        try testing.expectEqualStrings("type=wdata:mime=aW1hZ2UvcG5n", S.last_metadata.?);
+        try testing.expectEqualStrings("SGVsbG8=", S.last_payload.?);
+    }
+}
+
+test "kitty_clipboard mode 5522 set and reset" {
+    var t: Terminal = try .init(testing.allocator, .{ .cols = 80, .rows = 24 });
+    defer t.deinit(testing.allocator);
+
+    var s: Stream = .initAlloc(testing.allocator, .init(&t));
+    defer s.deinit();
+
+    // Default: off
+    try testing.expect(!t.modes.get(.kitty_clipboard_protocol));
+
+    // DECSET 5522
+    s.nextSlice("\x1b[?5522h");
+    try testing.expect(t.modes.get(.kitty_clipboard_protocol));
+
+    // DECRST 5522
+    s.nextSlice("\x1b[?5522l");
+    try testing.expect(!t.modes.get(.kitty_clipboard_protocol));
+
+    // Full reset clears it
+    s.nextSlice("\x1b[?5522h");
+    try testing.expect(t.modes.get(.kitty_clipboard_protocol));
+    t.fullReset();
+    try testing.expect(!t.modes.get(.kitty_clipboard_protocol));
+}
+
+test "kitty_clipboard effects callback receives multiple sequences in order" {
+    var t: Terminal = try .init(testing.allocator, .{ .cols = 80, .rows = 24 });
+    defer t.deinit(testing.allocator);
+
+    // An app may send several OSC 5522 in one write — each must dispatch.
+    // If the callback only fires for the last one (parser state bug) or
+    // metadata slices alias each other across calls, this catches it.
+    const S = struct {
+        var calls: std.ArrayList([]const u8) = .empty;
+        fn cb(_: *Handler, metadata: []const u8, _: ?[]const u8) void {
+            calls.append(testing.allocator, testing.allocator.dupe(u8, metadata) catch @panic("OOM")) catch @panic("OOM");
+        }
+    };
+    S.calls = .empty;
+    defer {
+        for (S.calls.items) |m| testing.allocator.free(m);
+        S.calls.deinit(testing.allocator);
+    }
+
+    var handler: Handler = .init(&t);
+    handler.effects.kitty_clipboard = &S.cb;
+
+    var s: Stream = .initAlloc(testing.allocator, handler);
+    defer s.deinit();
+
+    s.nextSlice(
+        "\x1b]5522;type=read:mime=AAA\x1b\\" ++
+            "\x1b]5522;type=read:mime=BBB\x1b\\" ++
+            "\x1b]5522;type=read:mime=CCC\x1b\\",
+    );
+
+    try testing.expectEqual(@as(usize, 3), S.calls.items.len);
+    try testing.expectEqualStrings("type=read:mime=AAA", S.calls.items[0]);
+    try testing.expectEqualStrings("type=read:mime=BBB", S.calls.items[1]);
+    try testing.expectEqualStrings("type=read:mime=CCC", S.calls.items[2]);
 }

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -330,6 +330,7 @@ pub const StreamHandler = struct {
             .progress_report => self.progressReport(value),
             .start_hyperlink => try self.startHyperlink(value.uri, value.id),
             .clipboard_contents => try self.clipboardContents(value.kind, value.data),
+            .kitty_clipboard => try self.kittyClipboard(value.metadata, value.payload),
             .semantic_prompt => try self.semanticPrompt(value),
             .mouse_shape => try self.setMouseShape(value),
             .configure_charset => self.configureCharset(value.slot, value.charset),
@@ -1067,6 +1068,23 @@ pub const StreamHandler = struct {
                     data,
                 ),
                 .clipboard_type = clipboard_type,
+            },
+        });
+    }
+
+    fn kittyClipboard(
+        self: *StreamHandler,
+        metadata: []const u8,
+        payload: ?[]const u8,
+    ) !void {
+        // We only handle read requests from the application — those have
+        // no payload by protocol. Write operations (which would have a
+        // payload) are not yet implemented.
+        _ = payload;
+        self.surfaceMessageWriter(.{
+            .kitty_clipboard_read = .{
+                .alloc = self.alloc,
+                .metadata = try self.alloc.dupe(u8, metadata),
             },
         });
     }


### PR DESCRIPTION
Partially addresses #10549 (macOS & read path only; write path is separate work).

Implements the read path of the Kitty Clipboard Protocol (OSC 5522, [spec](https://rockorager.dev/misc/bracketed-paste-mime/)). When mode 5522 is enabled, paste events send a MIME type listing instead of bracketed-paste text. The application then requests a specific MIME type and receives the clipboard data — including images and other non-text content — chunked through OSC sequences.

## Flow

1. Application enables mode 5522 via `CSI ? 5522 h`
2. User pastes. Instead of bracketed paste, the surface asks the apprt for available MIME types and sends an unsolicited `OSC 5522` listing with a single-use 16-byte password
3. Application sends `OSC 5522;type=read:mime=<b64>:password=<b64>` requesting one type
4. Surface validates the password, invalidates it (single-use), asks the apprt for that MIME type's bytes, and streams them back as base64-chunked DATA packets

## Security model

The password mechanism prevents an application from reading the clipboard outside of an explicit user paste:

- 16 random bytes from `std.crypto.random`, compared with `std.crypto.timing_safe.eql`
- 5-second timeout. The spec requires a short validity window so a stashed password can't authorize reads of *future* clipboard contents. Platforms without a monotonic clock decline to issue a password rather than skip the timeout
- Single-use: cleared as soon as a request validates, before the apprt is called
- Clipboard location (standard vs selection) captured at issue time so a request can't redirect
- A read with no/invalid password falls into the existing `clipboard-read` policy. For now that path returns `ENOSYS`

## Status codes

We emit `EINVAL` for malformed requests and `EIO` for apprt failures. The kitty spec only defines `ENOSYS`/`EPERM`/`EBUSY`, but the existing parser `Status` enum already has all five. Happy to collapse to spec-only codes if preferred — used the wider set for diagnostic precision.

`encodeError` takes the `Status` enum directly, so a typo would be a compile error rather than a non-spec status on the wire.

## Platform support

**macOS** is fully wired. `NSPasteboard` types map to MIME via `UTType.preferredMIMEType`; data path uses `data(forType:)` returning base64.

**GTK** returns `false` from `clipboardRequest` for the new request types, so the surface falls through to a normal text paste — enabling mode 5522 on GTK is a no-op rather than breaking paste. The hook is `gdk.Clipboard.getFormats()` + `readAsync()`; left as a TODO so this PR stays reviewable.

**libghostty** gets two C APIs (`ghostty_clipboard_request_type`, `ghostty_clipboard_request_mime`) so embedders can branch on the request type.

## Chunking

The spec caps DATA packets at 4096 raw bytes. We slice a pre-encoded base64 stream rather than re-encoding per chunk, so middle chunks have no padding: N base64 chars decode to `N/4*3` raw bytes. `(4096/3)*4 = 5460` chars → 4095 raw bytes per chunk. Asserted at comptime, with a test pinning both numbers.

The output buffer is pre-sized to avoid realloc growth on multi-megabyte images, and `completeKittyMimeRead` hands ownership directly to `.write_alloc` to skip the transient dupe that `writeReq` would do.

## MIME length cap

256 bytes, shared between the encoder and `ClipboardRequest.KittyMimeRead` (`comptime assert` keeps them in sync). MIME types over the limit are dropped from the advertised list — we don't advertise something the request struct can't carry back. 256 covers all IANA-registered types including the OpenXML Office types (65–73 bytes); there's a test with the real `.xlsx`/`.docx`/`.pptx` strings.

## Not in this PR

- Write path (`type=write`/`wdata`/`walias`). Returns `ENOSYS`.
- Unauthenticated reads with user prompt
- GTK MIME implementation

These build on the same plumbing.

## Test plan

- [x] `zig build test` on macOS arm64 — 2705/2717 passed, 10 skipped, 2 pre-existing `os/path` failures from a local `$PATH` quirk (`NotDir` at `path.zig:53`, untouched by this PR)

50 new tests:

- `kitty_clipboard.zig` (32, new file): byte-exact spec example reproduction (`secret123` → `c2VjcmV0MTIz`, etc.), `checkAllAllocationFailures` for both encoders, chunk-boundary data integrity at 5 sizes, capacity estimate verification, OSC framing safety with adversarial passwords containing `0x1b`, encoder→parser round-trips
- OSC parser (+9): adversarial — null bytes, key prefix collisions, embedded ST, 10K metadata
- `stream.zig` (+3), `stream_terminal.zig` (+3): mode 5522 dispatch and effects callback
- `Surface.zig` (+2): timeout constant pin, fresh password not expired
- `KittyMimeRead.init` doctest: boundary cases, real Office MIME types

Manual: pasted a PNG over SSH and it worked, got correct `image/png` data through.

## AI disclosure

I used Claude Code to implement basically all of this. I reviewed it and slightly edited it.