### PR TITLE
fix(macos): defer tab group KVO setup to avoid IconServices hang on boot

### DIFF
--- a/macos/Sources/Features/Terminal/Window Styles/TransparentTitlebarTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TransparentTitlebarTerminalWindow.swift
@@ -22,9 +22,15 @@ class TransparentTitlebarTerminalWindow: TerminalWindow {
     override func awakeFromNib() {
         super.awakeFromNib()
 
-        // Setup all the KVO we will use, see the docs for the respective functions
-        // to learn why we need KVO.
-        setupKVO()
+        // Defer KVO setup to the next run loop iteration. Accessing `tabGroup`
+        // synchronously during NIB loading triggers AppKit to build the tab bar,
+        // which makes a synchronous XPC call to IconServices for the app icon.
+        // Right after system boot, IconServices may not be ready yet, blocking
+        // the main thread for 15+ seconds. Deferring is safe because
+        // `syncAppearance` will also call `setupKVO` once the surface is ready.
+        DispatchQueue.main.async { [weak self] in
+            self?.setupKVO()
+        }
     }
 
     override func becomeMain() {


### PR DESCRIPTION
## Summary

- During window restoration at startup, `TransparentTitlebarTerminalWindow.awakeFromNib()` synchronously accesses `self.tabGroup` via `setupTabGroupObservation()`, which triggers AppKit to build the tab bar and make a **synchronous XPC call to IconServices** for the app icon
- Right after system boot, IconServices may not be responsive yet, **blocking the main thread for 15+ seconds**
- Fix: defer `setupKVO()` in `awakeFromNib()` to the next run loop iteration via `DispatchQueue.main.async` — this is safe because `syncAppearance()` also calls `setupKVO()` once the surface is ready

## Context

Spin report from macOS diagnostic logs shows the full blocking call chain:

```
TerminalWindowRestoration.restoreWindow
  → TerminalController.init → BaseTerminalController.init
    → surfaceTree.didSet → surfaceTreeDidChange → loadWindow
      → awakeFromNib → setupKVO → setupTabGroupObservation
        → self.tabGroup → NSWindowStackController
          → needs tab bar item → needs app icon
            → IconServices synchronous XPC → blocked 16s
```

System had only been booted for 48 seconds when the hang occurred. This is the same class of bug as #4632 (Linux: synchronous DBus call blocking startup), but on macOS.

## Test plan

- [ ] Launch Ghostty with `macos-titlebar-style = transparent` and `window-save-state = always`, verify window restores without hang
- [ ] Verify tab group KVO still works correctly (tab switching, tab bar visibility changes resync appearance)
- [ ] Test right after system boot to confirm no freeze

🤖 Generated with [Claude Code](https://claude.com/claude-code)