### PR TITLE
libghostty: add a test to ensure terminal modes are defined

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -320,7 +320,7 @@ pub fn build(b: *std.Build) !void {
             .root_module = mod.vt,
             .filters = test_filters,
         });
-        try c_deps.add(b, .ghostty_vt_h, mod.vt, &config, .{
+        try c_deps.add(b, .@"ghostty-vt-h", mod.vt, &config, .{
             .target = config.baselineTarget(),
             .optimize = .Debug,
         });
@@ -331,7 +331,7 @@ pub fn build(b: *std.Build) !void {
             .root_module = mod.vt_c,
             .filters = test_filters,
         });
-        try c_deps.add(b, .ghostty_vt_h, mod.vt_c, &config, .{
+        try c_deps.add(b, .@"ghostty-vt-h", mod.vt_c, &config, .{
             .target = config.baselineTarget(),
             .optimize = .Debug,
         });
@@ -359,11 +359,11 @@ pub fn build(b: *std.Build) !void {
         if (config.emit_test_exe) b.installArtifact(test_exe);
         _ = try deps.add(test_exe);
 
-        try c_deps.add(b, .ghostty_h, test_exe.root_module, &config, .{
+        try c_deps.add(b, .@"ghostty-h", test_exe.root_module, &config, .{
             .target = config.baselineTarget(),
             .optimize = .Debug,
         });
-        try c_deps.add(b, .ghostty_vt_h, test_exe.root_module, &config, .{
+        try c_deps.add(b, .@"ghostty-vt-h", test_exe.root_module, &config, .{
             .target = config.baselineTarget(),
             .optimize = .Debug,
         });

--- a/build.zig
+++ b/build.zig
@@ -3,6 +3,8 @@ const assert = std.debug.assert;
 const builtin = @import("builtin");
 const buildpkg = @import("src/build/main.zig");
 
+const c_deps = @import("src/build/c_deps.zig");
+
 /// App version from build.zig.zon.
 const app_zon_version = @import("build.zig.zon").version;
 
@@ -318,12 +320,20 @@ pub fn build(b: *std.Build) !void {
             .root_module = mod.vt,
             .filters = test_filters,
         });
+        try c_deps.add(b, .ghostty_vt_h, mod.vt, &config, .{
+            .target = config.baselineTarget(),
+            .optimize = .Debug,
+        });
         const mod_vt_test_run = b.addRunArtifact(mod_vt_test);
         test_lib_vt_step.dependOn(&mod_vt_test_run.step);
 
         const mod_vt_c_test = b.addTest(.{
             .root_module = mod.vt_c,
             .filters = test_filters,
+        });
+        try c_deps.add(b, .ghostty_vt_h, mod.vt_c, &config, .{
+            .target = config.baselineTarget(),
+            .optimize = .Debug,
         });
         const mod_vt_c_test_run = b.addRunArtifact(mod_vt_c_test);
         test_lib_vt_step.dependOn(&mod_vt_c_test_run.step);
@@ -349,13 +359,14 @@ pub fn build(b: *std.Build) !void {
         if (config.emit_test_exe) b.installArtifact(test_exe);
         _ = try deps.add(test_exe);
 
-        // Verify our internal libghostty header.
-        const ghostty_h = b.addTranslateC(.{
-            .root_source_file = b.path("include/ghostty.h"),
+        try c_deps.add(b, .ghostty_h, test_exe.root_module, &config, .{
             .target = config.baselineTarget(),
             .optimize = .Debug,
         });
-        test_exe.root_module.addImport("ghostty.h", ghostty_h.createModule());
+        try c_deps.add(b, .ghostty_vt_h, test_exe.root_module, &config, .{
+            .target = config.baselineTarget(),
+            .optimize = .Debug,
+        });
 
         // Normal test running
         const test_run = b.addRunArtifact(test_exe);

--- a/build.zig
+++ b/build.zig
@@ -3,6 +3,8 @@ const assert = std.debug.assert;
 const builtin = @import("builtin");
 const buildpkg = @import("src/build/main.zig");
 
+const c_deps = @import("src/build/c_deps.zig");
+
 /// App version from build.zig.zon.
 const app_zon_version = @import("build.zig.zon").version;
 
@@ -327,12 +329,20 @@ pub fn build(b: *std.Build) !void {
             .root_module = mod.vt,
             .filters = test_filters,
         });
+        try c_deps.add(b, .@"ghostty-vt-h", mod_vt_test.root_module, &config, .{
+            .optimize = .Debug,
+            .target = config.baselineTarget(b.graph.io),
+        });
         const mod_vt_test_run = b.addRunArtifact(mod_vt_test);
         test_lib_vt_step.dependOn(&mod_vt_test_run.step);
 
         const mod_vt_c_test = b.addTest(.{
             .root_module = mod.vt_c,
             .filters = test_filters,
+        });
+        try c_deps.add(b, .@"ghostty-vt-h", mod_vt_c_test.root_module, &config, .{
+            .optimize = .Debug,
+            .target = config.baselineTarget(b.graph.io),
         });
         const mod_vt_c_test_run = b.addRunArtifact(mod_vt_c_test);
         test_lib_vt_step.dependOn(&mod_vt_c_test_run.step);
@@ -362,7 +372,14 @@ pub fn build(b: *std.Build) !void {
         }
         _ = try deps.add(test_exe);
 
-        addGhosttyH(b, test_exe.root_module, config.baselineTarget(b.graph.io), .Debug);
+        try c_deps.add(b, .@"ghostty-h", test_exe.root_module, &config, .{
+            .target = config.baselineTarget(b.graph.io),
+            .optimize = .Debug,
+        });
+        try c_deps.add(b, .@"ghostty-vt-h", test_exe.root_module, &config, .{
+            .target = config.baselineTarget(b.graph.io),
+            .optimize = .Debug,
+        });
 
         // Normal test running
         const test_run = b.addRunArtifact(test_exe);
@@ -392,29 +409,4 @@ pub fn build(b: *std.Build) !void {
     } else {
         try translations_step.addError("cannot update translations when i18n is disabled", .{});
     }
-}
-
-fn addGhosttyH(
-    b: *std.Build,
-    module: *std.Build.Module,
-    target: std.Build.ResolvedTarget,
-    optimize: std.builtin.OptimizeMode,
-) void {
-    const translate_c = b.lazyImport(@This(), "translate_c") orelse return;
-    const translate_c_dep = b.lazyDependency("translate_c", .{}) orelse return;
-
-    const translated: translate_c.Translator = .init(translate_c_dep, .{
-        .c_source_file = b.addWriteFiles().add(
-            "hb_c.h",
-            \\#include <ghostty.h>
-            ,
-        ),
-        .target = target,
-        .optimize = optimize,
-        .link_libc = true,
-    });
-
-    translated.addSystemIncludePath(b.path("include"));
-
-    module.addImport("ghostty.h", translated.mod);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -11,8 +11,8 @@
         // Aro/translate-c itself.
         .translate_c = .{
             .lazy = true,
-            .url = "https://deps.files.ghostty.org/translate_c-80f8b6e4f45a303268717d8e5f4f91d7837138bb.tar.gz",
-            .hash = "translate_c-0.0.0-Q_BUWmU6BwB_9JKG2l2W7i_mhmYWeRseTGBEHi_YlV5f",
+            .url = "https://codeberg.org/vancluever/translate-c/archive/cec6ef8c9134c509f8ee008d34e9de845cbc10a8.tar.gz",
+            .hash = "translate_c-0.0.0-Q_BUWv5BBwDmJP04p9f68173JwpyqoNzH9In3u6CS3Lj",
         },
 
         // Zig libs

--- a/build.zig.zon.json
+++ b/build.zig.zon.json
@@ -1,8 +1,8 @@
 {
-  "aro-0.0.0-JSD1Qk8rOQDnuVcD4jAwMpHitA6pADRKzQ7M7hKRwxvD": {
+  "aro-0.0.0-JSD1Qm9yNgDMGFTikPpydON0cwZm0a6v1TSQZVKtgYh6": {
     "name": "aro",
-    "url": "https://github.com/vancluever/arocc/archive/ecbc5c799574e0da2758a961b12efa586007f03c.tar.gz",
-    "hash": "sha256-rjNfhWjmA/1WR/xuHo4ls4fnDCbsI1VZSvb8SFRvwso="
+    "url": "https://github.com/vancluever/arocc/archive/198c2d92b94e51c71b09c476cfbaac481c5add66.tar.gz",
+    "hash": "sha256-dx6pazuHc9CJu3YBFXTGnoBowui0CC6/ktifvxaSzec="
   },
   "N-V-__8AANT61wB--nJ95Gj_ctmzAtcjloZ__hRqNw5lC1Kr": {
     "name": "bindings",
@@ -114,10 +114,10 @@
     "url": "https://deps.files.ghostty.org/spirv_cross-1220fb3b5586e8be67bc3feb34cbe749cf42a60d628d2953632c2f8141302748c8da.tar.gz",
     "hash": "sha256-tStvz8Ref6abHwahNiwVVHNETizAmZVVaxVsU7pmV+M="
   },
-  "translate_c-0.0.0-Q_BUWmU6BwB_9JKG2l2W7i_mhmYWeRseTGBEHi_YlV5f": {
+  "translate_c-0.0.0-Q_BUWv5BBwDmJP04p9f68173JwpyqoNzH9In3u6CS3Lj": {
     "name": "translate_c",
-    "url": "https://deps.files.ghostty.org/translate_c-80f8b6e4f45a303268717d8e5f4f91d7837138bb.tar.gz",
-    "hash": "sha256-fB7OsZ2PIijMzVMYg8SzDBtTKX7IZHbEvPuBTdyGtWk="
+    "url": "https://codeberg.org/vancluever/translate-c/archive/cec6ef8c9134c509f8ee008d34e9de845cbc10a8.tar.gz",
+    "hash": "sha256-+9kR1nXQEjqELn69OdjrQLKoARuY7bMdrCi91L25HFM="
   },
   "uucode-0.2.0-ZZjBPlK5VADj7fdoq7G8LIHzD5o6FSkcBXXrRWr4jnrA": {
     "name": "uucode",

--- a/build.zig.zon.nix
+++ b/build.zig.zon.nix
@@ -98,11 +98,11 @@
 in
   linkFarm name [
     {
-      name = "aro-0.0.0-JSD1Qk8rOQDnuVcD4jAwMpHitA6pADRKzQ7M7hKRwxvD";
+      name = "aro-0.0.0-JSD1Qm9yNgDMGFTikPpydON0cwZm0a6v1TSQZVKtgYh6";
       path = fetchZigArtifact {
         name = "aro";
-        url = "https://github.com/vancluever/arocc/archive/ecbc5c799574e0da2758a961b12efa586007f03c.tar.gz";
-        hash = "sha256-rjNfhWjmA/1WR/xuHo4ls4fnDCbsI1VZSvb8SFRvwso=";
+        url = "https://github.com/vancluever/arocc/archive/198c2d92b94e51c71b09c476cfbaac481c5add66.tar.gz";
+        hash = "sha256-dx6pazuHc9CJu3YBFXTGnoBowui0CC6/ktifvxaSzec=";
         unpack = true;
       };
     }
@@ -305,11 +305,11 @@ in
       };
     }
     {
-      name = "translate_c-0.0.0-Q_BUWmU6BwB_9JKG2l2W7i_mhmYWeRseTGBEHi_YlV5f";
+      name = "translate_c-0.0.0-Q_BUWv5BBwDmJP04p9f68173JwpyqoNzH9In3u6CS3Lj";
       path = fetchZigArtifact {
         name = "translate_c";
-        url = "https://deps.files.ghostty.org/translate_c-80f8b6e4f45a303268717d8e5f4f91d7837138bb.tar.gz";
-        hash = "sha256-fB7OsZ2PIijMzVMYg8SzDBtTKX7IZHbEvPuBTdyGtWk=";
+        url = "https://codeberg.org/vancluever/translate-c/archive/cec6ef8c9134c509f8ee008d34e9de845cbc10a8.tar.gz";
+        hash = "sha256-+9kR1nXQEjqELn69OdjrQLKoARuY7bMdrCi91L25HFM=";
         unpack = true;
       };
     }

--- a/build.zig.zon.txt
+++ b/build.zig.zon.txt
@@ -1,5 +1,6 @@
 git+https://github.com/rockorager/libvaxis.git#c1e1f23be38951c425cdf31af455ba23ef178940
 git+https://github.com/zigimg/zigimg#d695acd97c02e57bb151e8f659d1280f5cd6ca70
+https://codeberg.org/vancluever/translate-c/archive/cec6ef8c9134c509f8ee008d34e9de845cbc10a8.tar.gz
 https://deps.files.ghostty.org/DearBindings_v0.17_ImGui_v1.92.5-docking.tar.gz
 https://deps.files.ghostty.org/JetBrainsMono-2.304.tar.gz
 https://deps.files.ghostty.org/N-V-__8AAEbOfQBnvcFcCX2W5z7tDaN8vaNZGamEQtNOe0UI.tar.gz
@@ -22,7 +23,6 @@ https://deps.files.ghostty.org/pixels-12207ff340169c7d40c570b4b6a97db614fe47e0d8
 https://deps.files.ghostty.org/plasma_wayland_protocols-12207e0851c12acdeee0991e893e0132fc87bb763969a585dc16ecca33e88334c566.tar.gz
 https://deps.files.ghostty.org/sentry-1220446be831adcca918167647c06c7b825849fa3fba5f22da394667974537a9c77e.tar.gz
 https://deps.files.ghostty.org/spirv_cross-1220fb3b5586e8be67bc3feb34cbe749cf42a60d628d2953632c2f8141302748c8da.tar.gz
-https://deps.files.ghostty.org/translate_c-80f8b6e4f45a303268717d8e5f4f91d7837138bb.tar.gz
 https://deps.files.ghostty.org/uucode-2826a37a4562284fdacd8fa029d49509cc9bffcd.tar.gz
 https://deps.files.ghostty.org/vaxis-1dbbe575dff4586fe51e3217aa5c3fecdcbb6089.tar.gz
 https://deps.files.ghostty.org/wayland-0.6.0-lQa1kqz8AQADQmdNJsNhLoNHcnEGEUjrOaPV-dtEnEmX.tar.gz
@@ -35,4 +35,4 @@ https://deps.files.ghostty.org/zig_js-3c23860e47fdcdc5af805efb7fd0bdac5fd3e9bc.t
 https://deps.files.ghostty.org/zig_objc-c8de82ff80281215ad92900866dab7103a8efa8b.tar.gz
 https://deps.files.ghostty.org/zlib-1220fed0c74e1019b3ee29edae2051788b080cd96e90d56836eea857b0b966742efb.tar.gz
 https://github.com/ghostty-org/zig-gobject/releases/download/0.10.0-2026-07-28-36-1/ghostty-gobject-0.10.0-2026-07-28-36-1.tar.zst
-https://github.com/vancluever/arocc/archive/ecbc5c799574e0da2758a961b12efa586007f03c.tar.gz
+https://github.com/vancluever/arocc/archive/198c2d92b94e51c71b09c476cfbaac481c5add66.tar.gz

--- a/flatpak/zig-packages.json
+++ b/flatpak/zig-packages.json
@@ -1,9 +1,9 @@
 [
   {
     "type": "archive",
-    "url": "https://github.com/vancluever/arocc/archive/ecbc5c799574e0da2758a961b12efa586007f03c.tar.gz",
-    "dest": "vendor/p/aro-0.0.0-JSD1Qk8rOQDnuVcD4jAwMpHitA6pADRKzQ7M7hKRwxvD",
-    "sha256": "aa54487bd727e8fa36744ff0a824dedb2f4ca45f4c2d4d9d2437cf5fd3d0ad1a"
+    "url": "https://github.com/vancluever/arocc/archive/198c2d92b94e51c71b09c476cfbaac481c5add66.tar.gz",
+    "dest": "vendor/p/aro-0.0.0-JSD1Qm9yNgDMGFTikPpydON0cwZm0a6v1TSQZVKtgYh6",
+    "sha256": "8c061559d2dcc1181944f4e0d4073c486680470ad4b3e3f261518c51e5fe7f2e"
   },
   {
     "type": "archive",
@@ -139,9 +139,9 @@
   },
   {
     "type": "archive",
-    "url": "https://deps.files.ghostty.org/translate_c-80f8b6e4f45a303268717d8e5f4f91d7837138bb.tar.gz",
-    "dest": "vendor/p/translate_c-0.0.0-Q_BUWmU6BwB_9JKG2l2W7i_mhmYWeRseTGBEHi_YlV5f",
-    "sha256": "38c9e59d58f36e3481f6fa38f11fe59c63c12492fccf399ca56f3dfcce17b53e"
+    "url": "https://codeberg.org/vancluever/translate-c/archive/cec6ef8c9134c509f8ee008d34e9de845cbc10a8.tar.gz",
+    "dest": "vendor/p/translate_c-0.0.0-Q_BUWv5BBwDmJP04p9f68173JwpyqoNzH9In3u6CS3Lj",
+    "sha256": "f798deededef404b180a1e813b40bed84a91aa870facf7cc1c0fa7b2a580cffa"
   },
   {
     "type": "archive",

--- a/include/ghostty/vt/modes.h
+++ b/include/ghostty/vt/modes.h
@@ -47,8 +47,10 @@ extern "C" {
  * @{
  */
 #define GHOSTTY_MODE_KAM              (ghostty_mode_new(2, true))    /**< Keyboard action (disable keyboard) */
+#define GHOSTTY_MODE_DISABLE_KEYBOARD GHOSTTY_MODE_KAM
 #define GHOSTTY_MODE_INSERT           (ghostty_mode_new(4, true))    /**< Insert mode */
 #define GHOSTTY_MODE_SRM              (ghostty_mode_new(12, true))   /**< Send/receive mode */
+#define GHOSTTY_MODE_SEND_RECEIVE_MODE GHOSTTY_MODE_SRM
 #define GHOSTTY_MODE_LINEFEED         (ghostty_mode_new(20, true))   /**< Linefeed/new line mode */
 /** @} */
 
@@ -57,6 +59,7 @@ extern "C" {
  * @{
  */
 #define GHOSTTY_MODE_DECCKM           (ghostty_mode_new(1, false))   /**< Cursor keys */
+#define GHOSTTY_MODE_CURSOR_KEYS GHOSTTY_MODE_DECCCKM
 #define GHOSTTY_MODE_132_COLUMN       (ghostty_mode_new(3, false))   /**< 132/80 column mode */
 #define GHOSTTY_MODE_SLOW_SCROLL      (ghostty_mode_new(4, false))   /**< Slow scroll */
 #define GHOSTTY_MODE_REVERSE_COLORS   (ghostty_mode_new(5, false))   /**< Reverse video */
@@ -64,6 +67,7 @@ extern "C" {
 #define GHOSTTY_MODE_WRAPAROUND       (ghostty_mode_new(7, false))   /**< Auto-wrap mode */
 #define GHOSTTY_MODE_AUTOREPEAT       (ghostty_mode_new(8, false))   /**< Auto-repeat keys */
 #define GHOSTTY_MODE_X10_MOUSE        (ghostty_mode_new(9, false))   /**< X10 mouse reporting */
+#define GHOSTTY_MODE_MOUSE_EVENT_X10 GHOSTTY_MODE_X10_MOUSE
 #define GHOSTTY_MODE_CURSOR_BLINKING  (ghostty_mode_new(12, false))  /**< Cursor blink */
 #define GHOSTTY_MODE_CURSOR_VISIBLE   (ghostty_mode_new(25, false))  /**< Cursor visible (DECTCEM) */
 #define GHOSTTY_MODE_ENABLE_MODE_3    (ghostty_mode_new(40, false))  /**< Allow 132 column mode */
@@ -72,27 +76,43 @@ extern "C" {
 #define GHOSTTY_MODE_KEYPAD_KEYS      (ghostty_mode_new(66, false))  /**< Application keypad */
 #define GHOSTTY_MODE_BACKARROW_KEY_MODE (ghostty_mode_new(67, false))  /**< Backarrow key mode (DECBKM) */
 #define GHOSTTY_MODE_LEFT_RIGHT_MARGIN (ghostty_mode_new(69, false)) /**< Left/right margin mode */
+#define GHOSTTY_MODE_ENABLE_LEFT_AND_RIGHT_MARGIN GHOSTTY_MODE_LEFT_RIGHT_MARGIN
 #define GHOSTTY_MODE_NORMAL_MOUSE     (ghostty_mode_new(1000, false)) /**< Normal mouse tracking */
+#define GHOSTTY_MODE_MOUSE_EVENT_NORMAL GHOSTTY_MODE_NORMAL_MOUSE
 #define GHOSTTY_MODE_BUTTON_MOUSE     (ghostty_mode_new(1002, false)) /**< Button-event mouse tracking */
+#define GHOSTTY_MODE_MOUSE_EVENT_BUTTON GHOSTTY_MODE_BUTTON_MOUSE
 #define GHOSTTY_MODE_ANY_MOUSE        (ghostty_mode_new(1003, false)) /**< Any-event mouse tracking */
+#define GHOSTTY_MODE_MOUSE_EVENT_ANY GHOSTTY_MODE_ANY_MOUSE
 #define GHOSTTY_MODE_FOCUS_EVENT      (ghostty_mode_new(1004, false)) /**< Focus in/out events */
 #define GHOSTTY_MODE_UTF8_MOUSE       (ghostty_mode_new(1005, false)) /**< UTF-8 mouse format */
+#define GHOSTTY_MODE_MOUSE_FORMAT_UTF8 GHOSTTY_MODE_UTF8_MOUSE
 #define GHOSTTY_MODE_SGR_MOUSE        (ghostty_mode_new(1006, false)) /**< SGR mouse format */
+#define GHOSTTY_MODE_MOUSE_FORMAT_SGR GHOSTTY_MODE_SGR_MOUSE
 #define GHOSTTY_MODE_ALT_SCROLL       (ghostty_mode_new(1007, false)) /**< Alternate scroll mode */
+#define GHOSTTY_MODE_MOUSE_ALTERNATE_SCROLL GHOSTTY_MODE_ALT_SCROLL
 #define GHOSTTY_MODE_URXVT_MOUSE      (ghostty_mode_new(1015, false)) /**< URxvt mouse format */
+#define GHOSTTY_MODE_MOUSE_FORMAT_URXVT GHOSTTY_MODE_URXVT_MOUSE
 #define GHOSTTY_MODE_SGR_PIXELS_MOUSE (ghostty_mode_new(1016, false)) /**< SGR-Pixels mouse format */
+#define GHOSTTY_MODE_MOUSE_FORMAT_SGR_PIXELS GHOSTTY_MODE_SGR_PIXELS_MOUSE
 #define GHOSTTY_MODE_NUMLOCK_KEYPAD   (ghostty_mode_new(1035, false)) /**< Ignore keypad with NumLock */
+#define GHOSTTY_MODE_IGNORE_KEYPAD_WITH_NUMLOCK GHOSTTY_MODE_NUMLOCK_KEYPAD
 #define GHOSTTY_MODE_ALT_ESC_PREFIX   (ghostty_mode_new(1036, false)) /**< Alt key sends ESC prefix */
 #define GHOSTTY_MODE_ALT_SENDS_ESC    (ghostty_mode_new(1039, false)) /**< Alt sends escape */
+#define GHOSTTY_MODE_ALT_SENDS_ESCAPE GHOSTTY_MODE_ALT_SENDS_ESC
 #define GHOSTTY_MODE_REVERSE_WRAP_EXT (ghostty_mode_new(1045, false)) /**< Extended reverse wrap */
+#define GHOSTTY_MODE_REVERSE_WRAP_EXTENDED GHOSTTY_MODE_REVERSE_WRAP_EXT
 #define GHOSTTY_MODE_ALT_SCREEN       (ghostty_mode_new(1047, false)) /**< Alternate screen */
 #define GHOSTTY_MODE_SAVE_CURSOR      (ghostty_mode_new(1048, false)) /**< Save cursor (DECSC) */
 #define GHOSTTY_MODE_ALT_SCREEN_SAVE  (ghostty_mode_new(1049, false)) /**< Alt screen + save cursor + clear */
+#define GHOSTTY_MODE_ALT_SCREEN_SAVE_CURSOR_CLEAR_ENTER GHOSTTY_ALT_SCREEN_SAVE
 #define GHOSTTY_MODE_BRACKETED_PASTE  (ghostty_mode_new(2004, false)) /**< Bracketed paste mode */
 #define GHOSTTY_MODE_SYNC_OUTPUT      (ghostty_mode_new(2026, false)) /**< Synchronized output */
+#define GHOSTTY_MODE_SYNCHRONIZED_OUTPUT GHOSTTY_MODE_SYNC_OUTPUT
 #define GHOSTTY_MODE_GRAPHEME_CLUSTER (ghostty_mode_new(2027, false)) /**< Grapheme cluster mode */
 #define GHOSTTY_MODE_COLOR_SCHEME_REPORT (ghostty_mode_new(2031, false)) /**< Report color scheme */
+#define GHOSTTY_MODE_REPORT_COLOR_SCHEME GHOSTTY_MODE_COLOR_SCHEME_REPORT
 #define GHOSTTY_MODE_IN_BAND_RESIZE   (ghostty_mode_new(2048, false)) /**< In-band size reports */
+#define GHOSTTY_MODE_IN_BAND_SIZE_REPORTS GHOSTTY_MODE_IN_BAND_RESIZE
 /** @} */
 
 /**

--- a/include/ghostty/vt/modes.h
+++ b/include/ghostty/vt/modes.h
@@ -47,8 +47,10 @@ extern "C" {
  * @{
  */
 #define GHOSTTY_MODE_KAM              (ghostty_mode_new(2, true))    /**< Keyboard action (disable keyboard) */
+#define GHOSTTY_MODE_DISABLE_KEYBOARD GHOSTTY_MODE_KAM
 #define GHOSTTY_MODE_INSERT           (ghostty_mode_new(4, true))    /**< Insert mode */
 #define GHOSTTY_MODE_SRM              (ghostty_mode_new(12, true))   /**< Send/receive mode */
+#define GHOSTTY_MODE_SEND_RECEIVE_MODE GHOSTTY_MODE_SRM
 #define GHOSTTY_MODE_LINEFEED         (ghostty_mode_new(20, true))   /**< Linefeed/new line mode */
 /** @} */
 
@@ -57,6 +59,7 @@ extern "C" {
  * @{
  */
 #define GHOSTTY_MODE_DECCKM           (ghostty_mode_new(1, false))   /**< Cursor keys */
+#define GHOSTTY_MODE_CURSOR_KEYS GHOSTTY_MODE_DECCKM
 #define GHOSTTY_MODE_132_COLUMN       (ghostty_mode_new(3, false))   /**< 132/80 column mode */
 #define GHOSTTY_MODE_SLOW_SCROLL      (ghostty_mode_new(4, false))   /**< Slow scroll */
 #define GHOSTTY_MODE_REVERSE_COLORS   (ghostty_mode_new(5, false))   /**< Reverse video */
@@ -64,6 +67,7 @@ extern "C" {
 #define GHOSTTY_MODE_WRAPAROUND       (ghostty_mode_new(7, false))   /**< Auto-wrap mode */
 #define GHOSTTY_MODE_AUTOREPEAT       (ghostty_mode_new(8, false))   /**< Auto-repeat keys */
 #define GHOSTTY_MODE_X10_MOUSE        (ghostty_mode_new(9, false))   /**< X10 mouse reporting */
+#define GHOSTTY_MODE_MOUSE_EVENT_X10 GHOSTTY_MODE_X10_MOUSE
 #define GHOSTTY_MODE_CURSOR_BLINKING  (ghostty_mode_new(12, false))  /**< Cursor blink */
 #define GHOSTTY_MODE_CURSOR_VISIBLE   (ghostty_mode_new(25, false))  /**< Cursor visible (DECTCEM) */
 #define GHOSTTY_MODE_ENABLE_MODE_3    (ghostty_mode_new(40, false))  /**< Allow 132 column mode */
@@ -72,28 +76,45 @@ extern "C" {
 #define GHOSTTY_MODE_KEYPAD_KEYS      (ghostty_mode_new(66, false))  /**< Application keypad */
 #define GHOSTTY_MODE_BACKARROW_KEY_MODE (ghostty_mode_new(67, false))  /**< Backarrow key mode (DECBKM) */
 #define GHOSTTY_MODE_LEFT_RIGHT_MARGIN (ghostty_mode_new(69, false)) /**< Left/right margin mode */
+#define GHOSTTY_MODE_ENABLE_LEFT_AND_RIGHT_MARGIN GHOSTTY_MODE_LEFT_RIGHT_MARGIN
 #define GHOSTTY_MODE_NORMAL_MOUSE     (ghostty_mode_new(1000, false)) /**< Normal mouse tracking */
+#define GHOSTTY_MODE_MOUSE_EVENT_NORMAL GHOSTTY_MODE_NORMAL_MOUSE
 #define GHOSTTY_MODE_BUTTON_MOUSE     (ghostty_mode_new(1002, false)) /**< Button-event mouse tracking */
+#define GHOSTTY_MODE_MOUSE_EVENT_BUTTON GHOSTTY_MODE_BUTTON_MOUSE
 #define GHOSTTY_MODE_ANY_MOUSE        (ghostty_mode_new(1003, false)) /**< Any-event mouse tracking */
+#define GHOSTTY_MODE_MOUSE_EVENT_ANY GHOSTTY_MODE_ANY_MOUSE
 #define GHOSTTY_MODE_FOCUS_EVENT      (ghostty_mode_new(1004, false)) /**< Focus in/out events */
 #define GHOSTTY_MODE_UTF8_MOUSE       (ghostty_mode_new(1005, false)) /**< UTF-8 mouse format */
+#define GHOSTTY_MODE_MOUSE_FORMAT_UTF8 GHOSTTY_MODE_UTF8_MOUSE
 #define GHOSTTY_MODE_SGR_MOUSE        (ghostty_mode_new(1006, false)) /**< SGR mouse format */
+#define GHOSTTY_MODE_MOUSE_FORMAT_SGR GHOSTTY_MODE_SGR_MOUSE
 #define GHOSTTY_MODE_ALT_SCROLL       (ghostty_mode_new(1007, false)) /**< Alternate scroll mode */
+#define GHOSTTY_MODE_MOUSE_ALTERNATE_SCROLL GHOSTTY_MODE_ALT_SCROLL
 #define GHOSTTY_MODE_URXVT_MOUSE      (ghostty_mode_new(1015, false)) /**< URxvt mouse format */
+#define GHOSTTY_MODE_MOUSE_FORMAT_URXVT GHOSTTY_MODE_URXVT_MOUSE
 #define GHOSTTY_MODE_SGR_PIXELS_MOUSE (ghostty_mode_new(1016, false)) /**< SGR-Pixels mouse format */
+#define GHOSTTY_MODE_MOUSE_FORMAT_SGR_PIXELS GHOSTTY_MODE_SGR_PIXELS_MOUSE
 #define GHOSTTY_MODE_NUMLOCK_KEYPAD   (ghostty_mode_new(1035, false)) /**< Ignore keypad with NumLock */
+#define GHOSTTY_MODE_IGNORE_KEYPAD_WITH_NUMLOCK GHOSTTY_MODE_NUMLOCK_KEYPAD
 #define GHOSTTY_MODE_ALT_ESC_PREFIX   (ghostty_mode_new(1036, false)) /**< Alt key sends ESC prefix */
 #define GHOSTTY_MODE_ALT_SENDS_ESC    (ghostty_mode_new(1039, false)) /**< Alt sends escape */
+#define GHOSTTY_MODE_ALT_SENDS_ESCAPE GHOSTTY_MODE_ALT_SENDS_ESC
 #define GHOSTTY_MODE_REVERSE_WRAP_EXT (ghostty_mode_new(1045, false)) /**< Extended reverse wrap */
+#define GHOSTTY_MODE_REVERSE_WRAP_EXTENDED GHOSTTY_MODE_REVERSE_WRAP_EXT
 #define GHOSTTY_MODE_ALT_SCREEN       (ghostty_mode_new(1047, false)) /**< Alternate screen */
 #define GHOSTTY_MODE_SAVE_CURSOR      (ghostty_mode_new(1048, false)) /**< Save cursor (DECSC) */
 #define GHOSTTY_MODE_ALT_SCREEN_SAVE  (ghostty_mode_new(1049, false)) /**< Alt screen + save cursor + clear */
+#define GHOSTTY_MODE_ALT_SCREEN_SAVE_CURSOR_CLEAR_ENTER GHOSTTY_MODE_ALT_SCREEN_SAVE
 #define GHOSTTY_MODE_BRACKETED_PASTE  (ghostty_mode_new(2004, false)) /**< Bracketed paste mode */
 #define GHOSTTY_MODE_SYNC_OUTPUT      (ghostty_mode_new(2026, false)) /**< Synchronized output */
+#define GHOSTTY_MODE_SYNCHRONIZED_OUTPUT GHOSTTY_MODE_SYNC_OUTPUT
 #define GHOSTTY_MODE_GRAPHEME_CLUSTER (ghostty_mode_new(2027, false)) /**< Grapheme cluster mode */
 #define GHOSTTY_MODE_COLOR_SCHEME_REPORT (ghostty_mode_new(2031, false)) /**< Report color scheme */
+#define GHOSTTY_MODE_REPORT_COLOR_SCHEME GHOSTTY_MODE_COLOR_SCHEME_REPORT
 #define GHOSTTY_MODE_VISIBILITY_REPORT (ghostty_mode_new(2033, false)) /**< Report terminal visibility */
+#define GHOSTTY_MODE_REPORT_VISIBILITY GHOSTTY_MODE_VISIBILITY_REPORT
 #define GHOSTTY_MODE_IN_BAND_RESIZE   (ghostty_mode_new(2048, false)) /**< In-band size reports */
+#define GHOSTTY_MODE_IN_BAND_SIZE_REPORTS GHOSTTY_MODE_IN_BAND_RESIZE
 /** @} */
 
 /**

--- a/pkg/gtk4-layer-shell/build.zig.zon
+++ b/pkg/gtk4-layer-shell/build.zig.zon
@@ -15,8 +15,8 @@
             .lazy = true,
         },
         .translate_c = .{
-            .url = "https://deps.files.ghostty.org/translate_c-80f8b6e4f45a303268717d8e5f4f91d7837138bb.tar.gz",
-            .hash = "translate_c-0.0.0-Q_BUWmU6BwB_9JKG2l2W7i_mhmYWeRseTGBEHi_YlV5f",
+            .url = "https://codeberg.org/vancluever/translate-c/archive/cec6ef8c9134c509f8ee008d34e9de845cbc10a8.tar.gz",
+            .hash = "translate_c-0.0.0-Q_BUWv5BBwDmJP04p9f68173JwpyqoNzH9In3u6CS3Lj",
             .lazy = true,
         },
     },

--- a/pkg/harfbuzz/build.zig.zon
+++ b/pkg/harfbuzz/build.zig.zon
@@ -5,8 +5,8 @@
     .paths = .{""},
     .dependencies = .{
         .translate_c = .{
-            .url = "https://deps.files.ghostty.org/translate_c-80f8b6e4f45a303268717d8e5f4f91d7837138bb.tar.gz",
-            .hash = "translate_c-0.0.0-Q_BUWmU6BwB_9JKG2l2W7i_mhmYWeRseTGBEHi_YlV5f",
+            .url = "https://codeberg.org/vancluever/translate-c/archive/cec6ef8c9134c509f8ee008d34e9de845cbc10a8.tar.gz",
+            .hash = "translate_c-0.0.0-Q_BUWv5BBwDmJP04p9f68173JwpyqoNzH9In3u6CS3Lj",
             .lazy = true,
         },
 

--- a/pkg/macos/build.zig.zon
+++ b/pkg/macos/build.zig.zon
@@ -6,8 +6,8 @@
     .dependencies = .{
         .apple_sdk = .{ .path = "../apple-sdk" },
         .translate_c = .{
-            .url = "https://deps.files.ghostty.org/translate_c-80f8b6e4f45a303268717d8e5f4f91d7837138bb.tar.gz",
-            .hash = "translate_c-0.0.0-Q_BUWmU6BwB_9JKG2l2W7i_mhmYWeRseTGBEHi_YlV5f",
+            .url = "https://codeberg.org/vancluever/translate-c/archive/cec6ef8c9134c509f8ee008d34e9de845cbc10a8.tar.gz",
+            .hash = "translate_c-0.0.0-Q_BUWv5BBwDmJP04p9f68173JwpyqoNzH9In3u6CS3Lj",
             .lazy = true,
         },
     },

--- a/pkg/wuffs/build.zig.zon
+++ b/pkg/wuffs/build.zig.zon
@@ -5,8 +5,8 @@
     .dependencies = .{
         .translate_c = .{
             .lazy = true,
-            .url = "https://deps.files.ghostty.org/translate_c-80f8b6e4f45a303268717d8e5f4f91d7837138bb.tar.gz",
-            .hash = "translate_c-0.0.0-Q_BUWmU6BwB_9JKG2l2W7i_mhmYWeRseTGBEHi_YlV5f",
+            .url = "https://codeberg.org/vancluever/translate-c/archive/cec6ef8c9134c509f8ee008d34e9de845cbc10a8.tar.gz",
+            .hash = "translate_c-0.0.0-Q_BUWv5BBwDmJP04p9f68173JwpyqoNzH9In3u6CS3Lj",
         },
 
         // google/wuffs

--- a/src/build/c_deps.zig
+++ b/src/build/c_deps.zig
@@ -1,0 +1,94 @@
+const std = @import("std");
+
+const Config = @import("Config.zig");
+
+pub const CDeps = enum {
+    ghostty_h,
+    ghostty_vt_h,
+};
+
+const Key = struct {
+    dep: CDeps,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+};
+
+const Value = *std.Build.Module;
+
+const Context = struct {
+    pub fn hash(_: Context, key: Key) u32 {
+        var h: std.hash.XxHash32 = .init(0);
+        h.update(std.mem.asBytes(&key.dep));
+        h.update(std.mem.asBytes(&key.target.result.cpu.arch));
+        h.update(key.target.result.cpu.features.asBytes());
+        h.update(std.mem.asBytes(&key.target.result.os.tag));
+        h.update(std.mem.asBytes(&key.target.result.abi));
+        h.update(std.mem.asBytes(&key.optimize));
+        return h.final();
+    }
+
+    pub fn eql(_: Context, a: Key, b: Key, _: usize) bool {
+        return a.dep == b.dep and
+            a.target.result.cpu.arch == b.target.result.cpu.arch and
+            a.target.result.cpu.features.eql(b.target.result.cpu.features) and
+            a.target.result.os.tag == b.target.result.os.tag and
+            a.target.result.abi == b.target.result.abi and
+            a.optimize == b.optimize;
+    }
+};
+
+var modules: std.ArrayHashMapUnmanaged(Key, Value, Context, false) = .empty;
+
+pub const Options = struct {
+    target: ?std.Build.ResolvedTarget = null,
+    optimize: ?std.builtin.OptimizeMode = null,
+};
+
+/// Add the specified C dependency to the given module.
+pub fn add(b: *std.Build, dep: CDeps, module: *std.Build.Module, config: *const Config, options: Options) !void {
+    const target = options.target orelse config.target;
+    const optimize = options.optimize orelse config.optimize;
+
+    // TranslateC requires libc, and these targets don't have libc
+    if (target.result.cpu.arch.isWasm()) return;
+    if (target.result.os.tag == .windows) return;
+
+    const key: Key = .{
+        .dep = dep,
+        .target = target,
+        .optimize = optimize,
+    };
+
+    const value = modules.get(key) orelse value: {
+        const value = switch (dep) {
+            .ghostty_h => v: {
+                // Verify our internal libghostty header.
+                const ghostty_h = b.addTranslateC(.{
+                    .root_source_file = b.path("include/ghostty.h"),
+                    .target = target,
+                    .optimize = optimize,
+                });
+                break :v ghostty_h.createModule();
+            },
+
+            .ghostty_vt_h => v: {
+                // Verify our libghostty-vt header.
+                const ghostty_vt_h = b.addTranslateC(.{
+                    .root_source_file = b.path("include/ghostty/vt.h"),
+                    .target = target,
+                    .optimize = optimize,
+                });
+                ghostty_vt_h.addIncludePath(b.path("include"));
+                break :v ghostty_vt_h.createModule();
+            },
+        };
+
+        try modules.put(b.allocator, key, value);
+        break :value value;
+    };
+
+    module.addImport(switch (dep) {
+        .ghostty_h => "ghostty-h",
+        .ghostty_vt_h => "ghostty-vt-h",
+    }, value);
+}

--- a/src/build/c_deps.zig
+++ b/src/build/c_deps.zig
@@ -87,8 +87,5 @@ pub fn add(b: *std.Build, dep: CDeps, module: *std.Build.Module, config: *const 
         break :value value;
     };
 
-    module.addImport(switch (dep) {
-        .ghostty_h => "ghostty-h",
-        .ghostty_vt_h => "ghostty-vt-h",
-    }, value);
+    module.addImport(@tagName(dep), value);
 }

--- a/src/build/c_deps.zig
+++ b/src/build/c_deps.zig
@@ -3,8 +3,8 @@ const std = @import("std");
 const Config = @import("Config.zig");
 
 pub const CDeps = enum {
-    ghostty_h,
-    ghostty_vt_h,
+    @"ghostty-h",
+    @"ghostty-vt-h",
 };
 
 const Key = struct {
@@ -61,7 +61,7 @@ pub fn add(b: *std.Build, dep: CDeps, module: *std.Build.Module, config: *const 
 
     const value = modules.get(key) orelse value: {
         const value = switch (dep) {
-            .ghostty_h => v: {
+            .@"ghostty-h" => v: {
                 // Verify our internal libghostty header.
                 const ghostty_h = b.addTranslateC(.{
                     .root_source_file = b.path("include/ghostty.h"),
@@ -71,7 +71,7 @@ pub fn add(b: *std.Build, dep: CDeps, module: *std.Build.Module, config: *const 
                 break :v ghostty_h.createModule();
             },
 
-            .ghostty_vt_h => v: {
+            .@"ghostty-vt-h" => v: {
                 // Verify our libghostty-vt header.
                 const ghostty_vt_h = b.addTranslateC(.{
                     .root_source_file = b.path("include/ghostty/vt.h"),

--- a/src/build/c_deps.zig
+++ b/src/build/c_deps.zig
@@ -1,0 +1,112 @@
+const std = @import("std");
+
+const Config = @import("Config.zig");
+
+pub const CDeps = enum {
+    @"ghostty-h",
+    @"ghostty-vt-h",
+};
+
+const Key = struct {
+    dep: CDeps,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+};
+
+const Value = *std.Build.Module;
+
+const Context = struct {
+    pub fn hash(_: Context, key: Key) u32 {
+        var h: std.hash.XxHash32 = .init(0);
+        h.update(std.mem.asBytes(&key.dep));
+        h.update(std.mem.asBytes(&key.target.result.cpu.arch));
+        h.update(key.target.result.cpu.features.asBytes());
+        h.update(std.mem.asBytes(&key.target.result.os.tag));
+        h.update(std.mem.asBytes(&key.target.result.abi));
+        h.update(std.mem.asBytes(&key.optimize));
+        return h.final();
+    }
+
+    pub fn eql(_: Context, a: Key, b: Key, _: usize) bool {
+        return a.dep == b.dep and
+            a.target.result.cpu.arch == b.target.result.cpu.arch and
+            a.target.result.cpu.features.eql(b.target.result.cpu.features) and
+            a.target.result.os.tag == b.target.result.os.tag and
+            a.target.result.abi == b.target.result.abi and
+            a.optimize == b.optimize;
+    }
+};
+
+var modules: std.ArrayHashMapUnmanaged(Key, Value, Context, false) = .empty;
+
+pub const Options = struct {
+    target: ?std.Build.ResolvedTarget = null,
+    optimize: ?std.builtin.OptimizeMode = null,
+};
+
+var _translate_c_dep: ?*std.Build.Dependency = null;
+
+/// Add the specified C dependency to the given module.
+pub fn add(b: *std.Build, dep: CDeps, module: *std.Build.Module, config: *const Config, options: Options) !void {
+    const translate_c = b.lazyImport(@This(), "translate_c") orelse return;
+    const translate_c_dep = d1: {
+        if (_translate_c_dep) |d2| break :d1 d2;
+        const d3 = b.lazyDependency("translate_c", .{}) orelse return;
+        _translate_c_dep = d3;
+        break :d1 d3;
+    };
+
+    const target = options.target orelse config.target;
+    const optimize = options.optimize orelse config.optimize;
+
+    // TranslateC requires libc, and these targets don't have libc
+    if (target.result.cpu.arch.isWasm()) return;
+    if (target.result.os.tag == .windows) return;
+
+    const key: Key = .{
+        .dep = dep,
+        .target = target,
+        .optimize = optimize,
+    };
+
+    const value = modules.get(key) orelse value: {
+        const value = switch (dep) {
+            .@"ghostty-h" => v: {
+                // Verify our internal libghostty header.
+                const translated: translate_c.Translator = .init(translate_c_dep, .{
+                    .c_source_file = b.addWriteFiles().add(
+                        "ghostty_h_c.h",
+                        \\#include <ghostty.h>
+                        ,
+                    ),
+                    .target = target,
+                    .optimize = optimize,
+                    .link_libc = true,
+                });
+                translated.addSystemIncludePath(b.path("include"));
+                break :v translated.mod;
+            },
+
+            .@"ghostty-vt-h" => v: {
+                // Verify our libghostty-vt header.
+                const translated: translate_c.Translator = .init(translate_c_dep, .{
+                    .c_source_file = b.addWriteFiles().add(
+                        "ghostty_vt_h_c.h",
+                        \\#include <ghostty/vt.h>
+                        ,
+                    ),
+                    .target = target,
+                    .optimize = optimize,
+                    .link_libc = true,
+                });
+                translated.addSystemIncludePath(b.path("include"));
+                break :v translated.mod;
+            },
+        };
+
+        try modules.put(b.allocator, key, value);
+        break :value value;
+    };
+
+    module.addImport(@tagName(dep), value);
+}

--- a/src/lib/enum.zig
+++ b/src/lib/enum.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
+const builtin = @import("builtin");
+
 const Target = @import("target.zig").Target;
+
+const std_enums = @import("std_enums.zig");
 
 /// Create an enum type with the given keys that is C ABI compatible
 /// if we're targeting C, otherwise a Zig enum with smallest possible
@@ -92,24 +96,54 @@ test "abi by removing a key" {
     }
 }
 
+const CheckError = error{ SkipZigTest, TestExpectedEqual, TestUnexpectedResult };
+
+fn ghosttyHEnumCheck(expected: anytype, actual: anytype) CheckError!void {
+    try std.testing.expectEqual(expected, actual);
+}
+
 /// Verify that for every key in enum T, there is a matching declaration in
 /// `ghostty.h` with the correct value. This should only ever be called inside a `test`
 /// because the `ghostty.h` module is only available then.
-pub fn checkGhosttyHEnum(
+pub fn checkGhosttyHEnum(comptime T: type, comptime prefix: []const u8) CheckError!void {
+    // these targets don't support libc, which is required for this test
+    if (comptime builtin.cpu.arch.isWasm()) return error.SkipZigTest;
+    if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
+
+    try checkEnum("ghostty.h", @import("ghostty-h"), T, null, prefix, ghosttyHEnumCheck);
+}
+
+/// Verify that for every key in enum T, there is a matching macro in
+/// `ghostty/vt.h`. This should only ever be called inside a `test` because the
+/// `ghostty/vt.h` module is only available then. The actual value of the macro
+/// is not checked as the value of the macro may be more complex than an integer
+/// that matches the Zig enum.
+pub fn checkGhosttyVtHMacroExists(comptime T: type, comptime prefix: []const u8) CheckError!void {
+    // these targets don't support libc, which is required for this test
+    if (comptime builtin.cpu.arch.isWasm()) return error.SkipZigTest;
+    if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
+
+    try checkEnum("ghostty/vt.h", @import("ghostty-vt-h"), T, null, prefix, null);
+}
+
+fn checkEnum(
+    comptime name: []const u8,
+    comptime c: anytype,
     comptime T: type,
+    comptime backint_int_type_: ?type,
     comptime prefix: []const u8,
+    comptime check_: ?fn (anytype, anytype) CheckError!void,
 ) !void {
     const info = @typeInfo(T);
 
     try std.testing.expect(info == .@"enum");
-    try std.testing.expect(info.@"enum".tag_type == c_int);
+    if (backint_int_type_) |backing_int_type|
+        try std.testing.expect(info.@"enum".tag_type == backing_int_type);
     try std.testing.expect(info.@"enum".is_exhaustive == true);
 
     @setEvalBranchQuota(100_000);
 
-    const c = @import("ghostty.h");
-
-    var set: std.EnumSet(T) = .initFull();
+    var set: std_enums.EnumSet(T) = .initFull();
 
     const enum_fields = info.@"enum".fields;
 
@@ -124,10 +158,15 @@ pub fn checkGhosttyHEnum(
         };
 
         if (@hasDecl(c, expected_name)) {
-            std.testing.expectEqual(field.value, @field(c, expected_name)) catch |e| {
-                std.log.err(@typeName(T) ++ " key " ++ field.name ++ " does not have the same backing int as " ++ expected_name, .{});
-                return e;
-            };
+            if (check_) |check| {
+                check(
+                    field.value,
+                    @field(c, expected_name),
+                ) catch |e| {
+                    std.log.err(@typeName(T) ++ " key " ++ field.name ++ " / " ++ expected_name ++ " failed its check: {t}", .{e});
+                    return e;
+                };
+            }
 
             set.remove(@enumFromInt(field.value));
         }
@@ -138,7 +177,7 @@ pub fn checkGhosttyHEnum(
         while (it.next()) |v| {
             var buf: [128]u8 = undefined;
             const upper_string = std.ascii.upperString(&buf, @tagName(v));
-            std.log.err("ghostty.h is missing value for {s}{s}", .{ prefix, upper_string });
+            std.log.err("{s} is missing value for {s}{s}", .{ name, prefix, upper_string });
         }
         return e;
     };

--- a/src/lib/enum.zig
+++ b/src/lib/enum.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
+const builtin = @import("builtin");
+
 const Target = @import("target.zig").Target;
+
+const std_enums = @import("std_enums.zig");
 
 /// Create an enum type with the given keys that is C ABI compatible
 /// if we're targeting C, otherwise a Zig enum with smallest possible
@@ -102,24 +106,54 @@ test "zig values remain stable across multiple holes" {
     try testing.expectEqual(5, @intFromEnum(T.f));
 }
 
+const CheckError = error{ SkipZigTest, TestExpectedEqual, TestUnexpectedResult };
+
+fn ghosttyHEnumCheck(expected: anytype, actual: anytype) CheckError!void {
+    try std.testing.expectEqual(expected, actual);
+}
+
 /// Verify that for every key in enum T, there is a matching declaration in
 /// `ghostty.h` with the correct value. This should only ever be called inside a `test`
 /// because the `ghostty.h` module is only available then.
-pub fn checkGhosttyHEnum(
+pub fn checkGhosttyHEnum(comptime T: type, comptime prefix: []const u8) CheckError!void {
+    // these targets don't support libc, which is required for this test
+    if (comptime builtin.cpu.arch.isWasm()) return error.SkipZigTest;
+    if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
+
+    try checkEnum("ghostty.h", @import("ghostty-h"), T, null, prefix, ghosttyHEnumCheck);
+}
+
+/// Verify that for every key in enum T, there is a matching macro in
+/// `ghostty/vt.h`. This should only ever be called inside a `test` because the
+/// `ghostty/vt.h` module is only available then. The actual value of the macro
+/// is not checked as the value of the macro may be more complex than an integer
+/// that matches the Zig enum.
+pub fn checkGhosttyVtHMacroExists(comptime T: type, comptime prefix: []const u8) CheckError!void {
+    // these targets don't support libc, which is required for this test
+    if (comptime builtin.cpu.arch.isWasm()) return error.SkipZigTest;
+    if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
+
+    try checkEnum("ghostty/vt.h", @import("ghostty-vt-h"), T, null, prefix, null);
+}
+
+fn checkEnum(
+    comptime name: []const u8,
+    comptime c: anytype,
     comptime T: type,
+    comptime backint_int_type_: ?type,
     comptime prefix: []const u8,
+    comptime check_: ?fn (anytype, anytype) CheckError!void,
 ) !void {
     const info = @typeInfo(T);
 
     try std.testing.expect(info == .@"enum");
-    try std.testing.expect(info.@"enum".tag_type == c_int);
+    if (backint_int_type_) |backing_int_type|
+        try std.testing.expect(info.@"enum".tag_type == backing_int_type);
     try std.testing.expect(info.@"enum".is_exhaustive == true);
 
     @setEvalBranchQuota(100_000);
 
-    const c = @import("ghostty.h");
-
-    var set: std.EnumSet(T) = .initFull();
+    var set: std_enums.EnumSet(T) = .initFull();
 
     const enum_fields = info.@"enum".fields;
 
@@ -141,6 +175,15 @@ pub fn checkGhosttyHEnum(
                 );
                 return e;
             };
+            if (check_) |check| {
+                check(
+                    field.value,
+                    @field(c, expected_name),
+                ) catch |e| {
+                    std.log.err("{s} key {s} / " ++ expected_name ++ " failed its check: {t}", .{ @typeName(T), field.name, e });
+                    return e;
+                };
+            }
 
             set.remove(@enumFromInt(field.value));
         }
@@ -151,7 +194,7 @@ pub fn checkGhosttyHEnum(
         while (it.next()) |v| {
             var buf: [128]u8 = undefined;
             const upper_string = std.ascii.upperString(&buf, @tagName(v));
-            std.log.err("ghostty.h is missing value for {s}{s}", .{ prefix, upper_string });
+            std.log.err("{s} is missing value for {s}{s}", .{ name, prefix, upper_string });
         }
         return e;
     };

--- a/src/lib/std_enums.zig
+++ b/src/lib/std_enums.zig
@@ -1,0 +1,310 @@
+const std = @import("std");
+
+// The following are taken from the Zig std library. We need to copy these
+// because `valuesFromFields()` needs to have a larger `@setEvalBranchQuota` set
+// to handle larger enums.
+//
+// https://codeberg.org/ziglang/zig/src/commit/e4cbd752c8c05f131051f8c873cff7823177d7d3/lib/std/enums.zig
+
+/// A set of enum elements, backed by a bitfield.  If the enum
+/// is exhaustive but not dense, a mapping will be constructed from enum values
+/// to dense indices.  This type does no dynamic allocation and
+/// can be copied by value.
+pub fn EnumSet(comptime E: type) type {
+    return struct {
+        const Self = @This();
+
+        /// The indexing rules for converting between keys and indices.
+        pub const Indexer = EnumIndexer(E);
+        /// The element type for this set.
+        pub const Key = Indexer.Key;
+
+        const BitSet = std.StaticBitSet(Indexer.count);
+
+        /// The maximum number of items in this set.
+        pub const len = Indexer.count;
+
+        bits: BitSet = BitSet.initEmpty(),
+
+        /// Initializes the set using a struct of bools
+        pub fn init(init_values: std.enums.EnumFieldStruct(E, bool, false)) Self {
+            @setEvalBranchQuota(2 * @typeInfo(E).@"enum".fields.len);
+            var result: Self = .{};
+            if (@typeInfo(E).@"enum".is_exhaustive) {
+                inline for (0..Self.len) |i| {
+                    const key = comptime Indexer.keyForIndex(i);
+                    const tag = @tagName(key);
+                    if (@field(init_values, tag)) {
+                        result.bits.set(i);
+                    }
+                }
+            } else {
+                inline for (std.meta.fields(E)) |field| {
+                    const key = @field(E, field.name);
+                    if (@field(init_values, field.name)) {
+                        const i = comptime Indexer.indexOf(key);
+                        result.bits.set(i);
+                    }
+                }
+            }
+            return result;
+        }
+
+        /// Returns a set containing no keys.
+        pub fn initEmpty() Self {
+            return .{ .bits = BitSet.initEmpty() };
+        }
+
+        /// Returns a set containing all possible keys.
+        pub fn initFull() Self {
+            return .{ .bits = BitSet.initFull() };
+        }
+
+        /// Returns a set containing multiple keys.
+        pub fn initMany(keys: []const Key) Self {
+            var set = initEmpty();
+            for (keys) |key| set.insert(key);
+            return set;
+        }
+
+        /// Returns a set containing a single key.
+        pub fn initOne(key: Key) Self {
+            return initMany(&[_]Key{key});
+        }
+
+        /// Returns the number of keys in the set.
+        pub fn count(self: Self) usize {
+            return self.bits.count();
+        }
+
+        /// Checks if a key is in the set.
+        pub fn contains(self: Self, key: Key) bool {
+            return self.bits.isSet(Indexer.indexOf(key));
+        }
+
+        /// Puts a key in the set.
+        pub fn insert(self: *Self, key: Key) void {
+            self.bits.set(Indexer.indexOf(key));
+        }
+
+        /// Removes a key from the set.
+        pub fn remove(self: *Self, key: Key) void {
+            self.bits.unset(Indexer.indexOf(key));
+        }
+
+        /// Changes the presence of a key in the set to match the passed bool.
+        pub fn setPresent(self: *Self, key: Key, present: bool) void {
+            self.bits.setValue(Indexer.indexOf(key), present);
+        }
+
+        /// Toggles the presence of a key in the set.  If the key is in
+        /// the set, removes it.  Otherwise adds it.
+        pub fn toggle(self: *Self, key: Key) void {
+            self.bits.toggle(Indexer.indexOf(key));
+        }
+
+        /// Toggles the presence of all keys in the passed set.
+        pub fn toggleSet(self: *Self, other: Self) void {
+            self.bits.toggleSet(other.bits);
+        }
+
+        /// Toggles all possible keys in the set.
+        pub fn toggleAll(self: *Self) void {
+            self.bits.toggleAll();
+        }
+
+        /// Adds all keys in the passed set to this set.
+        pub fn setUnion(self: *Self, other: Self) void {
+            self.bits.setUnion(other.bits);
+        }
+
+        /// Removes all keys which are not in the passed set.
+        pub fn setIntersection(self: *Self, other: Self) void {
+            self.bits.setIntersection(other.bits);
+        }
+
+        /// Returns true iff both sets have the same keys.
+        pub fn eql(self: Self, other: Self) bool {
+            return self.bits.eql(other.bits);
+        }
+
+        /// Returns true iff all the keys in this set are
+        /// in the other set. The other set may have keys
+        /// not found in this set.
+        pub fn subsetOf(self: Self, other: Self) bool {
+            return self.bits.subsetOf(other.bits);
+        }
+
+        /// Returns true iff this set contains all the keys
+        /// in the other set. This set may have keys not
+        /// found in the other set.
+        pub fn supersetOf(self: Self, other: Self) bool {
+            return self.bits.supersetOf(other.bits);
+        }
+
+        /// Returns a set with all the keys not in this set.
+        pub fn complement(self: Self) Self {
+            return .{ .bits = self.bits.complement() };
+        }
+
+        /// Returns a set with keys that are in either this
+        /// set or the other set.
+        pub fn unionWith(self: Self, other: Self) Self {
+            return .{ .bits = self.bits.unionWith(other.bits) };
+        }
+
+        /// Returns a set with keys that are in both this
+        /// set and the other set.
+        pub fn intersectWith(self: Self, other: Self) Self {
+            return .{ .bits = self.bits.intersectWith(other.bits) };
+        }
+
+        /// Returns a set with keys that are in either this
+        /// set or the other set, but not both.
+        pub fn xorWith(self: Self, other: Self) Self {
+            return .{ .bits = self.bits.xorWith(other.bits) };
+        }
+
+        /// Returns a set with keys that are in this set
+        /// except for keys in the other set.
+        pub fn differenceWith(self: Self, other: Self) Self {
+            return .{ .bits = self.bits.differenceWith(other.bits) };
+        }
+
+        /// Returns an iterator over this set, which iterates in
+        /// index order.  Modifications to the set during iteration
+        /// may or may not be observed by the iterator, but will
+        /// not invalidate it.
+        pub fn iterator(self: *const Self) Iterator {
+            return .{ .inner = self.bits.iterator(.{}) };
+        }
+
+        pub const Iterator = struct {
+            inner: BitSet.Iterator(.{}),
+
+            pub fn next(self: *Iterator) ?Key {
+                return if (self.inner.next()) |index|
+                    Indexer.keyForIndex(index)
+                else
+                    null;
+            }
+        };
+    };
+}
+
+/// Increment this value when adding APIs that add single backwards branches.
+const eval_branch_quota_cushion = 10;
+const EnumField = std.builtin.Type.EnumField;
+
+fn EnumIndexer(comptime E: type) type {
+    // n log n for `std.mem.sortUnstable` call below.
+    const fields_len = @typeInfo(E).@"enum".fields.len;
+    @setEvalBranchQuota(3 * fields_len * std.math.log2(@max(fields_len, 1)) + eval_branch_quota_cushion);
+
+    if (!@typeInfo(E).@"enum".is_exhaustive) {
+        const BackingInt = @typeInfo(E).@"enum".tag_type;
+        if (@bitSizeOf(BackingInt) > @bitSizeOf(usize))
+            @compileError("Cannot create an enum indexer for a given non-exhaustive enum, tag_type is larger than usize.");
+
+        return struct {
+            pub const Key: type = E;
+
+            const backing_int_sign = @typeInfo(BackingInt).int.signedness;
+            const min_value = std.math.minInt(BackingInt);
+            const max_value = std.math.maxInt(BackingInt);
+
+            const RangeType = std.meta.Int(.unsigned, @bitSizeOf(BackingInt));
+            pub const count: comptime_int = std.math.maxInt(RangeType) + 1;
+
+            pub fn indexOf(e: E) usize {
+                if (backing_int_sign == .unsigned)
+                    return @intFromEnum(e);
+
+                return if (@intFromEnum(e) < 0)
+                    @intCast(@intFromEnum(e) - min_value)
+                else
+                    @as(RangeType, -min_value) + @as(RangeType, @intCast(@intFromEnum(e)));
+            }
+            pub fn keyForIndex(i: usize) E {
+                if (backing_int_sign == .unsigned)
+                    return @enumFromInt(i);
+
+                return @enumFromInt(@as(std.meta.Int(.signed, @bitSizeOf(RangeType) + 1), @intCast(i)) + min_value);
+            }
+        };
+    }
+
+    if (fields_len == 0) {
+        return struct {
+            pub const Key = E;
+            pub const count: comptime_int = 0;
+            pub fn indexOf(e: E) usize {
+                _ = e;
+                unreachable;
+            }
+            pub fn keyForIndex(i: usize) E {
+                _ = i;
+                unreachable;
+            }
+        };
+    }
+
+    var fields: [fields_len]EnumField = @typeInfo(E).@"enum".fields[0..].*;
+
+    std.mem.sortUnstable(EnumField, &fields, {}, struct {
+        fn lessThan(ctx: void, lhs: EnumField, rhs: EnumField) bool {
+            ctx;
+            return lhs.value < rhs.value;
+        }
+    }.lessThan);
+
+    const min = fields[0].value;
+    const max = fields[fields_len - 1].value;
+    if (max - min == fields.len - 1) {
+        return struct {
+            pub const Key = E;
+            pub const count: comptime_int = fields_len;
+            pub fn indexOf(e: E) usize {
+                return @as(usize, @intCast(@intFromEnum(e) - min));
+            }
+            pub fn keyForIndex(i: usize) E {
+                // TODO fix addition semantics.  This calculation
+                // gives up some safety to avoid artificially limiting
+                // the range of signed enum values to max_isize.
+                const enum_value = if (min < 0) @as(isize, @bitCast(i)) +% min else i + min;
+                return @as(E, @enumFromInt(@as(@typeInfo(E).@"enum".tag_type, @intCast(enum_value))));
+            }
+        };
+    }
+
+    const keys = valuesFromFields(E, &fields);
+
+    return struct {
+        pub const Key = E;
+        pub const count: comptime_int = fields_len;
+        pub fn indexOf(e: E) usize {
+            for (keys, 0..) |k, i| {
+                if (k == e) return i;
+            }
+            unreachable;
+        }
+        pub fn keyForIndex(i: usize) E {
+            return keys[i];
+        }
+    };
+}
+
+/// Looks up the supplied fields in the given enum type.
+/// Uses only the field names, field values are ignored.
+/// The result array is in the same order as the input.
+inline fn valuesFromFields(comptime E: type, comptime fields: []const EnumField) []const E {
+    comptime {
+        @setEvalBranchQuota(2000);
+        var result: [fields.len]E = undefined;
+        for (&result, fields) |*r, f| {
+            r.* = @enumFromInt(f.value);
+        }
+        const final = result;
+        return &final;
+    }
+}

--- a/src/terminal/modes.zig
+++ b/src/terminal/modes.zig
@@ -9,6 +9,7 @@
 
 const std = @import("std");
 const testing = std.testing;
+const checkGhosttyVtHMacroExists = @import("../lib/enum.zig").checkGhosttyVtHMacroExists;
 
 /// A struct that maintains the state of all the settable modes.
 pub const ModeState = struct {
@@ -141,6 +142,10 @@ pub const Mode = mode_enum: {
         .is_exhaustive = true,
     } });
 };
+
+test "ghostty/vt.h Mode" {
+    try checkGhosttyVtHMacroExists(Mode, "GHOSTTY_MODE_");
+}
 
 /// The tag type for our enum is a u16 but we use a packed struct
 /// in order to pack the ansi bit into the tag.

--- a/src/terminal/modes.zig
+++ b/src/terminal/modes.zig
@@ -9,6 +9,7 @@
 
 const std = @import("std");
 const testing = std.testing;
+const checkGhosttyVtHMacroExists = @import("../lib/enum.zig").checkGhosttyVtHMacroExists;
 
 /// A struct that maintains the state of all the settable modes.
 pub const ModeState = struct {
@@ -154,6 +155,10 @@ pub const Mode = mode_enum: {
 
     break :mode_enum @Enum(ModeTag.Backing, .exhaustive, &names, &values);
 };
+
+test "ghostty/vt.h Mode" {
+    try checkGhosttyVtHMacroExists(Mode, "GHOSTTY_MODE_");
+}
 
 /// The tag type for our enum is a u16 but we use a packed struct
 /// in order to pack the ansi bit into the tag.


### PR DESCRIPTION
Adds a test to make sure that all terminal modes defined in Zig have a corresponding definition in `ghostty/vt.h`.