### PR TITLE
build(xcframework): exclude libghostty-vt headers from GhosttyKit

### DIFF
--- a/src/build/GhosttyXCFramework.zig
+++ b/src/build/GhosttyXCFramework.zig
@@ -53,6 +53,16 @@ pub fn init(
         }),
     ));
 
+    // Generate a headers directory with only ghostty.h and the module
+    // map. We can't use include/ directly because it also contains the
+    // libghostty-vt headers under include/ghostty/, which would trigger
+    // "umbrella header does not include header" warnings from Clang's
+    // module system.
+    const wf = b.addWriteFiles();
+    _ = wf.addCopyFile(b.path("include/ghostty.h"), "ghostty.h");
+    _ = wf.addCopyFile(b.path("include/module.modulemap"), "module.modulemap");
+    const headers = wf.getDirectory();
+
     // The xcframework wraps our ghostty library so that we can link
     // it to the final app built with Swift.
     const xcframework = XCFrameworkStep.create(b, .{
@@ -62,24 +72,24 @@ pub fn init(
             .universal => &.{
                 .{
                     .library = macos_universal.output,
-                    .headers = b.path("include"),
+                    .headers = headers,
                     .dsym = macos_universal.dsym,
                 },
                 .{
                     .library = ios.output,
-                    .headers = b.path("include"),
+                    .headers = headers,
                     .dsym = ios.dsym,
                 },
                 .{
                     .library = ios_sim.output,
-                    .headers = b.path("include"),
+                    .headers = headers,
                     .dsym = ios_sim.dsym,
                 },
             },
 
             .native => &.{.{
                 .library = macos_native.output,
-                .headers = b.path("include"),
+                .headers = headers,
                 .dsym = macos_native.dsym,
             }},
         },


### PR DESCRIPTION
The GhosttyKit xcframework previously shipped the entire include/ directory, which pulled in the libghostty-vt headers under include/ghostty/. Because those headers are not referenced from the ghostty.h umbrella, Clang's module system emitted "umbrella header for module 'GhosttyKit' does not include header 'ghostty/vt/*.h'" warnings in Xcode builds.

Stage only ghostty.h and module.modulemap via addWriteFiles so the xcframework Headers directory contains exactly the GhosttyKit API, mirroring the pattern used in GhosttyLibVt.xcframework.

## AI disclosure

Claude made the changes (including the commit message), I reviewed and tested them.