### PR TITLE
fix: Ensure snap paths come first in gio module loading

### DIFF
--- a/snap/local/launcher
+++ b/snap/local/launcher
@@ -45,9 +45,11 @@ export __EGL_VENDOR_LIBRARY_DIRS=${__EGL_VENDOR_LIBRARY_DIRS:+$__EGL_VENDOR_LIBR
 export __EGL_EXTERNAL_PLATFORM_CONFIG_DIRS=${__EGL_EXTERNAL_PLATFORM_CONFIG_DIRS:+$__EGL_EXTERNAL_PLATFORM_CONFIG_DIRS:}${SNAP}/usr/share/egl/egl_external_platform.d
 export DRIRC_CONFIGDIR=${SNAP}/usr/share/drirc.d
 export VK_LAYER_PATH=${VK_LAYER_PATH:+$VK_LAYER_PATH:}${SNAP}/usr/share/vulkan/implicit_layer.d/:${SNAP}/usr/share/vulkan/explicit_layer.d/
-export XDG_DATA_DIRS=${XDG_DATA_DIRS:+$XDG_DATA_DIRS:}${SNAP}/usr/share
+export XDG_DATA_DIRS=${SNAP}/usr/share${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}
 export XLOCALEDIR="${SNAP}/usr/share/X11/locale"
 export GTK_PATH="$SNAP/usr/lib/$ARCH/gtk-4.0"
+export GIO_MODULE_DIR="$SNAP/usr/lib/$ARCH/gio/modules"
+unset GIO_EXTRA_MODULES
 
 # Gdk-pixbuf loaders
 mkdir -p "$SNAP_USER_COMMON/.cache"


### PR DESCRIPTION
This fixes the issue reported in https://github.com/ghostty-org/ghostty/discussions/11311