### PR TITLE
snap: export TERMINFO_DIRS so child shells find xterm-ghostty

### DIFF
--- a/snap/local/launcher
+++ b/snap/local/launcher
@@ -50,6 +50,7 @@ export XLOCALEDIR="${SNAP}/usr/share/X11/locale"
 export GTK_PATH="$SNAP/usr/lib/$ARCH/gtk-4.0"
 export GIO_MODULE_DIR="$SNAP/usr/lib/$ARCH/gio/modules"
 unset GIO_EXTRA_MODULES
+export TERMINFO_DIRS="${SNAP}/share/terminfo${TERMINFO_DIRS:+:$TERMINFO_DIRS}"
 
 # Gdk-pixbuf loaders
 mkdir -p "$SNAP_USER_COMMON/.cache"


### PR DESCRIPTION
## Problem

When Ghostty is installed via snap, shells spawned inside Ghostty cannot find the `xterm-ghostty` terminfo entry. Commands like `clear` fail with:

```
terminals database is inaccessible
```

This happens because the snap packages terminfo at `$SNAP/share/terminfo/` which is inside the snap sandbox — invisible to ncurses on the host system.

## Fix

Export `TERMINFO_DIRS` in the snap launcher so all child processes (shells, scripts) can locate the terminfo entry without any manual setup:

```sh
export TERMINFO_DIRS="${SNAP}/share/terminfo${TERMINFO_DIRS:+:$TERMINFO_DIRS}"
```

## Testing

Simulated the snap environment and confirmed:
- **Before:** `TERMINFO_DIRS=` (empty), `infocmp xterm-ghostty` fails on fresh installs
- **After:** `TERMINFO_DIRS=/snap/ghostty/current/share/terminfo`, `infocmp xterm-ghostty` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)