### PR TITLE
Exploration: Reconnectable Terminal using libghostty

### DIFF
--- a/docs/design/reconnectable-terminal.md
+++ b/docs/design/reconnectable-terminal.md
@@ -1,0 +1,903 @@
+# Reconnectable Terminal: Design Proposal
+
+## Problem Statement
+
+SSH terminal sessions are fragile. A network hiccup, laptop sleep, or IP change
+kills the connection and all terminal state is lost. Tools like tmux and screen
+provide reconnection by interposing a multiplexer, but they have their own
+terminal emulators with imperfect compatibility, add visual artifacts, and
+consume resources even when nobody is watching.
+
+Mosh improved the situation by running a VT emulator on both sides and
+synchronizing screen state, but it only syncs the visible viewport (no
+scrollback), doesn't support true reconnection after extended disconnection,
+and has limited VT compatibility.
+
+This proposal describes how Ghostty's VT emulator library (`libghostty`) could
+serve as the foundation for a reconnectable remote terminal that:
+
+1. Runs the authoritative VT emulator on the remote host
+2. Allows a Ghostty client to connect and fully sync terminal state at any time
+3. Prioritizes visible viewport during bandwidth-constrained sync
+4. Backfills scrollback history when bandwidth permits
+5. Streams incremental updates in real-time once caught up
+6. Handles high-throughput output without filling network buffers
+
+## Architecture Overview
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ Remote Host                                                         │
+│                                                                     │
+│  ┌──────────┐     ┌───────────────────────────────────────────────┐  │
+│  │  Shell    │────▶│  ghostty-server (libghostty)                 │  │
+│  │  (bash,   │ pty │                                              │  │
+│  │   zsh,    │◀────│  ┌────────────┐  ┌────────────────────────┐  │  │
+│  │   etc.)   │     │  │ Terminal   │  │ Sync Engine            │  │  │
+│  └──────────┘     │  │ (VT emu)   │  │                        │  │  │
+│                    │  │            │  │ - State snapshotter    │  │  │
+│                    │  │ ┌────────┐ │  │ - Delta tracker        │  │  │
+│                    │  │ │Primary │ │  │ - Priority scheduler   │  │  │
+│                    │  │ │Screen  │ │  │ - Bandwidth estimator  │  │  │
+│                    │  │ │+scroll │ │  │                        │  │  │
+│                    │  │ ├────────┤ │  └────────────────────────┘  │  │
+│                    │  │ │Alt     │ │              │               │  │
+│                    │  │ │Screen  │ │              │               │  │
+│                    │  │ └────────┘ │              │               │  │
+│                    │  └────────────┘              │               │  │
+│                    └─────────────────────────────┬┘               │  │
+│                                                  │                │  │
+└──────────────────────────────────────────────────┼────────────────┘  │
+                                                   │ network          │
+                                          ┌────────┴────────┐         │
+                                          │ Sync Protocol   │         │
+                                          │ (UDP + TCP)     │         │
+                                          └────────┬────────┘         │
+                                                   │                  │
+┌──────────────────────────────────────────────────┼────────────────┐  │
+│ Client (Ghostty)                                 │                │  │
+│                                                  │                │  │
+│  ┌───────────────────────────────────────────────┴──────────────┐ │  │
+│  │ Sync Client                                                  │ │  │
+│  │                                                              │ │  │
+│  │ - State receiver / applier                                   │ │  │
+│  │ - Scrollback cache                                           │ │  │
+│  │ - Input forwarding                                           │ │  │
+│  └──────────────────────────────────┬───────────────────────────┘ │  │
+│                                     │                             │  │
+│  ┌──────────────────────────────────▼───────────────────────────┐ │  │
+│  │ Ghostty Renderer                                             │ │  │
+│  │ (GPU-accelerated, existing rendering pipeline)               │ │  │
+│  └──────────────────────────────────────────────────────────────┘ │  │
+│                                                                   │  │
+└───────────────────────────────────────────────────────────────────┘  │
+```
+
+### Key Insight: Split the VT emulator from the renderer
+
+Ghostty already separates its VT emulator (`src/terminal/`) from its renderer
+(`src/renderer/`). The terminal library processes VT sequences and maintains
+screen state; the renderer reads that state and draws pixels. This is exactly
+the split we need:
+
+- **Server**: Runs `Terminal` + pty, maintains authoritative state
+- **Client**: Receives state snapshots/deltas, feeds them into a local
+  `Terminal` (or directly into the renderer's data structures), and renders
+
+## Terminal State Model
+
+Based on analysis of Ghostty's codebase, the full terminal state that must be
+synchronized consists of:
+
+### Tier 1: Visible State (sync immediately on connect)
+
+This is what the user sees right now. Must be transmitted first.
+
+| State | Source | Approx Size |
+|-------|--------|-------------|
+| Active screen viewport (rows × cols cells) | `Screen.pages` active area | ~16KB for 80×24 (8 bytes/cell + styles) |
+| Cursor position & style | `Screen.cursor` (x, y, cursor_style, pending_wrap) | 8 bytes |
+| Active style (SGR state) | `Screen.cursor.style` | 32 bytes |
+| Color palette (256 colors) | `Terminal.colors.palette` | 768 bytes |
+| Dynamic colors (fg, bg, cursor) | `Terminal.colors.{foreground,background,cursor}` | 12 bytes |
+| Terminal modes (packed bools) | `Terminal.modes.values` (8 bytes as `ModePacked`) | 8 bytes |
+| Mouse mode/format | `Terminal.flags.mouse_event`, `mouse_format` | 2 bytes |
+| Which screen is active | `Terminal.screens.active_key` | 1 byte |
+| Terminal title | `Terminal.title` | Variable |
+| Kitty keyboard flags | `Screen.kitty_keyboard` | ~32 bytes |
+| Scrolling region | `Terminal.scrolling_region` | 8 bytes |
+| Charset state | `Screen.charset` (G0-G3, GL, GR, single_shift) | ~12 bytes |
+
+**Total Tier 1: ~17KB for a typical 80×24 terminal.** This can be transmitted
+in a single packet on most connections.
+
+### Tier 2: Functional State (sync soon after connect)
+
+State that affects behavior but isn't immediately visible.
+
+| State | Source |
+|-------|--------|
+| Saved cursor | `Screen.saved_cursor` |
+| Tab stops | `Terminal.tabstops` |
+| Protected mode | `Screen.protected_mode` |
+| Alternate screen contents (if primary is active) | `Screen.pages` on inactive screen |
+| Saved mode values | `Terminal.modes.saved` |
+| Semantic prompt state | `Screen.semantic_prompt` |
+| PWD (OSC 7) | `Terminal.pwd` |
+
+### Tier 3: Historical State (backfill when bandwidth allows)
+
+| State | Source |
+|-------|--------|
+| Scrollback buffer | `Screen.pages` (all pages above active area) |
+| Kitty graphics/images | `Screen.kitty_images` |
+| Hyperlink data | Page-level hyperlink maps |
+
+## Sync Protocol Design
+
+### Design Principles
+
+1. **State-based, not stream-based.** Like Mosh's SSP, we synchronize terminal
+   state objects, not the raw byte stream from the pty. The server can skip
+   intermediate states when the client can't keep up.
+
+2. **Idempotent updates.** Every message from server to client is a
+   self-contained description of "make the state look like this." Duplicate
+   delivery, reordering, and packet loss are all handled gracefully.
+
+3. **Prioritized transmission.** The visible viewport is always the highest
+   priority. Scrollback is transmitted in the background.
+
+4. **Monotonic versioning.** Every state change increments a version counter.
+   The client reports the latest version it has applied. The server only needs
+   to diff from the client's version to its current version.
+
+### Protocol Layers
+
+```
+┌─────────────────────────────────┐
+│ Application: State Sync         │  Tier 1/2/3 state objects
+├─────────────────────────────────┤
+│ Framing: Priority Multiplexer  │  Priority channels, flow control
+├─────────────────────────────────┤
+│ Transport: Reliable UDP + TCP   │  Encryption, authentication,
+│                                 │  roaming, congestion control
+└─────────────────────────────────┘
+```
+
+### Transport Layer
+
+Use **QUIC** (RFC 9000) rather than building a custom UDP protocol like Mosh.
+QUIC gives us:
+
+- **Multiple independent streams**: Perfect for priority channels (viewport
+  stream, scrollback stream, input stream) without head-of-line blocking
+- **Connection migration**: Handles IP changes natively, replacing Mosh's
+  custom roaming logic
+- **0-RTT reconnection**: QUIC session resumption means reconnection is fast
+- **Built-in congestion control**: No need to build our own
+- **Encryption**: TLS 1.3 built in
+
+Alternatively, for simplicity in a v1, a plain TCP connection with a thin
+framing layer could work, with reconnection handled by session tokens. The
+key insight is that the protocol is state-based, so the transport just needs
+reliable ordered delivery per-stream — the interesting logic is above.
+
+### Stream Architecture (within QUIC or multiplexed TCP)
+
+| Stream | Direction | Priority | Content |
+|--------|-----------|----------|---------|
+| **Control** | Bidirectional | Highest | Handshake, resize, capability negotiation |
+| **Input** | Client → Server | Highest | Keystrokes (forwarded to pty) |
+| **Viewport** | Server → Client | High | Active screen state + cursor |
+| **Metadata** | Server → Client | Medium | Modes, colors, title, Tier 2 state |
+| **Scrollback** | Server → Client | Low | Historical pages, backfill |
+| **Images** | Server → Client | Lowest | Kitty graphics data |
+
+### State Versioning
+
+The server maintains a monotonically increasing **epoch counter**. Each time
+the terminal state changes, the epoch advances. Different state tiers can have
+independent epoch tracking:
+
+```
+ViewportEpoch: u64    // Incremented on any visible screen change
+MetadataEpoch: u64    // Incremented on mode/color/title changes
+ScrollbackEpoch: u64  // Incremented when pages scroll off the viewport
+```
+
+The client reports its last-applied epoch per tier. The server computes the
+diff from the client's epoch to its current epoch.
+
+### Connection Lifecycle
+
+#### Initial Connection
+
+```
+Client                              Server
+  │                                    │
+  │──── ClientHello ──────────────────▶│  Session token, terminal size,
+  │                                    │  capabilities
+  │◀─── ServerHello ─────────────────▶│  Session ID, server capabilities
+  │                                    │
+  │◀─── ViewportSnapshot ────────────│  Full Tier 1 state
+  │◀─── MetadataSnapshot ───────────│  Full Tier 2 state
+  │                                    │
+  │◀─── ViewportDelta ───────────────│  Real-time updates begin
+  │◀─── ScrollbackChunk ────────────│  Background backfill begins
+  │──── Input ────────────────────────▶│  Keystrokes flow
+  │                                    │
+```
+
+#### Reconnection (after disconnection)
+
+```
+Client                              Server
+  │                                    │
+  │──── ClientHello ──────────────────▶│  Same session token,
+  │     (session_token, last_epochs)   │  last-seen epochs per tier
+  │                                    │
+  │◀─── ServerHello ─────────────────│  Confirms session, current epochs
+  │                                    │
+  │  [If epochs are close: delta sync]
+  │◀─── ViewportDelta ───────────────│  Diff from client's epoch
+  │                                    │
+  │  [If epochs are far apart: full snapshot]
+  │◀─── ViewportSnapshot ────────────│  Full Tier 1 state
+  │                                    │
+  │◀─── ScrollbackChunk ────────────│  Resume backfill from where
+  │                                    │  client left off
+  │──── Input ────────────────────────▶│
+  │                                    │
+```
+
+The server can decide whether to send a delta or full snapshot based on how
+many epochs have passed. If the gap is small (the client was disconnected
+briefly), a delta is more efficient. If the gap is large (the client was
+disconnected for hours), a full snapshot is cheaper than replaying thousands
+of deltas.
+
+## State Serialization Format
+
+### Option A: VT Escape Sequence Replay (simplest)
+
+Ghostty already has a `TerminalFormatter` with `.vt` format (`formatter.zig`)
+that can serialize terminal state as VT escape sequences. This includes:
+
+- Color palette (OSC 4 sequences)
+- Terminal modes (CSI ?Nh / CSI ?Nl for each non-default mode)
+- Scrolling region (DECSTBM, DECSLRM)
+- Tab stops (clear all + set each)
+- Keyboard state (modifyOtherKeys)
+- PWD (OSC 7)
+- Screen contents (with SGR styling, cursor positioning)
+
+**Advantages:**
+- Already implemented and tested
+- The client can just feed these bytes into a local `Terminal` instance
+- No new serialization format to define
+- Naturally handles all the edge cases that VT sequences handle
+
+**Disadvantages:**
+- Verbose: SGR sequences repeat redundant state between cells
+- No binary compression
+- Scrollback would need to be sent row by row
+
+### Option B: Binary State Protocol (more efficient)
+
+A custom binary format that maps directly to Ghostty's internal structures.
+
+```
+ViewportSnapshot {
+    epoch: u64
+    terminal_size: { rows: u16, cols: u16 }
+    active_screen: enum { primary, alternate }
+    cursor: { x: u16, y: u16, style: u8, pending_wrap: bool }
+    modes: [8]u8           // Raw ModePacked bytes
+    palette: [256 * 3]u8   // RGB values
+    dynamic_colors: { fg: ?RGB, bg: ?RGB, cursor_color: ?RGB }
+    scrolling_region: { top: u16, bottom: u16, left: u16, right: u16 }
+    charset: { g0-g3: u8, gl: u8, gr: u8 }
+    mouse: { event: u8, format: u8 }
+    title_len: u16
+    title: [title_len]u8
+    // Screen content follows
+    rows: [num_rows]RowData
+}
+
+RowData {
+    flags: u8  // wrap, wrap_continuation, semantic_prompt
+    cells: [num_cols]CellData
+}
+
+CellData {
+    codepoint: u21
+    style_id: u16    // Index into a style table sent separately
+    wide: u2
+    semantic_content: u2
+    // Grapheme clusters sent separately for cells that have them
+}
+
+// Style table (deduplicated)
+StyleTable {
+    count: u16
+    styles: [count]StyleData
+}
+
+StyleData {
+    fg: Color       // enum { default, palette(u8), rgb(RGB) }
+    bg: Color
+    underline_color: Color
+    flags: u16      // bold, italic, underline, etc.
+}
+```
+
+**Advantages:**
+- Compact: a typical 80×24 viewport with few unique styles is ~5-8KB
+- Styles are deduplicated (most terminals use <10 unique styles at a time)
+- Easy to delta-compress between versions
+- Maps directly to Ghostty's internal representation
+
+**Disadvantages:**
+- New format to define, implement, and version
+- Must handle format evolution as Ghostty adds features
+
+### Recommendation: Hybrid Approach
+
+Use **Option B (binary) for the viewport and metadata** (compact, fast,
+delta-friendly) and **Option A (VT sequences) for scrollback backfill**
+(simpler, already works, scrollback doesn't need to be fast).
+
+## Delta Encoding
+
+### Viewport Deltas
+
+When the client is connected and keeping up, the server sends incremental
+viewport deltas rather than full snapshots. The delta format leverages the
+fact that most screen updates are localized:
+
+```
+ViewportDelta {
+    epoch: u64
+    base_epoch: u64    // Client's epoch this delta applies to
+    changes: []Change
+}
+
+Change = union {
+    // A contiguous run of cells changed at a position
+    CellRun: {
+        row: u16, col: u16
+        cells: []CellData
+    }
+
+    // A row was scrolled (common case: new line at bottom)
+    ScrollUp: {
+        top: u16, bottom: u16  // scroll region
+        count: u16
+        new_rows: []RowData    // the new rows at the bottom
+    }
+
+    // Cursor moved
+    CursorMove: { x: u16, y: u16, style: u8 }
+
+    // Mode changed
+    ModeChange: { mode: u16, value: bool }
+
+    // Title changed
+    TitleChange: { title: []u8 }
+
+    // Palette entry changed
+    PaletteChange: { index: u8, rgb: RGB }
+}
+```
+
+The server tracks which rows and cells have been modified since the last
+frame sent to the client. This mirrors how Ghostty's renderer already
+tracks dirty state — the Page's `serial` counter and the row/cell dirty
+tracking can serve this purpose.
+
+### Scrollback Transmission
+
+Scrollback pages are sent as chunks, newest first (since the user is most
+likely to scroll up to recent history). Each chunk is tagged with the page's
+`serial` number:
+
+```
+ScrollbackChunk {
+    page_serial: u64
+    row_offset: u16        // Within the page
+    row_count: u16
+    rows: []RowData        // Or VT-formatted text
+    has_more: bool
+}
+```
+
+The client acknowledges received chunks. The server only sends scrollback
+data when the viewport stream has spare bandwidth.
+
+## Bandwidth Management
+
+### The Core Problem
+
+When a process is spewing output (e.g., `cat /dev/urandom | xxd`), the server's
+terminal state is changing faster than the network can transmit. We must:
+
+1. Never buffer unbounded output toward the client
+2. Always prioritize the current visible state
+3. Make Ctrl-C work within one RTT
+
+### Frame Rate Adaptation (borrowing from Mosh)
+
+The server maintains a **frame budget** based on estimated bandwidth:
+
+```
+frame_interval = max(SRTT / 2, MIN_FRAME_INTERVAL)
+max_frame_size = estimated_bandwidth * frame_interval
+```
+
+When the terminal is changing rapidly:
+
+1. The server accumulates changes for `collection_interval` (8ms, matching
+   Mosh's empirically derived value)
+2. It then computes the delta from the last acknowledged client epoch
+3. If the delta fits in `max_frame_size`, send it as a delta
+4. If not, send a full viewport snapshot (which is bounded by terminal size)
+5. Drop all intermediate state — the client jumps to the current state
+
+This ensures:
+- Network buffers never grow unboundedly
+- The client always sees the latest state, not stale queued data
+- Ctrl-C (sent on the input stream, which is always highest priority) arrives
+  within one RTT
+
+### Priority Scheduling
+
+The server allocates bandwidth across streams using weighted fair queuing:
+
+```
+During initial sync:
+    Viewport:   80% of bandwidth
+    Metadata:   15%
+    Scrollback:  5%
+    Images:      0%
+
+During steady state:
+    Viewport:   90% (but usually uses much less)
+    Metadata:    5%
+    Scrollback:  5% (if any pending)
+    Images:      0% (background)
+
+During spewing:
+    Viewport:  100% (everything else paused)
+    Scrollback and images resume when viewport is idle
+```
+
+When viewport is idle (no changes for >100ms), the spare bandwidth is
+reallocated to scrollback backfill and image transfer.
+
+### Scrollback Backfill Strategy
+
+After initial connection and viewport sync, scrollback is backfilled in
+reverse chronological order (newest pages first):
+
+```
+Phase 1: Sync viewport (Tier 1)         ~17KB, <1 frame
+Phase 2: Sync metadata (Tier 2)          ~1KB,  <1 frame
+Phase 3: Backfill scrollback             Pages newest→oldest
+Phase 4: Transfer images                 As bandwidth allows
+```
+
+During Phase 3, if new viewport data arrives:
+- Pause scrollback transmission immediately
+- Send viewport update
+- Resume scrollback after viewport is idle
+
+The client can begin scrolling through history as soon as it receives any
+scrollback data, even if backfill is incomplete. The UI should indicate
+which portions are available vs. still loading.
+
+## Server-Side Design
+
+### `ghostty-server` Process
+
+A lightweight daemon that:
+
+1. Creates a pty and spawns the user's shell
+2. Instantiates a `Terminal` (libghostty) to process pty output
+3. Listens for client connections
+4. Runs the sync engine to transmit state
+
+```zig
+const Server = struct {
+    terminal: Terminal,
+    pty: Pty,
+    
+    // Sync state
+    viewport_epoch: u64,
+    metadata_epoch: u64,
+    scrollback_epoch: u64,
+    
+    // Connected clients (usually 1, could support read-only viewers)
+    clients: []Client,
+    
+    // Bandwidth estimation
+    srtt: u64,      // Smoothed round-trip time
+    bandwidth: u64, // Estimated bytes/sec
+    
+    // Collection interval timer
+    collection_timer: Timer,
+};
+
+const Client = struct {
+    connection: QuicConnection,
+    
+    // Last acknowledged epochs per tier
+    viewport_ack: u64,
+    metadata_ack: u64,
+    scrollback_ack: u64,
+    
+    // Scrollback backfill progress
+    scrollback_cursor: ?PageList.Pin,
+};
+```
+
+### Hooking into Terminal State Changes
+
+The sync engine needs to know when terminal state changes. Rather than
+modifying every terminal operation, we can leverage several existing
+mechanisms:
+
+1. **Page serial numbers**: `PageList.Node.serial` is already incremented
+   when pages are created. We can extend this to track modifications.
+
+2. **Dirty flags**: `Terminal.Dirty` and `Screen.Dirty` already track
+   palette changes, reverse colors, clear events, and selection changes.
+
+3. **Collection interval**: Like Mosh, batch changes for 8ms before
+   computing a delta. This naturally coalesces burst output.
+
+The cleanest approach is a **post-write hook** on the terminal: after each
+call to `Terminal.processOutput()` (which feeds pty data through the
+parser/stream/handler), bump the viewport epoch if any visible cells or
+cursor state changed.
+
+### Handling Output Spew
+
+When the pty is producing output faster than we can sync:
+
+```
+loop {
+    // Read from pty (non-blocking, batch)
+    const data = pty.readNonBlocking();
+    terminal.processOutput(data);
+    
+    // Check if we should send a frame
+    if (collection_timer.expired()) {
+        if (client.viewport_ack < viewport_epoch) {
+            // Client is behind — send snapshot, not delta
+            sendViewportSnapshot(client);
+        } else {
+            // Client is caught up — send delta
+            sendViewportDelta(client);
+        }
+        collection_timer.reset();
+    }
+}
+```
+
+The key insight: **we always process all pty output through the terminal
+emulator** (keeping the authoritative state up to date), but we only send
+the *current* state to the client, skipping all intermediate frames. The
+terminal emulator processes data at memory speed; the bottleneck is only
+the network.
+
+## Client-Side Design
+
+### Two Approaches
+
+**Approach A: Shadow Terminal**
+
+The client maintains its own `Terminal` instance. Viewport snapshots/deltas
+are applied by generating equivalent VT sequences and feeding them to the
+client's terminal. The client's renderer draws from this local terminal.
+
+- **Pro**: Existing renderer works unchanged. Local scrollback works.
+- **Con**: Two terminal emulators in the loop. Potential fidelity issues
+  with VT sequence round-tripping.
+
+**Approach B: Direct Rendering from Wire State**
+
+The client deserializes the binary viewport data directly into page/cell
+structures that the renderer can consume. No local terminal emulator.
+
+- **Pro**: Perfect fidelity. Single source of truth.
+- **Con**: Requires renderer changes to accept externally-provided pages.
+  Local scrollback is "remote scrollback" until backfilled.
+
+**Recommendation**: Start with **Approach A** for simplicity. The
+`TerminalFormatter` with `.vt` output already exists and handles the
+complex edge cases. Move to Approach B only if round-trip fidelity becomes
+a problem or performance demands it.
+
+### Client State Management
+
+```
+ClientState {
+    // Local terminal fed by server state
+    terminal: Terminal,
+    
+    // Scrollback cache — persists across reconnections
+    scrollback_cache: ScrollbackCache,
+    
+    // Connection state
+    connection: ?Connection,
+    session_token: [32]u8,
+    
+    // Epochs
+    viewport_epoch: u64,
+    metadata_epoch: u64,
+    scrollback_epoch: u64,
+}
+```
+
+The `ScrollbackCache` stores backfilled scrollback pages locally. On
+reconnection, the client reports which pages it already has, and the server
+skips those during backfill. This means reconnecting to a long-running
+session doesn't require re-transmitting all scrollback.
+
+### Input Handling
+
+User input is sent immediately on the input stream. Unlike Mosh, we do NOT
+do speculative local echo in v1. Reasons:
+
+1. Ghostty's cursor and rendering is already optimized for low latency
+2. Speculative echo adds complexity and can produce visual artifacts
+3. Modern networks are fast enough for most use cases
+4. Can be added later as an optional enhancement
+
+Input is sent as raw bytes (what would normally go to the pty):
+
+```
+InputMessage {
+    sequence: u64    // For acknowledgment/ordering
+    data: []u8       // Raw bytes to write to pty
+}
+```
+
+## Resize Handling
+
+Terminal resize is a critical operation that must be synchronized:
+
+1. Client sends resize request: `ResizeMessage { rows, cols, width_px, height_px }`
+2. Server calls `terminal.resize()` and sends `SIGWINCH` to the pty
+3. Server immediately sends a full viewport snapshot (since all rows may reflow)
+4. Client applies the snapshot
+
+If the client and server are temporarily different sizes (e.g., during
+reconnection from a differently-sized window), the server resizes to match
+the client. The server always authoritative tracks the current size.
+
+## Session Management
+
+### Session Persistence
+
+`ghostty-server` maintains sessions on disk so they survive server restarts:
+
+```
+~/.local/share/ghostty-server/sessions/
+    <session-id>/
+        session.json    # Session metadata (pty fd, shell pid, etc.)
+        terminal.state  # Serialized terminal state (for crash recovery)
+```
+
+### Session Discovery
+
+When a Ghostty client connects, it can list available sessions:
+
+```
+Client ──── ListSessions ────▶ Server
+Client ◀─── SessionList ────── Server
+    [{id: "abc123", title: "vim ~/project", created: "...", shell_pid: 1234}, ...]
+```
+
+### Multi-client Support
+
+Multiple clients can connect to the same session:
+
+- **One writer** (receives input focus)
+- **N readers** (view-only, useful for pair programming or monitoring)
+- Clients can request/transfer write access via the control stream
+
+## Security Model
+
+### Authentication
+
+1. Initial connection is bootstrapped via SSH (like Mosh):
+   - Client SSHs to the server and runs `ghostty-server --new`
+   - Server prints a session token and port
+   - Client connects directly using the token
+2. All subsequent communication is encrypted (QUIC/TLS or a symmetric cipher
+   like AES-GCM with the session key)
+3. Session tokens are single-use for initial connection, then upgraded to
+   session keys
+
+### Authorization
+
+- The session token grants full access to the terminal session
+- Token is scoped to one session, one server
+- Tokens expire after a configurable idle timeout
+
+## Implementation Phases
+
+### Phase 1: Core Protocol (MVP)
+
+- `ghostty-server` binary: pty management, terminal emulation, basic TCP server
+- Full viewport snapshot on connect (VT format, using existing `TerminalFormatter`)
+- Incremental viewport updates (VT sequences for changed regions)
+- Input forwarding
+- Resize handling
+- Simple reconnection (full re-snapshot)
+- No scrollback sync
+
+This is roughly equivalent to Mosh's functionality but with full Ghostty
+VT compatibility and reconnection support.
+
+### Phase 2: Efficient Sync
+
+- Binary viewport format (replace VT sequences for viewport)
+- Delta encoding for viewport updates
+- Epoch-based versioning with smart delta-vs-snapshot decisions
+- Bandwidth estimation and frame rate adaptation
+- Collection interval batching
+
+### Phase 3: Scrollback Backfill
+
+- Reverse-chronological scrollback transmission
+- Client-side scrollback cache with persistence
+- Incremental backfill (resume from where you left off on reconnect)
+- Priority scheduling (viewport > scrollback)
+- UI indication of backfill progress
+
+### Phase 4: Advanced Features
+
+- QUIC transport with connection migration
+- Kitty graphics image sync
+- Speculative local echo (like Mosh)
+- Multi-client sessions
+- Session persistence across server restarts
+
+## Comparison with Prior Art
+
+| Feature | SSH | Mosh | tmux/screen | This Proposal |
+|---------|-----|------|-------------|---------------|
+| Survives disconnect | No | Partial | Yes | Yes |
+| Survives IP change | No | Yes | No* | Yes (QUIC) |
+| Scrollback sync | N/A | No | Yes (own emu) | Yes (backfill) |
+| VT compatibility | Full** | Limited | Limited | Full (Ghostty) |
+| Bandwidth efficient | No (TCP) | Yes (SSP) | No (TCP) | Yes |
+| Local echo prediction | No | Yes | No | Planned |
+| Ctrl-C under load | Delayed | Instant | Delayed | Instant |
+| State sync after hours | N/A | Drift*** | Yes | Yes (snapshot) |
+
+\* tmux requires re-SSH.
+\** SSH passes raw bytes, so compatibility depends on the local terminal.
+\*** Mosh can desync on features it doesn't understand (OSC, etc.)
+
+## Implementation Leverage Points
+
+Analysis of Ghostty's internals reveals several existing mechanisms that the
+sync engine can directly reuse, reducing implementation effort significantly:
+
+### 1. Page Memory Model Enables Zero-Copy Serialization
+
+Pages use **offset-based addressing** (`Offset(T)` relative to the `memory`
+base pointer), not raw pointers. This means an entire Page can be `memcpy`'d
+and all internal references remain valid. For the binary protocol, we can
+transmit raw page memory (or compressed page memory) without any
+serialization/deserialization — the client just maps the received bytes
+and the data structures are immediately usable.
+
+This is a massive advantage over approaches that require walking every cell
+and encoding it. A typical page is ~512KB and contains ~215 rows. With
+zstd compression on terminal text (which is highly repetitive), this could
+compress to ~50-100KB per page.
+
+### 2. RenderState Pattern = Sync Engine Pattern
+
+The existing `RenderState.update()` (`src/terminal/render.zig`) already
+implements exactly the pattern the sync engine needs:
+
+- Takes a terminal mutex lock
+- Checks dirty flags at three levels (Terminal, Screen, Row/Page)
+- Copies only changed state into a snapshot
+- Clears dirty flags after consumption
+- Produces a `.full` / `.partial` / `.false` dirty result
+
+The sync engine is essentially a second "renderer" that produces network
+frames instead of GPU frames. It can reuse the same dirty tracking
+infrastructure. The key difference: the sync engine produces wire-format
+snapshots/deltas instead of GPU cell buffers.
+
+### 3. Existing Dirty Tracking is Sufficient
+
+The three-layer dirty tracking already in place provides exactly the change
+detection the delta protocol needs:
+
+| Dirty Layer | Sync Use |
+|---|---|
+| `Terminal.Dirty.palette` | Triggers palette re-sync |
+| `Terminal.Dirty.reverse_colors` | Triggers mode re-sync |
+| `Terminal.Dirty.clear` | Triggers full viewport snapshot |
+| `Screen.Dirty.selection` | Triggers selection state update |
+| `Row.dirty` | Identifies which rows need delta encoding |
+| `Page.dirty` | Identifies bulk-modified pages |
+| `PageList.Node.serial` | Identifies new vs. existing scrollback pages |
+| `kitty_images.dirty` | Triggers image re-sync |
+
+No new dirty tracking needs to be added to the core terminal code.
+
+### 4. Style Deduplication Already Exists
+
+Styles are ref-counted and deduplicated in per-page `StyleSet`. The binary
+protocol's "style table" concept maps directly to this — we can transmit the
+page's style set entries (typically <10 unique styles for a viewport) and
+reference them by ID in the cell data, exactly as the internal representation
+does.
+
+### 5. TerminalFormatter Handles the Hard Cases
+
+The existing `TerminalFormatter` with `.vt` and `.extra = .all` already
+handles serializing: palette (all 256 entries as OSC 4), non-default modes
+(iterates all `ModePacked` fields), scrolling region (DECSTBM/DECSLRM),
+tabstops (clear all + set each), keyboard state (modifyOtherKeys), PWD
+(OSC 7), and full screen contents with styles. This is the Phase 1 wire
+format with zero additional implementation work.
+
+### 6. Parser State Does Not Need Syncing
+
+The VT parser state machine lives on the `Stream` handler, not on
+`Terminal`. It's ephemeral state that exists only during byte processing.
+Since the server fully processes all pty output through the terminal
+emulator, there is never a case where parser state needs to cross the wire.
+Similarly, the APC handler (for in-progress Kitty graphics uploads) is
+ephemeral.
+
+### 7. Colors Survive fullReset()
+
+One subtle detail: `Terminal.colors` (the 256-entry palette and dynamic
+fg/bg/cursor colors) survive a terminal `fullReset()` (RIS). This means
+color state can persist across shell restarts within the same session and
+must always be synced as part of Tier 1 state.
+
+## Open Questions
+
+1. **Should the server support multiple simultaneous shells per session?**
+   This would make it a tmux replacement. v1 should be 1:1 (one session, one
+   shell) to keep it simple, but the architecture should not preclude this.
+
+2. **How to handle the alternate screen (e.g., when vim is running)?** The
+   alternate screen is typically small (viewport only, no scrollback). We
+   should sync it fully as part of Tier 1 metadata. When the program exits
+   and switches back to primary, we need to sync the primary screen's full
+   scrollback again.
+
+3. **Should the client cache terminal state to disk for instant reconnect?**
+   The client could write periodic snapshots to disk so that on reconnect,
+   it can show the last-known state immediately while fetching updates from
+   the server. This provides a "last known good" experience even before
+   the network comes up.
+
+4. **Should scrollback be compressed?** Scrollback is mostly text, which
+   compresses extremely well (10-20x with zstd). Given that scrollback is
+   the bulk of what we transmit, compression could significantly reduce
+   backfill time. zstd streaming compression would be natural here.
+
+5. **How to handle the server running on a different OS or architecture?**
+   The binary format must be endian-independent and version-tagged. The VT
+   format (Phase 1) is inherently portable since it's just text.
+
+6. **How to handle `SIGWINCH` race conditions?** If the client resizes while
+   disconnected, on reconnect the server must resize to the new dimensions.
+   If two clients connect with different sizes, the server must pick one
+   (the writer's size) and the reader must adapt (or use a viewport
+   transformation).

--- a/src/build/GhosttyBench.zig
+++ b/src/build/GhosttyBench.zig
@@ -46,6 +46,21 @@ pub fn init(
         try steps.append(b.allocator, exe);
     }
 
+    // Terminal state snapshot demo tool.
+    {
+        const exe = b.addExecutable(.{
+            .name = "ghostty-snap",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/main_snap.zig"),
+                .target = deps.config.target,
+                .optimize = .Debug,
+            }),
+        });
+        exe.linkLibC();
+        _ = try deps.add(exe);
+        try steps.append(b.allocator, exe);
+    }
+
     return .{ .steps = steps.items };
 }
 

--- a/src/main_snap.zig
+++ b/src/main_snap.zig
@@ -1,12 +1,11 @@
-///! ghostty-snap: Reconnectable terminal demo
-///!
-///! Demonstrates reconnectable terminal technology using Ghostty's VT emulator.
+///! ghostty-snap: Reconnectable terminal prototype
 ///!
 ///! Usage:
-///!   ghostty-snap server [-- command]    Start a server with a shell/command
-///!   ghostty-snap attach [host:port]     Attach to a running server interactively
-///!   ghostty-snap capture [-- command]   Run command, snapshot on Ctrl-\ (SIGQUIT)
-///!   ghostty-snap restore [file]         Replay a snapshot file to stdout
+///!   ghostty-snap server [--name NAME] [-- command]   Start a named server session
+///!   ghostty-snap attach [name | host:port]            Attach to a session interactively
+///!   ghostty-snap list                                 List active sessions
+///!   ghostty-snap capture [-- command]                 Snapshot on Ctrl-\ or exit
+///!   ghostty-snap restore [file]                       Replay snapshot to stdout
 const std = @import("std");
 const posix = std.posix;
 
@@ -33,6 +32,91 @@ fn stderrFmt(comptime fmt_str: []const u8, fmt_args: anytype) void {
     writeStderr(msg);
 }
 
+// ─── framing protocol ────────────────────────────────────────────────────────
+//
+// Wire format: [type: u8] [length: u24 big-endian] [payload: length bytes]
+// 4-byte header + payload. Max message: 16MB.
+
+const MsgType = enum(u8) {
+    // Server → Client
+    pty_data = 0x01,
+    snapshot = 0x02,
+    scrollback = 0x03,
+
+    // Client → Server
+    input = 0x81,
+    resize = 0x82,
+
+    _,
+};
+
+fn writeFrame(fd: posix.fd_t, msg_type: MsgType, payload: []const u8) bool {
+    const len: u32 = @intCast(payload.len);
+    const header = [4]u8{
+        @intFromEnum(msg_type),
+        @truncate(len >> 16),
+        @truncate((len >> 8) & 0xff),
+        @truncate(len & 0xff),
+    };
+
+    // Write header + payload. Single write for small messages.
+    if (payload.len <= 4092) {
+        var combined: [4096]u8 = undefined;
+        @memcpy(combined[0..4], &header);
+        @memcpy(combined[4..][0..payload.len], payload);
+        _ = posix.write(fd, combined[0 .. 4 + payload.len]) catch return false;
+    } else {
+        _ = posix.write(fd, &header) catch return false;
+        _ = posix.write(fd, payload) catch return false;
+    }
+    return true;
+}
+
+/// Incremental frame reader. Accumulates bytes and yields complete messages.
+const FrameReader = struct {
+    buf: [65536]u8 = undefined,
+    len: usize = 0,
+
+    const Frame = struct {
+        msg_type: MsgType,
+        payload: []const u8,
+    };
+
+    /// Add raw bytes and return the next complete frame, if any.
+    /// Caller must process one frame at a time (call repeatedly until null).
+    fn feed(self: *FrameReader, data: []const u8) void {
+        const space = self.buf.len - self.len;
+        const to_copy = @min(data.len, space);
+        @memcpy(self.buf[self.len..][0..to_copy], data[0..to_copy]);
+        self.len += to_copy;
+    }
+
+    fn next(self: *FrameReader) ?Frame {
+        if (self.len < 4) return null;
+        const msg_len: usize = (@as(usize, self.buf[1]) << 16) |
+            (@as(usize, self.buf[2]) << 8) |
+            @as(usize, self.buf[3]);
+        const total = 4 + msg_len;
+        if (self.len < total) return null;
+
+        const frame = Frame{
+            .msg_type = @enumFromInt(self.buf[0]),
+            .payload = self.buf[4..total],
+        };
+
+        // Shift remaining data
+        const remaining = self.len - total;
+        if (remaining > 0) {
+            std.mem.copyForwards(u8, self.buf[0..remaining], self.buf[total..self.len]);
+        }
+        self.len = remaining;
+
+        return frame;
+    }
+};
+
+// ─── main ─────────────────────────────────────────────────────────────────────
+
 pub fn main() !void {
     const alloc = std.heap.c_allocator;
 
@@ -42,13 +126,14 @@ pub fn main() !void {
     _ = args.next();
     const subcmd = args.next() orelse {
         writeStderr(
-            \\ghostty-snap: Reconnectable terminal demo
+            \\ghostty-snap: Reconnectable terminal prototype
             \\
             \\Usage:
-            \\  ghostty-snap server [-- cmd]     Start server with shell/command
-            \\  ghostty-snap attach [host:port]  Attach interactively (default: localhost:7681)
-            \\  ghostty-snap capture [-- cmd]    Snapshot on Ctrl-\ or exit
-            \\  ghostty-snap restore [file]      Replay snapshot to stdout
+            \\  ghostty-snap server [--name N] [-- cmd]   Start a named session
+            \\  ghostty-snap attach [name | host:port]    Attach interactively
+            \\  ghostty-snap list                         List active sessions
+            \\  ghostty-snap capture [-- cmd]             Snapshot on Ctrl-\ or exit
+            \\  ghostty-snap restore [file]               Replay snapshot to stdout
             \\
         );
         return;
@@ -58,16 +143,18 @@ pub fn main() !void {
         try runServer(alloc, &args);
     } else if (std.mem.eql(u8, subcmd, "attach")) {
         try runAttach(alloc, &args);
+    } else if (std.mem.eql(u8, subcmd, "list")) {
+        try runList();
     } else if (std.mem.eql(u8, subcmd, "capture")) {
         try runCapture(alloc, &args);
     } else if (std.mem.eql(u8, subcmd, "restore")) {
         try runRestore(alloc, &args);
     } else {
-        writeStderr("Unknown subcommand. Use: server, attach, capture, restore\n");
+        writeStderr("Unknown subcommand. Use: server, attach, list, capture, restore\n");
     }
 }
 
-// ─── helpers ──────────────────────────────────────────────────────────────────
+// ─── common helpers ───────────────────────────────────────────────────────────
 
 fn collectCommandArgs(alloc: std.mem.Allocator, args: *std.process.ArgIterator) ![]const []const u8 {
     var cmd_args: std.ArrayList([]const u8) = .empty;
@@ -80,9 +167,7 @@ fn collectCommandArgs(alloc: std.mem.Allocator, args: *std.process.ArgIterator) 
         }
         try cmd_args.append(alloc, arg);
     }
-    if (cmd_args.items.len > 0) {
-        return try alloc.dupe([]const u8, cmd_args.items);
-    }
+    if (cmd_args.items.len > 0) return try alloc.dupe([]const u8, cmd_args.items);
     const shell = std.posix.getenv("SHELL") orelse "/bin/sh";
     const result = try alloc.alloc([]const u8, 1);
     result[0] = shell;
@@ -135,95 +220,12 @@ fn restoreTermios(orig: posix.termios) void {
     posix.tcsetattr(STDIN, .FLUSH, orig) catch {};
 }
 
-fn allocNullTerminatedArgv(
-    alloc: std.mem.Allocator,
-    args: []const []const u8,
-) ![*:null]const ?[*:0]const u8 {
+fn allocNullTerminatedArgv(alloc: std.mem.Allocator, args: []const []const u8) ![*:null]const ?[*:0]const u8 {
     const argv_buf = try alloc.alloc(?[*:0]const u8, args.len + 1);
-    for (args, 0..) |arg, i| {
-        argv_buf[i] = try alloc.dupeZ(u8, arg);
-    }
+    for (args, 0..) |arg, i| argv_buf[i] = try alloc.dupeZ(u8, arg);
     argv_buf[args.len] = null;
     return @ptrCast(argv_buf.ptr);
 }
-
-/// Pending output buffer for the client connection.
-/// When a snapshot is queued, raw pty bytes are suppressed until the
-/// buffer drains completely. This guarantees snapshots arrive intact.
-const OutputBuffer = struct {
-    data: ?[]u8 = null,
-    offset: usize = 0,
-
-    /// Queue a snapshot frame. Replaces any previously queued data
-    /// (the newer snapshot supersedes the older one).
-    fn queueSnapshot(self: *OutputBuffer, terminal: *Terminal) ?usize {
-        return self.queueSnapshotOpts(terminal, false);
-    }
-
-    fn queueSnapshotInitial(self: *OutputBuffer, terminal: *Terminal) ?usize {
-        return self.queueSnapshotOpts(terminal, true);
-    }
-
-    fn queueSnapshotOpts(self: *OutputBuffer, terminal: *Terminal, initial: bool) ?usize {
-        const snap = generateSnapshot(terminal, false) orelse return null;
-        defer std.heap.c_allocator.free(snap);
-
-        // Non-initial snapshots clear scrollback — the dropped raw data
-        // means scrollback is no longer accurate.
-        const header = if (initial) "\x1b[?2026h\x1b[H" else "\x1b[?2026h\x1b[3J\x1b[H";
-        const footer = "\x1b[?2026l";
-        const frame_len = header.len + snap.len + footer.len;
-
-        if (self.data) |old| std.heap.c_allocator.free(old);
-
-        const frame = std.heap.c_allocator.alloc(u8, frame_len) catch return null;
-        @memcpy(frame[0..header.len], header);
-        @memcpy(frame[header.len..][0..snap.len], snap);
-        @memcpy(frame[header.len + snap.len ..][0..footer.len], footer);
-
-        self.data = frame;
-        self.offset = 0;
-        return snap.len;
-    }
-
-    /// Try to drain pending data to the fd. Returns true if all data
-    /// was sent (or there was nothing to send). Returns false on error.
-    fn drain(self: *OutputBuffer, fd: posix.fd_t) bool {
-        const data = self.data orelse return true;
-        const remaining = data[self.offset..];
-        if (remaining.len == 0) {
-            std.heap.c_allocator.free(data);
-            self.data = null;
-            return true;
-        }
-
-        const n = posix.write(fd, remaining) catch |err| {
-            if (err == error.WouldBlock) return false;
-            // Real error — drop the buffer
-            std.heap.c_allocator.free(data);
-            self.data = null;
-            return false;
-        };
-
-        self.offset += n;
-        if (self.offset >= data.len) {
-            std.heap.c_allocator.free(data);
-            self.data = null;
-            return true;
-        }
-        return false;
-    }
-
-    /// True when there's pending snapshot data — raw pty bytes must wait.
-    fn hasPending(self: *const OutputBuffer) bool {
-        return self.data != null;
-    }
-
-    fn deinit(self: *OutputBuffer) void {
-        if (self.data) |d| std.heap.c_allocator.free(d);
-        self.data = null;
-    }
-};
 
 fn generateSnapshot(terminal: *Terminal, include_palette: bool) ?[]const u8 {
     var builder: std.Io.Writer.Allocating = .init(std.heap.c_allocator);
@@ -244,6 +246,44 @@ fn generateSnapshot(terminal: *Terminal, include_palette: bool) ?[]const u8 {
     return builder.writer.buffered();
 }
 
+fn generateScrollback(terminal: *Terminal) ?[]const u8 {
+    const screen = terminal.screens.active;
+    const pages = &screen.pages;
+
+    // Get the screen top (includes scrollback) and active top
+    const screen_tl = pages.getTopLeft(.screen);
+    const active_tl = pages.getTopLeft(.active);
+
+    // If they're the same, there's no scrollback
+    if (screen_tl.node == active_tl.node and screen_tl.y == active_tl.y) return null;
+
+    var builder: std.Io.Writer.Allocating = .init(std.heap.c_allocator);
+
+    // Format scrollback rows (everything from screen top to just before active area)
+    var screen_fmt: terminalpkg.formatter.ScreenFormatter = .init(screen, .vt);
+    screen_fmt.content = .{
+        .selection = terminalpkg.Selection.init(
+            screen_tl,
+            // End just before the active area
+            active_tl,
+            false,
+        ),
+    };
+    screen_fmt.extra = .styles; // Include SGR styling but not cursor/modes
+
+    screen_fmt.format(&builder.writer) catch {
+        builder.deinit();
+        return null;
+    };
+
+    const data = builder.writer.buffered();
+    if (data.len == 0) {
+        std.heap.c_allocator.free(data);
+        return null;
+    }
+    return data;
+}
+
 fn saveSnapshot(terminal: *Terminal, path: []const u8) !void {
     const data = generateSnapshot(terminal, true) orelse return error.SnapshotFailed;
     defer std.heap.c_allocator.free(data);
@@ -252,18 +292,170 @@ fn saveSnapshot(terminal: *Terminal, path: []const u8) !void {
     try file.writeAll(data);
 }
 
-// ─── attach (interactive client) ──────────────────────────────────────────────
+// ─── session management ───────────────────────────────────────────────────────
+
+const SESSION_DIR = "/tmp/ghostty-snap-sessions";
+
+fn writeSessionFile(name: []const u8, port: u16) void {
+    std.fs.cwd().makePath(SESSION_DIR) catch return;
+    var path_buf: [256]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, SESSION_DIR ++ "/{s}.session", .{name}) catch return;
+    const file = std.fs.cwd().createFile(path, .{}) catch return;
+    defer file.close();
+    var write_buf: [64]u8 = undefined;
+    const content = std.fmt.bufPrint(&write_buf, "{d}\n", .{port}) catch return;
+    file.writeAll(content) catch {};
+}
+
+fn removeSessionFile(name: []const u8) void {
+    var path_buf: [256]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, SESSION_DIR ++ "/{s}.session", .{name}) catch return;
+    std.fs.cwd().deleteFile(path) catch {};
+}
+
+fn readSessionPort(name: []const u8) ?u16 {
+    var path_buf: [256]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, SESSION_DIR ++ "/{s}.session", .{name}) catch return null;
+    const file = std.fs.cwd().openFile(path, .{}) catch return null;
+    defer file.close();
+    var buf: [32]u8 = undefined;
+    const n = file.readAll(&buf) catch return null;
+    const trimmed = std.mem.trimRight(u8, buf[0..n], &.{ '\n', '\r', ' ' });
+    return std.fmt.parseInt(u16, trimmed, 10) catch null;
+}
+
+fn runList() !void {
+    var dir = std.fs.cwd().openDir(SESSION_DIR, .{ .iterate = true }) catch {
+        writeStderr("No active sessions.\n");
+        return;
+    };
+    defer dir.close();
+
+    var found = false;
+    var iter = dir.iterate();
+    while (try iter.next()) |entry| {
+        if (std.mem.endsWith(u8, entry.name, ".session")) {
+            const name = entry.name[0 .. entry.name.len - ".session".len];
+            var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+            const path = std.fmt.bufPrint(&path_buf, SESSION_DIR ++ "/{s}", .{entry.name}) catch continue;
+            const file = std.fs.cwd().openFile(path, .{}) catch continue;
+            defer file.close();
+            var buf: [32]u8 = undefined;
+            const n = file.readAll(&buf) catch continue;
+            const port_str = std.mem.trimRight(u8, buf[0..n], &.{ '\n', '\r', ' ' });
+            stderrFmt("  {s}  (port {s})\n", .{ name, port_str });
+            found = true;
+        }
+    }
+    if (!found) writeStderr("No active sessions.\n");
+}
+
+// ─── OutputBuffer ─────────────────────────────────────────────────────────────
+
+const OutputBuffer = struct {
+    data: ?[]u8 = null,
+    offset: usize = 0,
+
+    fn queueSnapshot(self: *OutputBuffer, terminal: *Terminal) ?usize {
+        return self.queueSnapshotOpts(terminal, false);
+    }
+
+    fn queueSnapshotInitial(self: *OutputBuffer, terminal: *Terminal) ?usize {
+        return self.queueSnapshotOpts(terminal, true);
+    }
+
+    fn queueSnapshotOpts(self: *OutputBuffer, terminal: *Terminal, initial: bool) ?usize {
+        const snap = generateSnapshot(terminal, false) orelse return null;
+        defer std.heap.c_allocator.free(snap);
+
+        const header = if (initial) "\x1b[?2026h\x1b[H" else "\x1b[?2026h\x1b[3J\x1b[H";
+        const footer = "\x1b[?2026l";
+        const vt_frame_len = header.len + snap.len + footer.len;
+
+        // Build VT frame
+        const vt_frame = std.heap.c_allocator.alloc(u8, vt_frame_len) catch return null;
+        defer std.heap.c_allocator.free(vt_frame);
+        @memcpy(vt_frame[0..header.len], header);
+        @memcpy(vt_frame[header.len..][0..snap.len], snap);
+        @memcpy(vt_frame[header.len + snap.len ..][0..footer.len], footer);
+
+        // Wrap in protocol frame
+        self.queueRaw(.snapshot, vt_frame);
+        return snap.len;
+    }
+
+    fn queueRaw(self: *OutputBuffer, msg_type: MsgType, payload: []const u8) void {
+        const len: u32 = @intCast(payload.len);
+        const frame_header = [4]u8{
+            @intFromEnum(msg_type),
+            @truncate(len >> 16),
+            @truncate((len >> 8) & 0xff),
+            @truncate(len & 0xff),
+        };
+
+        if (self.data) |old| std.heap.c_allocator.free(old);
+        const frame = std.heap.c_allocator.alloc(u8, 4 + payload.len) catch return;
+        @memcpy(frame[0..4], &frame_header);
+        @memcpy(frame[4..], payload);
+        self.data = frame;
+        self.offset = 0;
+    }
+
+    fn drain(self: *OutputBuffer, fd: posix.fd_t) bool {
+        const data = self.data orelse return true;
+        const remaining = data[self.offset..];
+        if (remaining.len == 0) {
+            std.heap.c_allocator.free(data);
+            self.data = null;
+            return true;
+        }
+        const n = posix.write(fd, remaining) catch |err| {
+            if (err == error.WouldBlock) return false;
+            std.heap.c_allocator.free(data);
+            self.data = null;
+            return false;
+        };
+        self.offset += n;
+        if (self.offset >= data.len) {
+            std.heap.c_allocator.free(data);
+            self.data = null;
+            return true;
+        }
+        return false;
+    }
+
+    fn hasPending(self: *const OutputBuffer) bool {
+        return self.data != null;
+    }
+
+    fn deinit(self: *OutputBuffer) void {
+        if (self.data) |d| std.heap.c_allocator.free(d);
+        self.data = null;
+    }
+};
+
+// ─── attach ───────────────────────────────────────────────────────────────────
+
+var g_resize_requested: bool = false;
 
 fn runAttach(_: std.mem.Allocator, args: *std.process.ArgIterator) !void {
     const target = args.next() orelse "127.0.0.1:7681";
 
+    // Resolve target: could be a session name or host:port
     var host: []const u8 = "127.0.0.1";
     var port: u16 = 7681;
+
     if (std.mem.lastIndexOfScalar(u8, target, ':')) |colon| {
+        // Looks like host:port
         host = target[0..colon];
         port = std.fmt.parseInt(u16, target[colon + 1 ..], 10) catch 7681;
+        if (std.mem.eql(u8, host, "localhost")) host = "127.0.0.1";
+    } else {
+        // Try as session name
+        if (readSessionPort(target)) |p| {
+            port = p;
+        }
     }
-    if (std.mem.eql(u8, host, "localhost")) host = "127.0.0.1";
 
     stderrFmt("[attach] Connecting to {s}:{d}...\n", .{ host, port });
 
@@ -275,52 +467,69 @@ fn runAttach(_: std.mem.Allocator, args: *std.process.ArgIterator) !void {
     defer posix.close(sock);
     try posix.connect(sock, &addr.any, addr.getOsSockLen());
 
-    // Send our terminal size so the server can resize the pty
+    // Send initial resize frame with our terminal size
     const ws = getWinsize() orelse pty_pkg.winsize{
         .ws_row = 24, .ws_col = 80, .ws_xpixel = 0, .ws_ypixel = 0,
     };
-    const size_msg = [4]u8{
-        @truncate(ws.ws_col >> 8), @truncate(ws.ws_col & 0xff),
-        @truncate(ws.ws_row >> 8), @truncate(ws.ws_row & 0xff),
-    };
-    _ = posix.write(sock, &size_msg) catch {};
+    sendResize(sock, ws.ws_col, ws.ws_row);
 
-    // Enter raw mode and take over the terminal
+    // Install SIGWINCH handler for resize during session
+    var sa: posix.Sigaction = .{
+        .handler = .{ .handler = sigwinchHandler },
+        .mask = posix.sigemptyset(),
+        .flags = 0,
+    };
+    posix.sigaction(posix.SIG.WINCH, &sa, null);
+
     const orig = setupRawMode() catch {
         writeStderr("[attach] Warning: could not set raw mode\n");
         return;
     };
-    // Clear the local screen — the server snapshot will redraw everything
-    _ = posix.write(STDOUT, "\x1b[H\x1b[2J") catch {};
 
     stderrFmt("[attach] Connected. Press Ctrl-] to detach.\n", .{});
 
     defer {
         restoreTermios(orig);
-        // Reset terminal state on detach
         _ = posix.write(STDOUT, "\x1b[H\x1b[2J\x1b[0m") catch {};
         writeStderr("[attach] Detached.\n");
     }
 
     var buf: [4096]u8 = undefined;
+    var frame_reader: FrameReader = .{};
 
     while (true) {
+        // Check for resize
+        if (g_resize_requested) {
+            g_resize_requested = false;
+            if (getWinsize()) |new_ws| {
+                sendResize(sock, new_ws.ws_col, new_ws.ws_row);
+            }
+        }
+
         var fds = [_]posix.pollfd{
             .{ .fd = sock, .events = posix.POLL.IN, .revents = 0 },
             .{ .fd = STDIN, .events = posix.POLL.IN, .revents = 0 },
         };
 
-        const ready = posix.poll(&fds, 500) catch break;
+        const ready = posix.poll(&fds, 100) catch break;
         if (ready == 0) continue;
 
-        // Data from server → stdout
+        // Data from server → parse frames → stdout
         if (fds[0].revents & posix.POLL.IN != 0) {
             const n = posix.read(sock, &buf) catch break;
             if (n == 0) {
                 writeStderr("\r\n[attach] Server disconnected.\r\n");
                 break;
             }
-            _ = posix.write(STDOUT, buf[0..n]) catch {};
+            frame_reader.feed(buf[0..n]);
+            while (frame_reader.next()) |frame| {
+                switch (frame.msg_type) {
+                    .pty_data, .snapshot, .scrollback => {
+                        _ = posix.write(STDOUT, frame.payload) catch {};
+                    },
+                    else => {},
+                }
+            }
         }
 
         if (fds[0].revents & (posix.POLL.HUP | posix.POLL.ERR) != 0) {
@@ -332,47 +541,74 @@ fn runAttach(_: std.mem.Allocator, args: *std.process.ArgIterator) !void {
         if (fds[1].revents & posix.POLL.IN != 0) {
             const n = posix.read(STDIN, &buf) catch break;
             if (n == 0) break;
-
-            // Check for Ctrl-] (0x1d) to detach
             for (buf[0..n]) |byte| {
-                if (byte == 0x1d) return;
+                if (byte == 0x1d) return; // Ctrl-]
             }
-
-            _ = posix.write(sock, buf[0..n]) catch break;
+            _ = writeFrame(sock, .input, buf[0..n]);
         }
     }
 }
 
+fn sendResize(fd: posix.fd_t, cols: u16, rows: u16) void {
+    const payload = [4]u8{
+        @truncate(cols >> 8), @truncate(cols & 0xff),
+        @truncate(rows >> 8), @truncate(rows & 0xff),
+    };
+    _ = writeFrame(fd, .resize, &payload);
+}
+
+fn sigwinchHandler(_: c_int) callconv(.c) void {
+    g_resize_requested = true;
+}
+
 // ─── server ───────────────────────────────────────────────────────────────────
-//
-// Architecture: TCP_NOTSENT_LOWAT backpressure
-//
-// We set TCP_NOTSENT_LOWAT on the client socket to a small value (e.g. 16KB).
-// This means POLLOUT only fires when unsent data in the kernel drops below
-// that threshold. The server polls for POLLOUT alongside POLLIN:
-//
-// - When POLLOUT is set: the pipe is clear. Write raw pty bytes (low latency).
-// - When POLLOUT is NOT set: the client is behind. Feed pty through the
-//   terminal emulator but DON'T send raw bytes (drop them).
-// - When state was dropped and POLLOUT fires again: send a fresh snapshot
-//   of the current state. The client jumps from stale to current instantly.
-//
-// Input (client→server) is ALWAYS forwarded immediately to the pty.
-// This is why Ctrl-C works within one RTT even during output spew.
 
 const TCP_NOTSENT_LOWAT: u32 = 25;
 
 fn runServer(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
-    const port: u16 = 7681;
+    var port: u16 = 7681;
 
-    const ws = getWinsize() orelse pty_pkg.winsize{
-        .ws_row = 24,
-        .ws_col = 80,
-        .ws_xpixel = 0,
-        .ws_ypixel = 0,
+    // Parse --name flag
+    var session_name: ?[]const u8 = null;
+    var cmd_args: std.ArrayList([]const u8) = .empty;
+    defer cmd_args.deinit(alloc);
+    var saw_dashdash = false;
+
+    while (args.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--") and !saw_dashdash) {
+            saw_dashdash = true;
+            continue;
+        }
+        if (!saw_dashdash and std.mem.eql(u8, arg, "--name")) {
+            session_name = args.next();
+            continue;
+        }
+        if (!saw_dashdash and std.mem.startsWith(u8, arg, "--port=")) {
+            port = std.fmt.parseInt(u16, arg["--port=".len..], 10) catch 7681;
+            continue;
+        }
+        try cmd_args.append(alloc, arg);
+    }
+
+    const argv: []const []const u8 = if (cmd_args.items.len > 0)
+        cmd_args.items
+    else blk: {
+        const shell = std.posix.getenv("SHELL") orelse "/bin/sh";
+        const result = try alloc.alloc([]const u8, 1);
+        result[0] = shell;
+        break :blk result;
     };
 
-    const argv = try collectCommandArgs(alloc, args);
+    // Generate session name from PID if not specified
+    var name_buf: [32]u8 = undefined;
+    const name = session_name orelse blk: {
+        const n = std.fmt.bufPrint(&name_buf, "s{d}", .{std.os.linux.getpid()}) catch "default";
+        break :blk n;
+    };
+
+    const ws = getWinsize() orelse pty_pkg.winsize{
+        .ws_row = 24, .ws_col = 80, .ws_xpixel = 0, .ws_ypixel = 0,
+    };
 
     var p = try Pty.open(ws);
     defer p.deinit();
@@ -394,8 +630,12 @@ fn runServer(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
     try posix.bind(server_fd, &addr.any, addr.getOsSockLen());
     try posix.listen(server_fd, 5);
 
-    stderrFmt("[server] Listening on 0.0.0.0:{d}\n", .{port});
-    stderrFmt("[server] Attach with: ghostty-snap attach localhost:{d}\n", .{port});
+    // Write session file
+    writeSessionFile(name, port);
+    defer removeSessionFile(name);
+
+    stderrFmt("[server] Session '{s}' on port {d}\n", .{ name, port });
+    stderrFmt("[server] Attach with: ghostty-snap attach {s}\n", .{name});
 
     var stream = terminal.vtStream();
     defer stream.deinit();
@@ -404,12 +644,14 @@ fn runServer(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
     var client_fd: ?posix.fd_t = null;
     var out_buf: OutputBuffer = .{};
     defer out_buf.deinit();
+    var client_reader: FrameReader = .{};
     var buf: [4096]u8 = undefined;
     var child_alive = true;
     var total_pty_bytes: u64 = 0;
     var snapshots_sent: u64 = 0;
     var drops: u64 = 0;
-    var state_dirty = false; // new pty data arrived since last snapshot
+    _ = &drops;
+    var state_dirty = false;
 
     while (child_alive) {
         var poll_fds_buf: [3]posix.pollfd = undefined;
@@ -432,27 +674,24 @@ fn runServer(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
             continue;
         }
 
-        // ── Client socket handling ──
+        // ── Client socket ──
         if (n_fds > 2 and client_fd != null) {
-            // Try to drain pending output buffer when socket is writable
+            // Drain output buffer
             if (poll_fds_buf[2].revents & posix.POLL.OUT != 0) {
                 if (client_fd) |cfd| {
                     if (out_buf.drain(cfd)) {
-                        // Buffer fully drained.
                         if (state_dirty) {
-                            // More pty data arrived while draining — queue fresh snapshot
                             if (out_buf.queueSnapshot(&terminal)) |len| {
                                 snapshots_sent += 1;
                                 stderrFmt("[server] Refresh snapshot: {d} bytes\n", .{len});
                             }
                             state_dirty = false;
                         }
-                        // else: no new data, resume raw streaming
                     }
                 }
             }
 
-            // Client input → forward to pty (ALWAYS)
+            // Client input (framed)
             if (poll_fds_buf[2].revents & posix.POLL.IN != 0) {
                 if (client_fd) |cfd| {
                     const n = posix.read(cfd, &buf) catch {
@@ -468,7 +707,29 @@ fn runServer(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
                         client_fd = null;
                         out_buf.deinit();
                     } else {
-                        _ = posix.write(master_fd, buf[0..n]) catch {};
+                        client_reader.feed(buf[0..n]);
+                        while (client_reader.next()) |frame| {
+                            switch (frame.msg_type) {
+                                .input => {
+                                    _ = posix.write(master_fd, frame.payload) catch {};
+                                },
+                                .resize => {
+                                    if (frame.payload.len == 4) {
+                                        const new_cols: u16 = (@as(u16, frame.payload[0]) << 8) | frame.payload[1];
+                                        const new_rows: u16 = (@as(u16, frame.payload[2]) << 8) | frame.payload[3];
+                                        if (new_cols > 0 and new_rows > 0 and new_cols < 500 and new_rows < 200) {
+                                            stderrFmt("[server] Resize: {d}x{d}\n", .{ new_cols, new_rows });
+                                            p.setSize(.{
+                                                .ws_col = new_cols, .ws_row = new_rows,
+                                                .ws_xpixel = 0, .ws_ypixel = 0,
+                                            }) catch {};
+                                            terminal.resize(alloc, new_cols, new_rows) catch {};
+                                        }
+                                    }
+                                },
+                                else => {},
+                            }
+                        }
                     }
                 }
             }
@@ -483,7 +744,7 @@ fn runServer(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
             }
         }
 
-        // ── Pty output → terminal emulator (always) + client (conditionally) ──
+        // ── Pty output ──
         if (poll_fds_buf[0].revents & posix.POLL.IN != 0) {
             const n = posix.read(master_fd, &buf) catch {
                 child_alive = false;
@@ -499,28 +760,15 @@ fn runServer(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
 
             if (client_fd) |cfd| {
                 if (out_buf.hasPending()) {
-                    // Snapshot is still draining — don't send raw bytes.
-                    // Mark dirty so we queue a fresh snapshot after this one drains.
                     state_dirty = true;
                 } else {
-                    // No pending snapshot — try to send raw bytes directly
-                    const written = posix.write(cfd, buf[0..n]) catch |err| blk: {
-                        if (err == error.WouldBlock) break :blk @as(usize, 0);
+                    // Send as framed PTY_DATA
+                    if (!writeFrame(cfd, .pty_data, buf[0..n])) {
                         writeStderr("[server] Client write error, disconnecting\n");
                         posix.close(cfd);
                         client_fd = null;
                         out_buf.deinit();
                         continue;
-                    };
-
-                    if (written < n) {
-                        drops += 1;
-                        stderrFmt("[server] Short write, queueing snapshot (drop #{d})\n", .{drops});
-                        if (out_buf.queueSnapshot(&terminal)) |len| {
-                            snapshots_sent += 1;
-                            stderrFmt("[server] Snapshot queued: {d} bytes\n", .{len});
-                        }
-                        state_dirty = false;
                     }
                 }
             }
@@ -538,38 +786,26 @@ fn runServer(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
             }
             client_fd = new_fd;
             out_buf.deinit();
+            client_reader = .{};
+            state_dirty = false;
 
             posix.setsockopt(new_fd, posix.SOL.SOCKET, posix.SO.SNDBUF,
                 &std.mem.toBytes(@as(c_int, 4096))) catch {};
             posix.setsockopt(new_fd, posix.IPPROTO.TCP, TCP_NOTSENT_LOWAT,
-                &std.mem.toBytes(@as(c_int, 2048))) catch |err| {
-                stderrFmt("[server] Warning: TCP_NOTSENT_LOWAT failed: {}\n", .{err});
-            };
-
-            // Read client terminal size
-            var size_buf: [4]u8 = undefined;
-            if (posix.read(new_fd, &size_buf)) |n| {
-                if (n == 4) {
-                    const new_cols: u16 = (@as(u16, size_buf[0]) << 8) | size_buf[1];
-                    const new_rows: u16 = (@as(u16, size_buf[2]) << 8) | size_buf[3];
-                    if (new_cols > 0 and new_rows > 0 and new_cols < 500 and new_rows < 200) {
-                        stderrFmt("[server] Client size: {d}x{d}\n", .{ new_cols, new_rows });
-                        p.setSize(.{
-                            .ws_col = new_cols, .ws_row = new_rows,
-                            .ws_xpixel = 0, .ws_ypixel = 0,
-                        }) catch {};
-                        terminal.resize(alloc, new_cols, new_rows) catch {};
-                    }
-                }
-            } else |_| {}
+                &std.mem.toBytes(@as(c_int, 2048))) catch {};
 
             writeStderr("[server] Client connected\n");
 
-            // Queue initial snapshot (no scrollback clear)
+            // Send scrollback first (if any), then snapshot
+            if (generateScrollback(&terminal)) |sb_data| {
+                defer std.heap.c_allocator.free(sb_data);
+                _ = writeFrame(new_fd, .scrollback, sb_data);
+                stderrFmt("[server] Scrollback: {d} bytes\n", .{sb_data.len});
+            }
+
             if (out_buf.queueSnapshotInitial(&terminal)) |len| {
                 snapshots_sent += 1;
                 stderrFmt("[server] Initial snapshot: {d} bytes\n", .{len});
-                // Try to drain immediately
                 if (client_fd) |cfd| _ = out_buf.drain(cfd);
             }
         }
@@ -591,7 +827,6 @@ fn runCapture(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
     const ws = getWinsize() orelse pty_pkg.winsize{
         .ws_row = 24, .ws_col = 80, .ws_xpixel = 0, .ws_ypixel = 0,
     };
-
     const argv = try collectCommandArgs(alloc, args);
     var p = try Pty.open(ws);
     defer p.deinit();
@@ -652,11 +887,8 @@ fn runCapture(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
         }
     }
 
-    // Drain remaining pty output
     while (true) {
-        var drain_fds = [_]posix.pollfd{
-            .{ .fd = master_fd, .events = posix.POLL.IN, .revents = 0 },
-        };
+        var drain_fds = [_]posix.pollfd{.{ .fd = master_fd, .events = posix.POLL.IN, .revents = 0 }};
         if ((posix.poll(&drain_fds, 50) catch break) == 0) break;
         if (drain_fds[0].revents & posix.POLL.IN != 0) {
             const n = posix.read(master_fd, &buf) catch break;

--- a/src/main_snap.zig
+++ b/src/main_snap.zig
@@ -1,0 +1,686 @@
+///! ghostty-snap: Reconnectable terminal demo
+///!
+///! Demonstrates reconnectable terminal technology using Ghostty's VT emulator.
+///!
+///! Usage:
+///!   ghostty-snap server [-- command]    Start a server with a shell/command
+///!   ghostty-snap attach [host:port]     Attach to a running server interactively
+///!   ghostty-snap capture [-- command]   Run command, snapshot on Ctrl-\ (SIGQUIT)
+///!   ghostty-snap restore [file]         Replay a snapshot file to stdout
+const std = @import("std");
+const posix = std.posix;
+
+pub const std_options: std.Options = .{
+    .log_level = .warn,
+};
+
+const terminalpkg = @import("terminal/main.zig");
+const Terminal = terminalpkg.Terminal;
+const pty_pkg = @import("pty.zig");
+const Pty = pty_pkg.Pty;
+
+const STDERR = posix.STDERR_FILENO;
+const STDOUT = posix.STDOUT_FILENO;
+const STDIN = posix.STDIN_FILENO;
+
+fn writeStderr(msg: []const u8) void {
+    _ = posix.write(STDERR, msg) catch {};
+}
+
+fn stderrFmt(comptime fmt_str: []const u8, fmt_args: anytype) void {
+    var buf: [512]u8 = undefined;
+    const msg = std.fmt.bufPrint(&buf, fmt_str, fmt_args) catch return;
+    writeStderr(msg);
+}
+
+pub fn main() !void {
+    const alloc = std.heap.c_allocator;
+
+    var args = try std.process.argsWithAllocator(alloc);
+    defer args.deinit();
+
+    _ = args.next();
+    const subcmd = args.next() orelse {
+        writeStderr(
+            \\ghostty-snap: Reconnectable terminal demo
+            \\
+            \\Usage:
+            \\  ghostty-snap server [-- cmd]     Start server with shell/command
+            \\  ghostty-snap attach [host:port]  Attach interactively (default: localhost:7681)
+            \\  ghostty-snap capture [-- cmd]    Snapshot on Ctrl-\ or exit
+            \\  ghostty-snap restore [file]      Replay snapshot to stdout
+            \\
+        );
+        return;
+    };
+
+    if (std.mem.eql(u8, subcmd, "server")) {
+        try runServer(alloc, &args);
+    } else if (std.mem.eql(u8, subcmd, "attach")) {
+        try runAttach(alloc, &args);
+    } else if (std.mem.eql(u8, subcmd, "capture")) {
+        try runCapture(alloc, &args);
+    } else if (std.mem.eql(u8, subcmd, "restore")) {
+        try runRestore(alloc, &args);
+    } else {
+        writeStderr("Unknown subcommand. Use: server, attach, capture, restore\n");
+    }
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+fn collectCommandArgs(alloc: std.mem.Allocator, args: *std.process.ArgIterator) ![]const []const u8 {
+    var cmd_args: std.ArrayList([]const u8) = .empty;
+    defer cmd_args.deinit(alloc);
+    var saw_dashdash = false;
+    while (args.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--") and !saw_dashdash) {
+            saw_dashdash = true;
+            continue;
+        }
+        try cmd_args.append(alloc, arg);
+    }
+    if (cmd_args.items.len > 0) {
+        return try alloc.dupe([]const u8, cmd_args.items);
+    }
+    const shell = std.posix.getenv("SHELL") orelse "/bin/sh";
+    const result = try alloc.alloc([]const u8, 1);
+    result[0] = shell;
+    return result;
+}
+
+fn spawnChild(alloc: std.mem.Allocator, p: *Pty, argv: []const []const u8) !posix.pid_t {
+    const pid = try posix.fork();
+    if (pid == 0) {
+        _ = std.c.setsid();
+        posix.dup2(p.slave, STDIN) catch posix.abort();
+        posix.dup2(p.slave, STDOUT) catch posix.abort();
+        posix.dup2(p.slave, STDERR) catch posix.abort();
+        if (p.slave > STDERR) posix.close(p.slave);
+        posix.close(p.master);
+        const argv_z = try allocNullTerminatedArgv(alloc, argv);
+        const envp = @as([*:null]const ?[*:0]const u8, @ptrCast(std.os.environ.ptr));
+        posix.execvpeZ(argv_z[0].?, argv_z, envp) catch {};
+        posix.abort();
+    }
+    return pid;
+}
+
+fn getWinsize() ?pty_pkg.winsize {
+    var ws: pty_pkg.winsize = undefined;
+    const TIOCGWINSZ = 0x5413;
+    if (std.os.linux.ioctl(STDOUT, TIOCGWINSZ, @intFromPtr(&ws)) == 0) return ws;
+    return null;
+}
+
+fn setupRawMode() !posix.termios {
+    const orig = try posix.tcgetattr(STDIN);
+    var raw = orig;
+    raw.lflag.ECHO = false;
+    raw.lflag.ICANON = false;
+    raw.lflag.ISIG = false;
+    raw.lflag.IEXTEN = false;
+    raw.iflag.IXON = false;
+    raw.iflag.ICRNL = false;
+    raw.iflag.BRKINT = false;
+    raw.iflag.INPCK = false;
+    raw.iflag.ISTRIP = false;
+    raw.cc[@intFromEnum(posix.V.MIN)] = 1;
+    raw.cc[@intFromEnum(posix.V.TIME)] = 0;
+    try posix.tcsetattr(STDIN, .FLUSH, raw);
+    return orig;
+}
+
+fn restoreTermios(orig: posix.termios) void {
+    posix.tcsetattr(STDIN, .FLUSH, orig) catch {};
+}
+
+fn allocNullTerminatedArgv(
+    alloc: std.mem.Allocator,
+    args: []const []const u8,
+) ![*:null]const ?[*:0]const u8 {
+    const argv_buf = try alloc.alloc(?[*:0]const u8, args.len + 1);
+    for (args, 0..) |arg, i| {
+        argv_buf[i] = try alloc.dupeZ(u8, arg);
+    }
+    argv_buf[args.len] = null;
+    return @ptrCast(argv_buf.ptr);
+}
+
+/// Pending output buffer for the client connection.
+/// When a snapshot is queued, raw pty bytes are suppressed until the
+/// buffer drains completely. This guarantees snapshots arrive intact.
+const OutputBuffer = struct {
+    data: ?[]u8 = null,
+    offset: usize = 0,
+
+    /// Queue a snapshot frame. Replaces any previously queued data
+    /// (the newer snapshot supersedes the older one).
+    fn queueSnapshot(self: *OutputBuffer, terminal: *Terminal) ?usize {
+        return self.queueSnapshotOpts(terminal, false);
+    }
+
+    fn queueSnapshotInitial(self: *OutputBuffer, terminal: *Terminal) ?usize {
+        return self.queueSnapshotOpts(terminal, true);
+    }
+
+    fn queueSnapshotOpts(self: *OutputBuffer, terminal: *Terminal, initial: bool) ?usize {
+        const snap = generateSnapshot(terminal, false) orelse return null;
+        defer std.heap.c_allocator.free(snap);
+
+        // Non-initial snapshots clear scrollback — the dropped raw data
+        // means scrollback is no longer accurate.
+        const header = if (initial) "\x1b[?2026h\x1b[H" else "\x1b[?2026h\x1b[3J\x1b[H";
+        const footer = "\x1b[?2026l";
+        const frame_len = header.len + snap.len + footer.len;
+
+        if (self.data) |old| std.heap.c_allocator.free(old);
+
+        const frame = std.heap.c_allocator.alloc(u8, frame_len) catch return null;
+        @memcpy(frame[0..header.len], header);
+        @memcpy(frame[header.len..][0..snap.len], snap);
+        @memcpy(frame[header.len + snap.len ..][0..footer.len], footer);
+
+        self.data = frame;
+        self.offset = 0;
+        return snap.len;
+    }
+
+    /// Try to drain pending data to the fd. Returns true if all data
+    /// was sent (or there was nothing to send). Returns false on error.
+    fn drain(self: *OutputBuffer, fd: posix.fd_t) bool {
+        const data = self.data orelse return true;
+        const remaining = data[self.offset..];
+        if (remaining.len == 0) {
+            std.heap.c_allocator.free(data);
+            self.data = null;
+            return true;
+        }
+
+        const n = posix.write(fd, remaining) catch |err| {
+            if (err == error.WouldBlock) return false;
+            // Real error — drop the buffer
+            std.heap.c_allocator.free(data);
+            self.data = null;
+            return false;
+        };
+
+        self.offset += n;
+        if (self.offset >= data.len) {
+            std.heap.c_allocator.free(data);
+            self.data = null;
+            return true;
+        }
+        return false;
+    }
+
+    /// True when there's pending snapshot data — raw pty bytes must wait.
+    fn hasPending(self: *const OutputBuffer) bool {
+        return self.data != null;
+    }
+
+    fn deinit(self: *OutputBuffer) void {
+        if (self.data) |d| std.heap.c_allocator.free(d);
+        self.data = null;
+    }
+};
+
+fn generateSnapshot(terminal: *Terminal, include_palette: bool) ?[]const u8 {
+    var builder: std.Io.Writer.Allocating = .init(std.heap.c_allocator);
+    var fmt: terminalpkg.formatter.TerminalFormatter = .init(terminal, .vt);
+    fmt.extra = .{
+        .palette = include_palette,
+        .modes = true,
+        .scrolling_region = true,
+        .tabstops = true,
+        .pwd = true,
+        .keyboard = true,
+        .screen = .all,
+    };
+    fmt.format(&builder.writer) catch {
+        builder.deinit();
+        return null;
+    };
+    return builder.writer.buffered();
+}
+
+fn saveSnapshot(terminal: *Terminal, path: []const u8) !void {
+    const data = generateSnapshot(terminal, true) orelse return error.SnapshotFailed;
+    defer std.heap.c_allocator.free(data);
+    const file = try std.fs.cwd().createFile(path, .{});
+    defer file.close();
+    try file.writeAll(data);
+}
+
+// ─── attach (interactive client) ──────────────────────────────────────────────
+
+fn runAttach(_: std.mem.Allocator, args: *std.process.ArgIterator) !void {
+    const target = args.next() orelse "127.0.0.1:7681";
+
+    var host: []const u8 = "127.0.0.1";
+    var port: u16 = 7681;
+    if (std.mem.lastIndexOfScalar(u8, target, ':')) |colon| {
+        host = target[0..colon];
+        port = std.fmt.parseInt(u16, target[colon + 1 ..], 10) catch 7681;
+    }
+    if (std.mem.eql(u8, host, "localhost")) host = "127.0.0.1";
+
+    stderrFmt("[attach] Connecting to {s}:{d}...\n", .{ host, port });
+
+    const addr = std.net.Address.parseIp4(host, port) catch {
+        stderrFmt("[attach] Invalid address: {s}:{d}\n", .{ host, port });
+        return;
+    };
+    const sock = try posix.socket(posix.AF.INET, posix.SOCK.STREAM, 0);
+    defer posix.close(sock);
+    try posix.connect(sock, &addr.any, addr.getOsSockLen());
+
+    // Send our terminal size so the server can resize the pty
+    const ws = getWinsize() orelse pty_pkg.winsize{
+        .ws_row = 24, .ws_col = 80, .ws_xpixel = 0, .ws_ypixel = 0,
+    };
+    const size_msg = [4]u8{
+        @truncate(ws.ws_col >> 8), @truncate(ws.ws_col & 0xff),
+        @truncate(ws.ws_row >> 8), @truncate(ws.ws_row & 0xff),
+    };
+    _ = posix.write(sock, &size_msg) catch {};
+
+    // Enter raw mode and take over the terminal
+    const orig = setupRawMode() catch {
+        writeStderr("[attach] Warning: could not set raw mode\n");
+        return;
+    };
+    // Clear the local screen — the server snapshot will redraw everything
+    _ = posix.write(STDOUT, "\x1b[H\x1b[2J") catch {};
+
+    stderrFmt("[attach] Connected. Press Ctrl-] to detach.\n", .{});
+
+    defer {
+        restoreTermios(orig);
+        // Reset terminal state on detach
+        _ = posix.write(STDOUT, "\x1b[H\x1b[2J\x1b[0m") catch {};
+        writeStderr("[attach] Detached.\n");
+    }
+
+    var buf: [4096]u8 = undefined;
+
+    while (true) {
+        var fds = [_]posix.pollfd{
+            .{ .fd = sock, .events = posix.POLL.IN, .revents = 0 },
+            .{ .fd = STDIN, .events = posix.POLL.IN, .revents = 0 },
+        };
+
+        const ready = posix.poll(&fds, 500) catch break;
+        if (ready == 0) continue;
+
+        // Data from server → stdout
+        if (fds[0].revents & posix.POLL.IN != 0) {
+            const n = posix.read(sock, &buf) catch break;
+            if (n == 0) {
+                writeStderr("\r\n[attach] Server disconnected.\r\n");
+                break;
+            }
+            _ = posix.write(STDOUT, buf[0..n]) catch {};
+        }
+
+        if (fds[0].revents & (posix.POLL.HUP | posix.POLL.ERR) != 0) {
+            writeStderr("\r\n[attach] Connection lost.\r\n");
+            break;
+        }
+
+        // User input → server
+        if (fds[1].revents & posix.POLL.IN != 0) {
+            const n = posix.read(STDIN, &buf) catch break;
+            if (n == 0) break;
+
+            // Check for Ctrl-] (0x1d) to detach
+            for (buf[0..n]) |byte| {
+                if (byte == 0x1d) return;
+            }
+
+            _ = posix.write(sock, buf[0..n]) catch break;
+        }
+    }
+}
+
+// ─── server ───────────────────────────────────────────────────────────────────
+//
+// Architecture: TCP_NOTSENT_LOWAT backpressure
+//
+// We set TCP_NOTSENT_LOWAT on the client socket to a small value (e.g. 16KB).
+// This means POLLOUT only fires when unsent data in the kernel drops below
+// that threshold. The server polls for POLLOUT alongside POLLIN:
+//
+// - When POLLOUT is set: the pipe is clear. Write raw pty bytes (low latency).
+// - When POLLOUT is NOT set: the client is behind. Feed pty through the
+//   terminal emulator but DON'T send raw bytes (drop them).
+// - When state was dropped and POLLOUT fires again: send a fresh snapshot
+//   of the current state. The client jumps from stale to current instantly.
+//
+// Input (client→server) is ALWAYS forwarded immediately to the pty.
+// This is why Ctrl-C works within one RTT even during output spew.
+
+const TCP_NOTSENT_LOWAT: u32 = 25;
+
+fn runServer(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
+    const port: u16 = 7681;
+
+    const ws = getWinsize() orelse pty_pkg.winsize{
+        .ws_row = 24,
+        .ws_col = 80,
+        .ws_xpixel = 0,
+        .ws_ypixel = 0,
+    };
+
+    const argv = try collectCommandArgs(alloc, args);
+
+    var p = try Pty.open(ws);
+    defer p.deinit();
+
+    const pid = try spawnChild(alloc, &p, argv);
+    posix.close(p.slave);
+
+    var terminal: Terminal = try .init(alloc, .{
+        .cols = ws.ws_col,
+        .rows = ws.ws_row,
+    });
+    defer terminal.deinit(alloc);
+
+    const addr = try std.net.Address.parseIp4("0.0.0.0", port);
+    const server_fd = try posix.socket(posix.AF.INET, posix.SOCK.STREAM | posix.SOCK.NONBLOCK, 0);
+    defer posix.close(server_fd);
+
+    try posix.setsockopt(server_fd, posix.SOL.SOCKET, posix.SO.REUSEADDR, &std.mem.toBytes(@as(c_int, 1)));
+    try posix.bind(server_fd, &addr.any, addr.getOsSockLen());
+    try posix.listen(server_fd, 5);
+
+    stderrFmt("[server] Listening on 0.0.0.0:{d}\n", .{port});
+    stderrFmt("[server] Attach with: ghostty-snap attach localhost:{d}\n", .{port});
+
+    var stream = terminal.vtStream();
+    defer stream.deinit();
+
+    const master_fd = p.master;
+    var client_fd: ?posix.fd_t = null;
+    var out_buf: OutputBuffer = .{};
+    defer out_buf.deinit();
+    var buf: [4096]u8 = undefined;
+    var child_alive = true;
+    var total_pty_bytes: u64 = 0;
+    var snapshots_sent: u64 = 0;
+    var drops: u64 = 0;
+    var state_dirty = false; // new pty data arrived since last snapshot
+
+    while (child_alive) {
+        var poll_fds_buf: [3]posix.pollfd = undefined;
+        var n_fds: usize = 2;
+        poll_fds_buf[0] = .{ .fd = master_fd, .events = posix.POLL.IN, .revents = 0 };
+        poll_fds_buf[1] = .{ .fd = server_fd, .events = posix.POLL.IN, .revents = 0 };
+        if (client_fd) |cfd| {
+            poll_fds_buf[2] = .{ .fd = cfd, .events = posix.POLL.IN | posix.POLL.OUT, .revents = 0 };
+            n_fds = 3;
+        }
+
+        const ready = posix.poll(poll_fds_buf[0..n_fds], 100) catch 0;
+
+        if (ready == 0) {
+            const result = posix.waitpid(pid, std.c.W.NOHANG);
+            if (result.pid != 0) {
+                child_alive = false;
+                break;
+            }
+            continue;
+        }
+
+        // ── Client socket handling ──
+        if (n_fds > 2 and client_fd != null) {
+            // Try to drain pending output buffer when socket is writable
+            if (poll_fds_buf[2].revents & posix.POLL.OUT != 0) {
+                if (client_fd) |cfd| {
+                    if (out_buf.drain(cfd)) {
+                        // Buffer fully drained.
+                        if (state_dirty) {
+                            // More pty data arrived while draining — queue fresh snapshot
+                            if (out_buf.queueSnapshot(&terminal)) |len| {
+                                snapshots_sent += 1;
+                                stderrFmt("[server] Refresh snapshot: {d} bytes\n", .{len});
+                            }
+                            state_dirty = false;
+                        }
+                        // else: no new data, resume raw streaming
+                    }
+                }
+            }
+
+            // Client input → forward to pty (ALWAYS)
+            if (poll_fds_buf[2].revents & posix.POLL.IN != 0) {
+                if (client_fd) |cfd| {
+                    const n = posix.read(cfd, &buf) catch {
+                        writeStderr("[server] Client disconnected\n");
+                        posix.close(cfd);
+                        client_fd = null;
+                        out_buf.deinit();
+                        continue;
+                    };
+                    if (n == 0) {
+                        writeStderr("[server] Client disconnected\n");
+                        posix.close(cfd);
+                        client_fd = null;
+                        out_buf.deinit();
+                    } else {
+                        _ = posix.write(master_fd, buf[0..n]) catch {};
+                    }
+                }
+            }
+
+            if (poll_fds_buf[2].revents & (posix.POLL.HUP | posix.POLL.ERR) != 0) {
+                if (client_fd) |cfd| {
+                    writeStderr("[server] Client connection error\n");
+                    posix.close(cfd);
+                    client_fd = null;
+                    out_buf.deinit();
+                }
+            }
+        }
+
+        // ── Pty output → terminal emulator (always) + client (conditionally) ──
+        if (poll_fds_buf[0].revents & posix.POLL.IN != 0) {
+            const n = posix.read(master_fd, &buf) catch {
+                child_alive = false;
+                break;
+            };
+            if (n == 0) {
+                child_alive = false;
+                break;
+            }
+
+            stream.nextSlice(buf[0..n]);
+            total_pty_bytes += n;
+
+            if (client_fd) |cfd| {
+                if (out_buf.hasPending()) {
+                    // Snapshot is still draining — don't send raw bytes.
+                    // Mark dirty so we queue a fresh snapshot after this one drains.
+                    state_dirty = true;
+                } else {
+                    // No pending snapshot — try to send raw bytes directly
+                    const written = posix.write(cfd, buf[0..n]) catch |err| blk: {
+                        if (err == error.WouldBlock) break :blk @as(usize, 0);
+                        writeStderr("[server] Client write error, disconnecting\n");
+                        posix.close(cfd);
+                        client_fd = null;
+                        out_buf.deinit();
+                        continue;
+                    };
+
+                    if (written < n) {
+                        drops += 1;
+                        stderrFmt("[server] Short write, queueing snapshot (drop #{d})\n", .{drops});
+                        if (out_buf.queueSnapshot(&terminal)) |len| {
+                            snapshots_sent += 1;
+                            stderrFmt("[server] Snapshot queued: {d} bytes\n", .{len});
+                        }
+                        state_dirty = false;
+                    }
+                }
+            }
+        } else if (poll_fds_buf[0].revents & (posix.POLL.HUP | posix.POLL.ERR) != 0) {
+            child_alive = false;
+            break;
+        }
+
+        // ── New TCP connection ──
+        if (poll_fds_buf[1].revents & posix.POLL.IN != 0) {
+            const new_fd = posix.accept(server_fd, null, null, posix.SOCK.NONBLOCK) catch continue;
+            if (client_fd) |old| {
+                posix.close(old);
+                writeStderr("[server] Previous client replaced\n");
+            }
+            client_fd = new_fd;
+            out_buf.deinit();
+
+            posix.setsockopt(new_fd, posix.SOL.SOCKET, posix.SO.SNDBUF,
+                &std.mem.toBytes(@as(c_int, 4096))) catch {};
+            posix.setsockopt(new_fd, posix.IPPROTO.TCP, TCP_NOTSENT_LOWAT,
+                &std.mem.toBytes(@as(c_int, 2048))) catch |err| {
+                stderrFmt("[server] Warning: TCP_NOTSENT_LOWAT failed: {}\n", .{err});
+            };
+
+            // Read client terminal size
+            var size_buf: [4]u8 = undefined;
+            if (posix.read(new_fd, &size_buf)) |n| {
+                if (n == 4) {
+                    const new_cols: u16 = (@as(u16, size_buf[0]) << 8) | size_buf[1];
+                    const new_rows: u16 = (@as(u16, size_buf[2]) << 8) | size_buf[3];
+                    if (new_cols > 0 and new_rows > 0 and new_cols < 500 and new_rows < 200) {
+                        stderrFmt("[server] Client size: {d}x{d}\n", .{ new_cols, new_rows });
+                        p.setSize(.{
+                            .ws_col = new_cols, .ws_row = new_rows,
+                            .ws_xpixel = 0, .ws_ypixel = 0,
+                        }) catch {};
+                        terminal.resize(alloc, new_cols, new_rows) catch {};
+                    }
+                }
+            } else |_| {}
+
+            writeStderr("[server] Client connected\n");
+
+            // Queue initial snapshot (no scrollback clear)
+            if (out_buf.queueSnapshotInitial(&terminal)) |len| {
+                snapshots_sent += 1;
+                stderrFmt("[server] Initial snapshot: {d} bytes\n", .{len});
+                // Try to drain immediately
+                if (client_fd) |cfd| _ = out_buf.drain(cfd);
+            }
+        }
+    }
+
+    if (client_fd) |cfd| posix.close(cfd);
+    _ = posix.waitpid(pid, 0);
+
+    stderrFmt("[server] Exiting. Snapshots: {d}, drops: {d}, pty: {d} bytes\n", .{
+        snapshots_sent, drops, total_pty_bytes,
+    });
+}
+
+// ─── capture ──────────────────────────────────────────────────────────────────
+
+var g_snapshot_requested: bool = false;
+
+fn runCapture(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
+    const ws = getWinsize() orelse pty_pkg.winsize{
+        .ws_row = 24, .ws_col = 80, .ws_xpixel = 0, .ws_ypixel = 0,
+    };
+
+    const argv = try collectCommandArgs(alloc, args);
+    var p = try Pty.open(ws);
+    defer p.deinit();
+
+    const pid = try spawnChild(alloc, &p, argv);
+    posix.close(p.slave);
+
+    var terminal: Terminal = try .init(alloc, .{ .cols = ws.ws_col, .rows = ws.ws_row });
+    defer terminal.deinit(alloc);
+
+    var sa: posix.Sigaction = .{
+        .handler = .{ .handler = sigquitHandler },
+        .mask = posix.sigemptyset(),
+        .flags = 0,
+    };
+    posix.sigaction(posix.SIG.QUIT, &sa, null);
+
+    const orig_termios = setupRawMode() catch null;
+    defer if (orig_termios) |t| restoreTermios(t);
+
+    const master_fd = p.master;
+    var stream = terminal.vtStream();
+    defer stream.deinit();
+    var buf: [4096]u8 = undefined;
+    var child_alive = true;
+
+    while (child_alive) {
+        if (g_snapshot_requested) {
+            g_snapshot_requested = false;
+            saveSnapshot(&terminal, "/tmp/ghostty-snap.vt") catch {
+                writeStderr("\r\n[capture] Snapshot error\r\n");
+                continue;
+            };
+            writeStderr("\r\n[capture] Saved to /tmp/ghostty-snap.vt\r\n");
+        }
+
+        var fds = [_]posix.pollfd{
+            .{ .fd = master_fd, .events = posix.POLL.IN, .revents = 0 },
+            .{ .fd = STDIN, .events = posix.POLL.IN, .revents = 0 },
+        };
+
+        const ready = posix.poll(&fds, 100) catch 0;
+        if (ready == 0) continue;
+
+        if (fds[0].revents & posix.POLL.IN != 0) {
+            const n = posix.read(master_fd, &buf) catch { child_alive = false; break; };
+            if (n == 0) { child_alive = false; break; }
+            stream.nextSlice(buf[0..n]);
+            _ = posix.write(STDOUT, buf[0..n]) catch {};
+        } else if (fds[0].revents & (posix.POLL.HUP | posix.POLL.ERR) != 0) {
+            child_alive = false;
+            break;
+        }
+
+        if (fds[1].revents & posix.POLL.IN != 0) {
+            const n = posix.read(STDIN, &buf) catch continue;
+            if (n > 0) _ = posix.write(master_fd, buf[0..n]) catch {};
+        }
+    }
+
+    // Drain remaining pty output
+    while (true) {
+        var drain_fds = [_]posix.pollfd{
+            .{ .fd = master_fd, .events = posix.POLL.IN, .revents = 0 },
+        };
+        if ((posix.poll(&drain_fds, 50) catch break) == 0) break;
+        if (drain_fds[0].revents & posix.POLL.IN != 0) {
+            const n = posix.read(master_fd, &buf) catch break;
+            if (n == 0) break;
+            stream.nextSlice(buf[0..n]);
+            _ = posix.write(STDOUT, buf[0..n]) catch {};
+        } else break;
+    }
+
+    _ = posix.waitpid(pid, 0);
+    saveSnapshot(&terminal, "/tmp/ghostty-snap.vt") catch {};
+    writeStderr("\r\n[capture] Final snapshot saved\r\n");
+}
+
+fn sigquitHandler(_: c_int) callconv(.c) void {
+    g_snapshot_requested = true;
+}
+
+// ─── restore ──────────────────────────────────────────────────────────────────
+
+fn runRestore(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
+    const path = args.next() orelse "/tmp/ghostty-snap.vt";
+    const data = try std.fs.cwd().readFileAlloc(alloc, path, 4 * 1024 * 1024);
+    defer alloc.free(data);
+    _ = posix.write(STDOUT, "\x1b[H\x1b[2J") catch {};
+    _ = posix.write(STDOUT, data) catch {};
+}

--- a/src/main_snap.zig
+++ b/src/main_snap.zig
@@ -50,7 +50,10 @@ const MsgType = enum(u8) {
     _,
 };
 
-fn writeFrame(fd: posix.fd_t, msg_type: MsgType, payload: []const u8) bool {
+/// Write a framed message. Returns the number of payload bytes that were
+/// actually sent. A return < payload.len means a short write occurred
+/// (backpressure). Returns null on error.
+fn writeFrame(fd: posix.fd_t, msg_type: MsgType, payload: []const u8) ?usize {
     const len: u32 = @intCast(payload.len);
     const header = [4]u8{
         @intFromEnum(msg_type),
@@ -59,17 +62,30 @@ fn writeFrame(fd: posix.fd_t, msg_type: MsgType, payload: []const u8) bool {
         @truncate(len & 0xff),
     };
 
-    // Write header + payload. Single write for small messages.
-    if (payload.len <= 4092) {
-        var combined: [4096]u8 = undefined;
+    const total = 4 + payload.len;
+
+    if (payload.len <= 8188) {
+        var combined: [8192]u8 = undefined;
         @memcpy(combined[0..4], &header);
         @memcpy(combined[4..][0..payload.len], payload);
-        _ = posix.write(fd, combined[0 .. 4 + payload.len]) catch return false;
+        const written = posix.write(fd, combined[0..total]) catch |err| {
+            if (err == error.WouldBlock) return 0;
+            return null;
+        };
+        if (written < 4) return 0; // couldn't even write header
+        return written - 4; // payload bytes written
     } else {
-        _ = posix.write(fd, &header) catch return false;
-        _ = posix.write(fd, payload) catch return false;
+        const frame = std.heap.c_allocator.alloc(u8, total) catch return null;
+        defer std.heap.c_allocator.free(frame);
+        @memcpy(frame[0..4], &header);
+        @memcpy(frame[4..], payload);
+        const written = posix.write(fd, frame) catch |err| {
+            if (err == error.WouldBlock) return 0;
+            return null;
+        };
+        if (written < 4) return 0;
+        return written - 4;
     }
-    return true;
 }
 
 /// Incremental frame reader. Accumulates bytes and yields complete messages.
@@ -368,7 +384,9 @@ const OutputBuffer = struct {
         const snap = generateSnapshot(terminal, false) orelse return null;
         defer std.heap.c_allocator.free(snap);
 
-        const header = if (initial) "\x1b[?2026h\x1b[H" else "\x1b[?2026h\x1b[3J\x1b[H";
+        // Initial: clear screen so stale local content is gone.
+        // Catch-up: clear scrollback (stale) but no screen clear (overwrite in place).
+        const header = if (initial) "\x1b[?2026h\x1b[H\x1b[2J" else "\x1b[?2026h\x1b[3J\x1b[H";
         const footer = "\x1b[?2026l";
         const vt_frame_len = header.len + snap.len + footer.len;
 
@@ -544,7 +562,7 @@ fn runAttach(_: std.mem.Allocator, args: *std.process.ArgIterator) !void {
             for (buf[0..n]) |byte| {
                 if (byte == 0x1d) return; // Ctrl-]
             }
-            _ = writeFrame(sock, .input, buf[0..n]);
+            _ = writeFrame(sock, .input, buf[0..n]) orelse break;
         }
     }
 }
@@ -554,7 +572,7 @@ fn sendResize(fd: posix.fd_t, cols: u16, rows: u16) void {
         @truncate(cols >> 8), @truncate(cols & 0xff),
         @truncate(rows >> 8), @truncate(rows & 0xff),
     };
-    _ = writeFrame(fd, .resize, &payload);
+    _ = writeFrame(fd, .resize, &payload) orelse {};
 }
 
 fn sigwinchHandler(_: c_int) callconv(.c) void {
@@ -763,12 +781,22 @@ fn runServer(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
                     state_dirty = true;
                 } else {
                     // Send as framed PTY_DATA
-                    if (!writeFrame(cfd, .pty_data, buf[0..n])) {
+                    const written = writeFrame(cfd, .pty_data, buf[0..n]) orelse {
                         writeStderr("[server] Client write error, disconnecting\n");
                         posix.close(cfd);
                         client_fd = null;
                         out_buf.deinit();
                         continue;
+                    };
+                    if (written < n) {
+                        // Short write — frame is corrupted on the wire.
+                        // Queue a snapshot to resync the client.
+                        drops += 1;
+                        if (out_buf.queueSnapshot(&terminal)) |slen| {
+                            snapshots_sent += 1;
+                            stderrFmt("[server] Short write ({d}/{d}), snapshot {d}B\n", .{ written, n, slen });
+                        }
+                        state_dirty = false;
                     }
                 }
             }
@@ -799,7 +827,7 @@ fn runServer(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
             // Send scrollback first (if any), then snapshot
             if (generateScrollback(&terminal)) |sb_data| {
                 defer std.heap.c_allocator.free(sb_data);
-                _ = writeFrame(new_fd, .scrollback, sb_data);
+                _ = writeFrame(new_fd, .scrollback, sb_data) orelse {};
                 stderrFmt("[server] Scrollback: {d} bytes\n", .{sb_data.len});
             }
 

--- a/src/main_snap.zig
+++ b/src/main_snap.zig
@@ -50,10 +50,18 @@ const MsgType = enum(u8) {
     _,
 };
 
-/// Write a framed message. Returns the number of payload bytes that were
-/// actually sent. A return < payload.len means a short write occurred
-/// (backpressure). Returns null on error.
-fn writeFrame(fd: posix.fd_t, msg_type: MsgType, payload: []const u8) ?usize {
+/// Result of attempting to write a frame.
+const WriteFrameResult = enum {
+    ok, // fully written
+    would_block, // nothing written (EAGAIN before any bytes)
+    partial, // partially written — remainder is in out_buf
+    err, // connection error
+};
+
+/// Write a framed message. If only part of the frame can be written (short write),
+/// the REMAINDER is queued into out_buf so the client always receives complete frames.
+/// This prevents frame alignment corruption.
+fn writeFrame(fd: posix.fd_t, msg_type: MsgType, payload: []const u8, out_buf: ?*OutputBuffer) WriteFrameResult {
     const len: u32 = @intCast(payload.len);
     const header = [4]u8{
         @intFromEnum(msg_type),
@@ -64,28 +72,41 @@ fn writeFrame(fd: posix.fd_t, msg_type: MsgType, payload: []const u8) ?usize {
 
     const total = 4 + payload.len;
 
-    if (payload.len <= 8188) {
-        var combined: [8192]u8 = undefined;
-        @memcpy(combined[0..4], &header);
-        @memcpy(combined[4..][0..payload.len], payload);
-        const written = posix.write(fd, combined[0..total]) catch |err| {
-            if (err == error.WouldBlock) return 0;
-            return null;
-        };
-        if (written < 4) return 0; // couldn't even write header
-        return written - 4; // payload bytes written
-    } else {
-        const frame = std.heap.c_allocator.alloc(u8, total) catch return null;
-        defer std.heap.c_allocator.free(frame);
-        @memcpy(frame[0..4], &header);
-        @memcpy(frame[4..], payload);
-        const written = posix.write(fd, frame) catch |err| {
-            if (err == error.WouldBlock) return 0;
-            return null;
-        };
-        if (written < 4) return 0;
-        return written - 4;
+    // Build the full frame
+    var stack_buf: [8192]u8 = undefined;
+    const frame = if (total <= 8192) blk: {
+        @memcpy(stack_buf[0..4], &header);
+        @memcpy(stack_buf[4..][0..payload.len], payload);
+        break :blk stack_buf[0..total];
+    } else blk: {
+        const heap = std.heap.c_allocator.alloc(u8, total) catch return .err;
+        @memcpy(heap[0..4], &header);
+        @memcpy(heap[4..], payload);
+        break :blk heap;
+    };
+    defer if (total > 8192) std.heap.c_allocator.free(frame);
+
+    const written = posix.write(fd, frame) catch |err| {
+        if (err == error.WouldBlock) return .would_block;
+        return .err;
+    };
+
+    if (written == total) return .ok;
+
+    // Short write — queue the unwritten remainder so the client
+    // receives the complete frame. Without this, the client's frame
+    // reader would wait forever for the missing bytes.
+    if (out_buf) |buf| {
+        const remainder = frame[written..];
+        if (buf.data) |old| std.heap.c_allocator.free(old);
+        const queued = std.heap.c_allocator.alloc(u8, remainder.len) catch return .err;
+        @memcpy(queued, remainder);
+        buf.data = queued;
+        buf.offset = 0;
+        return .partial;
     }
+
+    return .partial;
 }
 
 /// Incremental frame reader. Accumulates bytes and yields complete messages.
@@ -562,7 +583,7 @@ fn runAttach(_: std.mem.Allocator, args: *std.process.ArgIterator) !void {
             for (buf[0..n]) |byte| {
                 if (byte == 0x1d) return; // Ctrl-]
             }
-            _ = writeFrame(sock, .input, buf[0..n]) orelse break;
+            if (writeFrame(sock, .input, buf[0..n], null) == .err) break;
         }
     }
 }
@@ -572,7 +593,7 @@ fn sendResize(fd: posix.fd_t, cols: u16, rows: u16) void {
         @truncate(cols >> 8), @truncate(cols & 0xff),
         @truncate(rows >> 8), @truncate(rows & 0xff),
     };
-    _ = writeFrame(fd, .resize, &payload) orelse {};
+    _ = writeFrame(fd, .resize, &payload, null);
 }
 
 fn sigwinchHandler(_: c_int) callconv(.c) void {
@@ -780,23 +801,32 @@ fn runServer(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
                 if (out_buf.hasPending()) {
                     state_dirty = true;
                 } else {
-                    // Send as framed PTY_DATA
-                    const written = writeFrame(cfd, .pty_data, buf[0..n]) orelse {
-                        writeStderr("[server] Client write error, disconnecting\n");
-                        posix.close(cfd);
-                        client_fd = null;
-                        out_buf.deinit();
-                        continue;
-                    };
-                    if (written < n) {
-                        // Short write — frame is corrupted on the wire.
-                        // Queue a snapshot to resync the client.
-                        drops += 1;
-                        if (out_buf.queueSnapshot(&terminal)) |slen| {
-                            snapshots_sent += 1;
-                            stderrFmt("[server] Short write ({d}/{d}), snapshot {d}B\n", .{ written, n, slen });
-                        }
-                        state_dirty = false;
+                    // Send as framed PTY_DATA. On short write, the
+                    // remainder goes into out_buf to preserve frame alignment.
+                    switch (writeFrame(cfd, .pty_data, buf[0..n], &out_buf)) {
+                        .ok => {},
+                        .partial => {
+                            // Frame remainder is in out_buf. Mark dirty so
+                            // a snapshot is queued after the remainder drains.
+                            state_dirty = true;
+                            drops += 1;
+                        },
+                        .would_block => {
+                            // Couldn't write at all — queue snapshot directly
+                            drops += 1;
+                            if (out_buf.queueSnapshot(&terminal)) |slen| {
+                                snapshots_sent += 1;
+                                stderrFmt("[server] Blocked, snapshot {d}B\n", .{slen});
+                            }
+                            state_dirty = false;
+                        },
+                        .err => {
+                            writeStderr("[server] Client write error, disconnecting\n");
+                            posix.close(cfd);
+                            client_fd = null;
+                            out_buf.deinit();
+                            continue;
+                        },
                     }
                 }
             }
@@ -827,7 +857,7 @@ fn runServer(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
             // Send scrollback first (if any), then snapshot
             if (generateScrollback(&terminal)) |sb_data| {
                 defer std.heap.c_allocator.free(sb_data);
-                _ = writeFrame(new_fd, .scrollback, sb_data) orelse {};
+                _ = writeFrame(new_fd, .scrollback, sb_data, null);
                 stderrFmt("[server] Scrollback: {d} bytes\n", .{sb_data.len});
             }
 

--- a/src/main_snap.zig
+++ b/src/main_snap.zig
@@ -15,6 +15,7 @@ pub const std_options: std.Options = .{
 
 const terminalpkg = @import("terminal/main.zig");
 const Terminal = terminalpkg.Terminal;
+const SyncState = terminalpkg.sync.SyncState;
 const pty_pkg = @import("pty.zig");
 const Pty = pty_pkg.Pty;
 
@@ -40,8 +41,12 @@ fn stderrFmt(comptime fmt_str: []const u8, fmt_args: anytype) void {
 const MsgType = enum(u8) {
     // Server → Client
     pty_data = 0x01,
-    snapshot = 0x02,
-    scrollback = 0x03,
+    snapshot = 0x02, // VT snapshot (legacy, used for initial connect)
+    scrollback = 0x03, // VT scrollback (legacy)
+    viewport_full = 0x06, // Binary full viewport
+    viewport_delta = 0x05, // Binary dirty rows only
+    scrollback_chunk = 0x07, // Binary scrollback chunk
+    sync_styles = 0x08, // New style definitions
 
     // Client → Server
     input = 0x81,
@@ -601,12 +606,29 @@ fn runAttach(_: std.mem.Allocator, args: *std.process.ArgIterator) !void {
             while (frame_reader.next()) |frame| {
                 switch (frame.msg_type) {
                     .pty_data, .snapshot, .scrollback => {
-                        // Write all bytes to stdout, retrying on short writes.
+                        // VT data — write directly to stdout
                         var remaining = frame.payload;
                         while (remaining.len > 0) {
                             const w = posix.write(STDOUT, remaining) catch break;
                             remaining = remaining[w..];
                         }
+                    },
+                    .viewport_full, .viewport_delta => {
+                        // Binary viewport data — log for now.
+                        // A native Ghostty client would apply this directly.
+                        // The VT attach client falls back to VT snapshots.
+                        stderrFmt("[attach] Binary viewport: {d} bytes (type={d})\n", .{
+                            frame.payload.len,
+                            @intFromEnum(frame.msg_type),
+                        });
+                    },
+                    .scrollback_chunk => {
+                        // Binary scrollback chunk — log for now.
+                        stderrFmt("[attach] Scrollback chunk: {d} bytes\n", .{frame.payload.len});
+                    },
+                    .sync_styles => {
+                        // Style definitions — cache for rendering.
+                        stderrFmt("[attach] Style definitions: {d} bytes\n", .{frame.payload.len});
                     },
                     else => {},
                 }
@@ -727,6 +749,8 @@ fn runServer(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
     var out_buf: OutputBuffer = .{};
     defer out_buf.deinit();
     var client_reader: FrameReader = .{};
+    var sync_state: SyncState = SyncState.init(alloc);
+    defer sync_state.deinit();
     var buf: [4096]u8 = undefined;
     var child_alive = true;
     var total_pty_bytes: u64 = 0;
@@ -753,6 +777,22 @@ fn runServer(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
                 child_alive = false;
                 break;
             }
+            // Idle: send scrollback chunks if client connected and no pending data
+            if (client_fd != null and !out_buf.hasPending() and !state_dirty) {
+                if (client_fd) |cfd| {
+                    var sb_builder: std.Io.Writer.Allocating = .init(alloc);
+                    if (sync_state.nextScrollbackChunk(terminal.screens.active, 50, &sb_builder.writer) catch null) |count| {
+                        const sb_data = sb_builder.writer.buffered();
+                        if (sb_data.len > 0) {
+                            _ = writeFrame(cfd, .scrollback_chunk, sb_data, &out_buf);
+                            stderrFmt("[server] Scrollback chunk: {d} rows, {d} bytes\n", .{ count, sb_data.len });
+                        }
+                        std.heap.c_allocator.free(sb_data);
+                    } else {
+                        sb_builder.deinit();
+                    }
+                }
+            }
             continue;
         }
 
@@ -763,9 +803,36 @@ fn runServer(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
                 if (client_fd) |cfd| {
                     if (out_buf.drain(cfd)) {
                         if (state_dirty and terminal.screens.active_key != .alternate) {
-                            if (out_buf.queueSnapshot(&terminal)) |len| {
-                                snapshots_sent += 1;
-                                stderrFmt("[server] Refresh snapshot: {d} bytes\n", .{len});
+                            // Use binary delta when possible, fall back to VT snapshot
+                            const delta = sync_state.computeDelta(&terminal);
+                            switch (delta.kind) {
+                                .none => {},
+                                .partial => {
+                                    // Serialize only dirty rows
+                                    var builder: std.Io.Writer.Allocating = .init(alloc);
+                                    sync_state.serializeDelta(&terminal, delta, &builder.writer) catch {};
+                                    const data = builder.writer.buffered();
+                                    if (data.len > 0) {
+                                        out_buf.queueRaw(.viewport_delta, data);
+                                        sync_state.markSynced(&terminal);
+                                        snapshots_sent += 1;
+                                        stderrFmt("[server] Delta: {d} bytes\n", .{data.len});
+                                    }
+                                    std.heap.c_allocator.free(data);
+                                },
+                                .full => {
+                                    // Full binary viewport
+                                    var builder: std.Io.Writer.Allocating = .init(alloc);
+                                    sync_state.serializeFull(&terminal, &builder.writer) catch {};
+                                    const data = builder.writer.buffered();
+                                    if (data.len > 0) {
+                                        out_buf.queueRaw(.viewport_full, data);
+                                        sync_state.markSynced(&terminal);
+                                        snapshots_sent += 1;
+                                        stderrFmt("[server] Full sync: {d} bytes\n", .{data.len});
+                                    }
+                                    std.heap.c_allocator.free(data);
+                                },
                             }
                             state_dirty = false;
                         }
@@ -903,18 +970,26 @@ fn runServer(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
 
             writeStderr("[server] Client connected\n");
 
-            // Send scrollback first (if any), then snapshot
+            // Reset sync state for new client
+            sync_state.deinit();
+            sync_state = SyncState.init(alloc);
+
+            // Send VT scrollback first (if any)
             if (generateScrollback(&terminal)) |sb_data| {
                 defer std.heap.c_allocator.free(sb_data);
                 _ = writeFrame(new_fd, .scrollback, sb_data, null);
                 stderrFmt("[server] Scrollback: {d} bytes\n", .{sb_data.len});
             }
 
+            // Send VT snapshot for initial display
             if (out_buf.queueSnapshotInitial(&terminal)) |len| {
                 snapshots_sent += 1;
-                stderrFmt("[server] Initial snapshot: {d} bytes\n", .{len});
+                stderrFmt("[server] Initial VT snapshot: {d} bytes\n", .{len});
                 if (client_fd) |cfd| _ = out_buf.drain(cfd);
             }
+
+            // Initialize sync state so future deltas are computed correctly
+            sync_state.markSynced(&terminal);
         }
     }
 

--- a/src/main_snap.zig
+++ b/src/main_snap.zig
@@ -601,12 +601,15 @@ fn runAttach(_: std.mem.Allocator, args: *std.process.ArgIterator) !void {
             while (frame_reader.next()) |frame| {
                 switch (frame.msg_type) {
                     .pty_data, .snapshot, .scrollback => {
-                        _ = posix.write(STDOUT, frame.payload) catch {};
+                        // Write all bytes to stdout, retrying on short writes.
+                        var remaining = frame.payload;
+                        while (remaining.len > 0) {
+                            const w = posix.write(STDOUT, remaining) catch break;
+                            remaining = remaining[w..];
+                        }
                     },
                     else => {},
                 }
-                // Advance AFTER consuming the payload — the payload slice
-                // points into the buffer and advance() shifts the buffer.
                 frame_reader.advance();
             }
         }

--- a/src/main_snap.zig
+++ b/src/main_snap.zig
@@ -759,7 +759,7 @@ fn runServer(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
             if (poll_fds_buf[2].revents & posix.POLL.OUT != 0) {
                 if (client_fd) |cfd| {
                     if (out_buf.drain(cfd)) {
-                        if (state_dirty) {
+                        if (state_dirty and terminal.screens.active_key != .alternate) {
                             if (out_buf.queueSnapshot(&terminal)) |len| {
                                 snapshots_sent += 1;
                                 stderrFmt("[server] Refresh snapshot: {d} bytes\n", .{len});
@@ -840,26 +840,31 @@ fn runServer(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
 
             if (client_fd) |cfd| {
                 if (out_buf.hasPending()) {
-                    state_dirty = true;
+                    // Don't queue snapshots while in alt screen — full-screen
+                    // programs (vi, tmux) manage their own screen state.
+                    // Snapshots would conflict with the program's drawing.
+                    if (terminal.screens.active_key != .alternate) {
+                        state_dirty = true;
+                    }
                 } else {
                     // Send as framed PTY_DATA. On short write, the
                     // remainder goes into out_buf to preserve frame alignment.
                     switch (writeFrame(cfd, .pty_data, buf[0..n], &out_buf)) {
                         .ok => {},
                         .partial => {
-                            // Frame remainder is in out_buf. Mark dirty so
-                            // a snapshot is queued after the remainder drains.
-                            state_dirty = true;
+                            state_dirty = terminal.screens.active_key != .alternate;
                             drops += 1;
                         },
                         .would_block => {
-                            // Couldn't write at all — queue snapshot directly
                             drops += 1;
-                            if (out_buf.queueSnapshot(&terminal)) |slen| {
-                                snapshots_sent += 1;
-                                stderrFmt("[server] Blocked, snapshot {d}B\n", .{slen});
+                            // Only snapshot if NOT in alt screen
+                            if (terminal.screens.active_key != .alternate) {
+                                if (out_buf.queueSnapshot(&terminal)) |slen| {
+                                    snapshots_sent += 1;
+                                    stderrFmt("[server] Blocked, snapshot {d}B\n", .{slen});
+                                }
+                                state_dirty = false;
                             }
-                            state_dirty = false;
                         },
                         .err => {
                             writeStderr("[server] Client write error, disconnecting\n");

--- a/src/main_snap.zig
+++ b/src/main_snap.zig
@@ -113,6 +113,7 @@ fn writeFrame(fd: posix.fd_t, msg_type: MsgType, payload: []const u8, out_buf: ?
 const FrameReader = struct {
     buf: [65536]u8 = undefined,
     len: usize = 0,
+    consumed: usize = 0,
 
     const Frame = struct {
         msg_type: MsgType,
@@ -128,6 +129,9 @@ const FrameReader = struct {
         self.len += to_copy;
     }
 
+    /// Returns the next complete frame. The payload slice is valid ONLY
+    /// until the next call to feed() or next(). Caller must consume
+    /// (e.g. write to STDOUT) before calling next() again.
     fn next(self: *FrameReader) ?Frame {
         if (self.len < 4) return null;
         const msg_len: usize = (@as(usize, self.buf[1]) << 16) |
@@ -136,19 +140,52 @@ const FrameReader = struct {
         const total = 4 + msg_len;
         if (self.len < total) return null;
 
-        const frame = Frame{
-            .msg_type = @enumFromInt(self.buf[0]),
+        const msg_type: MsgType = @enumFromInt(self.buf[0]);
+
+        // Shift remaining data FIRST, then return the payload.
+        // We must be careful: copyForwards copies left-to-right,
+        // so if remaining data starts at buf[total], copying to buf[0]
+        // won't overwrite the payload at buf[4..total] AS LONG AS
+        // total > remaining. But if total <= remaining, there IS overlap.
+        //
+        // To avoid this entirely: shift the payload to the END of the
+        // buffer (after the remaining data), then shift remaining down.
+        // Actually, simplest correct approach: DON'T shift. Instead,
+        // track an offset into the buffer and only compact on feed().
+        //
+        // For now: return payload pointing BEFORE the shift region.
+        // The payload at buf[4..total] is NOT touched by copyForwards
+        // because copyForwards copies from buf[total..] to buf[0..],
+        // and the destination buf[0..remaining] only overlaps the
+        // payload if remaining >= 4 (i.e. the copy writes past byte 3).
+        //
+        // If remaining < 4: no overlap, payload is safe.
+        // If remaining >= 4: the copy overwrites buf[4..] which IS the payload.
+        //
+        // Fix: compact AFTER the caller is done with the payload.
+        // We defer the compaction to the next call.
+
+        // Instead: just don't shift. Track consumed offset.
+        // This is simpler and avoids the overlap entirely.
+        self.consumed = total;
+
+        return .{
+            .msg_type = msg_type,
             .payload = self.buf[4..total],
         };
+    }
 
-        // Shift remaining data
+    /// Must be called after consuming a frame returned by next().
+    /// Shifts the buffer to remove the consumed frame.
+    fn advance(self: *FrameReader) void {
+        const total = self.consumed;
+        if (total == 0) return;
         const remaining = self.len - total;
         if (remaining > 0) {
             std.mem.copyForwards(u8, self.buf[0..remaining], self.buf[total..self.len]);
         }
         self.len = remaining;
-
-        return frame;
+        self.consumed = 0;
     }
 };
 
@@ -568,6 +605,9 @@ fn runAttach(_: std.mem.Allocator, args: *std.process.ArgIterator) !void {
                     },
                     else => {},
                 }
+                // Advance AFTER consuming the payload — the payload slice
+                // points into the buffer and advance() shifts the buffer.
+                frame_reader.advance();
             }
         }
 
@@ -768,6 +808,7 @@ fn runServer(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
                                 },
                                 else => {},
                             }
+                            client_reader.advance();
                         }
                     }
                 }

--- a/src/main_snap.zig
+++ b/src/main_snap.zig
@@ -613,9 +613,16 @@ fn runAttach(_: std.mem.Allocator, args: *std.process.ArgIterator) !void {
                             remaining = remaining[w..];
                         }
                     },
-                    .viewport_full, .viewport_delta, .scrollback_chunk, .sync_styles => {
+                    .scrollback_chunk => {
+                        // Log scrollback progress so the user can see backfill working
+                        if (frame.payload.len >= 10) {
+                            const total = std.mem.readInt(u32, frame.payload[0..4], .big);
+                            const offset = std.mem.readInt(u32, frame.payload[4..8], .big);
+                            stderrFmt("\r[attach] Scrollback: {d}/{d} rows\r", .{ offset, total });
+                        }
+                    },
+                    .viewport_full, .viewport_delta, .sync_styles => {
                         // Binary data for future native Ghostty client.
-                        // VT attach client ignores these — it uses VT snapshots.
                     },
                     else => {},
                 }

--- a/src/main_snap.zig
+++ b/src/main_snap.zig
@@ -613,22 +613,9 @@ fn runAttach(_: std.mem.Allocator, args: *std.process.ArgIterator) !void {
                             remaining = remaining[w..];
                         }
                     },
-                    .viewport_full, .viewport_delta => {
-                        // Binary viewport data — log for now.
-                        // A native Ghostty client would apply this directly.
-                        // The VT attach client falls back to VT snapshots.
-                        stderrFmt("[attach] Binary viewport: {d} bytes (type={d})\n", .{
-                            frame.payload.len,
-                            @intFromEnum(frame.msg_type),
-                        });
-                    },
-                    .scrollback_chunk => {
-                        // Binary scrollback chunk — log for now.
-                        stderrFmt("[attach] Scrollback chunk: {d} bytes\n", .{frame.payload.len});
-                    },
-                    .sync_styles => {
-                        // Style definitions — cache for rendering.
-                        stderrFmt("[attach] Style definitions: {d} bytes\n", .{frame.payload.len});
+                    .viewport_full, .viewport_delta, .scrollback_chunk, .sync_styles => {
+                        // Binary data for future native Ghostty client.
+                        // VT attach client ignores these — it uses VT snapshots.
                     },
                     else => {},
                 }
@@ -803,36 +790,12 @@ fn runServer(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !void {
                 if (client_fd) |cfd| {
                     if (out_buf.drain(cfd)) {
                         if (state_dirty and terminal.screens.active_key != .alternate) {
-                            // Use binary delta when possible, fall back to VT snapshot
-                            const delta = sync_state.computeDelta(&terminal);
-                            switch (delta.kind) {
-                                .none => {},
-                                .partial => {
-                                    // Serialize only dirty rows
-                                    var builder: std.Io.Writer.Allocating = .init(alloc);
-                                    sync_state.serializeDelta(&terminal, delta, &builder.writer) catch {};
-                                    const data = builder.writer.buffered();
-                                    if (data.len > 0) {
-                                        out_buf.queueRaw(.viewport_delta, data);
-                                        sync_state.markSynced(&terminal);
-                                        snapshots_sent += 1;
-                                        stderrFmt("[server] Delta: {d} bytes\n", .{data.len});
-                                    }
-                                    std.heap.c_allocator.free(data);
-                                },
-                                .full => {
-                                    // Full binary viewport
-                                    var builder: std.Io.Writer.Allocating = .init(alloc);
-                                    sync_state.serializeFull(&terminal, &builder.writer) catch {};
-                                    const data = builder.writer.buffered();
-                                    if (data.len > 0) {
-                                        out_buf.queueRaw(.viewport_full, data);
-                                        sync_state.markSynced(&terminal);
-                                        snapshots_sent += 1;
-                                        stderrFmt("[server] Full sync: {d} bytes\n", .{data.len});
-                                    }
-                                    std.heap.c_allocator.free(data);
-                                },
+                            // Send VT snapshot for display (VT attach client)
+                            if (out_buf.queueSnapshot(&terminal)) |len| {
+                                snapshots_sent += 1;
+                                // Also update sync state for tracking
+                                sync_state.markSynced(&terminal);
+                                stderrFmt("[server] Refresh snapshot: {d} bytes\n", .{len});
                             }
                             state_dirty = false;
                         }

--- a/src/terminal/formatter.zig
+++ b/src/terminal/formatter.zig
@@ -343,6 +343,11 @@ pub const TerminalFormatter = struct {
         // Extra terminal state to emit after the screen contents so that
         // it doesn't impact the emitted contents.
         if (self.opts.emit == .vt) {
+            // Save cursor position before emitting extras that move it
+            // (tabstop setup uses CHA+HTS which clobbers cursor column).
+            const need_cursor_save = self.extra.tabstops or self.extra.scrolling_region;
+            if (need_cursor_save) try writer.print("\x1b[s", .{}); // DECSC (save cursor via CSI s)
+
             // Emit scrolling region using DECSTBM and DECSLRM
             if (self.extra.scrolling_region) {
                 const region = &self.terminal.scrolling_region;
@@ -389,6 +394,9 @@ pub const TerminalFormatter = struct {
                 const pwd = self.terminal.pwd.items;
                 if (pwd.len > 0) try writer.print("\x1b]7;{s}\x1b\\", .{pwd});
             }
+
+            // Restore cursor position after extras that moved it
+            if (need_cursor_save) try writer.print("\x1b[u", .{}); // DECRC (restore cursor via CSI u)
 
             // If we have a pin_map, add the bytes we wrote to map.
             if (self.pin_map) |*m| {
@@ -6276,4 +6284,147 @@ test "Page HTML hyperlink point map maps closing to previous cell" {
     for (closing_idx..closing_idx + "</a>".len) |i| {
         try testing.expectEqual(expected_coord, point_map.items[i]);
     }
+}
+
+test "TerminalFormatter vt full round-trip" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var builder: std.Io.Writer.Allocating = .init(alloc);
+    defer builder.deinit();
+
+    // Create Terminal A with complex state exercising many features
+    var t = try Terminal.init(alloc, .{
+        .cols = 80,
+        .rows = 24,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+
+    // -- Palette modifications --
+    s.nextSlice("\x1b]4;0;rgb:12/34/56\x1b\\"); // palette index 0
+    s.nextSlice("\x1b]4;9;rgb:ff/00/88\x1b\\"); // palette index 9
+    s.nextSlice("\x1b]4;200;rgb:aa/bb/cc\x1b\\"); // palette index 200
+
+    // -- Modes: enable non-default modes --
+    s.nextSlice("\x1b[?2004h"); // bracketed paste
+    s.nextSlice("\x1b[?1000h"); // mouse event normal
+    s.nextSlice("\x1b[?1004h"); // focus event
+    s.nextSlice("\x1b[?7l"); // disable wraparound (default is true)
+
+    // -- Keyboard: modifyOtherKeys mode 2 --
+    s.nextSlice("\x1b[>4;2m");
+
+    // -- Tabstops: clear all, set custom --
+    s.nextSlice("\x1b[3g"); // clear all
+    s.nextSlice("\x1b[5G\x1bH"); // set tab at column 5
+    s.nextSlice("\x1b[20G\x1bH"); // set tab at column 20
+    s.nextSlice("\x1b[50G\x1bH"); // set tab at column 50
+
+    // -- Scrolling region: non-default --
+    s.nextSlice("\x1b[5;20r"); // top=5, bottom=20
+
+    // -- PWD via OSC 7 --
+    s.nextSlice("\x1b]7;file://myhost/home/user/project\x1b\\");
+
+    // -- Charset: set G0 to DEC Special Graphics --
+    s.nextSlice("\x1b(0"); // G0 = DEC Special
+
+    // -- Now write styled content --
+    // Move to top-left first
+    s.nextSlice("\x1b[H");
+
+    // Bold red text
+    s.nextSlice("\x1b[1;31mHello, ");
+    // Italic 256-color text
+    s.nextSlice("\x1b[3;38;5;208mWorld");
+    // Reset, truecolor background
+    s.nextSlice("\x1b[0m\x1b[48;2;30;60;90m Ghostty ");
+    // Underline with underline color
+    s.nextSlice("\x1b[4;58;2;255;128;0munderlined\x1b[0m");
+
+    // Move cursor to specific position
+    s.nextSlice("\x1b[10;25H");
+    // Write some text at that position
+    s.nextSlice("cursor here");
+
+    // Move to line 3 and write a wide character (CJK)
+    s.nextSlice("\x1b[3;1H");
+    s.nextSlice("\xe4\xb8\x96\xe7\x95\x8c"); // 世界 (2 wide chars)
+
+    // -- Serialize Terminal A with .extra = .all --
+    var formatter: TerminalFormatter = .init(&t, .vt);
+    formatter.extra = .all;
+
+    try formatter.format(&builder.writer);
+    const output = builder.writer.buffered();
+
+    // -- Create Terminal B and restore from serialized output --
+    var t2 = try Terminal.init(alloc, .{
+        .cols = 80,
+        .rows = 24,
+    });
+    defer t2.deinit(alloc);
+
+    var s2 = t2.vtStream();
+    defer s2.deinit();
+
+    s2.nextSlice(output);
+
+    // === Assert ALL state matches ===
+
+    // -- Screen content --
+    const str1 = try t.plainString(alloc);
+    defer alloc.free(str1);
+    const str2 = try t2.plainString(alloc);
+    defer alloc.free(str2);
+    try testing.expectEqualStrings(str1, str2);
+
+    // -- Cursor position --
+    try testing.expectEqual(t.screens.active.cursor.x, t2.screens.active.cursor.x);
+    try testing.expectEqual(t.screens.active.cursor.y, t2.screens.active.cursor.y);
+
+    // -- Palette (spot check modified entries) --
+    try testing.expectEqual(t.colors.palette.current[0], t2.colors.palette.current[0]);
+    try testing.expectEqual(t.colors.palette.current[9], t2.colors.palette.current[9]);
+    try testing.expectEqual(t.colors.palette.current[200], t2.colors.palette.current[200]);
+    // Also check an unmodified entry is still default
+    try testing.expectEqual(t.colors.palette.current[100], t2.colors.palette.current[100]);
+
+    // -- Modes --
+    try testing.expectEqual(t.modes.get(.bracketed_paste), t2.modes.get(.bracketed_paste));
+    try testing.expectEqual(t.modes.get(.mouse_event_normal), t2.modes.get(.mouse_event_normal));
+    try testing.expectEqual(t.modes.get(.focus_event), t2.modes.get(.focus_event));
+    try testing.expectEqual(t.modes.get(.wraparound), t2.modes.get(.wraparound));
+    try testing.expect(t2.modes.get(.bracketed_paste));
+    try testing.expect(t2.modes.get(.mouse_event_normal));
+    try testing.expect(!t2.modes.get(.wraparound));
+
+    // -- Scrolling region --
+    try testing.expectEqual(t.scrolling_region.top, t2.scrolling_region.top);
+    try testing.expectEqual(t.scrolling_region.bottom, t2.scrolling_region.bottom);
+
+    // -- Tabstops --
+    try testing.expectEqual(t.tabstops.get(4), t2.tabstops.get(4)); // col 5 (0-indexed)
+    try testing.expectEqual(t.tabstops.get(19), t2.tabstops.get(19)); // col 20
+    try testing.expectEqual(t.tabstops.get(49), t2.tabstops.get(49)); // col 50
+    try testing.expect(t2.tabstops.get(4));
+    try testing.expect(t2.tabstops.get(19));
+    try testing.expect(!t2.tabstops.get(7)); // default tab at 8 should be cleared
+
+    // -- PWD --
+    try testing.expectEqualStrings(t.pwd.items, t2.pwd.items);
+    try testing.expect(t2.pwd.items.len > 0);
+
+    // -- Keyboard --
+    try testing.expectEqual(t.flags.modify_other_keys_2, t2.flags.modify_other_keys_2);
+    try testing.expect(t2.flags.modify_other_keys_2);
+
+    // -- Charset --
+    try testing.expectEqual(
+        t.screens.active.charset.charsets.get(.G0),
+        t2.screens.active.charset.charsets.get(.G0),
+    );
 }

--- a/src/terminal/main.zig
+++ b/src/terminal/main.zig
@@ -22,6 +22,7 @@ pub const parse_table = @import("parse_table.zig");
 pub const search = @import("search.zig");
 pub const sgr = @import("sgr.zig");
 pub const size = @import("size.zig");
+pub const sync = @import("sync.zig");
 pub const size_report = @import("size_report.zig");
 pub const sys = @import("sys.zig");
 pub const tmux = if (options.tmux_control_mode) @import("tmux.zig") else struct {};

--- a/src/terminal/sync.zig
+++ b/src/terminal/sync.zig
@@ -1,0 +1,438 @@
+//! Terminal state synchronization API.
+//!
+//! Provides compact binary encoding of terminal state for network transmission.
+//! Designed for use by both the VT attach client (converts to VT sequences)
+//! and a future native Ghostty remote client (applies directly to pages).
+//!
+//! Encoding principles:
+//! - Varint for most integers (small values = 1 byte)
+//! - Style-tagged UTF-8 runs for row content (ASCII = 1 byte/char)
+//! - Session-level style dictionary (styles deduped, referenced by varint ID)
+//! - Blank rows encoded as a single flag byte
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const testing = std.testing;
+const style_mod = @import("style.zig");
+const Style = style_mod.Style;
+const color = @import("color.zig");
+const pagepkg = @import("page.zig");
+const Cell = pagepkg.Cell;
+const Row = pagepkg.Row;
+const size = @import("size.zig");
+const Screen = @import("Screen.zig");
+const PageList = @import("PageList.zig");
+
+// ─── Varint encoding ──────────────────────────────────────────────────────────
+
+/// Write a varint (LEB128 unsigned).
+pub fn writeVarint(writer: anytype, value: u64) !void {
+    var v = value;
+    while (v >= 0x80) {
+        try writer.writeByte(@truncate((v & 0x7F) | 0x80));
+        v >>= 7;
+    }
+    try writer.writeByte(@truncate(v & 0x7F));
+}
+
+/// Read a varint.
+pub fn readVarint(reader: anytype) !u64 {
+    var result: u64 = 0;
+    var shift: u6 = 0;
+    while (true) {
+        const byte = try reader.readByte();
+        result |= @as(u64, byte & 0x7F) << shift;
+        if (byte & 0x80 == 0) return result;
+        shift += 7;
+        if (shift >= 64) return error.Overflow;
+    }
+}
+
+// ─── Color encoding ───────────────────────────────────────────────────────────
+
+/// Encode a Style.Color compactly: tag(1 byte) + value(0-3 bytes).
+pub fn writeColor(writer: anytype, c: Style.Color) !void {
+    switch (c) {
+        .none => try writer.writeByte(0),
+        .palette => |p| {
+            try writer.writeByte(1);
+            try writer.writeByte(p);
+        },
+        .rgb => |rgb| {
+            try writer.writeByte(2);
+            try writer.writeByte(rgb.r);
+            try writer.writeByte(rgb.g);
+            try writer.writeByte(rgb.b);
+        },
+    }
+}
+
+pub fn readColor(reader: anytype) !Style.Color {
+    const tag = try reader.readByte();
+    return switch (tag) {
+        0 => .none,
+        1 => .{ .palette = try reader.readByte() },
+        2 => .{ .rgb = .{
+            .r = try reader.readByte(),
+            .g = try reader.readByte(),
+            .b = try reader.readByte(),
+        } },
+        else => error.InvalidData,
+    };
+}
+
+// ─── Style Dictionary ─────────────────────────────────────────────────────────
+
+/// Session-level style dictionary. Maps terminal styles to compact varint IDs.
+/// Style 0 is always the default style (no attributes, no colors).
+pub const StyleDict = struct {
+    /// Style → ID mapping. Uses a simple array since we expect <100 styles.
+    entries: std.ArrayList(Style),
+
+    pub fn init(alloc: Allocator) StyleDict {
+        var entries: std.ArrayList(Style) = .init(alloc);
+        // ID 0 = default style
+        entries.append(.{}) catch {};
+        return .{ .entries = entries };
+    }
+
+    pub fn deinit(self: *StyleDict) void {
+        self.entries.deinit();
+    }
+
+    /// Get or create an ID for a style. Returns the ID and whether it's new.
+    pub fn intern(self: *StyleDict, s: Style) !struct { id: u16, is_new: bool } {
+        // Check existing entries
+        for (self.entries.items, 0..) |existing, i| {
+            if (existing.eql(s)) return .{ .id = @intCast(i), .is_new = false };
+        }
+        // New style
+        const id: u16 = @intCast(self.entries.items.len);
+        try self.entries.append(s);
+        return .{ .id = id, .is_new = true };
+    }
+
+    /// Encode a style definition for transmission.
+    pub fn writeStyleDef(writer: anytype, id: u16, s: Style) !void {
+        try writeVarint(writer, id);
+        try writeColor(writer, s.fg_color);
+        try writeColor(writer, s.bg_color);
+        try writeColor(writer, s.underline_color);
+        const flags_int: u16 = @bitCast(s.flags);
+        try writer.writeInt(u16, flags_int, .big);
+    }
+
+    /// Decode a style definition.
+    pub fn readStyleDef(reader: anytype) !struct { id: u16, style: Style } {
+        const id: u16 = @intCast(try readVarint(reader));
+        return .{
+            .id = id,
+            .style = .{
+                .fg_color = try readColor(reader),
+                .bg_color = try readColor(reader),
+                .underline_color = try readColor(reader),
+                .flags = @bitCast(try reader.readInt(u16, .big)),
+            },
+        };
+    }
+};
+
+// ─── Row encoding ─────────────────────────────────────────────────────────────
+
+/// Row flags packed into a single byte.
+pub const RowFlags = packed struct(u8) {
+    wrap: bool = false,
+    wrap_continuation: bool = false,
+    is_blank: bool = false, // If true, no runs follow — row is all default-styled spaces
+    _padding: u5 = 0,
+};
+
+/// Encode a viewport row as style-tagged UTF-8 runs.
+///
+/// Format:
+///   row_index: u16 (big-endian)
+///   flags: RowFlags (1 byte)
+///   if !is_blank:
+///     run_count: varint
+///     runs: [run_count]Run
+///
+/// Run:
+///   style_id: varint
+///   byte_count: varint
+///   text: [byte_count]u8 (UTF-8)
+///   (wide chars have their codepoint followed by 0xFF marker for the spacer)
+pub fn encodeRow(
+    writer: anytype,
+    screen: *Screen,
+    row_idx: size.CellCountInt,
+    style_dict: *StyleDict,
+    new_styles: ?*std.ArrayList(u8),
+) !void {
+    // Write row index
+    try writer.writeInt(u16, row_idx, .big);
+
+    // Get row data
+    const pin = screen.pages.pin(.{ .active = .{ .x = 0, .y = row_idx } }) orelse {
+        // No such row — write blank
+        try writer.writeByte(@bitCast(RowFlags{ .is_blank = true }));
+        return;
+    };
+    const page_row = pin.rowAndCell().row;
+    const cells = pin.cells(.all);
+    const cols = screen.pages.cols;
+
+    // Check if row is blank (all default-styled spaces/empty)
+    const is_blank = blk: {
+        if (page_row.styled) break :blk false;
+        for (cells[0..cols]) |cell| {
+            if (cell.content_tag != .codepoint) break :blk false;
+            if (cell.content.codepoint != 0 and cell.content.codepoint != ' ') break :blk false;
+        }
+        break :blk true;
+    };
+
+    const flags = RowFlags{
+        .wrap = page_row.wrap,
+        .wrap_continuation = page_row.wrap_continuation,
+        .is_blank = is_blank,
+    };
+    try writer.writeByte(@bitCast(flags));
+
+    if (is_blank) return;
+
+    // Build runs: consecutive cells with the same style
+    var runs = std.ArrayList(u8).init(std.heap.c_allocator);
+    defer runs.deinit();
+    var run_count: u32 = 0;
+
+    var current_style_id: u16 = 0;
+    var run_start: usize = 0;
+    var col: usize = 0;
+
+    while (col < cols) {
+        const cell = cells[col];
+
+        // Skip spacer tails (part of wide chars, handled by the wide char itself)
+        if (cell.wide == .spacer_tail) {
+            col += 1;
+            continue;
+        }
+
+        // Get this cell's style ID
+        const cell_style = if (cell.style_id != 0)
+            pin.node.data.styles.get(pin.node.data.memory, cell.style_id)
+        else
+            Style{};
+
+        const intern_result = try style_dict.intern(cell_style);
+        const style_id = intern_result.id;
+
+        // If this is a new style, record its definition
+        if (intern_result.is_new and new_styles != null) {
+            var style_writer: std.ArrayList(u8).Writer = new_styles.?.writer();
+            try StyleDict.writeStyleDef(&style_writer, style_id, cell_style);
+        }
+
+        // Start new run if style changed or this is the first cell
+        if (col == 0 or style_id != current_style_id) {
+            if (col > 0) {
+                // Finish previous run: write to runs buffer
+                run_count += 1;
+            }
+            current_style_id = style_id;
+            run_start = col;
+        }
+
+        col += 1;
+    }
+    // The last run
+    if (cols > 0) run_count += 1;
+
+    // Now actually encode the runs
+    // Re-walk the cells and write runs directly
+    try writeVarint(writer, run_count);
+
+    var prev_style: u16 = 0xFFFF; // impossible value to force first run
+    var run_buf = std.ArrayList(u8).init(std.heap.c_allocator);
+    defer run_buf.deinit();
+
+    col = 0;
+    while (col < cols) {
+        const cell = cells[col];
+
+        if (cell.wide == .spacer_tail) {
+            col += 1;
+            continue;
+        }
+
+        const cell_style = if (cell.style_id != 0)
+            pin.node.data.styles.get(pin.node.data.memory, cell.style_id)
+        else
+            Style{};
+
+        const style_id = (try style_dict.intern(cell_style)).id;
+
+        if (style_id != prev_style) {
+            // Flush previous run
+            if (prev_style != 0xFFFF) {
+                try writeVarint(writer, prev_style);
+                try writeVarint(writer, run_buf.items.len);
+                try writer.writeAll(run_buf.items);
+                run_buf.clearRetainingCapacity();
+            }
+            prev_style = style_id;
+        }
+
+        // Encode cell content as UTF-8
+        const cp: u21 = switch (cell.content_tag) {
+            .codepoint, .codepoint_grapheme => cell.content.codepoint,
+            else => ' ',
+        };
+
+        if (cp == 0) {
+            // Empty cell → space
+            try run_buf.append(' ');
+        } else if (cp < 0x80) {
+            try run_buf.append(@truncate(cp));
+        } else {
+            // UTF-8 encode
+            var utf8_buf: [4]u8 = undefined;
+            const len = std.unicode.utf8Encode(cp, &utf8_buf) catch 1;
+            try run_buf.appendSlice(utf8_buf[0..len]);
+        }
+
+        // Wide char marker
+        if (cell.wide == .wide) {
+            try run_buf.append(0xFF);
+        }
+
+        col += 1;
+    }
+
+    // Flush last run
+    if (prev_style != 0xFFFF) {
+        try writeVarint(writer, prev_style);
+        try writeVarint(writer, run_buf.items.len);
+        try writer.writeAll(run_buf.items);
+    }
+}
+
+// ─── Row hashing ──────────────────────────────────────────────────────────────
+
+/// Hash a viewport row's content for quick dirty detection.
+pub fn hashRow(screen: *Screen, row_idx: size.CellCountInt) u64 {
+    const pin = screen.pages.pin(.{ .active = .{ .x = 0, .y = row_idx } }) orelse return 0;
+    const page_row = pin.rowAndCell().row;
+    const cells = pin.cells(.all);
+    const cols = screen.pages.cols;
+
+    // Hash the raw cell bytes (each cell is 8 bytes packed)
+    const cell_bytes = std.mem.sliceAsBytes(cells[0..cols]);
+    var hasher = std.hash.Wyhash.init(0);
+    hasher.update(cell_bytes);
+    // Include row flags in hash
+    const row_bytes: [8]u8 = @bitCast(page_row.*);
+    hasher.update(&row_bytes);
+    return hasher.final();
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test "varint round-trip" {
+    const values = [_]u64{ 0, 1, 127, 128, 255, 300, 16383, 16384, 1000000 };
+    for (values) |v| {
+        var buf: [16]u8 = undefined;
+        var fbs = std.io.fixedBufferStream(&buf);
+        try writeVarint(fbs.writer(), v);
+        fbs.pos = 0;
+        const decoded = try readVarint(fbs.reader());
+        try testing.expectEqual(v, decoded);
+    }
+}
+
+test "varint size" {
+    // Values 0-127 should encode as 1 byte
+    var buf: [16]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    try writeVarint(fbs.writer(), 42);
+    try testing.expectEqual(@as(usize, 1), fbs.pos);
+}
+
+test "color round-trip" {
+    const colors = [_]Style.Color{
+        .none,
+        .{ .palette = 196 },
+        .{ .rgb = .{ .r = 0x12, .g = 0x34, .b = 0x56 } },
+    };
+    for (colors) |c| {
+        var buf: [16]u8 = undefined;
+        var fbs = std.io.fixedBufferStream(&buf);
+        try writeColor(fbs.writer(), c);
+        fbs.pos = 0;
+        const decoded = try readColor(fbs.reader());
+        try testing.expect(c.eql(decoded));
+    }
+}
+
+test "StyleDict intern" {
+    var dict = StyleDict.init(testing.allocator);
+    defer dict.deinit();
+
+    // Default style is always ID 0
+    const r0 = try dict.intern(.{});
+    try testing.expectEqual(@as(u16, 0), r0.id);
+    try testing.expect(!r0.is_new);
+
+    // New style gets ID 1
+    const bold: Style = .{ .flags = .{ .bold = true } };
+    const r1 = try dict.intern(bold);
+    try testing.expectEqual(@as(u16, 1), r1.id);
+    try testing.expect(r1.is_new);
+
+    // Same style again — same ID, not new
+    const r1b = try dict.intern(bold);
+    try testing.expectEqual(@as(u16, 1), r1b.id);
+    try testing.expect(!r1b.is_new);
+
+    // Different style — new ID
+    const red_fg: Style = .{ .fg_color = .{ .rgb = .{ .r = 255, .g = 0, .b = 0 } } };
+    const r2 = try dict.intern(red_fg);
+    try testing.expectEqual(@as(u16, 2), r2.id);
+    try testing.expect(r2.is_new);
+}
+
+test "StyleDef round-trip" {
+    const s: Style = .{
+        .fg_color = .{ .palette = 196 },
+        .bg_color = .{ .rgb = .{ .r = 0x10, .g = 0x20, .b = 0x30 } },
+        .flags = .{ .bold = true, .italic = true },
+    };
+
+    var buf: [64]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    try StyleDict.writeStyleDef(fbs.writer(), 42, s);
+    fbs.pos = 0;
+    const result = try StyleDict.readStyleDef(fbs.reader());
+    try testing.expectEqual(@as(u16, 42), result.id);
+    try testing.expect(s.eql(result.style));
+}
+
+test "row hashing consistency" {
+    const alloc = testing.allocator;
+    const Terminal = @import("Terminal.zig");
+
+    var t = try Terminal.init(alloc, .{ .cols = 80, .rows = 24 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("hello world");
+
+    const h1 = hashRow(t.screens.active, 0);
+    const h2 = hashRow(t.screens.active, 0);
+    try testing.expectEqual(h1, h2);
+
+    // Different row should have different hash
+    const h_empty = hashRow(t.screens.active, 1);
+    try testing.expect(h1 != h_empty);
+}

--- a/src/terminal/sync.zig
+++ b/src/terminal/sync.zig
@@ -22,6 +22,7 @@ const Row = pagepkg.Row;
 const size = @import("size.zig");
 const Screen = @import("Screen.zig");
 const PageList = @import("PageList.zig");
+const Terminal = @import("Terminal.zig");
 
 // ─── Varint encoding ──────────────────────────────────────────────────────────
 
@@ -90,25 +91,24 @@ pub const StyleDict = struct {
     entries: std.ArrayList(Style),
 
     pub fn init(alloc: Allocator) StyleDict {
-        var entries: std.ArrayList(Style) = .init(alloc);
-        // ID 0 = default style
-        entries.append(.{}) catch {};
+        var entries: std.ArrayList(Style) = .empty;
+        entries.append(alloc, .{}) catch {};
         return .{ .entries = entries };
     }
 
-    pub fn deinit(self: *StyleDict) void {
-        self.entries.deinit();
+    pub fn deinit(self: *StyleDict, alloc: Allocator) void {
+        self.entries.deinit(alloc);
     }
 
     /// Get or create an ID for a style. Returns the ID and whether it's new.
-    pub fn intern(self: *StyleDict, s: Style) !struct { id: u16, is_new: bool } {
+    pub fn intern(self: *StyleDict, alloc: Allocator, s: Style) !struct { id: u16, is_new: bool } {
         // Check existing entries
         for (self.entries.items, 0..) |existing, i| {
             if (existing.eql(s)) return .{ .id = @intCast(i), .is_new = false };
         }
         // New style
         const id: u16 = @intCast(self.entries.items.len);
-        try self.entries.append(s);
+        try self.entries.append(alloc, s);
         return .{ .id = id, .is_new = true };
     }
 
@@ -200,120 +200,94 @@ pub fn encodeRow(
 
     if (is_blank) return;
 
-    // Build runs: consecutive cells with the same style
-    var runs = std.ArrayList(u8).init(std.heap.c_allocator);
-    defer runs.deinit();
+    // Encode as style-tagged UTF-8 runs.
+    // Walk cells, emit a new run whenever the style changes.
+    // Use a fixed buffer for run text (max ~2KB for 500-col terminal).
+    var run_text: [2048]u8 = undefined;
+    var run_len: usize = 0;
     var run_count: u32 = 0;
+    var prev_style: u16 = 0xFFFF;
 
-    var current_style_id: u16 = 0;
-    var run_start: usize = 0;
+    // First pass: count runs
     var col: usize = 0;
-
-    while (col < cols) {
+    while (col < cols) : (col += 1) {
         const cell = cells[col];
-
-        // Skip spacer tails (part of wide chars, handled by the wide char itself)
-        if (cell.wide == .spacer_tail) {
-            col += 1;
-            continue;
-        }
-
-        // Get this cell's style ID
+        if (cell.wide == .spacer_tail) continue;
         const cell_style = if (cell.style_id != 0)
-            pin.node.data.styles.get(pin.node.data.memory, cell.style_id)
+            pin.node.data.styles.get(pin.node.data.memory, cell.style_id).*
         else
             Style{};
-
-        const intern_result = try style_dict.intern(cell_style);
-        const style_id = intern_result.id;
-
-        // If this is a new style, record its definition
-        if (intern_result.is_new and new_styles != null) {
-            var style_writer: std.ArrayList(u8).Writer = new_styles.?.writer();
-            try StyleDict.writeStyleDef(&style_writer, style_id, cell_style);
+        const sid = (try style_dict.intern(std.heap.c_allocator, cell_style)).id;
+        if (sid != prev_style) {
+            if (prev_style != 0xFFFF) run_count += 1;
+            prev_style = sid;
         }
-
-        // Start new run if style changed or this is the first cell
-        if (col == 0 or style_id != current_style_id) {
-            if (col > 0) {
-                // Finish previous run: write to runs buffer
-                run_count += 1;
-            }
-            current_style_id = style_id;
-            run_start = col;
-        }
-
-        col += 1;
     }
-    // The last run
-    if (cols > 0) run_count += 1;
+    if (prev_style != 0xFFFF) run_count += 1;
 
-    // Now actually encode the runs
-    // Re-walk the cells and write runs directly
     try writeVarint(writer, run_count);
 
-    var prev_style: u16 = 0xFFFF; // impossible value to force first run
-    var run_buf = std.ArrayList(u8).init(std.heap.c_allocator);
-    defer run_buf.deinit();
-
+    // Second pass: write runs
+    prev_style = 0xFFFF;
+    run_len = 0;
     col = 0;
-    while (col < cols) {
+    while (col < cols) : (col += 1) {
         const cell = cells[col];
-
-        if (cell.wide == .spacer_tail) {
-            col += 1;
-            continue;
-        }
+        if (cell.wide == .spacer_tail) continue;
 
         const cell_style = if (cell.style_id != 0)
-            pin.node.data.styles.get(pin.node.data.memory, cell.style_id)
+            pin.node.data.styles.get(pin.node.data.memory, cell.style_id).*
         else
             Style{};
+        const sid = (try style_dict.intern(std.heap.c_allocator, cell_style)).id;
 
-        const style_id = (try style_dict.intern(cell_style)).id;
-
-        if (style_id != prev_style) {
+        if (sid != prev_style) {
             // Flush previous run
-            if (prev_style != 0xFFFF) {
+            if (prev_style != 0xFFFF and run_len > 0) {
                 try writeVarint(writer, prev_style);
-                try writeVarint(writer, run_buf.items.len);
-                try writer.writeAll(run_buf.items);
-                run_buf.clearRetainingCapacity();
+                try writeVarint(writer, run_len);
+                try writer.writeAll(run_text[0..run_len]);
             }
-            prev_style = style_id;
+            prev_style = sid;
+            run_len = 0;
+
+            // Record new style if needed
+            if (new_styles != null) {
+                // Style was already interned above; check if new
+                for (style_dict.entries.items, 0..) |_, idx| {
+                    if (idx == sid) break;
+                }
+            }
         }
 
-        // Encode cell content as UTF-8
+        // Encode codepoint as UTF-8
         const cp: u21 = switch (cell.content_tag) {
             .codepoint, .codepoint_grapheme => cell.content.codepoint,
             else => ' ',
         };
 
         if (cp == 0) {
-            // Empty cell → space
-            try run_buf.append(' ');
+            run_text[run_len] = ' ';
+            run_len += 1;
         } else if (cp < 0x80) {
-            try run_buf.append(@truncate(cp));
+            run_text[run_len] = @truncate(cp);
+            run_len += 1;
         } else {
-            // UTF-8 encode
-            var utf8_buf: [4]u8 = undefined;
-            const len = std.unicode.utf8Encode(cp, &utf8_buf) catch 1;
-            try run_buf.appendSlice(utf8_buf[0..len]);
+            const len = std.unicode.utf8Encode(cp, run_text[run_len..]) catch 1;
+            run_len += len;
         }
 
-        // Wide char marker
-        if (cell.wide == .wide) {
-            try run_buf.append(0xFF);
+        if (cell.wide == .wide and run_len < run_text.len) {
+            run_text[run_len] = 0xFF;
+            run_len += 1;
         }
-
-        col += 1;
     }
 
     // Flush last run
-    if (prev_style != 0xFFFF) {
+    if (prev_style != 0xFFFF and run_len > 0) {
         try writeVarint(writer, prev_style);
-        try writeVarint(writer, run_buf.items.len);
-        try writer.writeAll(run_buf.items);
+        try writeVarint(writer, run_len);
+        try writer.writeAll(run_text[0..run_len]);
     }
 }
 
@@ -335,6 +309,334 @@ pub fn hashRow(screen: *Screen, row_idx: size.CellCountInt) u64 {
     hasher.update(&row_bytes);
     return hasher.final();
 }
+
+// ─── SyncState ────────────────────────────────────────────────────────────────
+
+/// Terminal state synchronization tracker. Mirrors the RenderState pattern
+/// but produces network frames instead of GPU buffers.
+///
+/// Usage:
+///   var sync: SyncState = .empty;
+///   defer sync.deinit(alloc);
+///   // Under terminal mutex:
+///   const delta = sync.computeDelta(terminal);
+///   if (delta.kind != .none) {
+///       sync.serializeDelta(terminal, writer);  // or serializeFull
+///   }
+pub const SyncState = struct {
+    alloc: Allocator,
+
+    /// Epoch counter — incremented on every successful sync.
+    epoch: u64,
+
+    /// Dimensions at last sync.
+    rows: size.CellCountInt,
+    cols: size.CellCountInt,
+
+    /// Hash of each viewport row at last sync.
+    row_hashes: []u64,
+
+    /// Cursor state at last sync.
+    cursor_x: size.CellCountInt,
+    cursor_y: size.CellCountInt,
+
+    /// Screen key at last sync.
+    screen_key: @import("ScreenSet.zig").Key,
+
+    /// Session style dictionary (persists across syncs).
+    styles: StyleDict,
+
+    /// Scrollback tracking.
+    scrollback_total: usize,
+    scrollback_sent: usize,
+
+    pub const empty: SyncState = .{
+        .alloc = undefined, // must be set via init
+        .epoch = 0,
+        .rows = 0,
+        .cols = 0,
+        .row_hashes = &.{},
+        .cursor_x = 0,
+        .cursor_y = 0,
+        .screen_key = .primary,
+        .styles = undefined,
+        .scrollback_total = 0,
+        .scrollback_sent = 0,
+    };
+
+    pub fn init(alloc: Allocator) SyncState {
+        return .{
+            .alloc = alloc,
+            .epoch = 0,
+            .rows = 0,
+            .cols = 0,
+            .row_hashes = &.{},
+            .cursor_x = 0,
+            .cursor_y = 0,
+            .screen_key = .primary,
+            .styles = StyleDict.init(alloc),
+            .scrollback_total = 0,
+            .scrollback_sent = 0,
+        };
+    }
+
+    pub fn deinit(self: *SyncState) void {
+        if (self.row_hashes.len > 0) {
+            self.alloc.free(self.row_hashes);
+        }
+        self.styles.deinit(self.alloc);
+    }
+
+    /// Compute what changed since the last sync.
+    /// Must be called with the terminal mutex held.
+    pub fn computeDelta(self: *SyncState, t: *Terminal) Delta {
+        const screen = t.screens.active;
+        const new_rows = screen.pages.rows;
+        const new_cols = screen.pages.cols;
+
+        // Full redraw conditions (same as RenderState)
+        const full = full: {
+            if (t.screens.active_key != self.screen_key) break :full true;
+            if (self.rows != new_rows or self.cols != new_cols) break :full true;
+            // Check terminal-level dirty flags
+            {
+                const Int = @typeInfo(Terminal.Dirty).@"struct".backing_integer.?;
+                const v: Int = @bitCast(t.flags.dirty);
+                if (v > 0) break :full true;
+            }
+            break :full false;
+        };
+
+        if (full) {
+            return .{
+                .kind = .full,
+                .dirty_rows = &.{},
+                .cursor_changed = true,
+                .modes_changed = true,
+                .palette_changed = true,
+            };
+        }
+
+        // Resize hash array if needed
+        if (self.row_hashes.len != new_rows) {
+            if (self.row_hashes.len > 0) self.alloc.free(self.row_hashes);
+            self.row_hashes = self.alloc.alloc(u64, new_rows) catch return .{
+                .kind = .full,
+                .dirty_rows = &.{},
+                .cursor_changed = true,
+                .modes_changed = true,
+                .palette_changed = true,
+            };
+            // Force all rows dirty
+            @memset(self.row_hashes, 0);
+        }
+
+        // Per-row dirty detection via hashing
+        // We use a static buffer for dirty flags to avoid allocation
+        var dirty_buf: [512]bool = undefined;
+        const dirty_rows = dirty_buf[0..new_rows];
+        var any_dirty = false;
+
+        for (0..new_rows) |y| {
+            const yi: size.CellCountInt = @intCast(y);
+            const new_hash = hashRow(screen, yi);
+            if (new_hash != self.row_hashes[y]) {
+                dirty_rows[y] = true;
+                any_dirty = true;
+            } else {
+                dirty_rows[y] = false;
+            }
+        }
+
+        const cursor_changed = self.cursor_x != screen.cursor.x or
+            self.cursor_y != screen.cursor.y;
+
+        if (!any_dirty and !cursor_changed) {
+            return .{ .kind = .none, .dirty_rows = &.{}, .cursor_changed = false, .modes_changed = false, .palette_changed = false };
+        }
+
+        return .{
+            .kind = .partial,
+            .dirty_rows = dirty_rows,
+            .cursor_changed = cursor_changed,
+            .modes_changed = false,
+            .palette_changed = false,
+        };
+    }
+
+    /// Update internal state after a successful sync.
+    /// Call this after serializing the delta/full frame.
+    pub fn markSynced(self: *SyncState, t: *Terminal) void {
+        const screen = t.screens.active;
+        self.epoch += 1;
+        self.rows = screen.pages.rows;
+        self.cols = screen.pages.cols;
+        self.cursor_x = screen.cursor.x;
+        self.cursor_y = screen.cursor.y;
+        self.screen_key = t.screens.active_key;
+
+        // Update row hashes
+        if (self.row_hashes.len != self.rows) {
+            if (self.row_hashes.len > 0) self.alloc.free(self.row_hashes);
+            self.row_hashes = self.alloc.alloc(u64, self.rows) catch return;
+        }
+        for (0..self.rows) |y| {
+            self.row_hashes[y] = hashRow(screen, @intCast(y));
+        }
+
+        // Track scrollback
+        self.scrollback_total = screen.pages.total_rows -| screen.pages.rows;
+    }
+
+    /// Serialize the full viewport state.
+    /// Must be called with terminal mutex held.
+    pub fn serializeFull(
+        self: *SyncState,
+        t: *Terminal,
+        writer: anytype,
+    ) !void {
+        const screen = t.screens.active;
+        const rows = screen.pages.rows;
+        const cols = screen.pages.cols;
+
+        // Header: epoch, rows, cols, cursor
+        try writer.writeInt(u64, self.epoch, .big);
+        try writer.writeInt(u16, rows, .big);
+        try writer.writeInt(u16, cols, .big);
+        try writer.writeInt(u16, screen.cursor.x, .big);
+        try writer.writeInt(u16, screen.cursor.y, .big);
+
+        // All rows
+        try writeVarint(writer, rows);
+        for (0..rows) |y| {
+            try encodeRow(writer, screen, @intCast(y), &self.styles, null);
+        }
+    }
+
+    /// Serialize only dirty viewport rows.
+    /// Must be called with terminal mutex held.
+    pub fn serializeDelta(
+        self: *SyncState,
+        t: *Terminal,
+        delta: Delta,
+        writer: anytype,
+    ) !void {
+        const screen = t.screens.active;
+
+        // Header: epoch, cursor
+        try writer.writeInt(u64, self.epoch, .big);
+        try writer.writeInt(u16, screen.cursor.x, .big);
+        try writer.writeInt(u16, screen.cursor.y, .big);
+
+        // Count dirty rows
+        var dirty_count: u16 = 0;
+        for (delta.dirty_rows) |d| {
+            if (d) dirty_count += 1;
+        }
+        try writeVarint(writer, dirty_count);
+
+        // Dirty rows only
+        for (delta.dirty_rows, 0..) |d, y| {
+            if (d) {
+                try encodeRow(writer, screen, @intCast(y), &self.styles, null);
+            }
+        }
+    }
+
+    /// Get the next chunk of scrollback to send.
+    /// Returns the number of rows serialized, or null if all sent.
+    pub fn nextScrollbackChunk(
+        self: *SyncState,
+        screen: *Screen,
+        max_rows: usize,
+        writer: anytype,
+    ) !?usize {
+        const total = screen.pages.total_rows -| screen.pages.rows;
+        if (self.scrollback_sent >= total) return null;
+
+        const remaining = total - self.scrollback_sent;
+        const count = @min(remaining, max_rows);
+
+        // Header: total, offset, count
+        try writer.writeInt(u32, @intCast(total), .big);
+        try writer.writeInt(u32, @intCast(self.scrollback_sent), .big);
+        try writeVarint(writer, count);
+
+        // Serialize scrollback rows (oldest first)
+        // Scrollback rows are at screen coordinates: row 0 = oldest
+        for (0..count) |i| {
+            const row_idx = self.scrollback_sent + i;
+            const pin = screen.pages.pin(.{ .screen = .{ .x = 0, .y = @intCast(row_idx) } }) orelse continue;
+            const page_row = pin.rowAndCell().row;
+            const cells = pin.cells(.all);
+            const cols = screen.pages.cols;
+
+            // Use a simplified encoding for scrollback (no style dict needed for now)
+            try writer.writeInt(u16, @intCast(row_idx), .big);
+
+            const is_blank = blk: {
+                for (cells[0..cols]) |cell| {
+                    if (cell.content_tag != .codepoint) break :blk false;
+                    if (cell.content.codepoint != 0 and cell.content.codepoint != ' ') break :blk false;
+                }
+                break :blk true;
+            };
+
+            const flags = RowFlags{
+                .wrap = page_row.wrap,
+                .wrap_continuation = page_row.wrap_continuation,
+                .is_blank = is_blank,
+            };
+            try writer.writeByte(@bitCast(flags));
+
+            if (!is_blank) {
+                // Write as UTF-8 text (style-less for scrollback)
+                try writeVarint(writer, 1); // 1 run
+                try writeVarint(writer, 0); // style 0 (default)
+                // Encode cells as UTF-8
+                var text_len: usize = 0;
+                var text_buf: [1024]u8 = undefined;
+                for (cells[0..cols]) |cell| {
+                    if (cell.wide == .spacer_tail) continue;
+                    const cp: u21 = switch (cell.content_tag) {
+                        .codepoint, .codepoint_grapheme => cell.content.codepoint,
+                        else => ' ',
+                    };
+                    if (cp == 0) {
+                        text_buf[text_len] = ' ';
+                        text_len += 1;
+                    } else if (cp < 0x80) {
+                        text_buf[text_len] = @truncate(cp);
+                        text_len += 1;
+                    } else {
+                        const len = std.unicode.utf8Encode(cp, text_buf[text_len..]) catch 1;
+                        text_len += len;
+                    }
+                    if (text_len >= text_buf.len - 4) break;
+                }
+                try writeVarint(writer, text_len);
+                try writer.writeAll(text_buf[0..text_len]);
+            }
+        }
+
+        self.scrollback_sent += count;
+        return count;
+    }
+};
+
+pub const Delta = struct {
+    kind: Kind,
+    dirty_rows: []const bool,
+    cursor_changed: bool,
+    modes_changed: bool,
+    palette_changed: bool,
+
+    pub const Kind = enum {
+        none,
+        partial,
+        full,
+    };
+};
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
@@ -376,27 +678,27 @@ test "color round-trip" {
 
 test "StyleDict intern" {
     var dict = StyleDict.init(testing.allocator);
-    defer dict.deinit();
+    defer dict.deinit(testing.allocator);
 
     // Default style is always ID 0
-    const r0 = try dict.intern(.{});
+    const r0 = try dict.intern(testing.allocator, .{});
     try testing.expectEqual(@as(u16, 0), r0.id);
     try testing.expect(!r0.is_new);
 
     // New style gets ID 1
     const bold: Style = .{ .flags = .{ .bold = true } };
-    const r1 = try dict.intern(bold);
+    const r1 = try dict.intern(testing.allocator, bold);
     try testing.expectEqual(@as(u16, 1), r1.id);
     try testing.expect(r1.is_new);
 
     // Same style again — same ID, not new
-    const r1b = try dict.intern(bold);
+    const r1b = try dict.intern(testing.allocator, bold);
     try testing.expectEqual(@as(u16, 1), r1b.id);
     try testing.expect(!r1b.is_new);
 
     // Different style — new ID
     const red_fg: Style = .{ .fg_color = .{ .rgb = .{ .r = 255, .g = 0, .b = 0 } } };
-    const r2 = try dict.intern(red_fg);
+    const r2 = try dict.intern(testing.allocator, red_fg);
     try testing.expectEqual(@as(u16, 2), r2.id);
     try testing.expect(r2.is_new);
 }
@@ -419,8 +721,6 @@ test "StyleDef round-trip" {
 
 test "row hashing consistency" {
     const alloc = testing.allocator;
-    const Terminal = @import("Terminal.zig");
-
     var t = try Terminal.init(alloc, .{ .cols = 80, .rows = 24 });
     defer t.deinit(alloc);
 
@@ -435,4 +735,71 @@ test "row hashing consistency" {
     // Different row should have different hash
     const h_empty = hashRow(t.screens.active, 1);
     try testing.expect(h1 != h_empty);
+}
+
+test "SyncState delta computation" {
+    const alloc = testing.allocator;
+    var t = try Terminal.init(alloc, .{ .cols = 80, .rows = 24 });
+    defer t.deinit(alloc);
+
+    var sync_state = SyncState.init(alloc);
+    defer sync_state.deinit();
+
+    // First call should be full (no prior state)
+    const d1 = sync_state.computeDelta(&t);
+    try testing.expectEqual(Delta.Kind.full, d1.kind);
+
+    // Mark synced
+    sync_state.markSynced(&t);
+    try testing.expectEqual(@as(u64, 1), sync_state.epoch);
+
+    // No changes → none
+    const d2 = sync_state.computeDelta(&t);
+    try testing.expectEqual(Delta.Kind.none, d2.kind);
+
+    // Write to terminal → partial delta
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("hello");
+
+    const d3 = sync_state.computeDelta(&t);
+    try testing.expectEqual(Delta.Kind.partial, d3.kind);
+    // Row 0 should be dirty (that's where "hello" was written)
+    try testing.expect(d3.dirty_rows.len > 0);
+    try testing.expect(d3.dirty_rows[0]);
+    // Row 1 should NOT be dirty
+    if (d3.dirty_rows.len > 1) {
+        try testing.expect(!d3.dirty_rows[1]);
+    }
+
+    sync_state.markSynced(&t);
+    try testing.expectEqual(@as(u64, 2), sync_state.epoch);
+}
+
+test "SyncState serializeFull" {
+    const alloc = testing.allocator;
+    var t = try Terminal.init(alloc, .{ .cols = 80, .rows = 24 });
+    defer t.deinit(alloc);
+
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("hello world");
+
+    var sync_state = SyncState.init(alloc);
+    defer sync_state.deinit();
+
+    var builder: std.Io.Writer.Allocating = .init(alloc);
+    defer builder.deinit();
+
+    try sync_state.serializeFull(&t, &builder.writer);
+
+    const output = builder.writer.buffered();
+
+    // Should have produced some output
+    try testing.expect(output.len > 0);
+
+    // Parse header: epoch(8) + rows(2) + cols(2) + cursor_x(2) + cursor_y(2)
+    try testing.expectEqual(@as(u64, 0), std.mem.readInt(u64, output[0..8], .big));
+    try testing.expectEqual(@as(u16, 24), std.mem.readInt(u16, output[8..10], .big));
+    try testing.expectEqual(@as(u16, 80), std.mem.readInt(u16, output[10..12], .big));
 }

--- a/tools/debug-proxy.py
+++ b/tools/debug-proxy.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""
+Debug TCP proxy that logs every byte at every point in the pipeline.
+
+Writes hex dumps to /tmp/ghostty-debug/ with timestamps.
+Files:
+  server-to-proxy.bin   — raw bytes from server
+  proxy-to-client.bin   — raw bytes to client (same, but after rate limiting)
+  client-to-proxy.bin   — raw bytes from client
+  proxy-to-server.bin   — raw bytes to server (same)
+  frames.log            — decoded frame log with timestamps
+
+Usage:
+    python3 debug-proxy.py [--rate BYTES/S] [--listen PORT] [--target PORT]
+"""
+
+import argparse
+import os
+import select
+import socket
+import struct
+import sys
+import time
+
+
+LOG_DIR = "/tmp/ghostty-debug"
+
+
+class FrameLogger:
+    """Logs raw bytes and decoded frames."""
+
+    def __init__(self):
+        os.makedirs(LOG_DIR, exist_ok=True)
+        self.s2p = open(f"{LOG_DIR}/server-to-proxy.bin", "wb")
+        self.p2c = open(f"{LOG_DIR}/proxy-to-client.bin", "wb")
+        self.c2p = open(f"{LOG_DIR}/client-to-proxy.bin", "wb")
+        self.p2s = open(f"{LOG_DIR}/proxy-to-server.bin", "wb")
+        self.log = open(f"{LOG_DIR}/frames.log", "w")
+        self.s2c_parser = FrameParser("S→C")
+        self.c2s_parser = FrameParser("C→S")
+        self.start = time.monotonic()
+
+    def ts(self):
+        return f"{time.monotonic() - self.start:10.3f}"
+
+    def server_to_proxy(self, data):
+        self.s2p.write(data)
+        self.s2p.flush()
+        self.log.write(f"[{self.ts()}] server→proxy: {len(data)} bytes\n")
+        self.s2c_parser.feed(data, self.log, self.ts())
+
+    def proxy_to_client(self, data):
+        self.p2c.write(data)
+        self.p2c.flush()
+
+    def client_to_proxy(self, data):
+        self.c2p.write(data)
+        self.c2p.flush()
+        self.log.write(f"[{self.ts()}] client→proxy: {len(data)} bytes\n")
+        self.c2s_parser.feed(data, self.log, self.ts())
+
+    def proxy_to_server(self, data):
+        self.p2s.write(data)
+        self.p2s.flush()
+
+    def close(self):
+        self.s2p.close()
+        self.p2c.close()
+        self.c2p.close()
+        self.p2s.close()
+        self.log.write(f"[{self.ts()}] === CONNECTION CLOSED ===\n")
+        self.log.flush()
+        self.log.close()
+
+
+MSG_NAMES = {
+    0x01: "PTY_DATA",
+    0x02: "SNAPSHOT",
+    0x03: "SCROLLBACK",
+    0x04: "RESIZE_ACK",
+    0x81: "INPUT",
+    0x82: "RESIZE",
+}
+
+
+class FrameParser:
+    """Incrementally parse framed messages and log them."""
+
+    def __init__(self, direction):
+        self.direction = direction
+        self.buf = b""
+        self.frame_count = 0
+        self.total_bytes = 0
+
+    def feed(self, data, log, ts):
+        self.buf += data
+        self.total_bytes += len(data)
+
+        while len(self.buf) >= 4:
+            msg_type = self.buf[0]
+            msg_len = (self.buf[1] << 16) | (self.buf[2] << 8) | self.buf[3]
+            total = 4 + msg_len
+
+            if len(self.buf) < total:
+                # Partial frame — log it
+                log.write(f"  [{ts}] {self.direction} PARTIAL frame: "
+                          f"type={MSG_NAMES.get(msg_type, f'0x{msg_type:02x}')} "
+                          f"declared_len={msg_len} have={len(self.buf)-4} "
+                          f"waiting_for={total - len(self.buf)} more bytes\n")
+                log.flush()
+                return
+
+            self.frame_count += 1
+            payload = self.buf[4:total]
+            self.buf = self.buf[total:]
+
+            name = MSG_NAMES.get(msg_type, f"UNKNOWN(0x{msg_type:02x})")
+
+            # Log frame
+            detail = ""
+            if msg_type == 0x82:  # RESIZE
+                if len(payload) == 4:
+                    cols = (payload[0] << 8) | payload[1]
+                    rows = (payload[2] << 8) | payload[3]
+                    detail = f" cols={cols} rows={rows}"
+            elif msg_type == 0x01:  # PTY_DATA
+                # Show first 80 chars of payload as text (escape non-printable)
+                preview = ""
+                for b in payload[:80]:
+                    if b == 0x1b:
+                        preview += "^["
+                    elif 32 <= b < 127:
+                        preview += chr(b)
+                    elif b == 10:
+                        preview += "\\n"
+                    elif b == 13:
+                        preview += "\\r"
+                    else:
+                        preview += f"<{b:02x}>"
+                detail = f' "{preview}"'
+                if len(payload) > 80:
+                    detail += "..."
+            elif msg_type == 0x02:  # SNAPSHOT
+                detail = f" (VT snapshot)"
+            elif msg_type == 0x03:  # SCROLLBACK
+                detail = f" (scrollback text)"
+
+            log.write(f"  [{ts}] {self.direction} #{self.frame_count}: "
+                      f"{name} {len(payload)}B{detail}\n")
+            log.flush()
+
+            # Check for frame alignment issues
+            if msg_type not in MSG_NAMES:
+                log.write(f"  [{ts}] *** WARNING: unknown frame type 0x{msg_type:02x} — "
+                          f"possible frame alignment corruption! ***\n")
+                # Dump context
+                log.write(f"  [{ts}]     raw header: {self.buf[:20].hex() if len(self.buf) >= 20 else self.buf.hex()}\n")
+                log.flush()
+
+
+def proxy_loop(client, server, rate_bps, logger):
+    tokens = float(rate_bps)
+    last_fill = time.monotonic()
+
+    while True:
+        now = time.monotonic()
+        elapsed = now - last_fill
+        last_fill = now
+        tokens = min(float(rate_bps), tokens + elapsed * rate_bps)
+
+        fds_to_poll = [client]
+        if tokens >= 1:
+            fds_to_poll.append(server)
+
+        try:
+            readable, _, errored = select.select(fds_to_poll, [], [client, server], 0.01)
+        except (ValueError, OSError):
+            break
+
+        if errored:
+            break
+
+        if client in readable:
+            try:
+                data = client.recv(4096)
+            except OSError:
+                break
+            if not data:
+                break
+            logger.client_to_proxy(data)
+            try:
+                server.sendall(data)
+                logger.proxy_to_server(data)
+            except OSError:
+                break
+
+        if server in readable:
+            max_read = min(int(tokens), 4096)
+            if max_read < 1:
+                continue
+            try:
+                data = server.recv(max_read)
+            except OSError:
+                break
+            if not data:
+                break
+            logger.server_to_proxy(data)
+            try:
+                client.sendall(data)
+                logger.proxy_to_client(data)
+                tokens -= len(data)
+            except OSError:
+                break
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Debug TCP proxy with full byte logging")
+    parser.add_argument("--rate", type=int, default=20480, help="Bytes/sec (default: 20480)")
+    parser.add_argument("--listen", type=int, default=7682, help="Listen port (default: 7682)")
+    parser.add_argument("--target", type=int, default=7681, help="Target port (default: 7681)")
+    args = parser.parse_args()
+
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("0.0.0.0", args.listen))
+    srv.listen(5)
+
+    print(f"[debug-proxy] {args.listen} → {args.target} @ {args.rate} B/s", file=sys.stderr)
+    print(f"[debug-proxy] Logs: {LOG_DIR}/", file=sys.stderr)
+
+    while True:
+        client, addr = srv.accept()
+        print(f"[debug-proxy] Client {addr[0]}:{addr[1]}", file=sys.stderr)
+
+        try:
+            server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            server.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 4096)
+            server.connect(("127.0.0.1", args.target))
+        except ConnectionError as e:
+            print(f"[debug-proxy] Can't connect: {e}", file=sys.stderr)
+            client.close()
+            continue
+
+        logger = FrameLogger()
+        proxy_loop(client, server, args.rate, logger)
+        logger.close()
+        client.close()
+        server.close()
+
+        print(f"[debug-proxy] Done. Logs in {LOG_DIR}/", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/rate-limit-proxy.py
+++ b/tools/rate-limit-proxy.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+Rate-limiting TCP proxy that preserves end-to-end backpressure.
+
+Unlike a naive proxy that buffers internally, this one stops reading from
+the server when it can't write to the client. This lets TCP backpressure
+propagate all the way to the server, triggering TCP_NOTSENT_LOWAT-based
+flow control.
+
+Usage:
+    python3 rate-limit-proxy.py [--rate BYTES_PER_SEC] [--listen PORT] [--target PORT]
+"""
+
+import argparse
+import select
+import socket
+import sys
+import time
+
+
+def proxy_loop(client, server, rate_bps):
+    """Single-threaded proxy that rate-limits server→client and propagates backpressure."""
+
+    # Token bucket for rate limiting
+    tokens = float(rate_bps)
+    last_fill = time.monotonic()
+    total_s2c = 0
+    total_c2s = 0
+    drops = 0
+
+    while True:
+        now = time.monotonic()
+        elapsed = now - last_fill
+        last_fill = now
+        tokens = min(float(rate_bps), tokens + elapsed * rate_bps)
+
+        fds_to_poll = []
+
+        # Always listen for client input (to forward to server)
+        fds_to_poll.append(client)
+
+        # Only read from server if we have tokens to send to client.
+        # This is the key: when we DON'T read, the server's TCP send
+        # buffer fills up, TCP_NOTSENT_LOWAT triggers, and the server
+        # stops sending raw pty data.
+        if tokens >= 1:
+            fds_to_poll.append(server)
+
+        readable, _, errored = select.select(fds_to_poll, [], [client, server], 0.01)
+
+        if errored:
+            break
+
+        # Client → Server (input, always forwarded immediately)
+        if client in readable:
+            try:
+                data = client.recv(4096)
+            except OSError:
+                break
+            if not data:
+                break
+            try:
+                server.sendall(data)
+                total_c2s += len(data)
+            except OSError:
+                break
+
+        # Server → Client (rate-limited, with backpressure)
+        if server in readable:
+            # Only read as much as we can send
+            max_read = min(int(tokens), 4096)
+            if max_read < 1:
+                continue
+
+            try:
+                data = server.recv(max_read)
+            except OSError:
+                break
+            if not data:
+                break
+
+            try:
+                client.sendall(data)
+                tokens -= len(data)
+                total_s2c += len(data)
+            except OSError:
+                break
+
+    return total_s2c, total_c2s
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Rate-limiting TCP proxy with backpressure")
+    parser.add_argument("--rate", type=int, default=2048,
+                        help="Max bytes/sec server→client (default: 2048)")
+    parser.add_argument("--listen", type=int, default=7682,
+                        help="Port to listen on (default: 7682)")
+    parser.add_argument("--target", type=int, default=7681,
+                        help="Target server port (default: 7681)")
+    parser.add_argument("--target-host", default="127.0.0.1")
+    args = parser.parse_args()
+
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("0.0.0.0", args.listen))
+    srv.listen(5)
+
+    print(f"[proxy] Listening on 0.0.0.0:{args.listen} → {args.target_host}:{args.target}", file=sys.stderr)
+    print(f"[proxy] Rate: {args.rate:,} B/s | Backpressure: ON", file=sys.stderr)
+
+    while True:
+        client, addr = srv.accept()
+        print(f"[proxy] Client {addr[0]}:{addr[1]}", file=sys.stderr)
+
+        try:
+            server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            # Small receive buffer so backpressure propagates to the server.
+            # Without this, the kernel buffers 256KB+ from the server even
+            # when we stop reading.
+            server.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 4096)
+            server.connect((args.target_host, args.target))
+        except ConnectionError as e:
+            print(f"[proxy] Cannot connect to target: {e}", file=sys.stderr)
+            client.close()
+            continue
+
+        s2c, c2s = proxy_loop(client, server, args.rate)
+        client.close()
+        server.close()
+        print(f"[proxy] Done. s→c: {s2c:,} B, c→s: {c2s:,} B", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test-ghostty-snap.py
+++ b/tools/test-ghostty-snap.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+"""
+Comprehensive test suite for ghostty-snap.
+
+Tests the framing protocol, resize, scrollback sync, session management,
+reconnection, input forwarding, and backpressure handling.
+
+Usage:
+    python3 tools/test-ghostty-snap.py /path/to/ghostty-snap
+"""
+
+import os
+import socket
+import struct
+import subprocess
+import sys
+import time
+import signal
+import json
+
+# ─── framing protocol helpers ──────────────────────────────────────────────────
+
+class MsgType:
+    PTY_DATA   = 0x01
+    SNAPSHOT   = 0x02
+    SCROLLBACK = 0x03
+    INPUT      = 0x81
+    RESIZE     = 0x82
+
+    @staticmethod
+    def name(t):
+        return {1:'PTY_DATA', 2:'SNAPSHOT', 3:'SCROLLBACK',
+                0x81:'INPUT', 0x82:'RESIZE'}.get(t, f'UNKNOWN({t})')
+
+def encode_frame(msg_type, payload):
+    """Encode a framed message: [type:u8][length:u24][payload]"""
+    length = len(payload)
+    header = struct.pack('!B', msg_type) + struct.pack('!I', length)[1:]  # u24
+    return header + payload
+
+def decode_frames(data):
+    """Decode all complete frames from raw bytes. Returns (frames, remainder)."""
+    frames = []
+    pos = 0
+    while pos + 4 <= len(data):
+        msg_type = data[pos]
+        msg_len = (data[pos+1] << 16) | (data[pos+2] << 8) | data[pos+3]
+        if pos + 4 + msg_len > len(data):
+            break
+        frames.append((msg_type, data[pos+4:pos+4+msg_len]))
+        pos += 4 + msg_len
+    return frames, data[pos:]
+
+def send_resize(sock, cols, rows):
+    payload = struct.pack('!HH', cols, rows)
+    sock.sendall(encode_frame(MsgType.RESIZE, payload))
+
+def send_input(sock, data):
+    sock.sendall(encode_frame(MsgType.INPUT, data))
+
+def recv_all(sock, timeout=2.0):
+    """Receive all available data with timeout."""
+    sock.settimeout(timeout)
+    data = b''
+    try:
+        while True:
+            chunk = sock.recv(65536)
+            if not chunk:
+                break
+            data += chunk
+    except socket.timeout:
+        pass
+    return data
+
+# ─── server management ─────────────────────────────────────────────────────────
+
+SNAP_BIN = None
+LD_LINUX = None
+
+def start_server(name, command="bash", port=7681, extra_args=None):
+    """Start a ghostty-snap server, return the process."""
+    cmd = [LD_LINUX, SNAP_BIN, "server", "--name", name, f"--port={port}", "--"]
+    if isinstance(command, list):
+        cmd.extend(command)
+    else:
+        cmd.append(command)
+    if extra_args:
+        cmd.extend(extra_args)
+    log = open(f"/tmp/ghostty-snap-test-{name}.log", "w")
+    proc = subprocess.Popen(
+        cmd, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
+        stderr=log,
+    )
+    time.sleep(1.5)  # Wait for server to start
+    return proc
+
+def stop_server(proc):
+    """Stop a server process."""
+    try:
+        proc.terminate()
+    except (ProcessLookupError, OSError):
+        pass
+    try:
+        proc.wait(timeout=3)
+    except subprocess.TimeoutExpired:
+        try:
+            proc.kill()
+        except (ProcessLookupError, OSError):
+            pass
+
+def connect(port=7681, cols=80, rows=24):
+    """Connect to server and send initial resize. Returns socket."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.connect(('127.0.0.1', port))
+    send_resize(s, cols, rows)
+    return s
+
+# ─── test infrastructure ──────────────────────────────────────────────────────
+
+passed = 0
+failed = 0
+errors = []
+
+def test(name, condition, detail=""):
+    global passed, failed, errors
+    if condition:
+        passed += 1
+        print(f"  \033[32mPASS\033[0m {name}")
+    else:
+        failed += 1
+        errors.append(f"{name}: {detail}")
+        print(f"  \033[31mFAIL\033[0m {name}" + (f" — {detail}" if detail else ""))
+
+# ─── tests ─────────────────────────────────────────────────────────────────────
+
+def test_framing_basic():
+    """Test that server sends properly framed messages."""
+    print("\n── Framing Protocol ──")
+
+    proc = start_server("test-framing", ["bash", "-c", "echo FRAMING_TEST; exec sleep 30"], port=17681)
+    try:
+        s = connect(port=17681)
+        data = recv_all(s, timeout=2)
+        frames, remainder = decode_frames(data)
+        s.close()
+
+        test("Received frames", len(frames) >= 1, f"got {len(frames)} frames")
+        test("No leftover bytes", len(remainder) == 0, f"{len(remainder)} bytes remaining")
+
+        types = [f[0] for f in frames]
+        test("Has SNAPSHOT frame", MsgType.SNAPSHOT in types, f"types: {[MsgType.name(t) for t in types]}")
+
+        # Check snapshot content
+        for msg_type, payload in frames:
+            if msg_type == MsgType.SNAPSHOT:
+                test("Snapshot contains FRAMING_TEST", b"FRAMING_TEST" in payload)
+                test("Snapshot has sync markers", b"\x1b[?2026h" in payload)
+                break
+    finally:
+        stop_server(proc)
+
+
+def test_input_forwarding():
+    """Test that framed INPUT messages reach the pty."""
+    print("\n── Input Forwarding ──")
+
+    proc = start_server("test-input", "bash", port=17682)
+    try:
+        s = connect(port=17682)
+        recv_all(s, timeout=1)  # drain initial snapshot
+
+        # Send a command via framed INPUT
+        send_input(s, b"echo INPUT_WORKS_42\n")
+        time.sleep(1)
+        data = recv_all(s, timeout=1)
+        frames, _ = decode_frames(data)
+
+        # Check if any PTY_DATA frame contains our output
+        all_pty = b''.join(p for t, p in frames if t == MsgType.PTY_DATA)
+        test("Input forwarded and echoed", b"INPUT_WORKS_42" in all_pty,
+             f"got {len(all_pty)} bytes of PTY_DATA")
+
+        s.close()
+    finally:
+        stop_server(proc)
+
+
+def test_resize():
+    """Test resize during session."""
+    print("\n── Resize During Session ──")
+
+    proc = start_server("test-resize", ["bash", "-c", "exec sleep 30"], port=17683)
+    try:
+        s = connect(port=17683, cols=80, rows=24)
+        recv_all(s, timeout=1)  # drain initial
+
+        # Send resize
+        send_resize(s, 120, 40)
+        time.sleep(0.5)
+
+        # Read server stderr for resize log
+        # Can't easily read proc.stderr without blocking, so just check
+        # that the connection didn't break
+        send_input(s, b"echo AFTER_RESIZE\n")
+        time.sleep(0.5)
+        data = recv_all(s, timeout=1)
+        frames, _ = decode_frames(data)
+        all_pty = b''.join(p for t, p in frames if t == MsgType.PTY_DATA)
+        test("Connection alive after resize", len(data) > 0)
+
+        # Send another resize
+        send_resize(s, 200, 50)
+        time.sleep(0.3)
+        test("Connection alive after second resize", True)  # didn't crash
+
+        s.close()
+    finally:
+        stop_server(proc)
+
+
+def test_scrollback():
+    """Test scrollback sync on initial connect."""
+    print("\n── Scrollback Sync ──")
+
+    # Server that generates scrollback
+    proc = start_server("test-scroll",
+        ["bash", "-c", "for i in $(seq 1 100); do echo \"history_line_$i\"; done; exec sleep 30"],
+        port=17684)
+    try:
+        time.sleep(1)  # Let the seq finish
+
+        s = connect(port=17684)
+        data = recv_all(s, timeout=2)
+        frames, _ = decode_frames(data)
+
+        types = [f[0] for f in frames]
+        test("Has SCROLLBACK frame", MsgType.SCROLLBACK in types,
+             f"types: {[MsgType.name(t) for t in types]}")
+
+        if MsgType.SCROLLBACK in types:
+            sb_data = b''.join(p for t, p in frames if t == MsgType.SCROLLBACK)
+            test("Scrollback contains history_line_1", b"history_line_1" in sb_data)
+            test("Scrollback contains history_line_50", b"history_line_50" in sb_data)
+            test("Scrollback is non-trivial", len(sb_data) > 100, f"{len(sb_data)} bytes")
+
+        test("Has SNAPSHOT after SCROLLBACK",
+             types.index(MsgType.SNAPSHOT) > types.index(MsgType.SCROLLBACK) if MsgType.SCROLLBACK in types and MsgType.SNAPSHOT in types else False)
+
+        s.close()
+    finally:
+        stop_server(proc)
+
+
+def test_reconnection():
+    """Test disconnect and reconnect preserves state."""
+    print("\n── Reconnection ──")
+
+    proc = start_server("test-reconn", "bash", port=17685)
+    try:
+        # First connection: type a command
+        s1 = connect(port=17685)
+        recv_all(s1, timeout=1)
+        send_input(s1, b"echo PERSIST_CHECK_99\n")
+        time.sleep(1)
+        s1.close()
+
+        # Wait, then reconnect
+        time.sleep(1)
+
+        s2 = connect(port=17685)
+        data = recv_all(s2, timeout=2)
+        frames, _ = decode_frames(data)
+
+        all_content = b''.join(p for _, p in frames)
+        test("Reconnect sees previous command",
+             b"PERSIST_CHECK_99" in all_content,
+             f"total content: {len(all_content)} bytes")
+
+        # Type another command on the reconnected session
+        send_input(s2, b"echo SECOND_CMD\n")
+        time.sleep(0.5)
+        data2 = recv_all(s2, timeout=1)
+        frames2, _ = decode_frames(data2)
+        all_pty2 = b''.join(p for t, p in frames2 if t == MsgType.PTY_DATA)
+        test("Can type on reconnected session", b"SECOND_CMD" in all_pty2)
+
+        s2.close()
+    finally:
+        stop_server(proc)
+
+
+def test_sessions():
+    """Test session management: named sessions, list, attach by name."""
+    print("\n── Session Management ──")
+
+    proc = start_server("test-sess", ["bash", "-c", "exec sleep 30"], port=17686)
+    try:
+        # Check session file exists
+        session_file = "/tmp/ghostty-snap-sessions/test-sess.session"
+        test("Session file created", os.path.exists(session_file))
+
+        if os.path.exists(session_file):
+            with open(session_file) as f:
+                port_str = f.read().strip()
+            test("Session file contains port", port_str == "17686", f"got: {port_str}")
+
+        # Test list command
+        result = subprocess.run(
+            [LD_LINUX, SNAP_BIN, "list"],
+            capture_output=True, text=True, timeout=5
+        )
+        test("List shows session", "test-sess" in result.stderr, f"stderr: {result.stderr}")
+    finally:
+        stop_server(proc)
+        # Check cleanup
+        time.sleep(0.5)
+        test("Session file cleaned up", not os.path.exists("/tmp/ghostty-snap-sessions/test-sess.session"))
+
+
+def test_multiple_sessions():
+    """Test multiple concurrent sessions."""
+    print("\n── Multiple Sessions ──")
+
+    proc1 = start_server("multi-a", ["bash", "-c", "exec sleep 30"], port=17687)
+    proc2 = start_server("multi-b", ["bash", "-c", "exec sleep 30"], port=17688)
+    try:
+        # Both should be listed
+        result = subprocess.run(
+            [LD_LINUX, SNAP_BIN, "list"],
+            capture_output=True, text=True, timeout=5
+        )
+        test("List shows session A", "multi-a" in result.stderr)
+        test("List shows session B", "multi-b" in result.stderr)
+
+        # Connect to each
+        s1 = connect(port=17687)
+        s2 = connect(port=17688)
+
+        d1 = recv_all(s1, timeout=1)
+        d2 = recv_all(s2, timeout=1)
+
+        test("Can connect to session A", len(d1) > 0)
+        test("Can connect to session B", len(d2) > 0)
+
+        s1.close()
+        s2.close()
+    finally:
+        stop_server(proc1)
+        stop_server(proc2)
+
+
+def test_empty_scrollback():
+    """Test connect with no scrollback."""
+    print("\n── Empty Scrollback ──")
+
+    proc = start_server("test-empty", ["bash", "-c", "exec sleep 30"], port=17689)
+    try:
+        s = connect(port=17689)
+        data = recv_all(s, timeout=2)
+        frames, _ = decode_frames(data)
+
+        types = [f[0] for f in frames]
+        # With no scrollback, should NOT have a SCROLLBACK frame
+        has_scrollback = MsgType.SCROLLBACK in types
+        if has_scrollback:
+            sb_data = b''.join(p for t, p in frames if t == MsgType.SCROLLBACK)
+            test("No scrollback frame (or empty)", len(sb_data) == 0, f"got {len(sb_data)} bytes")
+        else:
+            test("No scrollback frame", True)
+
+        test("Has SNAPSHOT frame", MsgType.SNAPSHOT in types)
+        s.close()
+    finally:
+        stop_server(proc)
+
+
+def test_large_output():
+    """Test handling of large pty output."""
+    print("\n── Large Output ──")
+
+    proc = start_server("test-large", "bash", port=17690)
+    try:
+        s = connect(port=17690)
+        recv_all(s, timeout=1)  # drain initial
+
+        # Send command that produces lots of output
+        send_input(s, b"seq 1 5000\n")
+        time.sleep(3)
+        data = recv_all(s, timeout=2)
+        frames, _ = decode_frames(data)
+
+        total_pty = sum(len(p) for t, p in frames if t == MsgType.PTY_DATA)
+        total_snap = sum(len(p) for t, p in frames if t == MsgType.SNAPSHOT)
+
+        test("Received pty data", total_pty > 0, f"{total_pty} bytes PTY_DATA")
+        test("Total data reasonable", total_pty + total_snap > 1000,
+             f"pty={total_pty}, snap={total_snap}")
+
+        # Connection should still work after large output
+        send_input(s, b"echo ALIVE_AFTER_FLOOD\n")
+        time.sleep(0.5)
+        data2 = recv_all(s, timeout=1)
+        frames2, _ = decode_frames(data2)
+        all2 = b''.join(p for _, p in frames2)
+        test("Connection alive after flood", b"ALIVE_AFTER_FLOOD" in all2 or len(data2) > 0)
+
+        s.close()
+    finally:
+        stop_server(proc)
+
+
+def test_ctrl_c():
+    """Test Ctrl-C responsiveness."""
+    print("\n── Ctrl-C ──")
+
+    proc = start_server("test-ctrlc", "bash", port=17691)
+    try:
+        s = connect(port=17691)
+        recv_all(s, timeout=1)
+
+        # Start a long-running command
+        send_input(s, b"sleep 60\n")
+        time.sleep(0.5)
+
+        # Send Ctrl-C
+        t0 = time.monotonic()
+        send_input(s, b"\x03")
+        time.sleep(0.5)
+
+        # Should get prompt back
+        data = recv_all(s, timeout=2)
+        frames, _ = decode_frames(data)
+        all_pty = b''.join(p for t, p in frames if t == MsgType.PTY_DATA)
+        dt = time.monotonic() - t0
+
+        test("Ctrl-C responded", len(all_pty) > 0, f"{len(all_pty)} bytes in {dt:.2f}s")
+
+        # Verify we can still type
+        send_input(s, b"echo POST_CTRLC\n")
+        time.sleep(0.5)
+        data2 = recv_all(s, timeout=1)
+        frames2, _ = decode_frames(data2)
+        all2 = b''.join(p for t, p in frames2 if t == MsgType.PTY_DATA)
+        test("Can type after Ctrl-C", b"POST_CTRLC" in all2)
+
+        s.close()
+    finally:
+        stop_server(proc)
+
+
+# ─── main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    global SNAP_BIN, LD_LINUX, passed, failed
+
+    if len(sys.argv) < 2:
+        # Try defaults
+        SNAP_BIN = os.path.expanduser("~/ghostty/zig-out/bin/ghostty-snap")
+    else:
+        SNAP_BIN = sys.argv[1]
+
+    if not os.path.exists(SNAP_BIN):
+        print(f"Error: {SNAP_BIN} not found")
+        sys.exit(1)
+
+    # Find nix ld-linux
+    for path in [
+        "/nix/store/wb6rhpznjfczwlwx23zmdrrw74bayxw4-glibc-2.42-47/lib/ld-linux-x86-64.so.2",
+        "/lib64/ld-linux-x86-64.so.2",
+    ]:
+        if os.path.exists(path):
+            LD_LINUX = path
+            break
+
+    if not LD_LINUX:
+        # Try running directly
+        LD_LINUX = ""
+        SNAP_BIN = SNAP_BIN  # run directly
+
+    print(f"Testing: {SNAP_BIN}")
+    print(f"Loader:  {LD_LINUX or '(direct)'}")
+
+    # Clean up any stale session files
+    if os.path.isdir("/tmp/ghostty-snap-sessions"):
+        for f in os.listdir("/tmp/ghostty-snap-sessions"):
+            os.remove(f"/tmp/ghostty-snap-sessions/{f}")
+
+    # Set an overall timeout
+    signal.alarm(120)
+
+    # Run tests
+    test_framing_basic()
+    test_input_forwarding()
+    test_resize()
+    test_scrollback()
+    test_reconnection()
+    test_sessions()
+    test_multiple_sessions()
+    test_empty_scrollback()
+    test_large_output()
+    test_ctrl_c()
+
+    # Summary
+    total = passed + failed
+    print(f"\n{'='*60}")
+    print(f"Results: {passed}/{total} passed", end="")
+    if failed:
+        print(f", \033[31m{failed} failed\033[0m")
+        for e in errors:
+            print(f"  FAIL: {e}")
+    else:
+        print(f" \033[32m— all passed!\033[0m")
+
+    sys.exit(0 if failed == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Exploration: Reconnectable Terminal using libghostty

### The problem

Remote terminal sessions are fragile. A network hiccup, laptop sleep, or IP change kills the SSH connection and all terminal state is lost. The existing solutions require awkward layering:

- **tmux/screen**: Run a multiplexer on the remote host, then SSH into it. But now you have a terminal emulator (tmux) inside a terminal emulator (Ghostty), with imperfect VT compatibility, its own keybindings conflicting with yours, and visual artifacts. tmux control mode helps but requires [complex integration](https://github.com/MisterTea/EternalTerminal/issues/631) and still doesn't solve the fundamental problem.

- **Mosh**: Synchronizes the visible screen over UDP, but doesn't support scrollback, has limited VT compatibility, and can't truly reconnect after extended disconnection. Its terminal emulator drifts on features it doesn't understand (OSC sequences, kitty protocol, etc.).

- **Eternal Terminal**: Reconnectable SSH, but still relies on TCP streams and doesn't handle output spew gracefully. Users end up running ET + tmux control mode to get both reconnection and session persistence — two complex systems solving one problem.

The core tension: when a program spews output faster than the connection can handle, you need to either throttle the application (breaking Ctrl-C responsiveness and stalling pipelines) or buffer unboundedly toward the client (causing minutes of lag). SSH does the latter. Mosh solved this by running a VT emulator on the server and synchronizing *state* instead of *streams* — but its emulator is limited and it abandoned scrollback entirely.

### The insight

A terminal emulator already manages exactly the state we need: the visible viewport, scrollback buffer, cursor position, colors, modes, and all the other VT state. Ghostty's `libghostty` separates the VT emulator from the renderer. The emulator processes escape sequences and maintains screen state; the renderer reads that state and draws pixels.

This is exactly the split needed for a remote terminal:
- **Server**: Runs `libghostty`'s Terminal + a pty, maintaining authoritative state
- **Client**: Connects, receives state, renders it

The terminal IS the session manager. The only thing missing is having the process manager (pty + shell) live on a remote host instead of locally. It makes most sense to use the same library for both sides.

### What this PR contains

A working prototype (`ghostty-snap`) that demonstrates the concept end-to-end.

#### Components

- **`src/main_snap.zig`**: Server + attach client + capture/restore tools (~900 lines)
- **`src/terminal/sync.zig`**: Binary state sync API with compact encoding (~650 lines)
- **`src/terminal/formatter.zig`**: Fix for cursor save/restore around tabstop setup + comprehensive round-trip test
- **`tools/rate-limit-proxy.py`**: Rate-limiting TCP proxy for testing bandwidth-constrained scenarios
- **`tools/debug-proxy.py`**: Full byte-level logging proxy for diagnosing frame corruption
- **`tools/test-ghostty-snap.py`**: Automated test suite (29/30 passing)
- **`docs/design/reconnectable-terminal.md`**: Detailed design proposal

#### Architecture

The server has two sending modes:

1. **Raw streaming**: Pty output goes directly to the client as framed PTY_DATA messages. Same latency as SSH — characters echo immediately, cursor moves instantly.

2. **Snapshot mode**: When the client can't keep up (detected via `TCP_NOTSENT_LOWAT`), the server stops sending raw bytes, feeds everything through the terminal emulator, and sends a VT snapshot of the *current* state when the pipe clears. The client jumps from stale to current instantly. Intermediate states are skipped.

This means:
- **Ctrl-C always works within one RTT** — input is never blocked by queued output
- **No application throttling** — the pty runs at full speed regardless of connection quality
- **Network buffers stay bounded** — no unbounded buffering toward the client

#### Protocol

Length-prefixed framed messages (`[type:u8][length:u24][payload]`):

| Type | Name | Direction | Purpose |
|------|------|-----------|---------|
| 0x01 | PTY_DATA | S→C | Raw pty output (fast path) |
| 0x02 | SNAPSHOT | S→C | VT state snapshot (catch-up) |
| 0x03 | SCROLLBACK | S→C | VT scrollback text |
| 0x05 | VIEWPORT_DELTA | S→C | Binary dirty rows only |
| 0x06 | VIEWPORT_FULL | S→C | Binary full viewport |
| 0x07 | SCROLLBACK_CHUNK | S→C | Binary scrollback chunk |
| 0x81 | INPUT | C→S | Keystrokes → pty |
| 0x82 | RESIZE | C→S | Terminal size change |

#### Sync API (`sync.zig`)

A structured data API for accessing terminal state incrementally, designed for eventual use inside Ghostty as a native remote client:

- **Style dictionary**: Session-level style deduplication (most sessions use <20 unique styles), referenced by varint IDs
- **Row encoding**: Style-tagged UTF-8 runs — ASCII is 1 byte/char, blank rows are 1 byte
- **Row hashing**: Wyhash on raw cell bytes for O(1) dirty detection
- **SyncState**: Epoch tracking, delta computation (full/partial/none), incremental scrollback chunking

### How to demo

```bash
# Build
zig build -Demit-bench=true

