### PR TITLE
fix: replay key events when IME switches during composition

### DIFF
--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -225,6 +225,11 @@ extension Ghostty {
         // This is set to non-null during keyDown to accumulate insertText contents
         private var keyTextAccumulator: [String]?
 
+        // Accumulates key events during preedit state. When input method switches
+        // (e.g., via Caps Lock), these events are replayed to the terminal so
+        // they can be executed as commands in apps like Neovim normal mode.
+        private var preeditKeyEvents: [NSEvent] = []
+
         // True when we've consumed a left mouse-down only to move focus and
         // should suppress the matching mouse-up from being reported.
         private var suppressNextLeftMouseUp: Bool = false
@@ -1162,6 +1167,12 @@ extension Ghostty {
             // `interpretKeyEvents` may dispatch it.
             self.lastPerformKeyEvent = nil
 
+            // If we're already in preedit state, save this key event so it can be
+            // replayed if the input method is switched (e.g., via Caps Lock).
+            if markedTextBefore {
+                preeditKeyEvents.append(event)
+            }
+
             self.interpretKeyEvents([translationEvent])
 
             // If our keyboard changed from this we just assume an input method
@@ -1179,6 +1190,10 @@ extension Ghostty {
                 // If we have text, then we've composed a character, send that down.
                 // These never have "composing" set to true because these are the
                 // result of a composition.
+                
+                // Clear saved preedit key events since composition succeeded
+                preeditKeyEvents.removeAll(keepingCapacity: true)
+                
                 for text in list {
                     _ = keyAction(
                         action,
@@ -1863,6 +1878,7 @@ extension Ghostty.SurfaceView: NSTextInputClient {
     func unmarkText() {
         if self.markedText.length > 0 {
             self.markedText.mutableString.setString("")
+            preeditKeyEvents.removeAll(keepingCapacity: true)
             syncPreedit()
         }
     }
@@ -1983,6 +1999,10 @@ extension Ghostty.SurfaceView: NSTextInputClient {
             return
         }
 
+        // Check if we had marked text before clearing it.
+        // This helps us detect input method switches (e.g., via Caps Lock).
+        let hadMarkedText = markedText.length > 0
+
         // If insertText is called, our preedit must be over.
         unmarkText()
 
@@ -1991,6 +2011,21 @@ extension Ghostty.SurfaceView: NSTextInputClient {
         if var acc = keyTextAccumulator {
             acc.append(chars)
             keyTextAccumulator = acc
+            return
+        }
+
+        // If we're not in a keyDown event (keyTextAccumulator is nil) but we
+        // had marked text, this likely means the input method was switched
+        // (e.g., via Caps Lock). Instead of inserting the text, replay the
+        // saved key events so they can be executed as commands in apps like
+        // Neovim normal mode.
+        if hadMarkedText {
+            let eventsToReplay = preeditKeyEvents
+            preeditKeyEvents.removeAll(keepingCapacity: true)
+
+            for savedEvent in eventsToReplay {
+                self.keyDown(with: savedEvent)
+            }
             return
         }
 

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -549,6 +549,12 @@ pub const Surface = extern struct {
         };
     };
 
+    const PreeditKeyEvent = struct {
+        keyval: c_uint,
+        keycode: c_uint,
+        mods: gdk.ModifierType,
+    };
+
     const Private = struct {
         /// The configuration that this surface is using.
         config: ?*Config = null,
@@ -637,6 +643,15 @@ pub const Surface = extern struct {
         im_composing: bool = false,
         im_buf: [128]u8 = undefined,
         im_len: u7 = 0,
+
+        /// Current event controller key, updated on each key event.
+        /// Used for replaying key events when IME switches.
+        ec_key_current: ?*gtk.EventControllerKey = null,
+
+        /// Buffer for key events during preedit composition.
+        /// When input method switches (e.g., via Caps Lock), these events
+        /// are replayed so they execute as commands in apps like Neovim.
+        im_preedit_keys: std.ArrayListUnmanaged(PreeditKeyEvent) = .empty,
 
         /// True when we have a precision scroll in progress
         precision_scroll: bool = false,
@@ -1222,6 +1237,9 @@ pub const Surface = extern struct {
         const key_event = gobject.ext.cast(gdk.KeyEvent, event) orelse return false;
         const priv = self.private();
 
+        // Store ec_key for potential replay when IME switches
+        priv.ec_key_current = ec_key;
+
         // The block below is all related to input method handling. See the function
         // comment for some high level details and then the comments within
         // the block for more specifics.
@@ -1278,6 +1296,17 @@ pub const Surface = extern struct {
             //     self.im_len,
             //     self.im_composing,
             // });
+
+            // If we were composing before IME processing, save this key event.
+            // If IME switches (e.g., via Caps Lock), we'll replay these events
+            // so they execute as commands in apps like Neovim normal mode.
+            if (priv.in_keyevent == .composing and action == .press) {
+                priv.im_preedit_keys.append(self.allocator, .{
+                    .keyval = keyval,
+                    .keycode = keycode,
+                    .mods = gtk_mods,
+                }) catch {};
+            }
 
             // If the input method handled the event, you would think we would
             // never proceed with key encoding for Ghostty but that is not the
@@ -3089,6 +3118,9 @@ pub const Surface = extern struct {
         const priv = self.private();
         priv.im_composing = false;
 
+        // Clear saved preedit key events since preedit ended
+        priv.im_preedit_keys.clearRetainingCapacity();
+
         // End our preedit state in Ghostty core
         const surface = priv.core_surface orelse return;
         surface.preeditCallback(null) catch |err| {
@@ -3119,7 +3151,40 @@ pub const Surface = extern struct {
             // If we're not in a key event then this commit is from
             // some other source (i.e. on-screen keyboard, tablet, etc.)
             // and we want to commit the text to the core surface.
-            .false => {},
+            //
+            // However, if we were composing (im_composing is true), this
+            // likely means the input method was switched (e.g., via Caps Lock)
+            // and we should discard the preedit text rather than inserting it.
+            // This prevents unwanted text insertion in terminal apps like Neovim
+            // when switching input methods during composition.
+            .false => {
+                if (priv.im_composing) {
+                    priv.im_composing = false;
+                    if (priv.core_surface) |surface| {
+                        surface.preeditCallback(null) catch |err| {
+                            log.warn("error clearing preedit on IM switch: {}", .{err});
+                        };
+                    }
+
+                    // Replay saved key events so they execute as commands
+                    // in apps like Neovim normal mode
+                    const ec_key = priv.ec_key_current orelse return;
+                    const keys_to_replay = priv.im_preedit_keys.toOwnedSlice(self.allocator()) catch null;
+                    if (keys_to_replay) |keys| {
+                        defer self.allocator().free(keys);
+                        for (keys) |key_info| {
+                            _ = self.keyEvent(
+                                .press,
+                                ec_key,
+                                key_info.keyval,
+                                key_info.keycode,
+                                key_info.mods,
+                            );
+                        }
+                    }
+                    return;
+                }
+            },
 
             // If we're in a composing state and in a key event then this
             // key event is resulting in a commit of multiple keypresses
@@ -3153,6 +3218,9 @@ pub const Surface = extern struct {
 
         // Committing ends composing state
         priv.im_composing = false;
+
+        // Clear saved preedit key events since commit was successful
+        priv.im_preedit_keys.clearRetainingCapacity();
 
         // We can't set our preedit on our surface unless we're realized.
         // We do this now because we want to still keep our input method


### PR DESCRIPTION
## Summary

When using an input method (e.g., Chinese IME) in terminal apps like Neovim normal mode, switching the input method via Caps Lock would previously discard the key events. With this fix, those key events are now replayed so they execute as commands.

## Example

1. Open Neovim in normal mode
2. Switch to Chinese IME
3. Type `jjjj` (preedit state shows the characters)
4. Press Caps Lock to switch to English IME

**Before**: Nothing happens (keys are discarded)
**After**: Cursor moves down 4 lines (`j` command executed 4 times)

This behavior matches Kitty terminal's handling of the same scenario.

## Changes

### macOS (`SurfaceView_AppKit.swift`)
- Add `preeditKeyEvents` buffer to store key events during composition
- Replay buffered events when IME switch is detected (via `hadMarkedText` check in `insertText`)
- Clear buffer on successful composition or preedit cancellation (`unmarkText`)

### GTK (`surface.zig`)
- Add `PreeditKeyEvent` struct and `im_preedit_keys` buffer
- Store key events during composition (when `in_keyevent == .composing`)
- Replay buffered events when IME switch is detected (in `imCommit` with `in_keyevent == .false && im_composing`)
- Clear buffer on successful commit or preedit end (`imPreeditEnd`)

## Testing

- [ ] Chinese IME + Neovim normal mode + Caps Lock switch
- [ ] Japanese IME normal input (should not be affected)
- [ ] Korean IME normal input (should not be affected)
- [ ] IME composition with Enter confirmation (should work normally)
- [ ] IME composition with Escape cancellation (should work normally)