### PR TITLE
macOS: unset/reset keyboard shortcut for `unbind` and conflicts

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1078,6 +1078,8 @@ GHOSTTY_API bool ghostty_config_get(ghostty_config_t, void*, const char*, uintpt
 GHOSTTY_API ghostty_input_trigger_s ghostty_config_trigger(ghostty_config_t,
                                                               const char*,
                                                               uintptr_t);
+GHOSTTY_API bool ghostty_config_trigger_is_unbound(ghostty_config_t,
+                                                ghostty_input_trigger_s);
 GHOSTTY_API uint32_t ghostty_config_diagnostics_count(ghostty_config_t);
 GHOSTTY_API ghostty_diagnostic_s ghostty_config_get_diagnostic(ghostty_config_t, uint32_t);
 GHOSTTY_API ghostty_string_s ghostty_config_open_path(void);

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -154,7 +154,7 @@ class AppDelegate: NSObject,
     /// The custom app icon image that is currently in use.
     @Published private(set) var appIcon: NSImage?
 
-    @MainActor private lazy var menuShortcutManager = Ghostty.MenuShortcutManager()
+    @MainActor private var menuShortcutManager = Ghostty.MenuShortcutManager(nil)
 
     override init() {
 #if DEBUG
@@ -209,6 +209,8 @@ class AppDelegate: NSObject,
         if UserDefaults.ghostty.bool(forKey: "SecureInput") != SecureInput.shared.enabled {
             toggleSecureInput(self)
         }
+
+        menuShortcutManager = .init(NSApp.mainMenu)
 
         // Initial config loading
         ghosttyConfigDidChange(config: ghostty.config)

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -1144,8 +1144,13 @@ extension AppDelegate {
     @MainActor private func syncMenuShortcuts(_ config: Ghostty.Config) {
         guard ghostty.readiness == .ready else { return }
 
-        menuShortcutManager.reset()
+        menuShortcutManager.resetRegisteredGhosttyActions()
 
+        registerGhosttyActions(config)
+        menuShortcutManager.updateShortcut(in: NSApp.mainMenu, config: config)
+    }
+
+    @MainActor private func registerGhosttyActions(_ config: Ghostty.Config) {
         syncMenuShortcut(config, action: "check_for_updates", menuItem: self.menuCheckForUpdates)
         syncMenuShortcut(config, action: "open_config", menuItem: self.menuOpenConfig)
         syncMenuShortcut(config, action: "reload_config", menuItem: self.menuReloadConfig)
@@ -1212,7 +1217,7 @@ extension AppDelegate {
     }
 
     @MainActor private func syncMenuShortcut(_ config: Ghostty.Config, action: String, menuItem: NSMenuItem?) {
-        menuShortcutManager.syncMenuShortcut(config, action: action, menuItem: menuItem)
+        menuShortcutManager.register(action: action, menuItem: menuItem)
     }
 
     @MainActor func performGhosttyBindingMenuKeyEquivalent(with event: NSEvent) -> Bool {

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -122,6 +122,16 @@ extension Ghostty {
             let trigger = ghostty_config_trigger(cfg, action, UInt(action.lengthOfBytes(using: .utf8)))
             return Ghostty.keyboardShortcut(for: trigger)
         }
+
+        /// Check whether a keyboard shortcut is unbound in the config by `keybind=a=unbind`
+        func isKeyboardShortcutUnbound(_ keyboardShortcut: KeyboardShortcut) -> Bool {
+            guard
+                let cfg = self.config,
+                let trigger = Ghostty.ghosttyTrigger(keyboardShortcut)
+            else { return false }
+
+            return ghostty_config_trigger_is_unbound(cfg, trigger)
+        }
 #endif
 
         // MARK: - Configuration Values

--- a/macos/Sources/Ghostty/Ghostty.Input.swift
+++ b/macos/Sources/Ghostty/Ghostty.Input.swift
@@ -48,6 +48,30 @@ extension Ghostty {
             modifiers: EventModifiers(nsFlags: Ghostty.eventModifierFlags(mods: trigger.mods)))
     }
 
+    /// Map the KeyboardShortcut to `ghostty_input_trigger_s`
+    /// which is basically reversed from ``keyboardShortcut(for:)``
+    static func ghosttyTrigger(_ keyboardShortcut: KeyboardShortcut) -> ghostty_input_trigger_s? {
+
+        let flags = NSEvent.ModifierFlags(swiftUIFlags: keyboardShortcut.modifiers)
+        let mods = ghosttyMods(flags)
+        if let physicalKey = Self.equivalentToKey[keyboardShortcut.key.character] {
+            return ghostty_input_trigger_s(
+                tag: GHOSTTY_TRIGGER_PHYSICAL,
+                key: .init(physical: physicalKey),
+                mods: mods,
+            )
+        } else {
+            guard let unicodeValue = keyboardShortcut.key.character.unicodeScalars.first?.value else {
+                return nil
+            }
+            return ghostty_input_trigger_s(
+                tag: GHOSTTY_TRIGGER_UNICODE,
+                key: .init(unicode: unicodeValue),
+                mods: mods,
+            )
+        }
+    }
+
     // MARK: Mods
 
     /// Returns the event modifier flags set for the Ghostty mods enum.
@@ -80,6 +104,11 @@ extension Ghostty {
 
         return ghostty_input_mods_e(mods)
     }
+
+    /// Reverse map: KeyEquivalent character → ghostty_input_key_e, built lazily from `keyToEquivalent`.
+    private static let equivalentToKey: [Character: ghostty_input_key_e] = {
+        Dictionary(uniqueKeysWithValues: keyToEquivalent.map { ($0.value.character, $0.key) })
+    }()
 
     /// A map from the Ghostty key enum to the keyEquivalent string for shortcuts. Note that
     /// not all ghostty key enum values are represented here because not all of them can be

--- a/macos/Sources/Ghostty/Ghostty.Input.swift
+++ b/macos/Sources/Ghostty/Ghostty.Input.swift
@@ -113,6 +113,8 @@ extension Ghostty {
     /// A map from the Ghostty key enum to the keyEquivalent string for shortcuts. Note that
     /// not all ghostty key enum values are represented here because not all of them can be
     /// mapped to a KeyEquivalent.
+    ///
+    /// - Important: `KeyEquivalent` here should NOT be uppercased by any means
     static let keyToEquivalent: [ghostty_input_key_e: KeyEquivalent] = [
         // Function keys
         GHOSTTY_KEY_ARROW_UP: .upArrow,

--- a/macos/Sources/Ghostty/Ghostty.MenuShortcutManager.swift
+++ b/macos/Sources/Ghostty/Ghostty.MenuShortcutManager.swift
@@ -37,45 +37,45 @@ extension Ghostty {
 }
 
 extension Ghostty.MenuShortcutManager {
-        /// Attempts to perform a menu key equivalent only for menu items that represent
-        /// Ghostty keybind actions. This is important because it lets our surface dispatch
-        /// bindings through the menu so they flash but also lets our surface override macOS built-ins
-        /// like Cmd+H.
-        func performGhosttyBindingMenuKeyEquivalent(with event: NSEvent) -> Bool {
-            // Convert this event into the same normalized lookup key we use when
-            // syncing menu shortcuts from configuration.
-            guard let key = MenuShortcutKey(event: event) else {
-                return false
-            }
-
-            // If we don't have an entry for this key combo, no Ghostty-owned
-            // menu shortcut exists for this event.
-            guard let action = configuredShortcuts[key] else {
-                return false
-            }
-
-            guard let item = NSApp.mainMenu?.findItem(with: action) else {
-                return false
-            }
-
-            guard let parentMenu = item.menu else {
-                return false
-            }
-
-            // Keep enablement state fresh in case menu validation hasn't run yet.
-            parentMenu.update()
-            guard item.isEnabled else {
-                return false
-            }
-
-            let index = parentMenu.index(of: item)
-            guard index >= 0 else {
-                return false
-            }
-
-            parentMenu.performActionForItem(at: index)
-            return true
+    /// Attempts to perform a menu key equivalent only for menu items that represent
+    /// Ghostty keybind actions. This is important because it lets our surface dispatch
+    /// bindings through the menu so they flash but also lets our surface override macOS built-ins
+    /// like Cmd+H.
+    func performGhosttyBindingMenuKeyEquivalent(with event: NSEvent) -> Bool {
+        // Convert this event into the same normalized lookup key we use when
+        // syncing menu shortcuts from configuration.
+        guard let key = MenuShortcutKey(event: event) else {
+            return false
         }
+
+        // If we don't have an entry for this key combo, no Ghostty-owned
+        // menu shortcut exists for this event.
+        guard let action = configuredShortcuts[key] else {
+            return false
+        }
+
+        guard let item = NSApp.mainMenu?.findItem(with: action) else {
+            return false
+        }
+
+        guard let parentMenu = item.menu else {
+            return false
+        }
+
+        // Keep enablement state fresh in case menu validation hasn't run yet.
+        parentMenu.update()
+        guard item.isEnabled else {
+            return false
+        }
+
+        let index = parentMenu.index(of: item)
+        guard index >= 0 else {
+            return false
+        }
+
+        parentMenu.performActionForItem(at: index)
+        return true
+    }
 }
 
 // MARK: - Recursively process all of the menu items

--- a/macos/Sources/Ghostty/Ghostty.MenuShortcutManager.swift
+++ b/macos/Sources/Ghostty/Ghostty.MenuShortcutManager.swift
@@ -12,6 +12,15 @@ extension Ghostty {
         ///
         /// If multiple action map to the same shortcut, the most recent one wins.
         private var configuredShortcuts: [MenuShortcutKey: Selector] = [:]
+        /// Original shortcut configured in xib indexed by their action
+        private var originalMenuShortcutByAction: [Selector: MenuShortcutKey] = [:]
+
+        /// Save initial/default keyboard shortcut of every menu item recursively in this menu
+        ///
+        /// - Important: This should only be called once per app launch
+        init(_ menu: NSMenu?) {
+            saveOriginalMenuItemShortcutsRecursively(in: menu)
+        }
 
         /// Reset our shortcut index since we're about to rebuild all menu bindings.
         func resetRegisteredGhosttyActions() {
@@ -82,6 +91,21 @@ extension Ghostty.MenuShortcutManager {
 // MARK: - Recursively process all of the menu items
 
 private extension Ghostty.MenuShortcutManager {
+    /// Save initial/default keyboard shortcut of every menu item recursively in this menu
+    ///
+    /// - Important: This should only be called once per app launch
+    func saveOriginalMenuItemShortcutsRecursively(in menu: NSMenu?) {
+        guard let menu else {
+            return
+        }
+        for item in menu.items {
+            if let action = item.action, let shortcut = MenuShortcutKey(keyEquivalent: item.keyEquivalent, modifiers: item.keyEquivalentModifierMask) {
+                originalMenuShortcutByAction[action] = shortcut
+            }
+            saveOriginalMenuItemShortcutsRecursively(in: item.submenu)
+        }
+    }
+
     /// Map the keyboard shortcut of every menu item recursively in this menu based on previously register action
     func updateShortcutRecursively(in menu: NSMenu?, config: Ghostty.Config) {
         guard let menu else {
@@ -110,13 +134,23 @@ private extension Ghostty.MenuShortcutManager {
             return
         }
 
-        if let action = ghosttyActionsBySelector[selector] {
-            if !syncMenuShortcutFrom(config, action: action, menuItem: item) {
-                // No shortcut, clear the menu item
-                item.keyEquivalent = ""
-                item.keyEquivalentModifierMask = []
-            }
+        if let action = ghosttyActionsBySelector[selector],
+            syncMenuShortcutFrom(config, action: action, menuItem: item) {
+            // Overrode by Ghostty configuration
+            return
         }
+
+        // Restore to the original shortcut first,
+        // so we can then use the original one to check whether it's unbound
+        restoreMenuItemShortcut(item: item)
+
+        if let key = MenuShortcutKey(item), config.isKeyboardShortcutUnbound(key: key) {
+            // This is unbind by the user
+            item.keyEquivalent = ""
+            item.keyEquivalentModifierMask = []
+            return
+        }
+        // Restored to the original shortcut
     }
 
     /// Syncs a single menu shortcut for the given action. The action string is the same
@@ -139,6 +173,18 @@ private extension Ghostty.MenuShortcutManager {
         // Later registrations intentionally override earlier ones for the same key.
         configuredShortcuts[key] = menu.action
         return true
+    }
+
+    /// Restore the shortcut of the item to the original one registered when first launched
+    func restoreMenuItemShortcut(item: NSMenuItem) {
+        guard
+            let action = item.action,
+            let key = originalMenuShortcutByAction[action]
+        else {
+            return
+        }
+        item.keyEquivalent = key.keyEquivalent
+        item.keyEquivalentModifierMask = key.modifierFlags
     }
 }
 
@@ -213,5 +259,14 @@ private extension NSMenu {
             }
         }
         return nil
+    }
+}
+
+private extension Ghostty.Config {
+    func isKeyboardShortcutUnbound(key: Ghostty.MenuShortcutManager.MenuShortcutKey) -> Bool {
+        guard let swiftUIShortcut = key.swiftUIShortcut else {
+            return false
+        }
+        return isKeyboardShortcutUnbound(swiftUIShortcut)
     }
 }

--- a/macos/Sources/Ghostty/Ghostty.MenuShortcutManager.swift
+++ b/macos/Sources/Ghostty/Ghostty.MenuShortcutManager.swift
@@ -37,35 +37,6 @@ extension Ghostty {
 }
 
 extension Ghostty.MenuShortcutManager {
-        /// Syncs a single menu shortcut for the given action. The action string is the same
-        /// action string used for the Ghostty configuration.
-        private func syncMenuShortcutFrom(_ config: Ghostty.Config, action: String, menuItem menu: NSMenuItem) -> Bool {
-
-            guard let shortcut = config.keyboardShortcut(for: action) else {
-                return false
-            }
-
-            let keyEquivalent = shortcut.key.character.description
-            let modifierMask = NSEvent.ModifierFlags(swiftUIFlags: shortcut.modifiers)
-            // Build a direct lookup for key-equivalent dispatch so we don't need to
-            // linearly walk the full menu hierarchy at event time.
-            guard let key = MenuShortcutKey(
-                // We don't want to check missing `shift` for Ghostty configured shortcuts,
-                // because we know it's there when it needs to be
-                keyEquivalent: keyEquivalent.lowercased(),
-                modifiers: modifierMask
-            ) else {
-                return false
-            }
-
-            menu.keyEquivalent = keyEquivalent
-            menu.keyEquivalentModifierMask = modifierMask
-
-            // Later registrations intentionally override earlier ones for the same key.
-            configuredShortcuts[key] = menu.action
-            return true
-        }
-
         /// Attempts to perform a menu key equivalent only for menu items that represent
         /// Ghostty keybind actions. This is important because it lets our surface dispatch
         /// bindings through the menu so they flash but also lets our surface override macOS built-ins
@@ -145,6 +116,35 @@ private extension Ghostty.MenuShortcutManager {
                 item.keyEquivalentModifierMask = []
             }
         }
+    }
+
+    /// Syncs a single menu shortcut for the given action. The action string is the same
+    /// action string used for the Ghostty configuration.
+    func syncMenuShortcutFrom(_ config: Ghostty.Config, action: String, menuItem menu: NSMenuItem) -> Bool {
+
+        guard let shortcut = config.keyboardShortcut(for: action) else {
+            return false
+        }
+
+        let keyEquivalent = shortcut.key.character.description
+        let modifierMask = NSEvent.ModifierFlags(swiftUIFlags: shortcut.modifiers)
+        // Build a direct lookup for key-equivalent dispatch so we don't need to
+        // linearly walk the full menu hierarchy at event time.
+        guard let key = MenuShortcutKey(
+            // We don't want to check missing `shift` for Ghostty configured shortcuts,
+            // because we know it's there when it needs to be
+            keyEquivalent: keyEquivalent.lowercased(),
+            modifiers: modifierMask
+        ) else {
+            return false
+        }
+
+        menu.keyEquivalent = keyEquivalent
+        menu.keyEquivalentModifierMask = modifierMask
+
+        // Later registrations intentionally override earlier ones for the same key.
+        configuredShortcuts[key] = menu.action
+        return true
     }
 }
 

--- a/macos/Sources/Ghostty/Ghostty.MenuShortcutManager.swift
+++ b/macos/Sources/Ghostty/Ghostty.MenuShortcutManager.swift
@@ -42,6 +42,8 @@ extension Ghostty {
             configuredShortcuts.removeAll()
 
             updateShortcutRecursively(in: menu, config: config)
+
+            checkConflictsRecursively(in: menu)
         }
     }
 }
@@ -118,6 +120,21 @@ private extension Ghostty.MenuShortcutManager {
         }
         menu.update()
     }
+
+    /// Shortcuts in Ghostty configuration should have higher priority than default shortcuts
+    ///
+    /// We run this to do a final check for every menu item
+    func checkConflictsRecursively(in menu: NSMenu?) {
+        guard let menu else {
+            return
+        }
+
+        for item in menu.items {
+            checkConflicts(item: item)
+            checkConflictsRecursively(in: item.submenu)
+        }
+        menu.update()
+    }
 }
 
 // MARK: - Process a single menu item
@@ -185,6 +202,22 @@ private extension Ghostty.MenuShortcutManager {
         }
         item.keyEquivalent = key.keyEquivalent
         item.keyEquivalentModifierMask = key.modifierFlags
+    }
+
+    func checkConflicts(item: NSMenuItem) {
+        guard
+            let key = MenuShortcutKey(item),
+            // There should be an existing shortcut first
+            let existed = configuredShortcuts[key],
+            // Then we check if the action is the same
+            existed != item.action
+        else {
+            return
+        }
+        // User configured shortcut has conflicts with default one,
+        // clear the default one
+        item.keyEquivalent = ""
+        item.keyEquivalentModifierMask = []
     }
 }
 

--- a/macos/Sources/Ghostty/Ghostty.MenuShortcutManager.swift
+++ b/macos/Sources/Ghostty/Ghostty.MenuShortcutManager.swift
@@ -1,4 +1,5 @@
 import AppKit
+import SwiftUI
 
 extension Ghostty {
     /// The manager that's responsible for updating shortcuts of Ghostty's app menu
@@ -126,21 +127,14 @@ private extension Ghostty.MenuShortcutManager {
             return false
         }
 
-        let keyEquivalent = shortcut.key.character.description
-        let modifierMask = NSEvent.ModifierFlags(swiftUIFlags: shortcut.modifiers)
         // Build a direct lookup for key-equivalent dispatch so we don't need to
         // linearly walk the full menu hierarchy at event time.
-        guard let key = MenuShortcutKey(
-            // We don't want to check missing `shift` for Ghostty configured shortcuts,
-            // because we know it's there when it needs to be
-            keyEquivalent: keyEquivalent.lowercased(),
-            modifiers: modifierMask
-        ) else {
+        guard let key = MenuShortcutKey(shortcut) else {
             return false
         }
 
-        menu.keyEquivalent = keyEquivalent
-        menu.keyEquivalentModifierMask = modifierMask
+        menu.keyEquivalent = key.keyEquivalent
+        menu.keyEquivalentModifierMask = key.modifierFlags
 
         // Later registrations intentionally override earlier ones for the same key.
         configuredShortcuts[key] = menu.action
@@ -154,7 +148,11 @@ extension Ghostty.MenuShortcutManager {
         private static let shortcutModifiers: NSEvent.ModifierFlags = [.shift, .control, .option, .command]
 
         let keyEquivalent: String
-        let modifiersRawValue: UInt
+        private let modifiersRawValue: UInt
+
+        var modifierFlags: NSEvent.ModifierFlags {
+            NSEvent.ModifierFlags(rawValue: modifiersRawValue)
+        }
 
         init?(keyEquivalent: String, modifiers: NSEvent.ModifierFlags) {
             let normalized = keyEquivalent.lowercased()
@@ -174,6 +172,31 @@ extension Ghostty.MenuShortcutManager {
         init?(event: NSEvent) {
             guard let keyEquivalent = event.charactersIgnoringModifiers else { return nil }
             self.init(keyEquivalent: keyEquivalent, modifiers: event.modifierFlags)
+        }
+
+        /// Create from a `NSMenuItem`
+        ///
+        /// - Important: This will check whether the `keyEquivalent` is uppercased by `.shift` modifier.
+        init?(_ menuItem: NSMenuItem) {
+            self.init(
+                keyEquivalent: menuItem.keyEquivalent,
+                modifiers: menuItem.keyEquivalentModifierMask,
+            )
+        }
+
+        /// Create from a swiftUI `KeyboardShortcut`
+        init?(_ shortcut: KeyboardShortcut) {
+            let keyEquivalent = shortcut.key.character.description
+            let modifierMask = NSEvent.ModifierFlags(swiftUIFlags: shortcut.modifiers)
+            self.init(keyEquivalent: keyEquivalent, modifiers: modifierMask)
+        }
+
+        var swiftUIShortcut: KeyboardShortcut? {
+            guard let character = keyEquivalent.first else { return nil }
+            return KeyboardShortcut(
+                KeyEquivalent(character),
+                modifiers: .init(nsFlags: modifierFlags)
+            )
         }
     }
 }

--- a/macos/Sources/Ghostty/Ghostty.MenuShortcutManager.swift
+++ b/macos/Sources/Ghostty/Ghostty.MenuShortcutManager.swift
@@ -4,36 +4,49 @@ extension Ghostty {
     /// The manager that's responsible for updating shortcuts of Ghostty's app menu
     @MainActor
     class MenuShortcutManager {
-
-        /// Ghostty menu items indexed by their normalized shortcut. This avoids traversing
+        /// Ghostty action indexed by the action of their belonging menu item
+        private var ghosttyActionsBySelector: [Selector: String] = [:]
+        /// Ghostty menu action indexed by their normalized shortcut. This avoids traversing
         /// the entire menu tree on every key equivalent event.
         ///
-        /// We store a weak reference so this cache can never be the owner of menu items.
-        /// If multiple items map to the same shortcut, the most recent one wins.
-        private var menuItemsByShortcut: [MenuShortcutKey: Weak<NSMenuItem>] = [:]
+        /// If multiple action map to the same shortcut, the most recent one wins.
+        private var configuredShortcuts: [MenuShortcutKey: Selector] = [:]
 
         /// Reset our shortcut index since we're about to rebuild all menu bindings.
-        func reset() {
-            menuItemsByShortcut.removeAll(keepingCapacity: true)
+        func resetRegisteredGhosttyActions() {
+            ghosttyActionsBySelector.removeAll(keepingCapacity: true)
         }
 
+        /// Registers a single menu shortcut for the given action. The action string is the same
+        /// action string used for the Ghostty configuration.
+        func register(action ghosttyAction: String?, menuItem: NSMenuItem?) {
+            guard let selector = menuItem?.action else {
+                return
+            }
+            ghosttyActionsBySelector[selector] = ghosttyAction
+        }
+
+        /// Map the keyboard shortcut of every menu item (including submenu's) in this menu based on previously register action
+        func updateShortcut(in menu: NSMenu?, config: Ghostty.Config) {
+            /// Reset our shortcut index since we're about to rebuild all menu bindings.
+            configuredShortcuts.removeAll()
+
+            updateShortcutRecursively(in: menu, config: config)
+        }
+    }
+}
+
+extension Ghostty.MenuShortcutManager {
         /// Syncs a single menu shortcut for the given action. The action string is the same
         /// action string used for the Ghostty configuration.
-        func syncMenuShortcut(_ config: Ghostty.Config, action: String?, menuItem: NSMenuItem?) {
-            guard let menu = menuItem else { return }
+        private func syncMenuShortcutFrom(_ config: Ghostty.Config, action: String, menuItem menu: NSMenuItem) -> Bool {
 
-            guard let action, let shortcut = config.keyboardShortcut(for: action) else {
-                // No shortcut, clear the menu item
-                menu.keyEquivalent = ""
-                menu.keyEquivalentModifierMask = []
-                return
+            guard let shortcut = config.keyboardShortcut(for: action) else {
+                return false
             }
 
             let keyEquivalent = shortcut.key.character.description
             let modifierMask = NSEvent.ModifierFlags(swiftUIFlags: shortcut.modifiers)
-            menu.keyEquivalent = keyEquivalent
-            menu.keyEquivalentModifierMask = modifierMask
-
             // Build a direct lookup for key-equivalent dispatch so we don't need to
             // linearly walk the full menu hierarchy at event time.
             guard let key = MenuShortcutKey(
@@ -42,11 +55,15 @@ extension Ghostty {
                 keyEquivalent: keyEquivalent.lowercased(),
                 modifiers: modifierMask
             ) else {
-                return
+                return false
             }
 
+            menu.keyEquivalent = keyEquivalent
+            menu.keyEquivalentModifierMask = modifierMask
+
             // Later registrations intentionally override earlier ones for the same key.
-            menuItemsByShortcut[key] = .init(menu)
+            configuredShortcuts[key] = menu.action
+            return true
         }
 
         /// Attempts to perform a menu key equivalent only for menu items that represent
@@ -62,13 +79,11 @@ extension Ghostty {
 
             // If we don't have an entry for this key combo, no Ghostty-owned
             // menu shortcut exists for this event.
-            guard let weakItem = menuItemsByShortcut[key] else {
+            guard let action = configuredShortcuts[key] else {
                 return false
             }
 
-            // Weak references can be nil if a menu item was deallocated after sync.
-            guard let item = weakItem.value else {
-                menuItemsByShortcut.removeValue(forKey: key)
+            guard let item = NSApp.mainMenu?.findItem(with: action) else {
                 return false
             }
 
@@ -89,6 +104,46 @@ extension Ghostty {
 
             parentMenu.performActionForItem(at: index)
             return true
+        }
+}
+
+// MARK: - Recursively process all of the menu items
+
+private extension Ghostty.MenuShortcutManager {
+    /// Map the keyboard shortcut of every menu item recursively in this menu based on previously register action
+    func updateShortcutRecursively(in menu: NSMenu?, config: Ghostty.Config) {
+        guard let menu else {
+            return
+        }
+
+        for item in menu.items {
+            updateItemShortcut(item: item, config: config)
+            updateShortcutRecursively(in: item.submenu, config: config)
+        }
+        menu.update()
+    }
+}
+
+// MARK: - Process a single menu item
+
+private extension Ghostty.MenuShortcutManager {
+    /// Update shortcuts in the following order
+    ///
+    /// 1. Ghostty configuration
+    /// 2. Xib
+    /// 3. Remove unbound defined in Ghostty configuration
+    /// 4. Check conflicts between xib and Ghostty configuration
+    func updateItemShortcut(item: NSMenuItem, config: Ghostty.Config) {
+        guard let selector = item.action else {
+            return
+        }
+
+        if let action = ghosttyActionsBySelector[selector] {
+            if !syncMenuShortcutFrom(config, action: action, menuItem: item) {
+                // No shortcut, clear the menu item
+                item.keyEquivalent = ""
+                item.keyEquivalentModifierMask = []
+            }
         }
     }
 }
@@ -120,5 +175,20 @@ extension Ghostty.MenuShortcutManager {
             guard let keyEquivalent = event.charactersIgnoringModifiers else { return nil }
             self.init(keyEquivalent: keyEquivalent, modifiers: event.modifierFlags)
         }
+    }
+}
+
+private extension NSMenu {
+    /// Expensive operation, but it will be deleted later
+    func findItem(with action: Selector) -> NSMenuItem? {
+        for item in items {
+            if item.action == action {
+                return item
+            }
+            if let item = item.submenu?.findItem(with: action) {
+                return item
+            }
+        }
+        return nil
     }
 }

--- a/macos/Tests/Ghostty/ConfigTests.swift
+++ b/macos/Tests/Ghostty/ConfigTests.swift
@@ -235,4 +235,21 @@ struct ConfigTests {
         let shortcut2 = try #require(config2.keyboardShortcut(for: "goto_split:left"))
         #expect(shortcut2 == .init("ä", modifiers: [.command]))
     }
+
+    // MARK: - Unbind
+
+    @Test
+    func unbind() async throws {
+        let config = try TemporaryConfig("keybind=cmd+c=unbind")
+        #expect(config.isKeyboardShortcutUnbound(KeyboardShortcut("c", modifiers: .command)))
+
+        try config.reload("keybind=cmd+c=new_window")
+        #expect(!config.isKeyboardShortcutUnbound(KeyboardShortcut("c", modifiers: .command)))
+        try config.reload("""
+            keybind=cmd+c=unbind
+            keybind=super+h=unbind
+            """)
+        #expect(config.isKeyboardShortcutUnbound(KeyboardShortcut("c", modifiers: .command)))
+        #expect(config.isKeyboardShortcutUnbound(KeyboardShortcut("h", modifiers: .command)))
+    }
 }

--- a/macos/Tests/Ghostty/InputTests.swift
+++ b/macos/Tests/Ghostty/InputTests.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+import Testing
+@testable import Ghostty
+@testable import GhosttyKit
+
+@Suite
+struct InputTests {
+
+    // MARK: - equivalentToKey reverse map
+
+    @Test func equivalentToKeyContainsAllArrowKeys() throws {
+        let trigger = try #require(Ghostty.ghosttyTrigger(KeyboardShortcut(.upArrow, modifiers: [])))
+        #expect(trigger.tag == GHOSTTY_TRIGGER_PHYSICAL)
+        #expect(trigger.key.physical == GHOSTTY_KEY_ARROW_UP)
+    }
+
+    @Test func equivalentToKeyDistinguishesDeleteAndBackspace() throws {
+        let backspace = try #require(Ghostty.ghosttyTrigger(KeyboardShortcut(.delete, modifiers: [])))
+        #expect(backspace.tag == GHOSTTY_TRIGGER_PHYSICAL)
+        #expect(backspace.key.physical == GHOSTTY_KEY_BACKSPACE)
+
+        let forwardDelete = try #require(Ghostty.ghosttyTrigger(KeyboardShortcut(.deleteForward, modifiers: [])))
+        #expect(forwardDelete.tag == GHOSTTY_TRIGGER_PHYSICAL)
+        #expect(forwardDelete.key.physical == GHOSTTY_KEY_DELETE)
+    }
+
+    @Test func equivalentToKeyMapsAllSpecialKeys() throws {
+        let expected: [(KeyEquivalent, ghostty_input_key_e)] = [
+            (.upArrow, GHOSTTY_KEY_ARROW_UP),
+            (.downArrow, GHOSTTY_KEY_ARROW_DOWN),
+            (.leftArrow, GHOSTTY_KEY_ARROW_LEFT),
+            (.rightArrow, GHOSTTY_KEY_ARROW_RIGHT),
+            (.home, GHOSTTY_KEY_HOME),
+            (.end, GHOSTTY_KEY_END),
+            (.pageUp, GHOSTTY_KEY_PAGE_UP),
+            (.pageDown, GHOSTTY_KEY_PAGE_DOWN),
+            (.escape, GHOSTTY_KEY_ESCAPE),
+            (.return, GHOSTTY_KEY_ENTER),
+            (.tab, GHOSTTY_KEY_TAB),
+            (.delete, GHOSTTY_KEY_BACKSPACE),
+            (.deleteForward, GHOSTTY_KEY_DELETE),
+            (.space, GHOSTTY_KEY_SPACE),
+        ]
+
+        for (equiv, expectedKey) in expected {
+            let trigger = try #require(Ghostty.ghosttyTrigger(KeyboardShortcut(equiv, modifiers: [])))
+            #expect(trigger.tag == GHOSTTY_TRIGGER_PHYSICAL)
+            #expect(trigger.key.physical == expectedKey,
+                "Expected \(expectedKey) for \(equiv), got \(String(describing: trigger.key.physical))")
+        }
+    }
+
+    // MARK: - ghosttyTrigger
+
+    @Test func ghosttyTriggerPhysicalKeyWithModifiers() throws {
+        let trigger = try #require(Ghostty.ghosttyTrigger(KeyboardShortcut(.upArrow, modifiers: .command)))
+        #expect(trigger.tag == GHOSTTY_TRIGGER_PHYSICAL)
+        #expect(trigger.key.physical == GHOSTTY_KEY_ARROW_UP)
+        #expect(trigger.mods.rawValue & GHOSTTY_MODS_SUPER.rawValue != 0)
+    }
+
+    @Test func ghosttyTriggerUnicodeFallback() throws {
+        // Regular letter keys are not in keyToEquivalent, so they fall through to unicode.
+        let trigger = try #require(Ghostty.ghosttyTrigger(KeyboardShortcut("c", modifiers: .command)))
+        #expect(trigger.tag == GHOSTTY_TRIGGER_UNICODE)
+        #expect(trigger.key.unicode == UInt32(Character("c").asciiValue!))
+        #expect(trigger.mods.rawValue & GHOSTTY_MODS_SUPER.rawValue != 0)
+    }
+
+    // MARK: - roundtrip: keyboardShortcut → ghosttyTrigger
+
+    @Test func roundtripPhysicalKeys() {
+        // For physical keys, converting trigger → KeyboardShortcut → ghosttyTrigger
+        // should produce the same physical key.
+        let physicalKeys: [(ghostty_input_key_e, ghostty_input_mods_e)] = [
+            (GHOSTTY_KEY_ARROW_UP, ghostty_input_mods_e(0)),
+            (GHOSTTY_KEY_TAB, GHOSTTY_MODS_CTRL),
+            (GHOSTTY_KEY_ENTER, GHOSTTY_MODS_SUPER),
+        ]
+
+        for (key, mods) in physicalKeys {
+            let original = ghostty_input_trigger_s(
+                tag: GHOSTTY_TRIGGER_PHYSICAL,
+                key: .init(physical: key),
+                mods: mods
+            )
+
+            guard let shortcut = Ghostty.keyboardShortcut(for: original) else {
+                Issue.record("Could not create KeyboardShortcut for \(key)")
+                continue
+            }
+
+            guard let back = Ghostty.ghosttyTrigger(shortcut) else {
+                Issue.record("Could not convert KeyboardShortcut back for \(key)")
+                continue
+            }
+
+            #expect(back.tag == GHOSTTY_TRIGGER_PHYSICAL)
+            #expect(back.key.physical == key)
+        }
+    }
+}

--- a/macos/Tests/Ghostty/MenuShortcutManagerTests.swift
+++ b/macos/Tests/Ghostty/MenuShortcutManagerTests.swift
@@ -8,19 +8,26 @@ struct MenuShortcutManagerTests {
     func unbindShouldDiscardDefault() async throws {
         let config = try TemporaryConfig("keybind = super+d=unbind")
 
+        let menu = NSMenu()
         let item = NSMenuItem(title: "Split Right", action: #selector(BaseTerminalController.splitRight(_:)), keyEquivalent: "d")
         item.keyEquivalentModifierMask = .command
+        menu.addItem(item)
+
         let manager = await Ghostty.MenuShortcutManager()
-        await manager.reset()
-        await manager.syncMenuShortcut(config, action: "new_split:right", menuItem: item)
+        await manager.resetRegisteredGhosttyActions()
+        await manager.register(action: "new_split:right", menuItem: item)
+
+        await manager.updateShortcut(in: menu, config: config)
 
         #expect(item.keyEquivalent.isEmpty)
         #expect(item.keyEquivalentModifierMask.isEmpty)
 
         try config.reload("")
 
-        await manager.reset()
-        await manager.syncMenuShortcut(config, action: "new_split:right", menuItem: item)
+        await manager.resetRegisteredGhosttyActions()
+        await manager.register(action: "new_split:right", menuItem: item)
+
+        await manager.updateShortcut(in: menu, config: config)
 
         #expect(item.keyEquivalent == "d")
         #expect(item.keyEquivalentModifierMask == .command)
@@ -35,14 +42,46 @@ struct MenuShortcutManagerTests {
 
         let goToLeftItem = NSMenuItem(title: "Select Split Left", action: "splitMoveFocusLeft:", keyEquivalent: "")
 
-        let manager = await Ghostty.MenuShortcutManager()
-        await manager.reset()
+        let menu = NSMenu()
+        [hideItem, goToLeftItem].forEach(menu.addItem)
 
-        await manager.syncMenuShortcut(config, action: nil, menuItem: hideItem)
-        await manager.syncMenuShortcut(config, action: "goto_split:left", menuItem: goToLeftItem)
+        let manager = await Ghostty.MenuShortcutManager()
+        await manager.resetRegisteredGhosttyActions()
+
+        await manager.register(action: "dummy", menuItem: hideItem)
+        await manager.register(action: "goto_split:left", menuItem: goToLeftItem)
+
+        await manager.updateShortcut(in: menu, config: config)
 
         #expect(hideItem.keyEquivalent.isEmpty)
         #expect(hideItem.keyEquivalentModifierMask.isEmpty)
+
+        #expect(goToLeftItem.keyEquivalent == "h")
+        #expect(goToLeftItem.keyEquivalentModifierMask == .command)
+    }
+
+    @Test
+    func unreferencedItemShouldNOTBeChanged() async throws {
+        let config = try TemporaryConfig("keybind=super+h=goto_split:left")
+
+        let hideItem = NSMenuItem(title: "Hide Ghostty", action: "hide:", keyEquivalent: "h")
+        hideItem.keyEquivalentModifierMask = .command
+
+        let goToLeftItem = NSMenuItem(title: "Select Split Left", action: "splitMoveFocusLeft:", keyEquivalent: "")
+
+        let menu = NSMenu()
+        [hideItem, goToLeftItem].forEach(menu.addItem)
+
+        let manager = await Ghostty.MenuShortcutManager()
+
+        await manager.resetRegisteredGhosttyActions()
+        await manager.register(action: "goto_split:left", menuItem: goToLeftItem)
+
+        await manager.updateShortcut(in: menu, config: config)
+
+        // hideItem is not register, so it should stays the same
+        #expect(hideItem.keyEquivalent == "h")
+        #expect(hideItem.keyEquivalentModifierMask == .command)
 
         #expect(goToLeftItem.keyEquivalent == "h")
         #expect(goToLeftItem.keyEquivalentModifierMask == .command)

--- a/macos/Tests/Ghostty/MenuShortcutManagerTests.swift
+++ b/macos/Tests/Ghostty/MenuShortcutManagerTests.swift
@@ -13,7 +13,7 @@ struct MenuShortcutManagerTests {
         item.keyEquivalentModifierMask = .command
         menu.addItem(item)
 
-        let manager = await Ghostty.MenuShortcutManager()
+        let manager = await Ghostty.MenuShortcutManager(menu)
         await manager.resetRegisteredGhosttyActions()
         await manager.register(action: "new_split:right", menuItem: item)
 
@@ -45,7 +45,7 @@ struct MenuShortcutManagerTests {
         let menu = NSMenu()
         [hideItem, goToLeftItem].forEach(menu.addItem)
 
-        let manager = await Ghostty.MenuShortcutManager()
+        let manager = await Ghostty.MenuShortcutManager(menu)
         await manager.resetRegisteredGhosttyActions()
 
         await manager.register(action: "dummy", menuItem: hideItem)
@@ -61,7 +61,7 @@ struct MenuShortcutManagerTests {
     }
 
     @Test
-    func unreferencedItemShouldNOTBeChanged() async throws {
+    func unreferencedItemShouldBeResetIfUnbound() async throws {
         let config = try TemporaryConfig("keybind=super+h=goto_split:left")
 
         let hideItem = NSMenuItem(title: "Hide Ghostty", action: "hide:", keyEquivalent: "h")
@@ -72,18 +72,33 @@ struct MenuShortcutManagerTests {
         let menu = NSMenu()
         [hideItem, goToLeftItem].forEach(menu.addItem)
 
-        let manager = await Ghostty.MenuShortcutManager()
+        let manager = await Ghostty.MenuShortcutManager(menu)
 
         await manager.resetRegisteredGhosttyActions()
         await manager.register(action: "goto_split:left", menuItem: goToLeftItem)
 
         await manager.updateShortcut(in: menu, config: config)
 
-        // hideItem is not register, so it should stays the same
-        #expect(hideItem.keyEquivalent == "h")
-        #expect(hideItem.keyEquivalentModifierMask == .command)
+        // Even though hideItem is not register, it should still be cleared out
+        #expect(hideItem.keyEquivalent.isEmpty)
+        #expect(hideItem.keyEquivalentModifierMask.isEmpty)
 
         #expect(goToLeftItem.keyEquivalent == "h")
+        #expect(goToLeftItem.keyEquivalentModifierMask == .command)
+
+        try config.reload("""
+            keybind=super+h=unbind
+            keybind=super+l=goto_split:left
+            """)
+        await manager.resetRegisteredGhosttyActions()
+        await manager.register(action: "goto_split:left", menuItem: goToLeftItem)
+
+        await manager.updateShortcut(in: menu, config: config)
+
+        #expect(hideItem.keyEquivalent.isEmpty)
+        #expect(hideItem.keyEquivalentModifierMask.isEmpty)
+
+        #expect(goToLeftItem.keyEquivalent == "l")
         #expect(goToLeftItem.keyEquivalentModifierMask == .command)
     }
 }

--- a/macos/Tests/Ghostty/MenuShortcutManagerTests.swift
+++ b/macos/Tests/Ghostty/MenuShortcutManagerTests.swift
@@ -61,7 +61,7 @@ struct MenuShortcutManagerTests {
     }
 
     @Test
-    func unreferencedItemShouldBeResetIfUnbound() async throws {
+    func unreferencedItemShouldBeResetIfOverrodeOrUnbound() async throws {
         let config = try TemporaryConfig("keybind=super+h=goto_split:left")
 
         let hideItem = NSMenuItem(title: "Hide Ghostty", action: "hide:", keyEquivalent: "h")
@@ -100,5 +100,16 @@ struct MenuShortcutManagerTests {
 
         #expect(goToLeftItem.keyEquivalent == "l")
         #expect(goToLeftItem.keyEquivalentModifierMask == .command)
+
+        try config.reload("""
+            keybind=super+l=goto_split:left
+            """)
+        await manager.resetRegisteredGhosttyActions()
+        await manager.register(action: "goto_split:left", menuItem: goToLeftItem)
+
+        await manager.updateShortcut(in: menu, config: config)
+
+        #expect(hideItem.keyEquivalent == "h")
+        #expect(hideItem.keyEquivalentModifierMask == .command)
     }
 }

--- a/macos/Tests/Ghostty/NormalizedMenuShortcutKeyTests.swift
+++ b/macos/Tests/Ghostty/NormalizedMenuShortcutKeyTests.swift
@@ -28,28 +28,28 @@ struct NormalizedMenuShortcutKeyTests {
     @Test func preservesShortcutModifiers() {
         let key = Key(keyEquivalent: "c", modifiers: [.shift, .control, .option, .command])
         let allMods: NSEvent.ModifierFlags = [.shift, .control, .option, .command]
-        #expect(key?.modifiersRawValue == allMods.rawValue)
+        #expect(key?.modifierFlags == allMods)
     }
 
     @Test func uppercaseLetterInsertsShift() {
         // "A" is uppercase and case-sensitive, so .shift should be added
         let key = Key(keyEquivalent: "A", modifiers: .command)
-        let expected = NSEvent.ModifierFlags([.command, .shift]).rawValue
-        #expect(key?.modifiersRawValue == expected)
+        let expected = NSEvent.ModifierFlags([.command, .shift])
+        #expect(key?.modifierFlags == expected)
     }
 
     @Test func lowercaseLetterDoesNotInsertShift() {
         let key = Key(keyEquivalent: "a", modifiers: .command)
-        let expected = NSEvent.ModifierFlags.command.rawValue
-        #expect(key?.modifiersRawValue == expected)
+        let expected = NSEvent.ModifierFlags.command
+        #expect(key?.modifierFlags == expected)
     }
 
     @Test func nonCaseSensitiveCharacterDoesNotInsertShift() {
         // "1" is not case-sensitive (uppercased == lowercased is false for digits,
         // but "1".uppercased() == "1".lowercased() == "1" so isCaseSensitive is false)
         let key = Key(keyEquivalent: "1", modifiers: .command)
-        let expected = NSEvent.ModifierFlags.command.rawValue
-        #expect(key?.modifiersRawValue == expected)
+        let expected = NSEvent.ModifierFlags.command
+        #expect(key?.modifierFlags == expected)
     }
 
     // MARK: - Equality / Hashing

--- a/macos/Tests/Helpers/TemporaryConfig.swift
+++ b/macos/Tests/Helpers/TemporaryConfig.swift
@@ -14,14 +14,18 @@ class TemporaryConfig: Ghostty.Config {
         let temporaryFile = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
             .appendingPathExtension("ghostty")
-        try configText.write(to: temporaryFile, atomically: true, encoding: .utf8)
+        // Suppress `error.FileIsEmpty`
+        let text = configText.isEmpty ? " " : configText
+        try text.write(to: temporaryFile, atomically: true, encoding: .utf8)
         self.temporaryFile = temporaryFile
         super.init(config: Self.loadConfig(at: temporaryFile.path(), finalize: finalize))
     }
 
     func reload(_ newConfigText: String?, finalize: Bool = true) throws {
         if let newConfigText {
-            try newConfigText.write(to: temporaryFile, atomically: true, encoding: .utf8)
+            // Suppress `error.FileIsEmpty`
+            let text = newConfigText.isEmpty ? " " : newConfigText
+            try text.write(to: temporaryFile, atomically: true, encoding: .utf8)
         }
         guard let cfg = Self.loadConfig(at: temporaryFile.path(), finalize: finalize) else {
             throw Error.failedToLoad

--- a/src/config/CApi.zig
+++ b/src/config/CApi.zig
@@ -111,6 +111,14 @@ export fn ghostty_config_trigger(
     };
 }
 
+export fn ghostty_config_trigger_is_unbound(
+    self: *Config,
+    trigger: inputpkg.Binding.Trigger.C,
+) bool {
+    const t = inputpkg.Binding.Trigger.evalC(trigger);
+    return self.keybind.set.isUnbound(t);
+}
+
 fn config_trigger_(
     self: *Config,
     str: []const u8,

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -1983,6 +1983,17 @@ pub const Trigger = struct {
         };
     }
 
+    pub fn evalC(c: C) Trigger {
+        return .{
+            .key = switch (c.tag) {
+                .physical => .{ .physical = c.key.physical },
+                .unicode => .{ .unicode = @as(u21, @intCast(@as(u32, c.key.unicode))) },
+                .catch_all => .catch_all,
+            },
+            .mods = c.mods,
+        };
+    }
+
     /// Format implementation for fmt package.
     pub fn format(
         self: Trigger,
@@ -1999,6 +2010,22 @@ pub const Trigger = struct {
             .physical => |k| try writer.print("{t}", .{k}),
             .unicode => |c| try writer.print("{u}", .{c}),
             .catch_all => try writer.writeAll("catch_all"),
+        }
+    }
+
+    test "evalC roundtrip" {
+        const cases = [_]struct { input: []const u8, mods: key.Mods }{
+            .{ .input = "a", .mods = .{} },
+            .{ .input = "ctrl+a", .mods = .{ .ctrl = true } },
+            .{ .input = "shift+up", .mods = .{ .shift = true } },
+            .{ .input = "super+c", .mods = .{ .super = true } },
+        };
+
+        inline for (cases) |case| {
+            const zig = try Trigger.parse(case.input);
+            const c = zig.cval();
+            const back = evalC(c);
+            try std.testing.expectEqual(zig, back);
         }
     }
 };
@@ -2023,6 +2050,14 @@ pub const Set = struct {
 
     /// The set of bindings.
     bindings: HashMap = .{},
+
+    /// The set of triggers that have been unbound.
+    unbound_triggers: std.ArrayHashMapUnmanaged(
+        Trigger,
+        void,
+        Context(Trigger),
+        true,
+    ) = .{},
 
     /// The reverse mapping of action to binding. Note that multiple
     /// bindings can map to the same action and this map will only have
@@ -2252,6 +2287,7 @@ pub const Set = struct {
         };
 
         self.bindings.deinit(alloc);
+        self.unbound_triggers.deinit(alloc);
         self.reverse.deinit(alloc);
         self.* = undefined;
     }
@@ -2432,6 +2468,11 @@ pub const Set = struct {
             .binding => |b| switch (b.action) {
                 .unbind => {
                     set.remove(alloc, b.trigger);
+                    // move it to unbound_triggers if this is a root
+                    if (set == root) {
+                        try set.unbound_triggers.put(alloc, b.trigger, {});
+                    }
+                    // then return pervious error
                     return error.SequenceUnbind;
                 },
 
@@ -2478,6 +2519,8 @@ pub const Set = struct {
     ) Allocator.Error!void {
         // unbind should never go into the set, it should be handled prior
         assert(action != .unbind);
+        // Remove previous unbinds
+        _ = self.unbound_triggers.swapRemove(t);
 
         // This is true if we're going to track this entry as
         // a reverse mapping. There are certain scenarios we don't.
@@ -2604,6 +2647,11 @@ pub const Set = struct {
     /// Get a binding for a given trigger.
     pub fn get(self: Set, t: Trigger) ?Entry {
         return self.bindings.getEntry(t);
+    }
+
+    /// Returns true if the given trigger has been unbound.
+    pub fn isUnbound(self: Set, t: Trigger) bool {
+        return self.unbound_triggers.contains(t);
     }
 
     /// Get a trigger for the given action. An action can have multiple
@@ -2748,6 +2796,7 @@ pub const Set = struct {
     pub fn clone(self: *const Set, alloc: Allocator) !Set {
         var result: Set = .{
             .bindings = try self.bindings.clone(alloc),
+            .unbound_triggers = try self.unbound_triggers.clone(alloc),
             .reverse = try self.reverse.clone(alloc),
         };
 
@@ -3549,7 +3598,7 @@ test "set: parseAndPut unconsumed binding" {
     }
 }
 
-test "set: parseAndPut removed binding" {
+test "set: parseAndPut move unbind to disabled" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
@@ -3568,6 +3617,9 @@ test "set: parseAndPut removed binding" {
 
     // Sets up the chain parent properly
     try testing.expect(s.chain_parent == null);
+
+    // unbound_triggers should be set
+    try testing.expect(s.isUnbound(.{ .key = .{ .unicode = 'a' } }));
 }
 
 test "set: put sets chain_parent" {
@@ -3688,6 +3740,9 @@ test "set: sequence unbind clears chain_parent" {
 
     // After unbind, chain_parent should be cleared
     try testing.expect(s.chain_parent == null);
+
+    // unbound_triggers should NOT be set
+    try testing.expect(s.unbound_triggers.count() == 0);
 }
 
 test "set: sequence unbind with remaining leaves clears chain_parent" {
@@ -3709,6 +3764,9 @@ test "set: sequence unbind with remaining leaves clears chain_parent" {
     try testing.expect(a_entry.value_ptr.* == .leader);
     const inner_set = a_entry.value_ptr.*.leader;
     try testing.expect(inner_set.get(.{ .key = .{ .unicode = 'c' } }) != null);
+
+    // unbound_triggers should NOT be set
+    try testing.expect(s.unbound_triggers.count() == 0);
 }
 
 test "set: direct remove clears chain_parent" {
@@ -3945,6 +4003,9 @@ test "set: parseAndPut unbind sequence unbinds leader" {
         const t: Trigger = .{ .key = .{ .unicode = 'a' } };
         try testing.expect(current.get(t) == null);
     }
+
+    // unbound_triggers should NOT be set
+    try testing.expect(s.unbound_triggers.count() == 0);
 }
 
 test "set: parseAndPut unbind sequence unbinds leader if not set" {
@@ -3960,6 +4021,9 @@ test "set: parseAndPut unbind sequence unbinds leader if not set" {
         const t: Trigger = .{ .key = .{ .unicode = 'a' } };
         try testing.expect(current.get(t) == null);
     }
+
+    // unbound_triggers should NOT be set
+    try testing.expect(s.unbound_triggers.count() == 0);
 }
 
 test "set: parseAndPut sequence preserves reverse mapping" {
@@ -4241,6 +4305,43 @@ test "set: parseAndPut chain with unbind is error" {
     const entry = s.get(.{ .key = .{ .unicode = 'a' } }).?.value_ptr.*;
     try testing.expect(entry == .leaf);
     try testing.expect(entry.leaf.action == .new_window);
+}
+
+test "set: save and clone unbind triggers" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s: Set = .{};
+    defer s.deinit(alloc);
+
+    try s.parseAndPut(alloc, "a=unbind");
+    try s.parseAndPut(alloc, "a=new_window");
+    try s.parseAndPut(alloc, "b=unbind");
+    try s.parseAndPut(alloc, "super+c=unbind");
+
+    // New binding should still exist
+    const entry = s.get(.{ .key = .{ .unicode = 'a' } }).?.value_ptr.*;
+    try testing.expect(entry == .leaf);
+    try testing.expect(entry.leaf.action == .new_window);
+
+    // unbound_triggers should be set
+
+    try testing.expect(s.unbound_triggers.count() == 2);
+
+    try testing.expect(s.isUnbound(.{ .key = .{ .unicode = 'b' } }));
+
+    try testing.expect(s.isUnbound(.{ .key = .{ .unicode = 'c' }, .mods = .{ .super = true } }));
+
+    var cloned = try s.clone(alloc);
+    defer cloned.deinit(alloc);
+
+    // Clone should have the same result
+
+    try testing.expect(cloned.unbound_triggers.count() == 2);
+
+    try testing.expect(cloned.isUnbound(.{ .key = .{ .unicode = 'b' } }));
+
+    try testing.expect(cloned.isUnbound(.{ .key = .{ .unicode = 'c' }, .mods = .{ .super = true } }));
 }
 
 test "set: getEvent physical" {


### PR DESCRIPTION
Depends on #11995 and #12023.

This fixes 
1. `keybind=cmd+option+h=unbind` not working as expect
2. `keybind=cmd+option+h=goto_split:left` not hiding the shortcut on "Hide Others" and the menu is not highlighted