### PR TITLE
build: skip ghostty-test graph when building libghostty-vt

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -329,8 +329,8 @@ pub fn build(b: *std.Build) !void {
         test_lib_vt_step.dependOn(&mod_vt_c_test_run.step);
     }
 
-    // Tests
-    {
+    // Tests (skip when building libghostty-vt)
+    if (!config.emit_lib_vt) {
         // Full unit tests
         const test_exe = b.addTest(.{
             .name = "ghostty-test",


### PR DESCRIPTION
Fixes #12151

When `emit_lib_vt` is true, the `// Tests` block was still
evaluated, pulling in the full ghostty-test dependency graph
(freetype, zlib, dcimgui, etc.). This causes the Nix
`libghostty-vt` package to fail when `doCheck` is enabled,
since those system libraries aren't available in the sandbox.

Guard the block with `if (!config.emit_lib_vt)`, following
the existing pattern at line 179.