### PR TITLE
Fix mis-use of libxev.Async and copy-by-value issue with render thread wakeup

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -679,7 +679,7 @@ pub fn init(
             .backend = .{ .exec = io_exec },
             .mailbox = io_mailbox,
             .renderer_state = &self.renderer_state,
-            .renderer_wakeup = render_thread.wakeup,
+            .renderer_wakeup = &self.renderer_thread.wakeup,
             .renderer_mailbox = render_thread.mailbox,
             .surface_mailbox = .{ .surface = self, .app = app_mailbox },
         });

--- a/src/termio/Options.zig
+++ b/src/termio/Options.zig
@@ -32,7 +32,7 @@ renderer_state: *renderer.State,
 
 /// A handle to wake up the renderer. This hints to the renderer that
 /// a repaint should happen.
-renderer_wakeup: xev.Async,
+renderer_wakeup: *xev.Async,
 
 /// The mailbox for renderer messages.
 renderer_mailbox: *renderer.Thread.Mailbox,

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -45,7 +45,7 @@ renderer_state: *renderer.State,
 
 /// A handle to wake up the renderer. This hints to the renderer that
 /// a repaint should happen.
-renderer_wakeup: xev.Async,
+renderer_wakeup: *xev.Async,
 
 /// The mailbox for notifying the renderer of things.
 renderer_mailbox: *renderer.Thread.Mailbox,

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -38,7 +38,7 @@ pub const StreamHandler = struct {
 
     /// A handle to wake up the renderer. This hints to the renderer that
     /// a repaint should happen.
-    renderer_wakeup: xev.Async,
+    renderer_wakeup: *xev.Async,
 
     /// The default cursor state. This is used with CSI q. This is
     /// set to true when we're currently in the default cursor state.


### PR DESCRIPTION
This PR encapsulates the fix for the issue I identified in this discussion post: https://github.com/ghostty-org/ghostty/discussions/11877