### PR TITLE
zon2nix: update to a version that is compatible with Zig 0.16

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,16 +132,16 @@
       "locked": {
         "lastModified": 1776048155,
         "narHash": "sha256-aRhvYX6QFGdRVgyWeItzpMFw/43IuEFKTd5fO0B96fo=",
-        "ref": "0.16",
+        "owner": "jcollie",
+        "repo": "zon2nix",
         "rev": "7d1743d10d3dd417a4d3496abe8320e560173141",
-        "revCount": 492,
-        "type": "git",
-        "url": "https://codeberg.org/jcollie/zon2nix"
+        "type": "github"
       },
       "original": {
+        "owner": "jcollie",
         "ref": "0.16",
-        "type": "git",
-        "url": "https://codeberg.org/jcollie/zon2nix"
+        "repo": "zon2nix",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -101,25 +101,47 @@
         "type": "github"
       }
     },
-    "zon2nix": {
+    "zig_2": {
       "inputs": {
         "nixpkgs": [
+          "zon2nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1768231828,
-        "narHash": "sha256-wL/8Iij4T2OLkhHcc4NieOjf7YeJffaUYbCiCqKv/+0=",
-        "owner": "jcollie",
-        "repo": "zon2nix",
-        "rev": "c28e93f3ba133d4c1b1d65224e2eebede61fd071",
-        "type": "github"
+        "lastModified": 1775995979,
+        "narHash": "sha256-oeBCM9k5SLOTFfcWJKtL2gX+HOnE6+9/M6p+WfT25pY=",
+        "ref": "refs/heads/main",
+        "rev": "d6cec52cd4a55bc9cd4711828a2b74cfacf66b68",
+        "revCount": 1663,
+        "type": "git",
+        "url": "https://codeberg.org/jcollie/zig-overlay.git"
       },
       "original": {
-        "owner": "jcollie",
-        "repo": "zon2nix",
-        "rev": "c28e93f3ba133d4c1b1d65224e2eebede61fd071",
-        "type": "github"
+        "type": "git",
+        "url": "https://codeberg.org/jcollie/zig-overlay.git"
+      }
+    },
+    "zon2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "zig": "zig_2"
+      },
+      "locked": {
+        "lastModified": 1776048155,
+        "narHash": "sha256-aRhvYX6QFGdRVgyWeItzpMFw/43IuEFKTd5fO0B96fo=",
+        "ref": "0.16",
+        "rev": "7d1743d10d3dd417a4d3496abe8320e560173141",
+        "revCount": 492,
+        "type": "git",
+        "url": "https://codeberg.org/jcollie/zon2nix"
+      },
+      "original": {
+        "ref": "0.16",
+        "type": "git",
+        "url": "https://codeberg.org/jcollie/zon2nix"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
     };
 
     zon2nix = {
-      url = "git+https://codeberg.org/jcollie/zon2nix?ref=0.16";
+      url = "github:jcollie/zon2nix?ref=0.16";
       inputs = {
         nixpkgs.follows = "nixpkgs";
       };

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
     };
 
     zon2nix = {
-      url = "github:jcollie/zon2nix?rev=c28e93f3ba133d4c1b1d65224e2eebede61fd071";
+      url = "git+https://codeberg.org/jcollie/zon2nix?ref=0.16";
       inputs = {
         nixpkgs.follows = "nixpkgs";
       };


### PR DESCRIPTION
The `zon2nix` binary is now compiled with Zig 0.16, but it still produces Zig 0.15 compatible output (in fact the output is identical to previous versions).