### PR TITLE
build: sanitize all invalid chars in branch name for version

### DIFF
--- a/src/build/GitVersion.zig
+++ b/src/build/GitVersion.zig
@@ -29,11 +29,14 @@ pub fn detect(b: *std.Build) !Version {
             error.ExitCodeFailure => return error.GitNotRepository,
             else => return err,
         };
-        // Replace any '/' with '-' as including slashes will mess up building
-        // the dist tarball - the tarball uses the branch as part of the
-        // name and including slashes means that the tarball will end up in
-        // subdirectories instead of where it's supposed to be.
-        std.mem.replaceScalar(u8, tmp, '/', '-');
+
+        // Replace characters that are not valid in semantic version
+        // pre-release identifiers (which only allow [0-9A-Za-z-]).
+        // Slashes would also mess up dist tarball paths.
+        for (tmp) |*c| {
+            if (!std.ascii.isAlphanumeric(c.*) and c.* != '-') c.* = '-';
+        }
+
         break :b tmp;
     };
 


### PR DESCRIPTION
Fixes #11990

Previously only slashes were replaced with hyphens in the branch name used as the semver pre-release identifier. Branch names containing dots (e.g. dependabot branches like
"cachix/install-nix-action-31.10.4") would cause an InvalidVersion error because std.SemanticVersion only allows alphanumeric characters and hyphens in pre-release identifiers.

Replace all non-alphanumeric, non-hyphen characters instead of only slashes.