### PR TITLE
macOS: fix #12266 by using the correct coordinates for the hitTest

### DIFF
--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -617,7 +617,11 @@ extension Ghostty {
                   window == event.window else { return event }
 
             // The clicked location in this window should be this view.
-            let location = convert(event.locationInWindow, from: nil)
+            guard
+                let location = window.contentView?.convert(event.locationInWindow, from: nil)
+            else {
+                return event
+            }
             // We should use window to perform hitTest here,
             // because there could be some other overlays on top, like search bar
             guard window.contentView?.hitTest(location) == self else { return event }


### PR DESCRIPTION
Fixes #12266, regression of #11872.

Asked Claude to do some math explanations, looked confusing to me >_<, but this fix is the right way to go anyway.

<img width="1265" height="619" alt="image" src="https://github.com/user-attachments/assets/e4fa4130-5727-4b45-9c99-85297c2b8f24" />

### AI Disclosure:

I fixed the issue myself, only asked Claude to explain out of curiosity.