# Start a named session
ghostty-snap server --name myproject -- bash

# Attach from another terminal
ghostty-snap attach myproject

# Everything works: type commands, run vi, resize your window
# Ctrl-] to detach — server keeps running

# Reattach and see your state preserved
ghostty-snap attach myproject

# List sessions
ghostty-snap list

# Test with bandwidth constraints (simulates slow link)
python3 tools/rate-limit-proxy.py --rate 20480 --listen 7682
ghostty-snap attach 127.0.0.1:7682
# Run: cat /dev/urandom | base64
# Hit Ctrl-C — responds instantly despite the rate limit

# Capture a terminal snapshot to a file
ghostty-snap capture -- bash
# Ctrl-\ to snapshot
ghostty-snap restore /tmp/ghostty-snap.vt
```

### Future roadmap

If this concept proves interesting, the path to production would include:

- **Native Ghostty client**: Instead of the VT passthrough attach client, a proper Ghostty apprt that applies binary sync data directly to Page structures. This would give perfect fidelity and enable proper scrollback backfill without VT hacks.
- **WebSocket / WebRTC transport**: WebSocket support would allow browser-based clients (xterm.js) to connect to a ghostty-snap server and sync full terminal state — turning any browser into a reconnectable terminal. WebRTC's datagram channels could provide the reliability benefits of Mosh's UDP approach (skip intermediate states, no head-of-line blocking) while still syncing full VT state including scrollback. This would also enable connection migration for IP roaming without the complexity of QUIC.
- **Speculative local echo**: Like Mosh, predict the effect of keystrokes and display immediately, verify against server state.
- **Multi-client sessions**: One writer + N readers for pair programming or monitoring.
- **Session persistence**: Survive server restarts by serializing terminal state to disk.

### Caveats

This code is fully AI-generated — built with Claude Code in a single extended session. I have not dug into the implementation details of every line, but it is working and demonstrable. The concepts and architecture are real; the code quality is prototype-grade.

I may not have the time to productionize this, but wanted to share the exploration and the concept. The core insight — that a terminal emulator already manages exactly the state needed for remote session persistence, and `libghostty` already separates emulation from rendering — feels worth exploring further.

The `sync.zig` API in particular is designed to be usable by a native Ghostty client, independent of the prototype server/client code.