### PR TITLE
macOS: fix cannot rebind super+up and super+down

### DIFF
--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -1999,21 +1999,7 @@ extension Ghostty.SurfaceView: NSTextInputClient {
            let current = NSApp.currentEvent,
            lastPerformKeyEvent == current.timestamp {
             NSApp.sendEvent(current)
-            return
         }
-
-		guard let surfaceModel else { return }
-        // Process MacOS native scroll events
-        switch selector {
-        case #selector(moveToBeginningOfDocument(_:)):
-            _ = surfaceModel.perform(action: "scroll_to_top")
-        case #selector(moveToEndOfDocument(_:)):
-            _ = surfaceModel.perform(action: "scroll_to_bottom")
-        default:
-            break
-        }
-
-        print("SEL: \(selector)")
     }
 
     /// Sync the preedit state based on the markedText value to libghostty


### PR DESCRIPTION
Fix: #11989
Cause identified to: ab352b5af9694a7cba8e237d0b1b5a507a6e4226
Original PR: #10003
Problem: I don't think it is OK to hard code the keybind like this at all. Ghostty's config is flexible enough to achieve this.
Proposal: Revert the above commit via this PR.

@yasuf @bo2themax