### PR TITLE
macOS: double click title to enlarge window

### DIFF
--- a/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
@@ -241,11 +241,11 @@ class TitlebarTabsTahoeTerminalWindow: TransparentTitlebarTerminalWindow, NSTool
         switch itemIdentifier {
         case .title:
             let item = NSToolbarItem(itemIdentifier: .title)
-            item.view = NSHostingView(rootView: TitleItem(viewModel: viewModel))
+            item.view = ClickThroughHostingView(rootView: TitleItem(viewModel: viewModel))
             // Fix: https://github.com/ghostty-org/ghostty/discussions/9027
             item.view?.setContentCompressionResistancePriority(.required, for: .horizontal)
             item.visibilityPriority = .user
-            item.isEnabled = true
+            item.isEnabled = false
 
             // This is the documented way to avoid the glass view on an item.
             // We don't want glass on our title.
@@ -306,5 +306,12 @@ extension TitlebarTabsTahoeTerminalWindow {
                 .frame(maxWidth: .greatestFiniteMagnitude, alignment: .center)
                 .opacity(viewModel.hasTabBar ? 0 : 1) // hide when in fullscreen mode, where title bar will appear in the leading area under window buttons
         }
+    }
+}
+
+/// A "Ghosting" Hosting View, that acts like it's not there
+private class ClickThroughHostingView<Content: View>: NSHostingView<Content> {
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
     }
 }

--- a/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsVenturaTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsVenturaTerminalWindow.swift
@@ -689,6 +689,11 @@ private class CenteredDynamicLabel: NSTextField {
         setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
     }
 
+    /// Click through, so we can double click here to enlarge current window
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+
     // Vertically center the text
     override func draw(_ dirtyRect: NSRect) {
         guard let attributedString = self.attributedStringValue.mutableCopy() as? NSMutableAttributedString else {


### PR DESCRIPTION
Previously with `macos-titlebar-style = tabs`, double clicking title would do nothing