### PR TITLE
Revert "macOS: close search bar if needed when it loses focus (#11980)"

### DIFF
--- a/macos/Sources/Ghostty/Surface View/SurfaceView.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView.swift
@@ -437,10 +437,11 @@ extension Ghostty {
                         }
                     }
 #if canImport(AppKit)
-                    .onExitCommand(perform: onResignFirstResponder)
-                    .onChange(of: isSearchFieldFocused) {  newValue in
-                        if !newValue {
-                            onResignFirstResponder()
+                    .onExitCommand {
+                        if searchState.needle.isEmpty {
+                            onClose()
+                        } else {
+                            Ghostty.moveFocus(to: surfaceView)
                         }
                     }
 #endif
@@ -519,15 +520,7 @@ extension Ghostty {
                 )
             }
         }
-#if canImport(AppKit)
-        private func onResignFirstResponder() {
-            if searchState.needle.isEmpty {
-                onClose()
-            } else {
-                Ghostty.moveFocus(to: surfaceView)
-            }
-        }
-#endif
+
         private var clipShape: some Shape {
             if #available(iOS 26.0, macOS 26.0, *) {
                 return ConcentricRectangle(corners: .concentric(minimum: 8), isUniform: true)

--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -660,13 +660,6 @@ extension Ghostty {
                 return event
             }
 
-            guard searchState == nil else {
-                // We don't want to process events that
-                // are supposed to be handled by SearchOverlay
-                // When clicking outside, SurfaceView will become first responder automatically
-                return event
-            }
-
             // We only want to process events that are on this window.
             guard let window,
                   event.window != nil,


### PR DESCRIPTION
This reverts commit 20cfaae2e5ec84cca2c5a55843b399b32fb9c810, reversing changes made to 3509ccf78ef087fec2f0209fbc297a321106d339.

This breaks some behaviours when there are multiple splits, which requires another click to focus to another split in the same window🫪