### PR TITLE
gtk(chore): fix typos

### DIFF
--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -1736,11 +1736,11 @@ pub const Application = extern struct {
                 log.debug("new-window argument: {d} {s}", .{ i, str });
 
                 if (e_seen) {
-                    const cpy = alloc.dupeZ(u8, str) catch |err| {
+                    const duplicated = alloc.dupeZ(u8, str) catch |err| {
                         log.warn("unable to duplicate argument {d} {s}: {t}", .{ i, str, err });
                         break :overrides;
                     };
-                    args.append(alloc, cpy) catch |err| {
+                    args.append(alloc, duplicated) catch |err| {
                         log.warn("unable to append argument {d} {s}: {t}", .{ i, str, err });
                         break :overrides;
                     };
@@ -2451,7 +2451,7 @@ const Action = struct {
         };
         defer config.unref();
 
-        // Update the proper target. This will trigger a `confige_change`
+        // Update the proper target. This will trigger a `config_change`
         // apprt action which will propagate the config properly to our
         // property system.
         switch (target) {

--- a/typos.toml
+++ b/typos.toml
@@ -46,6 +46,8 @@ extend-ignore-re = [
   "\"hel\\\\x",
   # Ignore long hex-like IDs such as 815E26BA2EF1E00F005C67B1
   "[0-9A-F]{12,}",
+  # Ignore base64-encoded strings
+  "[A-Za-z0-9+/]{8,}={0,2}",
   # Ignore Apple four char codes
   'code="[A-Za-z]{4,8}"',
   '"[A-Za-z]{4}"\.fourCharCode',


### PR DESCRIPTION
### AI Disclosure

Claude wrote the regex to ignore base64-encoded sequences