### PR TITLE
macOS: fix memory leak of TerminalController

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -157,7 +157,7 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         scheduledWorkItem = DispatchWorkItem { [weak self] in
             guard let self else { return }
             defer { self.pendingInitialPresentation = nil }
-            guard scheduledWorkItem?.isCancelled == false else { return }
+            guard pendingInitialPresentation?.isCancelled == false else { return }
             block()
         }
 


### PR DESCRIPTION
Regression of #12119, this memory leak affects new tabs, since the terminal controller is not deallocated correctly, hitting `cmd+t` will create a new window with two tabs, but only one actually contains usable surface.

You can reproduce by:
1. Quit and Reopen Ghostty
2. Open a new window if no window is created (initial-window = false)
3. Close the window
4. Hit `cmd+t`