### PR TITLE
config: add `cursor-style-unfocused` option

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -892,6 +892,22 @@ palette: Palette = .{},
 ///   * `false`
 @"cursor-style-blink": ?bool = null,
 
+/// The style of the cursor when the terminal is not focused. If this is
+/// not set, the cursor will be a hollow block when unfocused.
+///
+/// This does not affect the cursor style when the cursor is explicitly
+/// hidden by the running program (e.g. via `DECTCEM`), nor does it affect
+/// preedit or password input cursor styles.
+///
+/// Valid values are:
+///
+///   * ` ` (blank, the default, uses hollow block)
+///   * `block`
+///   * `bar`
+///   * `underline`
+///   * `block_hollow`
+@"cursor-style-unfocused": ?terminal.CursorStyle = null,
+
 /// The color of the text under the cursor. If this is not set, a default will
 /// be chosen.
 /// Specified as either hex (`#RRGGBB` or `RRGGBB`) or a named X11 color.

--- a/src/renderer/cursor.zig
+++ b/src/renderer/cursor.zig
@@ -29,6 +29,7 @@ pub const StyleOptions = struct {
     preedit: bool = false,
     focused: bool = false,
     blink_visible: bool = false,
+    unfocused_style: ?Style = null,
 };
 
 /// Returns the cursor style to use for the current render state or null
@@ -55,9 +56,9 @@ pub fn style(
     // If the cursor is explicitly not visible by terminal mode, we don't render.
     if (!state.cursor.visible) return null;
 
-    // If we're not focused, our cursor is always visible so that
-    // we can show the hollow box.
-    if (!opts.focused) return .block_hollow;
+    // If we're not focused, our cursor is always visible. Use the
+    // configured unfocused style or default to hollow box.
+    if (!opts.focused) return opts.unfocused_style orelse .block_hollow;
 
     // If the cursor is blinking and our blink state is not visible,
     // then we don't show the cursor.
@@ -103,6 +104,50 @@ test "cursor: blinking disabled" {
     try testing.expect(style(&state, .{ .focused = true, .blink_visible = false }) == .bar);
     try testing.expect(style(&state, .{ .focused = false, .blink_visible = true }) == .block_hollow);
     try testing.expect(style(&state, .{ .focused = false, .blink_visible = false }) == .block_hollow);
+}
+
+test "cursor: unfocused custom style" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    var term: terminal.Terminal = try .init(alloc, .{ .cols = 10, .rows = 10 });
+    defer term.deinit(alloc);
+
+    term.screens.active.cursor.cursor_style = .block;
+    term.modes.set(.cursor_blinking, false);
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &term);
+
+    // Unfocused with custom style uses that style
+    try testing.expect(style(&state, .{ .focused = false, .unfocused_style = .bar }) == .bar);
+    try testing.expect(style(&state, .{ .focused = false, .unfocused_style = .underline }) == .underline);
+    try testing.expect(style(&state, .{ .focused = false, .unfocused_style = .block }) == .block);
+
+    // Unfocused without custom style defaults to block_hollow
+    try testing.expect(style(&state, .{ .focused = false }) == .block_hollow);
+
+    // Focused ignores unfocused_style entirely
+    try testing.expect(style(&state, .{ .focused = true, .blink_visible = true, .unfocused_style = .bar }) == .block);
+
+    // Preedit overrides unfocused_style
+    try testing.expect(style(&state, .{ .preedit = true, .focused = false, .unfocused_style = .bar }) == .block);
+}
+
+test "cursor: unfocused custom style hidden cursor" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    var term = try terminal.Terminal.init(alloc, .{ .cols = 10, .rows = 10 });
+    defer term.deinit(alloc);
+
+    term.modes.set(.cursor_visible, false);
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &term);
+
+    // Hidden cursor returns null even with unfocused_style set
+    try testing.expect(style(&state, .{ .focused = false, .unfocused_style = .bar }) == null);
 }
 
 test "cursor: explicitly not visible" {

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -544,6 +544,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             cursor_color: ?configpkg.Config.TerminalColor,
             cursor_opacity: f64,
             cursor_text: ?configpkg.Config.TerminalColor,
+            cursor_style_unfocused: ?renderer.CursorStyle,
             background: terminal.color.RGB,
             background_opacity: f64,
             background_opacity_cells: bool,
@@ -616,6 +617,10 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     .cursor_color = config.@"cursor-color",
                     .cursor_text = config.@"cursor-text",
                     .cursor_opacity = @max(0, @min(1, config.@"cursor-opacity")),
+                    .cursor_style_unfocused = if (config.@"cursor-style-unfocused") |s|
+                        renderer.CursorStyle.fromTerminal(s)
+                    else
+                        null,
 
                     .background = config.background.toTerminalRGB(),
                     .foreground = config.foreground.toTerminalRGB(),
@@ -1367,6 +1372,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                         .preedit = critical.preedit != null,
                         .focused = self.focused,
                         .blink_visible = cursor_blink_visible,
+                        .unfocused_style = self.config.cursor_style_unfocused,
                     }),
                     &critical.links,
                 ) catch |err| {


### PR DESCRIPTION
When a surface loses focus, the cursor is hardcoded to `block_hollow` in `renderer/cursor.zig`, ignoring user configuration. This adds a `cursor-style-unfocused` config option so users can choose what cursor style to show on unfocused surfaces.

```
cursor-style-unfocused = bar
```

Accepts the same values as `cursor-style`: `block`, `bar`, `underline`, `block_hollow`. When unset, the existing behavior (hollow block) is preserved.

The option flows through `DerivedConfig` and is passed via `StyleOptions` to the cursor style resolution function. Higher-priority states (preedit, password input, explicitly hidden cursor) still override it, and the unfocused cursor remains non-blinking.