### PR TITLE
android: Avoid referencing POSIX shared memory functions

### DIFF
--- a/src/terminal/kitty/graphics_image.zig
+++ b/src/terminal/kitty/graphics_image.zig
@@ -159,8 +159,9 @@ pub const LoadingImage = struct {
         t: command.Transmission,
         path: []const u8,
     ) !void {
+        // android does not support POSIX shared memory.
         // windows is currently unsupported, does it support shm?
-        if (comptime builtin.target.os.tag == .windows) {
+        if (comptime builtin.abi.isAndroid() or builtin.target.os.tag == .windows) {
             return error.UnsupportedMedium;
         }
 


### PR DESCRIPTION
Stop trying to use POSIX shared memory functions such as `shm_open` on Android as it's unsupported and the platform libc does not have those symbols.

This avoids an error such as the below when trying to use `libghostty-vt` on Android:

> dlopen failed: cannot locate symbol "shm_open" referenced by [..]