### PR TITLE
docs,ci: clarify that users can never open issues

### DIFF
--- a/.github/issue-unvouched-message
+++ b/.github/issue-unvouched-message
@@ -1,0 +1,5 @@
+Hi @{author}, thanks for your interest!
+
+Non-maintainers are not allowed to create issues in this repository — we ask that you create a discussion first. For more details on the why, see #3558 and our [CONTRIBUTING.md](https://github.com/ghostty-org/ghostty/blob/main/CONTRIBUTING.md).
+
+This issue will be closed automatically.

--- a/.github/workflows/vouch-check-issue.yml
+++ b/.github/workflows/vouch-check-issue.yml
@@ -18,5 +18,6 @@ jobs:
         with:
           issue-number: ${{ github.event.issue.number }}
           auto-close: true
+          template-file: .github/issue-unvouched-message
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,11 +177,6 @@ item is identified, it is moved to the issue tracker. **This pattern
 makes it easier for maintainers or contributors to find issues to work on
 since _every issue_ is ready to be worked on.**
 
-If you are experiencing a bug and have clear steps to reproduce it, please
-open an issue. If you are experiencing a bug but you are not sure how to
-reproduce it or aren't sure if it's a bug, please open a discussion.
-If you have an idea for a feature, please open a discussion.
-
 ### Pull Requests Implement an Issue
 
 Pull requests should be associated with a previously accepted issue.


### PR DESCRIPTION
I removed the entire paragraph in CONTRIBUTING.md because the "Quick Guide" section explains it all better already.