### PR TITLE
Add `middle-click-paste` config option

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -310,6 +310,7 @@ const DerivedConfig = struct {
     clipboard_paste_bracketed_safe: bool,
     clipboard_codepoint_map: configpkg.Config.RepeatableClipboardCodepointMap,
     copy_on_select: configpkg.CopyOnSelect,
+    middle_click_paste: configpkg.MiddleClickPaste,
     right_click_action: configpkg.RightClickAction,
     confirm_close_surface: configpkg.ConfirmCloseSurface,
     cursor_click_to_move: bool,
@@ -388,6 +389,7 @@ const DerivedConfig = struct {
             .clipboard_paste_bracketed_safe = config.@"clipboard-paste-bracketed-safe",
             .clipboard_codepoint_map = try config.@"clipboard-codepoint-map".clone(alloc),
             .copy_on_select = config.@"copy-on-select",
+            .middle_click_paste = config.@"middle-click-paste",
             .right_click_action = config.@"right-click-action",
             .confirm_close_surface = config.@"confirm-close-surface",
             .cursor_click_to_move = config.@"cursor-click-to-move",
@@ -4008,11 +4010,17 @@ pub fn mouseButtonCallback(
     }
 
     // Middle-click pastes from our selection clipboard
-    if (button == .middle and action == .press) {
-        const clipboard: apprt.Clipboard = if (self.rt_surface.supportsClipboard(.selection))
-            .selection
-        else
-            .standard;
+    if (button == .middle and action == .press and
+        self.config.middle_click_paste != .false)
+    {
+        const clipboard: apprt.Clipboard = switch (self.config.middle_click_paste) {
+            .false => unreachable,
+            .selection => if (self.rt_surface.supportsClipboard(.selection))
+                .selection
+            else
+                .standard,
+            .clipboard => .standard,
+        };
         _ = try self.startClipboardRequest(clipboard, .{ .paste = {} });
     }
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -22,6 +22,7 @@ pub const ClipboardAccess = Config.ClipboardAccess;
 pub const Command = Config.Command;
 pub const ConfirmCloseSurface = Config.ConfirmCloseSurface;
 pub const CopyOnSelect = Config.CopyOnSelect;
+pub const MiddleClickPaste = Config.MiddleClickPaste;
 pub const RightClickAction = Config.RightClickAction;
 pub const CustomShaderAnimation = Config.CustomShaderAnimation;
 pub const FontSyntheticStyle = Config.FontSyntheticStyle;

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2404,8 +2404,8 @@ keybind: Keybinds = .{},
 /// The value `clipboard` will always copy text to the selection clipboard
 /// as well as the system clipboard.
 ///
-/// Middle-click paste will always use the selection clipboard. Middle-click
-/// paste is always enabled even if this is `false`.
+/// Middle-click paste behavior can be configured with `middle-click-paste`,
+/// including disabling it entirely.
 ///
 /// The default value is true on Linux and macOS.
 @"copy-on-select": CopyOnSelect = switch (builtin.os.tag) {
@@ -2413,6 +2413,18 @@ keybind: Keybinds = .{},
     .macos => .true,
     else => .false,
 },
+
+/// The clipboard to use when pasting with the middle mouse button.
+///
+/// Valid values:
+///   * `selection` - Paste from the selection clipboard. Falls back to
+///     the system clipboard if the selection clipboard is not supported by
+///     the platform.
+///   * `clipboard` - Paste from the system clipboard.
+///   * `false` - Disable middle-click paste entirely.
+///
+/// The default value is `selection`.
+@"middle-click-paste": MiddleClickPaste = .selection,
 
 /// The action to take when the user right-clicks on the terminal surface.
 ///
@@ -8598,6 +8610,19 @@ pub const CopyOnSelect = enum {
 
     /// Copy on select is enabled and goes to both the system clipboard
     /// and the selection clipboard (for Linux).
+    clipboard,
+};
+
+/// Options for middle-click paste clipboard selection.
+pub const MiddleClickPaste = enum {
+    /// Disables middle-click paste entirely.
+    false,
+
+    /// Paste from the selection clipboard. Falls back to the system clipboard
+    /// if the selection clipboard is not supported by the platform.
+    selection,
+
+    /// Paste from the system clipboard.
     clipboard,
 };
 


### PR DESCRIPTION
### Summary
This PR implements a fix for: https://github.com/ghostty-org/ghostty/discussions/9788 and https://github.com/ghostty-org/ghostty/discussions/12108

- Added a new setting `middle-click-paste` to control which clipboard is used when pasting.
  - `selection` (default) pastes from the selection clipboard, falling back to the system clipboard if needed
  - `clipboard` pastes from the system clipboard
  - `false` disables middle click paste entirely

### AI Disclosure
I used claude code (Sonnet 4.6) to identify the best place to start when implementing this change. All code in this PR was written by me.