### PR TITLE
build: stop linking libc++ for utfcpp

### DIFF
--- a/pkg/utfcpp/build.zig
+++ b/pkg/utfcpp/build.zig
@@ -13,14 +13,6 @@ pub fn build(b: *std.Build) !void {
         .linkage = .static,
     });
     lib.linkLibC();
-    // On MSVC, we must not use linkLibCpp because Zig unconditionally
-    // passes -nostdinc++ and then adds its bundled libc++/libc++abi
-    // include paths, which conflict with MSVC's own C++ runtime headers.
-    // The MSVC SDK include directories (added via linkLibC) contain
-    // both C and C++ headers, so linkLibCpp is not needed.
-    if (target.result.abi != .msvc) {
-        lib.linkLibCpp();
-    }
 
     if (target.result.os.tag.isDarwin()) {
         const apple_sdk = @import("apple_sdk");


### PR DESCRIPTION
utfcpp is a header-only dependency, so its package wrapper does not need to link the C++ standard library. Keep the empty static archive for build integration, but stop adding an unnecessary libc++ dependency.