### PR TITLE
Add configurable title alignment support for macOS

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -593,6 +593,9 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
             window.titlebarFont = nil
         }
 
+        // Set the title alignment for the window and tab titles.
+        window.windowTitleAlignment = surfaceConfig.windowTitleAlignment
+
         // Call this last in case it uses any of the properties above.
         window.syncAppearance(surfaceConfig)
         terminalViewContainer?.ghosttyConfigDidChange(ghostty.config, preferredBackgroundColor: window.preferredBackgroundColor)

--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -219,6 +219,11 @@ class TerminalWindow: NSWindow {
             tabBarDidDisappear()
         }
         viewModel.isMainWindow = true
+
+        // Re-sync the title text field in case the titlebar was recreated since
+        // we last set up the KVO observation (e.g. after exiting fullscreen).
+        tab.attributedTitle = attributedTitle
+        syncTitleTextField()
     }
 
     override func resignMain() {
@@ -402,6 +407,8 @@ class TerminalWindow: NSWindow {
             /// Check ``titlebarFont`` down below
             /// to see why we need to check `hasMoreThanOneTabs` here
             titlebarTextField?.usesSingleLineMode = !hasMoreThanOneTabs
+            cachedNeededWidth = nil
+            syncTitleTextField()
         }
     }
 
@@ -418,6 +425,139 @@ class TerminalWindow: NSWindow {
             /// This behaviour is the opposite of what happens in the title bar’s text field, which is quite odd...
             titlebarTextField?.usesSingleLineMode = !hasMoreThanOneTabs
             tab.attributedTitle = attributedTitle
+            cachedNeededWidth = nil
+            syncTitleTextField()
+        }
+    }
+
+    // The configured horizontal alignment for the window title.
+    var windowTitleAlignment: Ghostty.Config.MacOSTitlebarTitleAlignment = .center {
+        didSet {
+            syncTitleTextField()
+        }
+    }
+
+    // Tracks which text field we're currently observing so we can detect when
+    // NSTitlebarView replaces it and set up a new observation.
+    private weak var observedTitleTextField: NSTextField?
+    private var titleTextFieldFrameObservation: NSKeyValueObservation?
+
+    // Guards against infinite recursion: our frame correction triggers the KVO
+    // observer, which would re-enter applyTitleTextFieldFrame endlessly.
+    private var isApplyingTitleFrame = false
+
+    // Cached width needed to display the current title in the current font.
+    // Reset to nil whenever title or titlebarFont changes (see their didSet
+    // observers) so it is recomputed exactly once on the next layout call
+    // rather than on every resize-driven KVO/setFrame callback.
+    private var cachedNeededWidth: CGFloat?
+
+    /// Ensures a KVO observation is live on the current title text field and
+    /// immediately applies the correct frame.
+    ///
+    /// NSTitlebarView re-lays out its subviews asynchronously in response to title
+    /// changes and window resizes, resetting the text field to system-font metrics.
+    /// By observing `frame` with KVO we react to every such reset synchronously
+    /// so the corrected frame is what gets rendered and no flash is visible.
+    private func syncTitleTextField() {
+        guard titlebarFont != nil || windowTitleAlignment != .center else {
+            titleTextFieldFrameObservation?.invalidate()
+            titleTextFieldFrameObservation = nil
+            observedTitleTextField = nil
+            cachedNeededWidth = nil
+            return
+        }
+        guard let tf = titlebarTextField else { return }
+
+        // Re-observe if the text field instance has changed.
+        if tf !== observedTitleTextField {
+            titleTextFieldFrameObservation?.invalidate()
+            titleTextFieldFrameObservation = tf.observe(\.frame, options: [.new]) { [weak self] _, _ in
+                guard let self, !self.isApplyingTitleFrame else { return }
+                self.applyTitleTextFieldFrame()
+            }
+            observedTitleTextField = tf
+        }
+
+        applyTitleTextFieldFrame()
+    }
+
+    private func applyTitleTextFieldFrame() {
+        // Use the cached reference instead of traversing the view hierarchy on
+        // every call; this function fires at up to 120 Hz during window resize.
+        guard let tf = observedTitleTextField, let superview = tf.superview else { return }
+
+        let font = titlebarFont ?? NSFont.titleBarFont(ofSize: NSFont.systemFontSize)
+
+        // Compute the required width at most once per title/font change.
+        // cachedNeededWidth is invalidated in title.didSet and titlebarFont.didSet.
+        let neededWidth: CGFloat
+
+        if let cached = cachedNeededWidth {
+            neededWidth = cached
+        } else {
+            let w = ceil((title as NSString).size(withAttributes: [.font: font]).width) + 8
+            cachedNeededWidth = w
+            neededWidth = w
+        }
+
+        let availableWidth = superview.bounds.width
+        let fieldWidth = min(neededWidth, availableWidth)
+
+        let leadingInset = titlebarLeadingInset(in: superview)
+        let trailingInset = titlebarTrailingInset(in: superview)
+
+        let originX: CGFloat
+
+        switch windowTitleAlignment {
+        case .center:
+            originX = (availableWidth - fieldWidth) / 2
+        case .left:
+            originX = leadingInset
+        case .right:
+            originX = availableWidth - fieldWidth - trailingInset
+        }
+
+        let oldFrame = tf.frame
+        let newFrame = NSRect(x: originX, y: oldFrame.origin.y, width: fieldWidth, height: oldFrame.height)
+
+        guard newFrame != oldFrame else { return }
+
+        isApplyingTitleFrame = true
+        tf.frame = newFrame
+        isApplyingTitleFrame = false
+    }
+
+    /// Returns the safe leading inset (left side) for the title text field within
+    /// the given NSTitlebarView, clearing the traffic light buttons.
+    private func titlebarLeadingInset(in titlebarView: NSView) -> CGFloat {
+        let maxX = titlebarView.subviews
+            .filter { $0 is NSButton && $0.frame.midX < titlebarView.bounds.width / 2 }
+            .map { $0.frame.maxX }
+            .max()
+        return (maxX ?? 0) + 8
+    }
+
+    /// Returns the safe trailing inset (right side) for the title text field within
+    /// the given NSTitlebarView, clearing any right-side accessory buttons.
+    private func titlebarTrailingInset(in titlebarView: NSView) -> CGFloat {
+        let width = titlebarView.bounds.width
+        let minX = titlebarView.subviews
+            .filter { $0 is NSButton && $0.frame.midX > width / 2 }
+            .map { $0.frame.minX }
+            .min()
+        return (minX.map { width - $0 } ?? 0) + 8
+    }
+
+    override func setFrame(_ frameRect: NSRect, display displayFlag: Bool) {
+        super.setFrame(frameRect, display: displayFlag)
+
+        // Belt-and-suspenders for resize: KVO handles the text field frame reset
+        // inside NSTitlebarView's layout pass, but a deferred call ensures we also
+        // catch any layout that fires after the KVO observation window.
+        guard titlebarFont != nil || windowTitleAlignment != .center else { return }
+        DispatchQueue.main.async { [weak self] in
+            self?.applyTitleTextFieldFrame()
         }
     }
 

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -347,6 +347,16 @@ extension Ghostty {
             return String(cString: ptr)
         }
 
