### PR TITLE
macOS: fix closing leftmost split visual glitch

### DIFF
--- a/macos/Sources/Ghostty/Surface View/SurfaceView.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView.swift
@@ -621,8 +621,10 @@ extension Ghostty {
         }
 
         func updateOSView(_ scrollView: SurfaceScrollView, context: Context) {
-            // Nothing to do: SwiftUI automatically updates the frame size, and
-            // SurfaceScrollView handles the rest in response to that
+            // Trigger layout to ensure PTY dimensions are synchronized after
+            // structural changes (e.g., closing a split).
+            // See: https://github.com/ghostty-org/ghostty/issues/7546
+            scrollView.needsLayout = true
         }
         #else
         func makeOSView(context: Context) -> SurfaceView {


### PR DESCRIPTION
Ensure PTY dimensions update after split changes on macOS Tahoe.

Tahoe defers NSSplitView layout propagation, causing stale PTY sizes. Force layout via `needsLayout = true`.

Discussion: #12098
Related: #10883

---
AI Disclosure: Used Claude Code for testing and PR preparation.