### PR TITLE
config: add split-resize-limit option

### DIFF
--- a/macos/Sources/Features/Splits/SplitTree.swift
+++ b/macos/Sources/Features/Splits/SplitTree.swift
@@ -256,7 +256,7 @@ extension SplitTree {
     ///   - bounds: The bounds used to construct the spatial tree representation
     /// - Returns: A new SplitTree with the adjusted split ratios
     /// - Throws: SplitError.viewNotFound if the node is not found in the tree or no suitable parent split exists
-    func resizing(node: Node, by pixels: UInt16, in direction: Spatial.Direction, with bounds: CGRect) throws -> Self {
+    func resizing(node: Node, by pixels: UInt16, in direction: Spatial.Direction, with bounds: CGRect, minRatio: Double = 0.1) throws -> Self {
         guard let root else { throw SplitError.viewNotFound }
 
         // Find the path to the target node
@@ -301,19 +301,21 @@ extension SplitTree {
         let pixelOffset = Double(pixels)
         let newRatio: Double
 
+        let maxRatio = 1 - minRatio
+
         switch (split.direction, direction) {
         case (.horizontal, .left):
             // Moving left boundary: decrease left side
-            newRatio = Swift.max(0.1, Swift.min(0.9, split.ratio - (pixelOffset / splitSlot.bounds.width)))
+            newRatio = Swift.max(minRatio, Swift.min(maxRatio, split.ratio - (pixelOffset / splitSlot.bounds.width)))
         case (.horizontal, .right):
             // Moving right boundary: increase left side
-            newRatio = Swift.max(0.1, Swift.min(0.9, split.ratio + (pixelOffset / splitSlot.bounds.width)))
+            newRatio = Swift.max(minRatio, Swift.min(maxRatio, split.ratio + (pixelOffset / splitSlot.bounds.width)))
         case (.vertical, .up):
             // Moving top boundary: decrease top side
-            newRatio = Swift.max(0.1, Swift.min(0.9, split.ratio - (pixelOffset / splitSlot.bounds.height)))
+            newRatio = Swift.max(minRatio, Swift.min(maxRatio, split.ratio - (pixelOffset / splitSlot.bounds.height)))
         case (.vertical, .down):
             // Moving bottom boundary: increase top side
-            newRatio = Swift.max(0.1, Swift.min(0.9, split.ratio + (pixelOffset / splitSlot.bounds.height)))
+            newRatio = Swift.max(minRatio, Swift.min(maxRatio, split.ratio + (pixelOffset / splitSlot.bounds.height)))
         default:
             // Direction doesn't match split type - shouldn't happen due to earlier logic
             throw SplitError.viewNotFound

--- a/macos/Sources/Features/Splits/SplitView.swift
+++ b/macos/Sources/Features/Splits/SplitView.swift
@@ -24,6 +24,9 @@ struct SplitView<L: View, R: View>: View {
     /// Called when the divider is double-tapped to equalize splits.
     let onEqualize: () -> Void
 
+    /// The minimum ratio (0 to 0.5) for a split during resize.
+    let splitResizeLimit: CGFloat
+
     /// The minimum size (in points) of a split
     let minSize: CGFloat = 10
 
@@ -73,6 +76,7 @@ struct SplitView<L: View, R: View>: View {
         _ direction: SplitViewDirection,
         _ split: Binding<CGFloat>,
         dividerColor: Color,
+        splitResizeLimit: CGFloat = 0.1,
         resizeIncrements: NSSize = .init(width: 1, height: 1),
         @ViewBuilder left: (() -> L),
         @ViewBuilder right: (() -> R),
@@ -81,6 +85,7 @@ struct SplitView<L: View, R: View>: View {
         self.direction = direction
         self._split = split
         self.dividerColor = dividerColor
+        self.splitResizeLimit = splitResizeLimit
         self.resizeIncrements = resizeIncrements
         self.left = left()
         self.right = right()
@@ -90,14 +95,15 @@ struct SplitView<L: View, R: View>: View {
     private func dragGesture(_ size: CGSize, splitterPoint: CGPoint) -> some Gesture {
         return DragGesture()
             .onChanged { gesture in
+                let maxRatio = 1 - splitResizeLimit
                 switch direction {
                 case .horizontal:
                     let new = min(max(minSize, gesture.location.x), size.width - minSize)
-                    split = new / size.width
+                    split = min(max(splitResizeLimit, new / size.width), maxRatio)
 
                 case .vertical:
                     let new = min(max(minSize, gesture.location.y), size.height - minSize)
-                    split = new / size.height
+                    split = min(max(splitResizeLimit, new / size.height), maxRatio)
                 }
             }
     }

--- a/macos/Sources/Features/Splits/TerminalSplitTreeView.swift
+++ b/macos/Sources/Features/Splits/TerminalSplitTreeView.swift
@@ -70,6 +70,7 @@ private struct TerminalSplitSubtreeView: View {
                     action(.resize(.init(node: node, ratio: $0)))
                 }),
                 dividerColor: ghostty.config.splitDividerColor,
+                splitResizeLimit: ghostty.config.splitResizeLimit,
                 resizeIncrements: .init(width: 1, height: 1),
                 left: {
                     TerminalSplitSubtreeView(node: split.left, action: action)

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -711,7 +711,7 @@ class BaseTerminalController: NSWindowController,
 
         // Perform the resize using the new SplitTree resize method
         do {
-            surfaceTree = try surfaceTree.resizing(node: targetNode, by: amount, in: spatialDirection, with: bounds)
+            surfaceTree = try surfaceTree.resizing(node: targetNode, by: amount, in: spatialDirection, with: bounds, minRatio: ghostty.config.splitResizeLimit)
         } catch {
             Ghostty.logger.warning("failed to resize split: \(error)")
         }

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -552,6 +552,14 @@ extension Ghostty {
             )
         }
 
+        var splitResizeLimit: Double {
+            guard let config = self.config else { return 0.1 }
+            var v: Double = 0.1
+            let key = "split-resize-limit"
+            _ = ghostty_config_get(config, &v, key, UInt(key.lengthOfBytes(using: .utf8)))
+            return v
+        }
+
         #if canImport(AppKit)
         var quickTerminalPosition: QuickTerminalPosition {
             guard let config = self.config else { return .top }

--- a/macos/Tests/Splits/SplitTreeTests.swift
+++ b/macos/Tests/Splits/SplitTreeTests.swift
@@ -223,6 +223,68 @@ struct SplitTreeTests {
         #expect(abs(s.ratio - expectedRatio) < 0.001)
     }
 
+    // MARK: - Resize with minRatio
+
+    @Test func resizingClampsToMinRatio() throws {
+        let view1 = MockView()
+        let view2 = MockView()
+        var tree = SplitTree<MockView>(view: view1)
+        tree = try tree.inserting(view: view2, at: view1, direction: .right)
+
+        let bounds = CGRect(x: 0, y: 0, width: 1000, height: 500)
+
+        // Resize right by 450px (would push ratio to 0.95 without limit)
+        let resized = try tree.resizing(
+            node: .leaf(view: view1), by: 450, in: .right, with: bounds, minRatio: 0.2)
+
+        guard case .split(let s) = resized.root else {
+            Issue.record("unexpected node type")
+            return
+        }
+        // Should be clamped to 0.8 (1 - minRatio)
+        #expect(abs(s.ratio - 0.8) < 0.001)
+    }
+
+    @Test func resizingClampsToMinRatioNegativeDirection() throws {
+        let view1 = MockView()
+        let view2 = MockView()
+        var tree = SplitTree<MockView>(view: view1)
+        tree = try tree.inserting(view: view2, at: view1, direction: .right)
+
+        let bounds = CGRect(x: 0, y: 0, width: 1000, height: 500)
+
+        // Resize left by 450px (would push ratio to 0.05 without limit)
+        let resized = try tree.resizing(
+            node: .leaf(view: view1), by: 450, in: .left, with: bounds, minRatio: 0.2)
+
+        guard case .split(let s) = resized.root else {
+            Issue.record("unexpected node type")
+            return
+        }
+        // Should be clamped to 0.2 (minRatio)
+        #expect(abs(s.ratio - 0.2) < 0.001)
+    }
+
+    @Test func resizingWithZeroMinRatioAllowsFullRange() throws {
+        let view1 = MockView()
+        let view2 = MockView()
+        var tree = SplitTree<MockView>(view: view1)
+        tree = try tree.inserting(view: view2, at: view1, direction: .right)
+
+        let bounds = CGRect(x: 0, y: 0, width: 1000, height: 500)
+
+        // Resize right by 450px with no limit
+        let resized = try tree.resizing(
+            node: .leaf(view: view1), by: 450, in: .right, with: bounds, minRatio: 0)
+
+        guard case .split(let s) = resized.root else {
+            Issue.record("unexpected node type")
+            return
+        }
+        // Should reach 0.95 with no clamping
+        #expect(abs(s.ratio - 0.95) < 0.001)
+    }
+
     // MARK: - Codable
 
     @Test func encodingAndDecodingPreservesTree() throws {

--- a/src/apprt/gtk/class/split_tree.zig
+++ b/src/apprt/gtk/class/split_tree.zig
@@ -311,11 +311,17 @@ pub const SplitTree = extern struct {
             .up, .down => .vertical,
         };
 
+        const app = Application.default();
+        const config_obj = app.getConfig();
+        defer config_obj.unref();
+        const limit: f16 = @floatCast(config_obj.get().@"split-resize-limit");
+
         var new_tree = try old_tree.resize(
-            Application.default().allocator(),
+            app.allocator(),
             active,
             layout,
             @floatCast(ratio),
+            limit,
         );
         defer new_tree.deinit();
         self.setTree(&new_tree);

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1101,6 +1101,17 @@ palette: Palette = .{},
 /// Available since: 1.3.0
 @"split-preserve-zoom": SplitPreserveZoom = .{},
 
+/// The minimum ratio for any split, clamped to this value during resize
+/// operations. This prevents a split from becoming too small when resizing.
+///
+/// A value of `0.1` means no split can be smaller than 10% of the total
+/// container size. A value of `0` disables this limit entirely, allowing
+/// splits to be resized freely (though they may still be constrained by
+/// minimum window sizes). The value is clamped to the range `0` to `0.5`.
+///
+/// Default: `0.1`
+@"split-resize-limit": f64 = 0.1,
+
 /// The foreground and background color for search matches. This only applies
 /// to non-focused search matches, also known as candidate matches.
 ///
@@ -4653,6 +4664,9 @@ pub fn finalize(self: *Config) !void {
 
     // Clamp our split opacity
     self.@"unfocused-split-opacity" = @min(1.0, @max(0.15, self.@"unfocused-split-opacity"));
+
+    // Clamp our split resize limit
+    self.@"split-resize-limit" = @min(0.5, @max(0, self.@"split-resize-limit"));
 
     // Clamp our contrast
     self.@"minimum-contrast" = @min(21, @max(1, self.@"minimum-contrast"));

--- a/src/datastruct/split_tree.zig
+++ b/src/datastruct/split_tree.zig
@@ -833,10 +833,12 @@ pub fn SplitTree(comptime V: type) type {
             from: Node.Handle,
             layout: Split.Layout,
             ratio: f16,
+            min_ratio: f16,
         ) Allocator.Error!Self {
             assert(ratio >= -1 and ratio <= 1);
             assert(!std.math.isNan(ratio));
             assert(!std.math.isInf(ratio));
+            assert(min_ratio >= 0 and min_ratio <= 0.5);
 
             // Fast path empty trees.
             if (self.isEmpty()) return .empty;
@@ -875,10 +877,11 @@ pub fn SplitTree(comptime V: type) type {
                 break :full_ratio current * scale;
             };
 
-            // Set the final new ratio, clamping it to [0, 1]
+            // Set the final new ratio, clamping it to [min_ratio, 1 - min_ratio]
+            const max_ratio: f16 = 1 - min_ratio;
             result.resizeInPlace(
                 parent_handle,
-                @min(@max(full_ratio + ratio, 0), 1),
+                @min(@max(full_ratio + ratio, min_ratio), max_ratio),
             );
             return result;
         }
@@ -2133,6 +2136,7 @@ test "SplitTree: resize" {
             },
             .horizontal, // resize right
             0.25,
+            0, // no min_ratio limit
         );
         defer resized.deinit();
         const str = try std.fmt.allocPrint(alloc, "{f}", .{std.fmt.alt(resized, .formatDiagram)});
@@ -2159,6 +2163,7 @@ test "SplitTree: resize" {
             },
             .horizontal, // resize left
             -0.25,
+            0, // no min_ratio limit
         );
         defer resized.deinit();
         const str = try std.fmt.allocPrint(alloc, "{f}", .{std.fmt.alt(resized, .formatDiagram)});
@@ -2169,6 +2174,74 @@ test "SplitTree: resize" {
             \\+---++-------------+
             \\
         );
+    }
+}
+
+test "SplitTree: resize with min_ratio clamp" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var v1: TestTree.View = .{ .label = "A" };
+    var t1: TestTree = try .init(alloc, &v1);
+    defer t1.deinit();
+    var v2: TestTree.View = .{ .label = "B" };
+    var t2: TestTree = try .init(alloc, &v2);
+    defer t2.deinit();
+
+    // A | B horizontal
+    var split = try t1.split(
+        alloc,
+        .root, // at root
+        .right, // split right
+        0.5,
+        &t2, // insert t2
+    );
+    defer split.deinit();
+
+    // Resize with a large ratio that would exceed min_ratio limit
+    {
+        var resized = try split.resize(
+            alloc,
+            at: {
+                var it = split.iterator();
+                break :at while (it.next()) |entry| {
+                    if (std.mem.eql(u8, entry.view.label, "B")) {
+                        break entry.handle;
+                    }
+                } else return error.NotFound;
+            },
+            .horizontal,
+            0.45, // would push to 0.95 without limit
+            0.2, // min_ratio = 0.2
+        );
+        defer resized.deinit();
+
+        // The ratio should be clamped to 0.8 (1 - min_ratio)
+        const ratio = resized.nodes[TestTree.Node.Handle.root.idx()].split.ratio;
+        try testing.expect(ratio <= 0.8 + 0.001);
+    }
+
+    // Resize in the negative direction with min_ratio limit
+    {
+        var resized = try split.resize(
+            alloc,
+            at: {
+                var it = split.iterator();
+                break :at while (it.next()) |entry| {
+                    if (std.mem.eql(u8, entry.view.label, "B")) {
+                        break entry.handle;
+                    }
+                } else return error.NotFound;
+            },
+            .horizontal,
+            -0.45, // would push to 0.05 without limit
+            0.2, // min_ratio = 0.2
+        );
+        defer resized.deinit();
+
+        // The ratio should be clamped to 0.2 (min_ratio)
+        const ratio = resized.nodes[TestTree.Node.Handle.root.idx()].split.ratio;
+        try testing.expect(ratio >= 0.2 - 0.001);
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `split-resize-limit` config option (`f64`, default `0.1`) to control the minimum ratio a split can occupy during resize
- The previous behavior hardcoded a 0.1–0.9 ratio range (macOS only), preventing splits from being resized beyond a 9:1 ratio
- Setting `split-resize-limit = 0` disables the limit entirely; the value is clamped to 0–0.5

## Changes

- **Config**: New `split-resize-limit` field in `Config.zig` with `finalize()` clamping
- **macOS (keyboard resize)**: `SplitTree.resizing(node:by:in:with:minRatio:)` now accepts the limit
- **macOS (mouse drag)**: `SplitView` clamps the drag ratio to the configured limit
- **GTK**: `split_tree.zig` reads the config and passes it to the Zig data structure's `resize()`
- **Zig data structure**: `split_tree.resize()` accepts a `min_ratio` parameter for cross-platform clamping

## Test plan

- [ ] Zig unit tests: `SplitTree: resize` (existing, updated) and `SplitTree: resize with min_ratio clamp` (new)
- [ ] Swift unit tests: 3 new tests in `SplitTreeTests.swift` — clamp upper bound, clamp lower bound, zero limit allows full range
- [ ] Manual: set `split-resize-limit = 0.05` and verify splits can be resized beyond the previous 9:1 limit
- [ ] Manual: set `split-resize-limit = 0` and verify no resize limit is enforced