### PR TITLE
Added support for macOS Material background effects and improved focus state and titlebar display logic

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -610,7 +610,7 @@ class QuickTerminalController: BaseTerminalController {
 
         // If we have window transparency then set it transparent. Otherwise set it opaque.
         // Also check if the user has overridden transparency to be fully opaque.
-        if !isBackgroundOpaque && (self.derivedConfig.backgroundOpacity < 1 || derivedConfig.backgroundBlur.isGlassStyle) {
+        if !isBackgroundOpaque && (self.derivedConfig.backgroundOpacity < 1 || derivedConfig.backgroundBlur.isSpecialStyle) {
             window.isOpaque = false
 
             // This is weird, but we don't use ".clear" because this creates a look that
@@ -618,7 +618,7 @@ class QuickTerminalController: BaseTerminalController {
             // Terminal.app more easily.
             window.backgroundColor = .white.withAlphaComponent(0.001)
 
-            if !derivedConfig.backgroundBlur.isGlassStyle {
+            if !derivedConfig.backgroundBlur.isSpecialStyle {
                 ghostty_set_window_background_blur(ghostty.app, Unmanaged.passUnretained(window).toOpaque())
             }
         } else {

--- a/macos/Sources/Features/Terminal/TerminalViewContainer.swift
+++ b/macos/Sources/Features/Terminal/TerminalViewContainer.swift
@@ -90,6 +90,114 @@ extension BaseTerminalController {
     }
 }
 
+enum TerminalMaterialStyle: Equatable {
+    case regular
+    case thick
+    case thin
+    case ultraThin
+    case ultraThick
+
+    var shapeStyle: AnyShapeStyle {
+        switch self {
+        case .regular:
+            return AnyShapeStyle(.regularMaterial)
+        case .thick:
+            return AnyShapeStyle(.thickMaterial)
+        case .thin:
+            return AnyShapeStyle(.thinMaterial)
+        case .ultraThin:
+            return AnyShapeStyle(.ultraThinMaterial)
+        case .ultraThick:
+            return AnyShapeStyle(.ultraThickMaterial)
+        }
+    }
+}
+
+private class TerminalMaterialView: NSView {
+    private struct MaterialBackground: View {
+        let style: TerminalMaterialStyle
+        let cornerRadius: CGFloat
+
+        var body: some View {
+            Rectangle()
+                .fill(style.shapeStyle)
+                .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+        }
+    }
+
+    private let hostingView: NSHostingView<MaterialBackground>
+    private let tintOverlay: NSView
+
+    init() {
+        self.hostingView = NSHostingView(rootView: .init(style: .regular, cornerRadius: 0))
+        self.tintOverlay = NSView()
+        super.init(frame: .zero)
+
+        translatesAutoresizingMaskIntoConstraints = false
+        wantsLayer = true
+
+        hostingView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(hostingView)
+        NSLayoutConstraint.activate([
+            hostingView.topAnchor.constraint(equalTo: topAnchor),
+            hostingView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            hostingView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            hostingView.trailingAnchor.constraint(equalTo: trailingAnchor),
+        ])
+
+        tintOverlay.translatesAutoresizingMaskIntoConstraints = false
+        tintOverlay.wantsLayer = true
+        addSubview(tintOverlay)
+        NSLayoutConstraint.activate([
+            tintOverlay.topAnchor.constraint(equalTo: topAnchor),
+            tintOverlay.leadingAnchor.constraint(equalTo: leadingAnchor),
+            tintOverlay.bottomAnchor.constraint(equalTo: bottomAnchor),
+            tintOverlay.trailingAnchor.constraint(equalTo: trailingAnchor),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(
+        style: TerminalMaterialStyle,
+        backgroundColor: NSColor,
+        backgroundOpacity: Double,
+        cornerRadius: CGFloat?,
+        isKeyWindow: Bool
+    ) {
+        let radius = cornerRadius ?? 0
+        hostingView.rootView = .init(style: style, cornerRadius: radius)
+
+        wantsLayer = true
+        layer?.cornerRadius = radius
+        layer?.masksToBounds = true
+
+        tintOverlay.layer?.backgroundColor = backgroundColor.withAlphaComponent(backgroundOpacity).cgColor
+        updateKeyStatus(isKeyWindow, backgroundColor: backgroundColor)
+    }
+
+    func updateKeyStatus(_ isKeyWindow: Bool, backgroundColor: NSColor) {
+        let tint = tintProperties(for: backgroundColor)
+        if isKeyWindow {
+            // Keep material visible while focused; use overlay only for unfocused tinting.
+            tintOverlay.alphaValue = 0
+        } else {
+            tintOverlay.layer?.backgroundColor = tint.color.cgColor
+            tintOverlay.alphaValue = max(tint.opacity, 0.35)
+        }
+    }
+
+    private func tintProperties(for color: NSColor) -> (color: NSColor, opacity: CGFloat) {
+        let isLight = color.isLightColor
+        let vibrant = color.adjustingSaturation(by: 1.2)
+        let overlayOpacity: CGFloat = isLight ? 0.35 : 0.85
+        return (vibrant, overlayOpacity)
+    }
+}
+
 // MARK: Glass
 
 /// An `NSView` that contains a liquid glass background effect and
@@ -203,24 +311,64 @@ extension TerminalViewContainer {
     }
 #endif // compiler(>=6.2)
 
+    @available(macOS 12.0, *)
+    private func addMaterialEffectViewIfNeeded() -> TerminalMaterialView {
+        if let existed = glassEffectView as? TerminalMaterialView {
+            return existed
+        }
+
+        glassEffectView?.removeFromSuperview()
+        let effectView = TerminalMaterialView()
+        addSubview(effectView, positioned: .below, relativeTo: terminalView)
+        NSLayoutConstraint.activate([
+            effectView.topAnchor.constraint(equalTo: topAnchor),
+            effectView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            effectView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            effectView.trailingAnchor.constraint(equalTo: trailingAnchor),
+        ])
+        glassEffectView = effectView
+        return effectView
+    }
+
     private func updateGlassEffectIfNeeded() {
 #if compiler(>=6.2)
-        guard #available(macOS 26.0, *), let derivedConfig else {
+        guard let derivedConfig else {
             glassEffectView?.removeFromSuperview()
             glassEffectView = nil
             return
         }
-        guard let effectView = addGlassEffectViewIfNeeded() else {
-            return
-        }
 
-        effectView.configure(
-            style: derivedConfig.style.official,
-            backgroundColor: derivedConfig.backgroundColor,
-            backgroundOpacity: derivedConfig.backgroundOpacity,
-            cornerRadius: derivedConfig.cornerRadius,
-            isKeyWindow: window?.isKeyWindow ?? true
-        )
+        switch derivedConfig.style {
+        case .glass(let style):
+            guard #available(macOS 26.0, *), let effectView = addGlassEffectViewIfNeeded() else {
+                glassEffectView?.removeFromSuperview()
+                glassEffectView = nil
+                return
+            }
+
+            effectView.configure(
+                style: style.official,
+                backgroundColor: derivedConfig.backgroundColor,
+                backgroundOpacity: derivedConfig.backgroundOpacity,
+                cornerRadius: derivedConfig.cornerRadius,
+                isKeyWindow: window?.isKeyWindow ?? true
+            )
+
+        case .material(let style):
+            if #available(macOS 12.0, *) {
+                let effectView = addMaterialEffectViewIfNeeded()
+                effectView.configure(
+                    style: style,
+                    backgroundColor: derivedConfig.backgroundColor,
+                    backgroundOpacity: derivedConfig.backgroundOpacity,
+                    cornerRadius: derivedConfig.cornerRadius,
+                    isKeyWindow: window?.isKeyWindow ?? true
+                )
+            } else {
+                glassEffectView?.removeFromSuperview()
+                glassEffectView = nil
+            }
+        }
 #endif // compiler(>=6.2)
     }
 
@@ -244,6 +392,11 @@ extension TerminalViewContainer {
             let effectView = glassEffectView as? TerminalGlassView,
             let derivedConfig
         else {
+            if #available(macOS 12.0, *),
+               let materialView = glassEffectView as? TerminalMaterialView,
+               let derivedConfig {
+                materialView.updateKeyStatus(isKeyWindow, backgroundColor: derivedConfig.backgroundColor)
+            }
             return
         }
         effectView.updateKeyStatus(isKeyWindow, backgroundColor: derivedConfig.backgroundColor)
@@ -251,7 +404,12 @@ extension TerminalViewContainer {
     }
 
     struct DerivedConfig: Equatable {
-        let style: BackportNSGlassStyle
+        enum Style: Equatable {
+            case glass(BackportNSGlassStyle)
+            case material(TerminalMaterialStyle)
+        }
+
+        let style: Style
         let backgroundColor: NSColor
         let backgroundOpacity: Double
         let cornerRadius: CGFloat?
@@ -259,9 +417,24 @@ extension TerminalViewContainer {
         init?(config: Ghostty.Config, preferredBackgroundColor: NSColor?, cornerRadius: CGFloat?) {
             switch config.backgroundBlur {
             case .macosGlassRegular:
-                style = .regular
+                style = .glass(.regular)
             case .macosGlassClear:
-                style = .clear
+                style = .glass(.clear)
+            case .macosMaterialRegular:
+                guard #available(macOS 12.0, *) else { return nil }
+                style = .material(.regular)
+            case .macosMaterialThick:
+                guard #available(macOS 12.0, *) else { return nil }
+                style = .material(.thick)
+            case .macosMaterialThin:
+                guard #available(macOS 12.0, *) else { return nil }
+                style = .material(.thin)
+            case .macosMaterialUltraThin:
+                guard #available(macOS 12.0, *) else { return nil }
+                style = .material(.ultraThin)
+            case .macosMaterialUltraThick:
+                guard #available(macOS 12.0, *) else { return nil }
+                style = .material(.ultraThick)
             default:
                 return nil
             }

--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -483,7 +483,7 @@ class TerminalWindow: NSWindow {
         let forceOpaque = terminalController?.isBackgroundOpaque ?? false
         if !styleMask.contains(.fullScreen) &&
             !forceOpaque &&
-            (surfaceConfig.backgroundOpacity < 1 || surfaceConfig.backgroundBlur.isGlassStyle) {
+            (surfaceConfig.backgroundOpacity < 1 || surfaceConfig.backgroundBlur.isSpecialStyle) {
             isOpaque = false
 
             // This is weird, but we don't use ".clear" because this creates a look that
@@ -491,8 +491,8 @@ class TerminalWindow: NSWindow {
             // Terminal.app more easily.
             backgroundColor = .white.withAlphaComponent(0.001)
 
-            // We don't need to set blur when using glass
-            if !surfaceConfig.backgroundBlur.isGlassStyle, let appDelegate = NSApp.delegate as? AppDelegate {
+            // We don't need to set blur when using platform effect styles.
+            if !surfaceConfig.backgroundBlur.isSpecialStyle, let appDelegate = NSApp.delegate as? AppDelegate {
                 ghostty_set_window_background_blur(
                     appDelegate.ghostty.app,
                     Unmanaged.passUnretained(self).toOpaque())

--- a/macos/Sources/Features/Terminal/Window Styles/TransparentTitlebarTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TransparentTitlebarTerminalWindow.swift
@@ -89,15 +89,21 @@ class TransparentTitlebarTerminalWindow: TerminalWindow {
         if let titlebarView = titlebarContainer?.firstDescendant(withClassName: "NSTitlebarView") {
             titlebarView.wantsLayer = true
 
-            // For glass background styles, use a transparent titlebar to let the glass effect show through
-            // Only apply this for transparent and tabs titlebar styles
-            let isGlassStyle = derivedConfig.backgroundBlur.isGlassStyle
+            // For glass styles, use a transparent titlebar to let the effect show through.
+            // For material styles, force an opaque titlebar color to keep title area solid.
+            // Only apply this behavior for transparent and tabs titlebar styles.
+            let isGlassStyle = surfaceConfig.backgroundBlur.isGlassStyle
+            let isMaterialStyle = surfaceConfig.backgroundBlur.isMaterialStyle
             let isTransparentTitlebar = derivedConfig.macosTitlebarStyle == .transparent ||
             derivedConfig.macosTitlebarStyle == .tabs
 
-            titlebarView.layer?.backgroundColor = (isGlassStyle && isTransparentTitlebar)
-                ? NSColor.clear.cgColor
-                : preferredBackgroundColor?.cgColor
+            titlebarView.layer?.backgroundColor = if isTransparentTitlebar && isGlassStyle {
+                NSColor.clear.cgColor
+            } else if isTransparentTitlebar && isMaterialStyle {
+                preferredBackgroundColor?.withAlphaComponent(1).cgColor
+            } else {
+                preferredBackgroundColor?.cgColor
+            }
         }
 
         // In all cases, we have to hide the background view since this has multiple subviews
@@ -111,7 +117,12 @@ class TransparentTitlebarTerminalWindow: TerminalWindow {
 
         // Setup the titlebar background color to match ours
         titlebarContainer.wantsLayer = true
-        titlebarContainer.layer?.backgroundColor = preferredBackgroundColor?.cgColor
+        let titlebarColor = if surfaceConfig.backgroundBlur.isMaterialStyle {
+            preferredBackgroundColor?.withAlphaComponent(1)
+        } else {
+            preferredBackgroundColor
+        }
+        titlebarContainer.layer?.backgroundColor = titlebarColor?.cgColor
 
         // See the docs for the function that sets this to true on why
         effectViewIsHidden = false

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -751,12 +751,17 @@ extension Ghostty.Config {
 
     /// Background blur configuration that maps from the C API values.
     /// Positive values represent blur radius, special negative values
-    /// represent macOS-specific glass effects.
+    /// represent macOS-specific glass or material effects.
     enum BackgroundBlur: Equatable {
         case disabled
         case radius(Int)
         case macosGlassRegular
         case macosGlassClear
+        case macosMaterialRegular
+        case macosMaterialThick
+        case macosMaterialThin
+        case macosMaterialUltraThin
+        case macosMaterialUltraThick
 
         init(fromCValue value: Int16) {
             switch value {
@@ -774,6 +779,16 @@ extension Ghostty.Config {
                 } else {
                     self = .disabled
                 }
+            case -3:
+                self = .macosMaterialRegular
+            case -4:
+                self = .macosMaterialThick
+            case -5:
+                self = .macosMaterialThin
+            case -6:
+                self = .macosMaterialUltraThin
+            case -7:
+                self = .macosMaterialUltraThick
             default:
                 self = .radius(Int(value))
             }
@@ -798,6 +813,25 @@ extension Ghostty.Config {
             }
         }
 
+        /// Returns true if this is one of the SwiftUI material styles.
+        var isMaterialStyle: Bool {
+            switch self {
+            case .macosMaterialRegular,
+                    .macosMaterialThick,
+                    .macosMaterialThin,
+                    .macosMaterialUltraThin,
+                    .macosMaterialUltraThick:
+                return true
+            default:
+                return false
+            }
+        }
+
+        /// Returns true if this uses a platform-provided macOS background effect.
+        var isSpecialStyle: Bool {
+            isGlassStyle || isMaterialStyle
+        }
+
         /// Returns the blur radius if applicable, nil for glass effects.
         var radius: Int? {
             switch self {
@@ -805,7 +839,13 @@ extension Ghostty.Config {
                 return nil
             case .radius(let r):
                 return r
-            case .macosGlassRegular, .macosGlassClear:
+            case .macosGlassRegular,
+                    .macosGlassClear,
+                    .macosMaterialRegular,
+                    .macosMaterialThick,
+                    .macosMaterialThin,
+                    .macosMaterialUltraThin,
+                    .macosMaterialUltraThick:
                 return nil
             }
         }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1032,6 +1032,13 @@ palette: Palette = .{},
 ///
 ///   * `macos-glass-regular` - Standard glass effect with some opacity
 ///   * `macos-glass-clear` - Highly transparent glass effect
+/// On macOS 12.0 and later, there are additional special values that
+/// can be set to use the native macOS material effects:
+///   * `macos-material-regular` - SwiftUI `regularMaterial`
+///   * `macos-material-thick` - SwiftUI `thickMaterial`
+///   * `macos-material-thin` - SwiftUI `thinMaterial`
+///   * `macos-material-ultrathin` - SwiftUI `ultraThinMaterial`
+///   * `macos-material-ultrathick` - SwiftUI `ultraThickMaterial`
 ///
 /// If the macOS values are set, then this implies `background-blur = true`
 /// on non-macOS platforms.
@@ -9624,6 +9631,11 @@ pub const BackgroundBlur = union(enum) {
     true,
     @"macos-glass-regular",
     @"macos-glass-clear",
+    @"macos-material-regular",
+    @"macos-material-thick",
+    @"macos-material-thin",
+    @"macos-material-ultrathin",
+    @"macos-material-ultrathick",
     radius: u8,
 
     pub fn parseCLI(self: *BackgroundBlur, input: ?[]const u8) !void {
@@ -9643,19 +9655,48 @@ pub const BackgroundBlur = union(enum) {
         if (std.meta.stringToEnum(
             std.meta.Tag(BackgroundBlur),
             input_,
-        )) |v| switch (v) {
-            inline else => |tag| tag: {
-                // We can only parse void types
-                const info = std.meta.fieldInfo(BackgroundBlur, tag);
-                if (info.type != void) break :tag;
-                self.* = @unionInit(
-                    BackgroundBlur,
-                    @tagName(tag),
-                    {},
-                );
-                return;
-            },
-        };
+        )) |v| {
+            switch (v) {
+                .false => {
+                    self.* = .false;
+                    return;
+                },
+                .true => {
+                    self.* = .true;
+                    return;
+                },
+                .@"macos-glass-regular" => {
+                    self.* = .@"macos-glass-regular";
+                    return;
+                },
+                .@"macos-glass-clear" => {
+                    self.* = .@"macos-glass-clear";
+                    return;
+                },
+                .@"macos-material-regular" => {
+                    self.* = .@"macos-material-regular";
+                    return;
+                },
+                .@"macos-material-thick" => {
+                    self.* = .@"macos-material-thick";
+                    return;
+                },
+                .@"macos-material-thin" => {
+                    self.* = .@"macos-material-thin";
+                    return;
+                },
+                .@"macos-material-ultrathin" => {
+                    self.* = .@"macos-material-ultrathin";
+                    return;
+                },
+                .@"macos-material-ultrathick" => {
+                    self.* = .@"macos-material-ultrathick";
+                    return;
+                },
+
+                .radius => {},
+            }
+        }
 
         self.* = .{ .radius = std.fmt.parseInt(
             u8,
@@ -9673,7 +9714,14 @@ pub const BackgroundBlur = union(enum) {
             // We treat these as true because they both imply some blur!
             // This has the effect of making the standard blur happen on
             // Linux.
-            .@"macos-glass-regular", .@"macos-glass-clear" => true,
+            .@"macos-glass-regular",
+            .@"macos-glass-clear",
+            .@"macos-material-regular",
+            .@"macos-material-thick",
+            .@"macos-material-thin",
+            .@"macos-material-ultrathin",
+            .@"macos-material-ultrathick",
+            => true,
         };
     }
 
@@ -9687,6 +9735,11 @@ pub const BackgroundBlur = union(enum) {
             // tagged union if we ever need to.
             .@"macos-glass-regular" => -1,
             .@"macos-glass-clear" => -2,
+            .@"macos-material-regular" => -3,
+            .@"macos-material-thick" => -4,
+            .@"macos-material-thin" => -5,
+            .@"macos-material-ultrathin" => -6,
+            .@"macos-material-ultrathick" => -7,
         };
     }
 
@@ -9700,6 +9753,11 @@ pub const BackgroundBlur = union(enum) {
             .radius => |v| try formatter.formatEntry(u8, v),
             .@"macos-glass-regular" => try formatter.formatEntry([]const u8, "macos-glass-regular"),
             .@"macos-glass-clear" => try formatter.formatEntry([]const u8, "macos-glass-clear"),
+            .@"macos-material-regular" => try formatter.formatEntry([]const u8, "macos-material-regular"),
+            .@"macos-material-thick" => try formatter.formatEntry([]const u8, "macos-material-thick"),
+            .@"macos-material-thin" => try formatter.formatEntry([]const u8, "macos-material-thin"),
+            .@"macos-material-ultrathin" => try formatter.formatEntry([]const u8, "macos-material-ultrathin"),
+            .@"macos-material-ultrathick" => try formatter.formatEntry([]const u8, "macos-material-ultrathick"),
         }
     }
 
@@ -9724,6 +9782,21 @@ pub const BackgroundBlur = union(enum) {
 
         try v.parseCLI("macos-glass-clear");
         try testing.expectEqual(.@"macos-glass-clear", v);
+
+        try v.parseCLI("macos-material-regular");
+        try testing.expectEqual(.@"macos-material-regular", v);
+
+        try v.parseCLI("macos-material-thick");
+        try testing.expectEqual(.@"macos-material-thick", v);
+
+        try v.parseCLI("macos-material-thin");
+        try testing.expectEqual(.@"macos-material-thin", v);
+
+        try v.parseCLI("macos-material-ultrathin");
+        try testing.expectEqual(.@"macos-material-ultrathin", v);
+
+        try v.parseCLI("macos-material-ultrathick");
+        try testing.expectEqual(.@"macos-material-ultrathick", v);
 
         try testing.expectError(error.InvalidValue, v.parseCLI(""));
         try testing.expectError(error.InvalidValue, v.parseCLI("aaaa"));

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1399,6 +1399,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 if (comptime builtin.os.tag == .macos) switch (self.config.background_blur) {
                     .@"macos-glass-regular",
                     .@"macos-glass-clear",
+                    .@"macos-material-regular",
+                    .@"macos-material-thick",
+                    .@"macos-material-thin",
+                    .@"macos-material-ultrathin",
+                    .@"macos-material-ultrathick",
                     => self.uniforms.bg_color[3] = 0,
 
                     else => {},


### PR DESCRIPTION
**This PR was written by me, with AI assistance for translation.**

## Overview of Changes
This update adds **macOS Material style support** to the `background-blur` configuration and unifies the existing macOS background effect code paths.  
In addition to new features, it fixes an issue where Material was being overwritten by a solid color in the focused state, and adjusts the titlebar to behave as intended (opaque) when using Material mode.

## Main Feature Updates
- Added 5 Material values for `background-blur`:
  - macos-material-regular
  - macos-material-thick
  - macos-material-thin
  - macos-material-ultrathin
  - macos-material-ultrathick
- Mapped to corresponding Swift Material types:
  - regularMaterial
  - thickMaterial
  - thinMaterial
  - ultraThinMaterial
  - ultraThickMaterial

## Implementation Details
1. **Zig config layer**:
   - Extended `BackgroundBlur` enum with new values, parsing, enable checks, formatting, and documentation
   - Added sentinel value mapping on the C side (Material uses negative range)
   - Added parsing test coverage
2. **Rendering layer**:
   1. On macOS, treat Material as a platform effect to avoid falling back to old radius-based blur
   2. **Swift config & window layer**:
      1. Added `BackgroundBlur` mapping and type checks for Material
      2. Implemented Material view and integrated it into the terminal background chain
      3. Unified effect mode detection between `TerminalWindow` and `QuickTerminal`
   3. **Transparent titlebar logic updated**:
      1. Glass mode remains transparent
      2. Material mode forces titlebar background opaque for stable readability

## Behavior Summary
- Background behaves more reliably across focus/unfocus when using `macos-material-*`
- Titlebar is opaque in Material mode, eliminating readability issues from transparency
- Clearer separation between Glass and Material behaviors, preventing cross-path interference

## Testing
- Passed Zig targeted tests (BackgroundBlur parsing)
- Passed macOS `xcodebuild test` (unsigned environment)
- Full test suite may still fail due to CodeSign issues in default local signing (unrelated to this PR)

## About AI Usage
Since I am not familiar with **Zig** or **UIKit**, parts of this PR were generated with AI assistance.  
I used **VS Code Copilot Agent** (specifically LLM: GPT-5.3-Codex-Xhigh) for auxiliary programming.

I first completed the concrete values for the `BackgroundBlur` enum in `src/config/Config.zig`,  
then used AI to generate the associated functions and add test cases for unit testing.

Next, I defined the `BackgroundBlur` enum in `macos/Sources/Ghostty/Ghostty.Config.swift`,  
and had the Agent further refine the implementation.

During compilation testing, I noticed the TitleBar styling was inconsistent under MaterialEffect.  
I then used the Agent to fix it by setting the TitleBar to **opaque** in MaterialEffect mode,  
matching the behavior seen in other SwiftUI apps using MaterialEffect.

## Screenshots
<table>
  <thead>
    <tr>
      <th>Config Value</th>
      <th>Light Mode</th>
      <th>Dark Mode</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><code>macos-material-ultrathin</code></td>
      <td><img width="480" alt="macOS 15.7 + macos-material-ultrathin + Light Mode" src="https://github.com/user-attachments/assets/4218a72d-4465-426b-b9e5-1ba6a403f346" /></td>
      <td><img width="480" alt="macOS 15.7 + macos-material-ultrathin + Dark Mode" src="https://github.com/user-attachments/assets/0e992f90-71d7-44b0-93ec-82356856a21c" /></td>
    </tr>
    <tr>
      <td><code>macos-material-thin</code></td>
      <td><img width="480" alt="macOS 15.7 + macos-material-thin + Light Mode" src="https://github.com/user-attachments/assets/b2dd827a-3ff4-4fb1-93eb-8a2446d2a41d" /></td>
      <td><img width="480" alt="macOS 15.7 + macos-material-thin + Dark Mode" src="https://github.com/user-attachments/assets/2beda48f-243a-4590-8871-a38a8b7b321f" /></td>
    </tr>
    <tr>
      <td><code>macos-material-regular</code></td>
      <td><img width="480" alt="macOS 15.7 + macos-material-regular + Light Mode" src="https://github.com/user-attachments/assets/7d0fa211-6c03-4539-ba8d-be236fb98919" /></td>
      <td><img width="480" alt="macOS 15.7 + macos-material-regular + Dark Mode" src="https://github.com/user-attachments/assets/0848cec5-471d-406b-9d20-d1cdf340548f" /></td>
    </tr>
    <tr>
      <td><code>macos-material-thick</code></td>
      <td><img width="480" alt="macOS 15.7 + macos-material-thick + Light Mode" src="https://github.com/user-attachments/assets/05829ed0-a21e-4af0-9d46-6e9466551337" /></td>
      <td><img width="480" alt="macOS 15.7 + macos-material-thick + Dark Mode" src="https://github.com/user-attachments/assets/e7ccd37f-201e-4423-9cdf-ea9626d59bf1" /></td>
    </tr>
    <tr>
      <td><code>macos-material-ultrathick</code></td>
      <td><img width="480" alt="macOS 15.7 + macos-material-ultrathick + Light Mode" src="https://github.com/user-attachments/assets/27f23718-76cd-4add-9965-d1dfd6d03fd6" /></td>
      <td><img width="480" alt="macOS 15.7 + macos-material-ultrathick + Dark Mode" src="https://github.com/user-attachments/assets/e7d02417-f396-4c5c-bdd3-bf6b42587fa6" /></td>
    </tr>
  </tbody>
</table>