### PR TITLE
Add swap_split action to exchange terminal content between panes

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -949,6 +949,7 @@ typedef enum {
   GHOSTTY_ACTION_SEARCH_SELECTED,
   GHOSTTY_ACTION_READONLY,
   GHOSTTY_ACTION_COPY_TITLE_TO_CLIPBOARD,
+  GHOSTTY_ACTION_SWAP_SPLIT,
 } ghostty_action_tag_e;
 
 typedef union {
@@ -957,6 +958,7 @@ typedef union {
   ghostty_action_move_tab_s move_tab;
   ghostty_action_goto_tab_e goto_tab;
   ghostty_action_goto_split_e goto_split;
+  ghostty_action_goto_split_e swap_split;
   ghostty_action_goto_window_e goto_window;
   ghostty_action_resize_split_s resize_split;
   ghostty_action_size_limit_s size_limit;

--- a/macos/Sources/Features/Splits/SplitTree.swift
+++ b/macos/Sources/Features/Splits/SplitTree.swift
@@ -231,6 +231,38 @@ extension SplitTree {
         }
     }
 
+    /// Swap two leaf nodes in the tree. The tree structure and all split
+    /// ratios are preserved; only the views at the two leaf positions are
+    /// exchanged. This lets the user rearrange which terminal occupies
+    /// which pane without reshaping the layout.
+    ///
+    /// The zoomed state is cleared by this operation (consistent with
+    /// `resizing` and `inserting`).
+    ///
+    /// Both nodes must be leaves and must exist in the tree. If `a == b`,
+    /// the tree is returned unchanged.
+    func swapping(_ a: Node, with b: Node) throws -> Self {
+        guard let root else { throw SplitError.viewNotFound }
+
+        // No-op fast path.
+        if a == b { return self }
+
+        guard case .leaf(let viewA) = a else { throw SplitError.viewNotFound }
+        guard case .leaf(let viewB) = b else { throw SplitError.viewNotFound }
+
+        guard let pathA = root.path(to: a) else { throw SplitError.viewNotFound }
+        guard let pathB = root.path(to: b) else { throw SplitError.viewNotFound }
+
+        // Replace node at pathA with a leaf containing viewB, then replace
+        // the node at pathB in that tree with a leaf containing viewA.
+        // Paths are structural so pathB is still valid after the first
+        // replacement.
+        let stepOne = try root.replacingNode(at: pathA, with: .leaf(view: viewB))
+        let newRoot = try stepOne.replacingNode(at: pathB, with: .leaf(view: viewA))
+
+        return .init(root: newRoot, zoomed: nil)
+    }
+
     /// Equalize all splits in the tree so that each split's ratio is based on the
     /// relative weight (number of leaves) of its children.
     func equalized() -> Self {

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -515,6 +515,9 @@ extension Ghostty {
             case GHOSTTY_ACTION_GOTO_SPLIT:
                 return gotoSplit(app, target: target, direction: action.action.goto_split)
 
+            case GHOSTTY_ACTION_SWAP_SPLIT:
+                return swapSplit(app, target: target, direction: action.action.swap_split)
+
             case GHOSTTY_ACTION_GOTO_WINDOW:
                 return gotoWindow(app, target: target, direction: action.action.goto_window)
 
@@ -1190,6 +1193,67 @@ extension Ghostty {
                         userInfo: [
                             Notification.SplitDirectionKey: splitDirection as Any,
                         ]
+                    )
+
+                    return true
+
+                default:
+                    assertionFailure()
+                    return false
+                }
+        }
+
+        private static func swapSplit(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s,
+            direction: ghostty_action_goto_split_e) -> Bool {
+                switch target.tag {
+                case GHOSTTY_TARGET_APP:
+                    Ghostty.logger.warning("swap split does nothing with an app target")
+                    return false
+
+                case GHOSTTY_TARGET_SURFACE:
+                    guard let surface = target.target.surface else { return false }
+                    guard let surfaceView = self.surfaceView(from: surface) else { return false }
+                    guard let controller = surfaceView.window?.windowController as? BaseTerminalController else { return false }
+
+                    guard controller.surfaceTree.isSplit else { return false }
+                    guard let splitDirection = SplitFocusDirection.from(direction: direction) else { return false }
+                    guard let currentNode = controller.surfaceTree.root?.node(view: surfaceView) else { return false }
+
+                    // Find the target view in the given direction. If none
+                    // exists, the action is not performable — let the key
+                    // pass through.
+                    let focusDirection: SplitTree<Ghostty.SurfaceView>.FocusDirection = splitDirection.toSplitTreeFocusDirection()
+                    guard let targetView = controller.surfaceTree.focusTarget(
+                        for: focusDirection,
+                        from: currentNode
+                    ) else {
+                        return false
+                    }
+
+                    // Don't swap with self (can happen with only-one-pane wrap).
+                    guard targetView !== surfaceView else { return false }
+
+                    guard let targetNode = controller.surfaceTree.root?.node(view: targetView) else { return false }
+
+                    let newTree: SplitTree<Ghostty.SurfaceView>
+                    do {
+                        newTree = try controller.surfaceTree.swapping(currentNode, with: targetNode)
+                    } catch {
+                        Ghostty.logger.warning("failed to swap splits: \(error)")
+                        return false
+                    }
+
+                    // Keep focus on the surface the user was on; its view has
+                    // moved to the target's old position, so focus follows
+                    // the content (matching "swap the position of my window"
+                    // mental model).
+                    controller.replaceSurfaceTree(
+                        newTree,
+                        moveFocusTo: surfaceView,
+                        moveFocusFrom: surfaceView,
+                        undoAction: "Swap Split"
                     )
 
                     return true

--- a/macos/Tests/Splits/SplitTreeTests.swift
+++ b/macos/Tests/Splits/SplitTreeTests.swift
@@ -166,6 +166,52 @@ struct SplitTreeTests {
         #expect(target === view1)
     }
 
+    // MARK: - Swapping
+
+    @Test func swappingExchangesTwoLeaves() throws {
+        let (tree, view1, view2) = try makeHorizontalSplit()
+
+        // Capture the original split's ratio and direction.
+        guard case .split(let originalSplit) = tree.root else {
+            Issue.record("expected split root")
+            return
+        }
+
+        let swapped = try tree.swapping(.leaf(view: view1), with: .leaf(view: view2))
+
+        // Layout must be preserved: same direction and ratio.
+        guard case .split(let newSplit) = swapped.root else {
+            Issue.record("expected split root after swap")
+            return
+        }
+        #expect(newSplit.direction == originalSplit.direction)
+        #expect(newSplit.ratio == originalSplit.ratio)
+
+        // Views must have swapped positions.
+        guard case .leaf(let newLeft) = newSplit.left,
+              case .leaf(let newRight) = newSplit.right else {
+            Issue.record("expected leaf children after swap")
+            return
+        }
+        #expect(newLeft === view2)
+        #expect(newRight === view1)
+    }
+
+    @Test func swappingWithSelfIsNoOp() throws {
+        let (tree, view1, _) = try makeHorizontalSplit()
+        let result = try tree.swapping(.leaf(view: view1), with: .leaf(view: view1))
+
+        // Result should equal the input tree structurally.
+        #expect(result.structuralIdentity == tree.structuralIdentity)
+    }
+
+    @Test func swappingClearsZoomedState() throws {
+        let (treeBase, view1, view2) = try makeHorizontalSplit()
+        let zoomed = SplitTree(root: treeBase.root, zoomed: .leaf(view: view1))
+        let swapped = try zoomed.swapping(.leaf(view: view1), with: .leaf(view: view2))
+        #expect(swapped.zoomed == nil)
+    }
+
     // MARK: - Equalized
 
     @Test func equalizedAdjustsRatioByLeafCount() throws {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -5523,6 +5523,17 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             },
         ),
 
+        .swap_split => |direction| return try self.rt_app.performAction(
+            .{ .surface = self },
+            .swap_split,
+            switch (direction) {
+                inline else => |tag| @field(
+                    apprt.action.GotoSplit,
+                    @tagName(tag),
+                ),
+            },
+        ),
+
         .goto_window => |direction| return try self.rt_app.performAction(
             .{ .surface = self },
             .goto_window,

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -139,6 +139,12 @@ pub const Action = union(Key) {
     /// Jump to a specific split.
     goto_split: GotoSplit,
 
+    /// Swap the current split with the split in the given direction. The
+    /// tree structure and split ratios are preserved; only the leaf views
+    /// (terminals) are exchanged. If no split exists in the given direction,
+    /// the action is a no-op.
+    swap_split: GotoSplit,
+
     /// Jump to next/previous window.
     goto_window: GotoWindow,
 
@@ -410,6 +416,7 @@ pub const Action = union(Key) {
         search_selected,
         readonly,
         copy_title_to_clipboard,
+        swap_split,
 
         test "ghostty.h Action.Key" {
             try lib.checkGhosttyHEnum(Key, "GHOSTTY_ACTION_");

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -689,6 +689,8 @@ pub const Application = extern struct {
 
             .goto_split => return Action.gotoSplit(target, value),
 
+            .swap_split => return Action.swapSplit(target, value),
+
             .goto_window => return Action.gotoWindow(value),
 
             .goto_tab => return Action.gotoTab(target, value),
@@ -2011,6 +2013,34 @@ const Action = struct {
                 };
 
                 return tree.goto(switch (to) {
+                    .previous => .previous_wrapped,
+                    .next => .next_wrapped,
+                    .up => .{ .spatial = .up },
+                    .down => .{ .spatial = .down },
+                    .left => .{ .spatial = .left },
+                    .right => .{ .spatial = .right },
+                });
+            },
+        }
+    }
+
+    pub fn swapSplit(
+        target: apprt.Target,
+        to: apprt.action.GotoSplit,
+    ) bool {
+        switch (target) {
+            .app => return false,
+            .surface => |core| {
+                const surface = core.rt_surface.surface;
+                const tree = ext.getAncestor(
+                    SplitTree,
+                    surface.as(gtk.Widget),
+                ) orelse {
+                    log.warn("surface is not in a split tree, ignoring swap_split", .{});
+                    return false;
+                };
+
+                return tree.swap(switch (to) {
                     .previous => .previous_wrapped,
                     .next => .next_wrapped,
                     .up => .{ .spatial = .up },

--- a/src/apprt/gtk/class/split_tree.zig
+++ b/src/apprt/gtk/class/split_tree.zig
@@ -322,6 +322,34 @@ pub const SplitTree = extern struct {
         return true;
     }
 
+    /// Swap the currently focused surface with the surface in the given
+    /// direction. The tree layout (structure and split ratios) is
+    /// preserved; only the two terminals trade places. Returns true if a
+    /// swap occurred, false if there is no surface in that direction or
+    /// if no swap is possible.
+    pub fn swap(self: *Self, to: Surface.Tree.Goto) bool {
+        const tree = self.getTree() orelse return false;
+        const active = self.getActiveSurfaceHandle() orelse return false;
+
+        const alloc = Application.default().allocator();
+        const target = if (tree.goto(alloc, active, to)) |handle_|
+            handle_ orelse return false
+        else |err| switch (err) {
+            error.OutOfMemory => return false,
+        };
+
+        // No target, or target is ourself: nothing to do.
+        if (active == target) return false;
+
+        var new_tree = tree.swap(alloc, active, target) catch |err| switch (err) {
+            error.OutOfMemory => return false,
+        };
+        defer new_tree.deinit();
+
+        self.setTree(&new_tree);
+        return true;
+    }
+
     /// Move focus from the currently focused surface to the given
     /// direction. Returns true if focus switched to a new surface.
     pub fn goto(self: *Self, to: Surface.Tree.Goto) bool {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -6696,6 +6696,32 @@ pub const Keybinds = struct {
                 .{ .performable = true },
             );
 
+            // Swapping splits (preserves layout, swaps the terminal content)
+            try self.set.putFlags(
+                alloc,
+                .{ .key = .{ .physical = .arrow_up }, .mods = .{ .ctrl = true, .alt = true, .shift = true } },
+                .{ .swap_split = .up },
+                .{ .performable = true },
+            );
+            try self.set.putFlags(
+                alloc,
+                .{ .key = .{ .physical = .arrow_down }, .mods = .{ .ctrl = true, .alt = true, .shift = true } },
+                .{ .swap_split = .down },
+                .{ .performable = true },
+            );
+            try self.set.putFlags(
+                alloc,
+                .{ .key = .{ .physical = .arrow_left }, .mods = .{ .ctrl = true, .alt = true, .shift = true } },
+                .{ .swap_split = .left },
+                .{ .performable = true },
+            );
+            try self.set.putFlags(
+                alloc,
+                .{ .key = .{ .physical = .arrow_right }, .mods = .{ .ctrl = true, .alt = true, .shift = true } },
+                .{ .swap_split = .right },
+                .{ .performable = true },
+            );
+
             // Resizing splits
             try self.set.putFlags(
                 alloc,
@@ -7041,6 +7067,33 @@ pub const Keybinds = struct {
                 .{ .key = .{ .physical = .arrow_right }, .mods = .{ .super = true, .alt = true } },
                 .{ .goto_split = .right },
             );
+
+            // Swapping splits (preserves layout, swaps terminal content)
+            try self.set.putFlags(
+                alloc,
+                .{ .key = .{ .physical = .arrow_up }, .mods = .{ .super = true, .alt = true, .shift = true } },
+                .{ .swap_split = .up },
+                .{ .performable = true },
+            );
+            try self.set.putFlags(
+                alloc,
+                .{ .key = .{ .physical = .arrow_down }, .mods = .{ .super = true, .alt = true, .shift = true } },
+                .{ .swap_split = .down },
+                .{ .performable = true },
+            );
+            try self.set.putFlags(
+                alloc,
+                .{ .key = .{ .physical = .arrow_left }, .mods = .{ .super = true, .alt = true, .shift = true } },
+                .{ .swap_split = .left },
+                .{ .performable = true },
+            );
+            try self.set.putFlags(
+                alloc,
+                .{ .key = .{ .physical = .arrow_right }, .mods = .{ .super = true, .alt = true, .shift = true } },
+                .{ .swap_split = .right },
+                .{ .performable = true },
+            );
+
             try self.set.put(
                 alloc,
                 .{ .key = .{ .physical = .arrow_up }, .mods = .{ .super = true, .ctrl = true } },

--- a/src/datastruct/split_tree.zig
+++ b/src/datastruct/split_tree.zig
@@ -473,6 +473,44 @@ pub fn SplitTree(comptime V: type) type {
             );
         }
 
+        /// Swap the views of two leaf nodes. The tree structure and all
+        /// split ratios are preserved; only the view pointers at the two
+        /// leaf positions are exchanged. This is useful for letting the
+        /// user rearrange which terminal occupies which pane without
+        /// reshaping the layout.
+        ///
+        /// Both handles must refer to leaf nodes (asserted).
+        ///
+        /// The zoomed handle (if any) is preserved as-is. Since the zoom
+        /// tracks a node position rather than a view, the zoomed pane
+        /// will show the newly-swapped-in view after this call.
+        pub fn swap(
+            self: *const Self,
+            gpa: Allocator,
+            a: Node.Handle,
+            b: Node.Handle,
+        ) Allocator.Error!Self {
+            assert(a.idx() < self.nodes.len);
+            assert(b.idx() < self.nodes.len);
+            assert(self.nodes[a.idx()] == .leaf);
+            assert(self.nodes[b.idx()] == .leaf);
+
+            var result = try self.clone(gpa);
+            errdefer result.deinit();
+
+            if (a == b) return result;
+
+            // Safe const cast: the cloned tree owns this memory via its
+            // arena. See resizeInPlace for the same pattern.
+            const node_a: *Node = @constCast(&result.nodes[a.idx()]);
+            const node_b: *Node = @constCast(&result.nodes[b.idx()]);
+            const view_a = node_a.leaf;
+            node_a.* = .{ .leaf = node_b.leaf };
+            node_b.* = .{ .leaf = view_a };
+
+            return result;
+        }
+
         /// Resize the given node in place. The node MUST be a split (asserted).
         ///
         /// In general, this is an immutable data structure so this is
@@ -2085,6 +2123,84 @@ test "SplitTree: spatial goto" {
             \\
         );
     }
+}
+
+test "SplitTree: swap leaves preserves layout" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var v1: TestTree.View = .{ .label = "A" };
+    var t1: TestTree = try .init(alloc, &v1);
+    defer t1.deinit();
+    var v2: TestTree.View = .{ .label = "B" };
+    var t2: TestTree = try .init(alloc, &v2);
+    defer t2.deinit();
+
+    // A | B horizontal with an asymmetric ratio so we can verify the
+    // ratio is preserved through the swap.
+    var splitAB = try t1.split(alloc, .root, .right, 0.7, &t2);
+    defer splitAB.deinit();
+
+    // Find handles for A and B.
+    const handle_a: TestTree.Node.Handle = h: {
+        var it = splitAB.iterator();
+        break :h while (it.next()) |entry| {
+            if (std.mem.eql(u8, entry.view.label, "A")) break entry.handle;
+        } else return error.NotFound;
+    };
+    const handle_b: TestTree.Node.Handle = h: {
+        var it = splitAB.iterator();
+        break :h while (it.next()) |entry| {
+            if (std.mem.eql(u8, entry.view.label, "B")) break entry.handle;
+        } else return error.NotFound;
+    };
+
+    // Swap A and B.
+    var swapped = try splitAB.swap(alloc, handle_a, handle_b);
+    defer swapped.deinit();
+
+    // The leaf that was A is now B, and vice versa.
+    try testing.expectEqualStrings("B", swapped.nodes[handle_a.idx()].leaf.label);
+    try testing.expectEqualStrings("A", swapped.nodes[handle_b.idx()].leaf.label);
+
+    // The root split node is unchanged (same layout, same ratio).
+    const root_before = splitAB.nodes[0].split;
+    const root_after = swapped.nodes[0].split;
+    try testing.expectEqual(root_before.layout, root_after.layout);
+    try testing.expectEqual(root_before.ratio, root_after.ratio);
+    try testing.expectEqual(root_before.left, root_after.left);
+    try testing.expectEqual(root_before.right, root_after.right);
+
+    // The original tree is untouched (immutability).
+    try testing.expectEqualStrings("A", splitAB.nodes[handle_a.idx()].leaf.label);
+    try testing.expectEqualStrings("B", splitAB.nodes[handle_b.idx()].leaf.label);
+}
+
+test "SplitTree: swap with self is a no-op clone" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var v1: TestTree.View = .{ .label = "A" };
+    var t1: TestTree = try .init(alloc, &v1);
+    defer t1.deinit();
+    var v2: TestTree.View = .{ .label = "B" };
+    var t2: TestTree = try .init(alloc, &v2);
+    defer t2.deinit();
+
+    var splitAB = try t1.split(alloc, .root, .right, 0.5, &t2);
+    defer splitAB.deinit();
+
+    const handle_a: TestTree.Node.Handle = h: {
+        var it = splitAB.iterator();
+        break :h while (it.next()) |entry| {
+            if (std.mem.eql(u8, entry.view.label, "A")) break entry.handle;
+        } else return error.NotFound;
+    };
+
+    var swapped = try splitAB.swap(alloc, handle_a, handle_a);
+    defer swapped.deinit();
+
+    try testing.expectEqualStrings("A", swapped.nodes[handle_a.idx()].leaf.label);
 }
 
 test "SplitTree: resize" {

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -608,6 +608,13 @@ pub const Action = union(enum) {
     /// (`previous` and `next`).
     goto_split: SplitFocusDirection,
 
+    /// Swap the current split with the split in the specified direction.
+    /// The layout (tree structure and split ratios) is preserved; only the
+    /// terminal content (the leaf views) is exchanged between the two
+    /// positions. If no split exists in the given direction, the action is
+    /// a no-op. Valid arguments are the same as `goto_split`.
+    swap_split: SplitFocusDirection,
+
     /// Focus on either the previous window or the next one ('previous', 'next')
     goto_window: GotoWindow,
 

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -506,6 +506,39 @@ fn actionCommands(action: Action.Key) []const Command {
             },
         },
 
+        .swap_split => comptime &.{
+            .{
+                .action = .{ .swap_split = .left },
+                .title = "Swap Split: Left",
+                .description = "Swap the current split with the split to the left, if it exists.",
+            },
+            .{
+                .action = .{ .swap_split = .right },
+                .title = "Swap Split: Right",
+                .description = "Swap the current split with the split to the right, if it exists.",
+            },
+            .{
+                .action = .{ .swap_split = .up },
+                .title = "Swap Split: Up",
+                .description = "Swap the current split with the split above, if it exists.",
+            },
+            .{
+                .action = .{ .swap_split = .down },
+                .title = "Swap Split: Down",
+                .description = "Swap the current split with the split below, if it exists.",
+            },
+            .{
+                .action = .{ .swap_split = .previous },
+                .title = "Swap Split: Previous",
+                .description = "Swap the current split with the previous split, if any.",
+            },
+            .{
+                .action = .{ .swap_split = .next },
+                .title = "Swap Split: Next",
+                .description = "Swap the current split with the next split, if any.",
+            },
+        },
+
         .goto_window => comptime &.{
             .{
                 .action = .{ .goto_window = .previous },


### PR DESCRIPTION
## Summary

  Adds a new `swap_split` action that exchanges the terminal content of the currently focused split with the neighbor split in a given direction. Unlike `goto_split` (which moves focus), `swap_split`
  preserves the tree layout and split ratios — only the two leaf views trade places. Useful for rearranging panes without reshaping the layout.

  Example: with a big left pane and a small right pane, pressing the swap binding with direction `right` puts the left pane's content in the small right position and vice versa. Pane sizes are unchanged.

  ## Default keybinds

  - **macOS**: `Cmd+Shift+Option+Arrow` (mirrors the existing `Cmd+Option+Arrow` for `goto_split`)
  - **Linux/GTK**: `Ctrl+Alt+Shift+Arrow` (mirrors the existing `Ctrl+Alt+Arrow` for `goto_split`)

  Both are marked `performable`, so at a layout edge with no neighbor in that direction the action is a no-op and the key passes through.

  ## Implementation

  - **Action** (`src/apprt/action.zig`): new `swap_split: GotoSplit` variant. `GHOSTTY_ACTION_SWAP_SPLIT` appended at the end of the C enum to avoid renumbering existing values.
  - **Binding** (`src/input/Binding.zig`): `swap_split: SplitFocusDirection`. Command palette entries added in `src/input/command.zig`.
  - **Surface dispatch** (`src/Surface.zig`): mirrors the `goto_split` arm.
  - **Core SplitTree** (`src/datastruct/split_tree.zig`): new `pub fn swap(gpa, a, b)` — clones the tree and swaps the two leaf view pointers in place (same `@constCast` pattern as `resizeInPlace`). Zoomed
  handle is preserved (zoom tracks position).
  - **GTK apprt**: `swap(to)` wrapper on `split_tree.zig` reusing `goto` for target resolution; `swapSplit` handler in `application.zig`.
  - **macOS Swift SplitTree**: new `swapping(_:with:)` using `path(to:)` + two `replacingNode` calls. Clears zoom (matches `resizing`/`inserting`).
  - **macOS dispatch** (`Ghostty.App.swift`): `swapSplit` handler uses `replaceSurfaceTree(_, moveFocusTo:, moveFocusFrom:, undoAction: "Swap Split")`, so the operation integrates with the existing undo
  system. Focus follows the content (user's terminal moves with them).

  ## Tests

  - `src/datastruct/split_tree.zig`: two tests — swap preserves layout/ratios and swaps leaf views; swap-with-self is a no-op clone.
  - `macos/Tests/Splits/SplitTreeTests.swift`: three tests — leaf swap preserves direction/ratio, self-swap no-op, zoomed state cleared on swap.

  ## Known inconsistency (matches existing goto_split)

  GTK spatial navigation wraps at edges (`nearestWrapped`); macOS spatial navigation does not (`slots(in:from:)` strict directional). So `swap_split:right` from the rightmost pane wraps to leftmost on GTK
  but is a no-op on macOS. This matches the pre-existing `goto_split` behavior in both apprts and is not addressed in this PR.