+        var windowTitleAlignment: MacOSTitlebarTitleAlignment {
+            let defaultValue = MacOSTitlebarTitleAlignment.default
+            guard let config = self.config else { return defaultValue }
+            var v: UnsafePointer<Int8>?
+            let key = "macos-titlebar-title-alignment"
+            guard ghostty_config_get(config, &v, key, UInt(key.lengthOfBytes(using: .utf8))) else { return defaultValue }
+            guard let ptr = v else { return defaultValue }
+            return MacOSTitlebarTitleAlignment(rawValue: String(cString: ptr)) ?? defaultValue
+        }
+
         var macosWindowButtons: MacOSWindowButtons {
             let defaultValue = MacOSWindowButtons.visible
             guard let config = self.config else { return defaultValue }
@@ -922,5 +932,10 @@ extension Ghostty.Config {
     enum MacOSTitlebarStyle: String {
         static let `default` = MacOSTitlebarStyle.transparent
         case native, transparent, tabs, hidden
+    }
+
+    enum MacOSTitlebarTitleAlignment: String {
+        static let `default` = MacOSTitlebarTitleAlignment.left
+        case left, center, right
     }
 }

--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -1737,6 +1737,7 @@ extension Ghostty {
             let backgroundBlur: Ghostty.Config.BackgroundBlur
             let macosWindowShadow: Bool
             let windowTitleFontFamily: String?
+            let windowTitleAlignment: Ghostty.Config.MacOSTitlebarTitleAlignment
             let windowAppearance: NSAppearance?
             let scrollbar: Ghostty.Config.Scrollbar
 
@@ -1746,6 +1747,7 @@ extension Ghostty {
                 self.backgroundBlur = .disabled
                 self.macosWindowShadow = true
                 self.windowTitleFontFamily = nil
+                self.windowTitleAlignment = .default
                 self.windowAppearance = nil
                 self.scrollbar = .system
             }
@@ -1756,6 +1758,7 @@ extension Ghostty {
                 self.backgroundBlur = config.backgroundBlur
                 self.macosWindowShadow = config.macosWindowShadow
                 self.windowTitleFontFamily = config.windowTitleFontFamily
+                self.windowTitleAlignment = config.windowTitleAlignment
                 self.windowAppearance = .init(ghosttyConfig: config)
                 self.scrollbar = config.scrollbar
             }

--- a/macos/Tests/Ghostty/ConfigTests.swift
+++ b/macos/Tests/Ghostty/ConfigTests.swift
@@ -106,6 +106,21 @@ struct ConfigTests {
         #expect(config.macosTitlebarStyle == expected)
     }
 
+    @Test func macosTitlebarTitleAlignmentDefaultsToLeft() throws {
+        let config = try TemporaryConfig("")
+        #expect(config.windowTitleAlignment == .left)
+    }
+
+    @Test(arguments: [
+        ("left", Ghostty.Config.MacOSTitlebarTitleAlignment.left),
+        ("center", Ghostty.Config.MacOSTitlebarTitleAlignment.center),
+        ("right", Ghostty.Config.MacOSTitlebarTitleAlignment.right),
+    ])
+    func macosTitlebarTitleAlignmentValues(raw: String, expected: Ghostty.Config.MacOSTitlebarTitleAlignment) throws {
+        let config = try TemporaryConfig("macos-titlebar-title-alignment = \(raw)")
+        #expect(config.windowTitleAlignment == expected)
+    }
+
     @Test func resizeOverlayDefaultsToAfterFirst() throws {
         let config = try TemporaryConfig("")
         #expect(config.resizeOverlay == .after_first)

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3238,6 +3238,21 @@ keybind: Keybinds = .{},
 /// Changing this option at runtime only applies to new windows.
 @"macos-titlebar-style": MacTitlebarStyle = .transparent,
 
+/// The horizontal alignment of the title text in the macOS titlebar.
+///
+/// This option only applies to macOS and is ignored on other platforms.
+///
+/// Valid values are:
+///
+///   * `left` - Align the title to the left side of the titlebar.
+///   * `center` - Align the title to the center of the titlebar.
+///   * `right` - Align the title to the right side of the titlebar.
+///
+/// The default value is `left` to match macOS 26 behavior.
+///
+/// Changing this option at runtime will apply to all currently open windows.
+@"macos-titlebar-title-alignment": MacTitlebarTitleAlignment = .left,
+
 /// Whether the proxy icon in the macOS titlebar is visible. The proxy icon
 /// is the icon that represents the folder of the current working directory.
 /// You can see this very clearly in the macOS built-in Terminal.app
@@ -8955,6 +8970,13 @@ pub const MacTitlebarStyle = enum {
 pub const MacTitlebarProxyIcon = enum {
     visible,
     hidden,
+};
+
+/// See macos-titlebar-title-alignment
+pub const MacTitlebarTitleAlignment = enum {
+    left,
+    center,
+    right,
 };
 
 /// See macos-hidden


### PR DESCRIPTION
### Summary
This PR implements a fix for: https://github.com/ghostty-org/ghostty/discussions/9140

This started off initially as an attempt to fix an issue with the titlebar text getting truncated when I used the `window-title-font-family: Operator Mono Book` (similar issue reported previously, and fixed: https://github.com/ghostty-org/ghostty/issues/1692). After digging into it a bit more, I realized I liked the look of a centered title better than the left aligned title.

- Added a new setting `macos-titlebar-title-alignment` with allowed values `left` (default), `center` and `right`.
- Changes to make sure the titlebar title updates correctly on window resize, tab change, etc
- Added test coverage for the new `macos-titlebar-title-alignment` config option

There is still an issue with the titlebar text in full screen being reverted back to a default font. After exiting full screen this default font persists until the tab is switched or closed / recreated. I verified this occurs on the latest tip build, this PR does not attempt to fix it.

### AI Disclosure
I used claude code (Sonnet 4.6) to identify the best place to start when implementing this change, for general Swift questions and to help with the left/center/right alignment functions. All code in this PR was either written by me, or reviewed by me prior to submitting.