### PR TITLE
macOS: fix upper cased letter is not correctly mapped to menu shortcut

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.Input.swift
+++ b/macos/Sources/Ghostty/Ghostty.Input.swift
@@ -29,8 +29,11 @@ extension Ghostty {
             }
 
         case GHOSTTY_TRIGGER_UNICODE:
-            guard let scalar = UnicodeScalar(trigger.key.unicode) else { return nil }
-            key = KeyEquivalent(Character(scalar))
+            guard
+                let scalar = UnicodeScalar(trigger.key.unicode),
+                let normalized = Character(scalar).lowercased().first
+            else { return nil }
+            key = KeyEquivalent(normalized)
 
         case GHOSTTY_TRIGGER_CATCH_ALL:
             // catch_all matches any key, so it can't be represented as a KeyboardShortcut

--- a/macos/Tests/Ghostty/ConfigTests.swift
+++ b/macos/Tests/Ghostty/ConfigTests.swift
@@ -220,4 +220,19 @@ struct ConfigTests {
         #expect(config.maximize == true)
         #expect(config.focusFollowsMouse == true)
     }
+
+    @Test
+    func uppercasedLetterShouldBeNormalized() async throws {
+        let config = try TemporaryConfig("""
+        keybind=cmd+L=goto_split:left
+        """)
+        let shortcut = try #require(config.keyboardShortcut(for: "goto_split:left"))
+        #expect(shortcut == .init("l", modifiers: [.command]))
+
+        let config2 = try TemporaryConfig("""
+        keybind=cmd+Ä=goto_split:left
+        """)
+        let shortcut2 = try #require(config2.keyboardShortcut(for: "goto_split:left"))
+        #expect(shortcut2 == .init("ä", modifiers: [.command]))
+    }
 }


### PR DESCRIPTION
This is known issues before key-related PRs, tested on fa9265636b6e14e012b9990868f60a6d2376fe59.

The following config is mapped incorrectly to the menu shortcut:
```
keybind=A=goto_split:left
```
<img width="223" height="106" alt="image" src="https://github.com/user-attachments/assets/b80da251-9cff-4b29-b143-64854a5c4271" />

Surfaces only accept `a` as a trigger to select left split, not `shift+a`