### PR TITLE
font: validate family match when discovering fonts

### DIFF
--- a/src/font/SharedGridSet.zig
+++ b/src/font/SharedGridSet.zig
@@ -191,10 +191,41 @@ fn collection(
         inline for (@typeInfo(Style).@"enum".fields) |field| {
             const style = @field(Style, field.name);
             for (key.descriptorsForStyle(style)) |desc| {
+                var found = false;
+
                 {
                     var disco_it = try disco.discover(self.alloc, desc);
                     defer disco_it.deinit();
-                    if (try disco_it.next()) |face| {
+
+                    // Iterate through results until we find one with matching family.
+                    // This is needed because fontconfig may return fonts with
+                    // different families when spacing=mono is in the pattern.
+                    while (try disco_it.next()) |face| {
+                        // Check if the returned font family matches what we requested.
+                        // If not, continue to the next result in the sorted list.
+                        if (!disco_it.familyMatches(&face)) {
+                            if (face.fc) |fc| {
+                                if (fc.pattern.get(.family, 0)) |family_result| {
+                                    log.warn("font {s} family mismatch: requested {s}, got {s}", .{
+                                        field.name,
+                                        desc.family.?,
+                                        family_result.string,
+                                    });
+                                } else |_| {
+                                    log.warn("font {s} family mismatch: requested {s}, got (unknown)", .{
+                                        field.name,
+                                        desc.family.?,
+                                    });
+                                }
+                            } else {
+                                log.warn("font {s} family mismatch: requested {s}, got (unknown)", .{
+                                    field.name,
+                                    desc.family.?,
+                                });
+                            }
+                            continue;
+                        }
+
                         log.info("font {s}: {s}", .{
                             field.name,
                             try face.name(&name_buf),
@@ -207,9 +238,13 @@ fn collection(
                             .size_adjustment = .none,
                         });
 
-                        continue;
+                        found = true;
+                        break; // Found matching font, exit the while loop
                     }
                 }
+
+                // If we found a font, continue to the next descriptor
+                if (found) continue;
 
                 // If there are variation configurations and we didn't find
                 // the font, then we retry the discovery with all stylistic
@@ -225,7 +260,12 @@ fn collection(
                         break :desc copy;
                     });
                     defer disco_it.deinit();
-                    if (try disco_it.next()) |face| {
+
+                    while (try disco_it.next()) |face| {
+                        if (!disco_it.familyMatches(&face)) {
+                            continue;
+                        }
+
                         log.info("font {s}: {s}", .{
                             field.name,
                             try face.name(&name_buf),
@@ -238,8 +278,11 @@ fn collection(
                             .size_adjustment = .none,
                         });
 
-                        continue;
+                        found = true;
+                        break;
                     }
+
+                    if (found) continue;
                 }
 
                 log.warn("font-family {s} not found: {s}", .{

--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -278,6 +278,7 @@ pub const Fontconfig = struct {
             .set = res.fs,
             .fonts = res.fs.fonts(),
             .variations = desc.variations,
+            .requested_family = desc.family,
             .i = 0,
         };
     }
@@ -298,12 +299,53 @@ pub const Fontconfig = struct {
         set: *fontconfig.FontSet,
         fonts: []*fontconfig.Pattern,
         variations: []const Variation,
+        requested_family: ?[:0]const u8 = null,
         i: usize,
 
         pub fn deinit(self: *DiscoverIterator) void {
             self.set.destroy();
             self.pattern.destroy();
             self.* = undefined;
+        }
+
+        /// Check if the discovered font matches the requested family.
+        /// This is needed because fontconfig may return a font with a
+        /// different family when spacing=mono is added to the pattern.
+        pub fn familyMatches(self: *DiscoverIterator, face: *const DeferredFace) bool {
+            if (self.requested_family == null) return true;
+
+            const fc = face.fc orelse return false;
+            const pattern = fc.pattern;
+            const requested = self.requested_family.?;
+
+            // Fontconfig patterns can have multiple family names (e.g.,
+            // localized names). We check all of them for a match.
+            var i: u32 = 0;
+            while (pattern.get(.family, i)) |family_result| {
+                const family = family_result.string;
+
+                // Exact match
+                if (std.mem.eql(u8, requested, family)) {
+                    return true;
+                }
+
+                // Prefix match: requested family is a prefix of the returned family.
+                // This handles cases like "Monaspace Argon" matching "Monaspace Argon Var"
+                // (variable fonts often have "Var" appended to the family name).
+                if (std.mem.startsWith(u8, family, requested)) {
+                    return true;
+                }
+
+                // Also check reverse: returned family is a prefix of requested.
+                // This handles cases where fontconfig returns a shorter family name.
+                if (std.mem.startsWith(u8, requested, family)) {
+                    return true;
+                }
+
+                i += 1;
+            } else |_| {}
+
+            return false;
         }
 
         pub fn next(self: *DiscoverIterator) fontconfig.Error!?DeferredFace {
@@ -371,6 +413,7 @@ pub const CoreText = struct {
             .alloc = alloc,
             .list = zig_list,
             .variations = desc.variations,
+            .requested_family = desc.family,
             .i = 0,
         };
     }
@@ -408,6 +451,7 @@ pub const CoreText = struct {
                 .alloc = alloc,
                 .list = list,
                 .variations = desc.variations,
+                .requested_family = desc.family,
                 .i = 0,
             };
         }
@@ -432,6 +476,7 @@ pub const CoreText = struct {
                 .alloc = alloc,
                 .list = list,
                 .variations = desc.variations,
+                .requested_family = desc.family,
                 .i = 0,
             };
         }
@@ -827,6 +872,7 @@ pub const CoreText = struct {
         alloc: Allocator,
         list: []const *macos.text.FontDescriptor,
         variations: []const Variation,
+        requested_family: ?[:0]const u8 = null,
         i: usize,
 
         pub fn deinit(self: *DiscoverIterator) void {
@@ -835,6 +881,44 @@ pub const CoreText = struct {
             }
             self.alloc.free(self.list);
             self.* = undefined;
+        }
+
+        /// Check if the discovered font matches the requested family.
+        /// This is needed because fontconfig may return a font with a
+        /// different family when spacing=mono is added to the pattern.
+        /// For CoreText, we check the family name of the font.
+        pub fn familyMatches(self: *DiscoverIterator, face: *const DeferredFace) bool {
+            if (self.requested_family == null) return true;
+
+            const ct = face.ct orelse return false;
+            const font = ct.font;
+            const requested = self.requested_family.?;
+
+            // Get the family name from the font
+            const family_name = font.copyFamilyName();
+            defer family_name.release();
+
+            // Get the family string
+            const family_str = family_name.cstringPtr(.utf8) orelse return false;
+
+            // Exact match
+            if (std.mem.eql(u8, requested, family_str)) {
+                return true;
+            }
+
+            // Prefix match: requested family is a prefix of the returned family.
+            // This handles cases like "Monaspace Argon" matching "Monaspace Argon Var"
+            // (variable fonts often have "Var" appended to the family name).
+            if (std.mem.startsWith(u8, family_str, requested)) {
+                return true;
+            }
+
+            // Also check reverse: returned family is a prefix of requested.
+            if (std.mem.startsWith(u8, requested, family_str)) {
+                return true;
+            }
+
+            return false;
         }
 
         pub fn next(self: *DiscoverIterator) !?DeferredFace {


### PR DESCRIPTION
## Summary

When using fontconfig with `spacing=mono` constraint, fontconfig may return fonts with a different family than requested. This happens because fontconfig prioritizes the spacing constraint over exact family matching.

For example:
```bash
$ fc-match "Monaspace Xenon:spacing=100"
Monaspace Argon Var Regular.ttf  # Wrong! Should return Xenon
```

This breaks user's font fallback chain configuration like:
```
font-family-italic = Monaspace Xenon
font-family-italic = LXGW WenKai Mono
font-family-italic = Symbols Nerd Font
```

Instead of using Xenon, Ghostty would incorrectly use Argon for italic text.

## Solution

This PR adds family validation in `DiscoverIterator`:

1. Store the requested family name in the iterator
2. Add `familyMatches()` method to check returned font's family
3. Iterate through fontconfig results until finding a matching family
4. Support multiple family aliases (localized names like Chinese "霞鹜文楷等宽" = "LXGW WenKai Mono")
5. Use prefix matching for variable fonts (e.g., "Monaspace Argon" matches "Monaspace Argon Var")

## Changes

- `src/font/discovery.zig`: Add `requested_family` field and `familyMatches()` method to both Fontconfig and CoreText `DiscoverIterator`
- `src/font/SharedGridSet.zig`: Iterate through discovery results and skip fonts with mismatched family

## Testing

Before fix:
```
font italic: Monaspace Argon Var Regular  # Wrong
```

After fix:
```
font italic: Monaspace Xenon Regular      # Correct
font italic: LXGW WenKai Mono             # Fallback works
font italic: Symbols Nerd Font            # Fallback works
```

## Notes

- CoreText backend also updated to maintain cross-platform compatibility
- Prefix matching handles variable font naming convention (family name with "Var" suffix)
- The fix preserves fontconfig's sorted result order, just adds validation