### PR TITLE
core: expose parent surface ID as GHOSTTY_SURFACE_PARENT_ID

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -414,6 +414,7 @@ pub const Surface = struct {
     size: apprt.SurfaceSize,
     cursor_pos: apprt.CursorPos,
     inspector: ?*Inspector = null,
+    parent_surface_id: u64 = 0,
 
     /// The current title of the surface. The embedded apprt saves this so
     /// that getTitle works without the implementer needing to save it.
@@ -460,6 +461,10 @@ pub const Surface = struct {
 
         /// Context for the new surface
         context: apprt.surface.NewSurfaceContext = .window,
+
+        /// The surface ID of the parent surface that this surface was
+        /// created from (e.g. via a split or tab). Zero means no parent.
+        parent_surface_id: u64 = 0,
     };
 
     pub fn init(self: *Surface, app: *App, opts: Options) !void {
@@ -474,6 +479,7 @@ pub const Surface = struct {
             },
             .size = .{ .width = 800, .height = 600 },
             .cursor_pos = .{ .x = -1, .y = -1 },
+            .parent_surface_id = opts.parent_surface_id,
         };
 
         // Add ourselves to the list of surfaces on the app.
@@ -945,6 +951,7 @@ pub const Surface = struct {
             .font_size = font_size,
             .working_directory = working_directory,
             .context = context,
+            .parent_surface_id = self.core_surface.id,
         };
     }
 
@@ -974,6 +981,17 @@ pub const Surface = struct {
             // the desktop then we didn't set our LANGUAGE var so we
             // don't need to remove it.
             if (internal_os.launchedFromDesktop()) env.remove("LANGUAGE");
+        }
+
+        // If this surface was created from a parent (split, tab), expose
+        // the parent's surface ID so child processes can find their
+        // sibling surfaces.
+        if (self.parent_surface_id != 0) {
+            var buf: [18]u8 = undefined;
+            try env.put(
+                "GHOSTTY_SURFACE_PARENT_ID",
+                std.fmt.bufPrint(&buf, "0x{x:0>16}", .{self.parent_surface_id}) catch unreachable,
+            );
         }
 
         return env;

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -692,6 +692,10 @@ pub const Surface = extern struct {
         /// The context for this surface (window, tab, or split)
         context: apprt.surface.NewSurfaceContext = .window,
 
+        /// The surface ID of the parent surface that this surface was
+        /// created from (e.g. via a split or tab). Zero means no parent.
+        parent_surface_id: u64 = 0,
+
         /// Whether primary paste (middle-click paste) is enabled.
         gtk_enable_primary_paste: bool = true,
 
@@ -766,6 +770,10 @@ pub const Surface = extern struct {
 
         // Store the context so initSurface can use it
         priv.context = context;
+
+        // Store the parent surface ID so we can expose it as an
+        // environment variable to the child process.
+        priv.parent_surface_id = parent.id;
 
         // Setup our font size
         const font_size_ptr = glib.ext.create(font.face.DesiredSize);
@@ -1607,6 +1615,18 @@ pub const Surface = extern struct {
             if (window.isQuickTerminal()) {
                 try env.put("GHOSTTY_QUICK_TERMINAL", "1");
             }
+        }
+
+        // If this surface was created from a parent (split, tab), expose
+        // the parent's surface ID so child processes can find their
+        // sibling surfaces.
+        const parent_id = self.private().parent_surface_id;
+        if (parent_id != 0) {
+            var buf: [18]u8 = undefined;
+            try env.put(
+                "GHOSTTY_SURFACE_PARENT_ID",
+                std.fmt.bufPrint(&buf, "0x{x:0>16}", .{parent_id}) catch unreachable,
+            );
         }
 
         return env;


### PR DESCRIPTION
## Summary

When a surface is created from a parent (via split or tab), this exposes the parent's surface ID as the `GHOSTTY_SURFACE_PARENT_ID` environment variable to child processes.

## Motivation

With `GHOSTTY_SURFACE_ID` (added in #12027), each surface has a unique identity. However, when splitting a pane, the new shell has no way to know which surface it was split from.

A concrete use case: a shell wrapper for [lazygit](https://github.com/jesseduffield/lazygit) that sets `LAZYGIT_NEW_DIR_FILE=/tmp/lazygit-newdir-$GHOSTTY_SURFACE_ID`. When lazygit navigates to a different repo, it writes the path to that file. A new split pane can then read `GHOSTTY_SURFACE_PARENT_ID`, look up `/tmp/lazygit-newdir-<parent-id>`, and `cd` there automatically -- landing in the same repo lazygit is browsing without lazygit needing to exit.

Without `GHOSTTY_SURFACE_PARENT_ID`, there's no reliable way for the new shell to find the correct file, especially when multiple Ghostty instances are running.

## Implementation

- **GTK apprt**: stores the parent's `id` in the surface's private data during `setParent`, then includes it in `defaultTermioEnv()`.
- **Embedded apprt** (macOS): adds `parent_surface_id` to `Options`, populates it in `newSurfaceOptions()`, stores it on the `Surface`, and includes it in `defaultTermioEnv()`.

The env var uses the same hex format as `GHOSTTY_SURFACE_ID` (`0x` + 16 hex digits). It is only set when a parent exists (not for the initial window).