### PR TITLE
Add Win32 application runtime for Windows port

### DIFF
--- a/src/apprt.zig
+++ b/src/apprt.zig
@@ -16,6 +16,7 @@ pub const action = @import("apprt/action.zig");
 pub const ipc = @import("apprt/ipc.zig");
 pub const gtk = @import("apprt/gtk.zig");
 pub const none = @import("apprt/none.zig");
+pub const win32 = @import("apprt/win32.zig");
 pub const browser = @import("apprt/browser.zig");
 pub const embedded = @import("apprt/embedded.zig");
 pub const surface = @import("apprt/surface.zig");
@@ -43,6 +44,7 @@ pub const runtime = switch (build_config.artifact) {
     .exe => switch (build_config.app_runtime) {
         .none => none,
         .gtk => gtk,
+        .win32 => win32,
     },
     .lib => embedded,
     .wasm_module => browser,

--- a/src/apprt/runtime.zig
+++ b/src/apprt/runtime.zig
@@ -11,11 +11,17 @@ pub const Runtime = enum {
     /// approach to building the application.
     gtk,
 
+    /// Win32. Native Windows application using the Win32 API with OpenGL
+    /// rendering.
+    win32,
+
     pub fn default(target: std.Target) Runtime {
         return switch (target.os.tag) {
             // The Linux and FreeBSD default is GTK because it is a full
             // featured application.
             .linux, .freebsd => .gtk,
+            // Windows uses the native Win32 API.
+            .windows => .win32,
             // Otherwise, we do NONE so we don't create an exe and we create
             // libghostty. On macOS, Xcode is used to build the app that links
             // to libghostty.

--- a/src/apprt/structs.zig
+++ b/src/apprt/structs.zig
@@ -54,7 +54,7 @@ pub const Clipboard = enum(Backing) {
             .{ .name = "GhosttyApprtClipboard" },
         ),
 
-        .none => void,
+        .none, .win32 => void,
     };
 };
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1,0 +1,8 @@
+// The required comptime API for any apprt.
+pub const App = @import("win32/App.zig");
+pub const Surface = @import("win32/Surface.zig");
+pub const resourcesDir = @import("../os/main.zig").resourcesDir;
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -122,6 +122,8 @@ extern "user32" fn SetWindowTextW(hWnd: HWND, lpString: [*:0]const u16) callconv
 extern "user32" fn GetDpiForWindow(hWnd: HWND) callconv(.winapi) UINT;
 extern "user32" fn SetProcessDpiAwarenessContext(value: isize) callconv(.winapi) BOOL;
 const DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2: isize = -4;
+extern "winmm" fn timeBeginPeriod(uPeriod: UINT) callconv(.winapi) UINT;
+extern "winmm" fn timeEndPeriod(uPeriod: UINT) callconv(.winapi) UINT;
 
 const COMPOSITIONFORM = extern struct {
     dwStyle: DWORD,
@@ -178,6 +180,9 @@ pub fn init(
     // Enable Per-Monitor DPI awareness
     _ = SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
 
+    // Raise timer resolution to 1ms for responsive rendering
+    _ = timeBeginPeriod(1);
+
     // Create the main window
     try self.createWindow();
 
@@ -212,6 +217,7 @@ pub fn run(self: *App) !void {
 }
 
 pub fn terminate(self: *App) void {
+    _ = timeEndPeriod(1);
     self.surface.deinit();
     if (self.hwnd) |hwnd| {
         _ = DestroyWindow(hwnd);

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -439,11 +439,10 @@ fn wndProc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) callconv(.wina
             return 0;
         },
         WM_PAINT => {
+            // Validate the window to prevent continuous WM_PAINT messages.
+            // Actual rendering is done by the renderer thread via SwapBuffers.
             var ps: PAINTSTRUCT = std.mem.zeroes(PAINTSTRUCT);
             _ = BeginPaint(hwnd, &ps);
-            if (getApp(hwnd)) |app| {
-                app.surface.swapBuffers();
-            }
             _ = EndPaint(hwnd, &ps);
             return 0;
         },

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -134,6 +134,24 @@ const COMPOSITIONFORM = extern struct {
 extern "imm32" fn ImmGetContext(hWnd: HWND) callconv(.winapi) ?*anyopaque;
 extern "imm32" fn ImmReleaseContext(hWnd: HWND, hIMC: ?*anyopaque) callconv(.winapi) BOOL;
 extern "imm32" fn ImmSetCompositionWindow(hIMC: ?*anyopaque, lpCompForm: *COMPOSITIONFORM) callconv(.winapi) BOOL;
+extern "imm32" fn ImmSetCompositionFontW(hIMC: ?*anyopaque, lplf: *LOGFONTW) callconv(.winapi) BOOL;
+
+const LOGFONTW = extern struct {
+    lfHeight: i32,
+    lfWidth: i32,
+    lfEscapement: i32 = 0,
+    lfOrientation: i32 = 0,
+    lfWeight: i32 = 0,
+    lfItalic: u8 = 0,
+    lfUnderline: u8 = 0,
+    lfStrikeOut: u8 = 0,
+    lfCharSet: u8 = 0,
+    lfOutPrecision: u8 = 0,
+    lfClipPrecision: u8 = 0,
+    lfQuality: u8 = 0,
+    lfPitchAndFamily: u8 = 0,
+    lfFaceName: [32]u16 = [_]u16{0} ** 32,
+};
 extern "user32" fn SetCapture(hWnd: HWND) callconv(.winapi) ?HWND;
 extern "user32" fn ReleaseCapture() callconv(.winapi) BOOL;
 
@@ -613,6 +631,13 @@ fn wndProc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) callconv(.wina
                             .rcArea = std.mem.zeroes(RECT),
                         };
                         _ = ImmSetCompositionWindow(ctx, &cf);
+
+                        // Set IME font to match terminal cell size
+                        var lf: LOGFONTW = std.mem.zeroes(LOGFONTW);
+                        lf.lfHeight = -@as(i32, @intCast(core.size.cell.height));
+                        lf.lfWidth = 0;
+                        lf.lfCharSet = 1; // DEFAULT_CHARSET
+                        _ = ImmSetCompositionFontW(ctx, &lf);
                     }
                 }
             }

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -344,6 +344,13 @@ fn createWindow(self: *App) !void {
 
     _ = ShowWindow(self.hwnd.?, SW_SHOWNORMAL);
     _ = UpdateWindow(self.hwnd.?);
+
+    // Get the actual client area size (excludes title bar and borders)
+    var client_rect: RECT = std.mem.zeroes(RECT);
+    if (GetClientRect(self.hwnd.?, &client_rect) != 0) {
+        self.surface.width = @intCast(client_rect.right - client_rect.left);
+        self.surface.height = @intCast(client_rect.bottom - client_rect.top);
+    }
 }
 
 fn getApp(hwnd: HWND) ?*App {

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -122,6 +122,16 @@ extern "user32" fn SetWindowTextW(hWnd: HWND, lpString: [*:0]const u16) callconv
 extern "user32" fn GetDpiForWindow(hWnd: HWND) callconv(.winapi) UINT;
 extern "user32" fn SetProcessDpiAwarenessContext(value: isize) callconv(.winapi) BOOL;
 const DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2: isize = -4;
+
+const COMPOSITIONFORM = extern struct {
+    dwStyle: DWORD,
+    ptCurrentPos: POINT,
+    rcArea: RECT,
+};
+
+extern "imm32" fn ImmGetContext(hWnd: HWND) callconv(.winapi) ?*anyopaque;
+extern "imm32" fn ImmReleaseContext(hWnd: HWND, hIMC: ?*anyopaque) callconv(.winapi) BOOL;
+extern "imm32" fn ImmSetCompositionWindow(hIMC: ?*anyopaque, lpCompForm: *COMPOSITIONFORM) callconv(.winapi) BOOL;
 extern "user32" fn SetCapture(hWnd: HWND) callconv(.winapi) ?HWND;
 extern "user32" fn ReleaseCapture() callconv(.winapi) BOOL;
 
@@ -536,6 +546,27 @@ fn wndProc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) callconv(.wina
                 }
             }
             return 0;
+        },
+        0x010D => { // WM_IME_STARTCOMPOSITION
+            if (getApp(hwnd)) |app| {
+                if (app.surface.core_surface) |core| {
+                    const pos = core.imePoint();
+                    const himc = ImmGetContext(hwnd);
+                    if (himc) |ctx| {
+                        defer _ = ImmReleaseContext(hwnd, ctx);
+                        var cf = COMPOSITIONFORM{
+                            .dwStyle = 0x0002, // CFS_POINT
+                            .ptCurrentPos = .{
+                                .x = @intFromFloat(pos.x),
+                                .y = @intFromFloat(pos.y),
+                            },
+                            .rcArea = std.mem.zeroes(RECT),
+                        };
+                        _ = ImmSetCompositionWindow(ctx, &cf);
+                    }
+                }
+            }
+            return DefWindowProcW(hwnd, msg, wparam, lparam);
         },
         0x0007, 0x0008 => { // WM_SETFOCUS, WM_KILLFOCUS
             if (getApp(hwnd)) |app| {

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -118,6 +118,8 @@ extern "user32" fn GetClientRect(hWnd: HWND, lpRect: *RECT) callconv(.winapi) BO
 extern "user32" fn InvalidateRect(hWnd: ?HWND, lpRect: ?*const RECT, bErase: BOOL) callconv(.winapi) BOOL;
 extern "kernel32" fn GetModuleHandleW(lpModuleName: ?[*:0]const u16) callconv(.winapi) ?HINSTANCE;
 extern "user32" fn GetKeyState(nVirtKey: c_int) callconv(.winapi) i16;
+extern "user32" fn SetCapture(hWnd: HWND) callconv(.winapi) ?HWND;
+extern "user32" fn ReleaseCapture() callconv(.winapi) BOOL;
 
 /// The core app instance.
 core_app: *CoreApp,
@@ -462,6 +464,59 @@ fn wndProc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) callconv(.wina
             }
             // Fall through to DefWindowProc so TranslateMessage generates WM_CHAR
             return DefWindowProcW(hwnd, msg, wparam, lparam);
+        },
+        0x0200 => { // WM_MOUSEMOVE
+            if (getApp(hwnd)) |app| {
+                if (app.surface.core_surface) |core| {
+                    const x: f32 = @floatFromInt(@as(i16, @truncate(lparam & 0xFFFF)));
+                    const y: f32 = @floatFromInt(@as(i16, @truncate((lparam >> 16) & 0xFFFF)));
+                    core.cursorPosCallback(.{ .x = x, .y = y }, getModifiers()) catch {};
+                }
+            }
+            return 0;
+        },
+        0x0201, 0x0204, 0x0207 => { // WM_LBUTTONDOWN, WM_RBUTTONDOWN, WM_MBUTTONDOWN
+            if (getApp(hwnd)) |app| {
+                if (app.surface.core_surface) |core| {
+                    const input = @import("../../input.zig");
+                    const button: input.MouseButton = switch (msg) {
+                        0x0201 => .left,
+                        0x0204 => .right,
+                        0x0207 => .middle,
+                        else => .unknown,
+                    };
+                    _ = core.mouseButtonCallback(.press, button, getModifiers()) catch false;
+                    _ = SetCapture(hwnd);
+                }
+            }
+            return 0;
+        },
+        0x0202, 0x0205, 0x0208 => { // WM_LBUTTONUP, WM_RBUTTONUP, WM_MBUTTONUP
+            if (getApp(hwnd)) |app| {
+                if (app.surface.core_surface) |core| {
+                    const input = @import("../../input.zig");
+                    const button: input.MouseButton = switch (msg) {
+                        0x0202 => .left,
+                        0x0205 => .right,
+                        0x0208 => .middle,
+                        else => .unknown,
+                    };
+                    _ = core.mouseButtonCallback(.release, button, getModifiers()) catch false;
+                    _ = ReleaseCapture();
+                }
+            }
+            return 0;
+        },
+        0x020A => { // WM_MOUSEWHEEL
+            if (getApp(hwnd)) |app| {
+                if (app.surface.core_surface) |core| {
+                    const delta: i16 = @truncate(@as(isize, @bitCast(wparam)) >> 16);
+                    const yoff: f64 = @as(f64, @floatFromInt(delta)) / 120.0;
+                    const input = @import("../../input.zig");
+                    core.scrollCallback(0, yoff, input.ScrollMods{}) catch {};
+                }
+            }
+            return 0;
         },
         WM_WAKEUP => {
             if (getApp(hwnd)) |app| {

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -383,6 +383,14 @@ fn wndProc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) callconv(.wina
                 if (width > 0 and height > 0) {
                     app.surface.width = width;
                     app.surface.height = height;
+                    if (app.surface.core_surface) |core| {
+                        core.sizeCallback(.{
+                            .width = width,
+                            .height = height,
+                        }) catch |err| {
+                            log.err("size callback error: {}", .{err});
+                        };
+                    }
                 }
             }
             return 0;

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -332,6 +332,20 @@ fn createWindow(self: *App) !void {
 
     const title = std.unicode.utf8ToUtf16LeStringLiteral("Ghostty");
 
+    // Calculate initial window size from config (grid cells) or use defaults
+    var init_width: i32 = 800;
+    var init_height: i32 = 600;
+    const cfg_w = self.config.@"window-width";
+    const cfg_h = self.config.@"window-height";
+    if (cfg_w > 0 and cfg_h > 0) {
+        // Estimate cell size from font size (approximate before font init)
+        const font_size = self.config.@"font-size";
+        const cell_w: i32 = @intFromFloat(font_size * 0.6);
+        const cell_h: i32 = @intFromFloat(font_size * 1.2);
+        init_width = @as(i32, @intCast(@max(10, cfg_w))) * cell_w;
+        init_height = @as(i32, @intCast(@max(4, cfg_h))) * cell_h;
+    }
+
     self.hwnd = CreateWindowExW(
         0,
         class_name,
@@ -339,8 +353,8 @@ fn createWindow(self: *App) !void {
         WS_OVERLAPPEDWINDOW,
         CW_USEDEFAULT,
         CW_USEDEFAULT,
-        800,
-        600,
+        init_width,
+        init_height,
         null,
         null,
         hinstance,

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -337,6 +337,39 @@ fn getApp(hwnd: HWND) ?*App {
     return @ptrFromInt(@as(usize, @bitCast(ptr)));
 }
 
+fn mapVirtualKey(vk: WPARAM) @import("../../input.zig").Key {
+    return switch (vk) {
+        0x08 => .backspace, // VK_BACK
+        0x09 => .tab, // VK_TAB
+        0x0D => .enter, // VK_RETURN
+        0x1B => .escape, // VK_ESCAPE
+        0x20 => .space, // VK_SPACE
+        0x25 => .arrow_left, // VK_LEFT
+        0x26 => .arrow_up, // VK_UP
+        0x27 => .arrow_right, // VK_RIGHT
+        0x28 => .arrow_down, // VK_DOWN
+        0x2E => .delete, // VK_DELETE
+        0x24 => .home, // VK_HOME
+        0x23 => .end, // VK_END
+        0x21 => .page_up, // VK_PRIOR
+        0x22 => .page_down, // VK_NEXT
+        0x2D => .insert, // VK_INSERT
+        0x70 => .f1,
+        0x71 => .f2,
+        0x72 => .f3,
+        0x73 => .f4,
+        0x74 => .f5,
+        0x75 => .f6,
+        0x76 => .f7,
+        0x77 => .f8,
+        0x78 => .f9,
+        0x79 => .f10,
+        0x7A => .f11,
+        0x7B => .f12,
+        else => .unidentified,
+    };
+}
+
 fn wndProc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) callconv(.winapi) LRESULT {
     switch (msg) {
         WM_CLOSE => {
@@ -362,6 +395,48 @@ fn wndProc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) callconv(.wina
             }
             _ = EndPaint(hwnd, &ps);
             return 0;
+        },
+        WM_CHAR => {
+            if (getApp(hwnd)) |app| {
+                if (app.surface.core_surface) |core| {
+                    const codepoint: u21 = @intCast(wparam);
+                    var utf8_buf: [4]u8 = undefined;
+                    const len = std.unicode.utf8Encode(codepoint, &utf8_buf) catch 0;
+                    if (len > 0) {
+                        const input = @import("../../input.zig");
+                        const event = input.KeyEvent{
+                            .action = .press,
+                            .utf8 = utf8_buf[0..len],
+                        };
+                        _ = core.keyCallback(event) catch |err| {
+                            log.err("key callback error: {}", .{err});
+                        };
+                    }
+                }
+            }
+            return 0;
+        },
+        WM_KEYDOWN => {
+            if (getApp(hwnd)) |app| {
+                if (app.surface.core_surface) |core| {
+                    const key = mapVirtualKey(wparam);
+                    if (key != .unidentified) {
+                        const input = @import("../../input.zig");
+                        const event = input.KeyEvent{
+                            .action = .press,
+                            .key = key,
+                        };
+                        const effect = core.keyCallback(event) catch |err| {
+                            log.err("key callback error: {}", .{err});
+                            return 0;
+                        };
+                        // If the key was consumed, don't pass to TranslateMessage
+                        if (effect == .consumed or effect == .closed) return 0;
+                    }
+                }
+            }
+            // Fall through to DefWindowProc so TranslateMessage generates WM_CHAR
+            return DefWindowProcW(hwnd, msg, wparam, lparam);
         },
         WM_WAKEUP => {
             if (getApp(hwnd)) |app| {

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -117,6 +117,7 @@ extern "user32" fn GetWindowLongPtrW(hWnd: HWND, nIndex: c_int) callconv(.winapi
 extern "user32" fn GetClientRect(hWnd: HWND, lpRect: *RECT) callconv(.winapi) BOOL;
 extern "user32" fn InvalidateRect(hWnd: ?HWND, lpRect: ?*const RECT, bErase: BOOL) callconv(.winapi) BOOL;
 extern "kernel32" fn GetModuleHandleW(lpModuleName: ?[*:0]const u16) callconv(.winapi) ?HINSTANCE;
+extern "user32" fn GetKeyState(nVirtKey: c_int) callconv(.winapi) i16;
 
 /// The core app instance.
 core_app: *CoreApp,
@@ -337,6 +338,17 @@ fn getApp(hwnd: HWND) ?*App {
     return @ptrFromInt(@as(usize, @bitCast(ptr)));
 }
 
+fn getModifiers() @import("../../input.zig").Mods {
+    const input = @import("../../input.zig");
+    var mods: input.Mods = .{};
+    // High bit of GetKeyState return value indicates key is down
+    if (GetKeyState(0x10) < 0) mods.shift = true; // VK_SHIFT
+    if (GetKeyState(0x11) < 0) mods.ctrl = true; // VK_CONTROL
+    if (GetKeyState(0x12) < 0) mods.alt = true; // VK_MENU
+    if (GetKeyState(0x5B) < 0 or GetKeyState(0x5C) < 0) mods.super = true; // VK_LWIN/VK_RWIN
+    return mods;
+}
+
 fn mapVirtualKey(vk: WPARAM) @import("../../input.zig").Key {
     return switch (vk) {
         0x08 => .backspace, // VK_BACK
@@ -407,6 +419,9 @@ fn wndProc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) callconv(.wina
         WM_CHAR => {
             if (getApp(hwnd)) |app| {
                 if (app.surface.core_surface) |core| {
+                    const mods = getModifiers();
+                    // Ctrl+letter generates control characters (0x01-0x1A).
+                    // Let these through as UTF-8 so the terminal handles them.
                     const codepoint: u21 = @intCast(wparam);
                     var utf8_buf: [4]u8 = undefined;
                     const len = std.unicode.utf8Encode(codepoint, &utf8_buf) catch 0;
@@ -414,6 +429,7 @@ fn wndProc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) callconv(.wina
                         const input = @import("../../input.zig");
                         const event = input.KeyEvent{
                             .action = .press,
+                            .mods = mods,
                             .utf8 = utf8_buf[0..len],
                         };
                         _ = core.keyCallback(event) catch |err| {
@@ -424,21 +440,22 @@ fn wndProc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) callconv(.wina
             }
             return 0;
         },
-        WM_KEYDOWN => {
+        WM_KEYDOWN, 0x0104 => { // WM_KEYDOWN, WM_SYSKEYDOWN
             if (getApp(hwnd)) |app| {
                 if (app.surface.core_surface) |core| {
+                    const mods = getModifiers();
                     const key = mapVirtualKey(wparam);
                     if (key != .unidentified) {
                         const input = @import("../../input.zig");
                         const event = input.KeyEvent{
                             .action = .press,
                             .key = key,
+                            .mods = mods,
                         };
                         const effect = core.keyCallback(event) catch |err| {
                             log.err("key callback error: {}", .{err});
                             return 0;
                         };
-                        // If the key was consumed, don't pass to TranslateMessage
                         if (effect == .consumed or effect == .closed) return 0;
                     }
                 }

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -118,6 +118,10 @@ extern "user32" fn GetClientRect(hWnd: HWND, lpRect: *RECT) callconv(.winapi) BO
 extern "user32" fn InvalidateRect(hWnd: ?HWND, lpRect: ?*const RECT, bErase: BOOL) callconv(.winapi) BOOL;
 extern "kernel32" fn GetModuleHandleW(lpModuleName: ?[*:0]const u16) callconv(.winapi) ?HINSTANCE;
 extern "user32" fn GetKeyState(nVirtKey: c_int) callconv(.winapi) i16;
+extern "user32" fn SetWindowTextW(hWnd: HWND, lpString: [*:0]const u16) callconv(.winapi) BOOL;
+extern "user32" fn GetDpiForWindow(hWnd: HWND) callconv(.winapi) UINT;
+extern "user32" fn SetProcessDpiAwarenessContext(value: isize) callconv(.winapi) BOOL;
+const DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2: isize = -4;
 extern "user32" fn SetCapture(hWnd: HWND) callconv(.winapi) ?HWND;
 extern "user32" fn ReleaseCapture() callconv(.winapi) BOOL;
 
@@ -160,6 +164,9 @@ pub fn init(
         .config = config_ptr,
         .alloc = alloc,
     };
+
+    // Enable Per-Monitor DPI awareness
+    _ = SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
 
     // Create the main window
     try self.createWindow();
@@ -216,17 +223,22 @@ pub fn performAction(
     comptime action: apprt.Action.Key,
     value: apprt.Action.Value(action),
 ) !bool {
-    _ = self;
     _ = target;
-    _ = value;
 
     switch (action) {
         .quit => {
             PostQuitMessage(0);
             return true;
         },
+        .set_title => {
+            if (self.hwnd) |hwnd| {
+                const utf16 = std.unicode.utf8ToUtf16LeAllocZ(self.alloc, value.title) catch return false;
+                defer self.alloc.free(utf16);
+                _ = SetWindowTextW(hwnd, utf16.ptr);
+            }
+            return true;
+        },
         .new_window => {
-            // TODO: implement multiple windows
             return false;
         },
         else => return false,
@@ -514,6 +526,16 @@ fn wndProc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) callconv(.wina
                     const yoff: f64 = @as(f64, @floatFromInt(delta)) / 120.0;
                     const input = @import("../../input.zig");
                     core.scrollCallback(0, yoff, input.ScrollMods{}) catch {};
+                }
+            }
+            return 0;
+        },
+        0x0007, 0x0008 => { // WM_SETFOCUS, WM_KILLFOCUS
+            if (getApp(hwnd)) |app| {
+                const focused = msg == 0x0007;
+                app.core_app.focusEvent(focused);
+                if (app.surface.core_surface) |core| {
+                    core.focusCallback(focused) catch {};
                 }
             }
             return 0;

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -1,0 +1,289 @@
+/// Win32 application runtime for Ghostty. This is a minimal native Windows
+/// application using the Win32 API with OpenGL rendering.
+const App = @This();
+
+const std = @import("std");
+const builtin = @import("builtin");
+const Allocator = std.mem.Allocator;
+const apprt = @import("../../apprt.zig");
+const configpkg = @import("../../config.zig");
+const Config = configpkg.Config;
+const CoreApp = @import("../../App.zig");
+const CoreSurface = @import("../../Surface.zig");
+const Surface = @import("Surface.zig");
+
+const log = std.log.scoped(.win32);
+
+// Win32 type definitions
+const BOOL = i32;
+const UINT = u32;
+const DWORD = u32;
+const WPARAM = usize;
+const LPARAM = isize;
+const LRESULT = isize;
+const HWND = std.os.windows.HWND;
+const HINSTANCE = std.os.windows.HINSTANCE;
+const HICON = ?*anyopaque;
+const HCURSOR = ?*anyopaque;
+const HBRUSH = ?*anyopaque;
+const HDC = ?*anyopaque;
+const HMENU = ?*anyopaque;
+const ATOM = u16;
+
+const POINT = extern struct {
+    x: i32,
+    y: i32,
+};
+
+const MSG = extern struct {
+    hwnd: ?HWND,
+    message: UINT,
+    wParam: WPARAM,
+    lParam: LPARAM,
+    time: DWORD,
+    pt: POINT,
+};
+
+const RECT = extern struct {
+    left: i32,
+    top: i32,
+    right: i32,
+    bottom: i32,
+};
+
+const PAINTSTRUCT = extern struct {
+    hdc: HDC,
+    fErase: BOOL,
+    rcPaint: RECT,
+    fRestore: BOOL,
+    fIncUpdate: BOOL,
+    rgbReserved: [32]u8,
+};
+
+const WNDPROC = *const fn (HWND, UINT, WPARAM, LPARAM) callconv(.winapi) LRESULT;
+
+const WNDCLASSEXW = extern struct {
+    cbSize: UINT,
+    style: UINT,
+    lpfnWndProc: WNDPROC,
+    cbClsExtra: c_int,
+    cbWndExtra: c_int,
+    hInstance: ?HINSTANCE,
+    hIcon: HICON,
+    hCursor: HCURSOR,
+    hbrBackground: HBRUSH,
+    lpszMenuName: ?[*:0]const u16,
+    lpszClassName: [*:0]const u16,
+    hIconSm: HICON,
+};
+
+// Win32 constants
+const WM_CLOSE = 0x0010;
+const WM_PAINT = 0x000F;
+const WM_USER = 0x0400;
+const WM_WAKEUP = WM_USER + 1;
+const CS_HREDRAW = 0x0002;
+const CS_VREDRAW = 0x0001;
+const CS_OWNDC = 0x0020;
+const WS_OVERLAPPEDWINDOW = 0x00CF0000;
+const CW_USEDEFAULT: i32 = @bitCast(@as(u32, 0x80000000));
+const SW_SHOWNORMAL = 1;
+const IDC_ARROW: ?[*:0]align(1) const u16 = @ptrFromInt(32512);
+
+// Win32 API extern declarations
+extern "user32" fn RegisterClassExW(lpWndClass: *const WNDCLASSEXW) callconv(.winapi) ATOM;
+extern "user32" fn CreateWindowExW(dwExStyle: DWORD, lpClassName: ?[*:0]const u16, lpWindowName: ?[*:0]const u16, dwStyle: DWORD, x: i32, y: i32, nWidth: i32, nHeight: i32, hWndParent: ?HWND, hMenu: HMENU, hInstance: ?HINSTANCE, lpParam: ?*anyopaque) callconv(.winapi) ?HWND;
+extern "user32" fn ShowWindow(hWnd: HWND, nCmdShow: c_int) callconv(.winapi) BOOL;
+extern "user32" fn UpdateWindow(hWnd: HWND) callconv(.winapi) BOOL;
+extern "user32" fn DestroyWindow(hWnd: HWND) callconv(.winapi) BOOL;
+extern "user32" fn DefWindowProcW(hWnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.winapi) LRESULT;
+extern "user32" fn GetMessageW(lpMsg: *MSG, hWnd: ?HWND, wMsgFilterMin: UINT, wMsgFilterMax: UINT) callconv(.winapi) BOOL;
+extern "user32" fn TranslateMessage(lpMsg: *const MSG) callconv(.winapi) BOOL;
+extern "user32" fn DispatchMessageW(lpMsg: *const MSG) callconv(.winapi) LRESULT;
+extern "user32" fn PostMessageW(hWnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.winapi) BOOL;
+extern "user32" fn PostQuitMessage(nExitCode: c_int) callconv(.winapi) void;
+extern "user32" fn BeginPaint(hWnd: HWND, lpPaint: *PAINTSTRUCT) callconv(.winapi) HDC;
+extern "user32" fn EndPaint(hWnd: HWND, lpPaint: *const PAINTSTRUCT) callconv(.winapi) BOOL;
+extern "user32" fn LoadCursorW(hInstance: ?HINSTANCE, lpCursorName: ?[*:0]align(1) const u16) callconv(.winapi) HCURSOR;
+extern "kernel32" fn GetModuleHandleW(lpModuleName: ?[*:0]const u16) callconv(.winapi) ?HINSTANCE;
+
+/// The core app instance.
+core_app: *CoreApp,
+
+/// The configuration.
+config: *Config,
+
+/// The allocator.
+alloc: Allocator,
+
+/// Whether the app is running.
+running: bool = true,
+
+/// The main window handle.
+hwnd: ?HWND = null,
+
+pub fn init(
+    self: *App,
+    core_app: *CoreApp,
+    opts: struct {},
+) !void {
+    _ = opts;
+
+    const alloc = core_app.alloc;
+
+    // Load configuration
+    var config = try Config.load(alloc);
+    errdefer config.deinit();
+
+    const config_ptr = try alloc.create(Config);
+    config_ptr.* = config;
+
+    self.* = .{
+        .core_app = core_app,
+        .config = config_ptr,
+        .alloc = alloc,
+    };
+
+    // Create the main window
+    try self.createWindow();
+}
+
+pub fn run(self: *App) !void {
+    log.info("starting Win32 event loop", .{});
+
+    while (self.running) {
+        var msg: MSG = std.mem.zeroes(MSG);
+        const ret = GetMessageW(&msg, null, 0, 0);
+        if (ret == 0) {
+            // WM_QUIT
+            self.running = false;
+            break;
+        }
+        if (ret == -1) {
+            log.err("GetMessage failed", .{});
+            return error.Win32Error;
+        }
+        _ = TranslateMessage(&msg);
+        _ = DispatchMessageW(&msg);
+    }
+}
+
+pub fn terminate(self: *App) void {
+    if (self.hwnd) |hwnd| {
+        _ = DestroyWindow(hwnd);
+        self.hwnd = null;
+    }
+    self.config.deinit();
+    self.alloc.destroy(self.config);
+}
+
+pub fn wakeup(self: *App) void {
+    if (self.hwnd) |hwnd| {
+        _ = PostMessageW(hwnd, WM_WAKEUP, 0, 0);
+    }
+}
+
+pub fn performAction(
+    self: *App,
+    target: apprt.Target,
+    comptime action: apprt.Action.Key,
+    value: apprt.Action.Value(action),
+) !bool {
+    _ = self;
+    _ = target;
+    _ = value;
+
+    switch (action) {
+        .quit => {
+            PostQuitMessage(0);
+            return true;
+        },
+        .new_window => {
+            // TODO: implement multiple windows
+            return false;
+        },
+        else => return false,
+    }
+}
+
+pub fn performIpc(
+    _: Allocator,
+    _: apprt.ipc.Target,
+    comptime action: apprt.ipc.Action.Key,
+    _: apprt.ipc.Action.Value(action),
+) !bool {
+    return false;
+}
+
+pub fn redrawInspector(_: *App, _: *Surface) void {}
+
+fn createWindow(self: *App) !void {
+    const class_name = std.unicode.utf8ToUtf16LeStringLiteral("GhosttyWindow");
+    const hinstance = GetModuleHandleW(null);
+
+    const wc: WNDCLASSEXW = .{
+        .cbSize = @sizeOf(WNDCLASSEXW),
+        .style = CS_HREDRAW | CS_VREDRAW | CS_OWNDC,
+        .lpfnWndProc = wndProc,
+        .cbClsExtra = 0,
+        .cbWndExtra = 0,
+        .hInstance = hinstance,
+        .hIcon = null,
+        .hCursor = LoadCursorW(null, IDC_ARROW),
+        .hbrBackground = null,
+        .lpszMenuName = null,
+        .lpszClassName = class_name,
+        .hIconSm = null,
+    };
+
+    if (RegisterClassExW(&wc) == 0) {
+        log.err("RegisterClassEx failed", .{});
+        return error.Win32Error;
+    }
+
+    const title = std.unicode.utf8ToUtf16LeStringLiteral("Ghostty");
+
+    self.hwnd = CreateWindowExW(
+        0,
+        class_name,
+        title,
+        WS_OVERLAPPEDWINDOW,
+        CW_USEDEFAULT,
+        CW_USEDEFAULT,
+        800,
+        600,
+        null,
+        null,
+        hinstance,
+        null,
+    );
+
+    if (self.hwnd == null) {
+        log.err("CreateWindowEx failed", .{});
+        return error.Win32Error;
+    }
+
+    _ = ShowWindow(self.hwnd.?, SW_SHOWNORMAL);
+    _ = UpdateWindow(self.hwnd.?);
+}
+
+fn wndProc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) callconv(.winapi) LRESULT {
+    switch (msg) {
+        WM_CLOSE => {
+            PostQuitMessage(0);
+            return 0;
+        },
+        WM_PAINT => {
+            var ps: PAINTSTRUCT = std.mem.zeroes(PAINTSTRUCT);
+            _ = BeginPaint(hwnd, &ps);
+            // TODO: render via OpenGL
+            _ = EndPaint(hwnd, &ps);
+            return 0;
+        },
+        WM_WAKEUP => {
+            // Wakeup from core app
+            return 0;
+        },
+        else => return DefWindowProcW(hwnd, msg, wparam, lparam),
+    }
+}

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -471,9 +471,10 @@ fn wndProc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) callconv(.wina
             if (getApp(hwnd)) |app| {
                 if (app.surface.core_surface) |core| {
                     const mods = getModifiers();
-                    // Ctrl+letter generates control characters (0x01-0x1A).
-                    // Let these through as UTF-8 so the terminal handles them.
                     const codepoint: u21 = @intCast(wparam);
+                    // Skip control characters — they are already handled
+                    // via WM_KEYDOWN (backspace, tab, enter, escape, Ctrl+letter).
+                    if (codepoint < 0x20 or codepoint == 0x7f) return 0;
                     var utf8_buf: [4]u8 = undefined;
                     const len = std.unicode.utf8Encode(codepoint, &utf8_buf) catch 0;
                     if (len > 0) {

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -550,16 +550,19 @@ fn wndProc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) callconv(.wina
         0x010D => { // WM_IME_STARTCOMPOSITION
             if (getApp(hwnd)) |app| {
                 if (app.surface.core_surface) |core| {
-                    const pos = core.imePoint();
+                    // Get cursor position in raw pixels (no DPI scaling)
+                    core.renderer_state.mutex.lock();
+                    const cursor = core.renderer_state.terminal.screens.active.cursor;
+                    core.renderer_state.mutex.unlock();
+                    const x: i32 = @intCast(cursor.x * core.size.cell.width + core.size.padding.left);
+                    const y: i32 = @intCast(cursor.y * core.size.cell.height + core.size.padding.top);
+
                     const himc = ImmGetContext(hwnd);
                     if (himc) |ctx| {
                         defer _ = ImmReleaseContext(hwnd, ctx);
                         var cf = COMPOSITIONFORM{
                             .dwStyle = 0x0002, // CFS_POINT
-                            .ptCurrentPos = .{
-                                .x = @intFromFloat(pos.x),
-                                .y = @intFromFloat(pos.y),
-                            },
+                            .ptCurrentPos = .{ .x = x, .y = y },
                             .rcArea = std.mem.zeroes(RECT),
                         };
                         _ = ImmSetCompositionWindow(ctx, &cf);

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -382,6 +382,19 @@ fn getModifiers() @import("../../input.zig").Mods {
 
 fn mapVirtualKey(vk: WPARAM) @import("../../input.zig").Key {
     return switch (vk) {
+        // Letters A-Z (VK_A .. VK_Z)
+        0x41 => .key_a, 0x42 => .key_b, 0x43 => .key_c, 0x44 => .key_d,
+        0x45 => .key_e, 0x46 => .key_f, 0x47 => .key_g, 0x48 => .key_h,
+        0x49 => .key_i, 0x4A => .key_j, 0x4B => .key_k, 0x4C => .key_l,
+        0x4D => .key_m, 0x4E => .key_n, 0x4F => .key_o, 0x50 => .key_p,
+        0x51 => .key_q, 0x52 => .key_r, 0x53 => .key_s, 0x54 => .key_t,
+        0x55 => .key_u, 0x56 => .key_v, 0x57 => .key_w, 0x58 => .key_x,
+        0x59 => .key_y, 0x5A => .key_z,
+        // Digits 0-9
+        0x30 => .digit_0, 0x31 => .digit_1, 0x32 => .digit_2, 0x33 => .digit_3,
+        0x34 => .digit_4, 0x35 => .digit_5, 0x36 => .digit_6, 0x37 => .digit_7,
+        0x38 => .digit_8, 0x39 => .digit_9,
+        // Special keys
         0x08 => .backspace, // VK_BACK
         0x09 => .tab, // VK_TAB
         0x0D => .enter, // VK_RETURN
@@ -397,18 +410,26 @@ fn mapVirtualKey(vk: WPARAM) @import("../../input.zig").Key {
         0x21 => .page_up, // VK_PRIOR
         0x22 => .page_down, // VK_NEXT
         0x2D => .insert, // VK_INSERT
-        0x70 => .f1,
-        0x71 => .f2,
-        0x72 => .f3,
-        0x73 => .f4,
-        0x74 => .f5,
-        0x75 => .f6,
-        0x76 => .f7,
-        0x77 => .f8,
-        0x78 => .f9,
-        0x79 => .f10,
-        0x7A => .f11,
-        0x7B => .f12,
+        // Modifier keys
+        0x10 => .shift_left, // VK_SHIFT
+        0x11 => .control_left, // VK_CONTROL
+        0x12 => .alt_left, // VK_MENU
+        // Punctuation
+        0xBD => .minus, // VK_OEM_MINUS
+        0xBB => .equal, // VK_OEM_PLUS (= key)
+        0xDB => .bracket_left, // VK_OEM_4
+        0xDD => .bracket_right, // VK_OEM_6
+        0xDC => .backslash, // VK_OEM_5
+        0xBA => .semicolon, // VK_OEM_1
+        0xDE => .quote, // VK_OEM_7
+        0xBC => .comma, // VK_OEM_COMMA
+        0xBE => .period, // VK_OEM_PERIOD
+        0xBF => .slash, // VK_OEM_2
+        // 0xC0 => grave/backtick not in Key enum
+        // Function keys
+        0x70 => .f1, 0x71 => .f2, 0x72 => .f3, 0x73 => .f4,
+        0x74 => .f5, 0x75 => .f6, 0x76 => .f7, 0x77 => .f8,
+        0x78 => .f9, 0x79 => .f10, 0x7A => .f11, 0x7B => .f12,
         else => .unidentified,
     };
 }

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -122,8 +122,6 @@ extern "user32" fn SetWindowTextW(hWnd: HWND, lpString: [*:0]const u16) callconv
 extern "user32" fn GetDpiForWindow(hWnd: HWND) callconv(.winapi) UINT;
 extern "user32" fn SetProcessDpiAwarenessContext(value: isize) callconv(.winapi) BOOL;
 const DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2: isize = -4;
-extern "winmm" fn timeBeginPeriod(uPeriod: UINT) callconv(.winapi) UINT;
-extern "winmm" fn timeEndPeriod(uPeriod: UINT) callconv(.winapi) UINT;
 
 const COMPOSITIONFORM = extern struct {
     dwStyle: DWORD,
@@ -180,9 +178,6 @@ pub fn init(
     // Enable Per-Monitor DPI awareness
     _ = SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
 
-    // Raise timer resolution to 1ms for responsive rendering
-    _ = timeBeginPeriod(1);
-
     // Create the main window
     try self.createWindow();
 
@@ -217,7 +212,6 @@ pub fn run(self: *App) !void {
 }
 
 pub fn terminate(self: *App) void {
-    _ = timeEndPeriod(1);
     self.surface.deinit();
     if (self.hwnd) |hwnd| {
         _ = DestroyWindow(hwnd);

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -119,6 +119,8 @@ extern "user32" fn InvalidateRect(hWnd: ?HWND, lpRect: ?*const RECT, bErase: BOO
 extern "kernel32" fn GetModuleHandleW(lpModuleName: ?[*:0]const u16) callconv(.winapi) ?HINSTANCE;
 extern "user32" fn GetKeyState(nVirtKey: c_int) callconv(.winapi) i16;
 extern "user32" fn SetWindowTextW(hWnd: HWND, lpString: [*:0]const u16) callconv(.winapi) BOOL;
+extern "user32" fn AdjustWindowRectEx(lpRect: *RECT, dwStyle: DWORD, bMenu: BOOL, dwExStyle: DWORD) callconv(.winapi) BOOL;
+extern "user32" fn SetWindowPos(hWnd: HWND, hWndInsertAfter: ?HWND, x: i32, y: i32, cx: i32, cy: i32, uFlags: UINT) callconv(.winapi) BOOL;
 extern "user32" fn GetDpiForWindow(hWnd: HWND) callconv(.winapi) UINT;
 extern "user32" fn SetProcessDpiAwarenessContext(value: isize) callconv(.winapi) BOOL;
 const DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2: isize = -4;
@@ -304,6 +306,30 @@ fn initCoreSurface(self: *App) !void {
 
     self.surface.core_surface = core_surface;
     log.info("core surface initialized successfully", .{});
+
+    // Resize window to match configured grid size using actual font metrics.
+    // Like GTK, only resize when both window-width and window-height are set.
+    self.applyConfiguredWindowSize();
+}
+
+fn applyConfiguredWindowSize(self: *App) void {
+    const cfg_w = self.config.@"window-width";
+    const cfg_h = self.config.@"window-height";
+    if (cfg_w == 0 or cfg_h == 0) return;
+    const hwnd = self.hwnd orelse return;
+    const core = self.surface.core_surface orelse return;
+
+    const cell_width = core.size.cell.width;
+    const cell_height = core.size.cell.height;
+    if (cell_width == 0 or cell_height == 0) return;
+
+    const w: i32 = @intCast(@max(10, cfg_w) * cell_width);
+    const h: i32 = @intCast(@max(4, cfg_h) * cell_height);
+
+    // AdjustWindowRect to account for title bar and borders
+    var rect: RECT = .{ .left = 0, .top = 0, .right = w, .bottom = h };
+    _ = AdjustWindowRectEx(&rect, WS_OVERLAPPEDWINDOW, 0, 0);
+    _ = SetWindowPos(hwnd, null, 0, 0, rect.right - rect.left, rect.bottom - rect.top, 0x0002 | 0x0004); // SWP_NOMOVE | SWP_NOZORDER
 }
 
 fn createWindow(self: *App) !void {
@@ -332,20 +358,6 @@ fn createWindow(self: *App) !void {
 
     const title = std.unicode.utf8ToUtf16LeStringLiteral("Ghostty");
 
-    // Calculate initial window size from config (grid cells) or use defaults
-    var init_width: i32 = 800;
-    var init_height: i32 = 600;
-    const cfg_w = self.config.@"window-width";
-    const cfg_h = self.config.@"window-height";
-    if (cfg_w > 0 and cfg_h > 0) {
-        // Estimate cell size from font size (approximate before font init)
-        const font_size = self.config.@"font-size";
-        const cell_w: i32 = @intFromFloat(font_size * 0.6);
-        const cell_h: i32 = @intFromFloat(font_size * 1.2);
-        init_width = @as(i32, @intCast(@max(10, cfg_w))) * cell_w;
-        init_height = @as(i32, @intCast(@max(4, cfg_h))) * cell_h;
-    }
-
     self.hwnd = CreateWindowExW(
         0,
         class_name,
@@ -353,8 +365,8 @@ fn createWindow(self: *App) !void {
         WS_OVERLAPPEDWINDOW,
         CW_USEDEFAULT,
         CW_USEDEFAULT,
-        init_width,
-        init_height,
+        800,
+        600,
         null,
         null,
         hinstance,

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -11,6 +11,7 @@ const Config = configpkg.Config;
 const CoreApp = @import("../../App.zig");
 const CoreSurface = @import("../../Surface.zig");
 const Surface = @import("Surface.zig");
+const renderer = @import("../../renderer.zig");
 
 const log = std.log.scoped(.win32);
 
@@ -29,6 +30,7 @@ const HBRUSH = ?*anyopaque;
 const HDC = ?*anyopaque;
 const HMENU = ?*anyopaque;
 const ATOM = u16;
+const LONG_PTR = isize;
 
 const POINT = extern struct {
     x: i32,
@@ -79,7 +81,11 @@ const WNDCLASSEXW = extern struct {
 
 // Win32 constants
 const WM_CLOSE = 0x0010;
+const WM_DESTROY = 0x0002;
 const WM_PAINT = 0x000F;
+const WM_SIZE = 0x0005;
+const WM_KEYDOWN = 0x0100;
+const WM_CHAR = 0x0102;
 const WM_USER = 0x0400;
 const WM_WAKEUP = WM_USER + 1;
 const CS_HREDRAW = 0x0002;
@@ -89,6 +95,7 @@ const WS_OVERLAPPEDWINDOW = 0x00CF0000;
 const CW_USEDEFAULT: i32 = @bitCast(@as(u32, 0x80000000));
 const SW_SHOWNORMAL = 1;
 const IDC_ARROW: ?[*:0]align(1) const u16 = @ptrFromInt(32512);
+const GWLP_USERDATA: c_int = -21;
 
 // Win32 API extern declarations
 extern "user32" fn RegisterClassExW(lpWndClass: *const WNDCLASSEXW) callconv(.winapi) ATOM;
@@ -105,6 +112,10 @@ extern "user32" fn PostQuitMessage(nExitCode: c_int) callconv(.winapi) void;
 extern "user32" fn BeginPaint(hWnd: HWND, lpPaint: *PAINTSTRUCT) callconv(.winapi) HDC;
 extern "user32" fn EndPaint(hWnd: HWND, lpPaint: *const PAINTSTRUCT) callconv(.winapi) BOOL;
 extern "user32" fn LoadCursorW(hInstance: ?HINSTANCE, lpCursorName: ?[*:0]align(1) const u16) callconv(.winapi) HCURSOR;
+extern "user32" fn SetWindowLongPtrW(hWnd: HWND, nIndex: c_int, dwNewLong: LONG_PTR) callconv(.winapi) LONG_PTR;
+extern "user32" fn GetWindowLongPtrW(hWnd: HWND, nIndex: c_int) callconv(.winapi) LONG_PTR;
+extern "user32" fn GetClientRect(hWnd: HWND, lpRect: *RECT) callconv(.winapi) BOOL;
+extern "user32" fn InvalidateRect(hWnd: ?HWND, lpRect: ?*const RECT, bErase: BOOL) callconv(.winapi) BOOL;
 extern "kernel32" fn GetModuleHandleW(lpModuleName: ?[*:0]const u16) callconv(.winapi) ?HINSTANCE;
 
 /// The core app instance.
@@ -121,6 +132,9 @@ running: bool = true,
 
 /// The main window handle.
 hwnd: ?HWND = null,
+
+/// The surface for the main window.
+surface: Surface = undefined,
 
 pub fn init(
     self: *App,
@@ -146,6 +160,12 @@ pub fn init(
 
     // Create the main window
     try self.createWindow();
+
+    // Initialize the surface with OpenGL
+    try self.surface.init(self.hwnd.?);
+
+    // Store self pointer in window for use in wndProc
+    _ = SetWindowLongPtrW(self.hwnd.?, GWLP_USERDATA, @bitCast(@intFromPtr(self)));
 }
 
 pub fn run(self: *App) !void {
@@ -169,6 +189,7 @@ pub fn run(self: *App) !void {
 }
 
 pub fn terminate(self: *App) void {
+    self.surface.deinit();
     if (self.hwnd) |hwnd| {
         _ = DestroyWindow(hwnd);
         self.hwnd = null;
@@ -215,7 +236,9 @@ pub fn performIpc(
     return false;
 }
 
-pub fn redrawInspector(_: *App, _: *Surface) void {}
+pub fn redrawInspector(_: *App, surface: *Surface) void {
+    surface.redrawInspector();
+}
 
 fn createWindow(self: *App) !void {
     const class_name = std.unicode.utf8ToUtf16LeStringLiteral("GhosttyWindow");
@@ -267,21 +290,44 @@ fn createWindow(self: *App) !void {
     _ = UpdateWindow(self.hwnd.?);
 }
 
+fn getApp(hwnd: HWND) ?*App {
+    const ptr = GetWindowLongPtrW(hwnd, GWLP_USERDATA);
+    if (ptr == 0) return null;
+    return @ptrFromInt(@as(usize, @bitCast(ptr)));
+}
+
 fn wndProc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) callconv(.winapi) LRESULT {
     switch (msg) {
         WM_CLOSE => {
             PostQuitMessage(0);
             return 0;
         },
+        WM_SIZE => {
+            if (getApp(hwnd)) |app| {
+                const width: u32 = @intCast(lparam & 0xFFFF);
+                const height: u32 = @intCast((lparam >> 16) & 0xFFFF);
+                if (width > 0 and height > 0) {
+                    app.surface.width = width;
+                    app.surface.height = height;
+                }
+            }
+            return 0;
+        },
         WM_PAINT => {
             var ps: PAINTSTRUCT = std.mem.zeroes(PAINTSTRUCT);
             _ = BeginPaint(hwnd, &ps);
-            // TODO: render via OpenGL
+            if (getApp(hwnd)) |app| {
+                app.surface.swapBuffers();
+            }
             _ = EndPaint(hwnd, &ps);
             return 0;
         },
         WM_WAKEUP => {
-            // Wakeup from core app
+            if (getApp(hwnd)) |app| {
+                app.core_app.tick(app) catch |err| {
+                    log.err("core app tick failed: {}", .{err});
+                };
+            }
             return 0;
         },
         else => return DefWindowProcW(hwnd, msg, wparam, lparam),

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -313,9 +313,9 @@ fn initCoreSurface(self: *App) !void {
 }
 
 fn applyConfiguredWindowSize(self: *App) void {
-    const cfg_w = self.config.@"window-width";
-    const cfg_h = self.config.@"window-height";
-    if (cfg_w == 0 or cfg_h == 0) return;
+    // Default to 80x24 when not configured
+    const cfg_w = if (self.config.@"window-width" > 0) self.config.@"window-width" else 80;
+    const cfg_h = if (self.config.@"window-height" > 0) self.config.@"window-height" else 24;
     const hwnd = self.hwnd orelse return;
     const core = self.surface.core_surface orelse return;
 

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -632,9 +632,12 @@ fn wndProc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) callconv(.wina
                         };
                         _ = ImmSetCompositionWindow(ctx, &cf);
 
-                        // Set IME font to match terminal cell size
+                        // Set IME font to match terminal font size (points → pixels)
+                        const dpi = GetDpiForWindow(hwnd);
+                        const dpi_f: f32 = if (dpi > 0) @floatFromInt(dpi) else 96.0;
+                        const font_px: i32 = @intFromFloat(app.config.@"font-size" * dpi_f / 72.0);
                         var lf: LOGFONTW = std.mem.zeroes(LOGFONTW);
-                        lf.lfHeight = -@as(i32, @intCast(core.size.cell.height));
+                        lf.lfHeight = -font_px;
                         lf.lfWidth = 0;
                         lf.lfCharSet = 1; // DEFAULT_CHARSET
                         _ = ImmSetCompositionFontW(ctx, &lf);

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -166,6 +166,9 @@ pub fn init(
 
     // Store self pointer in window for use in wndProc
     _ = SetWindowLongPtrW(self.hwnd.?, GWLP_USERDATA, @bitCast(@intFromPtr(self)));
+
+    // Initialize the core surface (terminal emulation + rendering)
+    try self.initCoreSurface();
 }
 
 pub fn run(self: *App) !void {
@@ -238,6 +241,44 @@ pub fn performIpc(
 
 pub fn redrawInspector(_: *App, surface: *Surface) void {
     surface.redrawInspector();
+}
+
+fn initCoreSurface(self: *App) !void {
+    const alloc = self.alloc;
+
+    // Set the app pointer on the surface
+    self.surface.app = self;
+
+    // Create the core surface
+    const core_surface = try alloc.create(CoreSurface);
+    errdefer alloc.destroy(core_surface);
+
+    // Register with the core app
+    try self.core_app.addSurface(&self.surface);
+    errdefer self.core_app.deleteSurface(&self.surface);
+
+    // Create a surface config
+    var config = try apprt.surface.newConfig(
+        self.core_app,
+        self.config,
+        .window,
+    );
+    defer config.deinit();
+
+    // Initialize the core surface
+    core_surface.init(
+        alloc,
+        &config,
+        self.core_app,
+        self,
+        &self.surface,
+    ) catch |err| {
+        log.err("failed to initialize core surface: {}", .{err});
+        return err;
+    };
+
+    self.surface.core_surface = core_surface;
+    log.info("core surface initialized successfully", .{});
 }
 
 fn createWindow(self: *App) !void {

--- a/src/apprt/win32/Surface.zig
+++ b/src/apprt/win32/Surface.zig
@@ -1,0 +1,11 @@
+/// Win32 surface - represents a terminal surface within a window.
+/// This is a minimal stub for now.
+const Self = @This();
+
+const std = @import("std");
+const apprt = @import("../../apprt.zig");
+const CoreSurface = @import("../../Surface.zig");
+
+pub fn deinit(self: *Self) void {
+    _ = self;
+}

--- a/src/apprt/win32/Surface.zig
+++ b/src/apprt/win32/Surface.zig
@@ -174,6 +174,14 @@ pub fn swapBuffers(self: *Self) void {
     }
 }
 
+/// Update the OpenGL viewport to match the current window size.
+/// Called from the renderer thread before each frame.
+pub fn updateViewport(self: *Self) void {
+    glViewport(0, 0, @intCast(self.width), @intCast(self.height));
+}
+
+extern "opengl32" fn glViewport(x: i32, y: i32, width: i32, height: i32) callconv(.winapi) void;
+
 /// Make the WGL context current on the calling thread.
 pub fn makeContextCurrent(self: *Self) void {
     if (self.hdc != null and self.hglrc != null) {

--- a/src/apprt/win32/Surface.zig
+++ b/src/apprt/win32/Surface.zig
@@ -228,9 +228,9 @@ pub fn setClipboard(
     // TODO: implement clipboard write
 }
 
-pub fn defaultTermioEnv(_: *Self) !std.process.EnvMap {
-    // Return an empty env map; the shell will inherit the process env.
-    return std.process.EnvMap.init(std.heap.page_allocator);
+pub fn defaultTermioEnv(self: *Self) !std.process.EnvMap {
+    const alloc = if (self.app) |app| app.alloc else std.heap.page_allocator;
+    return try @import("../../os/main.zig").getEnvMap(alloc);
 }
 
 pub fn redrawInspector(_: *Self) void {}

--- a/src/apprt/win32/Surface.zig
+++ b/src/apprt/win32/Surface.zig
@@ -194,10 +194,14 @@ pub fn releaseMainThreadContext(self: *Self) void {
 
 // --- Interface methods required by CoreSurface ---
 
-pub fn getContentScale(_: *const Self) !apprt.ContentScale {
-    // TODO: query DPI from the monitor
-    return .{ .x = 1.0, .y = 1.0 };
+pub fn getContentScale(self: *const Self) !apprt.ContentScale {
+    const dpi = GetDpiForWindow(self.hwnd);
+    if (dpi == 0) return .{ .x = 1.0, .y = 1.0 };
+    const scale: f32 = @as(f32, @floatFromInt(dpi)) / 96.0;
+    return .{ .x = scale, .y = scale };
 }
+
+extern "user32" fn GetDpiForWindow(hWnd: HWND) callconv(.winapi) u32;
 
 pub fn getSize(self: *const Self) !apprt.SurfaceSize {
     return .{

--- a/src/apprt/win32/Surface.zig
+++ b/src/apprt/win32/Surface.zig
@@ -165,8 +165,19 @@ fn initOpenGL(self: *Self) !void {
         return error.Win32Error;
     }
 
-    log.info("WGL OpenGL context created successfully", .{});
+    // Set initial viewport to client area
+    var client_rect: RECT = std.mem.zeroes(RECT);
+    if (GetClientRect(self.hwnd, &client_rect) != 0) {
+        self.width = @intCast(client_rect.right - client_rect.left);
+        self.height = @intCast(client_rect.bottom - client_rect.top);
+    }
+    glViewport(0, 0, @intCast(self.width), @intCast(self.height));
+
+    log.info("WGL OpenGL context created, client area {}x{}", .{ self.width, self.height });
 }
+
+const RECT = extern struct { left: i32, top: i32, right: i32, bottom: i32 };
+extern "user32" fn GetClientRect(hWnd: HWND, lpRect: *RECT) callconv(.winapi) BOOL;
 
 pub fn swapBuffers(self: *Self) void {
     if (self.hdc != null) {

--- a/src/apprt/win32/Surface.zig
+++ b/src/apprt/win32/Surface.zig
@@ -174,14 +174,6 @@ fn initOpenGL(self: *Self) !void {
     }
     glViewport(0, 0, @intCast(self.width), @intCast(self.height));
 
-    // Disable VSync for lower input latency. WGL swap interval of 0
-    // means SwapBuffers returns immediately.
-    const wglSwapIntervalEXT: ?*const fn (i32) callconv(.winapi) i32 = @ptrCast(wglGetProcAddress("wglSwapIntervalEXT"));
-    if (wglSwapIntervalEXT) |setInterval| {
-        _ = setInterval(0);
-        log.info("VSync disabled via wglSwapIntervalEXT", .{});
-    }
-
     log.info("WGL OpenGL context created, client area {}x{}", .{ self.width, self.height });
 }
 

--- a/src/apprt/win32/Surface.zig
+++ b/src/apprt/win32/Surface.zig
@@ -1,11 +1,209 @@
 /// Win32 surface - represents a terminal surface within a window.
-/// This is a minimal stub for now.
+/// Manages the WGL OpenGL context and provides the interface
+/// expected by CoreSurface.
 const Self = @This();
 
 const std = @import("std");
+const Allocator = std.mem.Allocator;
 const apprt = @import("../../apprt.zig");
+const configpkg = @import("../../config.zig");
 const CoreSurface = @import("../../Surface.zig");
+const CoreApp = @import("../../App.zig");
+
+const log = std.log.scoped(.win32_surface);
+
+// Win32 types
+const HWND = std.os.windows.HWND;
+const HINSTANCE = std.os.windows.HINSTANCE;
+const BOOL = i32;
+const HDC = ?*anyopaque;
+const HGLRC = ?*anyopaque;
+
+const PIXELFORMATDESCRIPTOR = extern struct {
+    nSize: u16,
+    nVersion: u16,
+    dwFlags: u32,
+    iPixelType: u8,
+    cColorBits: u8,
+    cRedBits: u8,
+    cRedShift: u8,
+    cGreenBits: u8,
+    cGreenShift: u8,
+    cBlueBits: u8,
+    cBlueShift: u8,
+    cAlphaBits: u8,
+    cAlphaShift: u8,
+    cAccumBits: u8,
+    cAccumRedBits: u8,
+    cAccumGreenBits: u8,
+    cAccumBlueBits: u8,
+    cAccumAlphaBits: u8,
+    cDepthBits: u8,
+    cStencilBits: u8,
+    cAuxBuffers: u8,
+    iLayerType: u8,
+    bReserved: u8,
+    dwLayerMask: u32,
+    dwVisibleMask: u32,
+    dwDamageMask: u32,
+};
+
+// WGL / GDI constants
+const PFD_DRAW_TO_WINDOW = 0x00000004;
+const PFD_SUPPORT_OPENGL = 0x00000020;
+const PFD_DOUBLEBUFFER = 0x00000001;
+const PFD_TYPE_RGBA = 0;
+const PFD_MAIN_PLANE = 0;
+
+// WGL / GDI extern declarations
+extern "user32" fn GetDC(hWnd: ?HWND) callconv(.winapi) HDC;
+extern "user32" fn ReleaseDC(hWnd: ?HWND, hDC: HDC) callconv(.winapi) c_int;
+extern "gdi32" fn ChoosePixelFormat(hdc: HDC, ppfd: *const PIXELFORMATDESCRIPTOR) callconv(.winapi) c_int;
+extern "gdi32" fn SetPixelFormat(hdc: HDC, format: c_int, ppfd: *const PIXELFORMATDESCRIPTOR) callconv(.winapi) BOOL;
+extern "gdi32" fn SwapBuffers(hdc: HDC) callconv(.winapi) BOOL;
+extern "opengl32" fn wglCreateContext(hdc: HDC) callconv(.winapi) HGLRC;
+extern "opengl32" fn wglDeleteContext(hglrc: HGLRC) callconv(.winapi) BOOL;
+extern "opengl32" fn wglMakeCurrent(hdc: HDC, hglrc: HGLRC) callconv(.winapi) BOOL;
+
+/// The window this surface belongs to.
+hwnd: HWND,
+
+/// GDI device context.
+hdc: HDC = null,
+
+/// OpenGL rendering context.
+hglrc: HGLRC = null,
+
+/// The core surface, if initialized.
+core_surface: ?*CoreSurface = null,
+
+/// Window dimensions.
+width: u32 = 800,
+height: u32 = 600,
+
+pub fn core(self: *Self) *CoreSurface {
+    return self.core_surface.?;
+}
+
+pub fn init(self: *Self, hwnd: HWND) !void {
+    self.* = .{ .hwnd = hwnd };
+    try self.initOpenGL();
+}
 
 pub fn deinit(self: *Self) void {
-    _ = self;
+    if (self.core_surface) |surface| {
+        surface.deinit();
+        // core_surface is allocated by CoreApp, freed there
+    }
+    if (self.hglrc != null) {
+        _ = wglMakeCurrent(null, null);
+        _ = wglDeleteContext(self.hglrc);
+    }
+    if (self.hdc != null) {
+        _ = ReleaseDC(self.hwnd, self.hdc);
+    }
 }
+
+fn initOpenGL(self: *Self) !void {
+    self.hdc = GetDC(self.hwnd);
+    if (self.hdc == null) {
+        log.err("GetDC failed", .{});
+        return error.Win32Error;
+    }
+
+    var pfd: PIXELFORMATDESCRIPTOR = std.mem.zeroes(PIXELFORMATDESCRIPTOR);
+    pfd.nSize = @sizeOf(PIXELFORMATDESCRIPTOR);
+    pfd.nVersion = 1;
+    pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
+    pfd.iPixelType = PFD_TYPE_RGBA;
+    pfd.cColorBits = 32;
+    pfd.cDepthBits = 24;
+    pfd.cStencilBits = 8;
+    pfd.iLayerType = PFD_MAIN_PLANE;
+
+    const pixel_format = ChoosePixelFormat(self.hdc, &pfd);
+    if (pixel_format == 0) {
+        log.err("ChoosePixelFormat failed", .{});
+        return error.Win32Error;
+    }
+
+    if (SetPixelFormat(self.hdc, pixel_format, &pfd) == 0) {
+        log.err("SetPixelFormat failed", .{});
+        return error.Win32Error;
+    }
+
+    self.hglrc = wglCreateContext(self.hdc);
+    if (self.hglrc == null) {
+        log.err("wglCreateContext failed", .{});
+        return error.Win32Error;
+    }
+
+    if (wglMakeCurrent(self.hdc, self.hglrc) == 0) {
+        log.err("wglMakeCurrent failed", .{});
+        return error.Win32Error;
+    }
+
+    log.info("WGL OpenGL context created successfully", .{});
+}
+
+pub fn swapBuffers(self: *Self) void {
+    if (self.hdc != null) {
+        _ = SwapBuffers(self.hdc);
+    }
+}
+
+// --- Interface methods required by CoreSurface ---
+
+pub fn getContentScale(_: *const Self) !apprt.ContentScale {
+    // TODO: query DPI from the monitor
+    return .{ .x = 1.0, .y = 1.0 };
+}
+
+pub fn getSize(self: *const Self) !apprt.SurfaceSize {
+    return .{
+        .width = self.width,
+        .height = self.height,
+    };
+}
+
+pub fn getCursorPos(_: *const Self) !apprt.CursorPos {
+    // TODO: track mouse position
+    return .{ .x = 0, .y = 0 };
+}
+
+pub fn getTitle(_: *Self) ?[:0]const u8 {
+    return null;
+}
+
+pub fn close(_: *Self, _: bool) void {
+    // TODO: handle close with confirmation
+}
+
+pub fn supportsClipboard(_: *Self, clipboard: apprt.Clipboard) bool {
+    return clipboard == .standard;
+}
+
+pub fn clipboardRequest(
+    _: *Self,
+    _: apprt.Clipboard,
+    _: apprt.ClipboardRequest,
+) !bool {
+    // TODO: implement clipboard read
+    return false;
+}
+
+pub fn setClipboard(
+    _: *Self,
+    _: apprt.Clipboard,
+    _: []const apprt.ClipboardContent,
+    _: bool,
+) !void {
+    // TODO: implement clipboard write
+}
+
+pub fn defaultTermioEnv(_: *Self) !std.process.EnvMap {
+    // Return an empty env map; the shell will inherit the process env.
+    return std.process.EnvMap.init(std.heap.page_allocator);
+}
+
+pub fn redrawInspector(_: *Self) void {}

--- a/src/apprt/win32/Surface.zig
+++ b/src/apprt/win32/Surface.zig
@@ -65,6 +65,19 @@ extern "opengl32" fn wglCreateContext(hdc: HDC) callconv(.winapi) HGLRC;
 extern "opengl32" fn wglDeleteContext(hglrc: HGLRC) callconv(.winapi) BOOL;
 extern "opengl32" fn wglMakeCurrent(hdc: HDC, hglrc: HGLRC) callconv(.winapi) BOOL;
 
+// Clipboard API
+const UINT = u32;
+const HANDLE = ?*anyopaque;
+extern "user32" fn OpenClipboard(hWndNewOwner: ?HWND) callconv(.winapi) BOOL;
+extern "user32" fn CloseClipboard() callconv(.winapi) BOOL;
+extern "user32" fn EmptyClipboard() callconv(.winapi) BOOL;
+extern "user32" fn GetClipboardData(uFormat: UINT) callconv(.winapi) HANDLE;
+extern "user32" fn SetClipboardData(uFormat: UINT, hMem: HANDLE) callconv(.winapi) HANDLE;
+extern "kernel32" fn GlobalAlloc(uFlags: UINT, dwBytes: usize) callconv(.winapi) HANDLE;
+extern "kernel32" fn GlobalFree(hMem: HANDLE) callconv(.winapi) HANDLE;
+extern "kernel32" fn GlobalLock(hMem: HANDLE) callconv(.winapi) ?*anyopaque;
+extern "kernel32" fn GlobalUnlock(hMem: HANDLE) callconv(.winapi) BOOL;
+
 /// The window this surface belongs to.
 hwnd: HWND,
 
@@ -211,21 +224,70 @@ pub fn supportsClipboard(_: *Self, clipboard: apprt.Clipboard) bool {
 }
 
 pub fn clipboardRequest(
-    _: *Self,
+    self: *Self,
     _: apprt.Clipboard,
-    _: apprt.ClipboardRequest,
+    req: apprt.ClipboardRequest,
 ) !bool {
-    // TODO: implement clipboard read
-    return false;
+    const surface = self.core_surface orelse return false;
+
+    // Try to read text from the Win32 clipboard synchronously
+    if (OpenClipboard(self.hwnd) == 0) return false;
+    defer _ = CloseClipboard();
+
+    const CF_UNICODETEXT: UINT = 13;
+    const handle = GetClipboardData(CF_UNICODETEXT);
+    if (handle == null) return false;
+
+    const ptr: ?[*:0]const u16 = @ptrCast(@alignCast(GlobalLock(handle)));
+    if (ptr == null) return false;
+    defer _ = GlobalUnlock(handle);
+
+    // Convert UTF-16 to UTF-8
+    const alloc = if (self.app) |app| app.alloc else std.heap.page_allocator;
+    const utf8 = std.unicode.utf16LeToUtf8AllocZ(alloc, std.mem.span(ptr.?)) catch return false;
+    defer alloc.free(utf8);
+
+    try surface.completeClipboardRequest(req, utf8, true);
+    return true;
 }
 
 pub fn setClipboard(
-    _: *Self,
+    self: *Self,
     _: apprt.Clipboard,
-    _: []const apprt.ClipboardContent,
+    contents: []const apprt.ClipboardContent,
     _: bool,
 ) !void {
-    // TODO: implement clipboard write
+    if (contents.len == 0) return;
+
+    const text = contents[0].data;
+    const alloc = if (self.app) |app| app.alloc else std.heap.page_allocator;
+
+    // Convert UTF-8 to UTF-16
+    const utf16 = try std.unicode.utf8ToUtf16LeAllocZ(alloc, text);
+    defer alloc.free(utf16);
+
+    const byte_len = (utf16.len + 1) * 2; // include null terminator
+    const GMEM_MOVEABLE: UINT = 0x0002;
+    const hmem = GlobalAlloc(GMEM_MOVEABLE, byte_len);
+    if (hmem == null) return;
+
+    const dst: ?[*]u16 = @ptrCast(@alignCast(GlobalLock(hmem)));
+    if (dst == null) {
+        _ = GlobalFree(hmem);
+        return;
+    }
+    @memcpy(dst.?[0..utf16.len], utf16);
+    dst.?[utf16.len] = 0;
+    _ = GlobalUnlock(hmem);
+
+    if (OpenClipboard(self.hwnd) == 0) {
+        _ = GlobalFree(hmem);
+        return;
+    }
+    _ = EmptyClipboard();
+    const CF_UNICODETEXT: UINT = 13;
+    _ = SetClipboardData(CF_UNICODETEXT, hmem);
+    _ = CloseClipboard();
 }
 
 pub fn defaultTermioEnv(self: *Self) !std.process.EnvMap {

--- a/src/apprt/win32/Surface.zig
+++ b/src/apprt/win32/Surface.zig
@@ -64,6 +64,7 @@ extern "gdi32" fn SwapBuffers(hdc: HDC) callconv(.winapi) BOOL;
 extern "opengl32" fn wglCreateContext(hdc: HDC) callconv(.winapi) HGLRC;
 extern "opengl32" fn wglDeleteContext(hglrc: HGLRC) callconv(.winapi) BOOL;
 extern "opengl32" fn wglMakeCurrent(hdc: HDC, hglrc: HGLRC) callconv(.winapi) BOOL;
+extern "opengl32" fn wglGetProcAddress(lpszProc: [*:0]const u8) callconv(.winapi) ?*const anyopaque;
 
 // Clipboard API
 const UINT = u32;
@@ -173,6 +174,14 @@ fn initOpenGL(self: *Self) !void {
     }
     glViewport(0, 0, @intCast(self.width), @intCast(self.height));
 
+    // Disable VSync for lower input latency. WGL swap interval of 0
+    // means SwapBuffers returns immediately.
+    const wglSwapIntervalEXT: ?*const fn (i32) callconv(.winapi) i32 = @ptrCast(wglGetProcAddress("wglSwapIntervalEXT"));
+    if (wglSwapIntervalEXT) |setInterval| {
+        _ = setInterval(0);
+        log.info("VSync disabled via wglSwapIntervalEXT", .{});
+    }
+
     log.info("WGL OpenGL context created, client area {}x{}", .{ self.width, self.height });
 }
 
@@ -182,6 +191,14 @@ extern "user32" fn GetClientRect(hWnd: HWND, lpRect: *RECT) callconv(.winapi) BO
 pub fn swapBuffers(self: *Self) void {
     if (self.hdc != null) {
         _ = SwapBuffers(self.hdc);
+    }
+}
+
+/// Disable VSync via WGL extension for lower input latency.
+pub fn disableVSync(_: *Self) void {
+    const func: ?*const fn (i32) callconv(.winapi) i32 = @ptrCast(wglGetProcAddress("wglSwapIntervalEXT"));
+    if (func) |setInterval| {
+        _ = setInterval(0);
     }
 }
 

--- a/src/apprt/win32/Surface.zig
+++ b/src/apprt/win32/Surface.zig
@@ -68,6 +68,9 @@ extern "opengl32" fn wglMakeCurrent(hdc: HDC, hglrc: HGLRC) callconv(.winapi) BO
 /// The window this surface belongs to.
 hwnd: HWND,
 
+/// Pointer back to the App.
+app: ?*App = null,
+
 /// GDI device context.
 hdc: HDC = null,
 
@@ -81,8 +84,14 @@ core_surface: ?*CoreSurface = null,
 width: u32 = 800,
 height: u32 = 600,
 
+const App = @import("App.zig");
+
 pub fn core(self: *Self) *CoreSurface {
     return self.core_surface.?;
+}
+
+pub fn rtApp(self: *Self) *App {
+    return self.app.?;
 }
 
 pub fn init(self: *Self, hwnd: HWND) !void {
@@ -150,6 +159,24 @@ pub fn swapBuffers(self: *Self) void {
     if (self.hdc != null) {
         _ = SwapBuffers(self.hdc);
     }
+}
+
+/// Make the WGL context current on the calling thread.
+pub fn makeContextCurrent(self: *Self) void {
+    if (self.hdc != null and self.hglrc != null) {
+        _ = wglMakeCurrent(self.hdc, self.hglrc);
+    }
+}
+
+/// Release the WGL context from the calling thread.
+pub fn releaseContext() void {
+    _ = wglMakeCurrent(null, null);
+}
+
+/// Release context from the main thread before handing off to renderer thread.
+pub fn releaseMainThreadContext(self: *Self) void {
+    _ = self;
+    _ = wglMakeCurrent(null, null);
 }
 
 // --- Interface methods required by CoreSurface ---

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -596,6 +596,11 @@ pub fn add(
         switch (self.config.app_runtime) {
             .none => {},
             .gtk => try self.addGtkNg(step),
+            .win32 => {
+                step.linkSystemLibrary2("user32", .{});
+                step.linkSystemLibrary2("gdi32", .{});
+                step.linkSystemLibrary2("opengl32", .{});
+            },
         }
     }
 

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -601,6 +601,7 @@ pub fn add(
                 step.linkSystemLibrary2("gdi32", .{});
                 step.linkSystemLibrary2("opengl32", .{});
                 step.linkSystemLibrary2("imm32", .{});
+                step.linkSystemLibrary2("winmm", .{});
             },
         }
     }

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -600,6 +600,7 @@ pub fn add(
                 step.linkSystemLibrary2("user32", .{});
                 step.linkSystemLibrary2("gdi32", .{});
                 step.linkSystemLibrary2("opengl32", .{});
+                step.linkSystemLibrary2("imm32", .{});
             },
         }
     }

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -601,7 +601,6 @@ pub fn add(
                 step.linkSystemLibrary2("gdi32", .{});
                 step.linkSystemLibrary2("opengl32", .{});
                 step.linkSystemLibrary2("imm32", .{});
-                step.linkSystemLibrary2("winmm", .{});
             },
         }
     }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -4625,7 +4625,7 @@ pub fn finalize(self: *Config) !void {
 
     // Apprt-specific defaults
     switch (build_config.app_runtime) {
-        .none => {},
+        .none, .win32 => {},
         .gtk => {
             switch (self.@"gtk-single-instance") {
                 .true, .false => {},

--- a/src/font/CodepointResolver.zig
+++ b/src/font/CodepointResolver.zig
@@ -12,6 +12,7 @@
 const CodepointResolver = @This();
 
 const std = @import("std");
+const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const uucode = @import("uucode");
 const font = @import("main.zig");
@@ -218,6 +219,14 @@ pub fn getIndex(
         }
     }
 
+    // On Windows without font discovery, try loading system fonts directly
+    // as a fallback for missing codepoints (e.g. CJK characters).
+    if (comptime builtin.os.tag == .windows and font.Discover == void) {
+        if (style == .regular) {
+            if (self.windowsFontFallback(alloc, cp, p_mode)) |idx| return idx;
+        }
+    }
+
     // If this is regular with any matching presentation, then we are done
     // there is nothing more we can do. Otherwise we fall through and do
     // an any presentation search.
@@ -225,6 +234,67 @@ pub fn getIndex(
 
     // For non-regular fonts, we fall back to regular with any presentation
     return self.collection.getIndex(cp, .regular, .{ .any = {} });
+}
+
+/// Windows-only: try loading system fonts directly as a fallback when
+/// font discovery is not available. This checks common system font files
+/// that are likely to contain CJK and other extended Unicode glyphs.
+fn windowsFontFallback(
+    self: *CodepointResolver,
+    alloc: Allocator,
+    cp: u32,
+    p_mode: Collection.PresentationMode,
+) ?Collection.Index {
+    if (comptime builtin.os.tag != .windows) return null;
+
+    // List of Windows system fonts to try for fallback, in priority order.
+    // These cover CJK, Arabic, Hebrew, Thai, and other scripts.
+    const fallback_fonts = [_][:0]const u8{
+        "C:\\Windows\\Fonts\\msgothic.ttc", // MS Gothic (Japanese)
+        "C:\\Windows\\Fonts\\meiryo.ttc", // Meiryo (Japanese)
+        "C:\\Windows\\Fonts\\YuGothM.ttc", // Yu Gothic (Japanese)
+        "C:\\Windows\\Fonts\\msyh.ttc", // Microsoft YaHei (Chinese)
+        "C:\\Windows\\Fonts\\simsun.ttc", // SimSun (Chinese)
+        "C:\\Windows\\Fonts\\malgun.ttf", // Malgun Gothic (Korean)
+        "C:\\Windows\\Fonts\\seguiemj.ttf", // Segoe UI Emoji
+        "C:\\Windows\\Fonts\\segoeui.ttf", // Segoe UI
+        "C:\\Windows\\Fonts\\arial.ttf", // Arial
+        "C:\\Windows\\Fonts\\arialuni.ttf", // Arial Unicode MS
+    };
+
+    const load_opts = self.collection.load_options orelse return null;
+
+    for (fallback_fonts) |font_path| {
+        // Try to load the font face
+        var face = Face.initFile(
+            load_opts.library,
+            font_path,
+            0,
+            load_opts.faceOptions(),
+        ) catch continue;
+
+        // Check if this face has the codepoint we need
+        const entry: Collection.Entry = .{
+            .face = .{ .loaded = face },
+            .fallback = true,
+        };
+        if (!entry.hasCodepoint(cp, p_mode)) {
+            face.deinit();
+            continue;
+        }
+
+        log.info("found codepoint 0x{X} in Windows fallback font: {s}", .{ cp, font_path });
+        return self.collection.add(alloc, face, .{
+            .style = .regular,
+            .fallback = true,
+            .size_adjustment = font.default_fallback_adjustment,
+        }) catch {
+            face.deinit();
+            return null;
+        };
+    }
+
+    return null;
 }
 
 /// Checks if the codepoint is in the map of codepoint overrides,

--- a/src/font/SharedGridSet.zig
+++ b/src/font/SharedGridSet.zig
@@ -250,6 +250,30 @@ fn collection(
         }
     }
 
+    // On Windows without font discovery, search system fonts by family name.
+    if (comptime builtin.os.tag == .windows and Discover == void) {
+        var name_buf: [256]u8 = undefined;
+
+        inline for (@typeInfo(Style).@"enum".fields) |field| {
+            const style = @field(Style, field.name);
+            for (key.descriptorsForStyle(style)) |desc| {
+                if (desc.family) |family| {
+                    if (self.findWindowsFont(family, desc, load_options)) |face| {
+                        log.info("font {s}: {s} (Windows)", .{
+                            field.name,
+                            face.name(&name_buf) catch "<unknown>",
+                        });
+                        _ = try c.add(self.alloc, face, .{
+                            .style = style,
+                            .fallback = false,
+                            .size_adjustment = .none,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
     // Complete our styles to ensure we have something to satisfy every
     // possible style request. We do this before adding our built-in font
     // because we want to ensure our built-in styles are fallbacks to
@@ -435,6 +459,76 @@ pub const Map = std.HashMapUnmanaged(
 /// Initialize once and return the font discovery mechanism. This remains
 /// initialized throughout the lifetime of the application because some
 /// font discovery mechanisms (i.e. fontconfig) are unsafe to reinit.
+/// On Windows, search the system font directory for a font matching
+/// the given family name. Returns a loaded Face if found, null otherwise.
+fn findWindowsFont(
+    self: *SharedGridSet,
+    family: [:0]const u8,
+    desc: font.discovery.Descriptor,
+    load_options: Collection.LoadOptions,
+) ?Face {
+    _ = desc;
+    if (comptime builtin.os.tag != .windows) return null;
+
+    const fonts_dir = std.fs.openDirAbsoluteZ("C:\\Windows\\Fonts", .{ .iterate = true }) catch return null;
+    var dir = fonts_dir;
+    defer dir.close();
+
+    var iter = dir.iterate();
+    while (iter.next() catch null) |entry| {
+        if (entry.kind != .file) continue;
+
+        // Only consider font files
+        const name = entry.name;
+        const is_font = std.mem.endsWith(u8, name, ".ttf") or
+            std.mem.endsWith(u8, name, ".ttc") or
+            std.mem.endsWith(u8, name, ".otf") or
+            std.mem.endsWith(u8, name, ".TTF") or
+            std.mem.endsWith(u8, name, ".TTC") or
+            std.mem.endsWith(u8, name, ".OTF");
+        if (!is_font) continue;
+
+        // Build the full path
+        var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const full_path = std.fmt.bufPrintZ(&path_buf, "C:/Windows/Fonts/{s}", .{name}) catch continue;
+
+        // Try loading with FreeType (try multiple face indices for .ttc)
+        var face_index: i32 = 0;
+        while (face_index < 16) : (face_index += 1) {
+            var face = Face.initFile(
+                self.font_lib,
+                full_path,
+                face_index,
+                load_options.faceOptions(),
+            ) catch break;
+
+            // Check the family name using both FreeType's family_name
+            // field and the SFNT name table for better matching.
+            const ft_family: ?[*:0]const u8 = face.face.handle.*.family_name;
+            const matches = if (ft_family) |fam|
+                std.ascii.eqlIgnoreCase(std.mem.span(fam), family)
+            else
+                false;
+
+            if (matches) return face;
+
+            // Also try the SFNT name table
+            var name_buf2: [256]u8 = undefined;
+            const sfnt_name = face.name(&name_buf2) catch "";
+            if (sfnt_name.len > 0 and std.ascii.eqlIgnoreCase(sfnt_name, family)) {
+                return face;
+            }
+
+            face.deinit();
+
+            // Only try multiple indices for .ttc files
+            if (!std.mem.endsWith(u8, name, ".ttc") and !std.mem.endsWith(u8, name, ".TTC")) break;
+        }
+    }
+
+    return null;
+}
+
 fn discover(self: *SharedGridSet) !?*Discover {
     // If we're built without a font discovery mechanism, return null
     if (comptime Discover == void) return null;

--- a/src/main_c.zig
+++ b/src/main_c.zig
@@ -168,8 +168,7 @@ pub export fn ghostty_string_free(str: String) void {
 // but not MSVC. No upstream issue tracks this exact gap as of 2026-03-26.
 // Closest: Codeberg ziglang/zig #30936 (reimplement crt0 code).
 // Remove this DllMain when Zig handles MSVC DLL CRT init natively.
-pub const DllMain = if (builtin.os.tag == .windows and
-    builtin.abi == .msvc) struct {
+pub const DllMain = if (builtin.os.tag != .windows) void else if (builtin.abi == .msvc) struct {
     const BOOL = std.os.windows.BOOL;
     const HINSTANCE = std.os.windows.HINSTANCE;
     const DWORD = std.os.windows.DWORD;
@@ -200,7 +199,19 @@ pub const DllMain = if (builtin.os.tag == .windows and
             else => return TRUE,
         }
     }
-}.handler else void;
+}.handler else struct {
+    // GNU ABI: provide a no-op DllMain so Zig's start.zig doesn't
+    // try to call a type instead of a function.
+    const BOOL = std.os.windows.BOOL;
+    const HINSTANCE = std.os.windows.HINSTANCE;
+    const DWORD = std.os.windows.DWORD;
+    const LPVOID = std.os.windows.LPVOID;
+    const TRUE = std.os.windows.TRUE;
+
+    pub fn handler(_: HINSTANCE, _: DWORD, _: LPVOID) callconv(.winapi) BOOL {
+        return TRUE;
+    }
+}.handler;
 
 test "ghostty_string_s empty string" {
     const testing = std.testing;

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -169,6 +169,11 @@ pub fn surfaceInit(surface: *apprt.Surface) !void {
         apprt.gtk,
         => try prepareContext(null),
 
+        // Win32: WGL context is already current, load via null (GLAD
+        // uses opengl32.dll + wglGetProcAddress automatically).
+        apprt.win32,
+        => try prepareContext(null),
+
         apprt.embedded => {
             // TODO(mitchellh): this does nothing today to allow libghostty
             // to compile for OpenGL targets but libghostty is strictly
@@ -208,6 +213,11 @@ pub fn threadEnter(self: *const OpenGL, surface: *apprt.Surface) !void {
             // on the main thread. As such, we don't do anything here.
         },
 
+        apprt.win32 => {
+            // Win32: WGL context is managed per-window and is already
+            // current on the renderer thread. Nothing extra needed.
+        },
+
         apprt.embedded => {
             // TODO(mitchellh): this does nothing today to allow libghostty
             // to compile for OpenGL targets but libghostty is strictly
@@ -226,6 +236,10 @@ pub fn threadExit(self: *const OpenGL) void {
         apprt.gtk => {
             // We don't need to do any unloading for GTK because we may
             // be sharing the global bindings with other windows.
+        },
+
+        apprt.win32 => {
+            // Win32: WGL context cleanup handled by the apprt surface.
         },
 
         apprt.embedded => {

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -215,6 +215,7 @@ pub fn threadEnter(self: *const OpenGL, surface: *apprt.Surface) !void {
         // reload GL function pointers.
         surface.makeContextCurrent();
         try prepareContext(null);
+        surface.disableVSync();
     }
     // GTK and embedded don't need thread-specific GL setup.
 }

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -195,57 +195,39 @@ pub fn surfaceInit(surface: *apprt.Surface) !void {
 /// thread for final main thread setup requirements.
 pub fn finalizeSurfaceInit(self: *const OpenGL, surface: *apprt.Surface) !void {
     _ = self;
-    _ = surface;
+
+    switch (apprt.runtime) {
+        apprt.win32 => {
+            // Release the WGL context from the main thread so the
+            // renderer thread can acquire it.
+            surface.releaseMainThreadContext();
+        },
+        else => {},
+    }
 }
 
 /// Callback called by renderer.Thread when it begins.
 pub fn threadEnter(self: *const OpenGL, surface: *apprt.Surface) !void {
     _ = self;
-    _ = surface;
 
-    switch (apprt.runtime) {
-        else => @compileError("unsupported app runtime for OpenGL"),
-
-        apprt.gtk => {
-            // GTK doesn't support threaded OpenGL operations as far as I can
-            // tell, so we use the renderer thread to setup all the state
-            // but then do the actual draws and texture syncs and all that
-            // on the main thread. As such, we don't do anything here.
-        },
-
-        apprt.win32 => {
-            // Win32: WGL context is managed per-window and is already
-            // current on the renderer thread. Nothing extra needed.
-        },
-
-        apprt.embedded => {
-            // TODO(mitchellh): this does nothing today to allow libghostty
-            // to compile for OpenGL targets but libghostty is strictly
-            // broken for rendering on this platforms.
-        },
+    if (apprt.runtime == apprt.win32) {
+        // Win32: make the WGL context current on this thread and
+        // reload GL function pointers.
+        surface.makeContextCurrent();
+        try prepareContext(null);
     }
+    // GTK and embedded don't need thread-specific GL setup.
 }
 
 /// Callback called by renderer.Thread when it exits.
 pub fn threadExit(self: *const OpenGL) void {
     _ = self;
 
-    switch (apprt.runtime) {
-        else => @compileError("unsupported app runtime for OpenGL"),
-
-        apprt.gtk => {
-            // We don't need to do any unloading for GTK because we may
-            // be sharing the global bindings with other windows.
-        },
-
-        apprt.win32 => {
-            // Win32: WGL context cleanup handled by the apprt surface.
-        },
-
-        apprt.embedded => {
-            // TODO: see threadEnter
-        },
+    if (apprt.runtime == apprt.win32) {
+        // Release the WGL context from this thread.
+        apprt.win32.Surface.releaseContext();
     }
+    // GTK and embedded don't need thread-specific GL cleanup.
 }
 
 pub fn displayRealized(self: *const OpenGL) void {

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -505,6 +505,12 @@ fn drawFrame(self: *Thread, now: bool) void {
             .{ .instant = {} },
         );
     } else {
+        // On Win32, update the GL viewport before drawing since there's
+        // no toolkit managing it for us.
+        if (comptime @hasDecl(apprt.runtime.Surface, "updateViewport")) {
+            self.surface.updateViewport();
+        }
+
         self.renderer.drawFrame(false) catch |err|
             log.warn("error drawing err={}", .{err});
 

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -507,6 +507,12 @@ fn drawFrame(self: *Thread, now: bool) void {
     } else {
         self.renderer.drawFrame(false) catch |err|
             log.warn("error drawing err={}", .{err});
+
+        // On Win32, we need to explicitly swap buffers after rendering
+        // since there's no toolkit managing the GL context for us.
+        if (comptime @hasDecl(apprt.runtime.Surface, "swapBuffers")) {
+            self.surface.swapBuffers();
+        }
     }
 }
 

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -594,6 +594,16 @@ fn drawCallback(
         return .disarm;
     };
 
+    // On Windows IOCP, async wakeup may be delayed, so we also
+    // update frame data on the draw timer to reduce input latency.
+    if (comptime @hasDecl(apprt.runtime.Surface, "swapBuffers")) {
+        t.drainMailbox() catch {};
+        t.renderer.updateFrame(
+            t.state,
+            t.flags.cursor_blink_visible,
+        ) catch {};
+    }
+
     // Draw
     t.drawFrame(false);
 

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -294,6 +294,11 @@ fn setQosClass(self: *const Thread) void {
 
 fn syncDrawTimer(self: *Thread) void {
     skip: {
+        // On Win32, always keep the draw timer active because the IOCP
+        // async wakeup may have latency. The draw timer polls for new
+        // frame data at regular intervals.
+        if (comptime @hasDecl(apprt.runtime.Surface, "swapBuffers")) break :skip;
+
         // If our renderer supports animations and has them, then we
         // can apply draw timer based on custom shader animation configuration.
         if (@hasDecl(rendererpkg.Renderer, "hasAnimations") and

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -237,6 +237,9 @@ pub fn focusGained(
     assert(td.backend == .exec);
     const execdata = &td.backend.exec;
 
+    // Windows doesn't have termios, so skip the timer entirely.
+    if (comptime builtin.os.tag == .windows) return;
+
     if (!focused) {
         // Flag the timer to end on the next iteration. This is
         // a lot cheaper than doing full timer cancellation.


### PR DESCRIPTION
This adds a minimal but functional Win32 application runtime (`apprt/win32`) that
enables Ghostty to build and run natively on Windows using MinGW (GNU ABI).

Built and tested on Windows 11 with Zig 0.15.2.

### Implemented

- [x] Win32 window creation and message loop
- [x] WGL OpenGL 4.6 rendering context with threaded drawing
- [x] ConPTY shell process (cmd.exe) via existing Pty implementation
- [x] Terminal emulation and text rendering (via CoreSurface)
- [x] Keyboard input: WM_KEYDOWN / WM_CHAR with A-Z, digits, punctuation, function keys, arrows, special keys
- [x] Key release events (WM_KEYUP / WM_SYSKEYUP)
- [x] Modifier keys: Ctrl, Alt, Shift, Super via GetKeyState
- [x] Dead keys and compose sequences (resolved by TranslateMessage into WM_CHAR)
- [x] Mouse input: click (left/right/middle), drag (SetCapture), scroll (WM_MOUSEWHEEL)
- [x] Mouse cursor position tracking (WM_MOUSEMOVE)
- [x] Mouse cursor shape changes (IDC_IBEAM, IDC_HAND, resize cursors, etc.)
- [x] Mouse cursor visibility toggle
- [x] Clipboard read/write via Win32 API (CF_UNICODETEXT)
- [x] Selection/primary clipboard aliased to standard (Windows has single clipboard)
- [x] OSC 52 clipboard integration (via existing clipboard API)
- [x] IME composition window positioning at terminal cursor
- [x] IME font size matching terminal font size
- [x] Window title update from terminal (set_title action)
- [x] Window icon from ID_ICON_GHOSTTY resource
- [x] Toggle maximize (ShowWindow SW_MAXIMIZE/SW_RESTORE)
- [x] Toggle fullscreen (monitor-aware borderless fullscreen)
- [x] Window resize with terminal grid reflow (WM_SIZE → sizeCallback)
- [x] GL viewport sync on resize (updateViewport)
- [x] SwapBuffers on renderer thread
- [x] Per-monitor DPI awareness (SetProcessDpiAwarenessContext)
- [x] DPI-based content scale (GetDpiForWindow)
- [x] Focus events (WM_SETFOCUS / WM_KILLFOCUS → focusCallback)
- [x] Windows light/dark theme detection (AppsUseLightTheme registry)
- [x] Color scheme update on WM_SETTINGCHANGE
- [x] URL open action (ShellExecuteW)
- [x] Bell / alert (MessageBeep)
- [x] Desktop notifications (Shell_NotifyIconW balloon with tray icon)
- [x] Quit confirmation dialog (MessageBoxW when process is active)
- [x] Child process exit notification dialog
- [x] Config hot reload (reload_config action)
- [x] Config file loading (%LOCALAPPDATA%\ghostty\config.ghostty)
- [x] font-family config via Windows system font directory scan (FreeType family_name matching)
- [x] CJK font fallback from C:\Windows\Fonts (msgothic, meiryo, msyh, malgun, etc.)
- [x] font-size config support
- [x] window-width / window-height config with actual font metrics (default 80x24)
- [x] Environment variable inheritance for child process
- [x] Skip termios timer on Windows (no POSIX termios)
- [x] DllMain for GNU ABI (MinGW build support)
- [x] Draw timer always active on Win32 to work around IOCP async latency
- [x] VSync disable on renderer thread for lower latency
- [x] Control character filtering in WM_CHAR to prevent double input
- [x] All remaining apprt actions handled explicitly (no-op for unsupported)

### Stubbed (action accepted but no-op)

Single-window, minimal implementation — these actions are acknowledged but not
acted on. They return success so callers don't treat them as errors:

- Multiple windows / tabs / splits (single-window design)
- `progress_report` — requires ITaskbarList3 COM
- `inspector` — debugging UI not implemented
- `mouse_over_link` — no tooltip/status bar UI
- `quit_timer` — single-window quits immediately
- `start_search` / `end_search` — search overlay UI
- `toggle_command_palette` — command palette UI
- `toggle_quick_terminal` — global hotkey/quick terminal
- `toggle_tab_overview`, `toggle_window_decorations`, `toggle_background_opacity`
- `open_config`, `pwd`, `float_window`, `secure_input`, `readonly`
- `key_sequence`, `key_table`, `color_change`
- `check_for_updates`, `show_on_screen_keyboard`, `command_finished`

### Known limitations

- Font discovery uses a Windows font directory scan + FreeType, not DirectWrite.
- IME preedit text is not rendered inline in the terminal yet.
- No shell integration scripts bundled.
- No accessibility / screen reader support.
- No custom shaders.

This Windows port was developed with the assistance of Claude Code (Anthropic's AI coding tool).