### PR TITLE
Sync middle-click paste with copy-on-select

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4007,12 +4007,19 @@ pub fn mouseButtonCallback(
         }
     }
 
-    // Middle-click pastes from our selection clipboard
+    // Middle-click paste source follows copy-on-select: when copy-on-select
+    // targets the selection clipboard, middle-click reads from it; when
+    // copy-on-select targets the system clipboard, middle-click reads from
+    // that instead. Falls back to the standard clipboard on platforms that
+    // do not support the selection clipboard.
     if (button == .middle and action == .press) {
-        const clipboard: apprt.Clipboard = if (self.rt_surface.supportsClipboard(.selection))
-            .selection
-        else
-            .standard;
+        const clipboard: apprt.Clipboard = switch (self.config.copy_on_select) {
+            .clipboard => .standard,
+            .true, .false => if (self.rt_surface.supportsClipboard(.selection))
+                .selection
+            else
+                .standard,
+        };
         _ = try self.startClipboardRequest(clipboard, .{ .paste = {} });
     }
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2404,8 +2404,11 @@ keybind: Keybinds = .{},
 /// The value `clipboard` will always copy text to the selection clipboard
 /// as well as the system clipboard.
 ///
-/// Middle-click paste will always use the selection clipboard. Middle-click
-/// paste is always enabled even if this is `false`.
+/// Middle-click paste is always enabled even if this is `false`. The
+/// clipboard it pastes from follows this setting: with `true` (or `false`)
+/// it reads from the selection clipboard (falling back to the system
+/// clipboard on platforms without a selection clipboard); with `clipboard`
+/// it reads from the system clipboard.
 ///
 /// The default value is true on Linux and macOS.
 @"copy-on-select": CopyOnSelect = switch (builtin.os.tag) {


### PR DESCRIPTION
Implements the behavior from #9788.

Today, middle-click paste always reads from the selection clipboard (or the
system clipboard on platforms without a selection clipboard). With this change
it follows `copy-on-select`:

- `true`: selection clipboard (unchanged)
- `clipboard`: system clipboard
- `false`: selection clipboard (also unchanged, preserves traditional X11
  middle-click behavior)

The idea is symmetry: if `copy-on-select = clipboard` writes selections to the
system clipboard, middle-click should come back from there too.

Also updated the config doc comment, which previously claimed middle-click
"will always use the selection clipboard".

### Testing

`zig build test` passes locally (macOS, Zig 0.15.2).

I couldn't do interactive runtime testing. My local env currently can't produce
a working `Ghostty.app` because of a Zig 0.15.2 + Xcode 26.4 TBD linker bug
(upstream fix in zig PR #31673, not released yet). Marking draft so nobody
merges before someone checks the three copy-on-select modes on a real build.